### PR TITLE
[SPARK-21867][CORE] Support async spilling in UnsafeShuffleWriter

### DIFF
--- a/core/src/main/java/org/apache/spark/memory/MemoryConsumer.java
+++ b/core/src/main/java/org/apache/spark/memory/MemoryConsumer.java
@@ -54,7 +54,7 @@ public abstract class MemoryConsumer {
   /**
    * Returns the size of used memory in bytes.
    */
-  protected long getUsed() {
+  public long getUsed() {
     return used;
   }
 

--- a/core/src/main/java/org/apache/spark/shuffle/sort/MultiShuffleSorter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/MultiShuffleSorter.java
@@ -1,0 +1,374 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.sort;
+
+/**
+ * A multi shuffle sorter that internally dispatches to multiple external shuffle sorters.
+ * <p>
+ * The benefit of running multiple shuffle sorters is that we can parallelize the insertion and
+ * sort, spill cycles for better I/O performance.  A shuffle sorter can be spilling to disk while
+ * another one is inserting records from a different file system or network.  This has been
+ * shown to reduce the end to end latency of large shuffle operations.  The multi shuffle sorter
+ * manages the pool of shuffle sorters.
+ */
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.executor.TaskMetrics;
+import org.apache.spark.memory.MemoryConsumer;
+import org.apache.spark.memory.TaskMemoryManager;
+import org.apache.spark.storage.BlockManager;
+import org.apache.spark.util.AccumulatorV2;
+import org.apache.spark.util.ThreadUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import scala.collection.JavaConversions;
+
+class MultiShuffleSorter extends ShuffleSorter {
+  private final Logger logger = LoggerFactory.getLogger(MultiShuffleSorter.class);
+
+  private int numSorters;
+  private TaskMetrics[] sorterMetrics;
+  private List<ShuffleSorter> allSorters;
+  private LinkedBlockingDeque<ShuffleSorter> availableSorters;
+  private ShuffleSorter currentSorter;
+  private ExecutorService executorService;
+
+  private TaskMetrics taskMetrics;
+  private boolean cleanedUp;
+
+  /**
+   * If the shuffle sorter has allocated at least this number of bytes, then trigger a spill.
+   */
+  private long spillThresholdBytes;
+
+  /**
+   * Minimum bound on spill threshold.  If we change the spill threshold, then we never set
+   * below this lower limit.
+   */
+  private long minSpillThresholdBytes;
+
+  /**
+   * Capture exceptions that may have occurred in asynchronously and propagate them on the
+   * main spill thread.
+   */
+  private AtomicReference<IOException> pendingException;
+
+  private long waitingIntervalMs;
+
+  MultiShuffleSorter(
+      TaskMemoryManager memoryManager,
+      BlockManager blockManager,
+      TaskMetrics taskMetrics,
+      int initialSize,
+      int numPartitions,
+      SparkConf conf,
+      int numSorters,
+      long initialMaxMemoryPerSorter,
+      ShuffleSorterFactory factory) {
+    super(memoryManager,
+      (int) Math.min(PackedRecordPointer.MAXIMUM_PAGE_SIZE_BYTES, memoryManager.pageSizeBytes()),
+      memoryManager.getTungstenMemoryMode());
+    assert(numSorters >= 1);
+
+    this.numSorters = numSorters;
+    this.sorterMetrics = new TaskMetrics[numSorters];
+
+    this.allSorters = new ArrayList<>(numSorters);
+    this.availableSorters = new LinkedBlockingDeque<>(numSorters);
+
+    for (int i=0; i<numSorters; i++) {
+      sorterMetrics[i] = TaskMetrics.empty();
+      ShuffleSorter sorter = factory.createShuffleExternalSorter(
+        memoryManager, blockManager, sorterMetrics[i], initialSize, numPartitions, conf, true);
+      allSorters.add(sorter);
+      availableSorters.add(sorter);
+    }
+
+    this.executorService = ThreadUtils.newDaemonFixedThreadPool(numSorters, "multishuffle-sorter-spill-thread");
+    this.taskMetrics = taskMetrics;
+    this.cleanedUp = false;
+
+    this.waitingIntervalMs = conf.getLong("spark.shuffle.writer.waiting.interval.ms", 10 * 1000);
+    this.minSpillThresholdBytes = conf.getSizeAsBytes("spark.shuffle.writer.spill.min.size", "100m");
+    this.spillThresholdBytes = Math.max(minSpillThresholdBytes, initialMaxMemoryPerSorter);
+    this.pendingException = new AtomicReference<>(null);
+
+    logger.info(
+      "MultiShuffleSorter on thread [{}] started with {} sorters and spill threshold {} bytes",
+      Thread.currentThread().getId(), numSorters, spillThresholdBytes);
+
+    try {
+      currentSorter = nextAvailableSorter();
+    } catch (IOException e) {
+      pendingException.set(e);
+    }
+  }
+
+  /**
+   * Note this is not called because the MultiShuffleSorter oes not directly allocate memory,
+   * rather this is delegated to individual ShuffleShuffleSorters.
+   */
+  @Override
+  public long spill(long size, MemoryConsumer trigger) throws IOException {
+    doAsyncSpillOnCurrentSorter();
+    currentSorter = nextAvailableSorter();
+    return 0L;
+  }
+
+  /**
+   * Return the peak memory used so far, in bytes.
+   */
+  @Override
+  public long getPeakMemoryUsedBytes() {
+    long peakMemoryUsedBytes = 0;
+    for (int i=0; i < numSorters; i++) {
+      peakMemoryUsedBytes += allSorters.get(i).getPeakMemoryUsedBytes();
+    }
+    return peakMemoryUsedBytes;
+  }
+
+  /**
+   * Force all memory and spill files to be deleted; called by shuffle error-handling code.
+   */
+  @Override
+  public void cleanupResources() {
+    logger.info("Cleaning up shuffle sorters.");
+    if (!cleanedUp) {
+
+      if (currentSorter != null) {
+        availableSorters.addLast(currentSorter);
+        currentSorter = null;
+      }
+
+      for (int i = 0; i < numSorters; i++) {
+        try {
+          ShuffleSorter sorter = nextAvailableSorter();
+          logger.info("Cleaning up resources for sorter {}", sorter);
+          sorter.cleanupResources();
+        } catch (IOException e) {
+          logger.error("Failed to clean up sorter", e);
+        }
+      }
+
+      cleanedUp = true;
+    }
+
+    logger.info("MultiShuffleSorter done with clean up");
+  }
+
+  /**
+   * Write a record to the shuffle sorter.
+   */
+  @Override
+  public void insertRecord(final Object recordBase, long recordOffset, int length, int partitionId)
+    throws IOException {
+    checkForPendingException();
+
+    if (!hasSpaceForInsertRecord()) {
+      logger.info("Forcing a spill on sorter {} because over spill threshold " +
+          "(used {} bytes > spill threshold {})",
+          currentSorter, currentSorter.getUsed(), spillThresholdBytes);
+      spill();
+    }
+
+    boolean retryInsert;
+    do {
+      retryInsert = false;
+      checkForPendingException();
+      try {
+        currentSorter.insertRecord(recordBase, recordOffset, length, partitionId);
+      } catch (OutOfMemoryError e) {
+        // If the current sorter fails to allocate memory and there's at least one
+        // outstanding sorter in the process of spilling, then we should wait for
+        // it to spill and tune the spillThresholdBytes down.
+        int numAvailableSorters = getNumAvailableSorters();
+        if (allSorters.size() - numAvailableSorters > 1) {
+          long newSpillThresholdBytes = Math.max(minSpillThresholdBytes, (spillThresholdBytes * 9) / 10);
+
+          logger.info("Sorter {} ran out of memory, waiting for asynchronous " +
+            "spilling to finish, adjusting spill threshold to {} bytes", currentSorter,
+            newSpillThresholdBytes);
+          spillThresholdBytes = newSpillThresholdBytes;
+
+          waitForAvailableSorters(numAvailableSorters + 1);
+
+          retryInsert = true;
+        } else {
+          // If there are no other sorters to spill and we still run out of memory, it
+          // could be our initial spillThresholdBytes is just too far off.  In this case
+          // we can spill this sorter and re-adjust the spillThresholdBytes based on peak
+          // memory used.
+
+          // Calculate all used memory across sorters
+          long used = 0;
+          for (int i = 0; i < allSorters.size(); i++) {
+            used += allSorters.get(i).getUsed();
+          }
+
+          // Calculate the spillThresholdBytes based on the total allocated memory across
+          // all sorters divided across the number of sorters.  Also reduce by 10% to
+          // buffer overhead to avoid OOM in the future.
+          long newSpillThresholdBytes = Math.max(minSpillThresholdBytes, ((used / numSorters) * 9) / 10);
+
+          logger.info("Sorter {} ran out of memory, no other sorter to spill!  Adjusting spill " +
+            "threshold to {} bytes", currentSorter, newSpillThresholdBytes);
+
+          spillThresholdBytes = newSpillThresholdBytes;
+
+          long spilledBytes = currentSorter.spill(Long.MAX_VALUE, currentSorter);
+
+          if (spilledBytes > 0) {
+            retryInsert = true;
+          } else {
+            // If spilling didn't release any memory then we are no different a situation
+            // and must give up!
+            logger.warn("Failed to free any memory when spilling, so throwing original error!");
+            throw e;
+          }
+        }
+      }
+    } while (retryInsert);
+  }
+
+  @Override
+  public boolean hasSpaceForInsertRecord() {
+    return currentSorter.getUsed() < spillThresholdBytes || currentSorter.hasSpaceForInsertRecord();
+  }
+
+  private void doAsyncSpillOnCurrentSorter() {
+    final ShuffleSorter sorter = currentSorter;
+
+    executorService.submit(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          logger.info("Sorter {} starting to spill.", sorter);
+          sorter.spill();
+        } catch (IOException e) {
+          logger.error("Sorter {} failed to spill.", e);
+          pendingException.set(e);
+        } catch (Throwable e) {
+          pendingException.set(new IOException("Failed to spill", e));
+        } finally {
+          logger.info("Sorter {} finished spilling and is available.", sorter);
+          availableSorters.add(sorter);
+        }
+      }
+    });
+  }
+
+  /**
+   * Close the sorter, causing any buffered data to be sorted and written out to disk.
+   *
+   * @return metadata for the spill files written by this sorter. If no records were ever inserted
+   *         into this sorter, then this will return an empty array.
+   * @throws IOException
+   */
+  @Override
+  public SpillInfo[] closeAndGetSpills() throws IOException {
+    ShuffleSorter lastSorter = currentSorter;
+
+    final List<SpillInfo> spillInfos = new ArrayList<>();
+    for (int i = 0; i < numSorters - 1; i++) {
+      ShuffleSorter sorter = nextAvailableSorter();
+      spillInfos.addAll(Lists.newArrayList(sorter.closeAndGetSpills()));
+    }
+
+    checkForPendingException();
+
+    // The UnsafeShuffleWriter makes an assumption that the last spill info comes from
+    // a non-spilled last file write, and adjusts the shuffle write metrics accordingly.
+    // To preserve this assumption, we ensure the current sorter spills is returned last.
+    spillInfos.addAll(Lists.newArrayList(lastSorter.closeAndGetSpills()));
+
+    updateTaskMetrics();
+
+    availableSorters.addAll(allSorters);
+
+    return spillInfos.toArray(new SpillInfo[0]);
+  }
+
+  /**
+   * This updates the task metrics based on the aggregation of metrics across the external sorters.U
+   * This also includes all shuffle write metrics.
+   */
+  private void updateTaskMetrics() {
+    for (TaskMetrics metrics: sorterMetrics) {
+      for (AccumulatorV2<?,?> accumulator : JavaConversions.asJavaIterable(metrics.accumulators())) {
+        String accumulatorName = accumulator.name().get().toString();
+        AccumulatorV2<?,?> taskAccumulator = taskMetrics.lookForAccumulatorByName(accumulatorName).get();
+        assert(taskAccumulator.getClass().getName().equals(accumulator.getClass().getName()));
+        taskAccumulator.merge(taskAccumulator.getClass().cast(accumulator));
+      }
+    }
+  }
+
+  private void waitForAvailableSorter() throws IOException {
+    waitForAvailableSorters(1);
+  }
+
+  @VisibleForTesting
+  protected void waitForAvailableSorters(int numSorters) throws IOException {
+    while (availableSorters.size() < numSorters) {
+      try {
+        Thread.sleep(waitingIntervalMs);
+      } catch (InterruptedException e) {
+        throw new IOException("Waiting for available sorter interrupted", e);
+      }
+    }
+  }
+
+  private ShuffleSorter nextAvailableSorter() throws IOException {
+    ShuffleSorter sorter;
+    try {
+      sorter = availableSorters.takeFirst();
+    } catch (InterruptedException e) {
+      throw new IOException("Failed to get next available sorter.", e);
+    }
+    return sorter;
+  }
+
+  private void checkForPendingException() throws IOException {
+    if (pendingException.get() != null) {
+      throw pendingException.get();
+    }
+  }
+
+  @VisibleForTesting
+  protected long getSpillThresholdBytes() {
+    return spillThresholdBytes;
+  }
+
+  @VisibleForTesting
+  protected int getNumAvailableSorters() {
+    return availableSorters.size();
+  }
+}

--- a/core/src/main/java/org/apache/spark/shuffle/sort/MultiShuffleSorter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/MultiShuffleSorter.java
@@ -108,7 +108,7 @@ class MultiShuffleSorter extends ShuffleSorter {
     this.allSorters = new ArrayList<>(numSorters);
     this.availableSorters = new LinkedBlockingDeque<>(numSorters);
 
-    for (int i=0; i<numSorters; i++) {
+    for (int i=0; i < numSorters; i++) {
       sorterMetrics[i] = TaskMetrics.empty();
       ShuffleSorter sorter = factory.createShuffleExternalSorter(
         memoryManager, blockManager, sorterMetrics[i], initialSize, numPartitions, conf, true);
@@ -342,13 +342,13 @@ class MultiShuffleSorter extends ShuffleSorter {
 
   @VisibleForTesting
   protected void waitForAvailableSorters(int numSorters) throws IOException {
-    while (availableSorters.size() < numSorters) {
-      try {
-        spillCompleteLock.lock();
+    try {
+      spillCompleteLock.lock();
+      while (availableSorters.size() < numSorters) {
         waitForAsyncSpillComplete();
-      } finally {
-        spillCompleteLock.unlock();
       }
+    } finally {
+      spillCompleteLock.unlock();
     }
   }
 

--- a/core/src/main/java/org/apache/spark/shuffle/sort/MultiShuffleSorter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/MultiShuffleSorter.java
@@ -53,7 +53,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import scala.collection.JavaConversions;
 
-class MultiShuffleSorter extends ShuffleSorter {
+public class MultiShuffleSorter extends ShuffleSorter {
   private final Logger logger = LoggerFactory.getLogger(MultiShuffleSorter.class);
 
   private int numSorters;

--- a/core/src/main/java/org/apache/spark/shuffle/sort/ShuffleExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/ShuffleExternalSorter.java
@@ -62,7 +62,7 @@ import org.apache.spark.util.Utils;
  * spill files. Instead, this merging is performed in {@link UnsafeShuffleWriter}, which uses a
  * specialized merge procedure that avoids extra serialization/deserialization.
  */
-final class ShuffleExternalSorter extends ShuffleSorter {
+public class ShuffleExternalSorter extends ShuffleSorter {
 
   private static final Logger logger = LoggerFactory.getLogger(ShuffleExternalSorter.class);
 

--- a/core/src/main/java/org/apache/spark/shuffle/sort/ShuffleSorter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/ShuffleSorter.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.sort;
+
+import java.io.IOException;
+
+import org.apache.spark.memory.MemoryConsumer;
+import org.apache.spark.memory.MemoryMode;
+import org.apache.spark.memory.TaskMemoryManager;
+
+/**
+ * An external sorter that defines helper methods useful for shuffling.
+ */
+abstract class ShuffleSorter extends MemoryConsumer {
+
+  protected ShuffleSorter(TaskMemoryManager taskMemoryManager, long pageSize, MemoryMode mode) {
+    super(taskMemoryManager, pageSize, mode);
+  }
+
+  /**
+   * Return the peak memory used so far, in bytes.
+   */
+  public abstract long getPeakMemoryUsedBytes();
+
+  /**
+   * Force all memory and spill files to be deleted; called by shuffle error-handling code.
+   */
+  public abstract void cleanupResources();
+
+  /**
+   * Write a record to the shuffle sorter.
+   */
+  public abstract void insertRecord(Object recordBase, long recordOffset, int length,
+                                    int partitionId)
+    throws IOException;
+
+  /**
+   * Close the sorter, causing any buffered data to be sorted and written out to disk.
+   *
+   * @return metadata for the spill files written by this sorter. If no records were ever inserted
+   *         into this sorter, then this will return an empty array.
+   * @throws IOException
+   */
+  public abstract SpillInfo[] closeAndGetSpills() throws IOException;
+
+  /**
+   * Is a spill pending on the next insert?
+   */
+  public abstract boolean hasSpaceForInsertRecord();
+}

--- a/core/src/main/java/org/apache/spark/shuffle/sort/ShuffleSorterFactory.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/ShuffleSorterFactory.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.sort;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.executor.TaskMetrics;
+import org.apache.spark.memory.TaskMemoryManager;
+import org.apache.spark.memory.UnifiedMemoryManager;
+import org.apache.spark.storage.BlockManager;
+
+public class ShuffleSorterFactory {
+  static final ShuffleSorterFactory INSTANCE = new ShuffleSorterFactory();
+
+  /**
+   * Create an external shuffle sorter based on the spark configuration.
+   *
+   * @return ExternalSorter for inserting and sorting shuffle data.
+   */
+  public ShuffleSorter create(TaskMemoryManager memoryManager,
+                              BlockManager blockManager,
+                              TaskMetrics taskMetrics,
+                              int initialSize,
+                              int numPartitions,
+                              SparkConf conf) {
+    int numSorters = conf.getInt("spark.shuffle.async.num.sorter", 1);
+    if (numSorters <= 1) {
+      return createShuffleExternalSorter(
+        memoryManager, blockManager, taskMetrics, initialSize, numPartitions, conf);
+    } else {
+      // Compute a maximum memory per sorter that is used to balance work between sorters.
+      long maxMemory = UnifiedMemoryManager.getMaxMemory(conf);
+      int maxExecutors = conf.getInt("spark.executor.instances", 1);
+      long maxMemoryPerSorter = maxMemory / maxExecutors;
+
+      return createMultiShuffleSorter(
+        memoryManager, blockManager, taskMetrics, initialSize, numPartitions, conf,
+        numSorters, maxMemoryPerSorter);
+    }
+  }
+
+  public ShuffleSorter createShuffleExternalSorter(
+      TaskMemoryManager memoryManager,
+      BlockManager blockManager,
+      TaskMetrics taskMetrics,
+      int initialSize,
+      int numPartitions,
+      SparkConf conf) {
+    return new ShuffleExternalSorter(
+      memoryManager, blockManager, taskMetrics, initialSize, numPartitions, conf,
+      taskMetrics.shuffleWriteMetrics(), false);
+  }
+
+  public ShuffleSorter createShuffleExternalSorter(
+    TaskMemoryManager memoryManager,
+    BlockManager blockManager,
+    TaskMetrics taskMetrics,
+    int initialSize,
+    int numPartitions,
+    SparkConf conf,
+    boolean disableSelfSpill) {
+    return new ShuffleExternalSorter(
+      memoryManager, blockManager, taskMetrics, initialSize, numPartitions, conf,
+      taskMetrics.shuffleWriteMetrics(), disableSelfSpill);
+  }
+
+  public ShuffleSorter createMultiShuffleSorter(
+      TaskMemoryManager memoryManager,
+      BlockManager blockManager,
+      TaskMetrics taskMetrics,
+      int initialSize,
+      int numPartitions,
+      SparkConf conf,
+      int numSorters,
+      long initialMaxMemoryPerSorter) {
+    return new MultiShuffleSorter(
+      memoryManager, blockManager, taskMetrics, initialSize, numPartitions, conf,
+      numSorters, initialMaxMemoryPerSorter, this);
+  }
+}

--- a/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
@@ -85,7 +85,7 @@ public class UnsafeShuffleWriter<K, V> extends ShuffleWriter<K, V> {
   private final int outputBufferSizeInBytes;
 
   @Nullable private MapStatus mapStatus;
-  @Nullable private ShuffleExternalSorter sorter;
+  @Nullable private ShuffleSorter sorter;
   private long peakMemoryUsedBytes = 0;
 
   /** Subclass of ByteArrayOutputStream that exposes `buf` directly. */
@@ -210,14 +210,13 @@ public class UnsafeShuffleWriter<K, V> extends ShuffleWriter<K, V> {
 
   private void open() {
     assert (sorter == null);
-    sorter = new ShuffleExternalSorter(
+    sorter = ShuffleSorterFactory.INSTANCE.create(
       memoryManager,
       blockManager,
-      taskContext,
+      taskContext.taskMetrics(),
       initialSortBufferSize,
       partitioner.numPartitions(),
-      sparkConf,
-      writeMetrics);
+      sparkConf);
     serBuffer = new MyByteArrayOutputStream(DEFAULT_INITIAL_SER_BUFFER_SIZE);
     serOutputStream = serializer.serializeStream(serBuffer);
   }

--- a/core/src/main/scala/org/apache/spark/executor/TaskMetrics.scala
+++ b/core/src/main/scala/org/apache/spark/executor/TaskMetrics.scala
@@ -258,6 +258,15 @@ class TaskMetrics private[spark] () extends Serializable {
 
   private[spark] def accumulators(): Seq[AccumulatorV2[_, _]] = internalAccums ++ externalAccums
 
+  /**
+   * Looks for a registered accumulator by accumulator name.
+   */
+  private[spark] def lookForAccumulatorByName(name: String): Option[AccumulatorV2[_, _]] = {
+    accumulators.find { acc =>
+      acc.name.isDefined && acc.name.get == name
+    }
+  }
+
   private[spark] def nonZeroInternalAccums(): Seq[AccumulatorV2[_, _]] = {
     // RESULT_SIZE accumulator is always zero at executor, we need to send it back as its
     // value will be updated at driver side.

--- a/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
@@ -208,7 +208,7 @@ object UnifiedMemoryManager {
   /**
    * Return the total amount of memory shared between execution and storage, in bytes.
    */
-  private def getMaxMemory(conf: SparkConf): Long = {
+  def getMaxMemory(conf: SparkConf): Long = {
     val systemMemory = conf.getLong("spark.testing.memory", Runtime.getRuntime.maxMemory)
     val reservedMemory = conf.getLong("spark.testing.reservedMemory",
       if (conf.contains("spark.testing")) 0 else RESERVED_SYSTEM_MEMORY_BYTES)

--- a/core/src/test/java/org/apache/spark/shuffle/sort/MultiShuffleSorterSuite.java
+++ b/core/src/test/java/org/apache/spark/shuffle/sort/MultiShuffleSorterSuite.java
@@ -202,8 +202,8 @@ public class MultiShuffleSorterSuite {
 
   @Test
   public void testCalculateNewSpillOnOOMWithNoAsyncSpilling() throws IOException {
-    ShuffleSorter sorter1 = Mockito.mock(ShuffleSorter.class);
-    ShuffleSorter sorter2 = Mockito.mock(ShuffleSorter.class);
+    ShuffleSorter sorter1 = Mockito.mock(ShuffleExternalSorter.class);
+    ShuffleSorter sorter2 = Mockito.mock(ShuffleExternalSorter.class);
 
     MultiShuffleSorter msorter = createMultiShuffleSorter(
       Long.MAX_VALUE / RECORD_SIZE, sorter1, sorter2);
@@ -241,9 +241,9 @@ public class MultiShuffleSorterSuite {
 
   @Test
   public void testCalculateNewSpillOnOOMWithAsyncSpilling() throws IOException {
-    final ShuffleSorter sorter1 = Mockito.mock(ShuffleSorter.class);
-    final ShuffleSorter sorter2 = Mockito.mock(ShuffleSorter.class);
-    final ShuffleSorter sorter3 = Mockito.mock(ShuffleSorter.class);
+    final ShuffleSorter sorter1 = Mockito.mock(ShuffleExternalSorter.class);
+    final ShuffleSorter sorter2 = Mockito.mock(ShuffleExternalSorter.class);
+    final ShuffleSorter sorter3 = Mockito.mock(ShuffleExternalSorter.class);
 
     long maxMemory = (Long.MAX_VALUE / RECORD_SIZE) * RECORD_SIZE;
 

--- a/core/src/test/java/org/apache/spark/shuffle/sort/MultiShuffleSorterSuite.java
+++ b/core/src/test/java/org/apache/spark/shuffle/sort/MultiShuffleSorterSuite.java
@@ -1,0 +1,521 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.sort;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.google.common.collect.Lists;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import scala.reflect.ClassTag;
+import scala.reflect.ClassTag$;
+
+import org.apache.spark.*;
+import org.apache.spark.executor.TaskMetrics;
+import org.apache.spark.memory.*;
+import org.apache.spark.storage.BlockManager;
+import org.apache.spark.storage.TempShuffleBlockId;
+import org.apache.spark.unsafe.Platform;
+
+import static org.junit.Assert.*;
+import static org.mockito.Answers.RETURNS_SMART_NULLS;
+import static org.mockito.Mockito.*;
+
+public class MultiShuffleSorterSuite {
+
+  private static final ClassTag<Object> OBJECT_CLASS_TAG = ClassTag$.MODULE$.Object();
+
+  static final int NUM_PARTITITONS = 4;
+
+  static final long DEFAULT_MAX_MEMORY_PER_SORTER = 4000;
+  static final long RECORD_SIZE = 1024;
+
+  SparkConf conf;
+  TestMemoryManager memoryManager;
+  TaskMemoryManager taskMemoryManager;
+  TaskMetrics taskMetrics;
+  HashPartitioner partitioner;
+  SequenceCounter forceOomsCount;
+
+  @Mock(answer = RETURNS_SMART_NULLS)
+  BlockManager blockManager;
+
+  class SequenceCounter {
+    private List<Integer> counts;
+
+    SequenceCounter(Integer... counts) {
+      reset(counts);
+    }
+
+    public void reset(Integer... counts) {
+      this.counts = Lists.newArrayList(counts);
+    }
+
+    public synchronized boolean nextCount() {
+      if (counts.size() > 0) {
+        counts.set(0, counts.get(0) - 1);
+        if (counts.get(0) == 0) {
+          counts.remove(0);
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+
+  class TestShuffleSorter extends ShuffleSorter {
+    TestShuffleSorter(
+        int sorterId,
+        TaskMemoryManager taskMemoryManager,
+        long pageSize,
+        MemoryMode mode,
+        SequenceCounter forceOomsCount
+        ) {
+      super(taskMemoryManager, pageSize, mode);
+      this.sorterId = sorterId;
+      this.forceOomsCount = forceOomsCount;
+    }
+
+    private int sorterId;
+    private List<SpillInfo> spillInfos = new ArrayList<>();
+    private long[] partitionCount = new long[NUM_PARTITITONS];
+    private long peakMemoryUsedBytes = 0;
+    private SequenceCounter forceOomsCount;
+    private List<Long> spillThresholdHistory = new ArrayList<>();
+
+    public boolean isEmpty() {
+      return getUsed() == 0;
+    }
+
+    @Override
+    public long getPeakMemoryUsedBytes() {
+      return peakMemoryUsedBytes;
+    }
+
+    @Override
+    public void cleanupResources() {
+      used = 0;
+    }
+
+    @Override
+    public void insertRecord(Object recordBase, long recordOffset, int length, int partitionId)
+        throws IOException {
+      if (forceOomsCount.nextCount()) {
+        throw new OutOfMemoryError();
+      }
+
+      partitionCount[partitionId]++;
+
+      incUsedBytes(RECORD_SIZE);
+    }
+
+    @Override
+    public SpillInfo[] closeAndGetSpills() throws IOException {
+      boolean hasAnyRecords = false;
+      for (int i=0; i<NUM_PARTITITONS; i++) {
+        hasAnyRecords |= (partitionCount[i] > 0);
+      }
+      if (hasAnyRecords) {
+        writeSortedFile();
+      }
+
+      used = 0;
+
+      return spillInfos.toArray(new SpillInfo[spillInfos.size()]);
+    }
+
+    @Override
+    public boolean hasSpaceForInsertRecord() {
+      return false;
+    }
+
+    @Override
+    public long spill(long size, MemoryConsumer trigger) throws IOException {
+      writeSortedFile();
+
+      long spilledBytes = used;
+      used = 0;
+
+      return spilledBytes;
+    }
+
+    private void writeSortedFile() {
+      TempShuffleBlockId blockId = new TempShuffleBlockId(UUID.randomUUID());
+      File file = new File(Integer.toString(sorterId) + "." + blockId.toString());
+
+      SpillInfo spillInfo = new SpillInfo(NUM_PARTITITONS, file, blockId);
+
+      for (int i=0; i<NUM_PARTITITONS; i++) {
+        spillInfo.partitionLengths[i] = partitionCount[i];
+        partitionCount[i] = 0;
+      }
+
+      spillInfos.add(spillInfo);
+    }
+
+    private void incUsedBytes(long usedBytes) {
+      used += usedBytes;
+      peakMemoryUsedBytes = Math.max(used, peakMemoryUsedBytes);
+    }
+  }
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    conf = new SparkConf()
+      .set("spark.buffer.pageSize", "1m")
+      .set("spark.memory.offHeap.enabled", "false")
+      .set("spark.shuffle.writer.async.log.period", "120s")
+      .set("spark.shuffle.writer.spill.min.size", "0")
+      .set("spark.shuffle.writer.spill.size", "0")
+      .set("spark.shuffle.writer.waiting.interval.ms", "0");
+    taskMetrics = TaskMetrics.empty();
+    memoryManager = new TestMemoryManager(conf);
+    taskMemoryManager = new TaskMemoryManager(memoryManager, 0);
+    partitioner = new HashPartitioner(NUM_PARTITITONS);
+    forceOomsCount = new SequenceCounter();
+  }
+
+  @Test
+  public void testCalculateNewSpillOnOOMWithNoAsyncSpilling() throws IOException {
+    ShuffleSorter sorter1 = Mockito.mock(ShuffleSorter.class);
+    ShuffleSorter sorter2 = Mockito.mock(ShuffleSorter.class);
+
+    MultiShuffleSorter msorter = createMultiShuffleSorter(
+      Long.MAX_VALUE / RECORD_SIZE, sorter1, sorter2);
+
+    final AtomicInteger count = new AtomicInteger(0);
+    doAnswer(new Answer() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        int curCount = count.getAndIncrement();
+        if (curCount == 0) {
+          throw new OutOfMemoryError();
+        }
+        return null;
+      }
+    }).when(sorter1).insertRecord(Matchers.anyObject(), anyLong(), anyInt(), anyInt());
+
+    when(sorter1.getUsed()).thenReturn(256000L);
+    when(sorter2.getUsed()).thenReturn(256000L);
+
+    when(sorter1.spill(anyLong(), any(MemoryConsumer.class))).thenAnswer(
+      new Answer<Long>() {
+        @Override
+        public Long answer(InvocationOnMock mock) {
+          return 1L;
+        }
+      }
+    );
+
+    insertRecordIntoSorter(0, 0, msorter);
+
+    // Sum up the total used memory and share across sorters, scale down by 10% buffer.
+    long newSpillThresholdBytes = Math.max(200, ((512000 / 2) * 9) / 10);
+    assertEquals(newSpillThresholdBytes, msorter.getSpillThresholdBytes());
+  }
+
+  @Test
+  public void testCalculateNewSpillOnOOMWithAsyncSpilling() throws IOException {
+    final ShuffleSorter sorter1 = Mockito.mock(ShuffleSorter.class);
+    final ShuffleSorter sorter2 = Mockito.mock(ShuffleSorter.class);
+    final ShuffleSorter sorter3 = Mockito.mock(ShuffleSorter.class);
+
+    long maxMemory = (Long.MAX_VALUE / RECORD_SIZE) * RECORD_SIZE;
+
+    MultiShuffleSorter msorter = createMultiShuffleSorterNoBlocking(
+      maxMemory / RECORD_SIZE, 0, sorter1, sorter2, sorter3);
+
+    when(sorter1.getUsed()).thenReturn(0L, maxMemory);
+    doNothing().when(sorter1).insertRecord(Matchers.anyObject(), anyLong(), anyInt(), anyInt());
+    when(sorter1.spill(anyLong(), any(MemoryConsumer.class))).thenReturn(1L);
+
+    when(sorter2.getUsed()).thenReturn(maxMemory);
+    doNothing().when(sorter2).insertRecord(Matchers.anyObject(), anyLong(), anyInt(), anyInt());
+    when(sorter2.spill(anyLong(), any(MemoryConsumer.class))).thenReturn(1L);
+
+    when(sorter3.getUsed()).thenReturn(256000L);
+    doThrow(new OutOfMemoryError()).doNothing().when(sorter3)
+      .insertRecord(Matchers.anyObject(), anyLong(), anyInt(), anyInt());
+
+    // Insert into sorter 1
+    insertRecordIntoSorter(0, 0, msorter);
+
+    // Async spill sorter 1 and insert into sorter 2
+    insertRecordIntoSorter(0, 0, msorter);
+
+    // Async spill sorter 2 and out of memory on sorter 3
+    insertRecordIntoSorter(0, 0, msorter);
+
+    // Take previous spill threshold and reduce by 10%
+    long newSpillThresholdBytes = Math.max(200, ((maxMemory / 3) * 9) / 10);
+    assertEquals(newSpillThresholdBytes, msorter.getSpillThresholdBytes());
+  }
+
+  @Test
+  public void testAsyncInsertSpillWithNoOutOfMemory() throws IOException {
+    TestShuffleSorter sorter1 = createTestShuffleSorter(0);
+    TestShuffleSorter sorter2 = createTestShuffleSorter(1);
+
+    List<Long> thresholdHistory = new ArrayList<>();
+    MultiShuffleSorter msorter = createMultiShuffleSorter(8, thresholdHistory, sorter1, sorter2);
+
+    for (int i=0; i<16; i++) {
+      insertRecordIntoSorter(i, i, msorter);
+    }
+
+    assertTrue(sorter1.getPeakMemoryUsedBytes() > 0);
+    assertTrue(sorter2.getPeakMemoryUsedBytes() > 0);
+
+    SpillInfo[] spillInfos = msorter.closeAndGetSpills();
+    assertSpillPartitions(spillInfos, 2, 4, 4, 4, 4, 4);
+    assertThresholdHistory(thresholdHistory, 4096L);
+
+    assertTrue(sorter1.isEmpty());
+    assertTrue(sorter2.isEmpty());
+  }
+
+  @Test
+  public void testAsyncInsertSpillWithOneEarlyOutOfMemory() throws IOException {
+    TestShuffleSorter sorter1 = createTestShuffleSorter(0);
+    TestShuffleSorter sorter2 = createTestShuffleSorter(1);
+
+    List<Long> thresholdHistory = new ArrayList<>();
+    MultiShuffleSorter msorter = createMultiShuffleSorter(8, thresholdHistory,
+      sorter1, sorter2);
+
+    forceOomsCount.reset(2);
+    for (int i=0; i<16; i++) {
+      insertRecordIntoSorter(i, i, msorter);
+    }
+
+    assertTrue(sorter1.getPeakMemoryUsedBytes() > 0);
+    assertTrue(sorter2.getPeakMemoryUsedBytes() > 0);
+
+    SpillInfo[] spillInfos = msorter.closeAndGetSpills();
+    assertSpillPartitions(spillInfos, 2, 16, 4, 4, 4, 4);
+    assertThresholdHistory(thresholdHistory, 4096L, 460L);
+
+    assertTrue(sorter1.isEmpty());
+    assertTrue(sorter2.isEmpty());
+  }
+
+  @Test
+  public void testAsyncInsertSpillWithOneLaterOutOfMemory() throws IOException {
+    TestShuffleSorter sorter1 = createTestShuffleSorter(0);
+    TestShuffleSorter sorter2 = createTestShuffleSorter(1);
+
+    List<Long> thresholdHistory = new ArrayList<>();
+    MultiShuffleSorter msorter = createMultiShuffleSorter(16, thresholdHistory,
+      sorter1, sorter2);
+
+    forceOomsCount.reset(7);
+    for (int i=0; i<32; i++) {
+      insertRecordIntoSorter(i, i, msorter);
+    }
+
+    assertTrue(sorter1.getPeakMemoryUsedBytes() > 0);
+    assertTrue(sorter2.getPeakMemoryUsedBytes() > 0);
+
+    SpillInfo[] spillInfos = msorter.closeAndGetSpills();
+    assertSpillPartitions(spillInfos, 2, 10, 8, 8, 8, 8);
+    assertThresholdHistory(thresholdHistory, 8192L, 2764L);
+
+    assertTrue(sorter1.isEmpty());
+    assertTrue(sorter2.isEmpty());
+  }
+
+  @Test
+  public void testAsyncInsertSpillWithMultipleOutOfMemory() throws IOException {
+    TestShuffleSorter sorter1 = createTestShuffleSorter(0);
+    TestShuffleSorter sorter2 = createTestShuffleSorter(1);
+
+    List<Long> thresholdHistory = new ArrayList<>();
+    MultiShuffleSorter msorter = createMultiShuffleSorter(32, thresholdHistory,
+      sorter1, sorter2);
+
+    forceOomsCount.reset(32, 16);
+    for (int i=0; i<128; i++) {
+      insertRecordIntoSorter(i, i, msorter);
+    }
+
+    assertTrue(sorter1.getPeakMemoryUsedBytes() > 0);
+    assertTrue(sorter2.getPeakMemoryUsedBytes() > 0);
+
+    SpillInfo[] spillInfos = msorter.closeAndGetSpills();
+    assertSpillPartitions(spillInfos, 2, 10, 32, 32, 32, 32);
+    assertThresholdHistory(thresholdHistory, 16384L, 14745L, 13270L);
+
+    assertTrue(sorter1.isEmpty());
+    assertTrue(sorter2.isEmpty());
+  }
+
+  @Test
+  public void testMultipleAsyncInsertSpillWithMultipleOutOfMemory() throws IOException {
+    TestShuffleSorter sorter1 = createTestShuffleSorter(0);
+    TestShuffleSorter sorter2 = createTestShuffleSorter(1);
+    TestShuffleSorter sorter3 = createTestShuffleSorter(2);
+    TestShuffleSorter sorter4 = createTestShuffleSorter(3);
+
+    List<Long> thresholdHistory = new ArrayList<>();
+    MultiShuffleSorter msorter = createMultiShuffleSorter(32, thresholdHistory,
+      sorter1, sorter2, sorter3, sorter4);
+
+    for (int i = 0; i < 128; i++) {
+      insertRecordIntoSorter(i, i, msorter);
+    }
+
+    assertTrue(sorter1.getPeakMemoryUsedBytes() > 0);
+    assertTrue(sorter2.getPeakMemoryUsedBytes() > 0);
+    assertTrue(sorter3.getPeakMemoryUsedBytes() > 0);
+    assertTrue(sorter4.getPeakMemoryUsedBytes() > 0);
+
+    SpillInfo[] spillInfos = msorter.closeAndGetSpills();
+    assertSpillPartitions(spillInfos, 4, 16, 32, 32, 32, 32);
+    assertThresholdHistory(thresholdHistory, 8192L);
+
+    assertTrue(sorter1.isEmpty());
+    assertTrue(sorter2.isEmpty());
+    assertTrue(sorter3.isEmpty());
+    assertTrue(sorter4.isEmpty());
+  }
+
+  private void assertSpillPartitions(
+      SpillInfo[] spillInfo, int expectedSorters, int expectedSpills,
+      int... expectedPartitionLengths) {
+    Set<Integer> sorters = new HashSet<>();
+    int[] partitionsTotal = new int[NUM_PARTITITONS];
+    for (int i=0; i<spillInfo.length; i++) {
+      String filename = spillInfo[i].file.getName();
+      int sorterId = Integer.parseInt(filename.substring(0, filename.indexOf('.')));
+      sorters.add(sorterId);
+
+      for (int j=0; j<NUM_PARTITITONS; j++) {
+        partitionsTotal[j] += spillInfo[i].partitionLengths[j];
+      }
+    }
+    assertEquals(expectedSorters, sorters.size());
+    assertEquals(expectedSpills, spillInfo.length);
+
+    for (int j=0; j<NUM_PARTITITONS; j++) {
+      assertEquals(expectedPartitionLengths[j], partitionsTotal[j]);
+    }
+  }
+
+  private TestShuffleSorter createTestShuffleSorter(int sorterId) {
+    return new TestShuffleSorter(sorterId, taskMemoryManager,
+      0, MemoryMode.ON_HEAP, forceOomsCount);
+  }
+
+  private MultiShuffleSorter createMultiShuffleSorter(final ShuffleSorter... sorters) {
+    return createMultiShuffleSorter(DEFAULT_MAX_MEMORY_PER_SORTER, sorters);
+  }
+
+  private MultiShuffleSorter createMultiShuffleSorter(
+    final long maxRecordsInMemory, final ShuffleSorter... sorters) {
+    return createMultiShuffleSorter(maxRecordsInMemory, new ArrayList<Long>(), sorters);
+  }
+
+  private MultiShuffleSorter createMultiShuffleSorter(
+    final long maxRecordsInMemory,
+    final List<Long> spillThresholdHistory,
+    final ShuffleSorter... sorters) {
+    final List<Long> history = Collections.synchronizedList(spillThresholdHistory);
+
+    return new MultiShuffleSorter(
+      taskMemoryManager, blockManager, taskMetrics, 0,
+      NUM_PARTITITONS, conf, sorters.length,
+      (maxRecordsInMemory * RECORD_SIZE) / sorters.length,
+      getShuffleSorterFactoryMock(sorters)) {
+
+      @Override
+      public void insertRecord(Object recordBase, long recordOffset, int length, int partitionId)
+          throws IOException {
+        super.insertRecord(recordBase, recordOffset, length, partitionId);
+        if (history != null) {
+          if (history.size() == 0 || history.get(history.size() - 1) != getSpillThresholdBytes()) {
+            history.add(getSpillThresholdBytes());
+          }
+        }
+      }
+    };
+  }
+
+  private MultiShuffleSorter createMultiShuffleSorterNoBlocking(
+    final long maxRecordsInMemory,
+    final int numAvailableSortersOnCheck,
+    final ShuffleSorter... sorters) {
+    return new MultiShuffleSorter(
+        taskMemoryManager, blockManager, taskMetrics, 0,
+        NUM_PARTITITONS, conf, sorters.length,
+        (maxRecordsInMemory * RECORD_SIZE) / sorters.length,
+        getShuffleSorterFactoryMock(sorters)) {
+
+      @Override
+      protected int getNumAvailableSorters() {
+        return numAvailableSortersOnCheck;
+      }
+
+      @Override
+      protected void waitForAvailableSorters(int numSorters) throws IOException {
+        return;
+      }
+    };
+  }
+
+  private ShuffleSorterFactory getShuffleSorterFactoryMock(final ShuffleSorter[] sorters) {
+    ShuffleSorterFactory factory = Mockito.mock(ShuffleSorterFactory.class);
+    final AtomicInteger sorterIndex = new AtomicInteger(0);
+    when(factory.createShuffleExternalSorter(any(TaskMemoryManager.class),
+      any(BlockManager.class), any(TaskMetrics.class), anyInt(), anyInt(),
+      any(SparkConf.class), anyBoolean()))
+      .thenAnswer(new Answer<Object>() {
+        @Override
+        public Object answer(InvocationOnMock invocation) throws Throwable {
+          ShuffleSorter sorter = sorters[sorterIndex.get()];
+          sorterIndex.incrementAndGet();
+          return sorter;
+        }
+      });
+    return factory;
+  }
+
+  private void insertRecordIntoSorter(Object key, Object value, ShuffleSorter sorter)
+      throws IOException {
+    final int partitionId = partitioner.getPartition(key);
+
+    byte[] dummyRecord = new byte[(int) RECORD_SIZE];
+    sorter.insertRecord(dummyRecord, Platform.BYTE_ARRAY_OFFSET, dummyRecord.length, partitionId);
+  }
+
+  private void assertThresholdHistory(List<Long> thresholdHistory, Long... expected) {
+    assertEquals(thresholdHistory.size(), expected.length);
+    for (int i=0; i<thresholdHistory.size(); i++) {
+      assertEquals(thresholdHistory.get(i), expected[i]);
+    }
+  }
+}

--- a/core/src/test/java/org/apache/spark/shuffle/sort/MultiShuffleSorterSuite.java
+++ b/core/src/test/java/org/apache/spark/shuffle/sort/MultiShuffleSorterSuite.java
@@ -493,9 +493,9 @@ public class MultiShuffleSorterSuite {
     when(factory.createShuffleExternalSorter(any(TaskMemoryManager.class),
       any(BlockManager.class), any(TaskMetrics.class), anyInt(), anyInt(),
       any(SparkConf.class), anyBoolean()))
-      .thenAnswer(new Answer<Object>() {
+      .thenAnswer(new Answer<ShuffleSorter>() {
         @Override
-        public Object answer(InvocationOnMock invocation) throws Throwable {
+        public ShuffleSorter answer(InvocationOnMock invocation) throws Throwable {
           ShuffleSorter sorter = sorters[sorterIndex.get()];
           sorterIndex.incrementAndGet();
           return sorter;

--- a/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterBaseSuite.java
+++ b/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterBaseSuite.java
@@ -1,0 +1,539 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.sort;
+
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.util.*;
+
+import org.apache.spark.security.CryptoStreamUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.mockito.MockitoAnnotations;
+import scala.Option;
+import scala.Product2;
+import scala.Tuple2;
+import scala.Tuple2$;
+import scala.collection.Iterator;
+
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.Iterators;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import org.apache.spark.HashPartitioner;
+import org.apache.spark.ShuffleDependency;
+import org.apache.spark.SparkConf;
+import org.apache.spark.TaskContext;
+import org.apache.spark.executor.ShuffleWriteMetrics;
+import org.apache.spark.executor.TaskMetrics;
+import org.apache.spark.io.CompressionCodec$;
+import org.apache.spark.io.LZ4CompressionCodec;
+import org.apache.spark.io.LZFCompressionCodec;
+import org.apache.spark.io.SnappyCompressionCodec;
+import org.apache.spark.memory.TaskMemoryManager;
+import org.apache.spark.memory.TestMemoryManager;
+import org.apache.spark.network.util.LimitedInputStream;
+import org.apache.spark.scheduler.MapStatus;
+import org.apache.spark.serializer.*;
+import org.apache.spark.shuffle.IndexShuffleBlockResolver;
+import org.apache.spark.storage.*;
+import org.apache.spark.util.Utils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.*;
+import static org.mockito.Answers.RETURNS_SMART_NULLS;
+import static org.mockito.Mockito.*;
+
+@Ignore
+public abstract class UnsafeShuffleWriterBaseSuite {
+
+  static final int NUM_PARTITITONS = 4;
+  TestMemoryManager memoryManager;
+  TaskMemoryManager taskMemoryManager;
+  final HashPartitioner hashPartitioner = new HashPartitioner(NUM_PARTITITONS);
+  File mergedOutputFile;
+  File tempDir;
+  long[] partitionSizesInMergedFile;
+  final LinkedList<File> spillFilesCreated = new LinkedList<>();
+  SparkConf conf;
+  final Serializer serializer = new KryoSerializer(new SparkConf());
+  TaskMetrics taskMetrics;
+
+  @Mock(answer = RETURNS_SMART_NULLS) BlockManager blockManager;
+  @Mock(answer = RETURNS_SMART_NULLS) IndexShuffleBlockResolver shuffleBlockResolver;
+  @Mock(answer = RETURNS_SMART_NULLS) DiskBlockManager diskBlockManager;
+  @Mock(answer = RETURNS_SMART_NULLS) TaskContext taskContext;
+  @Mock(answer = RETURNS_SMART_NULLS) ShuffleDependency<Object, Object, Object> shuffleDep;
+
+  @After
+  public void tearDown() {
+    Utils.deleteRecursively(tempDir);
+    final long leakedMemory = taskMemoryManager.cleanUpAllAllocatedMemory();
+    if (leakedMemory != 0) {
+      fail("Test leaked " + leakedMemory + " bytes of managed memory");
+    }
+  }
+
+  @Before
+  @SuppressWarnings("unchecked")
+  public void setUp() throws IOException {
+    MockitoAnnotations.initMocks(this);
+    tempDir = Utils.createTempDir("test", "test");
+    mergedOutputFile = File.createTempFile("mergedoutput", "", tempDir);
+    partitionSizesInMergedFile = null;
+    spillFilesCreated.clear();
+    conf = new SparkConf()
+      .set("spark.buffer.pageSize", "1m")
+      .set("spark.memory.offHeap.enabled", "false");
+    taskMetrics = TaskMetrics.empty();
+    memoryManager = new TestMemoryManager(conf);
+    taskMemoryManager = new TaskMemoryManager(memoryManager, 0);
+
+    // Some tests will override this manager because they change the configuration. This is a
+    // default for tests that don't need a specific one.
+    SerializerManager manager = new SerializerManager(serializer, conf);
+    when(blockManager.serializerManager()).thenReturn(manager);
+
+    when(blockManager.diskBlockManager()).thenReturn(diskBlockManager);
+    when(blockManager.getDiskWriter(
+      any(BlockId.class),
+      any(File.class),
+      any(SerializerInstance.class),
+      anyInt(),
+      any(ShuffleWriteMetrics.class))).thenAnswer(invocationOnMock -> {
+      Object[] args = invocationOnMock.getArguments();
+      return new DiskBlockObjectWriter(
+        (File) args[1],
+        blockManager.serializerManager(),
+        (SerializerInstance) args[2],
+        (Integer) args[3],
+        false,
+        (ShuffleWriteMetrics) args[4],
+        (BlockId) args[0]
+      );
+    });
+
+    when(shuffleBlockResolver.getDataFile(anyInt(), anyInt())).thenReturn(mergedOutputFile);
+    doAnswer(invocationOnMock -> {
+      partitionSizesInMergedFile = (long[]) invocationOnMock.getArguments()[2];
+      File tmp = (File) invocationOnMock.getArguments()[3];
+      mergedOutputFile.delete();
+      tmp.renameTo(mergedOutputFile);
+      return null;
+    }).when(shuffleBlockResolver)
+      .writeIndexFileAndCommit(anyInt(), anyInt(), any(long[].class), any(File.class));
+
+    when(diskBlockManager.createTempShuffleBlock()).thenAnswer(invocationOnMock -> {
+      TempShuffleBlockId blockId = new TempShuffleBlockId(UUID.randomUUID());
+      File file = File.createTempFile("spillFile", ".spill", tempDir);
+      spillFilesCreated.add(file);
+      return Tuple2$.MODULE$.apply(blockId, file);
+    });
+
+    when(taskContext.taskMetrics()).thenReturn(taskMetrics);
+    when(shuffleDep.serializer()).thenReturn(serializer);
+    when(shuffleDep.partitioner()).thenReturn(hashPartitioner);
+  }
+
+  protected abstract UnsafeShuffleWriter<Object, Object> createWriter(
+    boolean transferToEnabled) throws IOException;
+
+  private void assertSpillFilesWereCleanedUp() {
+    for (File spillFile : spillFilesCreated) {
+      assertFalse("Spill file " + spillFile.getPath() + " was not cleaned up",
+        spillFile.exists());
+    }
+  }
+
+  private List<Tuple2<Object, Object>> readRecordsFromFile() throws IOException {
+    final ArrayList<Tuple2<Object, Object>> recordsList = new ArrayList<>();
+    long startOffset = 0;
+    for (int i = 0; i < NUM_PARTITITONS; i++) {
+      final long partitionSize = partitionSizesInMergedFile[i];
+      if (partitionSize > 0) {
+        FileInputStream fin = new FileInputStream(mergedOutputFile);
+        fin.getChannel().position(startOffset);
+        InputStream in = new LimitedInputStream(fin, partitionSize);
+        in = blockManager.serializerManager().wrapForEncryption(in);
+        if (conf.getBoolean("spark.shuffle.compress", true)) {
+          in = CompressionCodec$.MODULE$.createCodec(conf).compressedInputStream(in);
+        }
+        DeserializationStream recordsStream = serializer.newInstance().deserializeStream(in);
+        Iterator<Tuple2<Object, Object>> records = recordsStream.asKeyValueIterator();
+        while (records.hasNext()) {
+          Tuple2<Object, Object> record = records.next();
+          assertEquals(i, hashPartitioner.getPartition(record._1()));
+          recordsList.add(record);
+        }
+        recordsStream.close();
+        startOffset += partitionSize;
+      }
+    }
+    return recordsList;
+  }
+
+  @Test(expected=IllegalStateException.class)
+  public void mustCallWriteBeforeSuccessfulStop() throws IOException {
+    createWriter(false).stop(true);
+  }
+
+  @Test
+  public void doNotNeedToCallWriteBeforeUnsuccessfulStop() throws IOException {
+    createWriter(false).stop(false);
+  }
+
+  static class PandaException extends RuntimeException {
+  }
+
+  @Test(expected=PandaException.class)
+  public void writeFailurePropagates() throws Exception {
+    class BadRecords extends scala.collection.AbstractIterator<Product2<Object, Object>> {
+      @Override public boolean hasNext() {
+        throw new PandaException();
+      }
+      @Override public Product2<Object, Object> next() {
+        return null;
+      }
+    }
+    final UnsafeShuffleWriter<Object, Object> writer = createWriter(true);
+    writer.write(new BadRecords());
+  }
+
+  @Test
+  public void writeEmptyIterator() throws Exception {
+    final UnsafeShuffleWriter<Object, Object> writer = createWriter(true);
+    writer.write(Iterators.emptyIterator());
+    final Option<MapStatus> mapStatus = writer.stop(true);
+    assertTrue(mapStatus.isDefined());
+    assertTrue(mergedOutputFile.exists());
+    assertArrayEquals(new long[NUM_PARTITITONS], partitionSizesInMergedFile);
+    assertEquals(0, taskMetrics.shuffleWriteMetrics().recordsWritten());
+    assertEquals(0, taskMetrics.shuffleWriteMetrics().bytesWritten());
+    assertEquals(0, taskMetrics.diskBytesSpilled());
+    assertEquals(0, taskMetrics.memoryBytesSpilled());
+  }
+
+  @Test
+  public void writeWithoutSpilling() throws Exception {
+    // In this example, each partition should have exactly one record:
+    final ArrayList<Product2<Object, Object>> dataToWrite = new ArrayList<>();
+    for (int i = 0; i < NUM_PARTITITONS; i++) {
+      dataToWrite.add(new Tuple2<>(i, i));
+    }
+    final UnsafeShuffleWriter<Object, Object> writer = createWriter(true);
+    writer.write(dataToWrite.iterator());
+    final Option<MapStatus> mapStatus = writer.stop(true);
+    assertTrue(mapStatus.isDefined());
+    assertTrue(mergedOutputFile.exists());
+
+    long sumOfPartitionSizes = 0;
+    for (long size: partitionSizesInMergedFile) {
+      // All partitions should be the same size:
+      assertEquals(partitionSizesInMergedFile[0], size);
+      sumOfPartitionSizes += size;
+    }
+    assertEquals(mergedOutputFile.length(), sumOfPartitionSizes);
+    assertEquals(
+      HashMultiset.create(dataToWrite),
+      HashMultiset.create(readRecordsFromFile()));
+    assertSpillFilesWereCleanedUp();
+    ShuffleWriteMetrics shuffleWriteMetrics = taskMetrics.shuffleWriteMetrics();
+    assertEquals(dataToWrite.size(), shuffleWriteMetrics.recordsWritten());
+    assertEquals(0, taskMetrics.diskBytesSpilled());
+    assertEquals(0, taskMetrics.memoryBytesSpilled());
+    assertEquals(mergedOutputFile.length(), shuffleWriteMetrics.bytesWritten());
+  }
+
+  private void testMergingSpills(
+    final boolean transferToEnabled,
+    String compressionCodecName,
+    boolean encrypt) throws Exception {
+    if (compressionCodecName != null) {
+      conf.set("spark.shuffle.compress", "true");
+      conf.set("spark.io.compression.codec", compressionCodecName);
+    } else {
+      conf.set("spark.shuffle.compress", "false");
+    }
+    conf.set(org.apache.spark.internal.config.package$.MODULE$.IO_ENCRYPTION_ENABLED(), encrypt);
+
+    SerializerManager manager;
+    if (encrypt) {
+      manager = new SerializerManager(serializer, conf,
+        Option.apply(CryptoStreamUtils.createKey(conf)));
+    } else {
+      manager = new SerializerManager(serializer, conf);
+    }
+
+    when(blockManager.serializerManager()).thenReturn(manager);
+    testMergingSpills(transferToEnabled, encrypt);
+  }
+
+  private void testMergingSpills(
+    boolean transferToEnabled,
+    boolean encrypted) throws IOException {
+    final UnsafeShuffleWriter<Object, Object> writer = createWriter(transferToEnabled);
+    final ArrayList<Product2<Object, Object>> dataToWrite = new ArrayList<>();
+    for (int i : new int[] { 1, 2, 3, 4, 4, 2 }) {
+      dataToWrite.add(new Tuple2<>(i, i));
+    }
+    writer.insertRecordIntoSorter(dataToWrite.get(0));
+    writer.insertRecordIntoSorter(dataToWrite.get(1));
+    writer.insertRecordIntoSorter(dataToWrite.get(2));
+    writer.insertRecordIntoSorter(dataToWrite.get(3));
+    writer.forceSorterToSpill();
+    writer.insertRecordIntoSorter(dataToWrite.get(4));
+    writer.insertRecordIntoSorter(dataToWrite.get(5));
+    writer.closeAndWriteOutput();
+    final Option<MapStatus> mapStatus = writer.stop(true);
+    assertTrue(mapStatus.isDefined());
+    assertTrue(mergedOutputFile.exists());
+    assertEquals(2, spillFilesCreated.size());
+
+    long sumOfPartitionSizes = 0;
+    for (long size: partitionSizesInMergedFile) {
+      sumOfPartitionSizes += size;
+    }
+
+    assertEquals(sumOfPartitionSizes, mergedOutputFile.length());
+
+    assertEquals(HashMultiset.create(dataToWrite), HashMultiset.create(readRecordsFromFile()));
+    assertSpillFilesWereCleanedUp();
+    ShuffleWriteMetrics shuffleWriteMetrics = taskMetrics.shuffleWriteMetrics();
+    assertEquals(dataToWrite.size(), shuffleWriteMetrics.recordsWritten());
+    assertThat(taskMetrics.diskBytesSpilled(), greaterThan(0L));
+    assertThat(taskMetrics.diskBytesSpilled(), lessThan(mergedOutputFile.length()));
+    assertThat(taskMetrics.memoryBytesSpilled(), greaterThan(0L));
+    assertEquals(mergedOutputFile.length(), shuffleWriteMetrics.bytesWritten());
+  }
+
+  @Test
+  public void mergeSpillsWithTransferToAndLZF() throws Exception {
+    testMergingSpills(true, LZFCompressionCodec.class.getName(), false);
+  }
+
+  @Test
+  public void mergeSpillsWithFileStreamAndLZF() throws Exception {
+    testMergingSpills(false, LZFCompressionCodec.class.getName(), false);
+  }
+
+  @Test
+  public void mergeSpillsWithTransferToAndLZ4() throws Exception {
+    testMergingSpills(true, LZ4CompressionCodec.class.getName(), false);
+  }
+
+  @Test
+  public void mergeSpillsWithFileStreamAndLZ4() throws Exception {
+    testMergingSpills(false, LZ4CompressionCodec.class.getName(), false);
+  }
+
+  @Test
+  public void mergeSpillsWithTransferToAndSnappy() throws Exception {
+    testMergingSpills(true, SnappyCompressionCodec.class.getName(), false);
+  }
+
+  @Test
+  public void mergeSpillsWithFileStreamAndSnappy() throws Exception {
+    testMergingSpills(false, SnappyCompressionCodec.class.getName(), false);
+  }
+
+  @Test
+  public void mergeSpillsWithTransferToAndNoCompression() throws Exception {
+    testMergingSpills(true, null, false);
+  }
+
+  @Test
+  public void mergeSpillsWithFileStreamAndNoCompression() throws Exception {
+    testMergingSpills(false, null, false);
+  }
+
+  @Test
+  public void mergeSpillsWithCompressionAndEncryption() throws Exception {
+    // This should actually be translated to a "file stream merge" internally, just have the
+    // test to make sure that it's the case.
+    testMergingSpills(true, LZ4CompressionCodec.class.getName(), true);
+  }
+
+  @Test
+  public void mergeSpillsWithFileStreamAndCompressionAndEncryption() throws Exception {
+    testMergingSpills(false, LZ4CompressionCodec.class.getName(), true);
+  }
+
+  @Test
+  public void mergeSpillsWithCompressionAndEncryptionSlowPath() throws Exception {
+    conf.set("spark.shuffle.unsafe.fastMergeEnabled", "false");
+    testMergingSpills(false, LZ4CompressionCodec.class.getName(), true);
+  }
+
+  @Test
+  public void mergeSpillsWithEncryptionAndNoCompression() throws Exception {
+    // This should actually be translated to a "file stream merge" internally, just have the
+    // test to make sure that it's the case.
+    testMergingSpills(true, null, true);
+  }
+
+  @Test
+  public void mergeSpillsWithFileStreamAndEncryptionAndNoCompression() throws Exception {
+    testMergingSpills(false, null, true);
+  }
+
+  @Test
+  public void writeEnoughDataToTriggerSpill() throws Exception {
+    memoryManager.limit(PackedRecordPointer.MAXIMUM_PAGE_SIZE_BYTES);
+    final UnsafeShuffleWriter<Object, Object> writer = createWriter(false);
+    final ArrayList<Product2<Object, Object>> dataToWrite = new ArrayList<>();
+    final byte[] bigByteArray = new byte[PackedRecordPointer.MAXIMUM_PAGE_SIZE_BYTES / 10];
+    for (int i = 0; i < 10 + 1; i++) {
+      dataToWrite.add(new Tuple2<>(i, bigByteArray));
+    }
+    writer.write(dataToWrite.iterator());
+    assertEquals(2, spillFilesCreated.size());
+    writer.stop(true);
+    readRecordsFromFile();
+    assertSpillFilesWereCleanedUp();
+    ShuffleWriteMetrics shuffleWriteMetrics = taskMetrics.shuffleWriteMetrics();
+    assertEquals(dataToWrite.size(), shuffleWriteMetrics.recordsWritten());
+    assertThat(taskMetrics.diskBytesSpilled(), greaterThan(0L));
+    assertThat(taskMetrics.diskBytesSpilled(), lessThan(mergedOutputFile.length()));
+    assertThat(taskMetrics.memoryBytesSpilled(), greaterThan(0L));
+    assertEquals(mergedOutputFile.length(), shuffleWriteMetrics.bytesWritten());
+  }
+
+  protected void writeEnoughRecordsToTriggerSortBufferExpansionAndSpill(int numRecords) throws Exception {
+    memoryManager.limit(numRecords * 16);
+    final UnsafeShuffleWriter<Object, Object> writer = createWriter(false);
+    final ArrayList<Product2<Object, Object>> dataToWrite = new ArrayList<>();
+    for (int i = 0; i < UnsafeShuffleWriter.DEFAULT_INITIAL_SORT_BUFFER_SIZE + 1; i++) {
+      dataToWrite.add(new Tuple2<>(i, i));
+    }
+    writer.write(dataToWrite.iterator());
+    writer.stop(true);
+    readRecordsFromFile();
+    assertSpillFilesWereCleanedUp();
+    ShuffleWriteMetrics shuffleWriteMetrics = taskMetrics.shuffleWriteMetrics();
+    assertEquals(dataToWrite.size(), shuffleWriteMetrics.recordsWritten());
+    assertThat(taskMetrics.diskBytesSpilled(), greaterThan(0L));
+    assertThat(taskMetrics.diskBytesSpilled(), lessThan(mergedOutputFile.length()));
+    assertThat(taskMetrics.memoryBytesSpilled(), greaterThan(0L));
+    assertEquals(mergedOutputFile.length(), shuffleWriteMetrics.bytesWritten());
+  }
+
+  @Test
+  public void writeRecordsThatAreBiggerThanDiskWriteBufferSize() throws Exception {
+    final UnsafeShuffleWriter<Object, Object> writer = createWriter(false);
+    final ArrayList<Product2<Object, Object>> dataToWrite = new ArrayList<>();
+    final byte[] bytes = new byte[(int) (ShuffleExternalSorter.DISK_WRITE_BUFFER_SIZE * 2.5)];
+    new Random(42).nextBytes(bytes);
+    dataToWrite.add(new Tuple2<>(1, ByteBuffer.wrap(bytes)));
+    writer.write(dataToWrite.iterator());
+    writer.stop(true);
+    assertEquals(
+      HashMultiset.create(dataToWrite),
+      HashMultiset.create(readRecordsFromFile()));
+    assertSpillFilesWereCleanedUp();
+  }
+
+  @Test
+  public void writeRecordsThatAreBiggerThanMaxRecordSize() throws Exception {
+    final UnsafeShuffleWriter<Object, Object> writer = createWriter(false);
+    final ArrayList<Product2<Object, Object>> dataToWrite = new ArrayList<>();
+    dataToWrite.add(new Tuple2<>(1, ByteBuffer.wrap(new byte[1])));
+    // We should be able to write a record that's right _at_ the max record size
+    final byte[] atMaxRecordSize = new byte[(int) taskMemoryManager.pageSizeBytes() - 4];
+    new Random(42).nextBytes(atMaxRecordSize);
+    dataToWrite.add(new Tuple2<>(2, ByteBuffer.wrap(atMaxRecordSize)));
+    // Inserting a record that's larger than the max record size
+    final byte[] exceedsMaxRecordSize = new byte[(int) taskMemoryManager.pageSizeBytes()];
+    new Random(42).nextBytes(exceedsMaxRecordSize);
+    dataToWrite.add(new Tuple2<>(3, ByteBuffer.wrap(exceedsMaxRecordSize)));
+    writer.write(dataToWrite.iterator());
+    writer.stop(true);
+    assertEquals(
+      HashMultiset.create(dataToWrite),
+      HashMultiset.create(readRecordsFromFile()));
+    assertSpillFilesWereCleanedUp();
+  }
+
+  @Test
+  public void spillFilesAreDeletedWhenStoppingAfterError() throws IOException {
+    final UnsafeShuffleWriter<Object, Object> writer = createWriter(false);
+    writer.insertRecordIntoSorter(new Tuple2<>(1, 1));
+    writer.insertRecordIntoSorter(new Tuple2<>(2, 2));
+    writer.forceSorterToSpill();
+    writer.insertRecordIntoSorter(new Tuple2<>(2, 2));
+    writer.stop(false);
+    assertSpillFilesWereCleanedUp();
+  }
+
+  @Test
+  public void testPeakMemoryUsed() throws Exception {
+    final long recordLengthBytes = 8;
+    final long pageSizeBytes = 256;
+    final long numRecordsPerPage = pageSizeBytes / recordLengthBytes;
+    taskMemoryManager = spy(taskMemoryManager);
+    when(taskMemoryManager.pageSizeBytes()).thenReturn(pageSizeBytes);
+    final UnsafeShuffleWriter<Object, Object> writer =
+      new UnsafeShuffleWriter<>(
+        blockManager,
+        shuffleBlockResolver,
+        taskMemoryManager,
+        new SerializedShuffleHandle<>(0, 1, shuffleDep),
+        0, // map id
+        taskContext,
+        conf);
+
+    // Peak memory should be monotonically increasing. More specifically, every time
+    // we allocate a new page it should increase by exactly the size of the page.
+    long previousPeakMemory = writer.getPeakMemoryUsedBytes();
+    long newPeakMemory;
+    try {
+      for (int i = 0; i < numRecordsPerPage * 10; i++) {
+        writer.insertRecordIntoSorter(new Tuple2<Object, Object>(1, 1));
+        newPeakMemory = writer.getPeakMemoryUsedBytes();
+        if (i % numRecordsPerPage == 0) {
+          // The first page is allocated in constructor, another page will be allocated after
+          // every numRecordsPerPage records (peak memory should change).
+          assertEquals(previousPeakMemory + pageSizeBytes, newPeakMemory);
+        } else {
+          assertEquals(previousPeakMemory, newPeakMemory);
+        }
+        previousPeakMemory = newPeakMemory;
+      }
+
+      // Spilling should not change peak memory
+      writer.forceSorterToSpill();
+      newPeakMemory = writer.getPeakMemoryUsedBytes();
+      assertEquals(previousPeakMemory, newPeakMemory);
+      for (int i = 0; i < numRecordsPerPage; i++) {
+        writer.insertRecordIntoSorter(new Tuple2<Object, Object>(1, 1));
+      }
+      newPeakMemory = writer.getPeakMemoryUsedBytes();
+      assertEquals(previousPeakMemory, newPeakMemory);
+
+      // Closing the writer should not change peak memory
+      writer.closeAndWriteOutput();
+      newPeakMemory = writer.getPeakMemoryUsedBytes();
+      assertEquals(previousPeakMemory, newPeakMemory);
+    } finally {
+      writer.stop(false);
+    }
+  }
+}

--- a/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterMultiSorterSuite.java
+++ b/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterMultiSorterSuite.java
@@ -19,15 +19,16 @@ package org.apache.spark.shuffle.sort;
 
 import org.junit.Test;
 
-import java.io.*;
+import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 
-public class UnsafeShuffleWriterSuite extends UnsafeShuffleWriterBaseSuite {
+public class UnsafeShuffleWriterMultiSorterSuite extends UnsafeShuffleWriterBaseSuite {
   @Override
   protected UnsafeShuffleWriter<Object, Object> createWriter(
     boolean transferToEnabled) throws IOException {
     conf.set("spark.file.transferTo", String.valueOf(transferToEnabled));
+    conf.set("spark.shuffle.async.num.sorter", "2");
     return new UnsafeShuffleWriter<>(
       blockManager,
       shuffleBlockResolver,
@@ -42,14 +43,17 @@ public class UnsafeShuffleWriterSuite extends UnsafeShuffleWriterBaseSuite {
   @Test
   public void writeEnoughRecordsToTriggerSortBufferExpansionAndSpillRadixOff() throws Exception {
     conf.set("spark.shuffle.sort.useRadixSort", "false");
-    writeEnoughRecordsToTriggerSortBufferExpansionAndSpill(UnsafeShuffleWriter.DEFAULT_INITIAL_SORT_BUFFER_SIZE);
+    writeEnoughRecordsToTriggerSortBufferExpansionAndSpill(
+      (UnsafeShuffleWriter.DEFAULT_INITIAL_SORT_BUFFER_SIZE * 3) / 2);
     assertEquals(2, spillFilesCreated.size());
   }
 
   @Test
   public void writeEnoughRecordsToTriggerSortBufferExpansionAndSpillRadixOn() throws Exception {
     conf.set("spark.shuffle.sort.useRadixSort", "true");
-    writeEnoughRecordsToTriggerSortBufferExpansionAndSpill(UnsafeShuffleWriter.DEFAULT_INITIAL_SORT_BUFFER_SIZE);
+    writeEnoughRecordsToTriggerSortBufferExpansionAndSpill(
+      (UnsafeShuffleWriter.DEFAULT_INITIAL_SORT_BUFFER_SIZE * 3) / 2);
     assertEquals(3, spillFilesCreated.size());
   }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a multi-shuffle sorter which supports asynchronous spilling during a shuffle external sort.  The benefit is that we can insert and sort/spill in parallel, reducing the overall latency for jobs that are heavy on shuffling. The multi-shuffle sorter is added between the UnsafeShuffleWriter and ShuffleExternalSorter such that few changes are needed outside of this component, and as such, we can see clearly there is little room for regressing other code paths.

The multi-shuffle sorter is enabled via a configuration flag, spark.shuffle.async.num.sorter (default 1)  If the value is 1, then the multi-shuffle sorter is not used, it must be configured to have multiple
sorters (>=2)

There is a design spec here attached to the jira.

## How was this patch tested?

Added unit tests specifically for the MultiShuffleSorter to exercise under various spill and insert conditions.
Extended the UnsafeShuffleWriterSuite to run against a single ShuffleExternalSorter or multiple via the MultiShuffleSorter to ensure no regressions.
Ran against production work loads and observed gains and validated based on logging.
One of the larger jobs went from ~6030 cpu-hr to ~4298 cpu-hr which was a total aggregate reduction of ~29%.  For larger jobs, this provides a great tuning option to reduce job time.
