### PR TITLE
[SPARK-22766] Install R linter package in spark lib directory

### DIFF
--- a/dev/lint-r.R
+++ b/dev/lint-r.R
@@ -26,9 +26,8 @@ if (! library(SparkR, lib.loc = LOCAL_LIB_LOC, logical.return = TRUE)) {
 
 # Installs lintr from Github in a local directory.
 # NOTE: The CRAN's version is too old to adapt to our rules.
-if ("lintr" %in% row.names(installed.packages()) == FALSE) {
-  devtools::with_libpaths(new = LOCAL_LIB_LOC, devtools::install_github("jimhester/lintr@5431140"))
-}
+# NOTE: We won't use the lintr package that might have been installed on the test machine
+devtools::with_libpaths(new = LOCAL_LIB_LOC, devtools::install_github("jimhester/lintr@5431140"))
 
 library(lintr, lib.loc = LOCAL_LIB_LOC)
 library(xmlparsedata, lib.loc = LOCAL_LIB_LOC)

--- a/dev/lint-r.R
+++ b/dev/lint-r.R
@@ -27,10 +27,11 @@ if (! library(SparkR, lib.loc = LOCAL_LIB_LOC, logical.return = TRUE)) {
 # Installs lintr from Github in a local directory.
 # NOTE: The CRAN's version is too old to adapt to our rules.
 if ("lintr" %in% row.names(installed.packages()) == FALSE) {
-  devtools::install_github("jimhester/lintr@5431140")
+  devtools::with_libpaths(new = LOCAL_LIB_LOC, devtools::install_github("jimhester/lintr@5431140"))
 }
 
-library(lintr)
+library(lintr, lib.loc = LOCAL_LIB_LOC)
+library(xmlparsedata, lib.loc = LOCAL_LIB_LOC)
 library(methods)
 library(testthat)
 path.to.package <- file.path(SPARK_ROOT_DIR, "R", "pkg")

--- a/dev/lint-r.R
+++ b/dev/lint-r.R
@@ -24,7 +24,11 @@ if (! library(SparkR, lib.loc = LOCAL_LIB_LOC, logical.return = TRUE)) {
   stop("You should install SparkR in a local directory with `R/install-dev.sh`.")
 }
 
-# Installs lintr from Github in a local directory.
+# Installs lintr and dependencies from Github in a local directory.
+
+# Pinning Rcpp version to CRAN snapshot from 2017-10-15
+install.packages("Rcpp", repos = "https://cran.microsoft.com/snapshot/2017-10-15", lib = LOCAL_LIB_LOC)
+
 # NOTE: The CRAN's version is too old to adapt to our rules.
 # NOTE: We won't use the lintr package that might have been installed on the test machine
 devtools::with_libpaths(new = LOCAL_LIB_LOC, devtools::install_github("jimhester/lintr@5431140"))


### PR DESCRIPTION
## What changes were proposed in this pull request?

`dev/lint-r.R` file installs uses `devtools` to install `jimhester/lintr` package in the default site library location which is `/usr/local/lib/R/site-library`. This is not recommended and can fail because we are running this script as jenkins while that directory is owned by root.

This patch changes `lint-r.R` to install the linter package in a local directory.

## How was this patch tested?
Existing linter should pass.

cc @JoshRosen 