### PR TITLE
[SPARK-20849][DOC][FOLLOWUP] Document R DecisionTree - Link Classification Example

### DIFF
--- a/docs/ml-classification-regression.md
+++ b/docs/ml-classification-regression.md
@@ -223,6 +223,14 @@ More details on parameters can be found in the [Python API documentation](api/py
 
 </div>
 
+<div data-lang="r" markdown="1">
+
+Refer to the [R API docs](api/R/spark.decisionTree.html) for more details.
+
+{% include_example classification r/ml/decisionTree.R %}
+
+</div>
+
 </div>
 
 ## Random forest classifier
@@ -713,6 +721,14 @@ More details on parameters can be found in the [Python API documentation](api/py
 Refer to the [R API docs](api/R/spark.decisionTree.html) for more details.
 
 {% include_example regression r/ml/decisionTree.R %}
+</div>
+
+<div data-lang="r" markdown="1">
+
+Refer to the [R API docs](api/R/spark.decisionTree.html) for more details.
+
+{% include_example classification r/ml/decisionTree.R %}
+
 </div>
 
 </div>

--- a/docs/ml-classification-regression.md
+++ b/docs/ml-classification-regression.md
@@ -723,14 +723,6 @@ Refer to the [R API docs](api/R/spark.decisionTree.html) for more details.
 {% include_example regression r/ml/decisionTree.R %}
 </div>
 
-<div data-lang="r" markdown="1">
-
-Refer to the [R API docs](api/R/spark.decisionTree.html) for more details.
-
-{% include_example classification r/ml/decisionTree.R %}
-
-</div>
-
 </div>
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
in https://github.com/apache/spark/pull/18067, only the regression example is linked

this pr link decision tree classification example to the doc

ping @felixcheung 

## How was this patch tested?
local build of docs

![default](https://user-images.githubusercontent.com/7322292/33922857-9b00fdd0-e008-11e7-92c2-85a3de52ea8f.png)
