### PR TITLE
[SPARK-22769][CORE] When driver stopping, there is errors: Could not find CoarseGrainedScheduler and RpcEnv already stopped

### DIFF
--- a/core/src/main/scala/org/apache/spark/rpc/RpcEndpointStoppedException.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/RpcEndpointStoppedException.scala
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.rpc
+
+import org.apache.spark.SparkException
+
+private[rpc] class RpcEndpointStoppedException(uri: String)
+  extends SparkException(s"The endpoint: $uri has been stopped.")

--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
@@ -645,7 +645,11 @@ private[netty] class NettyRpcHandler(
       client: TransportClient,
       message: ByteBuffer): Unit = {
     val messageToDispatch = internalReceive(client, message)
-    dispatcher.postOneWayMessage(messageToDispatch)
+    try {
+      dispatcher.postOneWayMessage(messageToDispatch)
+    } catch {
+      case e: RpcEnvStoppedException => logWarning(e.getMessage)
+    }
   }
 
   private def internalReceive(client: TransportClient, message: ByteBuffer): RequestMessage = {

--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
@@ -649,6 +649,7 @@ private[netty] class NettyRpcHandler(
       dispatcher.postOneWayMessage(messageToDispatch)
     } catch {
       case e: RpcEnvStoppedException => logWarning(e.getMessage)
+      case e: RpcEndpointStoppedException => logWarning(e.getMessage)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When driver stopping, there is a error:

> 17/12/12 18:30:16 INFO MapOutputTrackerMasterEndpoint: MapOutputTrackerMasterEndpoint stopped!
> 17/12/12 18:30:16 ERROR TransportRequestHandler: Error while invoking RpcHandler#receive() for one-way message.
> org.apache.spark.SparkException: Could not find CoarseGrainedScheduler.
> at org.apache.spark.rpc.netty.Dispatcher.postMessage(Dispatcher.scala:154)
> at org.apache.spark.rpc.netty.Dispatcher.postOneWayMessage(Dispatcher.scala:134)
> at org.apache.spark.rpc.netty.NettyRpcHandler.receive(NettyRpcEnv.scala:570)
> at org.apache.spark.network.server.TransportRequestHandler.processOneWayMessage(TransportRequestHandler.java:180)
> at org.apache.spark.network.server.TransportRequestHandler.handle(TransportRequestHandler.java:109)
> at org.apache.spark.network.server.TransportChannelHandler.channelRead0(TransportChannelHandler.java:119)
> at org.apache.spark.network.server.TransportChannelHandler.channelRead0(TransportChannelHandler.java:51)

Because the endpoint of CoarseGrainedScheduler is stopped, this error is not problem, so i think this error should not be printed.

And there is another error:

> 17/12/12 18:20:44 INFO MemoryStore: MemoryStore cleared
> 17/12/12 18:20:44 INFO BlockManager: BlockManager stopped
> 17/12/12 18:20:44 INFO BlockManagerMaster: BlockManagerMaster stopped
> 17/12/12 18:20:44 ERROR TransportRequestHandler: Error while invoking RpcHandler#receive() for one-way message.
> org.apache.spark.rpc.RpcEnvStoppedException: RpcEnv already stopped.
> at org.apache.spark.rpc.netty.Dispatcher.postMessage(Dispatcher.scala:152)
> at org.apache.spark.rpc.netty.Dispatcher.postOneWayMessage(Dispatcher.scala:134)
> at org.apache.spark.rpc.netty.NettyRpcHandler.receive(NettyRpcEnv.scala:570)

I think the log level should be warning, not error.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
