### PR TITLE
[SPARK-22774][SQL][Test] Add compilation check into TPCDSQuerySuite

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
@@ -26,7 +26,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.expressions.codegen.{CodeFormatter, CodegenContext, ExprCode}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodeAndComment, CodeFormatter, CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.trees.TreeNodeRef
 import org.apache.spark.util.{AccumulatorV2, LongAccumulator}
@@ -68,13 +68,8 @@ package object debug {
     output
   }
 
-  /**
-   * Get WholeStageCodegenExec subtrees and the codegen in a query plan
-   *
-   * @param plan the query plan for codegen
-   * @return Sequence of WholeStageCodegen subtrees and corresponding codegen
-   */
-  def codegenStringSeq(plan: SparkPlan): Seq[(String, String)] = {
+  private def codegenSubtreeSourceSeq(plan: SparkPlan):
+      Seq[(WholeStageCodegenExec, CodeAndComment)] = {
     val codegenSubtrees = new collection.mutable.HashSet[WholeStageCodegenExec]()
     plan transform {
       case s: WholeStageCodegenExec =>
@@ -84,8 +79,29 @@ package object debug {
     }
     codegenSubtrees.toSeq.map { subtree =>
       val (_, source) = subtree.doCodeGen()
-      (subtree.toString, CodeFormatter.format(source))
+      (subtree, source)
     }
+  }
+
+  /**
+   * Get WholeStageCodegenExec subtrees and the codegen in a query plan
+   *
+   * @param plan the query plan for codegen
+   * @return Sequence of WholeStageCodegen subtrees and corresponding codegen
+   */
+  def codegenStringSeq(plan: SparkPlan): Seq[(String, String)] = {
+    codegenSubtreeSourceSeq(plan).map(s => (s._1.toString, CodeFormatter.format(s._2)))
+  }
+
+
+  /**
+   * Get WholeStageCodegenExec subtrees' CodeAndComment in a query plan
+   *
+   * @param plan the query plan for CodeAndComment
+   * @return Sequence of WholeStageCodegen subtrees' `CodeAndComment`
+   */
+  def codegenCodeAndCommentSeq(plan: SparkPlan): Seq[CodeAndComment] = {
+    codegenSubtreeSourceSeq(plan).map(_._2)
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQuerySuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql
 
 import org.scalatest.BeforeAndAfterAll
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodeFormatter, CodeGenerator}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.catalyst.util.resourceToString
@@ -32,7 +31,7 @@ import org.apache.spark.util.Utils
  * This test suite ensures all the TPC-DS queries can be successfully analyzed and optimized
  * without hitting the max iteration threshold.
  */
-class TPCDSQuerySuite extends QueryTest with SharedSQLContext with BeforeAndAfterAll with Logging {
+class TPCDSQuerySuite extends QueryTest with SharedSQLContext with BeforeAndAfterAll {
 
   // When Utils.isTesting is true, the RuleExecutor will issue an exception when hitting
   // the max iteration of analyzer/optimizer batches.
@@ -372,7 +371,7 @@ class TPCDSQuerySuite extends QueryTest with SharedSQLContext with BeforeAndAfte
                |$subtree
                |Generated code:
                |${CodeFormatter.format(code)}
-             """
+             """.stripMargin
           throw new Exception(msg, e)
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQuerySuite.scala
@@ -358,7 +358,7 @@ class TPCDSQuerySuite extends QueryTest with SharedSQLContext with BeforeAndAfte
         codegenSubtrees += s
       case s => s
     }
-    codegenSubtrees.toSeq.map { subtree =>
+    codegenSubtrees.toSeq.foreach { subtree =>
       val code = subtree.doCodeGen()._2
       try {
         // Just check the generated code can be properly compiled
@@ -369,8 +369,7 @@ class TPCDSQuerySuite extends QueryTest with SharedSQLContext with BeforeAndAfte
           val msg =
             s"Subtree:\n$subtree\n" +
             s"Generated code:\n${CodeFormatter.format(code)}\n"
-          logDebug(msg)
-          throw e
+          throw new Exception(msg, e)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQuerySuite.scala
@@ -365,10 +365,14 @@ class TPCDSQuerySuite extends QueryTest with SharedSQLContext with BeforeAndAfte
         CodeGenerator.compile(code)
       } catch {
         case e: Exception =>
-          logError(s"failed to compile: $e", e)
           val msg =
-            s"Subtree:\n$subtree\n" +
-            s"Generated code:\n${CodeFormatter.format(code)}\n"
+            s"""
+               |failed to compile:
+               |Subtree:
+               |$subtree
+               |Generated code:
+               |${CodeFormatter.format(code)}
+             """
           throw new Exception(msg, e)
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds check whether Java code generated by Catalyst can be compiled by `janino` correctly or not into `TPCDSQuerySuite`. Before this PR, this suite only checks whether analysis can be performed correctly or not.

This check will be able to avoid unexpected performance degrade by interpreter execution due to a Java compilation error.


## How was this patch tested?

Existing a test case, but updated it.