### PR TITLE
[SPARK-22779] FallbackConfigEntry's default value should actually be a value

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala
@@ -158,7 +158,7 @@ private class FallbackConfigEntry[T] (
   extends ConfigEntry[T](key, alternatives,
     fallback.valueConverter, fallback.stringConverter, doc, isPublic) {
 
-  override def defaultValueString: String = s"<value of ${fallback.key}>"
+  override def defaultValueString: String = fallback.defaultValueString
 
   override def readFrom(reader: ConfigReader): T = {
     readString(reader).map(valueConverter).getOrElse(fallback.readFrom(reader))


### PR DESCRIPTION
## What changes were proposed in this pull request?
ConfigEntry's config value right now shows a human readable message. In some places in SQL we actually rely on default value for real to be setting the values.

## How was this patch tested?
Tested manually.