### PR TITLE
[SPARK-22784][CORE][WIP] Configure reading buffer size in Spark History Server

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -211,6 +211,14 @@ The history server can be configured as follows:
     </td>
   </tr>
   <tr>
+    <td>spark.history.fs.buffer.size</td>
+    <td>scala.io.Source.DefaultBufSize</td>
+    <td>
+      Specifies bufferSize for BufferedReader during event log reading. 
+      20 times more than average line size gives the optimal speedup</code>
+    </td>
+  </tr>
+  <tr>
     <td>spark.history.fs.cleaner.maxAge</td>
     <td>7d</td>
     <td>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added debug logging of spent time and line size for each job.
Parametrized `ReplayListenerBus` with a new buffer size parameter  `spark.history.fs.buffer.size`. 
Added documentation to the parameter. 

## How was this patch tested?
Existing tests for correctness, manual tests (reading a file in a loop with different buffer sizes) for performance measurements. 