### PR TITLE
[Spark-22795] [ML] Raise error when line search in FirstOrderMinimizer failed

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LinearSVC.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LinearSVC.scala
@@ -244,9 +244,10 @@ class LinearSVC @Since("2.2.0") (
       }
 
       bcFeaturesStd.destroy(blocking = false)
-      if (state == null) {
-        val msg = s"${optimizer.getClass.getName} failed."
-        logError(msg)
+      if (state == null || state.searchFailed) {
+        val msg = s"${optimizer.getClass.getName} failed" +
+          s"${if (state.searchFailed) " due to line search failure" else ""}."
+        logWarning(msg)
         throw new SparkException(msg)
       }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -811,9 +811,10 @@ class LogisticRegression @Since("1.2.0") (
         }
         bcFeaturesStd.destroy(blocking = false)
 
-        if (state == null) {
-          val msg = s"${optimizer.getClass.getName} failed."
-          logError(msg)
+        if (state == null || state.searchFailed) {
+          val msg = s"${optimizer.getClass.getName} failed" +
+            s"${if (state.searchFailed) " due to line search failure" else ""}."
+          logWarning(msg)
           throw new SparkException(msg)
         }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -519,9 +519,10 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
         state = states.next()
         arrayBuilder += state.adjustedValue
       }
-      if (state == null) {
-        val msg = s"${optimizer.getClass.getName} failed."
-        logError(msg)
+      if (state == null || state.searchFailed) {
+        val msg = s"${optimizer.getClass.getName} failed" +
+          s"${if (state.searchFailed) " due to line search failure" else ""}."
+        logWarning(msg)
         throw new SparkException(msg)
       }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When line search in FirstOrderMinimizer (LBFGS or OWLQN so on) failed, the fit method of estimator not failed, and a meaning-less transformer is returned. 
This pull request changes estimators to raise an error when line search failed.

The error should be discovered early.
