### PR TITLE
[SPARK-22799][ML] Bucketizer should throw exception if single- and multi-column params are both set

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
@@ -34,9 +34,9 @@ import org.apache.spark.sql.types.{DoubleType, StructField, StructType}
 /**
  * `Bucketizer` maps a column of continuous features to a column of feature buckets. Since 2.3.0,
  * `Bucketizer` can map multiple columns at once by setting the `inputCols` parameter. Note that
- * when both the `inputCol` and `inputCols` parameters are set, a log warning will be printed and
- * only `inputCol` will take effect, while `inputCols` will be ignored. The `splits` parameter is
- * only used for single column usage, and `splitsArray` is for multiple columns.
+ * when both the `inputCol` and `inputCols` parameters are set, an Exception will be thrown. The
+ * `splits` parameter is only used for single column usage, and `splitsArray` is for multiple
+ * columns.
  */
 @Since("1.4.0")
 final class Bucketizer @Since("1.4.0") (@Since("1.4.0") override val uid: String)
@@ -140,15 +140,15 @@ final class Bucketizer @Since("1.4.0") (@Since("1.4.0") override val uid: String
    * by `inputCol`. A warning will be printed if both are set.
    */
   private[feature] def isBucketizeMultipleColumns(): Boolean = {
-    if (isSet(inputCols) && isSet(inputCol) || isSet(inputCols) && isSet(outputCol) ||
-      isSet(inputCol) && isSet(outputCols)) {
-      throw new IllegalArgumentException("Both `inputCol` and `inputCols` are set, `Bucketizer` " +
-        "only supports setting either `inputCol` or `inputCols`.")
-    } else if (isSet(inputCols)) {
-      true
-    } else {
-      false
+    inputColsSanityCheck()
+    outputColsSanityCheck()
+    if (isSet(inputCol) && isSet(splitsArray)) {
+      raiseIncompatibleParamsException("inputCol", "splitsArray")
     }
+    if (isSet(inputCols) && isSet(splits)) {
+      raiseIncompatibleParamsException("inputCols", "splits")
+    }
+    isSet(inputCols)
   }
 
   @Since("2.0.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
@@ -137,16 +137,9 @@ final class Bucketizer @Since("1.4.0") (@Since("1.4.0") override val uid: String
   /**
    * Determines whether this `Bucketizer` is going to map multiple columns. If and only if
    * `inputCols` is set, it will map multiple columns. Otherwise, it just maps a column specified
-   * by `inputCol`. An exception will be thrown if both are set.
+   * by `inputCol`.
    */
   private[feature] def isBucketizeMultipleColumns(): Boolean = {
-    ParamValidators.assertColOrCols(this)
-    if (isSet(inputCol) && isSet(splitsArray)) {
-      ParamValidators.raiseIncompatibleParamsException("inputCol", "splitsArray")
-    }
-    if (isSet(inputCols) && isSet(splits)) {
-      ParamValidators.raiseIncompatibleParamsException("inputCols", "splits")
-    }
     isSet(inputCols)
   }
 
@@ -200,6 +193,13 @@ final class Bucketizer @Since("1.4.0") (@Since("1.4.0") override val uid: String
 
   @Since("1.4.0")
   override def transformSchema(schema: StructType): StructType = {
+    ParamValidators.assertColOrCols(this)
+    if (isSet(inputCol) && isSet(splitsArray)) {
+      ParamValidators.raiseIncompatibleParamsException("inputCol", "splitsArray")
+    }
+    if (isSet(inputCols) && isSet(splits)) {
+      ParamValidators.raiseIncompatibleParamsException("inputCols", "splits")
+    }
     if (isBucketizeMultipleColumns()) {
       var transformedSchema = schema
       $(inputCols).zip($(outputCols)).zipWithIndex.map { case ((inputCol, outputCol), idx) =>

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
@@ -193,7 +193,7 @@ final class Bucketizer @Since("1.4.0") (@Since("1.4.0") override val uid: String
 
   @Since("1.4.0")
   override def transformSchema(schema: StructType): StructType = {
-    ParamValidators.assertColOrCols(this)
+    ParamValidators.checkMultiColumnParams(this)
     if (isSet(inputCol) && isSet(splitsArray)) {
       ParamValidators.raiseIncompatibleParamsException("inputCol", "splitsArray")
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
@@ -134,20 +134,11 @@ final class Bucketizer @Since("1.4.0") (@Since("1.4.0") override val uid: String
   @Since("2.3.0")
   def setOutputCols(value: Array[String]): this.type = set(outputCols, value)
 
-  /**
-   * Determines whether this `Bucketizer` is going to map multiple columns. If and only if
-   * `inputCols` is set, it will map multiple columns. Otherwise, it just maps a column specified
-   * by `inputCol`.
-   */
-  private[feature] def isBucketizeMultipleColumns(): Boolean = {
-    isSet(inputCols)
-  }
-
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
     val transformedSchema = transformSchema(dataset.schema)
 
-    val (inputColumns, outputColumns) = if (isBucketizeMultipleColumns()) {
+    val (inputColumns, outputColumns) = if (isSet(inputCols)) {
       ($(inputCols).toSeq, $(outputCols).toSeq)
     } else {
       (Seq($(inputCol)), Seq($(outputCol)))
@@ -162,7 +153,7 @@ final class Bucketizer @Since("1.4.0") (@Since("1.4.0") override val uid: String
       }
     }
 
-    val seqOfSplits = if (isBucketizeMultipleColumns()) {
+    val seqOfSplits = if (isSet(inputCols)) {
       $(splitsArray).toSeq
     } else {
       Seq($(splits))
@@ -200,7 +191,7 @@ final class Bucketizer @Since("1.4.0") (@Since("1.4.0") override val uid: String
     if (isSet(inputCols) && isSet(splits)) {
       ParamValidators.raiseIncompatibleParamsException("inputCols", "splits")
     }
-    if (isBucketizeMultipleColumns()) {
+    if (isSet(inputCols)) {
       var transformedSchema = schema
       $(inputCols).zip($(outputCols)).zipWithIndex.map { case ((inputCol, outputCol), idx) =>
         SchemaUtils.checkNumericType(transformedSchema, inputCol)

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
@@ -140,13 +140,12 @@ final class Bucketizer @Since("1.4.0") (@Since("1.4.0") override val uid: String
    * by `inputCol`. An exception will be thrown if both are set.
    */
   private[feature] def isBucketizeMultipleColumns(): Boolean = {
-    inputColsSanityCheck()
-    outputColsSanityCheck()
+    ParamValidators.assertColOrCols(this)
     if (isSet(inputCol) && isSet(splitsArray)) {
-      raiseIncompatibleParamsException("inputCol", "splitsArray")
+      ParamValidators.raiseIncompatibleParamsException("inputCol", "splitsArray")
     }
     if (isSet(inputCols) && isSet(splits)) {
-      raiseIncompatibleParamsException("inputCols", "splits")
+      ParamValidators.raiseIncompatibleParamsException("inputCols", "splits")
     }
     isSet(inputCols)
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
@@ -184,16 +184,13 @@ final class Bucketizer @Since("1.4.0") (@Since("1.4.0") override val uid: String
 
   @Since("1.4.0")
   override def transformSchema(schema: StructType): StructType = {
-    ParamValidators.checkMultiColumnParams(this)
-    if (isSet(inputCol) && isSet(splitsArray)) {
-      ParamValidators.raiseIncompatibleParamsException("inputCol", "splitsArray")
-    }
-    if (isSet(inputCols) && isSet(splits)) {
-      ParamValidators.raiseIncompatibleParamsException("inputCols", "splits")
-    }
+    ParamValidators.checkExclusiveParams(this, "inputCol", "inputCols")
+    ParamValidators.checkExclusiveParams(this, "outputCol", "outputCols")
+    ParamValidators.checkExclusiveParams(this, "splits", "splitsArray")
+
     if (isSet(inputCols)) {
       var transformedSchema = schema
-      $(inputCols).zip($(outputCols)).zipWithIndex.map { case ((inputCol, outputCol), idx) =>
+      $(inputCols).zip($(outputCols)).zipWithIndex.foreach { case ((inputCol, outputCol), idx) =>
         SchemaUtils.checkNumericType(transformedSchema, inputCol)
         transformedSchema = SchemaUtils.appendColumn(transformedSchema,
           prepOutputField($(splitsArray)(idx), outputCol))

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
@@ -137,7 +137,7 @@ final class Bucketizer @Since("1.4.0") (@Since("1.4.0") override val uid: String
   /**
    * Determines whether this `Bucketizer` is going to map multiple columns. If and only if
    * `inputCols` is set, it will map multiple columns. Otherwise, it just maps a column specified
-   * by `inputCol`. A warning will be printed if both are set.
+   * by `inputCol`. An exception will be thrown if both are set.
    */
   private[feature] def isBucketizeMultipleColumns(): Boolean = {
     inputColsSanityCheck()

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
@@ -140,10 +140,10 @@ final class Bucketizer @Since("1.4.0") (@Since("1.4.0") override val uid: String
    * by `inputCol`. A warning will be printed if both are set.
    */
   private[feature] def isBucketizeMultipleColumns(): Boolean = {
-    if (isSet(inputCols) && isSet(inputCol)) {
-      logWarning("Both `inputCol` and `inputCols` are set, we ignore `inputCols` and this " +
-        "`Bucketizer` only map one column specified by `inputCol`")
-      false
+    if (isSet(inputCols) && isSet(inputCol) || isSet(inputCols) && isSet(outputCol) ||
+      isSet(inputCol) && isSet(outputCols)) {
+      throw new IllegalArgumentException("Both `inputCol` and `inputCols` are set, `Bucketizer` " +
+        "only supports setting either `inputCol` or `inputCols`.")
     } else if (isSet(inputCols)) {
       true
     } else {

--- a/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
@@ -256,7 +256,7 @@ object ParamValidators {
    * this is not true, an `IllegalArgumentException` is raised.
    * @param model
    */
-  private[spark] def assertColOrCols(model: Params): Unit = {
+  private[spark] def checkMultiColumnParams(model: Params): Unit = {
     model match {
       case m: HasInputCols with HasInputCol if m.isSet(m.inputCols) && m.isSet(m.inputCol) =>
         raiseIncompatibleParamsException("inputCols", "inputCol")

--- a/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
@@ -256,7 +256,7 @@ object ParamValidators {
    * this is not true, an `IllegalArgumentException` is raised.
    * @param model
    */
-  def assertColOrCols(model: Params): Unit = {
+  private[spark] def assertColOrCols(model: Params): Unit = {
     model match {
       case m: HasInputCols with HasInputCol if m.isSet(m.inputCols) && m.isSet(m.inputCol) =>
         raiseIncompatibleParamsException("inputCols", "inputCol")
@@ -270,8 +270,10 @@ object ParamValidators {
     }
   }
 
-  def raiseIncompatibleParamsException(paramName1: String, paramName2: String): Unit = {
-    throw new IllegalArgumentException(s"Both `$paramName1` and `$paramName2` are set.")
+  private[spark] def raiseIncompatibleParamsException(
+      paramName1: String,
+      paramName2: String): Unit = {
+    throw new IllegalArgumentException(s"`$paramName1` and `$paramName2` cannot be both set.")
   }
 }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
@@ -277,15 +277,17 @@ object ParamValidators {
 
       val mustUnsetParams = excludedParams.filter(p => model.isSet(p))
         .map(_.name).mkString(", ")
-      if (mustUnsetParams.nonEmpty)
+      if (mustUnsetParams.nonEmpty) {
         badParamsMsgBuilder ++=
           s"The following Params are not applicable and should not be set: $mustUnsetParams."
+      }
 
       val mustSetParams = requiredParams.filter(p => !model.isDefined(p))
         .map(_.name).mkString(", ")
-      if (mustSetParams.nonEmpty)
+      if (mustSetParams.nonEmpty) {
         badParamsMsgBuilder ++=
           s"The following Params must be defined but are not set: $mustSetParams."
+      }
 
       val badParamsMsg = badParamsMsgBuilder.toString()
 

--- a/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
@@ -260,10 +260,6 @@ object ParamValidators {
     model match {
       case m: HasInputCols with HasInputCol if m.isSet(m.inputCols) && m.isSet(m.inputCol) =>
         raiseIncompatibleParamsException("inputCols", "inputCol")
-      case m: HasOutputCols with HasInputCol if m.isSet(m.outputCols) && m.isSet(m.inputCol) =>
-        raiseIncompatibleParamsException("outputCols", "inputCol")
-      case m: HasInputCols with HasOutputCol if m.isSet(m.inputCols) && m.isSet(m.outputCol) =>
-        raiseIncompatibleParamsException("inputCols", "outputCol")
       case m: HasOutputCols with HasOutputCol if m.isSet(m.outputCols) && m.isSet(m.outputCol) =>
         raiseIncompatibleParamsException("outputCols", "outputCol")
       case _ =>

--- a/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
@@ -269,7 +269,7 @@ object ParamValidators {
   private[spark] def raiseIncompatibleParamsException(
       paramName1: String,
       paramName2: String): Unit = {
-    throw new IllegalArgumentException(s"`$paramName1` and `$paramName2` cannot be both set.")
+    throw new IllegalArgumentException(s"`$paramName1` and `$paramName2` cannot both be set.")
   }
 }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
@@ -834,6 +834,14 @@ trait Params extends Identifiable with Serializable {
     }
     to
   }
+
+  final def raiseIncompatibleParamsException(paramName1: String, paramName2: String): Unit = {
+    throw new IllegalArgumentException(
+      s"""
+         |Both `$paramName1` and `$paramName2` are set, `${this.getClass.getName}` only supports
+         |setting either `$paramName1` or `$paramName2`.
+          """.stripMargin)
+  }
 }
 
 /**

--- a/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
@@ -835,7 +835,7 @@ trait Params extends Identifiable with Serializable {
     to
   }
 
-  final def raiseIncompatibleParamsException(paramName1: String, paramName2: String): Unit = {
+  protected def raiseIncompatibleParamsException(paramName1: String, paramName2: String): Unit = {
     throw new IllegalArgumentException(
       s"""
          |Both `$paramName1` and `$paramName2` are set, `${this.getClass.getName}` only supports

--- a/mllib/src/main/scala/org/apache/spark/ml/param/shared/sharedParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/shared/sharedParams.scala
@@ -236,16 +236,6 @@ trait HasInputCols extends Params {
 
   /** @group getParam */
   final def getInputCols: Array[String] = $(inputCols)
-
-  final def inputColsSanityCheck(): Unit = {
-    this match {
-      case model: HasInputCol if isSet(inputCols) && isSet(model.inputCol) =>
-        raiseIncompatibleParamsException("inputCols", "inputCol")
-      case model: HasOutputCol if isSet(inputCols) && isSet(model.outputCol) =>
-        raiseIncompatibleParamsException("inputCols", "outputCol")
-      case _ =>
-    }
-  }
 }
 
 /**
@@ -282,16 +272,6 @@ trait HasOutputCols extends Params {
 
   /** @group getParam */
   final def getOutputCols: Array[String] = $(outputCols)
-
-  final def outputColsSanityCheck(): Unit = {
-    this match {
-      case model: HasInputCol if isSet(outputCols) && isSet(model.inputCol) =>
-        raiseIncompatibleParamsException("outputCols", "inputCol")
-      case model: HasOutputCol if isSet(outputCols) && isSet(model.outputCol) =>
-        raiseIncompatibleParamsException("outputCols", "outputCol")
-      case _ =>
-    }
-  }
 }
 
 /**

--- a/mllib/src/main/scala/org/apache/spark/ml/param/shared/sharedParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/shared/sharedParams.scala
@@ -236,6 +236,16 @@ trait HasInputCols extends Params {
 
   /** @group getParam */
   final def getInputCols: Array[String] = $(inputCols)
+
+  final def inputColsSanityCheck(): Unit = {
+    this match {
+      case model: HasInputCol if isSet(inputCols) && isSet(model.inputCol) =>
+        raiseIncompatibleParamsException("inputCols", "inputCol")
+      case model: HasOutputCol if isSet(inputCols) && isSet(model.outputCol) =>
+        raiseIncompatibleParamsException("inputCols", "outputCol")
+      case _ =>
+    }
+  }
 }
 
 /**
@@ -272,6 +282,16 @@ trait HasOutputCols extends Params {
 
   /** @group getParam */
   final def getOutputCols: Array[String] = $(outputCols)
+
+  final def outputColsSanityCheck(): Unit = {
+    this match {
+      case model: HasInputCol if isSet(outputCols) && isSet(model.inputCol) =>
+        raiseIncompatibleParamsException("outputCols", "inputCol")
+      case model: HasOutputCol if isSet(outputCols) && isSet(model.outputCol) =>
+        raiseIncompatibleParamsException("outputCols", "outputCol")
+      case _ =>
+    }
+  }
 }
 
 /**

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
@@ -402,7 +402,8 @@ class BucketizerSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
   }
 
   test("assert exception is thrown is both multi-column and single-column params are set") {
-    ParamsSuite.checkMultiColumnParams(classOf[Bucketizer], spark)
+    val df = Seq((0.5, 0.3), (0.5, -0.4)).toDF("feature1", "feature2")
+    ParamsSuite.testMultiColumnParams(classOf[Bucketizer], df)
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
@@ -216,8 +216,6 @@ class BucketizerSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
       .setOutputCols(Array("result1", "result2"))
       .setSplitsArray(splits)
 
-    assert(bucketizer1.isBucketizeMultipleColumns())
-
     bucketizer1.transform(dataFrame).select("result1", "expected1", "result2", "expected2")
     BucketizerSuite.checkBucketResults(bucketizer1.transform(dataFrame),
       Seq("result1", "result2"),
@@ -232,8 +230,6 @@ class BucketizerSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
       .setInputCols(Array("feature"))
       .setOutputCols(Array("result"))
       .setSplitsArray(Array(splits(0)))
-
-    assert(bucketizer2.isBucketizeMultipleColumns())
 
     withClue("Invalid feature value -0.9 was not caught as an invalid feature!") {
       intercept[SparkException] {
@@ -268,8 +264,6 @@ class BucketizerSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
       .setOutputCols(Array("result1", "result2"))
       .setSplitsArray(splits)
 
-    assert(bucketizer.isBucketizeMultipleColumns())
-
     BucketizerSuite.checkBucketResults(bucketizer.transform(dataFrame),
       Seq("result1", "result2"),
       Seq("expected1", "expected2"))
@@ -294,8 +288,6 @@ class BucketizerSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
       .setInputCols(Array("feature1", "feature2"))
       .setOutputCols(Array("result1", "result2"))
       .setSplitsArray(splits)
-
-    assert(bucketizer.isBucketizeMultipleColumns())
 
     bucketizer.setHandleInvalid("keep")
     BucketizerSuite.checkBucketResults(bucketizer.transform(dataFrame),
@@ -335,7 +327,6 @@ class BucketizerSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
       .setInputCols(Array("myInputCol"))
       .setOutputCols(Array("myOutputCol"))
       .setSplitsArray(Array(Array(0.1, 0.8, 0.9)))
-    assert(t.isBucketizeMultipleColumns())
     testDefaultReadWrite(t)
   }
 
@@ -347,8 +338,6 @@ class BucketizerSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
       .setInputCols(Array("feature1", "feature2"))
       .setOutputCols(Array("result1", "result2"))
       .setSplitsArray(Array(Array(-0.5, 0.0, 0.5), Array(-0.5, 0.0, 0.5)))
-
-    assert(bucket.isBucketizeMultipleColumns())
 
     val pl = new Pipeline()
       .setStages(Array(bucket))

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
@@ -423,11 +423,10 @@ class BucketizerSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
       .setOutputCols(Array("result1", "result2"))
 
     Seq(invalid1, invalid2, invalid3).foreach { bucketizer =>
-      // When both inputCol and inputCols are set, we throw Exception.
-      val e = intercept[IllegalArgumentException] {
+      // When both inputCol/outputCol and inputCols/outputCols are set, we throw Exception.
+      intercept[IllegalArgumentException] {
         bucketizer.transform(df)
       }
-      assert(e.getMessage.contains("Both `inputCol` and `inputCols` are set"))
     }
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
@@ -392,7 +392,12 @@ class BucketizerSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
 
   test("assert exception is thrown if both multi-column and single-column params are set") {
     val df = Seq((0.5, 0.3), (0.5, -0.4)).toDF("feature1", "feature2")
-    ParamsSuite.testMultiColumnParams(classOf[Bucketizer], df)
+    ParamsSuite.testExclusiveParams(new Bucketizer, df, ("inputCol", "feature1"),
+      ("inputCols", Array("feature1", "feature2")))
+    ParamsSuite.testExclusiveParams(new Bucketizer, df, ("outputCol", "result1"),
+      ("outputCols", Array("result1", "result2")))
+    ParamsSuite.testExclusiveParams(new Bucketizer, df, ("splits", Array(-0.5, 0.0, 0.5)),
+      ("splitsArray", Array(Array(-0.5, 0.0, 0.5), Array(-0.5, 0.0, 0.5))))
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
@@ -394,10 +394,20 @@ class BucketizerSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
     val df = Seq((0.5, 0.3), (0.5, -0.4)).toDF("feature1", "feature2")
     ParamsSuite.testExclusiveParams(new Bucketizer, df, ("inputCol", "feature1"),
       ("inputCols", Array("feature1", "feature2")))
-    ParamsSuite.testExclusiveParams(new Bucketizer, df, ("outputCol", "result1"),
+    ParamsSuite.testExclusiveParams(new Bucketizer, df, ("inputCol", "feature1"),
+      ("outputCol", "result1"), ("splits", Array(-0.5, 0.0, 0.5)),
       ("outputCols", Array("result1", "result2")))
-    ParamsSuite.testExclusiveParams(new Bucketizer, df, ("splits", Array(-0.5, 0.0, 0.5)),
+    ParamsSuite.testExclusiveParams(new Bucketizer, df, ("inputCol", "feature1"),
+      ("outputCol", "result1"), ("splits", Array(-0.5, 0.0, 0.5)),
       ("splitsArray", Array(Array(-0.5, 0.0, 0.5), Array(-0.5, 0.0, 0.5))))
+
+    // this should fail because at least one of inputCol and inputCols must be set
+    ParamsSuite.testExclusiveParams(new Bucketizer, df, ("outputCol", "feature1"),
+      ("splits", Array(-0.5, 0.0, 0.5)))
+
+    // the following should fail because not all the params are set
+    ParamsSuite.testExclusiveParams(new Bucketizer, df, ("inputCol", "feature1"),
+      ("outputCol", "result1"))
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
@@ -401,7 +401,7 @@ class BucketizerSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
     }
   }
 
-  test("assert exception is thrown is both multi-column and single-column params are set") {
+  test("assert exception is thrown if both multi-column and single-column params are set") {
     val df = Seq((0.5, 0.3), (0.5, -0.4)).toDF("feature1", "feature2")
     ParamsSuite.testMultiColumnParams(classOf[Bucketizer], df)
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
@@ -401,33 +401,8 @@ class BucketizerSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
     }
   }
 
-  test("Both inputCol and inputCols are set") {
-    val feature1 = Array(-0.5, -0.3, 0.0, 0.2)
-    val feature2 = Array(-0.3, -0.2, 0.5, 0.0)
-    val df = feature1.zip(feature2).toSeq.toDF("feature1", "feature2")
-
-    val invalid1 = new Bucketizer()
-      .setInputCol("feature1")
-      .setOutputCol("result")
-      .setSplits(Array(-0.5, 0.0, 0.5))
-      .setInputCols(Array("feature1", "feature2"))
-
-    val invalid2 = new Bucketizer()
-      .setOutputCol("result")
-      .setSplits(Array(-0.5, 0.0, 0.5))
-      .setInputCols(Array("feature1", "feature2"))
-
-    val invalid3 = new Bucketizer()
-      .setInputCol("feature1")
-      .setSplits(Array(-0.5, 0.0, 0.5))
-      .setOutputCols(Array("result1", "result2"))
-
-    Seq(invalid1, invalid2, invalid3).foreach { bucketizer =>
-      // When both inputCol/outputCol and inputCols/outputCols are set, we throw Exception.
-      intercept[IllegalArgumentException] {
-        bucketizer.transform(df)
-      }
-    }
+  test("assert exception is thrown is both multi-column and single-column params are set") {
+    ParamsSuite.checkMultiColumnParams(classOf[Bucketizer], spark)
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
@@ -408,6 +408,9 @@ class BucketizerSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
     // the following should fail because not all the params are set
     ParamsSuite.testExclusiveParams(new Bucketizer, df, ("inputCol", "feature1"),
       ("outputCol", "result1"))
+    ParamsSuite.testExclusiveParams(new Bucketizer, df,
+      ("inputCols", Array("feature1", "feature2")),
+      ("outputCols", Array("result1", "result2")))
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/param/ParamsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/param/ParamsSuite.scala
@@ -452,6 +452,5 @@ object ParamsSuite extends SparkFunSuite {
         case e: Estimator[_] => e.fit(dataset)
       }
     }
-    assert(e.getMessage.contains("are exclusive, but more than one"))
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/param/ParamsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/param/ParamsSuite.scala
@@ -437,7 +437,7 @@ object ParamsSuite extends SparkFunSuite {
   /**
    * Checks that the class throws an exception in case both `inputCols` and `inputCol` are set and
    * in case both `outputCols` and `outputCol` are set.
-   * These checks are performed only whether the class extends respectively both `HasInputCols` and
+   * These checks are performed only when the class extends respectively both `HasInputCols` and
    * `HasInputCol` and both `HasOutputCols` and `HasOutputCol`.
    *
    * @param paramsClass The Class to be checked

--- a/mllib/src/test/scala/org/apache/spark/ml/param/ParamsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/param/ParamsSuite.scala
@@ -435,24 +435,23 @@ object ParamsSuite extends SparkFunSuite {
   }
 
   /**
-   * Checks that the class throws an exception in case multiple exclusive params are set
+   * Checks that the class throws an exception in case multiple exclusive params are set.
    * The params to be checked are passed as arguments with their value.
-   * The checks are performed only if all the passed params are defined for the given model.
    */
-  def testExclusiveParams(model: Params, dataset: Dataset[_],
+  def testExclusiveParams(
+      model: Params,
+      dataset: Dataset[_],
       paramsAndValues: (String, Any)*): Unit = {
-    val params = paramsAndValues.map(_._1)
-    if (params.forall(model.hasParam)) {
-      paramsAndValues.foreach { case (paramName, paramValue) =>
-        model.set(model.getParam(paramName), paramValue)
-      }
-      val e = intercept[IllegalArgumentException] {
-        model match {
-          case t: Transformer => t.transform(dataset)
-          case e: Estimator[_] => e.fit(dataset)
-        }
-      }
-      assert(e.getMessage.contains("are exclusive, but more than one"))
+    val m = model.copy(ParamMap.empty)
+    paramsAndValues.foreach { case (paramName, paramValue) =>
+      m.set(m.getParam(paramName), paramValue)
     }
+    val e = intercept[IllegalArgumentException] {
+      m match {
+        case t: Transformer => t.transform(dataset)
+        case e: Estimator[_] => e.fit(dataset)
+      }
+    }
+    assert(e.getMessage.contains("are exclusive, but more than one"))
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/param/ParamsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/param/ParamsSuite.scala
@@ -446,7 +446,7 @@ object ParamsSuite extends SparkFunSuite {
     paramsAndValues.foreach { case (paramName, paramValue) =>
       m.set(m.getParam(paramName), paramValue)
     }
-    val e = intercept[IllegalArgumentException] {
+    intercept[IllegalArgumentException] {
       m match {
         case t: Transformer => t.transform(dataset)
         case e: Estimator[_] => e.fit(dataset)

--- a/mllib/src/test/scala/org/apache/spark/ml/param/ParamsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/param/ParamsSuite.scala
@@ -22,7 +22,6 @@ import java.io.{ByteArrayOutputStream, ObjectOutputStream}
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.{Estimator, Transformer}
 import org.apache.spark.ml.linalg.{Vector, Vectors}
-import org.apache.spark.ml.param.shared.{HasInputCol, HasInputCols, HasOutputCol, HasOutputCols}
 import org.apache.spark.ml.util.MyParams
 import org.apache.spark.sql.Dataset
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently there is a mixed situation when both single- and multi-column are supported. In some cases exceptions are thrown, in others only a warning log is emitted. In this discussion https://issues.apache.org/jira/browse/SPARK-8418?focusedCommentId=16275049&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16275049, the decision was to throw an exception.

The PR throws an exception in `Bucketizer`, instead of logging a warning.

## How was this patch tested?

modified UT
