### PR TITLE
[SPARK-22813][BUILD] Use lsof or /usr/sbin/lsof in run-tests.py

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -257,7 +257,7 @@ def kill_zinc_on_port(zinc_port):
     try:
         subprocess.check_call(cmd % ("lsof", zinc_port), shell=True)
     except:
-        subprocess.call(cmd % ("/usr/sbin/lsof", zinc_port), shell=True)
+        subprocess.check_call(cmd % ("/usr/sbin/lsof", zinc_port), shell=True)
 
 
 def exec_maven(mvn_args=()):

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -253,9 +253,14 @@ def kill_zinc_on_port(zinc_port):
     """
     Kill the Zinc process running on the given port, if one exists.
     """
-    cmd = ("/usr/sbin/lsof -P |grep %s | grep LISTEN "
-           "| awk '{ print $2; }' | xargs kill") % zinc_port
-    subprocess.check_call(cmd, shell=True)
+    try:
+        cmd = ("lsof -P |grep %s | grep LISTEN "
+               "| awk '{ print $2; }' | xargs kill") % zinc_port
+        subprocess.check_call(cmd, shell=True)
+    except:
+        cmd = ("/usr/sbin/lsof -P |grep %s | grep LISTEN "
+               "| awk '{ print $2; }' | xargs kill") % zinc_port
+        subprocess.call(cmd, shell=True)
 
 
 def exec_maven(mvn_args=()):

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -253,14 +253,11 @@ def kill_zinc_on_port(zinc_port):
     """
     Kill the Zinc process running on the given port, if one exists.
     """
+    cmd = "%s -P |grep %s | grep LISTEN | awk '{ print $2; }' | xargs kill"
     try:
-        cmd = ("lsof -P |grep %s | grep LISTEN "
-               "| awk '{ print $2; }' | xargs kill") % zinc_port
-        subprocess.check_call(cmd, shell=True)
+        subprocess.check_call(cmd % ("lsof", zinc_port), shell=True)
     except:
-        cmd = ("/usr/sbin/lsof -P |grep %s | grep LISTEN "
-               "| awk '{ print $2; }' | xargs kill") % zinc_port
-        subprocess.call(cmd, shell=True)
+        subprocess.call(cmd % ("/usr/sbin/lsof", zinc_port), shell=True)
 
 
 def exec_maven(mvn_args=()):

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -254,10 +254,8 @@ def kill_zinc_on_port(zinc_port):
     Kill the Zinc process running on the given port, if one exists.
     """
     cmd = "%s -P |grep %s | grep LISTEN | awk '{ print $2; }' | xargs kill"
-    try:
-        subprocess.check_call(cmd % ("lsof", zinc_port), shell=True)
-    except:
-        subprocess.check_call(cmd % ("/usr/sbin/lsof", zinc_port), shell=True)
+    lsof_exe = which("lsof")
+    subprocess.check_call(cmd % (lsof_exe if lsof_exe else "/usr/sbin/lsof", zinc_port), shell=True)
 
 
 def exec_maven(mvn_args=()):


### PR DESCRIPTION
## What changes were proposed in this pull request?

In [the environment where `/usr/sbin/lsof` does not exist](https://github.com/apache/spark/pull/19695#issuecomment-342865001), `./dev/run-tests.py` for `maven` causes the following error. This is because the current `./dev/run-tests.py` checks existence of only `/usr/sbin/lsof` and aborts immediately if it does not exist.

This PR changes to check whether `lsof` or `/usr/sbin/lsof` exists.

```
/bin/sh: 1: /usr/sbin/lsof: not found

Usage:
 kill [options] <pid> [...]

Options:
 <pid> [...]            send signal to every <pid> listed
 -<signal>, -s, --signal <signal>
                        specify the <signal> to be sent
 -l, --list=[<signal>]  list all signal names, or convert one to a name
 -L, --table            list all signal names in a nice table

 -h, --help     display this help and exit
 -V, --version  output version information and exit

For more details see kill(1).
Traceback (most recent call last):
  File "./dev/run-tests.py", line 626, in <module>
    main()
  File "./dev/run-tests.py", line 597, in main
    build_apache_spark(build_tool, hadoop_version)
  File "./dev/run-tests.py", line 389, in build_apache_spark
    build_spark_maven(hadoop_version)
  File "./dev/run-tests.py", line 329, in build_spark_maven
    exec_maven(profiles_and_goals)
  File "./dev/run-tests.py", line 270, in exec_maven
    kill_zinc_on_port(zinc_port)
  File "./dev/run-tests.py", line 258, in kill_zinc_on_port
    subprocess.check_call(cmd, shell=True)
  File "/usr/lib/python2.7/subprocess.py", line 541, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '/usr/sbin/lsof -P |grep 3156 | grep LISTEN | awk '{ print $2; }' | xargs kill' returned non-zero exit status 123
```

## How was this patch tested?

manually tested