### PR TITLE
JDBC support date/timestamp type as partitionColumn

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcRelationProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcRelationProvider.scala
@@ -45,11 +45,49 @@ class JdbcRelationProvider extends CreatableRelationProvider
       assert(lowerBound.nonEmpty && upperBound.nonEmpty && numPartitions.nonEmpty,
         s"When 'partitionColumn' is specified, '$JDBC_LOWER_BOUND', '$JDBC_UPPER_BOUND', and " +
           s"'$JDBC_NUM_PARTITIONS' are also required")
-      JDBCPartitioningInfo(
+      JDBCPartitioningInfo(resolvePartitionColumnType(parameters),
         partitionColumn.get, lowerBound.get, upperBound.get, numPartitions.get)
     }
     val parts = JDBCRelation.columnPartition(partitionInfo)
     JDBCRelation(parts, jdbcOptions)(sqlContext.sparkSession)
+  }
+
+  def resolvePartitionColumnType(parameters: Map[String, String]): Int = {
+    val options = new JDBCOptions(parameters)
+
+    val conn = JdbcUtils.createConnectionFactory(options)()
+
+    val partitionColumn = options.partitionColumn
+    val table = options.table
+
+    var stmt: java.sql.PreparedStatement = null
+    var rs: java.sql.ResultSet = null
+    try {
+      val resolveSql = s"select * from ($table) resolveTable where 1=0"
+      stmt = conn.prepareStatement(resolveSql)
+      rs = stmt.executeQuery()
+      val rsmd = rs.getMetaData
+      var partitionColumnType = -1
+      for (i <- 0 until rsmd.getColumnCount) {
+        if (rsmd.getColumnName(i + 1).equals(partitionColumn)) {
+          partitionColumnType = rsmd.getColumnType(i + 1)
+        }
+      }
+      partitionColumnType
+    } catch {
+      case e: Exception =>
+        -1
+    } finally {
+      if (rs != null) {
+        rs.close()
+      }
+      if (stmt != null) {
+        rs.close()
+      }
+      if (conn != null) {
+        conn.close()
+      }
+    }
   }
 
   override def createRelation(


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/SPARK-22814

PartitionColumn must be a numeric column from the table.
However, there are lots of table, which has no primary key, and has some date/timestamp indexes.

This patch solve this problem.
