### PR TITLE
[SPARK-22826][SQL] findWiderTypeForTwo Fails over StructField of Array

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -170,7 +170,7 @@ object TypeCoercion {
       widerTypeFunc: (DataType, DataType) => Option[DataType]): Option[DataType] = {
     (t1, t2) match {
       case (t1 @ ArrayType(pointType1, nullable1),
-          t2@ ArrayType(pointType2, nullable2)) if t1.sameType(t2)=>
+          t2@ ArrayType(pointType2, nullable2)) if t1.sameType(t2) =>
         val dataType = widerTypeFunc.apply(pointType1, pointType2)
 
         dataType.map(ArrayType(_, nullable1 || nullable2))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -80,13 +80,10 @@ object TypeCoercion {
    * with primitive types, because in that case the precision and scale of the result depends on
    * the operation. Those rules are implemented in [[DecimalPrecision]].
    */
-  def findTightestCommonType(
-      t1: DataType,
-      t2: DataType,
-      withStringPromotion: Boolean = true): Option[DataType] = (t1, t2) match {
-    case (_, _) if t1 == t2 => Some(t1)
-    case (_, NullType) => Some(t1)
-    case (NullType, _) => Some(t2)
+  val findTightestCommonType: (DataType, DataType) => Option[DataType] = {
+    case (t1, t2) if t1 == t2 => Some(t1)
+    case (NullType, t1) => Some(t1)
+    case (t1, NullType) => Some(t1)
 
     case (t1: IntegralType, t2: DecimalType) if t2.isWiderThan(t1) =>
       Some(t2)
@@ -102,32 +99,16 @@ object TypeCoercion {
     case (_: TimestampType, _: DateType) | (_: DateType, _: TimestampType) =>
       Some(TimestampType)
 
-    case (ArrayType(pointType1, nullable1), ArrayType(pointType2, nullable2)) =>
-      val dataType = if (withStringPromotion) {
-        findWiderTypeForTwo(pointType1, pointType2)
-      } else {
-        findWiderTypeWithoutStringPromotionForTwo(pointType1, pointType2)
-      }
+    case (t1 @ ArrayType(pointType1, nullable1), t2 @ ArrayType(pointType2, nullable2))
+        if t1.sameType(t2) =>
+      val dataType = findTightestCommonType(pointType1, pointType2).get
+      Some(ArrayType(dataType, nullable1 || nullable2))
 
-      dataType.map(ArrayType(_, nullable1 || nullable2))
-
-    case (MapType(keyType1, valueType1, nullable1), MapType(keyType2, valueType2, nullable2)) =>
-      val keyType = if (withStringPromotion) {
-        findWiderTypeForTwo(keyType1, keyType2)
-      } else {
-        findWiderTypeWithoutStringPromotionForTwo(keyType1, keyType2)
-      }
-      val valueType = if (withStringPromotion) {
-        findWiderTypeForTwo(valueType1, valueType2)
-      } else {
-        findWiderTypeWithoutStringPromotionForTwo(valueType1, valueType2)
-      }
-
-      if (keyType.nonEmpty && valueType.nonEmpty) {
-        Some(MapType(keyType.get, valueType.get, nullable1 || nullable2))
-      } else {
-        None
-      }
+    case (t1 @ MapType(keyType1, valueType1, nullable1),
+        t2 @ MapType(keyType2, valueType2, nullable2)) if t1.sameType(t2) =>
+      val keyType = findTightestCommonType(keyType1, keyType2).get
+      val valueType = findTightestCommonType(valueType1, valueType2).get
+      Some(MapType(keyType, valueType, nullable1 || nullable2))
 
     case (t1 @ StructType(fields1), t2 @ StructType(fields2)) if t1.sameType(t2) =>
       Some(StructType(fields1.zip(fields2).map { case (f1, f2) =>
@@ -205,7 +186,7 @@ object TypeCoercion {
   private[analysis] def findWiderTypeWithoutStringPromotionForTwo(
       t1: DataType,
       t2: DataType): Option[DataType] = {
-    findTightestCommonType(t1, t2, withStringPromotion = false)
+    findTightestCommonType(t1, t2)
       .orElse(findWiderTypeForDecimal(t1, t2))
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -169,12 +169,14 @@ object TypeCoercion {
       t2: DataType,
       widerTypeFunc: (DataType, DataType) => Option[DataType]): Option[DataType] = {
     (t1, t2) match {
-      case (ArrayType(pointType1, nullable1), ArrayType(pointType2, nullable2)) =>
+      case (t1 @ ArrayType(pointType1, nullable1),
+          t2@ ArrayType(pointType2, nullable2)) if t1.sameType(t2)=>
         val dataType = widerTypeFunc.apply(pointType1, pointType2)
 
         dataType.map(ArrayType(_, nullable1 || nullable2))
 
-      case (MapType(keyType1, valueType1, nullable1), MapType(keyType2, valueType2, nullable2)) =>
+      case (t1 @ MapType(keyType1, valueType1, nullable1),
+          t2 @ MapType(keyType2, valueType2, nullable2)) if t1.sameType(t2) =>
         val keyType = widerTypeFunc.apply(keyType1, keyType2)
         val valueType = widerTypeFunc.apply(valueType1, valueType2)
 
@@ -184,7 +186,7 @@ object TypeCoercion {
           None
         }
 
-      case (StructType(fields1), StructType(fields2)) =>
+      case (t1 @ StructType(fields1), t2 @ StructType(fields2)) if t1.sameType(t2) =>
         val fieldTypes = fields1.zip(fields2).map { case (f1, f2) =>
           widerTypeFunc(f1.dataType, f2.dataType)
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -21,6 +21,7 @@ import javax.annotation.Nullable
 
 import scala.annotation.tailrec
 import scala.collection.mutable
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -161,22 +161,20 @@ object TypeCoercion {
 
   /**
    * Case 2 type widening over complex types. `widerTypeFunc` is a function that finds the wider
-   * type over point types, and additionally specifies whether types should be promoted to
-   * StringType or not.
+   * type over point types. The `widerTypeFunc` specifies behavior over whether types should be
+   * promoted to StringType.
    */
   private def findWiderTypeForTwoComplex(
       t1: DataType,
       t2: DataType,
       widerTypeFunc: (DataType, DataType) => Option[DataType]): Option[DataType] = {
     (t1, t2) match {
-      case (t1 @ ArrayType(pointType1, nullable1),
-          t2@ ArrayType(pointType2, nullable2)) if t1.sameType(t2) =>
+      case (ArrayType(pointType1, nullable1), ArrayType(pointType2, nullable2)) =>
         val dataType = widerTypeFunc.apply(pointType1, pointType2)
 
         dataType.map(ArrayType(_, nullable1 || nullable2))
 
-      case (t1 @ MapType(keyType1, valueType1, nullable1),
-          t2 @ MapType(keyType2, valueType2, nullable2)) if t1.sameType(t2) =>
+      case (MapType(keyType1, valueType1, nullable1), MapType(keyType2, valueType2, nullable2)) =>
         val keyType = widerTypeFunc.apply(keyType1, keyType2)
         val valueType = widerTypeFunc.apply(valueType1, valueType2)
 
@@ -186,7 +184,7 @@ object TypeCoercion {
           None
         }
 
-      case (t1 @ StructType(fields1), t2 @ StructType(fields2)) if t1.sameType(t2) =>
+      case (StructType(fields1), StructType(fields2)) =>
         val fieldTypes = fields1.zip(fields2).map { case (f1, f2) =>
           widerTypeFunc(f1.dataType, f2.dataType)
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -100,9 +100,9 @@ object TypeCoercion {
     case (_: TimestampType, _: DateType) | (_: DateType, _: TimestampType) =>
       Some(TimestampType)
 
-    case (t1 @ ArrayType(pointType1, nullable1), t2 @ ArrayType(pointType2, nullable2))
+    case (t1 @ ArrayType(elementType1, nullable1), t2 @ ArrayType(elementType2, nullable2))
         if t1.sameType(t2) =>
-      val dataType = findTightestCommonType(pointType1, pointType2).get
+      val dataType = findTightestCommonType(elementType1, elementType2).get
       Some(ArrayType(dataType, nullable1 || nullable2))
 
     case (t1 @ MapType(keyType1, valueType1, nullable1),
@@ -174,8 +174,8 @@ object TypeCoercion {
       case (NullType, _) => Some(t1)
       case (_, NullType) => Some(t1)
 
-      case (ArrayType(pointType1, nullable1), ArrayType(pointType2, nullable2)) =>
-        val dataType = widerTypeFunc.apply(pointType1, pointType2)
+      case (ArrayType(elementType1, nullable1), ArrayType(elementType2, nullable2)) =>
+        val dataType = widerTypeFunc.apply(elementType1, elementType2)
 
         dataType.map(ArrayType(_, nullable1 || nullable2))
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -194,7 +194,7 @@ object TypeCoercion {
           // In order to match Case 2 widening of types, we do not require field data types be the
           // same type, but fields having different names are considered heterogeneous
           if ((SQLConf.get.caseSensitiveAnalysis && f1.name.equals(f2.name))
-            || f1.name.equalsIgnoreCase(f2.name)) {
+            || (!SQLConf.get.caseSensitiveAnalysis && f1.name.equalsIgnoreCase(f2.name))) {
             widerTypeFunc(f1.dataType, f2.dataType)
           } else {
             None

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -214,7 +214,6 @@ object TypeCoercion {
       .orElse(findWiderTypeForDecimal(t1, t2))
       .orElse(stringPromotion(t1, t2))
       .orElse(findWiderTypeForTwoComplex(t1, t2, findWiderTypeForTwo))
-
   }
 
   private def findWiderCommonType(types: Seq[DataType]): Option[DataType] = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -144,6 +144,22 @@ class TypeCoercionSuite extends AnalysisTest {
     }
   }
 
+  private def checkTightestCommonType(
+      t1: DataType,
+      t2: DataType,
+      expected: Option[DataType],
+      isSymmetric: Boolean = true): Unit = {
+    var found = TypeCoercion.findTightestCommonType(t1, t2)
+    assert(found == expected,
+      s"Expected $expected as wider common type for $t1 and $t2, found $found")
+    // Test both directions to make sure the widening is symmetric.
+    if (isSymmetric) {
+      found = TypeCoercion.findTightestCommonType(t2, t1)
+      assert(found == expected,
+        s"Expected $expected as wider common type for $t2 and $t1, found $found")
+    }
+  }
+
   test("implicit type cast - ByteType") {
     val checkedType = ByteType
     checkTypeCasting(checkedType, castableTypes = numericTypes ++ Seq(StringType))
@@ -328,7 +344,7 @@ class TypeCoercionSuite extends AnalysisTest {
 
   test("tightest common bound for types") {
     def widenTest(t1: DataType, t2: DataType, expected: Option[DataType]): Unit =
-      checkWidenType(TypeCoercion.findTightestCommonType, t1, t2, expected)
+      checkTightestCommonType(t1, t2, expected)
 
     // Null
     widenTest(NullType, NullType, Some(NullType))
@@ -393,6 +409,8 @@ class TypeCoercionSuite extends AnalysisTest {
       ArrayType(StringType, containsNull=true),
       ArrayType(StringType, containsNull=false),
       Some(ArrayType(StringType, containsNull=true)))
+    widenTest(ArrayType(IntegerType), ArrayType(LongType), Some(ArrayType(LongType)))
+    widenTest(ArrayType(FloatType), ArrayType(DoubleType), Some(ArrayType(DoubleType)))
     widenTest(
       MapType(StringType, StringType, valueContainsNull=true),
       MapType(StringType, StringType, valueContainsNull=false),
@@ -441,8 +459,7 @@ class TypeCoercionSuite extends AnalysisTest {
         None)
     }
     withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
-      checkWidenType(
-        TypeCoercion.findTightestCommonType,
+      checkTightestCommonType(
         StructType(Seq(StructField("a", IntegerType), StructField("B", IntegerType))),
         StructType(Seq(StructField("A", IntegerType), StructField("b", IntegerType))),
         Some(StructType(Seq(StructField("a", IntegerType), StructField("B", IntegerType)))),
@@ -494,6 +511,10 @@ class TypeCoercionSuite extends AnalysisTest {
     widenTestWithoutStringPromotion(StringType, TimestampType, None)
     widenTestWithoutStringPromotion(ArrayType(LongType), ArrayType(StringType), None)
     widenTestWithoutStringPromotion(ArrayType(StringType), ArrayType(TimestampType), None)
+    widenTestWithoutStringPromotion(
+      StructType(StructField("a", ArrayType(LongType)) :: Nil),
+      StructType(StructField("a", ArrayType(StringType)) :: Nil),
+      None)
 
     // String promotion
     widenTestWithStringPromotion(IntegerType, StringType, Some(StringType))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -390,6 +390,25 @@ class TypeCoercionSuite extends AnalysisTest {
     widenTest(ArrayType(IntegerType), StructType(Seq()), None)
 
     widenTest(
+      ArrayType(StringType, containsNull=true),
+      ArrayType(StringType, containsNull=false),
+      Some(ArrayType(StringType, containsNull=true)))
+    widenTest(
+      MapType(StringType, StringType, valueContainsNull=true),
+      MapType(StringType, StringType, valueContainsNull=false),
+      Some(MapType(StringType, StringType, valueContainsNull=true)))
+
+    widenTest(
+      StructType(StructField("a", ArrayType(StringType, containsNull=true)) :: Nil),
+      StructType(StructField("a", ArrayType(StringType, containsNull=false)) :: Nil),
+      Some(StructType(StructField("a", ArrayType(StringType, containsNull=true)) :: Nil)))
+    widenTest(
+      StructType(StructField("a", MapType(StringType, StringType, valueContainsNull=true)) :: Nil),
+      StructType(StructField("a", MapType(StringType, StringType, valueContainsNull=false)) :: Nil),
+      Some(StructType(
+        StructField("a", MapType(StringType, StringType, valueContainsNull=true)) :: Nil)))
+
+    widenTest(
       StructType(Seq(StructField("a", IntegerType))),
       StructType(Seq(StructField("b", IntegerType))),
       None)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -488,12 +488,21 @@ class TypeCoercionSuite extends AnalysisTest {
       ArrayType(ArrayType(IntegerType), containsNull = false),
       ArrayType(ArrayType(LongType), containsNull = false),
       Some(ArrayType(ArrayType(LongType), containsNull = false)))
+    widenTestWithStringPromotion(
+      StructType(StructField("a", ArrayType(LongType)) :: Nil),
+      StructType(StructField("a", ArrayType(StringType)) :: Nil),
+      Some(StructType(StructField("a", ArrayType(StringType)) :: Nil)))
+
 
     // Without string promotion
     widenTestWithoutStringPromotion(IntegerType, StringType, None)
     widenTestWithoutStringPromotion(StringType, TimestampType, None)
     widenTestWithoutStringPromotion(ArrayType(LongType), ArrayType(StringType), None)
     widenTestWithoutStringPromotion(ArrayType(StringType), ArrayType(TimestampType), None)
+    widenTestWithoutStringPromotion(
+      StructType(StructField("a", ArrayType(LongType)) :: Nil),
+      StructType(StructField("a", ArrayType(StringType)) :: Nil),
+      None)
 
     // String promotion
     widenTestWithStringPromotion(IntegerType, StringType, Some(StringType))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -519,6 +519,20 @@ class TypeCoercionSuite extends AnalysisTest {
         Seq(StructField("a", ArrayType(StringType, containsNull = false), nullable = false))),
       Some(StructType(
         Seq(StructField("a", ArrayType(StringType, containsNull = true), nullable = true)))))
+    widenTestWithStringPromotion(
+      ArrayType(StructType(Seq(StructField("a", LongType, nullable = true))), containsNull = true),
+      ArrayType(StructType(
+        Seq(StructField("a", StringType, nullable = false))), containsNull = false),
+      Some(ArrayType(StructType(
+        Seq(StructField("a", StringType, nullable = true))), containsNull = true)))
+    widenTestWithStringPromotion(
+      StructType(Seq(StructField("a", ArrayType(LongType)))),
+      StructType(Seq(StructField("b", ArrayType(StringType)))),
+      None)
+    widenTestWithStringPromotion(
+      ArrayType(StructType(Seq(StructField("a", LongType)))),
+      ArrayType(StructType(Seq(StructField("b", StringType)))),
+      None)
 
     // MapType
     widenTestWithStringPromotion(
@@ -539,6 +553,24 @@ class TypeCoercionSuite extends AnalysisTest {
         StringType, StringType, valueContainsNull = false), nullable = false))),
       Some(StructType(Seq(StructField("a", MapType(
         StringType, StringType, valueContainsNull = true), nullable = true)))))
+    widenTestWithStringPromotion(
+      MapType(StringType,
+        StructType(Seq(StructField("a", LongType, nullable = true))),
+        valueContainsNull = true),
+      MapType(StringType,
+        StructType(Seq(StructField("a", StringType, nullable = false))),
+        valueContainsNull = false),
+      Some(MapType(StringType,
+        StructType(Seq(StructField("a", StringType, nullable = true))),
+        valueContainsNull = true)))
+    widenTestWithStringPromotion(
+      StructType(Seq(StructField("a", MapType(StringType, LongType)))),
+      StructType(Seq(StructField("b", MapType(StringType, StringType)))),
+      None)
+    widenTestWithStringPromotion(
+      MapType(StringType, StructType(Seq(StructField("a", LongType)))),
+      MapType(StringType, StructType(Seq(StructField("b", StringType)))),
+      None)
 
     // String promotion
     widenTestWithStringPromotion(IntegerType, StringType, Some(StringType))
@@ -566,10 +598,6 @@ class TypeCoercionSuite extends AnalysisTest {
     widenTestWithoutStringPromotion(ArrayType(LongType), ArrayType(StringType), None)
     widenTestWithoutStringPromotion(ArrayType(StringType), ArrayType(TimestampType), None)
     widenTestWithoutStringPromotion(
-      StructType(Seq(StructField("a", ArrayType(LongType)))),
-      StructType(Seq(StructField("a", ArrayType(StringType)))),
-      None)
-    widenTestWithoutStringPromotion(
       MapType(StringType, LongType),
       MapType(StringType, TimestampType),
       None)
@@ -588,6 +616,29 @@ class TypeCoercionSuite extends AnalysisTest {
     widenTestWithoutStringPromotion(
       StructType(Seq(StructField("a", MapType(StringType, LongType)))),
       StructType(Seq(StructField("a", MapType(StringType, StringType)))),
+      None)
+    widenTestWithoutStringPromotion(
+      ArrayType(StructType(Seq(StructField("a", LongType)))),
+      ArrayType(StructType(Seq(StructField("a", StringType)))),
+      None)
+
+    // Although the data types promotion would not fail, tests should still return None due to field
+    // name mismatch
+    widenTestWithoutStringPromotion(
+      StructType(Seq(StructField("a", MapType(StringType, LongType)))),
+      StructType(Seq(StructField("b", MapType(StringType, LongType)))),
+      None)
+    widenTestWithoutStringPromotion(
+      StructType(Seq(StructField("a", ArrayType(LongType)))),
+      StructType(Seq(StructField("b", ArrayType(LongType)))),
+      None)
+    widenTestWithoutStringPromotion(
+      StructType(Seq(StructField("a", MapType(StringType, LongType)))),
+      StructType(Seq(StructField("b", MapType(StringType, LongType)))),
+      None)
+    widenTestWithStringPromotion(
+      ArrayType(StructType(Seq(StructField("a", LongType)))),
+      ArrayType(StructType(Seq(StructField("b", LongType)))),
       None)
   }
 


### PR DESCRIPTION

## What changes were proposed in this pull request?

[SPARK-22826](https://issues.apache.org/jira/browse/SPARK-22826)

Attempting to find the tightest common type over a struct holding fields of `ArrayType` or `MapType` will fail if the types of those struct fields are not exactly equal. See the JIRA for an example.

## How was this patch tested?

This patch adds a test case for `ArrayType` and `MapType` for finding tightest common types.
