### PR TITLE
[SPARK-19053][ML]Supporting multiple evaluation metrics in DataFrame-based API

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/evaluation/BinaryClassificationMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/evaluation/BinaryClassificationMetrics.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.ml.evaluation
+
+import org.apache.spark.annotation.{Experimental, Since}
+import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.sql.{Dataset, Row}
+
+/**
+ * :: Experimental ::
+ * Metrics for binary classification[0, 1], which expects two input columns: rawPrediction
+ * and label. The rawPrediction column can be of type double (binary 0/1 prediction, or
+ * probability of label 1) or of type vector (length-2 vector of raw predictions, scores,
+ * or label probabilities).
+ */
+@Since("2.3.0")
+@Experimental
+class BinaryClassificationMetrics private[spark] (dataset: Dataset[_]) {
+
+  private val mllibMetrics = {
+    val rdd = dataset.rdd.map {
+      case Row(rawPrediction: Vector, label: Double) => (rawPrediction(1), label)
+      case Row(rawPrediction: Double, label: Double) => (rawPrediction, label)
+    }
+    new org.apache.spark.mllib.evaluation.BinaryClassificationMetrics(rdd)
+  }
+
+  /**
+   * Computes the area under the receiver operating characteristic (ROC) curve.
+   */
+  @Since("2.3.0")
+  lazy val areaUnderROC: Double = mllibMetrics.areaUnderROC()
+
+  /**
+   * Computes the area under the precision-recall curve.
+   */
+  @Since("2.3.0")
+  lazy val areaUnderPR: Double = mllibMetrics.areaUnderPR()
+
+  /**
+   * Unpersist intermediate RDDs used in the computation.
+   */
+  @Since("2.3.0")
+  def unpersist() {
+    mllibMetrics.unpersist()
+  }
+
+}

--- a/mllib/src/main/scala/org/apache/spark/ml/evaluation/MultiClassClassificationMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/evaluation/MultiClassClassificationMetrics.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.evaluation
+
+import org.apache.spark.annotation.{Experimental, Since}
+import org.apache.spark.sql.{Dataset, Row}
+
+/**
+ * :: Experimental ::
+ * Metrics for multiclass classification, which expects two input columns: prediction and label.
+ */
+@Since("2.3.0")
+@Experimental
+class MultiClassClassificationMetrics private[spark](dataset: Dataset[_]) {
+
+  private val mllibMetrics = {
+    val rdd = dataset.toDF().rdd.map {
+      case Row(prediction: Double, label: Double) => (prediction, label)
+    }
+    new org.apache.spark.mllib.evaluation.MulticlassMetrics(rdd)
+  }
+
+  /**
+   * Returns accuracy
+   * (equals to the total number of correctly classified instances
+   * out of the total number of instances.)
+   */
+  @Since("2.3.0")
+  lazy val accuracy: Double = mllibMetrics.accuracy
+
+  /**
+   * Returns weighted averaged f1-measure.
+   */
+  @Since("2.3.0")
+  lazy val weightedFMeasure: Double = mllibMetrics.weightedFMeasure
+
+  /**
+   * Returns weighted averaged precision.
+   */
+  @Since("2.3.0")
+  lazy val weightedPrecision: Double = mllibMetrics.weightedPrecision
+
+  /**
+   * Returns weighted averaged recall.
+   */
+  @Since("2.3.0")
+  lazy val weightedRecall: Double = mllibMetrics.weightedRecall
+
+}

--- a/mllib/src/main/scala/org/apache/spark/ml/evaluation/RegressionMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/evaluation/RegressionMetrics.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.evaluation
+
+import org.apache.spark.annotation.{Experimental, Since}
+import org.apache.spark.sql.{Dataset, Row}
+
+/**
+ * :: Experimental ::
+ * Metrics for regression, which expects two input columns: prediction and label.
+ */
+@Since("2.3.0")
+@Experimental
+class RegressionMetrics private[spark] (dataset: Dataset[_], throughOrigin: Boolean = false) {
+
+  private val mllibMetrics = {
+    val rdd = dataset.toDF().rdd.map {
+      case Row(prediction: Double, label: Double) => (prediction, label)
+    }
+    new org.apache.spark.mllib.evaluation.RegressionMetrics(rdd, throughOrigin)
+  }
+
+  /**
+   * Returns the mean absolute error, which is a risk function corresponding to the
+   * expected value of the absolute error loss or l1-norm loss.
+   */
+  @Since("2.3.0")
+  lazy val meanAbsoluteError: Double = mllibMetrics.meanAbsoluteError
+
+  /**
+   * Returns the mean squared error, which is a risk function corresponding to the
+   * expected value of the squared error loss or quadratic loss.
+   */
+  @Since("2.3.0")
+  lazy val meanSquaredError: Double = mllibMetrics.meanSquaredError
+
+  /**
+   * Returns R^2^, the unadjusted coefficient of determination.
+   * @see <a href="http://en.wikipedia.org/wiki/Coefficient_of_determination">
+   * Coefficient of determination (Wikipedia)</a>
+   * In case of regression through the origin, the definition of R^2^ is to be modified.
+   * @see <a href="https://online.stat.psu.edu/~ajw13/stat501/SpecialTopics/Reg_thru_origin.pdf">
+   * J. G. Eisenhauer, Regression through the Origin. Teaching Statistics 25, 76-80 (2003)</a>
+   */
+  @Since("2.3.0")
+  lazy val r2: Double = mllibMetrics.r2
+
+  /**
+   * Returns the root mean squared error, which is defined as the square root of
+   * the mean squared error.
+   */
+  @Since("2.3.0")
+  lazy val rootMeanSquaredError: Double = mllibMetrics.rootMeanSquaredError
+
+}
+

--- a/mllib/src/test/scala/org/apache/spark/ml/evaluation/BinaryClassificationEvaluatorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/evaluation/BinaryClassificationEvaluatorSuite.scala
@@ -75,4 +75,15 @@ class BinaryClassificationEvaluatorSuite
     val evaluator = new BinaryClassificationEvaluator().setRawPredictionCol("prediction")
     MLTestingUtils.checkNumericTypes(evaluator, spark)
   }
+
+  test("getMetrics should return same result as evaluate") {
+    val vectorDF = Seq(
+      (Vectors.dense(12, 2.5), 0d),
+      (Vectors.dense(1, 3), 1d),
+      (Vectors.dense(10, 2), 0d)
+    ).toDF("rawPrediction", "label")
+    val evaluator = new BinaryClassificationEvaluator().setMetricName("areaUnderPR")
+    val metrics = evaluator.getMetrics(vectorDF)
+    assert(metrics.areaUnderPR == evaluator.evaluate(vectorDF))
+  }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/evaluation/BinaryClassificationMetricsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/evaluation/BinaryClassificationMetricsSuite.scala
@@ -18,38 +18,25 @@
 package org.apache.spark.ml.evaluation
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.ml.param.ParamsSuite
-import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTestingUtils}
+import org.apache.spark.ml.util.DefaultReadWriteTest
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 
-class MulticlassClassificationEvaluatorSuite
+class BinaryClassificationMetricsSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {
-  import testImplicits._
 
-  test("params") {
-    ParamsSuite.checkParams(new MulticlassClassificationEvaluator)
+  test("BinaryClassificationMetrics get same result as MLlib") {
+    val spark = this.spark
+    import spark.implicits._
+
+    val scoreAndLabels = sc.parallelize(
+      Seq((0.1, 0.0), (0.1, 1.0), (0.4, 0.0), (0.6, 0.0), (0.6, 1.0), (0.6, 1.0), (0.8, 1.0)), 2)
+    val mllibMetrics = new org.apache.spark.mllib.evaluation.BinaryClassificationMetrics(
+      scoreAndLabels)
+
+    val df = scoreAndLabels.toDF("rawPrediction", "label")
+    val metrics = new BinaryClassificationMetrics(df)
+    assert(metrics.areaUnderPR == mllibMetrics.areaUnderPR())
+    assert(metrics.areaUnderROC == mllibMetrics.areaUnderROC())
   }
 
-  test("read/write") {
-    val evaluator = new MulticlassClassificationEvaluator()
-      .setPredictionCol("myPrediction")
-      .setLabelCol("myLabel")
-      .setMetricName("accuracy")
-    testDefaultReadWrite(evaluator)
-  }
-
-  test("should support all NumericType labels and not support other types") {
-    MLTestingUtils.checkNumericTypes(new MulticlassClassificationEvaluator, spark)
-  }
-
-  test("getMetrics should return a MultiClassClassificationMetrics") {
-    val df = Seq(
-      (1d, 0d),
-      (0d, 1d),
-      (2d, 2d)
-    ).toDF("prediction", "label")
-    val evaluator = new MulticlassClassificationEvaluator().setMetricName("accuracy")
-    val metrics = evaluator.getMetrics(df)
-    assert(metrics.accuracy == evaluator.evaluate(df))
-  }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/evaluation/MulticlassClassificationMetricsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/evaluation/MulticlassClassificationMetricsSuite.scala
@@ -18,38 +18,30 @@
 package org.apache.spark.ml.evaluation
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.ml.param.ParamsSuite
-import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTestingUtils}
+import org.apache.spark.ml.util.DefaultReadWriteTest
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 
-class MulticlassClassificationEvaluatorSuite
+class MulticlassClassificationMetricsSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {
-  import testImplicits._
 
-  test("params") {
-    ParamsSuite.checkParams(new MulticlassClassificationEvaluator)
+  test("MulticlassClassificationMetricsSuite get same result as MLlib") {
+    val spark = this.spark
+    import spark.implicits._
+
+    val predictionAndLabels = sc.parallelize(
+      Seq((0.0, 0.0), (0.0, 1.0), (0.0, 0.0), (1.0, 0.0), (1.0, 1.0),
+        (1.0, 1.0), (1.0, 1.0), (2.0, 2.0), (2.0, 0.0)), 2)
+
+    val mllibMetrics = new org.apache.spark.mllib.evaluation.MulticlassMetrics(
+      predictionAndLabels)
+
+    val df = predictionAndLabels.toDF("prediction", "label")
+    val metrics = new MultiClassClassificationMetrics(df)
+    assert(metrics.accuracy == mllibMetrics.accuracy)
+    assert(metrics.weightedFMeasure == mllibMetrics.weightedFMeasure)
+    assert(metrics.weightedPrecision == mllibMetrics.weightedPrecision)
+    assert(metrics.weightedRecall == mllibMetrics.weightedRecall)
   }
 
-  test("read/write") {
-    val evaluator = new MulticlassClassificationEvaluator()
-      .setPredictionCol("myPrediction")
-      .setLabelCol("myLabel")
-      .setMetricName("accuracy")
-    testDefaultReadWrite(evaluator)
-  }
-
-  test("should support all NumericType labels and not support other types") {
-    MLTestingUtils.checkNumericTypes(new MulticlassClassificationEvaluator, spark)
-  }
-
-  test("getMetrics should return a MultiClassClassificationMetrics") {
-    val df = Seq(
-      (1d, 0d),
-      (0d, 1d),
-      (2d, 2d)
-    ).toDF("prediction", "label")
-    val evaluator = new MulticlassClassificationEvaluator().setMetricName("accuracy")
-    val metrics = evaluator.getMetrics(df)
-    assert(metrics.accuracy == evaluator.evaluate(df))
-  }
 }
+

--- a/mllib/src/test/scala/org/apache/spark/ml/evaluation/RegressionEvaluatorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/evaluation/RegressionEvaluatorSuite.scala
@@ -89,4 +89,15 @@ class RegressionEvaluatorSuite
   test("should support all NumericType labels and not support other types") {
     MLTestingUtils.checkNumericTypes(new RegressionEvaluator, spark)
   }
+
+  test("getMetrics should return same result as evaluate") {
+    val df = Seq(
+      (1d, 0d),
+      (0d, 1d),
+      (2d, 2d)
+    ).toDF("prediction", "label")
+    val evaluator = new RegressionEvaluator().setMetricName("r2")
+    val metrics = evaluator.getMetrics(df)
+    assert(metrics.r2 == evaluator.evaluate(df))
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

As an initial step, the PR creates BinaryClassificationMetrics, MultiClassClassificationMetrics, RegressionMetrics in ML. The long term target is to reach function parity with MLlib Metrics and be able to provide more enhancements for DataFrame-based API.

This PR allows the Binary/MultilclassClassification/Regression Evaluator to get a corresponding metrics instance, and users can use the metrics instance to access multiple evaluation Metrics after a single pass, while originally Evaluator only allows access for single metric.  
```
val evaluator = new MulticlassClassificationEvaluator()
val metrics = evaluator.getMetrics(df)
metrics.accuracy
metrics.weightedFMeasure
metrics.weightedPrecision
metrics.weightedRecall
```

To make the review easier, the current PR only includes metrics in the Evaluator to reach function parity. Plan for further development:
1. Initial API and function parity with ML Evaluators. (This PR)
2. Python API.
2. Function parity with MLlib Metrics.
3. Add requested enhancements like including weight, add per-row metrics, add ranking metrics.
4. Reorganize classification Metrics hierarchy, so Binary Classification Metrics can support metrics in MultiClassMetrics (accuracy, recall etc.).
5.  Possibly to be used in training summary.

The current implementation is still based on MLlib Metrics, which is kept completely internal and can be changed to DataFrame-based calculation when necessary.


## How was this patch tested?

new unit tests added.
