### PR TITLE
[SPARK-22873] [CORE] Init lastReportTimestamp with system current time when start() called…

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
@@ -112,6 +112,7 @@ private class AsyncEventQueue(val name: String, conf: SparkConf, metrics: LiveLi
   private[scheduler] def start(sc: SparkContext): Unit = {
     if (started.compareAndSet(false, true)) {
       this.sc = sc
+      lastReportTimestamp = System.currentTimeMillis()
       dispatchThread.start()
     } else {
       throw new IllegalStateException(s"$name already started!")


### PR DESCRIPTION
… in AsyncEventQueue

## What changes were proposed in this pull request?
```
 if (droppedEventsCounter.compareAndSet(droppedCount, 0)) {
      val prevLastReportTimestamp = lastReportTimestamp
      lastReportTimestamp = System.currentTimeMillis()
      val previous = new java.util.Date(prevLastReportTimestamp)
      logWarning(s"Dropped $droppedEvents events from $name since $previous.")
   }
```
First time we log previous date, it would be "Thu Jan 01 08:00:00 CST 1970" because of lastReportTimestamp was inited by 0L. Although there is no mistake in theory, AsyncEventQueue's starting time seems better:
```
private[scheduler] def start(sc: SparkContext): Unit = {
    if (started.compareAndSet(false, true)) {
      this.sc = sc
      lastReportTimestamp = System.currentTimeMillis()
      dispatchThread.start()
    } else {
      throw new IllegalStateException(s"$name already started!")
    }
  }

```
## How was this patch tested?

manual test:
Debug unit test '  test("metrics for dropped listener events") ' in SparkListenerSuit to check the previous date first time we log for drop events.

