### PR TITLE
[SPARK-22875][BUILD] Assembly build fails for a high user id

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -208,7 +208,8 @@
                 <configuration>
                   <descriptors>
                     <descriptor>src/main/assembly/assembly.xml</descriptor>
-                  </descriptors>
+                </descriptors>
+                <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>
               </execution>
             </executions>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -208,7 +208,7 @@
                 <configuration>
                   <descriptors>
                     <descriptor>src/main/assembly/assembly.xml</descriptor>
-                </descriptors>
+                  </descriptors>
                 </configuration>
               </execution>
             </executions>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -209,7 +209,6 @@
                   <descriptors>
                     <descriptor>src/main/assembly/assembly.xml</descriptor>
                 </descriptors>
-                <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -2295,6 +2295,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
           <version>3.1.0</version>
+          <configuration>
+            <tarLongFileMode>posix</tarLongFileMode>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add tarLongFileMode=posix configuration for the assembly plugin

## How was this patch tested?

Reran build successfully
```
./build/mvn package -Pbigtop-dist -DskipTests -rf :spark-assembly_2.11
[INFO] Spark Project Assembly ............................. SUCCESS [ 23.082 s]
```
