### PR TITLE
[SPARK-22922][ML][PySpark] Pyspark portion of the fit-multiple API

### DIFF
--- a/python/pyspark/ml/base.py
+++ b/python/pyspark/ml/base.py
@@ -27,7 +27,7 @@ from pyspark.sql.functions import udf
 from pyspark.sql.types import StructField, StructType
 
 
-class FitMultipleIterator(object):
+class _FitMultipleIterator(object):
     """
     Used by default implementation of Estimator.fitMultiple to produce models in a thread safe
     iterator. This class handles the simple case of fitMultiple where each param map should be
@@ -87,16 +87,15 @@ class Estimator(Params):
         raise NotImplementedError()
 
     @since("2.3.0")
-    def fitMultiple(self, dataset, params):
+    def fitMultiple(self, dataset, paramMaps):
         """
-        Fits a model to the input dataset for each param map in params.
+        Fits a model to the input dataset for each param map in `paramMaps`.
 
         :param dataset: input dataset, which is an instance of :py:class:`pyspark.sql.DataFrame`.
-        :param params: A Sequence of param maps.
+        :param paramMaps: A Sequence of param maps.
         :return: A thread safe iterable which contains one model for each param map. Each
                  call to `next(modelIterator)` will return `(index, model)` where model was fit
-                 using `params[index]`. Params maps may be fit in an order different than their
-                 order in params.
+                 using `paramMaps[index]`. `index` values may not be sequential.
 
         .. note:: DeveloperApi
         .. note:: Experimental
@@ -104,9 +103,9 @@ class Estimator(Params):
         estimator = self.copy()
 
         def fitSingleModel(index):
-            return estimator.fit(dataset, params[index])
+            return estimator.fit(dataset, paramMaps[index])
 
-        return FitMultipleIterator(fitSingleModel, len(params))
+        return _FitMultipleIterator(fitSingleModel, len(paramMaps))
 
     @since("1.3.0")
     def fit(self, dataset, params=None):

--- a/python/pyspark/ml/base.py
+++ b/python/pyspark/ml/base.py
@@ -74,6 +74,7 @@ class Estimator(Params):
         """
         raise NotImplementedError()
 
+    @since("2.3.0")
     def fitMultiple(self, dataset, params):
         """
         Fits a model to the input dataset for each param map in params.
@@ -83,6 +84,8 @@ class Estimator(Params):
         :return: A thread safe iterable which contains one model for each param map. Each
         call to `next(modelIterator)` will return `(index, model)` where model was fit using
         `params[index]`. Params maps may be fit in an order different than their order in params.
+
+        .. note:: Experimental
         """
         def fitSingleModel(index):
             return self.fit(dataset, params[index])

--- a/python/pyspark/ml/base.py
+++ b/python/pyspark/ml/base.py
@@ -82,8 +82,9 @@ class Estimator(Params):
         :param dataset: input dataset, which is an instance of :py:class:`pyspark.sql.DataFrame`.
         :param params: A list/tuple of param maps.
         :return: A thread safe iterable which contains one model for each param map. Each
-        call to `next(modelIterator)` will return `(index, model)` where model was fit using
-        `params[index]`. Params maps may be fit in an order different than their order in params.
+                 call to `next(modelIterator)` will return `(index, model)` where model was fit
+                 using `params[index]`. Params maps may be fit in an order different than their
+                 order in params.
 
         .. note:: Experimental
         """

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -2359,6 +2359,21 @@ class UnaryTransformerTests(SparkSessionTestCase):
             self.assertEqual(res.input + shiftVal, res.output)
 
 
+class TestFit(unittest.TestCase):
+
+    def testDefaultFitMultiple(self):
+        N = 4
+        data = MockDataset()
+        estimator = MockEstimator()
+        params = [{estimator.fake: i} for i in range(N)]
+        modelIter = estimator.fitMultiple(data, params)
+        indexList = []
+        for index, model in modelIter:
+            self.assertEqual(model.getFake(), index)
+            indexList.append(index)
+        self.assertEqual(sorted(indexList), list(range(N)))
+
+
 if __name__ == "__main__":
     from pyspark.ml.tests import *
     if xmlrunner:

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -2359,7 +2359,7 @@ class UnaryTransformerTests(SparkSessionTestCase):
             self.assertEqual(res.input + shiftVal, res.output)
 
 
-class TestFit(unittest.TestCase):
+class EstimatorTest(unittest.TestCase):
 
     def testDefaultFitMultiple(self):
         N = 4

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -35,7 +35,7 @@ def parallelFitTasks(est, train, eva, validation, epm):
     modelIter = est.fitMultiple(train, epm)
 
     def singleTask():
-        index, model = modelIter.next()
+        index, model = next(modelIter)
         metric = eva.evaluate(model.transform(validation, epm[index]))
         return index, metric
 
@@ -531,8 +531,8 @@ class TrainValidationSplit(Estimator, ValidatorParams, HasParallelism, MLReadabl
         tasks = parallelFitTasks(est, train, eva, validation, epm)
         pool = ThreadPool(processes=min(self.getParallelism(), numModels))
         metrics = [None] * numModels
-        for j, m in pool.imap_unordered(lambda f: f(), tasks):
-            metrics[j] = m
+        for j, metric in pool.imap_unordered(lambda f: f(), tasks):
+            metrics[j] = metric
         train.unpersist()
         validation.unpersist()
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding fitMultiple API to `Estimator` with default implementation. Also update have ml.tuning meta-estimators use this API.

## How was this patch tested?

Unit tests.
