### PR TITLE
[SPARK-22790][SQL] add a configurable factor to describe HadoopFsRelation's size

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1093,7 +1093,7 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.memory.offHeap.size</code></td>
   <td>0</td>
   <td>
-    The absolute amount of memory in bytes which can be used for off-heap allocation.
+    The absolute amount of memory (in terms by bytes) which can be used for off-heap allocation.
     This setting has no impact on heap memory usage, so if your executors' total memory consumption must fit within some hard limit then be sure to shrink your JVM heap size accordingly.
     This must be set to a positive value when <code>spark.memory.offHeap.enabled=true</code>.
   </td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1093,7 +1093,7 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.memory.offHeap.size</code></td>
   <td>0</td>
   <td>
-    The absolute amount of memory (in terms by bytes) which can be used for off-heap allocation.
+    The absolute amount of memory in bytes which can be used for off-heap allocation.
     This setting has no impact on heap memory usage, so if your executors' total memory consumption must fit within some hard limit then be sure to shrink your JVM heap size accordingly.
     This must be set to a positive value when <code>spark.memory.offHeap.enabled=true</code>.
   </td>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1250,7 +1250,7 @@ class SQLConf extends Serializable with Logging {
 
   def escapedStringLiterals: Boolean = getConf(ESCAPED_STRING_LITERALS)
 
-  def compressionFactor: Double = getConf(FILE_COMRESSION_FACTOR)
+  def fileCompressionFactor: Double = getConf(FILE_COMRESSION_FACTOR)
 
   def stringRedationPattern: Option[Regex] = SQL_STRING_REDACTION_PATTERN.readFrom(reader)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -264,14 +264,14 @@ object SQLConf {
     .createWithDefault(false)
 
   val DISK_TO_MEMORY_SIZE_FACTOR = buildConf(
-    "org.apache.spark.sql.execution.datasources.sizeFactor")
+    "org.apache.spark.sql.execution.datasources.fileDataSizeFactor")
     .internal()
     .doc("The result of multiplying this factor with the size of data source files is propagated " +
       "to serve as the stats to choose the best execution plan. In the case where the " +
       "in-disk and in-memory size of data is significantly different, users can adjust this " +
       "factor for a better choice of the execution plan. The default value is 1.0.")
     .doubleConf
-    .checkValue(_ > 0, "the value of sizeFactor must be larger than 0")
+    .checkValue(_ > 0, "the value of fileDataSizeFactor must be larger than 0")
     .createWithDefault(1.0)
 
   val PARQUET_SCHEMA_MERGING_ENABLED = buildConf("spark.sql.parquet.mergeSchema")
@@ -1252,7 +1252,7 @@ class SQLConf extends Serializable with Logging {
 
   def escapedStringLiterals: Boolean = getConf(ESCAPED_STRING_LITERALS)
 
-  def sizeToMemorySizeFactor: Double = getConf(DISK_TO_MEMORY_SIZE_FACTOR)
+  def diskToMemorySizeFactor: Double = getConf(DISK_TO_MEMORY_SIZE_FACTOR)
 
   def stringRedationPattern: Option[Regex] = SQL_STRING_REDACTION_PATTERN.readFrom(reader)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -263,7 +263,7 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
-  val HADOOPFSRELATION_SIZE_FACTOR = buildConf(
+  val DISK_TO_MEMORY_SIZE_FACTOR = buildConf(
     "org.apache.spark.sql.execution.datasources.sizeFactor")
     .internal()
     .doc("The result of multiplying this factor with the size of data source files is propagated " +
@@ -1252,7 +1252,7 @@ class SQLConf extends Serializable with Logging {
 
   def escapedStringLiterals: Boolean = getConf(ESCAPED_STRING_LITERALS)
 
-  def hadoopFSSizeFactor: Double = getConf(HADOOPFSRELATION_SIZE_FACTOR)
+  def sizeToMemorySizeFactor: Double = getConf(DISK_TO_MEMORY_SIZE_FACTOR)
 
   def stringRedationPattern: Option[Regex] = SQL_STRING_REDACTION_PATTERN.readFrom(reader)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -249,7 +249,7 @@ object SQLConf {
   val CONSTRAINT_PROPAGATION_ENABLED = buildConf("spark.sql.constraintPropagation.enabled")
     .internal()
     .doc("When true, the query optimizer will infer and propagate data constraints in the query " +
-      "plan to optimize them. Constraint propagation can sometimes be computationally expensive" +
+      "plan to optimize them. Constraint propagation can sometimes be computationally expensive " +
       "for certain kinds of query plans (such as those with a large number of predicates and " +
       "aliases) which might negatively impact overall runtime.")
     .booleanConf
@@ -266,10 +266,10 @@ object SQLConf {
   val HADOOPFSRELATION_SIZE_FACTOR = buildConf(
     "org.apache.spark.sql.execution.datasources.sizeFactor")
     .internal()
-    .doc("The result of multiplying this factor with the size of data source files is propagated" +
-      " to serve as the stats to choose the best execution plan. In the case where the " +
-      " the in-disk and in-memory size of data is significantly different, users can adjust this" +
-      " factor for a better choice of the execution plan. The default value is 1.0.")
+    .doc("The result of multiplying this factor with the size of data source files is propagated " +
+      "to serve as the stats to choose the best execution plan. In the case where the " +
+      "in-disk and in-memory size of data is significantly different, users can adjust this " +
+      "factor for a better choice of the execution plan. The default value is 1.0.")
     .doubleConf
     .checkValue(_ > 0, "the value of sizeFactor must be larger than 0")
     .createWithDefault(1.0)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -264,7 +264,7 @@ object SQLConf {
     .createWithDefault(false)
 
   val DISK_TO_MEMORY_SIZE_FACTOR = buildConf(
-    "org.apache.spark.sql.execution.datasources.fileDataSizeFactor")
+    "spark.sql.sources.compressionFactor")
     .internal()
     .doc("The result of multiplying this factor with the size of data source files is propagated " +
       "to serve as the stats to choose the best execution plan. In the case where the " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -271,6 +271,7 @@ object SQLConf {
       " the in-disk and in-memory size of data is significantly different, users can adjust this" +
       " factor for a better choice of the execution plan. The default value is 1.0.")
     .doubleConf
+    .checkValue(_ > 0, "the value of sizeFactor must be larger than 0")
     .createWithDefault(1.0)
 
   val PARQUET_SCHEMA_MERGING_ENABLED = buildConf("spark.sql.parquet.mergeSchema")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -263,13 +263,11 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
-  val DISK_TO_MEMORY_SIZE_FACTOR = buildConf(
-    "spark.sql.sources.compressionFactor")
+  val FILE_COMRESSION_FACTOR = buildConf("spark.sql.sources.fileCompressionFactor")
     .internal()
-    .doc("The result of multiplying this factor with the size of data source files is propagated " +
-      "to serve as the stats to choose the best execution plan. In the case where the " +
-      "in-disk and in-memory size of data is significantly different, users can adjust this " +
-      "factor for a better choice of the execution plan. The default value is 1.0.")
+    .doc("When estimating the output data size of a table scan, multiply the file size with this " +
+      "factor as the estimated data size, in case the data is compressed in the file and lead to" +
+      " a heavily underestimated result.")
     .doubleConf
     .checkValue(_ > 0, "the value of fileDataSizeFactor must be larger than 0")
     .createWithDefault(1.0)
@@ -1252,7 +1250,7 @@ class SQLConf extends Serializable with Logging {
 
   def escapedStringLiterals: Boolean = getConf(ESCAPED_STRING_LITERALS)
 
-  def diskToMemorySizeFactor: Double = getConf(DISK_TO_MEMORY_SIZE_FACTOR)
+  def compressionFactor: Double = getConf(FILE_COMRESSION_FACTOR)
 
   def stringRedationPattern: Option[Regex] = SQL_STRING_REDACTION_PATTERN.readFrom(reader)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -263,6 +263,16 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val HADOOPFSRELATION_SIZE_FACTOR = buildConf(
+    "org.apache.spark.sql.execution.datasources.sizeFactor")
+    .internal()
+    .doc("The result of multiplying this factor with the size of data source files is propagated" +
+      " to serve as the stats to choose the best execution plan. In the case where the " +
+      " the in-disk and in-memory size of data is significantly different, users can adjust this" +
+      " factor for a better choice of the execution plan. The default value is 1.0.")
+    .doubleConf
+    .createWithDefault(1.0)
+
   val PARQUET_SCHEMA_MERGING_ENABLED = buildConf("spark.sql.parquet.mergeSchema")
     .doc("When true, the Parquet data source merges schemas collected from all data files, " +
          "otherwise the schema is picked from the summary file or a random data file " +
@@ -1240,6 +1250,8 @@ class SQLConf extends Serializable with Logging {
   def constraintPropagationEnabled: Boolean = getConf(CONSTRAINT_PROPAGATION_ENABLED)
 
   def escapedStringLiterals: Boolean = getConf(ESCAPED_STRING_LITERALS)
+
+  def hadoopFSSizeFactor: Double = getConf(HADOOPFSRELATION_SIZE_FACTOR)
 
   def stringRedationPattern: Option[Regex] = SQL_STRING_REDACTION_PATTERN.readFrom(reader)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelation.scala
@@ -83,7 +83,7 @@ case class HadoopFsRelation(
   }
 
   override def sizeInBytes: Long = {
-    val sizeFactor = sqlContext.conf.sizeToMemorySizeFactor
+    val sizeFactor = sqlContext.conf.diskToMemorySizeFactor
     (location.sizeInBytes * sizeFactor).toLong
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelation.scala
@@ -83,8 +83,8 @@ case class HadoopFsRelation(
   }
 
   override def sizeInBytes: Long = {
-    val sizeFactor = sqlContext.conf.compressionFactor
-    (location.sizeInBytes * sizeFactor).toLong
+    val compressionFactor = sqlContext.conf.fileCompressionFactor
+    (location.sizeInBytes * compressionFactor).toLong
   }
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelation.scala
@@ -60,8 +60,6 @@ case class HadoopFsRelation(
     }
   }
 
-  private val hadoopFSSizeFactor = sqlContext.conf.hadoopFSSizeFactor
-
   val overlappedPartCols = mutable.Map.empty[String, StructField]
   partitionSchema.foreach { partitionField =>
     if (dataSchema.exists(getColName(_) == getColName(partitionField))) {
@@ -85,12 +83,8 @@ case class HadoopFsRelation(
   }
 
   override def sizeInBytes: Long = {
-    val size = location.sizeInBytes * hadoopFSSizeFactor
-    if (size > Long.MaxValue) {
-      Long.MaxValue
-    } else {
-      size.toLong
-    }
+    val sizeFactor = sqlContext.conf.sizeToMemorySizeFactor
+    (location.sizeInBytes * sizeFactor).toLong
   }
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelation.scala
@@ -60,6 +60,8 @@ case class HadoopFsRelation(
     }
   }
 
+  private val hadoopFSSizeFactor = sqlContext.conf.hadoopFSSizeFactor
+
   val overlappedPartCols = mutable.Map.empty[String, StructField]
   partitionSchema.foreach { partitionField =>
     if (dataSchema.exists(getColName(_) == getColName(partitionField))) {
@@ -82,7 +84,15 @@ case class HadoopFsRelation(
     }
   }
 
-  override def sizeInBytes: Long = location.sizeInBytes
+  override def sizeInBytes: Long = {
+    val size = location.sizeInBytes * hadoopFSSizeFactor
+    if (size > Long.MaxValue) {
+      Long.MaxValue
+    } else {
+      size.toLong
+    }
+  }
+
 
   override def inputFiles: Array[String] = location.inputFiles
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelation.scala
@@ -83,7 +83,7 @@ case class HadoopFsRelation(
   }
 
   override def sizeInBytes: Long = {
-    val sizeFactor = sqlContext.conf.diskToMemorySizeFactor
+    val sizeFactor = sqlContext.conf.compressionFactor
     (location.sizeInBytes * sizeFactor).toLong
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelationSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.datasources
 import java.io.{File, FilenameFilter}
 
 import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, SortMergeJoinExec}
 import org.apache.spark.sql.test.SharedSQLContext
 
 class HadoopFsRelationSuite extends QueryTest with SharedSQLContext {
@@ -37,6 +38,46 @@ class HadoopFsRelationSuite extends QueryTest with SharedSQLContext {
       val totalSize = allFiles.map(_.length()).sum
       val df = spark.read.parquet(dir.toString)
       assert(df.queryExecution.logical.stats.sizeInBytes === BigInt(totalSize))
+    }
+  }
+
+  test("SPARK-22790: spark.sql.sources.compressionFactor takes effect") {
+    import testImplicits._
+    Seq(1.0, 0.5).foreach { compressionFactor =>
+      withSQLConf("spark.sql.sources.compressionFactor" -> compressionFactor.toString,
+        "spark.sql.autoBroadcastJoinThreshold" -> "400") {
+        withTempPath { workDir =>
+          // the file size is 740 bytes
+          val workDirPath = workDir.getAbsolutePath
+          val data1 = Seq(100, 200, 300, 400).toDF("count")
+          data1.write.parquet(workDirPath + "/data1")
+          val df1FromFile = spark.read.parquet(workDirPath + "/data1")
+          val data2 = Seq(100, 200, 300, 400).toDF("count")
+          data2.write.parquet(workDirPath + "/data2")
+          val df2FromFile = spark.read.parquet(workDirPath + "/data2")
+          val joinedDF = df1FromFile.join(df2FromFile, Seq("count"))
+          if (compressionFactor == 0.5) {
+            val bJoinExec = joinedDF.queryExecution.executedPlan.collect {
+              case bJoin: BroadcastHashJoinExec => bJoin
+            }
+            assert(bJoinExec.nonEmpty)
+            val smJoinExec = joinedDF.queryExecution.executedPlan.collect {
+              case smJoin: SortMergeJoinExec => smJoin
+            }
+            assert(smJoinExec.isEmpty)
+          } else {
+            // compressionFactor is 1.0
+            val bJoinExec = joinedDF.queryExecution.executedPlan.collect {
+              case bJoin: BroadcastHashJoinExec => bJoin
+            }
+            assert(bJoinExec.isEmpty)
+            val smJoinExec = joinedDF.queryExecution.executedPlan.collect {
+              case smJoin: SortMergeJoinExec => smJoin
+            }
+            assert(smJoinExec.nonEmpty)
+          }
+        }
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelationSuite.scala
@@ -44,7 +44,7 @@ class HadoopFsRelationSuite extends QueryTest with SharedSQLContext {
   test("SPARK-22790: spark.sql.sources.compressionFactor takes effect") {
     import testImplicits._
     Seq(1.0, 0.5).foreach { compressionFactor =>
-      withSQLConf("spark.sql.sources.compressionFactor" -> compressionFactor.toString,
+      withSQLConf("spark.sql.sources.fileCompressionFactor" -> compressionFactor.toString,
         "spark.sql.autoBroadcastJoinThreshold" -> "400") {
         withTempPath { workDir =>
           // the file size is 740 bytes


### PR DESCRIPTION
## What changes were proposed in this pull request?

as per discussion in https://github.com/apache/spark/pull/19864#discussion_r156847927

the current HadoopFsRelation is purely based on the underlying file size which is not accurate and makes the execution vulnerable to errors like OOM

Users can enable CBO with the functionalities in https://github.com/apache/spark/pull/19864 to avoid this issue

This JIRA proposes to add a configurable factor to sizeInBytes method in HadoopFsRelation class so that users can mitigate this problem without CBO

## How was this patch tested?

Existing tests
