### PR TITLE
[SPARK-22906] Supporting different host for external Spark shuffle service

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -156,6 +156,9 @@ private[spark] class BlockManager(
   private val maxOnHeapMemory = memoryManager.maxOnHeapStorageMemory
   private val maxOffHeapMemory = memoryManager.maxOffHeapStorageMemory
 
+  private val externalShuffleServiceHost =
+    Utils.getSparkOrYarnConfig(conf, "spark.shuffle.service.host", blockTransferService.hostName)
+
   // Port used by the external shuffle service. In Yarn mode, this may be already be
   // set through the Hadoop configuration as the server is launched in the Yarn NM.
   private val externalShuffleServicePort = {
@@ -247,8 +250,8 @@ private[spark] class BlockManager(
     blockManagerId = if (idFromMaster != null) idFromMaster else id
 
     shuffleServerId = if (externalShuffleServiceEnabled) {
-      logInfo(s"external shuffle service port = $externalShuffleServicePort")
-      BlockManagerId(executorId, blockTransferService.hostName, externalShuffleServicePort)
+      logInfo(s"external shuffle service host:port = $externalShuffleServiceHost:$externalShuffleServicePort")
+      BlockManagerId(executorId, externalShuffleServiceHost, externalShuffleServicePort)
     } else {
       blockManagerId
     }

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -250,7 +250,8 @@ private[spark] class BlockManager(
     blockManagerId = if (idFromMaster != null) idFromMaster else id
 
     shuffleServerId = if (externalShuffleServiceEnabled) {
-      logInfo(s"external shuffle service host:port = $externalShuffleServiceHost:$externalShuffleServicePort")
+      logInfo(s"external shuffle service host:port = " +
+        s"$externalShuffleServiceHost:$externalShuffleServicePort")
       BlockManagerId(executorId, externalShuffleServiceHost, externalShuffleServicePort)
     } else {
       blockManagerId


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding an option as spark.shuffle.service.host let you to specify different ip for the external shuffle service. For example if you have this service in a Docker, or behind a CNI, you won't have the same ip in the service vs the spark executors.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
