### PR TITLE
[SPARK-22739][Catalyst][WIP] Additional Expression Support for Objects

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
@@ -327,11 +327,11 @@ object JavaTypeInference {
           } else {
             AssertNotNull(constructor, Seq("currently no type path record in java"))
           }
-          p.getWriteMethod.getName -> setter
-        }.toMap
+          p.getWriteMethod.getName -> (setter :: Nil)
+        }
 
         val newInstance = NewInstance(other, Nil, ObjectType(other), propagateNull = false)
-        val result = InitializeJavaBean(newInstance, setters)
+        val result = InitializeObject(newInstance, setters)
 
         if (path.nonEmpty) {
           expressions.If(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
@@ -327,7 +327,7 @@ object JavaTypeInference {
           } else {
             AssertNotNull(constructor, Seq("currently no type path record in java"))
           }
-          p.getWriteMethod.getName -> (setter :: Nil)
+          (p.getWriteMethod.getName, setter :: Nil)
         }
 
         val newInstance = NewInstance(other, Nil, ObjectType(other), propagateNull = false)

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/GenericBean.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/GenericBean.java
@@ -1,0 +1,56 @@
+package org.apache.spark.sql.catalyst.expressions;
+
+/**
+ *
+ */
+public class GenericBean {
+  private int field1;
+  private String field2;
+
+  public GenericBean() {}
+
+  public GenericBean(int field1, String field2) {
+    this.field1 = field1;
+    this.field2 = field2;
+  }
+
+  public int getField1() {
+    return field1;
+  }
+
+  public void setField1(int field1) {
+    this.field1 = field1;
+  }
+
+  public String getField2() {
+    return field2;
+  }
+
+  public void setField2(String field2) {
+    this.field2 = field2;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    GenericBean that = (GenericBean) o;
+
+    if (field1 != that.field1) {
+      return false;
+    }
+    return field2 != null ? field2.equals(that.field2) : that.field2 == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = field1;
+    result = 31 * result + (field2 != null ? field2.hashCode() : 0);
+    return result;
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
@@ -390,6 +390,7 @@ class CodeGenerationSuite extends SparkFunSuite with ExpressionEvalHelper {
 
   test("SPARK-22696: InitializeJavaBean should not use global variables") {
     val ctx = new CodegenContext
+<<<<<<< HEAD
     InitializeJavaBean(Literal.fromObject(new java.util.LinkedList[Int]),
       Map("add" -> Literal(1))).genCode(ctx)
     assert(ctx.inlinedMutableStates.isEmpty)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is a work-in-progress adding additional `Expression` support for object types. It intends to provide necessary expressions to support custom encoders (see discussion in [Spark-Avro](https://github.com/databricks/spark-avro/pull/217#issuecomment-342856719)). 

This is an initial review, looking for feedback concerning a few questions and guidance concerning best unit-testing practices for new `Expression` classes in Catalyst.