### PR TITLE
[SPARK-22903]Fix already being created exception in stage retry caused by wrong at…

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -344,7 +344,7 @@ private[spark] class Executor(
         val value = try {
           val res = task.run(
             taskAttemptId = taskId,
-            attemptNumber = taskDescription.attemptNumber,
+            attemptNumber = taskDescription.attemptNumberCountingFailedStages,
             metricsSystem = env.metricsSystem)
           threwException = false
           res

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskDescription.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskDescription.scala
@@ -47,6 +47,7 @@ import org.apache.spark.util.{ByteBufferInputStream, ByteBufferOutputStream, Uti
 private[spark] class TaskDescription(
     val taskId: Long,
     val attemptNumber: Int,
+    val attemptNumberCountingFailedStages: Int,
     val executorId: String,
     val name: String,
     val index: Int,    // Index within this task's TaskSet

--- a/core/src/test/scala/org/apache/spark/scheduler/SchedulerIntegrationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SchedulerIntegrationSuite.scala
@@ -514,9 +514,9 @@ class TestTaskScheduler(sc: SparkContext) extends TaskSchedulerImpl(sc) {
     super.submitTasks(taskSet)
   }
 
-  override def taskSetFinished(manager: TaskSetManager): Unit = {
+  override def taskSetFinished(manager: TaskSetManager, isFetchFailed: Boolean): Unit = {
     runningTaskSets -= manager.taskSet
-    super.taskSetFinished(manager)
+    super.taskSetFinished(manager, isFetchFailed)
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -124,7 +124,8 @@ class FakeTaskScheduler(sc: SparkContext, liveExecutors: (String, String)* /* ex
     }
   }
 
-  override def taskSetFinished(manager: TaskSetManager): Unit = finishedManagers += manager
+  override def taskSetFinished(manager: TaskSetManager,
+    isFetchFailed: Boolean): Unit = finishedManagers += manager
 
   override def isExecutorAlive(execId: String): Boolean = executors.contains(execId)
 
@@ -443,7 +444,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     // within the taskset.
     val mockListenerBus = mock(classOf[LiveListenerBus])
     val blacklistTrackerOpt = Some(new BlacklistTracker(mockListenerBus, conf, None, clock))
-    val manager = new TaskSetManager(sched, taskSet, 4, blacklistTrackerOpt, clock)
+    val manager = new TaskSetManager(sched, taskSet, 4, blacklistTrackerOpt, None, clock)
 
     {
       val offerResult = manager.resourceOffer("exec1", "host1", PROCESS_LOCAL)


### PR DESCRIPTION
…temptNumber

## What changes were proposed in this pull request?

This PR fix the wrong attemptNumber in stage retry, it will solve the probem of AlreadyBeingCreatedException thrown by executor when failedStages already created the taskAttemptPath.
Details see: https://issues.apache.org/jira/browse/SPARK-22903

(Please fill in changes proposed in this fix)

## How was this patch tested?

manual
(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
