### PR TITLE
[SPARK-22907]Clean broadcast garbage when IOException occurred in MetadataFetch

### DIFF
--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -829,14 +829,14 @@ private[spark] object MapOutputTracker extends Logging {
         // deserialize the Broadcast, pull .value array out of it, and then deserialize that
         val bcast = deserializeObject(bytes, 1, bytes.length - 1).
           asInstanceOf[Broadcast[Array[Byte]]]
+        try {
         logInfo("Broadcast mapstatuses size = " + bytes.length +
           ", actual size = " + bcast.value.length)
         // Important - ignore the DIRECT tag ! Start from offset 1
-        try {
           deserializeObject(bcast.value, 1, bcast.value.length - 1).asInstanceOf[Array[MapStatus]]
         } catch {
           case e: IOException =>
-            bcast.destroy()
+            SparkEnv.get.blockManager.removeBroadcast(bcast.id, false)
             throw new IOException(s"Failed to read broadcast for mapstatuses", e)
         }
       case _ => throw new IllegalArgumentException("Unexpected byte tag = " + bytes(0))


### PR DESCRIPTION
## What changes were proposed in this pull request?

When fetching mapStatuses, IOException is not handled in MapOutputTracker.deserializeMapStatuses which might cause old broadcast not cleaned up. In task retrying, when task was scheduled to the executor where old broadcast was stored, An "Block  is already present in the MemoryStore" exception would be thrown.

This PR will clean garbage broadcast when IOException occurred in MetadataFetch to avoid
repeated "Block  is already present in the MemoryStore" caused by the uncleaned broadcast garbage

details see: https://issues.apache.org/jira/browse/SPARK-22907

(Please fill in changes proposed in this fix)

## How was this patch tested?

manual
(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
