### PR TITLE
[SPARK-22126][ML] Added fitMultiple method with default implementation

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/Estimator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Estimator.scala
@@ -83,7 +83,7 @@ abstract class Estimator[M <: Model[M]] extends PipelineStage {
   @Since("2.0.0")
   def fit(dataset: Dataset[_], paramMaps: Array[ParamMap]): Seq[M] = {
     val modelIter = fitMultiple(dataset, paramMaps)
-    val models = paramMaps.map{ _ =>
+    val models = paramMaps.map { _ =>
       val (index, model) = modelIter.next()
       (index.toInt, model)
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/Estimator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Estimator.scala
@@ -17,9 +17,12 @@
 
 package org.apache.spark.ml
 
+import java.util.{Iterator => JIterator, NoSuchElementException}
+import java.util.concurrent.atomic.AtomicInteger
+
 import scala.annotation.varargs
 
-import org.apache.spark.annotation.{DeveloperApi, Since}
+import org.apache.spark.annotation.{DeveloperApi, Experimental, Since}
 import org.apache.spark.ml.param.{ParamMap, ParamPair}
 import org.apache.spark.sql.Dataset
 
@@ -79,7 +82,51 @@ abstract class Estimator[M <: Model[M]] extends PipelineStage {
    */
   @Since("2.0.0")
   def fit(dataset: Dataset[_], paramMaps: Array[ParamMap]): Seq[M] = {
-    paramMaps.map(fit(dataset, _))
+    val modelIter = fitMultiple(dataset, paramMaps)
+    val models = paramMaps.map{ _ =>
+      val (index, model) = modelIter.next()
+      (index.toInt, model)
+    }
+    paramMaps.indices.map(models.toMap)
+}
+
+  /**
+   * Fits multiple models to the input data with multiple sets of parameters. The default
+   * implementation calls `fit` once for each call to the iterator's `next` method. Subclasses
+   * could override this to optimize multi-model training.
+   *
+   * @param dataset input dataset
+   * @param paramMaps An array of parameter maps.
+   *                  These values override any specified in this Estimator's embedded ParamMap.
+   * @return An iterator which produces one model per call to `next`. The models may be produced in
+   *         a different order than the order of the parameters in paramMap. The next method of
+   *         the iterator will return a tuple of the form `(index, model)` where model corresponds
+   *         to `paramMaps(index)`. This Iterator should be thread safe, meaning concurrent calls
+   *         to `next` should always produce unique values of `index`.
+   *
+   * :: Experimental ::
+   */
+  @Experimental
+  @Since("2.3.0")
+  def fitMultiple(
+      dataset: Dataset[_],
+      paramMaps: Array[ParamMap]): JIterator[(Integer, M)] = {
+
+    val numModel = paramMaps.length
+    val counter = new AtomicInteger(0)
+    new JIterator[(Integer, M)] {
+      def next(): (Integer, M) = {
+        val index = counter.getAndIncrement()
+        if (index < numModel) {
+          (index, fit(dataset, paramMaps(index)))
+        } else {
+          counter.set(numModel)
+          throw new NoSuchElementException("Iterator finished.")
+        }
+      }
+
+      override def hasNext: Boolean = counter.get() < numModel
+    }
   }
 
   override def copy(extra: ParamMap): Estimator[M]

--- a/mllib/src/main/scala/org/apache/spark/ml/Estimator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Estimator.scala
@@ -81,6 +81,9 @@ abstract class Estimator[M <: Model[M]] extends PipelineStage {
    * @return fitted models, matching the input parameter maps
    */
   @Since("2.0.0")
+  @deprecated(
+    "`fit` with multiple paramMaps has been deprecated, use `fitMultiple` instead.",
+    "2.3.0")
   def fit(dataset: Dataset[_], paramMaps: Array[ParamMap]): Seq[M] = {
     val modelIter = fitMultiple(dataset, paramMaps)
     val models = paramMaps.map { _ =>
@@ -88,7 +91,7 @@ abstract class Estimator[M <: Model[M]] extends PipelineStage {
       (index.toInt, model)
     }
     paramMaps.indices.map(models.toMap)
-}
+  }
 
   /**
    * Fits multiple models to the input data with multiple sets of parameters. The default

--- a/mllib/src/main/scala/org/apache/spark/ml/Estimator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Estimator.scala
@@ -116,7 +116,7 @@ abstract class Estimator[M <: Model[M]] extends PipelineStage {
     val counter = new AtomicInteger(0)
     new JIterator[(Integer, M)] {
       def next(): (Integer, M) = {
-        var index: Int = _
+        var index: Int = 0
         do {
           index = counter.get()
           if (index >= numModel) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The fitMultiple API allows both model specific optimizations for fitting ML estimators & fitting models in parallel when appropriate. 

## How was this patch tested?

Existing tests.

Please review http://spark.apache.org/contributing.html before opening a pull request.
