### PR TITLE
[SPARK-22914][DEPLOY] Register history.ui.port

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -28,6 +28,7 @@ import org.eclipse.jetty.servlet.{ServletContextHandler, ServletHolder}
 
 import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.deploy.history.config.HISTORY_SERVER_UI_PORT
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.status.api.v1.{ApiRootResource, ApplicationInfo, UIRoot}
@@ -276,7 +277,7 @@ object HistoryServer extends Logging {
       .newInstance(conf)
       .asInstanceOf[ApplicationHistoryProvider]
 
-    val port = conf.getInt("spark.history.ui.port", 18080)
+    val port = conf.get(HISTORY_SERVER_UI_PORT)
 
     val server = new HistoryServer(conf, provider, securityManager, port)
     server.bind()

--- a/core/src/main/scala/org/apache/spark/deploy/history/config.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/config.scala
@@ -44,4 +44,9 @@ private[spark] object config {
     .bytesConf(ByteUnit.BYTE)
     .createWithDefaultString("10g")
 
+  val HISTORY_SERVER_UI_PORT = ConfigBuilder("spark.history.ui.port")
+    .doc("Web UI port to bind Spark History Server")
+    .intConf
+    .createWithDefault(18080)
+
 }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -427,7 +427,7 @@ private[spark] class ApplicationMaster(args: ApplicationMasterArguments) extends
       uiAddress: Option[String]) = {
     val appId = client.getAttemptId().getApplicationId().toString()
     val attemptId = client.getAttemptId().getAttemptId().toString()
-    val historyAddress = ApplicationMasterUtil
+    val historyAddress = ApplicationMaster
       .getHistoryServerAddress(_sparkConf, yarnConf, appId, attemptId)
 
     val driverUrl = RpcEndpointAddress(
@@ -831,15 +831,11 @@ object ApplicationMaster extends Logging {
     master.getAttemptId
   }
 
-}
-
-object ApplicationMasterUtil {
-  def getHistoryServerAddress(
-    sparkConf: SparkConf,
-    yarnConf: YarnConfiguration,
-    appId: String,
-    attemptId: String): String = {
-
+  private[spark] def getHistoryServerAddress(
+      sparkConf: SparkConf,
+      yarnConf: YarnConfiguration,
+      appId: String,
+      attemptId: String): String = {
     sparkConf.get(HISTORY_SERVER_ADDRESS)
       .map { text => SparkHadoopUtil.get.substituteHadoopVariables(text, yarnConf) }
       .map { address => s"${address}${HistoryServer.UI_PATH_PREFIX}/${appId}/${attemptId}" }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -427,11 +427,8 @@ private[spark] class ApplicationMaster(args: ApplicationMasterArguments) extends
       uiAddress: Option[String]) = {
     val appId = client.getAttemptId().getApplicationId().toString()
     val attemptId = client.getAttemptId().getAttemptId().toString()
-    val historyAddress =
-      _sparkConf.get(HISTORY_SERVER_ADDRESS)
-        .map { text => SparkHadoopUtil.get.substituteHadoopVariables(text, yarnConf) }
-        .map { address => s"${address}${HistoryServer.UI_PATH_PREFIX}/${appId}/${attemptId}" }
-        .getOrElse("")
+    val historyAddress = ApplicationMasterUtil
+      .getHistoryServerAddress(_sparkConf, yarnConf, appId, attemptId)
 
     val driverUrl = RpcEndpointAddress(
       _sparkConf.get("spark.driver.host"),
@@ -834,6 +831,20 @@ object ApplicationMaster extends Logging {
     master.getAttemptId
   }
 
+}
+
+object ApplicationMasterUtil {
+  def getHistoryServerAddress(
+    sparkConf: SparkConf,
+    yarnConf: YarnConfiguration,
+    appId: String,
+    attemptId: String): String = {
+
+    sparkConf.get(HISTORY_SERVER_ADDRESS)
+      .map { text => SparkHadoopUtil.get.substituteHadoopVariables(text, yarnConf) }
+      .map { address => s"${address}${HistoryServer.UI_PATH_PREFIX}/${appId}/${attemptId}" }
+      .getOrElse("")
+  }
 }
 
 /**

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ApplicationMasterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ApplicationMasterSuite.scala
@@ -18,27 +18,26 @@
 package org.apache.spark.deploy.yarn
 
 import org.apache.hadoop.yarn.conf.YarnConfiguration
-import org.apache.spark.{SparkConf, SparkFunSuite}
-import org.apache.spark.internal.Logging
-import org.apache.spark.util.ResetSystemProperties
-import org.scalatest.Matchers
 
-class ApplicationMasterUtilSuite extends SparkFunSuite with Matchers with Logging
-  with ResetSystemProperties {
+import org.apache.spark.{SparkConf, SparkFunSuite}
+
+class ApplicationMasterSuite extends SparkFunSuite {
 
   test("history url with hadoop and spark substitutions") {
+    val host = "rm.host.com"
+    val port = 18080
     val sparkConf = new SparkConf()
+
     sparkConf.set("spark.yarn.historyServer.address",
       "http://${hadoopconf-yarn.resourcemanager.hostname}:${spark.history.ui.port}")
-
     val yarnConf = new YarnConfiguration()
-    yarnConf.set("yarn.resourcemanager.hostname", "rm.host.com")
+    yarnConf.set("yarn.resourcemanager.hostname", host)
     val appId = "application_123_1"
     val attemptId = appId + "_1"
 
-    val shsAddr = ApplicationMasterUtil
+    val shsAddr = ApplicationMaster
       .getHistoryServerAddress(sparkConf, yarnConf, appId, attemptId)
 
-    shsAddr shouldEqual "http://rm.host.com:18080/history/application_123_1/application_123_1_1"
+    assert(shsAddr === s"http://${host}:${port}/history/${appId}/${attemptId}")
   }
 }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ApplicationMasterUtilSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ApplicationMasterUtilSuite.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.yarn
+
+import org.apache.hadoop.yarn.conf.YarnConfiguration
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.internal.Logging
+import org.apache.spark.util.ResetSystemProperties
+import org.scalatest.Matchers
+
+class ApplicationMasterUtilSuite extends SparkFunSuite with Matchers with Logging
+  with ResetSystemProperties {
+
+  test("history url with hadoop and spark substitutions") {
+    val sparkConf = new SparkConf()
+    sparkConf.set("spark.yarn.historyServer.address",
+      "http://${hadoopconf-yarn.resourcemanager.hostname}:${spark.history.ui.port}")
+
+    val yarnConf = new YarnConfiguration()
+    yarnConf.set("yarn.resourcemanager.hostname", "rm.host.com")
+    val appId = "application_123_1"
+    val attemptId = appId + "_1"
+
+    val shsAddr = ApplicationMasterUtil
+      .getHistoryServerAddress(sparkConf, yarnConf, appId, attemptId)
+
+    shsAddr shouldEqual "http://rm.host.com:18080/history/application_123_1/application_123_1_1"
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Register spark.history.ui.port as a known spark conf to be used in substitution expressions even if it's not set explicitly.

## How was this patch tested?

Added unit test to demonstrate the issue