### PR TITLE
[SPARK-22913][SQL] Improved Hive Partition Pruning

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -187,6 +187,21 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val ENABLE_HIVE_TIMESTAMP_TYPE_PARTITION_PRUNING =
+    buildConf("spark.sql.hive.metastore.partition.pruning.timestamps.enabled")
+      .internal()
+      .doc("When true, predicates for columns of type timestamp are pushed to hive metastore.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val ENABLE_HIVE_FRACTIONAL_TYPES_PARTITION_PRUNING =
+    buildConf("spark.sql.hive.metastore.partition.pruning.fractionals.enabled")
+      .internal()
+      .doc("When true, predicates for columns of type fractional (double, float, decimal) " +
+        "are pushed to hive metastore.")
+      .booleanConf
+      .createWithDefault(false)
+
   val ENABLE_FALL_BACK_TO_HDFS_FOR_STATS =
     buildConf("spark.sql.statistics.fallBackToHdfs")
     .doc("If the table statistics are not available from table metadata enable fall back to hdfs." +
@@ -1221,6 +1236,12 @@ class SQLConf extends Serializable with Logging {
 
   def advancedPartitionPredicatePushdownEnabled: Boolean =
     getConf(ADVANCED_PARTITION_PREDICATE_PUSHDOWN)
+
+  def pruneTimestampPartitionColumns: Boolean =
+    getConf(ENABLE_HIVE_TIMESTAMP_TYPE_PARTITION_PRUNING)
+
+  def pruneFractionalPartitionColumns: Boolean =
+    getConf(ENABLE_HIVE_FRACTIONAL_TYPES_PARTITION_PRUNING)
 
   def fallBackToHdfsForStatsEnabled: Boolean = getConf(ENABLE_FALL_BACK_TO_HDFS_FOR_STATS)
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
@@ -17,11 +17,12 @@
 
 package org.apache.spark.sql.hive.client
 
+import java.sql.Timestamp
+import java.time.Instant
 import java.util.Collections
 
 import org.apache.hadoop.hive.metastore.api.FieldSchema
 import org.apache.hadoop.hive.serde.serdeConstants
-
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.dsl.expressions._
@@ -60,7 +61,7 @@ class FiltersSuite extends SparkFunSuite with Logging with PlanTest {
     "1 = intcol")
 
   filterTest("int and string filter",
-    (Literal(1) === a("intcol", IntegerType)) :: (Literal("a") === a("strcol", IntegerType)) :: Nil,
+    (Literal(1) === a("intcol", IntegerType)) :: (Literal("a") === a("strcol", StringType)) :: Nil,
     "1 = intcol and \"a\" = strcol")
 
   filterTest("skip varchar",
@@ -72,9 +73,19 @@ class FiltersSuite extends SparkFunSuite with Logging with PlanTest {
       (Literal("p2\" and q=\"q2") === a("stringcol", StringType)) :: Nil,
     """stringcol = 'p1" and q="q1' and 'p2" and q="q2' = stringcol""")
 
+  filterTest("timestamp partition columns must be mapped to yyyy-mm-dd hh:mm:ss[.fffffffff] format",
+    (a("timestampcol", TimestampType) === Literal(812505600000000L, TimestampType)) :: Nil,
+    "timestampcol = '1995-10-01 00:00:00'")
+
+  filterTest("decimal filter",
+    (Literal(50D) === a("deccol", DecimalType(2, 0))) :: Nil,
+    "50.0 = deccol")
+
   private def filterTest(name: String, filters: Seq[Expression], result: String) = {
     test(name) {
-      withSQLConf(SQLConf.ADVANCED_PARTITION_PREDICATE_PUSHDOWN.key -> "true") {
+      withSQLConf(SQLConf.ADVANCED_PARTITION_PREDICATE_PUSHDOWN.key -> "true",
+        SQLConf.ENABLE_HIVE_FRACTIONAL_TYPES_PARTITION_PRUNING.key -> "true",
+        SQLConf.ENABLE_HIVE_TIMESTAMP_TYPE_PARTITION_PRUNING.key -> "true") {
         val converted = shim.convertFilters(testTable, filters)
         if (converted != result) {
           fail(s"Expected ${filters.mkString(",")} to convert to '$result' but got '$converted'")
@@ -93,6 +104,41 @@ class FiltersSuite extends SparkFunSuite with Logging with PlanTest {
         val converted = shim.convertFilters(testTable, filters)
         if (enabled) {
           assert(converted == "(1 = intcol or 2 = intcol)")
+        } else {
+          assert(converted.isEmpty)
+        }
+      }
+    }
+  }
+
+  test("turn on/off HIVE_FRACTIONAL_TYPES_PARTITION_PRUNING") {
+    import org.apache.spark.sql.catalyst.dsl.expressions._
+    Seq(true, false).foreach { enabled =>
+      withSQLConf(SQLConf.ENABLE_HIVE_FRACTIONAL_TYPES_PARTITION_PRUNING.key -> enabled.toString) {
+        val filters =
+          (Literal(1.0F) === a("floatcol", FloatType) ||
+            Literal(2.0D) === a("doublecol", DoubleType) ||
+            Literal(BigDecimal(3.0D)) === a("deccol", DecimalType(10, 0))) :: Nil
+        val converted = shim.convertFilters(testTable, filters)
+        if (enabled) {
+          assert(converted == "((1.0 = floatcol or 2.0 = doublecol) or 3.0 = deccol)")
+        } else {
+          assert(converted.isEmpty)
+        }
+      }
+    }
+  }
+
+  test("turn on/off HIVE_TIMESTAMP_PARTITION_PRUNING") {
+    import org.apache.spark.sql.catalyst.dsl.expressions._
+    val october23rd = Instant.parse("1984-10-23T00:00:00.00Z")
+    Seq(true, false).foreach { enabled =>
+      withSQLConf(SQLConf.ENABLE_HIVE_TIMESTAMP_TYPE_PARTITION_PRUNING.key -> enabled.toString) {
+        val filters = (Literal(new Timestamp(october23rd.toEpochMilli))
+          === a("tcol", TimestampType)) :: Nil
+        val converted = shim.convertFilters(testTable, filters)
+        if (enabled) {
+          assert(converted == "'1984-10-23 00:00:00' = tcol")
         } else {
           assert(converted.isEmpty)
         }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuites.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuites.scala
@@ -24,6 +24,6 @@ import org.scalatest.Suite
 class HiveClientSuites extends Suite with HiveClientVersions {
   override def nestedSuites: IndexedSeq[Suite] = {
     // Hive 0.12 does not provide the partition filtering API we call
-    versions.filterNot(_ == "0.12").map(new HiveClientSuite(_))
+    versions.filterNot(_ == "0.12").map(new HivePartitionFilteringSuite(_))
   }
 }


### PR DESCRIPTION
Adding support for Timestamp and Fractional column types. The pruning
of partitions of these types is being put behind default options
that are set to false, as it's not clear which hive metastore
implementations support predicates on these types of columns.

The AWS Glue Catalog http://docs.aws.amazon.com/glue/latest/dg/populate-data-catalog.html
does support filters on timestamp and fractional columns and pushing these filters
down to it has significant performance improvements in our use cases.

As part of this change the hive pruning suite is renamed (a TODO) and 2
ignored tests are added that will validate the functionality of partition
pruning through integration tests. The tests are ignored since the integration
test setup uses a Hive client that throws errors when it sees partition column
filters on non-integral and non-string columns.

Unit tests are added to validate filtering, which are active.

## What changes were proposed in this pull request?

See https://issues.apache.org/jira/browse/SPARK-22913

This change addresses the JIRA. I'm looking for feedback on the change itself and whether the config values I added make sense. I was not able to find official Hive specification on which filters a metastore needs to support and as such, feel hesitant to turn on this behavior by default. Piggybacking on top of "advancedPartitionPruning" option felt wrong because that config toggles whether "in (...)" queries are expanded in a series of "ors" and I don't want people to be forced to turn off that behavior alongside not pushing timestamp predicates.

## How was this patch tested?

This change is tested via unit tests, modified integration tests (that are ignored) and manual tests on EMR 5.10 running against AWS Glue Catalog as the Hive metastore.
