### PR TITLE
[SPARK-22921][PROJECT-INFRA] Choices for Assigning Jira on Merge

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -242,6 +242,9 @@ def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
     cur_summary = issue.fields.summary
     cur_assignee = issue.fields.assignee
     if cur_assignee is None:
+        cur_assignee = choose_jira_assignee(issue)
+    # Check again, we might not have chose an assignee
+    if cur_assignee is None:
         cur_assignee = "NOT ASSIGNED!!!"
     else:
         cur_assignee = cur_assignee.displayName
@@ -288,6 +291,31 @@ def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
         comment=comment, resolution={'id': resolution.raw['id']})
 
     print("Successfully resolved %s with fixVersions=%s!" % (jira_id, fix_versions))
+
+
+def choose_jira_assignee(issue, asf_jira):
+    """
+    Prompt the user to choose who to assign the issue to in jira, given a list of candidates,
+    including the original reporter and all commentors
+    """
+    reporter = issue.fields.reporter
+    commentors = map(lambda x: x.author, issue.fields.comment.comments)
+    candidates = set(commentors)
+    candidates.add(reporter)
+    candidates = list(candidates)
+    print("JIRA is unassigned, choose assignee")
+    for idx, author in enumerate(candidates):
+        annotations = ["Reporter"] if author == reporter else []
+        if author in commentors:
+            annotations.append("Commentor")
+        print("[%d] %s (%s)" % (idx, author.displayName, ",".join(annotations)))
+    assignee = raw_input("Enter number of user to assign to (blank to leave unassigned):")
+    if assignee == "":
+        return None
+    else:
+        assignee = candidates[int(assignee)]
+        asf_jira.assign_issue(issue.key, assignee.key)
+        return assignee
 
 
 def resolve_jira_issues(title, merge_branches, comment):


### PR DESCRIPTION
In general jiras are assigned to the original reporter or one of
the commentors.  This updates the merge script to give you a simple
choice to do that, so you don't have to do it manually.