### PR TITLE
[SPARK-22313][PYTHON][FOLLOWUP] Explicitly import warnings namespace in flume.py

### DIFF
--- a/python/pyspark/streaming/flume.py
+++ b/python/pyspark/streaming/flume.py
@@ -20,6 +20,8 @@ if sys.version >= "3":
     from io import BytesIO
 else:
     from StringIO import StringIO
+import warnings
+
 from py4j.protocol import Py4JJavaError
 
 from pyspark.storagelevel import StorageLevel


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR explicitly imports the missing `warnings` in `flume.py`. 

## How was this patch tested?

Manually tested.

```python
>>> import warnings
>>> warnings.simplefilter('always', DeprecationWarning)
>>> from pyspark.streaming import flume
>>> flume.FlumeUtils.createStream(None, None, None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../spark/python/pyspark/streaming/flume.py", line 60, in createStream
    warnings.warn(
NameError: global name 'warnings' is not defined
```

```python
>>> import warnings
>>> warnings.simplefilter('always', DeprecationWarning)
>>> from pyspark.streaming import flume
>>> flume.FlumeUtils.createStream(None, None, None)
/.../spark/python/pyspark/streaming/flume.py:65: DeprecationWarning: Deprecated in 2.3.0. Flume support is deprecated as of Spark 2.3.0. See SPARK-22142.
  DeprecationWarning)
...
```