### PR TITLE
[SPARK-22530][PYTHON][SQL] Adding Arrow support for ArrayType

### DIFF
--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3650,6 +3650,15 @@ class VectorizedUDFTests(ReusedSQLTestCase):
         result = df.select(array_f(col('array')))
         self.assertEquals(df.collect(), result.collect())
 
+    def test_vectorized_udf_null_array(self):
+        from pyspark.sql.functions import pandas_udf, col
+        data = [([1, 2],), (None,), (None,), ([3, 4],), (None,)]
+        array_schema = StructType([StructField("array", ArrayType(IntegerType()))])
+        df = self.spark.createDataFrame(data, schema=array_schema)
+        array_f = pandas_udf(lambda x: x, ArrayType(IntegerType()))
+        result = df.select(array_f(col('array')))
+        self.assertEquals(df.collect(), result.collect())
+
     def test_vectorized_udf_complex(self):
         from pyspark.sql.functions import pandas_udf, col, expr
         df = self.spark.range(10).select(

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3357,6 +3357,26 @@ class ArrowTests(ReusedSQLTestCase):
         schema_rt = from_arrow_schema(arrow_schema)
         self.assertEquals(self.schema, schema_rt)
 
+    def test_createDataFrame_with_array_type(self):
+        import pandas as pd
+        pdf = pd.DataFrame({"a": [[1, 2], [3, 4]], "b": [[u"x", u"y"], [u"y", u"z"]]})
+        df = self.spark.createDataFrame(pdf)
+        # TODO: assert is ArrayType and check values
+        df.show()
+        df.printSchema()
+        self.assertTrue(False)
+
+    def test_toPandas_with_array_type(self):
+        array_data = [([1, 2], ["x", "y"]), ([3, 4], ["y", "z"])]
+        array_schema = StructType([StructField("a", ArrayType(IntegerType())),
+                                   StructField("b", ArrayType(StringType()))])
+        df = self.spark.createDataFrame(array_data, schema=array_schema)
+        pdf = df.toPandas()
+        # TODO: assert
+        print(pdf)
+        print(pdf.dtypes)
+        self.assertTrue(False)
+
 
 @unittest.skipIf(not _have_pandas or not _have_arrow, "Pandas or Arrow not installed")
 class PandasUDFTests(ReusedSQLTestCase):

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3360,23 +3360,27 @@ class ArrowTests(ReusedSQLTestCase):
     def test_createDataFrame_with_array_type(self):
         import pandas as pd
         pdf = pd.DataFrame({"a": [[1, 2], [3, 4]], "b": [[u"x", u"y"], [u"y", u"z"]]})
-        df = self.spark.createDataFrame(pdf)
+        df, df_arrow = self._createDataFrame_toggle(pdf)
         result = df.collect()
+        result_arrow = df_arrow.collect()
         expected = [tuple(list(e) for e in rec) for rec in pdf.to_records(index=False)]
         for r in range(len(expected)):
             for e in range(len(expected[r])):
-                self.assertTrue(expected[r][e] == result[r][e])
+                self.assertTrue(expected[r][e] == result_arrow[r][e] and
+                                result[r][e] == result_arrow[r][e])
 
     def test_toPandas_with_array_type(self):
         expected = [([1, 2], [u"x", u"y"]), ([3, 4], [u"y", u"z"])]
         array_schema = StructType([StructField("a", ArrayType(IntegerType())),
                                    StructField("b", ArrayType(StringType()))])
         df = self.spark.createDataFrame(expected, schema=array_schema)
-        pdf_arrow = df.toPandas()
-        result = [tuple(list(e) for e in rec) for rec in pdf_arrow.to_records(index=False)]
+        pdf, pdf_arrow = self._toPandas_arrow_toggle(df)
+        result = [tuple(list(e) for e in rec) for rec in pdf.to_records(index=False)]
+        result_arrow = [tuple(list(e) for e in rec) for rec in pdf_arrow.to_records(index=False)]
         for r in range(len(expected)):
             for e in range(len(expected[r])):
-                self.assertTrue(expected[r][e] == result[r][e])
+                self.assertTrue(expected[r][e] == result_arrow[r][e] and
+                                result[r][e] == result_arrow[r][e])
 
 
 @unittest.skipIf(not _have_pandas or not _have_arrow, "Pandas or Arrow not installed")

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1669,11 +1669,12 @@ def from_arrow_type(at):
         raise TypeError("Unsupported type in conversion from Arrow: " + str(at))
     return spark_type
 
+
 def from_arrow_field(field):
     import pyarrow as pa
     at = field.type
-    if type(at) == pa.ListType:
-        element_type = from_arrow_field(at.value_type)
+    if type(at) == pa.lib.ListType:  # TODO: check with is_list?
+        element_type = from_arrow_type(at.value_type)
         element_nullable = field.nullable
         return ArrayType(element_type, element_nullable)
     else:

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1669,12 +1669,22 @@ def from_arrow_type(at):
         raise TypeError("Unsupported type in conversion from Arrow: " + str(at))
     return spark_type
 
+def from_arrow_field(field):
+    import pyarrow as pa
+    at = field.type
+    if type(at) == pa.ListType:
+        element_type = from_arrow_field(at.value_type)
+        element_nullable = field.nullable
+        return ArrayType(element_type, element_nullable)
+    else:
+        return from_arrow_type(at)
+
 
 def from_arrow_schema(arrow_schema):
     """ Convert schema from Arrow to Spark.
     """
     return StructType(
-        [StructField(field.name, from_arrow_type(field.type), nullable=field.nullable)
+        [StructField(field.name, from_arrow_field(field), nullable=field.nullable)
          for field in arrow_schema])
 
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1671,9 +1671,9 @@ def from_arrow_type(at):
 
 
 def from_arrow_field(field):
-    import pyarrow as pa
+    import pyarrow.types as types
     at = field.type
-    if type(at) == pa.lib.ListType:  # TODO: check with is_list?
+    if types.is_list(at):
         element_type = from_arrow_type(at.value_type)
         element_nullable = field.nullable
         return ArrayType(element_type, element_nullable)

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ArrowColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ArrowColumnVector.java
@@ -18,13 +18,14 @@
 package org.apache.spark.sql.execution.vectorized;
 
 import com.google.common.collect.ImmutableList;
+
 import io.netty.buffer.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.*;
 import org.apache.arrow.vector.complex.*;
 import org.apache.arrow.vector.holders.NullableVarCharHolder;
-
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
+
 import org.apache.spark.sql.execution.arrow.ArrowUtils;
 import org.apache.spark.sql.types.*;
 import org.apache.spark.unsafe.types.UTF8String;


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change adds `ArrayType` support for working with Arrow in pyspark when creating a DataFrame, calling `toPandas()`, and using vectorized `pandas_udf`.

## How was this patch tested?

Added new Python unit tests using Array data.