### PR TITLE
[WIP][SPARK-22126][ML] Fix model-specific optimization support for ML tuning.

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/Estimator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Estimator.scala
@@ -20,7 +20,7 @@ package org.apache.spark.ml
 import scala.annotation.varargs
 
 import org.apache.spark.annotation.{DeveloperApi, Since}
-import org.apache.spark.ml.param.{ParamMap, ParamPair}
+import org.apache.spark.ml.param.{Param, ParamMap, ParamPair}
 import org.apache.spark.sql.Dataset
 
 /**
@@ -81,6 +81,12 @@ abstract class Estimator[M <: Model[M]] extends PipelineStage {
   def fit(dataset: Dataset[_], paramMaps: Array[ParamMap]): Seq[M] = {
     paramMaps.map(fit(dataset, _))
   }
+
+  /**
+   * Return any Params that the estimator provides optimized training for.
+   * @return Array of optimized Params
+   */
+  private[ml] def getOptimizedParams: Array[Param[Any]] = Array.empty
 
   override def copy(extra: ParamMap): Estimator[M]
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/Estimator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Estimator.scala
@@ -86,7 +86,7 @@ abstract class Estimator[M <: Model[M]] extends PipelineStage {
    * Return any Params that the estimator provides optimized training for.
    * @return Array of optimized Params
    */
-  private[ml] def getOptimizedParams: Array[Param[Any]] = Array.empty
+  private[ml] def getOptimizedParams: Array[Param[_]] = Array.empty
 
   override def copy(extra: ParamMap): Estimator[M]
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/Pipeline.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Pipeline.scala
@@ -186,6 +186,14 @@ class Pipeline @Since("1.4.0") (
 
   @Since("1.6.0")
   override def write: MLWriter = new Pipeline.PipelineWriter(this)
+
+  override private[ml] def getOptimizedParams: Array[Param[_]] = {
+    val theStages = $(stages)
+    theStages.flatMap(_ match {
+        case estimator: Estimator[_] => estimator.getOptimizedParams
+        case _ => Array.empty
+    })
+  }
 }
 
 @Since("1.6.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/Pipeline.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Pipeline.scala
@@ -191,7 +191,7 @@ class Pipeline @Since("1.4.0") (
     val theStages = $(stages)
     theStages.flatMap(_ match {
         case estimator: Estimator[_] => estimator.getOptimizedParams
-        case _ => Array.empty
+        case _ => Array.empty[Param[_]]
     })
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/CrossValidator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/CrossValidator.scala
@@ -150,10 +150,11 @@ class CrossValidator @Since("1.2.0") (@Since("1.4.0") override val uid: String)
 
       // Fit models in a Future for training in parallel
       val foldMetricFutures = epmGrouped.zipWithIndex.map { case (paramMaps, groupIndex) =>
-        Future[Seq[Double]] {
-          val models = est.fit(trainingDataset, paramMaps).asInstanceOf[Seq[Model[_]]]
+        Future[Iterator[Double]] {
+          val modelIter = est.fit(trainingDataset, paramMaps).asInstanceOf[Seq[Model[_]]].iterator
+          val paramMapIter = paramMaps.iterator
           // TODO: duplicate evaluator to take extra params from input
-          models.zip(paramMaps).zipWithIndex.map { case ((model, paramMap), paramIndex) =>
+          modelIter.zip(paramMapIter).zipWithIndex.map { case ((model, paramMap), paramIndex) =>
             if (collectSubModelsParam) {
               subModels.get(splitIndex)(paramIndex + groupIndex * paramMaps.length) = model
             }

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/ParamGridBuilder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/ParamGridBuilder.scala
@@ -122,16 +122,16 @@ class ParamGridBuilder {
 }
 
 /**
-  *
-  */
+ *
+ */
 object ParamGridBuilder {
 
   /**
-    *
-    * @param paramMaps
-    * @param params
-    * @return
-    */
+   *
+   * @param paramMaps
+   * @param params
+   * @return
+   */
   def splitOnParams(paramMaps: Array[ParamMap], params: Array[Param[_]]): (Array[ParamMap], Array[ParamMap])  = {
     val leftValues = mutable.Map.empty[Param[_], mutable.LinkedHashSet[Any]]
     val rightValues = mutable.Map.empty[Param[_], mutable.LinkedHashSet[Any]]

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/ParamGridBuilder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/ParamGridBuilder.scala
@@ -19,15 +19,17 @@ package org.apache.spark.ml.tuning
 
 import scala.annotation.varargs
 import scala.collection.mutable
-
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.param._
+
+import scala.collection.mutable.ArrayBuffer
 
 /**
  * Builder for a param grid used in grid search-based model selection.
  */
 @Since("1.2.0")
-class ParamGridBuilder @Since("1.2.0") {
+class ParamGridBuilder {
+// class ParamGridBuilder @Since("1.2.0") { TODO
 
   private val paramGrid = mutable.Map.empty[Param[_], Iterable[_]]
 
@@ -116,5 +118,33 @@ class ParamGridBuilder @Since("1.2.0") {
       paramMaps = newParamMaps.toArray
     }
     paramMaps
+  }
+}
+
+/**
+  *
+  */
+object ParamGridBuilder {
+
+  /**
+    *
+    * @param paramMaps
+    * @param params
+    * @return
+    */
+  def splitOnParams(paramMaps: Array[ParamMap], params: Array[Param[_]]): (Array[ParamMap], Array[ParamMap])  = {
+    val leftParamMapsTemp = new ArrayBuffer[ParamMap]
+    val rightParamMaps = paramMaps.map { paramMap =>
+      val leftParamMap = ParamMap.empty
+      val paramMapCopy = paramMap.copy
+      params.foreach { param =>
+        val valueOption = paramMapCopy.remove(param)
+        valueOption.foreach(leftParamMap.put(param, _))
+      }
+      leftParamMapsTemp.append(leftParamMap)
+      paramMapCopy
+    }.distinct
+    val leftParamMaps = leftParamMapsTemp.filter(_.size != 0).distinct.toArray
+    (leftParamMaps, rightParamMaps)
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/ParamGridBuilder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/ParamGridBuilder.scala
@@ -159,4 +159,19 @@ object ParamGridBuilder {
 
     (leftGrid.build(), rightGrid.build())
   }
+
+  /**
+   *
+   * @param paramMaps
+   * @param params
+   * @return
+   */
+  def groupByParams(paramMaps: Array[ParamMap], params: Array[Param[_]]): Array[Array[ParamMap]] = {
+    val (leftParamMaps, rightParamMaps) = ParamGridBuilder.splitOnParams(paramMaps, params)
+
+    // Add the left paramMaps to each right paramMap
+    rightParamMaps.map { paramMap =>
+      if (leftParamMaps.isEmpty) Array(paramMap) else leftParamMaps.map(_ ++ paramMap)
+    }
+  }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/ParamGridBuilder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/ParamGridBuilder.scala
@@ -19,17 +19,15 @@ package org.apache.spark.ml.tuning
 
 import scala.annotation.varargs
 import scala.collection.mutable
+
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.param._
-
-import scala.collection.mutable.ArrayBuffer
 
 /**
  * Builder for a param grid used in grid search-based model selection.
  */
 @Since("1.2.0")
-class ParamGridBuilder {
-// class ParamGridBuilder @Since("1.2.0") { TODO
+class ParamGridBuilder @Since("1.2.0") {
 
   private val paramGrid = mutable.Map.empty[Param[_], Iterable[_]]
 
@@ -121,18 +119,19 @@ class ParamGridBuilder {
   }
 }
 
-/**
- *
- */
+
 object ParamGridBuilder {
 
   /**
+   * Split the given list of paramMaps in two such that the left list contains the supplied
+   * params and the right list does not.
    *
-   * @param paramMaps
-   * @param params
-   * @return
+   * @param paramMaps Array of paramMaps to split
+   * @param params Array of params that will be in the left list
+   * @return Tuple of two Array[ParamMap]
    */
-  def splitOnParams(paramMaps: Array[ParamMap], params: Array[Param[_]]): (Array[ParamMap], Array[ParamMap])  = {
+  def splitOnParams(paramMaps: Array[ParamMap],
+                    params: Array[Param[_]]): (Array[ParamMap], Array[ParamMap]) = {
     val leftValues = mutable.Map.empty[Param[_], mutable.LinkedHashSet[Any]]
     val rightValues = mutable.Map.empty[Param[_], mutable.LinkedHashSet[Any]]
 
@@ -161,12 +160,16 @@ object ParamGridBuilder {
   }
 
   /**
+   * First split the given list of paramMaps according to [[splitOnParams()]] and then group into
+   * subarrays such that each subarray contains the Array[ParamMap] from the supplied params
+   * combined with the additional Array[ParamMap] from other params.
    *
    * @param paramMaps
    * @param params
    * @return
    */
-  def groupByParams(paramMaps: Array[ParamMap], params: Array[Param[_]]): Array[Array[ParamMap]] = {
+  def groupByParams(paramMaps: Array[ParamMap],
+                    params: Array[Param[_]]): Array[Array[ParamMap]] = {
     val (leftParamMaps, rightParamMaps) = ParamGridBuilder.splitOnParams(paramMaps, params)
 
     // Add the left paramMaps to each right paramMap

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
@@ -20,7 +20,6 @@ package org.apache.spark.ml.tuning
 import java.util.{List => JList, Locale}
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.language.existentials

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
@@ -126,18 +126,7 @@ class TrainValidationSplit @Since("1.5.0") (@Since("1.5.0") override val uid: St
     val optimizedParams = est.getOptimizedParams
 
     // Create 2 Array[ParamMap]s, 1 with optimized params and 1 to parallelize over
-    val optimizedParamMapsAll = new ArrayBuffer[ParamMap]
-    val parallelParamMaps = epm.map { paramMap =>
-      val optimizedParamMap = ParamMap.empty
-      val paramMapCopy = paramMap.copy
-      optimizedParams.foreach { param =>
-        val valueOption = paramMapCopy.remove(param)
-        valueOption.foreach(optimizedParamMap.put(param, _))
-      }
-      optimizedParamMapsAll.append(optimizedParamMap)
-      paramMapCopy
-    }.distinct
-    val optimizedParamMaps = optimizedParamMapsAll.filter(_.size != 0).distinct.toArray
+    val (optimizedParamMaps, parallelParamMaps) = ParamGridBuilder.splitOnParams(epm, optimizedParams)
 
     // Add the optimized params to each parallel paramMap
     val trainingParamMaps = parallelParamMaps.map { paramMap =>

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
@@ -121,6 +121,7 @@ class TrainValidationSplit @Since("1.5.0") (@Since("1.5.0") override val uid: St
     transformSchema(schema, logging = true)
     val est = $(estimator)
     val eval = $(evaluator)
+    // Group paramMaps by params the estimator is optimized for, param groups are then parallelized
     val epmGrouped = ParamGridBuilder.groupByParams($(estimatorParamMaps), est.getOptimizedParams)
 
     // Create execution context based on $(parallelism)

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
@@ -32,7 +32,7 @@ import org.apache.spark.annotation.Since
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.{Estimator, Model}
 import org.apache.spark.ml.evaluation.Evaluator
-import org.apache.spark.ml.param.{DoubleParam, ParamMap, ParamPair, ParamValidators}
+import org.apache.spark.ml.param.{DoubleParam, ParamMap, ParamValidators}
 import org.apache.spark.ml.param.shared.{HasCollectSubModels, HasParallelism}
 import org.apache.spark.ml.util._
 import org.apache.spark.sql.{DataFrame, Dataset}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support model-specific optimizations for CrossValidator and TrainValidationSplit by grouping `ParamMap`s so that param groups can fit models in parallel, but still allow `Estimator`s to optimally fit a sequence of models themselves.  This PR adds a new API to `Estimator` that can be overridden to indicate optimized params, and additional functions in `ParamGridBuilder` to group `ParamMap` arrays that can then be used by the meta-algorithms.

## How was this patch tested?

WIP, need to add tests