### PR TITLE
[SPARK-22613][SQL] Make UNCACHE TABLE behaviour consistent with CACHE TABLE

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -153,7 +153,7 @@ statement
     | REFRESH TABLE tableIdentifier                                    #refreshTable
     | REFRESH (STRING | .*?)                                           #refreshResource
     | CACHE LAZY? TABLE tableIdentifier (AS? query)?                   #cacheTable
-    | UNCACHE TABLE (IF EXISTS)? tableIdentifier                       #uncacheTable
+    | UNCACHE LAZY? TABLE (IF EXISTS)? tableIdentifier                 #uncacheTable
     | CLEAR CACHE                                                      #clearCache
     | LOAD DATA LOCAL? INPATH path=STRING OVERWRITE? INTO TABLE
         tableIdentifier partitionSpec?                                 #loadData

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalog/Catalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalog/Catalog.scala
@@ -499,6 +499,17 @@ abstract class Catalog {
   def uncacheTable(tableName: String): Unit
 
   /**
+   * Removes the specified table from the in-memory cache.
+   *
+   * @param tableName is either a qualified or unqualified name that designates a table/view.
+   *                  If no database identifier is provided, it refers to a temporary view or
+   *                  a table/view in the current database.
+   * @param blocking Whether to block until all blocks are deleted.
+   * @since 2.3.0
+   */
+  def uncacheTable(tableName: String, blocking: Boolean): Unit
+
+  /**
    * Removes all cached tables from the in-memory cache.
    *
    * @since 2.0.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -279,7 +279,10 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
    * Create an [[UncacheTableCommand]] logical plan.
    */
   override def visitUncacheTable(ctx: UncacheTableContext): LogicalPlan = withOrigin(ctx) {
-    UncacheTableCommand(visitTableIdentifier(ctx.tableIdentifier), ctx.EXISTS != null)
+    UncacheTableCommand(
+      visitTableIdentifier(ctx.tableIdentifier),
+      ctx.EXISTS != null,
+      ctx.LAZY != null)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/cache.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/cache.scala
@@ -50,12 +50,13 @@ case class CacheTableCommand(
 
 case class UncacheTableCommand(
     tableIdent: TableIdentifier,
-    ifExists: Boolean) extends RunnableCommand {
+    ifExists: Boolean,
+    isLazy: Boolean) extends RunnableCommand {
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val tableId = tableIdent.quotedString
     if (!ifExists || sparkSession.catalog.tableExists(tableId)) {
-      sparkSession.catalog.uncacheTable(tableId)
+      sparkSession.catalog.uncacheTable(tableId, !isLazy)
     }
     Seq.empty[Row]
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -442,6 +442,18 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
   }
 
   /**
+   * Removes the specified table or view from the in-memory cache.
+   *
+   * @group cachemgmt
+   * @since 2.2.3
+   */
+  override def uncacheTable(tableName: String, blocking: Boolean): Unit = {
+    sparkSession.sharedState.cacheManager.uncacheQuery(
+      sparkSession.table(tableName),
+      blocking = blocking)
+  }
+
+  /**
    * Removes all cached tables or views from the in-memory cache.
    *
    * @group cachemgmt

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -254,6 +254,19 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with SharedSQLContext
     }
   }
 
+  test("SPARK-22613 'CACHE TABLE' and 'UNCACHE LAZY TABLE' SQL statement") {
+    sql("CACHE TABLE testData")
+    assertCached(spark.table("testData"))
+
+    val rddId = rddIdOf("testData")
+    assert(
+      isMaterialized(rddId),
+      "Eagerly cached in-memory table should have already been materialized")
+
+    sql("UNCACHE LAZY TABLE testData")
+    assert(!spark.catalog.isCached("testData"), "Table 'testData' should not be cached")
+  }
+
   test("CACHE TABLE tableName AS SELECT * FROM anotherTable") {
     withTempView("testCacheTable") {
       sql("CACHE TABLE testCacheTable AS SELECT * FROM testData")


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added an option LAZY for UNCACHE TABLE.
Eg: UNCACHE LAZY TABLE tableName
This will uncache the table lazily instead of blocking until all blocks are deleted.
## How was this patch tested?
Added Test cases 