### PR TITLE
[SPARK-22939] [PySpark] Support Spark UDF in registerFunction

### DIFF
--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -266,7 +266,7 @@ class Catalog(object):
         """
 
         if hasattr(f, 'asNondeterministic'):
-            udf = f._set_name(name, returnType)
+            udf = f._set_name_type(name, returnType)
         else:
             udf = UserDefinedFunction(f, returnType=returnType, name=name,
                                       evalType=PythonEvalType.SQL_BATCHED_UDF)

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -260,7 +260,7 @@ class Catalog(object):
         >>> from pyspark.sql.functions import udf
         >>> from pyspark.sql.types import IntegerType, StringType
         >>> random_udf = udf(lambda: int(random.random() * 100), IntegerType()).asNondeterministic()
-        >>> spark.catalog.registerFunction("random_udf", random_udf, StringType())
+        >>> spark.catalog.registerFunction("random_udf", random_udf, StringType())  # doctest: +SKIP
         >>> spark.sql("SELECT random_udf()").collect()  # doctest: +SKIP
         [Row(random_udf()=u'82')]
         """

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -263,7 +263,7 @@ class Catalog(object):
         >>> newRandom_udf = spark.catalog.registerFunction("random_udf", random_udf, StringType())  # doctest: +SKIP
         >>> spark.sql("SELECT random_udf()").collect()  # doctest: +SKIP
         [Row(random_udf()=u'82')]
-        >>> spark.range(1).select(newRandom_udf()).collect()
+        >>> spark.range(1).select(newRandom_udf()).collect()  # doctest: +SKIP
         [Row(random_udf()=u'62')]
         """
 

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -267,13 +267,11 @@ class Catalog(object):
 
         if hasattr(f, 'asNondeterministic'):
             udf = f._set_name(name, returnType)
-            self._jsparkSession.udf().registerPython(name, udf._judf)
-            return udf._wrapped()
         else:
             udf = UserDefinedFunction(f, returnType=returnType, name=name,
                                       evalType=PythonEvalType.SQL_BATCHED_UDF)
-            self._jsparkSession.udf().registerPython(name, udf._judf)
-            return udf._wrapped()
+        self._jsparkSession.udf().registerPython(name, udf._judf)
+        return udf._wrapped()
 
     @since(2.0)
     def isCached(self, tableName):

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -259,8 +259,9 @@ class Catalog(object):
         >>> import random
         >>> from pyspark.sql.functions import udf
         >>> from pyspark.sql.types import IntegerType, StringType
-        >>> random_udf = udf(lambda: int(random.random() * 100), IntegerType()).asNondeterministic()
-        >>> newRandom_udf = spark.catalog.registerFunction("random_udf", random_udf, StringType())  # doctest: +SKIP
+        >>> random_udf = udf(lambda: random.randint(0, 100), IntegerType()).asNondeterministic()
+        >>> newRandom_udf = spark.catalog.registerFunction(
+        ...     "random_udf", random_udf, StringType())  # doctest: +SKIP
         >>> spark.sql("SELECT random_udf()").collect()  # doctest: +SKIP
         [Row(random_udf()=u'82')]
         >>> spark.range(1).select(newRandom_udf()).collect()  # doctest: +SKIP

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -227,8 +227,8 @@ class Catalog(object):
     @ignore_unicode_prefix
     @since(2.0)
     def registerFunction(self, name, f, returnType=StringType()):
-        """Registers a Python function (including lambda function) or a wrapped/native UDF
-        so it can be used in SQL statements.
+        """Registers a Python function (including lambda function) or a :class:`UserDefinedFunction`
+        as a UDF. The registered UDF can be used in SQL statement.
 
         In addition to a name and the function itself, the return type can be optionally specified.
         When the return type is not given it default to a string and conversion will automatically

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -227,7 +227,7 @@ class Catalog(object):
     @ignore_unicode_prefix
     @since(2.0)
     def registerFunction(self, name, f, returnType=StringType()):
-        """Registers a python function (including lambda function) as a UDF
+        """Registers a Python function (including lambda function) or a wrapped/native UDF
         so it can be used in SQL statements.
 
         In addition to a name and the function itself, the return type can be optionally specified.
@@ -235,7 +235,7 @@ class Catalog(object):
         be done.  For any other return type, the produced object must match the specified type.
 
         :param name: name of the UDF
-        :param f: python function
+        :param f: a Python function, or a wrapped/native UserDefinedFunction
         :param returnType: a :class:`pyspark.sql.types.DataType` object
         :return: a wrapped :class:`UserDefinedFunction`
 
@@ -260,14 +260,14 @@ class Catalog(object):
         >>> from pyspark.sql.functions import udf
         >>> from pyspark.sql.types import IntegerType, StringType
         >>> random_udf = udf(lambda: random.randint(0, 100), IntegerType()).asNondeterministic()
-        >>> newRandom_udf = spark.catalog.registerFunction(
-        ...     "random_udf", random_udf, StringType())  # doctest: +SKIP
+        >>> newRandom_udf = spark.catalog.registerFunction("random_udf", random_udf, StringType())
         >>> spark.sql("SELECT random_udf()").collect()  # doctest: +SKIP
         [Row(random_udf()=u'82')]
         >>> spark.range(1).select(newRandom_udf()).collect()  # doctest: +SKIP
         [Row(random_udf()=u'62')]
         """
 
+        # This is to check whether the input function is a wrapped/native UserDefinedFunction
         if hasattr(f, 'asNondeterministic'):
             udf = UserDefinedFunction(f.func, returnType=returnType, name=name,
                                       evalType=PythonEvalType.SQL_BATCHED_UDF,

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -270,8 +270,8 @@ class Catalog(object):
 
         if hasattr(f, 'asNondeterministic'):
             udf = UserDefinedFunction(f.func, returnType=returnType, name=name,
-                                      evalType=PythonEvalType.SQL_BATCHED_UDF)
-            udf = udf if (f._deterministic) else udf.asNondeterministic()
+                                      evalType=PythonEvalType.SQL_BATCHED_UDF,
+                                      deterministic=f.deterministic)
         else:
             udf = UserDefinedFunction(f, returnType=returnType, name=name,
                                       evalType=PythonEvalType.SQL_BATCHED_UDF)

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -175,7 +175,7 @@ class SQLContext(object):
     @ignore_unicode_prefix
     @since(1.2)
     def registerFunction(self, name, f, returnType=StringType()):
-        """Registers a python function (including lambda function) as a UDF
+        """Registers a Python function (including lambda function) or a wrapped/native UDF
         so it can be used in SQL statements.
 
         In addition to a name and the function itself, the return type can be optionally specified.
@@ -183,7 +183,7 @@ class SQLContext(object):
         be done.  For any other return type, the produced object must match the specified type.
 
         :param name: name of the UDF
-        :param f: python function
+        :param f: a Python function, or a wrapped/native UserDefinedFunction
         :param returnType: a :class:`pyspark.sql.types.DataType` object
         :return: a wrapped :class:`UserDefinedFunction`
 
@@ -208,8 +208,7 @@ class SQLContext(object):
         >>> from pyspark.sql.functions import udf
         >>> from pyspark.sql.types import IntegerType, StringType
         >>> random_udf = udf(lambda: random.randint(0, 100), IntegerType()).asNondeterministic()
-        >>> newRandom_udf = sqlContext.registerFunction(
-        ...     "random_udf", random_udf, StringType())  # doctest: +SKIP
+        >>> newRandom_udf = sqlContext.registerFunction("random_udf", random_udf, StringType())
         >>> sqlContext.sql("SELECT random_udf()").collect()  # doctest: +SKIP
         [Row(random_udf()=u'82')]
         >>> sqlContext.range(1).select(newRandom_udf()).collect()  # doctest: +SKIP

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -175,8 +175,8 @@ class SQLContext(object):
     @ignore_unicode_prefix
     @since(1.2)
     def registerFunction(self, name, f, returnType=StringType()):
-        """Registers a Python function (including lambda function) or a wrapped/native UDF
-        so it can be used in SQL statements.
+        """Registers a Python function (including lambda function) or a :class:`UserDefinedFunction`
+        as a UDF. The registered UDF can be used in SQL statement.
 
         In addition to a name and the function itself, the return type can be optionally specified.
         When the return type is not given it default to a string and conversion will automatically

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -203,6 +203,17 @@ class SQLContext(object):
         >>> _ = sqlContext.udf.register("stringLengthInt", lambda x: len(x), IntegerType())
         >>> sqlContext.sql("SELECT stringLengthInt('test')").collect()
         [Row(stringLengthInt(test)=4)]
+
+        >>> import random
+        >>> from pyspark.sql.functions import udf
+        >>> from pyspark.sql.types import IntegerType, StringType
+        >>> random_udf = udf(lambda: random.randint(0, 100), IntegerType()).asNondeterministic()
+        >>> newRandom_udf = sqlContext.registerFunction(
+        ...     "random_udf", random_udf, StringType())  # doctest: +SKIP
+        >>> sqlContext.sql("SELECT random_udf()").collect()  # doctest: +SKIP
+        [Row(random_udf()=u'82')]
+        >>> sqlContext.range(1).select(newRandom_udf()).collect()  # doctest: +SKIP
+        [Row(random_udf()=u'62')]
         """
         return self.sparkSession.catalog.registerFunction(name, f, returnType)
 

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -382,15 +382,18 @@ class SQLTests(ReusedSQLTestCase):
         import random
         from pyspark.sql.functions import udf
         random_udf = udf(lambda: random.randint(6, 6), IntegerType()).asNondeterministic()
-        self.assertEqual(random_udf._deterministic, False)
+        self.assertEqual(random_udf.deterministic, False)
         random_udf1 = self.spark.catalog.registerFunction("randInt", random_udf, StringType())
-        self.assertEqual(random_udf1._deterministic, False)
+        self.assertEqual(random_udf1.deterministic, False)
         [row] = self.spark.sql("SELECT randInt()").collect()
         self.assertEqual(row[0], "6")
         [row] = self.spark.range(1).select(random_udf1()).collect()
         self.assertEqual(row[0], "6")
         [row] = self.spark.range(1).select(random_udf()).collect()
         self.assertEqual(row[0], 6)
+        pydoc.render_doc(lambda: random.randint(6, 6), IntegerType())
+        pydoc.render_doc(random_udf)
+        pydoc.render_doc(random_udf1)
 
     def test_chained_udf(self):
         self.spark.catalog.registerFunction("double", lambda x: x + x, IntegerType())

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -391,7 +391,7 @@ class SQLTests(ReusedSQLTestCase):
         self.assertEqual(row[0], "6")
         [row] = self.spark.range(1).select(random_udf()).collect()
         self.assertEqual(row[0], 6)
-        pydoc.render_doc(lambda: random.randint(6, 6), IntegerType())
+        pydoc.render_doc(udf(lambda: random.randint(6, 6), IntegerType()))
         pydoc.render_doc(random_udf)
         pydoc.render_doc(random_udf1)
 

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -163,6 +163,7 @@ class UserDefinedFunction(object):
         wrapper.returnType = self.returnType
         wrapper.evalType = self.evalType
         wrapper.asNondeterministic = self.asNondeterministic
+        wrapper._deterministic = self._deterministic
 
         return wrapper
 

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -138,6 +138,19 @@ class UserDefinedFunction(object):
         sc = SparkContext._active_spark_context
         return Column(judf.apply(_to_seq(sc, cols, _to_java_column)))
 
+    def _set_name(self, name, returnType=StringType()):
+        """
+        Updates the name of UserDefinedFunction.
+        """
+        # reset _judf
+        self._judf_placeholder = None
+        self._returnType_placeholder = None
+        self._name = name or (
+            func.__name__ if hasattr(func, '__name__')
+            else func.__class__.__name__)
+        self._returnType = returnType
+        return self
+
     def _wrapped(self):
         """
         Wrap this udf with a function and attach docstring from func
@@ -163,6 +176,10 @@ class UserDefinedFunction(object):
         wrapper.returnType = self.returnType
         wrapper.evalType = self.evalType
         wrapper.asNondeterministic = self.asNondeterministic
+        wrapper._judf = self._judf
+        wrapper._create_judf = self._create_judf
+        wrapper._wrapped = self._wrapped
+        wrapper._set_name = self._set_name
 
         return wrapper
 

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -141,6 +141,9 @@ class UserDefinedFunction(object):
         sc = SparkContext._active_spark_context
         return Column(judf.apply(_to_seq(sc, cols, _to_java_column)))
 
+    # This function is for improving the online help system in the interactive interpreter.
+    # For example, the built-in help / pydoc.help. It wraps the UDF with the docstring and
+    # argument annotation. (See: SPARK-19161)
     def _wrapped(self):
         """
         Wrap this udf with a function and attach docstring from func

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -56,7 +56,8 @@ def _create_udf(f, returnType, evalType):
             )
 
     # Set the name of the UserDefinedFunction object to be the name of function f
-    udf_obj = UserDefinedFunction(f, returnType=returnType, name=None, evalType=evalType)
+    udf_obj = UserDefinedFunction(
+        f, returnType=returnType, name=None, evalType=evalType, deterministic=True)
     return udf_obj._wrapped()
 
 
@@ -67,7 +68,8 @@ class UserDefinedFunction(object):
     .. versionadded:: 1.3
     """
     def __init__(self, func,
-                 returnType=StringType(), name=None,
+                 returnType=StringType(),
+                 name=None,
                  evalType=PythonEvalType.SQL_BATCHED_UDF,
                  deterministic=True):
         if not callable(func):
@@ -164,7 +166,7 @@ class UserDefinedFunction(object):
         wrapper.returnType = self.returnType
         wrapper.evalType = self.evalType
         wrapper.deterministic = self.deterministic
-        wrapper.asNondeterministic = self.asNondeterministic
+        wrapper.asNondeterministic = lambda: self.asNondeterministic()._wrapped()
 
         return wrapper
 
@@ -175,4 +177,4 @@ class UserDefinedFunction(object):
         .. versionadded:: 2.3
         """
         self.deterministic = False
-        return self._wrapped()
+        return self

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -138,7 +138,7 @@ class UserDefinedFunction(object):
         sc = SparkContext._active_spark_context
         return Column(judf.apply(_to_seq(sc, cols, _to_java_column)))
 
-    def _set_name(self, name, returnType=StringType()):
+    def _set_name_type(self, name, returnType=StringType()):
         """
         Updates the name of UserDefinedFunction.
         """
@@ -179,7 +179,7 @@ class UserDefinedFunction(object):
         wrapper._judf = self._judf
         wrapper._create_judf = self._create_judf
         wrapper._wrapped = self._wrapped
-        wrapper._set_name = self._set_name
+        wrapper._set_name_type = self._set_name_type
 
         return wrapper
 

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -138,19 +138,6 @@ class UserDefinedFunction(object):
         sc = SparkContext._active_spark_context
         return Column(judf.apply(_to_seq(sc, cols, _to_java_column)))
 
-    def _set_name_type(self, name, returnType=StringType()):
-        """
-        Updates the name of UserDefinedFunction.
-        """
-        # reset _judf
-        self._judf_placeholder = None
-        self._returnType_placeholder = None
-        self._name = name or (
-            func.__name__ if hasattr(func, '__name__')
-            else func.__class__.__name__)
-        self._returnType = returnType
-        return self
-
     def _wrapped(self):
         """
         Wrap this udf with a function and attach docstring from func
@@ -176,10 +163,6 @@ class UserDefinedFunction(object):
         wrapper.returnType = self.returnType
         wrapper.evalType = self.evalType
         wrapper.asNondeterministic = self.asNondeterministic
-        wrapper._judf = self._judf
-        wrapper._create_judf = self._create_judf
-        wrapper._wrapped = self._wrapped
-        wrapper._set_name_type = self._set_name_type
 
         return wrapper
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
```Python
import random
from pyspark.sql.functions import udf
from pyspark.sql.types import IntegerType, StringType
random_udf = udf(lambda: int(random.random() * 100), IntegerType()).asNondeterministic()
spark.catalog.registerFunction("random_udf", random_udf, StringType())
spark.sql("SELECT random_udf()").collect()
```

We will get the following error.
```
Py4JError: An error occurred while calling o29.__getnewargs__. Trace:
py4j.Py4JException: Method __getnewargs__([]) does not exist
	at py4j.reflection.ReflectionEngine.getMethod(ReflectionEngine.java:318)
	at py4j.reflection.ReflectionEngine.getMethod(ReflectionEngine.java:326)
	at py4j.Gateway.invoke(Gateway.java:274)
	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
	at py4j.commands.CallCommand.execute(CallCommand.java:79)
	at py4j.GatewayConnection.run(GatewayConnection.java:214)
	at java.lang.Thread.run(Thread.java:745)
```

This PR is to support it. 

## How was this patch tested?
WIP