### PR TITLE
[SPARK-22930][PYTHON][SQL] Improve the description of Vectorized UDFs for non-deterministic cases

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2214,7 +2214,17 @@ def pandas_udf(f=None, returnType=None, functionType=None):
 
        .. seealso:: :meth:`pyspark.sql.GroupedData.apply`
 
-    .. note:: The user-defined function must be deterministic.
+    .. note:: The user-defined functions are considered deterministic by default. Due to
+        optimization, duplicate invocations may be eliminated or the function may even be invoked
+        more times than it is present in the query. If your function is not deterministic, call
+        `asNondeterministic` on the user defined function. E.g.:
+
+    >>> @pandas_udf('double', PandasUDFType.SCALAR)  # doctest: +SKIP
+    ... def random(v):
+    ...     import numpy as np
+    ...     import pandas as pd
+    ...     return pd.Series(np.random.randn(len(v))
+    >>> random = random.asNondeterministic()  # doctest: +SKIP
 
     .. note:: The user-defined functions do not support conditional expressions or short curcuiting
         in boolean expressions and it ends up with being executed all internally. If the functions

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -386,8 +386,7 @@ class SQLTests(ReusedSQLTestCase):
         self.assertEqual(row[0], 5)
 
     def test_nondeterministic_udf(self):
-        # Test that the result of nondeterministic UDFs are evaluated only once in
-        # chained UDF evaluations
+        # Test that nondeterministic UDFs are evaluated only once in chained UDF evaluations
         from pyspark.sql.functions import udf
         import random
         udf_random_col = udf(lambda: int(100 * random.random()), IntegerType()).asNondeterministic()
@@ -3977,8 +3976,7 @@ class VectorizedUDFTests(ReusedSQLTestCase):
             self.spark.conf.set("spark.sql.session.timeZone", orig_tz)
 
     def test_nondeterministic_udf(self):
-        # Test that the result of nondeterministic UDFs are evaluated only once in
-        # chained UDF evaluations
+        # Test that nondeterministic UDFs are evaluated only once in chained UDF evaluations
         from pandas.testing import assert_series_equal
         from pyspark.sql.functions import udf, pandas_udf, col
 

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3977,7 +3977,6 @@ class VectorizedUDFTests(ReusedSQLTestCase):
 
     def test_nondeterministic_udf(self):
         # Test that nondeterministic UDFs are evaluated only once in chained UDF evaluations
-        from pandas.testing import assert_series_equal
         from pyspark.sql.functions import udf, pandas_udf, col
 
         @pandas_udf('double')
@@ -3989,7 +3988,7 @@ class VectorizedUDFTests(ReusedSQLTestCase):
         result1 = df.withColumn('plus_ten(rand)', plus_ten(df['rand'])).toPandas()
 
         self.assertEqual(random_udf.deterministic, False)
-        assert_series_equal(result1['plus_ten(rand)'], result1['rand'] + 10, check_names=False)
+        self.assertTrue(result1['plus_ten(rand)'].equals(result1['rand'] + 10))
 
     def test_nondeterministic_udf_in_aggregate(self):
         from pyspark.sql.functions import pandas_udf, sum


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add tests for using non deterministic UDFs in aggregate.

Update pandas_udf docstring w.r.t to determinism.

## How was this patch tested?
test_nondeterministic_udf_in_aggregate
