### PR TITLE
[SPARK-22950][SQL]Handle ChildFirstURLClassLoader's parent 

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -47,7 +47,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf._
 import org.apache.spark.sql.internal.StaticSQLConf.{CATALOG_IMPLEMENTATION, WAREHOUSE_PATH}
 import org.apache.spark.sql.types._
-import org.apache.spark.util.Utils
+import org.apache.spark.util.{ChildFirstURLClassLoader, Utils}
 
 
 private[spark] object HiveUtils extends Logging {
@@ -312,6 +312,8 @@ private[spark] object HiveUtils extends Logging {
       // starting from the given classLoader.
       def allJars(classLoader: ClassLoader): Array[URL] = classLoader match {
         case null => Array.empty[URL]
+        case childFirst: ChildFirstURLClassLoader =>
+          childFirst.getURLs() ++ allJars(Utils.getSparkClassLoader)
         case urlClassLoader: URLClassLoader =>
           urlClassLoader.getURLs ++ allJars(urlClassLoader.getParent)
         case other => allJars(other.getParent)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveUtilsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveUtilsSuite.scala
@@ -70,8 +70,6 @@ class HiveUtilsSuite extends QueryTest with SQLTestUtils with TestHiveSingleton 
 
 /**
  * A Fake [[ChildFirstURLClassLoader]] used for test
- * @param urls
- * @param parent
  */
-class FakeChildFirstURLClassLoader(urls: Array[URL], parent: ClassLoader)
+private[spark] class FakeChildFirstURLClassLoader(urls: Array[URL], parent: ClassLoader)
   extends MutableURLClassLoader(urls, null)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveUtilsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveUtilsSuite.scala
@@ -52,19 +52,31 @@ class HiveUtilsSuite extends QueryTest with SQLTestUtils with TestHiveSingleton 
     val conf = new SparkConf
     val contextClassLoader = Thread.currentThread().getContextClassLoader
     val loader = new FakeChildFirstURLClassLoader(Array(), contextClassLoader)
-    Thread.currentThread().setContextClassLoader(loader)
-    intercept[IllegalArgumentException](
-      HiveUtils.newClientForMetadata(conf, SparkHadoopUtil.newConfiguration(conf)))
-    Thread.currentThread().setContextClassLoader(contextClassLoader)
+    try {
+      Thread.currentThread().setContextClassLoader(loader)
+      intercept[IllegalArgumentException](
+        HiveUtils.newClientForMetadata(
+          conf,
+          SparkHadoopUtil.newConfiguration(conf),
+          HiveUtils.newTemporaryConfiguration(useInMemoryDerby = true)))
+    } finally {
+      Thread.currentThread().setContextClassLoader(contextClassLoader)
+    }
   }
 
   test("ChildFirstURLClassLoader's parent is null, get spark classloader instead") {
     val conf = new SparkConf
     val contextClassLoader = Thread.currentThread().getContextClassLoader
     val loader = new ChildFirstURLClassLoader(Array(), contextClassLoader)
-    Thread.currentThread().setContextClassLoader(loader)
-    HiveUtils.newClientForMetadata(conf, SparkHadoopUtil.newConfiguration(conf))
-    Thread.currentThread().setContextClassLoader(contextClassLoader)
+    try {
+      Thread.currentThread().setContextClassLoader(loader)
+      HiveUtils.newClientForMetadata(
+        conf,
+        SparkHadoopUtil.newConfiguration(conf),
+        HiveUtils.newTemporaryConfiguration(useInMemoryDerby = true))
+    } finally {
+      Thread.currentThread().setContextClassLoader(contextClassLoader)
+    }
   }
 }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveUtilsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveUtilsSuite.scala
@@ -48,22 +48,6 @@ class HiveUtilsSuite extends QueryTest with SQLTestUtils with TestHiveSingleton 
     }
   }
 
-  test("ChildFirstURLClassLoader's parent is null") {
-    val conf = new SparkConf
-    val contextClassLoader = Thread.currentThread().getContextClassLoader
-    val loader = new FakeChildFirstURLClassLoader(Array(), contextClassLoader)
-    try {
-      Thread.currentThread().setContextClassLoader(loader)
-      intercept[IllegalArgumentException](
-        HiveUtils.newClientForMetadata(
-          conf,
-          SparkHadoopUtil.newConfiguration(conf),
-          HiveUtils.newTemporaryConfiguration(useInMemoryDerby = true)))
-    } finally {
-      Thread.currentThread().setContextClassLoader(contextClassLoader)
-    }
-  }
-
   test("ChildFirstURLClassLoader's parent is null, get spark classloader instead") {
     val conf = new SparkConf
     val contextClassLoader = Thread.currentThread().getContextClassLoader
@@ -79,9 +63,3 @@ class HiveUtilsSuite extends QueryTest with SQLTestUtils with TestHiveSingleton 
     }
   }
 }
-
-/**
- * A Fake [[ChildFirstURLClassLoader]] used for test
- */
-private[spark] class FakeChildFirstURLClassLoader(urls: Array[URL], parent: ClassLoader)
-  extends MutableURLClassLoader(urls, null)


### PR DESCRIPTION
## What changes were proposed in this pull request?

ChildFirstClassLoader's parent is set to null, so we can't get jars from its parent. This will cause ClassNotFoundException during HiveClient initialization with builtin hive jars, where we may should use spark context loader instead.

## How was this patch tested?

add new ut
cc @cloud-fan @gatorsmile 
