### PR TITLE
[SPARK-22940][SQL] HiveExternalCatalogVersionsSuite should succeed on platforms that don't have wget

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
@@ -106,7 +106,7 @@ class HiveExternalCatalogVersionsSuite extends SparkSubmitTestUtils {
       outDir.mkdirs()
     }
 
-    // propogate exceptions up to the caller of getFileFromUrl
+    // propagate exceptions up to the caller of getFileFromUrl
     Utils.doFetchFile(urlString, outDir, filename, conf, securityManager, hadoopConf)
   }
 
@@ -114,7 +114,7 @@ class HiveExternalCatalogVersionsSuite extends SparkSubmitTestUtils {
     val contentFile = File.createTempFile("string-", ".txt")
     contentFile.deleteOnExit()
 
-    // exceptions will propogate to the caller of getStringFromUrl
+    // exceptions will propagate to the caller of getStringFromUrl
     getFileFromUrl(urlString, contentFile.getParent, contentFile.getName)
 
     val contentPath = Paths.get(contentFile.toURI)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
@@ -61,7 +61,6 @@ class HiveExternalCatalogVersionsSuite extends SparkSubmitTestUtils {
     for (i <- 0 until 3) {
       val preferredMirror =
         getStringFromUrl("https://www.apache.org/dyn/closer.lua?preferred=true")
-      logWarning("The mirror is " + preferredMirror)
       val filename = s"spark-$version-bin-hadoop2.7.tgz"
       val url = s"$preferredMirror/spark/spark-$version/" + filename
       logInfo(s"Downloading Spark $version from $url")
@@ -120,7 +119,6 @@ class HiveExternalCatalogVersionsSuite extends SparkSubmitTestUtils {
     }
 
     val contentFile = new File(outDir.toFile, filename)
-    logWarning("content file is " + contentFile.getAbsolutePath)
     try {
       Source.fromFile(contentFile)(Codec(encoding)).mkString
     } finally {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
@@ -61,7 +61,6 @@ class HiveExternalCatalogVersionsSuite extends SparkSubmitTestUtils {
     for (i <- 0 until 3) {
       val preferredMirror =
         getStringFromUrl("https://www.apache.org/dyn/closer.lua?preferred=true")
-      logWarning("Mirror is " + preferredMirror)
       val filename = s"spark-$version-bin-hadoop2.7.tgz"
       val url = s"$preferredMirror/spark/spark-$version/" + filename
       logInfo(s"Downloading Spark $version from $url")
@@ -101,11 +100,9 @@ class HiveExternalCatalogVersionsSuite extends SparkSubmitTestUtils {
       outDir.mkdirs()
     }
 
-    logWarning("Download url is " + urlString)
-    logWarning("Target file is " + outDir.getAbsolutePath + File.separator + filename)
     try {
       val result = Utils.doFetchFile(urlString, outDir, filename, conf, securityManager, hadoopConf)
-        result.exists()
+      result.exists()
     } catch {
       case ex: Exception => logError("Could not get file from url " + urlString + ": "
         + ex.getMessage)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
@@ -62,7 +62,6 @@ class HiveExternalCatalogVersionsSuite extends SparkSubmitTestUtils {
       // the test fails (getStringFromUrl will throw an exception)
       val preferredMirror =
         getStringFromUrl("https://www.apache.org/dyn/closer.lua?preferred=true")
-      logWarning(s"Mirror is $preferredMirror")
       val filename = s"spark-$version-bin-hadoop2.7.tgz"
       val url = s"$preferredMirror/spark/spark-$version/$filename"
       logInfo(s"Downloading Spark $version from $url")
@@ -117,8 +116,6 @@ class HiveExternalCatalogVersionsSuite extends SparkSubmitTestUtils {
 
     // exceptions will propogate to the caller of getStringFromUrl
     getFileFromUrl(urlString, contentFile.getParent, contentFile.getName)
-
-    logWarning(s"content file is at ${contentFile.getAbsolutePath}" )
 
     val contentPath = Paths.get(contentFile.toURI)
     new String(Files.readAllBytes(contentPath), StandardCharsets.UTF_8)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
@@ -90,7 +90,7 @@ class HiveExternalCatalogVersionsSuite extends SparkSubmitTestUtils {
     new File(tmpDataDir, name).getCanonicalPath
   }
 
-  def getFileFromUrl(urlString: String, targetDir: String, filename: String): Boolean = {
+  private def getFileFromUrl(urlString: String, targetDir: String, filename: String): Boolean = {
     val conf = new SparkConf
     val securityManager = new SecurityManager(conf)
     val hadoopConf = new Configuration
@@ -110,7 +110,7 @@ class HiveExternalCatalogVersionsSuite extends SparkSubmitTestUtils {
     }
   }
 
-  def getStringFromUrl(urlString: String, encoding: String = "UTF-8"): String = {
+  private def getStringFromUrl(urlString: String, encoding: String = "UTF-8"): String = {
     val outDir = Files.createTempDirectory("string-")
     val filename = "string-out.txt"
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
@@ -110,7 +110,7 @@ class HiveExternalCatalogVersionsSuite extends SparkSubmitTestUtils {
     Utils.doFetchFile(urlString, outDir, filename, conf, securityManager, hadoopConf)
   }
 
-  private def getStringFromUrl(urlString: String, encoding: String = "UTF-8"): String = {
+  private def getStringFromUrl(urlString: String): String = {
     val contentFile = File.createTempFile("string-", ".txt")
     contentFile.deleteOnExit()
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Modified HiveExternalCatalogVersionsSuite.scala to use Utils.doFetchFile to download different versions of Spark binaries rather than launching wget as an external process.

On platforms that don't have wget installed, this suite fails with an error.

@cloud-fan : would you like to check this change?

## How was this patch tested?

1) test-only of HiveExternalCatalogVersionsSuite on several platforms. Tested bad mirror, read timeout, and redirects.
2) ./dev/run-tests

