### PR TITLE
[PySpark] Fix typo in comments in PySpark's udf() definition

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2103,7 +2103,7 @@ def udf(f=None, returnType=StringType()):
     >>> import random
     >>> random_udf = udf(lambda: int(random.random() * 100), IntegerType()).asNondeterministic()
 
-    .. note:: The user-defined functions do not support conditional expressions or short curcuiting
+    .. note:: The user-defined functions do not support conditional expressions or short circuiting
         in boolean expressions and it ends up with being executed all internally. If the functions
         can fail on special rows, the workaround is to incorporate the condition into the functions.
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Just a simple typo fix from `curcuiting` to `circuiting`.

## How was this patch tested?

N/A. This patch does not change any code behavior.