### PR TITLE
[SPARK-22966][PYTHON][SQL] Python UDFs with returnType=StringType should treat return values of datetime.date or datetime.datetime as unconvertible

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/EvaluatePython.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/EvaluatePython.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.python
 
 import java.io.OutputStream
 import java.nio.charset.StandardCharsets
+import java.util.Calendar
 
 import scala.collection.JavaConverters._
 
@@ -144,6 +145,7 @@ object EvaluatePython {
     }
 
     case StringType => (obj: Any) => nullSafeConvert(obj) {
+      case _: Calendar => null
       case _ => UTF8String.fromString(obj.toString)
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Perform appropriate conversions for results coming from Python UDFs that return `datetime.date` or `datetime.datetime`.

Before this PR, Pyrolite would unpickle both `datetime.date` and `datetime.datetime` into a `java.util.Calendar`, which Spark SQL doesn't understand, which then leads to incorrect results. An example of such incorrect result is:

```
>>> py_date = udf(datetime.date)
>>> spark.range(1).select(py_date(lit(2017), lit(10), lit(30))).show(truncate=False)
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|date(2017, 10, 30)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|java.util.GregorianCalendar[time=?,areFieldsSet=false,areAllFieldsSet=false,lenient=true,zone=sun.util.calendar.ZoneInfo[id="America/Los_Angeles",offset=-28800000,dstSavings=3600000,useDaylight=true,transitions=185,lastRule=java.util.SimpleTimeZone[id=America/Los_Angeles,offset=-28800000,dstSavings=3600000,useDaylight=true,startYear=0,startMode=3,startMonth=2,startDay=8,startDayOfWeek=1,startTime=7200000,startTimeMode=0,endMode=3,endMonth=10,endDay=1,endDayOfWeek=1,endTime=7200000,endTimeMode=0]],firstDayOfWeek=1,minimalDaysInFirstWeek=1,ERA=?,YEAR=2017,MONTH=9,WEEK_OF_YEAR=?,WEEK_OF_MONTH=?,DAY_OF_MONTH=30,DAY_OF_YEAR=?,DAY_OF_WEEK=?,DAY_OF_WEEK_IN_MONTH=?,AM_PM=0,HOUR=0,HOUR_OF_DAY=0,MINUTE=0,SECOND=0,MILLISECOND=?,ZONE_OFFSET=?,DST_OFFSET=?]|
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```
After this PR, the same query above would give correct results:
```
>>> spark.range(1).select(py_date(lit(2017), lit(10), lit(30))).show(truncate=False)
+------------------+
|date(2017, 10, 30)|
+------------------+
|2017-10-30        |
+------------------+
```

An explicit non-goal of this PR is to change the behavior of timezone awareness or timezone settings of `datetime.datetime` objects collected from a `DataFrame`.
Currently PySpark always returns such `datetime.datetime` objects as timezone unaware (naive) ones that respect Python's current local timezone (#19607 changed the default behavior for Pandas support but not for plain `collect()`). This PR does not change that behavior.

## How was this patch tested?

Added some unit tests to `pyspark.sql.tests` for such UDFs, so that
 * `datetime.date` -> `StringType`
 * `datetime.date` -> `DateType`
 * `datetime.datetime` -> `StringType`
 * `datetime.datetime` -> `TimestampType`
* `datetime.datetime` with non-default timezone
* `datetime.datetime` with null timezone (naive datetime)
cases are covered.