### PR TITLE
[SPARK-22971][ML] OneVsRestModel should use temporary RawPredictionCol

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -183,9 +183,14 @@ final class OneVsRestModel private[ml] (
         val updateUDF = udf { (predictions: Map[Int, Double], prediction: Vector) =>
           predictions + ((index, prediction(1)))
         }
+
         model.setFeaturesCol($(featuresCol))
+        val rawPredictionColName = model.getRawPredictionCol
+        // set rawPredictionColName to a temporary column to avoid column conflict
         model.setRawPredictionCol(tmpRawPredictionColName)
         val transformedDataset = model.transform(df).select(columns: _*)
+        model.setRawPredictionCol(rawPredictionColName)
+
         val updatedDataset = transformedDataset
           .withColumn(tmpColName, updateUDF(col(accColName), col(tmpRawPredictionColName)))
         val newColumns = origCols ++ List(col(tmpColName))

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -176,8 +176,6 @@ final class OneVsRestModel private[ml] (
     // update the accumulator column with the result of prediction of models
     val aggregatedDataset = models.zipWithIndex.foldLeft[DataFrame](newDataset) {
       case (df, (model, index)) =>
-        model.setRawPredictionCol(tmpRawPredictionColName)
-
         val columns = origCols ++ List(col(tmpRawPredictionColName), col(accColName))
 
         // add temporary column to store intermediate scores and update
@@ -186,6 +184,7 @@ final class OneVsRestModel private[ml] (
           predictions + ((index, prediction(1)))
         }
         model.setFeaturesCol($(featuresCol))
+        model.setRawPredictionCol(tmpRawPredictionColName)
         val transformedDataset = model.transform(df).select(columns: _*)
         val updatedDataset = transformedDataset
           .withColumn(tmpColName, updateUDF(col(accColName), col(tmpRawPredictionColName)))

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -178,7 +178,6 @@ final class OneVsRestModel private[ml] (
     // update the accumulator column with the result of prediction of models
     val aggregatedDataset = models.zipWithIndex.foldLeft[DataFrame](newDataset) {
       case (df, (model, index)) =>
-
         // add temporary column to store intermediate scores and update
         val tmpColName = "update_" + UUID.randomUUID().toString
         val updateUDF = udf { (predictions: Map[Int, Double], prediction: Vector) =>

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -160,7 +160,7 @@ final class OneVsRestModel private[ml] (
     val origCols = dataset.schema.map(f => col(f.name))
 
     // add an accumulator column to store predictions of all the models
-    val accColName = "mbc$acc" + UUID.randomUUID().toString
+    val accColName = "acc_" + UUID.randomUUID().toString
     val initUDF = udf { () => Map[Int, Double]() }
     val newDataset = dataset.withColumn(accColName, initUDF())
 
@@ -171,7 +171,7 @@ final class OneVsRestModel private[ml] (
     }
 
     // temporary column to store intermediate raw prediction
-    val tmpRawPredictionColName = "mbc$tmpraw" + UUID.randomUUID().toString
+    val tmpRawPredictionColName = "rawPrediction_" + UUID.randomUUID().toString
 
     // update the accumulator column with the result of prediction of models
     val aggregatedDataset = models.zipWithIndex.foldLeft[DataFrame](newDataset) {
@@ -179,7 +179,7 @@ final class OneVsRestModel private[ml] (
         val columns = origCols ++ List(col(tmpRawPredictionColName), col(accColName))
 
         // add temporary column to store intermediate scores and update
-        val tmpColName = "mbc$tmp" + UUID.randomUUID().toString
+        val tmpColName = "update_" + UUID.randomUUID().toString
         val updateUDF = udf { (predictions: Map[Int, Double], prediction: Vector) =>
           predictions + ((index, prediction(1)))
         }

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
@@ -194,6 +194,17 @@ class OneVsRestSuite extends SparkFunSuite with MLlibTestSparkContext with Defau
     assert(output.schema.fieldNames.toSet === Set("label", "features", "prediction"))
   }
 
+  test("SPARK-22971: OneVsRestModel should use temp RawPredictionCol") {
+    val dataset2 = dataset.withColumn("rawPrediction", lit(0.0))
+    val logReg = new LogisticRegression()
+      .setMaxIter(1)
+    val ovr = new OneVsRest()
+      .setClassifier(logReg)
+    val output = ovr.fit(dataset2).transform(dataset2)
+    assert(output.schema.fieldNames.toSet ===
+      Set("label", "features", "prediction", "rawPrediction"))
+  }
+
   test("SPARK-21306: OneVsRest should support setWeightCol") {
     val dataset2 = dataset.withColumn("weight", lit(1))
     // classifier inherits hasWeightCol


### PR DESCRIPTION
## What changes were proposed in this pull request?
use temporary RawPredictionCol in `OneVsRestModel#transform`

## How was this patch tested?
existing tests and added tests