### PR TITLE
[SPARK-22972] Couldn't find corresponding Hive SerDe for data source provider org.apache.spark.sql.hive.orc

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/HiveSerDe.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/HiveSerDe.scala
@@ -72,7 +72,7 @@ object HiveSerDe {
   def sourceToSerDe(source: String): Option[HiveSerDe] = {
     val key = source.toLowerCase(Locale.ROOT) match {
       case s if s.startsWith("org.apache.spark.sql.parquet") => "parquet"
-      case s if s.startsWith("org.apache.spark.sql.orc") => "orc"
+      case s if s.startsWith("org.apache.spark.sql.hive.orc") => "orc"
       case s if s.equals("orcfile") => "orc"
       case s if s.equals("parquetfile") => "parquet"
       case s if s.equals("avrofile") => "avro"

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/HiveSerDe.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/HiveSerDe.scala
@@ -72,6 +72,7 @@ object HiveSerDe {
   def sourceToSerDe(source: String): Option[HiveSerDe] = {
     val key = source.toLowerCase(Locale.ROOT) match {
       case s if s.startsWith("org.apache.spark.sql.parquet") => "parquet"
+      case s if s.startsWith("org.apache.spark.sql.orc") => "orc"
       case s if s.startsWith("org.apache.spark.sql.hive.orc") => "orc"
       case s if s.equals("orcfile") => "orc"
       case s if s.equals("parquetfile") => "parquet"

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcSourceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcSourceSuite.scala
@@ -70,12 +70,13 @@ class HiveOrcSourceSuite extends OrcSuite with TestHiveSingleton {
          |OPTIONS (
          |  PATH '${new File(orcTableAsDir.getAbsolutePath).toURI}'
          |)
-       """.
-        stripMargin)
-    spark.sql(
-      "desc formatted normal_orc_as_source_hive").show()
+       """.stripMargin)
+    
+    spark.sql("desc formatted normal_orc_as_source_hive").show()
     checkAnswer(sql("SELECT COUNT(*) FROM normal_orc_as_source_hive"), Row(10))
     assert(HiveSerDe.sourceToSerDe("org.apache.spark.sql.hive.orc")
+      .equals(HiveSerDe.sourceToSerDe("orc")))
+    assert(HiveSerDe.sourceToSerDe("org.apache.spark.sql.orc")
       .equals(HiveSerDe.sourceToSerDe("orc")))
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcSourceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcSourceSuite.scala
@@ -67,14 +67,14 @@ class HiveOrcSourceSuite extends OrcSuite with TestHiveSingleton {
   test("SPARK-22972: hive orc source") {
     val tableName = "normal_orc_as_source_hive"
     withTable(tableName) {
-
       sql(
-        s"""CREATE TABLE $tableName
-           |USING org.apache.spark.sql.hive.orc
-           |OPTIONS (
-           |  PATH '${new File(orcTableAsDir.getAbsolutePath).toURI}'
-           |)
-       """.stripMargin)
+        s"""
+          |CREATE TABLE $tableName
+          |USING org.apache.spark.sql.hive.orc
+          |OPTIONS (
+          |  PATH '${new File(orcTableAsDir.getAbsolutePath).toURI}'
+          |)
+        """.stripMargin)
 
       val tableMetadata = spark.sessionState.catalog.getTableMetadata(
         TableIdentifier(tableName))

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcSourceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcSourceSuite.scala
@@ -67,6 +67,7 @@ class HiveOrcSourceSuite extends OrcSuite with TestHiveSingleton {
   test("SPARK-22972: hive orc source") {
     val tableName = "normal_orc_as_source_hive"
     withTable(tableName) {
+
       sql(
         s"""CREATE TABLE $tableName
            |USING org.apache.spark.sql.hive.orc
@@ -74,6 +75,7 @@ class HiveOrcSourceSuite extends OrcSuite with TestHiveSingleton {
            |  PATH '${new File(orcTableAsDir.getAbsolutePath).toURI}'
            |)
        """.stripMargin)
+
       val tableMetadata = spark.sessionState.catalog.getTableMetadata(
         TableIdentifier(tableName))
       assert(tableMetadata.storage.inputFormat ==

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcSourceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcSourceSuite.scala
@@ -71,7 +71,6 @@ class HiveOrcSourceSuite extends OrcSuite with TestHiveSingleton {
          |  PATH '${new File(orcTableAsDir.getAbsolutePath).toURI}'
          |)
        """.stripMargin)
-    
     spark.sql("desc formatted normal_orc_as_source_hive").show()
     checkAnswer(sql("SELECT COUNT(*) FROM normal_orc_as_source_hive"), Row(10))
     assert(HiveSerDe.sourceToSerDe("org.apache.spark.sql.hive.orc")


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix the warning: Couldn't find corresponding Hive SerDe for data source provider org.apache.spark.sql.hive.orc.

## How was this patch tested?
 test("SPARK-22972: hive orc source") 
    assert(HiveSerDe.sourceToSerDe("org.apache.spark.sql.hive.orc")
      .equals(HiveSerDe.sourceToSerDe("orc")))

  