### PR TITLE
[SPARK-22730][ML] Add ImageSchema support for all OpenCv types.

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/image/ImageSchema.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/image/ImageSchema.scala
@@ -39,6 +39,7 @@ object ImageSchema {
 
   /**
    * OpenCv type representation
+   *
    * @param mode ordinal for the type
    * @param dataType open cv data type
    * @param nChannels number of color channels
@@ -48,11 +49,23 @@ object ImageSchema {
     override def toString: String = s"OpenCvType(mode = $mode, name = $name)"
   }
 
+  /**
+   * Return the supported OpenCvType with matching name or raise error if there is no matching type.
+   *
+   * @param name: name of existing OpenCvType
+   * @return OpenCvType that matches the given name
+   */
   def ocvTypeByName(name: String): OpenCvType = {
     ocvTypes.find(x => x.name == name).getOrElse(
       throw new IllegalArgumentException("Unknown open cv type " + name))
   }
 
+  /**
+   * Return the supported OpenCvType with matching mode or raise error if there is no matching type.
+   *
+   * @param mode: mode of existing OpenCvType
+   * @return OpenCvType that matches the given mode
+   */
   def ocvTypeByMode(mode: Int): OpenCvType = {
     ocvTypes.find(x => x.mode == mode).getOrElse(
       throw new IllegalArgumentException("Unknown open cv mode " + mode))
@@ -72,7 +85,7 @@ object ImageSchema {
    * CV_32F  5 13  21  29
    * CV_64F  6 14  22  30
    */
-  val ocvTypes = {
+  val ocvTypes: IndexedSeq[OpenCvType] = {
     val types =
       for (nc <- Array(1, 2, 3, 4);
            dt <- Array("8U", "8S", "16U", "16S", "32S", "32F", "64F"))
@@ -82,9 +95,9 @@ object ImageSchema {
   }
 
   /**
-   *  (Java Specific) list of OpenCv types
+   * (Java-specific) list of OpenCv types
    */
-  val javaOcvTypes = ocvTypes.asJava
+  val javaOcvTypes: java.util.List[OpenCvType] = ocvTypes.asJava
 
   /**
    * Schema for the image column: Row(String, Int, Int, Int, Int, Array[Byte])

--- a/mllib/src/main/scala/org/apache/spark/ml/image/ImageSchema.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/image/ImageSchema.scala
@@ -37,20 +37,51 @@ import org.apache.spark.sql.types._
 @Since("2.3.0")
 object ImageSchema {
 
-  val undefinedImageType = "Undefined"
+  /**
+   * OpenCv type representation
+   * @param mode ordinal for the type
+   * @param dataType open cv data type
+   * @param nChannels number of color channels
+   */
+  case class OpenCvType(mode: Int, dataType: String, nChannels: Int) {
+    def name: String = "CV_" + dataType + "C" + nChannels
+    override def toString: String = "OpenCvType(mode = " + mode + ", name = " + name + ")"
+  }
+
+  object OpenCvType {
+    def get(name: String): OpenCvType = {
+      ocvTypes.find(x => x.name == name).getOrElse(
+        throw new IllegalArgumentException("Unknown open cv type " + name))
+    }
+    def get(mode: Int): OpenCvType = {
+      ocvTypes.find(x => x.mode == mode).getOrElse(
+        throw new IllegalArgumentException("Unknown open cv mode " + mode))
+    }
+    val undefinedType = OpenCvType(-1, "N/A", -1)
+  }
 
   /**
-   * (Scala-specific) OpenCV type mapping supported
+   * A Mapping of Type to Numbers in OpenCV
+   *
+   *        C1 C2  C3  C4
+   * CV_8U   0  8  16  24
+   * CV_8S   1  9  17  25
+   * CV_16U  2 10  18  26
+   * CV_16S  3 11  19  27
+   * CV_32S  4 12  20  28
+   * CV_32F  5 13  21  29
+   * CV_64F  6 14  22  30
    */
-  val ocvTypes: Map[String, Int] = Map(
-    undefinedImageType -> -1,
-    "CV_8U" -> 0, "CV_8UC1" -> 0, "CV_8UC3" -> 16, "CV_8UC4" -> 24
-  )
+  val ocvTypes = {
+    val types =
+      for (nc <- Array(1, 2, 3, 4);
+           dt <- Array("8U", "8S", "16U", "16S", "32S", "32F", "64F"))
+        yield (dt, nc)
+    val ordinals = for (i <- 0 to 3; j <- 0 to 6) yield ( i * 8 + j)
+    OpenCvType.undefinedType +: (ordinals zip types).map(x => OpenCvType(x._1, x._2._1, x._2._2))
+  }
 
-  /**
-   * (Java-specific) OpenCV type mapping supported
-   */
-  val javaOcvTypes: java.util.Map[String, Int] = ocvTypes.asJava
+  val javaOcvTypes = ocvTypes.asJava
 
   /**
    * Schema for the image column: Row(String, Int, Int, Int, Int, Array[Byte])
@@ -121,7 +152,7 @@ object ImageSchema {
    * @return Row with the default values
    */
   private[spark] def invalidImageRow(origin: String): Row =
-    Row(Row(origin, -1, -1, -1, ocvTypes(undefinedImageType), Array.ofDim[Byte](0)))
+    Row(Row(origin, -1, -1, -1, OpenCvType.undefinedType.mode, Array.ofDim[Byte](0)))
 
   /**
    * Convert the compressed image (jpeg, png, etc.) into OpenCV
@@ -143,12 +174,12 @@ object ImageSchema {
 
       val height = img.getHeight
       val width = img.getWidth
-      val (nChannels, mode) = if (isGray) {
-        (1, ocvTypes("CV_8UC1"))
+      val (nChannels, mode: Int) = if (isGray) {
+        (1, OpenCvType.get("CV_8UC1").mode)
       } else if (hasAlpha) {
-        (4, ocvTypes("CV_8UC4"))
+        (4, OpenCvType.get("CV_8UC4").mode)
       } else {
-        (3, ocvTypes("CV_8UC3"))
+        (3, OpenCvType.get("CV_8UC3").mode)
       }
 
       val imageSize = height * width * nChannels

--- a/mllib/src/main/scala/org/apache/spark/ml/image/ImageSchema.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/image/ImageSchema.scala
@@ -38,10 +38,13 @@ import org.apache.spark.sql.types._
 object ImageSchema {
 
   /**
-   * OpenCv type representation
+   * OpenCv type representation.
+   *
+   * @see <a href="https://docs.opencv.org/2.4/modules/core/doc/basic_structures.html">
+   * OpenCv/basic_structures</a>
    *
    * @param mode ordinal for the type
-   * @param dataType open cv data type
+   * @param dataType OpenCv data type
    * @param nChannels number of color channels
    */
   case class OpenCvType(mode: Int, dataType: String, nChannels: Int) {
@@ -57,7 +60,7 @@ object ImageSchema {
    */
   def ocvTypeByName(name: String): OpenCvType = {
     ocvTypes.find(x => x.name == name).getOrElse(
-      throw new IllegalArgumentException("Unknown open cv type " + name))
+      throw new IllegalArgumentException("Unknown OpenCv type " + name))
   }
 
   /**
@@ -68,7 +71,7 @@ object ImageSchema {
    */
   def ocvTypeByMode(mode: Int): OpenCvType = {
     ocvTypes.find(x => x.mode == mode).getOrElse(
-      throw new IllegalArgumentException("Unknown open cv mode " + mode))
+      throw new IllegalArgumentException("Unknown OpenCv mode " + mode))
   }
 
   val undefinedImageType = OpenCvType(-1, "N/A", -1)
@@ -76,14 +79,16 @@ object ImageSchema {
   /**
    * A Mapping of Type to Numbers in OpenCV
    *
-   *        C1 C2  C3  C4
-   * CV_8U   0  8  16  24
-   * CV_8S   1  9  17  25
-   * CV_16U  2 10  18  26
-   * CV_16S  3 11  19  27
-   * CV_32S  4 12  20  28
-   * CV_32F  5 13  21  29
-   * CV_64F  6 14  22  30
+   * name   |  num channels
+   *        | C1 C2  C3  C4
+   * -------+--------------
+   * CV_8U  |  0  8  16  24
+   * CV_8S  |  1  9  17  25
+   * CV_16U |  2 10  18  26
+   * CV_16S |  3 11  19  27
+   * CV_32S |  4 12  20  28
+   * CV_32F |  5 13  21  29
+   * CV_64F |  6 14  22  30
    */
   val ocvTypes: IndexedSeq[OpenCvType] = {
     val types =

--- a/mllib/src/test/scala/org/apache/spark/ml/image/ImageSchemaSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/image/ImageSchemaSuite.scala
@@ -36,7 +36,7 @@ class ImageSchemaSuite extends SparkFunSuite with MLlibTestSparkContext {
     val height = 1
     val nChannels = 3
     val data = Array[Byte](0, 0, 0)
-    val mode: Int = OpenCvType.get("CV_8UC3").mode
+    val mode: Int = ImageSchema.ocvTypeByName("CV_8UC3").mode
 
     // Internal Row corresponds to image StructType
     val rows = Seq(Row(Row(origin, height, width, nChannels, mode, data)),
@@ -83,7 +83,7 @@ class ImageSchemaSuite extends SparkFunSuite with MLlibTestSparkContext {
         val bytes20 = getData(row).slice(0, 20)
 
         val (expectedMode, expectedBytes) = firstBytes20(filename)
-        assert(OpenCvType.get(expectedMode).mode === mode,
+        assert(ImageSchema.ocvTypeByName(expectedMode).mode === mode,
           "mode of the image is not read correctly")
         assert(Arrays.equals(expectedBytes, bytes20), "incorrect numeric value for flattened image")
       }

--- a/mllib/src/test/scala/org/apache/spark/ml/image/ImageSchemaSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/image/ImageSchemaSuite.scala
@@ -36,7 +36,7 @@ class ImageSchemaSuite extends SparkFunSuite with MLlibTestSparkContext {
     val height = 1
     val nChannels = 3
     val data = Array[Byte](0, 0, 0)
-    val mode = ocvTypes("CV_8UC3")
+    val mode: Int = OpenCvType.get("CV_8UC3").mode
 
     // Internal Row corresponds to image StructType
     val rows = Seq(Row(Row(origin, height, width, nChannels, mode, data)),
@@ -83,7 +83,8 @@ class ImageSchemaSuite extends SparkFunSuite with MLlibTestSparkContext {
         val bytes20 = getData(row).slice(0, 20)
 
         val (expectedMode, expectedBytes) = firstBytes20(filename)
-        assert(ocvTypes(expectedMode) === mode, "mode of the image is not read correctly")
+        assert(OpenCvType.get(expectedMode).mode === mode,
+          "mode of the image is not read correctly")
         assert(Arrays.equals(expectedBytes, bytes20), "incorrect numeric value for flattened image")
       }
     }

--- a/mllib/src/test/scala/org/apache/spark/ml/image/ImageSchemaSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/image/ImageSchemaSuite.scala
@@ -82,8 +82,8 @@ class ImageSchemaSuite extends SparkFunSuite with MLlibTestSparkContext {
         val mode = getMode(row)
         val bytes20 = getData(row).slice(0, 20)
 
-        val (expectedMode, expectedBytes) = firstBytes20(filename)
-        assert(ImageSchema.ocvTypeByName(expectedMode).mode === mode,
+        val (expectedName, expectedBytes) = firstBytes20(filename)
+        assert(ImageSchema.ocvTypeByName(expectedName).mode === mode,
           "mode of the image is not read correctly")
         assert(Arrays.equals(expectedBytes, bytes20), "incorrect numeric value for flattened image")
       }

--- a/python/pyspark/ml/image.py
+++ b/python/pyspark/ml/image.py
@@ -80,9 +80,9 @@ class _ImageSchema(object):
     @property
     def ocvTypes(self):
         """
-        Returns the OpenCV type mapping supported.
+        Return the supported OpenCV types.
 
-        :return: a dictionary containing the OpenCV type mapping supported.
+        :return: a list containing the supported OpenCV types.
 
         .. versionadded:: 2.3.0
         """
@@ -99,6 +99,14 @@ class _ImageSchema(object):
         return self._ocvTypes[:]
 
     def ocvTypeByName(self, name):
+        """
+        Return the OpenCvType with matching name or raise error if there is no matching type.
+
+        :param: str name: OpenCv type name; must be equal to name of one of the supported types.
+        :return: OpenCvType with matching name.
+
+        """
+
         if self._ocvTypesByName is None:
             self._ocvTypesByName = {x.name: x for x in self.ocvTypes}
         if name not in self._ocvTypesByName:
@@ -108,6 +116,14 @@ class _ImageSchema(object):
         return self._ocvTypesByName[name]
 
     def ocvTypeByMode(self, mode):
+        """
+        Return the OpenCvType with matching mode or raise error if there is no matching type.
+
+        :param: int mode: OpenCv type mode; must be equal to mode of one of the supported types.
+        :return: OpenCvType with matching mode.
+
+        """
+
         if self._ocvTypesByMode is None:
             self._ocvTypesByMode = {x.mode: x for x in self.ocvTypes}
         if mode not in self._ocvTypesByMode:

--- a/python/pyspark/ml/image.py
+++ b/python/pyspark/ml/image.py
@@ -185,7 +185,7 @@ class _ImageSchema(object):
         ocvType = self.ocvTypeByMode(image.mode)
         if nChannels != ocvType.nChannels:
             raise ValueError(
-                "Image has %d channels but OcvType '%s' expects %d channels." %
+                "Image has %d channels but its OcvType '%s' expects %d channels." %
                 (nChannels, ocvType.name, ocvType.nChannels))
         itemSz = ocvType.nptype.itemsize
         return np.ndarray(

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -1854,13 +1854,12 @@ class ImageReaderTest(SparkSessionTestCase):
             self.assertEqual(x, ImageSchema.ocvTypeByMode(x.mode))
 
     def test_conversions(self):
-        ary_src = [[[1e7*random.random() for z in range(4)] for y in range(10)] for x in range(10)]
+        s = np.random.RandomState(seed=987)
+        ary_src = s.rand(4, 10, 10)
         for ocvType in ImageSchema.ocvTypes:
             if ocvType.name == 'Undefined':
                 continue
-            x = [[ary_src[i][j][0:ocvType.nChannels]
-                  for j in range(len(ary_src[0]))] for i in range(len(ary_src))]
-            npary0 = np.array(x).astype(ocvType.nptype)
+            npary0 = ary_src[..., 0:ocvType.nChannels].astype(ocvType.nptype)
             img = ImageSchema.toImage(npary0)
             self.assertEqual(ocvType, ImageSchema.ocvTypeByMode(img.mode))
             npary1 = ImageSchema.toNDArray(img)
@@ -1878,7 +1877,7 @@ class ImageReaderTest(SparkSessionTestCase):
 
         expected = ['origin', 'height', 'width', 'nChannels', 'mode', 'data']
         self.assertEqual(ImageSchema.imageFields, expected)
-        self.assertEqual(ImageSchema.undefinedImageType, "Undefined")
+        self.assertEqual(ImageSchema.undefinedImageType.name, "Undefined")
 
         with QuietTest(self.sc):
             self.assertRaisesRegexp(

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -1863,6 +1863,7 @@ class ImageReaderTest(SparkSessionTestCase):
             img = ImageSchema.toImage(npary0)
             self.assertEqual(ocvType, ImageSchema.ocvTypeByMode(img.mode))
             npary1 = ImageSchema.toNDArray(img)
+            self.assertEqual(ocvType.nptype, npary1.dtype)
             np.testing.assert_array_equal(npary0, npary1)
 
     def test_read_images(self):

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -1855,11 +1855,11 @@ class ImageReaderTest(SparkSessionTestCase):
 
     def test_conversions(self):
         s = np.random.RandomState(seed=987)
-        ary_src = s.rand(4, 10, 10)
+        array_src = s.rand(10, 10, 4)
         for ocvType in ImageSchema.ocvTypes:
             if ocvType.name == 'Undefined':
                 continue
-            npary0 = ary_src[..., 0:ocvType.nChannels].astype(ocvType.nptype)
+            npary0 = array_src[..., 0:ocvType.nChannels].astype(ocvType.nptype)
             img = ImageSchema.toImage(npary0)
             self.assertEqual(ocvType, ImageSchema.ocvTypeByMode(img.mode))
             npary1 = ImageSchema.toNDArray(img)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added functionality to handle all OpenCV modes to ImageSchema:
  1. updated toImage and toNDArray functions to handle non-uint8 based images.
  2. add information about individual OpenCv modes

## How was this patch tested?
Added test for conversion between numpy arrays and images stored as all possible OpenCV modes. 