### PR TITLE
[SPARK-22975][SS] MetricsReporter should not throw exception when there was no progress reported

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MetricsReporter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MetricsReporter.scala
@@ -35,14 +35,13 @@ class MetricsReporter(
 
   // Metric names should not have . in them, so that all the metrics of a query are identified
   // together in Ganglia as a single metric group
-  registerGauge("inputRate-total", (lastProgress) => lastProgress.inputRowsPerSecond, 0.0)
-  registerGauge("processingRate-total", (lastProgress) => lastProgress.processedRowsPerSecond, 0.0)
-  registerGauge("latency",
-    (lastProgress) => lastProgress.durationMs.get("triggerExecution").longValue(), 0L)
+  registerGauge("inputRate-total", _.inputRowsPerSecond, 0.0)
+  registerGauge("processingRate-total", _.processedRowsPerSecond, 0.0)
+  registerGauge("latency", _.durationMs.get("triggerExecution").longValue(), 0L)
 
   private def registerGauge[T](
       name: String,
-      f: (StreamingQueryProgress) => T,
+      f: StreamingQueryProgress => T,
       default: T): Unit = {
     synchronized {
       metricRegistry.register(name, new Gauge[T] {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MetricsReporter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MetricsReporter.scala
@@ -17,15 +17,11 @@
 
 package org.apache.spark.sql.execution.streaming
 
-import java.{util => ju}
-
-import scala.collection.mutable
-
 import com.codahale.metrics.{Gauge, MetricRegistry}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.metrics.source.{Source => CodahaleSource}
-import org.apache.spark.util.Clock
+import org.apache.spark.sql.streaming.StreamingQueryProgress
 
 /**
  * Serves metrics from a [[org.apache.spark.sql.streaming.StreamingQuery]] to
@@ -39,14 +35,18 @@ class MetricsReporter(
 
   // Metric names should not have . in them, so that all the metrics of a query are identified
   // together in Ganglia as a single metric group
-  registerGauge("inputRate-total", () => stream.lastProgress.inputRowsPerSecond)
-  registerGauge("processingRate-total", () => stream.lastProgress.processedRowsPerSecond)
-  registerGauge("latency", () => stream.lastProgress.durationMs.get("triggerExecution").longValue())
+  registerGauge("inputRate-total", (lastProgress) => lastProgress.inputRowsPerSecond, 0.0)
+  registerGauge("processingRate-total", (lastProgress) => lastProgress.processedRowsPerSecond, 0.0)
+  registerGauge("latency",
+    (lastProgress) => lastProgress.durationMs.get("triggerExecution").longValue(), 0L)
 
-  private def registerGauge[T](name: String, f: () => T)(implicit num: Numeric[T]): Unit = {
+  private def registerGauge[T](
+      name: String,
+      f: (StreamingQueryProgress) => T,
+      default: T): Unit = {
     synchronized {
       metricRegistry.register(name, new Gauge[T] {
-        override def getValue: T = f()
+        override def getValue: T = Option(stream.lastProgress).map(f).getOrElse(default)
       })
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -427,6 +427,7 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
   test("SPARK-22975: MetricsReporter defaults when there was no progress reported") {
     withSQLConf("spark.sql.streaming.metricsEnabled" -> "true") {
       testStream(MemoryStream[Int].toDF())(
+        StartStream(Trigger.ProcessingTime(1000 * 60 * 60)),
         AssertOnQuery { q =>
           q.streamMetrics.metricRegistry.getGauges.get("latency").getValue.asInstanceOf[Long] == 0L
         },
@@ -437,7 +438,8 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
         AssertOnQuery { q =>
           q.streamMetrics.metricRegistry.getGauges.get("processingRate-total").getValue
             .asInstanceOf[Double] == 0.0
-        }
+        },
+        StopStream
       )
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -426,21 +426,26 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
 
   test("SPARK-22975: MetricsReporter defaults when there was no progress reported") {
     withSQLConf("spark.sql.streaming.metricsEnabled" -> "true") {
-      testStream(MemoryStream[Int].toDF())(
-        StartStream(Trigger.ProcessingTime(1000 * 60 * 60)),
-        AssertOnQuery { q =>
-          q.streamMetrics.metricRegistry.getGauges.get("latency").getValue.asInstanceOf[Long] == 0L
-        },
-        AssertOnQuery { q =>
-          q.streamMetrics.metricRegistry.getGauges.get("inputRate-total").getValue
-            .asInstanceOf[Double] == 0.0
-        },
-        AssertOnQuery { q =>
-          q.streamMetrics.metricRegistry.getGauges.get("processingRate-total").getValue
-            .asInstanceOf[Double] == 0.0
-        },
-        StopStream
-      )
+      BlockingSource.latch = new CountDownLatch(1)
+      withTempDir { tempDir =>
+        val sq = spark.readStream
+          .format("org.apache.spark.sql.streaming.util.BlockingSource")
+          .load()
+          .writeStream
+          .format("org.apache.spark.sql.streaming.util.BlockingSource")
+          .option("checkpointLocation", tempDir.toString)
+          .start()
+          .asInstanceOf[StreamingQueryWrapper]
+          .streamingQuery
+        val gauges = sq.streamMetrics.metricRegistry.getGauges
+
+        assert(gauges.get("latency").getValue.asInstanceOf[Long] == 0)
+        assert(gauges.get("processingRate-total").getValue.asInstanceOf[Double] == 0.0)
+        assert(gauges.get("inputRate-total").getValue.asInstanceOf[Double] == 0.0)
+        BlockingSource.latch.countDown()
+        sq.stop()
+      }
+
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -426,18 +426,24 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
 
   test("SPARK-22975: MetricsReporter defaults when there was no progress reported") {
     withSQLConf("spark.sql.streaming.metricsEnabled" -> "true") {
-      val sq = MemoryStream[Int].toDF
-        .writeStream
-        .format("console")
-        .start()
-        .asInstanceOf[StreamingQueryWrapper]
-        .streamingQuery
+      BlockingSource.latch = new CountDownLatch(1)
+      withTempDir { tempDir =>
+        val sq = spark.readStream
+          .format("org.apache.spark.sql.streaming.util.BlockingSource")
+          .load()
+          .writeStream
+          .format("org.apache.spark.sql.streaming.util.BlockingSource")
+          .option("checkpointLocation", tempDir.toString)
+          .start()
+          .asInstanceOf[StreamingQueryWrapper]
+          .streamingQuery
 
-      val gauges = sq.streamMetrics.metricRegistry.getGauges
-      assert(gauges.get("latency").getValue.asInstanceOf[Long] == 0)
-      assert(gauges.get("processingRate-total").getValue.asInstanceOf[Double] == 0.0)
-      assert(gauges.get("inputRate-total").getValue.asInstanceOf[Double] == 0.0)
-      sq.stop()
+        val gauges = sq.streamMetrics.metricRegistry.getGauges
+        assert(gauges.get("latency").getValue.asInstanceOf[Long] == 0)
+        assert(gauges.get("processingRate-total").getValue.asInstanceOf[Double] == 0.0)
+        assert(gauges.get("inputRate-total").getValue.asInstanceOf[Double] == 0.0)
+        sq.stop()
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -426,26 +426,18 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
 
   test("SPARK-22975: MetricsReporter defaults when there was no progress reported") {
     withSQLConf("spark.sql.streaming.metricsEnabled" -> "true") {
-      BlockingSource.latch = new CountDownLatch(1)
-      withTempDir { tempDir =>
-        val sq = spark.readStream
-          .format("org.apache.spark.sql.streaming.util.BlockingSource")
-          .load()
-          .writeStream
-          .format("org.apache.spark.sql.streaming.util.BlockingSource")
-          .option("checkpointLocation", tempDir.toString)
-          .start()
-          .asInstanceOf[StreamingQueryWrapper]
-          .streamingQuery
-        val gauges = sq.streamMetrics.metricRegistry.getGauges
+      val sq = MemoryStream[Int].toDF
+        .writeStream
+        .format("console")
+        .start()
+        .asInstanceOf[StreamingQueryWrapper]
+        .streamingQuery
 
-        assert(gauges.get("latency").getValue.asInstanceOf[Long] == 0)
-        assert(gauges.get("processingRate-total").getValue.asInstanceOf[Double] == 0.0)
-        assert(gauges.get("inputRate-total").getValue.asInstanceOf[Double] == 0.0)
-        BlockingSource.latch.countDown()
-        sq.stop()
-      }
-
+      val gauges = sq.streamMetrics.metricRegistry.getGauges
+      assert(gauges.get("latency").getValue.asInstanceOf[Long] == 0)
+      assert(gauges.get("processingRate-total").getValue.asInstanceOf[Double] == 0.0)
+      assert(gauges.get("inputRate-total").getValue.asInstanceOf[Double] == 0.0)
+      sq.stop()
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`MetricsReporter ` assumes that there has been some progress for the query, ie. `lastProgress` is not null. If this is not true, as it might happen in particular conditions, a `NullPointerException` can be thrown.

The PR checks whether there is a `lastProgress` and if this is not true, it returns a default value for the metrics.

## How was this patch tested?

added UT
