### PR TITLE
[SPARK-23000] [TEST-HADOOP2.6] Fix Flaky test suite DataSourceWithHiveMetastoreCatalogSuite in Spark 2.3 [WIP]

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2546,4 +2546,6 @@ object UpdateOuterReferences extends Rule[LogicalPlan] {
       }
     }
   }
+
+  val dumb = 1
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveMetastoreCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveMetastoreCatalogSuite.scala
@@ -252,6 +252,5 @@ class DataSourceWithHiveMetastoreCatalogSuite
         }
       }
     }
-
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Tried to reproduce it.

## How was this patch tested?
N/A