### PR TITLE
[SPARK-23011][PYTHON][SQL] Prepend missing grouping columns in groupby apply

### DIFF
--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -233,6 +233,27 @@ class GroupedData(object):
         |  2| 1.1094003924504583|
         +---+-------------------+
 
+        Notes on grouping column:
+
+        Depending on whether the UDF returns grouping columns as part of its return type, this
+        function may or may not prepend grouping columns to the result. This is explained as
+        following:
+
+        1. UDF returns all grouping columns:
+
+           This function will not prepend any grouping columns to the result.
+
+        2. UDF returns some grouping columns:
+
+           This function will prepend grouping columns that are not returned by the UDF.
+
+        3. UDF returns no grouping columns:
+
+           This function will prepend all grouping columns.
+
+        In all cases, if the grouping column and the UDF output conflict, the value in the UDF
+        output will override the origin value of the grouping column.
+
         .. seealso:: :meth:`pyspark.sql.functions.pandas_udf`
 
         """

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -4011,8 +4011,9 @@ class GroupbyApplyTests(ReusedSQLTestCase):
         # Use expression in groupby. The grouping expression should be prepended to the result.
         result1 = df.groupby(col('id') % 2 == 0).apply(foo).sort('((id % 2) = 0)', 'v').toPandas()
         expected1 = pdf.groupby(pdf['id'] % 2 == 0).apply(foo.func)
-        expected1.index.names =  ['((id % 2) = 0)', None]
-        expected1 = expected1.reset_index(level=0).sort_values(['((id % 2) = 0)', 'v']).reset_index(drop=True)
+        expected1.index.names = ['((id % 2) = 0)', None]
+        expected1 = expected1.reset_index(level=0).sort_values(['((id % 2) = 0)', 'v'])\
+            .reset_index(drop=True)
 
         # Grouping column is not returned by the udf. The grouping column should be prepended.
         result2 = df.groupby('id').apply(foo).sort('id', 'v').toPandas()
@@ -4026,10 +4027,12 @@ class GroupbyApplyTests(ReusedSQLTestCase):
             .reset_index(drop=True).sort_values(['id', 'v'])
 
         # Mix expression and column
-        result4 = df.groupby(col('id') % 2 == 0, 'v').apply(foo).sort('((id % 2) = 0)', 'v').toPandas()
+        result4 = df.groupby(col('id') % 2 == 0, 'v').apply(foo).sort('((id % 2) = 0)', 'v')\
+            .toPandas()
         expected4 = pdf.groupby([pdf['id'] % 2 == 0, 'v']).apply(foo.func)
         expected4.index.names = ['((id % 2) = 0)', 'v', None]
-        expected4 = expected4.reset_index(level=0).sort_values(['((id % 2) = 0)', 'v']).reset_index(drop=True)
+        expected4 = expected4.reset_index(level=0).sort_values(['((id % 2) = 0)', 'v'])\
+            .reset_index(drop=True)
 
         self.assertFramesEqual(expected1, result1)
         self.assertFramesEqual(expected2, result2)

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -4013,6 +4013,23 @@ class GroupbyApplyTests(ReusedSQLTestCase):
         expected = expected.assign(norm=expected.norm.astype('float64'))
         self.assertFramesEqual(expected, result)
 
+    def test_groupkey(self):
+        import pandas as pd
+        from pyspark.sql.functions import pandas_udf, PandasUDFType
+        df = self.data
+        pdf = df.toPandas()
+
+        @pandas_udf('v double, v_norm double', PandasUDFType.GROUP_MAP)
+        def normalize(pdf):
+            v = pdf['v']
+            return pd.DataFrame({'v': v, 'v_norm': v - v.mean()})
+
+        result = df.groupby('id').apply(normalize).toPandas()
+        expected = pdf.groupby('id').apply(normalize.func)
+
+        print(result)
+        print(expected)
+
     def test_empty_groupby(self):
         from pyspark.sql.functions import pandas_udf, col, PandasUDFType
         df = self.data

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -452,7 +452,8 @@ object ColumnPruning extends Rule[LogicalPlan] {
     // Prunes the unused columns from child of Aggregate/Expand/Generate
     case a @ Aggregate(_, _, child) if (child.outputSet -- a.references).nonEmpty =>
       a.copy(child = prunedChild(child, a.references))
-    case f @ FlatMapGroupsInPandas(_, _, _, child) if (child.outputSet -- f.references).nonEmpty =>
+    case f @ FlatMapGroupsInPandas(_, _, _, _, child)
+      if (child.outputSet -- f.references).nonEmpty =>
       f.copy(child = prunedChild(child, f.references))
     case e @ Expand(_, _, child) if (child.outputSet -- e.references).nonEmpty =>
       e.copy(child = prunedChild(child, e.references))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/pythonLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/pythonLogicalOperators.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, Expre
  */
 case class FlatMapGroupsInPandas(
     groupingAttributes: Seq[Attribute],
+    additionalGroupingAttributes: Seq[Attribute],
     functionExpr: Expression,
     output: Seq[Attribute],
     child: LogicalPlan) extends UnaryNode {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -452,8 +452,9 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
       case logical.FlatMapGroupsInR(f, p, b, is, os, key, value, grouping, data, objAttr, child) =>
         execution.FlatMapGroupsInRExec(f, p, b, is, os, key, value, grouping,
           data, objAttr, planLater(child)) :: Nil
-      case logical.FlatMapGroupsInPandas(grouping, func, output, child) =>
-        execution.python.FlatMapGroupsInPandasExec(grouping, func, output, planLater(child)) :: Nil
+      case logical.FlatMapGroupsInPandas(grouping, additionalGrouping, func, output, child) =>
+        execution.python.FlatMapGroupsInPandasExec(
+          grouping, additionalGrouping, func, output, planLater(child)) :: Nil
       case logical.MapElements(f, _, _, objAttr, child) =>
         execution.MapElementsExec(f, objAttr, planLater(child)) :: Nil
       case logical.AppendColumns(f, _, _, in, out, child) =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

See https://issues.apache.org/jira/browse/SPARK-23011

## How was this patch tested?

Add more tests in `test_complex_groupby`

## TODO:
- [ ] Document the usage in groupby apply
