### PR TITLE
[SPARK-23024][WEB-UI]Spark ui about the contents of the form need to have hidden and show features, when the table records very much.

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/webui.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.js
@@ -50,4 +50,34 @@ function collapseTable(thisName, table){
 // to remember if it's collapsed on each page reload
 $(function() {
   collapseTablePageLoad('collapse-aggregated-metrics','aggregated-metrics');
+  collapseTablePageLoad('collapse-aggregated-executors','aggregated-executors');
+  collapseTablePageLoad('collapse-aggregated-removedExecutors','aggregated-removedExecutors');
+  collapseTablePageLoad('collapse-aggregated-workers','aggregated-workers');
+  collapseTablePageLoad('collapse-aggregated-activeApps','aggregated-activeApps');
+  collapseTablePageLoad('collapse-aggregated-activeDrivers','aggregated-activeDrivers');
+  collapseTablePageLoad('collapse-aggregated-completedApps','aggregated-completedApps');
+  collapseTablePageLoad('collapse-aggregated-completedDrivers','aggregated-completedDrivers');
+  collapseTablePageLoad('collapse-aggregated-runningExecutors','aggregated-runningExecutors');
+  collapseTablePageLoad('collapse-aggregated-runningDrivers','aggregated-runningDrivers');
+  collapseTablePageLoad('collapse-aggregated-finishedExecutors','aggregated-finishedExecutors');
+  collapseTablePageLoad('collapse-aggregated-finishedDrivers','aggregated-finishedDrivers');
+  collapseTablePageLoad('collapse-aggregated-runtimeInformation','aggregated-runtimeInformation');
+  collapseTablePageLoad('collapse-aggregated-sparkProperties','aggregated-sparkProperties');
+  collapseTablePageLoad('collapse-aggregated-systemProperties','aggregated-systemProperties');
+  collapseTablePageLoad('collapse-aggregated-classpathEntries','aggregated-classpathEntries');
+  collapseTablePageLoad('collapse-aggregated-activeJobs','aggregated-activeJobs');
+  collapseTablePageLoad('collapse-aggregated-completedJobs','aggregated-completedJobs');
+  collapseTablePageLoad('collapse-aggregated-failedJobs','aggregated-failedJobs');
+  collapseTablePageLoad('collapse-aggregated-poolTable','aggregated-poolTable');
+  collapseTablePageLoad('collapse-aggregated-allActiveStages','aggregated-allActiveStages');
+  collapseTablePageLoad('collapse-aggregated-allPendingStages','aggregated-allPendingStages');
+  collapseTablePageLoad('collapse-aggregated-allCompletedStages','aggregated-allCompletedStages');
+  collapseTablePageLoad('collapse-aggregated-allFailedStages','aggregated-allFailedStages');
+  collapseTablePageLoad('collapse-aggregated-activeStages','aggregated-activeStages');
+  collapseTablePageLoad('collapse-aggregated-pendingOrSkippedStages','aggregated-pendingOrSkippedStages');
+  collapseTablePageLoad('collapse-aggregated-completedStages','aggregated-completedStages');
+  collapseTablePageLoad('collapse-aggregated-failedStages','aggregated-failedStages');
+  collapseTablePageLoad('collapse-aggregated-poolActiveStages','aggregated-poolActiveStages');
+  collapseTablePageLoad('collapse-aggregated-tasks','aggregated-tasks');
+  collapseTablePageLoad('collapse-aggregated-rdds','aggregated-rdds');
 });

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
@@ -102,7 +102,8 @@ private[ui] class ApplicationPage(parent: MasterWebUI) extends WebUIPage("app") 
         <div class="span12">
           <h4 class="collapse-aggregated-executors collapse-table"
               onClick="collapseTable('collapse-aggregated-executors','aggregated-executors')">
-            Executor Summary ({allExecutors.length})
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Executor Summary ({allExecutors.length})</a>
           </h4>
           <div class="aggregated-executors collapsible-table">
             {executorsTable}
@@ -112,7 +113,8 @@ private[ui] class ApplicationPage(parent: MasterWebUI) extends WebUIPage("app") 
               <h4 class="collapse-aggregated-removedExecutors collapse-table"
                   onClick="collapseTable('collapse-aggregated-removedExecutors',
                   'aggregated-removedExecutors')">
-                Removed Executors ({removedExecutors.length})
+                <span class="collapse-table-arrow arrow-open"></span>
+                <a>Removed Executors ({removedExecutors.length})</a>
               </h4> ++
               <div class="aggregated-removedExecutors collapsible-table">
                 {removedExecutorsTable}

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
@@ -100,12 +100,23 @@ private[ui] class ApplicationPage(parent: MasterWebUI) extends WebUIPage("app") 
 
       <div class="row-fluid"> <!-- Executors -->
         <div class="span12">
-          <h4> Executor Summary ({allExecutors.length}) </h4>
-          {executorsTable}
+          <h4 class="collapse-aggregated-executors collapse-table"
+              onClick="collapseTable('collapse-aggregated-executors','aggregated-executors')">
+            Executor Summary ({allExecutors.length})
+          </h4>
+          <div class="aggregated-executors collapsible-table">
+            {executorsTable}
+          </div>
           {
             if (removedExecutors.nonEmpty) {
-              <h4> Removed Executors ({removedExecutors.length}) </h4> ++
-              removedExecutorsTable
+              <h4 class="collapse-aggregated-removedExecutors collapse-table"
+                  onClick="collapseTable('collapse-aggregated-removedExecutors',
+                  'aggregated-removedExecutors')">
+                Removed Executors ({removedExecutors.length})
+              </h4> ++
+              <div class="aggregated-removedExecutors collapsible-table">
+                {removedExecutorsTable}
+              </div>
             }
           }
         </div>

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
@@ -100,22 +100,26 @@ private[ui] class ApplicationPage(parent: MasterWebUI) extends WebUIPage("app") 
 
       <div class="row-fluid"> <!-- Executors -->
         <div class="span12">
-          <h4 class="collapse-aggregated-executors collapse-table"
+          <span class="collapse-aggregated-executors collapse-table"
               onClick="collapseTable('collapse-aggregated-executors','aggregated-executors')">
-            <span class="collapse-table-arrow arrow-open"></span>
-            <a>Executor Summary ({allExecutors.length})</a>
-          </h4>
+            <h4>
+              <span class="collapse-table-arrow arrow-open"></span>
+              <a>Executor Summary ({allExecutors.length})</a>
+            </h4>
+          </span>
           <div class="aggregated-executors collapsible-table">
             {executorsTable}
           </div>
           {
             if (removedExecutors.nonEmpty) {
-              <h4 class="collapse-aggregated-removedExecutors collapse-table"
+              <span class="collapse-aggregated-removedExecutors collapse-table"
                   onClick="collapseTable('collapse-aggregated-removedExecutors',
                   'aggregated-removedExecutors')">
-                <span class="collapse-table-arrow arrow-open"></span>
-                <a>Removed Executors ({removedExecutors.length})</a>
-              </h4> ++
+                <h4>
+                  <span class="collapse-table-arrow arrow-open"></span>
+                  <a>Removed Executors ({removedExecutors.length})</a>
+                </h4>
+              </span> ++
               <div class="aggregated-removedExecutors collapsible-table">
                 {removedExecutorsTable}
               </div>

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
@@ -130,7 +130,8 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
           <div class="span12">
             <h4 class="collapse-aggregated-workers collapse-table"
                 onClick="collapseTable('collapse-aggregated-workers','aggregated-workers')">
-              Workers ({workers.length})
+              <span class="collapse-table-arrow arrow-open"></span>
+              <a>Workers ({workers.length})</a>
             </h4>
             <div class="aggregated-workers collapsible-table">
               {workerTable}
@@ -142,7 +143,8 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
           <div class="span12">
             <h4 id="running-app" class="collapse-aggregated-activeApps collapse-table"
                 onClick="collapseTable('collapse-aggregated-activeApps','aggregated-activeApps')">
-              Running Applications ({activeApps.length})
+              <span class="collapse-table-arrow arrow-open"></span>
+              <a>Running Applications ({activeApps.length})</a>
             </h4>
             <div class="aggregated-activeApps collapsible-table">
               {activeAppsTable}
@@ -157,7 +159,9 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
                  <h4 class="collapse-aggregated-activeDrivers collapse-table"
                      onClick="collapseTable('collapse-aggregated-activeDrivers',
                      'aggregated-activeDrivers')">
-                   Running Drivers ({activeDrivers.length}) </h4>
+                   <span class="collapse-table-arrow arrow-open"></span>
+                   <a>Running Drivers ({activeDrivers.length})</a>
+                 </h4>
                  <div class="aggregated-activeDrivers collapsible-table">
                    {activeDriversTable}
                  </div>
@@ -172,7 +176,8 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
             <h4 id="completed-app" class="collapse-aggregated-completedApps collapse-table"
                 onClick="collapseTable('collapse-aggregated-completedApps',
                 'aggregated-completedApps')">
-              Completed Applications ({completedApps.length})
+              <span class="collapse-table-arrow arrow-open"></span>
+              <a>Completed Applications ({completedApps.length})</a>
             </h4>
             <div class="aggregated-completedApps collapsible-table">
               {completedAppsTable}
@@ -188,7 +193,8 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
                   <h4 class="collapse-aggregated-completedDrivers collapse-table"
                       onClick="collapseTable('collapse-aggregated-completedDrivers',
                       'aggregated-completedDrivers')">
-                    Completed Drivers ({completedDrivers.length})
+                    <span class="collapse-table-arrow arrow-open"></span>
+                    <a>Completed Drivers ({completedDrivers.length})</a>
                   </h4>
                   <div class="aggregated-completedDrivers collapsible-table">
                     {completedDriversTable}

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
@@ -128,15 +128,25 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
 
         <div class="row-fluid">
           <div class="span12">
-            <h4> Workers ({workers.length}) </h4>
-            {workerTable}
+            <h4 class="collapse-aggregated-workers collapse-table"
+                onClick="collapseTable('collapse-aggregated-workers','aggregated-workers')">
+              Workers ({workers.length})
+            </h4>
+            <div class="aggregated-workers collapsible-table">
+              {workerTable}
+            </div>
           </div>
         </div>
 
         <div class="row-fluid">
           <div class="span12">
-            <h4 id="running-app"> Running Applications ({activeApps.length}) </h4>
-            {activeAppsTable}
+            <h4 id="running-app" class="collapse-aggregated-activeApps collapse-table"
+                onClick="collapseTable('collapse-aggregated-activeApps','aggregated-activeApps')">
+              Running Applications ({activeApps.length})
+            </h4>
+            <div class="aggregated-activeApps collapsible-table">
+              {activeAppsTable}
+            </div>
           </div>
         </div>
 
@@ -144,8 +154,13 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
           {if (hasDrivers) {
              <div class="row-fluid">
                <div class="span12">
-                 <h4> Running Drivers ({activeDrivers.length}) </h4>
-                 {activeDriversTable}
+                 <h4 class="collapse-aggregated-activeDrivers collapse-table"
+                     onClick="collapseTable('collapse-aggregated-activeDrivers',
+                     'aggregated-activeDrivers')">
+                   Running Drivers ({activeDrivers.length}) </h4>
+                 <div class="aggregated-activeDrivers collapsible-table">
+                   {activeDriversTable}
+                 </div>
                </div>
              </div>
            }
@@ -154,8 +169,14 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
 
         <div class="row-fluid">
           <div class="span12">
-            <h4 id="completed-app"> Completed Applications ({completedApps.length}) </h4>
-            {completedAppsTable}
+            <h4 id="completed-app" class="collapse-aggregated-completedApps collapse-table"
+                onClick="collapseTable('collapse-aggregated-completedApps',
+                'aggregated-completedApps')">
+              Completed Applications ({completedApps.length})
+            </h4>
+            <div class="aggregated-completedApps collapsible-table">
+              {completedAppsTable}
+            </div>
           </div>
         </div>
 
@@ -164,8 +185,14 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
             if (hasDrivers) {
               <div class="row-fluid">
                 <div class="span12">
-                  <h4> Completed Drivers ({completedDrivers.length}) </h4>
-                  {completedDriversTable}
+                  <h4 class="collapse-aggregated-completedDrivers collapse-table"
+                      onClick="collapseTable('collapse-aggregated-completedDrivers',
+                      'aggregated-completedDrivers')">
+                    Completed Drivers ({completedDrivers.length})
+                  </h4>
+                  <div class="aggregated-completedDrivers collapsible-table">
+                    {completedDriversTable}
+                  </div>
                 </div>
               </div>
             }

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
@@ -128,11 +128,13 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
 
         <div class="row-fluid">
           <div class="span12">
-            <h4 class="collapse-aggregated-workers collapse-table"
+            <span class="collapse-aggregated-workers collapse-table"
                 onClick="collapseTable('collapse-aggregated-workers','aggregated-workers')">
-              <span class="collapse-table-arrow arrow-open"></span>
-              <a>Workers ({workers.length})</a>
-            </h4>
+              <h4>
+                <span class="collapse-table-arrow arrow-open"></span>
+                <a>Workers ({workers.length})</a>
+              </h4>
+            </span>
             <div class="aggregated-workers collapsible-table">
               {workerTable}
             </div>
@@ -141,11 +143,13 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
 
         <div class="row-fluid">
           <div class="span12">
-            <h4 id="running-app" class="collapse-aggregated-activeApps collapse-table"
+            <span id="running-app" class="collapse-aggregated-activeApps collapse-table"
                 onClick="collapseTable('collapse-aggregated-activeApps','aggregated-activeApps')">
-              <span class="collapse-table-arrow arrow-open"></span>
-              <a>Running Applications ({activeApps.length})</a>
-            </h4>
+              <h4>
+                <span class="collapse-table-arrow arrow-open"></span>
+                <a>Running Applications ({activeApps.length})</a>
+              </h4>
+            </span>
             <div class="aggregated-activeApps collapsible-table">
               {activeAppsTable}
             </div>
@@ -156,12 +160,14 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
           {if (hasDrivers) {
              <div class="row-fluid">
                <div class="span12">
-                 <h4 class="collapse-aggregated-activeDrivers collapse-table"
+                 <span class="collapse-aggregated-activeDrivers collapse-table"
                      onClick="collapseTable('collapse-aggregated-activeDrivers',
                      'aggregated-activeDrivers')">
-                   <span class="collapse-table-arrow arrow-open"></span>
-                   <a>Running Drivers ({activeDrivers.length})</a>
-                 </h4>
+                   <h4>
+                     <span class="collapse-table-arrow arrow-open"></span>
+                     <a>Running Drivers ({activeDrivers.length})</a>
+                   </h4>
+                 </span>
                  <div class="aggregated-activeDrivers collapsible-table">
                    {activeDriversTable}
                  </div>
@@ -173,12 +179,14 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
 
         <div class="row-fluid">
           <div class="span12">
-            <h4 id="completed-app" class="collapse-aggregated-completedApps collapse-table"
+            <span id="completed-app" class="collapse-aggregated-completedApps collapse-table"
                 onClick="collapseTable('collapse-aggregated-completedApps',
                 'aggregated-completedApps')">
-              <span class="collapse-table-arrow arrow-open"></span>
-              <a>Completed Applications ({completedApps.length})</a>
-            </h4>
+              <h4>
+                <span class="collapse-table-arrow arrow-open"></span>
+                <a>Completed Applications ({completedApps.length})</a>
+              </h4>
+            </span>
             <div class="aggregated-completedApps collapsible-table">
               {completedAppsTable}
             </div>
@@ -190,12 +198,14 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
             if (hasDrivers) {
               <div class="row-fluid">
                 <div class="span12">
-                  <h4 class="collapse-aggregated-completedDrivers collapse-table"
+                  <span class="collapse-aggregated-completedDrivers collapse-table"
                       onClick="collapseTable('collapse-aggregated-completedDrivers',
                       'aggregated-completedDrivers')">
-                    <span class="collapse-table-arrow arrow-open"></span>
-                    <a>Completed Drivers ({completedDrivers.length})</a>
-                  </h4>
+                    <h4>
+                      <span class="collapse-table-arrow arrow-open"></span>
+                      <a>Completed Drivers ({completedDrivers.length})</a>
+                    </h4>
+                  </span>
                   <div class="aggregated-completedDrivers collapsible-table">
                     {completedDriversTable}
                   </div>

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
@@ -80,7 +80,8 @@ private[ui] class WorkerPage(parent: WorkerWebUI) extends WebUIPage("") {
           <h4 class="collapse-aggregated-runningExecutors collapse-table"
               onClick="collapseTable('collapse-aggregated-runningExecutors',
               'aggregated-runningExecutors')">
-            Running Executors ({runningExecutors.size})
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Running Executors ({runningExecutors.size})</a>
           </h4>
           <div class="aggregated-runningExecutors collapsible-table">
             {runningExecutorTable}
@@ -90,7 +91,8 @@ private[ui] class WorkerPage(parent: WorkerWebUI) extends WebUIPage("") {
               <h4 class="collapse-aggregated-runningDrivers collapse-table"
                   onClick="collapseTable('collapse-aggregated-runningDrivers',
                   'aggregated-runningDrivers')">
-                Running Drivers ({runningDrivers.size})
+                <span class="collapse-table-arrow arrow-open"></span>
+                <a>Running Drivers ({runningDrivers.size})</a>
               </h4> ++
               <div class="aggregated-runningDrivers collapsible-table">
                 {runningDriverTable}
@@ -102,7 +104,8 @@ private[ui] class WorkerPage(parent: WorkerWebUI) extends WebUIPage("") {
               <h4 class="collapse-aggregated-finishedExecutors collapse-table"
                   onClick="collapseTable('collapse-aggregated-finishedExecutors',
                   'aggregated-finishedExecutors')">
-                Finished Executors ({finishedExecutors.size})
+                <span class="collapse-table-arrow arrow-open"></span>
+                <a>Finished Executors ({finishedExecutors.size})</a>
               </h4> ++
               <div class="aggregated-finishedExecutors collapsible-table">
                 {finishedExecutorTable}
@@ -114,7 +117,8 @@ private[ui] class WorkerPage(parent: WorkerWebUI) extends WebUIPage("") {
               <h4 class="collapse-aggregated-finishedDrivers collapse-table"
                   onClick="collapseTable('collapse-aggregated-finishedDrivers',
                   'aggregated-finishedDrivers')">
-                Finished Drivers ({finishedDrivers.size})
+                <span class="collapse-table-arrow arrow-open"></span>
+                <a>Finished Drivers ({finishedDrivers.size})</a>
               </h4> ++
               <div class="aggregated-finishedDrivers collapsible-table">
                 {finishedDriverTable}

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
@@ -77,24 +77,48 @@ private[ui] class WorkerPage(parent: WorkerWebUI) extends WebUIPage("") {
       </div>
       <div class="row-fluid"> <!-- Executors and Drivers -->
         <div class="span12">
-          <h4> Running Executors ({runningExecutors.size}) </h4>
-          {runningExecutorTable}
+          <h4 class="collapse-aggregated-runningExecutors collapse-table"
+              onClick="collapseTable('collapse-aggregated-runningExecutors',
+              'aggregated-runningExecutors')">
+            Running Executors ({runningExecutors.size})
+          </h4>
+          <div class="aggregated-runningExecutors collapsible-table">
+            {runningExecutorTable}
+          </div>
           {
             if (runningDrivers.nonEmpty) {
-              <h4> Running Drivers ({runningDrivers.size}) </h4> ++
-              runningDriverTable
+              <h4 class="collapse-aggregated-runningDrivers collapse-table"
+                  onClick="collapseTable('collapse-aggregated-runningDrivers',
+                  'aggregated-runningDrivers')">
+                Running Drivers ({runningDrivers.size})
+              </h4> ++
+              <div class="aggregated-runningDrivers collapsible-table">
+                {runningDriverTable}
+              </div>
             }
           }
           {
             if (finishedExecutors.nonEmpty) {
-              <h4>Finished Executors ({finishedExecutors.size}) </h4> ++
-              finishedExecutorTable
+              <h4 class="collapse-aggregated-finishedExecutors collapse-table"
+                  onClick="collapseTable('collapse-aggregated-finishedExecutors',
+                  'aggregated-finishedExecutors')">
+                Finished Executors ({finishedExecutors.size})
+              </h4> ++
+              <div class="aggregated-finishedExecutors collapsible-table">
+                {finishedExecutorTable}
+              </div>
             }
           }
           {
             if (finishedDrivers.nonEmpty) {
-              <h4> Finished Drivers ({finishedDrivers.size}) </h4> ++
-              finishedDriverTable
+              <h4 class="collapse-aggregated-finishedDrivers collapse-table"
+                  onClick="collapseTable('collapse-aggregated-finishedDrivers',
+                  'aggregated-finishedDrivers')">
+                Finished Drivers ({finishedDrivers.size})
+              </h4> ++
+              <div class="aggregated-finishedDrivers collapsible-table">
+                {finishedDriverTable}
+              </div>
             }
           }
         </div>

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
@@ -77,23 +77,27 @@ private[ui] class WorkerPage(parent: WorkerWebUI) extends WebUIPage("") {
       </div>
       <div class="row-fluid"> <!-- Executors and Drivers -->
         <div class="span12">
-          <h4 class="collapse-aggregated-runningExecutors collapse-table"
+          <span class="collapse-aggregated-runningExecutors collapse-table"
               onClick="collapseTable('collapse-aggregated-runningExecutors',
               'aggregated-runningExecutors')">
-            <span class="collapse-table-arrow arrow-open"></span>
-            <a>Running Executors ({runningExecutors.size})</a>
-          </h4>
+            <h4>
+              <span class="collapse-table-arrow arrow-open"></span>
+              <a>Running Executors ({runningExecutors.size})</a>
+            </h4>
+          </span>
           <div class="aggregated-runningExecutors collapsible-table">
             {runningExecutorTable}
           </div>
           {
             if (runningDrivers.nonEmpty) {
-              <h4 class="collapse-aggregated-runningDrivers collapse-table"
+              <span class="collapse-aggregated-runningDrivers collapse-table"
                   onClick="collapseTable('collapse-aggregated-runningDrivers',
                   'aggregated-runningDrivers')">
-                <span class="collapse-table-arrow arrow-open"></span>
-                <a>Running Drivers ({runningDrivers.size})</a>
-              </h4> ++
+                <h4>
+                  <span class="collapse-table-arrow arrow-open"></span>
+                  <a>Running Drivers ({runningDrivers.size})</a>
+                </h4>
+              </span> ++
               <div class="aggregated-runningDrivers collapsible-table">
                 {runningDriverTable}
               </div>
@@ -101,12 +105,14 @@ private[ui] class WorkerPage(parent: WorkerWebUI) extends WebUIPage("") {
           }
           {
             if (finishedExecutors.nonEmpty) {
-              <h4 class="collapse-aggregated-finishedExecutors collapse-table"
+              <span class="collapse-aggregated-finishedExecutors collapse-table"
                   onClick="collapseTable('collapse-aggregated-finishedExecutors',
                   'aggregated-finishedExecutors')">
-                <span class="collapse-table-arrow arrow-open"></span>
-                <a>Finished Executors ({finishedExecutors.size})</a>
-              </h4> ++
+                <h4>
+                  <span class="collapse-table-arrow arrow-open"></span>
+                  <a>Finished Executors ({finishedExecutors.size})</a>
+                </h4>
+              </span> ++
               <div class="aggregated-finishedExecutors collapsible-table">
                 {finishedExecutorTable}
               </div>
@@ -114,12 +120,14 @@ private[ui] class WorkerPage(parent: WorkerWebUI) extends WebUIPage("") {
           }
           {
             if (finishedDrivers.nonEmpty) {
-              <h4 class="collapse-aggregated-finishedDrivers collapse-table"
+              <span class="collapse-aggregated-finishedDrivers collapse-table"
                   onClick="collapseTable('collapse-aggregated-finishedDrivers',
                   'aggregated-finishedDrivers')">
-                <span class="collapse-table-arrow arrow-open"></span>
-                <a>Finished Drivers ({finishedDrivers.size})</a>
-              </h4> ++
+                <h4>
+                  <span class="collapse-table-arrow arrow-open"></span>
+                  <a>Finished Drivers ({finishedDrivers.size})</a>
+                </h4>
+              </span> ++
               <div class="aggregated-finishedDrivers collapsible-table">
                 {finishedDriverTable}
               </div>

--- a/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
@@ -48,10 +48,38 @@ private[ui] class EnvironmentPage(
       classPathHeaders, classPathRow, appEnv.classpathEntries, fixedWidth = true)
     val content =
       <span>
-        <h4>Runtime Information</h4> {runtimeInformationTable}
-        <h4>Spark Properties</h4> {sparkPropertiesTable}
-        <h4>System Properties</h4> {systemPropertiesTable}
-        <h4>Classpath Entries</h4> {classpathEntriesTable}
+        <h4 class="collapse-aggregated-runtimeInformation collapse-table"
+            onClick="collapseTable('collapse-aggregated-runtimeInformation',
+            'aggregated-runtimeInformation')">
+          Runtime Information
+        </h4>
+        <div class="aggregated-runtimeInformation collapsible-table">
+          {runtimeInformationTable}
+        </div>
+        <h4 class="collapse-aggregated-sparkProperties collapse-table"
+            onClick="collapseTable('collapse-aggregated-sparkProperties',
+            'aggregated-sparkProperties')">
+          Spark Properties
+        </h4>
+        <div class="aggregated-sparkProperties collapsible-table">
+          {sparkPropertiesTable}
+        </div>
+        <h4 class="collapse-aggregated-systemProperties collapse-table"
+            onClick="collapseTable('collapse-aggregated-systemProperties',
+            'aggregated-systemProperties')">
+          System Properties
+        </h4>
+        <div class="aggregated-systemProperties collapsible-table">
+          {systemPropertiesTable}
+        </div>
+        <h4 class="collapse-aggregated-classpathEntries collapse-table"
+            onClick="collapseTable('collapse-aggregated-classpathEntries',
+            'aggregated-classpathEntries')">
+          Classpath Entries
+        </h4>
+        <div class="aggregated-classpathEntries collapsible-table">
+          {classpathEntriesTable}
+        </div>
       </span>
 
     UIUtils.headerSparkPage("Environment", content, parent)

--- a/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
@@ -51,7 +51,8 @@ private[ui] class EnvironmentPage(
         <h4 class="collapse-aggregated-runtimeInformation collapse-table"
             onClick="collapseTable('collapse-aggregated-runtimeInformation',
             'aggregated-runtimeInformation')">
-          Runtime Information
+          <span class="collapse-table-arrow arrow-open"></span>
+          <a>Runtime Information</a>
         </h4>
         <div class="aggregated-runtimeInformation collapsible-table">
           {runtimeInformationTable}
@@ -59,7 +60,8 @@ private[ui] class EnvironmentPage(
         <h4 class="collapse-aggregated-sparkProperties collapse-table"
             onClick="collapseTable('collapse-aggregated-sparkProperties',
             'aggregated-sparkProperties')">
-          Spark Properties
+          <span class="collapse-table-arrow arrow-open"></span>
+          <a>Spark Properties</a>
         </h4>
         <div class="aggregated-sparkProperties collapsible-table">
           {sparkPropertiesTable}
@@ -67,7 +69,8 @@ private[ui] class EnvironmentPage(
         <h4 class="collapse-aggregated-systemProperties collapse-table"
             onClick="collapseTable('collapse-aggregated-systemProperties',
             'aggregated-systemProperties')">
-          System Properties
+          <span class="collapse-table-arrow arrow-open"></span>
+          <a>System Properties</a>
         </h4>
         <div class="aggregated-systemProperties collapsible-table">
           {systemPropertiesTable}
@@ -75,7 +78,8 @@ private[ui] class EnvironmentPage(
         <h4 class="collapse-aggregated-classpathEntries collapse-table"
             onClick="collapseTable('collapse-aggregated-classpathEntries',
             'aggregated-classpathEntries')">
-          Classpath Entries
+          <span class="collapse-table-arrow arrow-open"></span>
+          <a>Classpath Entries</a>
         </h4>
         <div class="aggregated-classpathEntries collapsible-table">
           {classpathEntriesTable}

--- a/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
@@ -48,39 +48,47 @@ private[ui] class EnvironmentPage(
       classPathHeaders, classPathRow, appEnv.classpathEntries, fixedWidth = true)
     val content =
       <span>
-        <h4 class="collapse-aggregated-runtimeInformation collapse-table"
+        <span class="collapse-aggregated-runtimeInformation collapse-table"
             onClick="collapseTable('collapse-aggregated-runtimeInformation',
             'aggregated-runtimeInformation')">
-          <span class="collapse-table-arrow arrow-open"></span>
-          <a>Runtime Information</a>
-        </h4>
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Runtime Information</a>
+          </h4>
+        </span>
         <div class="aggregated-runtimeInformation collapsible-table">
           {runtimeInformationTable}
         </div>
-        <h4 class="collapse-aggregated-sparkProperties collapse-table"
+        <span class="collapse-aggregated-sparkProperties collapse-table"
             onClick="collapseTable('collapse-aggregated-sparkProperties',
             'aggregated-sparkProperties')">
-          <span class="collapse-table-arrow arrow-open"></span>
-          <a>Spark Properties</a>
-        </h4>
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Spark Properties</a>
+          </h4>
+        </span>
         <div class="aggregated-sparkProperties collapsible-table">
           {sparkPropertiesTable}
         </div>
-        <h4 class="collapse-aggregated-systemProperties collapse-table"
+        <span class="collapse-aggregated-systemProperties collapse-table"
             onClick="collapseTable('collapse-aggregated-systemProperties',
             'aggregated-systemProperties')">
-          <span class="collapse-table-arrow arrow-open"></span>
-          <a>System Properties</a>
-        </h4>
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>System Properties</a>
+          </h4>
+        </span>
         <div class="aggregated-systemProperties collapsible-table">
           {systemPropertiesTable}
         </div>
-        <h4 class="collapse-aggregated-classpathEntries collapse-table"
+        <span class="collapse-aggregated-classpathEntries collapse-table"
             onClick="collapseTable('collapse-aggregated-classpathEntries',
             'aggregated-classpathEntries')">
-          <span class="collapse-table-arrow arrow-open"></span>
-          <a>Classpath Entries</a>
-        </h4>
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Classpath Entries</a>
+          </h4>
+        </span>
         <div class="aggregated-classpathEntries collapsible-table">
           {classpathEntriesTable}
         </div>

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -368,7 +368,8 @@ private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends We
       content ++=
         <h4 id="active" class="collapse-aggregated-activeJobs collapse-table"
             onClick="collapseTable('collapse-aggregated-activeJobs','aggregated-activeJobs')">
-          Active Jobs ({activeJobs.size})
+          <span class="collapse-table-arrow arrow-open"></span>
+          <a>Active Jobs ({activeJobs.size})</a>
         </h4> ++
         <div class="aggregated-activeJobs collapsible-table">
           {activeJobsTable}
@@ -378,7 +379,8 @@ private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends We
       content ++=
         <h4 id="completed" class="collapse-aggregated-completedJobs collapse-table"
             onClick="collapseTable('collapse-aggregated-completedJobs','aggregated-completedJobs')">
-          Completed Jobs ({completedJobNumStr})
+          <span class="collapse-table-arrow arrow-open"></span>
+          <a>Completed Jobs ({completedJobNumStr})</a>
         </h4> ++
         <div class="aggregated-completedJobs collapsible-table">
           {completedJobsTable}
@@ -388,7 +390,8 @@ private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends We
       content ++=
         <h4 id ="failed" class="collapse-aggregated-failedJobs collapse-table"
             onClick="collapseTable('collapse-aggregated-failedJobs','aggregated-failedJobs')">
-          Failed Jobs ({failedJobs.size})
+          <span class="collapse-table-arrow arrow-open"></span>
+          <a>Failed Jobs ({failedJobs.size})</a>
         </h4> ++
       <div class="aggregated-failedJobs collapsible-table">
         {failedJobsTable}

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -366,33 +366,39 @@ private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends We
 
     if (shouldShowActiveJobs) {
       content ++=
-        <h4 id="active" class="collapse-aggregated-activeJobs collapse-table"
+        <span id="active" class="collapse-aggregated-activeJobs collapse-table"
             onClick="collapseTable('collapse-aggregated-activeJobs','aggregated-activeJobs')">
-          <span class="collapse-table-arrow arrow-open"></span>
-          <a>Active Jobs ({activeJobs.size})</a>
-        </h4> ++
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Active Jobs ({activeJobs.size})</a>
+          </h4>
+        </span> ++
         <div class="aggregated-activeJobs collapsible-table">
           {activeJobsTable}
         </div>
     }
     if (shouldShowCompletedJobs) {
       content ++=
-        <h4 id="completed" class="collapse-aggregated-completedJobs collapse-table"
+        <span id="completed" class="collapse-aggregated-completedJobs collapse-table"
             onClick="collapseTable('collapse-aggregated-completedJobs','aggregated-completedJobs')">
-          <span class="collapse-table-arrow arrow-open"></span>
-          <a>Completed Jobs ({completedJobNumStr})</a>
-        </h4> ++
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Completed Jobs ({completedJobNumStr})</a>
+          </h4>
+        </span> ++
         <div class="aggregated-completedJobs collapsible-table">
           {completedJobsTable}
         </div>
     }
     if (shouldShowFailedJobs) {
       content ++=
-        <h4 id ="failed" class="collapse-aggregated-failedJobs collapse-table"
+        <span id ="failed" class="collapse-aggregated-failedJobs collapse-table"
             onClick="collapseTable('collapse-aggregated-failedJobs','aggregated-failedJobs')">
-          <span class="collapse-table-arrow arrow-open"></span>
-          <a>Failed Jobs ({failedJobs.size})</a>
-        </h4> ++
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Failed Jobs ({failedJobs.size})</a>
+          </h4>
+        </span> ++
       <div class="aggregated-failedJobs collapsible-table">
         {failedJobsTable}
       </div>

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -365,16 +365,34 @@ private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends We
       store.executorList(false), startTime)
 
     if (shouldShowActiveJobs) {
-      content ++= <h4 id="active">Active Jobs ({activeJobs.size})</h4> ++
-        activeJobsTable
+      content ++=
+        <h4 id="active" class="collapse-aggregated-activeJobs collapse-table"
+            onClick="collapseTable('collapse-aggregated-activeJobs','aggregated-activeJobs')">
+          Active Jobs ({activeJobs.size})
+        </h4> ++
+        <div class="aggregated-activeJobs collapsible-table">
+          {activeJobsTable}
+        </div>
     }
     if (shouldShowCompletedJobs) {
-      content ++= <h4 id="completed">Completed Jobs ({completedJobNumStr})</h4> ++
-        completedJobsTable
+      content ++=
+        <h4 id="completed" class="collapse-aggregated-completedJobs collapse-table"
+            onClick="collapseTable('collapse-aggregated-completedJobs','aggregated-completedJobs')">
+          Completed Jobs ({completedJobNumStr})
+        </h4> ++
+        <div class="aggregated-completedJobs collapsible-table">
+          {completedJobsTable}
+        </div>
     }
     if (shouldShowFailedJobs) {
-      content ++= <h4 id ="failed">Failed Jobs ({failedJobs.size})</h4> ++
-        failedJobsTable
+      content ++=
+        <h4 id ="failed" class="collapse-aggregated-failedJobs collapse-table"
+            onClick="collapseTable('collapse-aggregated-failedJobs','aggregated-failedJobs')">
+          Failed Jobs ({failedJobs.size})
+        </h4> ++
+      <div class="aggregated-failedJobs collapsible-table">
+        {failedJobsTable}
+      </div>
     }
 
     val helpText = """A job is triggered by an action, like count() or saveAsTextFile().""" +

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllStagesPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllStagesPage.scala
@@ -132,55 +132,57 @@ private[ui] class AllStagesPage(parent: StagesTab) extends WebUIPage("") {
       }
     if (shouldShowActiveStages) {
       content ++=
-        <span id="active" class="collapse-aggregated-activeStages collapse-table"
-            onClick="collapseTable('collapse-aggregated-activeStages','aggregated-activeStages')">
+        <span id="active" class="collapse-aggregated-allActiveStages collapse-table"
+            onClick="collapseTable('collapse-aggregated-allActiveStages',
+            'aggregated-allActiveStages')">
           <h4>
             <span class="collapse-table-arrow arrow-open"></span>
             <a>Active Stages ({activeStages.size})</a>
           </h4>
         </span> ++
-        <div class="aggregated-activeStages collapsible-table">
+        <div class="aggregated-allActiveStages collapsible-table">
           {activeStagesTable.toNodeSeq}
         </div>
     }
     if (shouldShowPendingStages) {
       content ++=
-        <span id="pending" class="collapse-aggregated-pendingStages collapse-table"
-            onClick="collapseTable('collapse-aggregated-pendingStages','aggregated-pendingStages')">
+        <span id="pending" class="collapse-aggregated-allPendingStages collapse-table"
+            onClick="collapseTable('collapse-aggregated-allPendingStages',
+            'aggregated-allPendingStages')">
           <h4>
             <span class="collapse-table-arrow arrow-open"></span>
             <a>Pending Stages ({pendingStages.size})</a>
           </h4>
         </span> ++
-        <div class="aggregated-pendingStages collapsible-table">
+        <div class="aggregated-allPendingStages collapsible-table">
           {pendingStagesTable.toNodeSeq}
         </div>
     }
     if (shouldShowCompletedStages) {
       content ++=
-        <span id="completed" class="collapse-aggregated-completedStages collapse-table"
-            onClick="collapseTable('collapse-aggregated-completedStages',
-            'aggregated-completedStages')">
+        <span id="completed" class="collapse-aggregated-allCompletedStages collapse-table"
+            onClick="collapseTable('collapse-aggregated-allCompletedStages',
+            'aggregated-allCompletedStages')">
           <h4>
             <span class="collapse-table-arrow arrow-open"></span>
             <a>Completed Stages ({completedStageNumStr})</a>
           </h4>
         </span> ++
-        <div class="aggregated-completedStages collapsible-table">
+        <div class="aggregated-allCompletedStages collapsible-table">
           {completedStagesTable.toNodeSeq}
         </div>
     }
     if (shouldShowFailedStages) {
       content ++=
-        <span id ="failed" class="collapse-aggregated-failedStages collapse-table"
-            onClick="collapseTable('collapse-aggregated-failedStages',
-            'aggregated-failedStages')">
+        <span id ="failed" class="collapse-aggregated-allFailedStages collapse-table"
+            onClick="collapseTable('collapse-aggregated-allFailedStages',
+            'aggregated-allFailedStages')">
           <h4>
             <span class="collapse-table-arrow arrow-open"></span>
             <a>Failed Stages ({numFailedStages})</a>
           </h4>
         </span> ++
-        <div class="aggregated-failedStages collapsible-table">
+        <div class="aggregated-allFailedStages collapsible-table">
           {failedStagesTable.toNodeSeq}
         </div>
     }

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllStagesPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllStagesPage.scala
@@ -116,26 +116,58 @@ private[ui] class AllStagesPage(parent: StagesTab) extends WebUIPage("") {
     var content = summary ++
       {
         if (sc.isDefined && isFairScheduler) {
-          <h4>Fair Scheduler Pools ({pools.size})</h4> ++ poolTable.toNodeSeq
+          <h4 class="collapse-aggregated-poolTable collapse-table"
+              onClick="collapseTable('collapse-aggregated-poolTable','aggregated-poolTable')">
+            Fair Scheduler Pools ({pools.size})
+          </h4> ++
+          <div class="aggregated-poolTable collapsible-table">
+            {poolTable.toNodeSeq}
+          </div>
         } else {
           Seq.empty[Node]
         }
       }
     if (shouldShowActiveStages) {
-      content ++= <h4 id="active">Active Stages ({activeStages.size})</h4> ++
-      activeStagesTable.toNodeSeq
+      content ++=
+        <h4 id="active" class="collapse-aggregated-activeStages collapse-table"
+            onClick="collapseTable('collapse-aggregated-activeStages','aggregated-activeStages')">
+          Active Stages ({activeStages.size})
+        </h4> ++
+        <div class="aggregated-activeStages collapsible-table">
+          {activeStagesTable.toNodeSeq}
+        </div>
     }
     if (shouldShowPendingStages) {
-      content ++= <h4 id="pending">Pending Stages ({pendingStages.size})</h4> ++
-      pendingStagesTable.toNodeSeq
+      content ++=
+        <h4 id="pending" class="collapse-aggregated-pendingStages collapse-table"
+            onClick="collapseTable('collapse-aggregated-pendingStages','aggregated-pendingStages')">
+          Pending Stages ({pendingStages.size})
+        </h4> ++
+        <div class="aggregated-pendingStages collapsible-table">
+          {pendingStagesTable.toNodeSeq}
+        </div>
     }
     if (shouldShowCompletedStages) {
-      content ++= <h4 id="completed">Completed Stages ({completedStageNumStr})</h4> ++
-      completedStagesTable.toNodeSeq
+      content ++=
+        <h4 id="completed" class="collapse-aggregated-completedStages collapse-table"
+            onClick="collapseTable('collapse-aggregated-completedStages',
+            'aggregated-completedStages')">
+          Completed Stages ({completedStageNumStr})
+        </h4> ++
+        <div class="aggregated-completedStages collapsible-table">
+          {completedStagesTable.toNodeSeq}
+        </div>
     }
     if (shouldShowFailedStages) {
-      content ++= <h4 id ="failed">Failed Stages ({numFailedStages})</h4> ++
-      failedStagesTable.toNodeSeq
+      content ++=
+        <h4 id ="failed" class="collapse-aggregated-failedStages collapse-table"
+            onClick="collapseTable('collapse-aggregated-failedStages',
+            'aggregated-failedStages')">
+          Failed Stages ({numFailedStages})
+        </h4> ++
+        <div class="aggregated-failedStages collapsible-table">
+          {failedStagesTable.toNodeSeq}
+        </div>
     }
     UIUtils.headerSparkPage("Stages for All Jobs", content, parent)
   }

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllStagesPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllStagesPage.scala
@@ -116,11 +116,13 @@ private[ui] class AllStagesPage(parent: StagesTab) extends WebUIPage("") {
     var content = summary ++
       {
         if (sc.isDefined && isFairScheduler) {
-          <h4 class="collapse-aggregated-poolTable collapse-table"
+          <span class="collapse-aggregated-poolTable collapse-table"
               onClick="collapseTable('collapse-aggregated-poolTable','aggregated-poolTable')">
-            <span class="collapse-table-arrow arrow-open"></span>
-            <a>Fair Scheduler Pools ({pools.size})</a>
-          </h4> ++
+            <h4>
+              <span class="collapse-table-arrow arrow-open"></span>
+              <a>Fair Scheduler Pools ({pools.size})</a>
+            </h4>
+          </span> ++
           <div class="aggregated-poolTable collapsible-table">
             {poolTable.toNodeSeq}
           </div>
@@ -130,46 +132,54 @@ private[ui] class AllStagesPage(parent: StagesTab) extends WebUIPage("") {
       }
     if (shouldShowActiveStages) {
       content ++=
-        <h4 id="active" class="collapse-aggregated-activeStages collapse-table"
+        <span id="active" class="collapse-aggregated-activeStages collapse-table"
             onClick="collapseTable('collapse-aggregated-activeStages','aggregated-activeStages')">
-          <span class="collapse-table-arrow arrow-open"></span>
-          <a>Active Stages ({activeStages.size})</a>
-        </h4> ++
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Active Stages ({activeStages.size})</a>
+          </h4>
+        </span> ++
         <div class="aggregated-activeStages collapsible-table">
           {activeStagesTable.toNodeSeq}
         </div>
     }
     if (shouldShowPendingStages) {
       content ++=
-        <h4 id="pending" class="collapse-aggregated-pendingStages collapse-table"
+        <span id="pending" class="collapse-aggregated-pendingStages collapse-table"
             onClick="collapseTable('collapse-aggregated-pendingStages','aggregated-pendingStages')">
-          <span class="collapse-table-arrow arrow-open"></span>
-          <a>Pending Stages ({pendingStages.size})</a>
-        </h4> ++
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Pending Stages ({pendingStages.size})</a>
+          </h4>
+        </span> ++
         <div class="aggregated-pendingStages collapsible-table">
           {pendingStagesTable.toNodeSeq}
         </div>
     }
     if (shouldShowCompletedStages) {
       content ++=
-        <h4 id="completed" class="collapse-aggregated-completedStages collapse-table"
+        <span id="completed" class="collapse-aggregated-completedStages collapse-table"
             onClick="collapseTable('collapse-aggregated-completedStages',
             'aggregated-completedStages')">
-          <span class="collapse-table-arrow arrow-open"></span>
-          <a>Completed Stages ({completedStageNumStr})</a>
-        </h4> ++
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Completed Stages ({completedStageNumStr})</a>
+          </h4>
+        </span> ++
         <div class="aggregated-completedStages collapsible-table">
           {completedStagesTable.toNodeSeq}
         </div>
     }
     if (shouldShowFailedStages) {
       content ++=
-        <h4 id ="failed" class="collapse-aggregated-failedStages collapse-table"
+        <span id ="failed" class="collapse-aggregated-failedStages collapse-table"
             onClick="collapseTable('collapse-aggregated-failedStages',
             'aggregated-failedStages')">
-          <span class="collapse-table-arrow arrow-open"></span>
-          <a>Failed Stages ({numFailedStages})</a>
-        </h4> ++
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Failed Stages ({numFailedStages})</a>
+          </h4>
+        </span> ++
         <div class="aggregated-failedStages collapsible-table">
           {failedStagesTable.toNodeSeq}
         </div>

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllStagesPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllStagesPage.scala
@@ -118,7 +118,8 @@ private[ui] class AllStagesPage(parent: StagesTab) extends WebUIPage("") {
         if (sc.isDefined && isFairScheduler) {
           <h4 class="collapse-aggregated-poolTable collapse-table"
               onClick="collapseTable('collapse-aggregated-poolTable','aggregated-poolTable')">
-            Fair Scheduler Pools ({pools.size})
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Fair Scheduler Pools ({pools.size})</a>
           </h4> ++
           <div class="aggregated-poolTable collapsible-table">
             {poolTable.toNodeSeq}
@@ -131,7 +132,8 @@ private[ui] class AllStagesPage(parent: StagesTab) extends WebUIPage("") {
       content ++=
         <h4 id="active" class="collapse-aggregated-activeStages collapse-table"
             onClick="collapseTable('collapse-aggregated-activeStages','aggregated-activeStages')">
-          Active Stages ({activeStages.size})
+          <span class="collapse-table-arrow arrow-open"></span>
+          <a>Active Stages ({activeStages.size})</a>
         </h4> ++
         <div class="aggregated-activeStages collapsible-table">
           {activeStagesTable.toNodeSeq}
@@ -141,7 +143,8 @@ private[ui] class AllStagesPage(parent: StagesTab) extends WebUIPage("") {
       content ++=
         <h4 id="pending" class="collapse-aggregated-pendingStages collapse-table"
             onClick="collapseTable('collapse-aggregated-pendingStages','aggregated-pendingStages')">
-          Pending Stages ({pendingStages.size})
+          <span class="collapse-table-arrow arrow-open"></span>
+          <a>Pending Stages ({pendingStages.size})</a>
         </h4> ++
         <div class="aggregated-pendingStages collapsible-table">
           {pendingStagesTable.toNodeSeq}
@@ -152,7 +155,8 @@ private[ui] class AllStagesPage(parent: StagesTab) extends WebUIPage("") {
         <h4 id="completed" class="collapse-aggregated-completedStages collapse-table"
             onClick="collapseTable('collapse-aggregated-completedStages',
             'aggregated-completedStages')">
-          Completed Stages ({completedStageNumStr})
+          <span class="collapse-table-arrow arrow-open"></span>
+          <a>Completed Stages ({completedStageNumStr})</a>
         </h4> ++
         <div class="aggregated-completedStages collapsible-table">
           {completedStagesTable.toNodeSeq}
@@ -163,7 +167,8 @@ private[ui] class AllStagesPage(parent: StagesTab) extends WebUIPage("") {
         <h4 id ="failed" class="collapse-aggregated-failedStages collapse-table"
             onClick="collapseTable('collapse-aggregated-failedStages',
             'aggregated-failedStages')">
-          Failed Stages ({numFailedStages})
+          <span class="collapse-table-arrow arrow-open"></span>
+          <a>Failed Stages ({numFailedStages})</a>
         </h4> ++
         <div class="aggregated-failedStages collapsible-table">
           {failedStagesTable.toNodeSeq}

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
@@ -340,24 +340,57 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
       jobId, store.operationGraphForJob(jobId))
 
     if (shouldShowActiveStages) {
-      content ++= <h4 id="active">Active Stages ({activeStages.size})</h4> ++
-        activeStagesTable.toNodeSeq
+      content ++=
+        <h4 id="active" class="collapse-aggregated-activeStages collapse-table"
+            onClick="collapseTable('collapse-aggregated-activeStages','aggregated-activeStages')">
+          Active Stages ({activeStages.size})
+        </h4> ++
+        <div class="aggregated-activeStages collapsible-table">
+          {activeStagesTable.toNodeSeq}
+        </div>
     }
     if (shouldShowPendingStages) {
-      content ++= <h4 id="pending">Pending Stages ({pendingOrSkippedStages.size})</h4> ++
-        pendingOrSkippedStagesTable.toNodeSeq
+      content ++=
+        <h4 id="pending" class="collapse-aggregated-pendingOrSkippedStages collapse-table"
+            onClick="collapseTable('collapse-aggregated-pendingOrSkippedStages',
+            'aggregated-pendingOrSkippedStages')">
+          Pending Stages ({pendingOrSkippedStages.size})
+        </h4> ++
+        <div class="aggregated-pendingOrSkippedStages collapsible-table">
+          {pendingOrSkippedStagesTable.toNodeSeq}
+        </div>
     }
     if (shouldShowCompletedStages) {
-      content ++= <h4 id="completed">Completed Stages ({completedStages.size})</h4> ++
-        completedStagesTable.toNodeSeq
+      content ++=
+        <h4 id="completed" class="collapse-aggregated-completedStages collapse-table"
+            onClick="collapseTable('collapse-aggregated-completedStages',
+            'aggregated-completedStages')">
+          Completed Stages ({completedStages.size})
+        </h4> ++
+        <div class="aggregated-completedStages collapsible-table">
+          {completedStagesTable.toNodeSeq}
+        </div>
     }
     if (shouldShowSkippedStages) {
-      content ++= <h4 id="skipped">Skipped Stages ({pendingOrSkippedStages.size})</h4> ++
-        pendingOrSkippedStagesTable.toNodeSeq
+      content ++=
+        <h4 id="skipped" class="collapse-aggregated-pendingOrSkippedStages collapse-table"
+            onClick="collapseTable('collapse-aggregated-pendingOrSkippedStages',
+            'aggregated-pendingOrSkippedStages')">
+          Skipped Stages ({pendingOrSkippedStages.size})
+        </h4> ++
+        <div class="aggregated-pendingOrSkippedStages collapsible-table">
+          {pendingOrSkippedStagesTable.toNodeSeq}
+        </div>
     }
     if (shouldShowFailedStages) {
-      content ++= <h4 id ="failed">Failed Stages ({failedStages.size})</h4> ++
-        failedStagesTable.toNodeSeq
+      content ++=
+        <h4 id ="failed" class="collapse-aggregated-failedStages collapse-table"
+            onClick="collapseTable('collapse-aggregated-failedStages','aggregated-failedStages')">
+          Failed Stages ({failedStages.size})
+        </h4> ++
+        <div class="aggregated-failedStages collapsible-table">
+          {failedStagesTable.toNodeSeq}
+        </div>
     }
     UIUtils.headerSparkPage(s"Details for Job $jobId", content, parent, showVisualization = true)
   }

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
@@ -343,7 +343,8 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
       content ++=
         <h4 id="active" class="collapse-aggregated-activeStages collapse-table"
             onClick="collapseTable('collapse-aggregated-activeStages','aggregated-activeStages')">
-          Active Stages ({activeStages.size})
+          <span class="collapse-table-arrow arrow-open"></span>
+          <a>Active Stages ({activeStages.size})</a>
         </h4> ++
         <div class="aggregated-activeStages collapsible-table">
           {activeStagesTable.toNodeSeq}
@@ -354,7 +355,8 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
         <h4 id="pending" class="collapse-aggregated-pendingOrSkippedStages collapse-table"
             onClick="collapseTable('collapse-aggregated-pendingOrSkippedStages',
             'aggregated-pendingOrSkippedStages')">
-          Pending Stages ({pendingOrSkippedStages.size})
+          <span class="collapse-table-arrow arrow-open"></span>
+          <a>Pending Stages ({pendingOrSkippedStages.size})</a>
         </h4> ++
         <div class="aggregated-pendingOrSkippedStages collapsible-table">
           {pendingOrSkippedStagesTable.toNodeSeq}
@@ -365,7 +367,8 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
         <h4 id="completed" class="collapse-aggregated-completedStages collapse-table"
             onClick="collapseTable('collapse-aggregated-completedStages',
             'aggregated-completedStages')">
-          Completed Stages ({completedStages.size})
+          <span class="collapse-table-arrow arrow-open"></span>
+          <a>Completed Stages ({completedStages.size})</a>
         </h4> ++
         <div class="aggregated-completedStages collapsible-table">
           {completedStagesTable.toNodeSeq}
@@ -376,7 +379,8 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
         <h4 id="skipped" class="collapse-aggregated-pendingOrSkippedStages collapse-table"
             onClick="collapseTable('collapse-aggregated-pendingOrSkippedStages',
             'aggregated-pendingOrSkippedStages')">
-          Skipped Stages ({pendingOrSkippedStages.size})
+          <span class="collapse-table-arrow arrow-open"></span>
+          <a>Skipped Stages ({pendingOrSkippedStages.size})</a>
         </h4> ++
         <div class="aggregated-pendingOrSkippedStages collapsible-table">
           {pendingOrSkippedStagesTable.toNodeSeq}
@@ -386,7 +390,8 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
       content ++=
         <h4 id ="failed" class="collapse-aggregated-failedStages collapse-table"
             onClick="collapseTable('collapse-aggregated-failedStages','aggregated-failedStages')">
-          Failed Stages ({failedStages.size})
+          <span class="collapse-table-arrow arrow-open"></span>
+          <a>Failed Stages ({failedStages.size})</a>
         </h4> ++
         <div class="aggregated-failedStages collapsible-table">
           {failedStagesTable.toNodeSeq}

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
@@ -341,58 +341,68 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
 
     if (shouldShowActiveStages) {
       content ++=
-        <h4 id="active" class="collapse-aggregated-activeStages collapse-table"
+        <span id="active" class="collapse-aggregated-activeStages collapse-table"
             onClick="collapseTable('collapse-aggregated-activeStages','aggregated-activeStages')">
-          <span class="collapse-table-arrow arrow-open"></span>
-          <a>Active Stages ({activeStages.size})</a>
-        </h4> ++
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Active Stages ({activeStages.size})</a>
+          </h4>
+        </span> ++
         <div class="aggregated-activeStages collapsible-table">
           {activeStagesTable.toNodeSeq}
         </div>
     }
     if (shouldShowPendingStages) {
       content ++=
-        <h4 id="pending" class="collapse-aggregated-pendingOrSkippedStages collapse-table"
+        <span id="pending" class="collapse-aggregated-pendingOrSkippedStages collapse-table"
             onClick="collapseTable('collapse-aggregated-pendingOrSkippedStages',
             'aggregated-pendingOrSkippedStages')">
-          <span class="collapse-table-arrow arrow-open"></span>
-          <a>Pending Stages ({pendingOrSkippedStages.size})</a>
-        </h4> ++
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Pending Stages ({pendingOrSkippedStages.size})</a>
+          </h4>
+        </span> ++
         <div class="aggregated-pendingOrSkippedStages collapsible-table">
           {pendingOrSkippedStagesTable.toNodeSeq}
         </div>
     }
     if (shouldShowCompletedStages) {
       content ++=
-        <h4 id="completed" class="collapse-aggregated-completedStages collapse-table"
+        <span id="completed" class="collapse-aggregated-completedStages collapse-table"
             onClick="collapseTable('collapse-aggregated-completedStages',
             'aggregated-completedStages')">
-          <span class="collapse-table-arrow arrow-open"></span>
-          <a>Completed Stages ({completedStages.size})</a>
-        </h4> ++
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Completed Stages ({completedStages.size})</a>
+          </h4>
+        </span> ++
         <div class="aggregated-completedStages collapsible-table">
           {completedStagesTable.toNodeSeq}
         </div>
     }
     if (shouldShowSkippedStages) {
       content ++=
-        <h4 id="skipped" class="collapse-aggregated-pendingOrSkippedStages collapse-table"
+        <span id="skipped" class="collapse-aggregated-pendingOrSkippedStages collapse-table"
             onClick="collapseTable('collapse-aggregated-pendingOrSkippedStages',
             'aggregated-pendingOrSkippedStages')">
-          <span class="collapse-table-arrow arrow-open"></span>
-          <a>Skipped Stages ({pendingOrSkippedStages.size})</a>
-        </h4> ++
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Skipped Stages ({pendingOrSkippedStages.size})</a>
+          </h4>
+        </span> ++
         <div class="aggregated-pendingOrSkippedStages collapsible-table">
           {pendingOrSkippedStagesTable.toNodeSeq}
         </div>
     }
     if (shouldShowFailedStages) {
       content ++=
-        <h4 id ="failed" class="collapse-aggregated-failedStages collapse-table"
+        <span id ="failed" class="collapse-aggregated-failedStages collapse-table"
             onClick="collapseTable('collapse-aggregated-failedStages','aggregated-failedStages')">
-          <span class="collapse-table-arrow arrow-open"></span>
-          <a>Failed Stages ({failedStages.size})</a>
-        </h4> ++
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Failed Stages ({failedStages.size})</a>
+          </h4>
+        </span> ++
         <div class="aggregated-failedStages collapsible-table">
           {failedStagesTable.toNodeSeq}
         </div>

--- a/core/src/main/scala/org/apache/spark/ui/jobs/PoolPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/PoolPage.scala
@@ -52,14 +52,15 @@ private[ui] class PoolPage(parent: StagesTab) extends WebUIPage("pool") {
     var content = <h4>Summary </h4> ++ poolTable.toNodeSeq
     if (activeStages.nonEmpty) {
       content ++=
-        <span class="collapse-aggregated-activeStages collapse-table"
-            onClick="collapseTable('collapse-aggregated-activeStages','aggregated-activeStages')">
+        <span class="collapse-aggregated-poolActiveStages collapse-table"
+            onClick="collapseTable('collapse-aggregated-poolActiveStages',
+            'aggregated-poolActiveStages')">
           <h4>
             <span class="collapse-table-arrow arrow-open"></span>
             <a>Active Stages ({activeStages.size})</a>
           </h4>
         </span> ++
-        <div class="aggregated-activeStages collapsible-table">
+        <div class="aggregated-poolActiveStages collapsible-table">
           {activeStagesTable.toNodeSeq}
         </div>
     }

--- a/core/src/main/scala/org/apache/spark/ui/jobs/PoolPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/PoolPage.scala
@@ -51,7 +51,14 @@ private[ui] class PoolPage(parent: StagesTab) extends WebUIPage("pool") {
     val poolTable = new PoolTable(Map(pool -> uiPool), parent)
     var content = <h4>Summary </h4> ++ poolTable.toNodeSeq
     if (activeStages.nonEmpty) {
-      content ++= <h4>Active Stages ({activeStages.size})</h4> ++ activeStagesTable.toNodeSeq
+      content ++=
+        <h4 class="collapse-aggregated-activeStages collapse-table"
+            onClick="collapseTable('collapse-aggregated-activeStages','aggregated-activeStages')">
+          Active Stages ({activeStages.size})
+        </h4> ++
+        <div class="aggregated-activeStages collapsible-table">
+          {activeStagesTable.toNodeSeq}
+        </div>
     }
 
     UIUtils.headerSparkPage("Fair Scheduler Pool: " + poolName, content, parent)

--- a/core/src/main/scala/org/apache/spark/ui/jobs/PoolPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/PoolPage.scala
@@ -54,7 +54,8 @@ private[ui] class PoolPage(parent: StagesTab) extends WebUIPage("pool") {
       content ++=
         <h4 class="collapse-aggregated-activeStages collapse-table"
             onClick="collapseTable('collapse-aggregated-activeStages','aggregated-activeStages')">
-          Active Stages ({activeStages.size})
+          <span class="collapse-table-arrow arrow-open"></span>
+          <a>Active Stages ({activeStages.size})</a>
         </h4> ++
         <div class="aggregated-activeStages collapsible-table">
           {activeStagesTable.toNodeSeq}

--- a/core/src/main/scala/org/apache/spark/ui/jobs/PoolPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/PoolPage.scala
@@ -52,11 +52,13 @@ private[ui] class PoolPage(parent: StagesTab) extends WebUIPage("pool") {
     var content = <h4>Summary </h4> ++ poolTable.toNodeSeq
     if (activeStages.nonEmpty) {
       content ++=
-        <h4 class="collapse-aggregated-activeStages collapse-table"
+        <span class="collapse-aggregated-activeStages collapse-table"
             onClick="collapseTable('collapse-aggregated-activeStages','aggregated-activeStages')">
-          <span class="collapse-table-arrow arrow-open"></span>
-          <a>Active Stages ({activeStages.size})</a>
-        </h4> ++
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Active Stages ({activeStages.size})</a>
+          </h4>
+        </span> ++
         <div class="aggregated-activeStages collapsible-table">
           {activeStagesTable.toNodeSeq}
         </div>

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -556,11 +556,13 @@ private[ui] class StagePage(parent: StagesTab, store: AppStatusStore) extends We
       <div>{summaryTable.getOrElse("No tasks have reported metrics yet.")}</div> ++
       aggMetrics ++
       maybeAccumulableTable ++
-      <h4 id="tasks-section" class="collapse-aggregated-tasks collapse-table"
+      <span id="tasks-section" class="collapse-aggregated-tasks collapse-table"
           onClick="collapseTable('collapse-aggregated-tasks','aggregated-tasks')">
-        <span class="collapse-table-arrow arrow-open"></span>
-        <a>Tasks ({totalTasksNumStr})</a>
-      </h4> ++
+        <h4>
+          <span class="collapse-table-arrow arrow-open"></span>
+          <a>Tasks ({totalTasksNumStr})</a>
+        </h4>
+      </span> ++
       <div class="aggregated-tasks collapsible-table">
         {taskTableHTML ++ jsForScrollingDownToTaskTable}
       </div>

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -558,7 +558,8 @@ private[ui] class StagePage(parent: StagesTab, store: AppStatusStore) extends We
       maybeAccumulableTable ++
       <h4 id="tasks-section" class="collapse-aggregated-tasks collapse-table"
           onClick="collapseTable('collapse-aggregated-tasks','aggregated-tasks')">
-        Tasks ({totalTasksNumStr})
+        <span class="collapse-table-arrow arrow-open"></span>
+        <a>Tasks ({totalTasksNumStr})</a>
       </h4> ++
       <div class="aggregated-tasks collapsible-table">
         {taskTableHTML ++ jsForScrollingDownToTaskTable}

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -556,8 +556,13 @@ private[ui] class StagePage(parent: StagesTab, store: AppStatusStore) extends We
       <div>{summaryTable.getOrElse("No tasks have reported metrics yet.")}</div> ++
       aggMetrics ++
       maybeAccumulableTable ++
-      <h4 id="tasks-section">Tasks ({totalTasksNumStr})</h4> ++
-        taskTableHTML ++ jsForScrollingDownToTaskTable
+      <h4 id="tasks-section" class="collapse-aggregated-tasks collapse-table"
+          onClick="collapseTable('collapse-aggregated-tasks','aggregated-tasks')">
+        Tasks ({totalTasksNumStr})
+      </h4> ++
+      <div class="aggregated-tasks collapsible-table">
+        {taskTableHTML ++ jsForScrollingDownToTaskTable}
+      </div>
     UIUtils.headerSparkPage(stageHeader, content, parent, showVisualization = true)
   }
 

--- a/core/src/main/scala/org/apache/spark/ui/storage/StoragePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/StoragePage.scala
@@ -41,8 +41,13 @@ private[ui] class StoragePage(parent: SparkUITab, store: AppStatusStore) extends
       Nil
     } else {
       <div>
-        <h4>RDDs</h4>
-        {UIUtils.listingTable(rddHeader, rddRow, rdds, id = Some("storage-by-rdd-table"))}
+        <h4 class="collapse-aggregated-rdds collapse-table"
+            onClick="collapseTable('collapse-aggregated-rdds','aggregated-rdds')">
+          RDDs
+        </h4>
+        <div class="aggregated-rdds collapsible-table">
+          {UIUtils.listingTable(rddHeader, rddRow, rdds, id = Some("storage-by-rdd-table"))}
+        </div>
       </div>
     }
   }

--- a/core/src/main/scala/org/apache/spark/ui/storage/StoragePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/StoragePage.scala
@@ -43,7 +43,8 @@ private[ui] class StoragePage(parent: SparkUITab, store: AppStatusStore) extends
       <div>
         <h4 class="collapse-aggregated-rdds collapse-table"
             onClick="collapseTable('collapse-aggregated-rdds','aggregated-rdds')">
-          RDDs
+          <span class="collapse-table-arrow arrow-open"></span>
+          <a>RDDs</a>
         </h4>
         <div class="aggregated-rdds collapsible-table">
           {UIUtils.listingTable(rddHeader, rddRow, rdds, id = Some("storage-by-rdd-table"))}

--- a/core/src/main/scala/org/apache/spark/ui/storage/StoragePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/StoragePage.scala
@@ -41,11 +41,13 @@ private[ui] class StoragePage(parent: SparkUITab, store: AppStatusStore) extends
       Nil
     } else {
       <div>
-        <h4 class="collapse-aggregated-rdds collapse-table"
+        <span class="collapse-aggregated-rdds collapse-table"
             onClick="collapseTable('collapse-aggregated-rdds','aggregated-rdds')">
-          <span class="collapse-table-arrow arrow-open"></span>
-          <a>RDDs</a>
-        </h4>
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>RDDs</a>
+          </h4>
+        </span>
         <div class="aggregated-rdds collapsible-table">
           {UIUtils.listingTable(rddHeader, rddRow, rdds, id = Some("storage-by-rdd-table"))}
         </div>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Spark ui about the contents of the form need to have hidden and show features, when the table records very much. Because sometimes you do not care about the record of the table, you just want to see the contents of the next table, but you have to scroll the scroll bar for a long time to see the contents of the next table.

Currently we have about 500 workers, but I just wanted to see the logs for the running applications table. I had to scroll through the scroll bars for a long time to see the logs for the running applications table.

In order to ensure functional consistency, I modified the Master Page, Worker Page, Job Page, Stage Page, Task Page, Configuration Page, Storage Page, Pool Page.

fix before:
![1](https://user-images.githubusercontent.com/26266482/34805936-601ed628-f6bb-11e7-8dd3-d8413573a076.png)

fix after:
![2](https://user-images.githubusercontent.com/26266482/34805949-6af8afba-f6bb-11e7-89f4-ab16584916fb.png)


## How was this patch tested?
manual tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
