### PR TITLE
[SPARK-23026] [PySpark] Add RegisterUDF to PySpark

### DIFF
--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -270,9 +270,9 @@ class Catalog(object):
     @since(2.3)
     def registerUDF(self, name, f):
         """Registers a :class:`UserDefinedFunction`. The registered UDF can be used in SQL
-        statement.
+        statements.
 
-        :param name: name of the UDF
+        :param name: name of the UDF in SQL statements
         :param f: a wrapped/native UserDefinedFunction. The UDF can be either row-at-a-time or
                   scalar vectorized. For example, the object returned by udf or pandas_udf.
                   Grouped vectorized UDFs are not supported.
@@ -293,7 +293,7 @@ class Catalog(object):
         >>> spark.sql("SELECT random_udf()").collect()  # doctest: +SKIP
         [Row(random_udf()=82)]
         >>> spark.range(1).select(newRandom_udf()).collect()  # doctest: +SKIP
-        [Row(random_udf()=62)]
+        [Row(<lambda>()=26)]
 
         >>> from pyspark.sql.functions import pandas_udf, PandasUDFType
         >>> @pandas_udf("integer", PandasUDFType.SCALAR)  # doctest: +SKIP
@@ -321,7 +321,7 @@ class Catalog(object):
                             "(including lambda function). The expected function of registerUDF "
                             "is a UDF")
         self._jsparkSession.udf().registerPython(name, udf._judf)
-        return udf._wrapped()
+        return f
 
     @since(2.0)
     def isCached(self, tableName):

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -276,7 +276,7 @@ class Catalog(object):
         :param f: a wrapped/native UserDefinedFunction. The UDF can be either row-at-a-time or
                   scalar vectorized. For example, the object returned by udf or pandas_udf.
                   Grouped vectorized UDFs are not supported.
-        :return: a wrapped :class:`UserDefinedFunction`
+        :return: a wrapped/native :class:`UserDefinedFunction`
 
         >>> from pyspark.sql.types import IntegerType
         >>> from pyspark.sql.functions import udf

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -274,7 +274,8 @@ class Catalog(object):
 
         :param name: name of the UDF
         :param f: a wrapped/native UserDefinedFunction. The UDF can be either row-at-a-time or
-                  scalar vectorized. Grouped vectorized UDFs are not supported.
+                  scalar vectorized. For example, the object returned by udf or pandas_udf.
+                  Grouped vectorized UDFs are not supported.
         :return: a wrapped :class:`UserDefinedFunction`
 
         >>> from pyspark.sql.types import IntegerType
@@ -300,7 +301,8 @@ class Catalog(object):
         ...     return x + 1
         ...
         >>> _ = spark.udf.registerUDF("add_one", add_one)  # doctest: +SKIP
-        >>> spark.sql("SELECT add_one(id) FROM range(10)").collect()  # doctest: +SKIP
+        >>> spark.sql("SELECT add_one(id) FROM range(3)").collect()  # doctest: +SKIP
+        [Row(add_one(id)=1), Row(add_one(id)=2), Row(add_one(id)=3)]
         """
 
         # This is to check whether the input function is a wrapped/native UserDefinedFunction
@@ -313,7 +315,9 @@ class Catalog(object):
                                       evalType=f.evalType,
                                       deterministic=f.deterministic)
         else:
-            raise TypeError("Please use registerFunction for registering a Python function "
+            raise TypeError("Invalid UDF: f must be either row-at-a-time or scalar vectorized UDF. "
+                            "For example, the object returned by udf or pandas_udf. Please use "
+                            "registerFunction for registering a Python function "
                             "(including lambda function). The expected function of registerUDF "
                             "is a UDF")
         self._jsparkSession.udf().registerPython(name, udf._judf)

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -214,7 +214,8 @@ class SQLContext(object):
 
         :param name: name of the UDF
         :param f: a wrapped/native UserDefinedFunction. The UDF can be either row-at-a-time or
-                  scalar vectorized. Grouped vectorized UDFs are not supported.
+                  scalar vectorized. For example, the object returned by udf or pandas_udf.
+                  Grouped vectorized UDFs are not supported.
         :return: a wrapped :class:`UserDefinedFunction`
 
         >>> from pyspark.sql.types import IntegerType
@@ -240,7 +241,8 @@ class SQLContext(object):
         ...     return x + 1
         ...
         >>> _ = sqlContext.udf.registerUDF("add_one", add_one)  # doctest: +SKIP
-        >>> sqlContext.sql("SELECT add_one(id) FROM range(10)").collect()  # doctest: +SKIP
+        >>> sqlContext.sql("SELECT add_one(id) FROM range(3)").collect()  # doctest: +SKIP
+        [Row(add_one(id)=1), Row(add_one(id)=2), Row(add_one(id)=3)]
         """
         return self.sparkSession.catalog.registerUDF(name, f)
 

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -216,7 +216,7 @@ class SQLContext(object):
         :param f: a wrapped/native UserDefinedFunction. The UDF can be either row-at-a-time or
                   scalar vectorized. For example, the object returned by udf or pandas_udf.
                   Grouped vectorized UDFs are not supported.
-        :return: a wrapped :class:`UserDefinedFunction`
+        :return: a wrapped/native :class:`UserDefinedFunction`
 
         >>> from pyspark.sql.types import IntegerType
         >>> from pyspark.sql.functions import udf

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -210,9 +210,9 @@ class SQLContext(object):
     @since(2.3)
     def registerUDF(self, name, f):
         """Registers a :class:`UserDefinedFunction`. The registered UDF can be used in SQL
-        statement.
+        statements.
 
-        :param name: name of the UDF
+        :param name: name of the UDF in SQL statements
         :param f: a wrapped/native UserDefinedFunction. The UDF can be either row-at-a-time or
                   scalar vectorized. For example, the object returned by udf or pandas_udf.
                   Grouped vectorized UDFs are not supported.
@@ -233,7 +233,7 @@ class SQLContext(object):
         >>> sqlContext.sql("SELECT random_udf()").collect()  # doctest: +SKIP
         [Row(random_udf()=82)]
         >>> sqlContext.range(1).select(newRandom_udf()).collect()  # doctest: +SKIP
-        [Row(random_udf()=62)]
+        [Row(<lambda>()=26)]
 
         >>> from pyspark.sql.functions import pandas_udf, PandasUDFType
         >>> @pandas_udf("integer", PandasUDFType.SCALAR)  # doctest: +SKIP

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -4124,11 +4124,11 @@ class VectorizedUDFTests(ReusedSQLTestCase):
         df = self.spark.range(10).select(
             col('id').cast('int').alias('a'),
             col('id').cast('int').alias('b'))
-        originalAdd = pandas_udf(lambda x, y: x + y, IntegerType())
-        self.assertEqual(originalAdd.deterministic, True)
-        self.assertEqual(originalAdd.evalType, PythonEvalType.SQL_PANDAS_SCALAR_UDF)
-        newAdd = self.spark.catalog.registerUDF("add1", originalAdd)
-        res1 = df.select(newAdd(col('a'), col('b')))
+        original_add = pandas_udf(lambda x, y: x + y, IntegerType())
+        self.assertEqual(original_add.deterministic, True)
+        self.assertEqual(original_add.evalType, PythonEvalType.SQL_PANDAS_SCALAR_UDF)
+        new_add = self.spark.catalog.registerUDF("add1", original_add)
+        res1 = df.select(new_add(col('a'), col('b')))
         res2 = self.spark.sql(
             "SELECT add1(t.a, t.b) FROM (SELECT id as a, id as b FROM range(10)) t")
         expected = df.select(expr('a + b'))
@@ -4170,7 +4170,7 @@ class GroupbyApplyTests(ReusedSQLTestCase):
         expected = df.toPandas().groupby('id').apply(foo_udf.func).reset_index(drop=True)
         self.assertFramesEqual(expected, result)
 
-    def test_registerGroupMapUDF(self):
+    def test_register_group_map_udf(self):
         from pyspark.sql.functions import pandas_udf, PandasUDFType
 
         foo_udf = pandas_udf(

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -380,11 +380,17 @@ class SQLTests(ReusedSQLTestCase):
         self.assertEqual(4, res[0])
 
     def test_udf3(self):
-        twoargs = self.spark.catalog.registerFunction(
-            "twoArgs", UserDefinedFunction(lambda x, y: len(x) + y), IntegerType())
+        twoargs = self.spark.catalog.registerUDF(
+            "twoArgs", UserDefinedFunction(lambda x, y: len(x) + y))
         self.assertEqual(twoargs.deterministic, True)
         [row] = self.spark.sql("SELECT twoArgs('test', 1)").collect()
-        self.assertEqual(row[0], 5)
+        self.assertEqual(row[0], u'5')
+
+    def test_udf_using_registerFunction(self):
+        with QuietTest(self.sc):
+            with self.assertRaisesRegexp(ValueError, "Please use registerUDF for registering UDF"):
+                self.spark.catalog.registerFunction(
+                    "f", UserDefinedFunction(lambda x, y: len(x) + y))
 
     def test_nondeterministic_udf(self):
         # Test that nondeterministic UDFs are evaluated only once in chained UDF evaluations
@@ -402,12 +408,12 @@ class SQLTests(ReusedSQLTestCase):
         from pyspark.sql.functions import udf
         random_udf = udf(lambda: random.randint(6, 6), IntegerType()).asNondeterministic()
         self.assertEqual(random_udf.deterministic, False)
-        random_udf1 = self.spark.catalog.registerFunction("randInt", random_udf, StringType())
+        random_udf1 = self.spark.catalog.registerUDF("randInt", random_udf)
         self.assertEqual(random_udf1.deterministic, False)
         [row] = self.spark.sql("SELECT randInt()").collect()
-        self.assertEqual(row[0], "6")
+        self.assertEqual(row[0], 6)
         [row] = self.spark.range(1).select(random_udf1()).collect()
-        self.assertEqual(row[0], "6")
+        self.assertEqual(row[0], 6)
         [row] = self.spark.range(1).select(random_udf()).collect()
         self.assertEqual(row[0], 6)
         # render_doc() reproduces the help() exception without printing output
@@ -3691,7 +3697,7 @@ class VectorizedUDFTests(ReusedSQLTestCase):
         ReusedSQLTestCase.tearDownClass()
 
     @property
-    def random_udf(self):
+    def nondeterministic_vectorized_udf(self):
         from pyspark.sql.functions import pandas_udf
 
         @pandas_udf('double')
@@ -4085,14 +4091,14 @@ class VectorizedUDFTests(ReusedSQLTestCase):
         finally:
             self.spark.conf.set("spark.sql.session.timeZone", orig_tz)
 
-    def test_nondeterministic_udf(self):
+    def test_nondeterministic_vectorized_udf(self):
         # Test that nondeterministic UDFs are evaluated only once in chained UDF evaluations
         from pyspark.sql.functions import udf, pandas_udf, col
 
         @pandas_udf('double')
         def plus_ten(v):
             return v + 10
-        random_udf = self.random_udf
+        random_udf = self.nondeterministic_vectorized_udf
 
         df = self.spark.range(10).withColumn('rand', random_udf(col('id')))
         result1 = df.withColumn('plus_ten(rand)', plus_ten(df['rand'])).toPandas()
@@ -4100,17 +4106,34 @@ class VectorizedUDFTests(ReusedSQLTestCase):
         self.assertEqual(random_udf.deterministic, False)
         self.assertTrue(result1['plus_ten(rand)'].equals(result1['rand'] + 10))
 
-    def test_nondeterministic_udf_in_aggregate(self):
+    def test_nondeterministic_vectorized_udf_in_aggregate(self):
         from pyspark.sql.functions import pandas_udf, sum
 
         df = self.spark.range(10)
-        random_udf = self.random_udf
+        random_udf = self.nondeterministic_vectorized_udf
 
         with QuietTest(self.sc):
             with self.assertRaisesRegexp(AnalysisException, 'nondeterministic'):
                 df.groupby(df.id).agg(sum(random_udf(df.id))).collect()
             with self.assertRaisesRegexp(AnalysisException, 'nondeterministic'):
                 df.agg(sum(random_udf(df.id))).collect()
+
+    def test_register_vectorized_udf_basic(self):
+        from pyspark.rdd import PythonEvalType
+        from pyspark.sql.functions import pandas_udf, col, expr
+        df = self.spark.range(10).select(
+            col('id').cast('int').alias('a'),
+            col('id').cast('int').alias('b'))
+        originalAdd = pandas_udf(lambda x, y: x + y, IntegerType())
+        self.assertEqual(originalAdd.deterministic, True)
+        self.assertEqual(originalAdd.evalType, PythonEvalType.SQL_PANDAS_SCALAR_UDF)
+        newAdd = self.spark.catalog.registerUDF("add1", originalAdd)
+        res1 = df.select(newAdd(col('a'), col('b')))
+        res2 = self.spark.sql(
+            "SELECT add1(t.a, t.b) FROM (SELECT id as a, id as b FROM range(10)) t")
+        expected = df.select(expr('a + b'))
+        self.assertEquals(expected.collect(), res1.collect())
+        self.assertEquals(expected.collect(), res2.collect())
 
 
 @unittest.skipIf(not _have_pandas or not _have_arrow, "Pandas or Arrow not installed")
@@ -4146,6 +4169,21 @@ class GroupbyApplyTests(ReusedSQLTestCase):
         result = df.groupby('id').apply(foo_udf).sort('id').toPandas()
         expected = df.toPandas().groupby('id').apply(foo_udf.func).reset_index(drop=True)
         self.assertFramesEqual(expected, result)
+
+    def test_registerGroupMapUDF(self):
+        from pyspark.sql.functions import pandas_udf, PandasUDFType
+
+        foo_udf = pandas_udf(
+            lambda pdf: pdf.assign(v1=pdf.id * 1.0),
+            StructType(
+                [StructField('id', LongType()),
+                 StructField('v1', DoubleType())]),
+            PandasUDFType.GROUP_MAP
+        )
+        with QuietTest(self.sc):
+            with self.assertRaisesRegexp(ValueError, 'f must be either SQL_BATCHED_UDF or '
+                                                     'SQL_PANDAS_SCALAR_UDF'):
+                self.spark.catalog.registerUDF("foo_udf", foo_udf)
 
     def test_decorator(self):
         from pyspark.sql.functions import pandas_udf, PandasUDFType


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a new API for registering row-at-a-time or scalar vectorized UDFs. The registered UDFs can be used in the SQL statement. For example,

```
>>> from pyspark.sql.types import IntegerType
>>> from pyspark.sql.functions import udf
>>> slen = udf(lambda s: len(s), IntegerType())
>>> _ = spark.udf.registerUDF("slen", slen)
>>> spark.sql("SELECT slen('test')").collect()
[Row(slen(test)=4)]

>>> import random
>>> from pyspark.sql.functions import udf
>>> from pyspark.sql.types import IntegerType
>>> random_udf = udf(lambda: random.randint(0, 100), IntegerType()).asNondeterministic()
>>> newRandom_udf = spark.catalog.registerUDF("random_udf", random_udf)
>>> spark.sql("SELECT random_udf()").collect()  
[Row(random_udf()=82)]
>>> spark.range(1).select(newRandom_udf()).collect()  
[Row(<lambda>()=26)]

>>> from pyspark.sql.functions import pandas_udf, PandasUDFType
>>> @pandas_udf("integer", PandasUDFType.SCALAR)  
... def add_one(x):
...     return x + 1
...
>>> _ = spark.udf.registerUDF("add_one", add_one)  
>>> spark.sql("SELECT add_one(id) FROM range(10)").collect()  
```
## How was this patch tested?
Added test cases
  