### PR TITLE
[SPARK-23000][TEST-HADOOP2.6] Fix Flaky test suite DataSourceWithHiveMetastoreCatalogSuite in Spark 2.3 [WIP]

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -560,7 +560,9 @@ def main():
         test_environ.update(m.environ)
     setup_test_environ(test_environ)
 
-    test_modules = determine_modules_to_test(changed_modules)
+    # test_modules = determine_modules_to_test(changed_modules)
+    # Force-run all tests
+    test_modules = [modules.root]
 
     # license checks
     run_apache_rat_checks()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Another attempt at reproducing the underlying failure (sbt/hadoop 2.6 against 2.3) by running all tests.

## How was this patch tested?

N/A