### PR TITLE
[SPARK-23047][PYTHON][SQL] Change MapVector to NullableMapVector in ArrowColumnVector

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
@@ -247,8 +247,8 @@ public final class ArrowColumnVector extends ColumnVector {
 
       childColumns = new ArrowColumnVector[1];
       childColumns[0] = new ArrowColumnVector(listVector.getDataVector());
-    } else if (vector instanceof MapVector) {
-      MapVector mapVector = (MapVector) vector;
+    } else if (vector instanceof NullableMapVector) {
+      NullableMapVector mapVector = (NullableMapVector) vector;
       accessor = new StructAccessor(mapVector);
 
       childColumns = new ArrowColumnVector[mapVector.size()];
@@ -555,7 +555,7 @@ public final class ArrowColumnVector extends ColumnVector {
 
   private static class StructAccessor extends ArrowVectorAccessor {
 
-    StructAccessor(MapVector vector) {
+    StructAccessor(NullableMapVector vector) {
       super(vector);
     }
   }

--- a/sql/core/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
@@ -554,7 +554,7 @@ public final class ArrowColumnVector extends ColumnVector {
   }
 
   /**
-   * This is a place holder class. Any "get" method will throw UnsupportedOperationException.
+   * Any call to "get" method will throw UnsupportedOperationException.
    *
    * Access struct values in a ArrowColumnVector doesn't use this accessor. Instead, it uses getStruct() method defined
    * in the parent class. Any call to "get" method in this class is a bug in the code.

--- a/sql/core/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
@@ -553,6 +553,13 @@ public final class ArrowColumnVector extends ColumnVector {
     }
   }
 
+  /**
+   * This is a place holder class. Any "get" method will throw UnsupportedOperationException.
+   *
+   * Access struct values in a ArrowColumnVector doesn't use this accessor. Instead, it uses getStruct() method defined
+   * in the parent class. Any call to "get" method in this class is a bug in the code.
+   *
+   */
   private static class StructAccessor extends ArrowVectorAccessor {
 
     StructAccessor(NullableMapVector vector) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR changes usage of `MapVector` in Spark codebase to use `NullableMapVector`.

`MapVector` is an internal Arrow class that is not supposed to be used directly. We should use `NullableMapVector` instead.

## How was this patch tested?

Existing test.