### PR TITLE
[SPARK-23008][ML][FOLLOW-UP] mark OneHotEncoder python API deprecated

### DIFF
--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -1577,6 +1577,8 @@ class OneHotEncoder(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, 
 
     .. note:: This is different from scikit-learn's OneHotEncoder,
         which keeps all categories. The output vectors are sparse.
+       Deprecated in 2.3.0. ``OneHotEncoderEstimator`` will be renamed ``OneHotEncoder`` and this
+        ``OneHotEncoder`` will be removed in 3.0.0..
 
     .. seealso::
 

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -1577,8 +1577,9 @@ class OneHotEncoder(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, 
 
     .. note:: This is different from scikit-learn's OneHotEncoder,
         which keeps all categories. The output vectors are sparse.
-       Deprecated in 2.3.0. ``OneHotEncoderEstimator`` will be renamed ``OneHotEncoder`` and this
-        ``OneHotEncoder`` will be removed in 3.0.0..
+
+    .. note:: Deprecated in 2.3.0. :py:class:`OneHotEncoderEstimator` will be renamed to
+        :py:class:`OneHotEncoder` and this :py:class:`OneHotEncoder` will be removed in 3.0.0.
 
     .. seealso::
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

mark OneHotEncoder python API deprecated

## How was this patch tested?

N/A