### PR TITLE
[SPARK-23058][SQL] Show non printable field delim as unicode

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -1023,7 +1023,12 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
 
       val serdeProps = metadata.storage.properties.map {
         case (key, value) =>
-          s"'${escapeSingleQuotedString(key)}' = '${escapeSingleQuotedString(value)}'"
+          val escapedValue = if (value.length == 1 && (value.head < 32 || value.head > 126)) {
+            s"\\${"%03d".format(value.head.toOctalString.toInt)}"
+          } else {
+            escapeSingleQuotedString(value)
+          }
+          s"'${escapeSingleQuotedString(key)}' = '$escapedValue'"
       }
 
       builder ++= serdeProps.mkString("WITH SERDEPROPERTIES (\n  ", ",\n  ", "\n)\n")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -1024,7 +1024,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
       val serdeProps = metadata.storage.properties.map {
         case (key, value) =>
           val escapedValue = if (value.length == 1 && (value.head < 32 || value.head > 126)) {
-            s"\\${"%03d".format(value.head.toOctalString.toInt)}"
+            "\\u%04X".format(value.head.toInt)
           } else {
             escapeSingleQuotedString(value)
           }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Create a table with  non printable delim like below:
```sql
CREATE EXTERNAL TABLE t1(col1 bigint)
ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
WITH SERDEPROPERTIES (
  'field.delim' = '\177',
  'serialization.format' = '\003'
)
STORED AS
  INPUTFORMAT 'org.apache.hadoop.mapred.SequenceFileInputFormat'
  OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat'
LOCATION 'file:/tmp/t1';
```

When `show create table t1`. **Before this PR:**:
```sql
CREATE EXTERNAL TABLE `t1`(`col1` bigint)
ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
WITH SERDEPROPERTIES (
  'field.delim' = '',
  'serialization.format' = ''
)
STORED AS
  INPUTFORMAT 'org.apache.hadoop.mapred.SequenceFileInputFormat'
  OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat'
LOCATION 'file:/tmp/t1'
TBLPROPERTIES (
  'transient_lastDdlTime' = '1515766958'
)
```
**After this PR:**
```
CREATE EXTERNAL TABLE `t1`(`col1` bigint)
ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
WITH SERDEPROPERTIES (
  'field.delim' = '\u007F',
  'serialization.format' = '\u0003'
)
STORED AS
  INPUTFORMAT 'org.apache.hadoop.mapred.SequenceFileInputFormat'
  OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat'
LOCATION 'file:/tmp/t1'
TBLPROPERTIES (
  'transient_lastDdlTime' = '1516066260'
)
```

This PR show non printable field delim as unicode when `show create table ...` and we can recreate table use this message now.

## How was this patch tested?

unit tests
