### PR TITLE
[WIP][SPARK-23057][SPARK-19235][SQL] SET LOCATION should change the path of partition in table

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -790,7 +790,7 @@ case class AlterTableSetLocationCommand(
           sparkSession, table, "ALTER TABLE ... SET LOCATION")
         // Partition spec is specified, so we set the location only for this partition
         val part = catalog.getPartition(table.identifier, spec)
-        val newProperties = updatePathInProps(part.storage, Some(locUri.toString))
+        val newProperties = updatePathInProps(part.storage, locUri.toString)
         val newPart = part.copy(storage = part.storage.copy(
           locationUri = Some(locUri), properties = newProperties))
         catalog.alterPartitions(table.identifier, Seq(newPart))
@@ -805,11 +805,11 @@ case class AlterTableSetLocationCommand(
 
   private def updatePathInProps(
       storage: CatalogStorageFormat,
-      newPath: Option[String]): Map[String, String] = {
+      newPath: String): Map[String, String] = {
     val propsWithoutPath = storage.properties.filter {
       case (k, _) => k.toLowerCase(Locale.ROOT) != "path"
     }
-    propsWithoutPath ++ newPath.map("path" -> _)
+    propsWithoutPath ++ Map("path" -> newPath)
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2601,13 +2601,13 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
 
 object DDLSuite {
   /**
-    * Check table partition path
-    *
-    * @param spark SparkSession
-    * @param path expect path
-    * @param partSpec  TablePartitionSpec
-    * @param table table name
-    */
+   * Check table partition path
+   *
+   * @param spark    SparkSession
+   * @param path     expect path
+   * @param partSpec TablePartitionSpec
+   * @param table    table name
+   */
   def checkPath(
       spark: SparkSession,
       path: String,

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -751,6 +751,25 @@ class HiveDDLSuite
     }
   }
 
+  test("SPARK-23057: SET LOCATION should change the path of partition in table") {
+    withTable("boxes") {
+      sql("CREATE TABLE boxes (height INT, length INT) PARTITIONED BY (width INT) LOCATION '/new'")
+      sql("INSERT OVERWRITE TABLE boxes PARTITION (width=4) SELECT 4, 4")
+      val expected = "/path/to/part/ways"
+      sql(s"ALTER TABLE boxes PARTITION (width=4) SET LOCATION '$expected'")
+      val catalog = spark.sessionState.catalog
+      val partSpec = Map("width" -> "4")
+      val spec = Some(partSpec)
+      val tableIdent = TableIdentifier("boxes", Some("default"))
+      val storageFormat = spec
+        .map { s => catalog.getPartition(tableIdent, s).storage }
+        .getOrElse {
+          catalog.getTableMetadata(tableIdent).storage
+        }
+      assert(storageFormat.properties.get("path").get === expected)
+    }
+  }
+
   test("alter table partition - storage information") {
     sql("CREATE TABLE boxes (height INT, length INT) PARTITIONED BY (width INT)")
     sql("INSERT OVERWRITE TABLE boxes PARTITION (width=4) SELECT 4, 4")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -757,16 +757,8 @@ class HiveDDLSuite
       sql("INSERT OVERWRITE TABLE boxes PARTITION (width=4) SELECT 4, 4")
       val expected = "/path/to/part/ways"
       sql(s"ALTER TABLE boxes PARTITION (width=4) SET LOCATION '$expected'")
-      val catalog = spark.sessionState.catalog
       val partSpec = Map("width" -> "4")
-      val spec = Some(partSpec)
-      val tableIdent = TableIdentifier("boxes", Some("default"))
-      val storageFormat = spec
-        .map { s => catalog.getPartition(tableIdent, s).storage }
-        .getOrElse {
-          catalog.getTableMetadata(tableIdent).storage
-        }
-      assert(storageFormat.properties.get("path").get === expected)
+      DDLSuite.checkPath(spark, expected, partSpec, "boxes")
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -753,7 +753,7 @@ class HiveDDLSuite
 
   test("SPARK-23057: SET LOCATION should change the path of partition in table") {
     withTable("boxes") {
-      sql("CREATE TABLE boxes (height INT, length INT) PARTITIONED BY (width INT) LOCATION '/new'")
+      sql("CREATE TABLE boxes (height INT, length INT) PARTITIONED BY (width INT)")
       sql("INSERT OVERWRITE TABLE boxes PARTITION (width=4) SELECT 4, 4")
       val expected = "/path/to/part/ways"
       sql(s"ALTER TABLE boxes PARTITION (width=4) SET LOCATION '$expected'")


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix error of SE T LOCATION

SET LOCATION should change the path of partition in table


For 

```
// TODO(gatorsmile): fix the bug in alter table set location.
      // if (isUsingHiveMetastore) {
      //  assert(storageFormat.properties.get("path") === expected)
      // }
```

When:

```
    // set table partition location
    sql("ALTER TABLE dbx.tab1 PARTITION (a='1', b='2') SET LOCATION '/path/to/part/ways'")
    verifyLocation(new URI("/path/to/part/ways"), Some(partSpec))
```
In https://github.com/apache/spark/pull/16592/files
## How was this patch tested?

add test cases:

 test("SPARK-23057: path option always represent the value of table location with partition") 
test("SPARK-23057: SET LOCATION for managed table with partition")
test("SPARK-23057: SET LOCATION should change the path of partition in table") 