### PR TITLE
[Spark-23051][core] Fix for broken job description in Spark UI

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -430,7 +430,7 @@ private[ui] class JobDataSource(
     val submissionTime = jobData.submissionTime
     val formattedSubmissionTime = submissionTime.map(UIUtils.formatDate).getOrElse("Unknown")
 
-    val lastStage = {
+    val lastStageAttempt = {
       val stageAttempts = jobData.stageIds.flatMap(store.stageData(_))
       if (stageAttempts.nonEmpty) {
         val lastAttempt = stageAttempts.maxBy(_.stageId)
@@ -441,12 +441,12 @@ private[ui] class JobDataSource(
     }
 
     val jobDescription = jobData.description
-      .getOrElse(lastStage.flatMap(_.description)
+      .getOrElse(lastStageAttempt.flatMap(_.description)
         .getOrElse(jobData.name))
 
-    val lastStageName = lastStage.map(_.name).getOrElse(jobData.name)
+    val lastStageName = lastStageAttempt.map(_.name).getOrElse(jobData.name)
 
-    val lastStageDescription = lastStage.flatMap(_.description)
+    val lastStageDescription = lastStageAttempt.flatMap(_.description)
       .getOrElse(jobData.description
           .getOrElse(jobData.name))
 

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -23,6 +23,8 @@ import javax.servlet.http.HttpServletRequest
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
+import scala.concurrent
+import scala.concurrent.duration
 import scala.xml._
 
 import org.apache.commons.lang3.StringEscapeUtils
@@ -438,17 +440,21 @@ private[ui] class JobDataSource(
       } else {
         None
       }}
-    val jobDescription = jobData.description.getOrElse {
-      lastStage.flatMap(_.description).getOrElse(jobData.name)}
-    val detailUrl = "%s/jobs/job?id=%s".format(basePath, jobData.jobId)
+
+    val jobDescription = jobData.description
+      .getOrElse(lastStage.flatMap(_.description).
+          getOrElse(jobData.name))
+
     val lastStageName = lastStage.map(_.name).getOrElse(jobData.name)
+
     val lastStageDescription = lastStage.flatMap(_.description)
-      .getOrElse(
-        jobData.description
+      .getOrElse(jobData.description
           .getOrElse(jobData.name))
 
     val formattedJobDescription =
       UIUtils.makeDescription(jobDescription, basePath, plainText = false)
+
+    val detailUrl = "%s/jobs/job?id=%s".format(basePath, jobData.jobId)
 
     new JobTableRowData(
       jobData,

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -23,8 +23,6 @@ import javax.servlet.http.HttpServletRequest
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
-import scala.concurrent
-import scala.concurrent.duration
 import scala.xml._
 
 import org.apache.commons.lang3.StringEscapeUtils

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -432,16 +432,17 @@ private[ui] class JobDataSource(
 
     val lastStage = {
       val stageAttempts = jobData.stageIds.flatMap(store.stageData(_))
-      if (!stageAttempts.isEmpty) {
-        val lastId = stageAttempts.map(_.stageId).max
-        stageAttempts.find(_.stageId == lastId)
+      if (stageAttempts.nonEmpty) {
+        val lastAttempt = stageAttempts.maxBy(_.stageId)
+        Some(lastAttempt)
       } else {
         None
-      }}
+      }
+    }
 
     val jobDescription = jobData.description
-      .getOrElse(lastStage.flatMap(_.description).
-          getOrElse(jobData.name))
+      .getOrElse(lastStage.flatMap(_.description)
+        .getOrElse(jobData.name))
 
     val lastStageName = lastStage.map(_.name).getOrElse(jobData.name)
 

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -431,7 +431,7 @@ private[ui] class JobDataSource(
     val formattedSubmissionTime = submissionTime.map(UIUtils.formatDate).getOrElse("Unknown")
 
     val lastStage = {
-      val stageAttempts = jobData.stageIds.map(store.stageData(_)).flatten
+      val stageAttempts = jobData.stageIds.flatMap(store.stageData(_))
       if (!stageAttempts.isEmpty) {
         val lastId = stageAttempts.map(_.stageId).max
         stageAttempts.find(_.stageId == lastId)
@@ -439,7 +439,7 @@ private[ui] class JobDataSource(
         None
       }}
     val jobDescription = jobData.description.getOrElse {
-      lastStage.get.description.getOrElse(jobData.name)}
+      lastStage.flatMap(_.description).getOrElse(jobData.name)}
     val detailUrl = "%s/jobs/job?id=%s".format(basePath, jobData.jobId)
     val lastStageName = lastStage.map(_.name).getOrElse(jobData.name)
     val lastStageDescription = lastStage.flatMap(_.description)

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -433,8 +433,7 @@ private[ui] class JobDataSource(
     val lastStageAttempt = {
       val stageAttempts = jobData.stageIds.flatMap(store.stageData(_))
       if (stageAttempts.nonEmpty) {
-        val lastAttempt = stageAttempts.maxBy(_.stageId)
-        Some(lastAttempt)
+        Some(stageAttempts.maxBy(_.stageId))
       } else {
         None
       }

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -67,7 +67,7 @@ private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends We
       val status = job.status
       val jobDescription = store.lastStageAttempt(job.stageIds.max).description
       val displayJobDescription = jobDescription
-          .map(UIUtils.makeDescription(_, "", plainText = true).text)
+        .map(UIUtils.makeDescription(_, "", plainText = true).text)
         .getOrElse("")
       val submissionTime = job.submissionTime.get.getTime()
       val completionTime = job.completionTime.map(_.getTime()).getOrElse(System.currentTimeMillis())


### PR DESCRIPTION
## What changes were proposed in this pull request?

In 2.2, Spark UI displayed the stage description if the job description was not set. This functionality was broken, the GUI has shown no description in this case. In addition, the code uses jobName and 
jobDescription instead of stageName and stageDescription when JobTableRowData is created.

In this PR the logic producing values for the job rows was modified to find the latest stage attempt for the job and use that as a fallback if job description was missing. 
StageName and stageDescription are also set using values from stage and jobName/description is used only as a fallback.

## How was this patch tested?
Manual testing of the UI, using the code in the bug report.