### PR TITLE
[SPARK-23060][Python] New feature - apply method to extend rdd's functionality

### DIFF
--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -747,22 +747,21 @@ class RDD(object):
         """
         return self.map(lambda x: (f(x), x)).groupByKey(numPartitions, partitionFunc)
 
-
+    # TODO: accept also *args
     def apply(self, func):
     	"""
     	Apply a function to the current RDD.
 		
-		>>> def foo(rdd):
-		...     return rdd.map(lambda x: x.split('|')).filter(lambda x: x[0] == 'ERROR')
-		>>> rdd = sc.parallelize(['ERROR|10', 'ERROR|12', 'WARNING|10', 'INFO|2'])
-		>>> result = rdd.apply(foo)
-		>>> result.collect()
-		[('ERROR', '10'), ('ERROR', '12')]
+        >>> def foo(rdd):
+        ...     return rdd.map(lambda x: x.split('|')).filter(lambda x: x[0] == 'ERROR')
+        >>> rdd = sc.parallelize(['ERROR|10', 'ERROR|12', 'WARNING|10', 'INFO|2'])
+        >>> result = rdd.apply(foo)
+        >>> result.collect()
+        [('ERROR', '10'), ('ERROR', '12')]
 
     	:param func: function to be applied to the current RDD
     	"""
     	return func(self)
-
 
     @ignore_unicode_prefix
     def pipe(self, command, env=None, checkCode=False):

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -747,6 +747,23 @@ class RDD(object):
         """
         return self.map(lambda x: (f(x), x)).groupByKey(numPartitions, partitionFunc)
 
+
+    def apply(self, func):
+    	"""
+    	Apply a function to the current RDD.
+		
+		>>> def foo(rdd):
+		...     return rdd.map(lambda x: x.split('|')).filter(lambda x: x[0] == 'ERROR')
+		>>> rdd = sc.parallelize(['ERROR|10', 'ERROR|12', 'WARNING|10', 'INFO|2'])
+		>>> result = rdd.apply(foo)
+		>>> result.collect()
+		[('ERROR', '10'), ('ERROR', '12')]
+
+    	:param func: function to be applied to the current RDD
+    	"""
+    	return func(self)
+
+
     @ignore_unicode_prefix
     def pipe(self, command, env=None, checkCode=False):
         """


### PR DESCRIPTION
## What changes were proposed in this pull request?

Extend the RDD class with the method apply.
This method should be like the pipe operator, attached to the RDD class itself.
Example:

`
def foo(rdd):  return rdd.map(lambda x: x.split('|')).filter(lambda x: x[0] == 'ERROR')
`
`
rdd = sc.parallelize(['ERROR|10', 'ERROR|12', 'WARNING|10', 'INFO|2'])
`
`
result = rdd.apply(foo)
`
`
result.collect()
`
`
[('ERROR', '10'), ('ERROR', '12')]
`


The idea is to have something like this:
https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.pipe.html?

## How was this patch tested?

Manual tests. Easy patch.

Please review http://spark.apache.org/contributing.html before opening a pull request.
