### PR TITLE
 [SPARK-23039][SQL] Finish TODO work in alter table set location.

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -787,7 +787,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     val storageWithLocation = {
       val tableLocation = getLocationFromStorageProps(table)
       // We pass None as `newPath` here, to remove the path option in storage properties.
-      updateLocationInStorageProps(table, newPath = None).copy(
+      table.storage.copy(
         locationUri = tableLocation.map(CatalogUtils.stringToURI(_)))
     }
     val partitionProvider = table.properties.get(TABLE_PARTITION_PROVIDER)


### PR DESCRIPTION

## What changes were proposed in this pull request?
 Finish TODO work in alter table set location.
  org.apache.spark.sql.execution.command.DDLSuite#testSetLocation

    // TODO(gatorsmile): fix the bug in alter table set location.
    //    if (isUsingHiveMetastore) {
    //    assert(storageFormat.properties.get("path") === expected)
    //   }

fix it by remove newPath = None in org.apache.spark.sql.hive.HiveExternalCatalog#restoreDataSourceTable
## How was this patch tested?

 test("SPARK-23039: check path after SET LOCATION")

Wait for https://github.com/apache/spark/pull/20249