### PR TITLE
[SPARK-23068][BUILD][RELEASE][WIP] doc build error from jekyll does not fail

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -290,6 +290,8 @@ if [[ "$1" == "docs" ]]; then
   cd docs
   # TODO: Make configurable to add this: PRODUCTION=1
   PRODUCTION=1 RELEASE_VERSION="$SPARK_VERSION" jekyll build
+  ret=$?
+  if [[ $ret != 0 ]]; then exit $ret; fi
   cd ..
   cd ..
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

check exit code. note that not all errors are reported by jekyll via exit code.
also there is still [this](https://github.com/apache/spark/blob/master/dev/create-release/release-build.sh#L259) for make_binary_release we should look at.

## How was this patch tested?

manual