### PR TITLE
[SPARK-23079][SQL] Fix query constraints propagation with aliases

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
@@ -97,12 +97,15 @@ trait QueryPlanConstraints { self: LogicalPlan =>
   // Collect aliases from expressions of the whole tree rooted by the current QueryPlan node, so
   // we may avoid producing recursive constraints.
   private lazy val aliasMap: AttributeMap[Expression] = {
-    val aliases = expressions.collect {
+    val childrenAliases = children.flatMap { child =>
+      val childOutputSet = child.outputSet
+      child.asInstanceOf[QueryPlanConstraints].aliasMap.filter {
+        case (_, c) => c.references.nonEmpty && c.references.subsetOf(childOutputSet)
+      }
+    }
+    AttributeMap(expressions.collect {
       case a: Alias if !a.child.isInstanceOf[Literal] => (a.toAttribute, a.child)
-    } ++ children.flatMap(_.asInstanceOf[QueryPlanConstraints].aliasMap)
-    AttributeMap(aliases.filter {
-      case (_, child) => child.references.nonEmpty && child.references.subsetOf(outputSet)
-    })
+    } ++ childrenAliases)
   }
 
     // Note: the explicit cast is necessary, since Scala compiler fails to infer the type.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Previously, PR #19201 fix the problem of non-converging constraints.

However, the case below will fail.

```

spark.range(5).write.saveAsTable("t")
val t = spark.read.table("t")
val left = t.withColumn("xid", $"id" + lit(1)).as("x")
val right = t.withColumnRenamed("id", "xid").as("y")
val df = left.join(right, "xid").filter("id = 3").toDF()
checkAnswer(df, Row(4, 3))

```

Because `aliasMap` replace all the aliased child. See the test case in PR for details.

This PR is to fix this bug by removing useless `aliasMap`.
 
Duplicated to #20278, this PR will be closed after test finished.
This PR makes sense but it takes time to understand the whole code.
## How was this patch tested?

Unit test
