### PR TITLE
[SPARK-23078] [CORE] [K8s] allow Spark Thrift Server to run in Kubernetes Cluster mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -328,7 +328,7 @@ object SparkSubmit extends CommandLineUtils with Logging {
         printErrorAndExit("Cluster deploy mode is not applicable to Spark shells.")
       case (_, CLUSTER) if isSqlShell(args.mainClass) =>
         printErrorAndExit("Cluster deploy mode is not applicable to Spark SQL shell.")
-      case (_, CLUSTER) if isThriftServer(args.mainClass) =>
+      case (_, CLUSTER) if (clusterManager != KUBERNETES) && isThriftServer(args.mainClass) =>
         printErrorAndExit("Cluster deploy mode is not applicable to Spark Thrift server.")
       case _ =>
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

allow Spark Thrift Server to run in Kubernetes Cluster mode

## How was this patch tested?

Edit: see https://github.com/apache-spark-on-k8s/spark-integration/pull/38