### PR TITLE
[SPARK-14948][SQL] disambiguate attributes in join condition

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -748,8 +748,8 @@ class Analyzer(
                 // `AnalysisBarrier`, or this `AttributeReference` is not associated with any
                 // `AnalysisBarrier`, or this `AttributeReference` refers to the de-duplicated
                 // `AnalysisBarrier`, i.e. barrierId matches.
-                if (barrierId.isEmpty || !a.metadata.contains("barrierId") ||
-                  barrierId.get == a.metadata.getLong("barrierId")) {
+                if (barrierId.isEmpty || !a.metadata.contains(AnalysisBarrier.metadataKey) ||
+                  barrierId.get == a.metadata.getLong(AnalysisBarrier.metadataKey)) {
                   dedupAttr(a, attributeRewrites)
                 } else {
                   a
@@ -2358,8 +2358,9 @@ object EliminateBarriers extends Rule[LogicalPlan] {
     case AnalysisBarrier(child, _) => child
 
     case other => other transformExpressions {
-      case a: AttributeReference if a.metadata.contains("barrierId") =>
-        val metadata = new MetadataBuilder().withMetadata(a.metadata).remove("barrierId").build()
+      case a: AttributeReference if a.metadata.contains(AnalysisBarrier.metadataKey) =>
+        val metadata = new MetadataBuilder()
+          .withMetadata(a.metadata).remove(AnalysisBarrier.metadataKey).build()
         a.withMetadata(metadata)
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -902,9 +902,18 @@ case class Deduplicate(
  *
  * This analysis barrier will be removed at the end of analysis stage.
  */
-case class AnalysisBarrier(child: LogicalPlan) extends LeafNode {
+case class AnalysisBarrier(child: LogicalPlan, id: Long) extends LeafNode {
   override protected def innerChildren: Seq[LogicalPlan] = Seq(child)
   override def output: Seq[Attribute] = child.output
   override def isStreaming: Boolean = child.isStreaming
   override def doCanonicalize(): LogicalPlan = child.canonicalized
+  override protected def stringArgs: Iterator[Any] = Iterator(child)
+}
+
+object AnalysisBarrier {
+  private val curId = new java.util.concurrent.atomic.AtomicLong()
+
+  def apply(child: LogicalPlan): AnalysisBarrier = {
+    AnalysisBarrier(child, curId.getAndIncrement())
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -913,6 +913,8 @@ case class AnalysisBarrier(child: LogicalPlan, id: Long) extends LeafNode {
 object AnalysisBarrier {
   private val curId = new java.util.concurrent.atomic.AtomicLong()
 
+  final val metadataKey = "BARRIER_ID"
+
   def apply(child: LogicalPlan): AnalysisBarrier = {
     AnalysisBarrier(child, curId.getAndIncrement())
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -901,6 +901,11 @@ case class Deduplicate(
  * will be put on the barrier, so only the new nodes created will be analyzed.
  *
  * This analysis barrier will be removed at the end of analysis stage.
+ *
+ * @param child The analyzed plan to be hidden from the barrier.
+ * @param id A globally unique ID for this barrier, which is also used as a DataFrame ID. The
+ *           analyzer relies on this ID to disambiguate attributes in join condition when resolving
+ *           self-join.
  */
 case class AnalysisBarrier(child: LogicalPlan, id: Long) extends LeafNode {
   override protected def innerChildren: Seq[LogicalPlan] = Seq(child)

--- a/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
@@ -140,7 +140,7 @@ class Column(val expr: Expression) extends Logging {
   override def toString: String = toPrettySQL(expr)
 
   override def equals(that: Any): Boolean = that match {
-    case that: Column => that.expr.equals(this.expr)
+    case that: Column => that.expr.semanticEquals(this.expr)
     case _ => false
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1246,7 +1246,7 @@ class Dataset[T] private[sql](
         // used to disambiguate the attributes in join condition when resolving self-join and
         // de-duplicating the right side plan. This special metadata will be remove after analysis.
         val metadata = new MetadataBuilder().withMetadata(a.metadata)
-          .putLong("barrierId", planWithBarrier.id).build()
+          .putLong(AnalysisBarrier.metadataKey, planWithBarrier.id).build()
         a.withMetadata(metadata)
     }
     Column(expr)

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1244,7 +1244,7 @@ class Dataset[T] private[sql](
         // Associate the returned `AttributeReference` with the `AnalysisBarrier` of this Dataset,
         // by putting the barrier id into `AttributeReference.metadata`. This information is only
         // used to disambiguate the attributes in join condition when resolving self-join and
-        // de-duplicating the right side plan.
+        // de-duplicating the right side plan. This special metadata will be remove after analysis.
         val metadata = new MetadataBuilder().withMetadata(a.metadata)
           .putLong("barrierId", planWithBarrier.id).build()
         a.withMetadata(metadata)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/InnerJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/InnerJoinSuite.scala
@@ -76,11 +76,11 @@ class InnerJoinSuite extends SparkPlanTest with SharedSQLContext {
       testName: String,
       leftRows: => DataFrame,
       rightRows: => DataFrame,
-      condition: () => Expression,
+      condition: => Expression,
       expectedAnswer: Seq[Product]): Unit = {
 
     def extractJoinParts(): Option[ExtractEquiJoinKeys.ReturnType] = {
-      val join = Join(leftRows.logicalPlan, rightRows.logicalPlan, Inner, Some(condition()))
+      val join = Join(leftRows.logicalPlan, rightRows.logicalPlan, Inner, Some(condition))
       ExtractEquiJoinKeys.unapply(join)
     }
 
@@ -190,7 +190,7 @@ class InnerJoinSuite extends SparkPlanTest with SharedSQLContext {
       withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "1",
         SQLConf.CROSS_JOINS_ENABLED.key -> "true") {
         checkAnswer2(leftRows, rightRows, (left: SparkPlan, right: SparkPlan) =>
-          CartesianProductExec(left, right, Some(condition())),
+          CartesianProductExec(left, right, Some(condition)),
           expectedAnswer.map(Row.fromTuple),
           sortAnswers = true)
       }
@@ -199,7 +199,7 @@ class InnerJoinSuite extends SparkPlanTest with SharedSQLContext {
     test(s"$testName using BroadcastNestedLoopJoin build left") {
       withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
         checkAnswer2(leftRows, rightRows, (left: SparkPlan, right: SparkPlan) =>
-          BroadcastNestedLoopJoinExec(left, right, BuildLeft, Inner, Some(condition())),
+          BroadcastNestedLoopJoinExec(left, right, BuildLeft, Inner, Some(condition)),
           expectedAnswer.map(Row.fromTuple),
           sortAnswers = true)
       }
@@ -208,7 +208,7 @@ class InnerJoinSuite extends SparkPlanTest with SharedSQLContext {
     test(s"$testName using BroadcastNestedLoopJoin build right") {
       withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
         checkAnswer2(leftRows, rightRows, (left: SparkPlan, right: SparkPlan) =>
-          BroadcastNestedLoopJoinExec(left, right, BuildRight, Inner, Some(condition())),
+          BroadcastNestedLoopJoinExec(left, right, BuildRight, Inner, Some(condition)),
           expectedAnswer.map(Row.fromTuple),
           sortAnswers = true)
       }
@@ -219,7 +219,7 @@ class InnerJoinSuite extends SparkPlanTest with SharedSQLContext {
     "inner join, one match per row",
     myUpperCaseData,
     myLowerCaseData,
-    () => (myUpperCaseData.col("N") === myLowerCaseData.col("n")).expr,
+    (myUpperCaseData.col("N") === myLowerCaseData.col("n")).expr,
     Seq(
       (1, "A", 1, "a"),
       (2, "B", 2, "b"),
@@ -235,7 +235,7 @@ class InnerJoinSuite extends SparkPlanTest with SharedSQLContext {
       "inner join, multiple matches",
       left,
       right,
-      () => (left.col("a") === right.col("a")).expr,
+      (left.col("a") === right.col("a")).expr,
       Seq(
         (1, 1, 1, 1),
         (1, 1, 1, 2),
@@ -252,7 +252,7 @@ class InnerJoinSuite extends SparkPlanTest with SharedSQLContext {
       "inner join, no matches",
       left,
       right,
-      () => (left.col("a") === right.col("a")).expr,
+      (left.col("a") === right.col("a")).expr,
       Seq.empty
     )
   }
@@ -264,7 +264,7 @@ class InnerJoinSuite extends SparkPlanTest with SharedSQLContext {
       "inner join, null safe",
       left,
       right,
-      () => (left.col("b") <=> right.col("b")).expr,
+      (left.col("b") <=> right.col("b")).expr,
       Seq(
         (1, 0, 1, 0),
         (2, null, 2, null)
@@ -280,7 +280,7 @@ class InnerJoinSuite extends SparkPlanTest with SharedSQLContext {
       "SPARK-15822 - test structs as keys",
       left,
       right,
-      () => (left.col("key") === right.col("key")).expr,
+      (left.col("key") === right.col("key")).expr,
       Seq(
         (Row(0, 0), "L0", Row(0, 0), "R0"),
         (Row(1, 1), "L1", Row(1, 1), "R1"),


### PR DESCRIPTION
## What changes were proposed in this pull request?

`Dataset.col/apply` returns a column reference, which is pretty useful to deal with duplicated names in join. e.g.
```
val df1 = ... // [a: int, b: int]
val df2 = ...// [b: int, c: int]

df1.join(df2, df1("b") === df2("b"))
df1.join(df2).drop(df2("b"))
...
```

However, this is problematic for self-join, or joining DataFrames derived from the same DataFrame. The reason is that, the column reference returned by `Dataset.col` is actually `AttributeReference`, which means different DataFrames may return same column reference. After join, the right side would be de-duplicated if it has conflicting attributes with the left side, and the column reference returned by right side would be missing after join, or be wrong and refers to columns from the left side. A simple example to illustrate this problem:
```
val left = spark.range(5)
val right = left.filter($"id" < 1)
left.join(right, left("id") === right("id") + 1, "cross") // This returns empty result, which is wrong
```

To fix this issue entirely, we may need to define a real column reference that is globally uique, and design a dataframe lineage mechanism so that we can use column reference from another dataframe in a dataframe operation, e.g.
```
val df3 = df1.join(df2)
df3.drop(df2("b"))
```

This is a lot of work and is too late for 2.3, here I propose a simple and safe solution to disambiguate attributes in join condition only, which is the most common problematic case.

The idea is simple, we assign a globally unique id to each dataframe, via `AnalysisBarrier`. 
`AttributeReference` returned by `Dataset.col` should be associated with the dataframe it comes from, via the barrier id. This barrier id is mostly ignored, and only used when we are de-duplicating the join right side plan, these attributes with barrier id inside join condition would be replaced by the new attributes generated by the right side plan.

## How was this patch tested?

new regression test