### PR TITLE
[SPARK-23121][WEB-UI] When the Spark Streaming app is running for a period of time, the page is incorrectly reported when accessing '/jobs' or '/jobs/job?id=13'

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
@@ -335,9 +335,12 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
 
     content ++= makeTimeline(activeStages ++ completedStages ++ failedStages,
       store.executorList(false), appStartTime)
-
-    content ++= UIUtils.showDagVizForJob(
-      jobId, store.operationGraphForJob(jobId))
+    try {
+      content ++= UIUtils.showDagVizForJob(
+        jobId, store.operationGraphForJob(jobId))
+    } catch {
+      case e => None
+    }
 
     if (shouldShowActiveStages) {
       content ++= <h4 id="active">Active Stages ({activeStages.size})</h4> ++


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the Spark Streaming app is running for a period of time, the page is incorrectly reported when accessing '/ jobs /' or '/ jobs / job /? Id = 13' and ui can not be accessed.
 
Test command:
./bin/spark-submit --class org.apache.spark.examples.streaming.HdfsWordCount ./examples/jars/spark-examples_2.11-2.4.0-SNAPSHOT.jar /spark
 
The app is running for a period of time,  ui can not be accessed, please see attachment.
fix before:
![1](https://user-images.githubusercontent.com/26266482/35024280-8c06f79e-fb79-11e7-8e5c-b804e06945d2.png)
![2](https://user-images.githubusercontent.com/26266482/35024281-8c353906-fb79-11e7-8f99-4e1bfbac9776.png)

## How was this patch tested?

manual tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
