### PR TITLE
[SPARK-23122][PYTHON][SQL] Deprecate register* for UDFs in SQLContext and Catalog in PySpark

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -400,6 +400,7 @@ pyspark_sql = Module(
         "pyspark.sql.functions",
         "pyspark.sql.readwriter",
         "pyspark.sql.streaming",
+        "pyspark.sql.udf",
         "pyspark.sql.window",
         "pyspark.sql.tests",
     ]

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -237,7 +237,7 @@ class Catalog(object):
             for :func:`spark.udf.register`.
         .. note:: Deprecated in 2.3.0. Use :func:`spark.udf.register` instead.
         .. versionadded:: 2.0
-    """ % _register_doc[:_register_doc.rfind('versionadded::')]
+    """ % _register_doc[:_register_doc.rfind('.. versionadded::')]
 
     @since(2.0)
     def isCached(self, tableName):

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -21,7 +21,7 @@ from collections import namedtuple
 from pyspark import since
 from pyspark.rdd import ignore_unicode_prefix, PythonEvalType
 from pyspark.sql.dataframe import DataFrame
-from pyspark.sql.udf import UserDefinedFunction, UDFRegistration
+from pyspark.sql.udf import UserDefinedFunction
 from pyspark.sql.types import IntegerType, StringType, StructType
 
 
@@ -224,20 +224,17 @@ class Catalog(object):
         """
         self._jcatalog.dropGlobalTempView(viewName)
 
+    @since(2.0)
     def registerFunction(self, name, f, returnType=None):
+        """An alias for :func:`spark.udf.register`.
+        See :meth:`pyspark.sql.UDFRegistration.register`.
+
+        .. note:: Deprecated in 2.3.0. Use :func:`spark.udf.register` instead.
+        """
         warnings.warn(
             "Deprecated in 2.3.0. Use spark.udf.register instead.",
             DeprecationWarning)
         return self._sparkSession.udf.register(name, f, returnType)
-    # Reuse the docstring from UDFRegistration but with few notes.
-    _register_doc = UDFRegistration.register.__doc__.strip()
-    registerFunction.__doc__ = """%s
-
-        .. note:: :func:`spark.catalog.registerFunction` is an alias
-            for :func:`spark.udf.register`.
-        .. note:: Deprecated in 2.3.0. Use :func:`spark.udf.register` instead.
-        .. versionadded:: 2.0
-    """ % _register_doc[:_register_doc.rfind('.. versionadded::')]
 
     @since(2.0)
     def isCached(self, tableName):

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -21,8 +21,7 @@ from collections import namedtuple
 from pyspark import since
 from pyspark.rdd import ignore_unicode_prefix, PythonEvalType
 from pyspark.sql.dataframe import DataFrame
-from pyspark.sql.session import UDFRegistration
-from pyspark.sql.udf import UserDefinedFunction
+from pyspark.sql.udf import UserDefinedFunction, UDFRegistration
 from pyspark.sql.types import IntegerType, StringType, StructType
 
 

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -231,12 +231,14 @@ class Catalog(object):
             DeprecationWarning)
         return self._sparkSession.udf.register(name, f, returnType)
     # Reuse the docstring from UDFRegistration but with few notes.
+    _register_doc = UDFRegistration.register.__doc__.strip()
     registerFunction.__doc__ = """%s
+
         .. note:: :func:`spark.catalog.registerFunction` is an alias
             for :func:`spark.udf.register`.
         .. note:: Deprecated in 2.3.0. Use :func:`spark.udf.register` instead.
         .. versionadded:: 2.0
-    """ % UDFRegistration.register.__doc__
+    """ % _register_doc[:_register_doc.rfind('versionadded::')]
 
     @since(2.0)
     def isCached(self, tableName):

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -173,34 +173,29 @@ class SQLContext(object):
         """
         return self.sparkSession.range(start, end, step, numPartitions)
 
+    @since(1.2)
     def registerFunction(self, name, f, returnType=None):
+        """An alias for :func:`spark.udf.register`.
+        See :meth:`pyspark.sql.UDFRegistration.register`.
+
+        .. note:: Deprecated in 2.3.0. Use :func:`spark.udf.register` instead.
+        """
         warnings.warn(
             "Deprecated in 2.3.0. Use spark.udf.register instead.",
             DeprecationWarning)
         return self.sparkSession.udf.register(name, f, returnType)
-    # Reuse the docstring from UDFRegistration but with few notes.
-    _register_doc = UDFRegistration.register.__doc__.strip()
-    registerFunction.__doc__ = """%s
 
-        .. note:: :func:`sqlContext.registerFunction` is an alias for
-            :func:`spark.udf.register`.
-        .. note:: Deprecated in 2.3.0. Use :func:`spark.udf.register` instead.
-        .. versionadded:: 1.2
-    """ % _register_doc[:_register_doc.rfind('.. versionadded::')]
-
+    @since(2.1)
     def registerJavaFunction(self, name, javaClassName, returnType=None):
+        """An alias for :func:`spark.udf.registerJavaFunction`.
+        See :meth:`pyspark.sql.UDFRegistration.registerJavaFunction`.
+
+        .. note:: Deprecated in 2.3.0. Use :func:`spark.udf.registerJavaFunction` instead.
+        """
         warnings.warn(
             "Deprecated in 2.3.0. Use spark.udf.registerJavaFunction instead.",
             DeprecationWarning)
         return self.sparkSession.udf.registerJavaFunction(name, javaClassName, returnType)
-    _registerJavaFunction_doc = UDFRegistration.registerJavaFunction.__doc__.strip()
-    registerJavaFunction.__doc__ = """%s
-
-        .. note:: :func:`sqlContext.registerJavaFunction` is an alias for
-            :func:`spark.udf.registerJavaFunction`
-        .. note:: Deprecated in 2.3.0. Use :func:`spark.udf.registerJavaFunction` instead.
-        .. versionadded:: 2.1
-    """ % _registerJavaFunction_doc[:_registerJavaFunction_doc.rfind('.. versionadded::')]
 
     # TODO(andrew): delete this once we refactor things to take in SparkSession
     def _inferSchema(self, rdd, samplingRatio=None):
@@ -528,9 +523,6 @@ def _test():
     globs['os'] = os
     globs['sc'] = sc
     globs['sqlContext'] = SQLContext(sc)
-    # 'spark' is used for reusing doctests. Please see the reassignment
-    # of docstrings above.
-    globs['spark'] = globs['sqlContext'].sparkSession
     globs['rdd'] = rdd = sc.parallelize(
         [Row(field1=1, field2="row1"),
          Row(field1=2, field2="row2"),

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -186,7 +186,7 @@ class SQLContext(object):
             :func:`spark.udf.register`.
         .. note:: Deprecated in 2.3.0. Use :func:`spark.udf.register` instead.
         .. versionadded:: 1.2
-    """ % _register_doc[:_register_doc.rfind('versionadded::')]
+    """ % _register_doc[:_register_doc.rfind('.. versionadded::')]
 
     def registerJavaFunction(self, name, javaClassName, returnType=None):
         warnings.warn(
@@ -200,7 +200,7 @@ class SQLContext(object):
             :func:`spark.udf.registerJavaFunction`
         .. note:: Deprecated in 2.3.0. Use :func:`spark.udf.registerJavaFunction` instead.
         .. versionadded:: 2.1
-    """ % _registerJavaFunction_doc[:_registerJavaFunction_doc.rfind('versionadded::')]
+    """ % _registerJavaFunction_doc[:_registerJavaFunction_doc.rfind('.. versionadded::')]
 
     # TODO(andrew): delete this once we refactor things to take in SparkSession
     def _inferSchema(self, rdd, samplingRatio=None):

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -47,8 +47,6 @@ class SQLContext(object):
     :param sparkSession: The :class:`SparkSession` around which this SQLContext wraps.
     :param jsqlContext: An optional JVM Scala SQLContext. If set, we do not instantiate a new
         SQLContext in the JVM, instead we make all calls to this object.
-
-    .. note:: Deprecated in 2.3.0. Use SparkSession.builder.getOrCreate().
     """
 
     _instantiatedContext = None
@@ -71,10 +69,6 @@ class SQLContext(object):
         >>> df.rdd.map(lambda x: (x.i, x.s, x.d, x.l, x.b, x.time, x.row.a, x.list)).collect()
         [(1, u'string', 1.0, 1, True, datetime.datetime(2014, 8, 1, 14, 1, 5), 1, [1, 2, 3])]
         """
-        warnings.warn(
-            "Deprecated in 2.0.0. Use SparkSession.builder.getOrCreate() instead.",
-            DeprecationWarning)
-
         self._sc = sparkContext
         self._jsc = self._sc._jsc
         self._jvm = self._sc._jvm

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -24,11 +24,12 @@ if sys.version >= '3':
 
 from pyspark import since
 from pyspark.rdd import ignore_unicode_prefix
-from pyspark.sql.session import _monkey_patch_RDD, SparkSession, UDFRegistration
+from pyspark.sql.session import _monkey_patch_RDD, SparkSession
 from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.readwriter import DataFrameReader
 from pyspark.sql.streaming import DataStreamReader
 from pyspark.sql.types import IntegerType, Row, StringType
+from pyspark.sql.udf import UDFRegistration
 from pyspark.sql.utils import install_exception_handler
 
 __all__ = ["SQLContext", "HiveContext"]

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -147,8 +147,7 @@ class SQLContext(object):
 
         :return: :class:`UDFRegistration`
         """
-        from pyspark.sql.session import UDFRegistration
-        return UDFRegistration(self.sparkSession)
+        return self.sparkSession.udf
 
     @since(1.4)
     def range(self, start, end=None, step=1, numPartitions=None):
@@ -179,36 +178,28 @@ class SQLContext(object):
             DeprecationWarning)
         return self.sparkSession.udf.register(name, f, returnType)
     # Reuse the docstring from UDFRegistration but with few notes.
+    _register_doc = UDFRegistration.register.__doc__.strip()
     registerFunction.__doc__ = """%s
+
         .. note:: :func:`sqlContext.registerFunction` is an alias for
             :func:`spark.udf.register`.
         .. note:: Deprecated in 2.3.0. Use :func:`spark.udf.register` instead.
         .. versionadded:: 1.2
-    """ % UDFRegistration.register.__doc__
+    """ % _register_doc[:_register_doc.rfind('versionadded::')]
 
     def registerJavaFunction(self, name, javaClassName, returnType=None):
         warnings.warn(
             "Deprecated in 2.3.0. Use spark.udf.registerJavaFunction instead.",
             DeprecationWarning)
         return self.sparkSession.udf.registerJavaFunction(name, javaClassName, returnType)
+    _registerJavaFunction_doc = UDFRegistration.registerJavaFunction.__doc__.strip()
     registerJavaFunction.__doc__ = """%s
+
         .. note:: :func:`sqlContext.registerJavaFunction` is an alias for
             :func:`spark.udf.registerJavaFunction`
         .. note:: Deprecated in 2.3.0. Use :func:`spark.udf.registerJavaFunction` instead.
         .. versionadded:: 2.1
-    """ % UDFRegistration.registerJavaFunction.__doc__
-
-    def registerJavaUDAF(self, name, javaClassName):
-        warnings.warn(
-            "Deprecated in 2.3.0. Use spark.udf.registerJavaUDAF instead.",
-            DeprecationWarning)
-        return self.sparkSession.udf.registerJavaUDAF(name, javaClassName)
-    registerJavaUDAF.__doc__ = """%s
-        .. note:: :func:`sqlContext.registerJavaUDAF` is an alias for
-            :func:`spark.udf.registerJavaUDAF`.
-        .. note:: Deprecated in 2.3.0. Use :func:`spark.udf.registerJavaUDAF` instead.
-        .. versionadded:: 2.3
-    """ % UDFRegistration.registerJavaUDAF.__doc__
+    """ % _registerJavaFunction_doc[:_registerJavaFunction_doc.rfind('versionadded::')]
 
     # TODO(andrew): delete this once we refactor things to take in SparkSession
     def _inferSchema(self, rdd, samplingRatio=None):
@@ -536,9 +527,9 @@ def _test():
     globs['os'] = os
     globs['sc'] = sc
     globs['sqlContext'] = SQLContext(sc)
-    # 'spark' alias is a small hack for reusing doctests. Please see the reassignment
+    # 'spark' is used for reusing doctests. Please see the reassignment
     # of docstrings above.
-    globs['spark'] = globs['sqlContext']
+    globs['spark'] = globs['sqlContext'].sparkSession
     globs['rdd'] = rdd = sc.parallelize(
         [Row(field1=1, field2="row1"),
          Row(field1=2, field2="row2"),

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2103,7 +2103,7 @@ def udf(f=None, returnType=StringType()):
     >>> import random
     >>> random_udf = udf(lambda: int(random.random() * 100), IntegerType()).asNondeterministic()
 
-    .. note:: The user-defined functions do not support conditional expressions or short curcuiting
+    .. note:: The user-defined functions do not support conditional expressions or short circuiting
         in boolean expressions and it ends up with being executed all internally. If the functions
         can fail on special rows, the workaround is to incorporate the condition into the functions.
 
@@ -2231,7 +2231,7 @@ def pandas_udf(f=None, returnType=None, functionType=None):
     ...     return pd.Series(np.random.randn(len(v))
     >>> random = random.asNondeterministic()  # doctest: +SKIP
 
-    .. note:: The user-defined functions do not support conditional expressions or short curcuiting
+    .. note:: The user-defined functions do not support conditional expressions or short circuiting
         in boolean expressions and it ends up with being executed all internally. If the functions
         can fail on special rows, the workaround is to incorporate the condition into the functions.
     """

--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -212,7 +212,8 @@ class GroupedData(object):
         This function does not support partial aggregation, and requires shuffling all the data in
         the :class:`DataFrame`.
 
-        :param udf: A function object returned by :meth:`pyspark.sql.functions.pandas_udf`
+        :param udf: a group map user-defined function returned by
+            :meth:`pyspark.sql.functions.pandas_udf`.
 
         >>> from pyspark.sql.functions import pandas_udf, PandasUDFType
         >>> df = spark.createDataFrame(

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -36,7 +36,7 @@ from pyspark.sql.streaming import DataStreamReader
 from pyspark.sql.types import Row, DataType, StringType, StructType, TimestampType, \
     _make_type_verifier, _infer_schema, _has_nulltype, _merge_type, _create_converter, \
     _parse_datatype_string
-from pyspark.sql.udf import UserDefinedFunction, UDFRegistration
+from pyspark.sql.udf import UserDefinedFunction
 from pyspark.sql.utils import install_exception_handler
 
 __all__ = ["SparkSession"]
@@ -292,6 +292,7 @@ class SparkSession(object):
 
         :return: :class:`UDFRegistration`
         """
+        from pyspark.sql.udf import UDFRegistration
         return UDFRegistration(self)
 
     @since(2.0)

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -36,10 +36,10 @@ from pyspark.sql.streaming import DataStreamReader
 from pyspark.sql.types import Row, DataType, StringType, StructType, TimestampType, \
     _make_type_verifier, _infer_schema, _has_nulltype, _merge_type, _create_converter, \
     _parse_datatype_string
-from pyspark.sql.udf import UserDefinedFunction
+from pyspark.sql.udf import UserDefinedFunction, UDFRegistration
 from pyspark.sql.utils import install_exception_handler
 
-__all__ = ["SparkSession", "UDFRegistration"]
+__all__ = ["SparkSession"]
 
 
 def _monkey_patch_RDD(sparkSession):
@@ -776,146 +776,6 @@ class SparkSession(object):
         Specifically stop the SparkSession on exit of the with block.
         """
         self.stop()
-
-
-class UDFRegistration(object):
-    """Wrapper for user-defined function registration."""
-
-    def __init__(self, sparkSession):
-        self.sparkSession = sparkSession
-
-    @ignore_unicode_prefix
-    def register(self, name, f, returnType=None):
-        """Registers a Python function (including lambda function) or a user-defined function
-        in SQL statements.
-
-        :param name: name of the user-defined function in SQL statements.
-        :param f: a Python function, or a user-defined function. The user-defined function can
-            be either row-at-a-time or vectorized. See :meth:`pyspark.sql.functions.udf` and
-            :meth:`pyspark.sql.functions.pandas_udf`.
-        :param returnType: the return type of the registered user-defined function.
-        :return: a user-defined function.
-
-        `returnType` can be optionally specified when `f` is a Python function but not
-        when `f` is a user-defined function. See below:
-
-        1. When `f` is a Python function, `returnType` defaults to string type and can be
-        optionally specified. The produced object must match the specified type. In this case,
-        this API works as if `register(name, f, returnType=StringType())`.
-
-            >>> strlen = spark.udf.register("stringLengthString", lambda x: len(x))
-            >>> spark.sql("SELECT stringLengthString('test')").collect()
-            [Row(stringLengthString(test)=u'4')]
-
-            >>> spark.sql("SELECT 'foo' AS text").select(strlen("text")).collect()
-            [Row(stringLengthString(text)=u'3')]
-
-            >>> from pyspark.sql.types import IntegerType
-            >>> _ = spark.udf.register("stringLengthInt", lambda x: len(x), IntegerType())
-            >>> spark.sql("SELECT stringLengthInt('test')").collect()
-            [Row(stringLengthInt(test)=4)]
-
-            >>> from pyspark.sql.types import IntegerType
-            >>> _ = spark.udf.register("stringLengthInt", lambda x: len(x), IntegerType())
-            >>> spark.sql("SELECT stringLengthInt('test')").collect()
-            [Row(stringLengthInt(test)=4)]
-
-        2. When `f` is a user-defined function, Spark uses the return type of the given a
-        user-defined function as the return type of the registered a user-defined function.
-        `returnType` should not be specified. In this case, this API works as if
-        `register(name, f)`.
-
-            >>> from pyspark.sql.types import IntegerType
-            >>> from pyspark.sql.functions import udf
-            >>> slen = udf(lambda s: len(s), IntegerType())
-            >>> _ = spark.udf.register("slen", slen)
-            >>> spark.sql("SELECT slen('test')").collect()
-            [Row(slen(test)=4)]
-
-            >>> import random
-            >>> from pyspark.sql.functions import udf
-            >>> from pyspark.sql.types import IntegerType
-            >>> random_udf = udf(lambda: random.randint(0, 100), IntegerType()).asNondeterministic()
-            >>> new_random_udf = spark.udf.register("random_udf", random_udf)
-            >>> spark.sql("SELECT random_udf()").collect()  # doctest: +SKIP
-            [Row(random_udf()=82)]
-
-            >>> from pyspark.sql.functions import pandas_udf, PandasUDFType
-            >>> @pandas_udf("integer", PandasUDFType.SCALAR)  # doctest: +SKIP
-            ... def add_one(x):
-            ...     return x + 1
-            ...
-            >>> _ = spark.udf.register("add_one", add_one)  # doctest: +SKIP
-            >>> spark.sql("SELECT add_one(id) FROM range(3)").collect()  # doctest: +SKIP
-            [Row(add_one(id)=1), Row(add_one(id)=2), Row(add_one(id)=3)]
-        """
-
-        # This is to check whether the input function is from a user-defined function or
-        # Python function.
-        if hasattr(f, 'asNondeterministic'):
-            if returnType is not None:
-                raise TypeError(
-                    "Invalid returnType: data type can not be specified when f is"
-                    "a user-defined function, but got %s." % returnType)
-            if f.evalType not in [PythonEvalType.SQL_BATCHED_UDF,
-                                  PythonEvalType.SQL_PANDAS_SCALAR_UDF]:
-                raise ValueError(
-                    "Invalid f: f must be either SQL_BATCHED_UDF or SQL_PANDAS_SCALAR_UDF")
-            register_udf = UserDefinedFunction(f.func, returnType=f.returnType, name=name,
-                                               evalType=f.evalType,
-                                               deterministic=f.deterministic)
-            return_udf = f
-        else:
-            if returnType is None:
-                returnType = StringType()
-            register_udf = UserDefinedFunction(f, returnType=returnType, name=name,
-                                               evalType=PythonEvalType.SQL_BATCHED_UDF)
-            return_udf = register_udf._wrapped()
-        self.sparkSession._jsparkSession.udf().registerPython(name, register_udf._judf)
-        return return_udf
-
-    @ignore_unicode_prefix
-    def registerJavaFunction(self, name, javaClassName, returnType=None):
-        """Register a Java user-defined function so it can be used in SQL statements.
-
-        In addition to a name and the function itself, the return type can be optionally specified.
-        When the return type is not specified we would infer it via reflection.
-
-        :param name:  name of the user-defined function
-        :param javaClassName: fully qualified name of java class
-        :param returnType: a :class:`pyspark.sql.types.DataType` object
-
-        >>> from pyspark.sql.types import IntegerType
-        >>> spark.udf.registerJavaFunction("javaStringLength",
-        ...   "test.org.apache.spark.sql.JavaStringLength", IntegerType())
-        >>> spark.sql("SELECT javaStringLength('test')").collect()
-        [Row(UDF:javaStringLength(test)=4)]
-        >>> spark.udf.registerJavaFunction("javaStringLength2",
-        ...   "test.org.apache.spark.sql.JavaStringLength")
-        >>> spark.sql("SELECT javaStringLength2('test')").collect()
-        [Row(UDF:javaStringLength2(test)=4)]
-
-        """
-        jdt = None
-        if returnType is not None:
-            jdt = self.sparkSession._jsparkSession.parseDataType(returnType.json())
-        self.sparkSession._jsparkSession.udf().registerJava(name, javaClassName, jdt)
-
-    @ignore_unicode_prefix
-    def registerJavaUDAF(self, name, javaClassName):
-        """Register a Java user-defined aggregate function so it can be used in SQL statements.
-
-        :param name: name of the user-defined aggregate function
-        :param javaClassName: fully qualified name of java class
-
-        >>> spark.udf.registerJavaUDAF("javaUDAF",
-        ...   "test.org.apache.spark.sql.MyDoubleAvg")
-        >>> df = spark.createDataFrame([(1, "a"),(2, "b"), (3, "a")],["id", "name"])
-        >>> df.registerTempTable("df")
-        >>> spark.sql("SELECT name, javaUDAF(id) as avg from df group by name").collect()
-        [Row(name=u'b', avg=102.0), Row(name=u'a', avg=102.0)]
-        """
-        self.sparkSession._jsparkSession.udf().registerJavaUDAF(name, javaClassName)
 
 
 def _test():

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -28,8 +28,7 @@ else:
     from itertools import izip as zip, imap as map
 
 from pyspark import since
-from pyspark.rdd import RDD, ignore_unicode_prefix
-from pyspark.sql.catalog import Catalog
+from pyspark.rdd import RDD, ignore_unicode_prefix, PythonEvalType
 from pyspark.sql.conf import RuntimeConfig
 from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.readwriter import DataFrameReader
@@ -37,9 +36,10 @@ from pyspark.sql.streaming import DataStreamReader
 from pyspark.sql.types import Row, DataType, StringType, StructType, TimestampType, \
     _make_type_verifier, _infer_schema, _has_nulltype, _merge_type, _create_converter, \
     _parse_datatype_string
+from pyspark.sql.udf import UserDefinedFunction
 from pyspark.sql.utils import install_exception_handler
 
-__all__ = ["SparkSession"]
+__all__ = ["SparkSession", "UDFRegistration"]
 
 
 def _monkey_patch_RDD(sparkSession):
@@ -280,6 +280,7 @@ class SparkSession(object):
 
         :return: :class:`Catalog`
         """
+        from pyspark.sql.catalog import Catalog
         if not hasattr(self, "_catalog"):
             self._catalog = Catalog(self)
         return self._catalog
@@ -291,8 +292,7 @@ class SparkSession(object):
 
         :return: :class:`UDFRegistration`
         """
-        from pyspark.sql.context import UDFRegistration
-        return UDFRegistration(self._wrapped)
+        return UDFRegistration(self)
 
     @since(2.0)
     def range(self, start, end=None, step=1, numPartitions=None):
@@ -776,6 +776,146 @@ class SparkSession(object):
         Specifically stop the SparkSession on exit of the with block.
         """
         self.stop()
+
+
+class UDFRegistration(object):
+    """Wrapper for user-defined function registration."""
+
+    def __init__(self, sparkSession):
+        self.sparkSession = sparkSession
+
+    @ignore_unicode_prefix
+    def register(self, name, f, returnType=None):
+        """Registers a Python function (including lambda function) or a user-defined function
+        in SQL statements.
+
+        :param name: name of the user-defined function in SQL statements.
+        :param f: a Python function, or a user-defined function. The user-defined function can
+            be either row-at-a-time or vectorized. See :meth:`pyspark.sql.functions.udf` and
+            :meth:`pyspark.sql.functions.pandas_udf`.
+        :param returnType: the return type of the registered user-defined function.
+        :return: a user-defined function.
+
+        `returnType` can be optionally specified when `f` is a Python function but not
+        when `f` is a user-defined function. See below:
+
+        1. When `f` is a Python function, `returnType` defaults to string type and can be
+        optionally specified. The produced object must match the specified type. In this case,
+        this API works as if `register(name, f, returnType=StringType())`.
+
+            >>> strlen = spark.udf.register("stringLengthString", lambda x: len(x))
+            >>> spark.sql("SELECT stringLengthString('test')").collect()
+            [Row(stringLengthString(test)=u'4')]
+
+            >>> spark.sql("SELECT 'foo' AS text").select(strlen("text")).collect()
+            [Row(stringLengthString(text)=u'3')]
+
+            >>> from pyspark.sql.types import IntegerType
+            >>> _ = spark.udf.register("stringLengthInt", lambda x: len(x), IntegerType())
+            >>> spark.sql("SELECT stringLengthInt('test')").collect()
+            [Row(stringLengthInt(test)=4)]
+
+            >>> from pyspark.sql.types import IntegerType
+            >>> _ = spark.udf.register("stringLengthInt", lambda x: len(x), IntegerType())
+            >>> spark.sql("SELECT stringLengthInt('test')").collect()
+            [Row(stringLengthInt(test)=4)]
+
+        2. When `f` is a user-defined function, Spark uses the return type of the given a
+        user-defined function as the return type of the registered a user-defined function.
+        `returnType` should not be specified. In this case, this API works as if
+        `register(name, f)`.
+
+            >>> from pyspark.sql.types import IntegerType
+            >>> from pyspark.sql.functions import udf
+            >>> slen = udf(lambda s: len(s), IntegerType())
+            >>> _ = spark.udf.register("slen", slen)
+            >>> spark.sql("SELECT slen('test')").collect()
+            [Row(slen(test)=4)]
+
+            >>> import random
+            >>> from pyspark.sql.functions import udf
+            >>> from pyspark.sql.types import IntegerType
+            >>> random_udf = udf(lambda: random.randint(0, 100), IntegerType()).asNondeterministic()
+            >>> new_random_udf = spark.udf.register("random_udf", random_udf)
+            >>> spark.sql("SELECT random_udf()").collect()  # doctest: +SKIP
+            [Row(random_udf()=82)]
+
+            >>> from pyspark.sql.functions import pandas_udf, PandasUDFType
+            >>> @pandas_udf("integer", PandasUDFType.SCALAR)  # doctest: +SKIP
+            ... def add_one(x):
+            ...     return x + 1
+            ...
+            >>> _ = spark.udf.register("add_one", add_one)  # doctest: +SKIP
+            >>> spark.sql("SELECT add_one(id) FROM range(3)").collect()  # doctest: +SKIP
+            [Row(add_one(id)=1), Row(add_one(id)=2), Row(add_one(id)=3)]
+        """
+
+        # This is to check whether the input function is from a user-defined function or
+        # Python function.
+        if hasattr(f, 'asNondeterministic'):
+            if returnType is not None:
+                raise TypeError(
+                    "Invalid returnType: data type can not be specified when f is"
+                    "a user-defined function, but got %s." % returnType)
+            if f.evalType not in [PythonEvalType.SQL_BATCHED_UDF,
+                                  PythonEvalType.SQL_PANDAS_SCALAR_UDF]:
+                raise ValueError(
+                    "Invalid f: f must be either SQL_BATCHED_UDF or SQL_PANDAS_SCALAR_UDF")
+            register_udf = UserDefinedFunction(f.func, returnType=f.returnType, name=name,
+                                               evalType=f.evalType,
+                                               deterministic=f.deterministic)
+            return_udf = f
+        else:
+            if returnType is None:
+                returnType = StringType()
+            register_udf = UserDefinedFunction(f, returnType=returnType, name=name,
+                                               evalType=PythonEvalType.SQL_BATCHED_UDF)
+            return_udf = register_udf._wrapped()
+        self.sparkSession._jsparkSession.udf().registerPython(name, register_udf._judf)
+        return return_udf
+
+    @ignore_unicode_prefix
+    def registerJavaFunction(self, name, javaClassName, returnType=None):
+        """Register a Java user-defined function so it can be used in SQL statements.
+
+        In addition to a name and the function itself, the return type can be optionally specified.
+        When the return type is not specified we would infer it via reflection.
+
+        :param name:  name of the user-defined function
+        :param javaClassName: fully qualified name of java class
+        :param returnType: a :class:`pyspark.sql.types.DataType` object
+
+        >>> from pyspark.sql.types import IntegerType
+        >>> spark.udf.registerJavaFunction("javaStringLength",
+        ...   "test.org.apache.spark.sql.JavaStringLength", IntegerType())
+        >>> spark.sql("SELECT javaStringLength('test')").collect()
+        [Row(UDF:javaStringLength(test)=4)]
+        >>> spark.udf.registerJavaFunction("javaStringLength2",
+        ...   "test.org.apache.spark.sql.JavaStringLength")
+        >>> spark.sql("SELECT javaStringLength2('test')").collect()
+        [Row(UDF:javaStringLength2(test)=4)]
+
+        """
+        jdt = None
+        if returnType is not None:
+            jdt = self.sparkSession._jsparkSession.parseDataType(returnType.json())
+        self.sparkSession._jsparkSession.udf().registerJava(name, javaClassName, jdt)
+
+    @ignore_unicode_prefix
+    def registerJavaUDAF(self, name, javaClassName):
+        """Register a Java user-defined aggregate function so it can be used in SQL statements.
+
+        :param name: name of the user-defined aggregate function
+        :param javaClassName: fully qualified name of java class
+
+        >>> spark.udf.registerJavaUDAF("javaUDAF",
+        ...   "test.org.apache.spark.sql.MyDoubleAvg")
+        >>> df = spark.createDataFrame([(1, "a"),(2, "b"), (3, "a")],["id", "name"])
+        >>> df.registerTempTable("df")
+        >>> spark.sql("SELECT name, javaUDAF(id) as avg from df group by name").collect()
+        [Row(name=u'b', avg=102.0), Row(name=u'a', avg=102.0)]
+        """
+        self.sparkSession._jsparkSession.udf().registerJavaUDAF(name, javaClassName)
 
 
 def _test():

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -28,7 +28,7 @@ else:
     from itertools import izip as zip, imap as map
 
 from pyspark import since
-from pyspark.rdd import RDD, ignore_unicode_prefix, PythonEvalType
+from pyspark.rdd import RDD, ignore_unicode_prefix
 from pyspark.sql.conf import RuntimeConfig
 from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.readwriter import DataFrameReader

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -36,7 +36,6 @@ from pyspark.sql.streaming import DataStreamReader
 from pyspark.sql.types import Row, DataType, StringType, StructType, TimestampType, \
     _make_type_verifier, _infer_schema, _has_nulltype, _merge_type, _create_converter, \
     _parse_datatype_string
-from pyspark.sql.udf import UserDefinedFunction
 from pyspark.sql.utils import install_exception_handler
 
 __all__ = ["SparkSession"]

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -187,7 +187,8 @@ class UserDefinedFunction(object):
 
 class UDFRegistration(object):
     """
-    Wrapper for user-defined function registration.
+    Wrapper for user-defined function registration. This instance can be accessed by
+    `spark.udf` or `sqlContext.udf`.
 
     .. versionadded:: 1.3.1
     """
@@ -300,17 +301,17 @@ class UDFRegistration(object):
         In addition to a name and the function itself, the return type can be optionally specified.
         When the return type is not specified we would infer it via reflection.
 
-        :param name:  name of the user-defined function
+        :param name: name of the user-defined function
         :param javaClassName: fully qualified name of java class
         :param returnType: a :class:`pyspark.sql.types.DataType` object
 
         >>> from pyspark.sql.types import IntegerType
-        >>> spark.udf.registerJavaFunction("javaStringLength",
-        ...   "test.org.apache.spark.sql.JavaStringLength", IntegerType())
+        >>> spark.udf.registerJavaFunction(
+        ...     "javaStringLength", "test.org.apache.spark.sql.JavaStringLength", IntegerType())
         >>> spark.sql("SELECT javaStringLength('test')").collect()
         [Row(UDF:javaStringLength(test)=4)]
-        >>> spark.udf.registerJavaFunction("javaStringLength2",
-        ...   "test.org.apache.spark.sql.JavaStringLength")
+        >>> spark.udf.registerJavaFunction(
+        ...    "javaStringLength2", "test.org.apache.spark.sql.JavaStringLength")
         >>> spark.sql("SELECT javaStringLength2('test')").collect()
         [Row(UDF:javaStringLength2(test)=4)]
         """
@@ -328,8 +329,7 @@ class UDFRegistration(object):
         :param name: name of the user-defined aggregate function
         :param javaClassName: fully qualified name of java class
 
-        >>> spark.udf.registerJavaUDAF("javaUDAF",
-        ...   "test.org.apache.spark.sql.MyDoubleAvg")
+        >>> spark.udf.registerJavaUDAF("javaUDAF", "test.org.apache.spark.sql.MyDoubleAvg")
         >>> df = spark.createDataFrame([(1, "a"),(2, "b"), (3, "a")],["id", "name"])
         >>> df.registerTempTable("df")
         >>> spark.sql("SELECT name, javaUDAF(id) as avg from df group by name").collect()

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -19,10 +19,12 @@ User-defined function related classes and functions
 """
 import functools
 
-from pyspark import SparkContext
-from pyspark.rdd import _prepare_for_python_RDD, PythonEvalType
+from pyspark import SparkContext, since
+from pyspark.rdd import _prepare_for_python_RDD, PythonEvalType, ignore_unicode_prefix
 from pyspark.sql.column import Column, _to_java_column, _to_seq
 from pyspark.sql.types import StringType, DataType, StructType, _parse_datatype_string
+
+__all__ = ["UDFRegistration"]
 
 
 def _wrap_function(sc, func, returnType):
@@ -181,3 +183,180 @@ class UserDefinedFunction(object):
         """
         self.deterministic = False
         return self
+
+
+class UDFRegistration(object):
+    """
+    Wrapper for user-defined function registration.
+
+    .. versionadded:: 1.3.1
+    """
+
+    def __init__(self, sparkSession):
+        self.sparkSession = sparkSession
+
+    @ignore_unicode_prefix
+    @since(1.3)
+    def register(self, name, f, returnType=None):
+        """Registers a Python function (including lambda function) or a user-defined function
+        in SQL statements.
+
+        :param name: name of the user-defined function in SQL statements.
+        :param f: a Python function, or a user-defined function. The user-defined function can
+            be either row-at-a-time or vectorized. See :meth:`pyspark.sql.functions.udf` and
+            :meth:`pyspark.sql.functions.pandas_udf`.
+        :param returnType: the return type of the registered user-defined function.
+        :return: a user-defined function.
+
+        `returnType` can be optionally specified when `f` is a Python function but not
+        when `f` is a user-defined function. See below:
+
+        1. When `f` is a Python function:
+
+            `returnType` defaults to string type and can be optionally specified. The produced
+            object must match the specified type. In this case, this API works as if
+            `register(name, f, returnType=StringType())`.
+
+            >>> strlen = spark.udf.register("stringLengthString", lambda x: len(x))
+            >>> spark.sql("SELECT stringLengthString('test')").collect()
+            [Row(stringLengthString(test)=u'4')]
+
+            >>> spark.sql("SELECT 'foo' AS text").select(strlen("text")).collect()
+            [Row(stringLengthString(text)=u'3')]
+
+            >>> from pyspark.sql.types import IntegerType
+            >>> _ = spark.udf.register("stringLengthInt", lambda x: len(x), IntegerType())
+            >>> spark.sql("SELECT stringLengthInt('test')").collect()
+            [Row(stringLengthInt(test)=4)]
+
+            >>> from pyspark.sql.types import IntegerType
+            >>> _ = spark.udf.register("stringLengthInt", lambda x: len(x), IntegerType())
+            >>> spark.sql("SELECT stringLengthInt('test')").collect()
+            [Row(stringLengthInt(test)=4)]
+
+
+        2. When `f` is a user-defined function:
+
+            Spark uses the return type of the given user-defined function as the return type of
+            the registered user-defined function. `returnType` should not be specified.
+            In this case, this API works as if `register(name, f)`.
+
+            >>> from pyspark.sql.types import IntegerType
+            >>> from pyspark.sql.functions import udf
+            >>> slen = udf(lambda s: len(s), IntegerType())
+            >>> _ = spark.udf.register("slen", slen)
+            >>> spark.sql("SELECT slen('test')").collect()
+            [Row(slen(test)=4)]
+
+            >>> import random
+            >>> from pyspark.sql.functions import udf
+            >>> from pyspark.sql.types import IntegerType
+            >>> random_udf = udf(lambda: random.randint(0, 100), IntegerType()).asNondeterministic()
+            >>> new_random_udf = spark.udf.register("random_udf", random_udf)
+            >>> spark.sql("SELECT random_udf()").collect()  # doctest: +SKIP
+            [Row(random_udf()=82)]
+
+            >>> from pyspark.sql.functions import pandas_udf, PandasUDFType
+            >>> @pandas_udf("integer", PandasUDFType.SCALAR)  # doctest: +SKIP
+            ... def add_one(x):
+            ...     return x + 1
+            ...
+            >>> _ = spark.udf.register("add_one", add_one)  # doctest: +SKIP
+            >>> spark.sql("SELECT add_one(id) FROM range(3)").collect()  # doctest: +SKIP
+            [Row(add_one(id)=1), Row(add_one(id)=2), Row(add_one(id)=3)]
+
+            .. note:: Registration for a user-defined function (case 2.) was added from
+                Spark 2.3.0.
+        """
+
+        # This is to check whether the input function is from a user-defined function or
+        # Python function.
+        if hasattr(f, 'asNondeterministic'):
+            if returnType is not None:
+                raise TypeError(
+                    "Invalid returnType: data type can not be specified when f is"
+                    "a user-defined function, but got %s." % returnType)
+            if f.evalType not in [PythonEvalType.SQL_BATCHED_UDF,
+                                  PythonEvalType.SQL_PANDAS_SCALAR_UDF]:
+                raise ValueError(
+                    "Invalid f: f must be either SQL_BATCHED_UDF or SQL_PANDAS_SCALAR_UDF")
+            register_udf = UserDefinedFunction(f.func, returnType=f.returnType, name=name,
+                                               evalType=f.evalType,
+                                               deterministic=f.deterministic)
+            return_udf = f
+        else:
+            if returnType is None:
+                returnType = StringType()
+            register_udf = UserDefinedFunction(f, returnType=returnType, name=name,
+                                               evalType=PythonEvalType.SQL_BATCHED_UDF)
+            return_udf = register_udf._wrapped()
+        self.sparkSession._jsparkSession.udf().registerPython(name, register_udf._judf)
+        return return_udf
+
+    @ignore_unicode_prefix
+    @since(2.3)
+    def registerJavaFunction(self, name, javaClassName, returnType=None):
+        """Register a Java user-defined function so it can be used in SQL statements.
+
+        In addition to a name and the function itself, the return type can be optionally specified.
+        When the return type is not specified we would infer it via reflection.
+
+        :param name:  name of the user-defined function
+        :param javaClassName: fully qualified name of java class
+        :param returnType: a :class:`pyspark.sql.types.DataType` object
+
+        >>> from pyspark.sql.types import IntegerType
+        >>> spark.udf.registerJavaFunction("javaStringLength",
+        ...   "test.org.apache.spark.sql.JavaStringLength", IntegerType())
+        >>> spark.sql("SELECT javaStringLength('test')").collect()
+        [Row(UDF:javaStringLength(test)=4)]
+        >>> spark.udf.registerJavaFunction("javaStringLength2",
+        ...   "test.org.apache.spark.sql.JavaStringLength")
+        >>> spark.sql("SELECT javaStringLength2('test')").collect()
+        [Row(UDF:javaStringLength2(test)=4)]
+        """
+
+        jdt = None
+        if returnType is not None:
+            jdt = self.sparkSession._jsparkSession.parseDataType(returnType.json())
+        self.sparkSession._jsparkSession.udf().registerJava(name, javaClassName, jdt)
+
+    @ignore_unicode_prefix
+    @since(2.3)
+    def registerJavaUDAF(self, name, javaClassName):
+        """Register a Java user-defined aggregate function so it can be used in SQL statements.
+
+        :param name: name of the user-defined aggregate function
+        :param javaClassName: fully qualified name of java class
+
+        >>> spark.udf.registerJavaUDAF("javaUDAF",
+        ...   "test.org.apache.spark.sql.MyDoubleAvg")
+        >>> df = spark.createDataFrame([(1, "a"),(2, "b"), (3, "a")],["id", "name"])
+        >>> df.registerTempTable("df")
+        >>> spark.sql("SELECT name, javaUDAF(id) as avg from df group by name").collect()
+        [Row(name=u'b', avg=102.0), Row(name=u'a', avg=102.0)]
+        """
+
+        self.sparkSession._jsparkSession.udf().registerJavaUDAF(name, javaClassName)
+
+
+def _test():
+    import doctest
+    from pyspark.sql import SparkSession
+    import pyspark.sql.udf
+    globs = pyspark.sql.udf.__dict__.copy()
+    spark = SparkSession.builder\
+        .master("local[4]")\
+        .appName("sql.udf tests")\
+        .getOrCreate()
+    globs['spark'] = spark
+    (failure_count, test_count) = doctest.testmod(
+        pyspark.sql.udf, globs=globs,
+        optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
+    spark.stop()
+    if failure_count:
+        exit(-1)
+
+
+if __name__ == "__main__":
+    _test()

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -188,7 +188,7 @@ class UserDefinedFunction(object):
 class UDFRegistration(object):
     """
     Wrapper for user-defined function registration. This instance can be accessed by
-    `spark.udf` or `sqlContext.udf`.
+    :attr:`spark.udf` or :attr:`sqlContext.udf`.
 
     .. versionadded:: 1.3.1
     """
@@ -197,7 +197,7 @@ class UDFRegistration(object):
         self.sparkSession = sparkSession
 
     @ignore_unicode_prefix
-    @since(1.3)
+    @since("1.3.1")
     def register(self, name, f, returnType=None):
         """Registers a Python function (including lambda function) or a user-defined function
         in SQL statements.

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -311,7 +311,7 @@ class UDFRegistration(object):
         >>> spark.sql("SELECT javaStringLength('test')").collect()
         [Row(UDF:javaStringLength(test)=4)]
         >>> spark.udf.registerJavaFunction(
-        ...    "javaStringLength2", "test.org.apache.spark.sql.JavaStringLength")
+        ...     "javaStringLength2", "test.org.apache.spark.sql.JavaStringLength")
         >>> spark.sql("SELECT javaStringLength2('test')").collect()
         [Row(UDF:javaStringLength2(test)=4)]
         """

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -209,7 +209,7 @@ class UDFRegistration(object):
         :return: a user-defined function.
 
         `returnType` can be optionally specified when `f` is a Python function but not
-        when `f` is a user-defined function. See below:
+        when `f` is a user-defined function. Please see below.
 
         1. When `f` is a Python function:
 
@@ -233,7 +233,6 @@ class UDFRegistration(object):
             >>> _ = spark.udf.register("stringLengthInt", lambda x: len(x), IntegerType())
             >>> spark.sql("SELECT stringLengthInt('test')").collect()
             [Row(stringLengthInt(test)=4)]
-
 
         2. When `f` is a user-defined function:
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to deprecate `register*` for UDFs in `SQLContext` and `Catalog` in Spark 2.3.0.

These are inconsistent with Scala / Java APIs and also these basically do the same things with `spark.udf.register*`.

Also, this PR moves the logcis from `[sqlContext|spark.catalog].register*` to `spark.udf.register*` and reuse the docstring.

This PR also handles minor doc corrections. It also includes https://github.com/apache/spark/pull/20158

## How was this patch tested?

Manually tested, manually checked the API documentation and tests added to check if deprecated APIs call the aliases correctly.