### PR TITLE
[SPARK-23129][CORE] Make deserializeStream of DiskMapIterator init lazily

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
@@ -528,10 +528,11 @@ class ExternalAppendOnlyMap[K, V, C](
     override def hasNext: Boolean = {
       if (nextItem == null) {
         if (deserializeStream.isEmpty) {
+          // In case that deserializeStream has not been initialized
           deserializeStream = nextBatchStream()
-        }
-        if (deserializeStream.isEmpty) {
-          return false
+          if (deserializeStream.isEmpty) {
+            return false
+          }
         }
         nextItem = readNextItem()
       }
@@ -539,6 +540,10 @@ class ExternalAppendOnlyMap[K, V, C](
     }
 
     override def next(): (K, C) = {
+      if (deserializeStream.isEmpty) {
+        // In case that deserializeStream has not been initialized when call next() directly
+        deserializeStream = nextBatchStream()
+      }
       val item = if (nextItem == null) readNextItem() else nextItem
       if (item == null) {
         throw new NoSuchElementException

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
@@ -540,14 +540,10 @@ class ExternalAppendOnlyMap[K, V, C](
     }
 
     override def next(): (K, C) = {
-      if (deserializeStream == null) {
-        // In case of deserializeStream has not been initialized when call next() directly
-        deserializeStream = nextBatchStream()
-      }
-      val item = if (nextItem == null) readNextItem() else nextItem
-      if (item == null) {
+      if (!hasNext) {
         throw new NoSuchElementException
       }
+      val item = nextItem
       nextItem = null
       item
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently,the deserializeStream in ExternalAppendOnlyMap#DiskMapIterator init when DiskMapIterator instance created.This will cause memory use overhead when ExternalAppendOnlyMap spill too much times.

We can avoid this by making deserializeStream init when it is used the first time.
This patch make deserializeStream init lazily.

## How was this patch tested?

Exist tests
