### PR TITLE
[SPARK-23011][SQL][PYTHON] Support alternative function form with group aggregate pandas UDF

### DIFF
--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -280,7 +280,10 @@ class ArrowStreamPandasSerializer(Serializer):
             pdf = batch.to_pandas()
             pdf = _check_dataframe_convert_date(pdf, schema)
             pdf = _check_dataframe_localize_timestamps(pdf, self._timezone)
-            yield [c for _, c in pdf.iteritems()]
+            # NOTE: changed from pa.Columns.to_pandas, timezone issue in conversion fixed in 0.7.1
+            # TODO: Fix timestamp
+            #pdf = _check_dataframe_localize_timestamps(batch.to_pandas(), self._timezone)
+            yield [c.to_pandas() for c in pa.Table.from_batches([batch]).itercolumns()]
 
     def __repr__(self):
         return "ArrowStreamPandasSerializer"

--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -283,7 +283,6 @@ class ArrowStreamPandasSerializer(Serializer):
         reader = pa.open_stream(stream)
 
         for batch in reader:
-            # NOTE: changed from pa.Columns.to_pandas, timezone issue in conversion fixed in 0.7.1
             yield [self.arrow_to_pandas(c, c.type)
                    for c in pa.Table.from_batches([batch]).itercolumns()]
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2267,6 +2267,30 @@ def pandas_udf(f=None, returnType=None, functionType=None):
        |  2| 1.1094003924504583|
        +---+-------------------+
 
+       Alternatively, the user can define a function that takes two arguments.
+       In this case, the grouping key will be passed as the first argument and the data will
+       be passed as the second argument. The grouping key will be passed as a tuple of numpy
+       data types, e.g., `numpy.int32` and `numpy.float64`. The data will still be passed in
+       as a `pandas.DataFrame` containing all columns from the original Spark DataFrame.
+       This is useful when the user doesn't want to hardcode grouping key in the function.
+
+       >>> from pyspark.sql.functions import pandas_udf, PandasUDFType
+       >>> df = spark.createDataFrame(
+       ...     [(1, 1.0), (1, 2.0), (2, 3.0), (2, 5.0), (2, 10.0)],
+       ...     ("id", "v"))  # doctest: +SKIP
+       >>> @pandas_udf("id long, v double", PandasUDFType.GROUP_MAP)  # doctest: +SKIP
+       ... def mean_udf(key, pdf):
+       ...     # key is a tuple of one numpy.int64, which is the value
+       ...     # of 'id' for the current group
+       ...     return pd.DataFrame([key + (pdf.v.mean(),)])
+       >>> df.groupby('id').apply(mean_udf).show()  #doctest: +SKIP
+       +---+---+
+       | id|  v|
+       +---+---+
+       |  1|1.5|
+       |  2|6.0|
+       +---+---+
+
        .. seealso:: :meth:`pyspark.sql.GroupedData.apply`
 
     3. GROUPED_AGG

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2272,18 +2272,19 @@ def pandas_udf(f=None, returnType=None, functionType=None):
        be passed as the second argument. The grouping key will be passed as a tuple of numpy
        data types, e.g., `numpy.int32` and `numpy.float64`. The data will still be passed in
        as a `pandas.DataFrame` containing all columns from the original Spark DataFrame.
-       This is useful when the user doesn't want to hardcode grouping key in the function.
+       This is useful when the user does not want to hardcode grouping key in the function.
 
        >>> from pyspark.sql.functions import pandas_udf, PandasUDFType
+       >>> import pandas as pd  # doctest: +SKIP
        >>> df = spark.createDataFrame(
        ...     [(1, 1.0), (1, 2.0), (2, 3.0), (2, 5.0), (2, 10.0)],
        ...     ("id", "v"))  # doctest: +SKIP
-       >>> @pandas_udf("id long, v double", PandasUDFType.GROUP_MAP)  # doctest: +SKIP
+       >>> @pandas_udf("id long, v double", PandasUDFType.GROUPED_MAP)  # doctest: +SKIP
        ... def mean_udf(key, pdf):
        ...     # key is a tuple of one numpy.int64, which is the value
        ...     # of 'id' for the current group
        ...     return pd.DataFrame([key + (pdf.v.mean(),)])
-       >>> df.groupby('id').apply(mean_udf).show()  #doctest: +SKIP
+       >>> df.groupby('id').apply(mean_udf).show()  # doctest: +SKIP
        +---+---+
        | id|  v|
        +---+---+

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3843,7 +3843,7 @@ class PandasUDFTests(ReusedSQLTestCase):
                     return df
             with self.assertRaisesRegexp(ValueError, 'Invalid function'):
                 @pandas_udf(returnType='k int, v double', functionType=PandasUDFType.GROUPED_MAP)
-                def foo(k, v):
+                def foo(k, v, w):
                     return k
 
 
@@ -4449,9 +4449,9 @@ class GroupedMapPandasUDFTests(ReusedSQLTestCase):
         result3 = df.groupby('id').apply(udf3).sort('id').toPandas()
         expected3 = expected1
 
-        self.assertFramesEqual(expected1, result1)
-        self.assertFramesEqual(expected2, result2)
-        self.assertFramesEqual(expected3, result3)
+        self.assertPandasEqual(expected1, result1)
+        self.assertPandasEqual(expected2, result2)
+        self.assertPandasEqual(expected3, result3)
 
     def test_register_grouped_map_udf(self):
         from pyspark.sql.functions import pandas_udf, PandasUDFType
@@ -4663,26 +4663,26 @@ class GroupedMapPandasUDFTests(ReusedSQLTestCase):
         expected1 = pdf.groupby('id')\
             .apply(lambda x: udf1.func((x.id.iloc[0],), x))\
             .sort_values(['id', 'v']).reset_index(drop=True)
-        self.assertFramesEqual(expected1, result1)
+        self.assertPandasEqual(expected1, result1)
 
         # Test groupby expression
         result2 = df.groupby(df.id % 2).apply(udf1).sort('id', 'v').toPandas()
         expected2 = pdf.groupby(pdf.id % 2)\
             .apply(lambda x: udf1.func((x.id.iloc[0] % 2,), x))\
             .sort_values(['id', 'v']).reset_index(drop=True)
-        self.assertFramesEqual(expected2, result2)
+        self.assertPandasEqual(expected2, result2)
 
         # Test complex groupby
         result3 = df.groupby(df.id, df.v % 2).apply(udf2).sort('id', 'v').toPandas()
         expected3 = pdf.groupby([pdf.id, pdf.v % 2])\
             .apply(lambda x: udf2.func((x.id.iloc[0], (x.v % 2).iloc[0],), x))\
             .sort_values(['id', 'v']).reset_index(drop=True)
-        self.assertFramesEqual(expected3, result3)
+        self.assertPandasEqual(expected3, result3)
 
         # Test empty groupby
         result4 = df.groupby().apply(udf3).sort('id', 'v').toPandas()
         expected4 = udf3.func((), pdf)
-        self.assertFramesEqual(expected4, result4)
+        self.assertPandasEqual(expected4, result4)
 
 
 @unittest.skipIf(

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -4646,17 +4646,17 @@ class GroupedMapPandasUDFTests(ReusedSQLTestCase):
         udf1 = pandas_udf(
             foo1,
             'id long, v int, v1 long, v2 int, v3 long, v4 double',
-            PandasUDFType.GROUP_MAP)
+            PandasUDFType.GROUPED_MAP)
 
         udf2 = pandas_udf(
             foo2,
             'id long, v int, v1 long, v2 int, v3 int, v4 int',
-            PandasUDFType.GROUP_MAP)
+            PandasUDFType.GROUPED_MAP)
 
         udf3 = pandas_udf(
             foo3,
             'id long, v int, v1 long',
-            PandasUDFType.GROUP_MAP)
+            PandasUDFType.GROUPED_MAP)
 
         # Test groupby column
         result1 = df.groupby('id').apply(udf1).sort('id', 'v').toPandas()

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -4417,26 +4417,29 @@ class GroupedMapPandasUDFTests(ReusedSQLTestCase):
         df = self.data.withColumn("arr", array(col("id")))
 
         # Different forms of group map pandas UDF, results of these are the same
+
+        output_schema = StructType(
+            [StructField('id', LongType()),
+             StructField('v', IntegerType()),
+             StructField('arr', ArrayType(LongType())),
+             StructField('v1', DoubleType()),
+             StructField('v2', LongType())])
+
         udf1 = pandas_udf(
             lambda pdf: pdf.assign(v1=pdf.v * pdf.id * 1.0, v2=pdf.v + pdf.id),
-            StructType(
-                [StructField('id', LongType()),
-                 StructField('v', IntegerType()),
-                 StructField('arr', ArrayType(LongType())),
-                 StructField('v1', DoubleType()),
-                 StructField('v2', LongType())]),
+            output_schema,
             PandasUDFType.GROUPED_MAP
         )
 
         udf2 = pandas_udf(
             lambda _, pdf: pdf.assign(v1=pdf.v * pdf.id * 1.0, v2=pdf.v + pdf.id),
-            'id long, v int, v1 double, v2 long',
+            output_schema,
             PandasUDFType.GROUPED_MAP
         )
 
         udf3 = pandas_udf(
             lambda key, pdf: pdf.assign(id=key[0], v1=pdf.v * pdf.id * 1.0, v2=pdf.v + pdf.id),
-            'id long, v int, v1 double, v2 long',
+            output_schema,
             PandasUDFType.GROUPED_MAP
         )
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1695,10 +1695,8 @@ def from_arrow_schema(arrow_schema):
          for field in arrow_schema])
 
 
-def _check_series_convert_date(series, arrow_type):
-    import pyarrow.types as types
-
-    if types.is_date32(arrow_type):
+def _check_series_convert_date(series, data_type):
+    if type(data_type) == DateType:
         return series.dt.date
     else:
         return series
@@ -1714,8 +1712,7 @@ def _check_dataframe_convert_date(pdf, schema):
     :param schema: a Spark schema of the pandas.DataFrame
     """
     for field in schema:
-        if type(field.dataType) == DateType:
-            pdf[field.name] = pdf[field.name].dt.date
+        pdf[field.name] = _check_series_convert_date(pdf[field.name], field.dataType)
     return pdf
 
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1696,6 +1696,12 @@ def from_arrow_schema(arrow_schema):
 
 
 def _check_series_convert_date(series, data_type):
+    """
+    Cast the series to datetime.date if it's a date type, otherwise returns the original series.
+
+    :param series: pandas.Series
+    :param data_type: a Spark data type for the series
+    """
     if type(data_type) == DateType:
         return series.dt.date
     else:

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1695,6 +1695,15 @@ def from_arrow_schema(arrow_schema):
          for field in arrow_schema])
 
 
+def _check_series_convert_date(series, arrow_type):
+    import pyarrow.types as types
+
+    if types.is_date32(arrow_type):
+        return series.dt.date
+    else:
+        return series
+
+
 def _check_dataframe_convert_date(pdf, schema):
     """ Correct date type value to use datetime.date.
 
@@ -1725,6 +1734,29 @@ def _get_local_timezone():
     return os.environ.get('TZ', 'dateutil/:')
 
 
+def _check_series_localize_timestamps(s, timezone):
+    """
+    Convert timezone aware timestamps to timezone-naive in the specified timezone or local timezone.
+
+    If the input series is not a timestamp series, then the same series is returned. If the input
+    series is a timestamp series, then a converted series is returned.
+
+    :param s: pandas.Series
+    :param timezone: the timezone to convert. if None then use local timezone
+    :return pandas.Series that have been converted to tz-naive
+    """
+    from pyspark.sql.utils import require_minimum_pandas_version
+    require_minimum_pandas_version()
+
+    from pandas.api.types import is_datetime64tz_dtype
+    tz = timezone or _get_local_timezone()
+    # TODO: handle nested timestamps, such as ArrayType(TimestampType())?
+    if is_datetime64tz_dtype(s.dtype):
+        return s.dt.tz_convert(tz).dt.tz_localize(None)
+    else:
+        return s
+
+
 def _check_dataframe_localize_timestamps(pdf, timezone):
     """
     Convert timezone aware timestamps to timezone-naive in the specified timezone or local timezone
@@ -1736,12 +1768,8 @@ def _check_dataframe_localize_timestamps(pdf, timezone):
     from pyspark.sql.utils import require_minimum_pandas_version
     require_minimum_pandas_version()
 
-    from pandas.api.types import is_datetime64tz_dtype
-    tz = timezone or _get_local_timezone()
     for column, series in pdf.iteritems():
-        # TODO: handle nested timestamps, such as ArrayType(TimestampType())?
-        if is_datetime64tz_dtype(series.dtype):
-            pdf[column] = series.dt.tz_convert(tz).dt.tz_localize(None)
+        pdf[column] = _check_series_localize_timestamps(series, timezone)
     return pdf
 
 

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -26,7 +26,7 @@ from pyspark.rdd import _prepare_for_python_RDD, PythonEvalType, ignore_unicode_
 from pyspark.sql.column import Column, _to_java_column, _to_seq
 from pyspark.sql.types import StringType, DataType, ArrayType, StructType, MapType, \
     _parse_datatype_string, to_arrow_type, to_arrow_schema
-from pyspark.sql.utils import get_argspec
+from pyspark.util import _get_argspec
 
 __all__ = ["UDFRegistration"]
 
@@ -47,7 +47,7 @@ def _create_udf(f, returnType, evalType):
         from pyspark.sql.utils import require_minimum_pyarrow_version
         require_minimum_pyarrow_version()
 
-        argspec = get_argspec(f)
+        argspec = _get_argspec(f)
 
         if evalType == PythonEvalType.SQL_SCALAR_PANDAS_UDF and len(argspec.args) == 0 and \
                 argspec.varargs is None:

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -61,7 +61,7 @@ def _create_udf(f, returnType, evalType):
                 "Instead, create a 1-arg pandas_udf and ignore the arg in your function."
             )
 
-        if evalType == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF and len(argspec.args) != 1:
+        if evalType == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF and len(argspec.args) not in (1, 2):
             raise ValueError(
                 "Invalid function: pandas_udfs with function type GROUPED_MAP "
                 "must take a single arg that is a pandas DataFrame."

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -61,11 +61,12 @@ def _create_udf(f, returnType, evalType):
                 "Instead, create a 1-arg pandas_udf and ignore the arg in your function."
             )
 
-        if evalType == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF and len(argspec.args) not in (1, 2):
+        if evalType == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF \
+                and len(argspec.args) not in (1, 2):
             raise ValueError(
                 "Invalid function: pandas_udfs with function type GROUPED_MAP "
                 "must take either one argument (data) or two arguments (key, data)."
-            )
+
 
     # Set the name of the UserDefinedFunction object to be the name of function f
     udf_obj = UserDefinedFunction(

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -64,7 +64,7 @@ def _create_udf(f, returnType, evalType):
         if evalType == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF and len(argspec.args) not in (1, 2):
             raise ValueError(
                 "Invalid function: pandas_udfs with function type GROUPED_MAP "
-                "must take a single arg that is a pandas DataFrame."
+                "must take either one argument (data) or two arguments (key, data)."
             )
 
     # Set the name of the UserDefinedFunction object to be the name of function f

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -26,6 +26,7 @@ from pyspark.rdd import _prepare_for_python_RDD, PythonEvalType, ignore_unicode_
 from pyspark.sql.column import Column, _to_java_column, _to_seq
 from pyspark.sql.types import StringType, DataType, ArrayType, StructType, MapType, \
     _parse_datatype_string, to_arrow_type, to_arrow_schema
+from pyspark.sql.utils import get_argspec
 
 __all__ = ["UDFRegistration"]
 
@@ -37,19 +38,6 @@ def _wrap_function(sc, func, returnType):
                                   sc.pythonVer, broadcast_vars, sc._javaAccumulator)
 
 
-def _get_argspec(f):
-    """
-    Get argspec of a function.
-    """
-    # `getargspec` is deprecated since python3.0 (incompatible with function annotations).
-    # See SPARK-23569.
-    if sys.version_info[0] < 3:
-        argspec = inspect.getargspec(f)
-    else:
-        argspec = inspect.getfullargspec(f)
-    return argspec
-
-
 def _create_udf(f, returnType, evalType):
 
     if evalType in (PythonEvalType.SQL_SCALAR_PANDAS_UDF,
@@ -59,7 +47,7 @@ def _create_udf(f, returnType, evalType):
         from pyspark.sql.utils import require_minimum_pyarrow_version
         require_minimum_pyarrow_version()
 
-        argspec = _get_argspec(f)
+        argspec = get_argspec(f)
 
         if evalType == PythonEvalType.SQL_SCALAR_PANDAS_UDF and len(argspec.args) == 0 and \
                 argspec.varargs is None:

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -65,8 +65,7 @@ def _create_udf(f, returnType, evalType):
                 and len(argspec.args) not in (1, 2):
             raise ValueError(
                 "Invalid function: pandas_udfs with function type GROUPED_MAP "
-                "must take either one argument (data) or two arguments (key, data)."
-
+                "must take either one argument (data) or two arguments (key, data).")
 
     # Set the name of the UserDefinedFunction object to be the name of function f
     udf_obj = UserDefinedFunction(

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -15,9 +15,7 @@
 # limitations under the License.
 #
 
-import sys
 import py4j
-import inspect
 
 
 class CapturedException(Exception):
@@ -147,15 +145,3 @@ def require_minimum_pyarrow_version():
         raise ImportError("PyArrow >= %s must be installed; however, "
                           "your version was %s." % (minimum_pyarrow_version, pyarrow.__version__))
 
-
-def get_argspec(f):
-    """
-    Get argspec of a function.
-    """
-    # `getargspec` is deprecated since python3.0 (incompatible with function annotations).
-    # See SPARK-23569.
-    if sys.version_info[0] < 3:
-        argspec = inspect.getargspec(f)
-    else:
-        argspec = inspect.getfullargspec(f)
-    return argspec

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -15,7 +15,9 @@
 # limitations under the License.
 #
 
+import sys
 import py4j
+import inspect
 
 
 class CapturedException(Exception):
@@ -144,3 +146,16 @@ def require_minimum_pyarrow_version():
     if LooseVersion(pyarrow.__version__) < LooseVersion(minimum_pyarrow_version):
         raise ImportError("PyArrow >= %s must be installed; however, "
                           "your version was %s." % (minimum_pyarrow_version, pyarrow.__version__))
+
+
+def get_argspec(f):
+    """
+    Get argspec of a function.
+    """
+    # `getargspec` is deprecated since python3.0 (incompatible with function annotations).
+    # See SPARK-23569.
+    if sys.version_info[0] < 3:
+        argspec = inspect.getargspec(f)
+    else:
+        argspec = inspect.getfullargspec(f)
+    return argspec

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -144,4 +144,3 @@ def require_minimum_pyarrow_version():
     if LooseVersion(pyarrow.__version__) < LooseVersion(minimum_pyarrow_version):
         raise ImportError("PyArrow >= %s must be installed; however, "
                           "your version was %s." % (minimum_pyarrow_version, pyarrow.__version__))
-

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -15,6 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+import sys
+import inspect
 from py4j.protocol import Py4JJavaError
 
 __all__ = []
@@ -43,6 +46,19 @@ def _exception_message(excp):
     if hasattr(excp, "message"):
         return excp.message
     return str(excp)
+
+
+def _get_argspec(f):
+    """
+    Get argspec of a function. Supports both Python 2 and Python 3.
+    """
+    # `getargspec` is deprecated since python3.0 (incompatible with function annotations).
+    # See SPARK-23569.
+    if sys.version_info[0] < 3:
+        argspec = inspect.getargspec(f)
+    else:
+        argspec = inspect.getfullargspec(f)
+    return argspec
 
 
 if __name__ == "__main__":

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -19,7 +19,6 @@
 Worker that receives input from Piped RDD.
 """
 from __future__ import print_function
-import inspect
 import os
 import sys
 import time
@@ -35,6 +34,7 @@ from pyspark.serializers import write_with_length, write_int, read_long, \
     write_long, read_int, SpecialLengths, UTF8Deserializer, PickleSerializer, \
     BatchedSerializer, ArrowStreamPandasSerializer
 from pyspark.sql.types import to_arrow_type
+from pyspark.sql.udf import _get_argspec
 from pyspark import shuffle
 
 pickleSer = PickleSerializer()
@@ -94,7 +94,7 @@ def wrap_scalar_pandas_udf(f, return_type):
 def wrap_grouped_map_pandas_udf(f, return_type):
     def wrapped(key_series, value_series):
         import pandas as pd
-        argspec = inspect.getargspec(f)
+        argspec = _get_argspec(f)
 
         if len(argspec.args) == 1:
             result = f(pd.concat(value_series, axis=1))

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -159,13 +159,13 @@ def read_udfs(pickleSer, infile, eval_type):
     mapper_str = ""
     if eval_type == PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF:
         # Create function like this:
-        #   lambda a: f([a[0]], [a[1], a[2]])
+        #   lambda a: f([a[0]], [a[0], a[1]])
         assert num_udfs == 1
         arg_offsets, udf = read_single_udf(pickleSer, infile, eval_type)
         udfs['f'] = udf
-        split_offset = arg_offsets[0]
-        arg0 = ["a[%d]" % o for o in range(0, split_offset)]
-        arg1 = ["a[%d]" % o for o in arg_offsets]
+        split_offset = arg_offsets[0] + 1
+        arg0 = ["a[%d]" % o for o in arg_offsets[1: split_offset]]
+        arg1 = ["a[%d]" % o for o in arg_offsets[split_offset:]]
         mapper_str = ("lambda a: f([%s], [%s])" % (", ".join(arg0), ", ".join(arg1)))
     else:
         # Create function like this:

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -19,6 +19,7 @@
 Worker that receives input from Piped RDD.
 """
 from __future__ import print_function
+import inspect
 import os
 import sys
 import time
@@ -91,10 +92,16 @@ def wrap_scalar_pandas_udf(f, return_type):
 
 
 def wrap_grouped_map_pandas_udf(f, return_type):
-    def wrapped(*series):
+    def wrapped(key_series, value_series):
         import pandas as pd
+        argspec = inspect.getargspec(f)
 
-        result = f(pd.concat(series, axis=1))
+        if len(argspec.args) == 1:
+            result = f(pd.concat(value_series, axis=1))
+        elif len(argspec.args) == 2:
+            key = tuple(s[0] for s in key_series)
+            result = f(key, pd.concat(value_series, axis=1))
+
         if not isinstance(result, pd.DataFrame):
             raise TypeError("Return type of the user-defined function should be "
                             "pandas.DataFrame, but is {}".format(type(result)))
@@ -149,18 +156,30 @@ def read_udfs(pickleSer, infile, eval_type):
     num_udfs = read_int(infile)
     udfs = {}
     call_udf = []
-    for i in range(num_udfs):
+    mapper_str = ""
+    if eval_type == PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF:
+        # Create function like this:
+        #   lambda a: f([a[0]], [a[1], a[2]])
+        assert num_udfs == 1
         arg_offsets, udf = read_single_udf(pickleSer, infile, eval_type)
-        udfs['f%d' % i] = udf
-        args = ["a[%d]" % o for o in arg_offsets]
-        call_udf.append("f%d(%s)" % (i, ", ".join(args)))
-    # Create function like this:
-    #   lambda a: (f0(a0), f1(a1, a2), f2(a3))
-    # In the special case of a single UDF this will return a single result rather
-    # than a tuple of results; this is the format that the JVM side expects.
-    mapper_str = "lambda a: (%s)" % (", ".join(call_udf))
-    mapper = eval(mapper_str, udfs)
+        udfs['f'] = udf
+        split_offset = arg_offsets[0]
+        arg0 = ["a[%d]" % o for o in range(0, split_offset)]
+        arg1 = ["a[%d]" % o for o in arg_offsets]
+        mapper_str = ("lambda a: f([%s], [%s])" % (", ".join(arg0), ", ".join(arg1)))
+    else:
+        # Create function like this:
+        #   lambda a: (f0(a[0]), f1(a[1], a[2]), f2(a[3]))
+        # In the special case of a single UDF this will return a single result rather
+        # than a tuple of results; this is the format that the JVM side expects.
+        for i in range(num_udfs):
+            arg_offsets, udf = read_single_udf(pickleSer, infile, eval_type)
+            udfs['f%d' % i] = udf
+            args = ["a[%d]" % o for o in arg_offsets]
+            call_udf.append("f%d(%s)" % (i, ", ".join(args)))
+            mapper_str = "lambda a: (%s)" % (", ".join(call_udf))
 
+    mapper = eval(mapper_str, udfs)
     func = lambda _, it: map(mapper, it)
 
     if eval_type in (PythonEvalType.SQL_SCALAR_PANDAS_UDF,

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -34,7 +34,7 @@ from pyspark.serializers import write_with_length, write_int, read_long, \
     write_long, read_int, SpecialLengths, UTF8Deserializer, PickleSerializer, \
     BatchedSerializer, ArrowStreamPandasSerializer
 from pyspark.sql.types import to_arrow_type
-from pyspark.sql.utils import get_argspec
+from pyspark.util import _get_argspec
 from pyspark import shuffle
 
 pickleSer = PickleSerializer()
@@ -94,7 +94,7 @@ def wrap_scalar_pandas_udf(f, return_type):
 def wrap_grouped_map_pandas_udf(f, return_type):
     def wrapped(key_series, value_series):
         import pandas as pd
-        argspec = get_argspec(f)
+        argspec = _get_argspec(f)
 
         if len(argspec.args) == 1:
             result = f(pd.concat(value_series, axis=1))

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -34,7 +34,7 @@ from pyspark.serializers import write_with_length, write_int, read_long, \
     write_long, read_int, SpecialLengths, UTF8Deserializer, PickleSerializer, \
     BatchedSerializer, ArrowStreamPandasSerializer
 from pyspark.sql.types import to_arrow_type
-from pyspark.sql.udf import _get_argspec
+from pyspark.sql.utils import get_argspec
 from pyspark import shuffle
 
 pickleSer = PickleSerializer()
@@ -94,7 +94,7 @@ def wrap_scalar_pandas_udf(f, return_type):
 def wrap_grouped_map_pandas_udf(f, return_type):
     def wrapped(key_series, value_series):
         import pandas as pd
-        argspec = _get_argspec(f)
+        argspec = get_argspec(f)
 
         if len(argspec.args) == 1:
             result = f(pd.concat(value_series, axis=1))

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -157,7 +157,7 @@ def read_udfs(pickleSer, infile, eval_type):
     udfs = {}
     call_udf = []
     mapper_str = ""
-    if eval_type == PythonEvalType.SQL_PANDAS_GROUP_MAP_UDF:
+    if eval_type == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF:
         # Create function like this:
         #   lambda a: f([a[0]], [a[0], a[1]])
         assert num_udfs == 1

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInPandasExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInPandasExec.scala
@@ -75,6 +75,12 @@ case class FlatMapGroupsInPandasExec(
     val bufferSize = inputRDD.conf.getInt("spark.buffer.size", 65536)
     val reuseWorker = inputRDD.conf.getBoolean("spark.python.worker.reuse", defaultValue = true)
     val chainedFunc = Seq(ChainedPythonFunctions(Seq(pandasFunction)))
+    /*
+    Use argOffsets[0] as a split index between grouping column and actual data column, i.e.,
+    column 0, 1, .., groupingAttributes.length - 1 are grouping columns
+    column groupingAttributes.length ... child.output.length - 1 are data columns
+    If a grouping column is a data column, then the column will be sent twice.
+     */
     val argOffsets = Array((groupingAttributes.length until child.output.length).toArray)
     val schema = child.schema
     val sessionLocalTimeZone = conf.sessionLocalTimeZone


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to support an alternative function from with group aggregate pandas UDF.

The current form:
```
def foo(pdf):
    return ...
```
Takes a single arg that is a pandas DataFrame.

With this PR, an alternative form is supported:
```
def foo(key, pdf):
    return ...
```
The alternative form takes two argument - a tuple that presents the grouping key, and a pandas DataFrame represents the data.

## How was this patch tested?

GroupbyApplyTests
