### PR TITLE
[SPARK-12963][CORE] NM host for driver end points

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -342,13 +342,15 @@ private[spark] object JettyUtils extends Logging {
           -1,
           -1,
           connectionFactories: _*)
+        connector.setHost(hostName)
         connector.setPort(port)
-        connector.start()
-
         // Currently we only use "SelectChannelConnector"
         // Limit the max acceptor number to 8 so that we don't waste a lot of threads
         connector.setAcceptQueueSize(math.min(connector.getAcceptors, 8))
-        connector.setHost(hostName)
+        // Done with connector configuration, start it
+
+        connector.start()
+
         // The number of selectors always equals to the number of acceptors
         minThreads += connector.getAcceptors * 2
 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
@@ -28,8 +28,8 @@ import org.apache.hadoop.yarn.webapp.util.WebAppUtils
 import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.deploy.yarn.config._
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config._
 import org.apache.spark.rpc.RpcEndpointRef
-import org.apache.spark.util.Utils
 
 /**
  * Handles registering and unregistering the application with the YARN ResourceManager.
@@ -71,7 +71,7 @@ private[spark] class YarnRMClient extends Logging {
 
     logInfo("Registering the ApplicationMaster")
     synchronized {
-      amClient.registerApplicationMaster(Utils.localHostName(), 0, trackingUrl)
+      amClient.registerApplicationMaster(sparkConf.get(DRIVER_BIND_ADDRESS), 0, trackingUrl)
       registered = true
     }
     new YarnAllocator(driverUrl, driverRef, conf, sparkConf, amClient, getAttemptId(), securityMgr,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Driver end points on YARN in the cluster mode are potentially bound to incorrect network interfaces because the host name is not retrieved from YARN as in the executor container case.

## How was this patch tested?

On a cluster previously experiencing `Service 'Driver' failed after 16 retries  (on a random free port) ...`