### PR TITLE
[SPARK-23121][core] Fix for ui becoming unaccessible for long running streaming apps 

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -69,12 +69,8 @@ private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends We
       val jobId = job.jobId
       val status = job.status
       val (_, lastStageDescription) = lastStageNameAndDescription(store, job)
-      val displayJobDescription =
-        if (lastStageDescription.nonEmpty) {
-          UIUtils.makeDescription(lastStageDescription, "", plainText = true).text
-        } else {
-          job.name
-        }
+      val jobDescription = UIUtils.makeDescription(lastStageDescription, "", plainText = true).text
+
       val submissionTime = job.submissionTime.get.getTime()
       val completionTime = job.completionTime.map(_.getTime()).getOrElse(System.currentTimeMillis())
       val classNameByStatus = status match {
@@ -86,7 +82,7 @@ private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends We
 
       // The timeline library treats contents as HTML, so we have to escape them. We need to add
       // extra layers of escaping in order to embed this in a Javascript string literal.
-      val escapedDesc = Utility.escape(displayJobDescription)
+      val escapedDesc = Utility.escape(jobDescription)
       val jsEscapedDesc = StringEscapeUtils.escapeEcmaScript(escapedDesc)
       val jobEventJsonAsStr =
         s"""

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -70,10 +70,10 @@ private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends We
       val status = job.status
       val (_, lastStageDescription) = lastStageNameAndDescription(store, job)
       val displayJobDescription =
-        if (lastStageDescription.isEmpty) {
-          job.name
-        } else {
+        if (lastStageDescription.nonEmpty) {
           UIUtils.makeDescription(lastStageDescription, "", plainText = true).text
+        } else {
+          job.name
         }
       val submissionTime = job.submissionTime.get.getTime()
       val completionTime = job.completionTime.map(_.getTime()).getOrElse(System.currentTimeMillis())

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -36,6 +36,9 @@ import org.apache.spark.util.Utils
 
 /** Page showing list of all ongoing and recently finished jobs */
 private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends WebUIPage("") {
+
+  import ApiHelper._
+
   private val JOBS_LEGEND =
     <div class="legend-area"><svg width="150px" height="85px">
       <rect class="succeeded-job-legend"
@@ -65,10 +68,13 @@ private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends We
     }.map { job =>
       val jobId = job.jobId
       val status = job.status
-      val jobDescription = store.lastStageAttempt(job.stageIds.max).description
-      val displayJobDescription = jobDescription
-        .map(UIUtils.makeDescription(_, "", plainText = true).text)
-        .getOrElse("")
+      val (_, lastStageDescription) = lastStageNameAndDescription(store)
+      val displayJobDescription =
+        if (lastStageDescription.isEmpty) {
+          job.name
+        } else {
+          UIUtils.makeDescription(lastStageDescription, "", plainText = true).text
+        }
       val submissionTime = job.submissionTime.get.getTime()
       val completionTime = job.completionTime.map(_.getTime()).getOrElse(System.currentTimeMillis())
       val classNameByStatus = status match {
@@ -403,6 +409,8 @@ private[ui] class JobDataSource(
     sortColumn: String,
     desc: Boolean) extends PagedDataSource[JobTableRowData](pageSize) {
 
+  import ApiHelper._
+
   // Convert JobUIData to JobTableRowData which contains the final contents to show in the table
   // so that we can avoid creating duplicate contents during sorting the data
   private val data = jobs.map(jobRow).sorted(ordering(sortColumn, desc))
@@ -427,23 +435,21 @@ private[ui] class JobDataSource(
     val formattedDuration = duration.map(d => UIUtils.formatDuration(d)).getOrElse("Unknown")
     val submissionTime = jobData.submissionTime
     val formattedSubmissionTime = submissionTime.map(UIUtils.formatDate).getOrElse("Unknown")
-    val lastStageAttempt = store.lastStageAttempt(jobData.stageIds.max)
-    val lastStageDescription = lastStageAttempt.description.getOrElse("")
+    val (lastStageName, lastStageDescription) = lastStageNameAndDescription(store)
 
-    val formattedJobDescription =
-      UIUtils.makeDescription(lastStageDescription, basePath, plainText = false)
+    val jobDescription = UIUtils.makeDescription(lastStageDescription, basePath, plainText = false)
 
     val detailUrl = "%s/jobs/job?id=%s".format(basePath, jobData.jobId)
 
     new JobTableRowData(
       jobData,
-      lastStageAttempt.name,
+      lastStageName,
       lastStageDescription,
       duration.getOrElse(-1),
       formattedDuration,
       submissionTime.map(_.getTime()).getOrElse(-1L),
       formattedSubmissionTime,
-      formattedJobDescription,
+      jobDescription,
       detailUrl
     )
   }

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -68,7 +68,7 @@ private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends We
     }.map { job =>
       val jobId = job.jobId
       val status = job.status
-      val (_, lastStageDescription) = lastStageNameAndDescription(store)
+      val (_, lastStageDescription) = lastStageNameAndDescription(store, job)
       val displayJobDescription =
         if (lastStageDescription.isEmpty) {
           job.name
@@ -435,7 +435,7 @@ private[ui] class JobDataSource(
     val formattedDuration = duration.map(d => UIUtils.formatDuration(d)).getOrElse("Unknown")
     val submissionTime = jobData.submissionTime
     val formattedSubmissionTime = submissionTime.map(UIUtils.formatDate).getOrElse("Unknown")
-    val (lastStageName, lastStageDescription) = lastStageNameAndDescription(store)
+    val (lastStageName, lastStageDescription) = lastStageNameAndDescription(store, jobData)
 
     val jobDescription = UIUtils.makeDescription(lastStageDescription, basePath, plainText = false)
 

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
@@ -340,7 +340,7 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
       case Some(operationGraph) => UIUtils.showDagVizForJob(jobId, operationGraph)
       case None =>
               <div id="no-info">
-                <p>No information to display for job {jobId}</p>
+                <p>No DAG visualization information to display for job {jobId}</p>
               </div>
     }
     content ++= operationGraphContent

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
@@ -336,8 +336,14 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
     content ++= makeTimeline(activeStages ++ completedStages ++ failedStages,
       store.executorList(false), appStartTime)
 
-    content ++= UIUtils.showDagVizForJob(
-      jobId, store.operationGraphForJob(jobId))
+    val operationGraphContent = store.asOption(store.operationGraphForJob(jobId)) match {
+      case Some(operationGraph) => UIUtils.showDagVizForJob(jobId, operationGraph)
+      case None =>
+              <div id="no-info">
+                <p>No information to display for job {jobId}</p>
+              </div>
+    }
+    content ++= operationGraphContent
 
     if (shouldShowActiveStages) {
       content ++= <h4 id="active">Active Stages ({activeStages.size})</h4> ++

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
@@ -339,9 +339,9 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
     val operationGraphContent = store.asOption(store.operationGraphForJob(jobId)) match {
       case Some(operationGraph) => UIUtils.showDagVizForJob(jobId, operationGraph)
       case None =>
-              <div id="no-info">
-                <p>No DAG visualization information to display for job {jobId}</p>
-              </div>
+        <div id="no-info">
+          <p>No DAG visualization information to display for job {jobId}</p>
+        </div>
     }
     content ++= operationGraphContent
 

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -1001,11 +1001,8 @@ private object ApiHelper {
   }
 
   def lastStageNameAndDescription(store: AppStatusStore, job: JobData): (String, String) = {
-    store.asOption(store.lastStageAttempt(job.stageIds.max)) match {
-      case Some(lastStageAttempt) =>
-        (lastStageAttempt.name, lastStageAttempt.description.getOrElse(job.name))
-      case None => ("", "")
-    }
+    val stage = store.asOption(store.lastStageAttempt(job.stageIds.max))
+    (stage.map(_.name).getOrElse(""), stage.flatMap(_.description).getOrElse(job.name))
   }
 
 }

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -18,20 +18,17 @@
 package org.apache.spark.ui.jobs
 
 import java.net.URLEncoder
-import java.util.{Collections, Date}
+import java.util.Date
 import java.util.concurrent.TimeUnit
 import javax.servlet.http.HttpServletRequest
 
 import scala.collection.mutable.{HashMap, HashSet}
-import scala.xml.{Elem, Node, Unparsed}
+import scala.xml.{Node, Unparsed}
 
 import org.apache.commons.lang3.StringEscapeUtils
 
-import org.apache.spark.SparkConf
-import org.apache.spark.internal.config._
 import org.apache.spark.scheduler.TaskLocality
 import org.apache.spark.status._
-import org.apache.spark.status.api.v1
 import org.apache.spark.status.api.v1._
 import org.apache.spark.ui._
 import org.apache.spark.util.Utils
@@ -1003,7 +1000,7 @@ private object ApiHelper {
     }
   }
 
-  def lastStageNameAndDescription(store: AppStatusStore, job: v1.JobData): (String, String) = {
+  def lastStageNameAndDescription(store: AppStatusStore, job: JobData): (String, String) = {
     store.asOption(store.lastStageAttempt(job.stageIds.max)) match {
       case Some(lastStageAttempt) =>
         (lastStageAttempt.name, lastStageAttempt.description.getOrElse(""))

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.ui.jobs
 
 import java.net.URLEncoder
-import java.util.Date
+import java.util.{Collections, Date}
 import java.util.concurrent.TimeUnit
 import javax.servlet.http.HttpServletRequest
 
@@ -999,6 +999,16 @@ private object ApiHelper {
     COLUMN_TO_INDEX.get(sortColumn) match {
       case Some(v) => Option(v)
       case _ => throw new IllegalArgumentException(s"Invalid sort column: $sortColumn")
+    }
+  }
+
+  def lastStageNameAndDescription(store: AppStatusStore): (String, String) = {
+    val stageData = store.stageList(Collections.emptyList()).toList
+    if (stageData.nonEmpty) {
+      val lastStageAttempt = stageData.maxBy(_.attemptId)
+      (lastStageAttempt.name, lastStageAttempt.description.getOrElse(""))
+    } else {
+      ("", "")
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -31,6 +31,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.internal.config._
 import org.apache.spark.scheduler.TaskLocality
 import org.apache.spark.status._
+import org.apache.spark.status.api.v1
 import org.apache.spark.status.api.v1._
 import org.apache.spark.ui._
 import org.apache.spark.util.Utils
@@ -1002,13 +1003,11 @@ private object ApiHelper {
     }
   }
 
-  def lastStageNameAndDescription(store: AppStatusStore): (String, String) = {
-    val stageData = store.stageList(Collections.emptyList()).toList
-    if (stageData.nonEmpty) {
-      val lastStageAttempt = stageData.maxBy(_.attemptId)
-      (lastStageAttempt.name, lastStageAttempt.description.getOrElse(""))
-    } else {
-      ("", "")
+  def lastStageNameAndDescription(store: AppStatusStore, job: v1.JobData): (String, String) = {
+    store.asOption(store.lastStageAttempt(job.stageIds.max)) match {
+      case Some(lastStageAttempt) =>
+        (lastStageAttempt.name, lastStageAttempt.description.getOrElse(""))
+      case None => ("", "")
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -1003,7 +1003,7 @@ private object ApiHelper {
   def lastStageNameAndDescription(store: AppStatusStore, job: JobData): (String, String) = {
     store.asOption(store.lastStageAttempt(job.stageIds.max)) match {
       case Some(lastStageAttempt) =>
-        (lastStageAttempt.name, lastStageAttempt.description.getOrElse(""))
+        (lastStageAttempt.name, lastStageAttempt.description.getOrElse(job.name))
       case None => ("", "")
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The allJobs and the job pages attempt to use stage attempt and DAG visualization from the store, but for long running jobs they are not guaranteed to be retained, leading to exceptions when these pages are rendered.

To fix it `store.lastStageAttempt(stageId)` and `store.operationGraphForJob(jobId)` are wrapped in `store.asOption` and default values are used if the info is missing.

## How was this patch tested?

Manual testing of the UI, also using the test command reported in SPARK-23121:

./bin/spark-submit --class org.apache.spark.examples.streaming.HdfsWordCount ./examples/jars/spark-examples_2.11-2.4.0-SNAPSHOT.jar /spark

Closes #20287
