### PR TITLE
[SPARK-23087][SQL] CheckCartesianProduct too restrictive when condition is false/null

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
@@ -283,7 +283,7 @@ class DataFrameJoinSuite extends QueryTest with SharedSQLContext {
     spark.sessionState.executePlan(planNull).optimizedPlan
 
     val dfOne = df.select(lit(1).as("a"))
-    val dfTwo = spark.range(10).select(lit(2).as("a"))
+    val dfTwo = spark.range(10).select(lit(2).as("b"))
     val planFalse = dfOne.join(dfTwo, $"a" === $"b", "left").queryExecution.analyzed
 
     spark.sessionState.executePlan(planFalse).optimizedPlan


### PR DESCRIPTION
## What changes were proposed in this pull request?

CheckCartesianProduct raises an AnalysisException also when the join condition is always false/null. In this case, we shouldn't raise it, since the result will not be a cartesian product. 

## How was this patch tested?

added UT