### PR TITLE
[SPARK-23172][SQL] Expand the ReorderJoin rule to handle Project nodes

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -119,7 +119,8 @@ object ReorderJoin extends Rule[LogicalPlan] with PredicateHelper {
         createOrderedJoin(input, conditions)
       }
 
-      // Checks if joins were reordered. If not reordered, returns the original plan
+      // To avoid applying this rule repeatedly, we don't change the plan in case of
+      // the same join order between `p` and `reordered`.
       if (!sameJoinOrder(reordered, p)) {
         if (p.sameOutput(reordered)) {
           reordered
@@ -129,7 +130,7 @@ object ReorderJoin extends Rule[LogicalPlan] with PredicateHelper {
           Project(p.output, reordered)
         }
       } else {
-        reordered
+        p
       }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -93,7 +93,8 @@ object ReorderJoin extends Rule[LogicalPlan] with PredicateHelper {
   // the same strategy to extract the plan list.
   private[optimizer] def extractLeftDeepInnerJoins(plan: LogicalPlan)
     : Seq[LogicalPlan] = plan match {
-    case Join(left, right, _: InnerLike, _, _) => right +: extractLeftDeepInnerJoins(left)
+    case Join(left, right, _: InnerLike, _, hint) if hint == JoinHint.NONE =>
+      right +: extractLeftDeepInnerJoins(left)
     case Filter(_, child) => extractLeftDeepInnerJoins(child)
     case Project(_, child) => extractLeftDeepInnerJoins(child)
     case _ => Seq(plan)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -252,8 +252,8 @@ object ExtractFiltersAndInnerJoins extends PredicateHelper {
       val (plans, conditions) = flattenJoin(left, joinType)
       (plans ++ Seq((right, joinType)), conditions ++
         cond.toSeq.flatMap(splitConjunctivePredicates))
-    case Filter(filterCondition, j @ Join(_, _, _: InnerLike, _, hint)) if hint == JoinHint.NONE =>
-      val (plans, conditions) = flattenJoin(j)
+    case Filter(filterCondition, child) =>
+      val (plans, conditions) = flattenJoin(child)
       (plans, conditions ++ splitConjunctivePredicates(filterCondition))
     case p @ Project(_, child)
         // Keep flattening joins when the project has attributes only

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinOptimizationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinOptimizationSuite.scala
@@ -137,7 +137,7 @@ class JoinOptimizationSuite extends PlanTest {
     }
   }
 
-  test("SPARK-23172 skip projections when flattening joins") {
+  test("Skip projections when flattening joins") {
     def checkExtractInnerJoins(plan: LogicalPlan): Unit = {
       val expectedTables = plan.collectLeaves().map { case p => (p, Inner) }
       val expectedConditions = plan.collect {
@@ -170,7 +170,7 @@ class JoinOptimizationSuite extends PlanTest {
     checkExtractInnerJoins(joined)
   }
 
-  test("SPARK-23172 reorder joins with projections") {
+  test("Reorder joins with projections") {
     withSQLConf(
         SQLConf.STARSCHEMA_DETECTION.key -> "true",
         SQLConf.CBO_ENABLED.key -> "false") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinOptimizationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinOptimizationSuite.scala
@@ -177,22 +177,22 @@ class JoinOptimizationSuite extends PlanTest {
       val r0output = Seq('a.int, 'b.int, 'c.int)
       val r0colStat = ColumnStat(distinctCount = Some(100000000), nullCount = Some(0))
       val r0colStats = AttributeMap(r0output.map(_ -> r0colStat))
-      val r0 = StatsTestPlan(r0output, 100000000, r0colStats, name = Some("r0")).subquery('r0)
+      val r0 = StatsTestPlan(r0output, 100000000, r0colStats, identifier = Some("r0")).subquery('r0)
 
       val r1output = Seq('a.int, 'd.int)
       val r1colStat = ColumnStat(distinctCount = Some(10), nullCount = Some(0))
       val r1colStats = AttributeMap(r1output.map(_ -> r1colStat))
-      val r1 = StatsTestPlan(r1output, 10, r1colStats, name = Some("r1")).subquery('r1)
+      val r1 = StatsTestPlan(r1output, 10, r1colStats, identifier = Some("r1")).subquery('r1)
 
       val r2output = Seq('b.int, 'e.int)
       val r2colStat = ColumnStat(distinctCount = Some(100), nullCount = Some(0))
       val r2colStats = AttributeMap(r2output.map(_ -> r2colStat))
-      val r2 = StatsTestPlan(r2output, 100, r2colStats, name = Some("r2")).subquery('r2)
+      val r2 = StatsTestPlan(r2output, 100, r2colStats, identifier = Some("r2")).subquery('r2)
 
       val r3output = Seq('c.int, 'f.int)
       val r3colStat = ColumnStat(distinctCount = Some(1), nullCount = Some(0))
       val r3colStats = AttributeMap(r3output.map(_ -> r3colStat))
-      val r3 = StatsTestPlan(r3output, 1, r3colStats, name = Some("r3")).subquery('r3)
+      val r3 = StatsTestPlan(r3output, 1, r3colStats, identifier = Some("r3")).subquery('r3)
 
       val joined = r0.join(r1, Inner, Some($"r0.a" === $"r1.a"))
         .select($"r0.b", $"r0.c", $"r1.d")
@@ -208,7 +208,7 @@ class JoinOptimizationSuite extends PlanTest {
       val optimized = Optimize.execute(joined)
       val optJoins = ReorderJoin.extractLeftDeepInnerJoins(optimized)
       val joinOrder = optJoins.flatMap(_.collect{ case p: StatsTestPlan => p }.headOption)
-        .flatMap(_.name)
+        .flatMap(_.identifier)
       assert(joinOrder === Seq("r2", "r1", "r3", "r0"))
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/StarJoinReorderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/StarJoinReorderSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap}
 import org.apache.spark.sql.catalyst.plans.{Inner, PlanTest}
-import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, LocalRelation, LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.catalyst.statsEstimation.{StatsEstimationTestBase, StatsTestPlan}
 import org.apache.spark.sql.internal.SQLConf._
@@ -580,12 +580,7 @@ class StarJoinReorderSuite extends PlanTest with StatsEstimationTestBase {
 
   private def assertEqualPlans(plan1: LogicalPlan, plan2: LogicalPlan): Unit = {
     val analyzed = plan1.analyze
-    val optimized = Optimize.execute(analyzed) match {
-      // `ReorderJoin` adds `Project` to keep the same order of output attributes.
-      // So, we drop a top `Project` for tests.
-      case project: Project => project.child
-      case p => p
-    }
+    val optimized = Optimize.execute(analyzed)
     val expected = plan2.analyze
 
     assert(equivalentOutput(analyzed, expected)) // if this fails, the expected itself is incorrect

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/StatsEstimationTestBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/StatsEstimationTestBase.scala
@@ -70,7 +70,7 @@ case class StatsTestPlan(
     rowCount: BigInt,
     attributeStats: AttributeMap[ColumnStat],
     size: Option[BigInt] = None,
-    name: Option[String] = None) extends LeafNode {
+    identifier: Option[String] = None) extends LeafNode {
   override def output: Seq[Attribute] = outputList
   override def computeStats(): Statistics = Statistics(
     // If sizeInBytes is useless in testing, we just use a fake value

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/StatsEstimationTestBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/StatsEstimationTestBase.scala
@@ -69,7 +69,8 @@ case class StatsTestPlan(
     outputList: Seq[Attribute],
     rowCount: BigInt,
     attributeStats: AttributeMap[ColumnStat],
-    size: Option[BigInt] = None) extends LeafNode {
+    size: Option[BigInt] = None,
+    name: Option[String] = None) extends LeafNode {
   override def output: Seq[Attribute] = outputList
   override def computeStats(): Statistics = Statistics(
     // If sizeInBytes is useless in testing, we just use a fake value


### PR DESCRIPTION
## What changes were proposed in this pull request?
The current `ReorderJoin` optimizer rule cannot flatten a pattern `Join -> Project -> Join` because `ExtractFiltersAndInnerJoins` doesn't handle `Project` nodes. So, the current master cannot reorder joins in a query below;
```
val df1 = spark.range(100).selectExpr("id % 10 AS k0", s"id % 10 AS k1", s"id % 10 AS k2", "id AS v1")
val df2 = spark.range(10).selectExpr("id AS k0", "id AS v2")
val df3 = spark.range(10).selectExpr("id AS k1", "id AS v3")
val df4 = spark.range(10).selectExpr("id AS k2", "id AS v4")
df1.join(df2, "k0").join(df3, "k1").join(df4, "k2").explain(true)

== Analyzed Logical Plan ==
k2: bigint, k1: bigint, k0: bigint, v1: bigint, v2: bigint, v3: bigint, v4: bigint
Project [k2#5L, k1#4L, k0#3L, v1#6L, v2#16L, v3#24L, v4#32L]
+- Join Inner, (k2#5L = k2#31L)
   :- Project [k1#4L, k0#3L, k2#5L, v1#6L, v2#16L, v3#24L]
   :  +- Join Inner, (k1#4L = k1#23L)
   :     :- Project [k0#3L, k1#4L, k2#5L, v1#6L, v2#16L]
   :     :  +- Join Inner, (k0#3L = k0#15L)
   :     :     :- Project [(id#0L % cast(10 as bigint)) AS k0#3L, (id#0L % cast(10 as bigint)) AS k1#4L, (id#0L % cast(10 as bigint)) AS k2#5L, id#0
L AS v1#6L]
   :     :     :  +- Range (0, 100, step=1, splits=Some(4))
   :     :     +- Project [id#12L AS k0#15L, id#12L AS v2#16L]
   :     :        +- Range (0, 10, step=1, splits=Some(4))
   :     +- Project [id#20L AS k1#23L, id#20L AS v3#24L]
   :        +- Range (0, 10, step=1, splits=Some(4))
   +- Project [id#28L AS k2#31L, id#28L AS v4#32L]
      +- Range (0, 10, step=1, splits=Some(4))
```
To reorder the query, this pr added code to handle `Project` in `ExtractFiltersAndInnerJoins`.

This pr also fixed an output attribute reorder problem when joins reordered; it checks if a join reordered plan and an original plan have the same output attribute order with each other. If not, `ReorderJoin` adds `Project` in the top of the join reordered plan.

## How was this patch tested?
This pr added new tests in `JoinOptimizationSuite` and modified some existing tests in `StarJoinReorderSuite` to check if `ReorderJoin` can handle `Project` nodes correctly. Also, it modified the existing tests in `JoinReorderSuite` for the output attribute reorder issue.