### PR TITLE
[SPARK-23186][SQL] Initialize DriverManager first before loading Drivers

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/DriverRegistry.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/DriverRegistry.scala
@@ -34,20 +34,18 @@ object DriverRegistry extends Logging {
 
   private val wrapperMap: mutable.Map[String, DriverWrapper] = mutable.Map.empty
 
-  def register(className: String): Unit = {
+  def register(className: String): Unit = synchronized {
     val cls = Utils.getContextOrSparkClassLoader.loadClass(className)
     if (cls.getClassLoader == null) {
       logTrace(s"$className has been loaded with bootstrap ClassLoader, wrapper is not required")
     } else if (wrapperMap.get(className).isDefined) {
       logTrace(s"Wrapper for $className already exists")
     } else {
-      synchronized {
-        if (wrapperMap.get(className).isEmpty) {
-          val wrapper = new DriverWrapper(cls.newInstance().asInstanceOf[Driver])
-          DriverManager.registerDriver(wrapper)
-          wrapperMap(className) = wrapper
-          logTrace(s"Wrapper for $className registered")
-        }
+      if (wrapperMap.get(className).isEmpty) {
+        val wrapper = new DriverWrapper(cls.newInstance().asInstanceOf[Driver])
+        DriverManager.registerDriver(wrapper)
+        wrapperMap(className) = wrapper
+        logTrace(s"Wrapper for $className registered")
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since some JDBC Drivers have class initialization code to call `DriverManager`, we need to synchronize loading drivers to avoid potential executor-side deadlock situations like [STORM-2527](https://issues.apache.org/jira/browse/STORM-2527).

## How was this patch tested?

This only extends the coverage of synchronized block from a part to the whole function.