### PR TITLE
Changing JDBC relation to better process quotes

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
@@ -78,7 +78,8 @@ private[sql] object JDBCRelation extends Logging {
     // Overflow and silliness can happen if you subtract then divide.
     // Here we get a little roundoff, but that's (hopefully) OK.
     val stride: Long = upperBound / numPartitions - lowerBound / numPartitions
-    val column = partitioning.column
+    val dialect = JdbcDialects.get(jdbcOptions.url)
+    val column = dialect.quoteIdentifier(partitioning.column)
     var i: Int = 0
     var currentValue: Long = lowerBound
     val ans = new ArrayBuffer[Partition]()


### PR DESCRIPTION
## What changes were proposed in this pull request?

The way JDBC writes currently work, they do not properly account for mixed case column names.  Instead, the user has to use quotes on each column name.  This change avoids that.

## How was this patch tested?

Manual tests and working with @dougbateman and @gatorsmile 

Please review http://spark.apache.org/contributing.html before opening a pull request.
