### PR TITLE
[SPARK-23195] [SQL] Keep the Hint of Cached Data

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -63,7 +63,7 @@ case class InMemoryRelation(
     tableName: Option[String])(
     @transient var _cachedColumnBuffers: RDD[CachedBatch] = null,
     val batchStats: LongAccumulator = child.sqlContext.sparkContext.longAccumulator,
-    statsOfPlanToCache: Statistics = null)
+    statsOfPlanToCache: Statistics)
   extends logical.LeafNode with MultiInstanceRelation {
 
   override protected def innerChildren: Seq[SparkPlan] = Seq(child)
@@ -77,7 +77,7 @@ case class InMemoryRelation(
       // Underlying columnar RDD hasn't been materialized, use the stats from the plan to cache
       statsOfPlanToCache
     } else {
-      Statistics(sizeInBytes = batchStats.value.longValue)
+      Statistics(sizeInBytes = batchStats.value.longValue, hints = statsOfPlanToCache.hints)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/BroadcastJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/BroadcastJoinSuite.scala
@@ -70,8 +70,8 @@ class BroadcastJoinSuite extends QueryTest with SQLTestUtils {
   private def testBroadcastJoin[T: ClassTag](
       joinType: String,
       forceBroadcast: Boolean = false): SparkPlan = {
-    val df1 = spark.createDataFrame(Seq((1, "4"), (2, "2"))).toDF("key", "value")
-    val df2 = spark.createDataFrame(Seq((1, "1"), (2, "2"))).toDF("key", "value")
+    val df1 = Seq((1, "4"), (2, "2")).toDF("key", "value")
+    val df2 = Seq((1, "1"), (2, "2")).toDF("key", "value")
 
     // Comparison at the end is for broadcast left semi join
     val joinExpression = df1("key") === df2("key") && df1("value") > df2("value")
@@ -99,23 +99,23 @@ class BroadcastJoinSuite extends QueryTest with SQLTestUtils {
 
   test("broadcast hint isn't bothered by authBroadcastJoinThreshold set to low values") {
     withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0") {
-      testBroadcastJoin[BroadcastHashJoinExec]("inner", true)
+      testBroadcastJoin[BroadcastHashJoinExec]("inner", forceBroadcast = true)
     }
   }
 
   test("broadcast hint isn't bothered by a disabled authBroadcastJoinThreshold") {
     withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
-      testBroadcastJoin[BroadcastHashJoinExec]("inner", true)
+      testBroadcastJoin[BroadcastHashJoinExec]("inner", forceBroadcast = true)
     }
   }
 
   test("broadcast hint is retained after using the cached data") {
     try {
       withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
-        val df1 = spark.createDataFrame(Seq((1, "4"), (2, "2"))).toDF("key", "value")
-        val df2 = spark.createDataFrame(Seq((1, "1"), (2, "2"))).toDF("key", "value")
+        val df1 = Seq((1, "4"), (2, "2")).toDF("key", "value")
+        val df2 = Seq((1, "1"), (2, "2")).toDF("key", "value")
         df2.cache()
-        val df3 = df1.join(broadcast(df2), Seq("key"), "inner")
+        val df3 = df1.join(broadcast(df2), Seq("key"))
         val numBroadCastHashJoin = df3.queryExecution.executedPlan.collect {
           case b: BroadcastHashJoinExec => b
         }.size
@@ -130,11 +130,11 @@ class BroadcastJoinSuite extends QueryTest with SQLTestUtils {
     Seq(true, false).foreach { materialized =>
       try {
         withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
-          val df1 = spark.createDataFrame(Seq((1, "4"), (2, "2"))).toDF("key", "value")
-          val df2 = spark.createDataFrame(Seq((1, "1"), (2, "2"))).toDF("key", "value")
+          val df1 = Seq((1, "4"), (2, "2")).toDF("key", "value")
+          val df2 = Seq((1, "1"), (2, "2")).toDF("key", "value")
           broadcast(df2).cache()
           if (materialized) df2.collect()
-          val df3 = df1.join(df2, Seq("key"), "inner")
+          val df3 = df1.join(df2, Seq("key"))
           val numBroadCastHashJoin = df3.queryExecution.executedPlan.collect {
             case b: BroadcastHashJoinExec => b
           }.size
@@ -148,12 +148,12 @@ class BroadcastJoinSuite extends QueryTest with SQLTestUtils {
 
   test("broadcast hint isn't propagated after a join") {
     withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
-      val df1 = spark.createDataFrame(Seq((1, "4"), (2, "2"))).toDF("key", "value")
-      val df2 = spark.createDataFrame(Seq((1, "1"), (2, "2"))).toDF("key", "value")
-      val df3 = df1.join(broadcast(df2), Seq("key"), "inner").drop(df2("key"))
+      val df1 = Seq((1, "4"), (2, "2")).toDF("key", "value")
+      val df2 = Seq((1, "1"), (2, "2")).toDF("key", "value")
+      val df3 = df1.join(broadcast(df2), Seq("key")).drop(df2("key"))
 
       val df4 = spark.createDataFrame(Seq((1, "5"), (2, "5"))).toDF("key", "value")
-      val df5 = df4.join(df3, Seq("key"), "inner")
+      val df5 = df4.join(df3, Seq("key"))
 
       val plan =
         EnsureRequirements(spark.sessionState.conf).apply(df5.queryExecution.sparkPlan)
@@ -165,7 +165,7 @@ class BroadcastJoinSuite extends QueryTest with SQLTestUtils {
 
   private def assertBroadcastJoin(df : Dataset[Row]) : Unit = {
     val df1 = spark.createDataFrame(Seq((1, "4"), (2, "2"))).toDF("key", "value")
-    val joined = df1.join(df, Seq("key"), "inner")
+    val joined = df1.join(df, Seq("key"))
 
     val plan =
       EnsureRequirements(spark.sessionState.conf).apply(joined.queryExecution.sparkPlan)
@@ -175,19 +175,20 @@ class BroadcastJoinSuite extends QueryTest with SQLTestUtils {
 
   test("broadcast hint programming API") {
     withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
-      val df2 = spark.createDataFrame(Seq((1, "1"), (2, "2"), (3, "2"))).toDF("key", "value")
+      val df2 = Seq((1, "1"), (2, "2"), (3, "2")).toDF("key", "value")
       val broadcasted = broadcast(df2)
-      val df3 = spark.createDataFrame(Seq((2, "2"), (3, "3"))).toDF("key", "value")
+      val df3 = Seq((2, "2"), (3, "3")).toDF("key", "value")
 
-      val cases = Seq(broadcasted.limit(2),
-                      broadcasted.filter("value < 10"),
-                      broadcasted.sample(true, 0.5),
-                      broadcasted.distinct(),
-                      broadcasted.groupBy("value").agg(min($"key").as("key")),
-                      // except and intersect are semi/anti-joins which won't return more data then
-                      // their left argument, so the broadcast hint should be propagated here
-                      broadcasted.except(df3),
-                      broadcasted.intersect(df3))
+      val cases =
+        Seq(broadcasted.limit(2),
+          broadcasted.filter("value < 10"),
+          broadcasted.sample(withReplacement = true, 0.5),
+          broadcasted.distinct(),
+          broadcasted.groupBy("value").agg(min($"key").as("key")),
+          // except and intersect are semi/anti-joins which won't return more data then
+          // their left argument, so the broadcast hint should be propagated here
+          broadcasted.except(df3),
+          broadcasted.intersect(df3))
 
       cases.foreach(assertBroadcastJoin)
     }
@@ -264,9 +265,8 @@ class BroadcastJoinSuite extends QueryTest with SQLTestUtils {
   test("Shouldn't change broadcast join buildSide if user clearly specified") {
 
     withTempView("t1", "t2") {
-      spark.createDataFrame(Seq((1, "4"), (2, "2"))).toDF("key", "value").createTempView("t1")
-      spark.createDataFrame(Seq((1, "1"), (2, "12.3"), (2, "123"))).toDF("key", "value")
-        .createTempView("t2")
+      Seq((1, "4"), (2, "2")).toDF("key", "value").createTempView("t1")
+      Seq((1, "1"), (2, "12.3"), (2, "123")).toDF("key", "value").createTempView("t2")
 
       val t1Size = spark.table("t1").queryExecution.analyzed.children.head.stats.sizeInBytes
       val t2Size = spark.table("t2").queryExecution.analyzed.children.head.stats.sizeInBytes
@@ -316,9 +316,8 @@ class BroadcastJoinSuite extends QueryTest with SQLTestUtils {
   test("Shouldn't bias towards build right if user didn't specify") {
 
     withTempView("t1", "t2") {
-      spark.createDataFrame(Seq((1, "4"), (2, "2"))).toDF("key", "value").createTempView("t1")
-      spark.createDataFrame(Seq((1, "1"), (2, "12.3"), (2, "123"))).toDF("key", "value")
-        .createTempView("t2")
+      Seq((1, "4"), (2, "2")).toDF("key", "value").createTempView("t1")
+      Seq((1, "1"), (2, "12.3"), (2, "123")).toDF("key", "value").createTempView("t2")
 
       val t1Size = spark.table("t1").queryExecution.analyzed.children.head.stats.sizeInBytes
       val t2Size = spark.table("t2").queryExecution.analyzed.children.head.stats.sizeInBytes


### PR DESCRIPTION
## What changes were proposed in this pull request?
The broadcast hint of the cached plan is lost if we cache the plan. This PR is to correct it.

```Scala
  val df1 = spark.createDataFrame(Seq((1, "4"), (2, "2"))).toDF("key", "value")
  val df2 = spark.createDataFrame(Seq((1, "1"), (2, "2"))).toDF("key", "value")
  broadcast(df2).cache()
  df2.collect()
  val df3 = df1.join(df2, Seq("key"), "inner")
```

## How was this patch tested?
Added a test.