### PR TITLE
[SPARK-23202][SQL] Break down DataSourceV2Writer.commit into two phase

### DIFF
--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaStreamWriter.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaStreamWriter.scala
@@ -49,8 +49,9 @@ class KafkaStreamWriter(
   override def createInternalRowWriterFactory(): KafkaStreamWriterFactory =
     KafkaStreamWriterFactory(topic, producerParams, schema)
 
-  override def commit(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {}
-  override def abort(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {}
+  override def add(message: WriterCommitMessage): Unit = {}
+  override def commit(epochId: Long): Unit = {}
+  override def abort(epochId: Long): Unit = {}
 }
 
 /**

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/streaming/writer/StreamWriter.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/streaming/writer/StreamWriter.java
@@ -37,18 +37,18 @@ public interface StreamWriter extends DataSourceWriter {
    * {@link DataWriter#commit()}.
    *
    * If this method fails (by throwing an exception), this writing job is considered to have been
-   * failed, and the execution engine will attempt to call {@link #abort(WriterCommitMessage[])}.
+   * failed, and the execution engine will attempt to call {@link #abort()}.
    *
    * To support exactly-once processing, writer implementations should ensure that this method is
    * idempotent. The execution engine may call commit() multiple times for the same epoch
    * in some circumstances.
    */
-  void commit(long epochId, WriterCommitMessage[] messages);
+  void commit(long epochId);
 
   /**
-   * Aborts this writing job because some data writers are failed and keep failing when retry, or
-   * the Spark job fails with some unknown reasons, or {@link #commit(WriterCommitMessage[])} fails.
-   *
+   * Aborts this writing job because some data writers are failed and keep failing when retry,
+   * or the Spark job fails with some unknown reasons,
+   * or {@link #commit()} /{@link #add(WriterCommitMessage)} fails
    * If this method fails (by throwing an exception), the underlying data source may require manual
    * cleanup.
    *
@@ -58,14 +58,14 @@ public interface StreamWriter extends DataSourceWriter {
    * driver when the abort is triggered. So this is just a "best effort" for data sources to
    * clean up the data left by data writers.
    */
-  void abort(long epochId, WriterCommitMessage[] messages);
+  void abort(long epochId);
 
-  default void commit(WriterCommitMessage[] messages) {
+  default void commit() {
     throw new UnsupportedOperationException(
         "Commit without epoch should not be called with StreamWriter");
   }
 
-  default void abort(WriterCommitMessage[] messages) {
+  default void abort() {
     throw new UnsupportedOperationException(
         "Abort without epoch should not be called with StreamWriter");
   }

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataSourceWriter.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataSourceWriter.java
@@ -40,11 +40,13 @@ import org.apache.spark.sql.types.StructType;
  *   1. Create a writer factory by {@link #createWriterFactory()}, serialize and send it to all the
  *      partitions of the input data(RDD).
  *   2. For each partition, create the data writer, and write the data of the partition with this
- *      writer. If all the data are written successfully, call {@link DataWriter#commit()}. If
- *      exception happens during the writing, call {@link DataWriter#abort()}.
- *   3. If all writers are successfully committed, call {@link #commit(WriterCommitMessage[])}. If
+ *      writer. If all the data are written successfully, call {@link DataWriter#commit()}.
+ *      On a writer being successfully committed, call {@link #add(WriterCommitMessage)} to
+ *      handle its commit message.
+ *      If exception happens during the writing, call {@link DataWriter#abort()}.
+ *   3. If all writers are successfully committed, call {@link #commit()}. If
  *      some writers are aborted, or the job failed with an unknown reason, call
- *      {@link #abort(WriterCommitMessage[])}.
+ *      {@link #abort()}.
  *
  * While Spark will retry failed writing tasks, Spark won't retry failed writing jobs. Users should
  * do it manually in their Spark applications if they want to retry.
@@ -63,32 +65,30 @@ public interface DataSourceWriter {
   DataWriterFactory<Row> createWriterFactory();
 
   /**
-   * Commits this writing job with a list of commit messages. The commit messages are collected from
-   * successful data writers and are produced by {@link DataWriter#commit()}.
+   * Handles a commit message produced by {@link DataWriter#commit()}.
    *
    * If this method fails (by throwing an exception), this writing job is considered to to have been
-   * failed, and {@link #abort(WriterCommitMessage[])} would be called. The state of the destination
-   * is undefined and @{@link #abort(WriterCommitMessage[])} may not be able to deal with it.
-   *
-   * Note that, one partition may have multiple committed data writers because of speculative tasks.
-   * Spark will pick the first successful one and get its commit message. Implementations should be
-   * aware of this and handle it correctly, e.g., have a coordinator to make sure only one data
-   * writer can commit, or have a way to clean up the data of already-committed writers.
+   * failed, and {@link #abort()} would be called. The state of the destination
+   * is undefined and @{@link #abort()} may not be able to deal with it.
    */
-  void commit(WriterCommitMessage[] messages);
+  void add(WriterCommitMessage message);
 
   /**
-   * Aborts this writing job because some data writers are failed and keep failing when retry, or
-   * the Spark job fails with some unknown reasons, or {@link #commit(WriterCommitMessage[])} fails.
+   * Commits this writing job.
+   *
+   * If this method fails (by throwing an exception), this writing job is considered to to have been
+   * failed, and {@link #abort()} would be called. The state of the destination
+   * is undefined and @{@link #abort()} may not be able to deal with it.
+   */
+  void commit();
+
+  /**
+   * Aborts this writing job because some data writers are failed and keep failing when retry,
+   * or the Spark job fails with some unknown reasons,
+   * or {@link #commit()} /{@link #add(WriterCommitMessage)} fails.
    *
    * If this method fails (by throwing an exception), the underlying data source may require manual
    * cleanup.
-   *
-   * Unless the abort is triggered by the failure of commit, the given messages should have some
-   * null slots as there maybe only a few data writers that are committed before the abort
-   * happens, or some data writers were committed but their commit messages haven't reached the
-   * driver when the abort is triggered. So this is just a "best effort" for data sources to
-   * clean up the data left by data writers.
    */
-  void abort(WriterCommitMessage[] messages);
+  void abort();
 }

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataSourceWriter.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataSourceWriter.java
@@ -51,8 +51,8 @@ import org.apache.spark.sql.types.StructType;
  * While Spark will retry failed writing tasks, Spark won't retry failed writing jobs. Users should
  * do it manually in their Spark applications if they want to retry.
  *
- * In general, all these function calls should be thread-safe in driver side and there is no need
- * to implement concurrency control.
+ * All these methods are guaranteed to be called in a single thread.
+ * No concurrency control is needed.
  *
  * Please refer to the documentation of add/commit/abort methods for detailed specifications.
  */

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataSourceWriter.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataSourceWriter.java
@@ -51,7 +51,10 @@ import org.apache.spark.sql.types.StructType;
  * While Spark will retry failed writing tasks, Spark won't retry failed writing jobs. Users should
  * do it manually in their Spark applications if they want to retry.
  *
- * Please refer to the documentation of commit/abort methods for detailed specifications.
+ * In general, all these function calls should be thread-safe in driver side and there is no need
+ * to implement concurrency control.
+ *
+ * Please refer to the documentation of add/commit/abort methods for detailed specifications.
  */
 @InterfaceStability.Evolving
 public interface DataSourceWriter {

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataWriter.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataWriter.java
@@ -33,11 +33,11 @@ import org.apache.spark.annotation.InterfaceStability;
  *
  * If this data writer succeeds(all records are successfully written and {@link #commit()}
  * succeeds), a {@link WriterCommitMessage} will be sent to the driver side and pass to
- * {@link DataSourceWriter#commit(WriterCommitMessage[])} with commit messages from other data
+ * {@link DataSourceWriter#commit()} with commit messages from other data
  * writers. If this data writer fails(one record fails to write or {@link #commit()} fails), an
  * exception will be sent to the driver side, and Spark will retry this writing task for some times,
  * each time {@link DataWriterFactory#createDataWriter(int, int)} gets a different `attemptNumber`,
- * and finally call {@link DataSourceWriter#abort(WriterCommitMessage[])} if all retry fail.
+ * and finally call {@link DataSourceWriter#abort()} if all retry fail.
  *
  * Besides the retry mechanism, Spark may launch speculative tasks if the existing writing task
  * takes too long to finish. Different from retried tasks, which are launched one by one after the
@@ -69,10 +69,10 @@ public interface DataWriter<T> {
   /**
    * Commits this writer after all records are written successfully, returns a commit message which
    * will be sent back to driver side and passed to
-   * {@link DataSourceWriter#commit(WriterCommitMessage[])}.
+   * {@link DataSourceWriter#commit()}.
    *
    * The written data should only be visible to data source readers after
-   * {@link DataSourceWriter#commit(WriterCommitMessage[])} succeeds, which means this method
+   * {@link DataSourceWriter#commit()} succeeds, which means this method
    * should still "hide" the written data and ask the {@link DataSourceWriter} at driver side to
    * do the final commit via {@link WriterCommitMessage}.
    *
@@ -91,7 +91,7 @@ public interface DataWriter<T> {
    * failed.
    *
    * If this method fails(by throwing an exception), the underlying data source may have garbage
-   * that need to be cleaned by {@link DataSourceWriter#abort(WriterCommitMessage[])} or manually,
+   * that need to be cleaned by {@link DataSourceWriter#abort()} or manually,
    * but these garbage should not be visible to data source readers.
    *
    * @throws IOException if failure happens during disk/network IO like writing files.

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/WriterCommitMessage.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/WriterCommitMessage.java
@@ -23,10 +23,10 @@ import org.apache.spark.annotation.InterfaceStability;
 
 /**
  * A commit message returned by {@link DataWriter#commit()} and will be sent back to the driver side
- * as the input parameter of {@link DataSourceWriter#commit(WriterCommitMessage[])}.
+ * as the input parameter of {@link DataSourceWriter#commit()}.
  *
  * This is an empty interface, data sources should define their own message class and use it in
- * their {@link DataWriter#commit()} and {@link DataSourceWriter#commit(WriterCommitMessage[])}
+ * their {@link DataWriter#commit()} and {@link DataSourceWriter#commit()}
  * implementations.
  */
 @InterfaceStability.Evolving

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2.scala
@@ -55,6 +55,9 @@ case class WriteToDataSourceV2Exec(writer: DataSourceWriter, query: SparkPlan) e
 
     val rdd = query.execute()
 
+    logInfo(s"Start processing data source writer: $writer. " +
+      s"The input RDD has ${rdd.partitions.length} partitions.")
+
     try {
       val runTask = writer match {
         // This case means that we're doing continuous processing. In microbatch streaming, the

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2.scala
@@ -54,10 +54,6 @@ case class WriteToDataSourceV2Exec(writer: DataSourceWriter, query: SparkPlan) e
     }
 
     val rdd = query.execute()
-    val messages = new Array[WriterCommitMessage](rdd.partitions.length)
-
-    logInfo(s"Start processing data source writer: $writer. " +
-      s"The input RDD has ${messages.length} partitions.")
 
     try {
       val runTask = writer match {
@@ -80,12 +76,12 @@ case class WriteToDataSourceV2Exec(writer: DataSourceWriter, query: SparkPlan) e
         rdd,
         runTask,
         rdd.partitions.indices,
-        (index, message: WriterCommitMessage) => messages(index) = message
+        (_, message: WriterCommitMessage) => writer.add(message)
       )
 
       if (!writer.isInstanceOf[StreamWriter]) {
         logInfo(s"Data source writer $writer is committing.")
-        writer.commit(messages)
+        writer.commit()
         logInfo(s"Data source writer $writer committed.")
       }
     } catch {
@@ -94,7 +90,7 @@ case class WriteToDataSourceV2Exec(writer: DataSourceWriter, query: SparkPlan) e
       case cause: Throwable =>
         logError(s"Data source writer $writer is aborting.")
         try {
-          writer.abort(messages)
+          writer.abort()
         } catch {
           case t: Throwable =>
             logError(s"Data source writer $writer failed to abort.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/EpochCoordinator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/EpochCoordinator.scala
@@ -148,7 +148,6 @@ private[continuous] class EpochCoordinator(
       logDebug(s"Epoch $epoch has received commits from all partitions. Committing globally.")
       // Sequencing is important here. We must commit to the writer before recording the commit
       // in the query, or we will end up dropping the commit if we restart in the middle.
-      thisEpochCommits.foreach(writer.add(_))
       writer.commit(epoch)
       query.commit(epoch)
 
@@ -171,6 +170,7 @@ private[continuous] class EpochCoordinator(
       logDebug(s"Got commit from partition $partitionId at epoch $epoch: $message")
       if (!partitionCommits.isDefinedAt((epoch, partitionId))) {
         partitionCommits.put((epoch, partitionId), message)
+        writer.add(message)
         resolveCommitsAtEpoch(epoch)
       }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/EpochCoordinator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/EpochCoordinator.scala
@@ -148,7 +148,8 @@ private[continuous] class EpochCoordinator(
       logDebug(s"Epoch $epoch has received commits from all partitions. Committing globally.")
       // Sequencing is important here. We must commit to the writer before recording the commit
       // in the query, or we will end up dropping the commit if we restart in the middle.
-      writer.commit(epoch, thisEpochCommits.toArray)
+      thisEpochCommits.foreach(writer.add(_))
+      writer.commit(epoch)
       query.commit(epoch)
 
       // Cleanup state from before this epoch, now that we know all partitions are forever past it.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/ConsoleWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/ConsoleWriter.scala
@@ -43,18 +43,20 @@ class ConsoleWriter(schema: StructType, options: DataSourceOptions)
 
   private val messages = new ArrayBuffer[WriterCommitMessage]()
 
-  override def add(message: WriterCommitMessage): Unit = synchronized {
+  override def add(message: WriterCommitMessage): Unit = {
     messages += message
   }
 
-  override def commit(epochId: Long): Unit = synchronized {
+  override def commit(epochId: Long): Unit = {
     // We have to print a "Batch" label for the epoch for compatibility with the pre-data source V2
     // behavior.
     printRows(messages.toArray, schema, s"Batch: $epochId")
     messages.clear()
   }
 
-  def abort(epochId: Long): Unit = {}
+  def abort(epochId: Long): Unit = {
+    messages.clear()
+  }
 
   protected def printRows(
       commitMessages: Array[WriterCommitMessage],

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/MicroBatchWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/MicroBatchWriter.scala
@@ -28,22 +28,30 @@ import org.apache.spark.sql.sources.v2.writer.{DataSourceWriter, DataWriterFacto
  * streaming writer.
  */
 class MicroBatchWriter(batchId: Long, writer: StreamWriter) extends DataSourceWriter {
-  override def commit(messages: Array[WriterCommitMessage]): Unit = {
-    writer.commit(batchId, messages)
+  override def add(message: WriterCommitMessage): Unit = {
+    writer.add(message)
   }
 
-  override def abort(messages: Array[WriterCommitMessage]): Unit = writer.abort(batchId, messages)
+  override def commit(): Unit = {
+    writer.commit(batchId)
+  }
+
+  override def abort(): Unit = writer.abort(batchId)
 
   override def createWriterFactory(): DataWriterFactory[Row] = writer.createWriterFactory()
 }
 
 class InternalRowMicroBatchWriter(batchId: Long, writer: StreamWriter)
   extends DataSourceWriter with SupportsWriteInternalRow {
-  override def commit(messages: Array[WriterCommitMessage]): Unit = {
-    writer.commit(batchId, messages)
+  override def add(message: WriterCommitMessage): Unit = {
+    writer.add(message)
   }
 
-  override def abort(messages: Array[WriterCommitMessage]): Unit = writer.abort(batchId, messages)
+  override def commit(): Unit = {
+    writer.commit(batchId)
+  }
+
+  override def abort(): Unit = writer.abort(batchId)
 
   override def createInternalRowWriterFactory(): DataWriterFactory[InternalRow] =
     writer match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/memoryV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/memoryV2.scala
@@ -118,14 +118,21 @@ class MemoryWriter(sink: MemorySinkV2, batchId: Long, outputMode: OutputMode)
 
   override def createWriterFactory: MemoryWriterFactory = MemoryWriterFactory(outputMode)
 
-  def commit(messages: Array[WriterCommitMessage]): Unit = {
-    val newRows = messages.flatMap {
-      case message: MemoryWriterCommitMessage => message.data
-    }
-    sink.write(batchId, outputMode, newRows)
+  private val messages = new ArrayBuffer[WriterCommitMessage]()
+
+  override def add(message: WriterCommitMessage): Unit = synchronized {
+    messages += message
   }
 
-  override def abort(messages: Array[WriterCommitMessage]): Unit = {
+  def commit(): Unit = synchronized {
+    val newRows = messages.flatMap {
+      case message: MemoryWriterCommitMessage => message.data
+    }.toArray
+    sink.write(batchId, outputMode, newRows)
+    messages.clear()
+  }
+
+  override def abort(): Unit = {
     // Don't accept any of the new input.
   }
 }
@@ -135,14 +142,21 @@ class MemoryStreamWriter(val sink: MemorySinkV2, outputMode: OutputMode)
 
   override def createWriterFactory: MemoryWriterFactory = MemoryWriterFactory(outputMode)
 
-  override def commit(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {
-    val newRows = messages.flatMap {
-      case message: MemoryWriterCommitMessage => message.data
-    }
-    sink.write(epochId, outputMode, newRows)
+  private val messages = new ArrayBuffer[WriterCommitMessage]()
+
+  override def add(message: WriterCommitMessage): Unit = synchronized {
+    messages += message
   }
 
-  override def abort(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {
+  override def commit(epochId: Long): Unit = synchronized {
+    val newRows = messages.flatMap {
+      case message: MemoryWriterCommitMessage => message.data
+    }.toArray
+    sink.write(epochId, outputMode, newRows)
+    messages.clear()
+  }
+
+  override def abort(epochId: Long): Unit = {
     // Don't accept any of the new input.
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/memoryV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/memoryV2.scala
@@ -120,11 +120,11 @@ class MemoryWriter(sink: MemorySinkV2, batchId: Long, outputMode: OutputMode)
 
   private val messages = new ArrayBuffer[WriterCommitMessage]()
 
-  override def add(message: WriterCommitMessage): Unit = synchronized {
+  override def add(message: WriterCommitMessage): Unit = {
     messages += message
   }
 
-  def commit(): Unit = synchronized {
+  def commit(): Unit = {
     val newRows = messages.flatMap {
       case message: MemoryWriterCommitMessage => message.data
     }.toArray
@@ -134,6 +134,7 @@ class MemoryWriter(sink: MemorySinkV2, batchId: Long, outputMode: OutputMode)
 
   override def abort(): Unit = {
     // Don't accept any of the new input.
+    messages.clear()
   }
 }
 
@@ -144,11 +145,11 @@ class MemoryStreamWriter(val sink: MemorySinkV2, outputMode: OutputMode)
 
   private val messages = new ArrayBuffer[WriterCommitMessage]()
 
-  override def add(message: WriterCommitMessage): Unit = synchronized {
+  override def add(message: WriterCommitMessage): Unit = {
     messages += message
   }
 
-  override def commit(epochId: Long): Unit = synchronized {
+  override def commit(epochId: Long): Unit = {
     val newRows = messages.flatMap {
       case message: MemoryWriterCommitMessage => message.data
     }.toArray
@@ -158,6 +159,7 @@ class MemoryStreamWriter(val sink: MemorySinkV2, outputMode: OutputMode)
 
   override def abort(epochId: Long): Unit = {
     // Don't accept any of the new input.
+    messages.clear()
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/MemorySinkV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/MemorySinkV2Suite.scala
@@ -41,21 +41,15 @@ class MemorySinkV2Suite extends StreamTest with BeforeAndAfter {
   test("continuous writer") {
     val sink = new MemorySinkV2
     val writer = new MemoryStreamWriter(sink, OutputMode.Append())
-    val messages = Seq(
-      MemoryWriterCommitMessage(0, Seq(Row(1), Row(2))),
-      MemoryWriterCommitMessage(1, Seq(Row(3), Row(4))),
-      MemoryWriterCommitMessage(2, Seq(Row(6), Row(7)))
-    )
-    messages.foreach(writer.add(_))
+    writer.add(MemoryWriterCommitMessage(0, Seq(Row(1), Row(2))))
+    writer.add(MemoryWriterCommitMessage(1, Seq(Row(3), Row(4))))
+    writer.add(MemoryWriterCommitMessage(2, Seq(Row(6), Row(7))))
     writer.commit(0)
     assert(sink.latestBatchId.contains(0))
     assert(sink.latestBatchData.map(_.getInt(0)).sorted == Seq(1, 2, 3, 4, 6, 7))
 
-    val newMessages = Seq(
-      MemoryWriterCommitMessage(3, Seq(Row(11), Row(22))),
-      MemoryWriterCommitMessage(0, Seq(Row(33)))
-    )
-    newMessages.foreach(writer.add(_))
+    writer.add(MemoryWriterCommitMessage(3, Seq(Row(11), Row(22))))
+    writer.add(MemoryWriterCommitMessage(0, Seq(Row(33))))
     writer.commit(19)
     assert(sink.latestBatchId.contains(19))
     assert(sink.latestBatchData.map(_.getInt(0)).sorted == Seq(11, 22, 33))
@@ -66,22 +60,16 @@ class MemorySinkV2Suite extends StreamTest with BeforeAndAfter {
   test("microbatch writer") {
     val sink = new MemorySinkV2
     val writer = new MemoryWriter(sink, 0, OutputMode.Append())
-    val messages = Seq(
-      MemoryWriterCommitMessage(0, Seq(Row(1), Row(2))),
-      MemoryWriterCommitMessage(1, Seq(Row(3), Row(4))),
-      MemoryWriterCommitMessage(2, Seq(Row(6), Row(7)))
-    )
-    messages.foreach(writer.add(_))
+    writer.add(MemoryWriterCommitMessage(0, Seq(Row(1), Row(2))))
+    writer.add(MemoryWriterCommitMessage(1, Seq(Row(3), Row(4))))
+    writer.add(MemoryWriterCommitMessage(2, Seq(Row(6), Row(7))))
     writer.commit()
     assert(sink.latestBatchId.contains(0))
     assert(sink.latestBatchData.map(_.getInt(0)).sorted == Seq(1, 2, 3, 4, 6, 7))
 
     val newWriter = new MemoryWriter(sink, 19, OutputMode.Append())
-    val newMessages = Seq(
-      MemoryWriterCommitMessage(3, Seq(Row(11), Row(22))),
-      MemoryWriterCommitMessage(0, Seq(Row(33)))
-    )
-    newMessages.foreach(newWriter.add(_))
+    newWriter.add(MemoryWriterCommitMessage(3, Seq(Row(11), Row(22))))
+    newWriter.add(MemoryWriterCommitMessage(0, Seq(Row(33))))
     newWriter.commit()
     assert(sink.latestBatchId.contains(19))
     assert(sink.latestBatchData.map(_.getInt(0)).sorted == Seq(11, 22, 33))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/MemorySinkV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/MemorySinkV2Suite.scala
@@ -41,19 +41,22 @@ class MemorySinkV2Suite extends StreamTest with BeforeAndAfter {
   test("continuous writer") {
     val sink = new MemorySinkV2
     val writer = new MemoryStreamWriter(sink, OutputMode.Append())
-    writer.commit(0,
-      Array(
-        MemoryWriterCommitMessage(0, Seq(Row(1), Row(2))),
-        MemoryWriterCommitMessage(1, Seq(Row(3), Row(4))),
-        MemoryWriterCommitMessage(2, Seq(Row(6), Row(7)))
-      ))
+    val messages = Seq(
+      MemoryWriterCommitMessage(0, Seq(Row(1), Row(2))),
+      MemoryWriterCommitMessage(1, Seq(Row(3), Row(4))),
+      MemoryWriterCommitMessage(2, Seq(Row(6), Row(7)))
+    )
+    messages.foreach(writer.add(_))
+    writer.commit(0)
     assert(sink.latestBatchId.contains(0))
     assert(sink.latestBatchData.map(_.getInt(0)).sorted == Seq(1, 2, 3, 4, 6, 7))
-    writer.commit(19,
-      Array(
-        MemoryWriterCommitMessage(3, Seq(Row(11), Row(22))),
-        MemoryWriterCommitMessage(0, Seq(Row(33)))
-      ))
+
+    val newMessages = Seq(
+      MemoryWriterCommitMessage(3, Seq(Row(11), Row(22))),
+      MemoryWriterCommitMessage(0, Seq(Row(33)))
+    )
+    newMessages.foreach(writer.add(_))
+    writer.commit(19)
     assert(sink.latestBatchId.contains(19))
     assert(sink.latestBatchData.map(_.getInt(0)).sorted == Seq(11, 22, 33))
 
@@ -62,19 +65,24 @@ class MemorySinkV2Suite extends StreamTest with BeforeAndAfter {
 
   test("microbatch writer") {
     val sink = new MemorySinkV2
-    new MemoryWriter(sink, 0, OutputMode.Append()).commit(
-      Array(
-        MemoryWriterCommitMessage(0, Seq(Row(1), Row(2))),
-        MemoryWriterCommitMessage(1, Seq(Row(3), Row(4))),
-        MemoryWriterCommitMessage(2, Seq(Row(6), Row(7)))
-      ))
+    val writer = new MemoryWriter(sink, 0, OutputMode.Append())
+    val messages = Seq(
+      MemoryWriterCommitMessage(0, Seq(Row(1), Row(2))),
+      MemoryWriterCommitMessage(1, Seq(Row(3), Row(4))),
+      MemoryWriterCommitMessage(2, Seq(Row(6), Row(7)))
+    )
+    messages.foreach(writer.add(_))
+    writer.commit()
     assert(sink.latestBatchId.contains(0))
     assert(sink.latestBatchData.map(_.getInt(0)).sorted == Seq(1, 2, 3, 4, 6, 7))
-    new MemoryWriter(sink, 19, OutputMode.Append()).commit(
-      Array(
-        MemoryWriterCommitMessage(3, Seq(Row(11), Row(22))),
-        MemoryWriterCommitMessage(0, Seq(Row(33)))
-      ))
+
+    val newWriter = new MemoryWriter(sink, 19, OutputMode.Append())
+    val newMessages = Seq(
+      MemoryWriterCommitMessage(3, Seq(Row(11), Row(22))),
+      MemoryWriterCommitMessage(0, Seq(Row(33)))
+    )
+    newMessages.foreach(newWriter.add(_))
+    newWriter.commit()
     assert(sink.latestBatchId.contains(19))
     assert(sink.latestBatchData.map(_.getInt(0)).sorted == Seq(11, 22, 33))
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/ConsoleWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/ConsoleWriterSuite.scala
@@ -45,7 +45,8 @@ class ConsoleWriterSuite extends StreamTest {
       }
     }
 
-    assert(captured.toString() ==
+    // The order of data in one batch can be random
+    assert(captured.toString().length ==
       """-------------------------------------------
         |Batch: 0
         |-------------------------------------------
@@ -76,7 +77,7 @@ class ConsoleWriterSuite extends StreamTest {
         |+-----+
         |+-----+
         |
-        |""".stripMargin)
+        |""".stripMargin.length)
   }
 
   test("microbatch - with numRows") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/ConsoleWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/ConsoleWriterSuite.scala
@@ -19,13 +19,16 @@ package org.apache.spark.sql.execution.streaming.sources
 
 import java.io.ByteArrayOutputStream
 
-import org.scalatest.time.SpanSugar._
-
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.streaming.{StreamTest, Trigger}
 
 class ConsoleWriterSuite extends StreamTest {
   import testImplicits._
+
+  override def sparkConf: SparkConf = {
+    super.sparkConf.set("spark.default.parallelism", "1")
+  }
 
   test("microbatch - default") {
     val input = MemoryStream[Int]
@@ -45,8 +48,7 @@ class ConsoleWriterSuite extends StreamTest {
       }
     }
 
-    // The order of data in one batch can be random
-    assert(captured.toString().length ==
+    assert(captured.toString() ==
       """-------------------------------------------
         |Batch: 0
         |-------------------------------------------
@@ -77,7 +79,7 @@ class ConsoleWriterSuite extends StreamTest {
         |+-----+
         |+-----+
         |
-        |""".stripMargin.length)
+        |""".stripMargin)
   }
 
   test("microbatch - with numRows") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/ConsoleWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/ConsoleWriterSuite.scala
@@ -26,10 +26,6 @@ import org.apache.spark.sql.streaming.{StreamTest, Trigger}
 class ConsoleWriterSuite extends StreamTest {
   import testImplicits._
 
-  override def sparkConf: SparkConf = {
-    super.sparkConf.set("spark.default.parallelism", "1")
-  }
-
   test("microbatch - default") {
     val input = MemoryStream[Int]
 
@@ -37,9 +33,9 @@ class ConsoleWriterSuite extends StreamTest {
     Console.withOut(captured) {
       val query = input.toDF().writeStream.format("console").start()
       try {
-        input.addData(1, 2, 3)
+        input.addData(1, 1, 1)
         query.processAllAvailable()
-        input.addData(4, 5, 6)
+        input.addData(2, 2, 2)
         query.processAllAvailable()
         input.addData()
         query.processAllAvailable()
@@ -56,8 +52,8 @@ class ConsoleWriterSuite extends StreamTest {
         ||value|
         |+-----+
         ||    1|
-        ||    2|
-        ||    3|
+        ||    1|
+        ||    1|
         |+-----+
         |
         |-------------------------------------------
@@ -66,9 +62,9 @@ class ConsoleWriterSuite extends StreamTest {
         |+-----+
         ||value|
         |+-----+
-        ||    4|
-        ||    5|
-        ||    6|
+        ||    2|
+        ||    2|
+        ||    2|
         |+-----+
         |
         |-------------------------------------------
@@ -89,7 +85,7 @@ class ConsoleWriterSuite extends StreamTest {
     Console.withOut(captured) {
       val query = input.toDF().writeStream.format("console").option("NUMROWS", 2).start()
       try {
-        input.addData(1, 2, 3)
+        input.addData(1, 1, 1)
         query.processAllAvailable()
       } finally {
         query.stop()
@@ -104,7 +100,7 @@ class ConsoleWriterSuite extends StreamTest {
         ||value|
         |+-----+
         ||    1|
-        ||    2|
+        ||    1|
         |+-----+
         |only showing top 2 rows
         |

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/v2/SimpleWritableDataSource.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/v2/SimpleWritableDataSource.scala
@@ -69,7 +69,9 @@ class SimpleWritableDataSource extends DataSourceV2 with ReadSupport with WriteS
       new SimpleCSVDataWriterFactory(path, jobId, new SerializableConfiguration(conf))
     }
 
-    override def commit(messages: Array[WriterCommitMessage]): Unit = {
+    override def add(message: WriterCommitMessage): Unit = {}
+
+    override def commit(): Unit = {
       val finalPath = new Path(path)
       val jobPath = new Path(new Path(finalPath, "_temporary"), jobId)
       val fs = jobPath.getFileSystem(conf)
@@ -85,7 +87,7 @@ class SimpleWritableDataSource extends DataSourceV2 with ReadSupport with WriteS
       }
     }
 
-    override def abort(messages: Array[WriterCommitMessage]): Unit = {
+    override def abort(): Unit = {
       val jobPath = new Path(new Path(path, "_temporary"), jobId)
       val fs = jobPath.getFileSystem(conf)
       fs.delete(jobPath, true)


### PR DESCRIPTION
This PR is deprecated.
See #20454
## What changes were proposed in this pull request?

Currently, the api `DataSourceV2Writer#commit(WriterCommitMessage[])` commits a 

writing job with a list of commit messages.

It makes sense in some scenarios, e.g. MicroBatchExecution.

However, the API makes it hard to implement `onTaskCommit(taskCommit: TaskCommitMessage)` in `FileCommitProtocol`.
In general, on receiving commit message, driver can start processing messages(e.g. persist messages into files) before all the messages are collected.

The proposal is to break down `DataSourceV2Writer.commit` into two phase:

1. `add(WriterCommitMessage message)`: Handles a commit message produced by`DataWriter#commit()`.
2. `commit()`:  Commits the writing job.

This should make the API compatible with `FileCommitProtocol`, and more flexible.

## How was this patch tested?

Unit test
