### PR TITLE
Update ApplicationMaster.scala

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -120,18 +120,19 @@ private[spark] class ApplicationMaster(args: ApplicationMasterArguments) extends
   // allocation is enabled), with a minimum of 3.
 
   private val maxNumExecutorFailures = {
-    val effectiveNumExecutors =
-      if (Utils.isDynamicAllocationEnabled(sparkConf)) {
-        sparkConf.get(DYN_ALLOCATION_MAX_EXECUTORS)
-      } else {
-        sparkConf.get(EXECUTOR_INSTANCES).getOrElse(0)
-      }
-    // By default, effectiveNumExecutors is Int.MaxValue if dynamic allocation is enabled. We need
-    // avoid the integer overflow here.
-    val defaultMaxNumExecutorFailures = math.max(3,
-      if (effectiveNumExecutors > Int.MaxValue / 2) Int.MaxValue else (2 * effectiveNumExecutors))
+  //   val effectiveNumExecutors =
+  //    if (Utils.isDynamicAllocationEnabled(sparkConf)) {
+  //       sparkConf.get(DYN_ALLOCATION_MAX_EXECUTORS)
+  //     } else {
+  //      sparkConf.get(EXECUTOR_INSTANCES).getOrElse(0)
+  //    }
+  //  // By default, effectiveNumExecutors is Int.MaxValue if dynamic allocation is enabled. We need
+  //  // avoid the integer overflow here.
+  //  val defaultMaxNumExecutorFailures = math.max(3,
+  //    if (effectiveNumExecutors > Int.MaxValue / 2) Int.MaxValue else (2 * effectiveNumExecutors))
 
-    sparkConf.get(MAX_EXECUTOR_FAILURES).getOrElse(defaultMaxNumExecutorFailures)
+  //  sparkConf.get(MAX_EXECUTOR_FAILURES).getOrElse(defaultMaxNumExecutorFailures)
+    sparkConf.get(MAX_EXECUTOR_FAILURES)
   }
 
   @volatile private var exitCode = 0


### PR DESCRIPTION
I have one question.
I think when maxNumExecutorFailures is calculated, MAX_EXECUTOR_FAILURES is already defined by specific by spark document (as numExecutors * 2, with minimum of 3)
So the annotation added by me in the code is not valid.
Give me the answer please.
Thank you

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
