### PR TITLE
[SPARK-23084][PYTHON]Add unboundedPreceding(), unboundedFollowing() and currentRow() to PySpark

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -814,10 +814,6 @@ def unboundedPreceding():
     """
     Window function: returns the special frame boundary that represents the first row
     in the window partition.
-
-    >>> df = spark.createDataFrame([(5,)])
-    >>> df.select(unboundedPreceding()).columns[0]
-    'UNBOUNDED PRECEDING'
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.unboundedPreceding())
@@ -828,10 +824,6 @@ def unboundedFollowing():
     """
     Window function: returns the special frame boundary that represents the last row
     in the window partition.
-
-    >>> df = spark.createDataFrame([(5,)])
-    >>> df.select(unboundedFollowing()).columns[0]
-    'UNBOUNDED FOLLOWING'
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.unboundedFollowing())
@@ -842,10 +834,6 @@ def currentRow():
     """
     Window function: returns the special frame boundary that represents the current row
     in the window partition.
-
-    >>> df = spark.createDataFrame([(5,)])
-    >>> df.select(currentRow()).columns[0]
-    'CURRENT ROW'
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.currentRow())

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -809,7 +809,7 @@ def ntile(n):
     return Column(sc._jvm.functions.ntile(int(n)))
 
 
-@since(2.3)
+@since(2.4)
 def unboundedPreceding():
     """
     Window function: returns the special frame boundary that represents the first row
@@ -819,7 +819,7 @@ def unboundedPreceding():
     return Column(sc._jvm.functions.unboundedPreceding())
 
 
-@since(2.3)
+@since(2.4)
 def unboundedFollowing():
     """
     Window function: returns the special frame boundary that represents the last row
@@ -829,7 +829,7 @@ def unboundedFollowing():
     return Column(sc._jvm.functions.unboundedFollowing())
 
 
-@since(2.3)
+@since(2.4)
 def currentRow():
     """
     Window function: returns the special frame boundary that represents the current row

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -814,6 +814,9 @@ def unboundedPreceding():
     """
     Window function: returns the special frame boundary that represents the first row
     in the window partition.
+    >>> df = spark.createDataFrame([(5,)])
+    >>> df.select(unboundedPreceding()).show
+    <bound method DataFrame.show of DataFrame[UNBOUNDED PRECEDING: null]>
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.unboundedPreceding())
@@ -824,6 +827,9 @@ def unboundedFollowing():
     """
     Window function: returns the special frame boundary that represents the last row
     in the window partition.
+    >>> df = spark.createDataFrame([(5,)])
+    >>> df.select(unboundedFollowing()).show
+    <bound method DataFrame.show of DataFrame[UNBOUNDED FOLLOWING: null]>
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.unboundedFollowing())
@@ -834,6 +840,9 @@ def currentRow():
     """
     Window function: returns the special frame boundary that represents the current row
     in the window partition.
+    >>> df = spark.createDataFrame([(5,)])
+    >>> df.select(currentRow()).show
+    <bound method DataFrame.show of DataFrame[CURRENT ROW: null]>
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.currentRow())

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -809,6 +809,36 @@ def ntile(n):
     return Column(sc._jvm.functions.ntile(int(n)))
 
 
+@since(2.3)
+def unboundedPreceding():
+    """
+    Window function: returns the special frame boundary that represents the first row
+    in the window partition.
+    """
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.functions.unboundedPreceding())
+
+
+@since(2.3)
+def unboundedFollowing():
+    """
+    Window function: returns the special frame boundary that represents the last row
+    in the window partition.
+    """
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.functions.unboundedFollowing())
+
+
+@since(2.3)
+def currentRow():
+    """
+    Window function: returns the special frame boundary that represents the current row
+    in the window partition.
+    """
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.functions.currentRow())
+
+
 # ---------------------- Date/Timestamp functions ------------------------------
 
 @since(1.5)

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -814,9 +814,10 @@ def unboundedPreceding():
     """
     Window function: returns the special frame boundary that represents the first row
     in the window partition.
+
     >>> df = spark.createDataFrame([(5,)])
-    >>> df.select(unboundedPreceding()).show
-    <bound method DataFrame.show of DataFrame[UNBOUNDED PRECEDING: null]>
+    >>> df.select(unboundedPreceding()).columns[0]
+    'UNBOUNDED PRECEDING'
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.unboundedPreceding())
@@ -827,9 +828,10 @@ def unboundedFollowing():
     """
     Window function: returns the special frame boundary that represents the last row
     in the window partition.
+
     >>> df = spark.createDataFrame([(5,)])
-    >>> df.select(unboundedFollowing()).show
-    <bound method DataFrame.show of DataFrame[UNBOUNDED FOLLOWING: null]>
+    >>> df.select(unboundedFollowing()).columns[0]
+    'UNBOUNDED FOLLOWING'
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.unboundedFollowing())
@@ -840,9 +842,10 @@ def currentRow():
     """
     Window function: returns the special frame boundary that represents the current row
     in the window partition.
+
     >>> df = spark.createDataFrame([(5,)])
-    >>> df.select(currentRow()).show
-    <bound method DataFrame.show of DataFrame[CURRENT ROW: null]>
+    >>> df.select(currentRow()).columns[0]
+    'CURRENT ROW'
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.currentRow())

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -122,22 +122,25 @@ class Window(object):
         and "5" means the five off after the current row.
 
         We recommend users use ``Window.unboundedPreceding``, ``Window.unboundedFollowing``,
-        and ``Window.currentRow`` to specify special boundary values, rather than using integral
-        values directly.
+        ``Window.currentRow``, ``pyspark.sql.functions.unboundedPreceding``,
+        ``pyspark.sql.functions.unboundedFollowing`` and ``pyspark.sql.functions.currentRow``
+        to specify special boundary values, rather than using integral values directly.
 
         :param start: boundary start, inclusive.
-                      The frame is unbounded if this is ``Window.unboundedPreceding``, or
+                      The frame is unbounded if this is ``Window.unboundedPreceding``,
+                      a column returned by ``pyspark.sql.functions.unboundedPreceding``, or
                       any value less than or equal to max(-sys.maxsize, -9223372036854775808).
         :param end: boundary end, inclusive.
-                    The frame is unbounded if this is ``Window.unboundedFollowing``, or
+                    The frame is unbounded if this is ``Window.unboundedFollowing``,
+                    a column returned by ``pyspark.sql.functions.unboundedFollowing``, or
                     any value greater than or equal to min(sys.maxsize, 9223372036854775807).
 
         >>> from pyspark.sql import functions as F, SparkSession, Window
         >>> spark = SparkSession.builder.getOrCreate()
-        >>> df = spark.createDataFrame([(1, "a"), (1, "a"), (2, "a"), (1, "b"), (2, "b"),
-        ... (3, "b")], ["id", "category"])
-        >>> window = Window.orderBy("id").partitionBy("category").rangeBetween(F.currentRow(),
-        ... F.lit(1))
+        >>> df = spark.createDataFrame(
+        ...     [(1, "a"), (1, "a"), (2, "a"), (1, "b"), (2, "b"), (3, "b")], ["id", "category"])
+        >>> window = Window.orderBy("id").partitionBy("category").rangeBetween(
+        ...     F.currentRow(), F.lit(1))
         >>> df.withColumn("sum", F.sum("id").over(window)).show()
         +---+--------+---+
         | id|category|sum|
@@ -233,16 +236,18 @@ class WindowSpec(object):
         and "5" means the five off after the current row.
 
         We recommend users use ``Window.unboundedPreceding``, ``Window.unboundedFollowing``,
-        and ``Window.currentRow`` to specify special boundary values, rather than using integral
-        values directly.
+        ``Window.currentRow``, ``pyspark.sql.functions.unboundedPreceding``,
+        ``pyspark.sql.functions.unboundedFollowing`` and ``pyspark.sql.functions.currentRow``
+        to specify special boundary values, rather than using integral values directly.
 
         :param start: boundary start, inclusive.
-                      The frame is unbounded if this is ``Window.unboundedPreceding``, or
+                      The frame is unbounded if this is ``Window.unboundedPreceding``,
+                      a column returned by ``pyspark.sql.functions.unboundedPreceding``, or
                       any value less than or equal to max(-sys.maxsize, -9223372036854775808).
         :param end: boundary end, inclusive.
-                    The frame is unbounded if this is ``Window.unboundedFollowing``, or
+                    The frame is unbounded if this is ``Window.unboundedFollowing``,
+                    a column returned by ``pyspark.sql.functions.unboundedFollowing``, or
                     any value greater than or equal to min(sys.maxsize, 9223372036854775807).
-
         """
         if isinstance(start, (int, long)) and isinstance(end, (int, long)):
             if start <= Window._PRECEDING_THRESHOLD:

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -132,7 +132,7 @@ class Window(object):
                     ``org.apache.spark.sql.catalyst.expressions.UnboundedPFollowing``, or
                     any value greater than or equal to min(sys.maxsize, 9223372036854775807).
         """
-        if isinstance(start, long) and isinstance(end, long):
+        if isinstance(start, int) and isinstance(end, int):
             if start <= Window._PRECEDING_THRESHOLD:
                 start = Window.unboundedPreceding
             if end >= Window._FOLLOWING_THRESHOLD:
@@ -223,7 +223,7 @@ class WindowSpec(object):
                     ``org.apache.spark.sql.catalyst.expressions.UnboundedFollowing``, or
                     any value greater than or equal to min(sys.maxsize, 9223372036854775807).
         """
-        if isinstance(start, long) and isinstance(end, long):
+        if isinstance(start, int) and isinstance(end, int):
             if start <= Window._PRECEDING_THRESHOLD:
                 start = Window.unboundedPreceding
             if end >= Window._FOLLOWING_THRESHOLD:

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -124,16 +124,19 @@ class Window(object):
         values directly.
 
         :param start: boundary start, inclusive.
-                      The frame is unbounded if this is ``Window.unboundedPreceding``, or
+                      The frame is unbounded if this is ``Window.unboundedPreceding``,
+                      ``org.apache.spark.sql.catalyst.expressions.UnboundedPreceding``, or
                       any value less than or equal to max(-sys.maxsize, -9223372036854775808).
         :param end: boundary end, inclusive.
-                    The frame is unbounded if this is ``Window.unboundedFollowing``, or
+                    The frame is unbounded if this is ``Window.unboundedFollowing``,
+                     org.apache.spark.sql.catalyst.expressions.UnboundedPFollowing, or
                     any value greater than or equal to min(sys.maxsize, 9223372036854775807).
         """
-        if start <= Window._PRECEDING_THRESHOLD:
-            start = Window.unboundedPreceding
-        if end >= Window._FOLLOWING_THRESHOLD:
-            end = Window.unboundedFollowing
+        if isinstance(start, long) and isinstance(end, long):
+            if start <= Window._PRECEDING_THRESHOLD:
+                start = Window.unboundedPreceding
+            if end >= Window._FOLLOWING_THRESHOLD:
+                end = Window.unboundedFollowing
         sc = SparkContext._active_spark_context
         jspec = sc._jvm.org.apache.spark.sql.expressions.Window.rangeBetween(start, end)
         return WindowSpec(jspec)
@@ -212,16 +215,19 @@ class WindowSpec(object):
         values directly.
 
         :param start: boundary start, inclusive.
-                      The frame is unbounded if this is ``Window.unboundedPreceding``, or
+                      The frame is unbounded if this is ``Window.unboundedPreceding``,
+                      ``org.apache.spark.sql.catalyst.expressions.UnboundedPreceding``, or
                       any value less than or equal to max(-sys.maxsize, -9223372036854775808).
         :param end: boundary end, inclusive.
-                    The frame is unbounded if this is ``Window.unboundedFollowing``, or
+                    The frame is unbounded if this is ``Window.unboundedFollowing``,
+                    ``org.apache.spark.sql.catalyst.expressions.UnboundedFollowing``, or
                     any value greater than or equal to min(sys.maxsize, 9223372036854775807).
         """
-        if start <= Window._PRECEDING_THRESHOLD:
-            start = Window.unboundedPreceding
-        if end >= Window._FOLLOWING_THRESHOLD:
-            end = Window.unboundedFollowing
+        if isinstance(start, long) and isinstance(end, long):
+            if start <= Window._PRECEDING_THRESHOLD:
+                start = Window.unboundedPreceding
+            if end >= Window._FOLLOWING_THRESHOLD:
+                end = Window.unboundedFollowing
         return WindowSpec(self._jspec.rangeBetween(start, end))
 
 

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -129,7 +129,7 @@ class Window(object):
                       any value less than or equal to max(-sys.maxsize, -9223372036854775808).
         :param end: boundary end, inclusive.
                     The frame is unbounded if this is ``Window.unboundedFollowing``,
-                     org.apache.spark.sql.catalyst.expressions.UnboundedPFollowing, or
+                    ``org.apache.spark.sql.catalyst.expressions.UnboundedPFollowing``, or
                     any value greater than or equal to min(sys.maxsize, 9223372036854775807).
         """
         if isinstance(start, long) and isinstance(end, long):

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -16,6 +16,8 @@
 #
 
 import sys
+if sys.version >= '3':
+    long = int
 
 from pyspark import since, SparkContext
 from pyspark.sql.column import _to_seq, _to_java_column
@@ -129,10 +131,11 @@ class Window(object):
                       any value less than or equal to max(-sys.maxsize, -9223372036854775808).
         :param end: boundary end, inclusive.
                     The frame is unbounded if this is ``Window.unboundedFollowing``,
-                    ``org.apache.spark.sql.catalyst.expressions.UnboundedPFollowing``, or
+                    ``org.apache.spark.sql.catalyst.expressions.UnboundedFollowing``, or
                     any value greater than or equal to min(sys.maxsize, 9223372036854775807).
+                    any value greater than or equal to 9223372036854775807.
         """
-        if isinstance(start, int) and isinstance(end, int):
+        if isinstance(start, (int, long)) and isinstance(end, (int, long)):
             if start <= Window._PRECEDING_THRESHOLD:
                 start = Window.unboundedPreceding
             if end >= Window._FOLLOWING_THRESHOLD:
@@ -222,8 +225,9 @@ class WindowSpec(object):
                     The frame is unbounded if this is ``Window.unboundedFollowing``,
                     ``org.apache.spark.sql.catalyst.expressions.UnboundedFollowing``, or
                     any value greater than or equal to min(sys.maxsize, 9223372036854775807).
+
         """
-        if isinstance(start, int) and isinstance(end, int):
+        if isinstance(start, (int, long)) and isinstance(end, (int, long)):
             if start <= Window._PRECEDING_THRESHOLD:
                 start = Window.unboundedPreceding
             if end >= Window._FOLLOWING_THRESHOLD:

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -152,7 +152,6 @@ class Window(object):
         |  1|       a|  4|
         |  2|       a|  2|
         +---+--------+---+
-        <BLANKLINE>
         """
         if isinstance(start, (int, long)) and isinstance(end, (int, long)):
             if start <= Window._PRECEDING_THRESHOLD:
@@ -263,7 +262,7 @@ class WindowSpec(object):
 def _test():
     import doctest
     SparkContext('local[4]', 'PythonTest')
-    (failure_count, test_count) = doctest.testmod()
+    (failure_count, test_count) = doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
     if failure_count:
         exit(-1)
 


### PR DESCRIPTION


## What changes were proposed in this pull request?

Added unboundedPreceding(), unboundedFollowing() and currentRow() to PySpark, also updated the rangeBetween API

## How was this patch tested?

did unit test on my local. Please let me know if I need to add unit test in tests.py
