### PR TITLE
[SPARK-23228][PYSPARK] Add Python Created jsparkSession to JVM's defaultSession

### DIFF
--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -400,8 +400,6 @@ class SparkContext(object):
         """
         if getattr(self, "_jsc", None):
             try:
-                # We should clean the default session up. See SPARK-23228.
-                self._jvm.SparkSession.clearDefaultSession()
                 self._jsc.stop()
             except Py4JError:
                 # Case: SPARK-18523

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -400,6 +400,8 @@ class SparkContext(object):
         """
         if getattr(self, "_jsc", None):
             try:
+                # We should clean the default session up. See SPARK-23228.
+                self._jvm.SparkSession.clearDefaultSession()
                 self._jsc.stop()
             except Py4JError:
                 # Case: SPARK-18523

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -213,7 +213,8 @@ class SparkSession(object):
         self._jsc = self._sc._jsc
         self._jvm = self._sc._jvm
         if jsparkSession is None:
-            if self._jvm.SparkSession.getDefaultSession().isDefined():
+            if self._jvm.SparkSession.getDefaultSession().isDefined() \
+                and not self._jvm.SparkSession.getDefaultSession().get().sparkContext().isStopped():
                 jsparkSession = self._jvm.SparkSession.getDefaultSession().get()
             else:
                 jsparkSession = self._jvm.SparkSession(self._jsc.sc())
@@ -228,7 +229,8 @@ class SparkSession(object):
         if SparkSession._instantiatedSession is None \
                 or SparkSession._instantiatedSession._sc._jsc is None:
             SparkSession._instantiatedSession = self
-            if self._jvm.SparkSession.getDefaultSession().isEmpty():
+            if self._jvm.SparkSession.getDefaultSession().isEmpty() \
+                or not jsparkSession.equals(self._jvm.SparkSession.getDefaultSession().get()):
                 self._jvm.SparkSession.setDefaultSession(self._jsparkSession)
 
     def _repr_html_(self):

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -230,9 +230,7 @@ class SparkSession(object):
         if SparkSession._instantiatedSession is None \
                 or SparkSession._instantiatedSession._sc._jsc is None:
             SparkSession._instantiatedSession = self
-            if self._jvm.SparkSession.getDefaultSession().isEmpty() \
-                    or not jsparkSession.equals(self._jvm.SparkSession.getDefaultSession().get()):
-                self._jvm.SparkSession.setDefaultSession(self._jsparkSession)
+            self._jvm.SparkSession.setDefaultSession(self._jsparkSession)
 
     def _repr_html_(self):
         return """

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -215,7 +215,7 @@ class SparkSession(object):
         if jsparkSession is None:
             if self._jvm.SparkSession.getDefaultSession().isDefined() \
                     and not self._jvm.SparkSession.getDefaultSession().get() \
-                            .sparkContext().isStopped():
+                        .sparkContext().isStopped():
                 jsparkSession = self._jvm.SparkSession.getDefaultSession().get()
             else:
                 jsparkSession = self._jvm.SparkSession(self._jsc.sc())

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -214,7 +214,8 @@ class SparkSession(object):
         self._jvm = self._sc._jvm
         if jsparkSession is None:
             if self._jvm.SparkSession.getDefaultSession().isDefined() \
-                and not self._jvm.SparkSession.getDefaultSession().get().sparkContext().isStopped():
+                    and not self._jvm.SparkSession.getDefaultSession().get() \
+                            .sparkContext().isStopped():
                 jsparkSession = self._jvm.SparkSession.getDefaultSession().get()
             else:
                 jsparkSession = self._jvm.SparkSession(self._jsc.sc())
@@ -230,7 +231,7 @@ class SparkSession(object):
                 or SparkSession._instantiatedSession._sc._jsc is None:
             SparkSession._instantiatedSession = self
             if self._jvm.SparkSession.getDefaultSession().isEmpty() \
-                or not jsparkSession.equals(self._jvm.SparkSession.getDefaultSession().get()):
+                    or not jsparkSession.equals(self._jvm.SparkSession.getDefaultSession().get()):
                 self._jvm.SparkSession.setDefaultSession(self._jsparkSession)
 
     def _repr_html_(self):

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -225,6 +225,7 @@ class SparkSession(object):
         if SparkSession._instantiatedSession is None \
                 or SparkSession._instantiatedSession._sc._jsc is None:
             SparkSession._instantiatedSession = self
+            self._jvm.org.apache.spark.sql.SparkSession.setDefaultSession(self._jsparkSession)
 
     def _repr_html_(self):
         return """

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -767,6 +767,8 @@ class SparkSession(object):
         """Stop the underlying :class:`SparkContext`.
         """
         self._sc.stop()
+        # We should clean the default session up. See SPARK-23228.
+        self._jvm.SparkSession.clearDefaultSession()
         SparkSession._instantiatedSession = None
 
     @since(2.0)

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -764,7 +764,6 @@ class SparkSession(object):
         """Stop the underlying :class:`SparkContext`.
         """
         self._sc.stop()
-        self._jvm.SparkSession.clearDefaultSession()
         SparkSession._instantiatedSession = None
 
     @since(2.0)

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -69,7 +69,7 @@ from pyspark.sql.types import UserDefinedType, _infer_type, _make_type_verifier
 from pyspark.sql.types import _array_signed_int_typecode_ctype_mappings, _array_type_mappings
 from pyspark.sql.types import _array_unsigned_int_typecode_ctype_mappings
 from pyspark.sql.types import _merge_type
-from pyspark.tests import QuietTest, ReusedPySparkTestCase, SparkSubmitTests
+from pyspark.tests import QuietTest, ReusedPySparkTestCase, PySparkTestCase, SparkSubmitTests
 from pyspark.sql.functions import UserDefinedFunction, sha2, lit
 from pyspark.sql.window import Window
 from pyspark.sql.utils import AnalysisException, ParseException, IllegalArgumentException
@@ -202,48 +202,6 @@ class ReusedSQLTestCase(ReusedPySparkTestCase):
                "\n\nExpected:\n%s\n%s" % (expected, expected.dtypes) +
                "\n\nResult:\n%s\n%s" % (result, result.dtypes))
         self.assertTrue(expected.equals(result), msg=msg)
-
-
-class PySparkSessionTests(unittest.TestCase):
-
-    def test_set_jvm_default_session(self):
-        spark = None
-        sc = None
-        try:
-            sc = SparkContext('local[4]', "test_spark_session")
-            spark = SparkSession(sc)
-            self.assertTrue(spark._jvm.SparkSession.getDefaultSession().isDefined())
-        finally:
-            if spark is not None:
-                spark.stop()
-                self.assertTrue(spark._jvm.SparkSession.getDefaultSession().isEmpty())
-                spark = None
-                sc = None
-
-            if sc is not None:
-                sc.stop()
-                sc = None
-
-    def test_jvm_default_session_already_set(self):
-        spark = None
-        sc = None
-        try:
-            sc = SparkContext('local[4]', "test_spark_session")
-            jsession = sc._jvm.SparkSession(sc._jsc.sc())
-            sc._jvm.SparkSession.setDefaultSession(jsession)
-
-            spark = SparkSession(sc, jsession)
-            self.assertTrue(spark._jvm.SparkSession.getDefaultSession().isDefined())
-            self.assertTrue(jsession.equals(spark._jvm.SparkSession.getDefaultSession().get()))
-        finally:
-            if spark is not None:
-                spark.stop()
-                spark = None
-                sc = None
-
-            if sc is not None:
-                sc.stop()
-                sc = None
 
 
 class DataTypeTests(unittest.TestCase):
@@ -2952,6 +2910,32 @@ class SQLTests2(ReusedSQLTestCase):
         finally:
             spark.stop()
             sc.stop()
+
+
+class SparkSessionTests(PySparkTestCase):
+
+    # This test is separate because it's closely related with session's start and stop.
+    # See SPARK-23228.
+    def test_set_jvm_default_session(self):
+        spark = SparkSession.builder.getOrCreate()
+        try:
+            self.assertTrue(spark._jvm.SparkSession.getDefaultSession().isDefined())
+        finally:
+            spark.stop()
+            self.assertTrue(spark._jvm.SparkSession.getDefaultSession().isEmpty())
+
+    def test_jvm_default_session_already_set(self):
+        # Here, we assume there is the default session already set in JVM.
+        jsession = self.sc._jvm.SparkSession(self.sc._jsc.sc())
+        self.sc._jvm.SparkSession.setDefaultSession(jsession)
+
+        spark = SparkSession.builder.getOrCreate()
+        try:
+            self.assertTrue(spark._jvm.SparkSession.getDefaultSession().isDefined())
+            # The session should be the same with the exiting one.
+            self.assertTrue(jsession.equals(spark._jvm.SparkSession.getDefaultSession().get()))
+        finally:
+            spark.stop()
 
 
 class UDFInitializationTests(unittest.TestCase):


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the current PySpark code, Python created `jsparkSession` doesn't add to JVM's defaultSession, this `SparkSession` object cannot be fetched from Java side, so the below scala code will be failed when loaded in PySpark application.

```scala
class TestSparkSession extends SparkListener with Logging {
  override def onOtherEvent(event: SparkListenerEvent): Unit = {
    event match {
      case CreateTableEvent(db, table) =>
        val session = SparkSession.getActiveSession.orElse(SparkSession.getDefaultSession)
        assert(session.isDefined)
        val tableInfo = session.get.sharedState.externalCatalog.getTable(db, table)
        logInfo(s"Table info ${tableInfo}")

      case e =>
        logInfo(s"event $e")

    }
  }
}
```

So here propose to add fresh create `jsparkSession` to `defaultSession`.

## How was this patch tested?

Manual verification.
