### PR TITLE
[SPARK-23229][SQL] Dataset.hint should use planWithBarrier logical plan

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -192,7 +192,7 @@ class Dataset[T] private[sql](
   }
 
   // Wraps analyzed logical plans with an analysis barrier so we won't traverse/resolve it again.
-  @transient private val planWithBarrier = AnalysisBarrier(logicalPlan)
+  @transient private[sql] val planWithBarrier = AnalysisBarrier(logicalPlan)
 
   /**
    * Currently [[ExpressionEncoder]] is the only implementation of [[Encoder]], here we turn the
@@ -1216,7 +1216,7 @@ class Dataset[T] private[sql](
    */
   @scala.annotation.varargs
   def hint(name: String, parameters: Any*): Dataset[T] = withTypedPlan {
-    UnresolvedHint(name, parameters, logicalPlan)
+    UnresolvedHint(name, parameters, planWithBarrier)
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameHintSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameHintSuite.scala
@@ -35,27 +35,23 @@ class DataFrameHintSuite extends AnalysisTest with SharedSQLContext {
   test("various hint parameters") {
     check(
       df.hint("hint1"),
-      UnresolvedHint("hint1", Seq(),
-        df.logicalPlan
-      )
+      UnresolvedHint("hint1", Seq(), df.planWithBarrier)
     )
 
     check(
       df.hint("hint1", 1, "a"),
-      UnresolvedHint("hint1", Seq(1, "a"), df.logicalPlan)
+      UnresolvedHint("hint1", Seq(1, "a"), df.planWithBarrier)
     )
 
     check(
       df.hint("hint1", 1, $"a"),
-      UnresolvedHint("hint1", Seq(1, $"a"),
-        df.logicalPlan
-      )
+      UnresolvedHint("hint1", Seq(1, $"a"), df.planWithBarrier)
     )
 
     check(
       df.hint("hint1", Seq(1, 2, 3), Seq($"a", $"b", $"c")),
       UnresolvedHint("hint1", Seq(Seq(1, 2, 3), Seq($"a", $"b", $"c")),
-        df.logicalPlan
+        df.planWithBarrier
       )
     )
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Every time `Dataset.hint` is used it triggers execution of logical commands, their unions and hint resolution (among other things that analyzer does).

`hint` should use `planWithBarrier` instead.

Fixes https://issues.apache.org/jira/browse/SPARK-23229

## How was this patch tested?

Existing unit tests, local build + awaiting Jenkins