### PR TITLE
[SPARK-23124][SQL] Allow to disable BroadcastNestedLoopJoin fallback

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -156,6 +156,15 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val ALLOW_NESTEDJOIN_FALLBACK = buildConf("spark.sql.join.broadcastJoinFallback.enabled")
+    .internal()
+    .doc("When true (default), if the other options are not available, fallback to try and use " +
+      "BroadcastNestedLoopJoin as join strategy. This can cause OOM which can be a problem " +
+      "in some scenarios, eg. when running the thriftserver. Turn to false to disable it: an " +
+      "AnalysisException will be thrown.")
+    .booleanConf
+    .createWithDefault(true)
+
   val RADIX_SORT_ENABLED = buildConf("spark.sql.sort.enableRadixSort")
     .internal()
     .doc("When true, enable use of radix sort when possible. Radix sort is much faster but " +
@@ -1325,6 +1334,8 @@ class SQLConf extends Serializable with Logging {
   def fallBackToHdfsForStatsEnabled: Boolean = getConf(ENABLE_FALL_BACK_TO_HDFS_FOR_STATS)
 
   def preferSortMergeJoin: Boolean = getConf(PREFER_SORTMERGEJOIN)
+
+  def allowNestedJoinFallback: Boolean = getConf(ALLOW_NESTEDJOIN_FALLBACK)
 
   def enableRadixSort: Boolean = getConf(RADIX_SORT_ENABLED)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In JoinStrategies, currently if no better option is available, it fallbacks to BroadcastNestedLoopJoin. This strategy can be very problematic, since it can cause OOM. While generally this is not a big problem, in some applications like Thriftserver this is an issue, because a failing job can cause the whole application to go in a bad state. Thus, in these cases, it might be useful to be able to disable this behavior and allow to fail only the jobs which can cause it.

## How was this patch tested?

added UT
