### PR TITLE
[SPARK-23233][PYTHON] Reset the cache in asNondeterministic to set deterministic properly

### DIFF
--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -188,6 +188,9 @@ class UserDefinedFunction(object):
 
         .. versionadded:: 2.3
         """
+        # Here, we explicitly clean the cache to create a JVM UDF instance
+        # with 'deterministic' updated. See SPARK-23233.
+        self._judf_placeholder = None
         self.deterministic = False
         return self
 


### PR DESCRIPTION
## What changes were proposed in this pull request?


Reproducer:

```python
from pyspark.sql.functions import udf
f = udf(lambda x: x)
spark.range(1).select(f("id"))  # cache JVM UDF instance.
f = f.asNondeterministic()
spark.range(1).select(f("id"))._jdf.logicalPlan().projectList().head().deterministic()
```

It should return `False` but the current master returns `True`. Seems it's because we cache the JVM UDF instance and then we reuse it even after setting `deterministic` disabled once it's called.

## How was this patch tested?

Manually tested. I am not sure if I should add the test with a lot of JVM accesses with the intetnal stuff .. Let me know if anyone feels so. I will add. 
