### PR TITLE
[SPARK-23234][ML][PYSPARK] Remove setting defaults on Java params

### DIFF
--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -118,10 +118,9 @@ class JavaParams(JavaWrapper, Params):
         """
         Transforms the embedded params to the companion Java object.
         """
-        paramMap = self.extractParamMap()
         for param in self.params:
-            if param in paramMap:
-                pair = self._make_java_param_pair(param, paramMap[param])
+            if param in self._paramMap:
+                pair = self._make_java_param_pair(param, self._paramMap[param])
                 self._java_obj.set(pair)
 
     def _transfer_param_map_to_java(self, pyParamMap):


### PR DESCRIPTION
## What changes were proposed in this pull request?

SPARK-22799 and SPARK-22797 are causing valid Python test failures. The reason is that Python is setting the default params with set. So an outputCol value is always set by the Python API for Bucketizer.

## How was this patch tested?

passing failing UTs
