### PR TITLE
[SPARK-17139][ML][FOLLOW-UP] update LogisticRegressionSummaryExample code

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/ml/LogisticRegressionSummaryExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/LogisticRegressionSummaryExample.scala
@@ -57,7 +57,7 @@ object LogisticRegressionSummaryExample {
     // Obtain the metrics useful to judge performance on test data.
     // We cast the summary to a BinaryLogisticRegressionSummary since the problem is a
     // binary classification problem.
-    val binarySummary = trainingSummary.asInstanceOf[BinaryLogisticRegressionSummary]
+    val binarySummary = trainingSummary.asBinary
 
     // Obtain the receiver-operating characteristic as a dataframe and areaUnderROC.
     val roc = binarySummary.roc


### PR DESCRIPTION
## What changes were proposed in this pull request?

New method `trainingSummary.asBinary` added so in this example change
`.asInstanceOf[BinaryLogisticRegressionSummary]` to `.asBinary`

## How was this patch tested?

N/A