### PR TITLE
[SPARK-23253][Core][Shuffle]Only write shuffle temporary index file when there is not an existing one

### DIFF
--- a/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
@@ -141,19 +141,6 @@ private[spark] class IndexShuffleBlockResolver(
     val indexFile = getIndexFile(shuffleId, mapId)
     val indexTmp = Utils.tempFileWith(indexFile)
     try {
-      val out = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(indexTmp)))
-      Utils.tryWithSafeFinally {
-        // We take in lengths of each block, need to convert it to offsets.
-        var offset = 0L
-        out.writeLong(offset)
-        for (length <- lengths) {
-          offset += length
-          out.writeLong(offset)
-        }
-      } {
-        out.close()
-      }
-
       val dataFile = getDataFile(shuffleId, mapId)
       // There is only one IndexShuffleBlockResolver per executor, this synchronization make sure
       // the following check and rename are atomic.
@@ -166,8 +153,20 @@ private[spark] class IndexShuffleBlockResolver(
           if (dataTmp != null && dataTmp.exists()) {
             dataTmp.delete()
           }
-          indexTmp.delete()
         } else {
+          val out = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(indexTmp)))
+          Utils.tryWithSafeFinally {
+            // We take in lengths of each block, need to convert it to offsets.
+            var offset = 0L
+            out.writeLong(offset)
+            for (length <- lengths) {
+              offset += length
+              out.writeLong(offset)
+            }
+          } {
+            out.close()
+          }
+
           // This is the first successful attempt in writing the map outputs for this task,
           // so override any existing index and data files with the ones we wrote.
           if (indexFile.exists()) {

--- a/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
@@ -154,6 +154,8 @@ private[spark] class IndexShuffleBlockResolver(
             dataTmp.delete()
           }
         } else {
+          // This is the first successful attempt in writing the map outputs for this task,
+          // so override any existing index and data files with the ones we wrote.
           val out = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(indexTmp)))
           Utils.tryWithSafeFinally {
             // We take in lengths of each block, need to convert it to offsets.
@@ -167,8 +169,6 @@ private[spark] class IndexShuffleBlockResolver(
             out.close()
           }
 
-          // This is the first successful attempt in writing the map outputs for this task,
-          // so override any existing index and data files with the ones we wrote.
           if (indexFile.exists()) {
             indexFile.delete()
           }

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
@@ -123,7 +123,6 @@ class IndexShuffleBlockResolverSuite extends SparkFunSuite with BeforeAndAfterEa
       indexIn.close()
     }
 
-
     // remove data file
     dataFile.delete()
 

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.shuffle.sort
 
-import java.io._
+import java.io.{File, FileInputStream, FileOutputStream}
 
 import org.mockito.{Mock, MockitoAnnotations}
 import org.mockito.Answers.RETURNS_SMART_NULLS
@@ -115,15 +115,15 @@ class IndexShuffleBlockResolverSuite extends SparkFunSuite with BeforeAndAfterEa
     assert(firstByte(0) === 0)
 
     // The index file should not change
-    val secondBytes = new Array[Byte](8)
+    val secondValueOffset = new Array[Byte](8)
     val indexIn = new FileInputStream(indexFile)
     Utils.tryWithSafeFinally {
-      indexIn.read(secondBytes)
-      indexIn.read(secondBytes)
+      indexIn.read(secondValueOffset)
+      indexIn.read(secondValueOffset)
     } {
       indexIn.close()
     }
-    assert(secondBytes(7) === 10, "The index file should not change")
+    assert(secondValueOffset(7) === 10, "The index file should not change")
 
     // remove data file
     dataFile.delete()
@@ -156,11 +156,11 @@ class IndexShuffleBlockResolverSuite extends SparkFunSuite with BeforeAndAfterEa
     // The index file should be updated, since we deleted the dataFile from the first attempt
     val indexIn2 = new FileInputStream(indexFile)
     Utils.tryWithSafeFinally {
-      indexIn2.read(secondBytes)
-      indexIn2.read(secondBytes)
+      indexIn2.read(secondValueOffset)
+      indexIn2.read(secondValueOffset)
     } {
       indexIn2.close()
     }
-    assert(secondBytes(7) === 7, "The index file should be updated")
+    assert(secondValueOffset(7) === 7, "The index file should be updated")
   }
 }


### PR DESCRIPTION

## What changes were proposed in this pull request?

Shuffle Index temporay file is used for atomic creating shuffle index file, it is not needed when the index file already exists after another attempts of same task had it done.

## How was this patch tested?

exitsting ut

cc @squito 