### PR TITLE
[Spark-23240][python] Better error message when extraneous data in pyspark.daemon's stdout

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.api.python
 
-import java.io._
+import java.io.{DataInputStream, DataOutputStream, EOFException, InputStream, OutputStreamWriter}
 import java.net.{InetAddress, ServerSocket, Socket, SocketException}
 import java.nio.charset.StandardCharsets
 import java.util.Arrays
@@ -196,7 +196,7 @@ private[spark] class PythonWorkerFactory(pythonExec: String, envVars: Map[String
           daemonPort = in.readInt()
         } catch {
           case _: EOFException =>
-            throw new IOException(s"No port number in $daemonModule's stdout")
+            throw new SparkException(s"No port number in $daemonModule's stdout")
         }
 
         // test that the returned port number is within a valid range.
@@ -204,13 +204,16 @@ private[spark] class PythonWorkerFactory(pythonExec: String, envVars: Map[String
         // is arbitrary data but is also coincidentally within range
         if (daemonPort < 1 || daemonPort > 0xffff) {
           val exceptionMessage = f"""
-               |Bad data in  $daemonModule's standard output.
-               |Expected valid port number, got 0x$daemonPort%08x.
-               |PYTHONPATH set to '$pythonPath'
-               |Python command is '${command.asScala.mkString(" ")}'
-               |One possibility is a sitecustomize.py module in your python installation
-               |that is printing to stdout"""
-          throw new IOException(exceptionMessage.stripMargin)
+               |Bad data in $daemonModule's standard output. Invalid port number:
+               |  $daemonPort (0x$daemonPort%08x)
+               |Python command to execute the daemon was:
+               |  ${command.asScala.mkString(" ")}
+               |Check that you don't have any unexpected modules or libraries in
+               |your PYTHONPATH:
+               |  $pythonPath
+               |Also, check if you have a sitecustomize.py module in your python path,
+               |or in your python installation, that is printing to standard output"""
+          throw new SparkException(exceptionMessage.stripMargin)
         }
 
         // Redirect daemon stdout and stderr

--- a/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.api.python
 
 import java.io._
-import java.net._
+import java.net.{InetAddress, ServerSocket, Socket, SocketException}
 import java.nio.charset.StandardCharsets
 import java.util.Arrays
 

--- a/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
@@ -204,15 +204,15 @@ private[spark] class PythonWorkerFactory(pythonExec: String, envVars: Map[String
         // is arbitrary data but is also coincidentally within range
         if (daemonPort < 1 || daemonPort > 0xffff) {
           val exceptionMessage = f"""
-               |Bad data in $daemonModule's standard output. Invalid port number:
-               |  $daemonPort (0x$daemonPort%08x)
-               |Python command to execute the daemon was:
-               |  ${command.asScala.mkString(" ")}
-               |Check that you don't have any unexpected modules or libraries in
-               |your PYTHONPATH:
-               |  $pythonPath
-               |Also, check if you have a sitecustomize.py module in your python path,
-               |or in your python installation, that is printing to standard output"""
+            |Bad data in $daemonModule's standard output. Invalid port number:
+            |  $daemonPort (0x$daemonPort%08x)
+            |Python command to execute the daemon was:
+            |  ${command.asScala.mkString(" ")}
+            |Check that you don't have any unexpected modules or libraries in
+            |your PYTHONPATH:
+            |  $pythonPath
+            |Also, check if you have a sitecustomize.py module in your python path,
+            |or in your python installation, that is printing to standard output"""
           throw new SparkException(exceptionMessage.stripMargin)
         }
 

--- a/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
@@ -208,7 +208,8 @@ private[spark] class PythonWorkerFactory(pythonExec: String, envVars: Map[String
                |Expected valid port number, got 0x$daemonPort%08x.
                |PYTHONPATH set to '$pythonPath'
                |Python command is '${command.asScala.mkString(" ")}'
-               |Check if you have a sitecustomize.py module in your python installation."""
+               |One possibility is a sitecustomize.py module in your python installation
+               |that is printing to stdout"""
           throw new IOException(exceptionMessage.stripMargin)
         }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Print more helpful message when daemon module's stdout is empty or contains a bad port number. 

## How was this patch tested?

Manually recreated the environmental issues that caused the mysterious exceptions at one site. Tested that the expected messages are logged.

Also, ran all scala unit tests.

Please review http://spark.apache.org/contributing.html before opening a pull request.
