### PR TITLE
[SPARK-23259][SQL] Clean up legacy code around hive external catalog and HiveClientImpl

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -114,7 +114,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
    * should interpret these special data source properties and restore the original table metadata
    * before returning it.
    */
-  private[hive] def getRawTable(db: String, table: String): CatalogTable = withClient {
+  private[hive] def getRawTable(db: String, table: String): CatalogTable = {
     client.getTable(db, table)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Three legacy statements are removed by this patch:

- in HiveExternalCatalog: The `withClient` wrapper is not necessary for the private method `getRawTable`. 

- in HiveClientImpl: The statement `runSqlHive()` is not necessary for the `addJar` method, after the jar being added to the single class loader.

- in HiveClientImpl: There are some redundant code in both the `tableExists` and `getTableOption` method.

## How was this patch tested?

Existing tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
