### PR TITLE
[SPARK-23174][BUILD][PYTHON][FOLLOWUP] Add pycodestyle*.py to .gitignore file.

### DIFF
--- a/dev/.gitignore
+++ b/dev/.gitignore
@@ -1,1 +1,2 @@
 pep8*.py
+pycodestyle*.py


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a follow-up pr of #20338 which changed the downloaded file name of the python code style checker but it's not contained in .gitignore file so the file remains as an untracked file for git after running the checker.
This pr adds the file name to .gitignore file.

## How was this patch tested?

Tested manually.
