### PR TITLE
[SPARK-23272][SQL] add calendar interval type support to ColumnVector

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/CalendarInterval.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/CalendarInterval.java
@@ -87,7 +87,7 @@ public final class CalendarInterval implements Serializable {
     }
   }
 
-  public static long toLongWithRange(String fieldName,
+  private static long toLongWithRange(String fieldName,
       String s, long minValue, long maxValue) throws IllegalArgumentException {
     long result = 0;
     if (s != null) {
@@ -235,7 +235,7 @@ public final class CalendarInterval implements Serializable {
   /**
    * Parse second_nano string in ss.nnnnnnnnn format to microseconds
    */
-  public static long parseSecondNano(String secondNano) throws IllegalArgumentException {
+  private static long parseSecondNano(String secondNano) throws IllegalArgumentException {
     String[] parts = secondNano.split("\\.");
     if (parts.length == 1) {
       return toLongWithRange("second", parts[0], Long.MIN_VALUE / MICROS_PER_SECOND,

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/CalendarInterval.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/CalendarInterval.java
@@ -87,7 +87,7 @@ public final class CalendarInterval implements Serializable {
     }
   }
 
-  private static long toLongWithRange(String fieldName,
+  public static long toLongWithRange(String fieldName,
       String s, long minValue, long maxValue) throws IllegalArgumentException {
     long result = 0;
     if (s != null) {
@@ -235,7 +235,7 @@ public final class CalendarInterval implements Serializable {
   /**
    * Parse second_nano string in ss.nnnnnnnnn format to microseconds
    */
-  private static long parseSecondNano(String secondNano) throws IllegalArgumentException {
+  public static long parseSecondNano(String secondNano) throws IllegalArgumentException {
     String[] parts = secondNano.split("\\.");
     if (parts.length == 1) {
       return toLongWithRange("second", parts[0], Long.MIN_VALUE / MICROS_PER_SECOND,

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/MutableColumnarRow.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/MutableColumnarRow.java
@@ -146,9 +146,7 @@ public final class MutableColumnarRow extends InternalRow {
   @Override
   public CalendarInterval getInterval(int ordinal) {
     if (columns[ordinal].isNullAt(rowId)) return null;
-    final int months = columns[ordinal].getChild(0).getInt(rowId);
-    final long microseconds = columns[ordinal].getChild(1).getLong(rowId);
-    return new CalendarInterval(months, microseconds);
+    return columns[ordinal].getInterval(rowId);
   }
 
   @Override

--- a/sql/core/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
@@ -28,7 +28,7 @@ import org.apache.spark.sql.types.*;
 import org.apache.spark.unsafe.types.UTF8String;
 
 /**
- * A column vector backed by Apache Arrow. Currently time interval type and map type are not
+ * A column vector backed by Apache Arrow. Currently calendar interval type and map type are not
  * supported.
  */
 @InterfaceStability.Evolving

--- a/sql/core/src/main/java/org/apache/spark/sql/vectorized/ColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/vectorized/ColumnVector.java
@@ -242,11 +242,11 @@ public abstract class ColumnVector implements AutoCloseable {
    *
    * In Spark, calendar interval type value is basically an integer value representing the number of
    * months in this interval, and a long value representing the number of microseconds in this
-   * interval. A interval type vector is same as a struct type vector with 2 fields: `months` and
-   * `microseconds`.
+   * interval. An interval type vector is the same as a struct type vector with 2 fields: `months`
+   * and `microseconds`.
    *
    * To support interval type, implementations must implement {@link #getChild(int)} and define 2
-   * child vectors: the first child vector is a int type vector, containing all the month values of
+   * child vectors: the first child vector is an int type vector, containing all the month values of
    * all the interval values in this vector. The second child vector is a long type vector,
    * containing all the microsecond values of all the interval values in this vector.
    */
@@ -258,7 +258,7 @@ public abstract class ColumnVector implements AutoCloseable {
   }
 
   /**
-   * Returns the ordinal's child column vector.
+   * @return child [[ColumnVector]] at the given ordinal.
    */
   protected abstract ColumnVector getChild(int ordinal);
 

--- a/sql/core/src/main/java/org/apache/spark/sql/vectorized/ColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/vectorized/ColumnVector.java
@@ -20,6 +20,7 @@ import org.apache.spark.annotation.InterfaceStability;
 import org.apache.spark.sql.catalyst.util.MapData;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.unsafe.types.CalendarInterval;
 import org.apache.spark.unsafe.types.UTF8String;
 
 /**
@@ -195,6 +196,7 @@ public abstract class ColumnVector implements AutoCloseable {
    * struct field.
    */
   public final ColumnarRow getStruct(int rowId) {
+    if (isNullAt(rowId)) return null;
     return new ColumnarRow(this, rowId);
   }
 
@@ -236,9 +238,29 @@ public abstract class ColumnVector implements AutoCloseable {
   public abstract byte[] getBinary(int rowId);
 
   /**
+   * Returns the calendar interval type value for rowId.
+   *
+   * In Spark, calendar interval type value is basically an integer value representing the number of
+   * months in this interval, and a long value representing the number of microseconds in this
+   * interval. A interval type vector is same as a struct type vector with 2 fields: `months` and
+   * `microseconds`.
+   *
+   * To support interval type, implementations must implement {@link #getChild(int)} and define 2
+   * child vectors: the first child vector is a int type vector, containing all the month values of
+   * all the interval values in this vector. The second child vector is a long type vector,
+   * containing all the microsecond values of all the interval values in this vector.
+   */
+  public final CalendarInterval getInterval(int rowId) {
+    if (isNullAt(rowId)) return null;
+    final int months = getChild(0).getInt(rowId);
+    final long microseconds = getChild(1).getLong(rowId);
+    return new CalendarInterval(months, microseconds);
+  }
+
+  /**
    * Returns the ordinal's child column vector.
    */
-  public abstract ColumnVector getChild(int ordinal);
+  protected abstract ColumnVector getChild(int ordinal);
 
   /**
    * Data type for this column.

--- a/sql/core/src/main/java/org/apache/spark/sql/vectorized/ColumnarArray.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/vectorized/ColumnarArray.java
@@ -135,9 +135,7 @@ public final class ColumnarArray extends ArrayData {
 
   @Override
   public CalendarInterval getInterval(int ordinal) {
-    int month = data.getChild(0).getInt(offset + ordinal);
-    long microseconds = data.getChild(1).getLong(offset + ordinal);
-    return new CalendarInterval(month, microseconds);
+    return data.getInterval(offset + ordinal);
   }
 
   @Override

--- a/sql/core/src/main/java/org/apache/spark/sql/vectorized/ColumnarRow.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/vectorized/ColumnarRow.java
@@ -139,9 +139,7 @@ public final class ColumnarRow extends InternalRow {
   @Override
   public CalendarInterval getInterval(int ordinal) {
     if (data.getChild(ordinal).isNullAt(rowId)) return null;
-    final int months = data.getChild(ordinal).getChild(0).getInt(rowId);
-    final long microseconds = data.getChild(ordinal).getChild(1).getLong(rowId);
-    return new CalendarInterval(months, microseconds);
+    return data.getChild(ordinal).getInterval(rowId);
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ColumnVector` is aimed to support all the data types, but `CalendarIntervalType` is missing. Actually we do support interval type for inner fields, e.g. `ColumnarRow`, `ColumnarArray` both support interval type. It's weird if we don't support interval type at the top level.

This PR adds the interval type support.

This PR also makes `ColumnVector.getChild` protect. We need it public because `MutableColumnaRow.getInterval` needs it. Now the interval implementation is in `ColumnVector.getInterval`.

## How was this patch tested?

a new test.