### PR TITLE
[SPARK-23323][SQL]: Support commit coordinator for DataSourceV2 writes

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataSourceWriter.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataSourceWriter.java
@@ -63,6 +63,16 @@ public interface DataSourceWriter {
   DataWriterFactory<Row> createWriterFactory();
 
   /**
+   * Returns whether Spark should use the commit coordinator to ensure that only one attempt for
+   * each task commits.
+   *
+   * @return true if commit coordinator should be used, false otherwise.
+   */
+  default boolean useCommitCoordinator() {
+    return true;
+  }
+
+  /**
    * Handles a commit message on receiving from a successful data writer.
    *
    * If this method fails (by throwing an exception), this writing job is considered to to have been
@@ -79,8 +89,8 @@ public interface DataSourceWriter {
    * is undefined and @{@link #abort(WriterCommitMessage[])} may not be able to deal with it.
    *
    * Note that speculative execution may cause multiple tasks to run for a partition. By default,
-   * Spark uses the OutputCommitCoordinator to allow only one attempt to commit.
-   * {@link DataWriterFactory} implementations can disable this behavior. If disabled, multiple
+   * Spark uses the commit coordinator to allow only one attempt to commit. Implementations can
+   * disable this behavior by overriding {@link #useCommitCoordinator()}. If disabled, multiple
    * attempts may have committed successfully and all successful commit messages are passed to this
    * commit method.
    */

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataSourceWriter.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataSourceWriter.java
@@ -79,10 +79,10 @@ public interface DataSourceWriter {
    * is undefined and @{@link #abort(WriterCommitMessage[])} may not be able to deal with it.
    *
    * Note that speculative execution may cause multiple tasks to run for a partition. By default,
-   * Spark uses the {@link org.apache.spark.scheduler.OutputCommitCoordinator} to allow only one
-   * attempt to commit. {@link DataWriterFactory} implementations can disable this behavior. If
-   * disabled, multiple attempts may have committed successfully and all successful commit messages
-   * are passed to this commit method.
+   * Spark uses the OutputCommitCoordinator to allow only one attempt to commit.
+   * {@link DataWriterFactory} implementations can disable this behavior. If disabled, multiple
+   * attempts may have committed successfully and all successful commit messages are passed to this
+   * commit method.
    */
   void commit(WriterCommitMessage[] messages);
 

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataSourceWriter.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataSourceWriter.java
@@ -63,7 +63,7 @@ public interface DataSourceWriter {
   DataWriterFactory<Row> createWriterFactory();
 
   /**
-   * Returns whether Spark should use the commit coordinator to ensure that only one attempt for
+   * Returns whether Spark should use the commit coordinator to ensure that at most one attempt for
    * each task commits.
    *
    * @return true if commit coordinator should be used, false otherwise.

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataSourceWriter.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataSourceWriter.java
@@ -89,10 +89,10 @@ public interface DataSourceWriter {
    * is undefined and @{@link #abort(WriterCommitMessage[])} may not be able to deal with it.
    *
    * Note that speculative execution may cause multiple tasks to run for a partition. By default,
-   * Spark uses the commit coordinator to allow only one attempt to commit. Implementations can
+   * Spark uses the commit coordinator to allow at most one attempt to commit. Implementations can
    * disable this behavior by overriding {@link #useCommitCoordinator()}. If disabled, multiple
-   * attempts may have committed successfully and all successful commit messages are passed to this
-   * commit method.
+   * attempts may have committed successfully and one successful commit message per task will be
+   * passed to this commit method. The remaining commit messages are ignored by Spark.
    */
   void commit(WriterCommitMessage[] messages);
 

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataSourceWriter.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataSourceWriter.java
@@ -78,10 +78,11 @@ public interface DataSourceWriter {
    * failed, and {@link #abort(WriterCommitMessage[])} would be called. The state of the destination
    * is undefined and @{@link #abort(WriterCommitMessage[])} may not be able to deal with it.
    *
-   * Note that, one partition may have multiple committed data writers because of speculative tasks.
-   * Spark will pick the first successful one and get its commit message. Implementations should be
-   * aware of this and handle it correctly, e.g., have a coordinator to make sure only one data
-   * writer can commit, or have a way to clean up the data of already-committed writers.
+   * Note that speculative execution may cause multiple tasks to run for a partition. By default,
+   * Spark uses the {@link org.apache.spark.scheduler.OutputCommitCoordinator} to allow only one
+   * attempt to commit. {@link DataWriterFactory} implementations can disable this behavior. If
+   * disabled, multiple attempts may have committed successfully and all successful commit messages
+   * are passed to this commit method.
    */
   void commit(WriterCommitMessage[] messages);
 

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataWriterFactory.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataWriterFactory.java
@@ -34,8 +34,8 @@ import org.apache.spark.scheduler.OutputCommitCoordinator;
 public interface DataWriterFactory<T> extends Serializable {
 
   /**
-   * Returns whether Spark should use the {@link OutputCommitCoordinator} to ensure that only one
-   * attempt for each task commits.
+   * Returns whether Spark should use the {@link org.apache.spark.scheduler.OutputCommitCoordinator}
+   * to ensure that only one attempt for each task commits.
    *
    * @return true if commit coordinator should be used, false otherwise.
    */

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataWriterFactory.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataWriterFactory.java
@@ -33,16 +33,6 @@ import org.apache.spark.annotation.InterfaceStability;
 public interface DataWriterFactory<T> extends Serializable {
 
   /**
-   * Returns whether Spark should use the OutputCommitCoordinator to ensure that only one attempt
-   * for each task commits.
-   *
-   * @return true if commit coordinator should be used, false otherwise.
-   */
-  default boolean useCommitCoordinator() {
-    return true;
-  }
-
-  /**
    * Returns a data writer to do the actual writing work.
    *
    * If this method fails (by throwing an exception), the action would fail and no Spark job was

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataWriterFactory.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataWriterFactory.java
@@ -20,6 +20,7 @@ package org.apache.spark.sql.sources.v2.writer;
 import java.io.Serializable;
 
 import org.apache.spark.annotation.InterfaceStability;
+import org.apache.spark.scheduler.OutputCommitCoordinator;
 
 /**
  * A factory of {@link DataWriter} returned by {@link DataSourceWriter#createWriterFactory()},
@@ -31,6 +32,16 @@ import org.apache.spark.annotation.InterfaceStability;
  */
 @InterfaceStability.Evolving
 public interface DataWriterFactory<T> extends Serializable {
+
+  /**
+   * Returns whether Spark should use the {@link OutputCommitCoordinator} to ensure that only one
+   * attempt for each task commits.
+   *
+   * @return true if commit coordinator should be used, false otherwise.
+   */
+  default boolean useCommitCoordinator() {
+    return true;
+  }
 
   /**
    * Returns a data writer to do the actual writing work.

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataWriterFactory.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataWriterFactory.java
@@ -34,8 +34,8 @@ import org.apache.spark.scheduler.OutputCommitCoordinator;
 public interface DataWriterFactory<T> extends Serializable {
 
   /**
-   * Returns whether Spark should use the {@link org.apache.spark.scheduler.OutputCommitCoordinator}
-   * to ensure that only one attempt for each task commits.
+   * Returns whether Spark should use the OutputCommitCoordinator to ensure that only one attempt
+   * for each task commits.
    *
    * @return true if commit coordinator should be used, false otherwise.
    */

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataWriterFactory.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataWriterFactory.java
@@ -20,7 +20,6 @@ package org.apache.spark.sql.sources.v2.writer;
 import java.io.Serializable;
 
 import org.apache.spark.annotation.InterfaceStability;
-import org.apache.spark.scheduler.OutputCommitCoordinator;
 
 /**
  * A factory of {@link DataWriter} returned by {@link DataSourceWriter#createWriterFactory()},

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2.scala
@@ -54,6 +54,7 @@ case class WriteToDataSourceV2Exec(writer: DataSourceWriter, query: SparkPlan) e
       case _ => new InternalRowDataWriterFactory(writer.createWriterFactory(), query.schema)
     }
 
+    val useCommitCoordinator = writer.useCommitCoordinator
     val rdd = query.execute()
     val messages = new Array[WriterCommitMessage](rdd.partitions.length)
 
@@ -74,7 +75,7 @@ case class WriteToDataSourceV2Exec(writer: DataSourceWriter, query: SparkPlan) e
             DataWritingSparkTask.runContinuous(writeTask, context, iter)
         case _ =>
           (context: TaskContext, iter: Iterator[InternalRow]) =>
-            DataWritingSparkTask.run(writeTask, context, iter, writer.useCommitCoordinator)
+            DataWritingSparkTask.run(writeTask, context, iter, useCommitCoordinator)
       }
 
       sparkContext.runJob(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.datasources.v2
 
 import org.apache.spark.{SparkEnv, SparkException, TaskContext}
+import org.apache.spark.executor.CommitDeniedException
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
@@ -117,20 +118,43 @@ object DataWritingSparkTask extends Logging {
       writeTask: DataWriterFactory[InternalRow],
       context: TaskContext,
       iter: Iterator[InternalRow]): WriterCommitMessage = {
-    val dataWriter = writeTask.createDataWriter(context.partitionId(), context.attemptNumber())
+    val stageId = context.stageId()
+    val partId = context.partitionId()
+    val attemptId = context.attemptNumber()
+    val dataWriter = writeTask.createDataWriter(partId, attemptId)
 
     // write the data and commit this writer.
     Utils.tryWithSafeFinallyAndFailureCallbacks(block = {
       iter.foreach(dataWriter.write)
-      logInfo(s"Writer for partition ${context.partitionId()} is committing.")
-      val msg = dataWriter.commit()
-      logInfo(s"Writer for partition ${context.partitionId()} committed.")
+
+      val msg = if (writeTask.useCommitCoordinator) {
+        val coordinator = SparkEnv.get.outputCommitCoordinator
+        val commitAuthorized = coordinator.canCommit(context.stageId(), partId, attemptId)
+        if (commitAuthorized) {
+          logInfo(s"Writer for stage $stageId, task $partId.$attemptId is authorized to commit.")
+          dataWriter.commit()
+
+        } else {
+          val message = s"Stage $stageId, task $partId.$attemptId: driver did not authorize commit"
+          logInfo(message)
+          // throwing CommitDeniedException will trigger the catch block for abort
+          throw new CommitDeniedException(message, stageId, partId, attemptId)
+        }
+
+      } else {
+        logInfo(s"Writer for partition ${context.partitionId()} is committing.")
+        dataWriter.commit()
+      }
+
+      logInfo(s"Writer for stage $stageId, task $partId.$attemptId committed.")
+
       msg
+
     })(catchBlock = {
       // If there is an error, abort this writer
-      logError(s"Writer for partition ${context.partitionId()} is aborting.")
+      logError(s"Writer for stage $stageId, task $partId.$attemptId is aborting.")
       dataWriter.abort()
-      logError(s"Writer for partition ${context.partitionId()} aborted.")
+      logError(s"Writer for stage $stageId, task $partId.$attemptId aborted.")
     })
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2.scala
@@ -135,7 +135,6 @@ object DataWritingSparkTask extends Logging {
         if (commitAuthorized) {
           logInfo(s"Writer for stage $stageId, task $partId.$attemptId is authorized to commit.")
           dataWriter.commit()
-
         } else {
           val message = s"Stage $stageId, task $partId.$attemptId: driver did not authorize commit"
           logInfo(message)


### PR DESCRIPTION
## What changes were proposed in this pull request?

DataSourceV2 batch writes should use the output commit coordinator if it is required by the data source. This adds a new method, `DataWriterFactory#useCommitCoordinator`, that determines whether the coordinator will be used. If the write factory returns true, `WriteToDataSourceV2` will use the coordinator for batch writes.

## How was this patch tested?

This relies on existing write tests, which now use the commit coordinator.