### PR TITLE
[SPARK-23299][SQL][PYSPARK] Fix __repr__ behaviour for Rows.

### DIFF
--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -234,6 +234,10 @@ class DataTypeTests(unittest.TestCase):
         row = Row()
         self.assertEqual(len(row), 0)
 
+    def test_row_without_column_name(self):
+        row = Row("Alice", 11)
+        self.assertEqual(row.__repr__(), "<Row(Alice, 11)>")
+
     def test_struct_field_type_name(self):
         struct_field = StructField("a", IntegerType())
         self.assertRaises(TypeError, struct_field.typeName)

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1581,7 +1581,7 @@ class Row(tuple):
             return "Row(%s)" % ", ".join("%s=%r" % (k, v)
                                          for k, v in zip(self.__fields__, tuple(self)))
         else:
-            return "<Row(%s)>" % ", ".join(self)
+            return "<Row(%s)>" % ", ".join(str(field) for field in self)
 
 
 class DateConverter(object):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1581,7 +1581,7 @@ class Row(tuple):
             return "Row(%s)" % ", ".join("%s=%r" % (k, v)
                                          for k, v in zip(self.__fields__, tuple(self)))
         else:
-            return "<Row(%s)>" % ", ".join(str(field) for field in self)
+            return "<Row(%s)>" % ", ".join("%s" % (fields) for fields in self)
 
 
 class DateConverter(object):


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix \_\_repr\_\_ behaviour for Rows.

Rows \_\_repr\_\_ assumes data is a string when column name is missing.
Examples,
```
>>> from pyspark.sql.types import Row
>>> Row ("Alice", "11")
<Row(Alice, 11)>

>>> Row (name="Alice", age=11)
Row(age=11, name='Alice')

>>> Row ("Alice", 11)
<snip stack trace>
TypeError: sequence item 1: expected string, int found
```

This is because Row () when called without column names assumes
everything is a string.

## How was this patch tested?

Manually tested and unittest was added in `python/pyspark/sql/tests.py`.