### PR TITLE
[SPARK-23251][SQL] Add checks for collection element Encoders

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
@@ -112,66 +112,88 @@ abstract class SQLImplicits extends LowPrioritySQLImplicits {
 
   /**
    * @since 1.6.1
-   * @deprecated use [[newSequenceEncoder]]
+   * @deprecated use [[newCheckedSequenceEncoder]]
    */
   def newIntSeqEncoder: Encoder[Seq[Int]] = ExpressionEncoder()
 
   /**
    * @since 1.6.1
-   * @deprecated use [[newSequenceEncoder]]
+   * @deprecated use [[newCheckedSequenceEncoder]]
    */
   def newLongSeqEncoder: Encoder[Seq[Long]] = ExpressionEncoder()
 
   /**
    * @since 1.6.1
-   * @deprecated use [[newSequenceEncoder]]
+   * @deprecated use [[newCheckedSequenceEncoder]]
    */
   def newDoubleSeqEncoder: Encoder[Seq[Double]] = ExpressionEncoder()
 
   /**
    * @since 1.6.1
-   * @deprecated use [[newSequenceEncoder]]
+   * @deprecated use [[newCheckedSequenceEncoder]]
    */
   def newFloatSeqEncoder: Encoder[Seq[Float]] = ExpressionEncoder()
 
   /**
    * @since 1.6.1
-   * @deprecated use [[newSequenceEncoder]]
+   * @deprecated use [[newCheckedSequenceEncoder]]
    */
   def newByteSeqEncoder: Encoder[Seq[Byte]] = ExpressionEncoder()
 
   /**
    * @since 1.6.1
-   * @deprecated use [[newSequenceEncoder]]
+   * @deprecated use [[newCheckedSequenceEncoder]]
    */
   def newShortSeqEncoder: Encoder[Seq[Short]] = ExpressionEncoder()
 
   /**
    * @since 1.6.1
-   * @deprecated use [[newSequenceEncoder]]
+   * @deprecated use [[newCheckedSequenceEncoder]]
    */
   def newBooleanSeqEncoder: Encoder[Seq[Boolean]] = ExpressionEncoder()
 
   /**
    * @since 1.6.1
-   * @deprecated use [[newSequenceEncoder]]
+   * @deprecated use [[newCheckedSequenceEncoder]]
    */
   def newStringSeqEncoder: Encoder[Seq[String]] = ExpressionEncoder()
 
   /**
    * @since 1.6.1
-   * @deprecated use [[newSequenceEncoder]]
+   * @deprecated use [[newCheckedSequenceEncoder]]
    */
   def newProductSeqEncoder[A <: Product : TypeTag]: Encoder[Seq[A]] = ExpressionEncoder()
 
-  /** @since 2.2.0 */
-  implicit def newSequenceEncoder[T[_], E : Encoder]
+  /**
+   * @since 2.2.0
+   * @deprecated use [[newCheckedSequenceEncoder]]
+   */
+  def newSequenceEncoder[T <: Seq[_] : TypeTag]: Encoder[T] = ExpressionEncoder()
+
+  /**
+   * @since 2.3.0
+   * @deprecated use [[newCheckedMapEncoder]]
+   */
+  def newMapEncoder[T <: Map[_, _] : TypeTag]: Encoder[T] = ExpressionEncoder()
+
+  /**
+   * Notice that we serialize `Set` to Catalyst array. The set property is only kept when
+   * manipulating the domain objects. The serialization format doesn't keep the set property.
+   * When we have a Catalyst array which contains duplicated elements and convert it to
+   * `Dataset[Set[T]]` by using the encoder, the elements will be de-duplicated.
+   *
+   * @since 2.3.0
+   * @deprecated use [[newCheckedSetEncoder]]
+   */
+  def newSetEncoder[T <: Set[_] : TypeTag]: Encoder[T] = ExpressionEncoder()
+
+  /** @since 2.4.0 */
+  implicit def newCheckedSequenceEncoder[T[_], E : Encoder]
   (implicit ev: T[E] <:< Seq[E], tag: TypeTag[T[E]]): Encoder[T[E]] =
     ExpressionEncoder()
 
-  // Maps
-  /** @since 2.3.0 */
-  implicit def newMapEncoder[T[_, _], K : Encoder, V : Encoder]
+  /** @since 2.4.0 */
+  implicit def newCheckedMapEncoder[T[_, _], K : Encoder, V : Encoder]
   (implicit ev: T[K, V] <:< Map[K, V], tag: TypeTag[T[K, V]]): Encoder[T[K, V]] =
     ExpressionEncoder()
 
@@ -181,9 +203,9 @@ abstract class SQLImplicits extends LowPrioritySQLImplicits {
    * When we have a Catalyst array which contains duplicated elements and convert it to
    * `Dataset[Set[T]]` by using the encoder, the elements will be de-duplicated.
    *
-   * @since 2.3.0
+   * @since 2.4.0
    */
-  implicit def newSetEncoder[T[_], E : Encoder]
+  implicit def newCheckedSetEncoder[T[_], E : Encoder]
   (implicit ev: T[E] <:< Set[E], tag: TypeTag[T[E]]): Encoder[T[E]] =
     ExpressionEncoder()
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql
 
 import scala.collection.Map
-import scala.language.implicitConversions
+import scala.language.{higherKinds, implicitConversions}
 import scala.reflect.runtime.universe.TypeTag
 
 import org.apache.spark.annotation.InterfaceStability
@@ -165,11 +165,15 @@ abstract class SQLImplicits extends LowPrioritySQLImplicits {
   def newProductSeqEncoder[A <: Product : TypeTag]: Encoder[Seq[A]] = ExpressionEncoder()
 
   /** @since 2.2.0 */
-  implicit def newSequenceEncoder[T <: Seq[_] : TypeTag]: Encoder[T] = ExpressionEncoder()
+  implicit def newSequenceEncoder[T[_], E : Encoder]
+  (implicit ev: T[E] <:< Seq[E], tag: TypeTag[T[E]]): Encoder[T[E]] =
+    ExpressionEncoder()
 
   // Maps
   /** @since 2.3.0 */
-  implicit def newMapEncoder[T <: Map[_, _] : TypeTag]: Encoder[T] = ExpressionEncoder()
+  implicit def newMapEncoder[T[_, _], K : Encoder, V : Encoder]
+  (implicit ev: T[K, V] <:< Map[K, V], tag: TypeTag[T[K, V]]): Encoder[T[K, V]] =
+    ExpressionEncoder()
 
   /**
    * Notice that we serialize `Set` to Catalyst array. The set property is only kept when
@@ -179,7 +183,9 @@ abstract class SQLImplicits extends LowPrioritySQLImplicits {
    *
    * @since 2.3.0
    */
-  implicit def newSetEncoder[T <: Set[_] : TypeTag]: Encoder[T] = ExpressionEncoder()
+  implicit def newSetEncoder[T[_], E : Encoder]
+  (implicit ev: T[E] <:< Set[E], tag: TypeTag[T[E]]): Encoder[T[E]] =
+    ExpressionEncoder()
 
   // Arrays
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetPrimitiveSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetPrimitiveSuite.scala
@@ -383,6 +383,12 @@ class DatasetPrimitiveSuite extends QueryTest with SharedSQLContext {
     checkDataset(Seq(HSet(Set(1, 2), Set(3, 4))).toDS(), HSet(Set(1, 2), Set(3, 4)))
   }
 
+  test("collections without element encoders") {
+    assertTypeError("Seq(Seq(1: Any)).toDS()")
+    assertTypeError("Seq(Map(1 -> (1: Any))).toDS()")
+    assertTypeError("Seq(Set(1: Any)).toDS()")
+  }
+
   test("package objects") {
     import packageobject._
     checkDataset(Seq(PackageClass(1)).toDS(), PackageClass(1))


### PR DESCRIPTION
Implicit methods of `SQLImplicits` providing Encoders for collections did not check for
Encoders for their elements. This resulted in unrelated error messages during run-time instead of proper failures during compilation.

## What changes were proposed in this pull request?

`Seq`, `Map` and `Set` `Encoder` providers' type parameters and implicit parameters were modified to facilitate the appropriate checks.

Unfortunately, this doesn't result in the desired "Unable to find encoder for type stored in a Dataset" error as the Scala compiler generates a different error when an implicit cannot be found due to missing arguments (see [ContextErrors](https://github.com/scala/scala/blob/v2.11.12/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala#L77)). `@implicitNotFound` is not used in this case.

## How was this patch tested?

New behavior:
```
scala> implicitly[Encoder[Map[String, Any]]]
<console>:25: error: diverging implicit expansion for type org.apache.spark.sql.Encoder[Map[String,Any]]
starting with method newStringEncoder in class SQLImplicits
       implicitly[Encoder[Map[String, Any]]]
                 ^
```

Old behavior:
```
scala> implicitly[Encoder[Map[String, Any]]]
java.lang.ClassNotFoundException: scala.Any
  at scala.reflect.internal.util.AbstractFileClassLoader.findClass(AbstractFileClassLoader.scala:62)
  at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
  at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
  at java.lang.Class.forName0(Native Method)
  at java.lang.Class.forName(Class.java:348)
  at scala.reflect.runtime.JavaMirrors$JavaMirror.javaClass(JavaMirrors.scala:555)
  at scala.reflect.runtime.JavaMirrors$JavaMirror$$anonfun$classToJava$1.apply(JavaMirrors.scala:1211)
  at scala.reflect.runtime.JavaMirrors$JavaMirror$$anonfun$classToJava$1.apply(JavaMirrors.scala:1203)
  at scala.reflect.runtime.TwoWayCaches$TwoWayCache$$anonfun$toJava$1.apply(TwoWayCaches.scala:49)
  at scala.reflect.runtime.Gil$class.gilSynchronized(Gil.scala:19)
  at scala.reflect.runtime.JavaUniverse.gilSynchronized(JavaUniverse.scala:16)
  at scala.reflect.runtime.TwoWayCaches$TwoWayCache.toJava(TwoWayCaches.scala:44)
  at scala.reflect.runtime.JavaMirrors$JavaMirror.classToJava(JavaMirrors.scala:1203)
  at scala.reflect.runtime.JavaMirrors$JavaMirror.runtimeClass(JavaMirrors.scala:194)
  at scala.reflect.runtime.JavaMirrors$JavaMirror.runtimeClass(JavaMirrors.scala:54)
  at org.apache.spark.sql.catalyst.ScalaReflection$.getClassFromType(ScalaReflection.scala:700)
  at org.apache.spark.sql.catalyst.ScalaReflection$$anonfun$org$apache$spark$sql$catalyst$ScalaReflection$$dataTypeFor$1.apply(ScalaReflection.scala:84)
  at org.apache.spark.sql.catalyst.ScalaReflection$$anonfun$org$apache$spark$sql$catalyst$ScalaReflection$$dataTypeFor$1.apply(ScalaReflection.scala:65)
  at scala.reflect.internal.tpe.TypeConstraints$UndoLog.undo(TypeConstraints.scala:56)
  at org.apache.spark.sql.catalyst.ScalaReflection$class.cleanUpReflectionObjects(ScalaReflection.scala:824)
  at org.apache.spark.sql.catalyst.ScalaReflection$.cleanUpReflectionObjects(ScalaReflection.scala:39)
  at org.apache.spark.sql.catalyst.ScalaReflection$.org$apache$spark$sql$catalyst$ScalaReflection$$dataTypeFor(ScalaReflection.scala:64)
  at org.apache.spark.sql.catalyst.ScalaReflection$$anonfun$org$apache$spark$sql$catalyst$ScalaReflection$$serializerFor$1.apply(ScalaReflection.scala:512)
  at org.apache.spark.sql.catalyst.ScalaReflection$$anonfun$org$apache$spark$sql$catalyst$ScalaReflection$$serializerFor$1.apply(ScalaReflection.scala:445)
  at scala.reflect.internal.tpe.TypeConstraints$UndoLog.undo(TypeConstraints.scala:56)
  at org.apache.spark.sql.catalyst.ScalaReflection$class.cleanUpReflectionObjects(ScalaReflection.scala:824)
  at org.apache.spark.sql.catalyst.ScalaReflection$.cleanUpReflectionObjects(ScalaReflection.scala:39)
  at org.apache.spark.sql.catalyst.ScalaReflection$.org$apache$spark$sql$catalyst$ScalaReflection$$serializerFor(ScalaReflection.scala:445)
  at org.apache.spark.sql.catalyst.ScalaReflection$.serializerFor(ScalaReflection.scala:434)
  at org.apache.spark.sql.catalyst.encoders.ExpressionEncoder$.apply(ExpressionEncoder.scala:71)
  at org.apache.spark.sql.SQLImplicits.newMapEncoder(SQLImplicits.scala:172)
  ... 49 elided
```

Also tested overriding with custom `Encoder` (this also compiles correctly in [SparkSQLExample](https://github.com/apache/spark/blob/425c4ada4c24e338b45d0e9987071f05c5766fa5/examples/src/main/scala/org/apache/spark/examples/sql/SparkSQLExample.scala#L223)):
```
scala> implicit val kryoEnc = Encoders.kryo[Map[String, Any]]
kryoEnc: org.apache.spark.sql.Encoder[Map[String,Any]] = class[value[0]: binary]

scala> implicitly[Encoder[Map[String, Any]]]
res0: org.apache.spark.sql.Encoder[Map[String,Any]] = class[value[0]: binary]
```

BUT, I was unable to add this as a unit test, getting the aforementioned "diverging implicit expansion" error instead. I did not explore this further as it worked everywhere else.