### PR TITLE
[Spark-23240][python] Don't let python site customizations interfere with communication between PythonWorkerFactory and daemon.py

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
@@ -224,7 +224,6 @@ private[spark] class PythonWorkerFactory(pythonExec: String, envVars: Map[String
           if (socketToDaemon != null) {
             socketToDaemon.close()
           }
-
         }
 
         val in = new DataInputStream(daemon.getInputStream)

--- a/python/pyspark/daemon.py
+++ b/python/pyspark/daemon.py
@@ -87,7 +87,7 @@ def manager(parent_port, token):
     outfile.flush()
     outfile.close()
     socket_to_parent.close()
-    
+
     # re-open stdin in 'wb' mode
     stdin_bin = os.fdopen(sys.stdin.fileno(), 'rb', 4)
 
@@ -199,7 +199,8 @@ if __name__ == '__main__':
     try:
         token = int(token_string)
     except ValueError:
-        print >> sys.stderr, "Non-numeric value set in environment variable PYSPARK_DAEMON_TOKEN:", token_string
+        print >> sys.stderr, \
+            "Non-numeric value set in environment variable PYSPARK_DAEMON_TOKEN:", token_string
         sys.exit(1)
-        
+
     manager(parent_port, token)

--- a/python/pyspark/daemon.py
+++ b/python/pyspark/daemon.py
@@ -29,7 +29,7 @@ from socket import AF_INET, SOCK_STREAM, SOMAXCONN
 from signal import SIGHUP, SIGTERM, SIGCHLD, SIG_DFL, SIG_IGN, SIGINT
 
 from pyspark.worker import main as worker_main
-from pyspark.serializers import read_int, write_int
+from pyspark.serializers import read_int, write_int, write_long
 
 
 def compute_real_exit_code(exit_code):
@@ -82,13 +82,13 @@ def manager(parent_port, token):
     socket_to_parent = socket.socket(AF_INET, SOCK_STREAM)
     socket_to_parent.connect(('127.0.0.1', parent_port))
     outfile = socket_to_parent.makefile(mode="wb")
-    write_int(token, outfile)
+    write_long(token, outfile)
     write_int(listen_port, outfile)
     outfile.flush()
     outfile.close()
     socket_to_parent.close()
 
-    # re-open stdin in 'wb' mode
+    # re-open stdin in 'rb' mode
     stdin_bin = os.fdopen(sys.stdin.fileno(), 'rb', 4)
 
     def shutdown(code):
@@ -197,7 +197,7 @@ if __name__ == '__main__':
         print >> sys.stderr, "PYSPARK_DAEMON_TOKEN environment variable is not set"
         sys.exit(1)
     try:
-        token = int(token_string)
+        token = long(token_string)
     except ValueError:
         print >> sys.stderr, \
             "Non-numeric value set in environment variable PYSPARK_DAEMON_TOKEN:", token_string

--- a/python/pyspark/daemon.py
+++ b/python/pyspark/daemon.py
@@ -69,7 +69,7 @@ def worker(sock):
     return exit_code
 
 
-def manager():
+def manager(parent_port):
     # Create a new process group to corral our children
     os.setpgid(0, 0)
 
@@ -79,11 +79,16 @@ def manager():
     listen_sock.listen(max(1024, SOMAXCONN))
     listen_host, listen_port = listen_sock.getsockname()
 
+    socket_to_parent = socket.socket(AF_INET, SOCK_STREAM)
+    socket_to_parent.connect(('127.0.0.1', parent_port))
+    outfile = socket_to_parent.makefile(mode="wb")
+    write_int(listen_port, outfile)
+    outfile.flush()
+    outfile.close()
+    socket_to_parent.close()
+    
     # re-open stdin/stdout in 'wb' mode
     stdin_bin = os.fdopen(sys.stdin.fileno(), 'rb', 4)
-    stdout_bin = os.fdopen(sys.stdout.fileno(), 'wb', 4)
-    write_int(listen_port, stdout_bin)
-    stdout_bin.flush()
 
     def shutdown(code):
         signal.signal(SIGTERM, SIG_DFL)
@@ -177,4 +182,13 @@ def manager():
 
 
 if __name__ == '__main__':
-    manager()
+    if len(sys.argv) < 2:
+        print >> sys.stderr, "No parent port number specified"
+        sys.exit(1)
+    try:
+        parent_port = int(sys.argv[1])
+    except ValueError:
+        print >> sys.stderr, "Non-numeric port number specified"
+        sys.exit(1)
+        
+    manager(parent_port)

--- a/python/pyspark/daemon.py
+++ b/python/pyspark/daemon.py
@@ -200,7 +200,8 @@ if __name__ == '__main__':
         # works for long values too
         token = int(token_string)
     except ValueError:
-        sys.stderr.write("Non-numeric value set in environment variable PYSPARK_DAEMON_TOKEN: %s\n" % token_string)
+        sys.stderr.write("Non-numeric value set in environment variable PYSPARK_DAEMON_TOKEN: %s\n"
+                         % token_string)
         sys.exit(1)
 
     manager(parent_port, token)

--- a/python/pyspark/daemon.py
+++ b/python/pyspark/daemon.py
@@ -184,23 +184,23 @@ def manager(parent_port, token):
 
 if __name__ == '__main__':
     if len(sys.argv) < 2:
-        print >> sys.stderr, "No parent port number specified"
+        sys.stderr.write("No parent port number specified\n")
         sys.exit(1)
     try:
         parent_port = int(sys.argv[1])
     except ValueError:
-        print >> sys.stderr, "Non-numeric port number specified:", sys.argv[1]
+        sys.stderr.write("Non-numeric port number specified: %s\n" % sys.argv[1])
         sys.exit(1)
 
     token_string = os.environ.get("PYSPARK_DAEMON_TOKEN")
     if token_string is None:
-        print >> sys.stderr, "PYSPARK_DAEMON_TOKEN environment variable is not set"
+        sys.stderr.write("PYSPARK_DAEMON_TOKEN environment variable is not set\n")
         sys.exit(1)
     try:
-        token = long(token_string)
+        # works for long values too
+        token = int(token_string)
     except ValueError:
-        print >> sys.stderr, \
-            "Non-numeric value set in environment variable PYSPARK_DAEMON_TOKEN:", token_string
+        sys.stderr.write("Non-numeric value set in environment variable PYSPARK_DAEMON_TOKEN: %s\n" % token_string)
         sys.exit(1)
 
     manager(parent_port, token)

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -1807,12 +1807,12 @@ class DaemonTests(unittest.TestCase):
         # set the token that the daemon will use to prove it is the daemon we launched
         expected_token = -99
         myEnv = os.environ.copy()
-        myEnv["PYSPARK_DAEMON_TOKEN"] = str(expected_token)        
+        myEnv["PYSPARK_DAEMON_TOKEN"] = str(expected_token)
 
         # start daemon
         daemon_path = os.path.join(os.path.dirname(__file__), "daemon.py")
         python_exec = sys.executable or os.environ.get("PYSPARK_PYTHON")
-        daemon = Popen([python_exec, daemon_path, str(listen_port)], stdin=PIPE, stdout=PIPE, \
+        daemon = Popen([python_exec, daemon_path, str(listen_port)], stdin=PIPE, stdout=PIPE,
                        env=myEnv)
 
         # get a connection to the daemon we just launched
@@ -1830,7 +1830,7 @@ class DaemonTests(unittest.TestCase):
         infile.close()
         sock.close()
         listen_sock.close()
-        
+
         # daemon should accept connections
         self.assertTrue(self.connect(port))
 

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -63,10 +63,10 @@ from pyspark.conf import SparkConf
 from pyspark.context import SparkContext
 from pyspark.rdd import RDD
 from pyspark.files import SparkFiles
-from pyspark.serializers import read_int, read_long, BatchedSerializer, MarshalSerializer, PickleSerializer, \
+from pyspark.serializers import read_int, BatchedSerializer, MarshalSerializer, PickleSerializer, \
     CloudPickleSerializer, CompressedSerializer, UTF8Deserializer, NoOpSerializer, \
     PairDeserializer, CartesianDeserializer, AutoBatchedSerializer, AutoSerializer, \
-    FlattenedValuesSerializer
+    FlattenedValuesSerializer, read_long
 from pyspark.shuffle import Aggregator, ExternalMerger, ExternalSorter
 from pyspark import shuffle
 from pyspark.profiler import BasicProfiler

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -1804,17 +1804,26 @@ class DaemonTests(unittest.TestCase):
         listen_sock.listen(max(1024, SOMAXCONN))
         listen_host, listen_port = listen_sock.getsockname()
 
+        # set the token that the daemon will use to prove it is the daemon we launched
+        expected_token = -99
+        myEnv = os.environ.copy()
+        myEnv["PYSPARK_DAEMON_TOKEN"] = str(expected_token)        
+
         # start daemon
         daemon_path = os.path.join(os.path.dirname(__file__), "daemon.py")
         python_exec = sys.executable or os.environ.get("PYSPARK_PYTHON")
-        daemon = Popen([python_exec, daemon_path, str(listen_port)], stdin=PIPE, stdout=PIPE)
+        daemon = Popen([python_exec, daemon_path, str(listen_port)], stdin=PIPE, stdout=PIPE, \
+                       env=myEnv)
 
         # get a connection to the daemon we just launched
         listen_sock.settimeout(10)
         (sock, _) = listen_sock.accept()
         infile = sock.makefile(mode='rb')
 
-        # read the port number
+        # read the token and port number
+        actual_token = read_int(infile)
+        if actual_token != expected_token:
+            self.fail("Daemon did not return expected auth token")
         port = read_int(infile)
 
         # done with this connection to the daemon

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -63,7 +63,7 @@ from pyspark.conf import SparkConf
 from pyspark.context import SparkContext
 from pyspark.rdd import RDD
 from pyspark.files import SparkFiles
-from pyspark.serializers import read_int, BatchedSerializer, MarshalSerializer, PickleSerializer, \
+from pyspark.serializers import read_int, read_long, BatchedSerializer, MarshalSerializer, PickleSerializer, \
     CloudPickleSerializer, CompressedSerializer, UTF8Deserializer, NoOpSerializer, \
     PairDeserializer, CartesianDeserializer, AutoBatchedSerializer, AutoSerializer, \
     FlattenedValuesSerializer
@@ -1821,7 +1821,7 @@ class DaemonTests(unittest.TestCase):
         infile = sock.makefile(mode='rb')
 
         # read the token and port number
-        actual_token = read_int(infile)
+        actual_token = read_long(infile)
         if actual_token != expected_token:
             self.fail("Daemon did not return expected auth token")
         port = read_int(infile)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use a socket, instead of stdout, as the inter-process communication method between PythonWorkerFactory and a newly launched daemon.py to avoid the issue described in the Jira (a case where python stdout can be polluted by extraneous messages).

## How was this patch tested?

- python/run-tests --modules "pyspark-core,pyspark-sql,pyspark-streaming"
- python/pyspark/tests.py
- all sbt tests
- selected queries on a Spark cluster that uses a python installation with site customizations

Note: The two python test scripts and cluster test were run using Python 2.7 only.

