### PR TITLE
[SPARK-23350][SS]Bug fix for exception handling when stopping continu…

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2.scala
@@ -92,8 +92,8 @@ case class WriteToDataSourceV2Exec(writer: DataSourceWriter, query: SparkPlan) e
         logInfo(s"Data source writer $writer committed.")
       }
     } catch {
-      case _: SparkException if writer.isInstanceOf[StreamWriter] =>
-        // SparkException is how continuous queries are ended, so accept and ignore the exception.
+      case _: InterruptedException if writer.isInstanceOf[StreamWriter] =>
+        // Interruption is how continuous queries are ended, so accept and ignore the exception.
       case cause: Throwable =>
         logError(s"Data source writer $writer is aborting.")
         try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

SparkException happends when stopping continuous processing application, using Ctrl-C in stand-alone mode. Stopping continuous processing application will throw SparkException, not InterruptedException as the code in [WriteToDataSourceV2](https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2.scala#L95)

## How was this patch tested?

manual tests
