### PR TITLE
[SPARK-23349][SQL]ShuffleExchangeExec: Duplicate and redundant type determination for ShuffleManager Object

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -163,13 +163,10 @@ object ShuffleExchangeExec {
     // passed instead of directly passing the number of partitions in order to guard against
     // corner-cases where a partitioner constructed with `numPartitions` partitions may output
     // fewer partitions (like RangePartitioner, for example).
-    val conf = SparkEnv.get.conf
-    val shuffleManager = SparkEnv.get.shuffleManager
-    val sortBasedShuffleOn = shuffleManager.isInstanceOf[SortShuffleManager]
-    val bypassMergeThreshold = conf.getInt("spark.shuffle.sort.bypassMergeThreshold", 200)
+    val sortBasedShuffleOn = SparkEnv.get.shuffleManager.isInstanceOf[SortShuffleManager]
     if (sortBasedShuffleOn) {
-      val bypassIsSupported = SparkEnv.get.shuffleManager.isInstanceOf[SortShuffleManager]
-      if (bypassIsSupported && partitioner.numPartitions <= bypassMergeThreshold) {
+	  val bypassMergeThreshold = SparkEnv.get.conf.getInt("spark.shuffle.sort.bypassMergeThreshold", 200)
+      if (partitioner.numPartitions <= bypassMergeThreshold) {
         // If we're using the original SortShuffleManager and the number of output partitions is
         // sufficiently small, then Spark will fall back to the hash-based shuffle write path, which
         // doesn't buffer deserialized records.


### PR DESCRIPTION
## What changes were proposed in this pull request?
org.apache.spark.sql.execution.exchange.ShuffleExchangeExec: 

There is a nested "if or else" branch within the "needtocopyobjectsbeforguffle()" function.
The \<sortBasedShufffleOn\> condition in the first layer "if" has the same value as the \<bypassIsSupported\> condition in the second layer "if", that is, \<bypassIsSupported\> must be true when \<sortBasedShufffleOn\> is true.
In addition, the \<byPassMergeThreshold\> condition will be used in the second layer "if" and  should not be calculated until needed.

It's to remove the \<bypassIsSupported\> condition in the second layer " if" and to move the \<bypassmergethreshold\> calculation backward

## How was this patch tested?

Existing tests