### PR TITLE
[SPARK-23341][SQL] define some standard options for data source v2

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/DataSourceOptions.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/DataSourceOptions.java
@@ -27,6 +27,39 @@ import org.apache.spark.annotation.InterfaceStability;
 /**
  * An immutable string-to-string map in which keys are case-insensitive. This is used to represent
  * data source options.
+ *
+ * Each data source implementation can define its own options and teach its users how to set them.
+ * Spark doesn't have any restrictions about what options a data source should or should not have.
+ * Instead Spark defines some standard options that data sources can optionally adopt. It's possible
+ * that some options are very common and many data sources use them. However different data
+ * sources may define the common options(key and meaning) differently, which is quite confusing to
+ * end users.
+ *
+ * The standard options defined by Spark:
+ * <table>
+ *   <tr>
+ *     <th><b>Option key</b></th>
+ *     <th><b>Option value</b></th>
+ *   </tr>
+ *   <tr>
+ *     <td>path</td>
+ *     <td>A comma separated paths string of the data files/directories, like
+ *     <code>path1,/absolute/file2,path3/*</code>. Each path can either be relative or absolute,
+ *     points to either file or directory, and can contain wildcards. This option is commonly used
+ *     by file-based data sources.</td>
+ *   </tr>
+ *   <tr>
+ *     <td>table</td>
+ *     <td>A table name string representing the table name directly without any interpretation.
+ *     For example, <code>db.tbl</code> means a table called "db.tbl", not a table called "tbl"
+ *     inside database "db". <code>`t$bl@`</code> means a table called "`t$bl@`", not "t$bl@".</td>
+ *   </tr>
+ *   <tr>
+ *     <td>database</td>
+ *     <td>A database name string representing the database name directly without any
+ *     interpretation, which is very similar to the table name option.</td>
+ *   </tr>
+ * </table>
  */
 @InterfaceStability.Evolving
 public class DataSourceOptions {
@@ -96,5 +129,21 @@ public class DataSourceOptions {
     String lcaseKey = toLowerCase(key);
     return keyLowerCasedMap.containsKey(lcaseKey) ?
       Double.parseDouble(keyLowerCasedMap.get(lcaseKey)) : defaultValue;
+  }
+
+  public static final String KEY_PATH = "path";
+  public static final String KEY_TABLE = "table";
+  public static final String KEY_DATABASE = "database";
+
+  public Optional<String> getPath() {
+    return get(KEY_PATH);
+  }
+
+  public Optional<String> getTableName() {
+    return get(KEY_TABLE);
+  }
+
+  public Optional<String> getDatabaseName() {
+    return get(KEY_DATABASE);
   }
 }

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/DataSourceOptions.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/DataSourceOptions.java
@@ -164,20 +164,13 @@ public class DataSourceOptions {
   public static final String DATABASE_KEY = "database";
 
   /**
-   * Returns the value of the singular path option.
-   */
-  public Optional<String> path() {
-    return get(PATH_KEY);
-  }
-
-  /**
    * Returns all the paths specified by both the singular path option and the multiple
    * paths option.
    */
   public String[] paths() {
-    String[] singularPath = path().map(s -> new String[]{s}).orElseGet(() -> new String[0]);
+    String[] singularPath =
+      get(PATH_KEY).map(s -> new String[]{s}).orElseGet(() -> new String[0]);
     Optional<String> pathsStr = get(PATHS_KEY);
-    System.out.println(pathsStr);
     if (pathsStr.isPresent()) {
       ObjectMapper objectMapper = new ObjectMapper();
       try {

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/DataSourceOptions.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/DataSourceOptions.java
@@ -36,7 +36,7 @@ import org.apache.spark.annotation.InterfaceStability;
  * end users.
  *
  * The standard options defined by Spark:
- * <table>
+ * <table summary="standard data source options">
  *   <tr>
  *     <th><b>Option key</b></th>
  *     <th><b>Option value</b></th>
@@ -52,7 +52,7 @@ import org.apache.spark.annotation.InterfaceStability;
  *     <td>table</td>
  *     <td>A table name string representing the table name directly without any interpretation.
  *     For example, <code>db.tbl</code> means a table called "db.tbl", not a table called "tbl"
- *     inside database "db". <code>`t$bl@`</code> means a table called "`t$bl@`", not "t$bl@".</td>
+ *     inside database "db". <code>`t*b.l`</code> means a table called "`t*b.l", not "t*b.l".</td>
  *   </tr>
  *   <tr>
  *     <td>database</td>

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -21,6 +21,8 @@ import java.util.{Locale, Properties}
 
 import scala.collection.JavaConverters._
 
+import com.fasterxml.jackson.databind.ObjectMapper
+
 import org.apache.spark.Partition
 import org.apache.spark.annotation.InterfaceStability
 import org.apache.spark.api.java.JavaRDD
@@ -34,7 +36,7 @@ import org.apache.spark.sql.execution.datasources.jdbc._
 import org.apache.spark.sql.execution.datasources.json.TextInputJsonDataSource
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Utils
-import org.apache.spark.sql.sources.v2.{DataSourceV2, ReadSupport, ReadSupportWithSchema}
+import org.apache.spark.sql.sources.v2.{DataSourceOptions, DataSourceV2, ReadSupport, ReadSupportWithSchema}
 import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -171,7 +173,8 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    * @since 1.4.0
    */
   def load(path: String): DataFrame = {
-    option("path", path).load(Seq.empty: _*) // force invocation of `load(...varargs...)`
+    // force invocation of `load(...varargs...)`
+    option(DataSourceOptions.PATH_KEY, path).load(Seq.empty: _*)
   }
 
   /**
@@ -193,10 +196,13 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
       if (ds.isInstanceOf[ReadSupport] || ds.isInstanceOf[ReadSupportWithSchema]) {
         val sessionOptions = DataSourceV2Utils.extractSessionConfigs(
           ds = ds, conf = sparkSession.sessionState.conf)
+        val pathsOption = {
+          val objectMapper = new ObjectMapper()
+          DataSourceOptions.PATHS_KEY -> objectMapper.writeValueAsString(paths.toArray)
+        }
         Dataset.ofRows(sparkSession, DataSourceV2Relation.create(
-          ds, extraOptions.toMap ++ sessionOptions,
+          ds, extraOptions.toMap ++ sessionOptions + pathsOption,
           userSpecifiedSchema = userSpecifiedSchema))
-
       } else {
         loadV1Source(paths: _*)
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/v2/DataSourceOptionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/v2/DataSourceOptionsSuite.scala
@@ -85,7 +85,7 @@ class DataSourceOptionsSuite extends SparkFunSuite {
       DataSourceOptions.PATH_KEY -> "abc",
       DataSourceOptions.TABLE_KEY -> "tbl").asJava)
 
-    assert(options.path.get() == "abc")
+    assert(options.paths().toSeq == Seq("abc"))
     assert(options.tableName().get() == "tbl")
     assert(!options.databaseName().isPresent)
   }
@@ -95,7 +95,6 @@ class DataSourceOptionsSuite extends SparkFunSuite {
       DataSourceOptions.PATH_KEY -> "abc",
       DataSourceOptions.PATHS_KEY -> """["c", "d"]""").asJava)
 
-    assert(options.path.get() == "abc")
     assert(options.paths().toSeq == Seq("abc", "c", "d"))
   }
 
@@ -103,7 +102,6 @@ class DataSourceOptionsSuite extends SparkFunSuite {
     val options = new DataSourceOptions(Map(
       DataSourceOptions.PATHS_KEY -> """["c", "d\"e"]""").asJava)
 
-    assert(!options.path.isPresent)
     assert(options.paths().toSeq == Seq("c", "d\"e"))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/v2/DataSourceOptionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/v2/DataSourceOptionsSuite.scala
@@ -82,11 +82,28 @@ class DataSourceOptionsSuite extends SparkFunSuite {
 
   test("standard options") {
     val options = new DataSourceOptions(Map(
-      DataSourceOptions.KEY_PATH -> "abc",
-      DataSourceOptions.KEY_TABLE -> "tbl").asJava)
+      DataSourceOptions.PATH_KEY -> "abc",
+      DataSourceOptions.TABLE_KEY -> "tbl").asJava)
 
-    assert(options.getPath.get() == "abc")
-    assert(options.getTableName.get() == "tbl")
-    assert(!options.getDatabaseName.isPresent)
+    assert(options.path.get() == "abc")
+    assert(options.tableName().get() == "tbl")
+    assert(!options.databaseName().isPresent)
+  }
+
+  test("standard options with both singular path and multi-paths") {
+    val options = new DataSourceOptions(Map(
+      DataSourceOptions.PATH_KEY -> "abc",
+      DataSourceOptions.PATHS_KEY -> """["c", "d"]""").asJava)
+
+    assert(options.path.get() == "abc")
+    assert(options.paths().toSeq == Seq("abc", "c", "d"))
+  }
+
+  test("standard options with only multi-paths") {
+    val options = new DataSourceOptions(Map(
+      DataSourceOptions.PATHS_KEY -> """["c", "d\"e"]""").asJava)
+
+    assert(!options.path.isPresent)
+    assert(options.paths().toSeq == Seq("c", "d\"e"))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/v2/DataSourceOptionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/v2/DataSourceOptionsSuite.scala
@@ -79,4 +79,14 @@ class DataSourceOptionsSuite extends SparkFunSuite {
       options.getDouble("foo", 0.1d)
     }
   }
+
+  test("standard options") {
+    val options = new DataSourceOptions(Map(
+      DataSourceOptions.KEY_PATH -> "abc",
+      DataSourceOptions.KEY_TABLE -> "tbl").asJava)
+
+    assert(options.getPath.get() == "abc")
+    assert(options.getTableName.get() == "tbl")
+    assert(!options.getDatabaseName.isPresent)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Each data source implementation can define its own options and teach its users how to set them. Spark doesn't have any restrictions about what options a data source should or should not have. It's possible that some options are very common and many data sources use them. However different data sources may define the common options(key and meaning) differently, which is quite confusing to end users.

This PR defines some standard options that data sources can optionally adopt: path, table and database.

## How was this patch tested?

a new test case.