### PR TITLE
[SPARK-23314][PYTHON] Add ambiguous=False when localizing tz-naive timestamps in Arrow codepath to deal with dst

### DIFF
--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3677,11 +3677,14 @@ class ArrowTests(ReusedSQLTestCase):
         # Daylight saving time for Los Angeles for 2015 is Sun, Nov 1 at 2:00 am
         dt = datetime.datetime(2015, 11, 1, 1, 29, 30)
         pdf_1 = pd.DataFrame({'time': [dt]})
-        pdf_2 = self.spark.createDataFrame([dt], 'timestamp').toDF('time').toPandas()
-        pdf_3 = self.spark.createDataFrame(pdf_1).toPandas()
+        df_2 = self.spark.createDataFrame([dt], 'timestamp').toDF('time')
+        df_3 = self.spark.createDataFrame(pdf_1)
 
-        self.assertPandasEqual(pdf_1, pdf_2)
-        self.assertPandasEqual(pdf_1, pdf_3)
+        self.assertPandasEqual(pdf_1, df_2.toPandas())
+        self.assertPandasEqual(pdf_1, df_3.toPandas())
+
+        self.assertEqual(dt, df_2.collect()[0].time)
+        self.assertEqual(dt, df_3.collect()[0].time)
 
 
 @unittest.skipIf(

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3670,6 +3670,21 @@ class ArrowTests(ReusedSQLTestCase):
         self.assertEqual(pdf_col_names, df.columns)
         self.assertEqual(pdf_col_names, df_arrow.columns)
 
+    def test_timestamp_dst(self):
+        """
+        SPARK-23314: Test daylight saving time
+        """
+        import pandas as pd
+        import datetime
+        # Daylight saving time for Los Angeles for 2015 is Sun, Nov 1 at 2:00 am
+        dt = datetime.datetime(2015, 11, 1, 1, 29, 30)
+        pdf_1 = pd.DataFrame({'time': [dt]})
+        pdf_2 = self.spark.createDataFrame([dt], 'timestamp').toDF('time').toPandas()
+        pdf_3 = self.spark.createDataFrame(pdf_1).toPandas()
+
+        self.assertPandasEqual(pdf_1, pdf_2)
+        self.assertPandasEqual(pdf_1, pdf_3)
+
 
 @unittest.skipIf(
     not _have_pandas or not _have_pyarrow,

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -4333,7 +4333,7 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
         from pyspark.sql.functions import pandas_udf
         # Daylight saving time for Los Angeles for 2015 is Sun, Nov 1 at 2:00 am
         dt = datetime.datetime(2015, 11, 1, 1, 29, 30)
-        df = spark.createDataFrame([dt], 'timestamp').toDF('time')
+        df = self.spark.createDataFrame([dt], 'timestamp').toDF('time')
         foo_udf = pandas_udf(lambda dt: dt, 'timestamp')
         result = df.withColumn('time', foo_udf(df.time))
         self.assertEquals(df.collect(), result.collect())
@@ -4515,7 +4515,7 @@ class GroupedMapPandasUDFTests(ReusedSQLTestCase):
 
         # Daylight saving time for Los Angeles for 2015 is Sun, Nov 1 at 2:00 am
         dt = datetime.datetime(2015, 11, 1, 1, 29, 30)
-        df = spark.createDataFrame([dt], 'timestamp').toDF('time')
+        df = self.spark.createDataFrame([dt], 'timestamp').toDF('time')
         foo_udf = pandas_udf(lambda pdf: pdf, 'time timestamp', PandasUDFType.GROUPED_MAP)
         result = df.groupby('time').apply(foo_udf)
         self.assertPandasEqual(df.toPandas(), result.toPandas())

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1759,28 +1759,26 @@ def _check_series_convert_timestamps_internal(s, timezone):
     from pandas.api.types import is_datetime64_dtype, is_datetime64tz_dtype
     # TODO: handle nested timestamps, such as ArrayType(TimestampType())?
     if is_datetime64_dtype(s.dtype):
+        # tz_localize with ambiguous=False has the same behavior of pytz.localize
+        # >>> import datetime
+        # >>> import pandas as pd
+        # >>> import pytz
+        # >>>
+        # >>> t = datetime.datetime(2015, 11, 1, 1, 23, 24)
+        # >>> ts = pd.Series([t])
+        # >>> tz = pytz.timezone('America/New_York')
+        # >>>
+        # >>> ts.dt.tz_localize(tz, ambiguous=False)
+        # 0   2015-11-01 01:23:24-05:00
+        # dtype: datetime64[ns, America/New_York]
+        # >>>
+        # >>> ts.dt.tz_localize(tz, ambiguous=True)
+        # 0   2015-11-01 01:23:24-04:00
+        # dtype: datetime64[ns, America/New_York]
+        # >>>
+        # >>> str(tz.localize(t))
+        # '2015-11-01 01:23:24-05:00'
         tz = timezone or _get_local_timezone()
-        """
-        tz_localize with ambiguous=False has the same behavior of pytz.localize
-        >>> import datetime
-        >>> import pandas as pd
-        >>> import pytz
-        >>>
-        >>> t = datetime.datetime(2015, 11, 1, 1, 23, 24)
-        >>> ts = pd.Series([t])
-        >>> tz = pytz.timezone('America/New_York')
-        >>>
-        >>> ts.dt.tz_localize(tz, ambiguous=False)
-        >>> 0   2015-11-01 01:23:24-05:00
-        >>> dtype: datetime64[ns, America/New_York]
-        >>>
-        >>> ts.dt.tz_localize(tz, ambiguous=True)
-        >>> 0   2015-11-01 01:23:24-04:00
-        >>> dtype: datetime64[ns, America/New_York]
-        >>>
-        >>> str(tz.localize(t))
-        >>> '2015-11-01 01:23:24-05:00'
-        """
         return s.dt.tz_localize(tz, ambiguous=False).dt.tz_convert('UTC')
     elif is_datetime64tz_dtype(s.dtype):
         return s.dt.tz_convert('UTC')

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1759,25 +1759,36 @@ def _check_series_convert_timestamps_internal(s, timezone):
     from pandas.api.types import is_datetime64_dtype, is_datetime64tz_dtype
     # TODO: handle nested timestamps, such as ArrayType(TimestampType())?
     if is_datetime64_dtype(s.dtype):
-        # tz_localize with ambiguous=False has the same behavior of pytz.localize
+        # When tz_localize a tz-naive timestamp, the result is ambiguous if the tz-naive
+        # timestamp is during the hour when the clock is adjusted backward during due to
+        # daylight saving time (dst).
+        # E.g., for America/New_York, the clock is adjusted backward on 2015-11-01 2:00 to
+        # 2015-11-01 1:00 from dst-time to standard time, and therefore, when tz_localize
+        # a tz-naive timestamp 2015-11-01 1:30 with America/New_York timezone, it can be either
+        # dst time (2015-01-01 1:30-0400) or standard time (2015-11-01 1:30-0500).
+        #
+        # Here we explicit choose to use standard time. This matches the default behavior of
+        # pytz.
+        #
+        # Here are some code to help understand this behavior:
         # >>> import datetime
         # >>> import pandas as pd
         # >>> import pytz
         # >>>
-        # >>> t = datetime.datetime(2015, 11, 1, 1, 23, 24)
+        # >>> t = datetime.datetime(2015, 11, 1, 1, 30)
         # >>> ts = pd.Series([t])
         # >>> tz = pytz.timezone('America/New_York')
         # >>>
-        # >>> ts.dt.tz_localize(tz, ambiguous=False)
-        # 0   2015-11-01 01:23:24-05:00
+        # >>> ts.dt.tz_localize(tz, ambiguous=True)
+        # 0   2015-11-01 01:30:00-04:00
         # dtype: datetime64[ns, America/New_York]
         # >>>
-        # >>> ts.dt.tz_localize(tz, ambiguous=True)
-        # 0   2015-11-01 01:23:24-04:00
+        # >>> ts.dt.tz_localize(tz, ambiguous=False)
+        # 0   2015-11-01 01:30:00-05:00
         # dtype: datetime64[ns, America/New_York]
         # >>>
         # >>> str(tz.localize(t))
-        # '2015-11-01 01:23:24-05:00'
+        # '2015-11-01 01:30:00-05:00'
         tz = timezone or _get_local_timezone()
         return s.dt.tz_localize(tz, ambiguous=False).dt.tz_convert('UTC')
     elif is_datetime64tz_dtype(s.dtype):


### PR DESCRIPTION
## What changes were proposed in this pull request?
When tz_localize a tz-naive timetamp, pandas will throw exception if the timestamp is during daylight saving time period, e.g., `2015-11-01 01:30:00`. This PR fixes this issue by setting `ambiguous=False` when calling tz_localize, which is the same default behavior of pytz.

## How was this patch tested?
Add `test_timestamp_dst`
