### PR TITLE
[SPARK-23357][CORE] 'SHOW TABLE EXTENDED LIKE pattern=STRING' add ‘Partitioned’ display similar to hive, and partition is empty, also need to show empty partition field []

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -326,7 +326,12 @@ case class CatalogTable(
     stats.foreach(s => map.put("Statistics", s.simpleString))
     map ++= storage.toLinkedHashMap
     if (tracksPartitionsInCatalog) map.put("Partition Provider", "Catalog")
-    if (partitionColumnNames.nonEmpty) map.put("Partition Columns", partitionColumns)
+    if (partitionColumnNames.nonEmpty) {
+      map.put("Partitioned", "true")
+    } else {
+      map.put("Partitioned", "false")
+    }
+    map.put("Partition Columns", partitionColumns)
     if (schema.nonEmpty) map.put("Schema", schema.treeString)
 
     map


### PR DESCRIPTION
## What changes were proposed in this pull request?
Use 'SHOW TABLE EXTENDED LIKE pattern=STRING' command in spark-sql client,add ‘Partitioned’  display similar to hive, and if the partition is empty, also need to show empty partition field []

hive:
![3](https://user-images.githubusercontent.com/26266482/35967523-12a15c70-0cfc-11e8-88ce-36b2595c1512.png)


sparkSQL Non-partitioned table fix before:
![1](https://user-images.githubusercontent.com/26266482/35967561-32098ede-0cfc-11e8-8382-57ae4857556b.png)


sparkSQL partitioned table fix before:
![2](https://user-images.githubusercontent.com/26266482/35967572-3e4f1150-0cfc-11e8-9956-5007ccb50761.png)


sparkSQL Non-partitioned table fix after:
![4](https://user-images.githubusercontent.com/26266482/35967586-493376b0-0cfc-11e8-8652-0618912bd63f.png)


sparkSQL partitioned table fix after:
![5](https://user-images.githubusercontent.com/26266482/35967602-52474588-0cfc-11e8-9b34-7532c6abae00.png)


## How was this patch tested?

manual tests

Please review http://spark.apache.org/contributing.html before opening a pull request.