### PR TITLE
[SPARK-23364][SQL]'desc table' command in spark-sql add column head display

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -539,7 +539,7 @@ case class DescribeTableCommand(
         throw new AnalysisException(
           s"DESC PARTITION is not allowed on a temporary view: ${table.identifier}")
       }
-      describeSchema(catalog.lookupRelation(table).schema, result, header = false)
+      describeSchema(catalog.lookupRelation(table).schema, result, header = true)
     } else {
       val metadata = catalog.getTableMetadata(table)
       if (metadata.schema.isEmpty) {
@@ -547,7 +547,7 @@ case class DescribeTableCommand(
         // inferred at runtime. We should still support it.
         describeSchema(sparkSession.table(metadata.identifier).schema, result, header = false)
       } else {
-        describeSchema(metadata.schema, result, header = false)
+        describeSchema(metadata.schema, result, header = true)
       }
 
       describePartitionInfo(metadata, result)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -381,7 +381,9 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
           try {
             while (!out.checkError() && driver.getResults(res)) {
               res.asScala.foreach { l =>
-                counter += 1
+                if (!l.startsWith("#")) {
+                  counter += 1
+                }
                 out.println(l)
               }
               res.clear()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use 'desc partition_table'  command in spark-sql client, i think it should add column head display.

Add 'col_name' ‘data_type’ 'comment'  column head display.

fix before:
![2](https://user-images.githubusercontent.com/26266482/36013945-283fea8c-0da2-11e8-8265-63d816dabd9b.png)

fix after:
![1](https://user-images.githubusercontent.com/26266482/36013954-3252fd7a-0da2-11e8-8e63-3b586f238072.png)

## How was this patch tested?

manual tests

Please review http://spark.apache.org/contributing.html before opening a pull request.