### PR TITLE
[SPARK-23360][SQL][PYTHON] Get local timezone from environment via pytz, or dateutil.

### DIFF
--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3415,7 +3415,9 @@ class ArrowTests(ReusedSQLTestCase):
                     (u"b", 2, 20, 0.4, 4.0, Decimal("4.0"),
                      date(2012, 2, 2), datetime(2012, 2, 2, 2, 2, 2)),
                     (u"c", 3, 30, 0.8, 6.0, Decimal("6.0"),
-                     date(2100, 3, 3), datetime(2100, 3, 3, 3, 3, 3))]
+                     date(2100, 3, 3), datetime(2100, 3, 3, 3, 3, 3)),
+                    (u"d", 4, 30, 1.0, 8.0, Decimal("8.0"),
+                     date(2100, 4, 4), datetime(2100, 4, 4, 4, 4, 4))]
 
     @classmethod
     def tearDownClass(cls):
@@ -4124,7 +4126,7 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
         data = [(0, datetime(1969, 1, 1, 1, 1, 1)),
                 (1, datetime(2012, 2, 2, 2, 2, 2)),
                 (2, None),
-                (3, datetime(2100, 3, 3, 3, 3, 3))]
+                (3, datetime(2100, 4, 4, 4, 4, 4))]
 
         df = self.spark.createDataFrame(data, schema=schema)
 
@@ -4206,7 +4208,7 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
         data = [(1, datetime(1969, 1, 1, 1, 1, 1)),
                 (2, datetime(2012, 2, 2, 2, 2, 2)),
                 (3, None),
-                (4, datetime(2100, 3, 3, 3, 3, 3))]
+                (4, datetime(2100, 4, 4, 4, 4, 4))]
         df = self.spark.createDataFrame(data, schema=schema)
 
         f_timestamp_copy = pandas_udf(lambda ts: ts, TimestampType())

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -2867,6 +2867,35 @@ class SQLTests(ReusedSQLTestCase):
                                     "d": [pd.Timestamp.now().date()]})
                 self.spark.createDataFrame(pdf)
 
+    # Regression test for SPARK-23360
+    @unittest.skipIf(not _have_pandas, _pandas_requirement_message)
+    def test_create_dateframe_from_pandas_with_dst(self):
+        import pandas as pd
+        from datetime import datetime
+
+        pdf = pd.DataFrame({'time': [datetime(2015, 10, 31, 22, 30)]})
+
+        df = self.spark.createDataFrame(pdf)
+        self.assertPandasEqual(pdf, df.toPandas())
+
+        orig_env_tz = os.environ.get('TZ', None)
+        orig_session_tz = self.spark.conf.get('spark.sql.session.timeZone')
+        try:
+            tz = 'America/Los_Angeles'
+            os.environ['TZ'] = tz
+            time.tzset()
+            self.spark.conf.set('spark.sql.session.timeZone', tz)
+
+            df = self.spark.createDataFrame(pdf)
+            df.show()
+            self.assertPandasEqual(pdf, df.toPandas())
+        finally:
+            del os.environ['TZ']
+            if orig_env_tz is not None:
+                os.environ['TZ'] = orig_env_tz
+            time.tzset()
+            self.spark.conf.set('spark.sql.session.timeZone', orig_session_tz)
+
 
 class HiveSparkSubmitTests(SparkSubmitTests):
 

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3415,9 +3415,7 @@ class ArrowTests(ReusedSQLTestCase):
                     (u"b", 2, 20, 0.4, 4.0, Decimal("4.0"),
                      date(2012, 2, 2), datetime(2012, 2, 2, 2, 2, 2)),
                     (u"c", 3, 30, 0.8, 6.0, Decimal("6.0"),
-                     date(2100, 3, 3), datetime(2100, 3, 3, 3, 3, 3)),
-                    (u"d", 4, 30, 1.0, 8.0, Decimal("8.0"),
-                     date(2100, 4, 4), datetime(2100, 4, 4, 4, 4, 4))]
+                     date(2100, 3, 3), datetime(2100, 3, 3, 3, 3, 3))]
 
     @classmethod
     def tearDownClass(cls):
@@ -4126,7 +4124,7 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
         data = [(0, datetime(1969, 1, 1, 1, 1, 1)),
                 (1, datetime(2012, 2, 2, 2, 2, 2)),
                 (2, None),
-                (3, datetime(2100, 4, 4, 4, 4, 4))]
+                (3, datetime(2100, 3, 3, 3, 3, 3))]
 
         df = self.spark.createDataFrame(data, schema=schema)
 
@@ -4208,7 +4206,7 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
         data = [(1, datetime(1969, 1, 1, 1, 1, 1)),
                 (2, datetime(2012, 2, 2, 2, 2, 2)),
                 (3, None),
-                (4, datetime(2100, 4, 4, 4, 4, 4))]
+                (4, datetime(2100, 3, 3, 3, 3, 3))]
         df = self.spark.createDataFrame(data, schema=schema)
 
         f_timestamp_copy = pandas_udf(lambda ts: ts, TimestampType())

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -2887,7 +2887,6 @@ class SQLTests(ReusedSQLTestCase):
             self.spark.conf.set('spark.sql.session.timeZone', tz)
 
             df = self.spark.createDataFrame(pdf)
-            df.show()
             self.assertPandasEqual(pdf, df.toPandas())
         finally:
             del os.environ['TZ']

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1787,7 +1787,9 @@ def _check_series_convert_timestamps_localize(s, from_timezone, to_timezone):
     if is_datetime64tz_dtype(s.dtype):
         return s.dt.tz_convert(to_tz).dt.tz_localize(None)
     elif is_datetime64_dtype(s.dtype) and from_tz != to_tz:
-        return s.dt.tz_localize(from_tz).dt.tz_convert(to_tz).dt.tz_localize(None)
+        # `s.dt.tz_localize('tzlocal()')` doesn't work properly when including NaT.
+        return s.apply(lambda ts: ts.tz_localize(from_tz).tz_convert(to_tz).tz_localize(None)
+                       if ts is not pd.NaT else pd.NaT)
     else:
         return s
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1710,10 +1710,16 @@ def _check_dataframe_convert_date(pdf, schema):
 
 
 def _get_local_timezone():
-    """ Get local timezone from environment vi pytz, or dateutil. """
-    from pyspark.sql.utils import require_minimum_pandas_version
-    require_minimum_pandas_version()
+    """ Get local timezone using pytz with environment variable, or dateutil.
 
+    If there is a 'TZ' environment variable, pass it to pandas to use pytz and use it as timezone
+    string, otherwise use the special word 'dateutil/:' which means that pandas uses dateutil and
+    it reads system configuration to know the system local timezone.
+
+    See also:
+    - https://github.com/pandas-dev/pandas/blob/0.19.x/pandas/tslib.pyx#L1753
+    - https://github.com/dateutil/dateutil/blob/2.6.1/dateutil/tz/tz.py#L1338
+    """
     import os
     return os.environ.get('TZ', 'dateutil/:')
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently we use `tzlocal()` to get Python local timezone, but it sometimes causes unexpected behavior.
I changed the way to get Python local timezone to use pytz if the timezone is specified in environment variable, or timezone file via dateutil .

## How was this patch tested?

Added a test and existing tests.
