### PR TITLE
[SPARK-23380][PYTHON] Make toPandas fallback to non-Arrow optimization if possible

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1941,12 +1941,24 @@ class DataFrame(object):
             timezone = None
 
         if self.sql_ctx.getConf("spark.sql.execution.arrow.enabled", "false").lower() == "true":
+            should_fall_back = False
             try:
+                from pyspark.sql.types import to_arrow_schema
+                from pyspark.sql.utils import require_minimum_pyarrow_version
+                require_minimum_pyarrow_version()
+                # Check if its schema is convertible in Arrow format.
+                to_arrow_schema(self.schema)
+            except Exception as e:
+                # Fallback to convert to Pandas DataFrame without arrow if raise some exception
+                should_fall_back = True
+                warnings.warn(
+                    "Arrow will not be used in toPandas: %s" % _exception_message(e))
+
+            if not should_fall_back:
+                import pyarrow
                 from pyspark.sql.types import _check_dataframe_convert_date, \
                     _check_dataframe_localize_timestamps
-                from pyspark.sql.utils import require_minimum_pyarrow_version
-                import pyarrow
-                require_minimum_pyarrow_version()
+
                 tables = self._collectAsArrow()
                 if tables:
                     table = pyarrow.concat_tables(tables)
@@ -1955,38 +1967,34 @@ class DataFrame(object):
                     return _check_dataframe_localize_timestamps(pdf, timezone)
                 else:
                     return pd.DataFrame.from_records([], columns=self.columns)
-            except ImportError as e:
-                msg = "note: pyarrow must be installed and available on calling Python process " \
-                      "if using spark.sql.execution.arrow.enabled=true"
-                raise ImportError("%s\n%s" % (_exception_message(e), msg))
+
+        pdf = pd.DataFrame.from_records(self.collect(), columns=self.columns)
+
+        dtype = {}
+        for field in self.schema:
+            pandas_type = _to_corrected_pandas_type(field.dataType)
+            # SPARK-21766: if an integer field is nullable and has null values, it can be
+            # inferred by pandas as float column. Once we convert the column with NaN back
+            # to integer type e.g., np.int16, we will hit exception. So we use the inferred
+            # float type, not the corrected type from the schema in this case.
+            if pandas_type is not None and \
+                not(isinstance(field.dataType, IntegralType) and field.nullable and
+                    pdf[field.name].isnull().any()):
+                dtype[field.name] = pandas_type
+
+        for f, t in dtype.items():
+            pdf[f] = pdf[f].astype(t, copy=False)
+
+        if timezone is None:
+            return pdf
         else:
-            pdf = pd.DataFrame.from_records(self.collect(), columns=self.columns)
-
-            dtype = {}
+            from pyspark.sql.types import _check_series_convert_timestamps_local_tz
             for field in self.schema:
-                pandas_type = _to_corrected_pandas_type(field.dataType)
-                # SPARK-21766: if an integer field is nullable and has null values, it can be
-                # inferred by pandas as float column. Once we convert the column with NaN back
-                # to integer type e.g., np.int16, we will hit exception. So we use the inferred
-                # float type, not the corrected type from the schema in this case.
-                if pandas_type is not None and \
-                    not(isinstance(field.dataType, IntegralType) and field.nullable and
-                        pdf[field.name].isnull().any()):
-                    dtype[field.name] = pandas_type
-
-            for f, t in dtype.items():
-                pdf[f] = pdf[f].astype(t, copy=False)
-
-            if timezone is None:
-                return pdf
-            else:
-                from pyspark.sql.types import _check_series_convert_timestamps_local_tz
-                for field in self.schema:
-                    # TODO: handle nested timestamps, such as ArrayType(TimestampType())?
-                    if isinstance(field.dataType, TimestampType):
-                        pdf[field.name] = \
-                            _check_series_convert_timestamps_local_tz(pdf[field.name], timezone)
-                return pdf
+                # TODO: handle nested timestamps, such as ArrayType(TimestampType())?
+                if isinstance(field.dataType, TimestampType):
+                    pdf[field.name] = \
+                        _check_series_convert_timestamps_local_tz(pdf[field.name], timezone)
+            return pdf
 
     def _collectAsArrow(self):
         """

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1941,7 +1941,7 @@ class DataFrame(object):
             timezone = None
 
         if self.sql_ctx.getConf("spark.sql.execution.arrow.enabled", "false").lower() == "true":
-            should_fall_back = False
+            should_fallback = False
             try:
                 from pyspark.sql.types import to_arrow_schema
                 from pyspark.sql.utils import require_minimum_pyarrow_version
@@ -1950,11 +1950,11 @@ class DataFrame(object):
                 to_arrow_schema(self.schema)
             except Exception as e:
                 # Fallback to convert to Pandas DataFrame without arrow if raise some exception
-                should_fall_back = True
+                should_fallback = True
                 warnings.warn(
                     "Arrow will not be used in toPandas: %s" % _exception_message(e))
 
-            if not should_fall_back:
+            if not should_fallback:
                 import pyarrow
                 from pyspark.sql.types import _check_dataframe_convert_date, \
                     _check_dataframe_localize_timestamps

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -37,6 +37,7 @@ from pyspark.sql.types import Row, DataType, StringType, StructType, TimestampTy
     _make_type_verifier, _infer_schema, _has_nulltype, _merge_type, _create_converter, \
     _parse_datatype_string
 from pyspark.sql.utils import install_exception_handler
+from pyspark.util import _exception_message
 
 __all__ = ["SparkSession"]
 
@@ -666,8 +667,9 @@ class SparkSession(object):
                 try:
                     return self._create_from_pandas_with_arrow(data, schema, timezone)
                 except Exception as e:
-                    warnings.warn("Arrow will not be used in createDataFrame: %s" % str(e))
                     # Fallback to create DataFrame without arrow if raise some exception
+                    warnings.warn(
+                        "Arrow will not be used in createDataFrame: %s" % _exception_message(e))
             data = self._convert_from_pandas(data, schema, timezone)
 
         if isinstance(schema, StructType):

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -50,6 +50,7 @@ else:
     import unittest
 
 from pyspark.util import _exception_message
+
 _pandas_requirement_message = None
 try:
     from pyspark.sql.utils import require_minimum_pandas_version


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to fallback to non-Arrow optimization if possible - for unsupported schema, PyArrow version mismatch and PyAarrow missing.

For example, see the unsupported schema case below:

```python
df = spark.createDataFrame([[{'a': 1}]])

spark.conf.set("spark.sql.execution.arrow.enabled", "false")
df.toPandas()
spark.conf.set("spark.sql.execution.arrow.enabled", "true")
df.toPandas()
```

**Before**

```
...
py4j.protocol.Py4JJavaError: An error occurred while calling o42.collectAsArrowToPython.
...
java.lang.UnsupportedOperationException: Unsupported data type: map<string,bigint>
```

**After**

```
...
          _1
0  {u'a': 1}

... UserWarning: Arrow will not be used in toPandas: Unsupported type in conversion to Arrow: MapType(StringType,LongType,true)
...
          _1
0  {u'a': 1}
```

Note that, in case of `createDataFrame`, we already fallback to make this at least working even though the optimisation is disabled: 

```python
df = spark.createDataFrame([[{'a': 1}]])
spark.conf.set("spark.sql.execution.arrow.enabled", "false")
pdf = df.toPandas()
spark.createDataFrame(pdf).show()
spark.conf.set("spark.sql.execution.arrow.enabled", "true")
spark.createDataFrame(pdf).show()
```

```
...
... UserWarning: Arrow will not be used in createDataFrame: Error inferring Arrow type ...
+--------+
|      _1|
+--------+
|[a -> 1]|
+--------+
```


## How was this patch tested?

Manually tested and unit tests were added in `python/pyspark/sql/tests.py`.
