### PR TITLE
[SPARK-23383][Build][Minor]Make a distribution should exit with usage while detecting wrong options

### DIFF
--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -38,7 +38,7 @@ MAKE_R=false
 NAME=none
 MVN="$SPARK_HOME/build/mvn"
 
-function exit_with_usage {
+function usage {
   echo "make-distribution.sh - tool for making binary distributions of Spark"
   echo ""
   echo "usage:"
@@ -46,6 +46,10 @@ function exit_with_usage {
   echo "make-distribution.sh $cl_options <maven build options>"
   echo "See Spark's \"Building Spark\" doc for correct Maven options."
   echo ""
+}
+
+function exit_with_usage {
+  usage
   exit 1
 }
 
@@ -72,8 +76,15 @@ while (( "$#" )); do
     --help)
       exit_with_usage
       ;;
+    --*)
+      echo "Error: $1 is not supported, it will be ignored and not take effect"
+      usage
+      shift
+      continue
+      ;;
     *)
-      break
+      echo "Error: $1 is not supported"
+      exit_with_usage
       ;;
   esac
   shift

--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -38,7 +38,7 @@ MAKE_R=false
 NAME=none
 MVN="$SPARK_HOME/build/mvn"
 
-function usage {
+function exit_with_usage {
   echo "make-distribution.sh - tool for making binary distributions of Spark"
   echo ""
   echo "usage:"
@@ -46,10 +46,6 @@ function usage {
   echo "make-distribution.sh $cl_options <maven build options>"
   echo "See Spark's \"Building Spark\" doc for correct Maven options."
   echo ""
-}
-
-function exit_with_usage {
-  usage
   exit 1
 }
 
@@ -77,10 +73,8 @@ while (( "$#" )); do
       exit_with_usage
       ;;
     --*)
-      echo "Error: $1 is not supported, it will be ignored and not take effect"
-      usage
-      shift
-      continue
+      echo "Error: $1 is not supported"
+      exit_with_usage
       ;;
     -*)
       break

--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -82,6 +82,9 @@ while (( "$#" )); do
       shift
       continue
       ;;
+    -*)
+      break
+      ;;
     *)
       echo "Error: $1 is not supported"
       exit_with_usage


### PR DESCRIPTION
## What changes were proposed in this pull request?
```shell
./dev/make-distribution.sh --name ne-1.0.0-SNAPSHOT xyz --tgz  -Phadoop-2.7
+++ dirname ./dev/make-distribution.sh
++ cd ./dev/..
++ pwd
+ SPARK_HOME=/Users/Kent/Documents/spark
+ DISTDIR=/Users/Kent/Documents/spark/dist
+ MAKE_TGZ=false
+ MAKE_PIP=false
+ MAKE_R=false
+ NAME=none
+ MVN=/Users/Kent/Documents/spark/build/mvn
+ ((  5  ))
+ case $1 in
+ NAME=ne-1.0.0-SNAPSHOT
+ shift
+ shift
+ ((  3  ))
+ case $1 in
+ break
+ '[' -z /Users/Kent/.jenv/candidates/java/current ']'
+ '[' -z /Users/Kent/.jenv/candidates/java/current ']'
++ command -v git
+ '[' /usr/local/bin/git ']'
++ git rev-parse --short HEAD
+ GITREV=98ea6a7
+ '[' '!' -z 98ea6a7 ']'
+ GITREVSTRING=' (git revision 98ea6a7)'
+ unset GITREV
++ command -v /Users/Kent/Documents/spark/build/mvn
+ '[' '!' /Users/Kent/Documents/spark/build/mvn ']'
++ /Users/Kent/Documents/spark/build/mvn help:evaluate -Dexpression=project.version xyz --tgz -Phadoop-2.7
++ grep -v INFO
++ tail -n 1
+ VERSION=' -X,--debug                             Produce execution debug output'
```
It is better to declare the mistakes and exit with usage than `break`

## How was this patch tested?

manually 

cc @srowen 