### PR TITLE
[SPARK-23385][CORE] Allow SparkUITab to be customized adding in Spark…

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -520,4 +520,10 @@ package object config {
       .checkValue(v => v > 0, "The threshold should be positive.")
       .createWithDefault(10000000)
 
+  private[spark] val EXTRA_UI_TABS = ConfigBuilder("spark.extraUITabs")
+    .doc("Class names of UI tabs to add to SparkUI during initialization.")
+    .stringConf
+    .toSequence
+    .createOptional
+
 }

--- a/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
@@ -30,7 +30,7 @@ import org.apache.spark.util.kvstore.{InMemoryStore, KVStore}
 /**
  * A wrapper around a KVStore that provides methods for accessing the API data stored within.
  */
-private[spark] class AppStatusStore(
+class AppStatusStore(
     val store: KVStore,
     val listener: Option[AppStatusListener] = None) {
 

--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -213,7 +213,7 @@ class SparkUI private (
 
 }
 
-private[spark] abstract class SparkUITab(parent: SparkUI, prefix: String)
+abstract class SparkUITab(parent: SparkUI, prefix: String)
   extends WebUITab(parent, prefix) {
 
   def appName: String = parent.appName


### PR DESCRIPTION
…Conf and loaded when creating SparkUI

## What changes were proposed in this pull request?

It would be nice if there was a mechanism to allow to add customized SparkUITab (embedded like Jobs, Stages, Storage, Environment, Executors,...) to be registered through SparkConf settings. This would be more flexible when we need display some special information in UI rather than adding the embedded one by one and wait community to merge.

I propose to introduce a new configuration option, spark.extraUITabs, that allows customized SparkUITab to be specified in SparkConf and registered when SparkUI is created. Here is the proposed documentation for the new option: 

> A comma-separated list of classes that implement SparkUITab; when initializing SparkUI, instances of these classes will be created and registered to the tabs array in SparkUI. If a class has a two-argument constructor that accepts a SparkUI and AppStatusStore, that constructor will be called; If a class has a single-argument constructor that accepts a SparkUI; otherwise, a zero-argument constructor will be called. If no valid constructor can be found, the SparkUI creation will fail with an exception.

## How was this patch tested?
1.  Offerred a unit test.
2. Check the WebUI to see a new tab called "Test" via
> bin/spark-shell` --master local --driver-class-path /path/spark-core_2.11-*-tests.jar --conf spark.extraUITabs=org.apache.spark.ui.TestUITab    