### PR TITLE
[SPARK-23404][CORE]When the underlying buffers are direct, we should copy them to the heap memory

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -940,7 +940,11 @@ private[spark] class BlockManager(
             if (memoryMode == MemoryMode.OFF_HEAP &&
                 bytes.chunks.exists(buffer => !buffer.isDirect)) {
               bytes.copy(Platform.allocateDirectBuffer)
-            } else {
+            } else if (memoryMode == MemoryMode.ON_HEAP &&
+              bytes.chunks.exists(buffer => buffer.isDirect)) {
+              bytes.copy(ByteBuffer.allocate)
+            }
+            else {
               bytes
             }
           })


### PR DESCRIPTION
## What changes were proposed in this pull request?
If the memory mode is `ON_HEAP`,when the underlying buffers are direct, we should copy them to the heap memory.

## How was this patch tested?
N/A
