### PR TITLE
[SPARK-23416][SS] handle streaming interrupts in ThreadUtils.awaitResult()

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -29,8 +29,8 @@ import scala.util.control.NonFatal
 
 import com.google.common.util.concurrent.UncheckedExecutionException
 import org.apache.hadoop.fs.Path
-import org.apache.spark.SparkException
 
+import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -29,6 +29,7 @@ import scala.util.control.NonFatal
 
 import com.google.common.util.concurrent.UncheckedExecutionException
 import org.apache.hadoop.fs.Path
+import org.apache.spark.SparkException
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql._
@@ -369,7 +370,11 @@ abstract class StreamExecution(
         //                      exception
         // UncheckedExecutionException - thrown by codes that cannot throw a checked
         //                               ExecutionException, such as BiFunction.apply
-        case e2 @ (_: UncheckedIOException | _: ExecutionException | _: UncheckedExecutionException)
+        // SparkException - thrown if the interrupt happens in the middle of an RPC wait
+        case e2 @ (_: UncheckedIOException |
+                   _: ExecutionException |
+                   _: UncheckedExecutionException |
+                   _: SparkException)
           if e2.getCause != null =>
           isInterruptedByStop(e2.getCause)
         case _ =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

StreamExecution.isInterruptedByStop() implements a whitelist of exceptions which indicate a benign stop() call. The DataSourceV2 write path introduces a new kind of exception, SparkException caused by InterruptedException, which must be added to this whitelist. (This exception comes from an interrupt in ThreadUtils.awaitResult().)

## How was this patch tested?

Existing unit tests. Unfortunately, the underlying flakiness is reasonably rare, so I don't have a good idea for how to test that this resolves it.
