### PR TITLE
Don't block on cleanup tasks by default

### DIFF
--- a/core/src/main/scala/org/apache/spark/ContextCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/ContextCleaner.scala
@@ -89,15 +89,9 @@ private[spark] class ContextCleaner(sc: SparkContext) extends Logging {
   /**
    * Whether the cleaning thread will block on cleanup tasks (other than shuffle, which
    * is controlled by the `spark.cleaner.referenceTracking.blocking.shuffle` parameter).
-   *
-   * Due to SPARK-3015, this is set to true by default. This is intended to be only a temporary
-   * workaround for the issue, which is ultimately caused by the way the BlockManager endpoints
-   * issue inter-dependent blocking RPC messages to each other at high frequencies. This happens,
-   * for instance, when the driver performs a GC and cleans up all broadcast blocks that are no
-   * longer in scope.
    */
   private val blockOnCleanupTasks = sc.conf.getBoolean(
-    "spark.cleaner.referenceTracking.blocking", true)
+    "spark.cleaner.referenceTracking.blocking", false)
 
   /**
    * Whether the cleaning thread will block on shuffle cleanup tasks.


### PR DESCRIPTION
This PR sets `"spark.cleaner.referenceTracking.blocking"` to `false` by
default. It had originally been set to `true` as a workaround for
SPARK-3015.

However, that issue has been resolved since 16/Aug/2014 already.
I would therefore think that it's safe to make this non-blocking by
default, which should help with cases where the cleanup thread can not
keep up any more.

If there are other reasons why this should stay blocking by default, I'd
be interested to learn about them. In that case the comment should
probably be updated.
