### PR TITLE
[SPARK-23368][SQL] Avoid unnecessary Exchange or Sort after projection

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -115,6 +115,25 @@ abstract class Expression extends TreeNode[Expression] {
     }
   }
 
+  /**
+   * Transform this [[Expression]] with substitutions from projected [[Expression Expressions]]
+   * to their corresponding aliases.
+   *
+   * @param projectList a [[Seq]] of projected [[Expression Expressions]]
+   * @return the transformed [[Expression]], or the original [[Expression]] if no substitution
+   *         is applied.
+   */
+  def substituteProjectedExpressions(projectList: Seq[NamedExpression]): Expression = {
+    this.transform {
+      case e =>
+        val found = projectList.find {
+          case Alias(child, _) => child.semanticEquals(e)
+          case _ => false
+        }
+        if (found.nonEmpty) found.get.toAttribute else e
+    }
+  }
+
   private def reduceCodeSize(ctx: CodegenContext, eval: ExprCode): Unit = {
     // TODO: support whole stage codegen too
     if (eval.code.trim.length > 1024 && ctx.INPUT_ROW != null && ctx.currentVars == null) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
@@ -119,6 +119,31 @@ object SortOrder {
       }
     }
   }
+
+  /**
+   * Transforms an ordering by substituting all projected [[Expression Expressions]]
+   * with their corresponding aliases from a projection. If this ordering is not
+   * concerned with any projected [[Expression]], return the original ordering.
+   *
+   * @param ordering the original ordering before projection
+   * @param projectList a [[Seq]] of projected [[Expression Expressions]]
+   * @return the transformed ordering after the projection
+   */
+  def projectOrdering(ordering: Seq[SortOrder], projectList: Seq[NamedExpression])
+  : Seq[SortOrder] = {
+    ordering.map {
+      o => {
+        val newChild = o.child.substituteProjectedExpressions(projectList)
+        val newSameOrderExpressions = o.sameOrderExpressions.map(
+          _.substituteProjectedExpressions(projectList))
+        if (newChild == o.child && newSameOrderExpressions == o.sameOrderExpressions) {
+          o
+        } else {
+          SortOrder(newChild, o.direction, o.nullOrdering, newSameOrderExpressions)
+        }
+      }
+    }
+  }
 }
 
 /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
@@ -170,4 +170,41 @@ class DistributionSuite extends SparkFunSuite {
       AllTuples,
       false)
   }
+
+  test("Output partitioning after projection") {
+    checkSatisfied(
+      HashPartitioning(Seq(('a + 1).asc, ('b + 1).asc), 10)
+        .project(Seq('a.as("a1"), ('b + 1).as("b1"))),
+      ClusteredDistribution(Seq(('a1 + 1).asc, 'b1.asc)),
+      true
+    )
+
+    checkSatisfied(
+      HashPartitioning(Seq(('a + 1).asc, ('b + 1).asc), 10)
+        .project(Seq('a.as("a1"), ('b + 1).as("b1"))),
+      ClusteredDistribution(Seq('b1.asc, ('a1 + 1).asc)),
+      true
+    )
+
+    checkSatisfied(
+      HashPartitioning(Seq(('a + 1).asc, ('b + 1).asc), 10)
+        .project(Seq('a.as("a1"), ('b + 1).as("b1"))),
+      ClusteredDistribution(Seq('a1.asc, 'b1.asc)),
+      false
+    )
+
+    checkSatisfied(
+      RangePartitioning(Seq(('a + 'c).asc, ('b + 'd).asc), 10)
+        .project(Seq('a.as("a1"), ('b + 'd).as("bd"), 'c.as("c1"))),
+      OrderedDistribution(Seq(('a1 + 'c1).asc, 'bd.asc)),
+      true
+    )
+
+    checkSatisfied(
+      RangePartitioning(Seq(('a + 'c).asc, ('b + 'd).asc), 10)
+        .project(Seq('a.as("a1"), ('b + 'd).as("bd"), 'c.as("c1"))),
+      OrderedDistribution(Seq('bd.asc, ('a1 + 'c1).asc)),
+      false
+    )
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
@@ -206,5 +206,27 @@ class DistributionSuite extends SparkFunSuite {
       OrderedDistribution(Seq('bd.asc, ('a1 + 'c1).asc)),
       false
     )
+
+    checkSatisfied(
+      PartitioningCollection(
+        Seq(
+          RangePartitioning(Seq(('a + 1).asc, ('b + 1).asc), 10),
+          RangePartitioning(Seq(('c - 1).asc, ('d - 1).asc), 10)
+        )
+      ).project(Seq('a.as("a1"), ('b + 1).as("b1"), ('c - 1).as("c1"), 'd.as("d1"))),
+      OrderedDistribution(Seq(('a1 + 1).asc, 'b1.asc)),
+      true
+    )
+
+    checkSatisfied(
+      PartitioningCollection(
+        Seq(
+          RangePartitioning(Seq(('a + 1).asc, ('b + 1).asc), 10),
+          RangePartitioning(Seq(('c - 1).asc, ('d - 1).asc), 10)
+        )
+      ).project(Seq('a.as("a1"), ('b + 1).as("b1"), ('c - 1).as("c1"), 'd.as("d1"))),
+      OrderedDistribution(Seq('c1.asc, ('d1 - 1).asc)),
+      true
+    )
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -65,7 +65,8 @@ case class HashAggregateExec(
 
   override def output: Seq[Attribute] = resultExpressions.map(_.toAttribute)
 
-  override def outputPartitioning: Partitioning = child.outputPartitioning
+  override def outputPartitioning: Partitioning =
+    child.outputPartitioning.project(resultExpressions)
 
   override def producedAttributes: AttributeSet =
     AttributeSet(aggregateAttributes) ++

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
@@ -95,7 +95,8 @@ case class ObjectHashAggregateExec(
     }
   }
 
-  override def outputPartitioning: Partitioning = child.outputPartitioning
+  override def outputPartitioning: Partitioning =
+    child.outputPartitioning.project(resultExpressions)
 
   protected override def doExecute(): RDD[InternalRow] = attachTree(this, "execute") {
     val numOutputRows = longMetric("numOutputRows")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
@@ -66,10 +66,13 @@ case class SortAggregateExec(
     groupingExpressions.map(SortOrder(_, Ascending)) :: Nil
   }
 
-  override def outputPartitioning: Partitioning = child.outputPartitioning
+  override def outputPartitioning: Partitioning =
+    child.outputPartitioning.project(resultExpressions)
 
   override def outputOrdering: Seq[SortOrder] = {
-    groupingExpressions.map(SortOrder(_, Ascending))
+    SortOrder.projectOrdering(
+      groupingExpressions.map(SortOrder(_, Ascending)),
+      resultExpressions)
   }
 
   protected override def doExecute(): RDD[InternalRow] = attachTree(this, "execute") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -75,9 +75,11 @@ case class ProjectExec(projectList: Seq[NamedExpression], child: SparkPlan)
     }
   }
 
-  override def outputOrdering: Seq[SortOrder] = child.outputOrdering
+  override def outputOrdering: Seq[SortOrder] =
+    SortOrder.projectOrdering(child.outputOrdering, projectList)
 
-  override def outputPartitioning: Partitioning = child.outputPartitioning
+  override def outputPartitioning: Partitioning =
+    child.outputPartitioning.project(projectList)
 }
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -25,8 +25,9 @@ import java.util.concurrent.atomic.AtomicBoolean
 import org.apache.spark.{AccumulatorSuite, SparkException}
 import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart}
 import org.apache.spark.sql.catalyst.util.StringUtils
-import org.apache.spark.sql.execution.aggregate
-import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, SortAggregateExec}
+import org.apache.spark.sql.execution.{aggregate, SortExec, SparkPlan}
+import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
+import org.apache.spark.sql.execution.exchange.Exchange
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, CartesianProductExec, SortMergeJoinExec}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
@@ -2790,5 +2791,72 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
           .as[String].collect().mkString(",").contains("i,p,j"))
       }
     }
+  }
+
+  test("SPARK-23368: Avoid unnecessary Exchange or Sort after projection (test Project)") {
+    val df = sql(
+      """
+        |SELECT * FROM (
+        |  SELECT t1.a a1, t2.a a2, t1.b + 1 b1, t2.b b2
+        |  FROM testData2 t1 JOIN testData2 t2
+        |  ON t1.a + 1 = t2.a AND t1.b + 1 = t2.b
+        |)
+        |JOIN testData2 t3
+        |ON a1 + 1 = t3.a AND b1 = t3.b
+      """.stripMargin)
+    val plan = df.queryExecution.executedPlan
+    val sortOrExchangeOverJoin = plan.find {
+      case s: SortExec =>
+        s.find {
+          case j: SortMergeJoinExec => true
+          case _ => false
+        }.nonEmpty
+      case e: Exchange =>
+        e.find {
+          case j: SortMergeJoinExec => true
+          case _ => false
+        }.nonEmpty
+      case _ => false
+    }
+    assert(sortOrExchangeOverJoin.isEmpty)
+    checkAnswer(df, Row(1, 2, 2, 2, 2, 2) :: Row(2, 3, 2, 2, 3, 2) :: Nil)
+  }
+
+  test("SPARK-23368: Avoid unnecessary Exchange or Sort after projection (test Aggregate)") {
+    val df = sql(
+      """
+        |SELECT a1, t2.b, c FROM (
+        |  SELECT a a1, b + 1 b1, count(*) c
+        |  FROM testData2
+        |  GROUP BY a, b + 1
+        |) t1
+        |JOIN testData2 t2
+        |ON a1 = t2.a AND b1 = t2.b
+      """.stripMargin)
+    val plan = df.queryExecution.executedPlan
+    val exchangeOverFinalAggregate = plan.find {
+      case e: Exchange =>
+        e.find {
+          case h: HashAggregateExec =>
+            h.child.find {
+              case h2: HashAggregateExec => true
+              case _ => false
+            }.nonEmpty
+          case s: SortAggregateExec =>
+            s.child.find {
+              case s2: SortAggregateExec => true
+              case _ => false
+            }.nonEmpty
+          case o: ObjectHashAggregateExec =>
+            o.child.find {
+              case o2: ObjectHashAggregateExec => true
+              case _ => false
+            }.nonEmpty
+          case _ => false
+        }.nonEmpty
+      case _ => false
+    }
+    assert(exchangeOverFinalAggregate.isEmpty)
+    checkAnswer(df, Row(1, 2, 1) :: Row(2, 2, 1) :: Row(3, 2, 1) :: Nil)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Add "project" methods for both Partitioning and Ordering (Seq[SortOrder]), which returns what should be the partitioning or ordering after the projection, i.e., substitutes the projected expressions with aliases specified in the project.

2. In ProjectExec, XXXAggregateExec, make outputPartitioning and outputOrdering return "child.outputPartitioning.project(projectList)" or "SortOrder.projectOrderings(child.outputOrdering, projectList)" instead of "child.outputPartitioning" or "child.outputOrdering".

## How was this patch tested?

1. Add 2 tests in SQLQuerySuite to verify that the unnecessary Exchange and/or Sort have been eliminated from the execution plan.
2. Add 1 unit test in DistributionSuite.

## Note
Note that there could be some variation in the implementation of "Partitioning.project(projectList)", depending on whether or not we'd choose to retain the original partitioning together with the projected partitioning, and how far we'd go to include all possible valid partitionings.
Since it is usually impossible to refer to the original expression once it is projected with an alias, unless it appears elsewhere in the projection list (without alias or with a different alias). This would lead to the implementation being more complex and generating a cartesian product of all substituted/unsubstituted expressions if 1) a partitioning contains more than one expression; 2) a partitioning contains expressions that consist of more than one projected expression.
That said, I consider "an expression being projected twice in one projection" to be a rare case which does not make much sense, so the current implementation should be good enough.
