### PR TITLE
[SPARK-23415][SQL][TEST] Make behavior of BufferHolderSparkSubmitSuite correct and stable

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
@@ -61,6 +61,10 @@ final class BufferHolder {
    * Grows the buffer by at least neededSize and points the row to the buffer.
    */
   void grow(int neededSize) {
+    if (neededSize < 0) {
+      throw new UnsupportedOperationException(
+        "Cannot grow BufferHolder by size " + neededSize + " because the size is negative");
+    }
     if (neededSize > ARRAY_MAX - totalSize()) {
       throw new UnsupportedOperationException(
         "Cannot grow BufferHolder by size " + neededSize + " because the size after growing " +

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
@@ -35,6 +35,7 @@ final class BufferHolder {
 
   private static final int ARRAY_MAX = ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH;
 
+  // buffer is guarantee to be word-aligned since UnsafeRow assumes each field is word-aligned.
   private byte[] buffer;
   private int cursor = Platform.BYTE_ARRAY_OFFSET;
   private final UnsafeRow row;
@@ -52,7 +53,8 @@ final class BufferHolder {
           "too many fields (number of fields: " + row.numFields() + ")");
     }
     this.fixedSize = bitsetWidthInBytes + 8 * row.numFields();
-    this.buffer = new byte[fixedSize + initialSize];
+    int roundedSize = ByteArrayMethods.roundNumberOfBytesToNearestWord(fixedSize + initialSize);
+    this.buffer = new byte[roundedSize];
     this.row = row;
     this.row.pointTo(buffer, buffer.length);
   }
@@ -63,17 +65,17 @@ final class BufferHolder {
   void grow(int neededSize) {
     assert neededSize < 0 :
       "Cannot grow BufferHolder by size " + neededSize + " because the size is negative";
-    int roundedSize = ByteArrayMethods.roundNumberOfBytesToNearestWord(neededSize);
-    if (roundedSize > ARRAY_MAX - totalSize()) {
+    if (neededSize > ARRAY_MAX - totalSize()) {
       throw new UnsupportedOperationException(
-        "Cannot grow BufferHolder by size " + roundedSize + " because the size after growing " +
+        "Cannot grow BufferHolder by size " + neededSize + " because the size after growing " +
           "exceeds size limitation " + ARRAY_MAX);
     }
-    final int length = totalSize() + roundedSize;
+    final int length = totalSize() + neededSize;
     if (buffer.length < length) {
       // This will not happen frequently, because the buffer is re-used.
       int newLength = length < ARRAY_MAX / 2 ? length * 2 : ARRAY_MAX;
-      final byte[] tmp = new byte[newLength];
+      int roundedSize = ByteArrayMethods.roundNumberOfBytesToNearestWord(newLength);
+      final byte[] tmp = new byte[roundedSize];
       Platform.copyMemory(
         buffer,
         Platform.BYTE_ARRAY_OFFSET,

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
@@ -35,6 +35,8 @@ final class BufferHolder {
 
   private static final int ARRAY_MAX = ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH;
 
+  // Buffer is guarantee to be word-aligned. This is because UnsafeRow assumes that each field
+  // is word-aligned.
   private byte[] buffer;
   private int cursor = Platform.BYTE_ARRAY_OFFSET;
   private final UnsafeRow row;
@@ -52,7 +54,8 @@ final class BufferHolder {
           "too many fields (number of fields: " + row.numFields() + ")");
     }
     this.fixedSize = bitsetWidthInBytes + 8 * row.numFields();
-    this.buffer = new byte[fixedSize + initialSize];
+    int roundedSize = ByteArrayMethods.roundNumberOfBytesToNearestWord(fixedSize + initialSize);
+    this.buffer = new byte[roundedSize];
     this.row = row;
     this.row.pointTo(buffer, buffer.length);
   }
@@ -63,17 +66,17 @@ final class BufferHolder {
   void grow(int neededSize) {
     assert neededSize < 0 :
       "Cannot grow BufferHolder by size " + neededSize + " because the size is negative";
-    int roundedSize = ByteArrayMethods.roundNumberOfBytesToNearestWord(neededSize);
-    if (roundedSize > ARRAY_MAX - totalSize()) {
+    if (neededSize > ARRAY_MAX - totalSize()) {
       throw new UnsupportedOperationException(
-        "Cannot grow BufferHolder by size " + roundedSize + " because the size after growing " +
+        "Cannot grow BufferHolder by size " + neededSize + " because the size after growing " +
           "exceeds size limitation " + ARRAY_MAX);
     }
-    final int length = totalSize() + roundedSize;
+    final int length = totalSize() + neededSize;
     if (buffer.length < length) {
       // This will not happen frequently, because the buffer is re-used.
       int newLength = length < ARRAY_MAX / 2 ? length * 2 : ARRAY_MAX;
-      final byte[] tmp = new byte[newLength];
+      int roundedSize = ByteArrayMethods.roundNumberOfBytesToNearestWord(newLength);
+      final byte[] tmp = new byte[roundedSize];
       Platform.copyMemory(
         buffer,
         Platform.BYTE_ARRAY_OFFSET,

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
@@ -63,7 +63,7 @@ final class BufferHolder {
    * Grows the buffer by at least neededSize and points the row to the buffer.
    */
   void grow(int neededSize) {
-    assert neededSize < 0 :
+    assert neededSize >= 0 :
       "Cannot grow BufferHolder by size " + neededSize + " because the size is negative";
     if (neededSize > ARRAY_MAX - totalSize()) {
       throw new UnsupportedOperationException(

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
@@ -61,16 +61,15 @@ final class BufferHolder {
    * Grows the buffer by at least neededSize and points the row to the buffer.
    */
   void grow(int neededSize) {
-    if (neededSize < 0) {
+    assert neededSize < 0 :
+      "Cannot grow BufferHolder by size " + neededSize + " because the size is negative";
+    int roundedSize = ByteArrayMethods.roundNumberOfBytesToNearestWord(neededSize);
+    if (roundedSize > ARRAY_MAX - totalSize()) {
       throw new UnsupportedOperationException(
-        "Cannot grow BufferHolder by size " + neededSize + " because the size is negative");
-    }
-    if (neededSize > ARRAY_MAX - totalSize()) {
-      throw new UnsupportedOperationException(
-        "Cannot grow BufferHolder by size " + neededSize + " because the size after growing " +
+        "Cannot grow BufferHolder by size " + roundedSize + " because the size after growing " +
           "exceeds size limitation " + ARRAY_MAX);
     }
-    final int length = totalSize() + neededSize;
+    final int length = totalSize() + roundedSize;
     if (buffer.length < length) {
       // This will not happen frequently, because the buffer is re-used.
       int newLength = length < ARRAY_MAX / 2 ? length * 2 : ARRAY_MAX;

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
@@ -63,9 +63,10 @@ final class BufferHolder {
    * Grows the buffer by at least neededSize and points the row to the buffer.
    */
   void grow(int neededSize) {
-    if (neededSize < 0)
+    if (neededSize < 0) {
       throw new IllegalArgumentException(
         "Cannot grow BufferHolder by size " + neededSize + " because the size is negative");
+    }
     if (neededSize > ARRAY_MAX - totalSize()) {
       throw new IllegalArgumentException(
         "Cannot grow BufferHolder by size " + neededSize + " because the size after growing " +

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
@@ -63,10 +63,11 @@ final class BufferHolder {
    * Grows the buffer by at least neededSize and points the row to the buffer.
    */
   void grow(int neededSize) {
-    assert neededSize >= 0 :
-      "Cannot grow BufferHolder by size " + neededSize + " because the size is negative";
+    if (neededSize < 0)
+      throw new IllegalArgumentException(
+        "Cannot grow BufferHolder by size " + neededSize + " because the size is negative");
     if (neededSize > ARRAY_MAX - totalSize()) {
-      throw new UnsupportedOperationException(
+      throw new IllegalArgumentException(
         "Cannot grow BufferHolder by size " + neededSize + " because the size after growing " +
           "exceeds size limitation " + ARRAY_MAX);
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
@@ -64,13 +64,13 @@ object BufferHolderSparkSubmitSuite {
     holder.grow(ARRAY_MAX / 2)
     assert(unsafeRow.getSizeInBytes % 8 == 0)
 
-    holder.grow(ARRAY_MAX / 2 + 7)
+    holder.grow(ARRAY_MAX / 2 + 8)
     assert(unsafeRow.getSizeInBytes % 8 == 0)
 
     holder.grow(Integer.MAX_VALUE / 2)
     assert(unsafeRow.getSizeInBytes % 8 == 0)
 
-    holder.grow(ARRAY_MAX - holder.totalSize())
+    holder.grow(ARRAY_MAX - 8192)
     assert(unsafeRow.getSizeInBytes % 8 == 0)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
@@ -58,27 +58,15 @@ object BufferHolderSparkSubmitSuite {
     val holder = new BufferHolder(new UnsafeRow(1000))
 
     holder.reset()
-    // execute here since reset() updates holder.cursor
-    val smallBuffer = new Array[Byte](holder.getCursor)
+
+    // while to reuse a buffer may happen, this test checks whether the buffer can be grown
     holder.grow(roundToWord(ARRAY_MAX / 2))
 
-    holder.reset()
-    setBuffer(holder, smallBuffer)  // avoid to reuse an allocated large byte array
     holder.grow(roundToWord(ARRAY_MAX / 2 + 8))
 
-    holder.reset()
-    setBuffer(holder, smallBuffer)  // avoid to reuse an allocated large byte array
     holder.grow(roundToWord(Integer.MAX_VALUE / 2))
 
-    holder.reset()
-    setBuffer(holder, smallBuffer)  // avoid to reuse an allocated large byte array
     holder.grow(roundToWord(Integer.MAX_VALUE))
-  }
-
-  def setBuffer(holder: BufferHolder, smallBuffer: Array[Byte]): Unit = {
-    val field = holder.getClass.getDeclaredField("buffer")
-    field.setAccessible(true)
-    field.set(holder, smallBuffer)
   }
 
   private def roundToWord(len: Int): Int = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
@@ -39,8 +39,8 @@ class BufferHolderSparkSubmitSuite
     val argsForSparkSubmit = Seq(
       "--class", BufferHolderSparkSubmitSuite.getClass.getName.stripSuffix("$"),
       "--name", "SPARK-22222",
-      "--master", "local-cluster[2,1,1024]",
-      "--driver-memory", "4g",
+      "--master", "local-cluster[1,1,7168]",
+      "--driver-memory", "7g",
       "--conf", "spark.ui.enabled=false",
       "--conf", "spark.master.rest.enabled=false",
       "--conf", "spark.driver.extraJavaOptions=-ea",
@@ -58,15 +58,20 @@ object BufferHolderSparkSubmitSuite {
     val holder = new BufferHolder(new UnsafeRow(1000))
 
     holder.reset()
+    // execute here since reset() updates holder.cursor
+    val smallBuffer = new Array[Byte](holder.cursor)
     holder.grow(roundToWord(ARRAY_MAX / 2))
 
     holder.reset()
+    holder.buffer = smallBuffer  // avoid to reuse an allocated large byte array
     holder.grow(roundToWord(ARRAY_MAX / 2 + 8))
 
     holder.reset()
+    holder.buffer = smallBuffer  // avoid to reuse an allocated large byte array
     holder.grow(roundToWord(Integer.MAX_VALUE / 2))
 
     holder.reset()
+    holder.buffer = smallBuffer  // avoid to reuse an allocated large byte array
     holder.grow(roundToWord(Integer.MAX_VALUE))
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
@@ -75,13 +75,5 @@ object BufferHolderSparkSubmitSuite {
 
     holder.grow(ARRAY_MAX - holder.totalSize())
     assert(unsafeRow.getSizeInBytes % 8 == 0)
-
-    try {
-      holder.grow(ARRAY_MAX + 1 - holder.totalSize())
-      assert(false)
-    } catch {
-        case _: UnsupportedOperationException => assert(true)
-        case _ => assert(false)
-    }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
@@ -64,13 +64,10 @@ object BufferHolderSparkSubmitSuite {
     holder.grow(ARRAY_MAX / 2)
     assert(unsafeRow.getSizeInBytes % 8 == 0)
 
-    holder.grow(ARRAY_MAX / 2 + 8)
+    holder.grow(ARRAY_MAX / 2 + 7)
     assert(unsafeRow.getSizeInBytes % 8 == 0)
 
     holder.grow(Integer.MAX_VALUE / 2)
-    assert(unsafeRow.getSizeInBytes % 8 == 0)
-
-    holder.grow(Integer.MAX_VALUE / 2 + 7)
     assert(unsafeRow.getSizeInBytes % 8 == 0)
 
     holder.grow(ARRAY_MAX - holder.totalSize())

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
@@ -59,20 +59,26 @@ object BufferHolderSparkSubmitSuite {
 
     holder.reset()
     // execute here since reset() updates holder.cursor
-    val smallBuffer = new Array[Byte](holder.cursor)
+    val smallBuffer = new Array[Byte](holder.getCursor)
     holder.grow(roundToWord(ARRAY_MAX / 2))
 
     holder.reset()
-    holder.buffer = smallBuffer  // avoid to reuse an allocated large byte array
+    setBuffer(holder, smallBuffer)  // avoid to reuse an allocated large byte array
     holder.grow(roundToWord(ARRAY_MAX / 2 + 8))
 
     holder.reset()
-    holder.buffer = smallBuffer  // avoid to reuse an allocated large byte array
+    setBuffer(holder, smallBuffer)  // avoid to reuse an allocated large byte array
     holder.grow(roundToWord(Integer.MAX_VALUE / 2))
 
     holder.reset()
-    holder.buffer = smallBuffer  // avoid to reuse an allocated large byte array
+    setBuffer(holder, smallBuffer)  // avoid to reuse an allocated large byte array
     holder.grow(roundToWord(Integer.MAX_VALUE))
+  }
+
+  def setBuffer(holder: BufferHolder, smallBuffer: Array[Byte]): Unit = {
+    val field = holder.getClass.getDeclaredField("buffer")
+    field.setAccessible(true)
+    field.set(holder, smallBuffer)
   }
 
   private def roundToWord(len: Int): Int = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
@@ -64,13 +64,21 @@ object BufferHolderSparkSubmitSuite {
     holder.grow(ARRAY_MAX / 2)
     assert(unsafeRow.getSizeInBytes % 8 == 0)
 
-    holder.grow(ARRAY_MAX / 2 + 8)
+    holder.grow(ARRAY_MAX / 2 + 7)
     assert(unsafeRow.getSizeInBytes % 8 == 0)
 
     holder.grow(Integer.MAX_VALUE / 2)
     assert(unsafeRow.getSizeInBytes % 8 == 0)
 
-    holder.grow(ARRAY_MAX - 8192)
+    holder.grow(ARRAY_MAX - holder.totalSize())
     assert(unsafeRow.getSizeInBytes % 8 == 0)
+
+    try {
+      holder.grow(ARRAY_MAX + 1 - holder.totalSize())
+      assert(false)
+    } catch {
+        case _: UnsupportedOperationException => assert(true)
+        case _: Throwable => assert(false)
+    }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
@@ -70,7 +70,18 @@ object BufferHolderSparkSubmitSuite {
     holder.grow(Integer.MAX_VALUE / 2)
     assert(unsafeRow.getSizeInBytes % 8 == 0)
 
-    holder.grow(ARRAY_MAX - 8192)
+    holder.grow(Integer.MAX_VALUE / 2 + 7)
     assert(unsafeRow.getSizeInBytes % 8 == 0)
+
+    holder.grow(ARRAY_MAX - holder.totalSize())
+    assert(unsafeRow.getSizeInBytes % 8 == 0)
+
+    try {
+      holder.grow(ARRAY_MAX + 1 - holder.totalSize())
+      assert(false)
+    } catch {
+        case _: UnsupportedOperationException => assert(true)
+        case _ => assert(false)
+    }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSparkSubmitSuite.scala
@@ -55,21 +55,22 @@ object BufferHolderSparkSubmitSuite {
 
     val ARRAY_MAX = ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH
 
-    val holder = new BufferHolder(new UnsafeRow(1000))
+    val unsafeRow = new UnsafeRow(1000)
+    val holder = new BufferHolder(unsafeRow)
 
     holder.reset()
 
     // while to reuse a buffer may happen, this test checks whether the buffer can be grown
-    holder.grow(roundToWord(ARRAY_MAX / 2))
+    holder.grow(ARRAY_MAX / 2)
+    assert(unsafeRow.getSizeInBytes % 8 == 0)
 
-    holder.grow(roundToWord(ARRAY_MAX / 2 + 8))
+    holder.grow(ARRAY_MAX / 2 + 8)
+    assert(unsafeRow.getSizeInBytes % 8 == 0)
 
-    holder.grow(roundToWord(Integer.MAX_VALUE / 2))
+    holder.grow(Integer.MAX_VALUE / 2)
+    assert(unsafeRow.getSizeInBytes % 8 == 0)
 
-    holder.grow(roundToWord(Integer.MAX_VALUE))
-  }
-
-  private def roundToWord(len: Int): Int = {
-    ByteArrayMethods.roundNumberOfBytesToNearestWord(len)
+    holder.grow(ARRAY_MAX - 8192)
+    assert(unsafeRow.getSizeInBytes % 8 == 0)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSuite.scala
@@ -31,7 +31,7 @@ class BufferHolderSuite extends SparkFunSuite {
     val holder = new BufferHolder(new UnsafeRow(1000))
     holder.reset()
     holder.grow(1000)
-    e = intercept[UnsupportedOperationException] {
+    e = intercept[IllegalArgumentException] {
       holder.grow(Integer.MAX_VALUE)
     }
     assert(e.getMessage.contains("exceeds size limitation"))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolderSuite.scala
@@ -23,17 +23,15 @@ import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 class BufferHolderSuite extends SparkFunSuite {
 
   test("SPARK-16071 Check the size limit to avoid integer overflow") {
-    var e = intercept[UnsupportedOperationException] {
+    assert(intercept[UnsupportedOperationException] {
       new BufferHolder(new UnsafeRow(Int.MaxValue / 8))
-    }
-    assert(e.getMessage.contains("too many fields"))
+    }.getMessage.contains("too many fields"))
 
     val holder = new BufferHolder(new UnsafeRow(1000))
     holder.reset()
     holder.grow(1000)
-    e = intercept[IllegalArgumentException] {
+    assert(intercept[IllegalArgumentException] {
       holder.grow(Integer.MAX_VALUE)
-    }
-    assert(e.getMessage.contains("exceeds size limitation"))
+    }.getMessage.contains("exceeds size limitation"))
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR addresses two issues in `BufferHolderSparkSubmitSuite`.

1. While `BufferHolderSparkSubmitSuite` tried to allocate a large object several times, it actually allocated an object once and reused the object.
2. `BufferHolderSparkSubmitSuite` may fail due to timeout 

To assign a small object before allocating a large object each time solved issue 1 by avoiding reuse.
To increasing heap size from 4g to 7g solved issue 2. It can also avoid OOM after fixing issue 1.

## How was this patch tested?

Updated existing `BufferHolderSparkSubmitSuite`
