### PR TITLE
[SPARK-23408][SS] Synchronize successive AddDataMemory actions in StreamTest.

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
@@ -633,18 +633,18 @@ trait StreamTest extends QueryTest with SharedSQLContext with TimeLimits with Be
               // Try to find the index of the source to which data was added. Either get the index
               // from the current active query or the original input logical plan.
               val sourceIndex =
-              queryToUse.flatMap { query =>
-                findSourceIndex(query.logicalPlan)
-              }.orElse {
-                findSourceIndex(stream.logicalPlan)
-              }.orElse {
-                queryToUse.flatMap { q =>
-                  findSourceIndex(q.lastExecution.logical)
+                queryToUse.flatMap { query =>
+                  findSourceIndex(query.logicalPlan)
+                }.orElse {
+                  findSourceIndex(stream.logicalPlan)
+                }.orElse {
+                  queryToUse.flatMap { q =>
+                    findSourceIndex(q.lastExecution.logical)
+                  }
+                }.getOrElse {
+                  throw new IllegalArgumentException(
+                    "Could not find index of the source to which data was added")
                 }
-              }.getOrElse {
-                throw new IllegalArgumentException(
-                  "Could not find index of the source to which data was added")
-              }
 
               // Store the expected offset of added data to wait for it later
               awaiting.put(sourceIndex, offset)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
@@ -110,10 +110,6 @@ trait StreamTest extends QueryTest with SharedSQLContext with TimeLimits with Be
      * offset of added data.
      */
     def addData(query: Option[StreamExecution]): (BaseStreamingSource, Offset)
-
-    def addAllData(query: Option[StreamExecution]): Seq[(BaseStreamingSource, Offset)] = {
-      Seq(addData(query))
-    }
   }
 
   /** A trait that can be extended when testing a source. */
@@ -634,25 +630,24 @@ trait StreamTest extends QueryTest with SharedSQLContext with TimeLimits with Be
                   .map(_._2)
               }
 
-                // Try to find the index of the source to which data was added. Either get the index
-                // from the current active query or the original input logical plan.
-                val sourceIndex =
-                queryToUse.flatMap { query =>
-                  findSourceIndex(query.logicalPlan)
-                }.orElse {
-                  findSourceIndex(stream.logicalPlan)
-                }.orElse {
-                  queryToUse.flatMap { q =>
-                    findSourceIndex(q.lastExecution.logical)
-                  }
-                }.getOrElse {
-                  throw new IllegalArgumentException(
-                    "Could not find index of the source to which data was added")
+              // Try to find the index of the source to which data was added. Either get the index
+              // from the current active query or the original input logical plan.
+              val sourceIndex =
+              queryToUse.flatMap { query =>
+                findSourceIndex(query.logicalPlan)
+              }.orElse {
+                findSourceIndex(stream.logicalPlan)
+              }.orElse {
+                queryToUse.flatMap { q =>
+                  findSourceIndex(q.lastExecution.logical)
                 }
-
-                // Store the expected offset of added data to wait for it later
-                awaiting.put(sourceIndex, offset)
+              }.getOrElse {
+                throw new IllegalArgumentException(
+                  "Could not find index of the source to which data was added")
               }
+
+              // Store the expected offset of added data to wait for it later
+              awaiting.put(sourceIndex, offset)
             } catch {
               case NonFatal(e) =>
                 failTest("Error adding data", e)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The stream-stream join tests add data to multiple sources, and expect it all to show up in the next batch. But there's a race condition; the new batch might trigger when only one of the AddData actions has been reached.

Fortunately, MemoryStream synchronizes batch generation on itself, and StreamExecution won't generate empty batches. So we can resolve this race condition by synchronizing successive AddDataMemory actions against every MemoryStream together. Then we can be sure StreamExecution won't start generating a batch before all the data is present.

## How was this patch tested?
existing tests
