### PR TITLE
[SPARK-23462][SQL] improve missing field error message in `StructType`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -273,7 +273,7 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
     nameToField.getOrElse(name,
       throw new IllegalArgumentException(
         s"""Field "$name" does not exist.
-           |Available fields: ${fieldNamesSet.mkString(",")}""".stripMargin))
+           |Available fields: ${fieldNamesSet.mkString(", ")}""".stripMargin))
   }
 
   /**
@@ -286,8 +286,8 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
     val nonExistFields = names -- fieldNamesSet
     if (nonExistFields.nonEmpty) {
       throw new IllegalArgumentException(
-        s"""Fields ${nonExistFields.mkString(",")} does not exist.
-           |Available fields: ${fieldNamesSet.mkString(",")}""".stripMargin)
+        s"""Fields ${nonExistFields.mkString(", ")} does not exist.
+           |Available fields: ${fieldNamesSet.mkString(", ")}""".stripMargin)
     }
     // Preserve the original order of fields.
     StructType(fields.filter(f => names.contains(f.name)))
@@ -302,7 +302,7 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
     nameToIndex.getOrElse(name,
       throw new IllegalArgumentException(
         s"""Field "$name" does not exist.
-           |Available fields: ${fieldNamesSet.mkString(",")}""".stripMargin))
+           |Available fields: ${fieldNamesSet.mkString(", ")}""".stripMargin))
   }
 
   private[sql] def getFieldIndex(name: String): Option[Int] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -286,7 +286,7 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
     val nonExistFields = names -- fieldNamesSet
     if (nonExistFields.nonEmpty) {
       throw new IllegalArgumentException(
-        s"""Fields ${nonExistFields.mkString(", ")} does not exist.
+        s"""Nonexistent field(s): ${nonExistFields.mkString(", ")}.
            |Available fields: ${fieldNamesSet.mkString(", ")}""".stripMargin)
     }
     // Preserve the original order of fields.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -273,7 +273,7 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
     nameToField.getOrElse(name,
       throw new IllegalArgumentException(
         s"""Field "$name" does not exist.
-           |Available fields: ${fieldNamesSet.mkString(", ")}""".stripMargin))
+           |Available fields: ${fieldNames.mkString(", ")}""".stripMargin))
   }
 
   /**
@@ -287,7 +287,7 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
     if (nonExistFields.nonEmpty) {
       throw new IllegalArgumentException(
         s"""Nonexistent field(s): ${nonExistFields.mkString(", ")}.
-           |Available fields: ${fieldNamesSet.mkString(", ")}""".stripMargin)
+           |Available fields: ${fieldNames.mkString(", ")}""".stripMargin)
     }
     // Preserve the original order of fields.
     StructType(fields.filter(f => names.contains(f.name)))
@@ -302,7 +302,7 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
     nameToIndex.getOrElse(name,
       throw new IllegalArgumentException(
         s"""Field "$name" does not exist.
-           |Available fields: ${fieldNamesSet.mkString(", ")}""".stripMargin))
+           |Available fields: ${fieldNames.mkString(", ")}""".stripMargin))
   }
 
   private[sql] def getFieldIndex(name: String): Option[Int] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -271,7 +271,9 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
    */
   def apply(name: String): StructField = {
     nameToField.getOrElse(name,
-      throw new IllegalArgumentException(s"""Field "$name" does not exist."""))
+      throw new IllegalArgumentException(
+        s"""Field "$name" does not exist.
+           |Available fields: ${fieldNamesSet.mkString(",")}""".stripMargin))
   }
 
   /**
@@ -284,7 +286,8 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
     val nonExistFields = names -- fieldNamesSet
     if (nonExistFields.nonEmpty) {
       throw new IllegalArgumentException(
-        s"Field ${nonExistFields.mkString(",")} does not exist.")
+        s"""Fields ${nonExistFields.mkString(",")} does not exist.
+           |Available fields: ${fieldNamesSet.mkString(",")}""".stripMargin)
     }
     // Preserve the original order of fields.
     StructType(fields.filter(f => names.contains(f.name)))
@@ -297,7 +300,9 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
    */
   def fieldIndex(name: String): Int = {
     nameToIndex.getOrElse(name,
-      throw new IllegalArgumentException(s"""Field "$name" does not exist."""))
+      throw new IllegalArgumentException(
+        s"""Field "$name" does not exist.
+           |Available fields: ${fieldNamesSet.mkString(",")}""".stripMargin))
   }
 
   private[sql] def getFieldIndex(name: String): Option[Int] = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
@@ -15,10 +15,9 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql
+package org.apache.spark.sql.types
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.types.StructType
 
 class StructTypeSuite extends SparkFunSuite {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/StructTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StructTypeSuite.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.types.StructType
+
+class StructTypeSuite extends SparkFunSuite{
+
+  test("SPARK-23462 lookup a single missing field should output existing fields") {
+    val s = StructType.fromDDL("a INT")
+    val e = intercept[IllegalArgumentException](s("b")).getMessage
+    assert(e.contains("Available fields: a"))
+  }
+
+  test("SPARK-23462 lookup a set of missing fields should output existing fields") {
+    val s = StructType.fromDDL("a INT")
+    val e = intercept[IllegalArgumentException](s(Set("a", "b"))).getMessage
+    assert(e.contains("Available fields: a"))
+  }
+
+  test("SPARK-23462 lookup fieldIndex for missing field should output existing fields") {
+    val s = StructType.fromDDL("a INT")
+    val e = intercept[IllegalArgumentException](s.fieldIndex("b")).getMessage
+    assert(e.contains("Available fields: a"))
+  }
+
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/StructTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StructTypeSuite.scala
@@ -22,22 +22,20 @@ import org.apache.spark.sql.types.StructType
 
 class StructTypeSuite extends SparkFunSuite {
 
-  test("SPARK-23462 lookup a single missing field should output existing fields") {
-    val s = StructType.fromDDL("a INT, b STRING")
+  val s = StructType.fromDDL("a INT, b STRING")
+
+  test("lookup a single missing field should output existing fields") {
     val e = intercept[IllegalArgumentException](s("c")).getMessage
-    assert(e.contains("Available fields: a,b"))
+    assert(e.contains("Available fields: a, b"))
   }
 
-  test("SPARK-23462 lookup a set of missing fields should output existing fields") {
-    val s = StructType.fromDDL("a INT, b STRING")
+  test("lookup a set of missing fields should output existing fields") {
     val e = intercept[IllegalArgumentException](s(Set("a", "c"))).getMessage
-    assert(e.contains("Available fields: a,b"))
+    assert(e.contains("Available fields: a, b"))
   }
 
-  test("SPARK-23462 lookup fieldIndex for missing field should output existing fields") {
-    val s = StructType.fromDDL("a INT, b STRING")
+  test("lookup fieldIndex for missing field should output existing fields") {
     val e = intercept[IllegalArgumentException](s.fieldIndex("c")).getMessage
-    assert(e.contains("Available fields: a,b"))
+    assert(e.contains("Available fields: a, b"))
   }
-
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/StructTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StructTypeSuite.scala
@@ -20,24 +20,24 @@ package org.apache.spark.sql
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.types.StructType
 
-class StructTypeSuite extends SparkFunSuite{
+class StructTypeSuite extends SparkFunSuite {
 
   test("SPARK-23462 lookup a single missing field should output existing fields") {
-    val s = StructType.fromDDL("a INT")
-    val e = intercept[IllegalArgumentException](s("b")).getMessage
-    assert(e.contains("Available fields: a"))
+    val s = StructType.fromDDL("a INT, b STRING")
+    val e = intercept[IllegalArgumentException](s("c")).getMessage
+    assert(e.contains("Available fields: a,b"))
   }
 
   test("SPARK-23462 lookup a set of missing fields should output existing fields") {
-    val s = StructType.fromDDL("a INT")
-    val e = intercept[IllegalArgumentException](s(Set("a", "b"))).getMessage
-    assert(e.contains("Available fields: a"))
+    val s = StructType.fromDDL("a INT, b STRING")
+    val e = intercept[IllegalArgumentException](s(Set("a", "c"))).getMessage
+    assert(e.contains("Available fields: a,b"))
   }
 
   test("SPARK-23462 lookup fieldIndex for missing field should output existing fields") {
-    val s = StructType.fromDDL("a INT")
-    val e = intercept[IllegalArgumentException](s.fieldIndex("b")).getMessage
-    assert(e.contains("Available fields: a"))
+    val s = StructType.fromDDL("a INT, b STRING")
+    val e = intercept[IllegalArgumentException](s.fieldIndex("c")).getMessage
+    assert(e.contains("Available fields: a,b"))
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The error message ```s"""Field "$name" does not exist."""``` is thrown when looking up an unknown field in StructType. In the error message, we should also contain the information about which columns/fields exist in this struct.

## How was this patch tested?

Added new unit tests. 

Note: I created a new `StructTypeSuite.scala` as I couldn't find an existing suite that's suitable to place these tests. I may be missing something so feel free to propose new locations. 

Please review http://spark.apache.org/contributing.html before opening a pull request.
