### PR TITLE
[SPARK-23488][python] Add missing catalog methods to python API

### DIFF
--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -29,7 +29,7 @@ from pyspark.sql.types import IntegerType, StringType, StructType
 Database = namedtuple("Database", "name description locationUri")
 Table = namedtuple("Table", "name database description tableType isTemporary")
 Column = namedtuple("Column", "name description dataType nullable isPartition isBucket")
-Function = namedtuple("Function", "name description className isTemporary")
+Function = namedtuple("Function", "name database description className isTemporary")
 
 
 class Catalog(object):
@@ -108,6 +108,7 @@ class Catalog(object):
             jfunction = iter.next()
             functions.append(Function(
                 name=jfunction.name(),
+                database=jfunction.database(),
                 description=jfunction.description(),
                 className=jfunction.className(),
                 isTemporary=jfunction.isTemporary()))
@@ -205,6 +206,7 @@ class Catalog(object):
         function = self._jcatalog.getFunction(dbName, functionName)
         return Function(
             name=function.name(),
+            database=function.database(),
             description=function.description(),
             className=function.className(),
             isTemporary=function.isTemporary())

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -172,9 +172,9 @@ class Catalog(object):
         """Get the database with the specified name."""
         database = self._jcatalog.getDatabase(dbName)
         return Database(
-                name=database.name(),
-                description=database.description(),
-                locationUri=database.locationUri())
+            name=database.name(),
+            description=database.description(),
+            locationUri=database.locationUri())
 
     @ignore_unicode_prefix
     @since(2.4)
@@ -187,11 +187,11 @@ class Catalog(object):
             dbName = self.currentDatabase()
         table = self._jcatalog.getTable(dbName, tableName)
         return Table(
-                name=table.name(),
-                database=table.database(),
-                description=table.description(),
-                tableType=table.tableType(),
-                isTemporary=table.isTemporary())
+            name=table.name(),
+            database=table.database(),
+            description=table.description(),
+            tableType=table.tableType(),
+            isTemporary=table.isTemporary())
 
     @ignore_unicode_prefix
     @since(2.4)
@@ -204,10 +204,10 @@ class Catalog(object):
             dbName = self.currentDatabase()
         function = self._jcatalog.getFunction(dbName, functionName)
         return Function(
-                name=function.name(),
-                description=function.description(),
-                className=function.className(),
-                isTemporary=function.isTemporary())
+            name=function.name(),
+            description=function.description(),
+            className=function.className(),
+            isTemporary=function.isTemporary())
 
     @since(2.0)
     def createExternalTable(self, tableName, path=None, source=None, schema=None, **options):

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -139,13 +139,13 @@ class Catalog(object):
         return columns
 
     @ignore_unicode_prefix
-    @since(2.4)
+    @since(3.0)
     def databaseExists(self, dbName):
         """Check if the database with the specified name exists."""
         return self._jcatalog.databaseExists(dbName)
 
     @ignore_unicode_prefix
-    @since(2.4)
+    @since(3.0)
     def functionExists(self, functionName, dbName=None):
         """Check if the function with the specified name exists.
 
@@ -156,7 +156,7 @@ class Catalog(object):
         return self._jcatalog.functionExists(dbName, functionName)
 
     @ignore_unicode_prefix
-    @since(2.4)
+    @since(3.0)
     def tableExists(self, tableName, dbName=None):
         """Check if the table or view with the specified name exists.
 
@@ -167,7 +167,7 @@ class Catalog(object):
         return self._jcatalog.tableExists(dbName, tableName)
 
     @ignore_unicode_prefix
-    @since(2.4)
+    @since(3.0)
     def getDatabase(self, dbName):
         """Get the database with the specified name."""
         database = self._jcatalog.getDatabase(dbName)
@@ -177,7 +177,7 @@ class Catalog(object):
             locationUri=database.locationUri())
 
     @ignore_unicode_prefix
-    @since(2.4)
+    @since(3.0)
     def getTable(self, tableName, dbName=None):
         """Get the table or view with the specified name.
 
@@ -194,7 +194,7 @@ class Catalog(object):
             isTemporary=table.isTemporary())
 
     @ignore_unicode_prefix
-    @since(2.4)
+    @since(3.0)
     def getFunction(self, functionName, dbName=None):
         """Get the function with the specified name.
 

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -29,7 +29,7 @@ from pyspark.sql.types import IntegerType, StringType, StructType
 Database = namedtuple("Database", "name description locationUri")
 Table = namedtuple("Table", "name database description tableType isTemporary")
 Column = namedtuple("Column", "name description dataType nullable isPartition isBucket")
-Function = namedtuple("Function", "name database description className isTemporary")
+Function = namedtuple("Function", "name description className isTemporary")
 
 
 class Catalog(object):
@@ -108,7 +108,6 @@ class Catalog(object):
             jfunction = iter.next()
             functions.append(Function(
                 name=jfunction.name(),
-                database=jfunction.database(),
                 description=jfunction.description(),
                 className=jfunction.className(),
                 isTemporary=jfunction.isTemporary()))
@@ -140,13 +139,13 @@ class Catalog(object):
         return columns
 
     @ignore_unicode_prefix
-    # TODO: @since() decorator?
+    @since(2.4)
     def databaseExists(self, dbName):
         """Check if the database with the specified name exists."""
         return self._jcatalog.databaseExists(dbName)
 
     @ignore_unicode_prefix
-    # TODO: @since() decorator?
+    @since(2.4)
     def functionExists(self, functionName, dbName=None):
         """Check if the function with the specified name exists.
 
@@ -157,7 +156,7 @@ class Catalog(object):
         return self._jcatalog.functionExists(dbName, functionName)
 
     @ignore_unicode_prefix
-    # TODO: @since() decorator?
+    @since(2.4)
     def tableExists(self, tableName, dbName=None):
         """Check if the table or view with the specified name exists.
 
@@ -168,7 +167,7 @@ class Catalog(object):
         return self._jcatalog.tableExists(dbName, tableName)
 
     @ignore_unicode_prefix
-    # TODO: @since() decorator?
+    @since(2.4)
     def getDatabase(self, dbName):
         """Get the database with the specified name."""
         database = self._jcatalog.getDatabase(dbName)
@@ -178,7 +177,7 @@ class Catalog(object):
                 locationUri=database.locationUri())
 
     @ignore_unicode_prefix
-    # TODO: @since() decorator?
+    @since(2.4)
     def getTable(self, tableName, dbName=None):
         """Get the table or view with the specified name.
 
@@ -195,7 +194,7 @@ class Catalog(object):
                 isTemporary=table.isTemporary())
 
     @ignore_unicode_prefix
-    # TODO: @since() decorator?
+    @since(2.4)
     def getFunction(self, functionName, dbName=None):
         """Get the function with the specified name.
 
@@ -206,7 +205,6 @@ class Catalog(object):
         function = self._jcatalog.getFunction(dbName, functionName)
         return Function(
                 name=function.name(),
-                database=function.database(),
                 description=function.description(),
                 className=function.className(),
                 isTemporary=function.isTemporary())

--- a/python/pyspark/sql/tests/test_catalog.py
+++ b/python/pyspark/sql/tests/test_catalog.py
@@ -108,6 +108,7 @@ class CatalogTests(ReusedSQLTestCase):
             self.assertTrue("current_database" in functions)
             self.assertEquals(functions["+"], Function(
                 name="+",
+                database=None,
                 description=None,
                 className="org.apache.spark.sql.catalyst.expressions.Add",
                 isTemporary=True))
@@ -258,6 +259,7 @@ class CatalogTests(ReusedSQLTestCase):
                 spark.sql("CREATE FUNCTION some_db.func2 AS 'org.apache.spark.data.bricks'")
                 self.assertEquals(spark.catalog.getFunction('func2', 'some_db'), Function(
                     name="func2",
+                    database="some_db",
                     description=None,
                     className="org.apache.spark.data.bricks",
                     isTemporary=False))


### PR DESCRIPTION
## What changes were proposed in this pull request?

As noted in SPARK-23488, the Python Catalog API was missing some methods that are present in the Scala API. Both for the sake of consistency, and because of their utility, I've added the missing methods (the database/table/functionExists() and getDatabase/Table/Function() methods).

I modeled these methods off of how the existing ones were written in catalog.py.

## How was this patch tested?

manually tested the added methods and compared functionality to the scala API counterparts

## Questions

I wasn't sure whether to set the `@since(x.y)` decorators on the new functions, and if so, what value to set them to?
