### PR TITLE
[SPARK-23405] Generate additional constraints for Join's children

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -661,7 +661,7 @@ object InferFiltersFromConstraints extends Rule[LogicalPlan] with PredicateHelpe
     case join @ Join(left, right, joinType, conditionOpt) =>
       // Only consider constraints that can be pushed down completely to either the left or the
       // right child
-      val constraints = join.constraints.filter { c =>
+      val constraints = join.allConstraints.filter { c =>
         c.references.subsetOf(left.outputSet) || c.references.subsetOf(right.outputSet)
       }
       // Remove those constraints that are already enforced by either the left or the right child

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
@@ -26,24 +26,24 @@ trait QueryPlanConstraints { self: LogicalPlan =>
    * An [[ExpressionSet]] that contains an additional set of constraints, such as equality
    * constraints and `isNotNull` constraints, etc.
    */
-  lazy val allConstraints: ExpressionSet = ExpressionSet(validConstraints
+  lazy val allConstraints: ExpressionSet = {
+    if (conf.constraintPropagationEnabled) {
+      ExpressionSet(validConstraints
         .union(inferAdditionalConstraints(validConstraints))
         .union(constructIsNotNullConstraints(validConstraints)))
+    } else {
+      ExpressionSet(Set.empty)
+    }
+  }
 
   /**
    * An [[ExpressionSet]] that contains invariants about the rows output by this operator. For
    * example, if this set contains the expression `a = 2` then that expression is guaranteed to
    * evaluate to `true` for all rows produced.
    */
-  lazy val constraints: ExpressionSet = {
-    if (conf.constraintPropagationEnabled) {
-      ExpressionSet(allConstraints.filter { c =>
+  lazy val constraints: ExpressionSet = ExpressionSet(allConstraints.filter { c =>
         c.references.nonEmpty && c.references.subsetOf(outputSet) && c.deterministic
       })
-    } else {
-      ExpressionSet(Set.empty)
-    }
-  }
 
   /**
    * This method can be overridden by any child class of QueryPlan to specify a set of constraints

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
@@ -23,8 +23,8 @@ import org.apache.spark.sql.catalyst.expressions._
 trait QueryPlanConstraints { self: LogicalPlan =>
 
   /**
-    * An [[ExpressionSet]] that contains an additional set of constraints about equality constraints
-    * and `isNotNull` constraints.
+    * An [[ExpressionSet]] that contains an additional set of constraints about equality
+    * constraints and `isNotNull` constraints.
     */
   lazy val allConstraints: ExpressionSet = ExpressionSet(validConstraints
     .union(inferAdditionalConstraints(validConstraints))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
@@ -23,8 +23,8 @@ import org.apache.spark.sql.catalyst.expressions._
 trait QueryPlanConstraints { self: LogicalPlan =>
 
   /**
-   * An [[ExpressionSet]] that contains an additional set of constraints about equality
-   * constraints and `isNotNull` constraints.
+   * An [[ExpressionSet]] that contains an additional set of constraints, such as equality
+   * constraints and `isNotNull` constraints, etc.
    */
   lazy val allConstraints: ExpressionSet = {
     if (conf.constraintPropagationEnabled) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
@@ -26,15 +26,9 @@ trait QueryPlanConstraints { self: LogicalPlan =>
    * An [[ExpressionSet]] that contains an additional set of constraints, such as equality
    * constraints and `isNotNull` constraints, etc.
    */
-  lazy val allConstraints: ExpressionSet = {
-    if (conf.constraintPropagationEnabled) {
-      ExpressionSet(validConstraints
+  lazy val allConstraints: ExpressionSet = ExpressionSet(validConstraints
         .union(inferAdditionalConstraints(validConstraints))
         .union(constructIsNotNullConstraints(validConstraints)))
-    } else {
-      ExpressionSet(Set.empty)
-    }
-  }
 
   /**
    * An [[ExpressionSet]] that contains invariants about the rows output by this operator. For

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
@@ -23,14 +23,18 @@ import org.apache.spark.sql.catalyst.expressions._
 trait QueryPlanConstraints { self: LogicalPlan =>
 
   /**
-   * An [[ExpressionSet]] that contains invariants about the rows output by this operator. For
-   * example, if this set contains the expression `a = 2` then that expression is guaranteed to
-   * evaluate to `true` for all rows produced.
-   */
+    * An [[ExpressionSet]] that contains an additional set of constraints about equality constraints
+    * and `isNotNull` constraints.
+    */
   lazy val allConstraints: ExpressionSet = ExpressionSet(validConstraints
     .union(inferAdditionalConstraints(validConstraints))
     .union(constructIsNotNullConstraints(validConstraints)))
 
+  /**
+    * An [[ExpressionSet]] that contains invariants about the rows output by this operator. For
+    * example, if this set contains the expression `a = 2` then that expression is guaranteed to
+    * evaluate to `true` for all rows produced.
+    */
   lazy val constraints: ExpressionSet = {
     if (conf.constraintPropagationEnabled) {
       ExpressionSet(allConstraints.filter { c =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersFromConstraintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersFromConstraintsSuite.scala
@@ -200,8 +200,7 @@ class InferFiltersFromConstraintsSuite extends PlanTest {
     val originalQuery = x.join(y, LeftSemi, condition).analyze
     val left = x.where(IsNotNull('a))
     val right = y.where(IsNotNull('a))
-    val correctAnswer = left.join(right, LeftSemi, condition)
-        .analyze
+    val correctAnswer = left.join(right, LeftSemi, condition).analyze
     val optimized = Optimize.execute(originalQuery)
     comparePlans(optimized, correctAnswer)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersFromConstraintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersFromConstraintsSuite.scala
@@ -193,7 +193,7 @@ class InferFiltersFromConstraintsSuite extends PlanTest {
     comparePlans(Optimize.execute(original.analyze), correct.analyze)
   }
 
-  test("single left-semi join: filter out nulls on either side on equi-join keys") {
+  test("SPARK-23405:single left-semi join, filter out nulls on either side on equi-join keys") {
     val x = testRelation.subquery('x)
     val y = testRelation.subquery('y)
     val originalQuery = x.join(y, LeftSemi,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersFromConstraintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersFromConstraintsSuite.scala
@@ -193,14 +193,14 @@ class InferFiltersFromConstraintsSuite extends PlanTest {
     comparePlans(Optimize.execute(original.analyze), correct.analyze)
   }
 
-  test("SPARK-23405:single left-semi join, filter out nulls on either side on equi-join keys") {
+  test("SPARK-23405: left-semi equal-join should filter out null join keys on both sides") {
     val x = testRelation.subquery('x)
     val y = testRelation.subquery('y)
-    val originalQuery = x.join(y, LeftSemi,
-      condition = Some("x.a".attr === "y.a".attr)).analyze
+    val condition = Some("x.a".attr === "y.a".attr)
+    val originalQuery = x.join(y, LeftSemi, condition).analyze
     val left = x.where(IsNotNull('a))
     val right = y.where(IsNotNull('a))
-    val correctAnswer = left.join(right, LeftSemi, condition = Some("x.a".attr === "y.a".attr))
+    val correctAnswer = left.join(right, LeftSemi, condition)
         .analyze
     val optimized = Optimize.execute(originalQuery)
     comparePlans(optimized, correctAnswer)


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
I run a sql: `select ls.cs_order_number from ls left semi join catalog_sales cs on ls.cs_order_number = cs.cs_order_number`, The `ls` table is a small table ,and the number is one. The `catalog_sales` table is a big table,  and the number is 10 billion. The task will be hang up. And i find the many null values of `cs_order_number` in the `catalog_sales` table. I think the null value should be removed in the logical plan.

>== Optimized Logical Plan ==
>Join LeftSemi, (cs_order_number#1 = cs_order_number#22)
>:- Project cs_order_number#1
>   : +- Filter isnotnull(cs_order_number#1)
>      : +- MetastoreRelation 100t, ls
>+- Project cs_order_number#22
>   +- MetastoreRelation 100t, catalog_sales

Now, use this patch, the plan will be:
>== Optimized Logical Plan ==
>Join LeftSemi, (cs_order_number#1 = cs_order_number#22)
>:- Project cs_order_number#1
>   : +- Filter isnotnull(cs_order_number#1)
>      : +- MetastoreRelation 100t, ls
>+- Project cs_order_number#22
>   : **+- Filter isnotnull(cs_order_number#22)**
>     :+- MetastoreRelation 100t, catalog_sales

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)


Please review http://spark.apache.org/contributing.html before opening a pull request.
