### PR TITLE
[SPARK-23515] Use input/output streams for large events in JsonProtocol.sparkEventToJson

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.util
 
-import java.io.{ByteArrayOutputStream, PipedInputStream, PipedOutputStream}
+import java.io.{PipedInputStream, PipedOutputStream}
 import java.util.{Properties, UUID}
 
 import scala.collection.JavaConverters._
@@ -103,12 +103,14 @@ private[spark] object JsonProtocol {
       case blockUpdate: SparkListenerBlockUpdated =>
         blockUpdateToJson(blockUpdate)
       case _ =>
+        // Use piped streams to avoid extra memory consumption
         val outputStream = new PipedOutputStream()
         val inputStream = new PipedInputStream(outputStream)
         try {
           mapper.writeValue(outputStream, event)
           parse(inputStream)
         } finally {
+          // close quietly in case Jackson auto closes streams
           IOUtils.closeQuietly(outputStream)
           IOUtils.closeQuietly(inputStream)
         }

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -106,7 +106,13 @@ private[spark] object JsonProtocol {
         val outputStream = new PipedOutputStream()
         val inputStream = new PipedInputStream(outputStream)
         try {
-          mapper.writeValue(outputStream, event)
+          val thread = new Thread("SparkListenerEvent json writer") {
+            override def run(): Unit = {
+              mapper.writeValue(outputStream, event)
+            }
+          }
+          thread.setDaemon(true)
+          thread.start()
           parse(inputStream)
         } finally {
           IOUtils.closeQuietly(outputStream)


### PR DESCRIPTION
## What changes were proposed in this pull request?

`def sparkEventToJson(event: SparkListenerEvent)`

has a fallback method which creates a JSON object by turning an unrecognized event to Json and then parsing it again. This method materializes the whole string to parse the json record, which is unnecessary, and can cause OOMs as seen in the stack trace below:

```
java.lang.OutOfMemoryError: Java heap space
at java.util.Arrays.copyOfRange(Arrays.java:3664)
at java.lang.String.<init>(String.java:207)
at java.lang.StringBuilder.toString(StringBuilder.java:407)
at com.fasterxml.jackson.core.util.TextBuffer.contentsAsString(TextBuffer.java:356)
at com.fasterxml.jackson.core.json.ReaderBasedJsonParser.getText(ReaderBasedJsonParser.java:235)
at org.json4s.jackson.JValueDeserializer.deserialize(JValueDeserializer.scala:20)
at org.json4s.jackson.JValueDeserializer.deserialize(JValueDeserializer.scala:42)
at org.json4s.jackson.JValueDeserializer.deserialize(JValueDeserializer.scala:35)
at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:3736)
at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2726)
at org.json4s.jackson.JsonMethods$class.parse(JsonMethods.scala:20)
at org.json4s.jackson.JsonMethods$.parse(JsonMethods.scala:50)
at org.apache.spark.util.JsonProtocol$.sparkEventToJson(JsonProtocol.scala:103)
```

We should just use the stream parsing to avoid such OOMs.

## How was this patch tested?

Unit tests for failure cases
