### PR TITLE
[SPARK-23465][SQL] Introduce new function to rename columns using an algoritm

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2250,21 +2250,10 @@ class Dataset[T] private[sql](
     */
   def withAllColumnsRenamed(convert: String => String): DataFrame = {
     val output = queryExecution.analyzed.output
-    var containsRename = false
     val columns = output.map { col =>
-      val newName = convert(col.name)
-      if (newName == col.name) {
-        Column(col)
-      } else {
-        containsRename = true
-        Column(col).as(newName)
-      }
+      Column(col).as(convert(col.name))
     }
-    if (containsRename) {
-      select(columns : _*)
-    } else {
-      toDF()
-    }
+    select(columns : _*)
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -896,6 +896,28 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     assert(df.schema.map(_.name) === Seq("key", "valueRenamed", "newCol"))
   }
 
+  test("withAllColumnsRenamed using identity column mapping") {
+    val df = testData.toDF().withColumn("newCol", col("key") + 1)
+      .withAllColumnsRenamed("" + _)
+    checkAnswer(
+      df,
+      testData.collect().map { case Row(key: Int, value: String) =>
+        Row(key, value, key + 1)
+      }.toSeq)
+    assert(df.schema.map(_.name) === Seq("key", "value", "newCol"))
+  }
+
+  test("withAllColumnsRenamed adding prefix to each column") {
+    val df = testData.toDF().withColumn("newCol", col("key") + 1)
+      .withAllColumnsRenamed("pre." + _)
+    checkAnswer(
+      df,
+      testData.collect().map { case Row(key: Int, value: String) =>
+        Row(key, value, key + 1)
+      }.toSeq)
+    assert(df.schema.map(_.name) === Seq("pre.key", "pre.value", "pre.newCol"))
+  }
+
   private lazy val person2: DataFrame = Seq(
     ("Bob", 16, 176),
     ("Alice", 32, 164),

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -896,17 +896,6 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     assert(df.schema.map(_.name) === Seq("key", "valueRenamed", "newCol"))
   }
 
-  test("withAllColumnsRenamed using identity column mapping") {
-    val df = testData.toDF().withColumn("newCol", col("key") + 1)
-      .withAllColumnsRenamed("" + _)
-    checkAnswer(
-      df,
-      testData.collect().map { case Row(key: Int, value: String) =>
-        Row(key, value, key + 1)
-      }.toSeq)
-    assert(df.schema.map(_.name) === Seq("key", "value", "newCol"))
-  }
-
   test("withAllColumnsRenamed adding prefix to each column") {
     val df = testData.toDF().withColumn("newCol", col("key") + 1)
       .withAllColumnsRenamed("pre." + _)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add an additional convenient method to rename multiple of columns by specifying a mapping between the old and the new column name.

## How was this patch tested?

Wrote additional unit test cases, ran scalastyle.