### PR TITLE
[SPARK-23033][SS][Follow Up] Task level retry for continuous processing

### DIFF
--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaContinuousReader.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaContinuousReader.scala
@@ -235,6 +235,13 @@ class KafkaContinuousDataReader(
     KafkaSourcePartitionOffset(topicPartition, nextKafkaOffset)
   }
 
+  override def setOffset(offset: PartitionOffset): Unit = {
+    val kafkaOffset = offset.asInstanceOf[KafkaSourcePartitionOffset]
+    assert(
+      kafkaOffset.topicPartition == topicPartition)
+    nextKafkaOffset = kafkaOffset.partitionOffset
+  }
+
   override def close(): Unit = {
     consumer.close()
   }

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/reader/streaming/ContinuousDataReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/reader/streaming/ContinuousDataReader.java
@@ -33,4 +33,16 @@ public interface ContinuousDataReader<T> extends DataReader<T> {
      * as a restart checkpoint.
      */
     PartitionOffset getOffset();
+
+    /**
+     * Set the start offset for the current record, only used in task retry. If setOffset keep
+     * default implementation, it means current ContinuousDataReader can't support task level retry.
+     *
+     * @param offset last offset before task retry.
+     */
+    default void setOffset(PartitionOffset offset) {
+        throw new UnsupportedOperationException(
+          "Current ContinuousDataReader can't support setOffset, task will restart " +
+            "with checkpoints in ContinuousExecution.");
+    }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousRateStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousRateStreamSource.scala
@@ -152,4 +152,11 @@ class RateStreamContinuousDataReader(
 
   override def getOffset(): PartitionOffset =
     RateStreamPartitionOffset(partitionIndex, currentValue, nextReadTime)
+
+  override def setOffset(offset: PartitionOffset): Unit = {
+    val rateStreamOffset = offset.asInstanceOf[RateStreamPartitionOffset]
+    assert(rateStreamOffset.partition == partitionIndex)
+    currentValue = rateStreamOffset.currentValue
+    nextReadTime = rateStreamOffset.currentTimeMs
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -332,6 +332,19 @@ object QueryTest {
     None
   }
 
+  def includesRowsOnlyOnce(
+      expectedRows: Seq[Row],
+      sparkAnswer: Seq[Row]): Option[String] = {
+    val expectedAnswer = prepareAnswer(expectedRows, true)
+    val actualAnswer = prepareAnswer(sparkAnswer, true)
+    val diffRow = actualAnswer.diff(expectedAnswer)
+    if (!expectedAnswer.toSet.subsetOf(actualAnswer.toSet)
+      || diffRow.intersect(expectedAnswer).nonEmpty) {
+      return Some(genError(expectedRows, sparkAnswer, true))
+    }
+    None
+  }
+
   def sameRows(
       expectedAnswer: Seq[Row],
       sparkAnswer: Seq[Row],


### PR DESCRIPTION
## What changes were proposed in this pull request?

Here we want to reimplement the task level retry for continuous processing, changes include:
1. Add a new `EpochCoordinatorMessage` named `GetLastEpochAndOffset`, it is used for getting last epoch and offset of particular partition while task restarted.
2. Add function setOffset for `ContinuousDataReader`, it supported BaseReader can restart from given offset.

## How was this patch tested?

Add new UT in `ContinuousSuite` and new `StreamAction` named `CheckAnswerRowsContainsOnlyOnce` for more accurate result checking.