### PR TITLE
[SPARK-23532][Standalone]Improve data locality when launching new executors for dynamic allocation

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
@@ -140,7 +140,8 @@ private[deploy] object DeployMessages {
 
   case class MasterChangeAcknowledged(appId: String)
 
-  case class RequestExecutors(appId: String, requestedTotal: Int)
+  case class RequestExecutors(appId: String, requestedTotal: Int,
+                              hostToLocalTaskCount: Map[String, Int] = Map.empty)
 
   case class KillExecutors(appId: String, executorIds: Seq[String])
 

--- a/core/src/main/scala/org/apache/spark/deploy/client/StandaloneAppClient.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/client/StandaloneAppClient.scala
@@ -295,9 +295,10 @@ private[spark] class StandaloneAppClient(
    *
    * @return whether the request is acknowledged.
    */
-  def requestTotalExecutors(requestedTotal: Int): Future[Boolean] = {
+  def requestTotalExecutors(requestedTotal: Int,
+                            hostToLocalTaskCount: Map[String, Int] = Map.empty): Future[Boolean] = {
     if (endpoint.get != null && appId.get != null) {
-      endpoint.get.ask[Boolean](RequestExecutors(appId.get, requestedTotal))
+      endpoint.get.ask[Boolean](RequestExecutors(appId.get, requestedTotal, hostToLocalTaskCount))
     } else {
       logWarning("Attempted to request executors before driver fully initialized.")
       Future.successful(false)

--- a/core/src/main/scala/org/apache/spark/deploy/master/ApplicationInfo.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ApplicationInfo.scala
@@ -47,6 +47,8 @@ private[spark] class ApplicationInfo(
   // application will this be set to a finite value. This is used for dynamic allocation.
   @transient private[master] var executorLimit: Int = _
 
+  @transient private[master] var hostToLocalTaskCount: Map[String, Int] = Map.empty
+
   @transient private var nextExecutorId: Int = _
 
   init()

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/StandaloneSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/StandaloneSchedulerBackend.scala
@@ -191,7 +191,7 @@ private[spark] class StandaloneSchedulerBackend(
    */
   protected override def doRequestTotalExecutors(requestedTotal: Int): Future[Boolean] = {
     Option(client) match {
-      case Some(c) => c.requestTotalExecutors(requestedTotal)
+      case Some(c) => c.requestTotalExecutors(requestedTotal, this.hostToLocalTaskCount)
       case None =>
         logWarning("Attempted to request executors before driver fully initialized.")
         Future.successful(false)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently Spark on Yarn supports better data locality by considering the preferred locations of the pending tasks when dynamic allocation is enabled, refer to _https://issues.apache.org/jira/browse/SPARK-4352_.
Mesos also supports data locality, refer to _https://issues.apache.org/jira/browse/SPARK-16944_

It would be better that Standalone can also support this feature.

## How was this patch tested?
1.Added a unit test.
2.Manual testing on HDFS in my environment.
Environment description: 5 workers, 3 HDFS nodes (**vmx01,vmx02,vmx04**).

_./spark-sql --master spark://vmx01:7077 --executor-memory 8G --total-executor-cores 26  --conf "spark.executor.cores=2" --conf "spark.shuffle.service.enabled=true" --conf "spark.dynamicAllocation.enabled=true"  --conf "spark.dynamicAllocation.minExecutors=0"_

Result(assigned more executors for vmx01,vmx02 and vmx04):
![default](https://user-images.githubusercontent.com/24688163/36776005-48fcd12a-1c9f-11e8-801d-8434bf14d9be.png)

