### PR TITLE
[SPARK-19185][SS] Make Kafka consumer cache configurable

### DIFF
--- a/docs/structured-streaming-kafka-integration.md
+++ b/docs/structured-streaming-kafka-integration.md
@@ -354,6 +354,13 @@ The following configurations are optional:
   <td>The timeout in milliseconds to poll data from Kafka in executors.</td>
 </tr>
 <tr>
+  <td>kafkaConsumer.useConsumerCache</td>
+  <td>true or false</td>
+  <td>true</td>
+  <td>streaming and batch</td>
+  <td>Whether enable or disable caching for Kafka consumers. Disabling the cache may be needed to workaround the problem described in SPARK-19185. This property may be removed in later versions of Spark, once SPARK-19185 is resolved.</td>
+</tr>
+<tr>
   <td>fetchOffset.numRetries</td>
   <td>int</td>
   <td>3</td>
@@ -375,6 +382,8 @@ The following configurations are optional:
   <td>Rate limit on maximum number of offsets processed per trigger interval. The specified total number of offsets will be proportionally split across topicPartitions of different volume.</td>
 </tr>
 </table>
+
+If you would like to disable the caching for Kafka consumers, you can set `spark.streaming.kafka.consumer.cache.enabled` to `false`. Disabling the cache may be needed to workaround the problem described in SPARK-19185. This property may be removed in later versions of Spark, once SPARK-19185 is resolved.
 
 ## Writing Data to Kafka
 

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -567,6 +567,7 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
       .readStream
       .format("kafka")
       .option("subscribe", topic)
+      .option("kafkaConsumer.useConsumerCache", false)
       .option("kafka.bootstrap.servers", testUtils.brokerAddress)
       .option("kafka.metadata.max.age.ms", "1")
       .load()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use property `spark.streaming.kafka.consumer.cache.enabled` in structured streaming introduced [here](https://github.com/apache/spark/pull/18234) that allows users to enable or disable the cache for Kafka consumers. This property can be especially handy in cases where issues like [SPARK-19185](https://issues.apache.org/jira/browse/SPARK-19185) get hit, for which there isn't a solution committed yet. By default, the cache is still on, so this change doesn't change any out-of-box behavior. The structured streaming problem reported in [SPARK-23526](https://issues.apache.org/jira/browse/SPARK-23526).

## How was this patch tested?

Automated: Passed Jenkins.
Manually:
```
cd docs
jekyll build
SKIP_API=1 jekyll build
```
open _site/structured-streaming-kafka-integration.html
