### PR TITLE
[SPARK-18630][PYTHON][ML] Move del method from JavaParams to JavaWrapper; add tests

### DIFF
--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -36,6 +36,10 @@ class JavaWrapper(object):
         super(JavaWrapper, self).__init__()
         self._java_obj = java_obj
 
+    def __del__(self):
+        if SparkContext._active_spark_context and not self._java_obj is None:
+            SparkContext._active_spark_context._gateway.detach(self._java_obj)
+
     @classmethod
     def _create_from_java_class(cls, java_class, *args):
         """
@@ -99,10 +103,6 @@ class JavaParams(JavaWrapper, Params):
     #: synced with the Python wrapper in fit/transform/evaluate/copy.
 
     __metaclass__ = ABCMeta
-
-    def __del__(self):
-        if SparkContext._active_spark_context:
-            SparkContext._active_spark_context._gateway.detach(self._java_obj)
 
     def _make_java_param_pair(self, param, value):
         """

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -37,7 +37,7 @@ class JavaWrapper(object):
         self._java_obj = java_obj
 
     def __del__(self):
-        if SparkContext._active_spark_context and not self._java_obj is None:
+        if SparkContext._active_spark_context and self._java_obj is not None:
             SparkContext._active_spark_context._gateway.detach(self._java_obj)
 
     @classmethod


### PR DESCRIPTION
The `__del__` method that explicitly detaches the object was moved from `JavaParams` to `JavaWrapper` class, this way model summaries could also be garbage collected in Java. A test case was added to make sure that relevant error messages are thrown after the objects are deleted.

I ran pyspark tests  agains `pyspark-ml` module
`./python/run-tests --python-executables=$(which python) --modules=pyspark-ml`
