### PR TITLE
[SPARK-23555][PYTHON] Add BinaryType support for Arrow in Python

### DIFF
--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -4261,7 +4261,7 @@ class ArrowTests(ReusedSQLTestCase):
 
     def test_createDataFrame_with_names(self):
         pdf = self.create_pandas_data_frame()
-        new_names = map(str, range(len(self.schema.fieldNames())))
+        new_names = list(map(str, range(len(self.schema.fieldNames()))))
         # Test that schema as a list of column names gets applied
         df = self.spark.createDataFrame(pdf, schema=list(new_names))
         self.assertEquals(df.schema.fieldNames(), new_names)

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -4368,7 +4368,7 @@ class ArrowTests(ReusedSQLTestCase):
             with QuietTest(self.sc):
                 with self.assertRaisesRegexp(TypeError, 'Unsupported type.*BinaryType'):
                     self.spark.createDataFrame(
-                        pd.DataFrame([[{'a': bytearray(b'aaa')}]]), "a: binary")
+                        pd.DataFrame([[{'a': b'aaa'}]]), "a: binary")
 
     # Regression test for SPARK-23314
     def test_timestamp_dst(self):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1598,8 +1598,11 @@ def to_arrow_type(dt):
         arrow_type = pa.decimal128(dt.precision, dt.scale)
     elif type(dt) == StringType:
         arrow_type = pa.string()
-    # TODO: remove version check once minimum pyarrow version is 0.10.0
-    elif type(dt) == BinaryType and LooseVersion("0.10.0") <= LooseVersion(pa.__version__):
+    elif type(dt) == BinaryType:
+        # TODO: remove version check once minimum pyarrow version is 0.10.0
+        if LooseVersion(pa.__version__) < LooseVersion("0.10.0"):
+            raise TypeError("Unsupported type in conversion to Arrow: " + str(dt) +
+                            "\nPlease install pyarrow >= 0.10.0 for BinaryType support.")
         arrow_type = pa.binary()
     elif type(dt) == DateType:
         arrow_type = pa.date32()
@@ -1648,8 +1651,11 @@ def from_arrow_type(at):
         spark_type = DecimalType(precision=at.precision, scale=at.scale)
     elif types.is_string(at):
         spark_type = StringType()
-    # TODO: remove version check once minimum pyarrow version is 0.10.0
-    elif types.is_binary(at) and LooseVersion("0.10.0") <= LooseVersion(pa.__version__):
+    elif types.is_binary(at):
+        # TODO: remove version check once minimum pyarrow version is 0.10.0
+        if LooseVersion(pa.__version__) < LooseVersion("0.10.0"):
+            raise TypeError("Unsupported type in conversion from Arrow: " + str(at) +
+                            "\nPlease install pyarrow >= 0.10.0 for BinaryType support.")
         spark_type = BinaryType()
     elif types.is_date32(at):
         spark_type = DateType()

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1578,6 +1578,7 @@ register_input_converter(DateConverter())
 def to_arrow_type(dt):
     """ Convert Spark data type to pyarrow type
     """
+    from distutils.version import LooseVersion
     import pyarrow as pa
     if type(dt) == BooleanType:
         arrow_type = pa.bool_()
@@ -1597,7 +1598,8 @@ def to_arrow_type(dt):
         arrow_type = pa.decimal128(dt.precision, dt.scale)
     elif type(dt) == StringType:
         arrow_type = pa.string()
-    elif type(dt) == BinaryType:
+    # TODO: remove version check once minimum pyarrow version is 0.10.0
+    elif type(dt) == BinaryType and LooseVersion("0.10.0") <= LooseVersion(pa.__version__):
         arrow_type = pa.binary()
     elif type(dt) == DateType:
         arrow_type = pa.date32()
@@ -1625,6 +1627,8 @@ def to_arrow_schema(schema):
 def from_arrow_type(at):
     """ Convert pyarrow type to Spark data type.
     """
+    from distutils.version import LooseVersion
+    import pyarrow as pa
     import pyarrow.types as types
     if types.is_boolean(at):
         spark_type = BooleanType()
@@ -1644,7 +1648,8 @@ def from_arrow_type(at):
         spark_type = DecimalType(precision=at.precision, scale=at.scale)
     elif types.is_string(at):
         spark_type = StringType()
-    elif types.is_binary(at):
+    # TODO: remove version check once minimum pyarrow version is 0.10.0
+    elif types.is_binary(at) and LooseVersion("0.10.0") <= LooseVersion(pa.__version__):
         spark_type = BinaryType()
     elif types.is_date32(at):
         spark_type = DateType()

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1597,6 +1597,8 @@ def to_arrow_type(dt):
         arrow_type = pa.decimal128(dt.precision, dt.scale)
     elif type(dt) == StringType:
         arrow_type = pa.string()
+    elif type(dt) == BinaryType:
+        arrow_type = pa.binary()
     elif type(dt) == DateType:
         arrow_type = pa.date32()
     elif type(dt) == TimestampType:
@@ -1642,6 +1644,8 @@ def from_arrow_type(at):
         spark_type = DecimalType(precision=at.precision, scale=at.scale)
     elif types.is_string(at):
         spark_type = StringType()
+    elif types.is_binary(at):
+        spark_type = BinaryType()
     elif types.is_date32(at):
         spark_type = DateType()
     elif types.is_timestamp(at):


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding `BinaryType` support for Arrow in pyspark, conditional on using pyarrow >= 0.10.0. Earlier versions will continue to raise a TypeError.

## How was this patch tested?

Additional unit tests in pyspark for code paths that use Arrow for createDataFrame, toPandas, and scalar pandas_udfs.