### PR TITLE
[SPARK-23578][ML] Add multicolumn support for Binarizer

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/ml/BinarizerExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/BinarizerExample.scala
@@ -45,7 +45,23 @@ object BinarizerExample {
     binarizedDataFrame.show()
     // $example off$
 
+    // $example on$
+    val data2 = Array((0, 0.1), (1, 0.8), (2, 0.2))
+    val dataFrame2 = spark.createDataFrame((0 until data.length).map { idx =>
+      (data(idx), data2(idx))
+    }).toDF("feature1", "feature2")
+
+    val binarizer2: Binarizer = new Binarizer()
+      .setInputCols(Array("feature1", "feature2"))
+      .setOutputCols(Array("result1", "result2"))
+      .setThresholds(Array(0.5, 0.5))
+
+    val binarizedDataFrame2 = binarizer2.transform(dataFrame2)
+    binarizedDataFrame2.show()
+    // $example off$
+
     spark.stop()
   }
 }
+
 // scalastyle:on println

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/BinarizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/BinarizerSuite.scala
@@ -27,10 +27,20 @@ class BinarizerSuite extends MLTest with DefaultReadWriteTest {
   import testImplicits._
 
   @transient var data: Array[Double] = _
+  @transient var data2: Array[Double] = _
+  @transient var expectedBinarizer1: Array[Double] = _
+  @transient var expectedBinarizer2: Array[Double] = _
+  @transient var expectedBinarizer3: Array[Double] = _
+  @transient var expectedBinarizer4: Array[Double] = _
 
   override def beforeAll(): Unit = {
     super.beforeAll()
     data = Array(0.1, -0.5, 0.2, -0.3, 0.8, 0.7, -0.1, -0.4)
+    data2 = Array(-0.1, 0.5, -0.2, 0.3, -0.8, -0.7, 0.1, 0.4)
+    expectedBinarizer1 = Array(1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0)
+    expectedBinarizer2 = Array(0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0)
+    expectedBinarizer3 = Array(0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0)
+    expectedBinarizer4 = Array(0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
   }
 
   test("params") {
@@ -51,6 +61,23 @@ class BinarizerSuite extends MLTest with DefaultReadWriteTest {
     }
   }
 
+  test("multiple columns: Binarize continuous features with default parameter") {
+    val dataFrame: DataFrame = (0 until data.length).map { idx =>
+      (data(idx), data2(idx), expectedBinarizer1(idx), expectedBinarizer2(idx))
+    }.toDF("feature1", "feature2", "expected1", "expected2")
+
+    val binarizer: Binarizer = new Binarizer()
+      .setInputCols(Array("feature1", "feature2"))
+      .setOutputCols(Array("result1", "result2"))
+      .setThresholds(Array(0.0, 0.0))
+
+    binarizer.transform(dataFrame).select("result1", "expected1", "result2", "expected2").collect().
+      foreach {
+        case Row(r1: Double, e1: Double, r2: Double, e2: Double ) => assert(r1 == e1 && r2 == e2,
+          "The feature value is not correct after binarization.")
+      }
+  }
+
   test("Binarize continuous features with setter") {
     val threshold: Double = 0.2
     val thresholdBinarized: Array[Double] = data.map(x => if (x > threshold) 1.0 else 0.0)
@@ -67,6 +94,23 @@ class BinarizerSuite extends MLTest with DefaultReadWriteTest {
     }
   }
 
+  test("multiple columns:Binarize continuous features with setter") {
+    val dataFrame: DataFrame = (0 until data.length).map { idx =>
+      (data(idx), data2(idx), expectedBinarizer3(idx), expectedBinarizer4(idx))
+    }.toDF("feature1", "feature2", "expected1", "expected2")
+
+    val binarizer: Binarizer = new Binarizer()
+      .setInputCols(Array("feature1", "feature2"))
+      .setOutputCols(Array("result1", "result2"))
+      .setThresholds(Array(0.2, 0.2))
+
+    binarizer.transform(dataFrame).select("result1", "expected1", "result2", "expected2").collect().
+      foreach {
+        case Row(r1: Double, e1: Double, r2: Double, e2: Double ) => assert(r1 == e1 && r2 == e2,
+          "The feature value is not correct after binarization.")
+      }
+  }
+
   test("Binarize vector of continuous features with default parameter") {
     val defaultBinarized: Array[Double] = data.map(x => if (x > 0.0) 1.0 else 0.0)
     val dataFrame: DataFrame = Seq(
@@ -80,6 +124,24 @@ class BinarizerSuite extends MLTest with DefaultReadWriteTest {
     binarizer.transform(dataFrame).select("binarized_feature", "expected").collect().foreach {
       case Row(x: Vector, y: Vector) =>
         assert(x == y, "The feature value is not correct after binarization.")
+    }
+  }
+
+  test("multiple column: Binarize vector of continuous features with default parameter") {
+    val dataFrame: DataFrame = Seq(
+      (Vectors.dense(data), Vectors.dense(data2),
+        Vectors.dense(expectedBinarizer1), Vectors.dense(expectedBinarizer2))
+    ).toDF("feature1", "feature2", "expected1", "expected2")
+
+    val binarizer: Binarizer = new Binarizer()
+      .setInputCols(Array("feature1", "feature2"))
+      .setOutputCols(Array("result1", "result2"))
+      .setThresholds(Array(0.0, 0.0))
+
+    binarizer.transform(dataFrame).select("result1", "expected1", "result2", "expected2").collect().
+      foreach {
+      case Row(r1: Vector, e1: Vector, r2: Vector, e2: Vector ) => assert(r1 == e1 && r2 == e2,
+          "The feature value is not correct after binarization.")
     }
   }
 
@@ -101,6 +163,23 @@ class BinarizerSuite extends MLTest with DefaultReadWriteTest {
     }
   }
 
+  test("multiple column: Binarize vector of continuous features with setter") {
+    val dataFrame: DataFrame = Seq(
+      (Vectors.dense(data), Vectors.dense(data2),
+        Vectors.dense(expectedBinarizer3), Vectors.dense(expectedBinarizer4))
+    ).toDF("feature1", "feature2", "expected1", "expected2")
+
+    val binarizer: Binarizer = new Binarizer()
+      .setInputCols(Array("feature1", "feature2"))
+      .setOutputCols(Array("result1", "result2"))
+      .setThresholds(Array(0.2, 0.2))
+
+    binarizer.transform(dataFrame).select("result1", "expected1", "result2", "expected2").collect().
+      foreach {
+        case Row(r1: Vector, e1: Vector, r2: Vector, e2: Vector ) => assert(r1 == e1 && r2 == e2,
+          "The feature value is not correct after binarization.")
+    }
+  }
 
   test("read/write") {
     val t = new Binarizer()
@@ -110,3 +189,5 @@ class BinarizerSuite extends MLTest with DefaultReadWriteTest {
     testDefaultReadWrite(t)
   }
 }
+
+


### PR DESCRIPTION
## What changes were proposed in this pull request?

[Spark-20542] added an API that Bucketizer that can bin multiple columns. Based on this change, a multicolumn support is added for Binarizer.

## How was this patch tested?
Added test cases.
