### PR TITLE
[SPARK-23585][SQL] Add interpreted execution to UnwrapOption

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -382,8 +382,14 @@ case class UnwrapOption(
 
   override def inputTypes: Seq[AbstractDataType] = ObjectType :: Nil
 
-  override def eval(input: InternalRow): Any =
-    throw new UnsupportedOperationException("Only code-generated evaluation is supported")
+  override def eval(input: InternalRow): Any = {
+    val inputObject = child.eval(input)
+    if (inputObject == null) {
+      null
+    } else {
+      inputObject.asInstanceOf[Option[_]].orNull
+    }
+  }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val javaType = CodeGenerator.javaType(dataType)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
@@ -67,7 +67,7 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       mapEncoder.serializer.head, mapExpected, mapInputRow)
   }
 
-  test("SPARK-23586: UnwrapOption should support interpreted execution") {
+  test("SPARK-23585: UnwrapOption should support interpreted execution") {
     val cls = classOf[Option[Int]]
     val inputObject = BoundReference(0, ObjectType(cls), nullable = true)
     val unwrapObject = UnwrapOption(IntegerType, inputObject)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
@@ -68,14 +68,11 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("SPARK-23586: UnwrapOption should support interpreted execution") {
-    val inputRowWithSome = InternalRow.fromSeq(Seq(Some(1)))
-    val inputRowWithNone = InternalRow.fromSeq(Seq(None))
-    val inputRowWithNull = InternalRow.fromSeq(Seq(null))
     val cls = classOf[Option[Int]]
     val inputObject = BoundReference(0, ObjectType(cls), nullable = true)
     val unwrapObject = UnwrapOption(IntegerType, inputObject)
-    assert(unwrapObject.eval(inputRowWithSome) == 1)
-    assert(unwrapObject.eval(inputRowWithNone) == null)
-    assert(unwrapObject.eval(inputRowWithNull) == null)
+    Seq((Some(1), 1), (None, null), (null, null)).foreach { case (input, expected) =>
+      checkEvaluation(unwrapObject, expected, InternalRow.fromSeq(Seq(input)))
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The PR adds interpreted execution to UnwrapOption.

## How was this patch tested?

added UT
