### PR TITLE
[SPARK-23603][SQL]When the length of the json is in a range,get_json_object will result in missing tail data

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
@@ -242,6 +242,13 @@ class JsonExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       "1234")
   }
 
+  test("some big value") {
+    val value = "x" * 3000
+    checkEvaluation(
+      GetJsonObject(NonFoldableLiteral((s"""{"big": "$value"}"""))
+        , NonFoldableLiteral("$.big")), value)
+  }
+
   val jsonTupleQuery = Literal("f1") ::
     Literal("f2") ::
     Literal("f3") ::


### PR DESCRIPTION
## What changes were proposed in this pull request?
Replace writeRaw(char[] text, int offset, int len) with writeRaw(String text)
Although using writeRaw(String text) will lose some performance

spark-shell:
```
val value = "x" * 3000
val json = s"""{"big": "$value"}"""
spark.sql("select length(get_json_object(\'"+json+"\','$.big'))" ).collect
res0: Array[org.apache.spark.sql.Row] = Array([2991])
```
expect result : 3000 
actual  result : 2991

> public abstract void writeRaw(char[] text,int offset,int len) throws IOException
Method that will force generator to copy input text verbatim with no modifications (including that no escaping is done and no separators are added even if context [array, object] would otherwise require such). If such separators are desired, use writeRawValue(String) instead.

> public abstract void writeRaw(String text) throws IOException
Method that will force generator to copy input text verbatim with no modifications (including that no escaping is done and no separators are added even if context [array, object] would otherwise require such). If such separators are desired, use writeRawValue(String) instead.

Jackson(>=2.7.7) fixes the possibility of missing tail data when the length of the value is in a range
[https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.7.7](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.7.7)
[https://github.com/FasterXML/jackson-core/issues/30](https://github.com/FasterXML/jackson-core/issues/307)


## How was this patch tested?
org.apache.spark.sql.catalyst.expressions.JsonExpressionsSuite
test("some big value")
