### PR TITLE
[SPARK-23586][SQL] Add interpreted execution to WrapOption

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -422,8 +422,7 @@ case class WrapOption(child: Expression, optType: DataType)
 
   override def inputTypes: Seq[AbstractDataType] = optType :: Nil
 
-  override def eval(input: InternalRow): Any =
-    throw new UnsupportedOperationException("Only code-generated evaluation is supported")
+  override def eval(input: InternalRow): Any = Option(child.eval(input))
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val inputObject = child.genCode(ctx)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
@@ -79,10 +79,9 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
   test("SPARK-23586: WrapOption should support interpreted execution") {
     val cls = ObjectType(classOf[java.lang.Integer])
     val inputObject = BoundReference(0, cls, nullable = true)
-    val unwrapObject = WrapOption(inputObject, cls)
-    unwrapObject.resolved
+    val wrapObject = WrapOption(inputObject, cls)
     Seq((1, Some(1)), (null, None)).foreach { case (input, expected) =>
-      checkEvaluation(unwrapObject, expected, InternalRow.fromSeq(Seq(input)))
+      checkEvaluation(wrapObject, expected, InternalRow.fromSeq(Seq(input)))
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The PR adds interpreted execution to WrapOption.

## How was this patch tested?

added UT