### PR TITLE
[SPARK-23287][CORE] Spark scheduler does not remove initial executor if not one job submitted

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -291,9 +291,6 @@ private[spark] class ExecutorAllocationManager(
    */
   private def schedule(): Unit = synchronized {
     val now = clock.getTimeMillis
-
-    updateAndSyncNumExecutorsTarget(now)
-
     val executorIdsToBeRemoved = ArrayBuffer[String]()
     removeTimes.retain { case (executorId, expireTime) =>
       val expired = now >= expireTime
@@ -303,6 +300,7 @@ private[spark] class ExecutorAllocationManager(
       }
       !expired
     }
+    updateAndSyncNumExecutorsTarget(now)
     if (executorIdsToBeRemoved.nonEmpty) {
       removeExecutors(executorIdsToBeRemoved)
     }

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -901,11 +901,6 @@ class ExecutorAllocationManagerSuite
 
     assert(maxNumExecutorsNeeded(manager) === 0)
     schedule(manager)
-    // Verify executor is timeout but numExecutorsTarget is not recalculated
-    assert(numExecutorsTarget(manager) === 3)
-
-    // Schedule again to recalculate the numExecutorsTarget after executor is timeout
-    schedule(manager)
     // Verify that current number of executors should be ramp down when executor is timeout
     assert(numExecutorsTarget(manager) === 2)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `ExecutorAllocationManager.schedule()`, `numExecutorsTarget` is getting updated as part of `updateAndSyncNumExecutorsTarget(now)` but it skips updating till initializing becomes false, `removeExecutors()` is not removing the expired executors since the condition `else if (newExecutorTotal - 1 < numExecutorsTarget) { ` is satisfying to skip them, and they are missing to remove and continues running till the application completes.

I moved the `updateAndSyncNumExecutorsTarget(now)` to after the expiry check and initializing var assignment if eligible so that the updated `numExecutorsTarget `can be used while removing executors. 

## How was this patch tested?

I verified it manually by enabling the dynamic allocation, now it removes the executors when they are not getting assigned any task for the specified executorIdleTimeout. 
