### PR TITLE
[SPARK-23595][SQL] ValidateExternalType should support interpreted execution

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -125,19 +125,6 @@ object ScalaReflection extends ScalaReflection {
     case _ => false
   }
 
-  def classForNativeTypeOf(dt: DataType): Class[_] = dt match {
-    case NullType => classOf[Object]
-    case BooleanType => classOf[java.lang.Boolean]
-    case ByteType => classOf[java.lang.Byte]
-    case ShortType => classOf[java.lang.Short]
-    case IntegerType => classOf[java.lang.Integer]
-    case LongType => classOf[java.lang.Long]
-    case FloatType => classOf[java.lang.Float]
-    case DoubleType => classOf[java.lang.Double]
-    case BinaryType => classOf[Array[Byte]]
-    case CalendarIntervalType => classOf[CalendarInterval]
-  }
-
   /**
    * Returns an expression that can be used to deserialize an input row to an object of type `T`
    * with a compatible schema.  Fields of the row will be extracted using UnresolvedAttributes

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -125,6 +125,19 @@ object ScalaReflection extends ScalaReflection {
     case _ => false
   }
 
+  def classForNativeTypeOf(dt: DataType): Class[_] = dt match {
+    case NullType => classOf[Object]
+    case BooleanType => classOf[java.lang.Boolean]
+    case ByteType => classOf[java.lang.Byte]
+    case ShortType => classOf[java.lang.Short]
+    case IntegerType => classOf[java.lang.Integer]
+    case LongType => classOf[java.lang.Long]
+    case FloatType => classOf[java.lang.Float]
+    case DoubleType => classOf[java.lang.Double]
+    case BinaryType => classOf[Array[Byte]]
+    case CalendarIntervalType => classOf[CalendarInterval]
+  }
+
   /**
    * Returns an expression that can be used to deserialize an input row to an object of type `T`
    * with a compatible schema.  Fields of the row will be extracted using UnresolvedAttributes

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -846,6 +846,19 @@ object ScalaReflection extends ScalaReflection {
     }
   }
 
+  def javaBoxedType(dt: DataType): Class[_] = dt match {
+    case _: DecimalType => classOf[Decimal]
+    case BinaryType => classOf[Array[Byte]]
+    case StringType => classOf[UTF8String]
+    case CalendarIntervalType => classOf[CalendarInterval]
+    case _: StructType => classOf[InternalRow]
+    case _: ArrayType => classOf[ArrayType]
+    case _: MapType => classOf[MapType]
+    case udt: UserDefinedType[_] => javaBoxedType(udt.sqlType)
+    case ObjectType(cls) => cls
+    case _ => ScalaReflection.typeBoxedJavaMapping.getOrElse(dt, classOf[java.lang.Object])
+  }
+
   def expressionJavaClasses(arguments: Seq[Expression]): Seq[Class[_]] = {
     if (arguments != Nil) {
       arguments.map(e => dataTypeJavaClass(e.dataType))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/RowEncoder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/RowEncoder.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.objects._
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData, DateTimeUtils}
 import org.apache.spark.sql.types._
-import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
+import org.apache.spark.unsafe.types.UTF8String
 
 /**
  * A factory for constructing encoders that convert external row to/from the Spark SQL
@@ -233,26 +233,6 @@ object RowEncoder {
     case _: StructType => ObjectType(classOf[Row])
     case p: PythonUserDefinedType => externalDataTypeFor(p.sqlType)
     case udt: UserDefinedType[_] => ObjectType(udt.userClass)
-  }
-
-  // Returns the runtime class corresponding to the provided external type that
-  // is retrieved by `externalDataTypeForInput`. Note that `PythonUserDefinedType` and
-  // `UserDefinedType` are converted into native types or `ObjectType`s in `externalDataTypeFor`,
-  // so this method can handle both types correctly.
-  def getClassFromExternalType(externalType: DataType): Class[_] = externalType match {
-    case NullType => classOf[Object]
-    case BooleanType => classOf[java.lang.Boolean]
-    case ByteType => classOf[java.lang.Byte]
-    case ShortType => classOf[java.lang.Short]
-    case IntegerType => classOf[java.lang.Integer]
-    case LongType => classOf[java.lang.Long]
-    case FloatType => classOf[java.lang.Float]
-    case DoubleType => classOf[java.lang.Double]
-    case BinaryType => classOf[Array[Byte]]
-    case CalendarIntervalType => classOf[CalendarInterval]
-    // External types for the other types (e.g., array, map, and struct)
-    // must be `ObjectType`.
-    case ObjectType(cls) => cls
   }
 
   private def deserializerFor(schema: StructType): Expression = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -1674,7 +1674,6 @@ case class ValidateExternalType(child: Expression, expected: DataType)
 
   private val errMsg = s" is not a valid external type for schema of ${expected.simpleString}"
 
-
   private lazy val checkType: (Any) => Boolean = expected match {
     case _: DecimalType =>
       (value: Any) => {
@@ -1686,13 +1685,7 @@ case class ValidateExternalType(child: Expression, expected: DataType)
         value.getClass.isArray || value.isInstanceOf[Seq[_]]
       }
     case _ =>
-      val dataTypeClazz = if (dataType.isInstanceOf[ObjectType]) {
-        dataType.asInstanceOf[ObjectType].cls
-      } else {
-        // Some external types (e.g., native types and `PythonUserDefinedType`)
-        // might not be ObjectType
-        ScalaReflection.classForNativeTypeOf(dataType)
-      }
+      val dataTypeClazz = RowEncoder.getClassFromExternalType(dataType)
       (value: Any) => {
         dataTypeClazz.isInstance(value)
       }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
@@ -274,7 +274,6 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(createExternalRow, Row.fromSeq(Seq(1, "x")), InternalRow.fromSeq(Seq()))
   }
 
-  // This is an alternative version of `checkEvaluation` to compare results
   // by scala values instead of catalyst values.
   private def checkObjectExprEvaluation(
       expression: => Expression, expected: Any, inputRow: InternalRow = EmptyRow): Unit = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData, Generic
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
-import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
 class InvokeTargetClass extends Serializable {
   def filterInt(e: Any): Any = e.asInstanceOf[Int] > 0
@@ -274,6 +274,7 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(createExternalRow, Row.fromSeq(Seq(1, "x")), InternalRow.fromSeq(Seq()))
   }
 
+  // This is an alternative version of `checkEvaluation` to compare results
   // by scala values instead of catalyst values.
   private def checkObjectExprEvaluation(
       expression: => Expression, expected: Any, inputRow: InternalRow = EmptyRow): Unit = {
@@ -296,7 +297,7 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     val inputObject = BoundReference(0, ObjectType(classOf[Row]), nullable = true)
     val getRowField = GetExternalRowField(inputObject, index = 0, fieldName = "c0")
     Seq((Row(1), 1), (Row(3), 3)).foreach { case (input, expected) =>
-      checkEvaluation(getRowField, expected, InternalRow.fromSeq(Seq(input)))
+      checkObjectExprEvaluation(getRowField, expected, InternalRow.fromSeq(Seq(input)))
     }
 
     // If an input row or a field are null, a runtime exception will be thrown
@@ -471,6 +472,35 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     val data = Map[Int, String](0 -> "v0", 1 -> "v1", 2 -> null, 3 -> "v3")
     val deserializer = toMapExpr.copy(inputData = Literal.create(data))
     checkObjectExprEvaluation(deserializer, expected = data)
+  }
+
+  test("SPARK-23595 ValidateExternalType should support interpreted execution") {
+    val inputObject = BoundReference(0, ObjectType(classOf[Row]), nullable = true)
+    Seq(
+      (true, BooleanType),
+      (2.toByte, ByteType),
+      (5.toShort, ShortType),
+      (23, IntegerType),
+      (61L, LongType),
+      (1.0f, FloatType),
+      (10.0, DoubleType),
+      ("abcd".getBytes, BinaryType),
+      ("abcd", StringType),
+      (BigDecimal.valueOf(10), DecimalType.IntDecimal),
+      (CalendarInterval.fromString("interval 3 day"), CalendarIntervalType),
+      (java.math.BigDecimal.valueOf(10), DecimalType.BigIntDecimal),
+      (Array(3, 2, 1), ArrayType(IntegerType))
+    ).foreach { case (input, dt) =>
+      val validateType = ValidateExternalType(
+        GetExternalRowField(inputObject, index = 0, fieldName = "c0"), dt)
+      checkObjectExprEvaluation(validateType, input, InternalRow.fromSeq(Seq(Row(input))))
+    }
+
+    checkExceptionInExpression[RuntimeException](
+      ValidateExternalType(
+        GetExternalRowField(inputObject, index = 0, fieldName = "c0"), DoubleType),
+      InternalRow.fromSeq(Seq(Row(1))),
+      "java.lang.Integer is not a valid external type for schema of double")
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr supported interpreted mode for `ValidateExternalType`.

## How was this patch tested?
Added tests in `ObjectExpressionsSuite`.
