### PR TITLE
[SPARK-23602][SQL] PrintToStderr prints value also in interpreted mode

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -31,7 +31,12 @@ case class PrintToStderr(child: Expression) extends UnaryExpression {
 
   override def dataType: DataType = child.dataType
 
-  protected override def nullSafeEval(input: Any): Any = input
+  protected override def nullSafeEval(input: Any): Any = {
+    // scalastyle:off println
+    System.err.println(outputPrefix + input)
+    // scalastyle:on println
+    input
+  }
 
   private val outputPrefix = s"Result of ${child.simpleString} is "
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MiscExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MiscExpressionsSuite.scala
@@ -58,7 +58,7 @@ class MiscExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       val outputEval = errorStream.toString
       errorStream.reset()
       // check with codegen
-      checkEvaluationWithoutCodegen(PrintToStderr(inputExpr), 1)
+      checkEvaluationWithGeneratedMutableProjection(PrintToStderr(inputExpr), 1)
       val outputCodegen = errorStream.toString
       (outputEval, outputCodegen)
     } finally {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MiscExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MiscExpressionsSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
+import java.io.PrintStream
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.types._
 
@@ -42,5 +44,22 @@ class MiscExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
   test("uuid") {
     checkEvaluation(Length(Uuid()), 36)
     assert(evaluateWithoutCodegen(Uuid()) !== evaluateWithoutCodegen(Uuid()))
+  }
+
+  test("PrintToStderr") {
+    val errorStream = new java.io.ByteArrayOutputStream()
+    val systemErr = System.err
+    System.setErr(new PrintStream(errorStream))
+    val inputExpr = Literal(1)
+    // check without codegen
+    checkEvaluationWithoutCodegen(PrintToStderr(inputExpr), 1)
+    val outputEval = errorStream.toString
+    errorStream.reset()
+    // check with codegen
+    checkEvaluationWithoutCodegen(PrintToStderr(inputExpr), 1)
+    val outputCodegen = errorStream.toString
+    System.setErr(systemErr)
+    assert(outputCodegen.contains(s"Result of $inputExpr is 1"))
+    assert(outputEval.contains(s"Result of $inputExpr is 1"))
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`PrintToStderr` was doing what is it supposed to only when code generation is enabled.
The PR adds the same behavior in interpreted mode too. 

## How was this patch tested?

added UT