### PR TITLE
[SPARK-23627][SQL] Provide isEmpty in DataSet

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -474,6 +474,14 @@ class Dataset[T] private[sql](
   def isLocal: Boolean = logicalPlan.isInstanceOf[LocalRelation]
 
   /**
+   * Returns true if the `DataSet` is empty
+   *
+   * @group basic
+   * @since 2.3.1
+   */
+  def isEmpty: Boolean = rdd.isEmpty()
+
+  /**
    * Returns true if this Dataset contains one or more sources that continuously
    * return data as it arrives. A Dataset that reads data from a streaming source
    * must be executed as a `StreamingQuery` using the `start()` method in

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1154,6 +1154,11 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     assert(errMsg3.getMessage.startsWith("cannot have circular references in class, but got the " +
       "circular reference of class"))
   }
+  
+  test("SPARK-23627: provide isEmpty in DataSet") {
+    val data = Seq()
+    assert(data.isEmpty)
+  }
 }
 
 case class WithImmutableMap(id: String, map_test: scala.collection.immutable.Map[Long, String])

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1154,10 +1154,13 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     assert(errMsg3.getMessage.startsWith("cannot have circular references in class, but got the " +
       "circular reference of class"))
   }
-  
+
   test("SPARK-23627: provide isEmpty in DataSet") {
-    val data = Seq()
-    assert(data.isEmpty)
+    val ds1 = spark.emptyDataset[Int]
+    val ds2 = Seq(1, 2, 3).toDS()
+
+    assert(ds1.isEmpty == true)
+    assert(ds2.isEmpty == false)
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds a isEmpty in DataSet

## How was this patch tested?

Unit tests added.

Please review http://spark.apache.org/contributing.html before opening a pull request.
