### PR TITLE
[SPARK-23486]cache the function name from the external catalog for lookupFunctions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1231,8 +1231,22 @@ class Analyzer(
     }
 
     def normalizeFuncName(name: FunctionIdentifier): FunctionIdentifier = {
-      FunctionIdentifier(name.funcName.toLowerCase(Locale.ROOT),
-        name.database.orElse(Some(catalog.getCurrentDatabase)))
+      val funcName = if (conf.caseSensitiveAnalysis) {
+        name.funcName
+      } else {
+        name.funcName.toLowerCase(Locale.ROOT)
+      }
+
+      val databaseName = name.database match {
+        case Some(a) => formatDatabaseName(a)
+        case None => catalog.getCurrentDatabase
+      }
+
+      FunctionIdentifier(funcName, Some(databaseName))
+    }
+
+    protected def formatDatabaseName(name: String): String = {
+      if (conf.caseSensitiveAnalysis) name else name.toLowerCase(Locale.ROOT)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1230,7 +1230,7 @@ class Analyzer(
       }
     }
 
-    private def normalizeFuncName(name: FunctionIdentifier): FunctionIdentifier = {
+    def normalizeFuncName(name: FunctionIdentifier): FunctionIdentifier = {
       FunctionIdentifier(name.funcName.toLowerCase(Locale.ROOT),
         name.database.orElse(Some(catalog.getCurrentDatabase)))
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1218,8 +1218,8 @@ class Analyzer(
       plan.transformAllExpressions {
         case f: UnresolvedFunction
           if externalFunctionNameSet.contains(normalizeFuncName(f.name)) => f
-        case f: UnresolvedFunction if catalog.builtinFunctionExists(f.name) => f
-        case f: UnresolvedFunction if catalog.externalFunctionExists(f.name) =>
+        case f: UnresolvedFunction if catalog.isRegisteredFunction(f.name) => f
+        case f: UnresolvedFunction if catalog.isPersistentFunction(f.name) =>
           externalFunctionNameSet.add(normalizeFuncName(f.name))
           f
         case f: UnresolvedFunction =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1215,7 +1215,8 @@ class Analyzer(
     override def apply(plan: LogicalPlan): LogicalPlan = {
       val catalogFunctionNameSet = new mutable.HashSet[FunctionIdentifier]()
       plan.transformAllExpressions {
-        case f: UnresolvedFunction if catalogFunctionNameSet.contains(f.name) => f
+        case f: UnresolvedFunction
+          if catalogFunctionNameSet.contains(normalizeFuncName(f.name)) => f
         case f: UnresolvedFunction if catalog.functionExists(f.name) =>
           catalogFunctionNameSet.add(normalizeFuncName(f.name))
           f

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1218,7 +1218,7 @@ class Analyzer(
       plan.transformAllExpressions {
         case f: UnresolvedFunction
           if externalFunctionNameSet.contains(normalizeFuncName(f.name)) => f
-        case f: UnresolvedFunction if catalog.buildinFunctionExists(f.name) => f
+        case f: UnresolvedFunction if catalog.builtinFunctionExists(f.name) => f
         case f: UnresolvedFunction if catalog.externalFunctionExists(f.name) =>
           externalFunctionNameSet.add(normalizeFuncName(f.name))
           f

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -1099,17 +1099,8 @@ class SessionCatalog(
   def functionExists(name: FunctionIdentifier): Boolean = {
     val db = formatDatabaseName(name.database.getOrElse(getCurrentDatabase))
     requireDbExists(db)
-    builtinFunctionExists(name) || externalFunctionExists(name)
-  }
-
-  def builtinFunctionExists(name: FunctionIdentifier): Boolean = {
-    functionRegistry.functionExists(name)
-  }
-
-  def externalFunctionExists(name: FunctionIdentifier): Boolean = {
-    val db = formatDatabaseName(name.database.getOrElse(getCurrentDatabase))
-    requireDbExists(db)
-    externalCatalog.functionExists(db, name.funcName)
+    functionRegistry.functionExists(name) ||
+      externalCatalog.functionExists(db, name.funcName)
   }
 
   // ----------------------------------------------------------------
@@ -1200,6 +1191,22 @@ class SessionCatalog(
       functionRegistry.functionExists(name) &&
       !FunctionRegistry.builtin.functionExists(name) &&
       !hiveFunctions.contains(name.funcName.toLowerCase(Locale.ROOT))
+  }
+
+  /**
+   * Return whether this function has been registered in the function registry of the current
+   * session. If not existed, return false.
+   */
+  def isRegisteredFunction(name: FunctionIdentifier): Boolean = {
+    functionRegistry.functionExists(name)
+  }
+
+  /**
+   * Returns whether it is a persistent function. If not existed, returns false.
+   */
+  def isPersistentFunction(name: FunctionIdentifier): Boolean = {
+    val db = formatDatabaseName(name.database.getOrElse(getCurrentDatabase))
+    databaseExists(db) && externalCatalog.functionExists(db, name.funcName)
   }
 
   protected def failFunctionLookup(name: FunctionIdentifier): Nothing = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -1103,6 +1103,16 @@ class SessionCatalog(
       externalCatalog.functionExists(db, name.funcName)
   }
 
+  def buildinFunctionExists(name: FunctionIdentifier): Boolean = {
+    functionRegistry.functionExists(name)
+  }
+
+  def externalFunctionExists(name: FunctionIdentifier): Boolean = {
+    val db = formatDatabaseName(name.database.getOrElse(getCurrentDatabase))
+    requireDbExists(db)
+    externalCatalog.functionExists(db, name.funcName)
+  }
+
   // ----------------------------------------------------------------
   // | Methods that interact with temporary and metastore functions |
   // ----------------------------------------------------------------

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -1099,11 +1099,10 @@ class SessionCatalog(
   def functionExists(name: FunctionIdentifier): Boolean = {
     val db = formatDatabaseName(name.database.getOrElse(getCurrentDatabase))
     requireDbExists(db)
-    functionRegistry.functionExists(name) ||
-      externalCatalog.functionExists(db, name.funcName)
+    builtinFunctionExists(name) || externalFunctionExists(name)
   }
 
-  def buildinFunctionExists(name: FunctionIdentifier): Boolean = {
+  def builtinFunctionExists(name: FunctionIdentifier): Boolean = {
     functionRegistry.functionExists(name)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/LookupFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/LookupFunctionsSuite.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import java.net.URI
+
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{CatalogDatabase, InMemoryCatalog, SessionCatalog}
+import org.apache.spark.sql.catalyst.expressions.Alias
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.internal.SQLConf
+
+class LookupFunctionsSuite extends PlanTest {
+
+  test("SPARK-23486: LookupFunctions should not check the same function name more than once") {
+    val externalCatalog = new CustomInMemoryCatalog
+    val analyzer = {
+      val conf = new SQLConf()
+      val catalog = new SessionCatalog(externalCatalog, FunctionRegistry.builtin, conf)
+      catalog.createDatabase(
+        CatalogDatabase("default", "", new URI("loc"), Map.empty),
+        ignoreIfExists = false)
+      new Analyzer(catalog, conf)
+    }
+
+    def table(ref: String): LogicalPlan = UnresolvedRelation(TableIdentifier(ref))
+    val unresolvedFunc = UnresolvedFunction("func", Seq.empty, false)
+    val plan = Project(
+      Seq(Alias(unresolvedFunc, "call1")(), Alias(unresolvedFunc, "call2")(),
+        Alias(unresolvedFunc, "call1")()),
+      table("TaBlE"))
+    analyzer.LookupFunctions.apply(plan)
+    assert(externalCatalog.getFunctionExistsCalledTimes == 1)
+  }
+}
+
+class CustomInMemoryCatalog extends InMemoryCatalog {
+
+  private var functionExistsCalledTimes: Int = 0
+
+  override def functionExists(db: String, funcName: String): Boolean = synchronized {
+    functionExistsCalledTimes = functionExistsCalledTimes + 1
+    true
+  }
+
+  def getFunctionExistsCalledTimes: Int = functionExistsCalledTimes
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/LookupFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/LookupFunctionsSuite.scala
@@ -48,14 +48,13 @@ class LookupFunctionsSuite extends PlanTest {
         Alias(unresolvedRegisteredFunc, "call5")()),
       table("TaBlE"))
     analyzer.LookupFunctions.apply(plan)
-   assert(externalCatalog.getFunctionExistsCalledTimes == 1)
 
+    assert(externalCatalog.getFunctionExistsCalledTimes == 1)
     assert(analyzer.LookupFunctions.normalizeFuncName
       (unresolvedPersistentFunc.name).database == Some("default"))
   }
 
   test("SPARK-23486: the functionExists for the Registered function check") {
-
     val externalCatalog = new InMemoryCatalog
     val conf = new SQLConf()
     val customerFunctionReg = new CustomerFunctionRegistry
@@ -73,11 +72,10 @@ class LookupFunctionsSuite extends PlanTest {
       Seq(Alias(unresolvedRegisteredFunc, "call1")(), Alias(unresolvedRegisteredFunc, "call2")()),
       table("TaBlE"))
     analyzer.LookupFunctions.apply(plan)
+
     assert(customerFunctionReg.getIsRegisteredFunctionCalledTimes == 2)
-
     assert(analyzer.LookupFunctions.normalizeFuncName
-    (unresolvedRegisteredFunc.name).database == Some("default"))
-
+      (unresolvedRegisteredFunc.name).database == Some("default"))
   }
 }
 
@@ -103,5 +101,4 @@ class CustomInMemoryCatalog extends InMemoryCatalog {
   }
 
   def getFunctionExistsCalledTimes: Int = functionExistsCalledTimes
-
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/LookupFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/LookupFunctionsSuite.scala
@@ -48,7 +48,8 @@ class LookupFunctionsSuite extends PlanTest {
     analyzer.LookupFunctions.apply(plan)
     assert(externalCatalog.getFunctionExistsCalledTimes == 1)
 
-    assert(analyzer.LookupFunctions.normalizeFuncName(unresolvedFunc.name).database == "default")
+    assert(analyzer.LookupFunctions.normalizeFuncName
+      (unresolvedFunc.name).database == Some("default"))
     assert(catalog.isRegisteredFunction(unresolvedFunc.name) == false)
     assert(catalog.isRegisteredFunction(FunctionIdentifier("max")) == true)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -1217,6 +1217,42 @@ abstract class SessionCatalogSuite extends AnalysisTest {
     }
   }
 
+  test("isRegisteredFunction") {
+    withBasicCatalog { catalog =>
+      // Returns false when the function does not register
+      assert(!catalog.isRegisteredFunction(FunctionIdentifier("temp1")))
+
+      // Returns true when the function does register
+      val tempFunc1 = (e: Seq[Expression]) => e.head
+      catalog.registerFunction(newFunc("iff", None), overrideIfExists = false,
+        functionBuilder = Some(tempFunc1) )
+      assert(catalog.isRegisteredFunction(FunctionIdentifier("iff")))
+
+      // Returns false when using the createFunction
+      catalog.createFunction(newFunc("sum", Some("db2")), ignoreIfExists = false)
+      assert(!catalog.isRegisteredFunction(FunctionIdentifier("sum")))
+      assert(!catalog.isRegisteredFunction(FunctionIdentifier("sum", Some("db2"))))
+    }
+  }
+
+  test("isPersistentFunction") {
+    withBasicCatalog { catalog =>
+      // Returns false when the function does not register
+      assert(!catalog.isPersistentFunction(FunctionIdentifier("temp2")))
+
+      // Returns false when the function does register
+      val tempFunc2 = (e: Seq[Expression]) => e.head
+      catalog.registerFunction(newFunc("iff", None), overrideIfExists = false,
+        functionBuilder = Some(tempFunc2))
+      assert(!catalog.isPersistentFunction(FunctionIdentifier("iff")))
+
+      // Return true when using the createFunction
+      catalog.createFunction(newFunc("sum", Some("db2")), ignoreIfExists = false)
+      assert(catalog.isPersistentFunction(FunctionIdentifier("sum", Some("db2"))))
+      assert(!catalog.isPersistentFunction(FunctionIdentifier("db2.sum")))
+    }
+  }
+
   test("drop function") {
     withBasicCatalog { catalog =>
       assert(catalog.externalCatalog.listFunctions("db2", "*").toSet == Set("func1"))

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -175,6 +175,8 @@ private[sql] class HiveSessionCatalog(
     super.functionExists(name) || hiveFunctions.contains(name.funcName)
   }
 
+  override def externalFunctionExists(name: FunctionIdentifier): Boolean = functionExists(name)
+
   /** List of functions we pass over to Hive. Note that over time this list should go to 0. */
   // We have a list of Hive built-in functions that we do not support. So, we will check
   // Hive's function registry and lazily load needed functions into our own function registry.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -175,8 +175,8 @@ private[sql] class HiveSessionCatalog(
     super.functionExists(name) || hiveFunctions.contains(name.funcName)
   }
 
-  override def externalFunctionExists(name: FunctionIdentifier): Boolean = {
-    super.externalFunctionExists(name) || hiveFunctions.contains(name.funcName)
+  override def isPersistentFunction(name: FunctionIdentifier): Boolean = {
+    super.isPersistentFunction(name) || hiveFunctions.contains(name.funcName)
   }
 
   /** List of functions we pass over to Hive. Note that over time this list should go to 0. */

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -175,7 +175,9 @@ private[sql] class HiveSessionCatalog(
     super.functionExists(name) || hiveFunctions.contains(name.funcName)
   }
 
-  override def externalFunctionExists(name: FunctionIdentifier): Boolean = functionExists(name)
+  override def externalFunctionExists(name: FunctionIdentifier): Boolean = {
+    super.externalFunctionExists(name) || hiveFunctions.contains(name.funcName)
+  }
 
   /** List of functions we pass over to Hive. Note that over time this list should go to 0. */
   // We have a list of Hive built-in functions that we do not support. So, we will check


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR will cache the function name from external catalog, it is used by lookupFunctions in the analyzer, and it is cached for each query plan. The original problem is reported in the [ spark-19737](https://issues.apache.org/jira/browse/SPARK-19737) 

## How was this patch tested?

create new test file LookupFunctionsSuite and add test case in SessionCatalogSuite