### PR TITLE
[SPARK-23651]Add a check for host name

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -975,6 +975,8 @@ private[spark] object Utils extends Logging {
 
   def checkHost(host: String) {
     assert(host != null && host.indexOf(':') == -1, s"Expected hostname (not IP) but got $host")
+    assert(host.matches("^[a-zA-Z0-9-]+$"),
+      s"Hostname is only allowed to include 0-9, a-z, A-Z and -, but got $host")
   }
 
   def checkHostPort(hostPort: String) {

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -1168,6 +1168,18 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
       Utils.checkAndGetK8sMasterUrl("k8s://foo://host:port")
     }
   }
+
+  test("check host name") {
+    intercept[AssertionError] {
+      Utils.checkHost("name_164")
+    }
+    intercept[AssertionError] {
+      Utils.checkHost("name-164#")
+    }
+    Utils.checkHost("name-164")
+    Utils.checkHost("name")
+    Utils.checkHost("950")
+  }
 }
 
 private class SimpleExtension


### PR DESCRIPTION
## What changes were proposed in this pull request?
I encountered an error like this:
`org.apache.spark.SparkException: Invalid Spark URL: spark://HeartbeatReceiver@ci_164:42849
        at org.apache.spark.rpc.RpcEndpointAddress$.apply(RpcEndpointAddress.scala:66)
        at org.apache.spark.rpc.netty.NettyRpcEnv.asyncSetupEndpointRefByURI(NettyRpcEnv.scala:134)
        at org.apache.spark.rpc.RpcEnv.setupEndpointRefByURI(RpcEnv.scala:101)
        at org.apache.spark.rpc.RpcEnv.setupEndpointRef(RpcEnv.scala:109)
        at org.apache.spark.util.RpcUtils$.makeDriverRef(RpcUtils.scala:32)
        at org.apache.spark.executor.Executor.<init>(Executor.scala:155)
        at org.apache.spark.scheduler.local.LocalEndpoint.<init>(LocalSchedulerBackend.scala:59)
        at org.apache.spark.scheduler.local.LocalSchedulerBackend.start(LocalSchedulerBackend.scala:126)
        at org.apache.spark.scheduler.TaskSchedulerImpl.start(TaskSchedulerImpl.scala:164)`

I didn't  know why this URL(spark://HeartbeatReceiver@ci_164:42849) is invalid, 
in fact, hostname is only allowed to include 0-9, a-z, A-Z , - and . ,  so i think we should give a clearer reminder for this error.

## How was this patch tested?
Added a unit test.