### PR TITLE
[SPARK-23651][core]Add a check for host name 

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -975,6 +975,8 @@ private[spark] object Utils extends Logging {
 
   def checkHost(host: String) {
     assert(host != null && host.indexOf(':') == -1, s"Expected hostname (not IP) but got $host")
+    assert(host.matches("^[a-zA-Z0-9-.]+$"),
+      s"Hostname is only allowed to include 0-9, a-z, A-Z, - and ., but got $host")
   }
 
   def checkHostPort(hostPort: String) {

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerReplicationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerReplicationSuite.scala
@@ -151,7 +151,7 @@ trait BlockManagerReplicationBehavior extends SparkFunSuite
 
     // Test whether asking for peers of a unregistered block manager id returns empty list
     assert(master.getPeers(stores(0).blockManagerId).isEmpty)
-    assert(master.getPeers(BlockManagerId("", "", 1)).isEmpty)
+    assert(master.getPeers(BlockManagerId("", "host1", 1)).isEmpty)
   }
 
 

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -69,9 +69,9 @@ class JsonProtocolSuite extends SparkFunSuite {
       "Classpath Entries" -> Seq(("Super library", "/tmp/super_library"))
     ))
     val blockManagerAdded = SparkListenerBlockManagerAdded(1L,
-      BlockManagerId("Stars", "In your multitude...", 300), 500)
+      BlockManagerId("Stars", "In-your-multitude", 300), 500)
     val blockManagerRemoved = SparkListenerBlockManagerRemoved(2L,
-      BlockManagerId("Scarce", "to be counted...", 100))
+      BlockManagerId("Scarce", "to-be-counted", 100))
     val unpersistRdd = SparkListenerUnpersistRDD(12345)
     val logUrlMap = Map("stderr" -> "mystderr", "stdout" -> "mystdout").toMap
     val applicationStart = SparkListenerApplicationStart("The winner of all", Some("appId"),
@@ -98,7 +98,7 @@ class JsonProtocolSuite extends SparkFunSuite {
     }
     val blockUpdated =
       SparkListenerBlockUpdated(BlockUpdatedInfo(BlockManagerId("Stars",
-        "In your multitude...", 300), RDDBlockId(0, 0), StorageLevel.MEMORY_ONLY, 100L, 0L))
+        "In-your-multitude", 300), RDDBlockId(0, 0), StorageLevel.MEMORY_ONLY, 100L, 0L))
 
     testEvent(stageSubmitted, stageSubmittedJsonString)
     testEvent(stageCompleted, stageCompletedJsonString)
@@ -157,7 +157,7 @@ class JsonProtocolSuite extends SparkFunSuite {
     testJobResult(jobFailed)
 
     // TaskEndReason
-    val fetchFailed = FetchFailed(BlockManagerId("With or", "without you", 15), 17, 18, 19,
+    val fetchFailed = FetchFailed(BlockManagerId("With or", "without-you", 15), 17, 18, 19,
       "Some exception")
     val fetchMetadataFailed = new MetadataFetchFailedException(17,
       19, "metadata Fetch failed exception").toTaskFailedReason
@@ -253,9 +253,9 @@ class JsonProtocolSuite extends SparkFunSuite {
   test("BlockManager events backward compatibility") {
     // SparkListenerBlockManagerAdded/Removed in Spark 1.0.0 do not have a "time" property.
     val blockManagerAdded = SparkListenerBlockManagerAdded(1L,
-      BlockManagerId("Stars", "In your multitude...", 300), 500)
+      BlockManagerId("Stars", "In-your-multitude", 300), 500)
     val blockManagerRemoved = SparkListenerBlockManagerRemoved(2L,
-      BlockManagerId("Scarce", "to be counted...", 100))
+      BlockManagerId("Scarce", "to-be-counted", 100))
 
     val oldBmAdded = JsonProtocol.blockManagerAddedToJson(blockManagerAdded)
       .removeField({ _._1 == "Timestamp" })
@@ -274,11 +274,11 @@ class JsonProtocolSuite extends SparkFunSuite {
 
   test("FetchFailed backwards compatibility") {
     // FetchFailed in Spark 1.1.0 does not have a "Message" property.
-    val fetchFailed = FetchFailed(BlockManagerId("With or", "without you", 15), 17, 18, 19,
+    val fetchFailed = FetchFailed(BlockManagerId("With or", "without-you", 15), 17, 18, 19,
       "ignored")
     val oldEvent = JsonProtocol.taskEndReasonToJson(fetchFailed)
       .removeField({ _._1 == "Message" })
-    val expectedFetchFailed = FetchFailed(BlockManagerId("With or", "without you", 15), 17, 18, 19,
+    val expectedFetchFailed = FetchFailed(BlockManagerId("With or", "without-you", 15), 17, 18, 19,
       "Unknown reason")
     assert(expectedFetchFailed === JsonProtocol.taskEndReasonFromJson(oldEvent))
   }
@@ -1705,7 +1705,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       |  "Event": "SparkListenerBlockManagerAdded",
       |  "Block Manager ID": {
       |    "Executor ID": "Stars",
-      |    "Host": "In your multitude...",
+      |    "Host": "In-your-multitude",
       |    "Port": 300
       |  },
       |  "Maximum Memory": 500,
@@ -1719,7 +1719,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       |  "Event": "SparkListenerBlockManagerRemoved",
       |  "Block Manager ID": {
       |    "Executor ID": "Scarce",
-      |    "Host": "to be counted...",
+      |    "Host": "to-be-counted",
       |    "Port": 100
       |  },
       |  "Timestamp": 2
@@ -2018,7 +2018,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       |  "Block Updated Info": {
       |    "Block Manager ID": {
       |      "Executor ID": "Stars",
-      |      "Host": "In your multitude...",
+      |      "Host": "In-your-multitude",
       |      "Port": 300
       |    },
       |    "Block ID": "rdd_0_0",

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -1168,6 +1168,19 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
       Utils.checkAndGetK8sMasterUrl("k8s://foo://host:port")
     }
   }
+
+  test("check host name") {
+    intercept[AssertionError] {
+      Utils.checkHost("name_164")
+    }
+    intercept[AssertionError] {
+      Utils.checkHost("name-164#")
+    }
+    Utils.checkHost("name-164")
+    Utils.checkHost("Name")
+    Utils.checkHost("Name164.com")
+    Utils.checkHost("950")
+  }
 }
 
 private class SimpleExtension


### PR DESCRIPTION
## What changes were proposed in this pull request?
I encountered an error like this:
`org.apache.spark.SparkException: Invalid Spark URL: spark://HeartbeatReceiver@ci_164:42849 at org.apache.spark.rpc.RpcEndpointAddress$.apply(RpcEndpointAddress.scala:66) at org.apache.spark.rpc.netty.NettyRpcEnv.asyncSetupEndpointRefByURI(NettyRpcEnv.scala:134) at org.apache.spark.rpc.RpcEnv.setupEndpointRefByURI(RpcEnv.scala:101) at org.apache.spark.rpc.RpcEnv.setupEndpointRef(RpcEnv.scala:109) at org.apache.spark.util.RpcUtils$.makeDriverRef(RpcUtils.scala:32) at org.apache.spark.executor.Executor.<init>(Executor.scala:155) at org.apache.spark.scheduler.local.LocalEndpoint.<init>(LocalSchedulerBackend.scala:59) at org.apache.spark.scheduler.local.LocalSchedulerBackend.start(LocalSchedulerBackend.scala:126) at org.apache.spark.scheduler.TaskSchedulerImpl.start(TaskSchedulerImpl.scala:164)`

I didn't know why this URL(spark://HeartbeatReceiver@ci_164:42849) is invalid,
in fact, hostname is only allowed to include 0-9, a-z, A-Z , - and . , so i think we should give a clearer reminder for this error.
## How was this patch tested?

Added a unit test.