### PR TITLE
[SPARK-21479][SQL] Outer join filter pushdown in null supplying table when condition is on one of the joined columns

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
@@ -29,7 +29,8 @@ trait QueryPlanConstraints { self: LogicalPlan =>
   lazy val allConstraints: ExpressionSet = {
     if (conf.constraintPropagationEnabled) {
       ExpressionSet(validConstraints
-        .union(inferAdditionalConstraints(validConstraints))
+        .union(inferAdditionalConstraints(
+          validConstraints.union(additionalValidConstraintsForInference)))
         .union(constructIsNotNullConstraints(validConstraints)))
     } else {
       ExpressionSet(Set.empty)
@@ -54,6 +55,16 @@ trait QueryPlanConstraints { self: LogicalPlan =>
    * See [[Canonicalize]] for more details.
    */
   protected def validConstraints: Set[Expression] = Set.empty
+
+  /**
+   * This method can be overridden by any child class of QueryPlan to specify a set of additional
+   * constraints used for constraint inference only based on the given operator's constraint
+   * propagation logic. These constraints are then canonicalized and filtered automatically to
+   * contain only those attributes that appear in the [[outputSet]].
+   *
+   * See [[Canonicalize]] for more details.
+   */
+  protected def additionalValidConstraintsForInference: Set[Expression] = Set.empty
 
   /**
    * Infers a set of `isNotNull` constraints from null intolerant expressions as well as

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -323,6 +323,20 @@ case class Join(
     }
   }
 
+  // For left or right outer joins, constraits coming from the preserved side should be
+  // propagated to the null-supplying side, but cannot be included in the validConstraints
+  // set.
+  override protected def additionalValidConstraintsForInference: Set[Expression] = {
+    joinType match {
+      case LeftOuter if condition.isDefined =>
+        splitConjunctivePredicates(condition.get).toSet
+      case RightOuter if condition.isDefined =>
+        splitConjunctivePredicates(condition.get).toSet
+      case _ =>
+        Set.empty[Expression]
+    }
+  }
+
   def duplicateResolved: Boolean = left.outputSet.intersect(right.outputSet).isEmpty
 
   // Joins are only resolved if they don't introduce ambiguous expression ids.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
@@ -242,6 +242,8 @@ class ConstraintPropagationSuite extends SparkFunSuite with PlanTest {
       .join(tr2.where('d.attr < 100), LeftOuter, Some("tr1.a".attr === "tr2.a".attr))
       .analyze.constraints,
       ExpressionSet(Seq(tr1.resolveQuoted("a", caseInsensitiveResolution).get > 10,
+        tr2.resolveQuoted("a", caseInsensitiveResolution).get > 10,
+        IsNotNull(tr2.resolveQuoted("a", caseInsensitiveResolution).get),
         IsNotNull(tr1.resolveQuoted("a", caseInsensitiveResolution).get))))
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In left/right outer joins, constraints derived from the preserved side can be propagated to the null-supplying side (not the other way around). Meanwhile, we do not want to include the join condition in the constraints set since this is an outer join and otherwise is-not-null constraints would be inferred incorrectly.

1. Add method QueryPlanConstraints#additionalValidConstraintsForInference to accommodate this requirement from the Join operator.
2. Override QueryPlanConstraints#additionalValidConstraintsForInference in the Join operator.

## How was this patch tested?

1. Added 3 new tests in InferFiltersFromConstraintsSuite.
2. Updated 1 test reference in ConstraintsSuitePropagationSuite.
