### PR TITLE
[SPARK-23661][SQL] Implement treeAggregate on Dataset API

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1446,6 +1446,16 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     val data = Seq(("a", null))
     checkDataset(data.toDS(), data: _*)
   }
+
+  test("treeAggregate on Dataset API") {
+    val ds = (0 to 100).map(x => DoubleData(x, x.toString)).toDS
+    val aggregated = ds.repartition(10).treeAggregate(DoubleData(0, "0"))(
+      (x, y) => DoubleData(x.id + y.id, (x.val1.toInt + y.val1.toInt).toString),
+      (x, y) => DoubleData(x.id + y.id, (x.val1.toInt + y.val1.toInt).toString), 5)
+
+    assert(aggregated.id == (0 to 100).sum)
+    assert(aggregated.val1 == (0 to 100).sum.toString)
+  }
 }
 
 case class SingleData(id: Int)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Many algorithms in MLlib are still not migrated their internal computing workload from RDD to DataFrame. `treeAggregate` is one of obstacles we need to address in order to see complete migration.

This patch is submitted to provide `treeAggregate` on Dataset API. For now this should be a private API used by ML component.

The approach of tree aggregation imitates RDD's `treeAggregate`.
 
## How was this patch tested?

Added unit test.
