### PR TITLE
[SPARK-23669] Executors fetch jars and name the jars with md5 prefix

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -754,7 +754,7 @@ private[spark] class Executor(
           // Fetch file with useCache mode, close cache for local mode.
           val url = Utils.fetchFile(name, new File(SparkFiles.getRootDirectory()), conf,
             env.securityManager, hadoopConf, timestamp, useCache = !isLocal,
-            conf.getBoolean("spark.jars.withDecoratedName", false)).toURI.toURL
+            conf.get(SPARK_JARS_DECORATE_NAME)).toURI.toURL
           currentJars(name) = timestamp
           if (!urlClassLoader.getURLs().contains(url)) {
             logInfo("Adding " + url + " to class loader")

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -752,11 +752,10 @@ private[spark] class Executor(
         if (currentTimeStamp < timestamp) {
           logInfo("Fetching " + name + " with timestamp " + timestamp)
           // Fetch file with useCache mode, close cache for local mode.
-          Utils.fetchFile(name, new File(SparkFiles.getRootDirectory()), conf,
-            env.securityManager, hadoopConf, timestamp, useCache = !isLocal)
+          val url = Utils.fetchFile(name, new File(SparkFiles.getRootDirectory()), conf,
+            env.securityManager, hadoopConf, timestamp, useCache = !isLocal,
+            conf.getBoolean("spark.jars.withDecoratedName", false)).toURI.toURL
           currentJars(name) = timestamp
-          // Add it to our class loader
-          val url = new File(SparkFiles.getRootDirectory(), localName).toURI.toURL
           if (!urlClassLoader.getURLs().contains(url)) {
             logInfo("Adding " + url + " to class loader")
             urlClassLoader.addURL(url)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -525,4 +525,12 @@ package object config {
     .bytesConf(ByteUnit.BYTE)
     .createWithDefaultString("1g")
 
+  private[spark] val SPARK_JARS_DECORATE_NAME =
+    ConfigBuilder("spark.jars.decorateName")
+      .doc("When executor updates dependencies, it's possible it will fetch different jars but" +
+          " with the same file name(e.g. /pathA/udfs.jar and /pathB/udfs.jar). To avoid the" +
+          " conflict, user can enable this config and all jars fetched by executor will be" +
+          " renamed with a MD5 prefix.")
+      .booleanConf
+      .createWithDefault(false)
 }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -455,7 +455,7 @@ private[spark] object Utils extends Logging {
       useCache: Boolean,
       withMD5Prefix: Boolean = false): File = {
     val fileName = if (withMD5Prefix) {
-      DigestUtils.md5Hex(url) + "-" + decodeFileNameInURI(new URI(url))
+      s"${DigestUtils.md5Hex(url)}-${decodeFileNameInURI(new URI(url))}"
     } else {
       decodeFileNameInURI(new URI(url))
     }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -46,6 +46,7 @@ import _root_.io.netty.channel.unix.Errors.NativeIoException
 import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
 import com.google.common.io.{ByteStreams, Files => GFiles}
 import com.google.common.net.InetAddresses
+import org.apache.commons.codec.digest.DigestUtils
 import org.apache.commons.lang3.SystemUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, FileUtil, Path}
@@ -451,8 +452,13 @@ private[spark] object Utils extends Logging {
       securityMgr: SecurityManager,
       hadoopConf: Configuration,
       timestamp: Long,
-      useCache: Boolean): File = {
-    val fileName = decodeFileNameInURI(new URI(url))
+      useCache: Boolean,
+      withMD5Prefix: Boolean = false): File = {
+    val fileName = if (withMD5Prefix) {
+      DigestUtils.md5Hex(url) + "-" + decodeFileNameInURI(new URI(url))
+    } else {
+      decodeFileNameInURI(new URI(url))
+    }
     val targetFile = new File(targetDir, fileName)
     val fetchCacheEnabled = conf.getBoolean("spark.files.useFetchCache", defaultValue = true)
     if (useCache && fetchCacheEnabled) {

--- a/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
@@ -29,6 +29,7 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 
 import com.google.common.io.Files
+import org.apache.commons.codec.digest.DigestUtils
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{mock, never, verify, when}
 import org.scalatest.BeforeAndAfterAll
@@ -873,6 +874,10 @@ abstract class RpcEnvSuite extends SparkFunSuite with BeforeAndAfterAll {
       Utils.fetchFile(uri, destDir, conf, sm, hc, 0L, false)
       assert(Files.equal(f, destFile))
     }
+    val jarWithMD5Prefix = Utils.fetchFile(jarUri, destDir, conf, sm, hc, 0L, false, true)
+    assert(jarWithMD5Prefix.getAbsolutePath ==
+        new File(destDir, DigestUtils.md5Hex(jarUri) + "-jar").getAbsolutePath)
+    assert(Files.equal(jarWithMD5Prefix, jar))
 
     // Try to download files that do not exist.
     Seq("files", "jars", "dir1").foreach { root =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

In our cluster, there are lots of UDF jars, some of them have the same filename but different path, for example:
```
hdfs://A/B/udf.jar  -> udfA
hdfs://C/D/udf.jar  -> udfB
```
When user uses udfA and udfB in same sql, executor will fetch both `hdfs://A/B/udf.jar` and `hdfs://C/D/udf.jar` to local. There will be a conflict for the same name. 

Can we config to fetch jars and save with a filename with MD5 prefix, so there will be no conflict.

## How was this patch tested?
 UT 