### PR TITLE
[SPARK-23599][SQL] Add a UUID generator from Pseudo-Random Numbers

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/RandomUUIDGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/RandomUUIDGenerator.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.util
+
+import java.util.UUID
+
+import scala.util.Random
+
+/**
+ * This class is used to generate a UUID from Pseudo-Random Numbers produced by
+ * Scala Random.
+ *
+ * For the algorithm, see RFC 4122: A Universally Unique IDentifier (UUID) URN Namespace,
+ * section 4.4 "Algorithms for Creating a UUID from Truly Random or Pseudo-Random Numbers".
+ */
+case class RandomUUIDGenerator(random: Random) {
+  def getNextUUID(): UUID = {
+    val mostSigBits = (random.nextLong() & 0xFFFFFFFFFFFF0FFFL) | 0x0000000000004000L
+    val leastSigBits = (random.nextLong() | 0x8000000000000000L) & 0xBFFFFFFFFFFFFFFFL
+
+    new UUID(mostSigBits, leastSigBits)
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/RandomUUIDGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/RandomUUIDGenerator.scala
@@ -21,6 +21,8 @@ import java.util.UUID
 
 import org.apache.commons.math3.random.MersenneTwister
 
+import org.apache.spark.unsafe.types.UTF8String
+
 /**
  * This class is used to generate a UUID from Pseudo-Random Numbers.
  *
@@ -36,4 +38,6 @@ case class RandomUUIDGenerator(randomSeed: Long) {
 
     new UUID(mostSigBits, leastSigBits)
   }
+
+  def getNextUUIDUTF8String(): UTF8String = UTF8String.fromString(getNextUUID().toString())
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/RandomUUIDGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/RandomUUIDGenerator.scala
@@ -19,16 +19,17 @@ package org.apache.spark.sql.catalyst.util
 
 import java.util.UUID
 
-import scala.util.Random
+import org.apache.commons.math3.random.MersenneTwister
 
 /**
- * This class is used to generate a UUID from Pseudo-Random Numbers produced by
- * Scala Random.
+ * This class is used to generate a UUID from Pseudo-Random Numbers.
  *
  * For the algorithm, see RFC 4122: A Universally Unique IDentifier (UUID) URN Namespace,
  * section 4.4 "Algorithms for Creating a UUID from Truly Random or Pseudo-Random Numbers".
  */
-case class RandomUUIDGenerator(random: Random) {
+case class RandomUUIDGenerator(randomSeed: Long) {
+  private val random = new MersenneTwister(randomSeed)
+
   def getNextUUID(): UUID = {
     val mostSigBits = (random.nextLong() & 0xFFFFFFFFFFFF0FFFL) | 0x0000000000004000L
     val leastSigBits = (random.nextLong() | 0x8000000000000000L) & 0xBFFFFFFFFFFFFFFFL

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/RandomUUIDGeneratorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/RandomUUIDGeneratorSuite.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.util
+
+import scala.util.Random
+
+import org.apache.spark.SparkFunSuite
+
+class RandomUUIDGeneratorSuite extends SparkFunSuite {
+  test("RandomUUIDGenerator should generate version 4, variant 2 UUIDs") {
+    val generator = RandomUUIDGenerator(new Random())
+    for (_ <- 0 to 100) {
+      val uuid = generator.getNextUUID()
+      assert(uuid.version() == 4)
+      assert(uuid.variant() == 2)
+    }
+  }
+
+ test("UUID from RandomUUIDGenerator should be deterministic") {
+   val r1 = new Random(100)
+   val generator1 = RandomUUIDGenerator(r1)
+   val r2 = new Random(100)
+   val generator2 = RandomUUIDGenerator(r2)
+   val r3 = new Random(101)
+   val generator3 = RandomUUIDGenerator(r3)
+
+   for (_ <- 0 to 100) {
+      val uuid1 = generator1.getNextUUID()
+      val uuid2 = generator2.getNextUUID()
+      val uuid3 = generator3.getNextUUID()
+      assert(uuid1 == uuid2)
+      assert(uuid1 != uuid3)
+   }
+ }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/RandomUUIDGeneratorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/RandomUUIDGeneratorSuite.scala
@@ -47,4 +47,11 @@ class RandomUUIDGeneratorSuite extends SparkFunSuite {
       assert(uuid1 != uuid3)
    }
  }
+
+ test("Get UTF8String UUID") {
+   val generator = RandomUUIDGenerator(new Random().nextLong())
+   val utf8StringUUID = generator.getNextUUIDUTF8String()
+   val uuid = java.util.UUID.fromString(utf8StringUUID.toString)
+   assert(uuid.version() == 4 && uuid.variant() == 2 && utf8StringUUID.toString == uuid.toString)
+ }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/RandomUUIDGeneratorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/RandomUUIDGeneratorSuite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.SparkFunSuite
 
 class RandomUUIDGeneratorSuite extends SparkFunSuite {
   test("RandomUUIDGenerator should generate version 4, variant 2 UUIDs") {
-    val generator = RandomUUIDGenerator(new Random())
+    val generator = RandomUUIDGenerator(new Random().nextLong())
     for (_ <- 0 to 100) {
       val uuid = generator.getNextUUID()
       assert(uuid.version() == 4)
@@ -33,11 +33,11 @@ class RandomUUIDGeneratorSuite extends SparkFunSuite {
 
  test("UUID from RandomUUIDGenerator should be deterministic") {
    val r1 = new Random(100)
-   val generator1 = RandomUUIDGenerator(r1)
+   val generator1 = RandomUUIDGenerator(r1.nextLong())
    val r2 = new Random(100)
-   val generator2 = RandomUUIDGenerator(r2)
+   val generator2 = RandomUUIDGenerator(r2.nextLong())
    val r3 = new Random(101)
-   val generator3 = RandomUUIDGenerator(r3)
+   val generator3 = RandomUUIDGenerator(r3.nextLong())
 
    for (_ <- 0 to 100) {
       val uuid1 = generator1.getNextUUID()


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch adds a UUID generator from Pseudo-Random Numbers. We can use it later to have deterministic `UUID()` expression.

## How was this patch tested?

Added unit tests.
