### PR TITLE
[SPARK-23676][SQL]Support left join codegen in SortMergeJoinExec

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/LeftJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/LeftJoinSuite.scala
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.joins
+
+import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
+import org.apache.spark.sql.catalyst.plans.LeftOuter
+import org.apache.spark.sql.catalyst.plans.logical.Join
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.exchange.EnsureRequirements
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
+
+class LeftJoinSuite extends SparkPlanTest with SharedSQLContext {
+  import testImplicits.newProductEncoder
+  import testImplicits.localSeqToDatasetHolder
+
+  private lazy val myUpperCaseData = spark.createDataFrame(
+    sparkContext.parallelize(Seq(
+      Row(1, "A"),
+      Row(2, "B"),
+      Row(3, "C"),
+      Row(4, "D"),
+      Row(5, "E"),
+      Row(6, "F"),
+      Row(null, "G")
+    )), new StructType().add("No", IntegerType).add("L", StringType))
+
+  private lazy val myLowerCaseData = spark.createDataFrame(
+    sparkContext.parallelize(Seq(
+      Row(1, "a"),
+      Row(2, "b"),
+      Row(3, "c"),
+      Row(4, "d"),
+      Row(null, "e")
+    )), new StructType().add("key", IntegerType).add("value", StringType))
+
+  private lazy val myTestData1 = Seq(
+    (1, 1),
+    (1, 2),
+    (2, 1),
+    (2, 2)
+  ).toDF("a", "b")
+
+  private lazy val myTestData2 = Seq(
+    (1, 1),
+    (1, 2),
+    (2, 1),
+    (2, 2)
+  ).toDF("c", "d")
+
+  // Note: the input dataframes and expression must be evaluated lazily because
+  // the SQLContext should be used only within a test to keep SQL tests stable
+  private def testLeftJoin(
+      testName: String,
+      leftRows: => DataFrame,
+      rightRows: => DataFrame,
+      condition: () => Expression,
+      expectedAnswer: Seq[Product]): Unit = {
+
+    def extractJoinParts(): Option[ExtractEquiJoinKeys.ReturnType] = {
+      val join = Join(leftRows.logicalPlan, rightRows.logicalPlan, LeftOuter, Some(condition()))
+      ExtractEquiJoinKeys.unapply(join)
+    }
+
+    def makeBroadcastHashJoin(
+      leftKeys: Seq[Expression],
+      rightKeys: Seq[Expression],
+      boundCondition: Option[Expression],
+      leftPlan: SparkPlan,
+      rightPlan: SparkPlan,
+      side: BuildSide) = {
+      val broadcastJoin = joins.BroadcastHashJoinExec(
+        leftKeys,
+        rightKeys,
+        LeftOuter,
+        side,
+        boundCondition,
+        leftPlan,
+        rightPlan)
+      EnsureRequirements(spark.sessionState.conf).apply(broadcastJoin)
+    }
+
+    def makeShuffledHashJoin(
+      leftKeys: Seq[Expression],
+      rightKeys: Seq[Expression],
+      boundCondition: Option[Expression],
+      leftPlan: SparkPlan,
+      rightPlan: SparkPlan,
+      side: BuildSide) = {
+      val shuffledHashJoin = joins.ShuffledHashJoinExec(leftKeys, rightKeys, LeftOuter,
+        side, boundCondition, leftPlan, rightPlan)
+      EnsureRequirements(spark.sessionState.conf).apply(shuffledHashJoin)
+    }
+
+    def makeSortMergeJoin(
+      leftKeys: Seq[Expression],
+      rightKeys: Seq[Expression],
+      boundCondition: Option[Expression],
+      leftPlan: SparkPlan,
+      rightPlan: SparkPlan) = {
+      val sortMergeJoin = joins.SortMergeJoinExec(leftKeys, rightKeys, LeftOuter, boundCondition,
+        leftPlan, rightPlan)
+      EnsureRequirements(spark.sessionState.conf).apply(sortMergeJoin)
+    }
+
+    test(s"$testName using SortMergeJoin") {
+      extractJoinParts().foreach { case (_, leftKeys, rightKeys, boundCondition, _, _) =>
+        Seq("true", "false").foreach { v =>
+          withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> v,
+            SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
+            checkAnswer2(leftRows, rightRows, (leftPlan: SparkPlan, rightPlan: SparkPlan) =>
+              makeSortMergeJoin(leftKeys, rightKeys, boundCondition, leftPlan, rightPlan),
+              expectedAnswer.map(Row.fromTuple),
+              sortAnswers = true)
+          }
+        }
+      }
+    }
+
+    test(s"$testName using BroadcastHashJoin (build=right)") {
+      extractJoinParts().foreach { case (_, leftKeys, rightKeys, boundCondition, _, _) =>
+        Seq("true", "false").foreach { v =>
+          withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> v,
+            SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
+            checkAnswer2(leftRows, rightRows, (leftPlan: SparkPlan, rightPlan: SparkPlan) =>
+              makeBroadcastHashJoin(
+                leftKeys, rightKeys, boundCondition, leftPlan, rightPlan, BuildRight),
+              expectedAnswer.map(Row.fromTuple),
+              sortAnswers = true)
+          }
+        }
+      }
+    }
+
+    test(s"$testName using ShuffledHashJoin (build=right)") {
+      extractJoinParts().foreach { case (_, leftKeys, rightKeys, boundCondition, _, _) =>
+        withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
+          checkAnswer2(leftRows, rightRows, (leftPlan: SparkPlan, rightPlan: SparkPlan) =>
+            makeShuffledHashJoin(
+              leftKeys, rightKeys, boundCondition, leftPlan, rightPlan, BuildRight),
+            expectedAnswer.map(Row.fromTuple),
+            sortAnswers = true)
+        }
+      }
+    }
+
+    test(s"$testName using BroadcastNestedLoopJoin build right") {
+      withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
+        checkAnswer2(leftRows, rightRows, (left: SparkPlan, right: SparkPlan) =>
+          BroadcastNestedLoopJoinExec(left, right, BuildRight, LeftOuter, Some(condition())),
+          expectedAnswer.map(Row.fromTuple),
+          sortAnswers = true)
+      }
+    }
+  }
+
+  testLeftJoin(
+    "left join, one match per row",
+    myUpperCaseData,
+    myLowerCaseData,
+    () => (myUpperCaseData.col("No") === myLowerCaseData.col("key")).expr,
+    Seq(
+      (1, "A", 1, "a"),
+      (2, "B", 2, "b"),
+      (3, "C", 3, "c"),
+      (4, "D", 4, "d"),
+      (5, "E", null, null),
+      (6, "F", null, null),
+      (null, "G", null, null)
+    )
+  )
+
+  {
+    lazy val left = myTestData1.where("a = 1")
+    lazy val right = myTestData2.where("c = 1")
+    testLeftJoin(
+      "left join, multiple matches",
+      left,
+      right,
+      () => (left.col("a") === right.col("c")).expr,
+      Seq(
+        (1, 1, 1, 1),
+        (1, 1, 1, 2),
+        (1, 2, 1, 1),
+        (1, 2, 1, 2)
+      )
+    )
+
+    testLeftJoin(
+      "left join, match with condition",
+      left,
+      right,
+      () => (left.col("a") === right.col("c") && left.col("b") < right.col("d")).expr,
+      Seq(
+        (1, 1, 1, 2),
+        (1, 2, null, null)
+      )
+    )
+  }
+
+  {
+    lazy val left = myTestData1.where("a = 1")
+    lazy val right = myTestData2.where("c = 2")
+    testLeftJoin(
+      "left join, no matches",
+      left,
+      right,
+      () => (left.col("a") === right.col("c")).expr,
+      Seq(
+        (1, 1, null, null),
+        (1, 2, null, null)
+      )
+    )
+  }
+
+  {
+    lazy val left = Seq((1, Some(0)), (2, None)).toDF("a", "b")
+    lazy val right = Seq((1, Some(0)), (2, None)).toDF("a", "b")
+    testLeftJoin(
+      "left join, null safe",
+      left,
+      right,
+      () => (left.col("b") <=> right.col("b")).expr,
+      Seq(
+        (1, 0, 1, 0),
+        (2, null, 2, null)
+      )
+    )
+  }
+
+  {
+    def df: DataFrame = spark.range(3).selectExpr("struct(id, id) as key", "id as value")
+    def df1: DataFrame = spark.range(2).selectExpr("struct(id, id) as key", "id as value")
+    lazy val left = df.selectExpr("key", "concat('L', value) as value").alias("left")
+    lazy val right = df1.selectExpr("key", "concat('R', value) as value").alias("right")
+    testLeftJoin(
+      "left join, test structs as keys",
+      left,
+      right,
+      () => (left.col("key") === right.col("key")).expr,
+      Seq(
+        (Row(0, 0), "L0", Row(0, 0), "R0"),
+        (Row(1, 1), "L1", Row(1, 1), "R1"),
+        (Row(2, 2), "L2", null, null)))
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR generates java code to directly complete the function of LeftOuter in `SortMergeJoinExec` without using an iterator. 
This PR improves runtime performance by this generates java code.

joinBenchmark result: **1.3x**
```
Java HotSpot(TM) 64-Bit Server VM 1.8.0_60-b27 on Windows 7 6.1
Intel(R) Core(TM) i5-6500 CPU @ 3.20GHz
left sort merge join:              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------
left merge join wholestage=off          2439 / 2575          0.9        1163.0       1.0X
left merge join wholestage=on           1890 / 1904          1.1         901.1       1.3X
```
joinBenchmark program
```
    val N = 2 << 20
    runBenchmark("left sort merge join", N) {
      val df1 = sparkSession.range(N)
        .selectExpr(s"(id * 15485863) % ${N*10} as k1")
      val df2 = sparkSession.range(N)
        .selectExpr(s"(id * 15485867) % ${N*10} as k2")
      val df = df1.join(df2, col("k1") === col("k2"), "left")
      assert(df.queryExecution.sparkPlan.find(_.isInstanceOf[SortMergeJoinExec]).isDefined)
      df.count()
```
code example
```
val df1 = spark.range(2 << 20).selectExpr("id as k1", "id * 2 as v1")
val df2 = spark.range(2 << 20).selectExpr("id as k2", "id * 3 as v2")
df1.join(df2, col("k1") === col("k2") && col("v1") < col("v2"), "left").collect
```
Generated code
```
/* 001 */ public Object generate(Object[] references) {
/* 002 */   return new GeneratedIteratorForCodegenStage5(references);
/* 003 */ }
/* 004 */
/* 005 */ // codegenStageId=5
/* 006 */ final class GeneratedIteratorForCodegenStage5 extends org.apache.spark.sql.execution.BufferedRowIterator {
/* 007 */   private Object[] references;
/* 008 */   private scala.collection.Iterator[] inputs;
/* 009 */   private scala.collection.Iterator smj_leftInput;
/* 010 */   private scala.collection.Iterator smj_rightInput;
/* 011 */   private InternalRow smj_leftRow;
/* 012 */   private InternalRow smj_rightRow;
/* 013 */   private long smj_value2;
/* 014 */   private org.apache.spark.sql.execution.ExternalAppendOnlyUnsafeRowArray smj_matches;
/* 015 */   private long smj_value3;
/* 016 */   private long smj_value4;
/* 017 */   private long smj_value5;
/* 018 */   private long smj_value6;
/* 019 */   private boolean smj_isNull2;
/* 020 */   private long smj_value7;
/* 021 */   private boolean smj_isNull3;
/* 022 */   private org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder[] smj_mutableStateArray1 = new org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder[1];
/* 023 */   private org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter[] smj_mutableStateArray2 = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter[1];
/* 024 */   private UnsafeRow[] smj_mutableStateArray = new UnsafeRow[1];
/* 025 */
/* 026 */   public GeneratedIteratorForCodegenStage5(Object[] references) {
/* 027 */     this.references = references;
/* 028 */   }
/* 029 */
/* 030 */   public void init(int index, scala.collection.Iterator[] inputs) {
/* 031 */     partitionIndex = index;
/* 032 */     this.inputs = inputs;
/* 033 */     smj_leftInput = inputs[0];
/* 034 */     smj_rightInput = inputs[1];
/* 035 */
/* 036 */     smj_matches = new org.apache.spark.sql.execution.ExternalAppendOnlyUnsafeRowArray(2147483647, 2147483647);
/* 037 */     smj_mutableStateArray[0] = new UnsafeRow(4);
/* 038 */     smj_mutableStateArray1[0] = new org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder(smj_mutableStateArray[0], 0);
/* 039 */     smj_mutableStateArray2[0] = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(smj_mutableStateArray1[0], 4);
/* 040 */
/* 041 */   }
/* 042 */
/* 043 */   private void writeJoinRows() throws java.io.IOException {
/* 044 */     smj_mutableStateArray2[0].zeroOutNullBytes();
/* 045 */
/* 046 */     smj_mutableStateArray2[0].write(0, smj_value4);
/* 047 */
/* 048 */     smj_mutableStateArray2[0].write(1, smj_value5);
/* 049 */
/* 050 */     if (smj_isNull2) {
/* 051 */       smj_mutableStateArray2[0].setNullAt(2);
/* 052 */     } else {
/* 053 */       smj_mutableStateArray2[0].write(2, smj_value6);
/* 054 */     }
/* 055 */
/* 056 */     if (smj_isNull3) {
/* 057 */       smj_mutableStateArray2[0].setNullAt(3);
/* 058 */     } else {
/* 059 */       smj_mutableStateArray2[0].write(3, smj_value7);
/* 060 */     }
/* 061 */     append(smj_mutableStateArray[0].copy());
/* 062 */
/* 063 */   }
/* 064 */
/* 065 */   private boolean findNextJoinRows(
/* 066 */     scala.collection.Iterator leftIter,
/* 067 */     scala.collection.Iterator rightIter) {
/* 068 */     smj_leftRow = null;
/* 069 */     int comp = 0;
/* 070 */     while (smj_leftRow == null) {
/* 071 */       if (!leftIter.hasNext()) return false;
/* 072 */       smj_leftRow = (InternalRow) leftIter.next();
/* 073 */
/* 074 */       long smj_value = smj_leftRow.getLong(0);
/* 075 */       if (false) {
/* 076 */         if (!smj_matches.isEmpty()) {
/* 077 */           smj_matches.clear();
/* 078 */         }
/* 079 */         return true;
/* 080 */       }
/* 081 */       if (!smj_matches.isEmpty()) {
/* 082 */         comp = 0;
/* 083 */         if (comp == 0) {
/* 084 */           comp = (smj_value > smj_value3 ? 1 : smj_value < smj_value3 ? -1 : 0);
/* 085 */         }
/* 086 */
/* 087 */         if (comp == 0) {
/* 088 */           return true;
/* 089 */         }
/* 090 */         smj_matches.clear();
/* 091 */       }
/* 092 */
/* 093 */       do {
/* 094 */         if (smj_rightRow == null) {
/* 095 */           if (!rightIter.hasNext()) {
/* 096 */             smj_value3 = smj_value;
/* 097 */             return true;
/* 098 */           }
/* 099 */           smj_rightRow = (InternalRow) rightIter.next();
/* 100 */
/* 101 */           long smj_value1 = smj_rightRow.getLong(0);
/* 102 */           if (false) {
/* 103 */             smj_rightRow = null;
/* 104 */             continue;
/* 105 */           }
/* 106 */           smj_value2 = smj_value1;
/* 107 */         }
/* 108 */
/* 109 */         comp = 0;
/* 110 */         if (comp == 0) {
/* 111 */           comp = (smj_value > smj_value2 ? 1 : smj_value < smj_value2 ? -1 : 0);
/* 112 */         }
/* 113 */
/* 114 */         if (comp > 0) {
/* 115 */           smj_rightRow = null;
/* 116 */         } else if (comp < 0) {
/* 117 */           if (!smj_matches.isEmpty()) {
/* 118 */             smj_value3 = smj_value;
/* 119 */           }
/* 120 */           return true;
/* 121 */         } else {
/* 122 */           smj_matches.add((UnsafeRow) smj_rightRow);
/* 123 */           smj_rightRow = null;
/* 124 */         }
/* 125 */       } while (smj_leftRow != null);
/* 126 */     }
/* 127 */     return false; // unreachable
/* 128 */   }
/* 129 */
/* 130 */   protected void processNext() throws java.io.IOException {
/* 131 */     while (findNextJoinRows(smj_leftInput, smj_rightInput)) {
/* 132 */       boolean smj_loaded = false;
/* 133 */       smj_value4 = smj_leftRow.getLong(0);
/* 134 */       smj_value5 = smj_leftRow.getLong(1);
/* 135 */       scala.collection.Iterator<UnsafeRow> smj_iterator = smj_matches.generateIterator();
/* 136 */       while (smj_iterator.hasNext()) {
/* 137 */         InternalRow smj_rightRow1 = (InternalRow) smj_iterator.next();
/* 138 */         smj_isNull3 = smj_rightRow1.isNullAt(1);
/* 139 */         smj_value7 = smj_rightRow1.getLong(1);
/* 140 */         boolean smj_isNull4 = true;
/* 141 */         boolean smj_value8 = false;
/* 142 */
/* 143 */         if (!smj_isNull3) {
/* 144 */           smj_isNull4 = false; // resultCode could change nullability.
/* 145 */           smj_value8 = smj_value5 < smj_value7;
/* 146 */
/* 147 */         }
/* 148 */         if (smj_isNull4 || !smj_value8) continue;
/* 149 */         smj_isNull2 = smj_rightRow1.isNullAt(0);
/* 150 */         smj_value6 = smj_rightRow1.getLong(0);
/* 151 */         ((org.apache.spark.sql.execution.metric.SQLMetric) references[0] /* numOutputRows */).add(1);
/* 152 */         smj_loaded = true;
/* 153 */         writeJoinRows();
/* 154 */       }
/* 155 */       if (!smj_loaded) {
/* 156 */         smj_isNull2 = true;
/* 157 */         smj_isNull3 = true;
/* 158 */         ((org.apache.spark.sql.execution.metric.SQLMetric) references[0] /* numOutputRows */).add(1);
/* 159 */         writeJoinRows();
/* 160 */       }
/* 161 */       if (shouldStop()) return;
/* 162 */     }
/* 163 */   }
/* 164 */
/* 165 */ }
```

## How was this patch tested?

Add test cases into `LeftJoinSuite` and `WholeStageCodegenSuite`
