### PR TITLE
[SPARK-23678][GraphX]  a more efficient partition strategy

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/PartitionStrategy.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/PartitionStrategy.scala
@@ -178,6 +178,7 @@ object PartitionStrategy {
     case "EdgePartition1D" => EdgePartition1D
     case "EdgePartition2D" => EdgePartition2D
     case "CanonicalRandomVertexCut" => CanonicalRandomVertexCut
+    case "EdgePartitionTriangle" => EdgePartitionTriangle
     case _ => throw new IllegalArgumentException("Invalid PartitionStrategy: " + s)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

add a new partition strategy with several advantage:

1. nicer bound on vertex replication, sqrt(2 * numParts), which is about 23% reducing compare with EdgePartition2D  partition strategy, which has bound 2 * sqrt(numParts). This reduce the shuffle size in several operation such as aggregateMessage and triplets.
2. colocate all edges between two vertices regardless of direction. 
3. same work balance compared with EdgePartition2D  

## How was this patch tested?

manual tests, see [https://github.com/weiwee/edgePartitionTri/blob/master/EdgePartitionTriangle.ipynb](https://github.com/weiwee/edgePartitionTri/blob/master/EdgePartitionTriangle.ipynb)