### PR TITLE
add impurity stats in tree leaf node debug string

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tree/Node.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/Node.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.ml.tree
 
-import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.mllib.tree.impurity.ImpurityCalculator
 import org.apache.spark.mllib.tree.model.{ImpurityStats, InformationGainStats => OldInformationGainStats, Node => OldNode, Predict => OldPredict}
 
@@ -122,8 +122,9 @@ class LeafNode private[ml] (
   override private[tree] def numDescendants: Int = 0
 
   override private[tree] def subtreeToString(indentFactor: Int = 0): String = {
+    val stats: Vector = Vectors.dense(impurityStats.stats)
     val prefix: String = " " * indentFactor
-    prefix + s"Predict: $prediction\n"
+    prefix + s"Predict: $prediction, Stats: $stats \n"
   }
 
   override private[tree] def subtreeDepth: Int = 0

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/Node.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/Node.scala
@@ -122,7 +122,7 @@ class LeafNode private[ml] (
   override private[tree] def numDescendants: Int = 0
 
   override private[tree] def subtreeToString(indentFactor: Int = 0): String = {
-    val stats: Vector = Vectors.dense(impurityStats.stats)
+    val stats: String = Vectors.dense(impurityStats.stats).toString
     val prefix: String = " " * indentFactor
     prefix + s"Predict: $prediction, Stats: $stats \n"
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

right now the debug str of tree doesn't contains  impurity stats, which is confusing, since we are not using the predictions directly, and some raw predictions of tree is redundant 

## How was this patch tested?



