### PR TITLE
[SPARK-23690][ML] Add handleinvalid to VectorAssembler

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
@@ -339,6 +339,7 @@ class RFormulaModel private[feature](
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
     checkCanTransform(dataset.schema)
+    // dataset.filter(....)
     transformLabel(pipelineModel.transform(dataset))
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
@@ -339,7 +339,6 @@ class RFormulaModel private[feature](
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
     checkCanTransform(dataset.schema)
-    // dataset.filter(....)
     transformLabel(pipelineModel.transform(dataset))
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -234,7 +234,7 @@ class StringIndexerModel (
     val metadata = NominalAttribute.defaultAttr
       .withName($(outputCol)).withValues(filteredLabels).toMetadata()
     // If we are skipping invalid records, filter them out.
-    val (filteredDataset, keepInvalid) = getHandleInvalid match {
+    val (filteredDataset, keepInvalid) = $(handleInvalid) match {
       case StringIndexer.SKIP_INVALID =>
         val filterer = udf { label: String =>
           labelToIndex.contains(label)

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/VectorAssembler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/VectorAssembler.scala
@@ -97,7 +97,7 @@ class VectorAssembler @Since("1.4.0") (@Since("1.4.0") override val uid: String)
             case _ =>
               Seq(attribute.withName(c))
           }
-        case _ : NumericType | BooleanType =>
+        case _: NumericType | BooleanType =>
           // If the input column type is a compatible scalar type, assume numeric.
           Seq(NumericAttribute.defaultAttr.withName(c))
         case _: VectorUDT =>

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/VectorAssembler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/VectorAssembler.scala
@@ -18,13 +18,14 @@
 package org.apache.spark.ml.feature
 
 import scala.collection.mutable.ArrayBuilder
+import scala.language.existentials
 
 import org.apache.spark.SparkException
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.Transformer
 import org.apache.spark.ml.attribute.{Attribute, AttributeGroup, NumericAttribute, UnresolvedAttribute}
 import org.apache.spark.ml.linalg.{Vector, Vectors, VectorUDT}
-import org.apache.spark.ml.param.ParamMap
+import org.apache.spark.ml.param.{Param, ParamMap, ParamValidators}
 import org.apache.spark.ml.param.shared._
 import org.apache.spark.ml.util._
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
@@ -36,7 +37,8 @@ import org.apache.spark.sql.types._
  */
 @Since("1.4.0")
 class VectorAssembler @Since("1.4.0") (@Since("1.4.0") override val uid: String)
-  extends Transformer with HasInputCols with HasOutputCol with DefaultParamsWritable {
+  extends Transformer with HasInputCols with HasOutputCol with HasHandleInvalid
+    with DefaultParamsWritable {
 
   @Since("1.4.0")
   def this() = this(Identifiable.randomUID("vecAssembler"))
@@ -49,21 +51,45 @@ class VectorAssembler @Since("1.4.0") (@Since("1.4.0") override val uid: String)
   @Since("1.4.0")
   def setOutputCol(value: String): this.type = set(outputCol, value)
 
+  /** @group setParam */
+  @Since("1.6.0")
+  def setHandleInvalid(value: String): this.type = set(handleInvalid, value)
+
+  /**
+   * Param for how to handle invalid data (NULL values). Options are 'skip' (filter out rows with
+   * invalid data), 'error' (throw an error), or 'keep' (return relevant number of NaN in the
+   * output).
+   * Default: "error"
+   * @group param
+   */
+  @Since("1.6.0")
+  override val handleInvalid: Param[String] = new Param[String](this, "handleInvalid",
+    "Hhow to handle invalid data (NULL values). Options are 'skip' (filter out rows with " +
+      "invalid data), 'error' (throw an error), or 'keep' (return relevant number of NaN " +
+      "in the * output).", ParamValidators.inArray(StringIndexer.supportedHandleInvalids))
+
+  setDefault(handleInvalid, StringIndexer.ERROR_INVALID)
+
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
     // Schema transformation.
     val schema = dataset.schema
     lazy val first = dataset.toDF.first()
-    val lengths = new Array[Int]($(inputCols).length)
+    val lengths = $(inputCols).map { c =>
+      val field = schema(c)
+      val index = schema.fieldIndex(c)
+      field.dataType match {
+        case _: NumericType | BooleanType => 1  // DoubleType is also NumericType
+        case _: VectorUDT => AttributeGroup.fromStructField(field).
+          numAttributes.getOrElse(first.getAs[Vector](index).size)
+      }
+    }
     val attrs = $(inputCols).flatMap { c =>
       val field = schema(c)
       val index = schema.fieldIndex(c)
-      var inputColIndex = 1
       field.dataType match {
         case DoubleType =>
-          lengths(inputColIndex) = 1
-          inputColIndex += 1
           val attr = Attribute.fromStructField(field)
           // If the input column doesn't have ML attribute, assume numeric.
           if (attr == UnresolvedAttribute) {
@@ -72,15 +98,11 @@ class VectorAssembler @Since("1.4.0") (@Since("1.4.0") override val uid: String)
             Some(attr.withName(c))
           }
         case _: NumericType | BooleanType =>
-          lengths(inputColIndex) = 1
-          inputColIndex += 1
           // If the input column type is a compatible scalar type, assume numeric.
           Some(NumericAttribute.defaultAttr.withName(c))
         case _: VectorUDT =>
           val group = AttributeGroup.fromStructField(field)
           val numAttrs = group.numAttributes.getOrElse(first.getAs[Vector](index).size)
-          lengths(inputColIndex) = numAttrs
-          inputColIndex += 1
           if (group.attributes.isDefined) {
             // If attributes are defined, copy them with updated names.
             group.attributes.get.zipWithIndex.map { case (attr, i) =>
@@ -101,10 +123,14 @@ class VectorAssembler @Since("1.4.0") (@Since("1.4.0") override val uid: String)
       }
     }
     val metadata = new AttributeGroup($(outputCol), attrs).toMetadata()
-
+    val (filteredDataset, keepInvalid) = $(handleInvalid) match {
+      case StringIndexer.SKIP_INVALID => (dataset.na.drop("any", $(inputCols)), false)
+      case StringIndexer.KEEP_INVALID => (dataset, true)
+      case StringIndexer.ERROR_INVALID => (dataset, false)
+    }
     // Data transformation.
     val assembleFunc = udf { r: Row =>
-      VectorAssembler.assemble(lengths)(r.toSeq: _*)
+      VectorAssembler.assemble(lengths, keepInvalid)(r.toSeq: _*)
     }.asNondeterministic()
     val args = $(inputCols).map { c =>
       schema(c).dataType match {
@@ -114,7 +140,7 @@ class VectorAssembler @Since("1.4.0") (@Since("1.4.0") override val uid: String)
       }
     }
 
-    dataset.select(col("*"), assembleFunc(struct(args: _*)).as($(outputCol), metadata))
+    filteredDataset.select(col("*"), assembleFunc(struct(args: _*)).as($(outputCol), metadata))
   }
 
   @Since("1.4.0")
@@ -144,10 +170,16 @@ class VectorAssembler @Since("1.4.0") (@Since("1.4.0") override val uid: String)
 @Since("1.6.0")
 object VectorAssembler extends DefaultParamsReadable[VectorAssembler] {
 
+  private[feature] val SKIP_INVALID: String = "skip"
+  private[feature] val ERROR_INVALID: String = "error"
+  private[feature] val KEEP_INVALID: String = "keep"
+  private[feature] val supportedHandleInvalids: Array[String] =
+    Array(SKIP_INVALID, ERROR_INVALID, KEEP_INVALID)
+
   @Since("1.6.0")
   override def load(path: String): VectorAssembler = super.load(path)
 
-  private[feature] def assemble(lengths: Array[Int])(vv: Any*): Vector = {
+  private[feature] def assemble(lengths: Array[Int], keepInvalid: Boolean)(vv: Any*): Vector = {
     val indices = ArrayBuilder.make[Int]
     val values = ArrayBuilder.make[Double]
     var featureIndex = 0
@@ -172,16 +204,17 @@ object VectorAssembler extends DefaultParamsReadable[VectorAssembler] {
         inputColumnIndex += 1
         featureIndex += vec.size
       case null =>
-        val length: Int = lengths(inputColumnIndex)
-        Array.range(0, length).foreach { case (i) =>
-            indices += featureIndex + i
-            values += Double.NaN
+        keepInvalid match {
+          case false => throw new SparkException("Values to assemble cannot be null.")
+          case true =>
+            val length: Int = lengths(inputColumnIndex)
+            Array.range(0, length).foreach { case (i) =>
+              indices += featureIndex + i
+              values += Double.NaN
+            }
+            inputColumnIndex += 1
+            featureIndex += length
         }
-        inputColumnIndex += 1
-        featureIndex += length
-        // TODO: output Double.NaN?
-        // throw new SparkException("Values to assemble cannot be null.")
-
       case o =>
         throw new SparkException(s"$o of type ${o.getClass.getName} is not supported.")
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/VectorAssembler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/VectorAssembler.scala
@@ -81,8 +81,12 @@ class VectorAssembler @Since("1.4.0") (@Since("1.4.0") override val uid: String)
       val index = schema.fieldIndex(c)
       field.dataType match {
         case _: NumericType | BooleanType => 1  // DoubleType is also NumericType
-        case _: VectorUDT => AttributeGroup.fromStructField(field).
-          numAttributes.getOrElse(first.getAs[Vector](index).size)
+        case _: VectorUDT =>
+          val group = AttributeGroup.fromStructField(field)
+          val first_not_null_row = dataset.na.drop(Seq(c)).first()
+          val first_size = first_not_null_row.getAs[Vector](index).size
+          println(first_size)
+          group.numAttributes.getOrElse(first_size)
       }
     }
     val attrs = $(inputCols).flatMap { c =>

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/VectorAssembler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/VectorAssembler.scala
@@ -54,7 +54,7 @@ class VectorAssembler @Since("1.4.0") (@Since("1.4.0") override val uid: String)
   def setOutputCol(value: String): this.type = set(outputCol, value)
 
   /** @group setParam */
-  @Since("1.6.0")
+  @Since("2.4.0")
   def setHandleInvalid(value: String): this.type = set(handleInvalid, value)
 
   /**
@@ -126,9 +126,9 @@ class VectorAssembler @Since("1.4.0") (@Since("1.4.0") override val uid: String)
     val lengths = featureAttributesMap.map(a => a.length)
     val metadata = new AttributeGroup($(outputCol), featureAttributes.toArray).toMetadata()
     val (filteredDataset, keepInvalid) = $(handleInvalid) match {
-      case StringIndexer.SKIP_INVALID => (dataset.na.drop($(inputCols)), false)
-      case StringIndexer.KEEP_INVALID => (dataset, true)
-      case StringIndexer.ERROR_INVALID => (dataset, false)
+      case VectorAssembler.SKIP_INVALID => (dataset.na.drop($(inputCols)), false)
+      case VectorAssembler.KEEP_INVALID => (dataset, true)
+      case VectorAssembler.ERROR_INVALID => (dataset, false)
     }
     // Data transformation.
     val assembleFunc = udf { r: Row =>

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/VectorAssembler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/VectorAssembler.scala
@@ -84,7 +84,6 @@ class VectorAssembler @Since("1.4.0") (@Since("1.4.0") override val uid: String)
         case _ => false
       }
     }
-    print("colsMissingNumAttrs: " + colsMissingNumAttrs.mkString(",") + "\n")
     if (dataset.isStreaming && colsMissingNumAttrs.nonEmpty) {
       throw new RuntimeException(
         s"""
@@ -149,7 +148,6 @@ class VectorAssembler @Since("1.4.0") (@Since("1.4.0") override val uid: String)
             // Otherwise, treat all attributes as numeric. If we cannot get the number of attributes
             // from metadata, check the first row.
             val numAttrs = lengths(c)
-            // group.numAttributes.getOrElse(missingVectorSizes(c))
             Array.tabulate(numAttrs)(i => NumericAttribute.defaultAttr.withName(c + "_" + i))
           }
         case otherType =>

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/VectorAssembler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/VectorAssembler.scala
@@ -80,7 +80,7 @@ class VectorAssembler @Since("1.4.0") (@Since("1.4.0") override val uid: String)
     val colsMissingNumAttrs = $(inputCols).filter { c =>
       val field = schema(c)
       field.dataType match {
-        case _: VectorUDT => AttributeGroup.fromStructField(field).numAttributes.isEmpty
+        case _: VectorUDT => -1 == AttributeGroup.fromStructField(field).size
         case _ => false
       }
     }
@@ -111,7 +111,7 @@ class VectorAssembler @Since("1.4.0") (@Since("1.4.0") override val uid: String)
       field.dataType match {
         case _: NumericType | BooleanType => c -> 1  // DoubleType is also NumericType
         case _: VectorUDT =>
-          c -> AttributeGroup.fromStructField(field).numAttributes.getOrElse(missingVectorSizes(c))
+          c -> missingVectorSizes.getOrElse(c, AttributeGroup.fromStructField(field).size)
       }
     }.toMap
     val attrs = $(inputCols).flatMap { c =>

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/VectorAssembler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/VectorAssembler.scala
@@ -85,7 +85,9 @@ class VectorAssembler @Since("1.4.0") (@Since("1.4.0") override val uid: String)
           val group = AttributeGroup.fromStructField(field)
           val first_not_null_row = dataset.na.drop(Seq(c)).first()
           val first_size = first_not_null_row.getAs[Vector](index).size
+          //scalastyle:off println
           println(first_size)
+          //scalastyle:on println
           group.numAttributes.getOrElse(first_size)
       }
     }

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
@@ -170,13 +170,10 @@ class VectorAssemblerSuite
 
   test("assemble should throw errors when keepInvalid is false") {
     import org.apache.spark.ml.feature.VectorAssembler.assemble
-    intercept[SparkException](assemble(Array(1, 1), false)(1.0, null) ===
-      Vectors.dense(1.0, Double.NaN))
-    intercept[SparkException](assemble(Array(1, 2), false)(1.0, null) ===
-      Vectors.dense(1.0, Double.NaN, Double.NaN))
-    intercept[SparkException](assemble(Array(1), false)(null) === Vectors.dense(Double.NaN))
-    intercept[SparkException](assemble(Array(2), false)(null) ===
-      Vectors.dense(Double.NaN, Double.NaN))
+    intercept[SparkException](assemble(Array(1, 1), false)(1.0, null))
+    intercept[SparkException](assemble(Array(1, 2), false)(1.0, null))
+    intercept[SparkException](assemble(Array(1), false)(null))
+    intercept[SparkException](assemble(Array(2), false)(null))
   }
 
   test("get lengths functions") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
@@ -37,24 +37,33 @@ class VectorAssemblerSuite
 
   test("assemble") {
     import org.apache.spark.ml.feature.VectorAssembler.assemble
-    assert(assemble(0.0) === Vectors.sparse(1, Array.empty, Array.empty))
-    assert(assemble(0.0, 1.0) === Vectors.sparse(2, Array(1), Array(1.0)))
+    assert(assemble(Array(1))(0.0) === Vectors.sparse(1, Array.empty, Array.empty))
+    assert(assemble(Array(1, 1))(0.0, 1.0) === Vectors.sparse(2, Array(1), Array(1.0)))
     val dv = Vectors.dense(2.0, 0.0)
-    assert(assemble(0.0, dv, 1.0) === Vectors.sparse(4, Array(1, 3), Array(2.0, 1.0)))
+    assert(assemble(Array(1, 2, 1))(0.0, dv, 1.0) ===
+      Vectors.sparse(4, Array(1, 3), Array(2.0, 1.0)))
     val sv = Vectors.sparse(2, Array(0, 1), Array(3.0, 4.0))
-    assert(assemble(0.0, dv, 1.0, sv) ===
+    assert(assemble(Array(1, 2, 1, 2))(0.0, dv, 1.0, sv) ===
       Vectors.sparse(6, Array(1, 3, 4, 5), Array(2.0, 1.0, 3.0, 4.0)))
-    for (v <- Seq(1, "a", null)) {
-      intercept[SparkException](assemble(v))
-      intercept[SparkException](assemble(1.0, v))
+    for (v <- Seq(1, "a")) {
+      intercept[SparkException](assemble(Array(1))(v))
+      intercept[SparkException](assemble(Array(1, 1))(1.0, v))
     }
+  }
+
+  test("assemble should keep nulls") {
+    import org.apache.spark.ml.feature.VectorAssembler.assemble
+    assert(assemble(Array(1, 1))(1.0, null) === Vectors.dense(1.0, Double.NaN))
+    assert(assemble(Array(1, 2))(1.0, null) === Vectors.dense(1.0, Double.NaN, Double.NaN))
+    assert(assemble(Array(1))(null) === Vectors.dense(Double.NaN))
+    assert(assemble(Array(2))(null) === Vectors.dense(Double.NaN, Double.NaN))
   }
 
   test("assemble should compress vectors") {
     import org.apache.spark.ml.feature.VectorAssembler.assemble
-    val v1 = assemble(0.0, 0.0, 0.0, Vectors.dense(4.0))
+    val v1 = assemble(Array(1, 1, 1, 4))(0.0, 0.0, 0.0, Vectors.dense(4.0))
     assert(v1.isInstanceOf[SparseVector])
-    val v2 = assemble(1.0, 2.0, 3.0, Vectors.sparse(1, Array(0), Array(4.0)))
+    val v2 = assemble(Array(1, 1, 1, 1))(1.0, 2.0, 3.0, Vectors.sparse(1, Array(0), Array(4.0)))
     assert(v2.isInstanceOf[DenseVector])
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
@@ -203,8 +203,8 @@ class VectorAssemblerSuite
 
     // behavior when first row has information
     assert(assembler.setHandleInvalid("skip").transform(df).count() == 1)
-    intercept[RuntimeException](assembler.setHandleInvalid("keep").transform(df).cache())
-    intercept[SparkException](assembler.setHandleInvalid("error").transform(df).cache())
+    intercept[RuntimeException](assembler.setHandleInvalid("keep").transform(df).collect())
+    intercept[SparkException](assembler.setHandleInvalid("error").transform(df).collect())
 
     // numeric column is all null
     intercept[RuntimeException](
@@ -214,7 +214,7 @@ class VectorAssemblerSuite
     val df2 = df.filter("0 == id1 % 2")
     intercept[RuntimeException](assembler.setHandleInvalid("skip").transform(df2))
     intercept[RuntimeException](assembler.setHandleInvalid("keep").transform(df2))
-    intercept[NullPointerException](assembler.setHandleInvalid("error").transform(df2).cache())
+    intercept[NullPointerException](assembler.setHandleInvalid("error").transform(df2).collect())
   }
 
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
@@ -37,26 +37,26 @@ class VectorAssemblerSuite
 
   test("assemble") {
     import org.apache.spark.ml.feature.VectorAssembler.assemble
-    assert(assemble(Array(1), true)(0.0) === Vectors.sparse(1, Array.empty, Array.empty))
-    assert(assemble(Array(1, 1), true)(0.0, 1.0) === Vectors.sparse(2, Array(1), Array(1.0)))
+    assert(assemble(Seq(1), true)(0.0) === Vectors.sparse(1, Array.empty, Array.empty))
+    assert(assemble(Seq(1, 1), true)(0.0, 1.0) === Vectors.sparse(2, Array(1), Array(1.0)))
     val dv = Vectors.dense(2.0, 0.0)
-    assert(assemble(Array(1, 2, 1), true)(0.0, dv, 1.0) ===
+    assert(assemble(Seq(1, 2, 1), true)(0.0, dv, 1.0) ===
       Vectors.sparse(4, Array(1, 3), Array(2.0, 1.0)))
     val sv = Vectors.sparse(2, Array(0, 1), Array(3.0, 4.0))
-    assert(assemble(Array(1, 2, 1, 2), true)(0.0, dv, 1.0, sv) ===
+    assert(assemble(Seq(1, 2, 1, 2), true)(0.0, dv, 1.0, sv) ===
       Vectors.sparse(6, Array(1, 3, 4, 5), Array(2.0, 1.0, 3.0, 4.0)))
     for (v <- Seq(1, "a")) {
-      intercept[SparkException](assemble(Array(1), true)(v))
-      intercept[SparkException](assemble(Array(1, 1), true)(1.0, v))
+      intercept[SparkException](assemble(Seq(1), true)(v))
+      intercept[SparkException](assemble(Seq(1, 1), true)(1.0, v))
     }
   }
 
   test("assemble should compress vectors") {
     import org.apache.spark.ml.feature.VectorAssembler.assemble
-    val v1 = assemble(Array(1, 1, 1, 4), true)(0.0, 0.0, 0.0, Vectors.dense(4.0))
+    val v1 = assemble(Seq(1, 1, 1, 4), true)(0.0, 0.0, 0.0, Vectors.dense(4.0))
     assert(v1.isInstanceOf[SparseVector])
     val sv = Vectors.sparse(1, Array(0), Array(4.0))
-    val v2 = assemble(Array(1, 1, 1, 1), true)(1.0, 2.0, 3.0, sv)
+    val v2 = assemble(Seq(1, 1, 1, 1), true)(1.0, 2.0, 3.0, sv)
     assert(v2.isInstanceOf[DenseVector])
   }
 
@@ -152,20 +152,20 @@ class VectorAssemblerSuite
 
   test("assemble should keep nulls") {
     import org.apache.spark.ml.feature.VectorAssembler.assemble
-    assert(assemble(Array(1, 1), true)(1.0, null) === Vectors.dense(1.0, Double.NaN))
-    assert(assemble(Array(1, 2), true)(1.0, null) === Vectors.dense(1.0, Double.NaN, Double.NaN))
-    assert(assemble(Array(1), true)(null) === Vectors.dense(Double.NaN))
-    assert(assemble(Array(2), true)(null) === Vectors.dense(Double.NaN, Double.NaN))
+    assert(assemble(Seq(1, 1), true)(1.0, null) === Vectors.dense(1.0, Double.NaN))
+    assert(assemble(Seq(1, 2), true)(1.0, null) === Vectors.dense(1.0, Double.NaN, Double.NaN))
+    assert(assemble(Seq(1), true)(null) === Vectors.dense(Double.NaN))
+    assert(assemble(Seq(2), true)(null) === Vectors.dense(Double.NaN, Double.NaN))
   }
 
   test("assemble should throw errors") {
     import org.apache.spark.ml.feature.VectorAssembler.assemble
-    intercept[SparkException](assemble(Array(1, 1), false)(1.0, null) ===
+    intercept[SparkException](assemble(Seq(1, 1), false)(1.0, null) ===
       Vectors.dense(1.0, Double.NaN))
-    intercept[SparkException](assemble(Array(1, 2), false)(1.0, null) ===
+    intercept[SparkException](assemble(Seq(1, 2), false)(1.0, null) ===
       Vectors.dense(1.0, Double.NaN, Double.NaN))
-    intercept[SparkException](assemble(Array(1), false)(null) === Vectors.dense(Double.NaN))
-    intercept[SparkException](assemble(Array(2), false)(null) ===
+    intercept[SparkException](assemble(Seq(1), false)(null) === Vectors.dense(Double.NaN))
+    intercept[SparkException](assemble(Seq(2), false)(null) ===
       Vectors.dense(Double.NaN, Double.NaN))
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
@@ -235,9 +235,10 @@ class VectorAssemblerSuite
     // behavior when vector size hint is given
     assert(runWithMetadata("keep").count() == 6, "should keep all rows")
     assert(runWithMetadata("skip").count() == 1, "should skip rows with nulls")
-    intercept[SparkException](runWithMetadata("error"), "should throw error with nulls")
-    intercept[SparkException](runWithMetadata("error", additional_filter = "id1 > 4"),
-      "should throw error with NaNs")
+    // should throw error with nulls
+    intercept[SparkException](runWithMetadata("error"))
+    // should throw error with NaNs
+    intercept[SparkException](runWithMetadata("error", additional_filter = "id1 > 4"))
 
     // behavior when first row has information
     assert(intercept[RuntimeException](runWithFirstRow("keep").count())

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
@@ -31,15 +31,18 @@ class VectorAssemblerSuite
 
   import testImplicits._
 
-  @transient var dfWithNulls: Dataset[_] = _
+  @transient var dfWithNullsAndNaNs: Dataset[_] = _
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    dfWithNulls = Seq[(Long, Long, java.lang.Double, Vector, String, Vector, Long, String)](
-      (1, 2, 0.0, Vectors.dense(1.0, 2.0), "a", Vectors.sparse(2, Array(1), Array(3.0)), 7L, null),
-      (2, 1, 0.0, null, "a", Vectors.sparse(2, Array(1), Array(3.0)), 6L, null),
-      (3, 3, null, Vectors.dense(1.0, 2.0), "a", Vectors.sparse(2, Array(1), Array(3.0)), 8L, null),
-      (4, 4, null, null, "a", Vectors.sparse(2, Array(1), Array(3.0)), 9L, null))
+    val sv = Vectors.sparse(2, Array(1), Array(3.0))
+    dfWithNullsAndNaNs = Seq[(Long, Long, java.lang.Double, Vector, String, Vector, Long, String)](
+      (1, 2, 0.0, Vectors.dense(1.0, 2.0), "a", sv, 7L, null),
+      (2, 1, 0.0, null, "a", sv, 6L, null),
+      (3, 3, null, Vectors.dense(1.0, 2.0), "a", sv, 8L, null),
+      (4, 4, null, null, "a", sv, 9L, null),
+      (5, 5, java.lang.Double.NaN, Vectors.dense(1.0, 2.0), "a", sv, 7L, null),
+      (6, 6, java.lang.Double.NaN, null, "a", sv, 8L, null))
       .toDF("id1", "id2", "x", "y", "name", "z", "n", "nulls")
   }
 
@@ -49,31 +52,35 @@ class VectorAssemblerSuite
 
   test("assemble") {
     import org.apache.spark.ml.feature.VectorAssembler.assemble
-    assert(assemble(Array(1), true)(0.0) === Vectors.sparse(1, Array.empty, Array.empty))
-    assert(assemble(Array(1, 1), true)(0.0, 1.0) === Vectors.sparse(2, Array(1), Array(1.0)))
+    assert(assemble(Array(1), keepInvalid = true)(0.0)
+      === Vectors.sparse(1, Array.empty, Array.empty))
+    assert(assemble(Array(1, 1), keepInvalid = true)(0.0, 1.0)
+      === Vectors.sparse(2, Array(1), Array(1.0)))
     val dv = Vectors.dense(2.0, 0.0)
-    assert(assemble(Array(1, 2, 1), true)(0.0, dv, 1.0) ===
+    assert(assemble(Array(1, 2, 1), keepInvalid = true)(0.0, dv, 1.0) ===
       Vectors.sparse(4, Array(1, 3), Array(2.0, 1.0)))
     val sv = Vectors.sparse(2, Array(0, 1), Array(3.0, 4.0))
-    assert(assemble(Array(1, 2, 1, 2), true)(0.0, dv, 1.0, sv) ===
+    assert(assemble(Array(1, 2, 1, 2), keepInvalid = true)(0.0, dv, 1.0, sv) ===
       Vectors.sparse(6, Array(1, 3, 4, 5), Array(2.0, 1.0, 3.0, 4.0)))
     for (v <- Seq(1, "a")) {
-      intercept[SparkException](assemble(Array(1), true)(v))
-      intercept[SparkException](assemble(Array(1, 1), true)(1.0, v))
+      intercept[SparkException](assemble(Array(1), keepInvalid = true)(v))
+      intercept[SparkException](assemble(Array(1, 1), keepInvalid = true)(1.0, v))
     }
   }
 
   test("assemble should compress vectors") {
     import org.apache.spark.ml.feature.VectorAssembler.assemble
-    val v1 = assemble(Array(1, 1, 1, 1), true)(0.0, 0.0, 0.0, Vectors.dense(4.0))
+    val v1 = assemble(Array(1, 1, 1, 1), keepInvalid = true)(0.0, 0.0, 0.0, Vectors.dense(4.0))
     assert(v1.isInstanceOf[SparseVector])
     val sv = Vectors.sparse(1, Array(0), Array(4.0))
-    val v2 = assemble(Array(1, 1, 1, 1), true)(1.0, 2.0, 3.0, sv)
+    val v2 = assemble(Array(1, 1, 1, 1), keepInvalid = true)(1.0, 2.0, 3.0, sv)
     assert(v2.isInstanceOf[DenseVector])
   }
 
   test("VectorAssembler") {
-    val df = dfWithNulls.filter("id1 == 1").withColumn("id", col("id1"))
+    val df = Seq((1, 2, 0.0, Vectors.dense(1.0, 2.0), "a",
+      Vectors.sparse(2, Array(1), Array(3.0)), 7L, null))
+      .toDF("id1", "id2", "x", "y", "name", "z", "n", "nulls")
     val assembler = new VectorAssembler()
       .setInputCols(Array("x", "y", "z", "n"))
       .setOutputCol("features")
@@ -162,27 +169,28 @@ class VectorAssemblerSuite
 
   test("assemble should keep nulls when keepInvalid is true") {
     import org.apache.spark.ml.feature.VectorAssembler.assemble
-    assert(assemble(Array(1, 1), true)(1.0, null) === Vectors.dense(1.0, Double.NaN))
-    assert(assemble(Array(1, 2), true)(1.0, null) === Vectors.dense(1.0, Double.NaN, Double.NaN))
-    assert(assemble(Array(1), true)(null) === Vectors.dense(Double.NaN))
-    assert(assemble(Array(2), true)(null) === Vectors.dense(Double.NaN, Double.NaN))
+    assert(assemble(Array(1, 1), keepInvalid = true)(1.0, null) === Vectors.dense(1.0, Double.NaN))
+    assert(assemble(Array(1, 2), keepInvalid = true)(1.0, null)
+      === Vectors.dense(1.0, Double.NaN, Double.NaN))
+    assert(assemble(Array(1), keepInvalid = true)(null) === Vectors.dense(Double.NaN))
+    assert(assemble(Array(2), keepInvalid = true)(null) === Vectors.dense(Double.NaN, Double.NaN))
   }
 
   test("assemble should throw errors when keepInvalid is false") {
     import org.apache.spark.ml.feature.VectorAssembler.assemble
-    intercept[SparkException](assemble(Array(1, 1), false)(1.0, null))
-    intercept[SparkException](assemble(Array(1, 2), false)(1.0, null))
-    intercept[SparkException](assemble(Array(1), false)(null))
-    intercept[SparkException](assemble(Array(2), false)(null))
+    intercept[SparkException](assemble(Array(1, 1), keepInvalid = false)(1.0, null))
+    intercept[SparkException](assemble(Array(1, 2), keepInvalid = false)(1.0, null))
+    intercept[SparkException](assemble(Array(1), keepInvalid = false)(null))
+    intercept[SparkException](assemble(Array(2), keepInvalid = false)(null))
   }
 
   test("get lengths functions") {
     import org.apache.spark.ml.feature.VectorAssembler._
-    val df = dfWithNulls
+    val df = dfWithNullsAndNaNs
     assert(getVectorLengthsFromFirstRow(df, Seq("y")) === Map("y" -> 2))
     assert(intercept[NullPointerException](getVectorLengthsFromFirstRow(df.sort("id2"), Seq("y")))
       .getMessage.contains("VectorSizeHint"))
-    assert(intercept[NoSuchElementException](getVectorLengthsFromFirstRow(df.filter("id1 > 4"),
+    assert(intercept[NoSuchElementException](getVectorLengthsFromFirstRow(df.filter("id1 > 6"),
       Seq("y"))).getMessage.contains("VectorSizeHint"))
 
     assert(getLengths(df.sort("id2"), Seq("y"), SKIP_INVALID).exists(_ == "y" -> 2))
@@ -197,50 +205,54 @@ class VectorAssemblerSuite
       .setInputCols(Array("x", "y", "z", "n"))
       .setOutputCol("features")
 
-    def run_with_metadata(mode: String, additional_filter: String = "true"): Dataset[_] = {
+    def runWithMetadata(mode: String, additional_filter: String = "true"): Dataset[_] = {
       val attributeY = new AttributeGroup("y", 2)
-      val subAttributesOfZ = Array(NumericAttribute.defaultAttr, NumericAttribute.defaultAttr)
       val attributeZ = new AttributeGroup(
         "z",
         Array[Attribute](
           NumericAttribute.defaultAttr.withName("foo"),
           NumericAttribute.defaultAttr.withName("bar")))
-      val dfWithMetadata = dfWithNulls.withColumn("y", col("y"), attributeY.toMetadata())
+      val dfWithMetadata = dfWithNullsAndNaNs.withColumn("y", col("y"), attributeY.toMetadata())
         .withColumn("z", col("z"), attributeZ.toMetadata()).filter(additional_filter)
       val output = assembler.setHandleInvalid(mode).transform(dfWithMetadata)
       output.collect()
       output
     }
-    def run_with_first_row(mode: String): Dataset[_] = {
-      val output = assembler.setHandleInvalid(mode).transform(dfWithNulls)
+
+    def runWithFirstRow(mode: String): Dataset[_] = {
+      val output = assembler.setHandleInvalid(mode).transform(dfWithNullsAndNaNs)
       output.collect()
       output
     }
-    def run_with_all_null_vectors(mode: String): Dataset[_] = {
-      val output = assembler.setHandleInvalid(mode).transform(dfWithNulls.filter("0 == id1 % 2"))
+
+    def runWithAllNullVectors(mode: String): Dataset[_] = {
+      val output = assembler.setHandleInvalid(mode)
+        .transform(dfWithNullsAndNaNs.filter("0 == id1 % 2"))
       output.collect()
       output
     }
 
     // behavior when vector size hint is given
-    assert(run_with_metadata("keep").count() == 4, "should keep all rows")
-    assert(run_with_metadata("skip").count() == 1, "should skip rows with nulls")
-    intercept[SparkException](run_with_metadata("error"))
+    assert(runWithMetadata("keep").count() == 6, "should keep all rows")
+    assert(runWithMetadata("skip").count() == 1, "should skip rows with nulls")
+    intercept[SparkException](runWithMetadata("error"), "should throw error with nulls")
+    intercept[SparkException](runWithMetadata("error", additional_filter = "id1 > 4"),
+      "should throw error with NaNs")
 
     // behavior when first row has information
-    assert(intercept[RuntimeException](run_with_first_row("keep").count())
+    assert(intercept[RuntimeException](runWithFirstRow("keep").count())
       .getMessage.contains("VectorSizeHint"), "should suggest to use metadata")
-    assert(run_with_first_row("skip").count() == 1, "should infer size and skip rows with nulls")
-    intercept[SparkException](run_with_first_row("error"))
+    assert(runWithFirstRow("skip").count() == 1, "should infer size and skip rows with nulls")
+    intercept[SparkException](runWithFirstRow("error"))
 
     // behavior when vector column is all null
-    assert(intercept[RuntimeException](run_with_all_null_vectors("skip"))
+    assert(intercept[RuntimeException](runWithAllNullVectors("skip"))
       .getMessage.contains("VectorSizeHint"), "should suggest to use metadata")
-    assert(intercept[NullPointerException](run_with_all_null_vectors("error"))
+    assert(intercept[NullPointerException](runWithAllNullVectors("error"))
       .getMessage.contains("VectorSizeHint"), "should suggest to use metadata")
 
     // behavior when scalar column is all null
-    assert(run_with_metadata("keep", additional_filter = "id1 > 2").count() == 2)
+    assert(runWithMetadata("keep", additional_filter = "id1 > 2").count() == 4)
   }
 
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
@@ -78,15 +78,15 @@ class VectorAssemblerSuite
   }
 
   test("VectorAssembler") {
-    val df = Seq((1, 2, 0.0, Vectors.dense(1.0, 2.0), "a",
-      Vectors.sparse(2, Array(1), Array(3.0)), 7L, null))
-      .toDF("id1", "id2", "x", "y", "name", "z", "n", "nulls")
+    val df = Seq(
+      (0, 0.0, Vectors.dense(1.0, 2.0), "a", Vectors.sparse(2, Array(1), Array(3.0)), 10L)
+    ).toDF("id", "x", "y", "name", "z", "n")
     val assembler = new VectorAssembler()
       .setInputCols(Array("x", "y", "z", "n"))
       .setOutputCol("features")
     assembler.transform(df).select("features").collect().foreach {
       case Row(v: Vector) =>
-        assert(v === Vectors.sparse(6, Array(1, 2, 4, 5), Array(1.0, 2.0, 3.0, 7.0)))
+        assert(v === Vectors.sparse(6, Array(1, 2, 4, 5), Array(1.0, 2.0, 3.0, 10.0)))
     }
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.feature
 
+import org.dmg.pmml.False
+
 import org.apache.spark.{SparkException, SparkFunSuite}
 import org.apache.spark.ml.attribute.{AttributeGroup, NominalAttribute, NumericAttribute}
 import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
@@ -37,33 +39,45 @@ class VectorAssemblerSuite
 
   test("assemble") {
     import org.apache.spark.ml.feature.VectorAssembler.assemble
-    assert(assemble(Array(1))(0.0) === Vectors.sparse(1, Array.empty, Array.empty))
-    assert(assemble(Array(1, 1))(0.0, 1.0) === Vectors.sparse(2, Array(1), Array(1.0)))
+    assert(assemble(Array(1), true)(0.0) === Vectors.sparse(1, Array.empty, Array.empty))
+    assert(assemble(Array(1, 1), true)(0.0, 1.0) === Vectors.sparse(2, Array(1), Array(1.0)))
     val dv = Vectors.dense(2.0, 0.0)
-    assert(assemble(Array(1, 2, 1))(0.0, dv, 1.0) ===
+    assert(assemble(Array(1, 2, 1), true)(0.0, dv, 1.0) ===
       Vectors.sparse(4, Array(1, 3), Array(2.0, 1.0)))
     val sv = Vectors.sparse(2, Array(0, 1), Array(3.0, 4.0))
-    assert(assemble(Array(1, 2, 1, 2))(0.0, dv, 1.0, sv) ===
+    assert(assemble(Array(1, 2, 1, 2), true)(0.0, dv, 1.0, sv) ===
       Vectors.sparse(6, Array(1, 3, 4, 5), Array(2.0, 1.0, 3.0, 4.0)))
     for (v <- Seq(1, "a")) {
-      intercept[SparkException](assemble(Array(1))(v))
-      intercept[SparkException](assemble(Array(1, 1))(1.0, v))
+      intercept[SparkException](assemble(Array(1), true)(v))
+      intercept[SparkException](assemble(Array(1, 1), true)(1.0, v))
     }
   }
 
-  test("assemble should keep nulls") {
+  test("keep invalid should keep nulls") {
     import org.apache.spark.ml.feature.VectorAssembler.assemble
-    assert(assemble(Array(1, 1))(1.0, null) === Vectors.dense(1.0, Double.NaN))
-    assert(assemble(Array(1, 2))(1.0, null) === Vectors.dense(1.0, Double.NaN, Double.NaN))
-    assert(assemble(Array(1))(null) === Vectors.dense(Double.NaN))
-    assert(assemble(Array(2))(null) === Vectors.dense(Double.NaN, Double.NaN))
+    assert(assemble(Array(1, 1), true)(1.0, null) === Vectors.dense(1.0, Double.NaN))
+    assert(assemble(Array(1, 2), true)(1.0, null) === Vectors.dense(1.0, Double.NaN, Double.NaN))
+    assert(assemble(Array(1), true)(null) === Vectors.dense(Double.NaN))
+    assert(assemble(Array(2), true)(null) === Vectors.dense(Double.NaN, Double.NaN))
+  }
+
+  test("error invalid should throw errors") {
+    import org.apache.spark.ml.feature.VectorAssembler.assemble
+    intercept[SparkException](assemble(Array(1, 1), false)(1.0, null) ===
+      Vectors.dense(1.0, Double.NaN))
+    intercept[SparkException](assemble(Array(1, 2), false)(1.0, null) ===
+      Vectors.dense(1.0, Double.NaN, Double.NaN))
+    intercept[SparkException](assemble(Array(1), false)(null) === Vectors.dense(Double.NaN))
+    intercept[SparkException](assemble(Array(2), false)(null) ===
+      Vectors.dense(Double.NaN, Double.NaN))
   }
 
   test("assemble should compress vectors") {
     import org.apache.spark.ml.feature.VectorAssembler.assemble
-    val v1 = assemble(Array(1, 1, 1, 4))(0.0, 0.0, 0.0, Vectors.dense(4.0))
+    val v1 = assemble(Array(1, 1, 1, 4), true)(0.0, 0.0, 0.0, Vectors.dense(4.0))
     assert(v1.isInstanceOf[SparseVector])
-    val v2 = assemble(Array(1, 1, 1, 1))(1.0, 2.0, 3.0, Vectors.sparse(1, Array(0), Array(4.0)))
+    val sv = Vectors.sparse(1, Array(0), Array(4.0))
+    val v2 = assemble(Array(1, 1, 1, 1), true)(1.0, 2.0, 3.0, sv)
     assert(v2.isInstanceOf[DenseVector])
   }
 
@@ -156,4 +170,25 @@ class VectorAssemblerSuite
       .filter(vectorUDF($"features") > 1)
       .count() == 1)
   }
+
+  test("Handle Invalid should behave properly") {
+    val df = Seq[(Long, java.lang.Double, Vector, String, Vector, Long)](
+      (0, 0.0, Vectors.dense(1.0, 2.0), "a", Vectors.sparse(2, Array(1), Array(3.0)), 10L),
+      (0, 0.0, null, "a", Vectors.sparse(2, Array(1), Array(3.0)), 10L),
+      (0, null, Vectors.dense(1.0, 2.0), "a", Vectors.sparse(2, Array(1), Array(3.0)), 10L),
+      (0, 0.0, Vectors.dense(1.0, 2.0), "a", Vectors.sparse(2, Array(1), Array(3.0)), 10L)
+    ).toDF("id", "x", "y", "name", "z", "n")
+
+    val assembler = new VectorAssembler()
+      .setInputCols(Array("x", "y", "z", "n"))
+      .setOutputCol("features")
+
+    assembler.setHandleInvalid("skip").transform(df).select("features").show(truncate = false)
+    assembler.setHandleInvalid("keep").transform(df).select("features").show(truncate = false)
+//    assembler.transform(df).select("features").collect().foreach {
+//      case Row(v: Vector) =>
+//        assert(v === Vectors.sparse(6, Array(1, 2, 4, 5), Array(1.0, 2.0, 3.0, 10.0)))
+//    }
+  }
+
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
@@ -51,25 +51,6 @@ class VectorAssemblerSuite
     }
   }
 
-  test("keep invalid should keep nulls") {
-    import org.apache.spark.ml.feature.VectorAssembler.assemble
-    assert(assemble(Array(1, 1), true)(1.0, null) === Vectors.dense(1.0, Double.NaN))
-    assert(assemble(Array(1, 2), true)(1.0, null) === Vectors.dense(1.0, Double.NaN, Double.NaN))
-    assert(assemble(Array(1), true)(null) === Vectors.dense(Double.NaN))
-    assert(assemble(Array(2), true)(null) === Vectors.dense(Double.NaN, Double.NaN))
-  }
-
-  test("error invalid should throw errors") {
-    import org.apache.spark.ml.feature.VectorAssembler.assemble
-    intercept[SparkException](assemble(Array(1, 1), false)(1.0, null) ===
-      Vectors.dense(1.0, Double.NaN))
-    intercept[SparkException](assemble(Array(1, 2), false)(1.0, null) ===
-      Vectors.dense(1.0, Double.NaN, Double.NaN))
-    intercept[SparkException](assemble(Array(1), false)(null) === Vectors.dense(Double.NaN))
-    intercept[SparkException](assemble(Array(2), false)(null) ===
-      Vectors.dense(Double.NaN, Double.NaN))
-  }
-
   test("assemble should compress vectors") {
     import org.apache.spark.ml.feature.VectorAssembler.assemble
     val v1 = assemble(Array(1, 1, 1, 4), true)(0.0, 0.0, 0.0, Vectors.dense(4.0))
@@ -167,6 +148,25 @@ class VectorAssemblerSuite
     assert(assembler.transform(filteredDF).select("features")
       .filter(vectorUDF($"features") > 1)
       .count() == 1)
+  }
+
+  test("assemble should keep nulls") {
+    import org.apache.spark.ml.feature.VectorAssembler.assemble
+    assert(assemble(Array(1, 1), true)(1.0, null) === Vectors.dense(1.0, Double.NaN))
+    assert(assemble(Array(1, 2), true)(1.0, null) === Vectors.dense(1.0, Double.NaN, Double.NaN))
+    assert(assemble(Array(1), true)(null) === Vectors.dense(Double.NaN))
+    assert(assemble(Array(2), true)(null) === Vectors.dense(Double.NaN, Double.NaN))
+  }
+
+  test("assemble should throw errors") {
+    import org.apache.spark.ml.feature.VectorAssembler.assemble
+    intercept[SparkException](assemble(Array(1, 1), false)(1.0, null) ===
+      Vectors.dense(1.0, Double.NaN))
+    intercept[SparkException](assemble(Array(1, 2), false)(1.0, null) ===
+      Vectors.dense(1.0, Double.NaN, Double.NaN))
+    intercept[SparkException](assemble(Array(1), false)(null) === Vectors.dense(Double.NaN))
+    intercept[SparkException](assemble(Array(2), false)(null) ===
+      Vectors.dense(Double.NaN, Double.NaN))
   }
 
   test("Handle Invalid should behave properly") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduce `handleInvalid` parameter in `VectorAssembler` that can take in `"keep", "skip", "error"` options. "error" throws an error on seeing a row containing a `null`, "skip" filters out all such rows, and "keep" adds relevant number of NaN. "keep" figures out an example to find out what this number of NaN s should be added and throws an error when no such number could be found.

## How was this patch tested?

Unit tests are added to check the behavior of `assemble` on specific rows and the transformer is called on `DataFrame`s of different configurations to test different corner cases.

