### PR TITLE
[SPARK-20536][SQL] Extend ColumnName to create StructFields with explicit nullable

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
@@ -1210,7 +1210,7 @@ class ColumnName(name: String) extends Column(name) {
 
   /**
    * Creates a new `StructField` of type boolean.
-   * @since 2.3.0
+   * @since 2.4.0
    */
   def boolean(nullable: Boolean): StructField = StructField(name, BooleanType, nullable)
 
@@ -1222,7 +1222,7 @@ class ColumnName(name: String) extends Column(name) {
 
   /**
    * Creates a new `StructField` of type byte.
-   * @since 2.3.0
+   * @since 2.4.0
    */
   def byte(nullable: Boolean): StructField = StructField(name, ByteType, nullable)
 
@@ -1234,7 +1234,7 @@ class ColumnName(name: String) extends Column(name) {
 
   /**
    * Creates a new `StructField` of type short.
-   * @since 2.3.0
+   * @since 2.4.0
    */
   def short(nullable: Boolean): StructField = StructField(name, ShortType, nullable)
 
@@ -1246,7 +1246,7 @@ class ColumnName(name: String) extends Column(name) {
 
   /**
    * Creates a new `StructField` of type int.
-   * @since 2.3.0
+   * @since 2.4.0
    */
   def int(nullable: Boolean): StructField = StructField(name, IntegerType, nullable)
 
@@ -1258,7 +1258,7 @@ class ColumnName(name: String) extends Column(name) {
 
   /**
    * Creates a new `StructField` of type long.
-   * @since 2.3.0
+   * @since 2.4.0
    */
   def long(nullable: Boolean): StructField = StructField(name, LongType, nullable)
 
@@ -1270,7 +1270,7 @@ class ColumnName(name: String) extends Column(name) {
 
   /**
    * Creates a new `StructField` of type float.
-   * @since 2.3.0
+   * @since 2.4.0
    */
   def float(nullable: Boolean): StructField = StructField(name, FloatType, nullable)
 
@@ -1282,7 +1282,7 @@ class ColumnName(name: String) extends Column(name) {
 
   /**
    * Creates a new `StructField` of type double.
-   * @since 2.3.0
+   * @since 2.4.0
    */
   def double(nullable: Boolean): StructField = StructField(name, DoubleType, nullable)
 
@@ -1294,7 +1294,7 @@ class ColumnName(name: String) extends Column(name) {
 
   /**
    * Creates a new `StructField` of type string.
-   * @since 2.3.0
+   * @since 2.4.0
    */
   def string(nullable: Boolean): StructField = StructField(name, StringType, nullable)
 
@@ -1306,7 +1306,7 @@ class ColumnName(name: String) extends Column(name) {
 
   /**
    * Creates a new `StructField` of type date.
-   * @since 2.3.0
+   * @since 2.4.0
    */
   def date(nullable: Boolean): StructField = StructField(name, DateType, nullable)
 
@@ -1318,7 +1318,7 @@ class ColumnName(name: String) extends Column(name) {
 
   /**
    * Creates a new `StructField` of type decimal.
-   * @since 2.3.0
+   * @since 2.4.0
    */
   def decimal(nullable: Boolean): StructField =
     StructField(name, DecimalType.USER_DEFAULT, nullable)
@@ -1332,7 +1332,7 @@ class ColumnName(name: String) extends Column(name) {
 
   /**
    * Creates a new `StructField` of type decimal.
-   * @since 2.3.0
+   * @since 2.4.0
    */
   def decimal(precision: Int, scale: Int, nullable: Boolean): StructField =
     StructField(name, DecimalType(precision, scale), nullable)
@@ -1345,7 +1345,7 @@ class ColumnName(name: String) extends Column(name) {
 
   /**
    * Creates a new `StructField` of type timestamp.
-   * @since 2.3.0
+   * @since 2.4.0
    */
   def timestamp(nullable: Boolean): StructField = StructField(name, TimestampType, nullable)
 
@@ -1357,7 +1357,7 @@ class ColumnName(name: String) extends Column(name) {
 
   /**
    * Creates a new `StructField` of type binary.
-   * @since 2.3.0
+   * @since 2.4.0
    */
   def binary(nullable: Boolean): StructField = StructField(name, BinaryType, nullable)
 
@@ -1369,7 +1369,7 @@ class ColumnName(name: String) extends Column(name) {
 
   /**
    * Creates a new `StructField` of type array.
-   * @since 2.3.0
+   * @since 2.4.0
    */
   def array(dataType: DataType, nullable: Boolean): StructField =
     StructField(name, ArrayType(dataType), nullable)
@@ -1385,7 +1385,7 @@ class ColumnName(name: String) extends Column(name) {
 
   /**
    * Creates a new `StructField` of type map.
-   * @since 2.3.0
+   * @since 2.4.0
    */
   def map(mapType: MapType, nullable: Boolean): StructField = StructField(name, mapType, nullable)
 
@@ -1403,7 +1403,7 @@ class ColumnName(name: String) extends Column(name) {
 
   /**
    * Creates a new `StructField` of type struct.
-   * @since 2.3.0
+   * @since 2.4.0
    */
   def struct(structType: StructType, nullable: Boolean): StructField =
     StructField(name, structType, nullable)

--- a/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
@@ -1209,10 +1209,22 @@ class ColumnName(name: String) extends Column(name) {
   def boolean: StructField = StructField(name, BooleanType)
 
   /**
+   * Creates a new `StructField` of type boolean.
+   * @since 2.3.0
+   */
+  def boolean(nullable: Boolean): StructField = StructField(name, BooleanType, nullable)
+
+  /**
    * Creates a new `StructField` of type byte.
    * @since 1.3.0
    */
   def byte: StructField = StructField(name, ByteType)
+
+  /**
+   * Creates a new `StructField` of type byte.
+   * @since 2.3.0
+   */
+  def byte(nullable: Boolean): StructField = StructField(name, ByteType, nullable)
 
   /**
    * Creates a new `StructField` of type short.
@@ -1221,10 +1233,22 @@ class ColumnName(name: String) extends Column(name) {
   def short: StructField = StructField(name, ShortType)
 
   /**
+   * Creates a new `StructField` of type short.
+   * @since 2.3.0
+   */
+  def short(nullable: Boolean): StructField = StructField(name, ShortType, nullable)
+
+  /**
    * Creates a new `StructField` of type int.
    * @since 1.3.0
    */
   def int: StructField = StructField(name, IntegerType)
+
+  /**
+   * Creates a new `StructField` of type int.
+   * @since 2.3.0
+   */
+  def int(nullable: Boolean): StructField = StructField(name, IntegerType, nullable)
 
   /**
    * Creates a new `StructField` of type long.
@@ -1233,10 +1257,22 @@ class ColumnName(name: String) extends Column(name) {
   def long: StructField = StructField(name, LongType)
 
   /**
+   * Creates a new `StructField` of type long.
+   * @since 2.3.0
+   */
+  def long(nullable: Boolean): StructField = StructField(name, LongType, nullable)
+
+  /**
    * Creates a new `StructField` of type float.
    * @since 1.3.0
    */
   def float: StructField = StructField(name, FloatType)
+
+  /**
+   * Creates a new `StructField` of type float.
+   * @since 2.3.0
+   */
+  def float(nullable: Boolean): StructField = StructField(name, FloatType, nullable)
 
   /**
    * Creates a new `StructField` of type double.
@@ -1245,16 +1281,34 @@ class ColumnName(name: String) extends Column(name) {
   def double: StructField = StructField(name, DoubleType)
 
   /**
+   * Creates a new `StructField` of type double.
+   * @since 2.3.0
+   */
+  def double(nullable: Boolean): StructField = StructField(name, DoubleType, nullable)
+
+  /**
    * Creates a new `StructField` of type string.
    * @since 1.3.0
    */
   def string: StructField = StructField(name, StringType)
 
   /**
+   * Creates a new `StructField` of type string.
+   * @since 2.3.0
+   */
+  def string(nullable: Boolean): StructField = StructField(name, StringType, nullable)
+
+  /**
    * Creates a new `StructField` of type date.
    * @since 1.3.0
    */
   def date: StructField = StructField(name, DateType)
+
+  /**
+   * Creates a new `StructField` of type date.
+   * @since 2.3.0
+   */
+  def date(nullable: Boolean): StructField = StructField(name, DateType, nullable)
 
   /**
    * Creates a new `StructField` of type decimal.
@@ -1264,10 +1318,24 @@ class ColumnName(name: String) extends Column(name) {
 
   /**
    * Creates a new `StructField` of type decimal.
+   * @since 2.3.0
+   */
+  def decimal(nullable: Boolean): StructField =
+    StructField(name, DecimalType.USER_DEFAULT, nullable)
+
+  /**
+   * Creates a new `StructField` of type decimal.
    * @since 1.3.0
    */
   def decimal(precision: Int, scale: Int): StructField =
     StructField(name, DecimalType(precision, scale))
+
+  /**
+   * Creates a new `StructField` of type decimal.
+   * @since 2.3.0
+   */
+  def decimal(precision: Int, scale: Int, nullable: Boolean): StructField =
+    StructField(name, DecimalType(precision, scale), nullable)
 
   /**
    * Creates a new `StructField` of type timestamp.
@@ -1276,16 +1344,35 @@ class ColumnName(name: String) extends Column(name) {
   def timestamp: StructField = StructField(name, TimestampType)
 
   /**
+   * Creates a new `StructField` of type timestamp.
+   * @since 2.3.0
+   */
+  def timestamp(nullable: Boolean): StructField = StructField(name, TimestampType, nullable)
+
+  /**
    * Creates a new `StructField` of type binary.
    * @since 1.3.0
    */
   def binary: StructField = StructField(name, BinaryType)
 
   /**
+   * Creates a new `StructField` of type binary.
+   * @since 2.3.0
+   */
+  def binary(nullable: Boolean): StructField = StructField(name, BinaryType, nullable)
+
+  /**
    * Creates a new `StructField` of type array.
    * @since 1.3.0
    */
   def array(dataType: DataType): StructField = StructField(name, ArrayType(dataType))
+
+  /**
+   * Creates a new `StructField` of type array.
+   * @since 2.3.0
+   */
+  def array(dataType: DataType, nullable: Boolean): StructField =
+    StructField(name, ArrayType(dataType), nullable)
 
   /**
    * Creates a new `StructField` of type map.
@@ -1295,6 +1382,12 @@ class ColumnName(name: String) extends Column(name) {
     map(MapType(keyType, valueType))
 
   def map(mapType: MapType): StructField = StructField(name, mapType)
+
+  /**
+   * Creates a new `StructField` of type map.
+   * @since 2.3.0
+   */
+  def map(mapType: MapType, nullable: Boolean): StructField = StructField(name, mapType, nullable)
 
   /**
    * Creates a new `StructField` of type struct.
@@ -1307,4 +1400,11 @@ class ColumnName(name: String) extends Column(name) {
    * @since 1.3.0
    */
   def struct(structType: StructType): StructField = StructField(name, structType)
+
+  /**
+   * Creates a new `StructField` of type struct.
+   * @since 2.3.0
+   */
+  def struct(structType: StructType, nullable: Boolean): StructField =
+    StructField(name, structType, nullable)
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Extended ColumnName with methods that create StructFields with explicit nullable property

## How was this patch tested?

Existing tests
