### PR TITLE
[SPARK-23692][SQL]Print metadata of files when infer schema failed

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -205,9 +205,14 @@ case class DataSource(
         caseInsensitiveOptions,
         tempFileIndex.allFiles())
     }.getOrElse {
+      val files = tempFileIndex.allFiles()
+      val errorMsg = if (files.length == 0) {
+        "There is no input files."
+      } else {
+        s"Failed at ${files.mkString(",")}"
+      }
       throw new AnalysisException(
-        s"Unable to infer schema for $format at ${tempFileIndex.allFiles().mkString(",")}. " +
-          s"It must be specified manually.")
+        s"Unable to infer schema for $format. It must be specified manually. $errorMsg")
     }
 
     // We just print a waring message if the data schema and partition schema have the duplicate

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -206,7 +206,8 @@ case class DataSource(
         tempFileIndex.allFiles())
     }.getOrElse {
       throw new AnalysisException(
-        s"Unable to infer schema for $format. It must be specified manually.")
+        s"Unable to infer schema for $format at ${tempFileIndex.allFiles().mkString(",")}. " +
+          s"It must be specified manually.")
     }
 
     // We just print a waring message if the data schema and partition schema have the duplicate

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -365,7 +365,8 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
           createFileStreamSourceAndGetSchema(
             format = Some("json"), path = Some(src.getCanonicalPath), schema = None)
         }
-        assert("Unable to infer schema for JSON. It must be specified manually.;" === e.getMessage)
+        assert("Unable to infer schema for JSON. It must be specified manually. " +
+          "There is no input files.;" === e.getMessage)
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

A trivial modify.
Currently, when we had no input files to infer schema,we will throw below exception.
For some users it may be misleading.If we can print files' metadata it will be more clearer for troubleshooting.
`Caused by: org.apache.spark.sql.AnalysisException: Unable to infer schema for Parquet. It must be specified manually.;
         at org.apache.spark.sql.execution.datasources.DataSource$$anonfun$8.apply(DataSource.scala:189)
         at org.apache.spark.sql.execution.datasources.DataSource$$anonfun$8.apply(DataSource.scala:189)
         at scala.Option.getOrElse(Option.scala:121)
         at org.apache.spark.sql.execution.datasources.DataSource.org$apache$spark$sql$execution$datasources$DataSource$$getOrInferFileFormatSchema(DataSource.scala:188)
         at org.apache.spark.sql.execution.datasources.DataSource.resolveRelation(DataSource.scala:387)
         at org.apache.spark.sql.DataFrameReader.load(DataFrameReader.scala:152)
         at org.apache.spark.sql.DataFrameReader.parquet(DataFrameReader.scala:441)
         at org.apache.spark.sql.DataFrameReader.parquet(DataFrameReader.scala:425)
         at com.xiaomi.matrix.pipeline.jobspark.importer.MatrixAdEventDailyImportJob.<init>(MatrixAdEventDailyImportJob.scala:18)`

## How was this patch tested?

Exsist tests
