### PR TITLE
[SPARK-23699][PYTHON][SQL] Raise same type of error caught with Arrow enabled

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2013,13 +2013,13 @@ class DataFrame(object):
                     warnings.warn(msg)
                     use_arrow = False
                 else:
-                    msg = (
+                    e.message = (
                         "toPandas attempted Arrow optimization because "
                         "'spark.sql.execution.arrow.enabled' is set to true; however, "
                         "failed by the reason below:\n  %s\n"
                         "For fallback to non-optimization automatically, please set true to "
                         "'spark.sql.execution.arrow.fallback.enabled'." % _exception_message(e))
-                    raise RuntimeError(msg)
+                    raise
 
             # Try to use Arrow optimization when the schema is supported and the required version
             # of PyArrow is found, if 'spark.sql.execution.arrow.enabled' is enabled.
@@ -2040,14 +2040,14 @@ class DataFrame(object):
                 except Exception as e:
                     # We might have to allow fallback here as well but multiple Spark jobs can
                     # be executed. So, simply fail in this case for now.
-                    msg = (
+                    e.message = (
                         "toPandas attempted Arrow optimization because "
                         "'spark.sql.execution.arrow.enabled' is set to true; however, "
                         "failed unexpectedly:\n  %s\n"
                         "Note that 'spark.sql.execution.arrow.fallback.enabled' does "
                         "not have an effect in such failure in the middle of "
                         "computation." % _exception_message(e))
-                    raise RuntimeError(msg)
+                    raise
 
         # Below is toPandas without Arrow optimization.
         pdf = pd.DataFrame.from_records(self.collect(), columns=self.columns)

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2007,7 +2007,7 @@ class DataFrame(object):
                         "toPandas attempted Arrow optimization because "
                         "'spark.sql.execution.arrow.enabled' is set to true; however, "
                         "failed by the reason below:\n  %s\n"
-                        "Attempts non-optimization as "
+                        "Attempting non-optimization as "
                         "'spark.sql.execution.arrow.fallback.enabled' is set to "
                         "true." % _exception_message(e))
                     warnings.warn(msg)

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2015,10 +2015,10 @@ class DataFrame(object):
                 else:
                     msg = (
                         "toPandas attempted Arrow optimization because "
-                        "'spark.sql.execution.arrow.enabled' is set to true; however, "
-                        "failed by the reason below:\n  %s\n"
-                        "For fallback to non-optimization automatically, please set true to "
-                        "'spark.sql.execution.arrow.fallback.enabled'." % _exception_message(e))
+                        "'spark.sql.execution.arrow.enabled' is set to true, but has reached "
+                        "the error below and will not continue because automatic fallback "
+                        "with 'spark.sql.execution.arrow.fallback.enabled' has been set to "
+                        "false.\n  %s" % _exception_message(e))
                     warnings.warn(msg)
                     raise
 
@@ -2043,12 +2043,10 @@ class DataFrame(object):
                     # be executed. So, simply fail in this case for now.
                     msg = (
                         "toPandas attempted Arrow optimization because "
-                        "'spark.sql.execution.arrow.enabled' is set to true; however, "
-                        "failed unexpectedly:\n  %s\n"
-                        "Note that 'spark.sql.execution.arrow.fallback.enabled' does "
-                        "not have an effect in such failure in the middle of "
-                        "computation." % _exception_message(e))
-                    # TODO: e.args = (msg,) + e.args[1:]
+                        "'spark.sql.execution.arrow.enabled' is set to true, but has reached "
+                        "the error below and can not continue. Note that "
+                        "'spark.sql.execution.arrow.fallback.enabled' does not have an effect "
+                        "on failures in the middle of computation.\n  %s" % _exception_message(e))
                     warnings.warn(msg)
                     raise
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2013,14 +2013,14 @@ class DataFrame(object):
                     warnings.warn(msg)
                     use_arrow = False
                 else:
-                    clazz = type(e)
                     msg = (
                         "toPandas attempted Arrow optimization because "
                         "'spark.sql.execution.arrow.enabled' is set to true; however, "
                         "failed by the reason below:\n  %s\n"
                         "For fallback to non-optimization automatically, please set true to "
                         "'spark.sql.execution.arrow.fallback.enabled'." % _exception_message(e))
-                    raise clazz(msg)
+                    warnings.warn(msg)
+                    raise
 
             # Try to use Arrow optimization when the schema is supported and the required version
             # of PyArrow is found, if 'spark.sql.execution.arrow.enabled' is enabled.
@@ -2041,7 +2041,6 @@ class DataFrame(object):
                 except Exception as e:
                     # We might have to allow fallback here as well but multiple Spark jobs can
                     # be executed. So, simply fail in this case for now.
-                    clazz = type(e)
                     msg = (
                         "toPandas attempted Arrow optimization because "
                         "'spark.sql.execution.arrow.enabled' is set to true; however, "
@@ -2049,7 +2048,9 @@ class DataFrame(object):
                         "Note that 'spark.sql.execution.arrow.fallback.enabled' does "
                         "not have an effect in such failure in the middle of "
                         "computation." % _exception_message(e))
-                    raise clazz(msg)
+                    # TODO: e.args = (msg,) + e.args[1:]
+                    warnings.warn(msg)
+                    raise
 
         # Below is toPandas without Arrow optimization.
         pdf = pd.DataFrame.from_records(self.collect(), columns=self.columns)

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2000,25 +2000,22 @@ class DataFrame(object):
                 require_minimum_pyarrow_version()
                 to_arrow_schema(self.schema)
             except Exception as e:
+                msg = (
+                    "toPandas attempted Arrow optimization because "
+                    "'spark.sql.execution.arrow.enabled' is set to true; however, "
+                    "failed by the reason below:\n  %s\n" % _exception_message(e))
 
                 if self.sql_ctx.getConf("spark.sql.execution.arrow.fallback.enabled", "true") \
                         .lower() == "true":
-                    msg = (
-                        "toPandas attempted Arrow optimization because "
-                        "'spark.sql.execution.arrow.enabled' is set to true; however, "
-                        "failed by the reason below:\n  %s\n"
-                        "Attempts non-optimization as "
-                        "'spark.sql.execution.arrow.fallback.enabled' is set to "
-                        "true." % _exception_message(e))
+                    msg += (
+                        "Attempting non-optimization as "
+                        "'spark.sql.execution.arrow.fallback.enabled' is set to true.")
                     warnings.warn(msg)
                     use_arrow = False
                 else:
-                    msg = (
-                        "toPandas attempted Arrow optimization because "
-                        "'spark.sql.execution.arrow.enabled' is set to true; however, "
-                        "failed by the reason below:\n  %s\n"
+                    msg += (
                         "For fallback to non-optimization automatically, please set true to "
-                        "'spark.sql.execution.arrow.fallback.enabled'." % _exception_message(e))
+                        "'spark.sql.execution.arrow.fallback.enabled'.")
                     warnings.warn(msg)
                     raise
 
@@ -2048,7 +2045,6 @@ class DataFrame(object):
                         "Note that 'spark.sql.execution.arrow.fallback.enabled' does "
                         "not have an effect in such failure in the middle of "
                         "computation." % _exception_message(e))
-                    # TODO: e.args = (msg,) + e.args[1:]
                     warnings.warn(msg)
                     raise
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2013,13 +2013,14 @@ class DataFrame(object):
                     warnings.warn(msg)
                     use_arrow = False
                 else:
-                    e.message = (
+                    clazz = type(e)
+                    msg = (
                         "toPandas attempted Arrow optimization because "
                         "'spark.sql.execution.arrow.enabled' is set to true; however, "
                         "failed by the reason below:\n  %s\n"
                         "For fallback to non-optimization automatically, please set true to "
                         "'spark.sql.execution.arrow.fallback.enabled'." % _exception_message(e))
-                    raise
+                    raise clazz(msg)
 
             # Try to use Arrow optimization when the schema is supported and the required version
             # of PyArrow is found, if 'spark.sql.execution.arrow.enabled' is enabled.
@@ -2040,14 +2041,15 @@ class DataFrame(object):
                 except Exception as e:
                     # We might have to allow fallback here as well but multiple Spark jobs can
                     # be executed. So, simply fail in this case for now.
-                    e.message = (
+                    clazz = type(e)
+                    msg = (
                         "toPandas attempted Arrow optimization because "
                         "'spark.sql.execution.arrow.enabled' is set to true; however, "
                         "failed unexpectedly:\n  %s\n"
                         "Note that 'spark.sql.execution.arrow.fallback.enabled' does "
                         "not have an effect in such failure in the middle of "
                         "computation." % _exception_message(e))
-                    raise
+                    raise clazz(msg)
 
         # Below is toPandas without Arrow optimization.
         pdf = pd.DataFrame.from_records(self.collect(), columns=self.columns)

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2000,22 +2000,25 @@ class DataFrame(object):
                 require_minimum_pyarrow_version()
                 to_arrow_schema(self.schema)
             except Exception as e:
-                msg = (
-                    "toPandas attempted Arrow optimization because "
-                    "'spark.sql.execution.arrow.enabled' is set to true; however, "
-                    "failed by the reason below:\n  %s\n" % _exception_message(e))
 
                 if self.sql_ctx.getConf("spark.sql.execution.arrow.fallback.enabled", "true") \
                         .lower() == "true":
-                    msg += (
-                        "Attempting non-optimization as "
-                        "'spark.sql.execution.arrow.fallback.enabled' is set to true.")
+                    msg = (
+                        "toPandas attempted Arrow optimization because "
+                        "'spark.sql.execution.arrow.enabled' is set to true; however, "
+                        "failed by the reason below:\n  %s\n"
+                        "Attempts non-optimization as "
+                        "'spark.sql.execution.arrow.fallback.enabled' is set to "
+                        "true." % _exception_message(e))
                     warnings.warn(msg)
                     use_arrow = False
                 else:
-                    msg += (
+                    msg = (
+                        "toPandas attempted Arrow optimization because "
+                        "'spark.sql.execution.arrow.enabled' is set to true; however, "
+                        "failed by the reason below:\n  %s\n"
                         "For fallback to non-optimization automatically, please set true to "
-                        "'spark.sql.execution.arrow.fallback.enabled'.")
+                        "'spark.sql.execution.arrow.fallback.enabled'." % _exception_message(e))
                     warnings.warn(msg)
                     raise
 
@@ -2045,6 +2048,7 @@ class DataFrame(object):
                         "Note that 'spark.sql.execution.arrow.fallback.enabled' does "
                         "not have an effect in such failure in the middle of "
                         "computation." % _exception_message(e))
+                    # TODO: e.args = (msg,) + e.args[1:]
                     warnings.warn(msg)
                     raise
 

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -679,14 +679,14 @@ class SparkSession(object):
                             "true." % _exception_message(e))
                         warnings.warn(msg)
                     else:
-                        clazz = type(e)
                         msg = (
                             "createDataFrame attempted Arrow optimization because "
                             "'spark.sql.execution.arrow.enabled' is set to true; however, "
                             "failed by the reason below:\n  %s\n"
                             "For fallback to non-optimization automatically, please set true to "
                             "'spark.sql.execution.arrow.fallback.enabled'." % _exception_message(e))
-                        raise clazz(msg)
+                        warnings.warn(msg)
+                        raise
             data = self._convert_from_pandas(data, schema, timezone)
 
         if isinstance(schema, StructType):

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -668,23 +668,21 @@ class SparkSession(object):
                 except Exception as e:
                     from pyspark.util import _exception_message
 
+                    msg = (
+                        "createDataFrame attempted Arrow optimization because "
+                        "'spark.sql.execution.arrow.enabled' is set to true; however, "
+                        "failed by the reason below:\n  %s\n" % _exception_message(e))
+
                     if self.conf.get("spark.sql.execution.arrow.fallback.enabled", "true") \
                             .lower() == "true":
-                        msg = (
-                            "createDataFrame attempted Arrow optimization because "
-                            "'spark.sql.execution.arrow.enabled' is set to true; however, "
-                            "failed by the reason below:\n  %s\n"
-                            "Attempts non-optimization as "
-                            "'spark.sql.execution.arrow.fallback.enabled' is set to "
-                            "true." % _exception_message(e))
+                        msg += (
+                            "Attempting non-optimization as "
+                            "'spark.sql.execution.arrow.fallback.enabled' is set to true.")
                         warnings.warn(msg)
                     else:
-                        msg = (
-                            "createDataFrame attempted Arrow optimization because "
-                            "'spark.sql.execution.arrow.enabled' is set to true; however, "
-                            "failed by the reason below:\n  %s\n"
-                            "For fallback to non-optimization automatically, please set true to "
-                            "'spark.sql.execution.arrow.fallback.enabled'." % _exception_message(e))
+                        msg += (
+                            "For fallback to non-optimization automatically, please set "
+                            "true to 'spark.sql.execution.arrow.fallback.enabled'.")
                         warnings.warn(msg)
                         raise
             data = self._convert_from_pandas(data, schema, timezone)

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -681,10 +681,10 @@ class SparkSession(object):
                     else:
                         msg = (
                             "createDataFrame attempted Arrow optimization because "
-                            "'spark.sql.execution.arrow.enabled' is set to true; however, "
-                            "failed by the reason below:\n  %s\n"
-                            "For fallback to non-optimization automatically, please set true to "
-                            "'spark.sql.execution.arrow.fallback.enabled'." % _exception_message(e))
+                            "'spark.sql.execution.arrow.enabled' is set to true, but has reached "
+                            "the error below and will not continue because automatic fallback "
+                            "with 'spark.sql.execution.arrow.fallback.enabled' has been set to "
+                            "false.\n  %s" % _exception_message(e))
                         warnings.warn(msg)
                         raise
             data = self._convert_from_pandas(data, schema, timezone)

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -679,13 +679,14 @@ class SparkSession(object):
                             "true." % _exception_message(e))
                         warnings.warn(msg)
                     else:
-                        e.message = (
+                        clazz = type(e)
+                        msg = (
                             "createDataFrame attempted Arrow optimization because "
                             "'spark.sql.execution.arrow.enabled' is set to true; however, "
                             "failed by the reason below:\n  %s\n"
                             "For fallback to non-optimization automatically, please set true to "
                             "'spark.sql.execution.arrow.fallback.enabled'." % _exception_message(e))
-                        raise
+                        raise clazz(msg)
             data = self._convert_from_pandas(data, schema, timezone)
 
         if isinstance(schema, StructType):

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -668,21 +668,23 @@ class SparkSession(object):
                 except Exception as e:
                     from pyspark.util import _exception_message
 
-                    msg = (
-                        "createDataFrame attempted Arrow optimization because "
-                        "'spark.sql.execution.arrow.enabled' is set to true; however, "
-                        "failed by the reason below:\n  %s\n" % _exception_message(e))
-
                     if self.conf.get("spark.sql.execution.arrow.fallback.enabled", "true") \
                             .lower() == "true":
-                        msg += (
-                            "Attempting non-optimization as "
-                            "'spark.sql.execution.arrow.fallback.enabled' is set to true.")
+                        msg = (
+                            "createDataFrame attempted Arrow optimization because "
+                            "'spark.sql.execution.arrow.enabled' is set to true; however, "
+                            "failed by the reason below:\n  %s\n"
+                            "Attempts non-optimization as "
+                            "'spark.sql.execution.arrow.fallback.enabled' is set to "
+                            "true." % _exception_message(e))
                         warnings.warn(msg)
                     else:
-                        msg += (
-                            "For fallback to non-optimization automatically, please set "
-                            "true to 'spark.sql.execution.arrow.fallback.enabled'.")
+                        msg = (
+                            "createDataFrame attempted Arrow optimization because "
+                            "'spark.sql.execution.arrow.enabled' is set to true; however, "
+                            "failed by the reason below:\n  %s\n"
+                            "For fallback to non-optimization automatically, please set true to "
+                            "'spark.sql.execution.arrow.fallback.enabled'." % _exception_message(e))
                         warnings.warn(msg)
                         raise
             data = self._convert_from_pandas(data, schema, timezone)

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -679,13 +679,13 @@ class SparkSession(object):
                             "true." % _exception_message(e))
                         warnings.warn(msg)
                     else:
-                        msg = (
+                        e.message = (
                             "createDataFrame attempted Arrow optimization because "
                             "'spark.sql.execution.arrow.enabled' is set to true; however, "
                             "failed by the reason below:\n  %s\n"
                             "For fallback to non-optimization automatically, please set true to "
                             "'spark.sql.execution.arrow.fallback.enabled'." % _exception_message(e))
-                        raise RuntimeError(msg)
+                        raise
             data = self._convert_from_pandas(data, schema, timezone)
 
         if isinstance(schema, StructType):

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -674,7 +674,7 @@ class SparkSession(object):
                             "createDataFrame attempted Arrow optimization because "
                             "'spark.sql.execution.arrow.enabled' is set to true; however, "
                             "failed by the reason below:\n  %s\n"
-                            "Attempts non-optimization as "
+                            "Attempting non-optimization as "
                             "'spark.sql.execution.arrow.fallback.enabled' is set to "
                             "true." % _exception_message(e))
                         warnings.warn(msg)

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3533,7 +3533,7 @@ class ArrowTests(ReusedSQLTestCase):
                         warn.message for warn in warns if isinstance(warn.message, UserWarning)]
                     self.assertTrue(len(user_warns) > 0)
                     self.assertTrue(
-                        "Attempts non-optimization" in _exception_message(user_warns[-1]))
+                        "Attempting non-optimization" in _exception_message(user_warns[-1]))
                     self.assertPandasEqual(pdf, pd.DataFrame({u'map': [{u'a': 1}]}))
 
     def test_toPandas_fallback_disabled(self):
@@ -3754,7 +3754,7 @@ class ArrowTests(ReusedSQLTestCase):
                         warn.message for warn in warns if isinstance(warn.message, UserWarning)]
                     self.assertTrue(len(user_warns) > 0)
                     self.assertTrue(
-                        "Attempts non-optimization" in _exception_message(user_warns[-1]))
+                        "Attempting non-optimization" in _exception_message(user_warns[-1]))
                     self.assertEqual(df.collect(), [Row(a={u'a': 1})])
 
     def test_createDataFrame_fallback_disabled(self):

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3661,7 +3661,7 @@ class ArrowTests(ReusedSQLTestCase):
         pdf = self.create_pandas_data_frame()
         wrong_schema = StructType(list(reversed(self.schema)))
         with QuietTest(self.sc):
-            with self.assertRaisesRegexp(RuntimeError, ".*No cast.*string.*timestamp.*"):
+            with self.assertRaisesRegexp(Exception, ".*No cast.*string.*timestamp.*"):
                 self.spark.createDataFrame(pdf, schema=wrong_schema)
 
     def test_createDataFrame_with_names(self):
@@ -3686,7 +3686,7 @@ class ArrowTests(ReusedSQLTestCase):
     def test_createDataFrame_with_single_data_type(self):
         import pandas as pd
         with QuietTest(self.sc):
-            with self.assertRaisesRegexp(RuntimeError, ".*IntegerType.*not supported.*"):
+            with self.assertRaisesRegexp(ValueError, ".*IntegerType.*not supported.*"):
                 self.spark.createDataFrame(pd.DataFrame({"a": [1]}), schema="int")
 
     def test_createDataFrame_does_not_modify_input(self):
@@ -3761,7 +3761,7 @@ class ArrowTests(ReusedSQLTestCase):
         import pandas as pd
 
         with QuietTest(self.sc):
-            with self.assertRaisesRegexp(Exception, 'Unsupported type'):
+            with self.assertRaisesRegexp(TypeError, 'Unsupported type'):
                 self.spark.createDataFrame(
                     pd.DataFrame([[{u'a': 1}]]), "a: map<string, int>")
 

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -121,7 +121,10 @@ def require_minimum_pandas_version():
     from distutils.version import LooseVersion
     try:
         import pandas
+        have_pandas = True
     except ImportError:
+        have_pandas = False
+    if not have_pandas:
         raise ImportError("Pandas >= %s must be installed; however, "
                           "it was not found." % minimum_pandas_version)
     if LooseVersion(pandas.__version__) < LooseVersion(minimum_pandas_version):
@@ -138,7 +141,10 @@ def require_minimum_pyarrow_version():
     from distutils.version import LooseVersion
     try:
         import pyarrow
+        have_arrow = True
     except ImportError:
+        have_arrow = False
+    if not have_arrow:
         raise ImportError("PyArrow >= %s must be installed; however, "
                           "it was not found." % minimum_pyarrow_version)
     if LooseVersion(pyarrow.__version__) < LooseVersion(minimum_pyarrow_version):


### PR DESCRIPTION
## What changes were proposed in this pull request?

When using Arrow for createDataFrame or toPandas and an error is encountered with fallback disabled, this will raise the same type of error instead of a RuntimeError.  This change also allows for the traceback of the error to be retained and prevents the accidental chaining of exceptions with Python 3.

## How was this patch tested?

Updated existing tests to verify error type.