### PR TITLE
[SPARK-23702][SS] Forbid watermarks on both sides of a streaming aggregate.

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -384,6 +384,16 @@ class UnsupportedOperationsSuite extends SparkFunSuite {
     outputMode = Append
   )
 
+  assertNotSupportedInStreamingPlan(
+    "Watermark both before and after streaming aggregation",
+    EventTimeWatermark(att, CalendarInterval.fromString("interval 1 minute"),
+      Aggregate(
+        Seq(attributeWithWatermark),
+        aggExprs("c"),
+        EventTimeWatermark(att, CalendarInterval.fromString("interval 1 minute"), streamRelation))),
+    outputMode = Append,
+    expectedMsgs = Seq("Watermarks both before and after"))
+
   // Inner joins: Multiple stream-stream joins supported only in append mode
   testBinaryOperationInStreamingPlan(
     "single inner join in append mode",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Forbid watermarks on both sides of a streaming aggregate. As detailed in the jira, we don't currently support this and doing so would require significant revision to the execution model.

## How was this patch tested?

new unit test