### PR TITLE
[SPARK-23162][PySpark][ML] Add r2adj into Python API in LinearRegressionSummary

### DIFF
--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -336,10 +336,10 @@ class LinearRegressionSummary(JavaWrapper):
     @since("2.0.0")
     def r2(self):
         """
-        Returns R^2^, the coefficient of determination.
+        Returns R^2, the coefficient of determination.
 
         .. seealso:: `Wikipedia coefficient of determination \
-        <http://en.wikipedia.org/wiki/Coefficient_of_determination>`
+        <http://en.wikipedia.org/wiki/Coefficient_of_determination>`_
 
         .. note:: This ignores instance weights (setting all to 1.0) from
             `LinearRegression.weightCol`. This will change in later Spark
@@ -351,10 +351,10 @@ class LinearRegressionSummary(JavaWrapper):
     @since("2.4.0")
     def r2adj(self):
         """
-        Returns Adjusted R^2^, the adjusted coefficient of determination.
+        Returns Adjusted R^2, the adjusted coefficient of determination.
 
         .. seealso:: `Wikipedia coefficient of determination \
-        <https://en.wikipedia.org/wiki/Coefficient_of_determination>`
+        <https://en.wikipedia.org/wiki/Coefficient_of_determination#Adjusted_R2>`_
 
         .. note:: This ignores instance weights (setting all to 1.0) from
             `LinearRegression.weightCol`. This will change in later Spark versions.

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -348,6 +348,20 @@ class LinearRegressionSummary(JavaWrapper):
         return self._call_java("r2")
 
     @property
+    @since("2.4.0")
+    def r2adj(self):
+        """
+        Returns Adjusted R^2^, the adjusted coefficient of determination.
+
+        .. seealso:: `Wikipedia coefficient of determination \
+        <https://en.wikipedia.org/wiki/Coefficient_of_determination>`
+
+        .. note:: This ignores instance weights (setting all to 1.0) from
+            `LinearRegression.weightCol`. This will change in later Spark versions.
+        """
+        return self._call_java("r2adj")
+
+    @property
     @since("2.0.0")
     def residuals(self):
         """

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -353,7 +353,7 @@ class LinearRegressionSummary(JavaWrapper):
         """
         Returns Adjusted R^2, the adjusted coefficient of determination.
 
-        .. seealso:: `Wikipedia coefficient of determination \
+        .. seealso:: `Wikipedia coefficient of determination, Adjusted R^2 \
         <https://en.wikipedia.org/wiki/Coefficient_of_determination#Adjusted_R2>`_
 
         .. note:: This ignores instance weights (setting all to 1.0) from

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -1488,6 +1488,7 @@ class TrainingSummaryTest(SparkSessionTestCase):
         self.assertAlmostEqual(s.meanSquaredError, 0.0)
         self.assertAlmostEqual(s.rootMeanSquaredError, 0.0)
         self.assertAlmostEqual(s.r2, 1.0, 2)
+        self.assertAlmostEqual(s.r2adj, 1.0, 2)
         self.assertTrue(isinstance(s.residuals, DataFrame))
         self.assertEqual(s.numInstances, 2)
         self.assertEqual(s.degreesOfFreedom, 1)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding r2adj in LinearRegressionSummary for Python API.



## How was this patch tested?

Added unit tests to exercise the api calls for the summary classes in tests.py.