### PR TITLE
[SPARK-23694] The staging directory should under hive.exec.stagingdir…

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/SaveAsHiveFile.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/SaveAsHiveFile.scala
@@ -228,17 +228,19 @@ private[hive] trait SaveAsHiveFile extends DataWritingCommand {
     // SPARK-20594: This is a walk-around fix to resolve a Hive bug. Hive requires that the
     // staging directory needs to avoid being deleted when users set hive.exec.stagingdir
     // under the table directory.
-    if (FileUtils.isSubDir(new Path(stagingPathName), inputPath, fs) &&
+    val dir: Path = if (FileUtils.isSubDir(new Path(stagingPathName), inputPath, fs) &&
       !stagingPathName.stripPrefix(inputPathName).stripPrefix(File.separator).startsWith(".")) {
       logDebug(s"The staging dir '$stagingPathName' should be a child directory starts " +
         "with '.' to avoid being deleted if we set hive.exec.stagingdir under the table " +
         "directory.")
       stagingPathName = new Path(inputPathName, ".hive-staging").toString
-    }
-
-    val dir: Path =
       fs.makeQualified(
         new Path(stagingPathName + "_" + executionId + "-" + TaskRunner.getTaskRunnerID))
+    } else {
+      fs.makeQualified(
+        new Path(stagingPathName + "/" + executionId + "-" + TaskRunner.getTaskRunnerID))
+    }
+
     logDebug("Created staging dir = " + dir + " for path = " + inputPath)
     try {
       if (!FileUtils.mkdir(fs, dir, true, hadoopConf)) {


### PR DESCRIPTION
JIRA Issue: https://issues.apache.org/jira/browse/SPARK-23694

When we set hive.exec.stagingdir but not under the table directory, for example: /tmp/hive-staging, I think the staging directory should under /tmp/hive-staging, not under /tmp/ like /tmp/hive-staging_xxx
