### PR TITLE
[SPARK-23713][SQL] Cleanup UnsafeWriter and BufferHolder classes

### DIFF
--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaContinuousReader.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaContinuousReader.scala
@@ -27,13 +27,10 @@ import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
-import org.apache.spark.sql.catalyst.expressions.codegen.{BufferHolder, UnsafeRowWriter}
-import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.kafka010.KafkaSourceProvider.{INSTRUCTION_FOR_FAIL_ON_DATA_LOSS_FALSE, INSTRUCTION_FOR_FAIL_ON_DATA_LOSS_TRUE}
 import org.apache.spark.sql.sources.v2.reader._
 import org.apache.spark.sql.sources.v2.reader.streaming.{ContinuousDataReader, ContinuousReader, Offset, PartitionOffset}
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.unsafe.types.UTF8String
 
 /**
  * A [[ContinuousReader]] for data from kafka.

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaRecordToUnsafeRowConverter.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaRecordToUnsafeRowConverter.scala
@@ -20,18 +20,17 @@ package org.apache.spark.sql.kafka010
 import org.apache.kafka.clients.consumer.ConsumerRecord
 
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
-import org.apache.spark.sql.catalyst.expressions.codegen.{BufferHolder, UnsafeRowWriter}
+import org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.unsafe.types.UTF8String
 
 /** A simple class for converting Kafka ConsumerRecord to UnsafeRow */
 private[kafka010] class KafkaRecordToUnsafeRowConverter {
   private val sharedRow = new UnsafeRow(7)
-  private val bufferHolder = new BufferHolder(sharedRow)
-  private val rowWriter = new UnsafeRowWriter(bufferHolder, 7)
+  private val rowWriter = new UnsafeRowWriter(sharedRow)
 
   def toUnsafeRow(record: ConsumerRecord[Array[Byte], Array[Byte]]): UnsafeRow = {
-    bufferHolder.reset()
+    rowWriter.reset()
 
     if (record.key == null) {
       rowWriter.setNullAt(0)
@@ -46,7 +45,7 @@ private[kafka010] class KafkaRecordToUnsafeRowConverter {
       5,
       DateTimeUtils.fromJavaTimestamp(new java.sql.Timestamp(record.timestamp)))
     rowWriter.write(6, record.timestampType.id)
-    sharedRow.setTotalSize(bufferHolder.totalSize)
+    rowWriter.setTotalSize()
     sharedRow
   }
 }

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaRecordToUnsafeRowConverter.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaRecordToUnsafeRowConverter.scala
@@ -26,8 +26,7 @@ import org.apache.spark.unsafe.types.UTF8String
 
 /** A simple class for converting Kafka ConsumerRecord to UnsafeRow */
 private[kafka010] class KafkaRecordToUnsafeRowConverter {
-  private val sharedRow = new UnsafeRow(7)
-  private val rowWriter = new UnsafeRowWriter(sharedRow)
+  private val rowWriter = new UnsafeRowWriter(7)
 
   def toUnsafeRow(record: ConsumerRecord[Array[Byte], Array[Byte]]): UnsafeRow = {
     rowWriter.reset()
@@ -46,6 +45,6 @@ private[kafka010] class KafkaRecordToUnsafeRowConverter {
       DateTimeUtils.fromJavaTimestamp(new java.sql.Timestamp(record.timestamp)))
     rowWriter.write(6, record.timestampType.id)
     rowWriter.setTotalSize()
-    sharedRow
+    rowWriter.getRow()
   }
 }

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaRecordToUnsafeRowConverter.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaRecordToUnsafeRowConverter.scala
@@ -44,7 +44,6 @@ private[kafka010] class KafkaRecordToUnsafeRowConverter {
       5,
       DateTimeUtils.fromJavaTimestamp(new java.sql.Timestamp(record.timestamp)))
     rowWriter.write(6, record.timestampType.id)
-    rowWriter.setTotalSize()
     rowWriter.getRow()
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
@@ -30,10 +30,6 @@ import org.apache.spark.unsafe.array.ByteArrayMethods;
  * this class per writing program, so that the memory segment/data buffer can be reused.  Note that
  * for each incoming record, we should call `reset` of BufferHolder instance before write the record
  * and reuse the data buffer.
- *
- * Generally we should call `UnsafeRowWriter.setTotalSize` using `BufferHolder.totalSize` to update
- * the size of the result row, after writing a record to the buffer. However, we can skip this step
- * if the fields of row are all fixed-length, as the size of result row is also fixed.
  */
 final class BufferHolder {
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
@@ -102,8 +102,7 @@ final class BufferHolder {
 
   int pushCursor() {
     if (cursorStack.length <= cursorStackIndex) {
-      int newSize = (cursorStack.length * 3 + 1) / 2;
-      int[] tmp = new int[newSize];
+      int[] tmp = new int[(cursorStack.length * 3 + 1) / 2];
       System.arraycopy(cursorStack, 0, tmp, 0, cursorStack.length);
       cursorStack = tmp;
     }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
@@ -35,7 +35,7 @@ import org.apache.spark.unsafe.array.ByteArrayMethods;
  * the size of the result row, after writing a record to the buffer. However, we can skip this step
  * if the fields of row are all fixed-length, as the size of result row is also fixed.
  */
-public final class BufferHolder {
+final class BufferHolder {
 
   private static final int ARRAY_MAX = ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH;
 
@@ -86,11 +86,17 @@ public final class BufferHolder {
     }
   }
 
-  byte[] buffer() { return buffer; }
+  byte[] buffer() {
+    return buffer;
+  }
 
-  int getCursor() { return cursor; }
+  int getCursor() {
+    return cursor;
+  }
 
-  void addCursor(int val) { cursor += val; }
+  void incrementCursor(int val) {
+    cursor += val;
+  }
 
   void reset() {
     cursor = Platform.BYTE_ARRAY_OFFSET + fixedSize;

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
@@ -43,8 +43,6 @@ final class BufferHolder {
   private int cursor = Platform.BYTE_ARRAY_OFFSET;
   private final UnsafeRow row;
   private final int fixedSize;
-  private int[] cursorStack = new int[1];
-  private int cursorStackIndex = 0;
 
   BufferHolder(UnsafeRow row) {
     this(row, 64);
@@ -98,21 +96,6 @@ final class BufferHolder {
 
   void incrementCursor(int val) {
     cursor += val;
-  }
-
-  int pushCursor() {
-    if (cursorStack.length <= cursorStackIndex) {
-      int[] tmp = new int[(cursorStack.length * 3 + 1) / 2];
-      System.arraycopy(cursorStack, 0, tmp, 0, cursorStack.length);
-      cursorStack = tmp;
-    }
-    int cur = getCursor();
-    cursorStack[cursorStackIndex++] = cur;
-    return cursor;
-  }
-
-  int popCursor() {
-    return cursorStack[--cursorStackIndex];
   }
 
   void reset() {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
@@ -90,7 +90,7 @@ final class BufferHolder {
     return cursor;
   }
 
-  void incrementCursor(int val) {
+  void increaseCursor(int val) {
     cursor += val;
   }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
@@ -43,6 +43,8 @@ final class BufferHolder {
   private int cursor = Platform.BYTE_ARRAY_OFFSET;
   private final UnsafeRow row;
   private final int fixedSize;
+  private int[] cursorStack = new int[1];
+  private int cursorStackIndex = 0;
 
   BufferHolder(UnsafeRow row) {
     this(row, 64);
@@ -96,6 +98,22 @@ final class BufferHolder {
 
   void incrementCursor(int val) {
     cursor += val;
+  }
+
+  int pushCursor() {
+    if (cursorStack.length <= cursorStackIndex) {
+      int newSize = (cursorStack.length * 3 + 1) / 2;
+      int[] tmp = new int[newSize];
+      System.arraycopy(cursorStack, 0, tmp, 0, cursorStack.length);
+      cursorStack = tmp;
+    }
+    int cur = getCursor();
+    cursorStack[cursorStackIndex++] = cur;
+    return cursor;
+  }
+
+  int popCursor() {
+    return cursorStack[--cursorStackIndex];
   }
 
   void reset() {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
@@ -82,7 +82,7 @@ final class BufferHolder {
     }
   }
 
-  byte[] buffer() {
+  byte[] getBuffer() {
     return buffer;
   }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
@@ -31,24 +31,24 @@ import org.apache.spark.unsafe.array.ByteArrayMethods;
  * for each incoming record, we should call `reset` of BufferHolder instance before write the record
  * and reuse the data buffer.
  *
- * Generally we should call `UnsafeRow.setTotalSize` and pass in `BufferHolder.totalSize` to update
+ * Generally we should call `UnsafeRowWriter.setTotalSize` using `BufferHolder.totalSize` to update
  * the size of the result row, after writing a record to the buffer. However, we can skip this step
  * if the fields of row are all fixed-length, as the size of result row is also fixed.
  */
-public class BufferHolder {
+public final class BufferHolder {
 
   private static final int ARRAY_MAX = ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH;
 
-  public byte[] buffer;
-  public int cursor = Platform.BYTE_ARRAY_OFFSET;
+  private byte[] buffer;
+  private int cursor = Platform.BYTE_ARRAY_OFFSET;
   private final UnsafeRow row;
   private final int fixedSize;
 
-  public BufferHolder(UnsafeRow row) {
+  BufferHolder(UnsafeRow row) {
     this(row, 64);
   }
 
-  public BufferHolder(UnsafeRow row, int initialSize) {
+  BufferHolder(UnsafeRow row, int initialSize) {
     int bitsetWidthInBytes = UnsafeRow.calculateBitSetWidthInBytes(row.numFields());
     if (row.numFields() > (ARRAY_MAX - initialSize - bitsetWidthInBytes) / 8) {
       throw new UnsupportedOperationException(
@@ -64,7 +64,7 @@ public class BufferHolder {
   /**
    * Grows the buffer by at least neededSize and points the row to the buffer.
    */
-  public void grow(int neededSize) {
+  void grow(int neededSize) {
     if (neededSize > ARRAY_MAX - totalSize()) {
       throw new UnsupportedOperationException(
         "Cannot grow BufferHolder by size " + neededSize + " because the size after growing " +
@@ -86,11 +86,17 @@ public class BufferHolder {
     }
   }
 
-  public void reset() {
+  byte[] buffer() { return buffer; }
+
+  int getCursor() { return cursor; }
+
+  void addCursor(int val) { cursor += val; }
+
+  void reset() {
     cursor = Platform.BYTE_ARRAY_OFFSET + fixedSize;
   }
 
-  public int totalSize() {
+  int totalSize() {
     return cursor - Platform.BYTE_ARRAY_OFFSET;
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
@@ -70,17 +70,11 @@ public final class UnsafeArrayWriter extends UnsafeWriter {
     for (int i = elementSize * numElements; i < fixedPartInBytes; i++) {
       Platform.putByte(buffer(), startingOffset + headerInBytes + i, (byte) 0);
     }
-    incrementCursor(headerInBytes + fixedPartInBytes);
+    increaseCursor(headerInBytes + fixedPartInBytes);
   }
 
   private long getElementOffset(int ordinal) {
     return startingOffset + headerInBytes + ordinal * elementSize;
-  }
-
-  @Override
-  public void setOffsetAndSizeFromPreviousCursor(int ordinal, int mark) {
-    assertIndexIsValid(ordinal);
-    _setOffsetAndSizeFromPreviousCursor(ordinal, mark);
   }
 
   private void setNullBit(int ordinal) {
@@ -170,7 +164,7 @@ public final class UnsafeArrayWriter extends UnsafeWriter {
         setOffsetAndSize(ordinal, numBytes);
 
         // move the cursor forward with 8-bytes boundary
-        incrementCursor(roundedSize);
+        increaseCursor(roundedSize);
       }
     } else {
       setNull(ordinal);

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
@@ -33,6 +33,9 @@ public final class UnsafeArrayWriter extends UnsafeWriter {
   // The number of elements in this array
   private int numElements;
 
+  // The element size in this array
+  private int elementSize;
+
   private int headerInBytes;
 
   private void assertIndexIsValid(int index) {
@@ -40,11 +43,12 @@ public final class UnsafeArrayWriter extends UnsafeWriter {
     assert index < numElements : "index (" + index + ") should < " + numElements;
   }
 
-  public UnsafeArrayWriter(UnsafeWriter writer) {
+  public UnsafeArrayWriter(UnsafeWriter writer, int elementSize) {
     super(writer.getBufferHolder());
+    this.elementSize = elementSize;
   }
 
-  public void initialize(int numElements, int elementSize) {
+  public void initialize(int numElements) {
     // We need 8 bytes to store numElements in header
     this.numElements = numElements;
     this.headerInBytes = calculateHeaderPortionInBytes(numElements);
@@ -66,7 +70,7 @@ public final class UnsafeArrayWriter extends UnsafeWriter {
     for (int i = elementSize * numElements; i < fixedPartInBytes; i++) {
       Platform.putByte(buffer(), startingOffset + headerInBytes + i, (byte) 0);
     }
-    addCursor(headerInBytes + fixedPartInBytes);
+    incrementCursor(headerInBytes + fixedPartInBytes);
   }
 
   protected long getOffset(int ordinal, int elementSize) {
@@ -116,37 +120,37 @@ public final class UnsafeArrayWriter extends UnsafeWriter {
 
   public void write(int ordinal, boolean value) {
     assertIndexIsValid(ordinal);
-    _write(getElementOffset(ordinal, 1), value);
+    writeBoolean(getElementOffset(ordinal, 1), value);
   }
 
   public void write(int ordinal, byte value) {
     assertIndexIsValid(ordinal);
-    _write(getElementOffset(ordinal, 1), value);
+    writeByte(getElementOffset(ordinal, 1), value);
   }
 
   public void write(int ordinal, short value) {
     assertIndexIsValid(ordinal);
-    _write(getElementOffset(ordinal, 2), value);
+    writeShort(getElementOffset(ordinal, 2), value);
   }
 
   public void write(int ordinal, int value) {
     assertIndexIsValid(ordinal);
-    _write(getElementOffset(ordinal, 4), value);
+    writeInt(getElementOffset(ordinal, 4), value);
   }
 
   public void write(int ordinal, long value) {
     assertIndexIsValid(ordinal);
-    _write(getElementOffset(ordinal, 8), value);
+    writeLong(getElementOffset(ordinal, 8), value);
   }
 
   public void write(int ordinal, float value) {
     assertIndexIsValid(ordinal);
-    _write(getElementOffset(ordinal, 4), value);
+    writeFloat(getElementOffset(ordinal, 4), value);
   }
 
   public void write(int ordinal, double value) {
     assertIndexIsValid(ordinal);
-    _write(getElementOffset(ordinal, 8), value);
+    writeDouble(getElementOffset(ordinal, 8), value);
   }
 
   public void write(int ordinal, Decimal input, int precision, int scale) {
@@ -170,7 +174,7 @@ public final class UnsafeArrayWriter extends UnsafeWriter {
         setOffsetAndSize(ordinal, numBytes);
 
         // move the cursor forward with 8-bytes boundary
-        addCursor(roundedSize);
+        incrementCursor(roundedSize);
       }
     } else {
       setNull(ordinal);

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
@@ -61,14 +61,14 @@ public final class UnsafeArrayWriter extends UnsafeWriter {
     holder.grow(headerInBytes + fixedPartInBytes);
 
     // Write numElements and clear out null bits to header
-    Platform.putLong(buffer(), startingOffset, numElements);
+    Platform.putLong(getBuffer(), startingOffset, numElements);
     for (int i = 8; i < headerInBytes; i += 8) {
-      Platform.putLong(buffer(), startingOffset + i, 0L);
+      Platform.putLong(getBuffer(), startingOffset + i, 0L);
     }
 
     // fill 0 into reminder part of 8-bytes alignment in unsafe array
     for (int i = elementSize * numElements; i < fixedPartInBytes; i++) {
-      Platform.putByte(buffer(), startingOffset + headerInBytes + i, (byte) 0);
+      Platform.putByte(getBuffer(), startingOffset + headerInBytes + i, (byte) 0);
     }
     increaseCursor(headerInBytes + fixedPartInBytes);
   }
@@ -79,31 +79,31 @@ public final class UnsafeArrayWriter extends UnsafeWriter {
 
   private void setNullBit(int ordinal) {
     assertIndexIsValid(ordinal);
-    BitSetMethods.set(buffer(), startingOffset + 8, ordinal);
+    BitSetMethods.set(getBuffer(), startingOffset + 8, ordinal);
   }
 
   public void setNull1Bytes(int ordinal) {
     setNullBit(ordinal);
     // put zero into the corresponding field when set null
-    Platform.putByte(buffer(), getElementOffset(ordinal), (byte)0);
+    writeByte(getElementOffset(ordinal), (byte)0);
   }
 
   public void setNull2Bytes(int ordinal) {
     setNullBit(ordinal);
     // put zero into the corresponding field when set null
-    Platform.putShort(buffer(), getElementOffset(ordinal), (short)0);
+    writeShort(getElementOffset(ordinal), (short)0);
   }
 
   public void setNull4Bytes(int ordinal) {
     setNullBit(ordinal);
     // put zero into the corresponding field when set null
-    Platform.putInt(buffer(), getElementOffset(ordinal), 0);
+    writeInt(getElementOffset(ordinal), 0);
   }
 
   public void setNull8Bytes(int ordinal) {
     setNullBit(ordinal);
     // put zero into the corresponding field when set null
-    Platform.putLong(buffer(), getElementOffset(ordinal), (long)0);
+    writeLong(getElementOffset(ordinal), 0);
   }
 
   public void setNull(int ordinal) { setNull8Bytes(ordinal); }
@@ -160,7 +160,7 @@ public final class UnsafeArrayWriter extends UnsafeWriter {
 
         // Write the bytes to the variable length portion.
         Platform.copyMemory(
-          bytes, Platform.BYTE_ARRAY_OFFSET, buffer(), cursor(), numBytes);
+          bytes, Platform.BYTE_ARRAY_OFFSET, getBuffer(), cursor(), numBytes);
         setOffsetAndSize(ordinal, numBytes);
 
         // move the cursor forward with 8-bytes boundary

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
@@ -73,18 +73,14 @@ public final class UnsafeArrayWriter extends UnsafeWriter {
     incrementCursor(headerInBytes + fixedPartInBytes);
   }
 
-  protected long getOffset(int ordinal, int elementSize) {
-    return getElementOffset(ordinal, elementSize);
-  }
-
-  private long getElementOffset(int ordinal, int elementSize) {
+  private long getElementOffset(int ordinal) {
     return startingOffset + headerInBytes + ordinal * elementSize;
   }
 
   @Override
-  public void setOffsetAndSizeFromMark(int ordinal, int mark) {
+  public void setOffsetAndSizeFromPreviousCursor(int ordinal, int mark) {
     assertIndexIsValid(ordinal);
-    _setOffsetAndSizeFromMark(ordinal, mark);
+    _setOffsetAndSizeFromPreviousCursor(ordinal, mark);
   }
 
   private void setNullBit(int ordinal) {
@@ -95,62 +91,62 @@ public final class UnsafeArrayWriter extends UnsafeWriter {
   public void setNull1Bytes(int ordinal) {
     setNullBit(ordinal);
     // put zero into the corresponding field when set null
-    Platform.putByte(buffer(), getElementOffset(ordinal, 1), (byte)0);
+    Platform.putByte(buffer(), getElementOffset(ordinal), (byte)0);
   }
 
   public void setNull2Bytes(int ordinal) {
     setNullBit(ordinal);
     // put zero into the corresponding field when set null
-    Platform.putShort(buffer(), getElementOffset(ordinal, 2), (short)0);
+    Platform.putShort(buffer(), getElementOffset(ordinal), (short)0);
   }
 
   public void setNull4Bytes(int ordinal) {
     setNullBit(ordinal);
     // put zero into the corresponding field when set null
-    Platform.putInt(buffer(), getElementOffset(ordinal, 4), 0);
+    Platform.putInt(buffer(), getElementOffset(ordinal), 0);
   }
 
   public void setNull8Bytes(int ordinal) {
     setNullBit(ordinal);
     // put zero into the corresponding field when set null
-    Platform.putLong(buffer(), getElementOffset(ordinal, 8), (long)0);
+    Platform.putLong(buffer(), getElementOffset(ordinal), (long)0);
   }
 
   public void setNull(int ordinal) { setNull8Bytes(ordinal); }
 
   public void write(int ordinal, boolean value) {
     assertIndexIsValid(ordinal);
-    writeBoolean(getElementOffset(ordinal, 1), value);
+    writeBoolean(getElementOffset(ordinal), value);
   }
 
   public void write(int ordinal, byte value) {
     assertIndexIsValid(ordinal);
-    writeByte(getElementOffset(ordinal, 1), value);
+    writeByte(getElementOffset(ordinal), value);
   }
 
   public void write(int ordinal, short value) {
     assertIndexIsValid(ordinal);
-    writeShort(getElementOffset(ordinal, 2), value);
+    writeShort(getElementOffset(ordinal), value);
   }
 
   public void write(int ordinal, int value) {
     assertIndexIsValid(ordinal);
-    writeInt(getElementOffset(ordinal, 4), value);
+    writeInt(getElementOffset(ordinal), value);
   }
 
   public void write(int ordinal, long value) {
     assertIndexIsValid(ordinal);
-    writeLong(getElementOffset(ordinal, 8), value);
+    writeLong(getElementOffset(ordinal), value);
   }
 
   public void write(int ordinal, float value) {
     assertIndexIsValid(ordinal);
-    writeFloat(getElementOffset(ordinal, 4), value);
+    writeFloat(getElementOffset(ordinal), value);
   }
 
   public void write(int ordinal, double value) {
     assertIndexIsValid(ordinal);
-    writeDouble(getElementOffset(ordinal, 8), value);
+    writeDouble(getElementOffset(ordinal), value);
   }
 
   public void write(int ordinal, Decimal input, int precision, int scale) {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
@@ -82,9 +82,9 @@ public final class UnsafeArrayWriter extends UnsafeWriter {
   }
 
   @Override
-  public void setOffsetAndSize(int ordinal, int currentCursor, int size) {
+  public void setOffsetAndSizeFromMark(int ordinal) {
     assertIndexIsValid(ordinal);
-    _setOffsetAndSize(ordinal, currentCursor, size);
+    _setOffsetAndSizeFromMark(ordinal);
   }
 
   private void setNullBit(int ordinal) {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
@@ -82,9 +82,9 @@ public final class UnsafeArrayWriter extends UnsafeWriter {
   }
 
   @Override
-  public void setOffsetAndSizeFromMark(int ordinal) {
+  public void setOffsetAndSizeFromMark(int ordinal, int mark) {
     assertIndexIsValid(ordinal);
-    _setOffsetAndSizeFromMark(ordinal);
+    _setOffsetAndSizeFromMark(ordinal, mark);
   }
 
   private void setNullBit(int ordinal) {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeRowWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeRowWriter.java
@@ -28,7 +28,7 @@ import org.apache.spark.unsafe.bitset.BitSetMethods;
  * It will remember the offset of row buffer which it starts to write, and move the cursor of row
  * buffer while writing.  If new data(can be the input record if this is the outermost writer, or
  * nested struct if this is an inner writer) comes, the starting cursor of row buffer may be
- * changed, so we need to call `UnsafeRowWriter.reset` before writing, to update the
+ * changed, so we need to call `UnsafeRowWriter.resetRowWriter` before writing, to update the
  * `startingOffset` and clear out null bits.
  *
  * Note that if this is the outermost writer, which means we will always write from the very

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeRowWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeRowWriter.java
@@ -34,10 +34,6 @@ import org.apache.spark.unsafe.bitset.BitSetMethods;
  * Note that if this is the outermost writer, which means we will always write from the very
  * beginning of the global row buffer, we don't need to update `startingOffset` and can just call
  * `zeroOutNullBytes` before writing new data.
- *
- * Generally we should call `UnsafeRowWriter.setTotalSize` to update the size of the result row,
- * after writing a record to the buffer. However, we can skip this step if the fields of row are
- * all fixed-length, as the size of result row is also fixed.
  */
 public final class UnsafeRowWriter extends UnsafeWriter {
 
@@ -74,12 +70,13 @@ public final class UnsafeRowWriter extends UnsafeWriter {
     this.startingOffset = cursor();
   }
 
+  /**
+   * Updates total size of the UnsafeRow using the size collected by BufferHolder, and returns
+   * the UnsafeRow created at a constructor
+   */
   public UnsafeRow getRow() {
-    return row;
-  }
-
-  public void setTotalSize() {
     row.setTotalSize(totalSize());
+    return row;
   }
 
   /**

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeRowWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeRowWriter.java
@@ -131,8 +131,8 @@ public final class UnsafeRowWriter extends UnsafeWriter {
   }
 
   @Override
-  protected final long getOffset(int oridinal, int elementSize) {
-    return getFieldOffset(oridinal);
+  protected final long getOffset(int ordinal, int elementSize) {
+    return getFieldOffset(ordinal);
   }
 
   public long getFieldOffset(int ordinal) {
@@ -140,8 +140,8 @@ public final class UnsafeRowWriter extends UnsafeWriter {
   }
 
   @Override
-  public void setOffsetAndSize(int ordinal, int currentCursor, int size) {
-    _setOffsetAndSize(ordinal, currentCursor, size);
+  public void setOffsetAndSizeFromMark(int ordinal) {
+    _setOffsetAndSizeFromMark(ordinal);
   }
 
   public void write(int ordinal, boolean value) {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeRowWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeRowWriter.java
@@ -140,8 +140,8 @@ public final class UnsafeRowWriter extends UnsafeWriter {
   }
 
   @Override
-  public void setOffsetAndSizeFromMark(int ordinal) {
-    _setOffsetAndSizeFromMark(ordinal);
+  public void setOffsetAndSizeFromMark(int ordinal, int mark) {
+    _setOffsetAndSizeFromMark(ordinal, mark);
   }
 
   public void write(int ordinal, boolean value) {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeRowWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeRowWriter.java
@@ -91,7 +91,7 @@ public final class UnsafeRowWriter extends UnsafeWriter {
 
     // grow the global buffer to make sure it has enough space to write fixed-length data.
     grow(fixedSize);
-    incrementCursor(fixedSize);
+    increaseCursor(fixedSize);
 
     zeroOutNullBytes();
   }
@@ -136,11 +136,6 @@ public final class UnsafeRowWriter extends UnsafeWriter {
 
   public long getFieldOffset(int ordinal) {
     return startingOffset + nullBitsSize + 8 * ordinal;
-  }
-
-  @Override
-  public void setOffsetAndSizeFromPreviousCursor(int ordinal, int previousCursor) {
-    _setOffsetAndSizeFromPreviousCursor(ordinal, previousCursor);
   }
 
   public void write(int ordinal, boolean value) {
@@ -217,7 +212,7 @@ public final class UnsafeRowWriter extends UnsafeWriter {
       }
 
       // move the cursor forward.
-      incrementCursor(16);
+      increaseCursor(16);
     }
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeRowWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeRowWriter.java
@@ -42,16 +42,24 @@ public final class UnsafeRowWriter extends UnsafeWriter {
   private final int nullBitsSize;
   private final int fixedSize;
 
-  public UnsafeRowWriter(UnsafeRow row, int initialBufferSize) {
-    this(row, new BufferHolder(row, initialBufferSize), row.numFields());
+  public UnsafeRowWriter(int numFields) {
+    this(new UnsafeRow(numFields));
   }
 
-  public UnsafeRowWriter(UnsafeRow row) {
-    this(row, new BufferHolder(row), row.numFields());
+  public UnsafeRowWriter(int numFields, int initialBufferSize) {
+    this(new UnsafeRow(numFields), initialBufferSize);
   }
 
   public UnsafeRowWriter(UnsafeWriter writer, int numFields) {
     this(null, writer.getBufferHolder(), numFields);
+  }
+
+  private UnsafeRowWriter(UnsafeRow row) {
+    this(row, new BufferHolder(row), row.numFields());
+  }
+
+  private UnsafeRowWriter(UnsafeRow row, int initialBufferSize) {
+    this(row, new BufferHolder(row, initialBufferSize), row.numFields());
   }
 
   private UnsafeRowWriter(UnsafeRow row, BufferHolder holder, int numFields) {
@@ -60,6 +68,10 @@ public final class UnsafeRowWriter extends UnsafeWriter {
     this.nullBitsSize = UnsafeRow.calculateBitSetWidthInBytes(numFields);
     this.fixedSize = nullBitsSize + 8 * numFields;
     this.startingOffset = cursor();
+  }
+
+  public UnsafeRow getRow() {
+    return row;
   }
 
   public void setTotalSize() {
@@ -75,7 +87,7 @@ public final class UnsafeRowWriter extends UnsafeWriter {
 
     // grow the global buffer to make sure it has enough space to write fixed-length data.
     grow(fixedSize);
-    addCursor(fixedSize);
+    incrementCursor(fixedSize);
 
     zeroOutNullBytes();
   }
@@ -135,39 +147,39 @@ public final class UnsafeRowWriter extends UnsafeWriter {
   public void write(int ordinal, boolean value) {
     final long offset = getFieldOffset(ordinal);
     Platform.putLong(buffer(), offset, 0L);
-    _write(offset, value);
+    writeBoolean(offset, value);
   }
 
   public void write(int ordinal, byte value) {
     final long offset = getFieldOffset(ordinal);
     Platform.putLong(buffer(), offset, 0L);
-    _write(offset, value);
+    writeByte(offset, value);
   }
 
   public void write(int ordinal, short value) {
     final long offset = getFieldOffset(ordinal);
     Platform.putLong(buffer(), offset, 0L);
-    _write(offset, value);
+    writeShort(offset, value);
   }
 
   public void write(int ordinal, int value) {
     final long offset = getFieldOffset(ordinal);
     Platform.putLong(buffer(), offset, 0L);
-    _write(offset, value);
+    writeInt(offset, value);
   }
 
   public void write(int ordinal, long value) {
-    _write(getFieldOffset(ordinal), value);
+    writeLong(getFieldOffset(ordinal), value);
   }
 
   public void write(int ordinal, float value) {
     final long offset = getFieldOffset(ordinal);
     Platform.putLong(buffer(), offset, 0L);
-    _write(offset, value);
+    writeFloat(offset, value);
   }
 
   public void write(int ordinal, double value) {
-    _write(getFieldOffset(ordinal), value);
+    writeDouble(getFieldOffset(ordinal), value);
   }
 
   public void write(int ordinal, Decimal input, int precision, int scale) {
@@ -206,7 +218,7 @@ public final class UnsafeRowWriter extends UnsafeWriter {
       }
 
       // move the cursor forward.
-      addCursor(16);
+      incrementCursor(16);
     }
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeWriter.java
@@ -17,6 +17,8 @@
 package org.apache.spark.sql.catalyst.expressions.codegen;
 
 import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.unsafe.Platform;
+import org.apache.spark.unsafe.array.ByteArrayMethods;
 import org.apache.spark.unsafe.types.CalendarInterval;
 import org.apache.spark.unsafe.types.UTF8String;
 
@@ -24,10 +26,62 @@ import org.apache.spark.unsafe.types.UTF8String;
  * Base class for writing Unsafe* structures.
  */
 public abstract class UnsafeWriter {
+  // Keep internal buffer holder
+  protected final BufferHolder holder;
+
+  // The offset of the global buffer where we start to write this structure.
+  protected int startingOffset;
+
+  protected UnsafeWriter(BufferHolder holder) {
+    this.holder = holder;
+  }
+
+  /**
+   * Accessor methods are delegated from BufferHolder class
+   */
+  public final BufferHolder getBufferHolder() {
+    return holder;
+  }
+
+  public final byte[] buffer() { return holder.buffer(); }
+
+  public final void reset() { holder.reset(); }
+
+  public final int totalSize() { return holder.totalSize(); }
+
+  public final void grow(int neededSize) { holder.grow(neededSize); }
+
+  public final int cursor() { return holder.getCursor(); }
+
+  public final void addCursor(int val) { holder.addCursor(val); }
+
+
+  public abstract void setOffsetAndSize(int ordinal, int currentCursor, int size);
+
+  protected void setOffsetAndSize(int ordinal, int size) {
+    setOffsetAndSize(ordinal, cursor(), size);
+  }
+
+  protected void _setOffsetAndSize(int ordinal, int currentCursor, int size) {
+    final long relativeOffset = currentCursor - startingOffset;
+    final long offsetAndSize = (relativeOffset << 32) | (long)size;
+
+    write(ordinal, offsetAndSize);
+  }
+
+  protected final void zeroOutPaddingBytes(int numBytes) {
+    if ((numBytes & 0x07) > 0) {
+      Platform.putLong(buffer(), cursor() + ((numBytes >> 3) << 3), 0L);
+    }
+  }
+
+  protected abstract long getOffset(int ordinal, int elementSize);
+
   public abstract void setNull1Bytes(int ordinal);
   public abstract void setNull2Bytes(int ordinal);
   public abstract void setNull4Bytes(int ordinal);
   public abstract void setNull8Bytes(int ordinal);
+
   public abstract void write(int ordinal, boolean value);
   public abstract void write(int ordinal, byte value);
   public abstract void write(int ordinal, short value);
@@ -36,8 +90,92 @@ public abstract class UnsafeWriter {
   public abstract void write(int ordinal, float value);
   public abstract void write(int ordinal, double value);
   public abstract void write(int ordinal, Decimal input, int precision, int scale);
-  public abstract void write(int ordinal, UTF8String input);
-  public abstract void write(int ordinal, byte[] input);
-  public abstract void write(int ordinal, CalendarInterval input);
-  public abstract void setOffsetAndSize(int ordinal, int currentCursor, int size);
+
+  public final void write(int ordinal, UTF8String input) {
+    final int numBytes = input.numBytes();
+    final int roundedSize = ByteArrayMethods.roundNumberOfBytesToNearestWord(numBytes);
+
+    // grow the global buffer before writing data.
+    grow(roundedSize);
+
+    zeroOutPaddingBytes(numBytes);
+
+    // Write the bytes to the variable length portion.
+    input.writeToMemory(buffer(), cursor());
+
+    setOffsetAndSize(ordinal, numBytes);
+
+    // move the cursor forward.
+    addCursor(roundedSize);
+  }
+
+  public final void write(int ordinal, byte[] input) {
+    write(ordinal, input, 0, input.length);
+  }
+
+  public final void write(int ordinal, byte[] input, int offset, int numBytes) {
+    final int roundedSize = ByteArrayMethods.roundNumberOfBytesToNearestWord(input.length);
+
+    // grow the global buffer before writing data.
+    grow(roundedSize);
+
+    zeroOutPaddingBytes(numBytes);
+
+    // Write the bytes to the variable length portion.
+    Platform.copyMemory(
+      input, Platform.BYTE_ARRAY_OFFSET + offset, buffer(), cursor(), numBytes);
+
+    setOffsetAndSize(ordinal, numBytes);
+
+    // move the cursor forward.
+    addCursor(roundedSize);
+  }
+
+  public final void write(int ordinal, CalendarInterval input) {
+    // grow the global buffer before writing data.
+    grow(16);
+
+    // Write the months and microseconds fields of Interval to the variable length portion.
+    Platform.putLong(buffer(), cursor(), input.months);
+    Platform.putLong(buffer(), cursor() + 8, input.microseconds);
+
+    setOffsetAndSize(ordinal, 16);
+
+    // move the cursor forward.
+    addCursor(16);
+  }
+
+  protected final void _write(long offset, boolean value) {
+    Platform.putBoolean(buffer(), offset, value);
+  }
+
+  protected final void _write(long offset, byte value) {
+    Platform.putByte(buffer(), offset, value);
+  }
+
+  protected final void _write(long offset, short value) {
+    Platform.putShort(buffer(), offset, value);
+  }
+
+  protected final void _write(long offset, int value) {
+    Platform.putInt(buffer(), offset, value);
+  }
+
+  protected final void _write(long offset, long value) {
+    Platform.putLong(buffer(), offset, value);
+  }
+
+  protected final void _write(long offset, float value) {
+    if (Float.isNaN(value)) {
+      value = Float.NaN;
+    }
+    Platform.putFloat(buffer(), offset, value);
+  }
+
+  protected final void _write(long offset, double value) {
+    if (Double.isNaN(value)) {
+      value = Double.NaN;
+    }
+    Platform.putDouble(buffer(), offset, value);
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeWriter.java
@@ -67,10 +67,10 @@ public abstract class UnsafeWriter {
     holder.incrementCursor(val);
   }
 
-  public abstract void setOffsetAndSizeFromMark(int ordinal, int mark);
+  public abstract void setOffsetAndSizeFromPreviousCursor(int ordinal, int previousCursor);
 
-  protected void _setOffsetAndSizeFromMark(int ordinal, int mark) {
-    setOffsetAndSize(ordinal, mark, cursor() - mark);
+  protected void _setOffsetAndSizeFromPreviousCursor(int ordinal, int previousCursor) {
+    setOffsetAndSize(ordinal, previousCursor, cursor() - previousCursor);
   }
 
   protected void setOffsetAndSize(int ordinal, int size) {
@@ -89,8 +89,6 @@ public abstract class UnsafeWriter {
       Platform.putLong(buffer(), cursor() + ((numBytes >> 3) << 3), 0L);
     }
   }
-
-  protected abstract long getOffset(int ordinal, int elementSize);
 
   public abstract void setNull1Bytes(int ordinal);
   public abstract void setNull2Bytes(int ordinal);

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeWriter.java
@@ -43,18 +43,29 @@ public abstract class UnsafeWriter {
     return holder;
   }
 
-  public final byte[] buffer() { return holder.buffer(); }
+  public final byte[] buffer() {
+    return holder.buffer();
+  }
 
-  public final void reset() { holder.reset(); }
+  public final void reset() {
+    holder.reset();
+  }
 
-  public final int totalSize() { return holder.totalSize(); }
+  public final int totalSize() {
+    return holder.totalSize();
+  }
 
-  public final void grow(int neededSize) { holder.grow(neededSize); }
+  public final void grow(int neededSize) {
+    holder.grow(neededSize);
+  }
 
-  public final int cursor() { return holder.getCursor(); }
+  public final int cursor() {
+    return holder.getCursor();
+  }
 
-  public final void addCursor(int val) { holder.addCursor(val); }
-
+  public final void incrementCursor(int val) {
+    holder.incrementCursor(val);
+  }
 
   public abstract void setOffsetAndSize(int ordinal, int currentCursor, int size);
 
@@ -106,7 +117,7 @@ public abstract class UnsafeWriter {
     setOffsetAndSize(ordinal, numBytes);
 
     // move the cursor forward.
-    addCursor(roundedSize);
+    incrementCursor(roundedSize);
   }
 
   public final void write(int ordinal, byte[] input) {
@@ -128,7 +139,7 @@ public abstract class UnsafeWriter {
     setOffsetAndSize(ordinal, numBytes);
 
     // move the cursor forward.
-    addCursor(roundedSize);
+    incrementCursor(roundedSize);
   }
 
   public final void write(int ordinal, CalendarInterval input) {
@@ -142,37 +153,37 @@ public abstract class UnsafeWriter {
     setOffsetAndSize(ordinal, 16);
 
     // move the cursor forward.
-    addCursor(16);
+    incrementCursor(16);
   }
 
-  protected final void _write(long offset, boolean value) {
+  protected final void writeBoolean(long offset, boolean value) {
     Platform.putBoolean(buffer(), offset, value);
   }
 
-  protected final void _write(long offset, byte value) {
+  protected final void writeByte(long offset, byte value) {
     Platform.putByte(buffer(), offset, value);
   }
 
-  protected final void _write(long offset, short value) {
+  protected final void writeShort(long offset, short value) {
     Platform.putShort(buffer(), offset, value);
   }
 
-  protected final void _write(long offset, int value) {
+  protected final void writeInt(long offset, int value) {
     Platform.putInt(buffer(), offset, value);
   }
 
-  protected final void _write(long offset, long value) {
+  protected final void writeLong(long offset, long value) {
     Platform.putLong(buffer(), offset, value);
   }
 
-  protected final void _write(long offset, float value) {
+  protected final void writeFloat(long offset, float value) {
     if (Float.isNaN(value)) {
       value = Float.NaN;
     }
     Platform.putFloat(buffer(), offset, value);
   }
 
-  protected final void _write(long offset, double value) {
+  protected final void writeDouble(long offset, double value) {
     if (Double.isNaN(value)) {
       value = Double.NaN;
     }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeWriter.java
@@ -67,13 +67,22 @@ public abstract class UnsafeWriter {
     holder.incrementCursor(val);
   }
 
-  public abstract void setOffsetAndSize(int ordinal, int currentCursor, int size);
+  public final int markCursor() {
+    return holder.pushCursor();
+  }
+
+  public abstract void setOffsetAndSizeFromMark(int ordinal);
+
+  protected void _setOffsetAndSizeFromMark(int ordinal) {
+    int mark = holder.popCursor();
+    setOffsetAndSize(ordinal, mark, cursor() - mark);
+  }
 
   protected void setOffsetAndSize(int ordinal, int size) {
     setOffsetAndSize(ordinal, cursor(), size);
   }
 
-  protected void _setOffsetAndSize(int ordinal, int currentCursor, int size) {
+  protected void setOffsetAndSize(int ordinal, int currentCursor, int size) {
     final long relativeOffset = currentCursor - startingOffset;
     final long offsetAndSize = (relativeOffset << 32) | (long)size;
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeWriter.java
@@ -43,8 +43,8 @@ public abstract class UnsafeWriter {
     return holder;
   }
 
-  public final byte[] buffer() {
-    return holder.buffer();
+  public final byte[] getBuffer() {
+    return holder.getBuffer();
   }
 
   public final void reset() {
@@ -84,7 +84,7 @@ public abstract class UnsafeWriter {
 
   protected final void zeroOutPaddingBytes(int numBytes) {
     if ((numBytes & 0x07) > 0) {
-      Platform.putLong(buffer(), cursor() + ((numBytes >> 3) << 3), 0L);
+      Platform.putLong(getBuffer(), cursor() + ((numBytes >> 3) << 3), 0L);
     }
   }
 
@@ -112,7 +112,7 @@ public abstract class UnsafeWriter {
     zeroOutPaddingBytes(numBytes);
 
     // Write the bytes to the variable length portion.
-    input.writeToMemory(buffer(), cursor());
+    input.writeToMemory(getBuffer(), cursor());
 
     setOffsetAndSize(ordinal, numBytes);
 
@@ -134,7 +134,7 @@ public abstract class UnsafeWriter {
 
     // Write the bytes to the variable length portion.
     Platform.copyMemory(
-      input, Platform.BYTE_ARRAY_OFFSET + offset, buffer(), cursor(), numBytes);
+      input, Platform.BYTE_ARRAY_OFFSET + offset, getBuffer(), cursor(), numBytes);
 
     setOffsetAndSize(ordinal, numBytes);
 
@@ -147,8 +147,8 @@ public abstract class UnsafeWriter {
     grow(16);
 
     // Write the months and microseconds fields of Interval to the variable length portion.
-    Platform.putLong(buffer(), cursor(), input.months);
-    Platform.putLong(buffer(), cursor() + 8, input.microseconds);
+    Platform.putLong(getBuffer(), cursor(), input.months);
+    Platform.putLong(getBuffer(), cursor() + 8, input.microseconds);
 
     setOffsetAndSize(ordinal, 16);
 
@@ -157,36 +157,36 @@ public abstract class UnsafeWriter {
   }
 
   protected final void writeBoolean(long offset, boolean value) {
-    Platform.putBoolean(buffer(), offset, value);
+    Platform.putBoolean(getBuffer(), offset, value);
   }
 
   protected final void writeByte(long offset, byte value) {
-    Platform.putByte(buffer(), offset, value);
+    Platform.putByte(getBuffer(), offset, value);
   }
 
   protected final void writeShort(long offset, short value) {
-    Platform.putShort(buffer(), offset, value);
+    Platform.putShort(getBuffer(), offset, value);
   }
 
   protected final void writeInt(long offset, int value) {
-    Platform.putInt(buffer(), offset, value);
+    Platform.putInt(getBuffer(), offset, value);
   }
 
   protected final void writeLong(long offset, long value) {
-    Platform.putLong(buffer(), offset, value);
+    Platform.putLong(getBuffer(), offset, value);
   }
 
   protected final void writeFloat(long offset, float value) {
     if (Float.isNaN(value)) {
       value = Float.NaN;
     }
-    Platform.putFloat(buffer(), offset, value);
+    Platform.putFloat(getBuffer(), offset, value);
   }
 
   protected final void writeDouble(long offset, double value) {
     if (Double.isNaN(value)) {
       value = Double.NaN;
     }
-    Platform.putDouble(buffer(), offset, value);
+    Platform.putDouble(getBuffer(), offset, value);
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeWriter.java
@@ -63,13 +63,11 @@ public abstract class UnsafeWriter {
     return holder.getCursor();
   }
 
-  public final void incrementCursor(int val) {
-    holder.incrementCursor(val);
+  public final void increaseCursor(int val) {
+    holder.increaseCursor(val);
   }
 
-  public abstract void setOffsetAndSizeFromPreviousCursor(int ordinal, int previousCursor);
-
-  protected void _setOffsetAndSizeFromPreviousCursor(int ordinal, int previousCursor) {
+  public final void setOffsetAndSizeFromPreviousCursor(int ordinal, int previousCursor) {
     setOffsetAndSize(ordinal, previousCursor, cursor() - previousCursor);
   }
 
@@ -119,7 +117,7 @@ public abstract class UnsafeWriter {
     setOffsetAndSize(ordinal, numBytes);
 
     // move the cursor forward.
-    incrementCursor(roundedSize);
+    increaseCursor(roundedSize);
   }
 
   public final void write(int ordinal, byte[] input) {
@@ -141,7 +139,7 @@ public abstract class UnsafeWriter {
     setOffsetAndSize(ordinal, numBytes);
 
     // move the cursor forward.
-    incrementCursor(roundedSize);
+    increaseCursor(roundedSize);
   }
 
   public final void write(int ordinal, CalendarInterval input) {
@@ -155,7 +153,7 @@ public abstract class UnsafeWriter {
     setOffsetAndSize(ordinal, 16);
 
     // move the cursor forward.
-    incrementCursor(16);
+    increaseCursor(16);
   }
 
   protected final void writeBoolean(long offset, boolean value) {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeWriter.java
@@ -67,14 +67,9 @@ public abstract class UnsafeWriter {
     holder.incrementCursor(val);
   }
 
-  public final int markCursor() {
-    return holder.pushCursor();
-  }
+  public abstract void setOffsetAndSizeFromMark(int ordinal, int mark);
 
-  public abstract void setOffsetAndSizeFromMark(int ordinal);
-
-  protected void _setOffsetAndSizeFromMark(int ordinal) {
-    int mark = holder.popCursor();
+  protected void _setOffsetAndSizeFromMark(int ordinal, int mark) {
     setOffsetAndSize(ordinal, mark, cursor() - mark);
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedUnsafeProjection.scala
@@ -80,7 +80,6 @@ class InterpretedUnsafeProjection(expressions: Array[Expression]) extends Unsafe
     // Write the intermediate row to an unsafe row.
     rowWriter.reset()
     writer(intermediate)
-    rowWriter.setTotalSize()
     rowWriter.getRow()
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedUnsafeProjection.scala
@@ -226,7 +226,7 @@ object InterpretedUnsafeProjection extends UnsafeProjectionCreator {
             case map =>
               // preserve 8 bytes to write the key array numBytes later.
               valueArrayWriter.grow(8)
-              valueArrayWriter.incrementCursor(8)
+              valueArrayWriter.increaseCursor(8)
 
               // Write the keys and write the numBytes of key array into the first 8 bytes.
               writeArray(keyArrayWriter, keyWriter, map.keyArray())
@@ -350,6 +350,6 @@ object InterpretedUnsafeProjection extends UnsafeProjectionCreator {
       writer.buffer,
       writer.cursor,
       sizeInBytes)
-    writer.incrementCursor(sizeInBytes)
+    writer.increaseCursor(sizeInBytes)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedUnsafeProjection.scala
@@ -174,7 +174,7 @@ object InterpretedUnsafeProjection extends UnsafeProjectionCreator {
         val rowWriter = new UnsafeRowWriter(writer, numFields)
         val structWriter = generateStructWriter(rowWriter, fields)
         (v, i) => {
-          rowWriter.markCursor()
+          writer.markCursor()
           v.getStruct(i, fields.length) match {
             case row: UnsafeRow =>
               writeUnsafeData(
@@ -198,7 +198,7 @@ object InterpretedUnsafeProjection extends UnsafeProjectionCreator {
           elementType,
           containsNull)
         (v, i) => {
-          arrayWriter.markCursor()
+          writer.markCursor()
           writeArray(arrayWriter, elementWriter, v.getArray(i))
           writer.setOffsetAndSizeFromMark(i)
         }
@@ -215,7 +215,7 @@ object InterpretedUnsafeProjection extends UnsafeProjectionCreator {
           valueType,
           valueContainsNull)
         (v, i) => {
-          val tmpCursor = valueArrayWriter.markCursor()
+          val tmpCursor = writer.markCursor()
           v.getMap(i) match {
             case map: UnsafeMapData =>
               writeUnsafeData(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedUnsafeProjection.scala
@@ -231,7 +231,7 @@ object InterpretedUnsafeProjection extends UnsafeProjectionCreator {
               // Write the keys and write the numBytes of key array into the first 8 bytes.
               writeArray(keyArrayWriter, keyWriter, map.keyArray())
               Platform.putLong(
-                valueArrayWriter.buffer,
+                valueArrayWriter.getBuffer,
                 previousCursor,
                 valueArrayWriter.cursor - previousCursor - 8
               )
@@ -347,7 +347,7 @@ object InterpretedUnsafeProjection extends UnsafeProjectionCreator {
     Platform.copyMemory(
       baseObject,
       baseOffset,
-      writer.buffer,
+      writer.getBuffer,
       writer.cursor,
       sizeInBytes)
     writer.increaseCursor(sizeInBytes)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedUnsafeProjection.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.codegen.{BufferHolder, UnsafeArrayWriter, UnsafeRowWriter, UnsafeWriter}
+import org.apache.spark.sql.catalyst.expressions.codegen.{UnsafeArrayWriter, UnsafeRowWriter, UnsafeWriter}
 import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.sql.types.{UserDefinedType, _}
 import org.apache.spark.unsafe.Platform
@@ -45,14 +45,12 @@ class InterpretedUnsafeProjection(expressions: Array[Expression]) extends Unsafe
   /** The row returned by the projection. */
   private[this] val result = new UnsafeRow(numFields)
 
-  /** The buffer which holds the resulting row's backing data. */
-  private[this] val holder = new BufferHolder(result, numFields * 32)
+  /* The row writer for UnsafeRow result */
+  private[this] val rowWriter = new UnsafeRowWriter(result, numFields * 32)
 
   /** The writer that writes the intermediate result to the result row. */
   private[this] val writer: InternalRow => Unit = {
-    val rowWriter = new UnsafeRowWriter(holder, numFields)
     val baseWriter = generateStructWriter(
-      holder,
       rowWriter,
       expressions.map(e => StructField("", e.dataType, e.nullable)))
     if (!expressions.exists(_.nullable)) {
@@ -83,9 +81,9 @@ class InterpretedUnsafeProjection(expressions: Array[Expression]) extends Unsafe
     }
 
     // Write the intermediate row to an unsafe row.
-    holder.reset()
+    rowWriter.reset()
     writer(intermediate)
-    result.setTotalSize(holder.totalSize())
+    rowWriter.setTotalSize()
     result
   }
 }
@@ -111,14 +109,13 @@ object InterpretedUnsafeProjection extends UnsafeProjectionCreator {
    * given buffer using the given [[UnsafeRowWriter]].
    */
   private def generateStructWriter(
-      bufferHolder: BufferHolder,
       rowWriter: UnsafeRowWriter,
       fields: Array[StructField]): InternalRow => Unit = {
     val numFields = fields.length
 
     // Create field writers.
     val fieldWriters = fields.map { field =>
-      generateFieldWriter(bufferHolder, rowWriter, field.dataType, field.nullable)
+      generateFieldWriter(rowWriter, field.dataType, field.nullable)
     }
     // Create basic writer.
     row => {
@@ -136,7 +133,6 @@ object InterpretedUnsafeProjection extends UnsafeProjectionCreator {
    * or array) to the given buffer using the given [[UnsafeWriter]].
    */
   private def generateFieldWriter(
-      bufferHolder: BufferHolder,
       writer: UnsafeWriter,
       dt: DataType,
       nullable: Boolean): (SpecializedGetters, Int) => Unit = {
@@ -178,81 +174,79 @@ object InterpretedUnsafeProjection extends UnsafeProjectionCreator {
 
       case StructType(fields) =>
         val numFields = fields.length
-        val rowWriter = new UnsafeRowWriter(bufferHolder, numFields)
-        val structWriter = generateStructWriter(bufferHolder, rowWriter, fields)
+        val rowWriter = new UnsafeRowWriter(writer, numFields)
+        val structWriter = generateStructWriter(rowWriter, fields)
         (v, i) => {
-          val tmpCursor = bufferHolder.cursor
+          val tmpCursor = rowWriter.cursor
           v.getStruct(i, fields.length) match {
             case row: UnsafeRow =>
               writeUnsafeData(
-                bufferHolder,
+                rowWriter,
                 row.getBaseObject,
                 row.getBaseOffset,
                 row.getSizeInBytes)
             case row =>
               // Nested struct. We don't know where this will start because a row can be
               // variable length, so we need to update the offsets and zero out the bit mask.
-              rowWriter.reset()
+              rowWriter.resetRowWriter()
               structWriter.apply(row)
           }
-          writer.setOffsetAndSize(i, tmpCursor, bufferHolder.cursor - tmpCursor)
+          writer.setOffsetAndSize(i, tmpCursor, rowWriter.cursor - tmpCursor)
         }
 
       case ArrayType(elementType, containsNull) =>
-        val arrayWriter = new UnsafeArrayWriter
+        val arrayWriter = new UnsafeArrayWriter(writer)
         val elementSize = getElementSize(elementType)
         val elementWriter = generateFieldWriter(
-          bufferHolder,
           arrayWriter,
           elementType,
           containsNull)
         (v, i) => {
-          val tmpCursor = bufferHolder.cursor
-          writeArray(bufferHolder, arrayWriter, elementWriter, v.getArray(i), elementSize)
-          writer.setOffsetAndSize(i, tmpCursor, bufferHolder.cursor - tmpCursor)
+          val tmpCursor = arrayWriter.cursor
+          writeArray(arrayWriter, elementWriter, v.getArray(i), elementSize)
+          writer.setOffsetAndSize(i, tmpCursor, arrayWriter.cursor - tmpCursor)
         }
 
       case MapType(keyType, valueType, valueContainsNull) =>
-        val keyArrayWriter = new UnsafeArrayWriter
+        val keyArrayWriter = new UnsafeArrayWriter(writer)
         val keySize = getElementSize(keyType)
         val keyWriter = generateFieldWriter(
-          bufferHolder,
           keyArrayWriter,
           keyType,
           nullable = false)
-        val valueArrayWriter = new UnsafeArrayWriter
+        val valueArrayWriter = new UnsafeArrayWriter(writer)
         val valueSize = getElementSize(valueType)
         val valueWriter = generateFieldWriter(
-          bufferHolder,
           valueArrayWriter,
           valueType,
           valueContainsNull)
         (v, i) => {
-          val tmpCursor = bufferHolder.cursor
+          val tmpCursor = valueArrayWriter.cursor
           v.getMap(i) match {
             case map: UnsafeMapData =>
               writeUnsafeData(
-                bufferHolder,
+                valueArrayWriter,
                 map.getBaseObject,
                 map.getBaseOffset,
                 map.getSizeInBytes)
             case map =>
               // preserve 8 bytes to write the key array numBytes later.
-              bufferHolder.grow(8)
-              bufferHolder.cursor += 8
+              valueArrayWriter.grow(8)
+              valueArrayWriter.addCursor(8)
 
               // Write the keys and write the numBytes of key array into the first 8 bytes.
-              writeArray(bufferHolder, keyArrayWriter, keyWriter, map.keyArray(), keySize)
-              Platform.putLong(bufferHolder.buffer, tmpCursor, bufferHolder.cursor - tmpCursor - 8)
+              writeArray(keyArrayWriter, keyWriter, map.keyArray(), keySize)
+              Platform.putLong(
+                valueArrayWriter.buffer, tmpCursor, valueArrayWriter.cursor - tmpCursor - 8)
 
               // Write the values.
-              writeArray(bufferHolder, valueArrayWriter, valueWriter, map.valueArray(), valueSize)
+              writeArray(valueArrayWriter, valueWriter, map.valueArray(), valueSize)
           }
-          writer.setOffsetAndSize(i, tmpCursor, bufferHolder.cursor - tmpCursor)
+          writer.setOffsetAndSize(i, tmpCursor, valueArrayWriter.cursor - tmpCursor)
         }
 
       case udt: UserDefinedType[_] =>
-        generateFieldWriter(bufferHolder, writer, udt.sqlType, nullable)
+        generateFieldWriter(writer, udt.sqlType, nullable)
 
       case NullType =>
         (_, _) => {}
@@ -324,20 +318,19 @@ object InterpretedUnsafeProjection extends UnsafeProjectionCreator {
    * copy.
    */
   private def writeArray(
-      bufferHolder: BufferHolder,
       arrayWriter: UnsafeArrayWriter,
       elementWriter: (SpecializedGetters, Int) => Unit,
       array: ArrayData,
       elementSize: Int): Unit = array match {
     case unsafe: UnsafeArrayData =>
       writeUnsafeData(
-        bufferHolder,
+        arrayWriter,
         unsafe.getBaseObject,
         unsafe.getBaseOffset,
         unsafe.getSizeInBytes)
     case _ =>
       val numElements = array.numElements()
-      arrayWriter.initialize(bufferHolder, numElements, elementSize)
+      arrayWriter.initialize(numElements, elementSize)
       var i = 0
       while (i < numElements) {
         elementWriter.apply(array, i)
@@ -350,17 +343,17 @@ object InterpretedUnsafeProjection extends UnsafeProjectionCreator {
    * [[UnsafeRow]], [[UnsafeArrayData]] and [[UnsafeMapData]] objects.
    */
   private def writeUnsafeData(
-      bufferHolder: BufferHolder,
+      writer: UnsafeWriter,
       baseObject: AnyRef,
       baseOffset: Long,
       sizeInBytes: Int) : Unit = {
-    bufferHolder.grow(sizeInBytes)
+    writer.grow(sizeInBytes)
     Platform.copyMemory(
       baseObject,
       baseOffset,
-      bufferHolder.buffer,
-      bufferHolder.cursor,
+      writer.buffer,
+      writer.cursor,
       sizeInBytes)
-    bufferHolder.cursor += sizeInBytes
+    writer.addCursor(sizeInBytes)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
@@ -276,7 +276,7 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
       } else {
         // preserve 8 bytes to write the key array numBytes later.
         $rowWriter.grow(8);
-        $rowWriter.incrementCursor(8);
+        $rowWriter.increaseCursor(8);
 
         // Remember the current cursor so that we can write numBytes of key array later.
         final int $tmpCursor = $rowWriter.cursor();
@@ -301,7 +301,7 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
       // grow the global buffer before writing data.
       $rowWriter.grow($sizeInBytes);
       $input.writeToMemory($rowWriter.buffer(), $rowWriter.cursor());
-      $rowWriter.incrementCursor($sizeInBytes);
+      $rowWriter.increaseCursor($sizeInBytes);
     """
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
@@ -207,22 +207,22 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
     val writeElement = et match {
       case t: StructType =>
         s"""
-          $rowWriter.markCursor();
-          ${writeStructToBuffer(ctx, element, t.map(_.dataType), rowWriter)}
+          $arrayWriter.markCursor();
+          ${writeStructToBuffer(ctx, element, t.map(_.dataType), arrayWriter)}
           $arrayWriter.setOffsetAndSizeFromMark($index);
         """
 
       case a @ ArrayType(et, _) =>
         s"""
-          $rowWriter.markCursor();
-          ${writeArrayToBuffer(ctx, element, et, rowWriter)}
+          $arrayWriter.markCursor();
+          ${writeArrayToBuffer(ctx, element, et, arrayWriter)}
           $arrayWriter.setOffsetAndSizeFromMark($index);
         """
 
       case m @ MapType(kt, vt, _) =>
         s"""
-          $rowWriter.markCursor();
-          ${writeMapToBuffer(ctx, element, kt, vt, rowWriter)}
+          $arrayWriter.markCursor();
+          ${writeMapToBuffer(ctx, element, kt, vt, arrayWriter)}
           $arrayWriter.setOffsetAndSizeFromMark($index);
         """
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
@@ -283,7 +283,7 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
 
         ${writeArrayToBuffer(ctx, s"$tmpInput.keyArray()", keyType, rowWriter)}
         // Write the numBytes of key array into the first 8 bytes.
-        Platform.putLong($rowWriter.buffer(), $tmpCursor - 8, $rowWriter.cursor() - $tmpCursor);
+        Platform.putLong($rowWriter.getBuffer(), $tmpCursor - 8, $rowWriter.cursor() - $tmpCursor);
 
         ${writeArrayToBuffer(ctx, s"$tmpInput.valueArray()", valueType, rowWriter)}
       }
@@ -300,7 +300,7 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
       final int $sizeInBytes = $input.getSizeInBytes();
       // grow the global buffer before writing data.
       $rowWriter.grow($sizeInBytes);
-      $input.writeToMemory($rowWriter.buffer(), $rowWriter.cursor());
+      $input.writeToMemory($rowWriter.getBuffer(), $rowWriter.cursor());
       $rowWriter.increaseCursor($sizeInBytes);
     """
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
@@ -322,17 +322,6 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
     val rowWriter = ctx.addMutableState(rowWriterClass, "rowWriter",
       v => s"$v = new $rowWriterClass(${expressions.length}, ${numVarLenFields * 32});")
 
-    val resetBufferHolder = if (numVarLenFields == 0) {
-      ""
-    } else {
-      s"$rowWriter.reset();"
-    }
-    val updateRowSize = if (numVarLenFields == 0) {
-      ""
-    } else {
-      s"$rowWriter.setTotalSize();"
-    }
-
     // Evaluate all the subexpression.
     val evalSubexpr = ctx.subexprFunctions.mkString("\n")
 
@@ -341,10 +330,9 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
 
     val code =
       s"""
-        $resetBufferHolder
+        $rowWriter.reset();
         $evalSubexpr
         $writeExpressions
-        $updateRowSize
       """
     ExprCode(code, "false", s"$rowWriter.getRow()")
   }

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/RowBasedKeyValueBatchSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/RowBasedKeyValueBatchSuite.java
@@ -27,7 +27,6 @@ import org.apache.spark.memory.TaskMemoryManager;
 import org.apache.spark.memory.TestMemoryManager;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.types.DataTypes;
-import org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder;
 import org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter;
 import org.apache.spark.unsafe.types.UTF8String;
 
@@ -56,34 +55,31 @@ public class RowBasedKeyValueBatchSuite {
 
   private UnsafeRow makeKeyRow(long k1, String k2) {
     UnsafeRow row = new UnsafeRow(2);
-    BufferHolder holder = new BufferHolder(row, 32);
-    UnsafeRowWriter writer = new UnsafeRowWriter(holder, 2);
-    holder.reset();
+    UnsafeRowWriter writer = new UnsafeRowWriter(row);
+    writer.reset();
     writer.write(0, k1);
     writer.write(1, UTF8String.fromString(k2));
-    row.setTotalSize(holder.totalSize());
+    writer.setTotalSize();
     return row;
   }
 
   private UnsafeRow makeKeyRow(long k1, long k2) {
     UnsafeRow row = new UnsafeRow(2);
-    BufferHolder holder = new BufferHolder(row, 0);
-    UnsafeRowWriter writer = new UnsafeRowWriter(holder, 2);
-    holder.reset();
+    UnsafeRowWriter writer = new UnsafeRowWriter(row);
+    writer.reset();
     writer.write(0, k1);
     writer.write(1, k2);
-    row.setTotalSize(holder.totalSize());
+    writer.setTotalSize();
     return row;
   }
 
   private UnsafeRow makeValueRow(long v1, long v2) {
     UnsafeRow row = new UnsafeRow(2);
-    BufferHolder holder = new BufferHolder(row, 0);
-    UnsafeRowWriter writer = new UnsafeRowWriter(holder, 2);
-    holder.reset();
+    UnsafeRowWriter writer = new UnsafeRowWriter(row);
+    writer.reset();
     writer.write(0, v1);
     writer.write(1, v2);
-    row.setTotalSize(holder.totalSize());
+    writer.setTotalSize();
     return row;
   }
 

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/RowBasedKeyValueBatchSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/RowBasedKeyValueBatchSuite.java
@@ -58,7 +58,6 @@ public class RowBasedKeyValueBatchSuite {
     writer.reset();
     writer.write(0, k1);
     writer.write(1, UTF8String.fromString(k2));
-    writer.setTotalSize();
     return writer.getRow();
   }
 
@@ -67,7 +66,6 @@ public class RowBasedKeyValueBatchSuite {
     writer.reset();
     writer.write(0, k1);
     writer.write(1, k2);
-    writer.setTotalSize();
     return writer.getRow();
   }
 
@@ -76,7 +74,6 @@ public class RowBasedKeyValueBatchSuite {
     writer.reset();
     writer.write(0, v1);
     writer.write(1, v2);
-    writer.setTotalSize();
     return writer.getRow();
   }
 

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/RowBasedKeyValueBatchSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/RowBasedKeyValueBatchSuite.java
@@ -54,33 +54,30 @@ public class RowBasedKeyValueBatchSuite {
   }
 
   private UnsafeRow makeKeyRow(long k1, String k2) {
-    UnsafeRow row = new UnsafeRow(2);
-    UnsafeRowWriter writer = new UnsafeRowWriter(row);
+    UnsafeRowWriter writer = new UnsafeRowWriter(2);
     writer.reset();
     writer.write(0, k1);
     writer.write(1, UTF8String.fromString(k2));
     writer.setTotalSize();
-    return row;
+    return writer.getRow();
   }
 
   private UnsafeRow makeKeyRow(long k1, long k2) {
-    UnsafeRow row = new UnsafeRow(2);
-    UnsafeRowWriter writer = new UnsafeRowWriter(row);
+    UnsafeRowWriter writer = new UnsafeRowWriter(2);
     writer.reset();
     writer.write(0, k1);
     writer.write(1, k2);
     writer.setTotalSize();
-    return row;
+    return writer.getRow();
   }
 
   private UnsafeRow makeValueRow(long v1, long v2) {
-    UnsafeRow row = new UnsafeRow(2);
-    UnsafeRowWriter writer = new UnsafeRowWriter(row);
+    UnsafeRowWriter writer = new UnsafeRowWriter(2);
     writer.reset();
     writer.write(0, v1);
     writer.write(1, v2);
     writer.setTotalSize();
-    return row;
+    return writer.getRow();
   }
 
   private UnsafeRow appendRow(RowBasedKeyValueBatch batch, UnsafeRow key, UnsafeRow value) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/RowBasedHashMapGenerator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/RowBasedHashMapGenerator.scala
@@ -166,17 +166,14 @@ class RowBasedHashMapGenerator(
        |      if (numRows < capacity && !isBatchFull) {
        |        // creating the unsafe for new entry
        |        UnsafeRow agg_result = new UnsafeRow(${groupingKeySchema.length});
-       |        org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder agg_holder
-       |          = new org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder(agg_result,
-       |            ${numVarLenFields * 32});
        |        org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter agg_rowWriter
        |          = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(
-       |              agg_holder,
-       |              ${groupingKeySchema.length});
-       |        agg_holder.reset(); //TODO: investigate if reset or zeroout are actually needed
+       |              agg_result,
+       |              ${numVarLenFields * 32});
+       |        agg_rowWriter.reset(); //TODO: investigate if reset or zeroout are actually needed
        |        agg_rowWriter.zeroOutNullBytes();
        |        ${createUnsafeRowForKey};
-       |        agg_result.setTotalSize(agg_holder.totalSize());
+       |        agg_rowWriter.setTotalSize();
        |        Object kbase = agg_result.getBaseObject();
        |        long koff = agg_result.getBaseOffset();
        |        int klen = agg_result.getSizeInBytes();

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/RowBasedHashMapGenerator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/RowBasedHashMapGenerator.scala
@@ -165,15 +165,15 @@ class RowBasedHashMapGenerator(
        |    if (buckets[idx] == -1) {
        |      if (numRows < capacity && !isBatchFull) {
        |        // creating the unsafe for new entry
-       |        UnsafeRow agg_result = new UnsafeRow(${groupingKeySchema.length});
        |        org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter agg_rowWriter
        |          = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(
-       |              agg_result,
-       |              ${numVarLenFields * 32});
+       |              ${groupingKeySchema.length}, ${numVarLenFields * 32});
        |        agg_rowWriter.reset(); //TODO: investigate if reset or zeroout are actually needed
        |        agg_rowWriter.zeroOutNullBytes();
        |        ${createUnsafeRowForKey};
        |        agg_rowWriter.setTotalSize();
+       |        org.apache.spark.sql.catalyst.expressions.UnsafeRow agg_result
+       |          = agg_rowWriter.getRow();
        |        Object kbase = agg_result.getBaseObject();
        |        long koff = agg_result.getBaseOffset();
        |        int klen = agg_result.getSizeInBytes();

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/RowBasedHashMapGenerator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/RowBasedHashMapGenerator.scala
@@ -171,7 +171,6 @@ class RowBasedHashMapGenerator(
        |        agg_rowWriter.reset(); //TODO: investigate if reset or zeroout are actually needed
        |        agg_rowWriter.zeroOutNullBytes();
        |        ${createUnsafeRowForKey};
-       |        agg_rowWriter.setTotalSize();
        |        org.apache.spark.sql.catalyst.expressions.UnsafeRow agg_result
        |          = agg_rowWriter.getRow();
        |        Object kbase = agg_result.getBaseObject();

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
@@ -165,8 +165,7 @@ object GenerateColumnAccessor extends CodeGenerator[Seq[DataType], ColumnarItera
 
         private ByteOrder nativeOrder = null;
         private byte[][] buffers = null;
-        private UnsafeRow unsafeRow = new UnsafeRow($numFields);
-        private UnsafeRowWriter rowWriter = new UnsafeRowWriter(unsafeRow);
+        private UnsafeRowWriter rowWriter = new UnsafeRowWriter($numFields);
         private MutableUnsafeRow mutableRow = null;
 
         private int currentRow = 0;
@@ -215,7 +214,7 @@ object GenerateColumnAccessor extends CodeGenerator[Seq[DataType], ColumnarItera
           rowWriter.zeroOutNullBytes();
           ${extractorCalls}
           rowWriter.setTotalSize();
-          return unsafeRow;
+          return rowWriter.getRow();
         }
 
         ${ctx.declareAddedFunctions()}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
@@ -166,8 +166,7 @@ object GenerateColumnAccessor extends CodeGenerator[Seq[DataType], ColumnarItera
         private ByteOrder nativeOrder = null;
         private byte[][] buffers = null;
         private UnsafeRow unsafeRow = new UnsafeRow($numFields);
-        private BufferHolder bufferHolder = new BufferHolder(unsafeRow);
-        private UnsafeRowWriter rowWriter = new UnsafeRowWriter(bufferHolder, $numFields);
+        private UnsafeRowWriter rowWriter = new UnsafeRowWriter(unsafeRow);
         private MutableUnsafeRow mutableRow = null;
 
         private int currentRow = 0;
@@ -212,10 +211,10 @@ object GenerateColumnAccessor extends CodeGenerator[Seq[DataType], ColumnarItera
 
         public InternalRow next() {
           currentRow += 1;
-          bufferHolder.reset();
+          rowWriter.reset();
           rowWriter.zeroOutNullBytes();
           ${extractorCalls}
-          unsafeRow.setTotalSize(bufferHolder.totalSize());
+          rowWriter.setTotalSize();
           return unsafeRow;
         }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
@@ -213,7 +213,6 @@ object GenerateColumnAccessor extends CodeGenerator[Seq[DataType], ColumnarItera
           rowWriter.reset();
           rowWriter.zeroOutNullBytes();
           ${extractorCalls}
-          rowWriter.setTotalSize();
           return rowWriter.getRow();
         }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextFileFormat.scala
@@ -29,7 +29,7 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
-import org.apache.spark.sql.catalyst.expressions.codegen.{BufferHolder, UnsafeRowWriter}
+import org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter
 import org.apache.spark.sql.catalyst.util.CompressionCodecs
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.sources._
@@ -134,14 +134,13 @@ class TextFileFormat extends TextBasedFileFormat with DataSourceRegister {
         reader.map(_ => emptyUnsafeRow)
       } else {
         val unsafeRow = new UnsafeRow(1)
-        val bufferHolder = new BufferHolder(unsafeRow)
-        val unsafeRowWriter = new UnsafeRowWriter(bufferHolder, 1)
+        val unsafeRowWriter = new UnsafeRowWriter(unsafeRow)
 
         reader.map { line =>
           // Writes to an UnsafeRow directly
-          bufferHolder.reset()
-          unsafeRowWriter.write(0, line.getBytes, 0, line.getLength)
-          unsafeRow.setTotalSize(bufferHolder.totalSize())
+          unsafeRowWriter.reset()
+          unsafeRowWriter.write(0, line.getBytes)
+          unsafeRowWriter.setTotalSize()
           unsafeRow
         }
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextFileFormat.scala
@@ -133,15 +133,14 @@ class TextFileFormat extends TextBasedFileFormat with DataSourceRegister {
         val emptyUnsafeRow = new UnsafeRow(0)
         reader.map(_ => emptyUnsafeRow)
       } else {
-        val unsafeRow = new UnsafeRow(1)
-        val unsafeRowWriter = new UnsafeRowWriter(unsafeRow)
+        val unsafeRowWriter = new UnsafeRowWriter(1)
 
         reader.map { line =>
           // Writes to an UnsafeRow directly
           unsafeRowWriter.reset()
           unsafeRowWriter.write(0, line.getBytes, 0, line.getLength)
           unsafeRowWriter.setTotalSize()
-          unsafeRow
+          unsafeRowWriter.getRow()
         }
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextFileFormat.scala
@@ -139,7 +139,6 @@ class TextFileFormat extends TextBasedFileFormat with DataSourceRegister {
           // Writes to an UnsafeRow directly
           unsafeRowWriter.reset()
           unsafeRowWriter.write(0, line.getBytes, 0, line.getLength)
-          unsafeRowWriter.setTotalSize()
           unsafeRowWriter.getRow()
         }
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextFileFormat.scala
@@ -139,7 +139,7 @@ class TextFileFormat extends TextBasedFileFormat with DataSourceRegister {
         reader.map { line =>
           // Writes to an UnsafeRow directly
           unsafeRowWriter.reset()
-          unsafeRowWriter.write(0, line.getBytes)
+          unsafeRowWriter.write(0, line.getBytes, 0, line.getLength)
           unsafeRowWriter.setTotalSize()
           unsafeRow
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR implemented the following cleanups related to  `UnsafeWriter` class:
- Remove code duplication between `UnsafeRowWriter` and `UnsafeArrayWriter`
- Make `BufferHolder` class internal by delegating its accessor methods to `UnsafeWriter`
- Replace `UnsafeRow.setTotalSize(...)` with `UnsafeRowWriter.setTotalSize()`

## How was this patch tested?

Tested by existing UTs