### PR TITLE
[SPARK-23728][BRANCH-2.3] Fix ML tests with expected exceptions running streaming tests 

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/util/MLTest.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/util/MLTest.scala
@@ -119,9 +119,15 @@ trait MLTest extends StreamTest with TempDirectory { self: Suite =>
     expectedMessagePart : String,
     firstResultCol: String) {
 
+    def hasExpectedMessageDirectly(exception: Throwable): Boolean =
+      exception.getMessage.contains(expectedMessagePart)
+
     def hasExpectedMessage(exception: Throwable): Boolean =
-      exception.getMessage.contains(expectedMessagePart) ||
-        (exception.getCause != null && exception.getCause.getMessage.contains(expectedMessagePart))
+      hasExpectedMessageDirectly(exception) || (
+        exception.getCause != null && (
+          hasExpectedMessageDirectly(exception.getCause) || (
+            exception.getCause.getCause != null &&
+            hasExpectedMessageDirectly(exception.getCause.getCause))))
 
     withClue(s"""Expected message part "${expectedMessagePart}" is not found in DF test.""") {
       val exceptionOnDf = intercept[Throwable] {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The testTransformerByInterceptingException failed to catch the expected message on 2.3 during streaming tests as the feature generated message is not at the direct caused by exception but even one level deeper.

## How was this patch tested?

Running the unit tests.
