### PR TITLE
[SPARK-23729][CORE] Respect URI fragment when resolving globs

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/DependencyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DependencyUtils.scala
@@ -151,8 +151,7 @@ private[deploy] object DependencyUtils {
   private def splitOnFragment(path: String): (URI, Option[String]) = {
     val uri = Utils.resolveURI(path)
     val withoutFragment = new URI(uri.getScheme, uri.getSchemeSpecificPart, null)
-    val fragment = if (uri.getFragment != null) Some(uri.getFragment) else None
-    (withoutFragment, fragment)
+    (withoutFragment, Option(uri.getFragment))
   }
 
   private def resolveGlobPath(uri: URI, hadoopConf: Configuration): Array[String] = {

--- a/core/src/main/scala/org/apache/spark/deploy/DependencyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DependencyUtils.scala
@@ -155,7 +155,7 @@ private[deploy] object DependencyUtils {
     (withoutFragment, fragment)
   }
 
-  private def resolveGlobPath(uri: URI, hadoopConf: Configuration): Array [String] = {
+  private def resolveGlobPath(uri: URI, hadoopConf: Configuration): Array[String] = {
     uri.getScheme match {
       case "local" | "http" | "https" | "ftp" => Array(uri.toString)
       case _ =>

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -248,9 +248,7 @@ object SparkSubmit extends CommandLineUtils with Logging {
     try {
       doPrepareSubmitEnvironment(args, conf)
     } catch {
-      case e: SparkException =>
-        printErrorAndExit(e.getMessage)
-        throw new RuntimeException("Unreachable production code")
+      case e: SparkException => printErrorAndExit(e.getMessage); throw e
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -245,6 +245,19 @@ object SparkSubmit extends CommandLineUtils with Logging {
       args: SparkSubmitArguments,
       conf: Option[HadoopConfiguration] = None)
       : (Seq[String], Seq[String], SparkConf, String) = {
+    try {
+      doPrepareSubmitEnvironment(args, conf)
+    } catch {
+      case e: SparkException =>
+        printErrorAndExit(e.getMessage)
+        throw new RuntimeException("Unreachable production code")
+    }
+  }
+
+  private def doPrepareSubmitEnvironment(
+      args: SparkSubmitArguments,
+      conf: Option[HadoopConfiguration] = None)
+      : (Seq[String], Seq[String], SparkConf, String) = {
     // Return values
     val childArgs = new ArrayBuffer[String]()
     val childClasspath = new ArrayBuffer[String]()

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -248,7 +248,9 @@ object SparkSubmit extends CommandLineUtils with Logging {
     try {
       doPrepareSubmitEnvironment(args, conf)
     } catch {
-      case e: SparkException => printErrorAndExit(e.getMessage); throw e
+      case e: SparkException =>
+        printErrorAndExit(e.getMessage)
+        throw e
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -609,11 +609,10 @@ class SparkSubmitSuite
     val dir = Utils.createTempDir()
     val archive = Paths.get(dir.toPath.toString, "single.zip")
     Files.createFile(archive)
-    val jars = "/jar1,/jar2"                 // --jars
-    val files = "local:/file1,file2"          // --files
+    val jars = "/jar1,/jar2"
+    val files = "local:/file1,file2"
     val archives = s"file:/archive1,${dir.toPath.toAbsolutePath.toString}/*.zip#archive3"
-                                             // --archives
-    val pyFiles = "py-file1,py-file2"        // --py-files
+    val pyFiles = "py-file1,py-file2"
 
     // Test jars and files
     val clArgs = Seq(
@@ -668,11 +667,10 @@ class SparkSubmitSuite
     val archive2 = Paths.get(dir.toPath.toString, "second.zip")
     Files.createFile(archive1)
     Files.createFile(archive2)
-    val jars = "/jar1,/jar2"                 // --jars
-    val files = "local:/file1,file2"          // --files
-    // --archives
+    val jars = "/jar1,/jar2"
+    val files = "local:/file1,file2"
     val archives = s"file:/archive1,${dir.toPath.toAbsolutePath.toString}/*.zip#archive3"
-    val pyFiles = "py-file1,py-file2"        // --py-files
+    val pyFiles = "py-file1,py-file2"
 
     // Test files and archives (Yarn)
     val clArgs2 = Seq(

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.deploy
 import java.io._
 import java.net.URI
 import java.nio.charset.StandardCharsets
-import java.nio.file.Files
+import java.nio.file.{Files, Paths}
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -105,11 +105,17 @@ class SparkSubmitSuite
 
   // Necessary to make ScalaTest 3.x interrupt a thread on the JVM like ScalaTest 2.2.x
   implicit val defaultSignaler: Signaler = ThreadSignaler
+  var dir: File = null
 
   override def beforeEach() {
+    dir = Utils.createTempDir()
     super.beforeEach()
   }
 
+  override def afterEach() {
+    super.afterEach()
+    Utils.deleteRecursively(dir)
+  }
   // scalastyle:off println
   test("prints usage on empty input") {
     testPrematureExit(Array.empty[String], "Usage: spark-submit")
@@ -606,9 +612,12 @@ class SparkSubmitSuite
   }
 
   test("resolves command line argument paths correctly") {
+    val archive = Paths.get(dir.toPath.toString, "single.zip")
+    Files.createFile(archive)
     val jars = "/jar1,/jar2"                 // --jars
     val files = "local:/file1,file2"          // --files
-    val archives = "file:/archive1,archive2" // --archives
+    val archives = s"file:/archive1,${dir.toPath.toAbsolutePath.toString}/*.zip#archive3"
+                                             // --archives
     val pyFiles = "py-file1,py-file2"        // --py-files
 
     // Test jars and files
@@ -636,9 +645,10 @@ class SparkSubmitSuite
     val appArgs2 = new SparkSubmitArguments(clArgs2)
     val (_, _, conf2, _) = SparkSubmit.prepareSubmitEnvironment(appArgs2)
     appArgs2.files should be (Utils.resolveURIs(files))
-    appArgs2.archives should be (Utils.resolveURIs(archives))
+    appArgs2.archives should fullyMatch regex ("file:/archive1,file:.*#archive3")
     conf2.get("spark.yarn.dist.files") should be (Utils.resolveURIs(files))
-    conf2.get("spark.yarn.dist.archives") should be (Utils.resolveURIs(archives))
+    conf2.get("spark.yarn.dist.archives") should fullyMatch regex
+      ("file:/archive1,file:.*#archive3")
 
     // Test python files
     val clArgs3 = Seq(
@@ -655,6 +665,31 @@ class SparkSubmitSuite
       PythonRunner.formatPaths(Utils.resolveURIs(pyFiles)).mkString(","))
     conf3.get(PYSPARK_DRIVER_PYTHON.key) should be ("python3.4")
     conf3.get(PYSPARK_PYTHON.key) should be ("python3.5")
+  }
+
+  var cleanExit = false
+
+  test("cannot resolve ambiguous archive mapping") {
+    val archive1 = Paths.get(dir.toPath.toString, "first.zip")
+    val archive2 = Paths.get(dir.toPath.toString, "second.zip")
+    Files.createFile(archive1)
+    Files.createFile(archive2)
+    val jars = "/jar1,/jar2"                 // --jars
+    val files = "local:/file1,file2"          // --files
+    // --archives
+    val archives = s"file:/archive1,${dir.toPath.toAbsolutePath.toString}/*.zip#archive3"
+    val pyFiles = "py-file1,py-file2"        // --py-files
+
+    // Test files and archives (Yarn)
+    val clArgs2 = Seq(
+      "--master", "yarn",
+      "--class", "org.SomeClass",
+      "--files", files,
+      "--archives", archives,
+      "thejar.jar"
+    )
+
+    testPrematureExit(clArgs2.toArray, "resolves ambiguously to multiple files")
   }
 
   test("resolves config paths correctly") {

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -105,17 +105,11 @@ class SparkSubmitSuite
 
   // Necessary to make ScalaTest 3.x interrupt a thread on the JVM like ScalaTest 2.2.x
   implicit val defaultSignaler: Signaler = ThreadSignaler
-  var dir: File = null
 
   override def beforeEach() {
-    dir = Utils.createTempDir()
     super.beforeEach()
   }
 
-  override def afterEach() {
-    super.afterEach()
-    Utils.deleteRecursively(dir)
-  }
   // scalastyle:off println
   test("prints usage on empty input") {
     testPrematureExit(Array.empty[String], "Usage: spark-submit")
@@ -612,6 +606,7 @@ class SparkSubmitSuite
   }
 
   test("resolves command line argument paths correctly") {
+    val dir = Utils.createTempDir()
     val archive = Paths.get(dir.toPath.toString, "single.zip")
     Files.createFile(archive)
     val jars = "/jar1,/jar2"                 // --jars
@@ -667,9 +662,8 @@ class SparkSubmitSuite
     conf3.get(PYSPARK_PYTHON.key) should be ("python3.5")
   }
 
-  var cleanExit = false
-
-  test("cannot resolve ambiguous archive mapping") {
+  test("ambiguous archive mapping results in error message") {
+    val dir = Utils.createTempDir()
     val archive1 = Paths.get(dir.toPath.toString, "first.zip")
     val archive2 = Paths.get(dir.toPath.toString, "second.zip")
     Files.createFile(archive1)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Firstly, glob resolution will not result in swallowing the remote name part (that is preceded by the `#` sign) in case of `--files` or `--archives` options

Moreover in the special case of multiple resolutions when the remote naming does not make sense and error is returned.
## How was this patch tested?

Enhanced current test and wrote additional test for the error case