### PR TITLE
[SPARK-23731][SQL] FileSourceScanExec throws NullPointerException in subexpression elimination

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -163,7 +163,7 @@ case class FileSourceScanExec(
     override val tableIdentifier: Option[TableIdentifier])
   extends DataSourceScanExec with ColumnarBatchScan  {
 
-  override val supportsBatch: Boolean = relation.fileFormat.supportBatch(
+  override val supportsBatch: Boolean = relation != null && relation.fileFormat.supportBatch(
     relation.sparkSession, StructType.fromAttributes(output))
 
   override val needsUnsafeRowConversion: Boolean = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoids ("fixes") a NullPointerException in subexpression elimination for subqueries with FileSourceScanExec.

## How was this patch tested?

Local build. No new tests as I could not reproduce it other than using the query and data under NDA. Waiting for Jenkins.