### PR TITLE
[SPARK-23735]Optimize  the document by adding an import streaming con…

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2288,6 +2288,13 @@ showDF(properties, numRows = 200, truncate = FALSE)
     on the receivers.
   </td>
 </tr>
+<tr>
+  <td><code>spark.streaming.concurrentJobs</code></td>
+  <td>1</td>
+  <td>
+    The number of concurrent jobs.This parameter directly affects the number of threads in the jobExecutor thread pool.
+  </td>
+</tr>
 </table>
 
 ### SparkR


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-23735
Optimize  the document by adding an import streaming configuration，spark.streaming.concurrentJobs。This parameter is quite import ,but is lacking in our current spark document.We should add this to make the document more friendly for users who is not very familiar with  parameter of streaming.
