### PR TITLE
[SPARK-23702][SS] Forbid watermarks on both sides of stateful streaming operators.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -179,8 +179,8 @@ object UnsupportedOperationChecker {
                 inner
             }
             if (innerNonEquivalentWatermarks.nonEmpty) {
-              throwError("Watermarks may not be present both before and after a stateful " +
-                "operator in a streaming DataFrame/Dataset.")
+              throwError("Watermarks both before and after a stateful operator in a streaming " +
+                "DataFrame/Dataset are not well-defined, and thus not supported.")
             }
           }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -141,7 +141,7 @@ class UnsupportedOperationsSuite extends SparkFunSuite {
     expectedMsgs = Seq("distinct aggregation"))
 
   assertNotSupportedInStreamingPlan(
-    "aggregate on both sides of stateful op",
+    "watermark on both sides of aggregate",
     EventTimeWatermark(
       attribute,
       CalendarInterval.fromString("interval 1 second"),
@@ -153,6 +153,35 @@ class UnsupportedOperationsSuite extends SparkFunSuite {
           CalendarInterval.fromString("interval 2 seconds"),
           streamRelation))),
     outputMode = Append,
+    expectedMsgs = Seq("both before and after"))
+
+  assertNotSupportedInStreamingPlan(
+    "watermark on both sides of deduplicate",
+    EventTimeWatermark(
+      attribute,
+      CalendarInterval.fromString("interval 1 second"),
+      Deduplicate(
+        attributeWithWatermark :: Nil,
+        EventTimeWatermark(
+          attribute,
+          CalendarInterval.fromString("interval 2 seconds"),
+          streamRelation))),
+    outputMode = Append,
+    expectedMsgs = Seq("both before and after"))
+
+  assertNotSupportedInStreamingPlan(
+    "watermark on both sides of flatMapGroupsWithState",
+    EventTimeWatermark(
+      attribute,
+      CalendarInterval.fromString("interval 1 second"),
+      FlatMapGroupsWithState(
+        null, attribute, attribute, Seq(attribute), Seq(attribute), attribute,
+        null, Update, isMapGroupsWithState = false, null,
+        EventTimeWatermark(
+          attribute,
+          CalendarInterval.fromString("interval 2 seconds"),
+          streamRelation))),
+    outputMode = Update,
     expectedMsgs = Seq("both before and after"))
 
   val att = new AttributeReference(name = "a", dataType = LongType)()

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -140,6 +140,21 @@ class UnsupportedOperationsSuite extends SparkFunSuite {
     outputMode = Complete,
     expectedMsgs = Seq("distinct aggregation"))
 
+  assertNotSupportedInStreamingPlan(
+    "aggregate on both sides of stateful op",
+    EventTimeWatermark(
+      attribute,
+      CalendarInterval.fromString("interval 1 second"),
+      Aggregate(
+        attributeWithWatermark :: Nil,
+        aggExprs("a"),
+        EventTimeWatermark(
+          attribute,
+          CalendarInterval.fromString("interval 2 seconds"),
+          streamRelation))),
+    outputMode = Append,
+    expectedMsgs = Seq("both before and after"))
+
   val att = new AttributeReference(name = "a", dataType = LongType)()
   // FlatMapGroupsWithState: Both function modes equivalent and supported in batch.
   for (funcMode <- Seq(Append, Update)) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Forbid watermarks on both sides of stateful streaming operators.

Multiple sequential watermarks are in general not supported by the execution engine; support is only in parallel, e.g. on both sides of a join. We can normally resolve this by simply picking the topmost watermark operator  and ignoring the rest, but this is not semantically valid when there's a stateful operator in between.

## How was this patch tested?

new unit test