### PR TITLE
[SPARK-23744][CORE]Fix memory leak in ReadableChannelFileRegion

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/DiskStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskStore.scala
@@ -301,7 +301,10 @@ private class ReadableChannelFileRegion(source: ReadableByteChannel, blockSize: 
     written
   }
 
-  override def deallocate(): Unit = source.close()
+  override def deallocate() {
+    source.close()
+    StorageUtils.dispose(buffer)
+  }
 }
 
 private class CountingWritableChannel(sink: WritableByteChannel) extends WritableByteChannel {

--- a/core/src/test/scala/org/apache/spark/storage/DiskStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskStoreSuite.scala
@@ -197,7 +197,7 @@ class DiskStoreSuite extends SparkFunSuite {
     while (region.transfered() < region.count()) {
       region.transferTo(byteChannel, region.transfered())
     }
-
+    region.release()
     byteChannel.close()
     byteChannel.getData
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
In the class `ReadableChannelFileRegion`,  the `buffer` is direct memory, we should  modify `deallocate` to free it, and `deallocate`  will be called by `release`

## How was this patch tested?
existing unit test 