### PR TITLE
[SPARK-23745][SQL]Remove the directories of the “hive.downloaded.resources.dir” when HiveThriftServer2 stopped

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -25,7 +25,7 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.hadoop.fs.Path
+import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.hive.common.StatsSetupConst
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars
@@ -181,6 +181,11 @@ private[hive] class HiveClientImpl(
       Hive.set(clientLoader.cachedHive.asInstanceOf[Hive])
     }
     SessionState.start(state)
+
+    val resourceDir = new Path(hiveConf.getVar(ConfVars.DOWNLOADED_RESOURCES_DIR))
+    val fs: FileSystem = resourceDir.getFileSystem(hiveConf)
+    fs.deleteOnExit(resourceDir)
+
     state.out = new PrintStream(outputBuffer, true, "UTF-8")
     state.err = new PrintStream(outputBuffer, true, "UTF-8")
     state


### PR DESCRIPTION
## What changes were proposed in this pull request?

![2018-03-20_164832](https://user-images.githubusercontent.com/24823338/37647937-871ff346-2c68-11e8-9ca4-1b3ebb291530.png)

when start the HiveThriftServer2(`./sbin/start-thriftserver.sh`), we create some  directories for hive.downloaded.resources.dir, but when stop the HiveThriftServer2(`./sbin/stop-thriftserver.sh`), we do not remove these directories.The directories could accumulate a lot.

## How was this patch tested?

manual tests

