### PR TITLE
[SPARK-23542] The exists action shoule be further optimized in logical plan

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -134,6 +134,11 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
       ReplaceExceptWithFilter,
       ReplaceExceptWithAntiJoin,
       ReplaceDistinctWithAggregate) ::
+    Batch("RewriteSubquery", Once,
+        RewritePredicateSubquery,
+        ColumnPruning,
+        CollapseProject,
+        RemoveRedundantProject) ::
     Batch("Aggregate", fixedPoint,
       RemoveLiteralFromGroupExpressions,
       RemoveRepetitionFromGroupExpressions) :: Nil ++
@@ -150,12 +155,7 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
       PropagateEmptyRelation) :+
     // The following batch should be executed after batch "Join Reorder" and "LocalRelation".
     Batch("Check Cartesian Products", Once,
-      CheckCartesianProducts) :+
-    Batch("RewriteSubquery", Once,
-      RewritePredicateSubquery,
-      ColumnPruning,
-      CollapseProject,
-      RemoveRedundantProject)
+      CheckCartesianProducts) 
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -155,7 +155,7 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
       PropagateEmptyRelation) :+
     // The following batch should be executed after batch "Join Reorder" and "LocalRelation".
     Batch("Check Cartesian Products", Once,
-      CheckCartesianProducts) 
+      CheckCartesianProducts)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -53,6 +53,7 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
         PushProjectionThroughUnion,
         ReorderJoin,
         EliminateOuterJoin,
+        RewritePredicateSubquery,
         PushPredicateThroughJoin,
         PushDownPredicate,
         LimitPushDown,
@@ -134,11 +135,6 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
       ReplaceExceptWithFilter,
       ReplaceExceptWithAntiJoin,
       ReplaceDistinctWithAggregate) ::
-    Batch("RewriteSubquery", Once,
-        RewritePredicateSubquery,
-        ColumnPruning,
-        CollapseProject,
-        RemoveRedundantProject) ::
     Batch("Aggregate", fixedPoint,
       RemoveLiteralFromGroupExpressions,
       RemoveRepetitionFromGroupExpressions) :: Nil ++
@@ -155,7 +151,13 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
       PropagateEmptyRelation) :+
     // The following batch should be executed after batch "Join Reorder" and "LocalRelation".
     Batch("Check Cartesian Products", Once,
-      CheckCartesianProducts)
+      CheckCartesianProducts) :+
+    Batch("RewriteSubquery", Once,
+      ColumnPruning,
+      CollapseProject,
+      RemoveRedundantProject)
+
+
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
The optimized logical plan of query `select * from tt1 where exists (select *  from tt2  where tt1.i = tt2.i)` is

> == Optimized Logical Plan ==
Join LeftSemi, (i#14 = i#16)
  :- HiveTableRelation `default`.`tt1`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, [i#14, s#15]
 +- Project [i#16]
  +- HiveTableRelation `default`.`tt2`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, [i#16, s#17]

 The `exists` action will be rewritten as semi jion. But i the query of `select * from tt1 left semi join tt2 on tt2.i = tt1.i`, the optimized logical plan is :

> == Optimized Logical Plan ==
Join LeftSemi, (i#22 = i#20)
:- `Filter isnotnull`(i#20)
: +- HiveTableRelation `default`.`tt1`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, [i#20, s#21]
+- Project [i#22]
+- HiveTableRelation `default`.`tt2`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, [i#22, s#23]

 So i think the  optimized logical plan of 'select * from tt1 where exists (select *  from tt2  where tt1.i = tt2.i);` should be further optimization.
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

With this patch, the  optimized logical plan of 'select * from tt1 where exists (select *  from tt2  where tt1.i = tt2.i);`  is:

> == Optimized Logical Plan ==
Join LeftSemi, (i#14 = i#16)
:- `Filter isnotnull(i#14)`
  : +- HiveTableRelation `default`.`tt1`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, [i#14, s#15]
+- Project [i#16]
 :- `Filter isnotnull(i#16)`
  +- HiveTableRelation `default`.`tt2`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, [i#16, s#17]

Please review http://spark.apache.org/contributing.html before opening a pull request.
