### PR TITLE
[SPARK-23750][SQL] Inner Join Elimination based on Informational RI constraints

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -120,6 +120,7 @@ statement
         DROP (IF EXISTS)? partitionSpec (',' partitionSpec)*           #dropTablePartitions
     | ALTER TABLE tableIdentifier partitionSpec? SET locationSpec      #setTableLocation
     | ALTER TABLE tableIdentifier RECOVER PARTITIONS                   #recoverPartitions
+    | ALTER TABLE tableIdentifier ADD tableConstraint                  #addTableConstraint
     | DROP TABLE (IF EXISTS)? tableIdentifier PURGE?                   #dropTable
     | DROP VIEW (IF EXISTS)? tableIdentifier                           #dropTable
     | CREATE (OR REPLACE)? (GLOBAL? TEMPORARY)?
@@ -237,6 +238,20 @@ skewSpec
 locationSpec
     : LOCATION STRING
     ;
+
+tableConstraint
+    : (CONSTRAINT identifier)?
+      (PRIMARY KEY keyColNames=identifierList
+        | FOREIGN KEY keyColNames=identifierList referenceClause) constraintState
+    ;
+
+constraintState
+    : (VALIDATE | NOVALIDATE)? (RELY | NORELY)?
+    ;
+
+referenceClause
+   : REFERENCES tableIdentifier (referenceColNames = identifierList)?
+   ;
 
 query
     : ctes? queryNoWith
@@ -753,6 +768,7 @@ nonReserved
     | DATABASE | SELECT | FROM | WHERE | HAVING | TO | TABLE | WITH | NOT
     | DIRECTORY
     | BOTH | LEADING | TRAILING
+    | CONSTRAINT | PRIMARY | FOREIGN | KEY | REFERENCES | VALIDATE | NOVALIDATE | RELY | NORELY
     ;
 
 SELECT: 'SELECT';
@@ -986,6 +1002,15 @@ OPTION: 'OPTION';
 ANTI: 'ANTI';
 LOCAL: 'LOCAL';
 INPATH: 'INPATH';
+CONSTRAINT: 'CONSTRAINT';
+PRIMARY: 'PRIMARY';
+FOREIGN: 'FOREIGN';
+KEY: 'KEY';
+REFERENCES: 'REFERENCES';
+VALIDATE: 'VALIDATE';
+NOVALIDATE: 'NOVALIDATE';
+RELY: 'RELY';
+NORELY: 'NORELY';
 
 STRING
     : '\'' ( ~('\''|'\\') | ('\\' .) )* '\''

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/TableConstraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/TableConstraints.scala
@@ -58,6 +58,22 @@ case class TableConstraints(
       case fk: ForeignKey => this.copy(foreignKeys = foreignKeys :+ fk)
     }
   }
+
+  /**
+   * Retrieves the foreign keys referencing the input table.
+   */
+  def findForeignKeys(
+      referencedTable: TableIdentifier,
+      resolver: Resolver): Seq[Seq[String]] =
+    foreignKeys.filter { fk =>
+      val fkReferencedTable = fk.referenceTableIdentifier
+      // TODO: uncomment validation when SPARK-22064 is implemented.
+      // fk.isValidated &&
+      resolver(fkReferencedTable.table, referencedTable.table) &&
+        fkReferencedTable.database.nonEmpty &&
+        referencedTable.database.nonEmpty &&
+        resolver(fkReferencedTable.database.get, referencedTable.database.get)
+    }.map { fk => fk.keyColumnNames}
 }
 
 object TableConstraints {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/TableConstraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/TableConstraints.scala
@@ -1,0 +1,322 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.catalog
+
+import java.util.UUID
+
+import org.json4s._
+import org.json4s.JsonAST.JValue
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.analysis.Resolver
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.util.SchemaUtils
+
+/**
+ * A container class to hold all the constraints defined on a table. Scope of the
+ * constraint names are at the table level.
+ */
+case class TableConstraints(
+    primaryKey: Option[PrimaryKey] = None,
+    foreignKeys: Seq[ForeignKey] = Seq.empty) {
+
+  /**
+   * Adds the given constraint to the existing table constraints, after verifying the
+   * constraint name is not a duplicate.
+   */
+  def addConstraint(constraint: TableConstraint, resolver: Resolver): TableConstraints = {
+    if ((primaryKey.exists(pk => resolver(pk.constraintName, constraint.constraintName))
+      || foreignKeys.exists(fk => resolver(fk.constraintName, constraint.constraintName)))) {
+      throw new AnalysisException(
+        s"Failed to add constraint, duplicate constraint name '${constraint.constraintName}'")
+    }
+    constraint match {
+      case pk: PrimaryKey =>
+        if (primaryKey.nonEmpty) {
+          throw new AnalysisException(
+            s"Primary key '${primaryKey.get.constraintName}' already exists.")
+        }
+        this.copy(primaryKey = Option(pk))
+      case fk: ForeignKey => this.copy(foreignKeys = foreignKeys :+ fk)
+    }
+  }
+}
+
+object TableConstraints {
+  /**
+   * Returns a [[TableConstraints]] containing [[PrimaryKey]] or [[ForeignKey]]
+   */
+  def apply(tableConstraint: TableConstraint): TableConstraints = {
+    tableConstraint match {
+      case pk: PrimaryKey => TableConstraints(primaryKey = Option(pk))
+      case fk: ForeignKey => TableConstraints(foreignKeys = Seq(fk))
+    }
+  }
+
+  /**
+   * Converts constraints represented in Json strings to [[TableConstraints]].
+   */
+  def fromJson(pkJson: Option[String], fksJson: Seq[String]): TableConstraints = {
+    val pk = pkJson.map(pk => PrimaryKey.fromJson(parse(pk)))
+    val fks = fksJson.map(fk => ForeignKey.fromJson(parse(fk)))
+    TableConstraints(pk, fks)
+  }
+}
+
+/**
+ * Common type representing a table constraint.
+ */
+sealed trait TableConstraint {
+  val constraintName : String
+  val keyColumnNames : Seq[String]
+}
+
+object TableConstraint {
+  private[TableConstraint] val curId = new java.util.concurrent.atomic.AtomicLong(0L)
+  private[TableConstraint] val jvmId = UUID.randomUUID()
+
+  /**
+   * Generates unique constraint name to use when adding table constraints,
+   * if user does not specify a name. The `curId` field is unique within a given JVM,
+   * while the `jvmId` is used to uniquely identify JVMs.
+   */
+  def generateConstraintName(constraintType: String = "constraint"): String = {
+    s"${constraintType}_${jvmId}_${curId.getAndIncrement()}"
+  }
+
+  def parseColumn(json: JValue): String = json match {
+    case JString(name) => name
+    case _ => json.toString
+  }
+
+  object JSortedObject {
+    def unapplySeq(value: JValue): Option[List[(String, JValue)]] = value match {
+      case JObject(seq) => Some(seq.toList.sortBy(_._1))
+      case _ => None
+    }
+  }
+
+  /**
+   * Returns [[StructField]] for the given column name if it exists in the given schema.
+   */
+  def findColumnByName(
+      schema: StructType, name: String, resolver: Resolver): StructField = {
+    schema.fields.collectFirst {
+      case field if resolver(field.name, name) => field
+    }.getOrElse(throw new AnalysisException(
+      s"Invalid column reference '$name', table data schema is '${schema}'"))
+  }
+
+  /**
+   * Verify the user input constraint information, and add the missing information
+   * like the unspecified reference columns that defaults to reference table's primary key.
+   */
+  def verifyAndBuildConstraint(
+      inputConstraint: TableConstraint,
+      table: CatalogTable,
+      catalog: SessionCatalog,
+      resolver: Resolver): TableConstraint = {
+    SchemaUtils.checkColumnNameDuplication(
+      inputConstraint.keyColumnNames, "in the constraint key definition", resolver)
+    // check if the column names are valid non-partition columns.
+    val keyColFields = inputConstraint.keyColumnNames
+      .map(findColumnByName(table.dataSchema, _, resolver))
+    // Constraints are only supported for basic sql types, throw error for any other data types.
+    keyColFields.map(_.dataType).foreach {
+      case ByteType | ShortType | IntegerType | LongType | FloatType |
+           DoubleType | BooleanType | _: DecimalType | TimestampType |
+           DateType | StringType | BinaryType =>
+      case otherType => throw new UnsupportedOperationException(
+        s"Constraints are not supported for ${otherType.simpleString} data type.")
+    }
+    inputConstraint match {
+      case pk: PrimaryKey => pk
+      case fk: ForeignKey => ForeignKey.verifyAndBuildForeignKey(fk, table, catalog, resolver)
+    }
+  }
+}
+
+/**
+ * A Primary key constraint defined on a table.
+ */
+case class PrimaryKey(
+  constraintName: String,
+  keyColumnNames: Seq[String],
+  isValidated: Boolean = false,
+  isRely: Boolean = false) extends TableConstraint {
+
+  def json: String = compact(render(jsonValue))
+
+  private def jsonValue: JValue = {
+    ("id" -> constraintName) ~
+      ("keyCols" -> keyColumnNames) ~
+      ("rely" -> isRely) ~
+      ("validate" -> isValidated)
+  }
+}
+
+object PrimaryKey {
+  import TableConstraint._
+
+  /**
+   * Converts the primary key represented in Json string to [[PrimaryKey]].
+   */
+  def fromJson(json: JValue): PrimaryKey = json match {
+    case JSortedObject(
+    ("id", JString(id)),
+    ("keyCols", JArray(keyCols)),
+    ("rely", JBool(rely)),
+    ("validate", JBool(validate))
+    ) =>
+      PrimaryKey(
+        constraintName = id,
+        keyColumnNames = keyCols.map(parseColumn),
+        isValidated = validate,
+        isRely = rely)
+  }
+}
+
+/**
+ * A Foreign key defined on a table.
+ */
+case class ForeignKey(
+  constraintName: String,
+  keyColumnNames: Seq[String],
+  referenceTableIdentifier: TableIdentifier,
+  referenceColumnNames: Seq[String] = Seq.empty,
+  isValidated: Boolean = false,
+  isRely: Boolean = false) extends TableConstraint {
+
+  def json: String = compact(render(jsonValue))
+
+  private def jsonValue: JValue = {
+    ("id" -> constraintName) ~
+      ("keyCols" -> keyColumnNames) ~
+      ("refCols" -> referenceColumnNames) ~
+      ("refDb" -> referenceTableIdentifier.database.get) ~
+      ("refTable" -> referenceTableIdentifier.table) ~
+      ("rely" -> isRely) ~
+      ("validate" -> isValidated)
+  }
+}
+
+object ForeignKey {
+  import TableConstraint._
+  /**
+   * Converts a foreign key represented in Json string to [[ForeignKey]].
+   */
+  def fromJson(json: JValue): ForeignKey = json match {
+    case JSortedObject(
+    ("id", JString(id)),
+    ("keyCols", JArray(keyCols)),
+    ("refCols", JArray(referenceCols)),
+    ("refDb", JString(referenceDb)),
+    ("refTable", JString(referenceTable)),
+    ("rely", JBool(rely)),
+    ("validate", JBool(validate))
+    ) =>
+      ForeignKey(
+        constraintName = id,
+        keyColumnNames = keyCols.map(parseColumn),
+        referenceTableIdentifier = TableIdentifier(referenceTable, Option(referenceDb)),
+        referenceColumnNames = referenceCols.map(parseColumn),
+        isValidated = validate,
+        isRely = rely)
+  }
+
+  /**
+   * Verify the user specified foreign key information, and add the missing information
+   * such as the the unspecified reference columns and the database of the reference table.
+   * When user does not specify reference columns, they are set to reference table's
+   * primary key columns.
+   */
+  def verifyAndBuildForeignKey(
+      inputFk: ForeignKey,
+      table: CatalogTable,
+      catalog: SessionCatalog,
+      resolver: Resolver): TableConstraint = {
+    SchemaUtils.checkColumnNameDuplication(
+      inputFk.referenceColumnNames, "in the foreign key references clause", resolver)
+    // verify the reference table has a primary key on the foreign key reference columns.
+    val refTable = catalog.getTableMetadata(inputFk.referenceTableIdentifier)
+    val refPk = refTable.tableConstraints.flatMap(_.primaryKey).getOrElse(
+      throw new AnalysisException(
+        "Primary key is not defined on the reference table:" + refTable.identifier)
+    )
+    // Set the reference column names to the referenced table primary key columns,
+    // when user does not specify reference column names using references clause.
+    val referenceColumnNames = if (inputFk.referenceColumnNames.isEmpty) {
+      refPk.keyColumnNames
+    } else {
+      // size of the reference columns list and the reference table
+      // primary key column list should be same
+      if (inputFk.referenceColumnNames.size != refPk.keyColumnNames.size) {
+        throw new AnalysisException(
+          s"""
+             |Referencing columns list size ${inputFk.referenceColumnNames.size}
+             |is not same as referenced table primary key columns list
+             |size ${refPk.keyColumnNames.size}")
+           """.stripMargin.replace("\n", " ").trim())
+      }
+
+      // reference column names should match primary key columns in the same order
+      for ((refColumn, refPkColumn) <- (inputFk.referenceColumnNames zip refPk.keyColumnNames)) {
+        if (!resolver(refColumn, refPkColumn)) {
+          throw new AnalysisException(
+            s"""
+               |Referencing columns ${inputFk.referenceColumnNames.mkString("(", ",", ")")} does not
+               |match reference table primary key
+               |columns ${refPk.keyColumnNames.mkString("(", ",", ")")}
+             """.stripMargin.replace("\n", " ").trim())
+        }
+      }
+      inputFk.referenceColumnNames
+    }
+
+    // size foreign key columns list and reference key column list should be same
+    if (inputFk.keyColumnNames.size != referenceColumnNames.size) {
+      throw new AnalysisException(
+        s"""
+           |Foreign key columns list size ${inputFk.keyColumnNames.size}
+           |is not same as referencing columns list size ${referenceColumnNames.size}")
+         """.stripMargin.replace("\n", " ").trim())
+    }
+
+    // Foreign key columns and referenced primary key columns data types should match
+    val keyColFields = inputFk.keyColumnNames.map(findColumnByName(table.dataSchema, _, resolver))
+    val refKeyColFields = referenceColumnNames
+      .map(findColumnByName(refTable.dataSchema, _, resolver))
+
+    for ((keyField, refKeyField) <- (keyColFields zip refKeyColFields)) {
+      if (!keyField.dataType.sameType(refKeyField.dataType)) {
+        throw new AnalysisException(
+          s"""
+             |Foreign key column data type ${keyField.name}:${keyField.dataType.simpleString}
+             |does not match with referencing column
+             |data type ${refKeyField.name}:${refKeyField.dataType.simpleString}.
+           """.stripMargin.replace("\n", " ").trim())
+      }
+    }
+    inputFk.copy(
+      referenceColumnNames = referenceColumnNames,
+      referenceTableIdentifier = refTable.identifier)
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -231,7 +231,8 @@ case class CatalogTable(
     unsupportedFeatures: Seq[String] = Seq.empty,
     tracksPartitionsInCatalog: Boolean = false,
     schemaPreservesCase: Boolean = true,
-    ignoredProperties: Map[String, String] = Map.empty) {
+    ignoredProperties: Map[String, String] = Map.empty,
+    tableConstraints: Option[TableConstraints] = None) {
 
   import CatalogTable._
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -610,3 +610,10 @@ case class HiveTableRelation(
     dataCols = dataCols.map(_.newInstance()),
     partitionCols = partitionCols.map(_.newInstance()))
 }
+
+/**
+ * An interface implemented by the LogicalRelation to return the underlying catalog table.
+ */
+trait CatalogMetadata {
+  def metadata: Option[CatalogTable] = None
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CostBasedJoinReorder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CostBasedJoinReorder.scala
@@ -74,7 +74,7 @@ object CostBasedJoinReorder extends Rule[LogicalPlan] with PredicateHelper {
    * Extracts items of consecutive inner joins and join conditions.
    * This method works for bushy trees and left/right deep trees.
    */
-  private def extractInnerJoins(plan: LogicalPlan): (Seq[LogicalPlan], Set[Expression]) = {
+  def extractInnerJoins(plan: LogicalPlan): (Seq[LogicalPlan], Set[Expression]) = {
     plan match {
       case Join(left, right, _: InnerLike, Some(cond)) =>
         val (leftPlans, leftConditions) = extractInnerJoins(left)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -57,6 +57,7 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
         PushDownPredicate,
         LimitPushDown,
         ColumnPruning,
+        EliminateRIInnerJoins,
         InferFiltersFromConstraints,
         // Operator combine
         CollapseRepartition,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -19,12 +19,15 @@ package org.apache.spark.sql.catalyst.optimizer
 
 import scala.annotation.tailrec
 
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.planning.ExtractFiltersAndInnerJoins
+import org.apache.spark.sql.catalyst.planning.{ExtractFiltersAndInnerJoins, PhysicalOperation}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{HIVE_TYPE_STRING, StringType}
 
 /**
  * Reorder the joins and push all the conditions into join, so that the bottom ones have at least
@@ -150,5 +153,473 @@ object EliminateOuterJoin extends Rule[LogicalPlan] with PredicateHelper {
     case f @ Filter(condition, j @ Join(_, _, RightOuter | LeftOuter | FullOuter, _)) =>
       val newJoinType = buildNewJoinType(f, j)
       if (j.joinType == newJoinType) f else Filter(condition, j.copy(joinType = newJoinType))
+  }
+}
+
+/**
+ * The inner join elimination rewrite optimization eliminates tables
+ * from the query when the join is a primary key to foreign key
+ * join and only the primary key columns from the primary table
+ * are referenced in the query.
+ */
+object EliminateRIInnerJoins extends Rule[LogicalPlan] with PredicateHelper {
+
+  private def conf = SQLConf.get
+
+  /**
+   * Finds the primary key information from a base table access plan.
+   */
+  private def findPKInfo(plan: LogicalPlan): Option[(TableIdentifier, Seq[Attribute])] = {
+    plan match {
+      case p @ PhysicalOperation(_, _, t @ HiveTableRelation(catalogTable, _, _)) =>
+        findPKInfo(catalogTable, p.outputSet)
+      case p @ PhysicalOperation(_, _, t: CatalogMetadata) if t.metadata.isDefined =>
+        findPKInfo(t.metadata.get, p.outputSet)
+      case _ =>
+        None
+    }
+  }
+
+  /**
+   * Finds the primary key info from a catalog table.
+   * It maps the primary key to the input set of columns.
+   */
+  private def findPKInfo (
+      catalogTable: CatalogTable,
+      columns: AttributeSet): Option[(TableIdentifier, Seq[Attribute])] = {
+    if (catalogTable.tableConstraints.nonEmpty &&
+      catalogTable.tableConstraints.get.primaryKey.nonEmpty) {
+      // TODO: Uncomment when SPARK-22064 is implemented.
+      // && catalogTable.tableConstraints.get.primaryKey.get.isValidated
+      val keys = catalogTable.tableConstraints.get.primaryKey.get.keyColumnNames
+      val mappedKeys = mapRIKeys(keys, columns)
+      if (mappedKeys.nonEmpty) {
+        Some((catalogTable.identifier, mappedKeys))
+      } else {
+        None
+      }
+    } else {
+      None
+    }
+  }
+
+  /**
+   * Finds the foreign keys from a base table access plan given a parent table.
+   */
+  private def findFKInfo(
+      plan: LogicalPlan,
+      referencedTable: TableIdentifier): Seq[Seq[Attribute]] = plan match {
+    case p @ PhysicalOperation(_, _, t @ HiveTableRelation(catalogTable, _, _)) =>
+      findFKInfo(catalogTable, referencedTable, p.outputSet)
+    case p @ PhysicalOperation(_, _, t: CatalogMetadata) if t.metadata.isDefined =>
+      findFKInfo(t.metadata.get, referencedTable, p.outputSet)
+    case _ =>
+      Seq.empty
+  }
+
+  /**
+   * Finds the foreign keys from a catalog table given a parent table.
+   * It maps the keys to the input set of columns.
+   */
+  private def findFKInfo (
+      catalogTable: CatalogTable,
+      referencedTable: TableIdentifier,
+      columns: AttributeSet): Seq[Seq[Attribute]] = {
+    if (catalogTable.tableConstraints.nonEmpty &&
+      catalogTable.tableConstraints.get.foreignKeys.nonEmpty) {
+      catalogTable.tableConstraints.get.findForeignKeys(referencedTable, conf.resolver)
+        .map { fk => mapRIKeys(fk, columns) }
+        .filter { f => f.nonEmpty }
+    } else {
+      Seq.empty
+    }
+  }
+
+  /**
+   * Maps the RI keys to a set of columns.
+   */
+  private def mapRIKeys(keys: Seq[String], columns: AttributeSet): Seq[Attribute] = {
+    if (keys.nonEmpty && keys.forall(key => columns.exists(col => conf.resolver(col.name, key)))) {
+      keys.map(key => columns.find(col => conf.resolver(col.name, key)).get)
+    } else {
+      Seq.empty
+    }
+  }
+
+  /**
+   * Determines if there is any non-eligible predicate for the RI join
+   * elimination rewrite. A predicate referencing a column from the PK table
+   * is non eligible under the following conditions:
+   * 1. Non deterministic
+   * 2. References non-PK columns.
+   * 3. References columns from other tables in a non equi-join predicate.
+   * 4. Contains length sensitive functions
+   *
+   * @param conditions Set of predicates
+   * @param pkPlanCols PK table columns
+   * @param pkCols     PK keys
+   * @param fkPlanCols FK table columns
+   * @return true/false
+   */
+  private def hasNonEligiblePredicates(
+      conditions: Seq[Expression],
+      pkPlanCols: Seq[Attribute],
+      pkCols: Seq[Attribute],
+      fkPlanCols: Seq[Attribute]): Boolean = conditions.exists { exp =>
+    val referencedCols = exp.references
+
+    if (referencedCols.exists(col => pkPlanCols.exists(pk => pk.semanticEquals(col)))) {
+
+      // Has non-PK columns
+      val hasNonPKCols = referencedCols.exists { expCol =>
+        pkPlanCols.exists(planCol => planCol.semanticEquals(expCol)) &&
+          pkCols.forall(pk => !pk.semanticEquals(expCol))
+      }
+
+      // Has columns from other tables than PK/FK tables
+      val hasOtherCols = referencedCols.exists { expCol =>
+        pkPlanCols.forall(pk => !pk.semanticEquals(expCol)) &&
+          fkPlanCols.forall(pk => !pk.semanticEquals(expCol))
+      }
+
+      if (!exp.deterministic || hasNonPKCols) {
+        true
+      } else if (hasOtherCols) {
+        // Conservatively, only allow equi joins between PK cols and other
+        // tables.
+        exp match {
+          case Equality(l: AttributeReference, r: AttributeReference) => false
+          case _ => true
+        }
+
+      } else {
+        val hasLengthSensFcts = hasLengthSensitiveExpr(exp, pkPlanCols)
+        val hasSubq = SubqueryExpression.hasSubquery(exp)
+
+        hasLengthSensFcts || hasSubq
+      }
+    } else {
+      false
+    }
+  }
+
+  /**
+   * Checks if two string data types have the same comparison
+   * semantics. For example, CHAR type uses a blank padded
+   * comparison, while VARCHAR type uses non-blank padded comparison.
+   */
+  private def sameComparisonSemantics(l: Attribute, r: Attribute): Boolean = {
+    (l.dataType, r.dataType) match {
+      case (lType: StringType, rType: StringType) =>
+        val left = l.metadata.contains(HIVE_TYPE_STRING)
+        val right = r.metadata.contains(HIVE_TYPE_STRING)
+        (left, right) match {
+          case (true, true) =>
+            l.metadata.getString(HIVE_TYPE_STRING) == r.metadata.getString(HIVE_TYPE_STRING)
+          case (false, false) => true
+          case (_, _) => false
+        }
+      case (_, _) => true
+    }
+  }
+
+  /**
+   * Checks if any columns in the input set are used in length sensitive functions.
+   */
+  private def hasLengthSensitiveExpr(
+      expr: Expression,
+      cols: Seq[Attribute]): Boolean = expr match {
+    case BinaryComparison(e1: AttributeReference, e2: Literal) => false
+    case BinaryComparison(e1: Literal, e2: AttributeReference) => false
+    case BinaryComparison(e1, e2) =>
+      hasLengthSensitiveExpr(e1, cols) || hasLengthSensitiveExpr(e2, cols)
+    case Like(e1: AttributeReference, e2: Literal) => false
+    case Like(e1: Literal, e2: AttributeReference) => false
+    case Like(e1, e2) =>
+      hasLengthSensitiveExpr(e1, cols) || hasLengthSensitiveExpr(e2, cols)
+    case IsNotNull(e: AttributeReference) => false
+    case IsNotNull(e) =>
+      hasLengthSensitiveExpr(e, cols)
+    // TODO: Refine the restriction with character specific functions.
+    // e.g. LENGTH()
+    case e =>
+      e.references.exists { col =>
+        col.dataType == StringType && cols.exists(_.semanticEquals(col))
+      }
+  }
+
+  // Keeps PK info for a given query plan
+  private case class RIPKInfo(
+    plan: LogicalPlan,
+    table: TableIdentifier,
+    key: Seq[Attribute])
+
+  // Keeps RI related information for a given query plan
+  private case class RIInfo(
+    pkPlan: LogicalPlan,
+    pkCols: Seq[Attribute],
+    fkPlan: LogicalPlan,
+    fkCols: Seq[Attribute],
+    joinCond: Seq[Expression],
+    joinKeys: Seq[(AttributeReference, AttributeReference)])
+
+  /**
+   * Returns a new plan after the join elimination transformation.
+   * The method takes as input an inner join and the required output.
+   * It first finds the PK-FK relationship among the input tables. The input
+   * tables are assumed to be simple base table accesses (i.e. simple Project/Filter
+   * over leaf nodes). Next, it decides if any PK tables can be removed. For that, it
+   * analyzes the predicates and the output columns for the presence of the PK table columns.
+   * If any PK tables can be removed, it rebuilds the plan after the transformation.
+   *
+   * @param plan Inner join
+   * @param outputCols Required output
+   * @return Transformed plan
+   */
+  private def eliminateInnerJoins(
+      plan: LogicalPlan,
+      outputCols: Seq[Expression]): Option[LogicalPlan] = plan match {
+    case join @ Join(_, _, t: InnerLike, joinCond) =>
+
+      // Find the input plans of the inner joins.
+      // Use CostBasedJoinReorder.extractInnerJoins() method to traverse both
+      // left and right deep trees.
+      val (innerPlans, jConditions) = CostBasedJoinReorder.extractInnerJoins(join)
+      val conditions = jConditions.toSeq
+
+      // Find the PK tables
+      val pkTables = innerPlans.collect {
+        case p @ PhysicalOperation(projectList, _, t: LeafNode)
+          if projectList.forall(_.isInstanceOf[Attribute]) =>
+          val pkInfo = findPKInfo(p)
+          (p, pkInfo)
+      }.collect {
+        case (p, Some(pkInfo)) => RIPKInfo(p, pkInfo._1, pkInfo._2)
+      }
+
+      // Find the PK-FK pairs
+      val pkFkPairs = pkTables.collect {
+        case RIPKInfo(pkPl, pkTbl, pkKey) =>
+          innerPlans.collect {
+            case f @ PhysicalOperation(projectList, _, t: LeafNode)
+              if projectList.forall(_.isInstanceOf[Attribute]) =>
+              val fkCols = findFKInfo(f, pkTbl)
+              (f, fkCols)
+          }.collect {
+            case (fkPl, fkCols) if fkCols.nonEmpty =>
+              fkCols.map { col => (RIPKInfo(pkPl, pkTbl, pkKey), fkPl, col)}
+          }.flatten
+      }.flatten
+
+      // Construct the RI info including the RI join predicates
+      val riInfo = pkFkPairs.collect {
+        case (RIPKInfo(pkPlan, _, pkCols), fkPlan, fkCols) =>
+
+          val pkFkPreds = conditions.flatMap {
+            case pred @ Equality(l: AttributeReference, r: AttributeReference)
+              if canEvaluate(l, pkPlan) && pkCols.exists(_.semanticEquals(l)) &&
+                canEvaluate(r, fkPlan) && fkCols.exists(_.semanticEquals(r)) &&
+                sameComparisonSemantics(l, r) =>
+              Some(pred)
+
+            case pred @ Equality(l: AttributeReference, r: AttributeReference)
+              if canEvaluate(l, fkPlan) && fkCols.exists(_.semanticEquals(l)) &&
+                canEvaluate(r, pkPlan) && pkCols.exists(_.semanticEquals(r)) &&
+                sameComparisonSemantics(l, r) =>
+              Some(pred)
+
+            case _ =>
+              None
+          }
+
+          // Deconstruct the RI predicates into the join keys
+          val pkFkKeys = pkFkPreds.flatMap {
+            case Equality(l: AttributeReference, r: AttributeReference)
+              if canEvaluate(l, pkPlan) && canEvaluate(r, fkPlan) =>
+              Some((l, r))
+
+            case Equality(l: AttributeReference, r: AttributeReference)
+              if canEvaluate(l, fkPlan) && canEvaluate(r, pkPlan) =>
+              Some((r, l))
+
+            case _ =>
+              None
+          }
+
+          // Check if the complete pk/fk keys are present in the RI join predicates
+          if (pkFkKeys.nonEmpty) {
+            val (pkKeys, fkKeys) = pkFkKeys.unzip
+            val foundAllPKs = pkCols.forall(col => pkKeys.exists(_.semanticEquals(col)))
+            val foundAllFKs = fkCols.forall(col => fkKeys.exists(_.semanticEquals(col)))
+
+            if (foundAllPKs && foundAllFKs) {
+              Some(RIInfo(pkPlan, pkCols, fkPlan, fkCols, pkFkPreds, pkFkKeys))
+            } else {
+              None
+            }
+          } else {
+            None
+          }
+      }.flatten
+
+      // Collect all the RI predicates.
+      val riJoins = riInfo.collect {
+        case RIInfo(_, _, _, _, riJoin, _) => riJoin
+      }.flatten
+
+      // Collect other predicates than the RI predicates.
+      val otherPreds = conditions.filterNot(riJoins.contains(_))
+
+      // Find the candidate PK tables to be removed
+      val (candidateTables, requiredTables) = riInfo.collect {
+        case ri @ RIInfo(pkPlan, pkCols, fkPlan, fkCols, preds, keys) =>
+
+          // Collect all PK table columns below the project.
+          // For example, if there is a pushed down Filter, some of the
+          // columns might not be projected out, but they need to be considered
+          // for the analysis.
+          val (allPkPlanCols, pkPlanPDPreds) = pkPlan match {
+            case PhysicalOperation(_, conds, t: LeafNode) =>
+              (t.output, conds)
+            case _ => (Seq.empty, Seq.empty)
+          }
+
+          // Construct non-RI predicates
+          val nonRIPreds = otherPreds ++ pkPlanPDPreds ++
+            riJoins.filterNot(ri.joinCond.contains(_))
+
+          // Check for non eligible predicates.
+          val nonEligiblePreds = hasNonEligiblePredicates(nonRIPreds,
+            allPkPlanCols, pkCols, fkPlan.output)
+
+          // Check if any PK table columns are used in the projected/output columns
+          val inOutputCols = outputCols.exists { exp =>
+            exp.references.exists { expCol =>
+              pkPlan.outputSet.exists { planCol =>
+                planCol.semanticEquals(expCol)
+              }
+            }
+          }
+
+          if (nonEligiblePreds || inOutputCols) {
+            (None, Some(pkPlan))
+          } else {
+            // Find those eligible predicates that have only PK columns and
+            // therefore can be replaced by their corresponding FK columns.
+            val replaceableConds = nonRIPreds.filter { exp =>
+              exp.references.exists { expCol =>
+                allPkPlanCols.exists(planCol => planCol.semanticEquals(expCol)) &&
+                  pkCols.exists(pk => pk.semanticEquals(expCol))
+              }
+            }
+
+            (Some((ri, replaceableConds)), None)
+          }
+      }.unzip
+
+
+      // For each candidate pk table, check if it can be removed
+      val removedPKTables = candidateTables.collect {
+        case Some(e) => e
+      }.collect {
+        case e @ (RIInfo(pkPlan, _, _, _, _, _), _) if !requiredTables.contains(Some(pkPlan)) => e
+      }
+
+      // Next, apply the transformations:
+      // For each PK plan to be removed, do the following:
+      // 1) replace the conditions i.e. cond -> newCond
+      // 2) remove the join predicates i.e cond -> newCond
+      // 3) add new ISNOTNULL predicates for the FK columns to enforce PK column semantics.
+      // 4) remove the PK tables
+      // 5) rebuild the join
+      removedPKTables match {
+        case Nil => None
+        case pkRIRemove =>
+          val newConds = pkRIRemove.collect {
+            case (RIInfo(_, _, _, _, _, jKeys), replaceableConds) =>
+              val (pkKeys, fkKeys) = jKeys.unzip
+              replaceableConds.map { expr =>
+                expr transform {
+                  case a: AttributeReference if pkKeys.contains(a) =>
+                    jKeys.find {
+                      case (e1, e2) if e1.semanticEquals(a) => true
+                      case _ => false
+                    }.get._2
+                }
+              }
+          }.flatten
+
+          // Add IsNotNull predicates for the FK columns
+          val isNotNullPreds = pkRIRemove.collect {
+            case (RIInfo(_, _, _, _, _, jKeys), _) =>
+              jKeys.collect {
+                case (e1, e2) => IsNotNull(e2)
+              }
+          }.flatten
+
+          // Build the new set of predicates.
+          val removedRIJoins = pkRIRemove.collect {
+            case (RIInfo(_, _, _, _, riJns, _), _) => riJns
+
+          }.flatten
+
+          val replaceablePreds = pkRIRemove.collect {
+            case (RIInfo(_, _, _, _, _, _), oldCond) => oldCond
+
+          }.flatten
+
+
+          val newConditions = conditions
+            .filterNot(removedRIJoins.contains(_))
+            .filterNot(replaceablePreds.contains(_)) ++ newConds ++ isNotNullPreds
+
+          // Find the new set of joins
+          val removedPlans = pkRIRemove.collect {
+            case (RIInfo(p, _, _, _, _, _), _) => p
+
+          }
+
+          val joinPlans = innerPlans.map { p =>
+            (p, Inner)
+          }
+
+          val newJoinPlans = joinPlans.filterNot {
+            case (p, _) if removedPlans.contains(p) => true
+            case _ => false
+          }
+
+          newJoinPlans match {
+            case Nil => None
+            case p1 :: Nil =>
+              newConditions match {
+                case Nil =>
+                  Some(p1._1)
+                case _ =>
+                  val newFilter = Filter(newConditions.reduce(And), p1._1)
+                  Some(newFilter)
+              }
+            case p1 :: p2 :: Nil =>
+              val newJoinPlan = ReorderJoin.createOrderedJoin(newJoinPlans, newConditions)
+              Some(newJoinPlan)
+          }
+      }
+    case _ => None
+  }
+
+  def apply(plan: LogicalPlan): LogicalPlan = plan transform {
+    case p @ Project(output, j @ Join(_, _, t: InnerLike, _)) if conf.riJoinElimination =>
+      val newJoinPlan = eliminateInnerJoins(j, output)
+      if (newJoinPlan.nonEmpty) {
+        Project(output, newJoinPlan.get)
+      } else {
+        p
+      }
+    case j @ Join(_, _, t: InnerLike, _) if conf.riJoinElimination =>
+      val newJoinPlan = eliminateInnerJoins(j, j.output)
+      if (newJoinPlan.nonEmpty) {
+        newJoinPlan.get
+      } else {
+        j
+      }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1205,6 +1205,13 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val RI_JOIN_ELIMINATION =
+    buildConf("spark.sql.riJoinElimination")
+      .internal()
+      .doc("Eliminates inner joins based on Referential Integrity constraints. ")
+      .booleanConf
+      .createWithDefault(false)
+
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"
   }
@@ -1367,6 +1374,8 @@ class SQLConf extends Serializable with Logging {
   def stringRedationPattern: Option[Regex] = SQL_STRING_REDACTION_PATTERN.readFrom(reader)
 
   def sortBeforeRepartition: Boolean = getConf(SORT_BEFORE_REPARTITION)
+
+  def riJoinElimination: Boolean = getConf(SQLConf.RI_JOIN_ELIMINATION)
 
   /**
    * Returns the [[Resolver]] for the current configuration, which can be used to determine if two

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -41,6 +41,7 @@ import org.apache.spark.sql.execution.datasources.csv.CSVFileFormat
 import org.apache.spark.sql.execution.datasources.json.JsonFileFormat
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.SchemaUtils
 import org.apache.spark.util.Utils
@@ -250,6 +251,43 @@ case class AlterTableAddColumnsCommand(
   }
 }
 
+/**
+ * A command that add constraint to a table
+ * The syntax of using this command in SQL is:
+ * {{{
+ *  ALTER TABLE [db_name.]table_name ADD [CONSTRAINT constraintName]
+ *  (PRIMARY KEY (col_names) |
+ *   FOREIGN KEY (col_names) REFERENCES [db_name.]table_name [(col_names)])
+ *  [VALIDATE | NOVALIDATE] [RELY | NORELY]
+ *
+ * }}}
+ */
+case class AlterTableAddConstraintCommand(
+    tableIdentifier: TableIdentifier,
+    inputConstraint: TableConstraint) extends RunnableCommand {
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val catalog = sparkSession.sessionState.catalog
+    val table = catalog.getTableMetadata(tableIdentifier)
+    // TODO: Support in-memory catalog, currently only Hive catalog is supported
+    if (!sparkSession.conf.get(CATALOG_IMPLEMENTATION.key).equals("hive")) {
+      throw new UnsupportedOperationException(
+        "Hive support is required to add table constraints.")
+    }
+    if (table.tableType == CatalogTableType.VIEW) {
+      throw new AnalysisException("Can not add table constraints on a view.")
+    }
+    val resolver = sparkSession.sessionState.conf.resolver
+    val constraint = TableConstraint
+      .verifyAndBuildConstraint(inputConstraint, table, catalog, resolver)
+    val newTableConstraints = table.tableConstraints match {
+      case Some(constraints) => constraints.addConstraint(constraint, resolver)
+      case None => TableConstraints(constraint)
+    }
+    catalog.alterTable(table.copy(tableConstraints = Option(newTableConstraints)))
+    Seq.empty[Row]
+  }
+}
 
 /**
  * A command that loads data into a Hive table.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/LogicalRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/LogicalRelation.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.execution.datasources
 
 import org.apache.spark.sql.catalyst.analysis.MultiInstanceRelation
-import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.catalyst.catalog.{CatalogMetadata, CatalogTable}
 import org.apache.spark.sql.catalyst.expressions.{AttributeMap, AttributeReference}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan, Statistics}
@@ -32,7 +32,9 @@ case class LogicalRelation(
     output: Seq[AttributeReference],
     catalogTable: Option[CatalogTable],
     override val isStreaming: Boolean)
-  extends LeafNode with MultiInstanceRelation {
+  extends LeafNode with MultiInstanceRelation with CatalogMetadata {
+
+  override val metadata = catalogTable
 
   // Only care about relation when canonicalizing.
   override def doCanonicalize(): LogicalPlan = copy(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -165,6 +165,16 @@ class InMemoryCatalogedDDLSuite extends DDLSuite with SharedSQLContext with Befo
       assert(e.message.contains("It doesn't match the specified format"))
     }
   }
+
+  test("alter table add constraint") {
+    withTable("t") {
+      sql("create table t (c1 int) using parquet")
+      val e = intercept[UnsupportedOperationException] {
+        sql("ALTER TABLE t ADD PRIMARY KEY(c1)")
+      }.getMessage
+      assert(e.contains("Hive support is required to add table constraints."))
+    }
+  }
 }
 
 abstract class DDLSuite extends QueryTest with SQLTestUtils {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -439,6 +439,27 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     properties
   }
 
+  /**
+   * Converts table constraints into table properties so that we can
+   * persist them through hive client.
+   */
+  private def tableConstraintsToTableProps(table: CatalogTable): mutable.Map[String, String] = {
+    val constraintProperties = new mutable.HashMap[String, String]
+    table.tableConstraints.foreach { tableConstraints =>
+      tableConstraints.primaryKey foreach { pk =>
+        constraintProperties += (s"$TABLE_CONSTRAINT_PRIMARY_KEY" -> pk.json)
+      }
+      val fks = tableConstraints.foreignKeys
+      if (fks.nonEmpty) {
+        constraintProperties += TABLE_CONSTRAINT_NUM_FOREIGN_KEYS -> fks.size.toString()
+        fks.zipWithIndex.foreach { case (fk, index) =>
+          constraintProperties += (s"$TABLE_CONSTRAINT_FOREIGNKEY_PREFIX$index" -> fk.json)
+        }
+      }
+    }
+    constraintProperties
+  }
+
   private def defaultTablePath(tableIdent: TableIdentifier): String = {
     val dbLocation = getDatabase(tableIdent.database.get).locationUri
     new Path(new Path(dbLocation), tableIdent.table).toString
@@ -607,7 +628,12 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
         k.startsWith(DATASOURCE_PREFIX) || k.startsWith(STATISTICS_PREFIX) ||
           k.startsWith(CREATED_SPARK_VERSION)
       }
-      val newTableProps = propsFromOldTable ++ tableDefinition.properties + partitionProviderProp
+
+      // convert table constraints to properties so that we can persist them through hive api
+      val constraintProperties = tableConstraintsToTableProps(tableDefinition)
+
+      val newTableProps = propsFromOldTable ++ tableDefinition.properties +
+        partitionProviderProp ++ constraintProperties
       val newDef = tableDefinition.copy(
         storage = newStorage,
         schema = oldTableDef.schema,
@@ -719,6 +745,12 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       statsFromProperties(table.properties, table.identifier.table, table.schema)
     if (restoredStats.isDefined) {
       table = table.copy(stats = restoredStats)
+    }
+
+    // construct table constraints from the constraint table properties in the Hive metastore
+    val tableConstraints = getConstraintsFromTableProperties(table)
+    if (tableConstraints.isDefined) {
+      table = table.copy(tableConstraints = tableConstraints)
     }
 
     // Get the original table properties as defined by the user.
@@ -1289,6 +1321,11 @@ object HiveExternalCatalog {
 
   val CREATED_SPARK_VERSION = SPARK_SQL_PREFIX + "create.version"
 
+  val TABLE_CONSTRAINT_PREFIX = SPARK_SQL_PREFIX + "constraint."
+  val TABLE_CONSTRAINT_PRIMARY_KEY = TABLE_CONSTRAINT_PREFIX + "pk"
+  val TABLE_CONSTRAINT_NUM_FOREIGN_KEYS = TABLE_CONSTRAINT_PREFIX + "numForeignKeys"
+  val TABLE_CONSTRAINT_FOREIGNKEY_PREFIX = TABLE_CONSTRAINT_PREFIX + "fk."
+
   // When storing data source tables in hive metastore, we need to set data schema to empty if the
   // schema is hive-incompatible. However we need a hack to preserve existing behavior. Before
   // Spark 2.0, we do not set a default serde here (this was done in Hive), and so if the user
@@ -1369,4 +1406,30 @@ object HiveExternalCatalog {
     provider.isDefined && provider != Some(DDLUtils.HIVE_PROVIDER)
   }
 
+  /**
+   * Constructs table constraints from the contraint table properties in Hive metastore.
+   */
+  private def getConstraintsFromTableProperties(table: CatalogTable): Option[TableConstraints] = {
+    val primaryKeyJson = table.properties.get(TABLE_CONSTRAINT_PRIMARY_KEY)
+    val numFkConstraints = table.properties.get(TABLE_CONSTRAINT_NUM_FOREIGN_KEYS)
+    val foreignKeysJson: Seq[String] = if (numFkConstraints.isDefined) {
+      (0 until numFkConstraints.get.toInt).flatMap { index =>
+        val key = s"$TABLE_CONSTRAINT_FOREIGNKEY_PREFIX$index"
+        val fkJson = table.properties.get(key).orElse {
+          throw new AnalysisException(
+            s"Could not read foreign key from the hive metastore because it is corrupted." +
+              s"Missing foreign key $key, ${numFkConstraints.get} foreign keys are expected).")
+        }
+        fkJson
+      }
+    } else {
+      Seq.empty[String]
+    }
+
+    if (primaryKeyJson.isDefined || foreignKeysJson.nonEmpty) {
+      Option(TableConstraints.fromJson(primaryKeyJson, foreignKeysJson))
+    } else {
+      None
+    }
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveRIJElimSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveRIJElimSuite.scala
@@ -1,0 +1,837 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.execution
+
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.hive.test.TestHiveSingleton
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SQLTestUtils
+
+class HiveRIJElimSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    createTablesHive()
+    createTablesParquet()
+    createTablesParquetDT()
+    createTablesParquetSelfJoin()
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      dropTables()
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  def testRIJElim(query: String, rewrittenQuery: String): Unit = {
+
+    withSQLConf(SQLConf.RI_JOIN_ELIMINATION.key -> "false") {
+      val expectedOptimized = sql(rewrittenQuery).queryExecution.optimizedPlan
+      val expectedAnswer = sql(rewrittenQuery).collect()
+
+      withSQLConf(SQLConf.RI_JOIN_ELIMINATION.key -> "true") {
+        comparePlans(sql(query).queryExecution.optimizedPlan, expectedOptimized)
+        checkAnswer(sql(query), expectedAnswer)
+      }
+    }
+  }
+
+  // Unit tests coverage:
+  // Unit tests RI1: Two way RI joins
+  // Unit tests RI2: Restrictions on predicates
+  // Unit tests RI3: Restrictions on columns in Select/Group By/Order By clauses
+  // Unit tests RI4: RI join with multiple PK columns
+  // Unit tests RI5: Multi-way joins
+  // Unit tests RI6: Restrictions on string data type
+
+  test("RI1.1. RI join with single PK column") {
+    val query =
+      """
+        | select fact.factc2
+        | from fact, dim1
+        | where fact.factc1 = dim1.dim1c1
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery =
+      """
+        | select fact.factc2
+        | from fact
+        | where fact.factc1 is not null
+        | order by 1
+        |
+      """.stripMargin
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI1.2. RI join with local predicate on the PK column") {
+    val query =
+      """
+        | select fact.factc2
+        | from fact, dim1
+        | where fact.factc1 = dim1.dim1c1 and dim1.dim1c1 < 3
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery =
+      """
+        | select fact.factc2
+        | from fact
+        | where fact.factc1 is not null and fact.factc1 < 3
+        | order by 1
+        |
+      """.stripMargin
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI1.3. RI join with local predicate on the PK column in expression") {
+    val query =
+      """
+        | select fact.factc2
+        | from fact, dim1
+        | where fact.factc1 = dim1.dim1c1 and abs(dim1.dim1c1) < 3
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery =
+      """
+        | select fact.factc2
+        | from fact
+        | where fact.factc1 is not null and abs(fact.factc1) < 3
+        | order by 1
+        |
+      """.stripMargin
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI1.4. RI join with additional join predicate on the PK column") {
+    val query =
+      """
+        | select fact.factc2
+        | from fact, dim1
+        | where fact.factc1 = dim1.dim1c1 and
+        |       fact.factc2 = dim1.dim1c1
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery =
+      """
+        | select fact.factc2
+        | from fact
+        | where fact.factc1 is not null and
+        |       fact.factc2 = fact.factc1
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+
+  test("RI2.1.Neg. RI join with local predicate on the non-PK column") {
+    val query =
+      """
+        | select fact.factc2
+        | from fact, dim1
+        | where fact.factc1 = dim1.dim1c1 and dim1.dim1c2 < 3
+        | order by 1
+      """.stripMargin
+
+    val rewrittenQuery = query
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI2.2.Neg. RI join with local predicate on PK and non-PK columns") {
+    val query =
+      """
+        | select fact.factc2
+        | from fact, dim1
+        | where fact.factc1 = dim1.dim1c1 and
+        |       dim1.dim1c2 < 3 and
+        |       dim1.dim1c1 < 5
+        | order by 1
+      """.stripMargin
+
+    val rewrittenQuery = query
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI2.3.Neg. RI join with local predicate on PK and non-PK columns with expressions") {
+    val query =
+      """
+        | select fact.factc2
+        | from fact, dim1
+        | where fact.factc1 = dim1.dim1c1 and
+        |       dim1.dim1c2 + abs(dim1.dim1c1) < 10 and
+        |       dim1.dim1c1 < 8 and fact.factc3 > 0
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery = query
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI2.5.Neg RI join with local predicate on PK column in IN subquery") {
+    val query =
+      """
+        | select fact.factc2
+        | from fact, dim1
+        | where fact.factc1 = dim1.dim1c1 and
+        |       dim1.dim1c1 IN (select t1c1 from t1)
+        | order by 1
+      """.
+        stripMargin
+
+    val rewrittenQuery = query
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI2.6.Neq RI join with local predicate on PK column in correlated EXISTS subquery") {
+    val query =
+      """
+        | select fact.factc2
+        | from fact, dim1
+        | where fact.factc1 = dim1.dim1c1 and
+        |       exists (select t1c1 from t1 where dim1.dim1c1 < 10)
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery = query
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI2.7.Neg RI join with local predicate on PK column in scalar subquery") {
+    val query =
+      """
+        | select fact.factc2
+        | from fact, dim1
+        | where fact.factc1 = dim1.dim1c1 and
+        |       dim1.dim1c1 = (select max(t1c1) from t1)
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery = query
+
+    // testRIJElim(query, rewrittenQuery)
+
+    withSQLConf(SQLConf.RI_JOIN_ELIMINATION.key -> "true") {
+      val expectedOptimized = sql(rewrittenQuery).queryExecution.optimizedPlan
+      val expectedAnswer = sql(rewrittenQuery).collect()
+
+      withSQLConf(SQLConf.RI_JOIN_ELIMINATION.key -> "true") {
+        // TODO: Scalar subquery plans are not traversed
+        // comparePlans(sql(query).queryExecution.optimizedPlan, expectedOptimized)
+        checkAnswer(sql(query), expectedAnswer)
+      }
+    }
+  }
+
+  test("RI2.8.Neg. RI join with additional join predicate on non-PK column") {
+    val query =
+      """
+        | select fact.factc2
+        | from fact, dim1
+        | where fact.factc1 = dim1.dim1c1 and
+        |       fact.factc2 = dim1.dim1c2
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery = query
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI2.9.Neg. Inequality join") {
+    val query =
+      """
+        | select fact.factc2
+        | from fact, dim1
+        | where fact.factc1 <= dim1.dim1c1
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery = query
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI2.10.Neg. Join over nested tables/views") {
+    val query =
+      """
+        | select myfact.c2
+        | from (select fact.factc2 as c2, fact.factc1 as c1 from fact) as myfact, dim1
+        | where myfact.c1 <= dim1.dim1c1
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery = query
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI.3.0 RI join in GroupBy ") {
+    val query =
+      """
+        | select fact.factc2, sum(fact.factc3)
+        | from fact, dim1
+        | where fact.factc1 = dim1.dim1c1
+        | group by fact.factc2
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery =
+      """
+        | select fact.factc2, sum(fact.factc3)
+        | from fact
+        | where fact.factc1 is not null
+        | group by fact.factc2
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI.3.1.Neg PK columns in the SELECT list") {
+    val query =
+      """
+        | select fact.factc2, dim1.dim1c2
+        | from fact, dim1
+        | where fact.factc1 = dim1.dim1c1
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery = query
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI.3.2.Neg PK columns in the SELECT list with expressions") {
+    val query =
+      """
+        | select fact.factc2, abs(dim1.dim1c2)
+        | from fact, dim1
+        | where fact.factc1 = dim1.dim1c1
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery = query
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI.3.3.Neg PK columns in the GroupBy list") {
+    val query =
+      """
+        | select fact.factc2, dim1.dim1c2
+        | from fact, dim1
+        | where fact.factc1 = dim1.dim1c1
+        | group by fact.factc2, dim1.dim1c2
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery = query
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI.3.4.Neg PK columns in the Aggregate functions") {
+    val query =
+      """
+        | select fact.factc2, sum(dim1.dim1c2)
+        | from fact, dim1
+        | where fact.factc1 = dim1.dim1c1
+        | group by fact.factc2
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery = query
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI.3.4.Neg PK columns in the Order By clause") {
+    val query =
+      """
+        | select fact.factc2, dim1.dim1c2
+        | from fact, dim1
+        | where fact.factc1 = dim1.dim1c1
+        | order by 1, 2
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery = query
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI4.1 (Parquet). RI join with multiple PK columns") {
+    val query =
+      """
+        | select fact1.fact1c2
+        | from fact1, dim11
+        | where fact1.fact1c1 = dim11.dim11c1 and
+        |       fact1.fact1c2 = dim11.dim11c2
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery =
+      """
+        | select fact1.fact1c2
+        | from fact1
+        | where fact1.fact1c1 is not null and
+        |       fact1.fact1c2 is not null
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI4.2.Neg (Parquet). RI join with multiple PK columns and missing RI column") {
+    val query =
+      """
+        | select fact1.fact1c2
+        | from fact1, dim11
+        | where fact1.fact1c2 = dim11.dim11c2
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery = query
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI4.3.Neg (Parquet). RI join with multiple PK columns and exprs in join preds") {
+    val query =
+      """
+        | select fact1.fact1c1
+        | from fact1, dim11
+        | where fact1.fact1c1 = dim11.dim11c1 and
+        |       fact1.fact1c2 = abs(dim11.dim11c2)
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery = query
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI4.4 Self-join with RI") {
+    val query =
+      """
+        | select b.pkfkc3
+        | from pkfk a, pkfk b
+        | where  a.pkfkc1 = b.pkfkc2
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery =
+      """
+        | select pkfkc3
+        | from pkfk
+        | where pkfkc2 is not null
+        | order by 1
+        |
+      """.stripMargin
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI.5.1 Multiple RI joins: one fact - two dimensions") {
+    val query =
+      """
+        | select fact.factc3
+        | from fact, dim1, dim2
+        | where fact.factc1 = dim1.dim1c1 and
+        |       fact.factc2 = dim2.dim2c1
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery =
+      """
+        | select fact.factc3
+        | from fact
+        | where fact.factc1 IS NOT NULL and
+        |       fact.factc2 IS NOT NULL
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI.5.2 Three way join with one RI join") {
+    val query =
+      """
+        | select fact.factc3
+        | from t1, fact, dim1
+        | where fact.factc1 = dim1.dim1c1 and
+        |       fact.factc2 = t1.t1c1
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery =
+      """
+        | select fact.factc3
+        | from t1, fact
+        | where fact.factc1 IS NOT NULL and
+        |       fact.factc2 = t1.t1c1
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI.5.3 Dimension in two RI joins") {
+    val query =
+      """
+        | select fact.factc2
+        | from fact, dim1, fact2
+        | where fact.factc1 = dim1.dim1c1 and
+        |       fact2.fact2c1 = dim1.dim1c1
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery =
+      """
+        | select fact.factc2
+        | from fact, fact2
+        | where fact.factc1 = fact2.fact2c1
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI.5.4 RI join and Cartesian product") {
+    val query =
+      """
+        | select fact.factc2
+        | from fact, dim1 cross join t1
+        | where fact.factc1 = dim1.dim1c1
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery =
+      """
+        | select fact.factc2
+        | from fact cross join t1
+        | where fact.factc1 IS NOT NULL
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI.5.5 RI join and Left outer join") {
+    val query =
+      """
+        | select fact.factc2
+        | from dim1 inner join fact on fact.factc1 = dim1.dim1c1 left outer join t1
+        | on fact.factc2 = t1.t1c1
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery =
+      """
+        | select fact.factc2
+        | from fact left outer join t1 on fact.factc2 = t1.t1c1
+        | where fact.factc1 is not null
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI.6.1 String comparison semantics - String data types") {
+    val query =
+      """
+        | select factdt.factdtc1
+        | from factdt, dimdt1
+        | where factdt.factdtc1 = dimdt1.dimdt1c1 and dimdt1.dimdt1c1 like 'ab%'
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery =
+      """
+        | select factdt.factdtc1
+        | from factdt
+        | where factdt.factdtc1 like 'ab%' and factdt.factdtc1 is not null
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI.6.2.Neg. String comparison semantics: With length sensitive functions") {
+    val query =
+      """
+        | select factdt.factdtc1
+        | from factdt, dimdt1
+        | where factdt.factdtc1 = dimdt1.dimdt1c1 and length(dimdt1.dimdt1c1) < 10
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery = query
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI.6.3 String comparison semantics - CHAR data types") {
+    val query =
+      """
+        | select factdt.factdtc2
+        | from factdt, dimdt2
+        | where factdt.factdtc2 = dimdt2.dimdt2c1
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery =
+      """
+        | select factdt.factdtc2
+        | from factdt
+        | where factdt.factdtc2 is not null
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  test("RI.6.4 String comparison semantics - VARCHAR data types") {
+    val query =
+      """
+        | select factdt.factdtc3
+        | from factdt, dimdt3
+        | where factdt.factdtc3 = dimdt3.dimdt3c1
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    val rewrittenQuery =
+      """
+        | select factdt.factdtc3
+        | from factdt
+        | where factdt.factdtc3 is not null
+        | order by 1
+        |
+      """.
+        stripMargin
+
+    testRIJElim(query, rewrittenQuery)
+  }
+
+  def createTablesHive(): Unit = {
+    sql("create table dim1 (dim1c1 int, dim1c2 int, dim1c3 int, dim1c4 int)")
+    sql("create table dim2 (dim2c1 int, dim2c2 int, dim2c3 int, dim2c4 int)")
+    sql("create table fact (factc1 int, factc2 int, factc3 int, factc4 int)")
+    sql("create table fact2 (fact2c1 int, fact2c2 int, fact2c3 int, fact2c4 int)")
+
+    sql("alter table dim1 add constraint pk1 primary key(dim1c1)")
+    sql("alter table dim2 add constraint pk1 primary key(dim2c1)")
+    sql("alter table fact add constraint fk1 foreign key (factc1) references dim1(dim1c1)")
+    sql("alter table fact add constraint fk2 foreign key (factc2) references dim2(dim2c1)")
+    sql("alter table fact2 add constraint fk21 foreign key (fact2c1)" +
+      "references dim1(dim1c1)")
+    sql("alter table fact2 add constraint fk22 foreign key (fact2c2)" +
+      "references dim1(dim1c1)")
+
+    sql("create table t1 (t1c1 int, t1c2 int, t1c3 int, t1c4 int)")
+
+    sql("insert into dim1 values (1,1,1,1)")
+    sql("insert into dim1 values (2,2,2,2)")
+
+    sql("insert into dim2 values (1,1,1,1)")
+    sql("insert into dim2 values (2,2,2,2)")
+
+    sql("insert into fact values (1,1,1,1)")
+    sql("insert into fact values (1,1,1,1)")
+    sql("insert into fact values (2,2,2,2)")
+    sql("insert into fact values (2,2,2,2)")
+
+    sql("insert into fact2 values (1,1,1,1)")
+    sql("insert into fact2 values (2,2,2,2)")
+
+    sql("insert into t1 values (1,1,1,1)")
+    sql("insert into t1 values (2,2,2,2)")
+  }
+
+  def createTablesParquet(): Unit = {
+    sql("create table dim11 (dim11c1 int, dim11c2 int, dim11c3 int," +
+      " dim11c4 int) using Parquet")
+    sql("create table fact1 (fact1c1 int, fact1c2 int, fact1c3 int," +
+      " fact1c4 int) using Parquet")
+
+    sql("alter table dim11 add constraint pk11 primary key(dim11c1, dim11c2)")
+    sql("alter table fact1 add constraint fk11 foreign key (fact1c1, fact1c2)" +
+      "references dim11(dim11c1, dim11c2)")
+
+    sql("insert into fact1 values (1,1,1,1)")
+    sql("insert into fact1 values (1,1,1,1)")
+    sql("insert into fact1 values (2,2,2,2)")
+    sql("insert into fact1 values (2,2,2,2)")
+
+    sql("insert into dim11 values (1,1,1,1)")
+    sql("insert into dim11 values (2,2,2,2)")
+
+  }
+
+  def createTablesParquetSelfJoin(): Unit = {
+    sql("create table pkfk (pkfkc1 int, pkfkc2 int, pkfkc3 int, pkfkc4 int) using parquet")
+    sql("alter table pkfk add constraint pk1 primary key(pkfkc1)")
+    sql("alter table pkfk add constraint fk1 foreign key (pkfkc2) references pkfk(pkfkc1)")
+
+    sql("insert into pkfk values (1,1,1,1)")
+    sql("insert into pkfk values (1,1,1,1)")
+    sql("insert into pkfk values (2,2,2,2)")
+    sql("insert into pkfk values (2,2,2,2)")
+
+  }
+
+  def createTablesParquetDT(): Unit = {
+    sql("create table dimdt1 (dimdt1c1 String, dimdt1c2 int) using Parquet")
+    sql("create table dimdt2 (dimdt2c1 char(10), dimdt2c2 int) using Parquet")
+    sql("create table dimdt3 (dimdt3c1 varchar(10), dimdt3c2 int) using Parquet")
+
+    sql("create table factdt (factdtc1 String, factdtc2 char(10)," +
+      "factdtc3 varchar(10), factdtc4 char(10)) using Parquet")
+
+    sql("alter table dimdt1 add constraint pk1 primary key(dimdt1c1)")
+    sql("alter table dimdt2 add constraint pk1 primary key(dimdt2c1)")
+    sql("alter table dimdt3 add constraint pk1 primary key(dimdt3c1)")
+
+    sql("alter table factdt add constraint fk1 foreign key (factdtc1)" +
+      "references dimdt1(dimdt1c1)")
+    sql("alter table factdt add constraint fk2 foreign key (factdtc2)" +
+      "references dimdt2(dimdt2c1)")
+    sql("alter table factdt add constraint fk3 foreign key (factdtc3)" +
+      "references dimdt3(dimdt3c1)")
+    sql("alter table factdt add constraint fk4 foreign key (factdtc4)" +
+      "references dimdt1(dimdt1c1)")
+
+    sql("insert into dimdt1 values ('1',1)")
+    sql("insert into dimdt1 values ('1 ',1)")
+    sql("insert into dimdt1 values ('1  ',1)")
+
+    sql("insert into dimdt2 values ('1',1)")
+
+    sql("insert into dimdt3 values ('1',1)")
+    sql("insert into dimdt3 values ('1 ',1)")
+    sql("insert into dimdt3 values ('1  ',1)")
+
+    sql("insert into factdt values ('1', '1     ', '1',  '1')")
+    sql("insert into factdt values ('1 ','1  ',    '1 ', '1 ')")
+
+  }
+
+  def dropTables(): Unit = {
+    sql("DROP TABLE IF EXISTS DIM1")
+    sql("DROP TABLE IF EXISTS DIM2")
+    sql("DROP TABLE IF EXISTS DIM11")
+    sql("DROP TABLE IF EXISTS FACT")
+    sql("DROP TABLE IF EXISTS FACT1")
+    sql("DROP TABLE IF EXISTS FACT2")
+    sql("DROP TABLE IF EXISTS T1")
+    sql("DROP TABLE IF EXISTS PKFK")
+    sql("DROP TABLE IF EXISTS DIMDT1")
+    sql("DROP TABLE IF EXISTS DIMDT2")
+    sql("DROP TABLE IF EXISTS DIMDT3")
+    sql("DROP TABLE IF EXISTS FACTDT")
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This transformation detects RI joins and eliminates the parent/PK table if none of its columns, other than the PK columns, are referenced in the query. 

**Example:**

```SQL
select fact.c1
from fact, dim1, dim2
where fact.c1 = dim1.pk /* FK = PK */ and
      fact.c2 = dim2.pk /* FK = PK */ and
      dim1.pk = 10 and
      dim2.pk like ‘abc%’
```

**Internal optimized query after join elimination:**

```SQL
select fact.c1
from fact 
where fact.c1 = 10 and fact.c2 like ‘abc%’
```

The transformation will apply under the following restrictions:

- No columns from the parent table are retrieved.
- No columns from the parent table other than the PK columns are referenced in the predicates.
- Conservatively, only allow local predicates on PK columns or equi-joins between PK columns and other tables.
- The join is directly above a base table access i.e. no aliases or other expressions above base table access
- Other restrictions on string data types

## How was this patch tested?

A new test suite HiveRIJElimSuite.scala was introduced.

