### PR TITLE
[SPARK-22744][CORE] Cannot get the submit hostname of application

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -776,6 +776,9 @@ object SparkSubmit extends CommandLineUtils with Logging {
       sparkConf.set("spark.submit.pyFiles", formattedPyFiles)
     }
 
+    // [SPARK-22744] Cannot get the submit hostname of application
+    sparkConf.set("spark.submit.hostname", Utils.localHostName)
+
     (childArgs, childClasspath, sparkConf, childMainClass)
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -171,6 +171,16 @@ class SparkSubmitSuite
     appArgs.toString should include ("thequeue")
   }
 
+  test("SPARK-22744 check the default application submit hostname") {
+    val clArgs = Seq(
+      "--name", "myApp",
+      "--class", "Foo",
+      "userjar.jar")
+    val appArgs = new SparkSubmitArguments(clArgs)
+    val (_, _, conf, _) = prepareSubmitEnvironment(appArgs)
+    conf.get("spark.submit.hostname") should be (Utils.localHostName())
+  }
+
   test("specify deploy mode through configuration") {
     val clArgs = Seq(
       "--master", "yarn",


### PR DESCRIPTION
## What changes were proposed in this pull request?
In MapReduce, we can get the submit hostname via checking the value of configuration mapreduce.job.submithostname. It can help infra team or other people to do support work and debug. Bu in Spark, the information is not included.

In a big company, spark infra team can get the submit host list of all applications in a clusters. It can help them to control the submition, unify upgrade and find the bad jobs where it submitted.
Then, I suggest to set the submit hostname in spark internal with name spark.submit.hostname, spark user can not set it ( any manually set will be override).

## How was this patch tested?

unit tests
