### PR TITLE
[SPARK-23653][SQL] Capture sql statements user input and show them in…

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -38,6 +38,7 @@ import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, Range}
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.execution.ui.SparkListenerSQLTextCaptured
 import org.apache.spark.sql.internal._
 import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
 import org.apache.spark.sql.sources.BaseRelation
@@ -145,6 +146,8 @@ class SparkSession private(
         state
       }
   }
+
+  lazy private val substitutor = new VariableSubstitution(sessionState.conf)
 
   /**
    * A wrapped version of this session in the form of a [[SQLContext]], for backward compatibility.
@@ -635,6 +638,9 @@ class SparkSession private(
    * @since 2.0.0
    */
   def sql(sqlText: String): DataFrame = {
+    sparkContext.listenerBus.post(
+      SparkListenerSQLTextCaptured(System.currentTimeMillis(), substitutor.substitute(sqlText))
+    )
     Dataset.ofRows(self, sessionState.sqlParser.parsePlan(sqlText))
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/AllExecutionsPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/AllExecutionsPage.scala
@@ -110,6 +110,15 @@ private[ui] class AllExecutionsPage(parent: SQLTab) extends WebUIPage("") with L
           }
         </ul>
       </div>
+
+    val captured = sqlStore.capturedSqlTexts
+    if (captured.nonEmpty) {
+      val sqlTexts: NodeSeq = new SQLTextTable(
+        parent, "captured-sql-text-table",
+        s"Captured SQL sentences (${captured.size})", captured).toNodeSeq
+      content ++= sqlTexts
+    }
+
     UIUtils.headerSparkPage("SQL", summary ++ content, parent, Some(5000))
   }
 }
@@ -268,4 +277,34 @@ private[ui] class FailedExecutionTable(
 
   override protected def header: Seq[String] =
     baseHeader ++ Seq("Succeeded Job IDs", "Failed Job IDs")
+}
+
+private[ui] class SQLTextTable(
+    parent: SQLTab,
+    tableId: String,
+    tableName: String,
+    sqlTextDatas: Seq[SQLTextData]) {
+
+  def header: Seq[String] = Seq(
+    "Submission Time",
+    "SQL Text")
+
+  def row(sqlTextData: SQLTextData): Seq[Node] = {
+    <tr>
+      <td sorttable_customkey={sqlTextData.submissionTime.toString}>
+        {UIUtils.formatDate(sqlTextData.submissionTime)}
+      </td>
+      <td>
+        {sqlTextData.sqlText}
+      </td>
+    </tr>
+  }
+
+  def toNodeSeq: Seq[Node] = {
+    <div>
+      <h4>{tableName}</h4>
+      {UIUtils.listingTable[SQLTextData](
+      header, row(_), sqlTextDatas, id = Some(tableId))}
+    </div>
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusStore.scala
@@ -71,6 +71,13 @@ class SQLAppStatusStore(
   def planGraph(executionId: Long): SparkPlanGraph = {
     store.read(classOf[SparkPlanGraphWrapper], executionId).toSparkPlanGraph()
   }
+
+  def capturedSqlTexts: Seq[SQLTextData] = {
+    listener match {
+      case Some(l) => l.sqlTexts.toSeq
+      case None => Seq.empty[SQLTextData]
+    }
+  }
 }
 
 class SQLExecutionUIData(
@@ -139,3 +146,7 @@ case class SQLPlanMetric(
     name: String,
     accumulatorId: Long,
     metricType: String)
+
+case class SQLTextData(
+    submissionTime: Long,
+    sqlText: String)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLListener.scala
@@ -41,6 +41,11 @@ case class SparkListenerSQLExecutionStart(
 case class SparkListenerSQLExecutionEnd(executionId: Long, time: Long)
   extends SparkListenerEvent
 
+@DeveloperApi
+case class SparkListenerSQLTextCaptured(
+  submissionTime: Long,
+  sqlText: String) extends SparkListenerEvent
+
 /**
  * A message used to update SQL metric value for driver-side updates (which doesn't get reflected
  * automatically).


### PR DESCRIPTION
… SQL UI

## What changes were proposed in this pull request?

[SPARK-4871](https://issues.apache.org/jira/browse/SPARK-4871) had already added the sql statement in job description for using spark-sql. But it has some problems:

1. long sql statement cannot be displayed in description column. 
![screen shot 2018-03-12 at 14 25 51](https://user-images.githubusercontent.com/1853780/37287438-c833385e-263f-11e8-86ea-0f8ebb9b151e.png)


2. variables like `${var}`, `${env:var}` in sql cannot be resolved.
spark-sql --hiveconf a=avalue --hivevar b=bvalue
`spark-sql> select '${a}', '${b}';`

![screen shot 2018-03-22 at 14 53 03](https://user-images.githubusercontent.com/1853780/37755515-c78b7da0-2de0-11e8-807d-7e8ed3b859eb.png)


3. sql statement submitted in spark-shell or spark-submit cannot be covered.

In eBay, most spark sql applications like ETL, reporting using spark-submit to schedule their jobs with a few sql files. The sql statement in those applications cannot be saw in current spark UI. 

![screen shot 2018-03-12 at 20 16 23](https://user-images.githubusercontent.com/1853780/37287410-bde5166a-263f-11e8-8435-8db29a2eef33.png)

More detail a scenario is team A developed a framework to submit application with sql sentences in a file
> spark-submit --master yarn-cluster --class com.ebay.SQLFramework -s biz.sql

In the biz.sql, there are many sql sentences like
> create or replace temporary view view_a select xx from table ${old_db}.table_a where dt=${check_date};
> insert overwrite table ${new_db}.table_a select xx from view_a join ${new_db}.table_b;
> ...

Team B (Platform) need to capture the really sql sentences which are executed in whole cluster, as the sql files from Team A contains many variables. A better way is recording the really sql sentence in EventLog.

## How was this patch tested?
![screen shot 2018-03-21 at 23 22 07](https://user-images.githubusercontent.com/1853780/37718931-ceb341c6-2d5e-11e8-8f41-4f53a7d83d99.png)
