### PR TITLE
Add a note about jobs running in FIFO order in the default pool

### DIFF
--- a/docs/job-scheduling.md
+++ b/docs/job-scheduling.md
@@ -215,8 +215,8 @@ pool), but inside each pool, jobs run in FIFO order. For example, if you create 
 means that each user will get an equal share of the cluster, and that each user's queries will run in
 order instead of later queries taking resources from that user's earlier ones.
 
-If jobs are not explicitely set to use a given pool, they end up in the default pool. This means that even if
-`spark.scheduler.mode` is set to `FAIR` those jobs will be ran in `FIFO` order (within the default pool).
+If jobs are not explicitly set to use a given pool, they end up in the default pool. This means that even if
+`spark.scheduler.mode` is set to `FAIR` those jobs will be run in `FIFO` order (within the default pool).
 
 ## Configuring Pool Properties
 

--- a/docs/job-scheduling.md
+++ b/docs/job-scheduling.md
@@ -215,6 +215,9 @@ pool), but inside each pool, jobs run in FIFO order. For example, if you create 
 means that each user will get an equal share of the cluster, and that each user's queries will run in
 order instead of later queries taking resources from that user's earlier ones.
 
+If jobs are not explicitely set to use a given pool, they end up in the default pool. This means that even if
+`spark.scheduler.mode` is set to `FAIR` those jobs will be ran in `FIFO` order (within the default pool).
+
 ## Configuring Pool Properties
 
 Specific pools' properties can also be modified through a configuration file. Each pool supports three


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make it clear in the doc that setting `spark.scheduler.mode` to `FAIR` isn't enough to get jobs to run in a `FAIR` fashion if the default pool is used.