### PR TITLE
[MINOR][CORE] Renamed long URL with shortened version

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockReplicationPolicy.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockReplicationPolicy.scala
@@ -54,10 +54,9 @@ trait BlockReplicationPolicy {
 }
 
 object BlockReplicationUtils {
-  // scalastyle:off line.size.limit
   /**
    * Uses sampling algorithm by Robert Floyd. Finds a random sample in O(n) while
-   * minimizing space usage. Please see <a href="http://math.stackexchange.com/questions/178690/whats-the-proof-of-correctness-for-robert-floyds-algorithm-for-selecting-a-sin">
+   * minimizing space usage. Please see <a href="https://math.stackexchange.com/q/178690">
    * here</a>.
    *
    * @param n total number of indices
@@ -65,7 +64,6 @@ object BlockReplicationUtils {
    * @param r random number generator
    * @return list of m random unique indices
    */
-  // scalastyle:on line.size.limit
   private def getSampleIds(n: Int, m: Int, r: Random): List[Int] = {
     val indices = (n - m + 1 to n).foldLeft(mutable.LinkedHashSet.empty[Int]) {case (set, i) =>
       val t = r.nextInt(i) + 1


### PR DESCRIPTION
## What changes were proposed in this pull request?

We found that Scalastyle was disabled in `BlockReplicationPolicy.scala` because there was a URL in there that caused the line length to be exceeded. The URL was to a `stackexchange.com` site which actually accepts shortened versions of their normal URL as well. So we could replace the URL with the officially supported shortened version and enable Scalastyle again since this no longer exceeds the line length. I also changed the URL from `http` to `https` since the site automatically redirects to `https` anyway.

## How was this patch tested?

We tested this by running `./dev/lint-scala`. First we ran it with the long URL to ensure that it actually detects the violation. Then we changed this to the shortened URL and ran it again. This time it said `Scalastyle checks passed.`

## Co-contributors:
@chialun-yeh
@Hrayo712
@vpourquie