### PR TITLE
[SPARK-23775][TEST] Make DataFrameRangeSuite not flaky

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameRangeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameRangeSuite.scala
@@ -167,7 +167,10 @@ class DataFrameRangeSuite extends QueryTest with SharedSQLContext with Eventuall
         DataFrameRangeSuite.stageToKill = DataFrameRangeSuite.INVALID_STAGE_ID
         val ex = intercept[SparkException] {
           spark.range(0, 100000000000L, 1, 1).map { x =>
-            DataFrameRangeSuite.stageToKill = TaskContext.get().stageId()
+            val taskContext = TaskContext.get()
+            if (!taskContext.isInterrupted()) {
+              DataFrameRangeSuite.stageToKill = taskContext.stageId()
+            }
             x
           }.toDF("id").agg(sum("id")).collect()
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

DataFrameRangeSuite.test("Cancelling stage in a query with Range.") stays sometimes in an infinite loop and times out the build.

There were multiple issues with the test:

1. The first valid stageId is zero when the test started alone and not in a suite and the following code waits until timeout:

```
eventually(timeout(10.seconds), interval(1.millis)) {
  assert(DataFrameRangeSuite.stageToKill > 0)
}
```

2. The `DataFrameRangeSuite.stageToKill` was overwritten by the task's thread after the reset which ended up in canceling the same stage 2 times. This caused the infinite wait.

This PR solves this mentioned flakyness by removing the shared `DataFrameRangeSuite.stageToKill` and using `wait` and `CountDownLatch` for synhronization.

## How was this patch tested?

Existing unit test.
