### PR TITLE
[SPARK-23789][SQL] Shouldn't set hive.metastore.uris before invoking HiveDelegationTokenProvider

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -94,6 +94,10 @@ private[hive] object SparkSQLCLIDriver extends Logging {
         cliConf.set(k, v)
     }
 
+    // Shouldn't set hive.metastore.uris before invoking HiveDelegationTokenProvider
+    val defaultMetastore = HiveConf.ConfVars.METASTOREURIS
+    cliConf.setVar(defaultMetastore, defaultMetastore.defaultStrVal)
+
     val sessionState = new CliSessionState(cliConf)
 
     sessionState.in = System.in


### PR DESCRIPTION
## What changes were proposed in this pull request?

`spark-sql` can't connect to metastore with a security Hadoop cluster after [SPARK-21428](https://issues.apache.org/jira/browse/SPARK-21428).

`hive.metastore.uris` was `HiveConf.ConfVars.METASTOREURIS.defaultStrVal` here before SPARK-21428. 

This pr revert `hive.metastore.uris` to `HiveConf.ConfVars.METASTOREURIS.defaultStrVal`.


## How was this patch tested?

manual tests with a security Hadoop cluster
