### PR TITLE
[SPARK-23795][LAUNCHER] Make AbstractLauncher#self() protected

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractLauncher.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractLauncher.java
@@ -274,7 +274,7 @@ public abstract class AbstractLauncher<T extends AbstractLauncher> {
   public abstract SparkAppHandle startApplication(SparkAppHandle.Listener... listeners)
     throws IOException;
 
-  abstract T self();
+  protected abstract T self();
 
   private static class ArgumentValidator extends SparkSubmitOptionParser {
 

--- a/launcher/src/main/java/org/apache/spark/launcher/InProcessLauncher.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/InProcessLauncher.java
@@ -77,7 +77,7 @@ public class InProcessLauncher extends AbstractLauncher<InProcessLauncher> {
   }
 
   @Override
-  InProcessLauncher self() {
+  protected InProcessLauncher self() {
     return this;
   }
 

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
@@ -453,7 +453,7 @@ public class SparkLauncher extends AbstractLauncher<SparkLauncher> {
   }
 
   @Override
-  SparkLauncher self() {
+  protected SparkLauncher self() {
     return this;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make `AbstractLauncher#self()` protected.
The class is `public abstract` but because `self()` is package-private, it cannot actually be implemented, which seems like an oversight.

## How was this patch tested?

https://github.com/palantir/spark/pull/341