### PR TITLE
[SPARK-23776][python][test] Check for needed components/files before running pyspark-sql tests

### DIFF
--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -949,13 +949,24 @@ class DataFrameWriter(OptionUtils):
 def _test():
     import doctest
     import os
+    import os.path
+    import glob
     import tempfile
     import py4j
     from pyspark.context import SparkContext
     from pyspark.sql import SparkSession, Row
     import pyspark.sql.readwriter
 
-    os.chdir(os.environ["SPARK_HOME"])
+    SPARK_HOME = os.environ["SPARK_HOME"]
+    filename_pattern = "assembly/target/scala-*/jars/spark-hive_*-*.jar"
+    if not glob.glob(os.path.join(SPARK_HOME, filename_pattern)):
+        raise Exception(
+            ("Failed to find Hive assembly jar. ") +
+            "You need to build Spark with "
+            "'build/sbt -Phive package' or "
+            "'build/mvn -DskipTests -Phive package' before running this test.")
+
+    os.chdir(SPARK_HOME)
 
     globs = pyspark.sql.readwriter.__dict__.copy()
     sc = SparkContext('local[4]', 'PythonTest')

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -949,8 +949,6 @@ class DataFrameWriter(OptionUtils):
 def _test():
     import doctest
     import os
-    import os.path
-    import glob
     import tempfile
     import py4j
     from pyspark.context import SparkContext

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -961,10 +961,9 @@ def _test():
     filename_pattern = "assembly/target/scala-*/jars/spark-hive_*-*.jar"
     if not glob.glob(os.path.join(SPARK_HOME, filename_pattern)):
         raise Exception(
-            ("Failed to find Hive assembly jar. ") +
-            "You need to build Spark with "
-            "'build/sbt -Phive package' or "
-            "'build/mvn -DskipTests -Phive package' before running this test.")
+            "Failed to find Hive assembly jar. You need to build Spark with "
+            "'build/sbt -Phive package' or 'build/mvn -DskipTests -Phive package' "
+            "before running this test.")
 
     os.chdir(SPARK_HOME)
 

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -945,6 +945,7 @@ class DataFrameWriter(OptionUtils):
             jprop.setProperty(k, properties[k])
         self.mode(mode)._jwrite.jdbc(url, table, jprop)
 
+
 def _test():
     import doctest
     import os
@@ -955,14 +956,6 @@ def _test():
     from pyspark.context import SparkContext
     from pyspark.sql import SparkSession, Row
     import pyspark.sql.readwriter
-
-    # SPARK_HOME = os.environ["SPARK_HOME"]
-    # filename_pattern = "assembly/target/scala-*/jars/spark-hive_*-*.jar"
-    # if not glob.glob(os.path.join(SPARK_HOME, filename_pattern)):
-    #     raise Exception(
-    #         "Failed to find Hive assembly jar. You need to build Spark with "
-    #         "'build/sbt -Phive package' or 'build/mvn -DskipTests -Phive package' "
-    #         "before running this test.")
 
     os.chdir(os.environ["SPARK_HOME"])
 
@@ -981,8 +974,10 @@ def _test():
     except TypeError:
         hive_enabled = False
 
-    # if hive is not enabled, then skip doctests that will fail
     if not hive_enabled:
+        # if hive is not enabled, then skip doctests that need hive
+        # TODO: Need to communicate with outside world that this test
+        # has been skipped.
         m = pyspark.sql.readwriter
         m.__dict__["DataFrameReader"].__dict__["table"].__doc__ = ""
 

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -2977,6 +2977,20 @@ class SQLTests(ReusedSQLTestCase):
 
 class HiveSparkSubmitTests(SparkSubmitTests):
 
+    @classmethod
+    def setUpClass(cls):
+        # get a SparkContext to check for availability of Hive
+        sc = SparkContext('local[4]', cls.__name__)
+        try:
+            sc._jvm.org.apache.hadoop.hive.conf.HiveConf()
+        except py4j.protocol.Py4JError:
+            raise unittest.SkipTest("Hive is not available")
+        except TypeError:
+            raise unittest.SkipTest("Hive is not available")
+        finally:
+            # we don't need SparkContext for the test
+            sc.stop()
+
     def test_hivecontext(self):
         # This test checks that HiveContext is using Hive metastore (SPARK-16224).
         # It sets a metastore url and checks if there is a derby dir created by

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -21,7 +21,6 @@ Unit tests for pyspark.sql; additional tests are implemented as doctests in
 individual modules.
 """
 import os
-import glob
 import sys
 import subprocess
 import pydoc
@@ -83,31 +82,6 @@ from pyspark.tests import QuietTest, ReusedPySparkTestCase, PySparkTestCase, Spa
 from pyspark.sql.functions import UserDefinedFunction, sha2, lit
 from pyspark.sql.window import Window
 from pyspark.sql.utils import AnalysisException, ParseException, IllegalArgumentException
-
-
-def found_file(pattern):
-    SPARK_HOME = os.environ["SPARK_HOME"]
-    files = glob.glob(os.path.join(SPARK_HOME, pattern))
-    return len(files) > 0
-
-
-def search_hive_assembly_jars():
-    pattern = "assembly/target/scala-*/jars/spark-hive_*-*.jar"
-    if not found_file(pattern):
-        raise Exception(
-            ("Failed to find Hive assembly jar. ") +
-            "You need to build Spark with "
-            "'build/sbt -Phive package' or "
-            "'build/mvn -DskipTests -Phive package' before running this test.")
-
-
-def search_test_udf_classes():
-    pattern = "sql/core/target/scala-*/test-classes/" + \
-              "test/org/apache/spark/sql/JavaStringLength.class"
-    if not found_file(pattern):
-        raise Exception(
-            ("Failed to find test udf classes. ") +
-            "You need to build Spark with 'build/sbt sql/test:compile'")
 
 
 class UTCOffsetTimezone(datetime.tzinfo):
@@ -5231,8 +5205,6 @@ class GroupedAggPandasUDFTests(ReusedSQLTestCase):
 
 if __name__ == "__main__":
     from pyspark.sql.tests import *
-    search_hive_assembly_jars()
-    search_test_udf_classes()
     if xmlrunner:
         unittest.main(testRunner=xmlrunner.XMLTestRunner(output='target/test-reports'))
     else:

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -395,9 +395,13 @@ def _test():
     filename_pattern = "sql/core/target/scala-*/test-classes/" + \
                        "test/org/apache/spark/sql/JavaStringLength.class"
     if not glob.glob(os.path.join(SPARK_HOME, filename_pattern)):
-        raise Exception(
-            "Failed to find test udf classes. "
-            "You need to build Spark with 'build/sbt sql/test:compile'")
+        # if test udf files are not compiled, then skip the below doctests
+        # TODO: Need to communicate with outside world that these tests
+        # have been skipped.
+        m = pyspark.sql.udf
+        m.__dict__["UDFRegistration"].__dict__["registerJavaFunction"].__doc__ = ""
+        m.__dict__["UDFRegistration"].__dict__["registerJavaUDAF"].__doc__ = ""
+
     globs = pyspark.sql.udf.__dict__.copy()
     spark = SparkSession.builder\
         .master("local[4]")\

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -396,7 +396,7 @@ def _test():
                        "test/org/apache/spark/sql/JavaStringLength.class"
     if not glob.glob(os.path.join(SPARK_HOME, filename_pattern)):
         raise Exception(
-            ("Failed to find test udf classes. ") +
+            "Failed to find test udf classes. "
             "You need to build Spark with 'build/sbt sql/test:compile'")
     globs = pyspark.sql.udf.__dict__.copy()
     spark = SparkSession.builder\

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -385,8 +385,19 @@ class UDFRegistration(object):
 
 def _test():
     import doctest
+    import os
+    import os.path
+    import glob
     from pyspark.sql import SparkSession
     import pyspark.sql.udf
+
+    SPARK_HOME = os.environ["SPARK_HOME"]
+    filename_pattern = "sql/core/target/scala-*/test-classes/" + \
+                       "test/org/apache/spark/sql/JavaStringLength.class"
+    if not glob.glob(os.path.join(SPARK_HOME, filename_pattern)):
+        raise Exception(
+            ("Failed to find test udf classes. ") +
+            "You need to build Spark with 'build/sbt sql/test:compile'")
     globs = pyspark.sql.udf.__dict__.copy()
     spark = SparkSession.builder\
         .master("local[4]")\


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change pyspark-sql tests to check the following:
- Spark was built with the Hive profile
- Spark scala tests were compiled

If either condition is not met, throw an exception with a message explaining how to appropriately build Spark.

These checks are similar to the ones found in the pyspark-streaming tests.

These required files will be missing if you follow the sbt build instructions. They are less likely to be missing if you follow the mvn build instructions (mvn compiles the test scala files, and there are mvn build instructions for running the pyspark tests).

## How was this patch tested?

For sbt build:
- run ./build/sbt package
- run python/run-tests --modules "pyspark-sql" --python-executables python2.7
- see failure, follow sbt instructions in exception message
- run test again
- see second failure (sbt only), follow sbt instructions in exception message
- run test again, verify success
- repeat for python3.4

For mvn build:
- run ./build/mvn -DskipTests clean package
- run python/run-tests --modules "pyspark-sql" --python-executables python2.7
- see failure, follow mvn instructions in exception message
- run test again, verify success
- repeat for python3.4


