### PR TITLE
[SPARK-23812][SQL] DFS should be removed from unsupportedHiveNativeCommands  in SqlBase.g4

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -214,7 +214,6 @@ unsupportedHiveNativeCommands
     | kw1=START kw2=TRANSACTION
     | kw1=COMMIT
     | kw1=ROLLBACK
-    | kw1=DFS
     | kw1=DELETE kw2=FROM
     ;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Dfs command has been supported，but SqlBase.g4 also put it in unsupportedHiveNativeCommands.

(Please fill in changes proposed in this fix)

## How was this patch tested?

manual tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
