### PR TITLE
[SPARK-23818][SQL][WIP] an official UDF interface for Spark SQL

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/JavaUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/JavaUDF.scala
@@ -18,8 +18,7 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.SparkException
-
-import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode}
 import org.apache.spark.sql.types.DataType
 
@@ -37,6 +36,8 @@ private[sql] case class JavaUDF (
     nullable: Boolean = true,
     udfDeterministic: Boolean = true)
   extends Expression with ImplicitCastInputTypes with NonSQLExpression with UserDefinedExpression {
+
+  // TODO: add check for prohibiting UDT dataType, we do not plan to support it for now.
 
   override lazy val deterministic: Boolean = udfDeterministic && children.forall(_.deterministic)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/JavaUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/JavaUDF.scala
@@ -69,56 +69,6 @@ private[sql] case class JavaUDF (
     s"Failed to execute user defined function($funcCls: ($inputTypes) => ${dataType.simpleString})"
   }
 
-  /*
-  override def doGenCode(
-      ctx: CodegenContext,
-      ev: ExprCode): ExprCode = {
-
-    val errorMsgTerm = ctx.addReferenceObj("errMsg", udfErrorMessage)
-    val resultTerm = ctx.freshName("result")
-
-    // codegen for children expressions
-    val evals = children.map(_.genCode(ctx))
-
-    // Generate the codes for expressions and calling user-defined function
-    // We need to get the boxedType of dataType's javaType here. Because for the dataType
-    // such as IntegerType, its javaType is `int` and the returned type of user-defined
-    // function is Object. Trying to convert an Object to `int` will cause casting exception.
-    val evalCode = evals.map(_.code).mkString("\n")
-    val (funcArgs, initArgs) = evals.zipWithIndex.map { case (eval, i) =>
-      val argTerm = ctx.freshName("arg")
-      val initArg = s"Object $argTerm = ${eval.isNull} ? null : ${eval.value};"
-      (argTerm, initArg)
-    }.unzip
-
-    val udf = ctx.addReferenceObj("udf", function, s"scala.Function${children.length}")
-    val getFuncResult = s"$udf.apply(${funcArgs.mkString(", ")})"
-    val boxedType = CodeGenerator.boxedType(dataType)
-    val callFunc =
-      s"""
-         |$boxedType $resultTerm = null;
-         |try {
-         |  $resultTerm = ($boxedType)$getFuncResult;
-         |} catch (Exception e) {
-         |  throw new org.apache.spark.SparkException($errorMsgTerm, e);
-         |}
-       """.stripMargin
-
-    ev.copy(code =
-      s"""
-         |$evalCode
-         |${initArgs.mkString("\n")}
-         |$callFunc
-         |
-         |boolean ${ev.isNull} = $resultTerm == null;
-         |${CodeGenerator.javaType(dataType)} ${ev.value} = ${CodeGenerator.defaultValue(dataType)};
-         |if (!${ev.isNull}) {
-         |  ${ev.value} = $resultTerm;
-         |}
-       """.stripMargin)
-  }
-  */
-
   // scalastyle:on line.size.limit
   override def doGenCode(
       ctx: CodegenContext,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/JavaUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/JavaUDF.scala
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.SparkException
+import org.apache.spark.api.java.function._
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode}
+import org.apache.spark.sql.types.DataType
+
+
+private[sql] case class JavaUDF (
+    function: AnyRef,
+    dataType: DataType,
+    children: Seq[Expression],
+    inputTypes: Seq[DataType],
+    udfName: Option[String] = None,
+    nullable: Boolean = true,
+    udfDeterministic: Boolean = true)
+  extends Expression with ImplicitCastInputTypes with NonSQLExpression with UserDefinedExpression {
+
+  override lazy val deterministic: Boolean = udfDeterministic && children.forall(_.deterministic)
+
+  override def toString: String =
+    s"${udfName.map(name => s"UDF:$name").getOrElse("UDF")}(${children.mkString(", ")})"
+
+  // TODO: generate this method by script
+  private[this] val f = function match {
+    case func: Function0[Any] =>
+      (input: InternalRow) => {
+        func.call()
+      }
+    case func: Function[Any, Any] =>
+      (input: InternalRow) => {
+        func.call(children(0).eval(input))
+      }
+    case func: Function[Any, Any, Any] =>
+      (input: InternalRow) => {
+        func.call(children(0).eval(input), children(1).eval(input))
+      }
+    case _ => throw new IllegalArgumentException("unknown function type.")
+  }
+
+  lazy val udfErrorMessage = {
+    val funcCls = function.getClass.getSimpleName
+    val inputTypes = children.map(_.dataType.simpleString).mkString(", ")
+    s"Failed to execute user defined function($funcCls: ($inputTypes) => ${dataType.simpleString})"
+  }
+
+  override def doGenCode(
+      ctx: CodegenContext,
+      ev: ExprCode): ExprCode = {
+
+    val errorMsgTerm = ctx.addReferenceObj("errMsg", udfErrorMessage)
+    val resultTerm = ctx.freshName("result")
+
+    // codegen for children expressions
+    val evals = children.map(_.genCode(ctx))
+
+    // Generate the codes for expressions and calling user-defined function
+    // We need to get the boxedType of dataType's javaType here. Because for the dataType
+    // such as IntegerType, its javaType is `int` and the returned type of user-defined
+    // function is Object. Trying to convert an Object to `int` will cause casting exception.
+    val evalCode = evals.map(_.code).mkString("\n")
+    val (funcArgs, initArgs) = evals.zipWithIndex.map { case (eval, i) =>
+      val argTerm = ctx.freshName("arg")
+      val initArg = s"Object $argTerm = ${eval.isNull} ? null : ${eval.value};"
+      (argTerm, initArg)
+    }.unzip
+
+    val udf = ctx.addReferenceObj("udf", function, s"scala.Function${children.length}")
+    val getFuncResult = s"$udf.apply(${funcArgs.mkString(", ")})"
+    val boxedType = CodeGenerator.boxedType(dataType)
+    val callFunc =
+      s"""
+         |$boxedType $resultTerm = null;
+         |try {
+         |  $resultTerm = ($boxedType)$getFuncResult;
+         |} catch (Exception e) {
+         |  throw new org.apache.spark.SparkException($errorMsgTerm, e);
+         |}
+       """.stripMargin
+
+    ev.copy(code =
+      s"""
+         |$evalCode
+         |${initArgs.mkString("\n")}
+         |$callFunc
+         |
+         |boolean ${ev.isNull} = $resultTerm == null;
+         |${CodeGenerator.javaType(dataType)} ${ev.value} = ${CodeGenerator.defaultValue(dataType)};
+         |if (!${ev.isNull}) {
+         |  ${ev.value} = $resultTerm;
+         |}
+       """.stripMargin)
+  }
+
+
+  override def eval(input: InternalRow): Any = {
+    val result = try {
+      f(input)
+    } catch {
+      case e: Exception =>
+        throw new SparkException(udfErrorMessage, e)
+    }
+    result
+  }
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/UDFRegistration.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/UDFRegistration.scala
@@ -221,7 +221,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
    * Registers a deterministic Scala closure of 2 arguments as user-defined function (UDF).
    * @since 2.4.0
    */
-  def register(name: String, func: Function2[_, _, _], returnType: DataType,
+  def registerV2(name: String, func: Function2[_, _, _], returnType: DataType,
     input1Type: DataType, input2Type: DataType, nullable: Boolean, deterministic: Boolean)
     : UserDefinedFunctionV2 = {
     val inputTypes = Seq(input1Type, input2Type)
@@ -758,7 +758,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
    * Register a deterministic Java UDF2 instance as user-defined function v2 (UDF v2).
    * @since 2.4.0
    */
-  def registerV2(name: String, f: UDF2[_, _, _], returnType: DataType,
+  def registerV2j(name: String, f: UDF2[_, _, _], returnType: DataType,
     input1Type: DataType, input2Type: DataType, nullable: Boolean, deterministic: Boolean)
     : UserDefinedFunctionV2 = {
     val func = f.asInstanceOf[UDF2[Any, Any, Any]].call(_: Any, _: Any)

--- a/sql/core/src/main/scala/org/apache/spark/sql/expressions/UserDefinedFunctionV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/expressions/UserDefinedFunctionV2.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.expressions
+
+import org.apache.spark.annotation.InterfaceStability
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.expressions.ScalaUDF
+import org.apache.spark.sql.types.DataType
+
+@InterfaceStability.Stable
+class UserDefinedFunctionV2 (
+    f: AnyRef,
+    dataType: DataType,
+    inputTypes: Seq[DataType],
+    nameOption: Option[String] = None,
+    nullable: Boolean = true,
+    deterministic: Boolean = true) {
+
+  @scala.annotation.varargs
+  def apply(exprs: Column*): Column = {
+    Column(ScalaUDF(
+      f,
+      dataType,
+      exprs.map(_.expr),
+      inputTypes,
+      nameOption,
+      nullable,
+      deterministic))
+  }
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/expressions/UserDefinedFunctionV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/expressions/UserDefinedFunctionV2.scala
@@ -18,8 +18,8 @@
 package org.apache.spark.sql.expressions
 
 import org.apache.spark.annotation.InterfaceStability
-import org.apache.spark.sql.api.java._
 import org.apache.spark.sql.Column
+import org.apache.spark.sql.api.java._
 import org.apache.spark.sql.catalyst.expressions.JavaUDF
 import org.apache.spark.sql.types.DataType
 

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaUDFSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaUDFSuite.java
@@ -121,4 +121,13 @@ public class JavaUDFSuite implements Serializable {
     Row result = spark.sql("SELECT returnOne()").head();
     Assert.assertEquals(1, result.getInt(0));
   }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void udfV2Test() {
+    spark.udf().registerV2j("udfv2", (Integer a, Integer b) -> a + b,
+      DataTypes.IntegerType, DataTypes.IntegerType, DataTypes.IntegerType, true, true);
+    Row result = spark.sql("SELECT udfv2(2, 3)").head();
+    Assert.assertEquals(5, result.getInt(0));
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
@@ -23,7 +23,8 @@ import org.apache.spark.sql.execution.command.ExplainCommand
 import org.apache.spark.sql.functions.udf
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.test.SQLTestData._
-import org.apache.spark.sql.types.{DataTypes, DoubleType}
+import org.apache.spark.sql.types.{DataTypes, DoubleType, IntegerType, StringType}
+import org.apache.spark.unsafe.types.UTF8String
 
 private case class FunctionResult(f1: String, f2: String)
 
@@ -322,6 +323,16 @@ class UDFSuite extends QueryTest with SharedSQLContext {
         spark.sql("SELECT f(a._1) FROM x").show
       }
       assert(outputStream.toString.contains("UDF:f(a._1 AS `_1`)"))
+    }
+  }
+
+  test("udfv2 test") {
+    spark.udf.register("myUdfV1", (a: Int, b: String) => a.toString + b)
+    spark.udf.register("myUdfV2", (a: Int, b: UTF8String) => {
+      UTF8String.concat(UTF8String.fromString(a.toString), b)
+    }, StringType, IntegerType, StringType, true, true)
+    testData.selectExpr("myUdfV1(a, b)", "myUdfV2(a, b)").as[(String, String)].collect().foreach {
+      case (v1: String, v2: String) => assert(v1 === v2)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
@@ -327,12 +327,13 @@ class UDFSuite extends QueryTest with SharedSQLContext {
   }
 
   test("udfv2 test") {
-    spark.udf.register("myUdfV1", (a: Int, b: String) => a.toString + b)
-    spark.udf.register("myUdfV2", (a: Int, b: UTF8String) => {
-      UTF8String.concat(UTF8String.fromString(a.toString), b)
-    }, StringType, IntegerType, StringType, true, true)
-    testData.selectExpr("myUdfV1(a, b)", "myUdfV2(a, b)").as[(String, String)].collect().foreach {
-      case (v1: String, v2: String) => assert(v1 === v2)
+    spark.udf.register("myUdfV1", (a: Int, b: Int) => a + b)
+    spark.udf.registerV2("myUdfV2", (a: Int, b: Int) => {
+      a + b
+    }, IntegerType, IntegerType, IntegerType, true, true)
+    sql("select myUdfV1(key, value), myUdfV2(key, value) from testData")
+      .as[(Int, Int)].collect().foreach {
+      case (v1: Int, v2: Int) => assert(v1 === v2)
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

API: (to be discussed), use 2-args as example:

```
UDFRegistration
  // scala version
  def registerV2(name: String, func: Function2[_, _, _], returnType: DataType,
      input1Type: DataType, input2Type: DataType, nullable: Boolean, deterministic: Boolean):UserDefinedFunctionV2
  // java version
  def registerV2j(name: String, f: UDF2[_, _, _], returnType: DataType,
    input1Type: DataType, input2Type: DataType, nullable: Boolean, deterministic: Boolean):UserDefinedFunctionV2
```

## How was this patch tested?

Two simple testcase added.
Others will add later.