### PR TITLE
[SPARK-23823][SQL] ResolveReferences should preserve treenode origins

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -814,7 +814,7 @@ class Analyzer(
       }
     }
 
-    private def resolve(e: Expression, q: LogicalPlan): Expression = e match {
+    private def resolve(e: Expression, q: LogicalPlan): Expression = e.transformUp {
       case u @ UnresolvedAttribute(nameParts) =>
         // Leave unchanged if resolution fails. Hopefully will be resolved next round.
         val result =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -827,7 +827,6 @@ class Analyzer(
         result
       case UnresolvedExtractValue(child, fieldExpr) if child.resolved =>
         ExtractValue(child, fieldExpr, resolver)
-      case _ => e.mapChildren(resolve(_, q))
     }
 
     def apply(plan: LogicalPlan): LogicalPlan = plan.transformUp {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes https://issues.apache.org/jira/browse/SPARK-23823

Introduced in apache#19585

ResolveReferences stopped doing transfromsUp after this change and Attributes sometimes lose its correct origin

## How was this patch tested?

Manually tested after this change analyze won't throw away correct Origin for columns