### PR TITLE
[SPARK-23790][Mesos] fix metastore connection issue

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -123,7 +123,9 @@ class SparkHadoopUtil extends Logging {
    */
   def addCredentials(conf: JobConf): Unit = {
     val jobCreds = conf.getCredentials()
-    jobCreds.mergeAll(UserGroupInformation.getCurrentUser().getCredentials())
+    val userCreds = UserGroupInformation.getCurrentUser().getCredentials()
+    logInfo(s"Adding user credentials: ${SparkHadoopUtil.get.dumpTokens(userCreds)}")
+    jobCreds.mergeAll(userCreds)
   }
 
   def addCurrentUserCredentials(creds: Credentials): Unit = {

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -611,7 +611,8 @@ object SparkSubmit extends CommandLineUtils with Logging {
       // An internal option used only for spark-shell to add user jars to repl's classloader,
       // previously it uses "spark.jars" or "spark.yarn.dist.jars" which now may be pointed to
       // remote jars, so adding a new option to only specify local jars for spark-shell internally.
-      OptionAssigner(localJars, ALL_CLUSTER_MGRS, CLIENT, confKey = "spark.repl.local.jars")
+      OptionAssigner(localJars, ALL_CLUSTER_MGRS, CLIENT, confKey = "spark.repl.local.jars"),
+      OptionAssigner(args.proxyUser, MESOS, CLUSTER, confKey = "spark.mesos.proxyUser")
     )
 
     // In client mode, launch the application main class directly

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -197,6 +197,7 @@ class HadoopRDD[K, V](
     val jobConf = getJobConf()
     // add the credentials here as this can be called before SparkContext initialized
     SparkHadoopUtil.get.addCredentials(jobConf)
+    logInfo(s"HadoopRDD credentials: ${SparkHadoopUtil.get.dumpTokens(jobConf.getCredentials)}")
     val allInputSplits = getInputFormat(jobConf).getSplits(jobConf, minPartitions)
     val inputSplits = if (ignoreEmptySplits) {
       allInputSplits.filter(_.getLength > 0)

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -506,6 +506,10 @@ private[spark] class MesosClusterScheduler(
       options ++= Seq("--class", desc.command.mainClass)
     }
 
+    desc.conf.getOption("spark.mesos.proxyUser").foreach { v =>
+      options ++= Seq("--proxy-user", v)
+    }
+
     desc.conf.getOption("spark.executor.memory").foreach { v =>
       options ++= Seq("--executor-memory", v)
     }
@@ -521,6 +525,7 @@ private[spark] class MesosClusterScheduler(
 
     // --conf
     val replicatedOptionsBlacklist = Set(
+      "spark.mesos.proxyUser",
       "spark.jars", // Avoids duplicate classes in classpath
       "spark.submit.deployMode", // this would be set to `cluster`, but we need client
       "spark.master" // this contains the address of the dispatcher, not master


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Adds delegations tokens to ugi if the proxy user exists. We run this early when the mesos backend starts. 
- Adds support for the proxy user in mesos client/cluster mode.
- Fixes the HMS connection issue
## How was this patch tested?

This was manually tested with a secured HDFS and by running the spark hive examples, both in client and cluster mode.

In cluster mode this was tested with a ticket cache by passing the following args:
> --proxy-user nobody \
>  --conf spark.mesos.driver.labels=DCOS_SPACE:/kerberized-spark \
>  --conf spark.mesos.containerizer=mesos \
>  --conf spark.mesos.driverEnv.SPARK_USER=nobody \
>  --conf spark.mesos.driver.secret.names=/kerberized-spark/krb5cc_65534 \
>  --conf spark.mesos.driver.secret.filenames=krb5cc_65534 \
>  --conf spark.mesos.driverEnv.KRB5CCNAME=/mnt/mesos/sandbox/krb5cc_65534 \

