### PR TITLE
[SPARK-23565] [SS] New error message for structured streaming sources assertion

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/OffsetSeq.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/OffsetSeq.scala
@@ -40,7 +40,7 @@ case class OffsetSeq(offsets: Seq[Option[Offset]], metadata: Option[OffsetSeqMet
    */
   def toStreamProgress(sources: Seq[BaseStreamingSource]): StreamProgress = {
     assert(sources.size == offsets.size, s"There are [${offsets.size}] sources in the " +
-      s"checkpoint offsets and now there are [${sources.size}] sources requested by the query.  " +
+      s"checkpoint offsets and now there are [${sources.size}] sources requested by the query. " +
       s"Cannot continue.")
     new StreamProgress ++ sources.zip(offsets).collect { case (s, Some(o)) => (s, o) }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/OffsetSeq.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/OffsetSeq.scala
@@ -39,7 +39,9 @@ case class OffsetSeq(offsets: Seq[Option[Offset]], metadata: Option[OffsetSeqMet
    * cannot be serialized).
    */
   def toStreamProgress(sources: Seq[BaseStreamingSource]): StreamProgress = {
-    assert(sources.size == offsets.size)
+    assert(sources.size == offsets.size, s"There are [${offsets.size}] sources in the " +
+      s"checkpoint offsets and now there are [${sources.size}] sources requested by the query.  " +
+      s"Cannot continue.")
     new StreamProgress ++ sources.zip(offsets).collect { case (s, Some(o)) => (s, o) }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/OffsetSeqLogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/OffsetSeqLogSuite.scala
@@ -125,19 +125,6 @@ class OffsetSeqLogSuite extends SparkFunSuite with SharedSQLContext {
     assert(offsetSeq.metadata === Some(OffsetSeqMetadata(0L, 1480981499528L)))
   }
 
-  test("assertion that number of checkpoint offsets match number of sources") {
-    val checkpointOffsets = OffsetSeq.fill(LongOffset(0), LongOffset(1))
-    class FakeUnitTestStreamingSource extends BaseStreamingSource {
-      override def stop(): Unit = {}
-    }
-    val streams = Seq(new FakeUnitTestStreamingSource())
-    val e = intercept[AssertionError] {
-      checkpointOffsets.toStreamProgress(streams)
-    }
-    assert(e.getMessage.contains("There are [2] sources in the checkpoint offsets " +
-      "and now there are [1] sources requested by the query.  Cannot continue."))
-  }
-
   private def readFromResource(dir: String): (Long, OffsetSeq) = {
     val input = getClass.getResource(s"/structured-streaming/$dir")
     val log = new OffsetSeqLog(spark, input.toString)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/OffsetSeqLogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/OffsetSeqLogSuite.scala
@@ -125,6 +125,19 @@ class OffsetSeqLogSuite extends SparkFunSuite with SharedSQLContext {
     assert(offsetSeq.metadata === Some(OffsetSeqMetadata(0L, 1480981499528L)))
   }
 
+  test("assertion that number of checkpoint offsets match number of sources") {
+    val checkpointOffsets = OffsetSeq.fill(LongOffset(0), LongOffset(1))
+    class FakeUnitTestStreamingSource extends BaseStreamingSource {
+      override def stop(): Unit = {}
+    }
+    val streams = Seq(new FakeUnitTestStreamingSource())
+    val e = intercept[AssertionError] {
+      checkpointOffsets.toStreamProgress(streams)
+    }
+    assert(e.getMessage.contains("There are [2] sources in the checkpoint offsets " +
+      "and now there are [1] sources requested by the query.  Cannot continue."))
+  }
+
   private def readFromResource(dir: String): (Long, OffsetSeq) = {
     val input = getClass.getResource(s"/structured-streaming/$dir")
     val log = new OffsetSeqLog(spark, input.toString)


### PR DESCRIPTION
## What changes were proposed in this pull request?

A more informative message to tell you why a structured streaming query cannot continue if you have added more sources, than there are in the existing checkpoint offsets.

## How was this patch tested?

I added a Unit Test.
