### PR TITLE
[SPARK-23705][SQL]Handle non-distinct columns in DataSet.groupBy

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1518,7 +1518,10 @@ class Dataset[T] private[sql](
    */
   @scala.annotation.varargs
   def groupBy(cols: Column*): RelationalGroupedDataset = {
-    RelationalGroupedDataset(toDF(), cols.map(_.expr), RelationalGroupedDataset.GroupByType)
+    RelationalGroupedDataset(
+      toDF(),
+      cols.distinct.map(_.expr),
+      RelationalGroupedDataset.GroupByType)
   }
 
   /**
@@ -1593,7 +1596,9 @@ class Dataset[T] private[sql](
   def groupBy(col1: String, cols: String*): RelationalGroupedDataset = {
     val colNames: Seq[String] = col1 +: cols
     RelationalGroupedDataset(
-      toDF(), colNames.map(colName => resolve(colName)), RelationalGroupedDataset.GroupByType)
+      toDF(),
+      colNames.distinct.map(colName => resolve(colName)),
+      RelationalGroupedDataset.GroupByType)
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1425,6 +1425,13 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     }
   }
 
+  test("SPARK-23705: Handle non-distinct columns in groupBy") {
+    val kvDataset = ((1 to 3) ++ (1 to 4)).toDF("id")
+    val data = Row(1, 2) :: Row(2, 2) :: Row(3, 2) :: Row(4, 1) :: Nil
+    checkAnswer(kvDataset.groupBy("id", "id").count, data)
+    checkAnswer(kvDataset.groupBy($"id", $"id").count, data)
+  }
+
   test("SPARK-22472: add null check for top-level primitive values") {
     // If the primitive values are from Option, we need to do runtime null check.
     val ds = Seq(Some(1), None).toDS().as[Int]


### PR DESCRIPTION
## What changes were proposed in this pull request?

If input columns to DataSet.groupBy contains non unique columns, remove those columns

## How was this patch tested?
Added unit test