### PR TITLE
[SPARK-23822][SQL] Improve error message for Parquet schema mismatches

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/SchemaColumnConvertNotSupportedException.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/SchemaColumnConvertNotSupportedException.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.execution.datasources.parquet;
+package org.apache.spark.sql.execution.datasources;
 
 import org.apache.spark.annotation.InterfaceStability;
 
@@ -23,7 +23,7 @@ import org.apache.spark.annotation.InterfaceStability;
  * Exception thrown when the parquet reader find column type mismatches.
  */
 @InterfaceStability.Unstable
-public class ParquetSchemaColumnConvertNotSupportedException extends RuntimeException {
+public class SchemaColumnConvertNotSupportedException extends RuntimeException {
 
   /**
    * Name of the column which cannot be converted.
@@ -50,7 +50,7 @@ public class ParquetSchemaColumnConvertNotSupportedException extends RuntimeExce
     return logicalType;
   }
 
-  public ParquetSchemaColumnConvertNotSupportedException(
+  public SchemaColumnConvertNotSupportedException(
       String column,
       String physicalType,
       String logicalType) {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaColumnConvertNotSupportedException.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaColumnConvertNotSupportedException.java
@@ -47,7 +47,9 @@ public class ParquetSchemaColumnConvertNotSupportedException extends RuntimeExce
     return logicalType;
   }
 
-  public ParquetSchemaColumnConvertNotSupportedException(String column, String physicalType,
+  public ParquetSchemaColumnConvertNotSupportedException(
+      String column,
+      String physicalType,
       String logicalType) {
     super();
     this.column = column;

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaColumnConvertNotSupportedException.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaColumnConvertNotSupportedException.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet;
+
+/**
+ * Exception thrown when the parquet reader find column type mismatches.
+ */
+public class ParquetSchemaColumnConvertNotSupportedException extends RuntimeException {
+
+  /**
+   * Name of the column which cannot be converted.
+   */
+  private String column;
+  /**
+   * Physical column type in the actual parquet file.
+   */
+  private String physicalType;
+  /**
+   * Logical column type in the parquet schema the parquet reader use to parse all files.
+   */
+  private String logicalType;
+
+  public String getColumn() {
+    return column;
+  }
+
+  public String getPhysicalType() {
+    return physicalType;
+  }
+
+  public String getLogicalType() {
+    return logicalType;
+  }
+
+  public ParquetSchemaColumnConvertNotSupportedException(String column, String physicalType,
+      String logicalType) {
+    super();
+    this.column = column;
+    this.physicalType = physicalType;
+    this.logicalType = logicalType;
+  }
+}

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaColumnConvertNotSupportedException.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaColumnConvertNotSupportedException.java
@@ -17,9 +17,12 @@
 
 package org.apache.spark.sql.execution.datasources.parquet;
 
+import org.apache.spark.annotation.InterfaceStability;
+
 /**
  * Exception thrown when the parquet reader find column type mismatches.
  */
+@InterfaceStability.Unstable
 public class ParquetSchemaColumnConvertNotSupportedException extends RuntimeException {
 
   /**

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.datasources.parquet;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.TimeZone;
 
 import org.apache.parquet.bytes.BytesUtils;
@@ -232,6 +233,18 @@ public class VectorizedColumnReader {
   }
 
   /**
+   * Helper function to construct exception for parquet schema mismatch.
+   */
+  private ParquetSchemaColumnConvertNotSupportedException constructConvertNotSupportedException(
+          ColumnDescriptor descriptor,
+          WritableColumnVector column) {
+    return new ParquetSchemaColumnConvertNotSupportedException(
+            Arrays.toString(descriptor.getPath()),
+            descriptor.getType().toString(),
+            column.dataType().toString());
+  }
+
+  /**
    * Reads `num` values into column, decoding the values from `dictionaryIds` and `dictionary`.
    */
   private void decodeDictionaryIds(
@@ -261,7 +274,7 @@ public class VectorizedColumnReader {
             }
           }
         } else {
-          throw new UnsupportedOperationException("Unimplemented type: " + column.dataType());
+          throw constructConvertNotSupportedException(descriptor, column);
         }
         break;
 
@@ -282,7 +295,7 @@ public class VectorizedColumnReader {
             }
           }
         } else {
-          throw new UnsupportedOperationException("Unimplemented type: " + column.dataType());
+          throw constructConvertNotSupportedException(descriptor, column);
         }
         break;
 
@@ -321,7 +334,7 @@ public class VectorizedColumnReader {
             }
           }
         } else {
-          throw new UnsupportedOperationException();
+          throw constructConvertNotSupportedException(descriptor, column);
         }
         break;
       case BINARY:
@@ -360,7 +373,7 @@ public class VectorizedColumnReader {
             }
           }
         } else {
-          throw new UnsupportedOperationException();
+          throw constructConvertNotSupportedException(descriptor, column);
         }
         break;
 
@@ -375,7 +388,9 @@ public class VectorizedColumnReader {
    */
 
   private void readBooleanBatch(int rowId, int num, WritableColumnVector column) {
-    assert(column.dataType() == DataTypes.BooleanType);
+    if (column.dataType() != DataTypes.BooleanType) {
+      throw constructConvertNotSupportedException(descriptor, column);
+    }
     defColumn.readBooleans(
         num, column, rowId, maxDefLevel, (VectorizedValuesReader) dataColumn);
   }
@@ -394,7 +409,7 @@ public class VectorizedColumnReader {
       defColumn.readShorts(
           num, column, rowId, maxDefLevel, (VectorizedValuesReader) dataColumn);
     } else {
-      throw new UnsupportedOperationException("Unimplemented type: " + column.dataType());
+      throw constructConvertNotSupportedException(descriptor, column);
     }
   }
 
@@ -414,7 +429,7 @@ public class VectorizedColumnReader {
         }
       }
     } else {
-      throw new UnsupportedOperationException("Unsupported conversion to: " + column.dataType());
+      throw constructConvertNotSupportedException(descriptor, column);
     }
   }
 
@@ -425,7 +440,7 @@ public class VectorizedColumnReader {
       defColumn.readFloats(
           num, column, rowId, maxDefLevel, (VectorizedValuesReader) dataColumn);
     } else {
-      throw new UnsupportedOperationException("Unsupported conversion to: " + column.dataType());
+      throw constructConvertNotSupportedException(descriptor, column);
     }
   }
 
@@ -436,7 +451,7 @@ public class VectorizedColumnReader {
       defColumn.readDoubles(
           num, column, rowId, maxDefLevel, (VectorizedValuesReader) dataColumn);
     } else {
-      throw new UnsupportedOperationException("Unimplemented type: " + column.dataType());
+      throw constructConvertNotSupportedException(descriptor, column);
     }
   }
 
@@ -471,7 +486,7 @@ public class VectorizedColumnReader {
         }
       }
     } else {
-      throw new UnsupportedOperationException("Unimplemented type: " + column.dataType());
+      throw constructConvertNotSupportedException(descriptor, column);
     }
   }
 
@@ -510,7 +525,7 @@ public class VectorizedColumnReader {
         }
       }
     } else {
-      throw new UnsupportedOperationException("Unimplemented type: " + column.dataType());
+      throw constructConvertNotSupportedException(descriptor, column);
     }
   }
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
@@ -32,6 +32,7 @@ import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.PrimitiveType;
 
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;
+import org.apache.spark.sql.execution.datasources.SchemaColumnConvertNotSupportedException;
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.DecimalType;
@@ -235,10 +236,10 @@ public class VectorizedColumnReader {
   /**
    * Helper function to construct exception for parquet schema mismatch.
    */
-  private ParquetSchemaColumnConvertNotSupportedException constructConvertNotSupportedException(
+  private SchemaColumnConvertNotSupportedException constructConvertNotSupportedException(
       ColumnDescriptor descriptor,
       WritableColumnVector column) {
-    return new ParquetSchemaColumnConvertNotSupportedException(
+    return new SchemaColumnConvertNotSupportedException(
       Arrays.toString(descriptor.getPath()),
       descriptor.getType().toString(),
       column.dataType().toString());

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
@@ -236,12 +236,12 @@ public class VectorizedColumnReader {
    * Helper function to construct exception for parquet schema mismatch.
    */
   private ParquetSchemaColumnConvertNotSupportedException constructConvertNotSupportedException(
-          ColumnDescriptor descriptor,
-          WritableColumnVector column) {
+      ColumnDescriptor descriptor,
+      WritableColumnVector column) {
     return new ParquetSchemaColumnConvertNotSupportedException(
-            Arrays.toString(descriptor.getPath()),
-            descriptor.getType().toString(),
-            column.dataType().toString());
+      Arrays.toString(descriptor.getPath()),
+      descriptor.getType().toString(),
+      column.dataType().toString());
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecutionException.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecutionException.scala
@@ -17,4 +17,5 @@
 
 package org.apache.spark.sql.execution
 
-class QueryExecutionException(message: String) extends Exception(message)
+class QueryExecutionException(message: String, cause: Throwable = null)
+  extends Exception(message, cause)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
@@ -21,11 +21,15 @@ import java.io.{FileNotFoundException, IOException}
 
 import scala.collection.mutable
 
+import org.apache.parquet.io.ParquetDecodingException
+
 import org.apache.spark.{Partition => RDDPartition, TaskContext, TaskKilledException}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.rdd.{InputFileBlockHolder, RDD}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.QueryExecutionException
+import org.apache.spark.sql.execution.datasources.parquet.ParquetSchemaColumnConvertNotSupportedException
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.NextIterator
 
@@ -179,7 +183,23 @@ class FileScanRDD(
             currentIterator = readCurrentFile()
           }
 
-          hasNext
+          try {
+            hasNext
+          } catch {
+            case e: ParquetSchemaColumnConvertNotSupportedException =>
+              val message = "Parquet column cannot be converted in " +
+                s"file ${currentFile.filePath}. Column: ${e.getColumn}, " +
+                s"Expected: ${e.getPhysicalType}, Found: ${e.getLogicalType}"
+              throw new QueryExecutionException(message, e)
+            case e: ParquetDecodingException =>
+              if (e.getMessage.contains("Can not read value at")) {
+                val message = "Encounter error while reading parquet files. " +
+                  "One possible cause: Parquet column cannot be converted in the " +
+                  "corresponding files. Details: "
+                throw new QueryExecutionException(message, e)
+              }
+              throw e
+          }
         } else {
           currentFile = null
           InputFileBlockHolder.unset()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
@@ -189,7 +189,7 @@ class FileScanRDD(
             case e: ParquetSchemaColumnConvertNotSupportedException =>
               val message = "Parquet column cannot be converted in " +
                 s"file ${currentFile.filePath}. Column: ${e.getColumn}, " +
-                s"Expected: ${e.getPhysicalType}, Found: ${e.getLogicalType}"
+                s"Expected: ${e.getLogicalType}, Found: ${e.getPhysicalType}"
               throw new QueryExecutionException(message, e)
             case e: ParquetDecodingException =>
               if (e.getMessage.contains("Can not read value at")) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
@@ -29,7 +29,6 @@ import org.apache.spark.rdd.{InputFileBlockHolder, RDD}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.QueryExecutionException
-import org.apache.spark.sql.execution.datasources.parquet.ParquetSchemaColumnConvertNotSupportedException
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.NextIterator
 
@@ -186,7 +185,7 @@ class FileScanRDD(
           try {
             hasNext
           } catch {
-            case e: ParquetSchemaColumnConvertNotSupportedException =>
+            case e: SchemaColumnConvertNotSupportedException =>
               val message = "Parquet column cannot be converted in " +
                 s"file ${currentFile.filePath}. Column: ${e.getColumn}, " +
                 s"Expected: ${e.getLogicalType}, Found: ${e.getPhysicalType}"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
@@ -390,7 +390,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
   def testSchemaMismatch(path: String, vectorizedReaderEnabled: Boolean): SparkException = {
     import testImplicits._
 
-    var e : SparkException = null
+    var e: SparkException = null
     // Disable databricks' vectorized parquet reader and use open source version.
     withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> vectorizedReaderEnabled.toString) {
       // Create two parquet files with different schemas in the same folder
@@ -401,7 +401,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
         spark.read.parquet(s"$path/parquet").collect()
       }
     }
-    return e
+    e
   }
 
   test("schema mismatch failure error message for parquet reader") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
@@ -26,6 +26,7 @@ import org.apache.parquet.schema.{MessageType, MessageTypeParser}
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.execution.QueryExecutionException
+import org.apache.spark.sql.execution.datasources.SchemaColumnConvertNotSupportedException
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types._
@@ -391,7 +392,6 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
     import testImplicits._
 
     var e: SparkException = null
-    // Disable databricks' vectorized parquet reader and use open source version.
     withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> vectorizedReaderEnabled.toString) {
       // Create two parquet files with different schemas in the same folder
       Seq(("bcd", 2)).toDF("a", "b").coalesce(1).write.mode("overwrite").parquet(s"$path/parquet")
@@ -420,7 +420,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
     withTempPath { dir =>
       val e = testSchemaMismatch(dir.getCanonicalPath, vectorizedReaderEnabled = true)
       assert(e.getCause.isInstanceOf[QueryExecutionException])
-      assert(e.getCause.getCause.isInstanceOf[ParquetSchemaColumnConvertNotSupportedException])
+      assert(e.getCause.getCause.isInstanceOf[SchemaColumnConvertNotSupportedException])
 
       // Check if the physical type is reporting correctly
       val errMsg = e.getCause.getMessage


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request tries to improve the error message for spark while reading parquet files with different schemas, e.g. One with a STRING column and the other with a INT column. A new ParquetSchemaColumnConvertNotSupportedException is added to replace the old UnsupportedOperationException. The Exception is again wrapped in FileScanRdd.scala to throw a more a general QueryExecutionException with the actual parquet file name which trigger the exception.

## How was this patch tested?

Unit tests added to check the new exception and verify the error messages.

Also manually tested with two parquet with different schema to check the error message.

<img width="1125" alt="screen shot 2018-03-30 at 4 03 04 pm" src="https://user-images.githubusercontent.com/37087310/38156580-dd58a140-3433-11e8-973a-b816d859fbe1.png">