### PR TITLE
[SPARK-23847][PYTHON][SQL]Add asc_nulls_first, asc_nulls_last to PySpark

### DIFF
--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -454,6 +454,32 @@ class Column(object):
     >>> df.select(df.name).orderBy(df.name.asc()).collect()
     [Row(name=u'Alice'), Row(name=u'Tom')]
     """
+    _asc_nulls_first_doc = """
+    Returns a sort expression based on the ascending order of the given column name and null values
+    return before non-null values
+
+    >>> from pyspark.sql import Row
+    >>> df = spark.createDataFrame([
+    ...     Row(name=u'Tom', height=80),
+    ...     Row(name=None, height=None),
+    ...     Row(name=u'Alice', height=None)
+    ... ])
+    >>> df.select(df.name).orderBy(df.name.asc_nulls_first()).collect()
+    [Row(name=None), Row(name=u'Alice'), Row(name=u'Tom')]
+    """
+    _asc_nulls_last_doc = """
+    Returns a sort expression based on the ascending order of the given column name and null values
+    return after non-null values
+
+    >>> from pyspark.sql import Row
+    >>> df = spark.createDataFrame([
+    ...     Row(name=u'Tom', height=80),
+    ...     Row(name=None, height=None),
+    ...     Row(name=u'Alice', height=None)
+    ... ])
+    >>> df.select(df.name).orderBy(df.name.asc_nulls_last()).collect()
+    [Row(name=u'Alice'), Row(name=u'Tom'), Row(name=None)]
+    """
     _desc_doc = """
     Returns a sort expression based on the descending order of the given column name.
 
@@ -462,9 +488,39 @@ class Column(object):
     >>> df.select(df.name).orderBy(df.name.desc()).collect()
     [Row(name=u'Tom'), Row(name=u'Alice')]
     """
+    _desc_nulls_first_doc = """
+    Returns a sort expression based on the descending order of the given column name and null values
+    return before non-null values
+
+    >>> from pyspark.sql import Row
+    >>> df = spark.createDataFrame([
+    ...     Row(name=u'Tom', height=80),
+    ...     Row(name=None, height=None),
+    ...     Row(name=u'Alice', height=None)
+    ... ])
+    >>> df.select(df.name).orderBy(df.name.desc_nulls_first()).collect()
+    [Row(name=None), Row(name=u'Tom'), Row(name=u'Alice')]
+    """
+    _desc_nulls_last_doc = """
+    Returns a sort expression based on the descending order of the given column name and null values
+    appear after non-null values.
+
+    >>> from pyspark.sql import Row
+    >>> df = spark.createDataFrame([
+    ...     Row(name=u'Tom', height=80),
+    ...     Row(name=None, height=None),
+    ...     Row(name=u'Alice', height=None)
+    ... ])
+    >>> df.select(df.name).orderBy(df.name.desc_nulls_last()).collect()
+    [Row(name=u'Tom'), Row(name=u'Alice'), Row(name=None)]
+    """
 
     asc = ignore_unicode_prefix(_unary_op("asc", _asc_doc))
+    asc_nulls_first = ignore_unicode_prefix(_unary_op("asc_nulls_first", _asc_nulls_first_doc))
+    asc_nulls_last = ignore_unicode_prefix(_unary_op("asc_nulls_last", _asc_nulls_last_doc))
     desc = ignore_unicode_prefix(_unary_op("desc", _desc_doc))
+    desc_nulls_first = ignore_unicode_prefix(_unary_op("desc_nulls_first", _desc_nulls_first_doc))
+    desc_nulls_last = ignore_unicode_prefix(_unary_op("desc_nulls_last", _desc_nulls_last_doc))
 
     _isNull_doc = """
     True if the current expression is null.

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -447,7 +447,7 @@ class Column(object):
 
     # order
     _asc_doc = """
-    Returns a sort expression based on the ascending order of the given column name
+    Returns a sort expression based on ascending order of the column.
 
     >>> from pyspark.sql import Row
     >>> df = spark.createDataFrame([('Tom', 80), ('Alice', None)], ["name", "height"])
@@ -455,8 +455,8 @@ class Column(object):
     [Row(name=u'Alice'), Row(name=u'Tom')]
     """
     _asc_nulls_first_doc = """
-    Returns a sort expression based on the ascending order of the given column name and null values
-    return before non-null values
+    Returns a sort expression based on ascending order of the column, and null values
+    return before non-null values.
 
     >>> from pyspark.sql import Row
     >>> df = spark.createDataFrame([('Tom', 80), (None, 60), ('Alice', None)], ["name", "height"])
@@ -466,8 +466,8 @@ class Column(object):
     .. versionadded:: 2.4
     """
     _asc_nulls_last_doc = """
-    Returns a sort expression based on the ascending order of the given column name and null values
-    return after non-null values
+    Returns a sort expression based on ascending order of the column, and null values
+    appear after non-null values.
 
     >>> from pyspark.sql import Row
     >>> df = spark.createDataFrame([('Tom', 80), (None, 60), ('Alice', None)], ["name", "height"])
@@ -477,7 +477,7 @@ class Column(object):
     .. versionadded:: 2.4
     """
     _desc_doc = """
-    Returns a sort expression based on the descending order of the given column name.
+    Returns a sort expression based on the descending order of the column.
 
     >>> from pyspark.sql import Row
     >>> df = spark.createDataFrame([('Tom', 80), ('Alice', None)], ["name", "height"])
@@ -485,8 +485,8 @@ class Column(object):
     [Row(name=u'Tom'), Row(name=u'Alice')]
     """
     _desc_nulls_first_doc = """
-    Returns a sort expression based on the descending order of the given column name and null values
-    return before non-null values
+    Returns a sort expression based on the descending order of the column, and null values
+    appear before non-null values.
 
     >>> from pyspark.sql import Row
     >>> df = spark.createDataFrame([('Tom', 80), (None, 60), ('Alice', None)], ["name", "height"])
@@ -496,7 +496,7 @@ class Column(object):
     .. versionadded:: 2.4
     """
     _desc_nulls_last_doc = """
-    Returns a sort expression based on the descending order of the given column name and null values
+    Returns a sort expression based on the descending order of the column, and null values
     appear after non-null values.
 
     >>> from pyspark.sql import Row

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -450,7 +450,7 @@ class Column(object):
     Returns a sort expression based on the ascending order of the given column name
 
     >>> from pyspark.sql import Row
-    >>> df = spark.createDataFrame([Row(name=u'Tom', height=80), Row(name=u'Alice', height=None)])
+    >>> df = spark.createDataFrame([('Tom', 80), ('Alice', None)], ["name", "height"])
     >>> df.select(df.name).orderBy(df.name.asc()).collect()
     [Row(name=u'Alice'), Row(name=u'Tom')]
     """
@@ -459,32 +459,28 @@ class Column(object):
     return before non-null values
 
     >>> from pyspark.sql import Row
-    >>> df = spark.createDataFrame([
-    ...     Row(name=u'Tom', height=80),
-    ...     Row(name=None, height=None),
-    ...     Row(name=u'Alice', height=None)
-    ... ])
+    >>> df = spark.createDataFrame([('Tom', 80), (None, 60), ('Alice', None)], ["name", "height"])
     >>> df.select(df.name).orderBy(df.name.asc_nulls_first()).collect()
     [Row(name=None), Row(name=u'Alice'), Row(name=u'Tom')]
+
+    .. versionadded:: 2.4
     """
     _asc_nulls_last_doc = """
     Returns a sort expression based on the ascending order of the given column name and null values
     return after non-null values
 
     >>> from pyspark.sql import Row
-    >>> df = spark.createDataFrame([
-    ...     Row(name=u'Tom', height=80),
-    ...     Row(name=None, height=None),
-    ...     Row(name=u'Alice', height=None)
-    ... ])
+    >>> df = spark.createDataFrame([('Tom', 80), (None, 60), ('Alice', None)], ["name", "height"])
     >>> df.select(df.name).orderBy(df.name.asc_nulls_last()).collect()
     [Row(name=u'Alice'), Row(name=u'Tom'), Row(name=None)]
+
+    .. versionadded:: 2.4
     """
     _desc_doc = """
     Returns a sort expression based on the descending order of the given column name.
 
     >>> from pyspark.sql import Row
-    >>> df = spark.createDataFrame([Row(name=u'Tom', height=80), Row(name=u'Alice', height=None)])
+    >>> df = spark.createDataFrame([('Tom', 80), ('Alice', None)], ["name", "height"])
     >>> df.select(df.name).orderBy(df.name.desc()).collect()
     [Row(name=u'Tom'), Row(name=u'Alice')]
     """
@@ -493,26 +489,22 @@ class Column(object):
     return before non-null values
 
     >>> from pyspark.sql import Row
-    >>> df = spark.createDataFrame([
-    ...     Row(name=u'Tom', height=80),
-    ...     Row(name=None, height=None),
-    ...     Row(name=u'Alice', height=None)
-    ... ])
+    >>> df = spark.createDataFrame([('Tom', 80), (None, 60), ('Alice', None)], ["name", "height"])
     >>> df.select(df.name).orderBy(df.name.desc_nulls_first()).collect()
     [Row(name=None), Row(name=u'Tom'), Row(name=u'Alice')]
+
+    .. versionadded:: 2.4
     """
     _desc_nulls_last_doc = """
     Returns a sort expression based on the descending order of the given column name and null values
     appear after non-null values.
 
     >>> from pyspark.sql import Row
-    >>> df = spark.createDataFrame([
-    ...     Row(name=u'Tom', height=80),
-    ...     Row(name=None, height=None),
-    ...     Row(name=u'Alice', height=None)
-    ... ])
+    >>> df = spark.createDataFrame([('Tom', 80), (None, 60), ('Alice', None)], ["name", "height"])
     >>> df.select(df.name).orderBy(df.name.desc_nulls_last()).collect()
     [Row(name=u'Tom'), Row(name=u'Alice'), Row(name=None)]
+
+    .. versionadded:: 2.4
     """
 
     asc = ignore_unicode_prefix(_unary_op("asc", _asc_doc))

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -87,7 +87,15 @@ _functions = {
     'col': 'Returns a :class:`Column` based on the given column name.',
     'column': 'Returns a :class:`Column` based on the given column name.',
     'asc': 'Returns a sort expression based on the ascending order of the given column name.',
+    'asc_nulls_first': 'Returns a sort expression based on the ascending order of the given' +
+                       ' column name, and null values return before non-null values.',
+    'asc_nulls_last': 'Returns a sort expression based on the ascending order of the given' +
+                      ' column name, and null values appear after non-null values.',
     'desc': 'Returns a sort expression based on the descending order of the given column name.',
+    'desc_nulls_first': 'Returns a sort expression based on the descending order of the given' +
+                        ' column name, and null values appear before non-null values.',
+    'desc_nulls_last': 'Returns a sort expression based on the descending order of the given' +
+                       ' column name, and null values appear after non-null values',
 
     'upper': 'Converts a string expression to upper case.',
     'lower': 'Converts a string expression to upper case.',

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -87,15 +87,7 @@ _functions = {
     'col': 'Returns a :class:`Column` based on the given column name.',
     'column': 'Returns a :class:`Column` based on the given column name.',
     'asc': 'Returns a sort expression based on the ascending order of the given column name.',
-    'asc_nulls_first': 'Returns a sort expression based on the ascending order of the given' +
-                       ' column name, and null values return before non-null values.',
-    'asc_nulls_last': 'Returns a sort expression based on the ascending order of the given' +
-                      ' column name, and null values appear after non-null values.',
     'desc': 'Returns a sort expression based on the descending order of the given column name.',
-    'desc_nulls_first': 'Returns a sort expression based on the descending order of the given' +
-                        ' column name, and null values appear before non-null values.',
-    'desc_nulls_last': 'Returns a sort expression based on the descending order of the given' +
-                       ' column name, and null values appear after non-null values',
 
     'upper': 'Converts a string expression to upper case.',
     'lower': 'Converts a string expression to upper case.',
@@ -144,6 +136,17 @@ _functions_1_4 = {
     'toDegrees': '.. note:: Deprecated in 2.1, use :func:`degrees` instead.',
     'toRadians': '.. note:: Deprecated in 2.1, use :func:`radians` instead.',
     'bitwiseNOT': 'Computes bitwise not.',
+}
+
+_functions_2_4 = {
+    'asc_nulls_first': 'Returns a sort expression based on the ascending order of the given' +
+                       ' column name, and null values return before non-null values.',
+    'asc_nulls_last': 'Returns a sort expression based on the ascending order of the given' +
+                      ' column name, and null values appear after non-null values.',
+    'desc_nulls_first': 'Returns a sort expression based on the descending order of the given' +
+                        ' column name, and null values appear before non-null values.',
+    'desc_nulls_last': 'Returns a sort expression based on the descending order of the given' +
+                       ' column name, and null values appear after non-null values',
 }
 
 _collect_list_doc = """
@@ -258,6 +261,8 @@ for _name, _doc in _functions_2_1.items():
     globals()[_name] = since(2.1)(_create_function(_name, _doc))
 for _name, _message in _functions_deprecated.items():
     globals()[_name] = _wrap_deprecated_function(globals()[_name], _message)
+for _name, _doc in _functions_2_4.items():
+    globals()[_name] = since(2.4)(_create_function(_name, _doc))
 del _name, _doc
 
 

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -2991,6 +2991,20 @@ class SQLTests(ReusedSQLTestCase):
                 os.environ['TZ'] = orig_env_tz
             time.tzset()
 
+    def test_2_4_functions(self):
+        from pyspark.sql import functions
+
+        df = self.spark.createDataFrame(
+            [('Tom', 80), (None, 60), ('Alice', 50)], ["name", "height"])
+        df.select(df.name).orderBy(functions.asc_nulls_first('name')).collect()
+        [Row(name=None), Row(name=u'Alice'), Row(name=u'Tom')]
+        df.select(df.name).orderBy(functions.asc_nulls_last('name')).collect()
+        [Row(name=u'Alice'), Row(name=u'Tom'), Row(name=None)]
+        df.select(df.name).orderBy(functions.desc_nulls_first('name')).collect()
+        [Row(name=None), Row(name=u'Tom'), Row(name=u'Alice')]
+        df.select(df.name).orderBy(functions.desc_nulls_last('name')).collect()
+        [Row(name=u'Tom'), Row(name=u'Alice'), Row(name=None)]
+
 
 class HiveSparkSubmitTests(SparkSubmitTests):
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
@@ -1083,10 +1083,10 @@ class Column(val expr: Expression) extends Logging {
    * and null values return before non-null values.
    * {{{
    *   // Scala: sort a DataFrame by age column in ascending order and null values appearing first.
-   *   df.sort(df("age").asc_nulls_last)
+   *   df.sort(df("age").asc_nulls_first)
    *
    *   // Java
-   *   df.sort(df.col("age").asc_nulls_last());
+   *   df.sort(df.col("age").asc_nulls_first());
    * }}}
    *
    * @group expr_ops

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -132,7 +132,7 @@ object functions {
    * Returns a sort expression based on ascending order of the column,
    * and null values return before non-null values.
    * {{{
-   *   df.sort(asc_nulls_last("dept"), desc("age"))
+   *   df.sort(asc_nulls_first("dept"), desc("age"))
    * }}}
    *
    * @group sort_funcs


### PR DESCRIPTION
## What changes were proposed in this pull request?

Column.scala and Functions.scala have asc_nulls_first, asc_nulls_last,  desc_nulls_first and desc_nulls_last. Add the corresponding python APIs in column.py and functions.py

## How was this patch tested?
Add doctest
