### PR TITLE
[SPARK-23854] Update Guava to 16.0.1

### DIFF
--- a/core/src/main/scala/org/apache/spark/SecurityManager.scala
+++ b/core/src/main/scala/org/apache/spark/SecurityManager.scala
@@ -24,7 +24,7 @@ import java.security.{KeyStore, SecureRandom}
 import java.security.cert.X509Certificate
 import javax.net.ssl._
 
-import com.google.common.hash.HashCodes
+import com.google.common.hash.HashCode
 import com.google.common.io.Files
 import org.apache.hadoop.io.Text
 import org.apache.hadoop.security.{Credentials, UserGroupInformation}
@@ -364,7 +364,7 @@ private[spark] class SecurityManager(
     rnd.nextBytes(secretBytes)
 
     val creds = new Credentials()
-    val secretStr = HashCodes.fromBytes(secretBytes).toString()
+    val secretStr = HashCode.fromBytes(secretBytes).toString()
     creds.addSecretKey(SECRET_LOOKUP_KEY, secretStr.getBytes(UTF_8))
     UserGroupInformation.getCurrentUser().addCredentials(creds)
   }

--- a/pom.xml
+++ b/pom.xml
@@ -388,7 +388,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>14.0.1</version>
+        <version>16.0.1</version>
         <scope>provided</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Currently Spark is still on Guava 14.0.1, and therefore I would like to bump the version to 16.0.1.

Babysteps are important here, because we don't want to become incompatible with other technology stacks, but 14.0.1 is getting old. HashCodes has been deprecated in favor of HashCode.

https://issues.apache.org/jira/projects/SPARK/issues/SPARK-23854

## What changes were proposed in this pull request?

To stay compatible with the software that uses a later version of Guava.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Running the testsuite

Please review http://spark.apache.org/contributing.html before opening a pull request.
