### PR TITLE
[SPARK-23826] [TEST] TestHiveSparkSession should set default session

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -159,9 +159,10 @@ private[hive] class TestHiveSparkSession(
     private val loadTestTables: Boolean)
   extends SparkSession(sc) with Logging { self =>
 
-  // TODO(SPARK-23826): TestHiveSparkSession should set default session the same way as
-  // TestSparkSession, but doing this the same way breaks many tests in the package. We need
-  // to investigate and find a different strategy.
+  // The base spark session does this in getOrCreate(), here we emulate that behavior for tests.
+  if (SparkSession.getDefaultSession.isEmpty) {
+    SparkSession.setDefaultSession(this)
+  }
 
   def this(sc: SparkContext, loadTestTables: Boolean) {
     this(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -159,11 +159,6 @@ private[hive] class TestHiveSparkSession(
     private val loadTestTables: Boolean)
   extends SparkSession(sc) with Logging { self =>
 
-  // The base spark session does this in getOrCreate(), here we emulate that behavior for tests.
-  if (SparkSession.getDefaultSession.isEmpty) {
-    SparkSession.setDefaultSession(this)
-  }
-
   def this(sc: SparkContext, loadTestTables: Boolean) {
     this(
       sc,


### PR DESCRIPTION
## What changes were proposed in this pull request?
In TestHive, the base spark session does this in getOrCreate(), we emulate that behavior for tests.

## How was this patch tested?
N/A