### PR TITLE
Fixes misspelling in configuration.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2178,7 +2178,7 @@ Spark's classpath for each application. In a Spark cluster running on YARN, thes
 files are set cluster-wide, and cannot safely be changed by the application.
 
 The better choice is to use spark hadoop properties in the form of `spark.hadoop.*`. 
-They can be considered as same as normal spark properties which can be set in `$SPARK_HOME/conf/spark-defalut.conf`
+They can be considered as same as normal spark properties which can be set in `$SPARK_HOME/conf/spark-default.conf`
 
 In some cases, you may want to avoid hard-coding certain configurations in a `SparkConf`. For
 instance, Spark allows you to simply create an empty conf and set spark/spark hadoop properties.


### PR DESCRIPTION

## What changes were proposed in this pull request?

Fixes a misspelling in `configuration.md`. Changes `spark-defalut.conf` to `spark-default.conf`

## How was this patch tested?

Viewed the new markdown in Github
