### PR TITLE
[SPARK-23862][SQL] Spark ExpressionEncoder should support java enum type in scala

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -260,6 +260,14 @@ object ScalaReflection extends ScalaReflection {
           getPath :: Nil,
           returnNullable = false)
 
+      case t if t <:< localTypeOf[java.lang.Enum[_]] =>
+        StaticInvoke(
+          getClassFromType(t),
+          ObjectType(getClassFromType(t)),
+          "valueOf",
+          Invoke(getPath, "toString", ObjectType(classOf[String]), returnNullable = false) :: Nil,
+          returnNullable = false)
+
       case t if t <:< localTypeOf[java.lang.String] =>
         Invoke(getPath, "toString", ObjectType(classOf[String]), returnNullable = false)
 
@@ -582,6 +590,14 @@ object ScalaReflection extends ScalaReflection {
           inputObject :: Nil,
           returnNullable = false)
 
+      case t if t <:< localTypeOf[java.lang.Enum[_]] =>
+        StaticInvoke(
+          classOf[UTF8String],
+          StringType,
+          "fromString",
+          Invoke(inputObject, "name", ObjectType(classOf[String]), returnNullable = false) :: Nil,
+          returnNullable = false)
+
       case t if t <:< localTypeOf[java.lang.Integer] =>
         Invoke(inputObject, "intValue", IntegerType)
       case t if t <:< localTypeOf[java.lang.Long] =>
@@ -762,6 +778,7 @@ object ScalaReflection extends ScalaReflection {
       case t if t <:< localTypeOf[java.lang.Short] => Schema(ShortType, nullable = true)
       case t if t <:< localTypeOf[java.lang.Byte] => Schema(ByteType, nullable = true)
       case t if t <:< localTypeOf[java.lang.Boolean] => Schema(BooleanType, nullable = true)
+      case t if t <:< localTypeOf[java.lang.Enum[_]] => Schema(StringType, nullable = true)
       case t if t <:< definitions.IntTpe => Schema(IntegerType, nullable = false)
       case t if t <:< definitions.LongTpe => Schema(LongType, nullable = false)
       case t if t <:< definitions.DoubleTpe => Schema(DoubleType, nullable = false)

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
@@ -108,6 +108,10 @@ abstract class SQLImplicits extends LowPrioritySQLImplicits {
   /** @since 2.0.0 */
   implicit def newBoxedBooleanEncoder: Encoder[java.lang.Boolean] = Encoders.BOOLEAN
 
+  /** @since 2.4.0 */
+  implicit def newJavaEnumEncoder[A <: java.lang.Enum[_] : TypeTag]: Encoder[T] =
+    ExpressionEncoder()
+
   // Seqs
 
   /**


### PR DESCRIPTION

## What changes were proposed in this pull request?

In SPARK-21255, spark upstream adds support for creating encoders for java enum types, but the support is only added to Java API(for enum working within Java Beans). Since the java enum can come from third-party java library, we have use case that requires 
1. using java enum types as field of scala case class
2. using java enum as the type T in Dataset[T]

Spark ExpressionEncoder already supports ser/de many java types in ScalaReflection, so we propose to add support for java enum as well, as a follow up of SPARK-21255.


## How was this patch tested?

Tested the patch in our production cluster.  Added unit test.
Since:
1. it is not possible to define a java enum in scala directly, since the defined enum class in scala will miss method like valueOf which is added by java compiler
2. it is not possible to define a test enum java class and use in scala test because the compilation of single scala test(-DwildcardSuites=org.apache.spark.sql.DatasetSuite) won't compile the test java class first

As a result, I use the Spark SQL public java enum API(SaveMode.java) in the test. Please advise if there is a better way to test 

