### PR TITLE
[SPARK-23861][SQL][Doc] Clarify default window frame with and without orderBy clause

### DIFF
--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -44,6 +44,10 @@ class Window(object):
     >>> # PARTITION BY country ORDER BY date RANGE BETWEEN 3 PRECEDING AND 3 FOLLOWING
     >>> window = Window.orderBy("date").partitionBy("country").rangeBetween(-3, 3)
 
+    .. note:: The default frame boundaries for window are (rowFrame, unboundedPreceding,
+         unboundedFollowing). When a ordering is defined, the default frame boundaries
+         for window are (rangeFrame, unboundedPreceding, currentRow).
+
     .. note:: Experimental
 
     .. versionadded:: 1.4

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -44,9 +44,9 @@ class Window(object):
     >>> # PARTITION BY country ORDER BY date RANGE BETWEEN 3 PRECEDING AND 3 FOLLOWING
     >>> window = Window.orderBy("date").partitionBy("country").rangeBetween(-3, 3)
 
-    .. note:: The default frame boundaries for window are (rowFrame, unboundedPreceding,
-         unboundedFollowing). When a ordering is defined, the default frame boundaries
-         for window are (rangeFrame, unboundedPreceding, currentRow).
+    .. note:: When ordering is not defined, the default frame boundaries are (rowFrame,
+         unboundedPreceding, unboundedFollowing). When ordering is defined, the default frame
+         boundaries are (rangeFrame, unboundedPreceding, currentRow).
 
     .. note:: Experimental
 

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -44,9 +44,9 @@ class Window(object):
     >>> # PARTITION BY country ORDER BY date RANGE BETWEEN 3 PRECEDING AND 3 FOLLOWING
     >>> window = Window.orderBy("date").partitionBy("country").rangeBetween(-3, 3)
 
-    .. note:: When ordering is not defined, the default frame boundaries are (rowFrame,
-         unboundedPreceding, unboundedFollowing). When ordering is defined, the default frame
-         boundaries are (rangeFrame, unboundedPreceding, currentRow).
+    .. note:: When ordering is not defined, an unbounded window frame (rowFrame,
+         unboundedPreceding, unboundedFollowing) is used by default. When ordering is defined,
+         a growing window frame (rangeFrame, unboundedPreceding, currentRow) is used by default.
 
     .. note:: Experimental
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/expressions/Window.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/expressions/Window.scala
@@ -33,9 +33,9 @@ import org.apache.spark.sql.catalyst.expressions._
  *   Window.partitionBy("country").orderBy("date").rowsBetween(-3, 3)
  * }}}
  *
- * @note The default frame boundaries for window are (rowFrame, unboundedPreceding,
- *       unboundedFollowing). When a ordering is defined, the default frame boundaries
- *       for window are (rangeFrame, unboundedPreceding, currentRow).
+ * @note When ordering is not defined, the default frame boundaries are (rowFrame,
+ *       unboundedPreceding, unboundedFollowing). When ordering is defined, the default frame
+ *       boundaries are (rangeFrame, unboundedPreceding, currentRow).
  *
  * @since 1.4.0
  */

--- a/sql/core/src/main/scala/org/apache/spark/sql/expressions/Window.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/expressions/Window.scala
@@ -33,6 +33,10 @@ import org.apache.spark.sql.catalyst.expressions._
  *   Window.partitionBy("country").orderBy("date").rowsBetween(-3, 3)
  * }}}
  *
+ * @note The default frame boundaries for window are (rowFrame, unboundedPreceding,
+ *       unboundedFollowing). When a ordering is defined, the default frame boundaries
+ *       for window are (rangeFrame, unboundedPreceding, currentRow).
+ *
  * @since 1.4.0
  */
 @InterfaceStability.Stable

--- a/sql/core/src/main/scala/org/apache/spark/sql/expressions/Window.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/expressions/Window.scala
@@ -33,9 +33,9 @@ import org.apache.spark.sql.catalyst.expressions._
  *   Window.partitionBy("country").orderBy("date").rowsBetween(-3, 3)
  * }}}
  *
- * @note When ordering is not defined, the default frame boundaries are (rowFrame,
- *       unboundedPreceding, unboundedFollowing). When ordering is defined, the default frame
- *       boundaries are (rangeFrame, unboundedPreceding, currentRow).
+ * @note When ordering is not defined, an unbounded window frame (rowFrame, unboundedPreceding,
+ *       unboundedFollowing) is used by default. When ordering is defined, a growing window frame
+ *       (rangeFrame, unboundedPreceding, currentRow) is used by default.
  *
  * @since 1.4.0
  */


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add docstring to clarify default window frame boundaries with and without orderBy clause 

## How was this patch tested?

Manually generate doc and check.
