### PR TITLE
[SPARK-23589][SQL] ExternalMapToCatalyst should support interpreted execution

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
@@ -357,7 +357,8 @@ object JavaTypeInference {
     }
   }
 
-  private def serializerFor(inputObject: Expression, typeToken: TypeToken[_]): Expression = {
+  private[catalyst] def serializerFor(
+      inputObject: Expression, typeToken: TypeToken[_]): Expression = {
 
     def toCatalystArray(input: Expression, elementType: TypeToken[_]): Expression = {
       val (dataType, nullable) = inferDataType(elementType)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
@@ -358,7 +358,8 @@ object JavaTypeInference {
   }
 
   private[catalyst] def serializerFor(
-      inputObject: Expression, typeToken: TypeToken[_]): Expression = {
+      inputObject: Expression,
+      typeToken: TypeToken[_]): Expression = {
 
     def toCatalystArray(input: Expression, elementType: TypeToken[_]): Expression = {
       val (dataType, nullable) = inferDataType(elementType)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
@@ -357,9 +357,7 @@ object JavaTypeInference {
     }
   }
 
-  private[catalyst] def serializerFor(
-      inputObject: Expression,
-      typeToken: TypeToken[_]): Expression = {
+  private def serializerFor(inputObject: Expression, typeToken: TypeToken[_]): Expression = {
 
     def toCatalystArray(input: Expression, elementType: TypeToken[_]): Expression = {
       val (dataType, nullable) = inferDataType(elementType)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -1255,23 +1255,59 @@ case class ExternalMapToCatalyst private(
   override def dataType: MapType = MapType(
     keyConverter.dataType, valueConverter.dataType, valueContainsNull = valueConverter.nullable)
 
-  private lazy val keyCatalystConverter =
-    CatalystTypeConverters.createToCatalystConverter(dataType.keyType)
-  private lazy val valueCatalystConverter =
-    CatalystTypeConverters.createToCatalystConverter(dataType.valueType)
+  private lazy val mapCatalystConverter: Any => (Array[Any], Array[Any]) = child.dataType match {
+    case ObjectType(cls) if classOf[java.util.Map[_, _]].isAssignableFrom(cls) =>
+      (input: Any) => {
+        val data = input.asInstanceOf[java.util.Map[Any, Any]]
+        val keys = new Array[Any](data.size)
+        val values = new Array[Any](data.size)
+        val iter = data.entrySet().iterator()
+        var i = 0
+        while (iter.hasNext) {
+          val entry = iter.next()
+          val (key, value) = (entry.getKey, entry.getValue)
+          keys(i) = if (key != null) {
+            keyConverter.eval(InternalRow.fromSeq(key :: Nil))
+          } else {
+            throw new RuntimeException("Cannot use null as map key!")
+          }
+          values(i) = if (value != null) {
+            valueConverter.eval(InternalRow.fromSeq(value :: Nil))
+          } else {
+            null
+          }
+          i += 1
+        }
+        (keys, values)
+      }
+
+    case ObjectType(cls) if classOf[scala.collection.Map[_, _]].isAssignableFrom(cls) =>
+      (input: Any) => {
+        val data = input.asInstanceOf[scala.collection.Map[Any, Any]]
+        val keys = new Array[Any](data.size)
+        val values = new Array[Any](data.size)
+        var i = 0
+        for ((key, value) <- data) {
+          keys(i) = if (key != null) {
+            keyConverter.eval(InternalRow.fromSeq(key :: Nil))
+          } else {
+            throw new RuntimeException("Cannot use null as map key!")
+          }
+          values(i) = if (value != null) {
+            valueConverter.eval(InternalRow.fromSeq(value :: Nil))
+          } else {
+            null
+          }
+          i += 1
+        }
+        (keys, values)
+      }
+  }
 
   override def eval(input: InternalRow): Any = {
     val result = child.eval(input)
     if (result != null) {
-      val mapValue = result.asInstanceOf[Map[Any, Any]]
-      val keys = new Array[Any](mapValue.size)
-      val values = new Array[Any](mapValue.size)
-      var i = 0
-      for ((k, v) <- mapValue) {
-        keys(i) = if (k != null) keyCatalystConverter(k) else null
-        values(i) = if (v != null) valueCatalystConverter(v) else null
-        i += 1
-      }
+      val (keys, values) = mapCatalystConverter(result)
       new ArrayBasedMapData(ArrayData.toArrayData(keys), ArrayData.toArrayData(values))
     } else {
       null

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -1308,7 +1308,7 @@ case class ExternalMapToCatalyst private(
     val result = child.eval(input)
     if (result != null) {
       val (keys, values) = mapCatalystConverter(result)
-      new ArrayBasedMapData(ArrayData.toArrayData(keys), ArrayData.toArrayData(values))
+      new ArrayBasedMapData(new GenericArrayData(keys), new GenericArrayData(values))
     } else {
       null
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
@@ -26,7 +26,7 @@ import scala.util.Random
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.serializer.{JavaSerializer, KryoSerializer}
 import org.apache.spark.sql.{RandomDataGenerator, Row}
-import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow, ScalaReflection}
 import org.apache.spark.sql.catalyst.analysis.{ResolveTimeZone, SimpleAnalyzer, UnresolvedDeserializer}
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.encoders._
@@ -473,6 +473,7 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkObjectExprEvaluation(deserializer, expected = data)
   }
 
+<<<<<<< c48085aa91c60615a4de3b391f019f46f3fcdbe3
   test("SPARK-23595 ValidateExternalType should support interpreted execution") {
     val inputObject = BoundReference(0, ObjectType(classOf[Row]), nullable = true)
     Seq(
@@ -500,6 +501,14 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
         GetExternalRowField(inputObject, index = 0, fieldName = "c0"), DoubleType),
       InternalRow.fromSeq(Seq(Row(1))),
       "java.lang.Integer is not a valid external type for schema of double")
+  }
+
+  test("SPARK-23589 ExternalMapToCatalyst should support interpreted execution") {
+    val data = Map[Int, String](0 -> "v0", 1 -> "v1", 2 -> null, 3 -> "v3")
+    val serializer = GetStructField(
+      ScalaReflection.serializerFor[Map[Int, String]](Literal.fromObject(data)), 0)
+    val catalystValue = CatalystTypeConverters.convertToCatalyst(data)
+    checkEvaluation(serializer, catalystValue)
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr supported interpreted mode for `ExternalMapToCatalyst`.

## How was this patch tested?
Added tests in `ObjectExpressionsSuite`.