### PR TITLE
[SPARK-23779][SQL] TaskMemoryManager and UnsafeSorter related classes use MemoryBlock

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/UnsafeAlignedOffset.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/UnsafeAlignedOffset.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.unsafe;
 
+import org.apache.spark.unsafe.memory.MemoryBlock;
+
 /**
  * Class to make changes to record length offsets uniform through out
  * various areas of Apache Spark core and unsafe.  The SPARC platform
@@ -32,24 +34,24 @@ public class UnsafeAlignedOffset {
     return UAO_SIZE;
   }
 
-  public static int getSize(Object object, long offset) {
+  public static int getSize(MemoryBlock mb, long offset) {
     switch (UAO_SIZE) {
       case 4:
-        return Platform.getInt(object, offset);
+        return mb.getInt(offset);
       case 8:
-        return (int)Platform.getLong(object, offset);
+        return (int)mb.getLong(offset);
       default:
         throw new AssertionError("Illegal UAO_SIZE");
     }
   }
 
-  public static void putSize(Object object, long offset, int value) {
+  public static void putSize(MemoryBlock mb, long offset, int value) {
     switch (UAO_SIZE) {
       case 4:
-        Platform.putInt(object, offset, value);
+        mb.putInt(offset, value);
         break;
       case 8:
-        Platform.putLong(object, offset, value);
+        mb.putLong(offset, value);
         break;
       default:
         throw new AssertionError("Illegal UAO_SIZE");

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/memory/ByteArrayMemoryBlock.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/memory/ByteArrayMemoryBlock.java
@@ -26,18 +26,23 @@ import org.apache.spark.unsafe.Platform;
  */
 public final class ByteArrayMemoryBlock extends MemoryBlock {
 
-  private final byte[] array;
+  private byte[] array;
 
   public ByteArrayMemoryBlock(byte[] obj, long offset, long size) {
     super(obj, offset, size);
     this.array = obj;
-    assert(offset + size <= Platform.BYTE_ARRAY_OFFSET + obj.length) :
+    assert(obj == null || offset + size <= Platform.BYTE_ARRAY_OFFSET + obj.length) :
       "The sum of size " + size + " and offset " + offset + " should not be larger than " +
         "the size of the given memory space " + (obj.length + Platform.BYTE_ARRAY_OFFSET);
   }
 
   public ByteArrayMemoryBlock(long length) {
     this(new byte[Ints.checkedCast(length)], Platform.BYTE_ARRAY_OFFSET, length);
+  }
+
+  public void set(Object obj, long offset, long size) {
+    super.set(obj, offset, size);
+    this.array = (byte[])obj;
   }
 
   @Override

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/memory/ByteArrayMemoryBlock.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/memory/ByteArrayMemoryBlock.java
@@ -40,9 +40,21 @@ public final class ByteArrayMemoryBlock extends MemoryBlock {
     this(new byte[Ints.checkedCast(length)], Platform.BYTE_ARRAY_OFFSET, length);
   }
 
-  public void set(Object obj, long offset, long size) {
-    super.set(obj, offset, size);
-    this.array = (byte[])obj;
+  // TODO(kiszk) This method should be removed when UnsafeRow uses MemoryBlock
+  // this method is tentatively introduced to alleviate overhead to pass UnsafeRow to MemoryBlock
+  // in a loop at UnsafeHashedRelation.apply().
+  public void set(byte[] obj, long offset, long size) {
+    this.obj = obj;
+    this.offset = offset;
+    this.length = size;
+    this.array = obj;
+    assert(offset + length <= Platform.BYTE_ARRAY_OFFSET + array.length);
+  }
+
+  @Override
+  public void setLength(long length) {
+    super.setLength(length);
+    assert(length >= 0 && offset + length <= Platform.BYTE_ARRAY_OFFSET + array.length);
   }
 
   @Override

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/memory/MemoryBlock.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/memory/MemoryBlock.java
@@ -81,6 +81,16 @@ public abstract class MemoryBlock {
     return offset;
   }
 
+  public void set(@Nullable Object obj, long offset, long length) {
+    this.obj = obj;
+    this.offset = offset;
+    this.length = length;
+  }
+
+  public final void setLength(long length) {
+    this.length = length;
+  }
+
   public void resetObjAndOffset() {
     this.obj = null;
     this.offset = 0;

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/memory/MemoryBlock.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/memory/MemoryBlock.java
@@ -81,13 +81,11 @@ public abstract class MemoryBlock {
     return offset;
   }
 
-  public void set(@Nullable Object obj, long offset, long length) {
-    this.obj = obj;
-    this.offset = offset;
-    this.length = length;
-  }
-
-  public final void setLength(long length) {
+  /**
+   * Change length of this MemoryBlock. The length should be fit into the existing memory region
+   * This is mainly used for performance to reuse one MemoryBlock in a loop
+   */
+  public void setLength(long length) {
     this.length = length;
   }
 

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/memory/MemoryBlock.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/memory/MemoryBlock.java
@@ -206,7 +206,7 @@ public abstract class MemoryBlock {
   }
 
   public final void copyFrom(Object src, long srcOffset, long dstOffset, long length) {
-    assert(length <= this.length - srcOffset);
+    assert(length <= this.length - dstOffset);
     Platform.copyMemory(src, srcOffset, obj, offset + dstOffset, length);
   }
 

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/memory/OnHeapMemoryBlock.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/memory/OnHeapMemoryBlock.java
@@ -40,9 +40,10 @@ public final class OnHeapMemoryBlock extends MemoryBlock {
     this(new long[Ints.checkedCast((size + 7) / 8)], Platform.LONG_ARRAY_OFFSET, size);
   }
 
-  public void set(Object obj, long offset, long size) {
-    super.set(obj, offset, size);
-    this.array = (long[])obj;
+  @Override
+  public void setLength(long length) {
+    super.setLength(length);
+    assert(length >= 0 && offset + length <= Platform.LONG_ARRAY_OFFSET + array.length);
   }
 
   @Override

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/memory/OnHeapMemoryBlock.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/memory/OnHeapMemoryBlock.java
@@ -26,18 +26,23 @@ import org.apache.spark.unsafe.Platform;
  */
 public final class OnHeapMemoryBlock extends MemoryBlock {
 
-  private final long[] array;
+  private long[] array;
 
   public OnHeapMemoryBlock(long[] obj, long offset, long size) {
     super(obj, offset, size);
     this.array = obj;
-    assert(offset + size <= obj.length * 8L + Platform.LONG_ARRAY_OFFSET) :
+    assert(obj == null || offset + size <= obj.length * 8L + Platform.LONG_ARRAY_OFFSET) :
       "The sum of size " + size + " and offset " + offset + " should not be larger than " +
         "the size of the given memory space " + (obj.length * 8L + Platform.LONG_ARRAY_OFFSET);
   }
 
   public OnHeapMemoryBlock(long size) {
     this(new long[Ints.checkedCast((size + 7) / 8)], Platform.LONG_ARRAY_OFFSET, size);
+  }
+
+  public void set(Object obj, long offset, long size) {
+    super.set(obj, offset, size);
+    this.array = (long[])obj;
   }
 
   @Override

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/RecordComparator.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/RecordComparator.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.util.collection.unsafe.sort;
 
+import org.apache.spark.unsafe.memory.MemoryBlock;
+
 /**
  * Compares records for ordering. In cases where the entire sorting key can fit in the 8-byte
  * prefix, this may simply return 0.
@@ -30,10 +32,10 @@ public abstract class RecordComparator {
    *         equal to, or greater than the second.
    */
   public abstract int compare(
-    Object leftBaseObject,
+    MemoryBlock leftBaseObject,
     long leftBaseOffset,
     int leftBaseLength,
-    Object rightBaseObject,
+    MemoryBlock rightBaseObject,
     long rightBaseOffset,
     int rightBaseLength);
 }

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeInMemorySorter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeInMemorySorter.java
@@ -60,13 +60,13 @@ public final class UnsafeInMemorySorter {
       final int prefixComparisonResult = prefixComparator.compare(r1.keyPrefix, r2.keyPrefix);
       int uaoSize = UnsafeAlignedOffset.getUaoSize();
       if (prefixComparisonResult == 0) {
-        final Object baseObject1 = memoryManager.getPage(r1.recordPointer);
+        final MemoryBlock mb1 = memoryManager.getPage(r1.recordPointer);
         final long baseOffset1 = memoryManager.getOffsetInPage(r1.recordPointer) + uaoSize;
-        final int baseLength1 = UnsafeAlignedOffset.getSize(baseObject1, baseOffset1 - uaoSize);
-        final Object baseObject2 = memoryManager.getPage(r2.recordPointer);
+        final int baseLength1 = UnsafeAlignedOffset.getSize(mb1, baseOffset1 - uaoSize);
+        final MemoryBlock mb2 = memoryManager.getPage(r2.recordPointer);
         final long baseOffset2 = memoryManager.getOffsetInPage(r2.recordPointer) + uaoSize;
-        final int baseLength2 = UnsafeAlignedOffset.getSize(baseObject2, baseOffset2 - uaoSize);
-        return recordComparator.compare(baseObject1, baseOffset1, baseLength1, baseObject2,
+        final int baseLength2 = UnsafeAlignedOffset.getSize(mb2, baseOffset2 - uaoSize);
+        return recordComparator.compare(mb1, baseOffset1, baseLength1, mb2,
           baseOffset2, baseLength2);
       } else {
         return prefixComparisonResult;
@@ -256,7 +256,7 @@ public final class UnsafeInMemorySorter {
     private final int numRecords;
     private int position;
     private int offset;
-    private Object baseObject;
+    private MemoryBlock baseMemoryBlock;
     private long baseOffset;
     private long keyPrefix;
     private int recordLength;
@@ -272,7 +272,7 @@ public final class UnsafeInMemorySorter {
     public SortedIterator clone() {
       SortedIterator iter = new SortedIterator(numRecords, offset);
       iter.position = position;
-      iter.baseObject = baseObject;
+      iter.baseMemoryBlock = baseMemoryBlock;
       iter.baseOffset = baseOffset;
       iter.keyPrefix = keyPrefix;
       iter.recordLength = recordLength;
@@ -304,16 +304,16 @@ public final class UnsafeInMemorySorter {
       final long recordPointer = array.get(offset + position);
       currentPageNumber = TaskMemoryManager.decodePageNumber(recordPointer);
       int uaoSize = UnsafeAlignedOffset.getUaoSize();
-      baseObject = memoryManager.getPage(recordPointer);
+      baseMemoryBlock = memoryManager.getPage(recordPointer);
       // Skip over record length
       baseOffset = memoryManager.getOffsetInPage(recordPointer) + uaoSize;
-      recordLength = UnsafeAlignedOffset.getSize(baseObject, baseOffset - uaoSize);
+      recordLength = UnsafeAlignedOffset.getSize(baseMemoryBlock, baseOffset - uaoSize);
       keyPrefix = array.get(offset + position + 1);
       position += 2;
     }
 
     @Override
-    public Object getBaseObject() { return baseObject; }
+    public MemoryBlock getMemoryBlock() { return baseMemoryBlock; }
 
     @Override
     public long getBaseOffset() { return baseOffset; }

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterIterator.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterIterator.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.util.collection.unsafe.sort;
 
+import org.apache.spark.unsafe.memory.MemoryBlock;
+
 import java.io.IOException;
 
 public abstract class UnsafeSorterIterator {
@@ -25,7 +27,7 @@ public abstract class UnsafeSorterIterator {
 
   public abstract void loadNext() throws IOException;
 
-  public abstract Object getBaseObject();
+  public abstract MemoryBlock getMemoryBlock();
 
   public abstract long getBaseOffset();
 

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillMerger.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillMerger.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import java.util.Comparator;
 import java.util.PriorityQueue;
 
+import org.apache.spark.unsafe.memory.MemoryBlock;
+
 final class UnsafeSorterSpillMerger {
 
   private int numRecords = 0;
@@ -35,8 +37,8 @@ final class UnsafeSorterSpillMerger {
         prefixComparator.compare(left.getKeyPrefix(), right.getKeyPrefix());
       if (prefixComparisonResult == 0) {
         return recordComparator.compare(
-          left.getBaseObject(), left.getBaseOffset(), left.getRecordLength(),
-          right.getBaseObject(), right.getBaseOffset(), right.getRecordLength());
+          left.getMemoryBlock(), left.getBaseOffset(), left.getRecordLength(),
+          right.getMemoryBlock(), right.getBaseOffset(), right.getRecordLength());
       } else {
         return prefixComparisonResult;
       }
@@ -87,7 +89,7 @@ final class UnsafeSorterSpillMerger {
       }
 
       @Override
-      public Object getBaseObject() { return spillReader.getBaseObject(); }
+      public MemoryBlock getMemoryBlock() { return spillReader.getMemoryBlock(); }
 
       @Override
       public long getBaseOffset() { return spillReader.getBaseOffset(); }

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillWriter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillWriter.java
@@ -31,6 +31,7 @@ import org.apache.spark.storage.BlockManager;
 import org.apache.spark.storage.DiskBlockObjectWriter;
 import org.apache.spark.storage.TempLocalBlockId;
 import org.apache.spark.unsafe.Platform;
+import org.apache.spark.unsafe.memory.MemoryBlock;
 import org.apache.spark.internal.config.package$;
 
 /**
@@ -101,13 +102,13 @@ public final class UnsafeSorterSpillWriter {
   /**
    * Write a record to a spill file.
    *
-   * @param baseObject the base object / memory page containing the record
+   * @param baseMemoryBlock the base memory page containing the record
    * @param baseOffset the base offset which points directly to the record data.
    * @param recordLength the length of the record.
    * @param keyPrefix a sort key prefix
    */
   public void write(
-      Object baseObject,
+      MemoryBlock baseMemoryBlock,
       long baseOffset,
       int recordLength,
       long keyPrefix) throws IOException {
@@ -124,8 +125,7 @@ public final class UnsafeSorterSpillWriter {
     long recordReadPosition = baseOffset;
     while (dataRemaining > 0) {
       final int toTransfer = Math.min(freeSpaceInWriteBuffer, dataRemaining);
-      Platform.copyMemory(
-        baseObject,
+      baseMemoryBlock.writeTo(
         recordReadPosition,
         writeBuffer,
         Platform.BYTE_ARRAY_OFFSET + (diskWriteBufferSize - freeSpaceInWriteBuffer),

--- a/core/src/test/java/org/apache/spark/shuffle/sort/PackedRecordPointerSuite.java
+++ b/core/src/test/java/org/apache/spark/shuffle/sort/PackedRecordPointerSuite.java
@@ -40,14 +40,13 @@ public class PackedRecordPointerSuite {
     final MemoryConsumer c = new TestMemoryConsumer(memoryManager, MemoryMode.ON_HEAP);
     final MemoryBlock page0 = memoryManager.allocatePage(128, c);
     final MemoryBlock page1 = memoryManager.allocatePage(128, c);
-    final long addressInPage1 = memoryManager.encodePageNumberAndOffset(page1,
-      page1.getBaseOffset() + 42);
+    final long addressInPage1 = memoryManager.encodePageNumberAndOffset(page1, 42);
     PackedRecordPointer packedPointer = new PackedRecordPointer();
     packedPointer.set(PackedRecordPointer.packPointer(addressInPage1, 360));
     assertEquals(360, packedPointer.getPartitionId());
     final long recordPointer = packedPointer.getRecordPointer();
     assertEquals(1, TaskMemoryManager.decodePageNumber(recordPointer));
-    assertEquals(page1.getBaseOffset() + 42, memoryManager.getOffsetInPage(recordPointer));
+    assertEquals(42, memoryManager.getOffsetInPage(recordPointer));
     assertEquals(addressInPage1, recordPointer);
     memoryManager.cleanUpAllAllocatedMemory();
   }
@@ -62,14 +61,13 @@ public class PackedRecordPointerSuite {
     final MemoryConsumer c = new TestMemoryConsumer(memoryManager, MemoryMode.OFF_HEAP);
     final MemoryBlock page0 = memoryManager.allocatePage(128, c);
     final MemoryBlock page1 = memoryManager.allocatePage(128, c);
-    final long addressInPage1 = memoryManager.encodePageNumberAndOffset(page1,
-      page1.getBaseOffset() + 42);
+    final long addressInPage1 = memoryManager.encodePageNumberAndOffset(page1, 42);
     PackedRecordPointer packedPointer = new PackedRecordPointer();
     packedPointer.set(PackedRecordPointer.packPointer(addressInPage1, 360));
     assertEquals(360, packedPointer.getPartitionId());
     final long recordPointer = packedPointer.getRecordPointer();
     assertEquals(1, TaskMemoryManager.decodePageNumber(recordPointer));
-    assertEquals(page1.getBaseOffset() + 42, memoryManager.getOffsetInPage(recordPointer));
+    assertEquals(42, memoryManager.getOffsetInPage(recordPointer));
     assertEquals(addressInPage1, recordPointer);
     memoryManager.cleanUpAllAllocatedMemory();
   }

--- a/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorterSuite.java
+++ b/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorterSuite.java
@@ -44,6 +44,7 @@ import org.apache.spark.serializer.SerializerInstance;
 import org.apache.spark.serializer.SerializerManager;
 import org.apache.spark.storage.*;
 import org.apache.spark.unsafe.Platform;
+import org.apache.spark.unsafe.memory.MemoryBlock;
 import org.apache.spark.util.Utils;
 
 import static org.hamcrest.Matchers.greaterThan;
@@ -70,10 +71,10 @@ public class UnsafeExternalSorterSuite {
   final RecordComparator recordComparator = new RecordComparator() {
     @Override
     public int compare(
-      Object leftBaseObject,
+      MemoryBlock leftBaseObject,
       long leftBaseOffset,
       int leftBaseLength,
-      Object rightBaseObject,
+      MemoryBlock rightBaseObject,
       long rightBaseOffset,
       int rightBaseLength) {
       return 0;
@@ -186,7 +187,7 @@ public class UnsafeExternalSorterSuite {
       iter.loadNext();
       assertEquals(i, iter.getKeyPrefix());
       assertEquals(4, iter.getRecordLength());
-      assertEquals(i, Platform.getInt(iter.getBaseObject(), iter.getBaseOffset()));
+      assertEquals(i, iter.getMemoryBlock().getInt(iter.getBaseOffset()));
     }
 
     sorter.cleanupResources();
@@ -257,7 +258,7 @@ public class UnsafeExternalSorterSuite {
       iter.loadNext();
       assertEquals(i, iter.getKeyPrefix());
       assertEquals(4, iter.getRecordLength());
-      assertEquals(i, Platform.getInt(iter.getBaseObject(), iter.getBaseOffset()));
+      assertEquals(i, iter.getMemoryBlock().getInt(iter.getBaseOffset()));
       i++;
     }
     assertEquals(numRecords + 1, i);
@@ -297,25 +298,25 @@ public class UnsafeExternalSorterSuite {
     iter.loadNext();
     assertEquals(123, iter.getKeyPrefix());
     assertEquals(smallRecord.length * 4, iter.getRecordLength());
-    assertEquals(123, Platform.getInt(iter.getBaseObject(), iter.getBaseOffset()));
+    assertEquals(123, iter.getMemoryBlock().getInt(iter.getBaseOffset()));
     // Small record
     assertTrue(iter.hasNext());
     iter.loadNext();
     assertEquals(123, iter.getKeyPrefix());
     assertEquals(smallRecord.length * 4, iter.getRecordLength());
-    assertEquals(123, Platform.getInt(iter.getBaseObject(), iter.getBaseOffset()));
+    assertEquals(123, iter.getMemoryBlock().getInt(iter.getBaseOffset()));
     // Large record
     assertTrue(iter.hasNext());
     iter.loadNext();
     assertEquals(456, iter.getKeyPrefix());
     assertEquals(largeRecord.length * 4, iter.getRecordLength());
-    assertEquals(456, Platform.getInt(iter.getBaseObject(), iter.getBaseOffset()));
+    assertEquals(456, iter.getMemoryBlock().getInt(iter.getBaseOffset()));
     // Large record
     assertTrue(iter.hasNext());
     iter.loadNext();
     assertEquals(456, iter.getKeyPrefix());
     assertEquals(largeRecord.length * 4, iter.getRecordLength());
-    assertEquals(456, Platform.getInt(iter.getBaseObject(), iter.getBaseOffset()));
+    assertEquals(456, iter.getMemoryBlock().getInt(iter.getBaseOffset()));
 
     assertFalse(iter.hasNext());
     sorter.cleanupResources();
@@ -339,16 +340,16 @@ public class UnsafeExternalSorterSuite {
     for (int i = 0; i < n / 3; i++) {
       iter.hasNext();
       iter.loadNext();
-      assertTrue(Platform.getLong(iter.getBaseObject(), iter.getBaseOffset()) == i);
+      assertTrue(iter.getMemoryBlock().getLong(iter.getBaseOffset()) == i);
       lastv = i;
     }
     assertTrue(iter.spill() > 0);
     assertEquals(0, iter.spill());
-    assertTrue(Platform.getLong(iter.getBaseObject(), iter.getBaseOffset()) == lastv);
+    assertTrue(iter.getMemoryBlock().getLong(iter.getBaseOffset()) == lastv);
     for (int i = n / 3; i < n; i++) {
       iter.hasNext();
       iter.loadNext();
-      assertEquals(i, Platform.getLong(iter.getBaseObject(), iter.getBaseOffset()));
+      assertEquals(i, iter.getMemoryBlock().getLong(iter.getBaseOffset()));
     }
     sorter.cleanupResources();
     assertSpillFilesWereCleanedUp();
@@ -372,7 +373,7 @@ public class UnsafeExternalSorterSuite {
     for (int i = 0; i < n; i++) {
       iter.hasNext();
       iter.loadNext();
-      assertEquals(i, Platform.getLong(iter.getBaseObject(), iter.getBaseOffset()));
+      assertEquals(i, iter.getMemoryBlock().getLong(iter.getBaseOffset()));
     }
     sorter.cleanupResources();
     assertSpillFilesWereCleanedUp();
@@ -406,7 +407,7 @@ public class UnsafeExternalSorterSuite {
     for (int i = 0; i < n; i++) {
       iter.hasNext();
       iter.loadNext();
-      assertEquals(i, Platform.getLong(iter.getBaseObject(), iter.getBaseOffset()));
+      assertEquals(i, iter.getMemoryBlock().getLong(iter.getBaseOffset()));
     }
     sorter.cleanupResources();
     assertSpillFilesWereCleanedUp();
@@ -550,7 +551,7 @@ public class UnsafeExternalSorterSuite {
     for (int i = start; i < end; i++) {
       assert (iter.hasNext());
       iter.loadNext();
-      assert (Platform.getInt(iter.getBaseObject(), iter.getBaseOffset()) == i);
+      assert (iter.getMemoryBlock().getInt(iter.getBaseOffset()) == i);
     }
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
@@ -170,6 +170,10 @@ public final class UnsafeRow extends InternalRow implements Externalizable, Kryo
     this.sizeInBytes = sizeInBytes;
   }
 
+  public void pointTo(MemoryBlock mb, long baseOffset, int sizeInBytes) {
+    pointTo(mb.getBaseObject(), mb.getBaseOffset() + baseOffset, sizeInBytes);
+  }
+
   /**
    * Update this UnsafeRow to point to the underlying byte array.
    *

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/execution/RecordBinaryComparator.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/execution/RecordBinaryComparator.java
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution;
 
 import org.apache.spark.unsafe.Platform;
+import org.apache.spark.unsafe.memory.MemoryBlock;
 import org.apache.spark.util.collection.unsafe.sort.RecordComparator;
 
 public final class RecordBinaryComparator extends RecordComparator {
@@ -25,7 +26,12 @@ public final class RecordBinaryComparator extends RecordComparator {
   // TODO(jiangxb) Add test suite for this.
   @Override
   public int compare(
-      Object leftObj, long leftOff, int leftLen, Object rightObj, long rightOff, int rightLen) {
+      MemoryBlock leftMb,
+      long leftOff,
+      int leftLen,
+      MemoryBlock rightMb,
+      long rightOff,
+      int rightLen) {
     int i = 0;
     int res = 0;
 
@@ -40,8 +46,8 @@ public final class RecordBinaryComparator extends RecordComparator {
     // check if stars align and we can get both offsets to be aligned
     if ((leftOff % 8) == (rightOff % 8)) {
       while ((leftOff + i) % 8 != 0 && i < leftLen) {
-        res = (Platform.getByte(leftObj, leftOff + i) & 0xff) -
-                (Platform.getByte(rightObj, rightOff + i) & 0xff);
+        res = (leftMb.getByte(leftOff + i) & 0xff) -
+                (rightMb.getByte(rightOff + i) & 0xff);
         if (res != 0) return res;
         i += 1;
       }
@@ -49,8 +55,8 @@ public final class RecordBinaryComparator extends RecordComparator {
     // for architectures that support unaligned accesses, chew it up 8 bytes at a time
     if (Platform.unaligned() || (((leftOff + i) % 8 == 0) && ((rightOff + i) % 8 == 0))) {
       while (i <= leftLen - 8) {
-        res = (int) ((Platform.getLong(leftObj, leftOff + i) -
-                Platform.getLong(rightObj, rightOff + i)) % Integer.MAX_VALUE);
+        res = (int) ((leftMb.getLong(leftOff + i) -
+                rightMb.getLong(rightOff + i)) % Integer.MAX_VALUE);
         if (res != 0) return res;
         i += 8;
       }
@@ -58,8 +64,8 @@ public final class RecordBinaryComparator extends RecordComparator {
     // this will finish off the unaligned comparisons, or do the entire aligned comparison
     // whichever is needed.
     while (i < leftLen) {
-      res = (Platform.getByte(leftObj, leftOff + i) & 0xff) -
-              (Platform.getByte(rightObj, rightOff + i) & 0xff);
+      res = (leftMb.getByte(leftOff + i) & 0xff) -
+              (rightMb.getByte(rightOff + i) & 0xff);
       if (res != 0) return res;
       i += 1;
     }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowSorter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowSorter.java
@@ -33,6 +33,7 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.Platform;
+import org.apache.spark.unsafe.memory.MemoryBlock;
 import org.apache.spark.util.collection.unsafe.sort.PrefixComparator;
 import org.apache.spark.util.collection.unsafe.sort.RecordComparator;
 import org.apache.spark.util.collection.unsafe.sort.UnsafeExternalSorter;
@@ -186,7 +187,7 @@ public final class UnsafeExternalRowSorter {
           try {
             sortedIterator.loadNext();
             row.pointTo(
-              sortedIterator.getBaseObject(),
+              sortedIterator.getMemoryBlock(),
               sortedIterator.getBaseOffset(),
               sortedIterator.getRecordLength());
             if (!hasNext()) {
@@ -232,16 +233,16 @@ public final class UnsafeExternalRowSorter {
 
     @Override
     public int compare(
-        Object baseObj1,
+        MemoryBlock baseMb1,
         long baseOff1,
         int baseLen1,
-        Object baseObj2,
+        MemoryBlock baseMb2,
         long baseOff2,
         int baseLen2) {
       // Note that since ordering doesn't need the total length of the record, we just pass 0
       // into the row.
-      row1.pointTo(baseObj1, baseOff1, 0);
-      row2.pointTo(baseObj2, baseOff2, 0);
+      row1.pointTo(baseMb1, baseOff1, 0);
+      row2.pointTo(baseMb2, baseOff2, 0);
       return ordering.compare(row1, row2);
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArray.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArray.scala
@@ -216,7 +216,7 @@ private[sql] class ExternalAppendOnlyUnsafeRowArray(
     override def next(): UnsafeRow = {
       throwExceptionIfModified()
       iterator.loadNext()
-      currentRow.pointTo(iterator.getBaseObject, iterator.getBaseOffset, iterator.getRecordLength)
+      currentRow.pointTo(iterator.getMemoryBlock, iterator.getBaseOffset, iterator.getRecordLength)
       currentRow
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -315,8 +315,11 @@ private[joins] object UnsafeHashedRelation {
       numFields = row.numFields()
       val key = keyGenerator(row)
       if (!key.anyNull) {
-        keyMb.set(key.getBaseObject, key.getBaseOffset, key.getSizeInBytes)
-        rowMb.set(row.getBaseObject, row.getBaseOffset, row.getSizeInBytes)
+        // TODO(kiszk) pass MemoryBlock of UnsafeRow to lookup() and append()
+        keyMb.set(
+          key.getBaseObject.asInstanceOf[Array[Byte]], key.getBaseOffset, key.getSizeInBytes)
+        rowMb.set(
+          row.getBaseObject.asInstanceOf[Array[Byte]], row.getBaseOffset, row.getSizeInBytes)
         val loc = binaryMap.lookup(keyMb)
         val success = loc.append(keyMb, rowMb)
         if (!success) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArrayBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArrayBenchmark.scala
@@ -137,7 +137,7 @@ object ExternalAppendOnlyUnsafeRowArrayBenchmark {
         val iter = array.getIterator(0)
         while (iter.hasNext) {
           iter.loadNext()
-          unsafeRow.pointTo(iter.getBaseObject, iter.getBaseOffset, iter.getRecordLength)
+          unsafeRow.pointTo(iter.getMemoryBlock, iter.getBaseOffset, iter.getRecordLength)
           sum = sum + unsafeRow.getLong(0)
         }
         array.cleanupResources()


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR tries to use `MemoryBlock` in `TaskMemoryManager` and `UnsafeSorter` related classes. There are two advantages to use `MemoryBlock`.

1. Has clean API calls rather than using a Java array or `PlatformMemory`
2. Improve runtime performance of memory access instead of using `Object` with `Platform.get/put...`.

** ToDo: Add benchmark result **

## How was this patch tested?

Used existing UTs