### PR TITLE
[SPARK-23884][CORE] hasLaunchedTask should be true when launchedAnyTask be true

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -370,11 +370,9 @@ private[spark] class TaskSchedulerImpl(
       }
       if (!launchedAnyTask) {
         taskSet.abortIfCompletelyBlacklisted(hostToExecutors)
+      } else {
+        hasLaunchedTask = true
       }
-    }
-
-    if (tasks.size > 0) {
-      hasLaunchedTask = true
     }
     return tasks
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`hasLaunchedTask` should be `true` when `launchedAnyTask` be `true`, rather than `task's size > 0`.
`task'size` would be greater than 0 as long as there‘s any `WorkOffers`，but this dose not ensure there's any tasks launched.

## How was this patch tested?

exists 