### PR TITLE
[SPARK-19320][MESOS]allow specifying a hard limit on number of gpus required in each spark executor when running on mesos

### DIFF
--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -679,10 +679,18 @@ See the [configuration page](configuration.html) for information on Spark config
   <td><code>spark.mesos.gpus.max</code></td>
   <td><code>0</code></td>
   <td>
-    Set the maximum number GPU resources to acquire for this job. Note that executors will still launch when no GPU resources are found
-    since this configuration is just a upper limit and not a guaranteed amount.
+    Set the maximum number of GPU resources that can be acquired for this job. If total number of gpus to request
+    exceeds this setting, the new executors will not get launched. The executors that have obtained gpus before
+    exceeding this setting will still be launched
   </td>
-  </tr>
+</tr>
+<tr>
+  <td><code>spark.mesos.executor.gpus</code></td>
+  <td><code>0</code></td>
+  <td>
+    Set the hard limit on the number of gpus to request for each executor
+  </td>
+</tr>
 <tr>
   <td><code>spark.mesos.network.name</code></td>
   <td><code>(none)</code></td>

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -86,8 +86,6 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
 
   private val taskLabels = conf.get("spark.mesos.task.labels", "")
 
-  private val gpuCores = conf.getInt("spark.mesos.gpus", 0)
-
   private[this] val shutdownTimeoutMS =
     conf.getTimeAsMs("spark.mesos.coarse.shutdownTimeout", "10s")
       .ensuring(_ >= 0, "spark.mesos.coarse.shutdownTimeout must be >= 0")

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
@@ -190,10 +190,10 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
                         Resources(executorMemory, 1, 2)))
 
     val taskInfos = verifyTaskLaunched(driver, "o1")
-    assert(backend.getResource(taskInfos.head.getResourcesList, "gpus") == executorGpus)
+    assert(backend.getResource(taskInfos.head.getResourcesList, "gpus") == 2)
 
-    val taskInfos = verifyTaskLaunched(driver, "o2")
-    assert(backend.getResource(taskInfos.head.getResourcesList, "gpus") == executorGpus)
+    taskInfos = verifyTaskLaunched(driver, "o2")
+    assert(backend.getResource(taskInfos.head.getResourcesList, "gpus") == 2)
 
     verifyDeclinedOffer(driver, createOfferId("o3"), true)
   }

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
@@ -190,6 +190,16 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
   }
 
 
+  test("mesos declines offers where spark.mesos.gpus.max less than spark.mesos.executor.gpus") {
+    setBackend(Map("spark.mesos.gpus.max" -> "2",
+                   "spark.mesos.executor.gpus" -> "5"))
+
+    val executorMemory = backend.executorMemory(sc)
+    offerResources(List(Resources(executorMemory, 1, 5)))
+    verifyDeclinedOffer(driver, createOfferId("o1"))
+  }
+
+
   test("mesos declines offers that exceed spark.mesos.gpus.max") {
     setBackend(Map("spark.mesos.gpus.max" -> "5",
                    "spark.mesos.executor.gpus" -> "2"))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, Spark only allows specifying overall gpu resources as an upper limit, this adds a new conf parameter to allow specifying a hard limit on the number of gpu cores for each executor while still respecting the overall gpu resource constraint

## How was this patch tested?

Unit Testing

Please review http://spark.apache.org/contributing.html before opening a pull request.
