### PR TITLE
[SPARK-23958][CORE] HadoopRdd filters empty files to avoid generating empty tasks that affect the performance of the Spark computing performance.

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -323,7 +323,7 @@ package object config {
       .internal()
       .doc("When true, HadoopRDD/NewHadoopRDD will not create partitions for empty input splits.")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   private[spark] val SECRET_REDACTION_PATTERN =
     ConfigBuilder("spark.redaction.regex")

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -56,8 +56,7 @@ private[spark] class HadoopPartition(rddId: Int, override val index: Int, s: Inp
 
   /**
    * Get any environment variables that should be added to the users environment when running pipes
-    *
-    * @return a Map with the environment variables and corresponding values, it could be empty
+   * @return a Map with the environment variables and corresponding values, it could be empty
    */
   def getPipeEnvVars(): Map[String, String] = {
     val envVars: Map[String, String] = if (inputSplit.value.isInstanceOf[FileSplit]) {
@@ -88,7 +87,8 @@ private[spark] class HadoopPartition(rddId: Int, override val index: Int, s: Inp
  * @param keyClass Class of the key associated with the inputFormatClass.
  * @param valueClass Class of the value associated with the inputFormatClass.
  * @param minPartitions Minimum number of HadoopRDD partitions (Hadoop Splits) to generate.
-  * @note Instantiating this class directly is not recommended, please use
+ *
+ * @note Instantiating this class directly is not recommended, please use
  * `org.apache.spark.SparkContext.hadoopRDD()`
  */
 @DeveloperApi


### PR DESCRIPTION
## What changes were proposed in this pull request?

HadoopRdd filter empty files to avoid generating empty tasks that affect the performance of the Spark computing performance.

Empty file's length is zero.

## How was this patch tested?

manual tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
