### PR TITLE
[SPARK-23919][SQL] Add array_position function

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1851,8 +1851,8 @@ def array_position(col, value):
     Collection function: Locates the position of the first occurrence of the given value
     in the given array. Returns null if either of the arguments are null.
 
-    .. note:: The position is not zero based, but 1 based index. Returns 0 if substr
-        could not be found in str.
+    .. note:: The position is not zero based, but 1 based index. Returns 0 if the given
+        value could not be found in the array.
 
     >>> df = spark.createDataFrame([(["c", "b", "a"],), ([],)], ['data'])
     >>> df.select(array_position(df.data, "a")).collect()

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1845,6 +1845,23 @@ def array_contains(col, value):
     return Column(sc._jvm.functions.array_contains(_to_java_column(col), value))
 
 
+@since(2.4)
+def array_position(str, substr):
+    """
+    Collection function: Locates the position of the first occurrence of substr column
+    in the given string as Decimal. Returns null if either of the arguments are null.
+
+    .. note:: The position is not zero based, but 1 based index. Returns 0 if substr
+        could not be found in str.
+
+    >>> df = spark.createDataFrame([('abcd',)], ['s',])
+    >>> df.select(array_position(df.s, 'b').alias('s')).collect()
+    [Row(s=Decimal(2))]
+    """
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.functions.array_position(_to_java_column(str), substr))
+
+
 @since(1.4)
 def explode(col):
     """Returns a new row for each element in the given array or map.

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1848,15 +1848,15 @@ def array_contains(col, value):
 @since(2.4)
 def array_position(col, value):
     """
-    Collection function: Locates the position of the first occurrence of substr column
-    in the given string as Decimal. Returns null if either of the arguments are null.
+    Collection function: Locates the position of the first occurrence of the given value
+    in the given array. Returns null if either of the arguments are null.
 
     .. note:: The position is not zero based, but 1 based index. Returns 0 if substr
         could not be found in str.
 
     >>> df = spark.createDataFrame([(["c", "b", "a"],), ([],)], ['data'])
-    >>> df.select(array_position(df.s, "a")).collect()
-    [Row(array_position(data, a)=Decimal(3)), Row(array_position(data, a)=Decimal(0))]
+    >>> df.select(array_position(df.data, "a")).collect()
+    [Row(array_position(data, a)=3), Row(array_position(data, a)=0)]
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.array_position(_to_java_column(col), value))

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1846,7 +1846,7 @@ def array_contains(col, value):
 
 
 @since(2.4)
-def array_position(str, substr):
+def array_position(col, value):
     """
     Collection function: Locates the position of the first occurrence of substr column
     in the given string as Decimal. Returns null if either of the arguments are null.
@@ -1854,12 +1854,12 @@ def array_position(str, substr):
     .. note:: The position is not zero based, but 1 based index. Returns 0 if substr
         could not be found in str.
 
-    >>> df = spark.createDataFrame([('abcd',)], ['s',])
-    >>> df.select(array_position(df.s, 'b').alias('s')).collect()
-    [Row(s=Decimal(2))]
+    >>> df = spark.createDataFrame([(["c", "b", "a"],), ([],)], ['data'])
+    >>> df.select(array_position(df.s, "a")).collect()
+    [Row(array_position(data, a)=Decimal(3)), Row(array_position(data, a)=Decimal(0))]
     """
     sc = SparkContext._active_spark_context
-    return Column(sc._jvm.functions.array_position(_to_java_column(str), substr))
+    return Column(sc._jvm.functions.array_position(_to_java_column(col), value))
 
 
 @since(1.4)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -402,6 +402,7 @@ object FunctionRegistry {
     // collection functions
     expression[CreateArray]("array"),
     expression[ArrayContains]("array_contains"),
+    expression[ArrayPosition]("array_position"),
     expression[CreateMap]("map"),
     expression[CreateNamedStruct]("named_struct"),
     expression[MapKeys]("map_keys"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -509,9 +509,11 @@ case class ArrayMax(child: Expression) extends UnaryExpression with ImplicitCast
 
 /**
  * Returns the position of the first occurrence of element in the given array as long.
- * Returns 0 if substr could not be found in str. Returns null if either of the arguments are null
+ * Returns 0 if the given value could not be found in the array. Returns null if either of
+ * the arguments are null
  *
- * NOTE: that this is not zero based, but 1-based index. The first character in str has index 1.
+ * NOTE: that this is not zero based, but 1-based index. The first element in the array has
+ *       index 1.
  */
 @ExpressionDescription(
   usage = """
@@ -529,10 +531,6 @@ case class ArrayPosition(left: Expression, right: Expression)
   override def dataType: DataType = LongType
   override def inputTypes: Seq[AbstractDataType] =
     Seq(ArrayType, left.dataType.asInstanceOf[ArrayType].elementType)
-
-  override def nullable: Boolean = {
-    left.nullable || right.nullable
-  }
 
   override def nullSafeEval(arr: Any, value: Any): Any = {
     arr.asInstanceOf[ArrayData].foreach(right.dataType, (i, v) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -508,9 +508,8 @@ case class ArrayMax(child: Expression) extends UnaryExpression with ImplicitCast
 
 
 /**
- * A function that returns the position of the first occurrence of element in the given array
- * as long. Returns 0 if substr could not be found in str.
- * Returns null if either of the arguments are null and
+ * Returns the position of the first occurrence of element in the given array as long.
+ * Returns 0 if substr could not be found in str. Returns null if either of the arguments are null
  *
  * NOTE: that this is not zero based, but 1-based index. The first character in str has index 1.
  */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -508,15 +508,15 @@ case class ArrayMax(child: Expression) extends UnaryExpression with ImplicitCast
 
 
 /**
- * A function that returns the position of the first occurrence of substr in the given string
- * as BigInt. Returns 0 if substr could not be found in str.
+ * A function that returns the position of the first occurrence of element in the given array
+ * as long. Returns 0 if substr could not be found in str.
  * Returns null if either of the arguments are null and
  *
  * NOTE: that this is not zero based, but 1-based index. The first character in str has index 1.
  */
 @ExpressionDescription(
   usage = """
-    _FUNC_(array, element) - Returns the (1-based) index of the first element of the array.
+    _FUNC_(array, element) - Returns the (1-based) index of the first element of the array as long.
   """,
   examples = """
     Examples:
@@ -527,7 +527,7 @@ case class ArrayMax(child: Expression) extends UnaryExpression with ImplicitCast
 case class ArrayPosition(left: Expression, right: Expression)
   extends BinaryExpression with ImplicitCastInputTypes {
 
-  override def dataType: DataType = DecimalType.BigIntDecimal
+  override def dataType: DataType = LongType
   override def inputTypes: Seq[AbstractDataType] =
     Seq(ArrayType, left.dataType.asInstanceOf[ArrayType].elementType)
 
@@ -538,10 +538,10 @@ case class ArrayPosition(left: Expression, right: Expression)
   override def nullSafeEval(arr: Any, value: Any): Any = {
     arr.asInstanceOf[ArrayData].foreach(right.dataType, (i, v) =>
       if (v == value) {
-        return new Decimal().setOrNull((i + 1).toLong, DecimalType.MAX_PRECISION, 0)
+        return (i + 1).toLong
       }
     )
-    new Decimal().setOrNull(0.toLong, DecimalType.MAX_PRECISION, 0)
+    0L
   }
 
   override def prettyName: String = "array_position"
@@ -559,7 +559,7 @@ case class ArrayPosition(left: Expression, right: Expression)
          |    break;
          |  }
          |}
-         |${ev.value} = Decimal.apply((long)$pos);
+         |${ev.value} = (long) $pos;
        """
     })
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -531,7 +531,7 @@ case class ArrayPosition(left: Expression, right: Expression)
     Seq(ArrayType, left.dataType.asInstanceOf[ArrayType].elementType)
 
   override def nullable: Boolean = {
-    left.nullable || right.nullable || left.dataType.asInstanceOf[ArrayType].containsNull
+    left.nullable || right.nullable
   }
 
   override def nullSafeEval(arr: Any, value: Any): Any = {
@@ -551,15 +551,15 @@ case class ArrayPosition(left: Expression, right: Expression)
       val i = ctx.freshName("i")
       val getValue = CodeGenerator.getValue(arr, right.dataType, i)
       s"""
-         |int ${pos} = 0;
+         |int $pos = 0;
          |for (int $i = 0; $i < $arr.numElements(); $i ++) {
-         |  if (${ctx.genEqual(right.dataType, value, getValue)}) {
-         |    ${pos} = $i + 1;
+         |  if (!$arr.isNullAt($i) && ${ctx.genEqual(right.dataType, value, getValue)}) {
+         |    $pos = $i + 1;
          |    break;
          |  }
          |}
          |${ev.value} = (long) $pos;
-       """
+       """.stripMargin
     })
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -1017,7 +1017,8 @@ case class StringInstr(str: Expression, substr: Expression)
     Examples:
       > SELECT _FUNC_('SparkSQL', 'SQL');
        6
-  """)
+  """,
+  since = "2.4.0")
 case class ArrayPosition(str: Expression, substr: Expression)
   extends BinaryExpression with ImplicitCastInputTypes {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -1009,7 +1009,6 @@ case class StringInstr(str: Expression, substr: Expression)
  *
  * NOTE: that this is not zero based, but 1-based index. The first character in str has index 1.
  */
-// scalastyle:off line.size.limit
 @ExpressionDescription(
   usage = """
     _FUNC_(str, substr) - Returns the (1-based) index of the first occurrence of `substr` in `str`.
@@ -1019,7 +1018,6 @@ case class StringInstr(str: Expression, substr: Expression)
       > SELECT _FUNC_('SparkSQL', 'SQL');
        6
   """)
-// scalastyle:on line.size.limit
 case class ArrayPosition(str: Expression, substr: Expression)
   extends BinaryExpression with ImplicitCastInputTypes {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -1003,58 +1003,6 @@ case class StringInstr(str: Expression, substr: Expression)
 }
 
 /**
- * A function that returns the position of the first occurrence of substr in the given string
- * as BigInt. Returns 0 if substr could not be found in str.
- * Returns null if either of the arguments are null and
- *
- * NOTE: that this is not zero based, but 1-based index. The first character in str has index 1.
- */
-@ExpressionDescription(
-  usage = """
-    _FUNC_(str, substr) - Returns the (1-based) index of the first occurrence of `substr` in `str`.
-  """,
-  examples = """
-    Examples:
-      > SELECT _FUNC_('SparkSQL', 'SQL');
-       6
-  """,
-  since = "2.4.0")
-case class ArrayPosition(str: Expression, substr: Expression)
-  extends BinaryExpression with ImplicitCastInputTypes {
-
-  override def left: Expression = str
-  override def right: Expression = substr
-  override def dataType: DataType = DecimalType.BigIntDecimal
-  override def inputTypes: Seq[DataType] = Seq(StringType, StringType)
-
-  private val stringInstr = StringInstr(str, substr)
-
-  override def nullSafeEval(string: Any, sub: Any): Any = {
-    val r = stringInstr.nullSafeEval(string, sub)
-    if (r == null) null else {
-      new Decimal().setOrNull(r.asInstanceOf[Int].toLong, DecimalType.MAX_PRECISION, 0)
-    }
-  }
-
-  override def prettyName: String = "array_position"
-
-  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    val value = ctx.freshName("arrayPositionValue")
-    val evPosition = stringInstr.doGenCode(
-      ctx, ExprCode("", ev.isNull, VariableValue(value, CodeGenerator.JAVA_INT)))
-    ev.copy(
-      code = evPosition.code +
-        s"""
-           |Decimal ${ev.value} = ${CodeGenerator.defaultValue(dataType)};
-           |if (!${evPosition.isNull}) {
-           |  ${ev.value} = Decimal.apply((long)$value);
-           |}
-         """.stripMargin,
-      isNull = evPosition.isNull)
-  }
-}
-
-/**
  * Returns the substring from string str before count occurrences of the delimiter delim.
  * If count is positive, everything the left of the final delimiter (counting from left) is
  * returned. If count is negative, every to the right of the final delimiter (counting from the

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.types._
 
 class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -177,15 +177,15 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
     val a2 = Literal.create(Seq(null), ArrayType(LongType))
     val a3 = Literal.create(null, ArrayType(StringType))
 
-    checkEvaluation(ArrayPosition(a0, Literal(1)), Decimal(BigInt(1)))
-    checkEvaluation(ArrayPosition(a0, Literal(0)), Decimal(BigInt(0)))
+    checkEvaluation(ArrayPosition(a0, Literal(1)), 1L)
+    checkEvaluation(ArrayPosition(a0, Literal(0)), 0L)
     checkEvaluation(ArrayPosition(a0, Literal.create(null, IntegerType)), null)
 
-    checkEvaluation(ArrayPosition(a1, Literal("")), Decimal(BigInt(2)))
-    checkEvaluation(ArrayPosition(a1, Literal("a")), Decimal(BigInt(0)))
+    checkEvaluation(ArrayPosition(a1, Literal("")), 2L)
+    checkEvaluation(ArrayPosition(a1, Literal("a")), 0L)
     checkEvaluation(ArrayPosition(a1, Literal.create(null, StringType)), null)
 
-    checkEvaluation(ArrayPosition(a2, Literal(1L)), Decimal(BigInt(0)))
+    checkEvaluation(ArrayPosition(a2, Literal(1L)), 0L)
     checkEvaluation(ArrayPosition(a2, Literal.create(null, LongType)), null)
 
     checkEvaluation(ArrayPosition(a3, Literal("")), null)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -44,29 +44,6 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
     checkEvaluation(Size(Literal.create(null, ArrayType(StringType))), -1)
   }
 
-  test("Array Position") {
-    val s1 = 'a.string.at(0)
-    val s2 = 'b.string.at(1)
-    val s3 = 'c.string.at(2)
-    val row1 = create_row("aaads", "aa", "zz")
-    val nullString = Literal.create(null, StringType)
-
-    checkEvaluation(ArrayPosition(Literal("aaads"), Literal("aa")), Decimal(BigInt(1)), row1)
-    checkEvaluation(ArrayPosition(Literal("aaads"), Literal("de")), Decimal(BigInt(0)), row1)
-    checkEvaluation(ArrayPosition(nullString, Literal("de")), null, row1)
-    checkEvaluation(ArrayPosition(Literal("aaads"), nullString), null, row1)
-
-    checkEvaluation(ArrayPosition(s1, s2), Decimal(BigInt(1)), row1)
-    checkEvaluation(ArrayPosition(s1, s3), Decimal(BigInt(0)), row1)
-
-    // scalastyle:off
-    // non ascii characters are not allowed in the source code, so we disable the scalastyle.
-    checkEvaluation(ArrayPosition(s1, s2), Decimal(BigInt(3)), create_row("花花世界", "世界"))
-    checkEvaluation(ArrayPosition(s1, s2), Decimal(BigInt(1)), create_row("花花世界", "花"))
-    checkEvaluation(ArrayPosition(s1, s2), Decimal(BigInt(0)), create_row("花花世界", "小"))
-    // scalastyle:on
-  }
-
   test("MapKeys/MapValues") {
     val m0 = Literal.create(Map("a" -> "1", "b" -> "2"), MapType(StringType, StringType))
     val m1 = Literal.create(Map[String, String](), MapType(StringType, StringType))
@@ -192,5 +169,26 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
     checkEvaluation(Reverse(as6), Seq.empty)
     checkEvaluation(Reverse(as7), null)
     checkEvaluation(Reverse(aa), Seq(Seq("e"), Seq("c", "d"), Seq("a", "b")))
+  }
+
+  test("Array Position") {
+    val a0 = Literal.create(Seq(1, 2, 3), ArrayType(IntegerType))
+    val a1 = Literal.create(Seq[String](null, ""), ArrayType(StringType))
+    val a2 = Literal.create(Seq(null), ArrayType(LongType))
+    val a3 = Literal.create(null, ArrayType(StringType))
+
+    checkEvaluation(ArrayPosition(a0, Literal(1)), Decimal(BigInt(1)))
+    checkEvaluation(ArrayPosition(a0, Literal(0)), Decimal(BigInt(0)))
+    checkEvaluation(ArrayPosition(a0, Literal.create(null, IntegerType)), null)
+
+    checkEvaluation(ArrayPosition(a1, Literal("")), Decimal(BigInt(2)))
+    checkEvaluation(ArrayPosition(a1, Literal("a")), Decimal(BigInt(0)))
+    checkEvaluation(ArrayPosition(a1, Literal.create(null, StringType)), null)
+
+    checkEvaluation(ArrayPosition(a2, Literal(1L)), Decimal(BigInt(0)))
+    checkEvaluation(ArrayPosition(a2, Literal.create(null, LongType)), null)
+
+    checkEvaluation(ArrayPosition(a3, Literal("")), null)
+    checkEvaluation(ArrayPosition(a3, Literal.create(null, StringType)), null)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -172,11 +172,12 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
   }
 
   test("Array Position") {
-    val a0 = Literal.create(Seq(1, 2, 3), ArrayType(IntegerType))
+    val a0 = Literal.create(Seq(1, null, 2, 3), ArrayType(IntegerType))
     val a1 = Literal.create(Seq[String](null, ""), ArrayType(StringType))
     val a2 = Literal.create(Seq(null), ArrayType(LongType))
     val a3 = Literal.create(null, ArrayType(StringType))
 
+    checkEvaluation(ArrayPosition(a0, Literal(3)), 4L)
     checkEvaluation(ArrayPosition(a0, Literal(1)), 1L)
     checkEvaluation(ArrayPosition(a0, Literal(0)), 0L)
     checkEvaluation(ArrayPosition(a0, Literal.create(null, IntegerType)), null)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.types._
 
 class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
@@ -41,6 +42,29 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
 
     checkEvaluation(Size(Literal.create(null, MapType(StringType, StringType))), -1)
     checkEvaluation(Size(Literal.create(null, ArrayType(StringType))), -1)
+  }
+
+  test("Array Position") {
+    val s1 = 'a.string.at(0)
+    val s2 = 'b.string.at(1)
+    val s3 = 'c.string.at(2)
+    val row1 = create_row("aaads", "aa", "zz")
+    val nullString = Literal.create(null, StringType)
+
+    checkEvaluation(ArrayPosition(Literal("aaads"), Literal("aa")), Decimal(BigInt(1)), row1)
+    checkEvaluation(ArrayPosition(Literal("aaads"), Literal("de")), Decimal(BigInt(0)), row1)
+    checkEvaluation(ArrayPosition(nullString, Literal("de")), null, row1)
+    checkEvaluation(ArrayPosition(Literal("aaads"), nullString), null, row1)
+
+    checkEvaluation(ArrayPosition(s1, s2), Decimal(BigInt(1)), row1)
+    checkEvaluation(ArrayPosition(s1, s3), Decimal(BigInt(0)), row1)
+
+    // scalastyle:off
+    // non ascii characters are not allowed in the source code, so we disable the scalastyle.
+    checkEvaluation(ArrayPosition(s1, s2), Decimal(BigInt(3)), create_row("花花世界", "世界"))
+    checkEvaluation(ArrayPosition(s1, s2), Decimal(BigInt(1)), create_row("花花世界", "花"))
+    checkEvaluation(ArrayPosition(s1, s2), Decimal(BigInt(0)), create_row("花花世界", "小"))
+    // scalastyle:on
   }
 
   test("MapKeys/MapValues") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3039,6 +3039,20 @@ object functions {
   }
 
   /**
+   * Locate the position of the first occurrence of substr column in the given string.
+   * Returns null if either of the arguments are null.
+   *
+   * @note The position is not zero based, but 1 based index. Returns 0 if substr
+   * could not be found in str.
+   *
+   * @group string_funcs
+   * @since 2.4.0
+   */
+  def array_position(str: Column, substring: String): Column = withExpr {
+    ArrayPosition(str.expr, lit(substring).expr)
+  }
+
+  /**
    * Creates a new row for each element in the given array or map column.
    *
    * @group collection_funcs

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3039,17 +3039,17 @@ object functions {
   }
 
   /**
-   * Locate the position of the first occurrence of substr column in the given string.
+   * Locate the position of the first occurrence of the value in the given array.
    * Returns null if either of the arguments are null.
    *
-   * @note The position is not zero based, but 1 based index. Returns 0 if substr
-   * could not be found in str.
+   * @note The position is not zero based, but 1 based index. Returns 0 if value
+   * could not be found in array.
    *
-   * @group string_funcs
+   * @group collection_funcs
    * @since 2.4.0
    */
-  def array_position(str: Column, substring: String): Column = withExpr {
-    ArrayPosition(str.expr, lit(substring).expr)
+  def array_position(column: Column, value: Any): Column = withExpr {
+    ArrayPosition(column.expr, Literal(value))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3039,7 +3039,7 @@ object functions {
   }
 
   /**
-   * Locate the position of the first occurrence of the value in the given array.
+   * Locates the position of the first occurrence of the value in the given array as long.
    * Returns null if either of the arguments are null.
    *
    * @note The position is not zero based, but 1 based index. Returns 0 if value

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -543,11 +543,11 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
 
     checkAnswer(
       df.select(array_position(df("a"), 1)),
-      Seq(Row(BigInt(1)), Row(BigInt(0)))
+      Seq(Row(1L), Row(0L))
     )
     checkAnswer(
       df.selectExpr("array_position(a, 1)"),
-      Seq(Row(BigInt(1)), Row(BigInt(0)))
+      Seq(Row(1L), Row(0L))
     )
 
     checkAnswer(
@@ -561,11 +561,11 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
 
     checkAnswer(
       df.selectExpr("array_position(array(array(1), null)[0], 1)"),
-      Seq(Row(BigInt(1)), Row(BigInt(1)))
+      Seq(Row(1L), Row(1L))
     )
     checkAnswer(
       df.selectExpr("array_position(array(1, null), array(1, null)[0])"),
-      Seq(Row(BigInt(1)), Row(BigInt(1)))
+      Seq(Row(1L), Row(1L))
     )
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -326,6 +326,24 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
     }.getMessage().contains("only supports array input"))
   }
 
+  test("array position function") {
+    val df = Seq(("aaads", "aa", "zz", null)).toDF("a", "b", "c", "nul")
+
+    checkAnswer(
+      df.select(
+        array_position($"a", "aa"),
+        array_position($"a", "gg"),
+        array_position($"nul", "gg")),
+      Row(BigInt(1), BigInt(0), null))
+    checkAnswer(
+      df.selectExpr(
+        "array_position(a, b)",
+        "array_position(a, c)",
+        "array_position(a, nul)",
+        "array_position(nul, c)"),
+      Row(BigInt(1), BigInt(0), null, null))
+  }
+
   test("array size function") {
     val df = Seq(
       (Seq[Int](1, 2), "x"),


### PR DESCRIPTION
## What changes were proposed in this pull request?

The PR adds the SQL function `array_position`. The behavior of the function is based on Presto's one.

The function returns the position of the first occurrence of the element in array x (or 0 if not found) using 1-based index as BigInt.

## How was this patch tested?

Added UTs