### PR TITLE
[SPARK-9312][ML] Add RawPrediction, numClasses, and numFeatures for OneVsRestModel

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -215,8 +215,9 @@ final class OneVsRestModel private[ml] (
       }
 
       // output the index of the classifier with highest confidence as prediction
-      val labelUDF = udf { (predictions: Vector) => predictions.argmax.toDouble }
+      val labelUDF = udf { (rawpredictions: Vector) => rawpredictions.argmax.toDouble }
 
+      // output confidence as raw prediction, label and label metadata as prediction
       aggregatedDataset
         .withColumn(getRawPredictionCol, rawPredictionUDF(col(accColName)))
         .withColumn(getPredictionCol, labelUDF(col(getRawPredictionCol)), labelMetadata)
@@ -227,7 +228,7 @@ final class OneVsRestModel private[ml] (
       val labelUDF = udf { (predictions: Map[Int, Double]) =>
         predictions.maxBy(_._2)._1.toDouble
       }
-      // output confidence as rwa prediction, label and label metadata as prediction
+      // output label and label metadata as prediction
       aggregatedDataset
         .withColumn(getPredictionCol, labelUDF(col(accColName)), labelMetadata)
         .drop(accColName)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -209,9 +209,9 @@ final class OneVsRestModel private[ml] (
     // output the RawPrediction as vector
     if (getRawPredictionCol != "") {
       val rawPredictionUDF = udf { (predictions: Map[Int, Double]) =>
-        val myArray = Array.fill[Double](numClasses)(0.0)
-        predictions.foreach { case (idx, value) => myArray(idx) = value }
-        Vectors.dense(myArray)
+        val predArray = Array.fill[Double](numClasses)(0.0)
+        predictions.foreach { case (idx, value) => predArray(idx) = value }
+        Vectors.dense(predArray)
       }
 
       // output the index of the classifier with highest confidence as prediction

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
@@ -180,10 +180,10 @@ class OneVsRestSuite extends MLTest with DefaultReadWriteTest {
     val dataset2 = dataset.select(col("label").as("y"), col("features").as("fea"))
     ovaModel.setFeaturesCol("fea")
     ovaModel.setPredictionCol("pred")
-    ovaModel.setRawPredictionCol("rawpred")
+    ovaModel.setRawPredictionCol("")
     val transformedDataset = ovaModel.transform(dataset2)
     val outputFields = transformedDataset.schema.fieldNames.toSet
-    assert(outputFields === Set("y", "fea", "pred", "rawpred"))
+    assert(outputFields === Set("y", "fea", "pred"))
   }
 
   test("SPARK-8049: OneVsRest shouldn't output temp columns") {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
@@ -72,11 +72,12 @@ class OneVsRestSuite extends MLTest with DefaultReadWriteTest {
       .setClassifier(new LogisticRegression)
     assert(ova.getLabelCol === "label")
     assert(ova.getPredictionCol === "prediction")
+    assert(ova.getRawPredictionCol === "rawPrediction")
     val ovaModel = ova.fit(dataset)
 
     MLTestingUtils.checkCopyAndUids(ova, ovaModel)
 
-    assert(ovaModel.models.length === numClasses)
+    assert(ovaModel.numClasses === numClasses)
     val transformedDataset = ovaModel.transform(dataset)
 
     // check for label metadata in prediction col
@@ -179,9 +180,10 @@ class OneVsRestSuite extends MLTest with DefaultReadWriteTest {
     val dataset2 = dataset.select(col("label").as("y"), col("features").as("fea"))
     ovaModel.setFeaturesCol("fea")
     ovaModel.setPredictionCol("pred")
+    ovaModel.setRawPredictionCol("rawpred")
     val transformedDataset = ovaModel.transform(dataset2)
     val outputFields = transformedDataset.schema.fieldNames.toSet
-    assert(outputFields === Set("y", "fea", "pred"))
+    assert(outputFields === Set("y", "fea", "pred", "rawpred"))
   }
 
   test("SPARK-8049: OneVsRest shouldn't output temp columns") {
@@ -190,7 +192,8 @@ class OneVsRestSuite extends MLTest with DefaultReadWriteTest {
     val ovr = new OneVsRest()
       .setClassifier(logReg)
     val output = ovr.fit(dataset).transform(dataset)
-    assert(output.schema.fieldNames.toSet === Set("label", "features", "prediction"))
+    assert(output.schema.fieldNames.toSet
+      === Set("label", "features", "prediction", "rawPrediction"))
   }
 
   test("SPARK-21306: OneVsRest should support setWeightCol") {


### PR DESCRIPTION
add RawPrediction as output column 
add numClasses and numFeatures to OneVsRestModel

## What changes were proposed in this pull request?

- Add two val numClasses and numFeatures in OneVsRestModel so that we can inherit from Classifier in the future

- Add rawPrediction output column in transform, the prediction label in calculated by the rawPrediciton like raw2prediction

 

## How was this patch tested?


(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
Please review http://spark.apache.org/contributing.html before opening a pull request.
