### PR TITLE
[MINOR][PYTHON] 2 Improvements to Pyspark docs

### DIFF
--- a/python/pyspark/streaming/kafka.py
+++ b/python/pyspark/streaming/kafka.py
@@ -104,7 +104,7 @@ class KafkaUtils(object):
         :param topics:  list of topic_name to consume.
         :param kafkaParams: Additional params for Kafka.
         :param fromOffsets: Per-topic/partition Kafka offsets defining the (inclusive) starting
-                            point of the stream.
+                            point of the stream (a dictionary mapping `TopicAndPartition` to integers).
         :param keyDecoder:  A function used to decode key (default is utf8_decoder).
         :param valueDecoder:  A function used to decode value (default is utf8_decoder).
         :param messageHandler: A function used to convert KafkaMessageAndMetadata. You can assess

--- a/python/pyspark/streaming/listener.py
+++ b/python/pyspark/streaming/listener.py
@@ -22,6 +22,10 @@ class StreamingListener(object):
 
     def __init__(self):
         pass
+    
+    def onStreamingStarted(self, streamingStarted):
+       pass
+    
 
     def onReceiverStarted(self, receiverStarted):
         """


### PR DESCRIPTION
Each of these 2 items has cost me a few hours of debugging. Hopefully, this will stop others from having to debug the same thing.

1. Describe the expected type of `fromOffsets` param.
2. Add missing method to `StreamingListener`, which is invoked by proxy from the Java/Scala side, and throws a strange exception when not found.