### PR TITLE
[SPARK-23974][CORE] fix when numExecutorsTarget equals maxNumExecutors

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -368,7 +368,7 @@ private[spark] class ExecutorAllocationManager(
    */
   private def addExecutors(maxNumExecutorsNeeded: Int): Int = {
     // Do not request more executors if it would put our target over the upper bound
-    if (numExecutorsTarget >= maxNumExecutors) {
+    if (numExecutorsTarget > maxNumExecutors) {
       logDebug(s"Not adding executors because our current target total " +
         s"is already $numExecutorsTarget (limit $maxNumExecutors)")
       numExecutorsToAdd = 1
@@ -390,7 +390,7 @@ private[spark] class ExecutorAllocationManager(
 
     // If our target has not changed, do not send a message
     // to the cluster manager and reset our exponential growth
-    if (delta == 0) {
+    if (delta == 0 && numExecutorsTarget != maxNumExecutors) {
       // Check if there is any speculative jobs pending
       if (listener.pendingTasks == 0 && listener.pendingSpeculativeTasks > 0) {
         numExecutorsTarget =


### PR DESCRIPTION
## What changes were proposed in this pull request?

In dynamic allocation, there are cases that the `numExecutorsTarget` has reached `maxNumExecutors`, but for some reason (client.requestTotalExecutors didn't work as expected or throw exceptions due to RPC failure), the  method `addExecutors` always returns 0 without do `client.requestTotalExecutors`. And there are too many tasks to handle, `maxNeeded < numExecutorsTarget` is false, in `updateAndSyncNumExecutorsTarget` we always run into `addExecutors` with `numExecutorsTarget == maxNumExecutors`. Since numExecutorsTarget is hard to decrease, as a result, we are using only a few executors to handle the heavy tasks without dynamically increasing the number of executors.

Since the semantics of `client.requestTotalExecutors` are requesting executors up to a number. And for Yarn, it finally set the `targetNumExecutors` in `YarnAllocator`. It won't be a problem that we call this method repeatedly.

## How was this patch tested?
Existing tests.