### PR TITLE
[SPARK-23977][CLOUD][WIP] Add commit protocol binding to Hadoop 3.1 PathOutputCommitter mechanism

### DIFF
--- a/hadoop-cloud/pom.xml
+++ b/hadoop-cloud/pom.xml
@@ -200,6 +200,47 @@
     -->
     <profile>
       <id>hadoop-3.2</id>
+      <properties>
+        <extra.source.dir>src/hadoop-3/main/scala</extra.source.dir>
+        <extra.testsource.dir>src/hadoop-3/test/scala</extra.testsource.dir>
+      </properties>
+
+      <build>
+        <plugins>
+          <!-- Include a source dir for Hadoop 3 only; will only compile against
+               Hadoop 3.0.2+ -->
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-scala-sources</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>${extra.source.dir}</source>
+                  </sources>
+                </configuration>
+              </execution>
+              <execution>
+                <id>add-scala-test-sources</id>
+                <phase>generate-test-sources</phase>
+                <goals>
+                  <goal>add-test-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>${extra.testsource.dir}</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
       <dependencies>
         <!--
         There's now a hadoop-cloud-storage which transitively pulls in the store JARs,

--- a/hadoop-cloud/src/hadoop-3/main/scala/org/apache/spark/internal/io/cloud/BindingParquetOutputCommitter.scala
+++ b/hadoop-cloud/src/hadoop-3/main/scala/org/apache/spark/internal/io/cloud/BindingParquetOutputCommitter.scala
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.internal.io.cloud
+
+import java.io.IOException
+
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapreduce.lib.output.{BindingPathOutputCommitter, PathOutputCommitter}
+import org.apache.hadoop.mapreduce.{JobContext, JobStatus, TaskAttemptContext}
+import org.apache.parquet.hadoop.ParquetOutputCommitter
+
+import org.apache.spark.internal.Logging
+
+
+/**
+ * This dynamically binds to the factory-configured
+ * output committer, and is intended to allow callers to use any [[PathOutputCommitter]],
+ * even if not a subclass of [[ParquetOutputCommitter]].
+ *
+ * The Parquet "parquet.enable.summary-metadata" option will only be supported
+ * if the instantiated committer itself supports it.
+ */
+
+class BindingParquetOutputCommitter(
+    path: Path,
+    context: TaskAttemptContext)
+  extends ParquetOutputCommitter(path, context) with Logging {
+
+  logInfo(s"${this.getClass.getName} binding to configured PathOutputCommitter and dest $path")
+
+  val committer = new BindingPathOutputCommitter(path, context)
+
+  /**
+   * This is the committer ultimately bound to.
+   * @return the committer instantiated by the factory.
+   */
+  def boundCommitter(): PathOutputCommitter = {
+    committer.getCommitter()
+  }
+
+  override def getWorkPath: Path = {
+    committer.getWorkPath()
+  }
+
+  override def setupTask(taskAttemptContext: TaskAttemptContext): Unit = {
+    committer.setupTask(taskAttemptContext)
+  }
+
+  override def commitTask(taskAttemptContext: TaskAttemptContext): Unit = {
+    committer.commitTask(taskAttemptContext)
+  }
+
+  override def abortTask(taskAttemptContext: TaskAttemptContext): Unit = {
+    committer.abortTask(taskAttemptContext)
+  }
+
+  override def setupJob(jobContext: JobContext): Unit = {
+    committer.setupJob(jobContext)
+  }
+
+  override def needsTaskCommit(taskAttemptContext: TaskAttemptContext): Boolean = {
+    committer.needsTaskCommit(taskAttemptContext)
+  }
+
+  override def cleanupJob(jobContext: JobContext): Unit = {
+    committer.cleanupJob(jobContext)
+  }
+
+  override def isCommitJobRepeatable(jobContext: JobContext): Boolean = {
+    committer.isCommitJobRepeatable(jobContext)
+  }
+
+  override def commitJob(jobContext: JobContext): Unit = {
+    committer.commitJob(jobContext)
+  }
+
+  override def recoverTask(taskAttemptContext: TaskAttemptContext): Unit = {
+    committer.recoverTask(taskAttemptContext)
+  }
+
+  /**
+   * Abort the job; log and ignore any IO exception thrown.
+   *
+   * @param jobContext job context
+   * @param state final state of the job
+   */
+  override def abortJob(
+      jobContext: JobContext,
+      state: JobStatus.State): Unit = {
+    try {
+      committer.abortJob(jobContext, state)
+    } catch {
+      case e: IOException =>
+        logWarning("Abort job failed", e)
+    }
+  }
+
+  override def isRecoverySupported: Boolean = {
+    committer.isRecoverySupported()
+  }
+
+  override def isRecoverySupported(jobContext: JobContext): Boolean = {
+    committer.isRecoverySupported(jobContext)
+  }
+
+  override def toString: String = s"BindingParquetOutputCommitter($committer)"
+}

--- a/hadoop-cloud/src/hadoop-3/main/scala/org/apache/spark/internal/io/cloud/BindingParquetOutputCommitter.scala
+++ b/hadoop-cloud/src/hadoop-3/main/scala/org/apache/spark/internal/io/cloud/BindingParquetOutputCommitter.scala
@@ -41,7 +41,7 @@ class BindingParquetOutputCommitter(
     context: TaskAttemptContext)
   extends ParquetOutputCommitter(path, context) with Logging {
 
-  logInfo(s"${this.getClass.getName} binding to configured PathOutputCommitter and dest $path")
+  logDebug(s"${this.getClass.getName} binding to configured PathOutputCommitter and dest $path")
 
   val committer = new BindingPathOutputCommitter(path, context)
 
@@ -95,6 +95,8 @@ class BindingParquetOutputCommitter(
 
   /**
    * Abort the job; log and ignore any IO exception thrown.
+   * This is invariably invoked in an exception handler; raising
+   * an exception here will lose the root cause of the failure.
    *
    * @param jobContext job context
    * @param state final state of the job
@@ -106,6 +108,8 @@ class BindingParquetOutputCommitter(
       committer.abortJob(jobContext, state)
     } catch {
       case e: IOException =>
+        // swallow exception to avoid problems when called within exception
+        // handlers
         logWarning("Abort job failed", e)
     }
   }

--- a/hadoop-cloud/src/hadoop-3/main/scala/org/apache/spark/internal/io/cloud/BindingParquetOutputCommitter.scala
+++ b/hadoop-cloud/src/hadoop-3/main/scala/org/apache/spark/internal/io/cloud/BindingParquetOutputCommitter.scala
@@ -28,14 +28,13 @@ import org.apache.spark.internal.Logging
 
 
 /**
- * This dynamically binds to the factory-configured
+ * This Parquet Committer subclass dynamically binds to the factory-configured
  * output committer, and is intended to allow callers to use any [[PathOutputCommitter]],
  * even if not a subclass of [[ParquetOutputCommitter]].
  *
  * The Parquet "parquet.enable.summary-metadata" option will only be supported
  * if the instantiated committer itself supports it.
  */
-
 class BindingParquetOutputCommitter(
     path: Path,
     context: TaskAttemptContext)

--- a/hadoop-cloud/src/hadoop-3/main/scala/org/apache/spark/internal/io/cloud/PathOutputCommitProtocol.scala
+++ b/hadoop-cloud/src/hadoop-3/main/scala/org/apache/spark/internal/io/cloud/PathOutputCommitProtocol.scala
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.internal.io.cloud
+
+import java.io.IOException
+
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapreduce.{JobContext, TaskAttemptContext}
+import org.apache.hadoop.mapreduce.lib.output.{FileOutputCommitter, PathOutputCommitter, PathOutputCommitterFactory}
+
+import org.apache.spark.internal.io.{FileCommitProtocol, HadoopMapReduceCommitProtocol}
+import org.apache.spark.internal.io.FileCommitProtocol.TaskCommitMessage
+
+/**
+ * Spark Commit protocol for Path Output Committers.
+ * This committer will work with the `FileOutputCommitter` and subclasses.
+ * All implementations *must* be serializable.
+ *
+ * Rather than ask the `FileOutputFormat` for a committer, it uses the
+ * `org.apache.hadoop.mapreduce.lib.output.PathOutputCommitterFactory` factory
+ * API to create the committer.
+ * This is what [[org.apache.hadoop.mapreduce.lib.output.FileOutputFormat]] does,
+ * but as [[HadoopMapReduceCommitProtocol]] still uses the original
+ * `org.apache.hadoop.mapred.FileOutputFormat` binding
+ * subclasses do not do this, overrides those subclasses to using the
+ * factory mechanism now supported in the base class.
+ *
+ * In `setupCommitter` the factory is bonded to and the committer for
+ * the destination path chosen.
+ *
+ * @constructor Instantiate. dynamic partition overwrite is not supported,
+ *              so that committers for stores which do not support rename
+ *              will not get confused.
+ * @param jobId                     job
+ * @param destination               destination
+ * @param dynamicPartitionOverwrite does the caller want support for dynamic
+ *                                  partition overwrite. If so, it will be
+ *                                  refused.
+ * @throws IOException when an unsupported dynamicPartitionOverwrite option is supplied.
+ */
+class PathOutputCommitProtocol(
+  jobId: String,
+  destination: String,
+  dynamicPartitionOverwrite: Boolean = false)
+  extends HadoopMapReduceCommitProtocol(
+    jobId,
+    destination,
+    false) with Serializable {
+
+  @transient var committer: PathOutputCommitter = _
+
+  require(destination != null, "Null destination specified")
+
+  val destPath = new Path(destination)
+
+  logInfo(s"Instantiated committer with job ID=$jobId;" +
+    s" destination=$destPath;" +
+    s" dynamicPartitionOverwrite=$dynamicPartitionOverwrite")
+
+  if (dynamicPartitionOverwrite) {
+    // until there's explicit extensions to the PathOutputCommitProtocols
+    // to support the spark mechanism, it's left to the individual committer
+    // choice to handle partitioning.
+    throw new IOException("PathOutputCommitProtocol does not support dynamicPartitionOverwrite")
+  }
+
+  import PathOutputCommitProtocol._
+
+  /**
+   * Set up the committer.
+   * This creates it by talking directly to the Hadoop factories, instead
+   * of the V1 `mapred.FileOutputFormat` methods.
+   * @param context task attempt
+   * @return the committer to use. This will always be a subclass of
+   *         [[PathOutputCommitter]].
+   */
+  override protected def setupCommitter(
+    context: TaskAttemptContext): PathOutputCommitter = {
+
+    logInfo(s"Setting up committer for path $destination")
+    committer = PathOutputCommitterFactory.createCommitter(destPath, context)
+
+    // Special feature to force out the FileOutputCommitter, so as to guarantee
+    // that the binding is working properly.
+    val rejectFileOutput = context.getConfiguration
+      .getBoolean(REJECT_FILE_OUTPUT, REJECT_FILE_OUTPUT_DEFVAL)
+    if (rejectFileOutput && committer.isInstanceOf[FileOutputCommitter]) {
+      // the output format returned a file output format committer, which
+      // is exactly what we do not want. So switch back to the factory.
+      val factory = PathOutputCommitterFactory.getCommitterFactory(
+        destPath,
+        context.getConfiguration)
+      logInfo(s"Using committer factory $factory")
+      committer = factory.createOutputCommitter(destPath, context)
+    }
+
+    logInfo(s"Using committer ${committer.getClass}")
+    logInfo(s"Committer details: $committer")
+    if (committer.isInstanceOf[FileOutputCommitter]) {
+      require(!rejectFileOutput,
+        s"Committer created is the FileOutputCommitter $committer")
+
+      if (committer.isCommitJobRepeatable(context)) {
+        // If FileOutputCommitter says its job commit is repeatable, it means
+        // it is using the v2 algorithm, which is not safe for task commit
+        // failures. Warn
+        logWarning(s"Committer $committer may not be tolerant of task commit failures")
+      }
+    }
+    committer
+  }
+
+  /**
+   * Create a temporary file for a task.
+   *
+   * @param taskContext task context
+   * @param dir         optional subdirectory
+   * @param ext         file extension
+   * @return a path as a string
+   */
+  override def newTaskTempFile(
+    taskContext: TaskAttemptContext,
+    dir: Option[String],
+    ext: String): String = {
+
+    val workDir = committer.getWorkPath
+    val parent = dir.map(d => new Path(workDir, d)).getOrElse(workDir)
+    val file = new Path(parent, buildFilename(taskContext, ext))
+    logInfo(s"Creating task file $file for dir $dir and ext $ext")
+    file.toString
+  }
+
+  /**
+   * Absolute files are still renamed into place with a warning.
+   *
+   * @param taskContext task
+   * @param absoluteDir destination dir
+   * @param ext         extension
+   * @return an absolute path
+   */
+  override def newTaskTempFileAbsPath(
+    taskContext: TaskAttemptContext,
+    absoluteDir: String,
+    ext: String): String = {
+
+    val file = super.newTaskTempFileAbsPath(taskContext, absoluteDir, ext)
+    logWarning(
+      s"Creating temporary file $file for absolute path for dir $absoluteDir")
+    file
+  }
+
+  /**
+   * Build a filename which is unique across all task events.
+   * It does not have to be consistent across multiple attempts of the same
+   * task or job.
+   *
+   * @param taskContext task context
+   * @param ext         extension
+   * @return a name for a file which must be unique across all task attempts
+   */
+  protected def buildFilename(
+    taskContext: TaskAttemptContext,
+    ext: String): String = {
+
+    // The file name looks like part-00000-2dd664f9-d2c4-4ffe-878f-c6c70c1fb0cb_00003-c000.parquet
+    // Note that %05d does not truncate the split number, so if we have more than 100000 tasks,
+    // the file name is fine and won't overflow.
+    val split = taskContext.getTaskAttemptID.getTaskID.getId
+    f"part-$split%05d-$jobId$ext"
+  }
+
+  override def setupJob(jobContext: JobContext): Unit = {
+    logInfo("setup job")
+    super.setupJob(jobContext)
+  }
+
+  override def commitJob(
+    jobContext: JobContext,
+    taskCommits: Seq[FileCommitProtocol.TaskCommitMessage]): Unit = {
+    logInfo(s"commit job with ${taskCommits.length} task commit message(s)")
+    super.commitJob(jobContext, taskCommits)
+  }
+
+  /**
+   * Abort the job; log and ignore any IO exception thrown.
+   *
+   * @param jobContext job context
+   */
+  override def abortJob(jobContext: JobContext): Unit = {
+    try {
+      super.abortJob(jobContext)
+    } catch {
+      case e: IOException =>
+        logWarning("Abort job failed", e)
+    }
+  }
+
+  override def setupTask(taskContext: TaskAttemptContext): Unit = {
+    super.setupTask(taskContext)
+  }
+
+  override def commitTask(
+    taskContext: TaskAttemptContext): FileCommitProtocol.TaskCommitMessage = {
+    logInfo("Commit task")
+    super.commitTask(taskContext)
+  }
+
+  /**
+   * Abort the task; log and ignore any failure thrown.
+   *
+   * @param taskContext context
+   */
+  override def abortTask(taskContext: TaskAttemptContext): Unit = {
+    logInfo("Abort task")
+    try {
+      super.abortTask(taskContext)
+    } catch {
+      case e: IOException =>
+        logWarning("Abort task failed", e)
+    }
+  }
+
+  override def onTaskCommit(msg: TaskCommitMessage): Unit = {
+    logInfo(s"onTaskCommit($msg)")
+  }
+}
+
+object PathOutputCommitProtocol {
+
+  /**
+   * Hadoop configuration option.
+   * Fail fast if the committer is using the path output protocol.
+   * This option can be used to catch configuration issues early.
+   *
+   * It's mostly relevant when testing/diagnostics, as it can be used to
+   * enforce that schema-specific options are triggering a switch
+   * to a new committer.
+   */
+  val REJECT_FILE_OUTPUT = "pathoutputcommit.reject.fileoutput"
+
+  /**
+   * Default behavior: accept the file output.
+   */
+  val REJECT_FILE_OUTPUT_DEFVAL = false
+}

--- a/hadoop-cloud/src/hadoop-3/main/scala/org/apache/spark/internal/io/cloud/package.scala
+++ b/hadoop-cloud/src/hadoop-3/main/scala/org/apache/spark/internal/io/cloud/package.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.internal.io
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Package object to assist in switching to the Hadoop Hadoop 3
+ * [[org.apache.hadoop.mapreduce.lib.output.PathOutputCommitterFactory]] factory
+ * mechanism for dynamically loading committers for the destination stores.
+ *
+ * = Using Alternative Committers with Spark and Hadoop 3 =
+ *
+ * Hadoop 3.1 adds a means to select a different output committer when writing
+ * data to object stores. This can provide higher performance as well as
+ * addressing the consistency and atomicity problems encountered on some filesystems.
+ *
+ * Every object store can implement its own committer factory: the factory
+ * itself will then instantiated the committer of its choice.
+ *
+ * == Prerequisites ==
+ *
+ * Apache Hadoop 3.0.2 or later for the factory APIs, for the S3A connectors, Hadoop 3.1+
+ *
+ * The Hadoop cluster needs to be configured for the binding from filesystem scheme
+ * to factory. In Hadoop 3.1 this is done automatically for s3a in the file
+ * `mapred-default.xml`.
+ * Other stores' committers may need to be explicitly declared.
+ *
+ * {{{
+ *   <property>
+ *   <name>mapreduce.outputcommitter.factory.scheme.s3a</name>
+ *   <value>org.apache.hadoop.fs.s3a.commit.S3ACommitterFactory</value>
+ *   <description>
+ *     The committer factory to use when writing data to S3A filesystems.
+ *     If mapreduce.outputcommitter.factory.class is set, it will
+ *     override this property.
+ *   </description>
+ * </property>
+ * }}}
+ *
+ * == Binding a Spark Context to use the new committers for a store ==
+ *
+ * Spark uses the Hadoop committers in
+ * [[org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelationCommand]]
+ * by instantiating and then invoking an instance of
+ * [[org.apache.spark.internal.io.HadoopMapReduceCommitProtocol]].
+ * `InsertIntoHadoopFsRelationCommand` needs to be configured to use
+ * [[org.apache.spark.internal.io.cloud.PathOutputCommitProtocol]] as
+ * the commit protocol to use. This instantiates the committer through
+ * the factory mechanism, and relays operations to it.
+ *
+ * When working with Parquet data, you need to explicitly switch
+ * the Parquet committers to use the same mechanism
+ *
+ * In `spark-defaults.conf`, everything can be set up with the following settings:
+ * {{{
+ *   spark.sql.parquet.output.committer.class org.apache.spark.internal.io.cloud.BindingParquetOutputCommitter
+ *   spark.sql.sources.commitProtocolClass org.apache.spark.internal.io.cloud.PathOutputCommitProtocol
+ * }}}
+ *
+ * It can be done programmatically by calling [[cloud.bind()]] on the
+ * spark configuration.
+ */
+package object cloud {
+
+  /**
+   * Options for committer setup.
+   * When applied to a spark configuration, this will set the
+   * Dataframe output to use the factory mechanism for writing data for
+   * all file formats.
+   */
+  val COMMITTER_BINDING_OPTIONS: Map[String, String] = Map(
+    SQLConf.PARQUET_OUTPUT_COMMITTER_CLASS.key ->
+      classOf[BindingParquetOutputCommitter].getName,
+    SQLConf.FILE_COMMIT_PROTOCOL_CLASS.key ->
+      classOf[PathOutputCommitProtocol].getName)
+
+  /**
+   * Set the options defined in [[cloud.COMMITTER_BINDING_OPTIONS]] on the
+   * spark context.
+   *
+   * @param sparkConf spark configuration to bind.
+   */
+  def bind(sparkConf: SparkConf): Unit = {
+    sparkConf.setAll(COMMITTER_BINDING_OPTIONS)
+  }
+
+}

--- a/hadoop-cloud/src/hadoop-3/main/scala/org/apache/spark/internal/io/cloud/package.scala
+++ b/hadoop-cloud/src/hadoop-3/main/scala/org/apache/spark/internal/io/cloud/package.scala
@@ -81,21 +81,30 @@ import org.apache.spark.sql.internal.SQLConf
 package object cloud {
 
   /**
+   * The classname to use when referring to the path output committer.
+   */
+  val PATH_COMMIT_PROTOCOL_CLASSNAME: String = classOf[PathOutputCommitProtocol].getName
+
+  /**
+   * The name of the parquet committer.
+   */
+  val PARQUET_COMMITTER_CLASSNAME: String = classOf[BindingParquetOutputCommitter].getName
+
+  /**
    * Options for committer setup.
    * When applied to a spark configuration, this will set the
    * Dataframe output to use the factory mechanism for writing data for
    * all file formats.
    */
   val COMMITTER_BINDING_OPTIONS: Map[String, String] = Map(
-    SQLConf.PARQUET_OUTPUT_COMMITTER_CLASS.key ->
-      classOf[BindingParquetOutputCommitter].getName,
-    SQLConf.FILE_COMMIT_PROTOCOL_CLASS.key ->
-      classOf[PathOutputCommitProtocol].getName)
+    SQLConf.PARQUET_OUTPUT_COMMITTER_CLASS.key -> PARQUET_COMMITTER_CLASSNAME,
+    SQLConf.FILE_COMMIT_PROTOCOL_CLASS.key -> PATH_COMMIT_PROTOCOL_CLASSNAME)
 
   /**
    * Set the options defined in [[cloud.COMMITTER_BINDING_OPTIONS]] on the
    * spark context.
    *
+   * Warning: this is purely experimental.
    * @param sparkConf spark configuration to bind.
    */
   def bind(sparkConf: SparkConf): Unit = {

--- a/hadoop-cloud/src/hadoop-3/test/scala/org/apache/spark/internal/io/cloud/CommitterBindingSuite.scala
+++ b/hadoop-cloud/src/hadoop-3/test/scala/org/apache/spark/internal/io/cloud/CommitterBindingSuite.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.internal.io.cloud
+
+import java.io.IOException
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat
+import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
+import org.apache.hadoop.mapreduce.{Job, JobStatus, MRJobConfig, TaskAttemptID}
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.internal.io.cloud
+import org.apache.spark.internal.io.cloud.PathCommitterConstants._
+
+/**
+ * Test committer binding logic.
+ */
+class CommitterBindingSuite extends SparkFunSuite {
+
+
+  private val jobId = "2007071202143_0101"
+  private val attempt0 = "attempt_" + jobId + "_m_000000_0"
+  private val taskAttempt0 = TaskAttemptID.forName(attempt0)
+
+  /**
+   * Does the
+   * [[BindingParquetOutputCommitter]] committer bind to the schema-specific
+   * committer declared for the destination path?
+   */
+  test("BindingParquetOutputCommitter lifecycle") {
+    val path = new Path("http://example/data")
+    val job = newJob(path)
+    val conf = job.getConfiguration
+    conf.set(MRJobConfig.TASK_ATTEMPT_ID, attempt0)
+    conf.setInt(MRJobConfig.APPLICATION_ATTEMPT_ID, 1)
+
+    StubPathOutputCommitterFactory.bind(conf, "http")
+    val tContext = new TaskAttemptContextImpl(conf, taskAttempt0)
+    val parquet = new BindingParquetOutputCommitter(path, tContext)
+    val inner = parquet.boundCommitter().asInstanceOf[StubPathOutputCommitter]
+    parquet.setupJob(tContext)
+    assert(inner.setup, s"$inner not setup")
+    parquet.commitJob(tContext)
+    assert(inner.committed, s"$inner not committed")
+    parquet.abortJob(tContext, JobStatus.State.RUNNING)
+    assert(inner.aborted, s"$inner not aborted")
+  }
+
+  test("cloud binding to SparkConf") {
+    val sc = new SparkConf()
+    cloud.bind(sc)
+  }
+
+  /**
+   * Create a a new job. Sets the task attempt ID.
+   *
+   * @return the new job
+   * @throws IOException failure
+   */
+  @throws[IOException]
+  def newJob(outDir: Path): Job = {
+    val job = Job.getInstance(new Configuration())
+    val conf = job.getConfiguration
+    conf.set(MRJobConfig.TASK_ATTEMPT_ID, attempt0)
+    conf.setBoolean(CREATE_SUCCESSFUL_JOB_OUTPUT_DIR_MARKER, true)
+    FileOutputFormat.setOutputPath(job, outDir)
+    job
+  }
+}

--- a/hadoop-cloud/src/hadoop-3/test/scala/org/apache/spark/internal/io/cloud/StubPathOutputCommitter.scala
+++ b/hadoop-cloud/src/hadoop-3/test/scala/org/apache/spark/internal/io/cloud/StubPathOutputCommitter.scala
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.internal.io.cloud
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapreduce.lib.output.{PathOutputCommitter, PathOutputCommitterFactory}
+import org.apache.hadoop.mapreduce.{JobContext, JobStatus, TaskAttemptContext}
+
+/**
+ * A local path output committer which tracks its state, for use in
+ * tests.
+ * @param outputPath final destination.
+ * @param workPath work path
+ * @param context task/job attempt.
+ */
+class StubPathOutputCommitter(
+    outputPath: Path,
+    workPath: Path,
+    context: TaskAttemptContext) extends PathOutputCommitter(workPath, context) {
+
+  var setup: Boolean = false
+  var committed: Boolean = false
+  var aborted: Boolean = false
+
+  override def getOutputPath: Path = outputPath
+
+  override def getWorkPath: Path = {
+    workPath
+  }
+
+  override def setupTask(taskAttemptContext: TaskAttemptContext): Unit = {
+    setup = true
+  }
+
+  override def abortTask(taskAttemptContext: TaskAttemptContext): Unit = {
+    aborted = true
+  }
+
+  override def setupJob(jobContext: JobContext): Unit = {
+    setup = true
+  }
+
+  override def commitTask(taskAttemptContext: TaskAttemptContext): Unit = {
+    committed = true
+  }
+
+  override def commitJob(jobContext: JobContext): Unit = {
+    committed = true
+  }
+
+  override def abortJob(
+      jobContext: JobContext,
+      state: JobStatus.State): Unit = {
+    aborted = true
+  }
+
+  override def needsTaskCommit(taskAttemptContext: TaskAttemptContext): Boolean = {
+    true
+  }
+
+  override def toString(): String  = s"StubPathOutputCommitter(setup=$setup," +
+    s" committed=$committed, aborted=$aborted)"
+}
+
+/**
+ * Factory.
+ */
+class StubPathOutputCommitterFactory extends PathOutputCommitterFactory {
+
+  override def createOutputCommitter(
+      outputPath: Path,
+      context: TaskAttemptContext): PathOutputCommitter = {
+    new StubPathOutputCommitter(outputPath, workPath(outputPath), context)
+  }
+
+
+  private def workPath(out: Path): Path = new Path(out, PathCommitterConstants.TEMP_DIR_NAME)
+}
+
+object StubPathOutputCommitterFactory {
+  val Name: String = "org.apache.spark.internal.io.cloud.StubPathOutputCommitterFactory"
+
+  /**
+   * Given a hadoop configuration, set up the factory binding for the scheme.
+   * @param conf config to patch
+   * @param scheme filesystem scheme.
+   */
+  def bind(conf: Configuration, scheme: String): Unit = {
+    val key = String.format(
+      PathCommitterConstants.OUTPUTCOMMITTER_FACTORY_SCHEME_PATTERN, scheme)
+    conf.set(key, Name)
+  }
+
+}

--- a/hadoop-cloud/src/hadoop-3/test/scala/org/apache/spark/internal/io/cloud/StubPathOutputCommitter.scala
+++ b/hadoop-cloud/src/hadoop-3/test/scala/org/apache/spark/internal/io/cloud/StubPathOutputCommitter.scala
@@ -34,9 +34,14 @@ class StubPathOutputCommitter(
     workPath: Path,
     context: TaskAttemptContext) extends PathOutputCommitter(workPath, context) {
 
-  var setup: Boolean = false
-  var committed: Boolean = false
-  var aborted: Boolean = false
+  var jobSetup: Boolean = false
+  var jobCommitted: Boolean = false
+  var jobAborted: Boolean = false
+
+  var taskSetup: Boolean = false
+  var taskCommitted: Boolean = false
+  var taskAborted: Boolean = false
+  var needsTaskCommit: Boolean = true
 
   override def getOutputPath: Path = outputPath
 
@@ -45,37 +50,37 @@ class StubPathOutputCommitter(
   }
 
   override def setupTask(taskAttemptContext: TaskAttemptContext): Unit = {
-    setup = true
+    taskSetup = true
   }
 
   override def abortTask(taskAttemptContext: TaskAttemptContext): Unit = {
-    aborted = true
-  }
-
-  override def setupJob(jobContext: JobContext): Unit = {
-    setup = true
+    taskAborted = true
   }
 
   override def commitTask(taskAttemptContext: TaskAttemptContext): Unit = {
-    committed = true
+    taskCommitted = true
+  }
+
+  override def setupJob(jobContext: JobContext): Unit = {
+    jobSetup = true
   }
 
   override def commitJob(jobContext: JobContext): Unit = {
-    committed = true
+    jobCommitted = true
   }
 
   override def abortJob(
       jobContext: JobContext,
       state: JobStatus.State): Unit = {
-    aborted = true
+    jobAborted = true
   }
 
   override def needsTaskCommit(taskAttemptContext: TaskAttemptContext): Boolean = {
-    true
+    needsTaskCommit
   }
 
-  override def toString(): String  = s"StubPathOutputCommitter(setup=$setup," +
-    s" committed=$committed, aborted=$aborted)"
+  override def toString(): String  = s"StubPathOutputCommitter(setup=$jobSetup," +
+    s" committed=$jobCommitted, aborted=$jobAborted)"
 }
 
 /**

--- a/hadoop-cloud/src/main/scala/org/apache/spark/internal/io/cloud/PathCommitterConstants.scala
+++ b/hadoop-cloud/src/main/scala/org/apache/spark/internal/io/cloud/PathCommitterConstants.scala
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.internal.io.cloud
+
+/**
+ * Constants related to Hadoop committer setup and configuration.
+ * Most of these are scattered around the hadoop-mapreduce classes.
+ */
+object PathCommitterConstants {
+
+  /**
+   * Scheme prefix for per-filesystem scheme committers.
+   */
+  val OUTPUTCOMMITTER_FACTORY_SCHEME = "mapreduce.outputcommitter.factory.scheme"
+
+  /**
+   * String format pattern for per-filesystem scheme committers.
+   */
+  val OUTPUTCOMMITTER_FACTORY_SCHEME_PATTERN: String =
+    OUTPUTCOMMITTER_FACTORY_SCHEME + ".%s"
+
+  /**
+   * Name of the configuration option used to configure the
+   * output committer factory to use unless there is a specific
+   * one for a schema.
+   */
+  val OUTPUTCOMMITTER_FACTORY_CLASS = "mapreduce.pathoutputcommitter.factory.class"
+
+  /** Default committer factory. */
+  val DEFAULT_COMMITTER_FACTORY =
+    "org.apache.hadoop.mapreduce.lib.output.PathOutputCommitterFactory"
+
+  /**
+   * The committer which can be directly instantiated and which then delegates
+   * all operations to the factory-created committer it creates itself.
+   */
+  val BINDING_PATH_OUTPUT_COMMITTER_CLASS =
+    "org.apache.hadoop.mapreduce.lib.output.BindingPathOutputCommitter"
+
+  /**
+   * Classname of a parquet committer which just hands off to the
+   * `BindingPathOutputCommitter` in hadoop-mapreduce, which takes on the
+   * task of binding to the current factory.
+   */
+  val BINDING_PARQUET_OUTPUT_COMMITTER_CLASS =
+    "org.apache.spark.internal.io.cloud.BindingParquetOutputCommitter"
+
+  /** hadoop-mapreduce option to choose the algorithm. */
+  val FILEOUTPUTCOMMITTER_ALGORITHM_VERSION = "mapreduce.fileoutputcommitter.algorithm.version"
+
+  /** The default committer is not actually safe during task commit failures. */
+  val FILEOUTPUTCOMMITTER_ALGORITHM_VERSION_DEFAULT = 2
+
+  /** Skip cleanup _temporary folders under job's output directory? */
+  val FILEOUTPUTCOMMITTER_CLEANUP_SKIPPED = "mapreduce.fileoutputcommitter.cleanup.skipped"
+
+  /**
+   * This is the "Pending" directory of the FileOutputCommitter;
+   * data written here is, in that algorithm, renamed into place.
+   */
+  val TEMP_DIR_NAME = "_temporary"
+
+  /**
+   * Name of the marker file created on success.
+   * This is a 0-byte file with the FileOutputCommitter; object store committers
+   * often add a (non-standard) manifest here.
+   */
+  val SUCCESS_FILE_NAME = "_SUCCESS"
+
+  /** hadoop-mapreduce option to enable the _SUCCESS marker. */
+  val CREATE_SUCCESSFUL_JOB_OUTPUT_DIR_MARKER = "mapreduce.fileoutputcommitter.marksuccessfuljobs"
+}

--- a/hadoop-cloud/src/test/resources/log4j.properties
+++ b/hadoop-cloud/src/test/resources/log4j.properties
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set everything to be logged to the file target/unit-tests.log
+test.appender=file
+log4j.rootCategory=INFO, ${test.appender}
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.append=true
+log4j.appender.file.file=target/unit-tests.log
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
+
+# Tests that launch java subprocesses can set the "test.appender" system property to
+# "console" to avoid having the child process's logs overwrite the unit test's
+# log file.
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%t: %m%n
+
+# Ignore messages below warning level from Jetty, because it's a bit verbose
+log4j.logger.org.spark_project.jetty=WARN

--- a/hadoop-cloud/src/test/scala/org/apache/spark/internal/io/cloud/StubPackageEntry.scala
+++ b/hadoop-cloud/src/test/scala/org/apache/spark/internal/io/cloud/StubPackageEntry.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.internal.io.cloud
+
+/**
+ * This class is here to make sure that the source tree is found and built.
+ * and so that the profile-specific directory is also included in a build.
+ */
+private class StubPackageEntry {
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch has on SPARK-23807 as prerequisite; this PR initially includes it so it builds and tests independently.

* Add source tree under `hadoop-cloud` which builds iff the `hadoop-3.1` profile is enabled.
* Add a subclass of `HadoopMapReduceCommitProtocol` , `org.apache.spark.internal.io.cloud.PathOutputCommitProtocol`, which uses the Hadoop 3.1 `PathOutputCommitterFactory` to create the committers.
* Add a `org.apache.spark.internal.io.cloud.BindingParquetOutputCommitter` class which extends `ParquetOutputCommitter` to wire up Parquet output even when code requires the committer to be a `ParquetOutputCommitter`.

If the application configures the spark context to use the new committers, then jobs will switch to the factory mechanism and so pick up the configured committer for the destination filesystem, with FileOutputCommitter being the standard default. 
If/when Spark switches to `org.apache.hadoop.mapreduce.lib.output` output classes it would get the factory binding automatically, except for Parquet, whose committer subclassing always complicates things. A binding class will always be needed there.

## How was this patch tested?

Automated tests in [cloud-examples](https://github.com/hortonworks-spark/cloud-integration/tree/master/cloud-examples) test the commit mechanism working with: CSV, ORC and Parquet output. 

Tests include:

* Copies of some of the tests in `org.apache.spark.sql.sources.HadoopFsRelationTest`, tests reworked to setup, probe and teardown with FileSystem instances, rather than the local FS direct.
* Full funtional tests reading in public datasources, transforming and saving them using different committer options.
* The Fault injection feature of Hadoop 3.1's S3A connector, which can simulate S3 listing inconsistency at a higher rate than would normally be seen; this will force eventual-consistency related bugs to surface.

The S3A committers take advantage of the fact that writing a file is always atomic, and save summary data as JSON in the `_SUCCESS` file created in jobs. The tests use this to verify the correct committer was used in the different tests.

The Hadoop 3/hive version check problem fails all the tests unless one of the following fixes is applied.
* hadoop-3.x built locally with a false published version of 2.x (built with `-Ddeclared.hadoop.version=2.11` or similar)
* spark built with a modified org.sparkproject.hive JAR.

I've done both.