### PR TITLE
[SPARK-21962][CORE] Distributed Tracing in Spark

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -401,7 +401,11 @@
       <artifactId>libfb303</artifactId>
       <scope>provided</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.apache.htrace</groupId>
+      <artifactId>htrace-core4</artifactId>
+      <version>4.1.0-incubating</version>
+    </dependency>
   </dependencies>
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/StandaloneSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/StandaloneSchedulerBackend.scala
@@ -78,7 +78,8 @@ private[spark] class StandaloneSchedulerBackend(
       "--hostname", "{{HOSTNAME}}",
       "--cores", "{{CORES}}",
       "--app-id", "{{APP_ID}}",
-      "--worker-url", "{{WORKER_URL}}")
+      "--worker-url", "{{WORKER_URL}}",
+      "--span-id", sc.spanId)
     val extraJavaOpts = sc.conf.getOption("spark.executor.extraJavaOptions")
       .map(Utils.splitCommandString).getOrElse(Seq.empty)
     val classPathEntries = sc.conf.getOption("spark.executor.extraClassPath")

--- a/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
@@ -57,7 +57,8 @@ private[spark] class LocalEndpoint(
   val localExecutorHostname = "localhost"
 
   private val executor = new Executor(
-    localExecutorId, localExecutorHostname, SparkEnv.get, userClassPath, isLocal = true)
+    localExecutorId, localExecutorHostname, SparkEnv.get, userClassPath, isLocal = true,
+    tracer = scheduler.sc.tracer, spanId = scheduler.sc.spanId)
 
   override def receive: PartialFunction[Any, Unit] = {
     case ReviveOffers =>

--- a/core/src/main/scala/org/apache/spark/trace/SparkAppTracer.scala
+++ b/core/src/main/scala/org/apache/spark/trace/SparkAppTracer.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.trace
+
+import org.apache.htrace.core.{HTraceConfiguration, Tracer}
+
+import org.apache.spark.SparkConf
+
+object SparkAppTracer {
+  private val SPARK_HTRACE_PREFIX = "spark.htrace."
+
+  def getTracer(name: String, conf: SparkConf): Tracer = {
+    new Tracer.Builder(name).conf(wrapSparkConf(conf)).build()
+  }
+
+  def wrapSparkConf(conf: SparkConf): HTraceConfiguration = {
+    new HTraceConfiguration {
+      override def get(key: String, defaultVal: String): String =
+        conf.get(SPARK_HTRACE_PREFIX + key, defaultVal)
+
+      override def get(key: String): String = {
+        get(key, null)
+      }
+    }
+  }
+}

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/executor/MesosExecutorBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/executor/MesosExecutorBackend.scala
@@ -80,7 +80,7 @@ private[spark] class MesosExecutorBackend
     executor = new Executor(
       executorId,
       slaveInfo.getHostname,
-      env)
+      env, tracer = null, spanId = null)
   }
 
   override def launchTask(d: ExecutorDriver, taskInfo: TaskInfo) {

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -278,7 +278,8 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
         s" --executor-id $taskId" +
         s" --hostname ${executorHostname(offer)}" +
         s" --cores $numCores" +
-        s" --app-id $appId")
+        s" --app-id $appId" +
+        s" --span-id ${sc.spanId}")
     } else {
       // Grab everything to the first '.'. We'll use that and '*' to
       // glob the directory "correctly".
@@ -290,7 +291,8 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
         s" --executor-id $taskId" +
         s" --hostname ${executorHostname(offer)}" +
         s" --cores $numCores" +
-        s" --app-id $appId")
+        s" --app-id $appId" +
+        s" --span-id ${sc.spanId}")
       command.addUris(CommandInfo.URI.newBuilder().setValue(uri.get).setCache(useFetcherCache))
     }
 

--- a/resource-managers/yarn/pom.xml
+++ b/resource-managers/yarn/pom.xml
@@ -189,6 +189,11 @@
       <artifactId>libfb303</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.htrace</groupId>
+      <artifactId>htrace-core4</artifactId>
+      <version>4.1.0-incubating</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMasterArguments.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMasterArguments.scala
@@ -26,6 +26,7 @@ class ApplicationMasterArguments(val args: Array[String]) {
   var primaryRFile: String = null
   var userArgs: Seq[String] = Nil
   var propertiesFile: String = null
+  var spanId: String = null
 
   parseArgs(args.toList)
 
@@ -62,6 +63,10 @@ class ApplicationMasterArguments(val args: Array[String]) {
           propertiesFile = value
           args = tail
 
+        case ("--span-id") :: value :: tail =>
+          spanId = value
+          args = tail
+
         case _ =>
           printUsageAndExit(1, args)
       }
@@ -92,6 +97,7 @@ class ApplicationMasterArguments(val args: Array[String]) {
       |  --arg ARG            Argument to be passed to your application's main class.
       |                       Multiple invocations are possible, each will be passed in order.
       |  --properties-file FILE Path to a custom Spark properties file.
+      |  --span-id SPAN_ID    Span Id of the application.
       """.stripMargin)
     // scalastyle:on println
     System.exit(exitCode)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -960,9 +960,17 @@ private[spark] class Client(
     val userArgs = args.userArgs.flatMap { arg =>
       Seq("--arg", YarnSparkHadoopUtil.escapeForShell(arg))
     }
+    val spanId =
+      if (args.spanId != null) {
+        Seq("--span-id", args.spanId)
+      } else {
+        Nil
+      }
     val amArgs =
       Seq(amClass) ++ userClass ++ userJar ++ primaryPyFile ++ primaryRFile ++ userArgs ++
-      Seq("--properties-file", buildPath(Environment.PWD.$$(), LOCALIZED_CONF_DIR, SPARK_CONF_FILE))
+      Seq("--properties-file", buildPath(Environment.PWD.$$(),
+        LOCALIZED_CONF_DIR, SPARK_CONF_FILE)) ++ spanId
+
 
     // Command for the ApplicationMaster
     val commands = prefixEnv ++

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
@@ -27,6 +27,7 @@ private[spark] class ClientArguments(args: Array[String]) {
   var primaryPyFile: String = null
   var primaryRFile: String = null
   var userArgs: ArrayBuffer[String] = new ArrayBuffer[String]()
+  var spanId: String = null
 
   parseArgs(args.toList)
 
@@ -55,6 +56,10 @@ private[spark] class ClientArguments(args: Array[String]) {
           userArgs += value
           args = tail
 
+        case ("--span-id") :: value :: tail =>
+          spanId = value
+          args = tail
+
         case Nil =>
 
         case _ =>
@@ -81,6 +86,7 @@ private[spark] class ClientArguments(args: Array[String]) {
       |  --primary-r-file         A main R file
       |  --arg ARG                Argument to be passed to your application's main class.
       |                           Multiple invocations are possible, each will be passed in order.
+      |  --span-id SPAN_ID        Span Id of the application.
       """.stripMargin
   }
 }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
@@ -34,6 +34,7 @@ import org.apache.hadoop.yarn.client.api.NMClient
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.hadoop.yarn.ipc.YarnRPC
 import org.apache.hadoop.yarn.util.{ConverterUtils, Records}
+import org.apache.htrace.core.SpanId
 
 import org.apache.spark.{SecurityManager, SparkConf, SparkException}
 import org.apache.spark.internal.Logging
@@ -52,7 +53,8 @@ private[yarn] class ExecutorRunnable(
     executorCores: Int,
     appId: String,
     securityMgr: SecurityManager,
-    localResources: Map[String, LocalResource]) extends Logging {
+    localResources: Map[String, LocalResource],
+    spanId: String = null) extends Logging {
 
   var rpc: YarnRPC = YarnRPC.create(conf)
   var nmClient: NMClient = _
@@ -206,7 +208,8 @@ private[yarn] class ExecutorRunnable(
         "--executor-id", executorId,
         "--hostname", hostname,
         "--cores", executorCores.toString,
-        "--app-id", appId) ++
+        "--app-id", appId,
+        "--span-id", spanId) ++
       userClassPath ++
       Seq(
         s"1>${ApplicationConstants.LOG_DIR_EXPANSION_VAR}/stdout",

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -31,6 +31,7 @@ import org.apache.hadoop.yarn.api.records._
 import org.apache.hadoop.yarn.client.api.AMRMClient
 import org.apache.hadoop.yarn.client.api.AMRMClient.ContainerRequest
 import org.apache.hadoop.yarn.conf.YarnConfiguration
+import org.apache.htrace.core.SpanId
 
 import org.apache.spark.{SecurityManager, SparkConf, SparkException}
 import org.apache.spark.deploy.yarn.YarnSparkHadoopUtil._
@@ -66,7 +67,8 @@ private[yarn] class YarnAllocator(
     appAttemptId: ApplicationAttemptId,
     securityMgr: SecurityManager,
     localResources: Map[String, LocalResource],
-    resolver: SparkRackResolver)
+    resolver: SparkRackResolver,
+    spanId: String = null)
   extends Logging {
 
   import YarnAllocator._
@@ -530,7 +532,8 @@ private[yarn] class YarnAllocator(
                   executorCores,
                   appAttemptId.getApplicationId.toString,
                   securityMgr,
-                  localResources
+                  localResources,
+                  spanId
                 ).run()
                 updateInternalState()
               } catch {

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
@@ -58,7 +58,8 @@ private[spark] class YarnRMClient extends Logging {
       uiAddress: Option[String],
       uiHistoryAddress: String,
       securityMgr: SecurityManager,
-      localResources: Map[String, LocalResource]
+      localResources: Map[String, LocalResource],
+      spanId: String = null
     ): YarnAllocator = {
     amClient = AMRMClient.createAMRMClient()
     amClient.init(conf)
@@ -75,7 +76,7 @@ private[spark] class YarnRMClient extends Logging {
       registered = true
     }
     new YarnAllocator(driverUrl, driverRef, conf, sparkConf, amClient, getAttemptId(), securityMgr,
-      localResources, new SparkRackResolver())
+      localResources, new SparkRackResolver(), spanId)
   }
 
   /**

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -49,6 +49,7 @@ private[spark] class YarnClientSchedulerBackend(
 
     val argsArrayBuf = new ArrayBuffer[String]()
     argsArrayBuf += ("--arg", hostport)
+    argsArrayBuf += ("--span-id", sc.spanId)
 
     logDebug("ClientArguments called with: " + argsArrayBuf.mkString(" "))
     val args = new ClientArguments(argsArrayBuf.toArray)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR integrates with HTrace, it sends traces for the application and tasks when the span receivers are configured. The trace configurations can be updated along with spark configurations by adding prefix 'spark.htrace.' to the HTrace configurations like below,

`spark.htrace.span.receiver.classes`	org.apache.htrace.core.LocalFileSpanReceiver;org.apache.htrace.impl.HTracedSpanReceiver;org.apache.htrace.impl.ZipkinSpanReceiver
`spark.htrace.htraced.receiver.address`	IP:PORT
`spark.htrace.local.file.span.receiver.path`	/path/local-span-file
`spark.htrace.sampler.classes`	org.apache.htrace.core.AlwaysSampler

And also it provides an additional configuration to receive the parent span with the config name `spark.app.spanId`, if the `spark.app.spanId` configuration exist then it takes it as parent span, otherwise it starts a new span for each application.

## How was this patch tested?

I have verified using the existing tests with the added test and also verified manually in all these below deployment modes with different tracers individually and together.

1. Local and local-cluster
2. Standalone Client and Cluster modes
3. Yarn Client and Cluster modes
4. Mesos Client and Cluster modes