### PR TITLE
[SPARK-23529][K8s] Support mounting hostPath volumes

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -117,6 +117,13 @@ private[spark] object Config extends Logging {
       .stringConf
       .createWithDefault("spark")
 
+  val KUBERNETES_EXECUTOR_VOLUMES =
+    ConfigBuilder("spark.kubernetes.executor.volumes")
+      .doc("List of volumes mounted into the executor container. The format of this property is " +
+        "a comma-separated list of mappings following the form hostPath:containerPath:name")
+      .stringConf
+      .createWithDefault("")
+
   val KUBERNETES_ALLOCATION_BATCH_SIZE =
     ConfigBuilder("spark.kubernetes.allocation.batch.size")
       .doc("Number of pods to launch at once in each round of executor allocation.")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -120,7 +120,7 @@ private[spark] object Config extends Logging {
   val KUBERNETES_EXECUTOR_VOLUMES =
     ConfigBuilder("spark.kubernetes.executor.volumes")
       .doc("List of volumes mounted into the executor container. The format of this property is " +
-        "a comma-separated list of mappings following the form hostPath:containerPath:name")
+        "a comma-separated list of mappings following the form hostPath:containerPath[:ro|rw]")
       .stringConf
       .createWithDefault("")
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -117,13 +117,6 @@ private[spark] object Config extends Logging {
       .stringConf
       .createWithDefault("spark")
 
-  val KUBERNETES_EXECUTOR_VOLUMES =
-    ConfigBuilder("spark.kubernetes.executor.volumes")
-      .doc("List of volumes mounted into the executor container. The format of this property is " +
-        "a comma-separated list of mappings following the form hostPath:containerPath[:ro|rw]")
-      .stringConf
-      .createWithDefault("")
-
   val KUBERNETES_ALLOCATION_BATCH_SIZE =
     ConfigBuilder("spark.kubernetes.allocation.batch.size")
       .doc("Number of pods to launch at once in each round of executor allocation.")
@@ -169,10 +162,18 @@ private[spark] object Config extends Logging {
   val KUBERNETES_DRIVER_LABEL_PREFIX = "spark.kubernetes.driver.label."
   val KUBERNETES_DRIVER_ANNOTATION_PREFIX = "spark.kubernetes.driver.annotation."
   val KUBERNETES_DRIVER_SECRETS_PREFIX = "spark.kubernetes.driver.secrets."
+  val KUBERNETES_DRIVER_VOLUMES_PREFIX = "spark.kubernetes.driver.volumes."
 
   val KUBERNETES_EXECUTOR_LABEL_PREFIX = "spark.kubernetes.executor.label."
   val KUBERNETES_EXECUTOR_ANNOTATION_PREFIX = "spark.kubernetes.executor.annotation."
   val KUBERNETES_EXECUTOR_SECRETS_PREFIX = "spark.kubernetes.executor.secrets."
+  val KUBERNETES_EXECUTOR_VOLUMES_PREFIX = "spark.kubernetes.executor.volumes."
+
+  val KUBERNETES_VOLUMES_HOSTPATH_KEY = "hostPath"
+  val KUBERNETES_VOLUMES_MOUNT_KEY = "mount"
+  val KUBERNETES_VOLUMES_PATH_KEY = "path"
+  val KUBERNETES_VOLUMES_READONLY_KEY = "readOnly"
+  val KUBERNETES_VOLUMES_OPTIONS_KEY = "options"
 
   val KUBERNETES_DRIVER_ENV_PREFIX = "spark.kubernetes.driverEnv."
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.deploy.k8s
 
-import io.fabric8.kubernetes.api.model.LocalObjectReference
+import io.fabric8.kubernetes.api.model._
 
 import org.apache.spark.SparkConf
 import org.apache.spark.util.Utils
@@ -35,6 +35,35 @@ private[spark] object KubernetesUtils {
       sparkConf: SparkConf,
       prefix: String): Map[String, String] = {
     sparkConf.getAllWithPrefix(prefix).toMap
+  }
+
+  /**
+    * Parse a comma-delimited list of volume specs, each of which
+    * takes the form hostPath:containerPath:name and add to pod.
+    *
+    * @param pod original specification of the pod
+    * @param container original specification of the container
+    * @param volumes list of volume specs
+    * @return the pod with the init-container added to the list of InitContainers
+   */
+  def addVolumes(pod: Pod, container : Container, volumes: String): (Pod, Container) = {
+    val podBuilder = new PodBuilder(pod).editOrNewSpec()
+    val containerBuilder = new ContainerBuilder(container)
+    volumes.split(",").map(_.split(":")).map { spec =>
+      spec match {
+        case Array(hostPath, containerPath, name) =>
+          podBuilder
+            .withVolumes(new VolumeBuilder()
+              .withHostPath(new HostPathVolumeSource(hostPath)).withName(name).build())
+          containerBuilder.addToVolumeMounts(new VolumeMountBuilder()
+            .withMountPath(containerPath)
+            .withName(name)
+            .build())
+        case spec =>
+          None
+      }
+    }
+    (podBuilder.endSpec().build(), containerBuilder.build())
   }
 
   def requireNandDefined(opt1: Option[_], opt2: Option[_], errMessage: String): Unit = {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -16,12 +16,7 @@
  */
 package org.apache.spark.deploy.k8s
 
-import scala.collection.mutable.HashMap
-
-import io.fabric8.kubernetes.api.model._
-
 import org.apache.spark.SparkConf
-import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.util.Utils
 
 private[spark] object KubernetesUtils {
@@ -38,88 +33,6 @@ private[spark] object KubernetesUtils {
       sparkConf: SparkConf,
       prefix: String): Map[String, String] = {
     sparkConf.getAllWithPrefix(prefix).toMap
-  }
-
-  /**
-   * Extract Spark hostPath volume configuration properties with a given name prefix and
-   * return the result as a Map.
-   *
-   * @param sparkConf Spark configuration
-   * @param prefix the given property name prefix
-   * @return a Map storing with volume name as key and spec as value
-   */
-  def parseHostPathVolumesWithPrefix(
-      sparkConf: SparkConf,
-      prefix: String): Map[String, KubernetesVolumeSpec] = {
-    val volumes = HashMap[String, KubernetesVolumeSpec]()
-    val properties = sparkConf.getAllWithPrefix(s"$prefix$KUBERNETES_VOLUMES_HOSTPATH_KEY.").toList
-    // Extract volume names
-    properties.foreach {
-      k =>
-        val keys = k._1.split("\\.")
-        if (keys.nonEmpty && !volumes.contains(keys(0))) {
-          volumes.update(keys(0), KubernetesVolumeSpec.emptySpec())
-        }
-    }
-    // Populate spec
-    volumes.foreach {
-      case (name, spec) =>
-        properties.foreach {
-          k =>
-            k._1.split("\\.") match {
-              case Array(`name`, KUBERNETES_VOLUMES_MOUNT_KEY, KUBERNETES_VOLUMES_PATH_KEY) =>
-                spec.mountPath = Some(k._2)
-              case Array(`name`, KUBERNETES_VOLUMES_MOUNT_KEY, KUBERNETES_VOLUMES_READONLY_KEY) =>
-                spec.mountReadOnly = Some(k._2.toBoolean)
-              case Array(`name`, KUBERNETES_VOLUMES_OPTIONS_KEY, option) =>
-                spec.optionsSpec.update(option, k._2)
-              case _ =>
-                None
-            }
-        }
-    }
-    volumes.toMap
-  }
-
-  /**
-   * Given hostPath volume specs, add volume to pod and volume mount to container.
-   *
-   * @param pod original specification of the pod
-   * @param container original specification of the container
-   * @param volumes list of named volume specs
-   * @return a tuple of (pod with the volume(s) added, container with mount(s) added)
-   */
-  def addHostPathVolumes(
-      pod: Pod,
-      container: Container,
-      volumes: Map[String, KubernetesVolumeSpec]): (Pod, Container) = {
-    val podBuilder = new PodBuilder(pod).editOrNewSpec()
-    val containerBuilder = new ContainerBuilder(container)
-    volumes foreach {
-      case (name, spec) =>
-        var hostPath: Option[String] = None
-        if (spec.optionsSpec.contains(KUBERNETES_VOLUMES_PATH_KEY)) {
-          hostPath = Some(spec.optionsSpec(KUBERNETES_VOLUMES_PATH_KEY))
-        }
-        if (hostPath.isDefined && spec.mountPath.isDefined) {
-          podBuilder.addToVolumes(new VolumeBuilder()
-            .withHostPath(new HostPathVolumeSource(hostPath.get))
-            .withName(name)
-            .build())
-          val volumeBuilder = new VolumeMountBuilder()
-            .withMountPath(spec.mountPath.get)
-            .withName(name)
-          if (spec.mountReadOnly.isDefined) {
-            containerBuilder
-              .addToVolumeMounts(volumeBuilder
-                .withReadOnly(spec.mountReadOnly.get)
-                .build())
-          } else {
-            containerBuilder.addToVolumeMounts(volumeBuilder.build())
-          }
-        }
-    }
-    (podBuilder.endSpec().build(), containerBuilder.build())
   }
 
   def requireNandDefined(opt1: Option[_], opt2: Option[_], errMessage: String): Unit = {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -52,7 +52,7 @@ private[spark] object KubernetesUtils {
       sparkConf: SparkConf,
       prefix: String): Map[String, KubernetesVolumeSpec] = {
     val volumes = HashMap[String, KubernetesVolumeSpec]()
-    val properties = sparkConf.getAllWithPrefix(s"$prefix$KUBERNETES_VOLUMES_HOSTPATH_KEY")
+    val properties = sparkConf.getAllWithPrefix(s"$prefix$KUBERNETES_VOLUMES_HOSTPATH_KEY.")
     // Extract volume names
     properties foreach {
       case (k, _) =>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -38,57 +38,50 @@ private[spark] object KubernetesUtils {
   }
 
   /**
-    * Parse a comma-delimited list of volume specs, each of which takes the form
-    * hostPath:containerPath[:ro|rw]; and add volume to pod and volume mount to container.
-    *
-    * @param pod original specification of the pod
-    * @param container original specification of the container
-    * @param volumes list of volume specs
-    * @return the pod with the init-container added to the list of InitContainers
+   * Parse a comma-delimited list of volume specs, each of which takes the form
+   * hostPath:containerPath[:ro|rw]; and add volume to pod and volume mount to container.
+   *
+   * @param pod original specification of the pod
+   * @param container original specification of the container
+   * @param volumes list of volume specs
+   * @return the pod with the init-container added to the list of InitContainers
    */
   def addVolumes(pod: Pod, container : Container, volumes: String): (Pod, Container) = {
     val podBuilder = new PodBuilder(pod).editOrNewSpec()
     val containerBuilder = new ContainerBuilder(container)
     var volumeCount = 0
     volumes.split(",").map(_.split(":")).map { spec =>
+      var hostPath: Option[String] = None
+      var containerPath: Option[String] = None
+      var readOnly: Option[Boolean] = None
       spec match {
-        case Array(hostPath, containerPath) =>
-          podBuilder
-            .withVolumes(new VolumeBuilder()
-              .withHostPath(new HostPathVolumeSource(hostPath))
-              .withName(s"executor-volume-$volumeCount")
-              .build())
-          containerBuilder.addToVolumeMounts(new VolumeMountBuilder()
-            .withMountPath(containerPath)
+        case Array(hostPathV, containerPathV) =>
+          hostPath = Some(hostPathV)
+          containerPath = Some(containerPathV)
+        case Array(hostPathV, containerPathV, "ro") =>
+          hostPath = Some(hostPathV)
+          containerPath = Some(containerPathV)
+          readOnly = Some(true)
+        case Array(hostPathV, containerPathV, "rw") =>
+          hostPath = Some(hostPathV)
+          containerPath = Some(containerPathV)
+          readOnly = Some(false)
+      }
+      if (hostPath.isDefined && containerPath.isDefined) {
+        podBuilder
+          .withVolumes(new VolumeBuilder()
+            .withHostPath(new HostPathVolumeSource(hostPath.get))
             .withName(s"executor-volume-$volumeCount")
             .build())
-          volumeCount += 1
-        case Array(hostPath, containerPath, "ro") =>
-          podBuilder
-            .withVolumes(new VolumeBuilder()
-              .withHostPath(new HostPathVolumeSource(hostPath))
-              .withName(s"executor-volume-$volumeCount")
-              .build())
-          containerBuilder.addToVolumeMounts(new VolumeMountBuilder()
-            .withMountPath(containerPath)
-            .withName(s"executor-volume-$volumeCount")
-            .withReadOnly(true)
-            .build())
-          volumeCount += 1
-        case Array(hostPath, containerPath, "rw") =>
-          podBuilder
-            .withVolumes(new VolumeBuilder()
-              .withHostPath(new HostPathVolumeSource(hostPath))
-              .withName(s"executor-volume-$volumeCount")
-              .build())
-          containerBuilder.addToVolumeMounts(new VolumeMountBuilder()
-            .withMountPath(containerPath)
-            .withName(s"executor-volume-$volumeCount")
-            .withReadOnly(false)
-            .build())
-          volumeCount += 1
-        case spec =>
-          None
+        val volumeBuilder = new VolumeMountBuilder()
+          .withMountPath(containerPath.get)
+          .withName(s"executor-volume-$volumeCount")
+        if (readOnly.isDefined) {
+          containerBuilder.addToVolumeMounts(volumeBuilder.withReadOnly(readOnly.get).build())
+        } else {
+          containerBuilder.addToVolumeMounts(volumeBuilder.build())
+        }
+        volumeCount += 1
       }
     }
     (podBuilder.endSpec().build(), containerBuilder.build())

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -44,7 +44,7 @@ private[spark] object KubernetesUtils {
    * @param pod original specification of the pod
    * @param container original specification of the container
    * @param volumes list of volume specs
-   * @return the pod with the init-container added to the list of InitContainers
+   * @return a tuple of (pod with the volume(s) added, container with mount(s) added)
    */
   def addVolumes(pod: Pod, container : Container, volumes: String): (Pod, Container) = {
     val podBuilder = new PodBuilder(pod).editOrNewSpec()

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -66,10 +66,11 @@ private[spark] object KubernetesUtils {
           hostPath = Some(hostPathV)
           containerPath = Some(containerPathV)
           readOnly = Some(false)
+        case spec =>
+          None
       }
       if (hostPath.isDefined && containerPath.isDefined) {
-        podBuilder
-          .withVolumes(new VolumeBuilder()
+        podBuilder.addToVolumes(new VolumeBuilder()
             .withHostPath(new HostPathVolumeSource(hostPath.get))
             .withName(s"hostPath-volume-$volumeCount")
             .build())

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -71,11 +71,11 @@ private[spark] object KubernetesUtils {
         podBuilder
           .withVolumes(new VolumeBuilder()
             .withHostPath(new HostPathVolumeSource(hostPath.get))
-            .withName(s"executor-volume-$volumeCount")
+            .withName(s"hostPath-volume-$volumeCount")
             .build())
         val volumeBuilder = new VolumeMountBuilder()
           .withMountPath(containerPath.get)
-          .withName(s"executor-volume-$volumeCount")
+          .withName(s"hostPath-volume-$volumeCount")
         if (readOnly.isDefined) {
           containerBuilder.addToVolumeMounts(volumeBuilder.withReadOnly(readOnly.get).build())
         } else {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -38,8 +38,8 @@ private[spark] object KubernetesUtils {
   }
 
   /**
-    * Parse a comma-delimited list of volume specs, each of which
-    * takes the form hostPath:containerPath:name and add to pod.
+    * Parse a comma-delimited list of volume specs, each of which takes the form
+    * hostPath:containerPath[:ro|rw]; and add volume to pod and volume mount to container.
     *
     * @param pod original specification of the pod
     * @param container original specification of the container
@@ -49,16 +49,44 @@ private[spark] object KubernetesUtils {
   def addVolumes(pod: Pod, container : Container, volumes: String): (Pod, Container) = {
     val podBuilder = new PodBuilder(pod).editOrNewSpec()
     val containerBuilder = new ContainerBuilder(container)
+    var volumeCount = 0
     volumes.split(",").map(_.split(":")).map { spec =>
       spec match {
-        case Array(hostPath, containerPath, name) =>
+        case Array(hostPath, containerPath) =>
           podBuilder
             .withVolumes(new VolumeBuilder()
-              .withHostPath(new HostPathVolumeSource(hostPath)).withName(name).build())
+              .withHostPath(new HostPathVolumeSource(hostPath))
+              .withName(s"executor-volume-$volumeCount")
+              .build())
           containerBuilder.addToVolumeMounts(new VolumeMountBuilder()
             .withMountPath(containerPath)
-            .withName(name)
+            .withName(s"executor-volume-$volumeCount")
             .build())
+          volumeCount += 1
+        case Array(hostPath, containerPath, "ro") =>
+          podBuilder
+            .withVolumes(new VolumeBuilder()
+              .withHostPath(new HostPathVolumeSource(hostPath))
+              .withName(s"executor-volume-$volumeCount")
+              .build())
+          containerBuilder.addToVolumeMounts(new VolumeMountBuilder()
+            .withMountPath(containerPath)
+            .withName(s"executor-volume-$volumeCount")
+            .withReadOnly(true)
+            .build())
+          volumeCount += 1
+        case Array(hostPath, containerPath, "rw") =>
+          podBuilder
+            .withVolumes(new VolumeBuilder()
+              .withHostPath(new HostPathVolumeSource(hostPath))
+              .withName(s"executor-volume-$volumeCount")
+              .build())
+          containerBuilder.addToVolumeMounts(new VolumeMountBuilder()
+            .withMountPath(containerPath)
+            .withName(s"executor-volume-$volumeCount")
+            .withReadOnly(false)
+            .build())
+          volumeCount += 1
         case spec =>
           None
       }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesVolumeSpec.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesVolumeSpec.scala
@@ -16,11 +16,13 @@
  */
 package org.apache.spark.deploy.k8s
 
+import scala.collection.mutable.Map
+
 private[spark] case class KubernetesVolumeSpec(
     var mountPath: Option[String],
     var mountReadOnly: Option[Boolean],
-    var optionsSpec: Option[Map[String, String]])
+    var optionsSpec: Map[String, String])
 
 private[spark] object KubernetesVolumeSpec {
-  def emptySpec(): KubernetesVolumeSpec = new KubernetesVolumeSpec(None, None, None)
+  def emptySpec(): KubernetesVolumeSpec = new KubernetesVolumeSpec(None, None, Map())
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesVolumeSpec.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesVolumeSpec.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.k8s
+
+private[spark] case class KubernetesVolumeSpec(
+    var mountPath: Option[String],
+    var mountReadOnly: Option[Boolean],
+    var optionsSpec: Option[Map[String, String]])
+
+private[spark] object KubernetesVolumeSpec {
+  def emptySpec(): KubernetesVolumeSpec = new KubernetesVolumeSpec(None, None, None)
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesVolumeUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesVolumeUtils.scala
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.k8s
+
+import scala.collection.mutable.HashMap
+
+import io.fabric8.kubernetes.api.model._
+
+import org.apache.spark.SparkConf
+import org.apache.spark.deploy.k8s.Config._
+
+private[spark] object KubernetesVolumeUtils {
+
+  /**
+   * Given hostPath volume specs, add volume to pod and volume mount to container.
+   *
+   * @param pod original specification of the pod
+   * @param container original specification of the container
+   * @param sparkConf Spark configuration
+   * @param prefix the prefix for volume configuration
+   * @return a tuple of (pod with the volume(s) added, container with mount(s) added)
+   */
+  def addVolumes(
+      pod: Pod,
+      container: Container,
+      sparkConf: SparkConf,
+      prefix : String): (Pod, Container) = {
+    val hostPathVolumeSpecs = parseHostPathVolumesWithPrefix(sparkConf, prefix)
+    addHostPathVolumes(pod, container, hostPathVolumeSpecs)
+  }
+
+  /**
+   * Extract Spark volume configuration properties with a given name prefix.
+   *
+   * @param sparkConf Spark configuration
+   * @param prefix the given property name prefix
+   * @param volumeTypeKey the given property name prefix
+   * @return a Map storing with volume name as key and spec as value
+   */
+  def parseVolumesWithPrefix(
+      sparkConf: SparkConf,
+      prefix: String,
+      volumeTypeKey: String): Map[String, KubernetesVolumeSpec] = {
+    val volumes = HashMap[String, KubernetesVolumeSpec]()
+    val properties = sparkConf.getAllWithPrefix(s"$prefix$volumeTypeKey.").toList
+    // Extract volume names
+    properties.foreach {
+      k =>
+        val keys = k._1.split("\\.")
+        if (keys.nonEmpty && !volumes.contains(keys(0))) {
+          volumes.update(keys(0), KubernetesVolumeSpec.emptySpec())
+        }
+    }
+    // Populate spec
+    volumes.foreach {
+      case (name, spec) =>
+        properties.foreach {
+          k =>
+            k._1.split("\\.") match {
+              case Array(`name`, KUBERNETES_VOLUMES_MOUNT_KEY, KUBERNETES_VOLUMES_PATH_KEY) =>
+                spec.mountPath = Some(k._2)
+              case Array(`name`, KUBERNETES_VOLUMES_MOUNT_KEY, KUBERNETES_VOLUMES_READONLY_KEY) =>
+                spec.mountReadOnly = Some(k._2.toBoolean)
+              case Array(`name`, KUBERNETES_VOLUMES_OPTIONS_KEY, option) =>
+                spec.optionsSpec.update(option, k._2)
+              case _ =>
+                None
+            }
+        }
+    }
+    volumes.toMap
+  }
+
+  /**
+   * Extract Spark hostPath volume configuration properties with a given name prefix and
+   * return the result as a Map.
+   *
+   * @param sparkConf Spark configuration
+   * @param prefix the given property name prefix
+   * @return a Map storing with volume name as key and spec as value
+   */
+  def parseHostPathVolumesWithPrefix(
+      sparkConf: SparkConf,
+      prefix: String): Map[String, KubernetesVolumeSpec] = {
+    parseVolumesWithPrefix(sparkConf, prefix, KUBERNETES_VOLUMES_HOSTPATH_KEY)
+  }
+
+  /**
+   * Given hostPath volume specs, add volume to pod and volume mount to container.
+   *
+   * @param pod original specification of the pod
+   * @param container original specification of the container
+   * @param volumes list of named volume specs
+   * @return a tuple of (pod with the volume(s) added, container with mount(s) added)
+   */
+  def addHostPathVolumes(
+      pod: Pod,
+      container: Container,
+      volumes: Map[String, KubernetesVolumeSpec]): (Pod, Container) = {
+    val podBuilder = new PodBuilder(pod).editOrNewSpec()
+    val containerBuilder = new ContainerBuilder(container)
+    volumes foreach {
+      case (name, spec) =>
+        var hostPath: Option[String] = None
+        if (spec.optionsSpec.contains(KUBERNETES_VOLUMES_PATH_KEY)) {
+          hostPath = Some(spec.optionsSpec(KUBERNETES_VOLUMES_PATH_KEY))
+        }
+        if (hostPath.isDefined && spec.mountPath.isDefined) {
+          podBuilder.addToVolumes(new VolumeBuilder()
+            .withHostPath(new HostPathVolumeSource(hostPath.get))
+            .withName(name)
+            .build())
+          val volumeBuilder = new VolumeMountBuilder()
+            .withMountPath(spec.mountPath.get)
+            .withName(name)
+          if (spec.mountReadOnly.isDefined) {
+            containerBuilder
+              .addToVolumeMounts(volumeBuilder
+                .withReadOnly(spec.mountReadOnly.get)
+                .build())
+          } else {
+            containerBuilder.addToVolumeMounts(volumeBuilder.build())
+          }
+        }
+    }
+    (podBuilder.endSpec().build(), containerBuilder.build())
+  }
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
@@ -19,10 +19,10 @@ package org.apache.spark.deploy.k8s.features
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
-import io.fabric8.kubernetes.api.model.{ContainerBuilder, EnvVarBuilder, EnvVarSourceBuilder, HasMetadata, PodBuilder, QuantityBuilder}
+import io.fabric8.kubernetes.api.model._
 
 import org.apache.spark.SparkException
-import org.apache.spark.deploy.k8s.{KubernetesConf, KubernetesDriverSpecificConf, KubernetesUtils, SparkPod}
+import org.apache.spark.deploy.k8s._
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.internal.config._
@@ -110,12 +110,14 @@ private[spark] class BasicDriverFeatureStep(
         .endSpec()
       .build()
 
-    val driverHostPathVolumesSpec = KubernetesUtils.parseHostPathVolumesWithPrefix(
-      conf.sparkConf, KUBERNETES_DRIVER_VOLUMES_PREFIX)
-    val (driverPodWithHostPathVolumes, driverContainerWithHostPathVolumes) =
-      KubernetesUtils.addHostPathVolumes(driverPod, driverContainer, driverHostPathVolumesSpec)
+    val (driverPodWithVolumes, driverContainerVolumes) =
+      KubernetesVolumeUtils.addVolumes(
+        driverPod,
+        driverContainer,
+        conf.sparkConf,
+        KUBERNETES_DRIVER_VOLUMES_PREFIX)
 
-    SparkPod(driverPodWithHostPathVolumes, driverContainerWithHostPathVolumes)
+    SparkPod(driverPodWithVolumes, driverContainerVolumes)
   }
 
   override def getAdditionalPodSystemProperties(): Map[String, String] = {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
@@ -109,7 +109,13 @@ private[spark] class BasicDriverFeatureStep(
         .addToImagePullSecrets(conf.imagePullSecrets(): _*)
         .endSpec()
       .build()
-    SparkPod(driverPod, driverContainer)
+
+    val driverHostPathVolumesSpec = KubernetesUtils.parseHostPathVolumesWithPrefix(
+      conf.sparkConf, KUBERNETES_DRIVER_VOLUMES_PREFIX)
+    val (driverPodWithHostPathVolumes, driverContainerWithHostPathVolumes) =
+      KubernetesUtils.addHostPathVolumes(driverPod, driverContainer, driverHostPathVolumesSpec)
+
+    SparkPod(driverPodWithHostPathVolumes, driverContainerWithHostPathVolumes)
   }
 
   override def getAdditionalPodSystemProperties(): Map[String, String] = {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -21,7 +21,7 @@ import scala.collection.JavaConverters._
 import io.fabric8.kubernetes.api.model._
 
 import org.apache.spark.SparkException
-import org.apache.spark.deploy.k8s.{KubernetesConf, KubernetesExecutorSpecificConf, KubernetesUtils, SparkPod}
+import org.apache.spark.deploy.k8s._
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.internal.config.{EXECUTOR_CLASS_PATH, EXECUTOR_JAVA_OPTIONS, EXECUTOR_MEMORY, EXECUTOR_MEMORY_OVERHEAD}
@@ -171,14 +171,13 @@ private[spark] class BasicExecutorFeatureStep(
         .endSpec()
       .build()
 
-    val executorHostPathVolumesSpec = KubernetesUtils.parseHostPathVolumesWithPrefix(
-      kubernetesConf.sparkConf, KUBERNETES_EXECUTOR_VOLUMES_PREFIX)
-    val (executorPodWithHostPathVolumes, executorContainerWithHostPathVolumes) =
-      KubernetesUtils.addHostPathVolumes(executorPod,
+    val (executorPodWithVolumes, executorContainerWithVolumes) =
+      KubernetesVolumeUtils.addVolumes(executorPod,
         containerWithLimitCores,
-        executorHostPathVolumesSpec)
+        kubernetesConf.sparkConf,
+        KUBERNETES_EXECUTOR_VOLUMES_PREFIX)
 
-    SparkPod(executorPodWithHostPathVolumes, executorContainerWithHostPathVolumes)
+    SparkPod(executorPodWithVolumes, executorContainerWithVolumes)
   }
 
   override def getAdditionalPodSystemProperties(): Map[String, String] = Map.empty

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -170,11 +170,10 @@ private[spark] class BasicExecutorFeatureStep(
         .endSpec()
       .build()
 
-    val volumes = kubernetesConf.get(KUBERNETES_EXECUTOR_VOLUMES)
-    val executorPodAndContainerWithVolumes =
-      KubernetesUtils.addVolumes(executorPod, containerWithLimitCores, volumes)
-    val executorPodWithVolumes = executorPodAndContainerWithVolumes._1
-    val executorContainerWithVolumes = executorPodAndContainerWithVolumes._2
+    val (executorPodWithVolumes, executorContainerWithVolumes) =
+      KubernetesUtils.addVolumes(executorPod,
+        executorContainer,
+        kubernetesConf.get(KUBERNETES_EXECUTOR_VOLUMES))
 
     SparkPod(executorPodWithVolumes, executorContainerWithVolumes)
   }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.deploy.k8s.features
 
 import scala.collection.JavaConverters._
+
 import io.fabric8.kubernetes.api.model._
 
 import org.apache.spark.SparkException

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -170,12 +170,14 @@ private[spark] class BasicExecutorFeatureStep(
         .endSpec()
       .build()
 
-    val (executorPodWithVolumes, executorContainerWithVolumes) =
-      KubernetesUtils.addVolumes(executorPod,
+    val executorHostPathVolumesSpec = KubernetesUtils.parseHostPathVolumesWithPrefix(
+      kubernetesConf.sparkConf, KUBERNETES_EXECUTOR_VOLUMES_PREFIX)
+    val (executorPodWithHostPathVolumes, executorContainerWithHostPathVolumes) =
+      KubernetesUtils.addHostPathVolumes(executorPod,
         containerWithLimitCores,
-        kubernetesConf.get(KUBERNETES_EXECUTOR_VOLUMES))
+        executorHostPathVolumesSpec)
 
-    SparkPod(executorPodWithVolumes, executorContainerWithVolumes)
+    SparkPod(executorPodWithHostPathVolumes, executorContainerWithHostPathVolumes)
   }
 
   override def getAdditionalPodSystemProperties(): Map[String, String] = Map.empty

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -172,7 +172,7 @@ private[spark] class BasicExecutorFeatureStep(
 
     val (executorPodWithVolumes, executorContainerWithVolumes) =
       KubernetesUtils.addVolumes(executorPod,
-        executorContainer,
+        containerWithLimitCores,
         kubernetesConf.get(KUBERNETES_EXECUTOR_VOLUMES))
 
     SparkPod(executorPodWithVolumes, executorContainerWithVolumes)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -17,11 +17,10 @@
 package org.apache.spark.deploy.k8s.features
 
 import scala.collection.JavaConverters._
-
-import io.fabric8.kubernetes.api.model.{ContainerBuilder, ContainerPortBuilder, EnvVar, EnvVarBuilder, EnvVarSourceBuilder, HasMetadata, PodBuilder, QuantityBuilder}
+import io.fabric8.kubernetes.api.model._
 
 import org.apache.spark.SparkException
-import org.apache.spark.deploy.k8s.{KubernetesConf, KubernetesExecutorSpecificConf, SparkPod}
+import org.apache.spark.deploy.k8s.{KubernetesConf, KubernetesExecutorSpecificConf, KubernetesUtils, SparkPod}
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.internal.config.{EXECUTOR_CLASS_PATH, EXECUTOR_JAVA_OPTIONS, EXECUTOR_MEMORY, EXECUTOR_MEMORY_OVERHEAD}
@@ -170,7 +169,14 @@ private[spark] class BasicExecutorFeatureStep(
         .addToImagePullSecrets(kubernetesConf.imagePullSecrets(): _*)
         .endSpec()
       .build()
-    SparkPod(executorPod, containerWithLimitCores)
+
+    val volumes = kubernetesConf.get(KUBERNETES_EXECUTOR_VOLUMES)
+    val executorPodAndContainerWithVolumes =
+      KubernetesUtils.addVolumes(executorPod, containerWithLimitCores, volumes)
+    val executorPodWithVolumes = executorPodAndContainerWithVolumes._1
+    val executorContainerWithVolumes = executorPodAndContainerWithVolumes._2
+
+    SparkPod(executorPodWithVolumes, executorContainerWithVolumes)
   }
 
   override def getAdditionalPodSystemProperties(): Map[String, String] = Map.empty

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -154,7 +154,8 @@ class BasicExecutorFeatureStepSuite
 
   test("single executor hostPath volume gets mounted") {
     val conf = baseConf.clone()
-    conf.set(KUBERNETES_EXECUTOR_VOLUMES, "/tmp/mount:/opt/mount")
+    conf.set("spark.kubernetes.executor.volumes.hostPath.hostPath-1.mount.path", "/opt/mount")
+    conf.set("spark.kubernetes.executor.volumes.hostPath.hostPath-1.options.path", "/tmp/mount")
 
     val step = new BasicExecutorFeatureStep(
       KubernetesConf(
@@ -181,7 +182,10 @@ class BasicExecutorFeatureStepSuite
 
   test("multiple executor hostPath volumes get mounted") {
     val conf = baseConf.clone()
-    conf.set(KUBERNETES_EXECUTOR_VOLUMES, "/tmp/mount1:/opt/mount1,/tmp/mount2:/opt/mount2")
+    conf.set("spark.kubernetes.executor.volumes.hostPath.hostPath-1.mount.path", "/opt/mount1")
+    conf.set("spark.kubernetes.executor.volumes.hostPath.hostPath-1.options.path", "/tmp/mount1")
+    conf.set("spark.kubernetes.executor.volumes.hostPath.hostPath-2.mount.path", "/opt/mount2")
+    conf.set("spark.kubernetes.executor.volumes.hostPath.hostPath-2.options.path", "/tmp/mount2")
     val step = new BasicExecutorFeatureStep(
       KubernetesConf(
         conf,
@@ -196,9 +200,9 @@ class BasicExecutorFeatureStepSuite
 
     assert(executor.container.getImage === EXECUTOR_IMAGE)
     assert(executor.container.getVolumeMounts.size() === 2)
-    assert(executor.container.getVolumeMounts.get(0).getName === "hostPath-volume-0")
+    assert(executor.container.getVolumeMounts.get(0).getName === "hostPath-1")
     assert(executor.container.getVolumeMounts.get(0).getMountPath === "/opt/mount1")
-    assert(executor.container.getVolumeMounts.get(1).getName === "hostPath-volume-1")
+    assert(executor.container.getVolumeMounts.get(1).getName === "hostPath-2")
     assert(executor.container.getVolumeMounts.get(1).getMountPath === "/opt/mount2")
 
     assert(executor.pod.getSpec.getVolumes.size() === 2)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -170,7 +170,7 @@ class BasicExecutorFeatureStepSuite
 
     assert(executor.container.getImage === EXECUTOR_IMAGE)
     assert(executor.container.getVolumeMounts.size() === 1)
-    assert(executor.container.getVolumeMounts.get(0).getName === "hostPath-volume-1")
+    assert(executor.container.getVolumeMounts.get(0).getName === "hostPath-volume-0")
     assert(executor.container.getVolumeMounts.get(0).getMountPath === "/opt/mount")
 
     assert(executor.pod.getSpec.getVolumes.size() === 1)
@@ -196,9 +196,9 @@ class BasicExecutorFeatureStepSuite
 
     assert(executor.container.getImage === EXECUTOR_IMAGE)
     assert(executor.container.getVolumeMounts.size() === 2)
-    assert(executor.container.getVolumeMounts.get(0).getName === "hostPath-volume-1")
+    assert(executor.container.getVolumeMounts.get(0).getName === "hostPath-volume-0")
     assert(executor.container.getVolumeMounts.get(0).getMountPath === "/opt/mount1")
-    assert(executor.container.getVolumeMounts.get(1).getName === "hostPath-volume-2")
+    assert(executor.container.getVolumeMounts.get(1).getName === "hostPath-volume-1")
     assert(executor.container.getVolumeMounts.get(1).getMountPath === "/opt/mount2")
 
     assert(executor.pod.getSpec.getVolumes.size() === 2)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -176,7 +176,7 @@ class BasicExecutorFeatureStepSuite
       conf.set(s"spark.kubernetes.executor.volumes.hostPath.hostPath-$i.options.path",
         s"/tmp/mount$i")
       if (readOnly) {
-        conf.set(s"spark.kubernetes.executor.volumes.hostPath.hostPath-$i.options.readOnly",
+        conf.set(s"spark.kubernetes.executor.volumes.hostPath.hostPath-$i.mount.readOnly",
           "true")
       }
     }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -171,11 +171,11 @@ class BasicExecutorFeatureStepSuite
 
     assert(executor.container.getImage === EXECUTOR_IMAGE)
     assert(executor.container.getVolumeMounts.size() === 1)
-    assert(executor.container.getVolumeMounts.get(0).getName === "hostPath-volume-0")
+    assert(executor.container.getVolumeMounts.get(0).getName === "hostPath-1")
     assert(executor.container.getVolumeMounts.get(0).getMountPath === "/opt/mount")
 
     assert(executor.pod.getSpec.getVolumes.size() === 1)
-    assert(executor.pod.getSpec.getVolumes.get(0).getHostPath === "/tmp/mount")
+    assert(executor.pod.getSpec.getVolumes.get(0).getHostPath.getPath === "/tmp/mount")
 
     checkOwnerReferences(executor.pod, DRIVER_POD_UID)
   }
@@ -206,8 +206,8 @@ class BasicExecutorFeatureStepSuite
     assert(executor.container.getVolumeMounts.get(1).getMountPath === "/opt/mount2")
 
     assert(executor.pod.getSpec.getVolumes.size() === 2)
-    assert(executor.pod.getSpec.getVolumes.get(0).getHostPath === "/tmp/mount1")
-    assert(executor.pod.getSpec.getVolumes.get(1).getHostPath === "/tmp/mount2")
+    assert(executor.pod.getSpec.getVolumes.get(0).getHostPath.getPath === "/tmp/mount1")
+    assert(executor.pod.getSpec.getVolumes.get(1).getHostPath.getPath === "/tmp/mount2")
     checkOwnerReferences(executor.pod, DRIVER_POD_UID)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR introduces a new config `spark.kubernetes.driver/executor.volumes` taking a values of the format documented [here](https://docs.google.com/document/d/15-mk7UnOYNTXoF6EKaVlelWYc9DTrTXrYoodwDuAwY4/edit?usp=sharing)

The use case is to enable short-circuit writes to distributed storage on k8s. The Alluxio File System uses domain sockets to enable short-circuit writes from the client to worker memory when co-located on the same host machine. A directory, lets say /tmp/domain on the host, is mounted on the Alluxio worker container as well as the Alluxio client ( = Spark executor) container. The worker creates a domain socket /tmp/domain/d and if the client container mounts the same directory, it can write directly to the Alluxio worker w/o passing through network stack. The end result is faster data access when data is local.

## How was this patch tested?

Manual testing on a k8s v1.8 cluster. Unit tests added to `Driver/ExecutorPodFactorySuite`.

This PR replaces https://github.com/apache/spark/pull/21032.