### PR TITLE
[SPARK-22371][CORE] Return None instead of throwing an exception when an accumulator is garbage collected.

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
+++ b/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
@@ -258,14 +258,8 @@ private[spark] object AccumulatorContext {
    * Returns the [[AccumulatorV2]] registered with the given ID, if any.
    */
   def get(id: Long): Option[AccumulatorV2[_, _]] = {
-    Option(originals.get(id)).map { ref =>
-      // Since we are storing weak references, we must check whether the underlying data is valid.
-      val acc = ref.get
-      if (acc eq null) {
-        throw new IllegalStateException(s"Attempted to access garbage collected accumulator $id")
-      }
-      acc
-    }
+    val ref = originals.get(id)
+    Option(if (ref != null) ref.get else null)
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/AccumulatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/AccumulatorSuite.scala
@@ -209,10 +209,8 @@ class AccumulatorSuite extends SparkFunSuite with Matchers with LocalSparkContex
     System.gc()
     assert(ref.get.isEmpty)
 
-    // Getting a garbage collected accum should throw error
-    intercept[IllegalStateException] {
-      AccumulatorContext.get(accId)
-    }
+    // Getting a garbage collected accum should return None.
+    assert(AccumulatorContext.get(accId).isEmpty)
 
     // Getting a normal accumulator. Note: this has to be separate because referencing an
     // accumulator above in an `assert` would keep it from being garbage collected.

--- a/core/src/test/scala/org/apache/spark/AccumulatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/AccumulatorSuite.scala
@@ -31,7 +31,6 @@ import org.scalatest.exceptions.TestFailedException
 import org.apache.spark.AccumulatorParam.StringAccumulatorParam
 import org.apache.spark.scheduler._
 import org.apache.spark.serializer.JavaSerializer
-import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.util.{AccumulatorContext, AccumulatorMetadata, AccumulatorV2, LongAccumulator}
 
 
@@ -236,65 +235,6 @@ class AccumulatorSuite extends SparkFunSuite with Matchers with LocalSparkContex
     acc.merge("kindness")
     assert(acc.value === "kindness")
   }
-
-  test("updating garbage collected accumulators") {
-    // Simulate FetchFailedException in the first attempt to force a retry.
-    // Then complete remaining task from the first attempt after the second
-    // attempt started, but before it completes. Completion event for the first
-    // attempt will try to update garbage collected accumulators.
-    val numPartitions = 2
-    sc = new SparkContext("local[2]", "test")
-
-    val attempt0Latch = new TestLatch("attempt0")
-    val attempt1Latch = new TestLatch("attempt1")
-
-    val x = sc.parallelize(1 to 100, numPartitions).groupBy(identity)
-    val sid = x.dependencies.head.asInstanceOf[ShuffleDependency[_, _, _]].shuffleHandle.shuffleId
-    val rdd = x.mapPartitionsWithIndex { case (i, iter) =>
-      val taskContext = TaskContext.get()
-      if (taskContext.stageAttemptNumber() == 0) {
-        if (i == 0) {
-          // Fail the first task in the first stage attempt to force retry.
-          throw new FetchFailedException(
-            SparkEnv.get.blockManager.blockManagerId,
-            sid,
-            taskContext.partitionId(),
-            taskContext.partitionId(),
-            "simulated fetch failure")
-        } else {
-          // Wait till the second attempt starts.
-          attempt0Latch.await()
-          iter
-        }
-      } else {
-        if (i == 0) {
-          // Wait till the first attempt completes.
-          attempt1Latch.await()
-        }
-        iter
-      }
-    }
-
-    sc.addSparkListener(new SparkListener {
-      override def onTaskStart(taskStart: SparkListenerTaskStart): Unit = {
-        if (taskStart.stageId == 1 && taskStart.stageAttemptId == 1) {
-          // Second attempt started, force GC to collect accumulators and
-          // resume the first attempt.
-          System.gc()
-          attempt0Latch.signal()
-        }
-      }
-
-      override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
-        if (taskEnd.stageId == 1 && taskEnd.stageAttemptId == 0 && taskEnd.taskInfo.index == 1) {
-          // First attempt completed, resume the job.
-          attempt1Latch.signal()
-        }
-      }
-    })
-
-    rdd.count()
-  }
 }
 
 private[spark] object AccumulatorSuite {
@@ -407,30 +347,5 @@ private class SaveInfoListener extends SparkListener {
   override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
     completedTaskInfos.getOrElseUpdate(
       (taskEnd.stageId, taskEnd.stageAttemptId), new ArrayBuffer[TaskInfo]) += taskEnd.taskInfo
-  }
-}
-
-/**
- * A simple latch to synchronize driver and executors in local mode.
- * After deserialization on executor it will still use the same
- * internalized string object for synchronization.
- */
-private class TestLatch(name: String) extends Serializable {
-
-  sys.props.remove(name)
-
-  def await(): Unit = {
-    name.intern().synchronized {
-      if (!sys.props.contains(name)) {
-        name.intern().wait()
-      }
-    }
-  }
-
-  def signal(): Unit = {
-    name.intern().synchronized {
-      sys.props.put(name, "")
-      name.intern().notifyAll()
-    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

There's a period of time when an accumulator has been garbage collected, but hasn't been removed from AccumulatorContext.originals by ContextCleaner. When an update is received for such accumulator it will throw an exception and kill the whole job. This can happen when a stage completes, but there're still running tasks from other attempts, speculation etc. Since AccumulatorContext.get() returns an option we can just return None in such case.

## How was this patch tested?

Unit test.
