### PR TITLE
[SPARK-24052][CORE][UI] Add spark version information on environment page

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -467,6 +467,39 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>buildnumber-maven-plugin</artifactId>
+        <version>1.2</version>
+        <configuration>
+          <revisionOnScmFailure>UNKNOWN</revisionOnScmFailure>
+          <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>create</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>templating-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <executions>
+          <execution>
+            <id>generate-version-class</id>
+            <goals>
+              <goal>filter-sources</goal>
+            </goals>
+            <configuration>
+              <sourceDirectory>${basedir}/src/main/templates</sourceDirectory>
+              <outputDirectory>${project.build.directory}/generated-sources/java</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -23,9 +23,7 @@ import java.util.Locale
 
 import scala.collection.mutable
 import scala.util.Properties
-
 import com.google.common.collect.MapMaker
-
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.api.python.PythonWorkerFactory
 import org.apache.spark.broadcast.BroadcastManager
@@ -415,7 +413,10 @@ object SparkEnv extends Logging {
     val jvmInformation = Seq(
       ("Java Version", s"$javaVersion ($javaVendor)"),
       ("Java Home", javaHome),
-      ("Scala Version", versionString)
+      ("Scala Version", versionString),
+      ("Spark Version", Version.getVersion),
+      ("Spark Revision", Version.getRevision),
+      ("Spark Build Info", Version.getBuildInfo)
     ).sorted
 
     // Spark properties
@@ -426,7 +427,8 @@ object SparkEnv extends Logging {
       } else {
         Seq.empty[(String, String)]
       }
-    val sparkProperties = (conf.getAll ++ schedulerMode).sorted
+    val sparkVersion = Seq(("spark.version", Version.getVersion))
+    val sparkProperties = (conf.getAll ++ schedulerMode ++ sparkVersion).sorted
 
     // System properties that are not java classpaths
     val systemProperties = Utils.getSystemProperties.toSeq

--- a/core/src/main/templates/Version.java
+++ b/core/src/main/templates/Version.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Date;
+
+public final class Version {
+  private static final Logger LOG = LoggerFactory.getLogger(Version.class);
+
+  private static final String VERSION = "${project.version}";
+
+  private static final String URL = "${project.scm.url}";
+  private static final String BRANCH = "${scmBranch}";
+  private static final String REVISION = "${buildNumber}";
+  private static final long timestamp = ${timestamp}L;
+
+  private static final String username = "${user.name}";
+
+  public static String getVersion() {
+    return VERSION;
+  }
+
+  public static String getUrl() {
+    return URL;
+  }
+
+  public static String getRevision() {
+    return REVISION;
+  }
+
+  public static String getBranch() {
+    return BRANCH;
+  }
+
+  public static String getUser() {
+    return username;
+  }
+
+  public static Date getDate() {
+    return new Date(timestamp);
+  }
+
+  public static String getBuildInfo() {
+    return "Compiled by " + getUser() + " on " + getDate();
+  }
+
+  static String[] versionReport() {
+    return new String[]{
+        "Spark " + getVersion(),
+        "Source code repository " + getUrl() + " revision " + getRevision(),
+        "Compiled by " + getUser() + " on " + getDate()
+    };
+  }
+
+  public static void logVersion() {
+    for (String line : versionReport()) {
+      LOG.info(line);
+    }
+  }
+
+  public static void main(String[] args) {
+    logVersion();
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since we may have multiple version in production cluster,we can showing some information on environment page like below:
![environment-page](https://user-images.githubusercontent.com/26762018/39121222-8b0bba5a-4723-11e8-8d52-b1a5ede9b0e7.png)


## How was this patch tested?
Exist UT
