### PR TITLE
[SPARK-24053][CORE] Support add subdirectory named as user name on staging directory

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -127,7 +127,14 @@ private[spark] class Client(
 
   // The app staging dir based on the STAGING_DIR configuration if configured
   // otherwise based on the users home directory.
-  private val appStagingBaseDir = sparkConf.get(STAGING_DIR).map { new Path(_) }
+  private val appStagingBaseDir = sparkConf.get(STAGING_DIR)
+    .map {
+      if (sparkConf.get(ENABLE_USERLEVEL_STAGING_DIR)) {
+        new Path(_, UserGroupInformation.getCurrentUser.getShortUserName)
+      } else {
+        new Path(_)
+      }
+    }
     .getOrElse(FileSystem.get(hadoopConf).getHomeDirectory())
 
   def reportLauncherState(state: SparkAppHandle.State): Unit = {

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -127,6 +127,12 @@ package object config {
     .stringConf
     .createOptional
 
+  private[spark] val ENABLE_USERLEVEL_STAGING_DIR =
+    ConfigBuilder("spark.yarn.staging.enable.userLevel")
+    .doc("Enable to add subdirectory for STAGING_DIR which named as login user.")
+    .booleanConf
+    .createWithDefault(false)
+
   /* Launcher configuration. */
 
   private[spark] val WAIT_FOR_APP_COMPLETION = ConfigBuilder("spark.yarn.submit.waitAppCompletion")


### PR DESCRIPTION
## What changes were proposed in this pull request?

When we have multiple users on the same cluster,we can support add subdirectory which named as login user

## How was this patch tested?
Exist UT
