### PR TITLE
[SPARK-24056] [SS] Make consumer creation lazy in Kafka source for Structured streaming

### DIFF
--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReader.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReader.scala
@@ -53,7 +53,7 @@ private[kafka010] class KafkaOffsetReader(
    */
   val kafkaReaderThread = Executors.newSingleThreadExecutor(new ThreadFactory {
     override def newThread(r: Runnable): Thread = {
-      val t = new UninterruptibleThread(s"Kafka Offset Reader") {
+      val t = new UninterruptibleThread("Kafka Offset Reader") {
         override def run(): Unit = {
           r.run()
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, the driver side of the Kafka source (i.e. KafkaMicroBatchReader) eagerly creates a consumer as soon as the Kafk aMicroBatchReader is created. However, we create dummy KafkaMicroBatchReader to get the schema and immediately stop it. Its better to make the consumer creation lazy, it will be created on the first attempt to fetch offsets using the KafkaOffsetReader.


## How was this patch tested?
Existing unit tests