### PR TITLE
[SPARK-24060][TEST] StreamingSymmetricHashJoinHelperSuite should initialize after SparkSession creation

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingSymmetricHashJoinHelperSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingSymmetricHashJoinHelperSuite.scala
@@ -35,8 +35,14 @@ class StreamingSymmetricHashJoinHelperSuite extends StreamTest {
   val rightColC = new Column(rightAttributeC)
   val rightColD = new Column(rightAttributeD)
 
-  val left = new LocalTableScanExec(Seq(leftAttributeA, leftAttributeB), Seq())
-  val right = new LocalTableScanExec(Seq(rightAttributeC, rightAttributeD), Seq())
+  var left: LocalTableScanExec = _
+  var right: LocalTableScanExec = _
+
+  protected override def beforeAll(): Unit = {
+    super.beforeAll()
+    left = new LocalTableScanExec(Seq(leftAttributeA, leftAttributeB), Seq())
+    right = new LocalTableScanExec(Seq(rightAttributeC, rightAttributeD), Seq())
+  }
 
   test("empty") {
     val split = JoinConditionSplitPredicates(None, left, right)


### PR DESCRIPTION
## What changes were proposed in this pull request?
We should ensure that the SparkSession for this test suite has initialized before creating the LocalTableScanExecs

## How was this patch tested?
Existing tests 
