### PR TITLE
[SPARK-24075][MESOS] Option to limit number of retries for a supervised driver

### DIFF
--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -532,7 +532,14 @@ See the [configuration page](configuration.html) for information on Spark config
     for formatting information.
   </td>
 </tr>
-
+<tr>
+  <td><code>spark.mesos.driver.supervise.maxRetries</code></td>
+  <td><code>(none)</code></td>
+  <td>
+    Set the maximum number of times the driver should be retried in case
+    of failure. This setting takes effect only if supervise is enabled.
+  </td>
+</tr>
 <tr>
   <td>
     <code>spark.mesos.driver.secret.values</code>,


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Spark drivers run on mesos with supervise enabled will try the driver indefinitely on failures. This PR is to optionally limit the number of retries to a configurable number.
* Introducing sparkConf "spark.mesos.driver.supervise.maxRetries" which limits the number of times the driver can be retried. The default behavior is for the driver to be retried indefinitely.
* When the check is made to see if supervise is enabled and the job has to be retried, an additional check is made to see if the allowable retries have been exceeded.
* Added unit tests for method hasDriverExceededRetries.
* Added documentation for "spark.mesos.driver.supervise.maxRetries".

## How was this patch tested?

Added unit tests

Built spark package, dockerized it and deployed it as a service on Mesos. Once spark service was running on mesos, a series of drivers were submitted

1. With supervise disabled, ran a successful driver
2. With supervise disabled, ran a failure driver
3. With supervise enabled, ran a successful driver
4. With supervise enabled and without setting "spark.mesos.driver.supervise.maxRetries", ran failure driver
5. With supervise enabled and setting "spark.mesos.driver.supervise.maxRetries=1", ran a failure driver
6. With supervise enabled and setting "spark.mesos.driver.supervise.maxRetries=3", ran a failure driver
