### PR TITLE
[SPARK-21645]left outer join synchronize the condition from left table to right

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -138,7 +138,7 @@ object EliminateOuterJoin extends Rule[LogicalPlan] with PredicateHelper {
 
     join.joinType match {
       case RightOuter if leftHasNonNullPredicate => Inner
-      case LeftOuter if rightHasNonNullPredicate => Inner
+      case LeftOuter if rightHasNonNullPredicate => LeftOuter
       case FullOuter if leftHasNonNullPredicate && rightHasNonNullPredicate => Inner
       case FullOuter if leftHasNonNullPredicate => LeftOuter
       case FullOuter if rightHasNonNullPredicate => RightOuter

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -317,6 +317,8 @@ case class Join(
         left.constraints
       case LeftOuter =>
         left.constraints
+          .union(right.constraints)
+          .union(splitConjunctivePredicates(condition.get).toSet)
       case RightOuter =>
         right.constraints
       case FullOuter =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

JIRA Issue:https://issues.apache.org/jira/browse/SPARK-21645
Change the optimize rule of leftouter join, if the filter column is contained in join column, the can synchronize the filter from left to right, For example,  left join sql:
Select * from a left outer join b on a.id=b.id where a.id=12345；

After join optimizer rule, the filter a.id = 12345 of table a should be synchronized to table b(b.id=12345)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

To see the query plan by explain the sql like 'Select * from a left outer join b on a.id=b.id where a.id=12345',  guarantee the filter a.id=12345 is synchronized to table b.