### PR TITLE
[SPARK-11334][CORE] clear idle executors in executorIdToTaskIds keySet

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -699,6 +699,12 @@ private[spark] class ExecutorAllocationManager(
         // This is needed in case the stage is aborted for any reason
         if (stageIdToNumTasks.isEmpty && stageIdToNumSpeculativeTasks.isEmpty) {
           allocationManager.onSchedulerQueueEmpty()
+          if (executorIdToTaskIds.nonEmpty) {
+            log.warn(s"There are no running tasks," +
+              s" but ${executorIdToTaskIds.size} executors are not idle")
+            executorIdToTaskIds.keySet.foreach(allocationManager.onExecutorIdle)
+            executorIdToTaskIds.clear()
+          }
         }
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

quote from #11205 

> Executors may never be idle. Currently we use the executor to tasks mapping relation to identify the status of executors, in maximum task failure situation, some TaskEnd events may never be delivered, which makes the related executor always be busy.

#19580 fix the incorrect number of running tasks.

This PR solves the problem in a similar way on the `fact` that TaskEnd events may never be delivered but StageCompleted events would be delivered eventually.

## How was this patch tested?

Existing tests
