### PR TITLE
[SPARK-23120][PYSPARK][ML] Add basic PMML export support to PySpark

### DIFF
--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -95,6 +95,7 @@ class LinearRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPrediction
     True
     >>> model.numFeatures
     1
+    >>> model.write().format("pmml").save(model_path + "_2")
 
     .. versionadded:: 1.4.0
     """
@@ -161,7 +162,7 @@ class LinearRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPrediction
         return self.getOrDefault(self.epsilon)
 
 
-class LinearRegressionModel(JavaModel, JavaPredictionModel, JavaMLWritable, JavaMLReadable):
+class LinearRegressionModel(JavaModel, JavaPredictionModel, GeneralJavaMLWritable, JavaMLReadable):
     """
     Model fitted by :class:`LinearRegression`.
 

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -1370,7 +1370,7 @@ class PersistenceTest(SparkSessionTestCase):
         pmml_text_list = self.sc.textFile(lr_path).collect()
         pmml_text = "\n".join(pmml_text_list)
         self.assertIn("Apache Spark", pmml_text)
-        self.assertIn("xs:element", pmml_text)
+        self.assertIn("PMML", pmml_text)
 
     def test_logistic_regression(self):
         lr = LogisticRegression(maxIter=1)

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -1368,8 +1368,8 @@ class PersistenceTest(SparkSessionTestCase):
         lr_path = path + "/lr-pmml"
         model.write().format("pmml").save(lr_path)
         pmml_text = self.sc.textFile(lr_path).collect()
-        self.assertTrue("Apache Spark" in pmml_text)
-        self.assertTrue("xs:element" in pmml_text)
+        self.assertIn("Apache Spark", pmml_text)
+        self.assertIn("xs:element", pmml_text)
 
     def test_logistic_regression(self):
         lr = LogisticRegression(maxIter=1)

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -1367,7 +1367,8 @@ class PersistenceTest(SparkSessionTestCase):
         path = tempfile.mkdtemp()
         lr_path = path + "/lr-pmml"
         model.write().format("pmml").save(lr_path)
-        pmml_text = self.sc.textFile(lr_path).collect()
+        pmml_text_list = self.sc.textFile(lr_path).collect()
+        pmml_text = "\n".join(pmml_text_list)
         self.assertIn("Apache Spark", pmml_text)
         self.assertIn("xs:element", pmml_text)
 

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -148,6 +148,23 @@ class MLWriter(BaseReadWrite):
 
 
 @inherit_doc
+class GeneralMLWriter(MLWriter):
+    """
+    Utility class that can save ML instances in different formats.
+
+    .. versionadded:: 2.4.0
+    """
+
+    def format(self, source):
+        """
+        Specifies the format of ML export (e.g. "pmml", "internal", or the fully qualified class
+        name for export).
+        """
+        self.source = source
+        return self
+
+
+@inherit_doc
 class JavaMLWriter(MLWriter):
     """
     (Private) Specialization of :py:class:`MLWriter` for :py:class:`JavaParams` types
@@ -192,6 +209,24 @@ class JavaMLWriter(MLWriter):
 
 
 @inherit_doc
+class GeneralJavaMLWriter(JavaMLWriter):
+    """
+    (Private) Specialization of :py:class:`GeneralMLWriter` for :py:class:`JavaParams` types
+    """
+
+    def __init__(self, instance):
+        super(GeneralJavaMLWriter, self).__init__(instance)
+
+    def format(self, source):
+        """
+        Specifies the format of ML export (e.g. "pmml", "internal", or the fully qualified class
+        name for export).
+        """
+        self._jwrite.format(source)
+        return self
+
+
+@inherit_doc
 class MLWritable(object):
     """
     Mixin for ML instances that provide :py:class:`MLWriter`.
@@ -217,6 +252,17 @@ class JavaMLWritable(MLWritable):
     def write(self):
         """Returns an MLWriter instance for this ML instance."""
         return JavaMLWriter(self)
+
+
+@inherit_doc
+class GeneralJavaMLWritable(JavaMLWritable):
+    """
+    (Private) Mixin for ML instances that provide :py:class:`GeneralJavaMLWriter`.
+    """
+
+    def write(self):
+        """Returns an GeneralMLWriter instance for this ML instance."""
+        return GeneralJavaMLWriter(self)
 
 
 @inherit_doc


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds basic PMML export support for Spark ML stages to PySpark as was previously done in Scala. Includes LinearRegressionModel as the first stage to implement.

## How was this patch tested?

Doctest, the main testing work for this is on the Scala side. (TODO holden add the unittest once I finish locally).