### PR TITLE
[SPARK-24110][Thrift-Server] Avoid UGI.loginUserFromKeytab in STS

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/HiveAuthFactory.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/HiveAuthFactory.java
@@ -103,6 +103,8 @@ public class HiveAuthFactory {
       keytabFile = clz.getDeclaredField("keytabFile");
       keytabFile.setAccessible(true);
     } catch (NoSuchFieldException nfe) {
+      LOG.debug("Cannot find private field \"keytabFile\" in class: " +
+        UserGroupInformation.class.getCanonicalName(), nfe);
       keytabFile = null;
     }
 
@@ -110,6 +112,8 @@ public class HiveAuthFactory {
       getKeytab = clz.getDeclaredMethod("getKeytab");
       getKeytab.setAccessible(true);
     } catch(NoSuchMethodException nme) {
+      LOG.debug("Cannot find private method \"getKeytab\" in class:" +
+        UserGroupInformation.class.getCanonicalName(), nme);
       getKeytab = null;
     }
   }
@@ -407,6 +411,7 @@ public class HiveAuthFactory {
           return null;
         }
       } catch (Exception e) {
+        LOG.debug("Fail to get keytabFile path via reflection", e);
         return null;
       }
     }

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/HiveAuthFactory.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/HiveAuthFactory.java
@@ -22,7 +22,13 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 
 import javax.net.ssl.SSLServerSocket;
 import javax.security.auth.login.LoginException;
@@ -381,11 +387,11 @@ public class HiveAuthFactory {
       }
     } catch (NoSuchFieldException nfe) {
       try {
+        // In Hadoop 3 we don't have "keytabFile" field, instead we should use private method
+        // getKeytab().
         Method method = clz.getDeclaredMethod("getKeytab");
         method.setAccessible(true);
         synchronized (clz) {
-          // In Hadoop 3 we don't have "keytabFile" field, instead we should use private method
-          // getKeytab().
           return (String) method.invoke(UserGroupInformation.getCurrentUser());
         }
       } catch (Exception e) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spark ThriftServer will call UGI.loginUserFromKeytab twice in initialization. This is unnecessary and will cause various potential problems, like Hadoop IPC failure after 7 days, or RM failover issue and so on.

So here we need to remove all the unnecessary login logics and make sure UGI in the context never be created again.

Note this is actually a HS2 issue, If later on we upgrade supported Hive version, the issue may already be fixed in Hive side.

## How was this patch tested?

Local verification in secure cluster.
