### PR TITLE
[SPARK-24134][Docs]A missing full-stop in doc "Tuning Spark".

### DIFF
--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -132,7 +132,7 @@ The best way to size the amount of memory consumption a dataset will require is 
 into cache, and look at the "Storage" page in the web UI. The page will tell you how much memory the RDD
 is occupying.
 
-To estimate the memory consumption of a particular object, use `SizeEstimator`'s `estimate` method
+To estimate the memory consumption of a particular object, use `SizeEstimator`'s `estimate` method.
 This is useful for experimenting with different data layouts to trim memory usage, as well as
 determining the amount of space a broadcast variable will occupy on each executor heap.
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the document [Tuning Spark -> Determining Memory Consumption](https://spark.apache.org/docs/latest/tuning.html#determining-memory-consumption), a full stop was missing in the second paragraph.

It's `...use SizeEstimator’s estimate method This is useful for experimenting...`, while there is supposed to be a full stop before `This`.

Screenshot showing before change is attached below.
<img width="1033" alt="screen shot 2018-05-01 at 5 22 32 pm" src="https://user-images.githubusercontent.com/11539188/39468206-778e3d8a-4d64-11e8-8a92-38464952b54b.png">


## How was this patch tested?

This is a simple change in doc. Only one full stop was added in plain text.



Please review http://spark.apache.org/contributing.html before opening a pull request.
