### PR TITLE
[SPARK-24133][SQL] Check for integer overflows when resizing WritableColumnVectors

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
@@ -99,7 +99,7 @@ public abstract class WritableColumnVector extends ColumnVector {
 
   private void throwUnsupportedException(int requiredCapacity, Throwable cause) {
     String message = "Cannot reserve additional contiguous bytes in the vectorized reader (" +
-        (requiredCapacity >= 0 ?"requested " + requiredCapacity + " bytes" : "integer overflow") +
+        (requiredCapacity >= 0 ? "requested " + requiredCapacity + " bytes" : "integer overflow") +
         "). As a workaround, you can reduce the vectorized reader batch size, or disable the " +
         "vectorized reader. For parquet file format, refer to " +
         SQLConf.PARQUET_VECTORIZED_READER_BATCH_SIZE().key() +

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
@@ -92,17 +92,20 @@ public abstract class WritableColumnVector extends ColumnVector {
       } else {
         throwUnsupportedException(requiredCapacity, null);
       }
+    } else if (requiredCapacity < 0) {
+      throwUnsupportedException(requiredCapacity, null);
     }
   }
 
   private void throwUnsupportedException(int requiredCapacity, Throwable cause) {
-    String message = "Cannot reserve additional contiguous bytes in the vectorized reader " +
-        "(requested = " + requiredCapacity + " bytes). As a workaround, you can disable the " +
-        "vectorized reader, or increase the vectorized reader batch size. For parquet file " +
-        "format, refer to " + SQLConf.PARQUET_VECTORIZED_READER_ENABLED().key() + " and " +
-        SQLConf.PARQUET_VECTORIZED_READER_BATCH_SIZE().key() + "; for orc file format, refer to " +
-        SQLConf.ORC_VECTORIZED_READER_ENABLED().key() + " and " +
-        SQLConf.ORC_VECTORIZED_READER_BATCH_SIZE().key() + ".";
+    String message = "Cannot reserve additional contiguous bytes in the vectorized reader (" +
+        (requiredCapacity >= 0 ?"requested " + requiredCapacity + " bytes" : "integer overflow") +
+        "). As a workaround, you can reduce the vectorized reader batch size, or disable the " +
+        "vectorized reader. For parquet file format, refer to " +
+        SQLConf.PARQUET_VECTORIZED_READER_BATCH_SIZE().key() + " and " +
+        SQLConf.PARQUET_VECTORIZED_READER_ENABLED().key() + "; for orc file format, refer to " +
+        SQLConf.ORC_VECTORIZED_READER_BATCH_SIZE().key() + " and " +
+        SQLConf.ORC_VECTORIZED_READER_ENABLED().key() + ".";
     throw new RuntimeException(message, cause);
   }
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
@@ -81,7 +81,9 @@ public abstract class WritableColumnVector extends ColumnVector {
   }
 
   public void reserve(int requiredCapacity) {
-    if (requiredCapacity > capacity) {
+    if (requiredCapacity < 0) {
+      throwUnsupportedException(requiredCapacity, null);
+    } else if (requiredCapacity > capacity) {
       int newCapacity = (int) Math.min(MAX_CAPACITY, requiredCapacity * 2L);
       if (requiredCapacity <= newCapacity) {
         try {
@@ -92,8 +94,6 @@ public abstract class WritableColumnVector extends ColumnVector {
       } else {
         throwUnsupportedException(requiredCapacity, null);
       }
-    } else if (requiredCapacity < 0) {
-      throwUnsupportedException(requiredCapacity, null);
     }
   }
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
@@ -102,10 +102,12 @@ public abstract class WritableColumnVector extends ColumnVector {
         (requiredCapacity >= 0 ?"requested " + requiredCapacity + " bytes" : "integer overflow") +
         "). As a workaround, you can reduce the vectorized reader batch size, or disable the " +
         "vectorized reader. For parquet file format, refer to " +
-        SQLConf.PARQUET_VECTORIZED_READER_BATCH_SIZE().key() + " and " +
-        SQLConf.PARQUET_VECTORIZED_READER_ENABLED().key() + "; for orc file format, refer to " +
-        SQLConf.ORC_VECTORIZED_READER_BATCH_SIZE().key() + " and " +
-        SQLConf.ORC_VECTORIZED_READER_ENABLED().key() + ".";
+        SQLConf.PARQUET_VECTORIZED_READER_BATCH_SIZE().key() +
+        " (default " + SQLConf.PARQUET_VECTORIZED_READER_BATCH_SIZE().defaultValueString() +
+        ") and " + SQLConf.PARQUET_VECTORIZED_READER_ENABLED().key() + "; for orc file format, " +
+        "refer to " + SQLConf.ORC_VECTORIZED_READER_BATCH_SIZE().key() +
+        " (default " + SQLConf.ORC_VECTORIZED_READER_BATCH_SIZE().defaultValueString() +
+        ") and " + SQLConf.ORC_VECTORIZED_READER_ENABLED().key() + ".";
     throw new RuntimeException(message, cause);
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -32,9 +32,8 @@ import org.apache.spark.memory.MemoryMode
 import org.apache.spark.sql.{RandomDataGenerator, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.arrow.ArrowUtils
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch}
+import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch, ColumnVector}
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.unsafe.types.CalendarInterval
 
@@ -1338,7 +1337,7 @@ class ColumnarBatchSuite extends SparkFunSuite {
   testVector("WritableColumnVector.reserve(): requested capacity is negative", 1024, ByteType) {
     column =>
       val ex = intercept[RuntimeException] { column.reserve(-1) }
-      assert(ex.getMessage.contains(SQLConf.PARQUET_VECTORIZED_READER_BATCH_SIZE.key))
-      assert(ex.getMessage.contains("integer overflow"))
+      assert(ex.getMessage.contains(
+          "Cannot reserve additional contiguous bytes in the vectorized reader (integer overflow)"))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -1337,7 +1337,7 @@ class ColumnarBatchSuite extends SparkFunSuite {
 
   testVector("WritableColumnVector.reserve(): requested capacity is too large", 1024, ByteType) {
     column =>
-      val capacity = Integer.MAX_VALUE - 1
+      val capacity = column.MAX_CAPACITY + 1
       val ex = intercept[RuntimeException] { column.reserve(capacity) }
       assert(ex.getMessage.contains(SQLConf.PARQUET_VECTORIZED_READER_BATCH_SIZE.key))
       assert(ex.getMessage.contains(capacity.toString))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -1335,14 +1335,6 @@ class ColumnarBatchSuite extends SparkFunSuite {
       column.close()
   }
 
-  testVector("WritableColumnVector.reserve(): requested capacity is too large", 1024, ByteType) {
-    column =>
-      val capacity = column.MAX_CAPACITY + 1
-      val ex = intercept[RuntimeException] { column.reserve(capacity) }
-      assert(ex.getMessage.contains(SQLConf.PARQUET_VECTORIZED_READER_BATCH_SIZE.key))
-      assert(ex.getMessage.contains(capacity.toString))
-  }
-
   testVector("WritableColumnVector.reserve(): requested capacity is negative", 1024, ByteType) {
     column =>
       val ex = intercept[RuntimeException] { column.reserve(-1) }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ColumnVector`s store string data in one big byte array. Since the array size is capped at just under Integer.MAX_VALUE, a single `ColumnVector` cannot store more than 2GB of string data.
But since the Parquet files commonly contain large blobs stored as strings, and `ColumnVector`s by default carry 4096 values, it's entirely possible to go past that limit. In such cases a negative capacity is requested from `WritableColumnVector.reserve()`. The call succeeds (requested capacity is smaller than already allocated capacity), and consequently `java.lang.ArrayIndexOutOfBoundsException` is thrown when the reader actually attempts to put the data into the array.

This change introduces a simple check for integer overflow to `WritableColumnVector.reserve()` which should help catch the error earlier and provide more informative exception. Additionally, the error message in `WritableColumnVector.throwUnsupportedException()` was corrected, as it previously encouraged users to increase rather than reduce the batch size.

## How was this patch tested?

New units tests were added.
