### PR TITLE
[SPARK-24131][PYSPARK][Followup] Add majorMinorVersion API to PySpark for determining Spark versions

### DIFF
--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -2303,6 +2303,15 @@ class UtilTests(PySparkTestCase):
 
         self.assertTrue('NullPointerException' in _exception_message(context.exception))
 
+    def test_parsing_version_string(self):
+        from pyspark.util import VersionUtils
+
+        (major, minor) = VersionUtils.majorMinorVersion("2.4.0")
+        self.assertEqual(major, 2)
+        self.assertEqual(minor, 4)
+
+        self.assertRaises(ValueError, lambda: VersionUtils.majorMinorVersion("abced"))
+
 
 @unittest.skipIf(not _have_scipy, "SciPy not installed")
 class SciPyTests(PySparkTestCase):

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -2305,11 +2305,6 @@ class UtilTests(PySparkTestCase):
 
     def test_parsing_version_string(self):
         from pyspark.util import VersionUtils
-
-        (major, minor) = VersionUtils.majorMinorVersion("2.4.0")
-        self.assertEqual(major, 2)
-        self.assertEqual(minor, 4)
-
         self.assertRaises(ValueError, lambda: VersionUtils.majorMinorVersion("abced"))
 
 

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -67,23 +67,26 @@ class VersionUtils(object):
     Provides utility method to determine Spark versions with given input string.
     """
     @staticmethod
-    def majorMinorVersion(version):
+    def majorMinorVersion(sparkVersion):
         """
-        Get major and minor version numbers for given Spark version string.
+        Given a Spark version string, return the (major version number, minor version number).
+        E.g., for 2.0.1-SNAPSHOT, return (2, 0).
 
-        >>> version = "2.4.0"
-        >>> majorMinorVersion(version)
+        >>> sparkVersion = "2.4.0"
+        >>> VersionUtils.majorMinorVersion(sparkVersion)
         (2, 4)
-        >>> version = "2.3.0-SNAPSHOT"
-        >>> majorMinorVersion(version)
+        >>> sparkVersion = "2.3.0-SNAPSHOT"
+        >>> VersionUtils.majorMinorVersion(sparkVersion)
         (2, 3)
 
         """
-        m = re.search('^(\d+)\.(\d+)(\..*)?$', version)
-        if m is None:
-            raise ValueError("invalid version string: " + version)
-        else:
+        m = re.search('^(\d+)\.(\d+)(\..*)?$', sparkVersion)
+        if m is not None:
             return (int(m.group(1)), int(m.group(2)))
+        else:
+            raise ValueError("Spark tried to parse '%s' as a Spark" % sparkVersion +
+                             " version string, but it could not find the major and minor" +
+                             " version numbers.")
 
 
 if __name__ == "__main__":

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -62,24 +62,28 @@ def _get_argspec(f):
     return argspec
 
 
-def majorMinorVersion(version):
+class VersionUtils(object):
     """
-    Get major and minor version numbers for given Spark version string.
-
-    >>> version = "2.4.0"
-    >>> majorMinorVersion(version)
-    (2, 4)
-
-    >>> version = "abc"
-    >>> majorMinorVersion(version) is None
-    True
-
+    Provides utility method to determine Spark versions with given input string.
     """
-    m = re.search('^(\d+)\.(\d+)(\..*)?$', version)
-    if m is None:
-        return None
-    else:
-        return (int(m.group(1)), int(m.group(2)))
+    @staticmethod
+    def majorMinorVersion(version):
+        """
+        Get major and minor version numbers for given Spark version string.
+
+        >>> version = "2.4.0"
+        >>> majorMinorVersion(version)
+        (2, 4)
+        >>> version = "2.3.0-SNAPSHOT"
+        >>> majorMinorVersion(version)
+        (2, 3)
+
+        """
+        m = re.search('^(\d+)\.(\d+)(\..*)?$', version)
+        if m is None:
+            raise ValueError("invalid version string: " + version)
+        else:
+            return (int(m.group(1)), int(m.group(2)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changes were proposed in this pull request?

More close to Scala API behavior when can't parse input by throwing exception. Add tests.

## How was this patch tested?

Added tests.