### PR TITLE
[SPARK-24120] Show `Jobs` page when `jobId` is missing

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -208,7 +208,8 @@ private[spark] object UIUtils extends Logging {
       refreshInterval: Option[Int] = None,
       helpText: Option[String] = None,
       showVisualization: Boolean = false,
-      useDataTables: Boolean = false): Seq[Node] = {
+      useDataTables: Boolean = false,
+      redirectPath: Option[String] = None) : Seq[Node] = {
 
     val appName = activeTab.appName
     val shortAppName = if (appName.length < 36) appName else appName.take(32) + "..."
@@ -218,12 +219,16 @@ private[spark] object UIUtils extends Logging {
       </li>
     }
     val helpButton: Seq[Node] = helpText.map(tooltip(_, "bottom")).getOrElse(Seq.empty)
+    val redirectMetaContent: Option[Node] = redirectPath.map{ path =>
+      <meta http-equiv="refresh" content={s"0; url=${prependBaseUri(path)}"} />
+    }
 
     <html>
       <head>
         {commonHeaderNodes}
         {if (showVisualization) vizHeaderNodes else Seq.empty}
         {if (useDataTables) dataTablesHeaderNodes else Seq.empty}
+        {if (redirectMetaContent.isDefined) redirectMetaContent.get}
         <link rel="shortcut icon" href={prependBaseUri("/static/spark-logo-77x50px-hd.png")}></link>
         <title>{appName} - {title}</title>
       </head>

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
@@ -186,7 +186,14 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
   def render(request: HttpServletRequest): Seq[Node] = {
     // stripXSS is called first to remove suspicious characters used in XSS attacks
     val parameterId = UIUtils.stripXSS(request.getParameter("id"))
-    require(parameterId != null && parameterId.nonEmpty, "Missing id parameter")
+    if (parameterId == null || parameterId.isEmpty) {
+      val content =
+        <div id="no-info">
+          <p>Missing id parameter. Will redirect to Jobs page</p>
+        </div>
+      return UIUtils.headerSparkPage(
+        "Missing Job Id", content, parent, redirectPath = Some(s"/${parent.name}"))
+    }
 
     val jobId = parameterId.toInt
     val jobData = store.asOption(store.job(jobId)).getOrElse {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Change the case which doesn't have jobId as a parameter so that it will redirect to `Jobs` page.

## How was this patch tested?
1. Build with this PR
1. Access http://<fqcn>:4040/jobs/job without any specific `jobId` parameter
1. Check to be redirected to http://<fqcn>:4040/jobs