### PR TITLE
[SPARK-24149][YARN] Retrieve all federated namespaces tokens

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -426,8 +426,10 @@ To use a custom metrics.properties for the application master and executors, upd
 Standard Kerberos support in Spark is covered in the [Security](security.html#kerberos) page.
 
 In YARN mode, when accessing Hadoop file systems, aside from the service hosting the user's home
-directory, Spark will also automatically obtain delegation tokens for the service hosting the
-staging directory of the Spark application.
+directory, Spark will also automatically obtain delegation tokens for:
+
+- the filesystem hosting the staging directory of the Spark application;
+- if Hadoop federation is enabled, all the federated filesystems in the configuration.
 
 If an application needs to interact with other secure Hadoop filesystems, their URIs need to be
 explicitly provided to Spark at launch time. This is done by listing them in the

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -425,10 +425,11 @@ To use a custom metrics.properties for the application master and executors, upd
 
 Standard Kerberos support in Spark is covered in the [Security](security.html#kerberos) page.
 
-In YARN mode, when accessing Hadoop file systems, aside from the service hosting the user's home
-directory, Spark will also automatically obtain delegation tokens for:
+In YARN mode, when accessing Hadoop filesystems, Spark will automatically obtain delegation tokens
+for:
 
-- the filesystem hosting the staging directory of the Spark application;
+- the filesystem hosting the staging directory of the Spark application (which is the default
+  filesystem if `spark.yarn.stagingDir` is not set);
 - if Hadoop federation is enabled, all the federated filesystems in the configuration.
 
 If an application needs to interact with other secure Hadoop filesystems, their URIs need to be

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -199,7 +199,7 @@ object YarnSparkHadoopUtil {
     // add the list of available namenodes for all namespaces in HDFS federation
     val hadoopFilesystems = Option(hadoopConf.get("dfs.nameservices"))
       .toSeq.flatMap(_.split(","))
-      .map(ns => hadoopConf.get(s"dfs.namenode.rpc-address.$ns"))
+      .flatMap(ns => Option(hadoopConf.get(s"dfs.namenode.rpc-address.$ns")))
       .map(nn => new Path(s"hdfs://$nn").getFileSystem(hadoopConf))
 
     val stagingFS = sparkConf.get(STAGING_DIR)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -196,11 +196,17 @@ object YarnSparkHadoopUtil {
       .map(new Path(_).getFileSystem(hadoopConf))
       .toSet
 
+    // add the list of available namenodes for all namespaces in HDFS federation
+    val hadoopFilesystems = Option(hadoopConf.get("dfs.nameservices"))
+      .toSeq.flatMap(_.split(","))
+      .map(ns => hadoopConf.get(s"dfs.namenode.rpc-address.$ns"))
+      .map(nn => new Path(s"hdfs://$nn").getFileSystem(hadoopConf))
+
     val stagingFS = sparkConf.get(STAGING_DIR)
       .map(new Path(_).getFileSystem(hadoopConf))
       .getOrElse(FileSystem.get(hadoopConf))
 
-    filesystemsToAccess + stagingFS
+    filesystemsToAccess ++ hadoopFilesystems + stagingFS
   }
 
 }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -209,13 +209,15 @@ object YarnSparkHadoopUtil {
       val nameservices = hadoopConf.getTrimmedStrings("dfs.nameservices")
       // Retrieving the filesystem for the nameservices where HA is not enabled
       val filesystemsWithoutHA = nameservices.flatMap { ns =>
-        Option(hadoopConf.get(s"dfs.namenode.rpc-address.$ns")).map(nameNode =>
-          Some(new Path(s"hdfs://$nameNode").getFileSystem(hadoopConf)))
+        Option(hadoopConf.get(s"dfs.namenode.rpc-address.$ns")).map { nameNode =>
+          new Path(s"hdfs://$nameNode").getFileSystem(hadoopConf)
+        }
       }
       // Retrieving the filesystem for the nameservices where HA is enabled
       val filesystemsWithHA = nameservices.flatMap { ns =>
-        Option(hadoopConf.get(s"dfs.ha.namenodes.$ns")).map(_ =>
-          Some(new Path(s"hdfs://$ns").getFileSystem(hadoopConf)))
+        Option(hadoopConf.get(s"dfs.ha.namenodes.$ns")).map { _ =>
+          new Path(s"hdfs://$ns").getFileSystem(hadoopConf)
+        }
       }
       (filesystemsWithoutHA ++ filesystemsWithHA).toSet
     }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -209,17 +209,13 @@ object YarnSparkHadoopUtil {
       val nameservices = hadoopConf.getTrimmedStrings("dfs.nameservices")
       // Retrieving the filesystem for the nameservices where HA is not enabled
       val filesystemsWithoutHA = nameservices.flatMap { ns =>
-        hadoopConf.get(s"dfs.namenode.rpc-address.$ns") match {
-          case null => None
-          case nameNode => Some(new Path(s"hdfs://$nameNode").getFileSystem(hadoopConf))
-        }
+        Option(hadoopConf.get(s"dfs.namenode.rpc-address.$ns")).map(nameNode =>
+          Some(new Path(s"hdfs://$nameNode").getFileSystem(hadoopConf)))
       }
       // Retrieving the filesystem for the nameservices where HA is enabled
       val filesystemsWithHA = nameservices.flatMap { ns =>
-        hadoopConf.get(s"dfs.ha.namenodes.$ns") match {
-          case null => None
-          case _ => Some(new Path(s"hdfs://$ns").getFileSystem(hadoopConf))
-        }
+        Option(hadoopConf.get(s"dfs.ha.namenodes.$ns")).map(_ =>
+          Some(new Path(s"hdfs://$ns").getFileSystem(hadoopConf)))
       }
       (filesystemsWithoutHA ++ filesystemsWithHA).toSet
     }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtilSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtilSuite.scala
@@ -181,7 +181,27 @@ class YarnSparkHadoopUtilSuite extends SparkFunSuite with Matchers with Logging
       new Path("hdfs://localhost:8020").getFileSystem(noFederationConf))
     val noFederationResult = YarnSparkHadoopUtil.hadoopFSsToAccess(sparkConf, noFederationConf)
     noFederationResult should be (noFederationExpected)
+
+    // federation and HA enabled
+    val federationAndHAConf = new Configuration()
+    federationAndHAConf.set("fs.defaultFS", "hdfs://clusterXHA")
+    federationAndHAConf.set("dfs.nameservices", "clusterXHA,clusterYHA")
+    federationAndHAConf.set("dfs.ha.namenodes.clusterXHA", "x-nn1,x-nn2")
+    federationAndHAConf.set("dfs.ha.namenodes.clusterYHA", "y-nn1,y-nn2")
+    federationAndHAConf.set("dfs.namenode.rpc-address.clusterXHA.x-nn1", "localhost:8020")
+    federationAndHAConf.set("dfs.namenode.rpc-address.clusterXHA.x-nn2", "localhost:8021")
+    federationAndHAConf.set("dfs.namenode.rpc-address.clusterYHA.y-nn1", "localhost:8022")
+    federationAndHAConf.set("dfs.namenode.rpc-address.clusterYHA.y-nn2", "localhost:8023")
+    federationAndHAConf.set("dfs.client.failover.proxy.provider.clusterXHA",
+      "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider")
+    federationAndHAConf.set("dfs.client.failover.proxy.provider.clusterYHA",
+      "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider")
+
+    val federationAndHAExpected = Set(
+      new Path("hdfs://clusterXHA").getFileSystem(federationAndHAConf),
+      new Path("hdfs://clusterYHA").getFileSystem(federationAndHAConf))
+    val federationAndHAResult = YarnSparkHadoopUtil.hadoopFSsToAccess(
+      sparkConf, federationAndHAConf)
+    federationAndHAResult should be (federationAndHAExpected)
   }
-
-
 }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtilSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtilSuite.scala
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.hadoop.yarn.api.records.ApplicationAccessType
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.scalatest.Matchers
+
 import org.apache.spark.{SecurityManager, SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hadoop 3 introduces HDFS federation. This means that multiple namespaces are allowed on the same HDFS cluster. In Spark, we need to ask the delegation token for all the namenodes (for each namespace), otherwise accessing any other namespace different from the default one (for which we already fetch the delegation token) fails.

The PR adds the automatic discovery of all the namenodes related to all the namespaces available according to the configs in hdfs-site.xml.

## How was this patch tested?

manual tests in dockerized env
