### PR TITLE
[SPARK-24161][SS] Enable debug package feature on structured streaming

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
@@ -108,11 +108,12 @@ package object debug {
    */
   def codegenString(query: StreamingQuery): String = {
     val msg = query match {
-      case w: StreamExecution if w.lastExecution != null =>
-        codegenString(w.lastExecution.executedPlan)
-
-      case w: StreamExecution if w.lastExecution == null =>
-        "No physical plan. Waiting for data."
+      case w: StreamExecution =>
+        if (w.lastExecution != null) {
+          codegenString(w.lastExecution.executedPlan)
+        } else {
+          "No physical plan. Waiting for data."
+        }
 
       case _ => "Only supported for StreamExecution."
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -577,8 +577,7 @@ class StreamSuite extends StreamTest {
       .format("memory")
       .trigger(Trigger.ProcessingTime("1 seconds"))
       .start()
-      .asInstanceOf[StreamingQueryWrapper]
-      .streamingQuery
+
     try {
       assert("No physical plan. Waiting for data." === codegenString(q))
       assert(codegenStringSeq(q).isEmpty)
@@ -616,12 +615,11 @@ class StreamSuite extends StreamTest {
       .format("memory")
       .trigger(Trigger.Continuous("1 seconds"))
       .start()
-      .asInstanceOf[StreamingQueryWrapper]
-      .streamingQuery
+
     try {
       // in continuous mode, the query will be run even there's no data
       // sleep a bit to ensure initialization
-      waitForLastExecution(q)
+      waitForLastExecution(q.asInstanceOf[StreamingQueryWrapper].streamingQuery)
 
       // just ensure that it doesn't raise any error
       // it will provide the message that continuous mode doesn't support debug

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -586,10 +586,6 @@ class StreamSuite extends StreamTest {
       inputData.addData(1, 2, 3, 4, 5)
       q.processAllAvailable()
 
-      // just ensure that it doesn't raise any error
-      // it will provide debug information on last execution
-      q.debug()
-
       val codegenStr = codegenString(q)
       assert(codegenStr.contains("Found 1 WholeStageCodegen subtrees."))
       // assuming that code is generated for the test query
@@ -623,10 +619,6 @@ class StreamSuite extends StreamTest {
       eventually(timeout(2.seconds), interval(100.milliseconds)) {
         assert(q.asInstanceOf[StreamingQueryWrapper].streamingQuery.lastExecution != null)
       }
-
-      // just ensure that it doesn't raise any error
-      // it will provide the message that continuous mode doesn't support debug
-      q.debug()
 
       val codegenStr = codegenString(q)
       assert(codegenStr.contains("Found 1 WholeStageCodegen subtrees."))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, debug package has a implicit class "DebugQuery" which matches Dataset to provide debug features on Dataset class. It doesn't work with structured streaming: it requires query is already started, and the information can be retrieved from StreamingQuery, not Dataset. I guess that's why "explain" had to be placed to StreamingQuery whereas it already exists on Dataset.

This patch adds a new implicit class "DebugStreamQuery" which matches StreamingQuery to provide similar debug features on StreamingQuery class.

## How was this patch tested?

Added relevant unit tests.