### PR TITLE
[SPARK-24135][K8s] Resilience to init-container errors on executors.

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -562,6 +562,13 @@ specific to Spark on Kubernetes.
     parallelism, e.g., number of tasks an executor can run concurrently is not affected by this.
 </tr>
 <tr>
+  <td><code>spark.kubernetes.executor.maxInitFailures</code></td>
+  <td>10</td>
+  <td>
+    Maximum number of times executors are allowed to fail with an Init:Error state before failing the application. Note that Init:Error failures should not be caused by Spark itself because Spark does not attach init-containers to pods. Init-containers can be attached by the cluster itself. Users should check with their cluster administrator if these kinds of failures to start the executor pod occur frequently.
+  </td>
+</tr>
+<tr>
   <td><code>spark.kubernetes.executor.limit.cores</code></td>
   <td>(none)</td>
   <td>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -117,6 +117,16 @@ private[spark] object Config extends Logging {
       .stringConf
       .createWithDefault("spark")
 
+  val KUBERNETES_EXECUTOR_MAX_INIT_ERRORS =
+    ConfigBuilder("spark.kubernetes.executor.maxInitFailures")
+      .doc("Maximum number of times executors are allowed to fail with an Init:Error state" +
+        " before failing the application. Note that Init:Error failures should not be caused" +
+        " by Spark itself because Spark does not attach init-containers to pods. Init-containers" +
+        " can be attached by the cluster itself. Users should check with their cluster" +
+        " administrator if these kinds of failures to start the executor pod occur frequently.")
+      .intConf
+      .createWithDefault(10)
+
   val KUBERNETES_ALLOCATION_BATCH_SIZE =
     ConfigBuilder("spark.kubernetes.allocation.batch.size")
       .doc("Number of pods to launch at once in each round of executor allocation.")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -335,8 +335,8 @@ private[spark] class KubernetesClusterSchedulerBackend(
           val executorId = getExecutorId(pod)
           failedInitExecutors.add(executorId)
           if (failedInitExecutors.size >= executorMaxInitErrors) {
-            val errorMessage = s"Aborting Spark application because $executorMaxInitErrors executors
-              s" failed to start. The maximum number of allowed startup failures is" +
+            val errorMessage = s"Aborting Spark application because $executorMaxInitErrors" +
+              s" executors failed to start. The maximum number of allowed startup failures is" +
               s" $executorMaxInitErrors. Please contact your cluster administrator or increase" +
               s" your setting of ${KUBERNETES_EXECUTOR_MAX_INIT_ERRORS.key}."
             logError(errorMessage)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spark doesn't attach init-containers. But if a custom web hook or pod preset adds init-containers, we need to be resilient to transient failures of these containers and to at least retry them.

## How was this patch tested?

Unit tests.
