### PR TITLE
[SPARK-24193] create TakeOrderedAndProjectExec only when the limit number is below spark.sql.execution.topKSortFallbackThreshold.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1246,7 +1246,6 @@ object SQLConf {
       .intConf
       .createWithDefault(2000)
 
-
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1238,6 +1238,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val SORT_IN_MEM_FOR_LIMIT_THRESHOLD =
+    buildConf("spark.sql.limit.sortInMemThreshold")
+      .internal()
+      .doc("In sql like 'select x from t order by y limit m', if m is under this threshold, " +
+          "sort in memory, otherwise do a global sort with disk.")
+      .intConf
+      .createWithDefault(2000)
+
+
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"
   }
@@ -1405,6 +1414,8 @@ class SQLConf extends Serializable with Logging {
   def stringRedationPattern: Option[Regex] = SQL_STRING_REDACTION_PATTERN.readFrom(reader)
 
   def sortBeforeRepartition: Boolean = getConf(SORT_BEFORE_REPARTITION)
+
+  def sortInMemForLimitThreshold: Int = getConf(SORT_IN_MEM_FOR_LIMIT_THRESHOLD)
 
   /**
    * Returns the [[Resolver]] for the current configuration, which can be used to determine if two

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1238,12 +1238,12 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
-  val COMBINE_LIMIT_AFTER_SORT_THRESHOLD =
-    buildConf("spark.sql.execution.combineLimitAfterSortThreshold")
+  val TOP_K_SORT_FALLBACK_THRESHOLD =
+    buildConf("spark.sql.execution.topKSortFallbackThreshold")
       .internal()
       .doc("In SQL queries with a SORT followed by a LIMIT like " +
-          "'SELECT x FROM t ORDER BY y LIMIT m', if m is under this threshold, sort in memory, " +
-          "otherwise do a global sort which spills to disk if necessary.")
+          "'SELECT x FROM t ORDER BY y LIMIT m', if m is under this threshold, do a top-K sort" +
+          " in memory, otherwise do a global sort which spills to disk if necessary.")
       .intConf
       .createWithDefault(Int.MaxValue)
 
@@ -1415,7 +1415,7 @@ class SQLConf extends Serializable with Logging {
 
   def sortBeforeRepartition: Boolean = getConf(SORT_BEFORE_REPARTITION)
 
-  def combineLimitAfterSortThreshold: Int = getConf(COMBINE_LIMIT_AFTER_SORT_THRESHOLD)
+  def topKSortFallbackThreshold: Int = getConf(TOP_K_SORT_FALLBACK_THRESHOLD)
 
   /**
    * Returns the [[Resolver]] for the current configuration, which can be used to determine if two

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1241,8 +1241,9 @@ object SQLConf {
   val COMBINE_LIMIT_AFTER_SORT_THRESHOLD =
     buildConf("spark.sql.execution.combineLimitAfterSortThreshold")
       .internal()
-      .doc("In sql like 'select x from t order by y limit m', if m is under this threshold, " +
-          "sort in memory, otherwise do a global sort which spills to disk if necessary.")
+      .doc("In SQL queries with a SORT followed by a LIMIT like " +
+          "'SELECT x FROM t ORDER BY y LIMIT m', if m is under this threshold, sort in memory, " +
+          "otherwise do a global sort which spills to disk if necessary.")
       .intConf
       .createWithDefault(Int.MaxValue)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1238,13 +1238,13 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
-  val SORT_IN_MEM_FOR_LIMIT_THRESHOLD =
-    buildConf("spark.sql.limit.sortInMemThreshold")
+  val COMBINE_LIMIT_AFTER_SORT_THRESHOLD =
+    buildConf("spark.sql.execution.combineLimitAfterSortThreshold")
       .internal()
       .doc("In sql like 'select x from t order by y limit m', if m is under this threshold, " +
-          "sort in memory, otherwise do a global sort with disk.")
+          "sort in memory, otherwise do a global sort which spills to disk if necessary.")
       .intConf
-      .createWithDefault(2000)
+      .createWithDefault(Int.MaxValue)
 
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"
@@ -1414,7 +1414,7 @@ class SQLConf extends Serializable with Logging {
 
   def sortBeforeRepartition: Boolean = getConf(SORT_BEFORE_REPARTITION)
 
-  def sortInMemForLimitThreshold: Int = getConf(SORT_IN_MEM_FOR_LIMIT_THRESHOLD)
+  def combineLimitAfterSortThreshold: Int = getConf(COMBINE_LIMIT_AFTER_SORT_THRESHOLD)
 
   /**
    * Returns the [[Resolver]] for the current configuration, which can be used to determine if two

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -67,10 +67,10 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
     override def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
       case ReturnAnswer(rootPlan) => rootPlan match {
         case Limit(IntegerLiteral(limit), Sort(order, true, child))
-            if limit < conf.combineLimitAfterSortThreshold =>
+            if limit < conf.topKSortFallbackThreshold =>
           TakeOrderedAndProjectExec(limit, order, child.output, planLater(child)) :: Nil
         case Limit(IntegerLiteral(limit), Project(projectList, Sort(order, true, child)))
-            if limit < conf.combineLimitAfterSortThreshold =>
+            if limit < conf.topKSortFallbackThreshold =>
           TakeOrderedAndProjectExec(limit, order, projectList, planLater(child)) :: Nil
         case Limit(IntegerLiteral(limit), child) =>
           // With whole stage codegen, Spark releases resources only when all the output data of the
@@ -82,10 +82,10 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         case other => planLater(other) :: Nil
       }
       case Limit(IntegerLiteral(limit), Sort(order, true, child))
-          if limit < conf.combineLimitAfterSortThreshold =>
+          if limit < conf.topKSortFallbackThreshold =>
         TakeOrderedAndProjectExec(limit, order, child.output, planLater(child)) :: Nil
       case Limit(IntegerLiteral(limit), Project(projectList, Sort(order, true, child)))
-          if limit < conf.combineLimitAfterSortThreshold =>
+          if limit < conf.topKSortFallbackThreshold =>
         TakeOrderedAndProjectExec(limit, order, projectList, planLater(child)) :: Nil
       case _ => Nil
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -67,10 +67,10 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
     override def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
       case ReturnAnswer(rootPlan) => rootPlan match {
         case Limit(IntegerLiteral(limit), Sort(order, true, child))
-            if limit < conf.sortInMemForLimitThreshold =>
+            if limit < conf.combineLimitAfterSortThreshold =>
           TakeOrderedAndProjectExec(limit, order, child.output, planLater(child)) :: Nil
         case Limit(IntegerLiteral(limit), Project(projectList, Sort(order, true, child)))
-            if limit < conf.sortInMemForLimitThreshold =>
+            if limit < conf.combineLimitAfterSortThreshold =>
           TakeOrderedAndProjectExec(limit, order, projectList, planLater(child)) :: Nil
         case Limit(IntegerLiteral(limit), child) =>
           // With whole stage codegen, Spark releases resources only when all the output data of the
@@ -82,10 +82,10 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         case other => planLater(other) :: Nil
       }
       case Limit(IntegerLiteral(limit), Sort(order, true, child))
-          if limit < conf.sortInMemForLimitThreshold =>
+          if limit < conf.combineLimitAfterSortThreshold =>
         TakeOrderedAndProjectExec(limit, order, child.output, planLater(child)) :: Nil
       case Limit(IntegerLiteral(limit), Project(projectList, Sort(order, true, child)))
-          if limit < conf.sortInMemForLimitThreshold =>
+          if limit < conf.combineLimitAfterSortThreshold =>
         TakeOrderedAndProjectExec(limit, order, projectList, planLater(child)) :: Nil
       case _ => Nil
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
@@ -127,13 +127,36 @@ case class TakeOrderedAndProjectExec(
     projectList: Seq[NamedExpression],
     child: SparkPlan) extends UnaryExecNode {
 
+  val sortInMemThreshold = conf.sortInMemForLimitThreshold
+
+  override def requiredChildDistribution: Seq[Distribution] = {
+    if (limit < sortInMemThreshold) {
+      super.requiredChildDistribution
+    } else {
+      Seq(AllTuples)
+    }
+  }
+
+  override def requiredChildOrdering: Seq[Seq[SortOrder]] = {
+    if (limit < sortInMemThreshold) {
+      super.requiredChildOrdering
+    } else {
+      Seq(sortOrder)
+    }
+  }
+
   override def output: Seq[Attribute] = {
     projectList.map(_.toAttribute)
   }
 
   override def executeCollect(): Array[InternalRow] = {
-    val ord = new LazilyGeneratedOrdering(sortOrder, child.output)
-    val data = child.execute().map(_.copy()).takeOrdered(limit)(ord)
+
+    val data = if (limit < sortInMemThreshold) {
+      val ord = new LazilyGeneratedOrdering(sortOrder, child.output)
+      child.execute().map(_.copy()).takeOrdered(limit)(ord)
+    } else {
+      child.execute().map(_.copy()).take(limit)
+    }
     if (projectList != child.output) {
       val proj = UnsafeProjection.create(projectList, child.output)
       data.map(r => proj(r).copy())
@@ -145,22 +168,47 @@ case class TakeOrderedAndProjectExec(
   private val serializer: Serializer = new UnsafeRowSerializer(child.output.size)
 
   protected override def doExecute(): RDD[InternalRow] = {
-    val ord = new LazilyGeneratedOrdering(sortOrder, child.output)
-    val localTopK: RDD[InternalRow] = {
-      child.execute().map(_.copy()).mapPartitions { iter =>
-        org.apache.spark.util.collection.Utils.takeOrdered(iter, limit)(ord)
+    if (limit < sortInMemThreshold) {
+      val ord = new LazilyGeneratedOrdering(sortOrder, child.output)
+      val localTopK: RDD[InternalRow] = {
+        child.execute().map(_.copy()).mapPartitions { iter =>
+          org.apache.spark.util.collection.Utils.takeOrdered(iter, limit)(ord)
+        }
       }
-    }
-    val shuffled = new ShuffledRowRDD(
-      ShuffleExchangeExec.prepareShuffleDependency(
-        localTopK, child.output, SinglePartition, serializer))
-    shuffled.mapPartitions { iter =>
-      val topK = org.apache.spark.util.collection.Utils.takeOrdered(iter.map(_.copy()), limit)(ord)
-      if (projectList != child.output) {
-        val proj = UnsafeProjection.create(projectList, child.output)
-        topK.map(r => proj(r))
-      } else {
-        topK
+      val shuffled = new ShuffledRowRDD(
+        ShuffleExchangeExec.prepareShuffleDependency(
+          localTopK, child.output, SinglePartition, serializer))
+      shuffled.mapPartitions { iter =>
+        val topK =
+          org.apache.spark.util.collection.Utils.takeOrdered(iter.map(_.copy()), limit)(ord)
+        if (projectList != child.output) {
+          val proj = UnsafeProjection.create(projectList, child.output)
+          topK.map(r => proj(r))
+        } else {
+          topK
+        }
+      }
+    } else {
+      child.execute().mapPartitions { iter =>
+        new Iterator[InternalRow] {
+          var index = 0L
+          override def hasNext: Boolean = {
+            if (index < limit && iter.hasNext) {
+              true
+            } else {
+              false
+            }
+          }
+          override def next(): InternalRow = {
+            val row = iter.next()
+            if (projectList != child.output) {
+              val proj = UnsafeProjection.create(projectList, child.output)
+              proj(row)
+            } else {
+              row
+            }
+          }
+        }
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -198,7 +198,7 @@ class PlannerSuite extends SharedSQLContext {
   }
 
   test("TakeOrderedAndProjectExec appears only when number of limit is below the threshold.") {
-    withSQLConf(SQLConf.COMBINE_LIMIT_AFTER_SORT_THRESHOLD.key -> "1000") {
+    withSQLConf(SQLConf.TOP_K_SORT_FALLBACK_THRESHOLD.key -> "1000") {
       val query0 = testData.select('value).orderBy('key).limit(100)
       val planned0 = query0.queryExecution.executedPlan
       assert(planned0.find(_.isInstanceOf[TakeOrderedAndProjectExec]).isDefined)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Physical plan of `select colA from t order by colB limit M` is `TakeOrderedAndProject`;
Currently `TakeOrderedAndProject` sorts data in memory, see https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala#L158 
We can add a config – if the number of limit (M) is too big, we can sort by disk. Thus memory issue can be resolved.

## How was this patch tested?

Test added
