### PR TITLE
[SPARK-24194] [SQL]HadoopFsRelation cannot overwrite a path that is also being read from.

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/io/FileCommitProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/FileCommitProtocol.scala
@@ -120,8 +120,9 @@ abstract class FileCommitProtocol {
    * Specifies that a file should be deleted with the commit of this job. The default
    * implementation deletes the file immediately.
    */
-  def deleteWithJob(fs: FileSystem, path: Path, recursive: Boolean): Boolean = {
-    fs.delete(path, recursive)
+  def deleteWithJob(fs: FileSystem, path: Path,
+      canDeleteNow: Boolean = true): Boolean = {
+    fs.delete(path, true)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -889,13 +889,17 @@ object DDLUtils {
    * Throws exception if outputPath tries to overwrite inputpath.
    */
   def verifyNotReadPath(query: LogicalPlan, outputPath: Path) : Unit = {
+    if (isInReadPath(query, outputPath)) {
+      throw new AnalysisException(
+        "Cannot overwrite a path that is also being read from.")
+    }
+  }
+
+  def isInReadPath(query: LogicalPlan, outputPath: Path): Boolean = {
     val inputPaths = query.collect {
       case LogicalRelation(r: HadoopFsRelation, _, _, _) => r.location.rootPaths
     }.flatten
 
-    if (inputPaths.contains(outputPath)) {
-      throw new AnalysisException(
-        "Cannot overwrite a path that is also being read from.")
-    }
+    inputPaths.contains(outputPath)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -189,7 +189,6 @@ case class DataSourceAnalysis(conf: SQLConf) extends Rule[LogicalPlan] with Cast
       }
 
       val outputPath = t.location.rootPaths.head
-      if (overwrite) DDLUtils.verifyNotReadPath(actualQuery, outputPath)
 
       val mode = if (overwrite) SaveMode.Overwrite else SaveMode.Append
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -231,16 +231,16 @@ class InsertSuite extends DataSourceTest with SharedSQLContext {
     }
   }
 
-  test("it is not allowed to write to a table while querying it.") {
-    val message = intercept[AnalysisException] {
-      sql(
+  test("allowed to write to a table while querying it.") {
+    val df = sql(s"SELECT * FROM jsonTable")
+    sql(
         s"""
         |INSERT OVERWRITE TABLE jsonTable SELECT a, b FROM jsonTable
       """.stripMargin)
-    }.getMessage
-    assert(
-      message.contains("Cannot overwrite a path that is also being read from."),
-      "INSERT OVERWRITE to a table while querying it should not be allowed.")
+
+    checkAnswer(
+      sql("SELECT * FROM jsonTable"),
+      df)
   }
 
   test("Caching")  {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -1184,7 +1184,7 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
     }
   }
 
-  test("insertInto - source and target are the same table") {
+  test("insertInto - source and target can be the same table") {
     val tableName = "tab1"
     withTable(tableName) {
       Seq((1, 2)).toDF("i", "j").write.saveAsTable(tableName)
@@ -1204,10 +1204,11 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
         table(tableName),
         Seq(Row(1, 2), Row(1, 2), Row(1, 2), Row(1, 2), Row(1, 2), Row(1, 2), Row(1, 2), Row(1, 2)))
 
-      val e = intercept[AnalysisException] {
-        table(tableName).write.mode(SaveMode.Overwrite).insertInto(tableName)
-      }.getMessage
-      assert(e.contains(s"Cannot overwrite a path that is also being read from"))
+      table(tableName).write.mode(SaveMode.Overwrite).insertInto(tableName)
+      checkAnswer(
+        table(tableName),
+        Seq(Row(1, 2), Row(1, 2), Row(1, 2), Row(1, 2), Row(1, 2), Row(1, 2), Row(1, 2), Row(1, 2))
+      )
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When insert overwrite a parquet table. There is a check.

```
 if (overwrite) DDLUtils.verifyNotReadPath(actualQuery, outputPath)
```
The check throws exception if output path tries to overwrite the same input path. This check(limitation) only exists in datasource table but not hive table. Shall we remove this check?

We cannot read and overwrite a `HadoopFsRelation` with the same path -- input and output should be different. The reason is that spark deletes the output partition path before reading. 
This pr proposes to mark/cache the paths(to delete) before reading. And postpone deletion when commit job.


## How was this patch tested?

I just udpated `InsertSuite` and `MetastoreDataSourceSuite`. 

