### PR TITLE
[SPARK-24203][core] Add spark.executor.bindAddress

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -197,10 +197,11 @@ object SparkEnv extends Logging {
       numCores: Int,
       ioEncryptionKey: Option[Array[Byte]],
       isLocal: Boolean): SparkEnv = {
+    val bindAddress = conf.get(EXECUTOR_BIND_ADDRESS)
     val env = create(
       conf,
       executorId,
-      hostname,
+      bindAddress,
       hostname,
       None,
       isLocal,

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -95,6 +95,11 @@ package object config {
     .bytesConf(ByteUnit.MiB)
     .createOptional
 
+  private[spark] val EXECUTOR_BIND_ADDRESS = ConfigBuilder("spark.executor.bindAddress")
+    .doc("Address where to bind network listen sockets on the executor.")
+    .stringConf
+    .createWithDefault(Utils.localHostName())
+
   private[spark] val MEMORY_OFFHEAP_ENABLED = ConfigBuilder("spark.memory.offHeap.enabled")
     .doc("If true, Spark will attempt to use off-heap memory for certain operations. " +
       "If off-heap memory use is enabled, then spark.memory.offHeap.size must be positive.")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -190,6 +190,18 @@ of the most common options to set are:
   </td>
 </tr>
 <tr>
+<td><code>spark.executor.bindAddress</code></td>
+  <td>(local hostname)</td>
+  <td>
+    Hostname or IP address where to bind listening sockets. This config overrides the SPARK_LOCAL_IP
+    environment variable (see below).
+    <br />It also allows a different address from the local one to be advertised to other
+    executors or external systems. This is useful, for example, when running containers with bridged networking.
+    For this to properly work, the different ports used by the driver (RPC, block manager and UI) need to be
+    forwarded from the container's host.
+  </td>
+</tr>
+<tr>
   <td><code>spark.extraListeners</code></td>
   <td>(none)</td>
   <td>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Adding spark.executor.bindAddress to allow overriding the address to which the RPC server will bind to on each executor.

## How was this patch tested?
Have been running a private build with this in our production cluster for a while.
