### PR TITLE
[SPARK-24213][ML]Power Iteration Clustering in SparkML throws exception, when the ID in IntType

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/PowerIterationClustering.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/PowerIterationClustering.scala
@@ -226,17 +226,10 @@ class PowerIterationClustering private[clustering] (
     val predictionsSchema = StructType(Seq(
       StructField($(idCol), LongType, nullable = false),
       StructField($(predictionCol), IntegerType, nullable = false)))
-    val predictions = {
-      val uncastPredictions = sparkSession.createDataFrame(predictionsRDD, predictionsSchema)
-      dataset.schema($(idCol)).dataType match {
-        case _: LongType =>
-          uncastPredictions
-        case otherType =>
-          uncastPredictions.select(col($(idCol)).cast(otherType).alias($(idCol)))
-      }
-    }
 
-    dataset.join(predictions, $(idCol))
+    val predictions = sparkSession.createDataFrame(predictionsRDD, predictionsSchema)
+
+    predictions
   }
 
   @Since("2.4.0")

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/PowerIterationClusteringSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/PowerIterationClusteringSuite.scala
@@ -183,6 +183,25 @@ class PowerIterationClusteringSuite extends SparkFunSuite
     assert(msg.contains(s"Row for ID ${model.getIdCol}=1"))
   }
 
+  test("invalid input:r and similarity arrays") {
+
+    val data = spark.createDataFrame(Seq(
+      (0, Array(1L), Array(0.9)),
+      (1, Array(2L), Array(0.9)),
+      (2, Array(3L), Array(0.9)),
+      (3, Array(4L), Array(0.1)),
+      (4, Array(5L), Array(0.9))
+    )).toDF("id", "neighbors", "similarities")
+    val result2 = new PowerIterationClustering()
+      .setK(2)
+      .setMaxIter(10)
+      .setInitMode("random")
+      .transform(data)
+  val pred = result2.collect()
+
+    assert(true, true)
+  }
+
   test("read/write") {
     val t = new PowerIterationClustering()
       .setK(4)


### PR DESCRIPTION
While running the following code, PIC throws exception.
```
val data = spark.createDataFrame(Seq(
      (0, Array(1), Array(0.9)),
      (1, Array(2), Array(0.9)),
      (2, Array(3), Array(0.9)),
      (3, Array(4), Array(0.1)),
      (4, Array(5), Array(0.9))
    )).toDF("id", "neighbors", "similarities")

val result = new PowerIterationClustering()
      .setK(2)
      .setMaxIter(10)
      .setInitMode("random")
      .transform(data)
      .select("id", "prediction")
```

**Result**
`org.apache.spark.sql.AnalysisException: cannot resolve '`prediction`' given input columns: [id, neighbors, similarities];;
'Project [id#215, 'prediction]
+- AnalysisBarrier
      +- Project [id#215, neighbors#216, similarities#217]
         +- Join Inner, (id#215 = id#234)
            :- Project [_1#209 AS id#215, _2#210 AS neighbors#216, _3#211 AS similarities#217]
            :  +- LocalRelation [_1#209, _2#210, _3#211]
            +- Project [cast(id#230L as int) AS id#234]
               +- LogicalRDD [id#230L, prediction#231], false

	at org.apache.spark.sql.catalyst.analysis.package$AnalysisErrorAt.failAnalysis(package.scala:42)
	at org.apache.spark.sql.catalyst.analysis.CheckAnalysis$$anonfun$checkAnalysis$1$$anonfun$apply$2.applyOrElse(CheckAnalysis.scala:88)
	at org.apache.spark.sql.catalyst.analysis.CheckAnalysis$$anonfun$checkAnalysis$1$$anonfun$apply$2.applyOrElse(CheckAnalysis.scala:85)
	at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$transformUp$1.apply(TreeNode.scala:289)
	at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$transformUp$1.apply(TreeNode.scala:289)
	at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(TreeNode.scala:70)
	at org.apache.spark.sql.catalyst.trees.TreeNode.transformUp(TreeNode.scala:288)

`


## What changes were proposed in this pull request?

  1) PIC needs to return only "id" and "predictions". Currently it returns the entire data, including neighborhood array and similarity array.

2) Join operation to the existing dataset will skip the cluster labels of ID, which are not there in the ID column but there in the neighborhood ID column. So, instead of joining, we can directly return the "id-prediction" dataFrame, so that it will not skip any nodes. (This is the behavior of Spark MLLib)


## How was this patch tested?
Added a UT
