### PR TITLE
[SPARK-24216][SQL] Spark TypedAggregateExpression uses getSimpleName that is not safe in scala

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
+++ b/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
@@ -202,9 +202,9 @@ abstract class AccumulatorV2[IN, OUT] extends Serializable {
     // getClass.getSimpleName can cause Malformed class name error,
     // call safer `Utils.getSimpleName` instead
     if (metadata == null) {
-      "Un-registered Accumulator: " + Utils.getSimpleName(getClass.getName)
+      "Un-registered Accumulator: " + Utils.getSimpleName(getClass)
     } else {
-      Utils.getSimpleName(getClass.getName) + s"(id: $id, name: $name, value: $value)"
+      Utils.getSimpleName(getClass) + s"(id: $id, name: $name, value: $value)"
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
+++ b/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
@@ -199,10 +199,12 @@ abstract class AccumulatorV2[IN, OUT] extends Serializable {
   }
 
   override def toString: String = {
+    // getClass.getSimpleName can cause Malformed class name error,
+    // call safer `Utils.getSimpleName` instead
     if (metadata == null) {
-      "Un-registered Accumulator: " + getClass.getSimpleName
+      "Un-registered Accumulator: " + Utils.getSimpleName(getClass.getName)
     } else {
-      getClass.getSimpleName + s"(id: $id, name: $name, value: $value)"
+      Utils.getSimpleName(getClass.getName) + s"(id: $id, name: $name, value: $value)"
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2722,7 +2722,7 @@ private[spark] object Utils extends Logging {
    */
   def getSimpleName(cls: Class[_]): String = {
     try {
-      return cls.getSimpleName
+      return cls.getSimpleName.stripSuffix("$")
     } catch {
       case err: InternalError => return stripDollars(stripPackages(cls.getName))
     }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2722,7 +2722,7 @@ private[spark] object Utils extends Logging {
    */
   def getSimpleName(cls: Class[_]): String = {
     try {
-      return cls.getSimpleName.stripSuffix("$")
+      return cls.getSimpleName
     } catch {
       case err: InternalError => return stripDollars(stripPackages(cls.getName))
     }

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -1169,7 +1169,11 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     }
   }
 
-  test("Test that Utils.getSimpleName works as expected") {
+  object A {
+    class B
+  }
+
+  test("Safe getSimpleName") {
     val fullname1 = "org.apache.spark.TestClass$MyClass"
     assert(Utils.getSimpleName(fullname1) === "TestClass$MyClass")
 
@@ -1184,6 +1188,11 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
 
     val fullname5 = "$iwC$iwC$$iwC$$iwC$TestClass$MyClass$"
     assert(Utils.getSimpleName(fullname5) === "MyClass")
+
+    intercept[java.lang.InternalError] {
+      classOf[A.B].getSimpleName
+    }
+    assert(Utils.getSimpleName(classOf[A.B].getName) === "UtilsSuite$A$B")
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -1174,27 +1174,14 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
   }
 
   test("Safe getSimpleName") {
-    val fullname1 = "org.apache.spark.TestClass$MyClass"
-    assert(Utils.getSimpleName(fullname1) === "TestClass$MyClass")
-
-    val fullname2 = "org.apache.spark.TestClass$MyClass$"
-    assert(Utils.getSimpleName(fullname2) === "TestClass$MyClass")
-
-    val fullname3 = "org.apache.spark.TestClass$MyClass$1$"
-    assert(Utils.getSimpleName(fullname3) === "TestClass$MyClass$1")
-
-    val fullname4 = "TestClass$MyClass$1$"
-    assert(Utils.getSimpleName(fullname4) === "TestClass$MyClass$1")
-
-    val fullname5 = "$iwC$iwC$$iwC$$iwC$TestClass$MyClass$"
-    assert(Utils.getSimpleName(fullname5) === "MyClass")
-
-    // getSimpleName on class MalformedClass will result in error: Malformed class name
+    // getSimpleName on class of MalformedClass will result in error: Malformed class name
     // Utils.getSimpleName works
-    intercept[java.lang.InternalError] {
+    val err = intercept[java.lang.InternalError] {
       classOf[MalformedClassObject.MalformedClass].getSimpleName
     }
-    assert(Utils.getSimpleName(classOf[MalformedClassObject.MalformedClass].getName) ===
+    assert(err.getMessage === "Malformed class name")
+
+    assert(Utils.getSimpleName(classOf[MalformedClassObject.MalformedClass]) ===
       "UtilsSuite$MalformedClassObject$MalformedClass")
   }
 }

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -1169,8 +1169,8 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     }
   }
 
-  object A {
-    class B
+  object MalformedClassObject {
+    class MalformedClass
   }
 
   test("Safe getSimpleName") {
@@ -1189,10 +1189,13 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     val fullname5 = "$iwC$iwC$$iwC$$iwC$TestClass$MyClass$"
     assert(Utils.getSimpleName(fullname5) === "MyClass")
 
+    // getSimpleName on class MalformedClass will result in error: Malformed class name
+    // Utils.getSimpleName works
     intercept[java.lang.InternalError] {
-      classOf[A.B].getSimpleName
+      classOf[MalformedClassObject.MalformedClass].getSimpleName
     }
-    assert(Utils.getSimpleName(classOf[A.B].getName) === "UtilsSuite$A$B")
+    assert(Utils.getSimpleName(classOf[MalformedClassObject.MalformedClass].getName) ===
+      "UtilsSuite$MalformedClassObject$MalformedClass")
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -1168,6 +1168,23 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
       Utils.checkAndGetK8sMasterUrl("k8s://foo://host:port")
     }
   }
+
+  test("Test that Utils.getSimpleName works as expected") {
+    val fullname1 = "org.apache.spark.TestClass$MyClass"
+    assert(Utils.getSimpleName(fullname1) === "TestClass$MyClass")
+
+    val fullname2 = "org.apache.spark.TestClass$MyClass$"
+    assert(Utils.getSimpleName(fullname2) === "TestClass$MyClass")
+
+    val fullname3 = "org.apache.spark.TestClass$MyClass$1$"
+    assert(Utils.getSimpleName(fullname3) === "TestClass$MyClass$1")
+
+    val fullname4 = "TestClass$MyClass$1$"
+    assert(Utils.getSimpleName(fullname4) === "TestClass$MyClass$1")
+
+    val fullname5 = "$iwC$iwC$$iwC$$iwC$TestClass$MyClass$"
+    assert(Utils.getSimpleName(fullname5) === "MyClass")
+  }
 }
 
 private class SimpleExtension

--- a/mllib/src/main/scala/org/apache/spark/ml/util/Instrumentation.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/Instrumentation.scala
@@ -30,6 +30,7 @@ import org.apache.spark.ml.{Estimator, Model}
 import org.apache.spark.ml.param.Param
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Dataset
+import org.apache.spark.util.Utils
 
 /**
  * A small wrapper that defines a training session for an estimator, and some methods to log
@@ -47,7 +48,9 @@ private[spark] class Instrumentation[E <: Estimator[_]] private (
 
   private val id = UUID.randomUUID()
   private val prefix = {
-    val className = estimator.getClass.getSimpleName
+    // estimator.getClass.getSimpleName can cause Malformed class name error,
+    // call safer `Utils.getSimpleName` instead
+    val className = Utils.getSimpleName(estimator.getClass.getName)
     s"$className-${estimator.uid}-${dataset.hashCode()}-$id: "
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/util/Instrumentation.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/Instrumentation.scala
@@ -50,7 +50,7 @@ private[spark] class Instrumentation[E <: Estimator[_]] private (
   private val prefix = {
     // estimator.getClass.getSimpleName can cause Malformed class name error,
     // call safer `Utils.getSimpleName` instead
-    val className = Utils.getSimpleName(estimator.getClass.getName)
+    val className = Utils.getSimpleName(estimator.getClass)
     s"$className-${estimator.uid}-${dataset.hashCode()}-$id: "
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TypedAggregateExpression.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TypedAggregateExpression.scala
@@ -110,7 +110,8 @@ trait TypedAggregateExpression extends AggregateFunction {
     s"$nodeName($input)"
   }
 
-  // Utils.getSimpleName is safer than aggregator.getClass.getSimpleName in scala.
+  // aggregator.getClass.getSimpleName can cause Malformed class name error,
+  // call safer `Utils.getSimpleName` instead
   override def nodeName: String = Utils.getSimpleName(aggregator.getClass.getName);
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TypedAggregateExpression.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TypedAggregateExpression.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.catalyst.expressions.codegen.GenerateSafeProjection
 import org.apache.spark.sql.catalyst.expressions.objects.Invoke
 import org.apache.spark.sql.expressions.Aggregator
 import org.apache.spark.sql.types._
+import org.apache.spark.util.Utils
 
 object TypedAggregateExpression {
   def apply[BUF : Encoder, OUT : Encoder](
@@ -109,7 +110,8 @@ trait TypedAggregateExpression extends AggregateFunction {
     s"$nodeName($input)"
   }
 
-  override def nodeName: String = aggregator.getClass.getSimpleName.stripSuffix("$")
+  // Utils.getSimpleName is safer than aggregator.getClass.getSimpleName in scala.
+  override def nodeName: String = Utils.getSimpleName(aggregator.getClass.getName);
 }
 
 // TODO: merge these 2 implementations once we refactor the `AggregateFunction` interface.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TypedAggregateExpression.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TypedAggregateExpression.scala
@@ -112,7 +112,7 @@ trait TypedAggregateExpression extends AggregateFunction {
 
   // aggregator.getClass.getSimpleName can cause Malformed class name error,
   // call safer `Utils.getSimpleName` instead
-  override def nodeName: String = Utils.getSimpleName(aggregator.getClass.getName);
+  override def nodeName: String = Utils.getSimpleName(aggregator.getClass);
 }
 
 // TODO: merge these 2 implementations once we refactor the `AggregateFunction` interface.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TypedAggregateExpression.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TypedAggregateExpression.scala
@@ -112,7 +112,7 @@ trait TypedAggregateExpression extends AggregateFunction {
 
   // aggregator.getClass.getSimpleName can cause Malformed class name error,
   // call safer `Utils.getSimpleName` instead
-  override def nodeName: String = Utils.getSimpleName(aggregator.getClass);
+  override def nodeName: String = Utils.getSimpleName(aggregator.getClass).stripSuffix("$");
 }
 
 // TODO: merge these 2 implementations once we refactor the `AggregateFunction` interface.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StringFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StringFormat.scala
@@ -55,7 +55,7 @@ trait DataSourceV2StringFormat {
     case registered: DataSourceRegister => registered.shortName()
     // source.getClass.getSimpleName can cause Malformed class name error,
     // call safer `Utils.getSimpleName` instead
-    case _ => Utils.getSimpleName(source.getClass.getName)
+    case _ => Utils.getSimpleName(source.getClass)
   }
 
   def metadataString: String = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StringFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StringFormat.scala
@@ -53,7 +53,9 @@ trait DataSourceV2StringFormat {
 
   private def sourceName: String = source match {
     case registered: DataSourceRegister => registered.shortName()
-    case _ => source.getClass.getSimpleName.stripSuffix("$")
+    // source.getClass.getSimpleName can cause Malformed class name error,
+    // call safer `Utils.getSimpleName` instead
+    case _ => Utils.getSimpleName(source.getClass.getName)
   }
 
   def metadataString: String = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When user create a aggregator object in scala and pass the aggregator to Spark Dataset's agg() method, Spark's will initialize TypedAggregateExpression with the nodeName field as aggregator.getClass.getSimpleName. However, getSimpleName is not safe in scala environment, depending on how user creates the aggregator object. For example, if the aggregator class full qualified name is "com.my.company.MyUtils$myAgg$2$", the getSimpleName will throw java.lang.InternalError "Malformed class name". This has been reported in scalatest https://github.com/scalatest/scalatest/pull/1044 and discussed in many scala upstream jiras such as SI-8110, SI-5425.

To fix this issue, we follow the solution in https://github.com/scalatest/scalatest/pull/1044 to add safer version of getSimpleName as a util method, and TypedAggregateExpression will invoke this util method rather than getClass.getSimpleName.

## How was this patch tested?
added unit test
