### PR TITLE
[SPARK-24217][ML]Power Iteration Clustering is not displaying cluster indices corresponding to some vertices

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/PowerIterationClustering.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/PowerIterationClustering.scala
@@ -226,17 +226,9 @@ class PowerIterationClustering private[clustering] (
     val predictionsSchema = StructType(Seq(
       StructField($(idCol), LongType, nullable = false),
       StructField($(predictionCol), IntegerType, nullable = false)))
-    val predictions = {
-      val uncastPredictions = sparkSession.createDataFrame(predictionsRDD, predictionsSchema)
-      dataset.schema($(idCol)).dataType match {
-        case _: LongType =>
-          uncastPredictions
-        case otherType =>
-          uncastPredictions.select(col($(idCol)).cast(otherType).alias($(idCol)))
-      }
-    }
+    val predictions = sparkSession.createDataFrame(predictionsRDD, predictionsSchema)
 
-    dataset.join(predictions, $(idCol))
+    predictions
   }
 
   @Since("2.4.0")

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/PowerIterationClusteringSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/PowerIterationClusteringSuite.scala
@@ -119,7 +119,6 @@ class PowerIterationClusteringSuite extends SparkFunSuite
       case Row(id: Long, cluster: Integer) => predictions(cluster) += id
     }
     assert(predictions.toSet == Set((0 until 4).toSet, Set(4, 5)))
-    assert(result.columns(1).equals("prediction"))
   }
 
   test("supported input types") {

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/PowerIterationClusteringSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/PowerIterationClusteringSuite.scala
@@ -84,7 +84,7 @@ class PowerIterationClusteringSuite extends SparkFunSuite
     result.select("id", "prediction").collect().foreach {
       case Row(id: Long, cluster: Integer) => predictions(cluster) += id
     }
-    assert(predictions.toSet == Set((1 until n1).toSet, (n1 until n).toSet))
+    assert(predictions.toSet == Set((0 until n1).toSet, (n1 until n).toSet))
 
     val result2 = new PowerIterationClustering()
       .setK(2)
@@ -95,7 +95,31 @@ class PowerIterationClusteringSuite extends SparkFunSuite
     result2.select("id", "prediction").collect().foreach {
       case Row(id: Long, cluster: Integer) => predictions2(cluster) += id
     }
-    assert(predictions2.toSet == Set((1 until n1).toSet, (n1 until n).toSet))
+    assert(predictions2.toSet == Set((0 until n1).toSet, (n1 until n).toSet))
+  }
+
+  test("power iteration clustering: random init mode") {
+
+    val data = spark.createDataFrame(Seq(
+      (0, Array(1), Array(0.9)),
+      (1, Array(2), Array(0.9)),
+      (2, Array(3), Array(0.9)),
+      (3, Array(4), Array(0.1)),
+      (4, Array(5), Array(0.9))
+    )).toDF("id", "neighbors", "similarities")
+
+    val result = new PowerIterationClustering()
+      .setK(2)
+      .setMaxIter(10)
+      .setInitMode("random")
+      .transform(data)
+
+    val predictions = Array.fill(2)(mutable.Set.empty[Long])
+    result.select("id", "prediction").collect().foreach {
+      case Row(id: Long, cluster: Integer) => predictions(cluster) += id
+    }
+    assert(predictions.toSet == Set((0 until 4).toSet, Set(4, 5)))
+    assert(result.columns(1).equals("prediction"))
   }
 
   test("supported input types") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

1) Currently PIC in ML displays cluster indices of nodes in the ID column. If some of the nodes there in the neighboring column, but not there in the ID column, It will not display the cluster indices corresponding to that node.

As per the definition of PIC clustering, given in the code,
>  
PIC takes an affinity matrix between items (or vertices) as input.  An affinity matrix
 is a symmetric matrix whose entries are non-negative similarities between items.
 PIC takes this matrix (or graph) as an adjacency matrix.  Specifically, each input row includes:
 - `idCol`: vertex ID
  - `neighborsCol`: neighbors of vertex in `idCol`
 - `similaritiesCol`: non-negative weights (similarities) of edges between the vertex
         in `idCol` and each neighbor in `neighborsCol`
 * **"PIC returns a cluster assignment for each input vertex."**  It appends a new column `predictionCol`
  containing the cluster assignment in `[0,k)` for each row (vertex).

2) We should display prediction and id corresponding to all the nodes. So, instead of the join operation to the existing dataFrame, we can directly return the prediction-id dataFrame corresponding to all the nodes.
For the same input in spark.ml and spark.mllib, spark.mllib giving cluster id for all the vertices.


## How was this patch tested?
UT



Please review http://spark.apache.org/contributing.html before opening a pull request.
