### PR TITLE
[SPARK-24219][k8s] Improve the docker building script to avoid copying everything under examples to docker image

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -19,6 +19,7 @@ FROM openjdk:8-alpine
 
 ARG spark_jars=jars
 ARG img_path=kubernetes/dockerfiles
+ARG spark_examples=examples
 
 # Before building the docker image, first build and make a Spark distribution following
 # the instructions in http://spark.apache.org/docs/latest/building-spark.html.
@@ -41,7 +42,7 @@ COPY ${spark_jars} /opt/spark/jars
 COPY bin /opt/spark/bin
 COPY sbin /opt/spark/sbin
 COPY ${img_path}/spark/entrypoint.sh /opt/
-COPY examples /opt/spark/examples
+COPY ${spark_examples} /opt/spark/examples
 COPY data /opt/spark/data
 
 ENV SPARK_HOME /opt/spark


### PR DESCRIPTION
## What changes were proposed in this pull request?

Current docker build script will copy everything under example folder to docker image if it is invoked in Spark's development directory, this unnecessarily copies too many files like building temporary files, duplicated jars into the docker image. So here propose to improve the script.

## How was this patch tested?

Manually verified in local build with minikube.
