### PR TITLE
[SPARK-19181][Core] Fixing flaky "SparkListenerSuite.local metrics" 

### DIFF
--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -297,7 +297,7 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     sc.addSparkListener(new StatsReportListener)
     // just to make sure some of the tasks and their deserialization take a noticeable
     // amount of time
-    val slowDeserializable = new SlowDeserializable(readDuration = 1)
+    val slowDeserializable = new SlowDeserializable
     val w = { i: Int =>
       if (i == 0) {
         Thread.sleep(100)
@@ -588,22 +588,11 @@ private class FirehoseListenerThatAcceptsSparkConf(conf: SparkConf) extends Spar
   }
 }
 
-private class SlowDeserializable(var readDuration: Int)
-  extends Externalizable {
+private class SlowDeserializable extends Externalizable {
 
-  def this() = this(0)
+  override def writeExternal(out: ObjectOutput): Unit = { }
 
-  @throws[IOException]
-  override def writeExternal(out: ObjectOutput): Unit = {
-    out.writeInt(readDuration)
-  }
-
-  @throws[IOException]
-  @throws[ClassNotFoundException]
-  override def readExternal(in: ObjectInput): Unit = {
-    readDuration = in.readInt()
-    Thread.sleep(readDuration)
-  }
+  override def readExternal(in: ObjectInput): Unit = Thread.sleep(1)
 
   def use(): Unit = { }
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.scheduler
 
+import java.io.{Externalizable, IOException, ObjectInput, ObjectOutput}
 import java.util.concurrent.Semaphore
 
 import scala.collection.JavaConverters._
@@ -294,10 +295,13 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     val listener = new SaveStageAndTaskInfo
     sc.addSparkListener(listener)
     sc.addSparkListener(new StatsReportListener)
-    // just to make sure some of the tasks take a noticeable amount of time
+    // just to make sure some of the tasks and their deserialization take a noticeable
+    // amount of time
+    val slowDeserializable = new SlowDeserializable(readDuration = 1)
     val w = { i: Int =>
       if (i == 0) {
         Thread.sleep(100)
+        slowDeserializable.use()
       }
       i
     }
@@ -582,4 +586,24 @@ private class FirehoseListenerThatAcceptsSparkConf(conf: SparkConf) extends Spar
     case job: SparkListenerJobEnd => count += 1
     case _ =>
   }
+}
+
+private class SlowDeserializable(var readDuration: Int)
+  extends Externalizable {
+
+  def this() = this(0)
+
+  @throws[IOException]
+  override def writeExternal(out: ObjectOutput): Unit = {
+    out.writeInt(readDuration)
+  }
+
+  @throws[IOException]
+  @throws[ClassNotFoundException]
+  override def readExternal(in: ObjectInput): Unit = {
+    readDuration = in.readInt()
+    Thread.sleep(readDuration)
+  }
+
+  def use(): Unit = { }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Sometimes "SparkListenerSuite.local metrics" test fails because the average of executorDeserializeTime is too short. As @squito suggested to avoid these situations in one of the task a reference introduced to an object implementing a custom Externalizable.readExternal which sleeps 1ms before returning.   

## How was this patch tested?

With unit tests (and checking the effect of this change to the average with a much larger sleep time).