### PR TITLE
[SPARK-24176][SQL] LOAD DATA can't identify wildcard in the hdfs file path 

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -304,9 +304,9 @@ case class LoadDataCommand(
       }
     }
 
-    val loadPath =
+    val loadPath = {
+      val uri = Utils.resolveURI(path)
       if (isLocal) {
-        val uri = Utils.resolveURI(path)
         val file = new File(uri.getPath)
         val exists = if (file.getAbsolutePath.contains("*")) {
           val fileSystem = FileSystems.getDefault
@@ -341,7 +341,6 @@ case class LoadDataCommand(
         }
         uri
       } else {
-        val uri = new URI(path)
         val hdfsUri = if (uri.getScheme() != null && uri.getAuthority() != null) {
           uri
         } else {
@@ -390,6 +389,7 @@ case class LoadDataCommand(
         }
         hdfsUri
       }
+    }
 
     if (partition.nonEmpty) {
       catalog.loadPartition(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.test.SQLTestUtils
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.Utils
 
 class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
   import testImplicits._
@@ -170,6 +171,7 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
     // 16|john
     // 17|robert
     val testData = hiveContext.getHiveFile("data/files/employee.dat").getCanonicalFile()
+    val testData2 = new File(testData.getCanonicalPath, "data/files/??ployee.dat")
 
     /**
      * Run a function with a copy of the input data file when running with non-local input. The
@@ -226,6 +228,11 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
         intercept[AnalysisException] {
           sql(s"""LOAD DATA LOCAL INPATH "$incorrectUri" INTO TABLE non_part_table""")
         }
+      } else {
+        intercept[AnalysisException] {
+          sql(s"""LOAD DATA INPATH "${testData2.toURI}" INTO TABLE non_part_table""")
+        }
+        Utils.deleteRecursively(testData2)
       }
 
       // Use URI as inpath:


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the wildcard characters (like "?") were in the LOAD DATA command's path name, the Path related API (hadoop and URI) couldn't parse it correctly. For example:
`val srcPath = new Path(hdfsUri)` in the `tables.scala`, returned wrong result for the following cases:
- `hdfsUri` = `file: /user/testdemo1/user1/t??eddata60.txt`, 
   `srcPath` = `file:/user/testdemo1/user1/t`
- `hdfsUri` = `file:/user/testdemo1/user1/?eddata60.txt'`, 
   `srcPath` = `file:/user/testdemo1/user1/`
(the same problem exists at `val uriPath = uri.getPath()`)

 The LOAD DATA LOCAL works  because the local case called a utility `Utils.resolveURI` to replaced the "?" to "%3F", then the PATH API will not truncate the file name.

This fix uses `Utils.resolveURI` method for both local and non-local cases.

I did similar test on hive, it seems the hive has the same behavior.

`hive> load data inpath 'hdfs:/tmp/?evin.txt' into table foo1;
FAILED: SemanticException Line 1:17 Invalid path ''hdfs:/tmp/?evin.txt'': No files matching path hdfs://stcindia-node-6.fyre.ibm.com:8020/tmp/%3Fevin.txt
hive> load data inpath 'hdfs:/tmp/k?evin.txt' into table foo1;
FAILED: SemanticException Line 1:17 Invalid path ''hdfs:/tmp/k?evin.txt'': No files matching path hdfs://stcindia-node-6.fyre.ibm.com:8020/tmp/k%3Fevin.txt
hive> 
`
## How was this patch tested?
Did the unit test locally, and added new test cases.

