### PR TITLE
[SPARK-24238][SQL] HadoopFsRelation can't append the same table with multi job at the same time

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/io/FileCommitProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/FileCommitProtocol.scala
@@ -45,6 +45,7 @@ import org.apache.spark.util.Utils
 abstract class FileCommitProtocol {
   import FileCommitProtocol._
 
+  def getJobId(): String
   /**
    * Setups up a job. Must be called on the driver before any other methods can be invoked.
    */

--- a/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
@@ -174,15 +174,17 @@ class HadoopMapReduceCommitProtocol(
 
       val fs = stagingDir.getFileSystem(jobContext.getConfiguration)
       // move all file from temp dir to output
-      val files = fs.listFiles(tempDir, false)
-      while (files.hasNext) {
-        val file = files.next()
-        val name = file.getPath().getName()
-        val to = new Path(path, name)
-        fs.rename(file.getPath, to)
-      }
+      if (fs.exists(tempDir)) {
+        val files = fs.listFiles(tempDir, false)
+        while (files.hasNext) {
+          val file = files.next()
+          val name = file.getPath().getName()
+          val to = new Path(path, name)
+          fs.rename(file.getPath, to)
+        }
 
-      fs.delete(tempDir, true)
+        fs.delete(tempDir, true)
+      }
 
       val (allAbsPathFiles, allPartitionPaths) =
         taskCommits.map(_.obj.asInstanceOf[(Map[String, String], Set[String])]).unzip

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -117,7 +117,10 @@ object FileFormatWriter extends Logging {
     val job = Job.getInstance(hadoopConf)
     job.setOutputKeyClass(classOf[Void])
     job.setOutputValueClass(classOf[InternalRow])
-    FileOutputFormat.setOutputPath(job, new Path(outputSpec.outputPath))
+    val jobOutputPath = new Path(outputSpec.outputPath, s".temp-${committer.getJobId()}")
+    val fs = jobOutputPath.getFileSystem(hadoopConf)
+    fs.mkdirs(jobOutputPath)
+    FileOutputFormat.setOutputPath(job, jobOutputPath)
 
     val partitionSet = AttributeSet(partitionColumns)
     val dataColumns = outputSpec.outputColumns.filterNot(partitionSet.contains)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SQLHadoopMapReduceCommitProtocol.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SQLHadoopMapReduceCommitProtocol.scala
@@ -55,7 +55,8 @@ class SQLHadoopMapReduceCommitProtocol(
         // The specified output committer is a FileOutputCommitter.
         // So, we will use the FileOutputCommitter-specified constructor.
         val ctor = clazz.getDeclaredConstructor(classOf[Path], classOf[TaskAttemptContext])
-        committer = ctor.newInstance(new Path(path), context)
+
+        committer = ctor.newInstance(new Path(path, tempDir), context)
       } else {
         // The specified output committer is just an OutputCommitter.
         // So, we will use the no-argument constructor.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ManifestFileCommitProtocol.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ManifestFileCommitProtocol.scala
@@ -117,4 +117,6 @@ class ManifestFileCommitProtocol(jobId: String, path: String)
     // Do nothing
     // TODO: we can also try delete the addedFiles as a best-effort cleanup.
   }
+
+  override def getJobId(): String = jobId
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When there are multiple jobs at the same time append a `HadoopFsRelation`, there will be an error, there are the following two errors: 

1. A job will succeed, but the data will be wrong and more data than excepted will appear
2. Other jobs will fail with `java.io.FileNotFoundException: Failed to get file status skip_dir/_temporary/0`

The main reason for this problem is because multiple job will use the same `_temporary` directory.

So the core idea of this `PR` is to create a different temporary directory with jobId for the different Job in the `output` folder , so that conflicts can be avoided.

## How was this patch tested?

I manually tested. 
