### PR TITLE
[SPARK-24206][SQL] Improve FilterPushdownBenchmark benchmark code

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/FilterPushdownBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FilterPushdownBenchmark.scala
@@ -34,10 +34,10 @@ object FilterPushdownBenchmark {
   val conf = new SparkConf()
     .setMaster("local[1]")
     .setAppName("FilterPushdownBenchmark")
-    .set("spark.driver.memory", "3g")
-    .set("spark.executor.memory", "3g")
-    .set("orc.compression", "snappy")
-    .set("spark.sql.parquet.compression.codec", "snappy")
+    .setIfMissing("spark.driver.memory", "3g")
+    .setIfMissing("spark.executor.memory", "3g")
+    .setIfMissing("orc.compression", "snappy")
+    .setIfMissing("spark.sql.parquet.compression.codec", "snappy")
 
   private val spark = SparkSession.builder().config(conf).getOrCreate()
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/FilterPushdownBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/FilterPushdownBenchmark.scala
@@ -135,209 +135,210 @@ object FilterPushdownBenchmark {
 
     /*
     OpenJDK 64-Bit Server VM 1.8.0_171-b10 on Linux 4.14.33-51.37.amzn1.x86_64
-    Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz
+    Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
     Select 0 string row (value IS NULL):     Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            3354 / 3431          4.7         213.2       1.0X
-    Parquet Vectorized (Pushdown)                  131 /  147        119.9           8.3      25.6X
-    Native ORC Vectorized                         5244 / 5288          3.0         333.4       0.6X
-    Native ORC Vectorized (Pushdown)               147 /  168        107.1           9.3      22.8X
+    Parquet Vectorized                            9201 / 9300          1.7         585.0       1.0X
+    Parquet Vectorized (Pushdown)                   89 /  105        176.3           5.7     103.1X
+    Native ORC Vectorized                         8886 / 8898          1.8         564.9       1.0X
+    Native ORC Vectorized (Pushdown)               110 /  128        143.4           7.0      83.9X
 
 
     Select 0 string row
-    ('7864320' < value < '7864320'): Best/Avg Time(ms)            Rate(M/s)   Per Row(ns)   Relative
+    ('7864320' < value < '7864320'):         Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            3475 / 3564          4.5         221.0       1.0X
-    Parquet Vectorized (Pushdown)                  153 /  171        102.7           9.7      22.7X
-    Native ORC Vectorized                         5478 / 5675          2.9         348.3       0.6X
-    Native ORC Vectorized (Pushdown)               173 /  180         90.9          11.0      20.1X
+    Parquet Vectorized                            9336 / 9357          1.7         593.6       1.0X
+    Parquet Vectorized (Pushdown)                  927 /  937         17.0          58.9      10.1X
+    Native ORC Vectorized                         9026 / 9041          1.7         573.9       1.0X
+    Native ORC Vectorized (Pushdown)               257 /  272         61.1          16.4      36.3X
 
 
     Select 1 string row (value = '7864320'): Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            3273 / 3373          4.8         208.1       1.0X
-    Parquet Vectorized (Pushdown)                  132 /  145        118.9           8.4      24.8X
-    Native ORC Vectorized                         5546 / 5610          2.8         352.6       0.6X
-    Native ORC Vectorized (Pushdown)               169 /  177         93.2          10.7      19.4X
+    Parquet Vectorized                            9209 / 9223          1.7         585.5       1.0X
+    Parquet Vectorized (Pushdown)                  908 /  925         17.3          57.7      10.1X
+    Native ORC Vectorized                         8878 / 8904          1.8         564.4       1.0X
+    Native ORC Vectorized (Pushdown)               248 /  261         63.4          15.8      37.1X
 
 
     Select 1 string row
     (value <=> '7864320'):                   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            3358 / 3414          4.7         213.5       1.0X
-    Parquet Vectorized (Pushdown)                  123 /  134        128.2           7.8      27.4X
-    Native ORC Vectorized                         5453 / 5652          2.9         346.7       0.6X
-    Native ORC Vectorized (Pushdown)               170 /  179         92.4          10.8      19.7X
+    Parquet Vectorized                            9194 / 9216          1.7         584.5       1.0X
+    Parquet Vectorized (Pushdown)                  899 /  908         17.5          57.2      10.2X
+    Native ORC Vectorized                         8934 / 8962          1.8         568.0       1.0X
+    Native ORC Vectorized (Pushdown)               249 /  254         63.3          15.8      37.0X
 
 
     Select 1 string row
     ('7864320' <= value <= '7864320'):       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            3604 / 3652          4.4         229.1       1.0X
-    Parquet Vectorized (Pushdown)                  147 /  157        106.8           9.4      24.5X
-    Native ORC Vectorized                         5795 / 5935          2.7         368.5       0.6X
-    Native ORC Vectorized (Pushdown)               180 /  189         87.6          11.4      20.1X
+    Parquet Vectorized                            9332 / 9351          1.7         593.3       1.0X
+    Parquet Vectorized (Pushdown)                  915 /  934         17.2          58.2      10.2X
+    Native ORC Vectorized                         9049 / 9057          1.7         575.3       1.0X
+    Native ORC Vectorized (Pushdown)               248 /  258         63.5          15.8      37.7X
 
 
     Select all string rows
     (value IS NOT NULL):                     Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            8780 / 9055          1.8         558.2       1.0X
-    Parquet Vectorized (Pushdown)                 9010 / 9228          1.7         572.9       1.0X
-    Native ORC Vectorized                       12970 / 13162          1.2         824.6       0.7X
-    Native ORC Vectorized (Pushdown)            12785 / 13283          1.2         812.8       0.7X
+    Parquet Vectorized                          20478 / 20497          0.8        1301.9       1.0X
+    Parquet Vectorized (Pushdown)               20461 / 20550          0.8        1300.9       1.0X
+    Native ORC Vectorized                       27464 / 27482          0.6        1746.1       0.7X
+    Native ORC Vectorized (Pushdown)            27454 / 27488          0.6        1745.5       0.7X
 
 
     Select 0 int row (value IS NULL):        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            2740 / 2880          5.7         174.2       1.0X
-    Parquet Vectorized (Pushdown)                   88 /  103        178.5           5.6      31.1X
-    Native ORC Vectorized                         4786 / 4870          3.3         304.3       0.6X
-    Native ORC Vectorized (Pushdown)               125 /  137        126.2           7.9      22.0X
+    Parquet Vectorized                            8489 / 8519          1.9         539.7       1.0X
+    Parquet Vectorized (Pushdown)                   64 /   69        246.1           4.1     132.8X
+    Native ORC Vectorized                         8064 / 8099          2.0         512.7       1.1X
+    Native ORC Vectorized (Pushdown)                88 /   94        178.6           5.6      96.4X
 
 
     Select 0 int row
     (7864320 < value < 7864320):             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            2852 / 2896          5.5         181.3       1.0X
-    Parquet Vectorized (Pushdown)                  140 /  148        112.3           8.9      20.4X
-    Native ORC Vectorized                         4743 / 4931          3.3         301.5       0.6X
-    Native ORC Vectorized (Pushdown)               155 /  168        101.3           9.9      18.4X
+    Parquet Vectorized                            8494 / 8514          1.9         540.0       1.0X
+    Parquet Vectorized (Pushdown)                  835 /  840         18.8          53.1      10.2X
+    Native ORC Vectorized                         8090 / 8106          1.9         514.4       1.0X
+    Native ORC Vectorized (Pushdown)               249 /  257         63.2          15.8      34.1X
+
 
     Select 1 int row (value = 7864320):      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            2859 / 2896          5.5         181.8       1.0X
-    Parquet Vectorized (Pushdown)                  136 /  142        115.7           8.6      21.0X
-    Native ORC Vectorized                         4942 / 5069          3.2         314.2       0.6X
-    Native ORC Vectorized (Pushdown)               155 /  164        101.2           9.9      18.4X
+    Parquet Vectorized                            8552 / 8560          1.8         543.7       1.0X
+    Parquet Vectorized (Pushdown)                  837 /  841         18.8          53.2      10.2X
+    Native ORC Vectorized                         8178 / 8188          1.9         519.9       1.0X
+    Native ORC Vectorized (Pushdown)               249 /  258         63.2          15.8      34.4X
 
 
     Select 1 int row (value <=> 7864320):    Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            2863 / 2914          5.5         182.0       1.0X
-    Parquet Vectorized (Pushdown)                  125 /  133        125.9           7.9      22.9X
-    Native ORC Vectorized                         4885 / 4980          3.2         310.6       0.6X
-    Native ORC Vectorized (Pushdown)               146 /  158        107.6           9.3      19.6X
+    Parquet Vectorized                            8562 / 8580          1.8         544.3       1.0X
+    Parquet Vectorized (Pushdown)                  833 /  836         18.9          53.0      10.3X
+    Native ORC Vectorized                         8164 / 8185          1.9         519.0       1.0X
+    Native ORC Vectorized (Pushdown)               245 /  254         64.3          15.6      35.0X
 
 
     Select 1 int row
     (7864320 <= value <= 7864320):           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            2863 / 2926          5.5         182.0       1.0X
-    Parquet Vectorized (Pushdown)                  135 /  145        116.1           8.6      21.1X
-    Native ORC Vectorized                         4924 / 5154          3.2         313.1       0.6X
-    Native ORC Vectorized (Pushdown)               156 /  166        101.1           9.9      18.4X
+    Parquet Vectorized                            8540 / 8555          1.8         542.9       1.0X
+    Parquet Vectorized (Pushdown)                  837 /  839         18.8          53.2      10.2X
+    Native ORC Vectorized                         8182 / 8231          1.9         520.2       1.0X
+    Native ORC Vectorized (Pushdown)               250 /  259         62.9          15.9      34.1X
 
 
     Select 1 int row
     (7864319 < value < 7864321):             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            2856 / 2886          5.5         181.6       1.0X
-    Parquet Vectorized (Pushdown)                  131 /  143        120.4           8.3      21.9X
-    Native ORC Vectorized                         5167 / 5258          3.0         328.5       0.6X
-    Native ORC Vectorized (Pushdown)               152 /  158        103.8           9.6      18.9X
+    Parquet Vectorized                            8535 / 8555          1.8         542.6       1.0X
+    Parquet Vectorized (Pushdown)                  835 /  841         18.8          53.1      10.2X
+    Native ORC Vectorized                         8159 / 8179          1.9         518.8       1.0X
+    Native ORC Vectorized (Pushdown)               244 /  250         64.5          15.5      35.0X
 
 
     Select 10% int rows (value < 1572864):   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            3439 / 3493          4.6         218.6       1.0X
-    Parquet Vectorized (Pushdown)                  931 /  952         16.9          59.2       3.7X
-    Native ORC Vectorized                         5653 / 5734          2.8         359.4       0.6X
-    Native ORC Vectorized (Pushdown)              1405 / 1416         11.2          89.3       2.4X
+    Parquet Vectorized                            9609 / 9634          1.6         610.9       1.0X
+    Parquet Vectorized (Pushdown)                 2663 / 2672          5.9         169.3       3.6X
+    Native ORC Vectorized                         9824 / 9850          1.6         624.6       1.0X
+    Native ORC Vectorized (Pushdown)              2717 / 2722          5.8         172.7       3.5X
 
 
     Select 50% int rows (value < 7864320):   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            3545 / 3626          4.4         225.4       1.0X
-    Parquet Vectorized (Pushdown)                 1068 / 1153         14.7          67.9       3.3X
-    Native ORC Vectorized                         5578 / 5829          2.8         354.6       0.6X
-    Native ORC Vectorized (Pushdown)              1502 / 1550         10.5          95.5       2.4X
+    Parquet Vectorized                          13592 / 13613          1.2         864.2       1.0X
+    Parquet Vectorized (Pushdown)                 9720 / 9738          1.6         618.0       1.4X
+    Native ORC Vectorized                       16366 / 16397          1.0        1040.5       0.8X
+    Native ORC Vectorized (Pushdown)            12437 / 12459          1.3         790.7       1.1X
 
 
     Select 90% int rows (value < 14155776):  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            3567 / 3608          4.4         226.8       1.0X
-    Parquet Vectorized (Pushdown)                 1072 / 1152         14.7          68.1       3.3X
-    Native ORC Vectorized                         5713 / 5845          2.8         363.2       0.6X
-    Native ORC Vectorized (Pushdown)              1571 / 1686         10.0          99.9       2.3X
+    Parquet Vectorized                          17580 / 17617          0.9        1117.7       1.0X
+    Parquet Vectorized (Pushdown)               16803 / 16827          0.9        1068.3       1.0X
+    Native ORC Vectorized                       24169 / 24187          0.7        1536.6       0.7X
+    Native ORC Vectorized (Pushdown)            22147 / 22341          0.7        1408.1       0.8X
 
 
     Select all int rows (value IS NOT NULL): Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            8099 / 8360          1.9         514.9       1.0X
-    Parquet Vectorized (Pushdown)                 8257 / 8552          1.9         525.0       1.0X
-    Native ORC Vectorized                       12113 / 12390          1.3         770.1       0.7X
-    Native ORC Vectorized (Pushdown)            12485 / 12595          1.3         793.8       0.6X
+    Parquet Vectorized                          18461 / 18491          0.9        1173.7       1.0X
+    Parquet Vectorized (Pushdown)               18466 / 18530          0.9        1174.1       1.0X
+    Native ORC Vectorized                       24231 / 24270          0.6        1540.6       0.8X
+    Native ORC Vectorized (Pushdown)            24207 / 24304          0.6        1539.0       0.8X
 
 
     Select all int rows (value > -1):        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            8201 / 8348          1.9         521.4       1.0X
-    Parquet Vectorized (Pushdown)                 8410 / 8561          1.9         534.7       1.0X
-    Native ORC Vectorized                       12408 / 12545          1.3         788.9       0.7X
-    Native ORC Vectorized (Pushdown)            12403 / 12489          1.3         788.6       0.7X
+    Parquet Vectorized                          18414 / 18453          0.9        1170.7       1.0X
+    Parquet Vectorized (Pushdown)               18435 / 18464          0.9        1172.1       1.0X
+    Native ORC Vectorized                       24430 / 24454          0.6        1553.2       0.8X
+    Native ORC Vectorized (Pushdown)            24410 / 24465          0.6        1552.0       0.8X
 
 
     Select all int rows (value != -1):       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            8133 / 8526          1.9         517.1       1.0X
-    Parquet Vectorized (Pushdown)                 8301 / 8401          1.9         527.8       1.0X
-    Native ORC Vectorized                       12411 / 12809          1.3         789.1       0.7X
-    Native ORC Vectorized (Pushdown)            12316 / 12605          1.3         783.0       0.7X
+    Parquet Vectorized                          18446 / 18457          0.9        1172.8       1.0X
+    Parquet Vectorized (Pushdown)               18428 / 18440          0.9        1171.6       1.0X
+    Native ORC Vectorized                       24414 / 24450          0.6        1552.2       0.8X
+    Native ORC Vectorized (Pushdown)            24385 / 24472          0.6        1550.4       0.8X
 
 
     Select 0 distinct string row
     (value IS NULL):                         Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            2800 / 2886          5.6         178.0       1.0X
-    Parquet Vectorized (Pushdown)                   84 /   99        187.0           5.3      33.3X
-    Native ORC Vectorized                         4593 / 4709          3.4         292.0       0.6X
-    Native ORC Vectorized (Pushdown)               122 /  129        128.5           7.8      22.9X
+    Parquet Vectorized                            8322 / 8352          1.9         529.1       1.0X
+    Parquet Vectorized (Pushdown)                   53 /   57        296.3           3.4     156.7X
+    Native ORC Vectorized                         7903 / 7953          2.0         502.4       1.1X
+    Native ORC Vectorized (Pushdown)                80 /   82        197.2           5.1     104.3X
 
 
     Select 0 distinct string row
     ('100' < value < '100'):                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            2870 / 2954          5.5         182.5       1.0X
-    Parquet Vectorized (Pushdown)                  109 /  130        144.4           6.9      26.4X
-    Native ORC Vectorized                         4794 / 5000          3.3         304.8       0.6X
-    Native ORC Vectorized (Pushdown)               128 /  135        122.5           8.2      22.3X
+    Parquet Vectorized                            8712 / 8743          1.8         553.9       1.0X
+    Parquet Vectorized (Pushdown)                  995 / 1030         15.8          63.3       8.8X
+    Native ORC Vectorized                         8345 / 8362          1.9         530.6       1.0X
+    Native ORC Vectorized (Pushdown)                84 /   87        187.6           5.3     103.9X
 
 
     Select 1 distinct string row
     (value = '100'):                         Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            3008 / 3095          5.2         191.3       1.0X
-    Parquet Vectorized (Pushdown)                  328 /  348         47.9          20.9       9.2X
-    Native ORC Vectorized                         4997 / 5101          3.1         317.7       0.6X
-    Native ORC Vectorized (Pushdown)               406 /  416         38.7          25.8       7.4X
+    Parquet Vectorized                            8574 / 8610          1.8         545.1       1.0X
+    Parquet Vectorized (Pushdown)                 1127 / 1135         14.0          71.6       7.6X
+    Native ORC Vectorized                         8163 / 8181          1.9         519.0       1.1X
+    Native ORC Vectorized (Pushdown)               426 /  433         36.9          27.1      20.1X
 
 
     Select 1 distinct string row
     (value <=> '100'):                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            3048 / 3150          5.2         193.8       1.0X
-    Parquet Vectorized (Pushdown)                  326 /  341         48.3          20.7       9.4X
-    Native ORC Vectorized                         4979 / 5008          3.2         316.5       0.6X
-    Native ORC Vectorized (Pushdown)               396 /  401         39.7          25.2       7.7X
+    Parquet Vectorized                            8549 / 8568          1.8         543.5       1.0X
+    Parquet Vectorized (Pushdown)                 1124 / 1131         14.0          71.4       7.6X
+    Native ORC Vectorized                         8163 / 8210          1.9         519.0       1.0X
+    Native ORC Vectorized (Pushdown)               426 /  436         36.9          27.1      20.1X
 
 
     Select 1 distinct string row
     ('100' <= value <= '100'):               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            3123 / 3213          5.0         198.5       1.0X
-    Parquet Vectorized (Pushdown)                  337 /  352         46.7          21.4       9.3X
-    Native ORC Vectorized                         5211 / 5247          3.0         331.3       0.6X
-    Native ORC Vectorized (Pushdown)               402 /  412         39.1          25.6       7.8X
+    Parquet Vectorized                            8889 / 8896          1.8         565.2       1.0X
+    Parquet Vectorized (Pushdown)                 1161 / 1168         13.6          73.8       7.7X
+    Native ORC Vectorized                         8519 / 8554          1.8         541.6       1.0X
+    Native ORC Vectorized (Pushdown)               430 /  437         36.6          27.3      20.7X
 
 
     Select all distinct string rows
     (value IS NOT NULL):                     Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            7995 / 8324          2.0         508.3       1.0X
-    Parquet Vectorized (Pushdown)                 8094 / 8333          1.9         514.6       1.0X
-    Native ORC Vectorized                       11501 / 11872          1.4         731.2       0.7X
-    Native ORC Vectorized (Pushdown)            11436 / 11904          1.4         727.1       0.7X
+    Parquet Vectorized                          20433 / 20533          0.8        1299.1       1.0X
+    Parquet Vectorized (Pushdown)               20433 / 20456          0.8        1299.1       1.0X
+    Native ORC Vectorized                       25435 / 25513          0.6        1617.1       0.8X
+    Native ORC Vectorized (Pushdown)            25435 / 25507          0.6        1617.1       0.8X
     */
 
     benchmark.run()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/FilterPushdownBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/FilterPushdownBenchmark.scala
@@ -36,9 +36,11 @@ import org.apache.spark.util.{Benchmark, Utils}
 object FilterPushdownBenchmark {
   val conf = new SparkConf()
     .setAppName("FilterPushdownBenchmark")
-    .setIfMissing("spark.master", "local[1]")
+    // Since `spark.master` always exists, overrides this value
+    .set("spark.master", "local[1]")
     .setIfMissing("spark.driver.memory", "3g")
     .setIfMissing("spark.executor.memory", "3g")
+    .setIfMissing("spark.ui.enabled", "false")
     .setIfMissing("orc.compression", "snappy")
     .setIfMissing("spark.sql.parquet.compression.codec", "snappy")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/FilterPushdownBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/FilterPushdownBenchmark.scala
@@ -96,7 +96,8 @@ object FilterPushdownBenchmark {
   }
 
   private def saveAsOrcTable(df: DataFrame, dir: String): Unit = {
-    df.write.mode("overwrite").orc(dir)
+    // To always turn on dictionary encoding, we set 1.0 at the threshold (the default is 0.8)
+    df.write.mode("overwrite").option("orc.dictionary.key.threshold", 1.0).orc(dir)
     spark.read.orc(dir).createOrReplaceTempView("orcTable")
   }
 
@@ -131,211 +132,214 @@ object FilterPushdownBenchmark {
     }
 
     /*
+    OpenJDK 64-Bit Server VM 1.8.0_171-b10 on Linux 4.14.26-46.32.amzn1.x86_64
     Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz
     Select 0 string row (value IS NULL):     Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            8452 / 8504          1.9         537.3       1.0X
-    Parquet Vectorized (Pushdown)                  274 /  281         57.3          17.4      30.8X
-    Native ORC Vectorized                         8167 / 8185          1.9         519.3       1.0X
-    Native ORC Vectorized (Pushdown)               365 /  379         43.1          23.2      23.1X
+    Parquet Vectorized                            2961 / 3123          5.3         188.3       1.0X
+    Parquet Vectorized (Pushdown)                 3057 / 3121          5.1         194.4       1.0X
+    Native ORC Vectorized                         4083 / 4139          3.9         259.6       0.7X
+    Native ORC Vectorized (Pushdown)               123 /  140        127.9           7.8      24.1X
 
 
     Select 0 string row
     ('7864320' < value < '7864320'):         Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            8532 / 8564          1.8         542.4       1.0X
-    Parquet Vectorized (Pushdown)                  366 /  386         43.0          23.3      23.3X
-    Native ORC Vectorized                         8289 / 8300          1.9         527.0       1.0X
-    Native ORC Vectorized (Pushdown)               378 /  385         41.6          24.0      22.6X
+    Parquet Vectorized                            3153 / 3235          5.0         200.4       1.0X
+    Parquet Vectorized (Pushdown)                 3161 / 3252          5.0         201.0       1.0X
+    Native ORC Vectorized                         4254 / 4337          3.7         270.5       0.7X
+    Native ORC Vectorized (Pushdown)               138 /  163        114.1           8.8      22.9X
 
 
-    Select 1 string row (value = '7864320'): Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+    Select 1 string row
+    (value = '7864320'):                     Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            8547 / 8564          1.8         543.4       1.0X
-    Parquet Vectorized (Pushdown)                  351 /  356         44.9          22.3      24.4X
-    Native ORC Vectorized                         8310 / 8323          1.9         528.3       1.0X
-    Native ORC Vectorized (Pushdown)               370 /  375         42.5          23.5      23.1X
+    Parquet Vectorized                            3140 / 3192          5.0         199.7       1.0X
+    Parquet Vectorized (Pushdown)                 3136 / 3173          5.0         199.4       1.0X
+    Native ORC Vectorized                         4266 / 4348          3.7         271.2       0.7X
+    Native ORC Vectorized (Pushdown)               139 /  147        113.5           8.8      22.7X
 
 
     Select 1 string row
     (value <=> '7864320'):                   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            8537 / 8563          1.8         542.8       1.0X
-    Parquet Vectorized (Pushdown)                  310 /  319         50.7          19.7      27.5X
-    Native ORC Vectorized                         8316 / 8335          1.9         528.7       1.0X
-    Native ORC Vectorized (Pushdown)               364 /  367         43.2          23.1      23.5X
+    Parquet Vectorized                            3103 / 3178          5.1         197.3       1.0X
+    Parquet Vectorized (Pushdown)                 3131 / 3179          5.0         199.1       1.0X
+    Native ORC Vectorized                         4316 / 4342          3.6         274.4       0.7X
+    Native ORC Vectorized (Pushdown)               132 /  143        118.9           8.4      23.5X
 
 
     Select 1 string row
     ('7864320' <= value <= '7864320'):       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            8594 / 8607          1.8         546.4       1.0X
-    Parquet Vectorized (Pushdown)                  370 /  374         42.5          23.5      23.2X
-    Native ORC Vectorized                         8350 / 8358          1.9         530.9       1.0X
-    Native ORC Vectorized (Pushdown)               371 /  374         42.4          23.6      23.2X
+    Parquet Vectorized                            3287 / 3311          4.8         209.0       1.0X
+    Parquet Vectorized (Pushdown)                 3301 / 3326          4.8         209.9       1.0X
+    Native ORC Vectorized                         4432 / 4475          3.5         281.8       0.7X
+    Native ORC Vectorized (Pushdown)               140 /  146        112.4           8.9      23.5X
 
 
     Select all string rows
     (value IS NOT NULL):                     Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                          19601 / 19625          0.8        1246.2       1.0X
-    Parquet Vectorized (Pushdown)               19698 / 19703          0.8        1252.3       1.0X
-    Native ORC Vectorized                       19435 / 19470          0.8        1235.6       1.0X
-    Native ORC Vectorized (Pushdown)            19568 / 19590          0.8        1244.1       1.0X
+    Parquet Vectorized                            8005 / 8230          2.0         509.0       1.0X
+    Parquet Vectorized (Pushdown)                 8046 / 8112          2.0         511.6       1.0X
+    Native ORC Vectorized                       10443 / 10627          1.5         664.0       0.8X
+    Native ORC Vectorized (Pushdown)            10695 / 10847          1.5         680.0       0.7X
 
 
     Select 0 int row (value IS NULL):        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            7815 / 7824          2.0         496.9       1.0X
-    Parquet Vectorized (Pushdown)                  245 /  251         64.2          15.6      31.9X
-    Native ORC Vectorized                         7436 / 7460          2.1         472.8       1.1X
-    Native ORC Vectorized (Pushdown)               344 /  351         45.7          21.9      22.7X
+    Parquet Vectorized                            2797 / 2859          5.6         177.8       1.0X
+    Parquet Vectorized (Pushdown)                   66 /   80        238.5           4.2      42.4X
+    Native ORC Vectorized                         3837 / 3936          4.1         244.0       0.7X
+    Native ORC Vectorized (Pushdown)               113 /  117        139.6           7.2      24.8X
 
 
     Select 0 int row
     (7864320 < value < 7864320):             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            7792 / 7807          2.0         495.4       1.0X
-    Parquet Vectorized (Pushdown)                  349 /  353         45.1          22.2      22.3X
-    Native ORC Vectorized                         7451 / 7465          2.1         473.7       1.0X
-    Native ORC Vectorized (Pushdown)               365 /  368         43.0          23.2      21.3X
+    Parquet Vectorized                            2754 / 2815          5.7         175.1       1.0X
+    Parquet Vectorized (Pushdown)                   91 /  101        173.7           5.8      30.4X
+    Native ORC Vectorized                         3858 / 3964          4.1         245.3       0.7X
+    Native ORC Vectorized (Pushdown)               134 /  141        117.4           8.5      20.5X
 
 
     Select 1 int row (value = 7864320):      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            7836 / 7872          2.0         498.2       1.0X
-    Parquet Vectorized (Pushdown)                  322 /  327         48.8          20.5      24.3X
-    Native ORC Vectorized                         7533 / 7540          2.1         478.9       1.0X
-    Native ORC Vectorized (Pushdown)               358 /  363         43.9          22.8      21.9X
+    Parquet Vectorized                            2735 / 2780          5.8         173.9       1.0X
+    Parquet Vectorized (Pushdown)                   93 /   98        169.8           5.9      29.5X
+    Native ORC Vectorized                         3859 / 3951          4.1         245.3       0.7X
+    Native ORC Vectorized (Pushdown)               133 /  142        118.1           8.5      20.5X
 
 
     Select 1 int row (value <=> 7864320):    Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            7855 / 7870          2.0         499.4       1.0X
-    Parquet Vectorized (Pushdown)                  286 /  297         54.9          18.2      27.4X
-    Native ORC Vectorized                         7511 / 7557          2.1         477.5       1.0X
-    Native ORC Vectorized (Pushdown)               358 /  361         43.9          22.8      21.9X
+    Parquet Vectorized                            2709 / 2806          5.8         172.2       1.0X
+    Parquet Vectorized (Pushdown)                   87 /   94        180.8           5.5      31.1X
+    Native ORC Vectorized                         3787 / 3904          4.2         240.8       0.7X
+    Native ORC Vectorized (Pushdown)               128 /  138        122.8           8.1      21.1X
 
 
     Select 1 int row
     (7864320 <= value <= 7864320):           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            7851 / 7870          2.0         499.2       1.0X
-    Parquet Vectorized (Pushdown)                  345 /  347         45.6          21.9      22.8X
-    Native ORC Vectorized                         7543 / 7554          2.1         479.6       1.0X
-    Native ORC Vectorized (Pushdown)               364 /  374         43.2          23.1      21.6X
+    Parquet Vectorized                            2691 / 2829          5.8         171.1       1.0X
+    Parquet Vectorized (Pushdown)                   91 /   98        172.9           5.8      29.6X
+    Native ORC Vectorized                         3915 / 4071          4.0         248.9       0.7X
+    Native ORC Vectorized (Pushdown)               131 /  137        120.2           8.3      20.6X
 
 
     Select 1 int row
     (7864319 < value < 7864321):             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            7837 / 7840          2.0         498.2       1.0X
-    Parquet Vectorized (Pushdown)                  338 /  339         46.6          21.5      23.2X
-    Native ORC Vectorized                         7524 / 7541          2.1         478.3       1.0X
-    Native ORC Vectorized (Pushdown)               361 /  364         43.6          22.9      21.7X
+    Parquet Vectorized                            2861 / 2880          5.5         181.9       1.0X
+    Parquet Vectorized (Pushdown)                   90 /   96        174.7           5.7      31.8X
+    Native ORC Vectorized                         3937 / 4029          4.0         250.3       0.7X
+    Native ORC Vectorized (Pushdown)               132 /  140        118.7           8.4      21.6X
 
 
     Select 10% int rows (value < 1572864):   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            8864 / 8900          1.8         563.5       1.0X
-    Parquet Vectorized (Pushdown)                 2088 / 2095          7.5         132.7       4.2X
-    Native ORC Vectorized                         8562 / 8579          1.8         544.3       1.0X
-    Native ORC Vectorized (Pushdown)              2127 / 2131          7.4         135.2       4.2X
+    Parquet Vectorized                            3211 / 3361          4.9         204.2       1.0X
+    Parquet Vectorized (Pushdown)                  784 /  849         20.1          49.8       4.1X
+    Native ORC Vectorized                         4420 / 4462          3.6         281.0       0.7X
+    Native ORC Vectorized (Pushdown)              1112 / 1172         14.1          70.7       2.9X
 
 
     Select 50% int rows (value < 7864320):   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                          12671 / 12684          1.2         805.6       1.0X
-    Parquet Vectorized (Pushdown)                 9032 / 9041          1.7         574.2       1.4X
-    Native ORC Vectorized                       12388 / 12411          1.3         787.6       1.0X
-    Native ORC Vectorized (Pushdown)              8873 / 8884          1.8         564.1       1.4X
+    Parquet Vectorized                            3329 / 3378          4.7         211.7       1.0X
+    Parquet Vectorized (Pushdown)                  962 / 1036         16.3          61.2       3.5X
+    Native ORC Vectorized                         4595 / 4640          3.4         292.2       0.7X
+    Native ORC Vectorized (Pushdown)              1291 / 1362         12.2          82.1       2.6X
 
 
     Select 90% int rows (value < 14155776):  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                          16481 / 16495          1.0        1047.8       1.0X
-    Parquet Vectorized (Pushdown)               15906 / 15919          1.0        1011.3       1.0X
-    Native ORC Vectorized                       16224 / 16254          1.0        1031.5       1.0X
-    Native ORC Vectorized (Pushdown)            15632 / 15661          1.0         993.9       1.1X
+    Parquet Vectorized                            3355 / 3403          4.7         213.3       1.0X
+    Parquet Vectorized (Pushdown)                  976 / 1037         16.1          62.1       3.4X
+    Native ORC Vectorized                         4594 / 4685          3.4         292.1       0.7X
+    Native ORC Vectorized (Pushdown)              1220 / 1335         12.9          77.6       2.8X
 
 
     Select all int rows (value IS NOT NULL): Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                          17341 / 17354          0.9        1102.5       1.0X
-    Parquet Vectorized (Pushdown)               17463 / 17481          0.9        1110.2       1.0X
-    Native ORC Vectorized                       17073 / 17089          0.9        1085.4       1.0X
-    Native ORC Vectorized (Pushdown)            17194 / 17232          0.9        1093.2       1.0X
+    Parquet Vectorized                            7300 / 7426          2.2         464.1       1.0X
+    Parquet Vectorized (Pushdown)                 7195 / 7381          2.2         457.4       1.0X
+    Native ORC Vectorized                         9677 / 9989          1.6         615.2       0.8X
+    Native ORC Vectorized (Pushdown)              9610 / 9830          1.6         611.0       0.8X
 
 
     Select all int rows (value > -1):        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                          17452 / 17467          0.9        1109.6       1.0X
-    Parquet Vectorized (Pushdown)               17613 / 17630          0.9        1119.8       1.0X
-    Native ORC Vectorized                       17259 / 17271          0.9        1097.3       1.0X
-    Native ORC Vectorized (Pushdown)            17385 / 17429          0.9        1105.3       1.0X
+    Parquet Vectorized                            7317 / 7452          2.1         465.2       1.0X
+    Parquet Vectorized (Pushdown)                 7229 / 7537          2.2         459.6       1.0X
+    Native ORC Vectorized                         9553 / 9744          1.6         607.4       0.8X
+    Native ORC Vectorized (Pushdown)              9780 / 9996          1.6         621.8       0.7X
 
 
     Select all int rows (value != -1):       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                          17363 / 17372          0.9        1103.9       1.0X
-    Parquet Vectorized (Pushdown)               17526 / 17535          0.9        1114.2       1.0X
-    Native ORC Vectorized                       17052 / 17089          0.9        1084.2       1.0X
-    Native ORC Vectorized (Pushdown)            17209 / 17229          0.9        1094.1       1.0X
+    Parquet Vectorized                            7378 / 7508          2.1         469.1       1.0X
+    Parquet Vectorized (Pushdown)                 7343 / 7512          2.1         466.8       1.0X
+    Native ORC Vectorized                         9611 / 9842          1.6         611.1       0.8X
+    Native ORC Vectorized (Pushdown)              9564 / 9894          1.6         608.1       0.8X
 
 
     Select 0 distinct string row
     (value IS NULL):                         Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            7697 / 7751          2.0         489.4       1.0X
-    Parquet Vectorized (Pushdown)                  264 /  284         59.5          16.8      29.1X
-    Native ORC Vectorized                         6942 / 6970          2.3         441.4       1.1X
-    Native ORC Vectorized (Pushdown)               372 /  381         42.3          23.7      20.7X
+    Parquet Vectorized                            2622 / 2681          6.0         166.7       1.0X
+    Parquet Vectorized (Pushdown)                 2637 / 2676          6.0         167.6       1.0X
+    Native ORC Vectorized                         3638 / 3702          4.3         231.3       0.7X
+    Native ORC Vectorized (Pushdown)               102 /  109        153.6           6.5      25.6X
 
 
     Select 0 distinct string row
     ('100' < value < '100'):                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            7983 / 8018          2.0         507.5       1.0X
-    Parquet Vectorized (Pushdown)                  334 /  337         47.0          21.3      23.9X
-    Native ORC Vectorized                         7307 / 7313          2.2         464.5       1.1X
-    Native ORC Vectorized (Pushdown)               363 /  371         43.3          23.1      22.0X
+    Parquet Vectorized                            2712 / 2753          5.8         172.4       1.0X
+    Parquet Vectorized (Pushdown)                 2637 / 2713          6.0         167.7       1.0X
+    Native ORC Vectorized                         3853 / 3930          4.1         244.9       0.7X
+    Native ORC Vectorized (Pushdown)               106 /  119        147.9           6.8      25.5X
 
 
     Select 1 distinct string row
     (value = '100'):                         Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            7882 / 7915          2.0         501.1       1.0X
-    Parquet Vectorized (Pushdown)                  504 /  522         31.2          32.1      15.6X
-    Native ORC Vectorized                         7143 / 7155          2.2         454.1       1.1X
-    Native ORC Vectorized (Pushdown)               555 /  573         28.4          35.3      14.2X
+    Parquet Vectorized                            2747 / 2878          5.7         174.7       1.0X
+    Parquet Vectorized (Pushdown)                 2758 / 2821          5.7         175.3       1.0X
+    Native ORC Vectorized                         3807 / 4026          4.1         242.0       0.7X
+    Native ORC Vectorized (Pushdown)               316 /  322         49.8          20.1       8.7X
 
 
     Select 1 distinct string row
     (value <=> '100'):                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            7898 / 7912          2.0         502.1       1.0X
-    Parquet Vectorized (Pushdown)                  470 /  481         33.5          29.9      16.8X
-    Native ORC Vectorized                         7135 / 7149          2.2         453.6       1.1X
-    Native ORC Vectorized (Pushdown)               552 /  557         28.5          35.1      14.3X
+    Parquet Vectorized                            2753 / 2800          5.7         175.0       1.0X
+    Parquet Vectorized (Pushdown)                 2747 / 2805          5.7         174.6       1.0X
+    Native ORC Vectorized                         3902 / 3967          4.0         248.1       0.7X
+    Native ORC Vectorized (Pushdown)               316 /  331         49.8          20.1       8.7X
 
 
     Select 1 distinct string row
     ('100' <= value <= '100'):               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            8189 / 8213          1.9         520.7       1.0X
-    Parquet Vectorized (Pushdown)                  527 /  534         29.9          33.5      15.5X
-    Native ORC Vectorized                         7477 / 7498          2.1         475.3       1.1X
-    Native ORC Vectorized (Pushdown)               558 /  566         28.2          35.5      14.7X
+    Parquet Vectorized                            2906 / 2917          5.4         184.8       1.0X
+    Parquet Vectorized (Pushdown)                 2819 / 2886          5.6         179.2       1.0X
+    Native ORC Vectorized                         4025 / 4102          3.9         255.9       0.7X
+    Native ORC Vectorized (Pushdown)               325 /  341         48.4          20.7       8.9X
 
 
     Select all distinct string rows
     (value IS NOT NULL):                     Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                          19462 / 19476          0.8        1237.4       1.0X
-    Parquet Vectorized (Pushdown)               19570 / 19582          0.8        1244.2       1.0X
-    Native ORC Vectorized                       18577 / 18604          0.8        1181.1       1.0X
-    Native ORC Vectorized (Pushdown)            18701 / 18742          0.8        1189.0       1.0X
+    Parquet Vectorized                            7582 / 7942          2.1         482.0       1.0X
+    Parquet Vectorized (Pushdown)                 7450 / 7916          2.1         473.6       1.0X
+    Native ORC Vectorized                         9497 / 9784          1.7         603.8       0.8X
+    Native ORC Vectorized (Pushdown)              9423 / 9646          1.7         599.1       0.8X
     */
+
     benchmark.run()
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/FilterPushdownBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/FilterPushdownBenchmark.scala
@@ -15,13 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql
+package org.apache.spark.sql.execution.benchmark
 
 import java.io.File
 
 import scala.util.{Random, Try}
 
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.functions.monotonically_increasing_id
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.{Benchmark, Utils}
@@ -29,11 +30,13 @@ import org.apache.spark.util.{Benchmark, Utils}
 
 /**
  * Benchmark to measure read performance with Filter pushdown.
+ * To run this:
+ *  spark-submit --class <this class> <spark sql test jar>
  */
 object FilterPushdownBenchmark {
   val conf = new SparkConf()
-    .setMaster("local[1]")
     .setAppName("FilterPushdownBenchmark")
+    .setIfMissing("spark.master", "local[1]")
     .setIfMissing("spark.driver.memory", "3g")
     .setIfMissing("spark.executor.memory", "3g")
     .setIfMissing("orc.compression", "snappy")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/FilterPushdownBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/FilterPushdownBenchmark.scala
@@ -132,212 +132,210 @@ object FilterPushdownBenchmark {
     }
 
     /*
-    OpenJDK 64-Bit Server VM 1.8.0_171-b10 on Linux 4.14.26-46.32.amzn1.x86_64
+    OpenJDK 64-Bit Server VM 1.8.0_171-b10 on Linux 4.14.33-51.37.amzn1.x86_64
     Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz
     Select 0 string row (value IS NULL):     Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            2961 / 3123          5.3         188.3       1.0X
-    Parquet Vectorized (Pushdown)                 3057 / 3121          5.1         194.4       1.0X
-    Native ORC Vectorized                         4083 / 4139          3.9         259.6       0.7X
-    Native ORC Vectorized (Pushdown)               123 /  140        127.9           7.8      24.1X
+    Parquet Vectorized                            3354 / 3431          4.7         213.2       1.0X
+    Parquet Vectorized (Pushdown)                  131 /  147        119.9           8.3      25.6X
+    Native ORC Vectorized                         5244 / 5288          3.0         333.4       0.6X
+    Native ORC Vectorized (Pushdown)               147 /  168        107.1           9.3      22.8X
 
 
     Select 0 string row
-    ('7864320' < value < '7864320'):         Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+    ('7864320' < value < '7864320'): Best/Avg Time(ms)            Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            3153 / 3235          5.0         200.4       1.0X
-    Parquet Vectorized (Pushdown)                 3161 / 3252          5.0         201.0       1.0X
-    Native ORC Vectorized                         4254 / 4337          3.7         270.5       0.7X
-    Native ORC Vectorized (Pushdown)               138 /  163        114.1           8.8      22.9X
+    Parquet Vectorized                            3475 / 3564          4.5         221.0       1.0X
+    Parquet Vectorized (Pushdown)                  153 /  171        102.7           9.7      22.7X
+    Native ORC Vectorized                         5478 / 5675          2.9         348.3       0.6X
+    Native ORC Vectorized (Pushdown)               173 /  180         90.9          11.0      20.1X
 
 
-    Select 1 string row
-    (value = '7864320'):                     Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+    Select 1 string row (value = '7864320'): Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            3140 / 3192          5.0         199.7       1.0X
-    Parquet Vectorized (Pushdown)                 3136 / 3173          5.0         199.4       1.0X
-    Native ORC Vectorized                         4266 / 4348          3.7         271.2       0.7X
-    Native ORC Vectorized (Pushdown)               139 /  147        113.5           8.8      22.7X
+    Parquet Vectorized                            3273 / 3373          4.8         208.1       1.0X
+    Parquet Vectorized (Pushdown)                  132 /  145        118.9           8.4      24.8X
+    Native ORC Vectorized                         5546 / 5610          2.8         352.6       0.6X
+    Native ORC Vectorized (Pushdown)               169 /  177         93.2          10.7      19.4X
 
 
     Select 1 string row
     (value <=> '7864320'):                   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            3103 / 3178          5.1         197.3       1.0X
-    Parquet Vectorized (Pushdown)                 3131 / 3179          5.0         199.1       1.0X
-    Native ORC Vectorized                         4316 / 4342          3.6         274.4       0.7X
-    Native ORC Vectorized (Pushdown)               132 /  143        118.9           8.4      23.5X
+    Parquet Vectorized                            3358 / 3414          4.7         213.5       1.0X
+    Parquet Vectorized (Pushdown)                  123 /  134        128.2           7.8      27.4X
+    Native ORC Vectorized                         5453 / 5652          2.9         346.7       0.6X
+    Native ORC Vectorized (Pushdown)               170 /  179         92.4          10.8      19.7X
 
 
     Select 1 string row
     ('7864320' <= value <= '7864320'):       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            3287 / 3311          4.8         209.0       1.0X
-    Parquet Vectorized (Pushdown)                 3301 / 3326          4.8         209.9       1.0X
-    Native ORC Vectorized                         4432 / 4475          3.5         281.8       0.7X
-    Native ORC Vectorized (Pushdown)               140 /  146        112.4           8.9      23.5X
+    Parquet Vectorized                            3604 / 3652          4.4         229.1       1.0X
+    Parquet Vectorized (Pushdown)                  147 /  157        106.8           9.4      24.5X
+    Native ORC Vectorized                         5795 / 5935          2.7         368.5       0.6X
+    Native ORC Vectorized (Pushdown)               180 /  189         87.6          11.4      20.1X
 
 
     Select all string rows
     (value IS NOT NULL):                     Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            8005 / 8230          2.0         509.0       1.0X
-    Parquet Vectorized (Pushdown)                 8046 / 8112          2.0         511.6       1.0X
-    Native ORC Vectorized                       10443 / 10627          1.5         664.0       0.8X
-    Native ORC Vectorized (Pushdown)            10695 / 10847          1.5         680.0       0.7X
+    Parquet Vectorized                            8780 / 9055          1.8         558.2       1.0X
+    Parquet Vectorized (Pushdown)                 9010 / 9228          1.7         572.9       1.0X
+    Native ORC Vectorized                       12970 / 13162          1.2         824.6       0.7X
+    Native ORC Vectorized (Pushdown)            12785 / 13283          1.2         812.8       0.7X
 
 
     Select 0 int row (value IS NULL):        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            2797 / 2859          5.6         177.8       1.0X
-    Parquet Vectorized (Pushdown)                   66 /   80        238.5           4.2      42.4X
-    Native ORC Vectorized                         3837 / 3936          4.1         244.0       0.7X
-    Native ORC Vectorized (Pushdown)               113 /  117        139.6           7.2      24.8X
+    Parquet Vectorized                            2740 / 2880          5.7         174.2       1.0X
+    Parquet Vectorized (Pushdown)                   88 /  103        178.5           5.6      31.1X
+    Native ORC Vectorized                         4786 / 4870          3.3         304.3       0.6X
+    Native ORC Vectorized (Pushdown)               125 /  137        126.2           7.9      22.0X
 
 
     Select 0 int row
     (7864320 < value < 7864320):             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            2754 / 2815          5.7         175.1       1.0X
-    Parquet Vectorized (Pushdown)                   91 /  101        173.7           5.8      30.4X
-    Native ORC Vectorized                         3858 / 3964          4.1         245.3       0.7X
-    Native ORC Vectorized (Pushdown)               134 /  141        117.4           8.5      20.5X
-
+    Parquet Vectorized                            2852 / 2896          5.5         181.3       1.0X
+    Parquet Vectorized (Pushdown)                  140 /  148        112.3           8.9      20.4X
+    Native ORC Vectorized                         4743 / 4931          3.3         301.5       0.6X
+    Native ORC Vectorized (Pushdown)               155 /  168        101.3           9.9      18.4X
 
     Select 1 int row (value = 7864320):      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            2735 / 2780          5.8         173.9       1.0X
-    Parquet Vectorized (Pushdown)                   93 /   98        169.8           5.9      29.5X
-    Native ORC Vectorized                         3859 / 3951          4.1         245.3       0.7X
-    Native ORC Vectorized (Pushdown)               133 /  142        118.1           8.5      20.5X
+    Parquet Vectorized                            2859 / 2896          5.5         181.8       1.0X
+    Parquet Vectorized (Pushdown)                  136 /  142        115.7           8.6      21.0X
+    Native ORC Vectorized                         4942 / 5069          3.2         314.2       0.6X
+    Native ORC Vectorized (Pushdown)               155 /  164        101.2           9.9      18.4X
 
 
     Select 1 int row (value <=> 7864320):    Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            2709 / 2806          5.8         172.2       1.0X
-    Parquet Vectorized (Pushdown)                   87 /   94        180.8           5.5      31.1X
-    Native ORC Vectorized                         3787 / 3904          4.2         240.8       0.7X
-    Native ORC Vectorized (Pushdown)               128 /  138        122.8           8.1      21.1X
+    Parquet Vectorized                            2863 / 2914          5.5         182.0       1.0X
+    Parquet Vectorized (Pushdown)                  125 /  133        125.9           7.9      22.9X
+    Native ORC Vectorized                         4885 / 4980          3.2         310.6       0.6X
+    Native ORC Vectorized (Pushdown)               146 /  158        107.6           9.3      19.6X
 
 
     Select 1 int row
     (7864320 <= value <= 7864320):           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            2691 / 2829          5.8         171.1       1.0X
-    Parquet Vectorized (Pushdown)                   91 /   98        172.9           5.8      29.6X
-    Native ORC Vectorized                         3915 / 4071          4.0         248.9       0.7X
-    Native ORC Vectorized (Pushdown)               131 /  137        120.2           8.3      20.6X
+    Parquet Vectorized                            2863 / 2926          5.5         182.0       1.0X
+    Parquet Vectorized (Pushdown)                  135 /  145        116.1           8.6      21.1X
+    Native ORC Vectorized                         4924 / 5154          3.2         313.1       0.6X
+    Native ORC Vectorized (Pushdown)               156 /  166        101.1           9.9      18.4X
 
 
     Select 1 int row
     (7864319 < value < 7864321):             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            2861 / 2880          5.5         181.9       1.0X
-    Parquet Vectorized (Pushdown)                   90 /   96        174.7           5.7      31.8X
-    Native ORC Vectorized                         3937 / 4029          4.0         250.3       0.7X
-    Native ORC Vectorized (Pushdown)               132 /  140        118.7           8.4      21.6X
+    Parquet Vectorized                            2856 / 2886          5.5         181.6       1.0X
+    Parquet Vectorized (Pushdown)                  131 /  143        120.4           8.3      21.9X
+    Native ORC Vectorized                         5167 / 5258          3.0         328.5       0.6X
+    Native ORC Vectorized (Pushdown)               152 /  158        103.8           9.6      18.9X
 
 
     Select 10% int rows (value < 1572864):   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            3211 / 3361          4.9         204.2       1.0X
-    Parquet Vectorized (Pushdown)                  784 /  849         20.1          49.8       4.1X
-    Native ORC Vectorized                         4420 / 4462          3.6         281.0       0.7X
-    Native ORC Vectorized (Pushdown)              1112 / 1172         14.1          70.7       2.9X
+    Parquet Vectorized                            3439 / 3493          4.6         218.6       1.0X
+    Parquet Vectorized (Pushdown)                  931 /  952         16.9          59.2       3.7X
+    Native ORC Vectorized                         5653 / 5734          2.8         359.4       0.6X
+    Native ORC Vectorized (Pushdown)              1405 / 1416         11.2          89.3       2.4X
 
 
     Select 50% int rows (value < 7864320):   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            3329 / 3378          4.7         211.7       1.0X
-    Parquet Vectorized (Pushdown)                  962 / 1036         16.3          61.2       3.5X
-    Native ORC Vectorized                         4595 / 4640          3.4         292.2       0.7X
-    Native ORC Vectorized (Pushdown)              1291 / 1362         12.2          82.1       2.6X
+    Parquet Vectorized                            3545 / 3626          4.4         225.4       1.0X
+    Parquet Vectorized (Pushdown)                 1068 / 1153         14.7          67.9       3.3X
+    Native ORC Vectorized                         5578 / 5829          2.8         354.6       0.6X
+    Native ORC Vectorized (Pushdown)              1502 / 1550         10.5          95.5       2.4X
 
 
     Select 90% int rows (value < 14155776):  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            3355 / 3403          4.7         213.3       1.0X
-    Parquet Vectorized (Pushdown)                  976 / 1037         16.1          62.1       3.4X
-    Native ORC Vectorized                         4594 / 4685          3.4         292.1       0.7X
-    Native ORC Vectorized (Pushdown)              1220 / 1335         12.9          77.6       2.8X
+    Parquet Vectorized                            3567 / 3608          4.4         226.8       1.0X
+    Parquet Vectorized (Pushdown)                 1072 / 1152         14.7          68.1       3.3X
+    Native ORC Vectorized                         5713 / 5845          2.8         363.2       0.6X
+    Native ORC Vectorized (Pushdown)              1571 / 1686         10.0          99.9       2.3X
 
 
     Select all int rows (value IS NOT NULL): Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            7300 / 7426          2.2         464.1       1.0X
-    Parquet Vectorized (Pushdown)                 7195 / 7381          2.2         457.4       1.0X
-    Native ORC Vectorized                         9677 / 9989          1.6         615.2       0.8X
-    Native ORC Vectorized (Pushdown)              9610 / 9830          1.6         611.0       0.8X
+    Parquet Vectorized                            8099 / 8360          1.9         514.9       1.0X
+    Parquet Vectorized (Pushdown)                 8257 / 8552          1.9         525.0       1.0X
+    Native ORC Vectorized                       12113 / 12390          1.3         770.1       0.7X
+    Native ORC Vectorized (Pushdown)            12485 / 12595          1.3         793.8       0.6X
 
 
     Select all int rows (value > -1):        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            7317 / 7452          2.1         465.2       1.0X
-    Parquet Vectorized (Pushdown)                 7229 / 7537          2.2         459.6       1.0X
-    Native ORC Vectorized                         9553 / 9744          1.6         607.4       0.8X
-    Native ORC Vectorized (Pushdown)              9780 / 9996          1.6         621.8       0.7X
+    Parquet Vectorized                            8201 / 8348          1.9         521.4       1.0X
+    Parquet Vectorized (Pushdown)                 8410 / 8561          1.9         534.7       1.0X
+    Native ORC Vectorized                       12408 / 12545          1.3         788.9       0.7X
+    Native ORC Vectorized (Pushdown)            12403 / 12489          1.3         788.6       0.7X
 
 
     Select all int rows (value != -1):       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            7378 / 7508          2.1         469.1       1.0X
-    Parquet Vectorized (Pushdown)                 7343 / 7512          2.1         466.8       1.0X
-    Native ORC Vectorized                         9611 / 9842          1.6         611.1       0.8X
-    Native ORC Vectorized (Pushdown)              9564 / 9894          1.6         608.1       0.8X
+    Parquet Vectorized                            8133 / 8526          1.9         517.1       1.0X
+    Parquet Vectorized (Pushdown)                 8301 / 8401          1.9         527.8       1.0X
+    Native ORC Vectorized                       12411 / 12809          1.3         789.1       0.7X
+    Native ORC Vectorized (Pushdown)            12316 / 12605          1.3         783.0       0.7X
 
 
     Select 0 distinct string row
     (value IS NULL):                         Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            2622 / 2681          6.0         166.7       1.0X
-    Parquet Vectorized (Pushdown)                 2637 / 2676          6.0         167.6       1.0X
-    Native ORC Vectorized                         3638 / 3702          4.3         231.3       0.7X
-    Native ORC Vectorized (Pushdown)               102 /  109        153.6           6.5      25.6X
+    Parquet Vectorized                            2800 / 2886          5.6         178.0       1.0X
+    Parquet Vectorized (Pushdown)                   84 /   99        187.0           5.3      33.3X
+    Native ORC Vectorized                         4593 / 4709          3.4         292.0       0.6X
+    Native ORC Vectorized (Pushdown)               122 /  129        128.5           7.8      22.9X
 
 
     Select 0 distinct string row
     ('100' < value < '100'):                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            2712 / 2753          5.8         172.4       1.0X
-    Parquet Vectorized (Pushdown)                 2637 / 2713          6.0         167.7       1.0X
-    Native ORC Vectorized                         3853 / 3930          4.1         244.9       0.7X
-    Native ORC Vectorized (Pushdown)               106 /  119        147.9           6.8      25.5X
+    Parquet Vectorized                            2870 / 2954          5.5         182.5       1.0X
+    Parquet Vectorized (Pushdown)                  109 /  130        144.4           6.9      26.4X
+    Native ORC Vectorized                         4794 / 5000          3.3         304.8       0.6X
+    Native ORC Vectorized (Pushdown)               128 /  135        122.5           8.2      22.3X
 
 
     Select 1 distinct string row
     (value = '100'):                         Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            2747 / 2878          5.7         174.7       1.0X
-    Parquet Vectorized (Pushdown)                 2758 / 2821          5.7         175.3       1.0X
-    Native ORC Vectorized                         3807 / 4026          4.1         242.0       0.7X
-    Native ORC Vectorized (Pushdown)               316 /  322         49.8          20.1       8.7X
+    Parquet Vectorized                            3008 / 3095          5.2         191.3       1.0X
+    Parquet Vectorized (Pushdown)                  328 /  348         47.9          20.9       9.2X
+    Native ORC Vectorized                         4997 / 5101          3.1         317.7       0.6X
+    Native ORC Vectorized (Pushdown)               406 /  416         38.7          25.8       7.4X
 
 
     Select 1 distinct string row
     (value <=> '100'):                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            2753 / 2800          5.7         175.0       1.0X
-    Parquet Vectorized (Pushdown)                 2747 / 2805          5.7         174.6       1.0X
-    Native ORC Vectorized                         3902 / 3967          4.0         248.1       0.7X
-    Native ORC Vectorized (Pushdown)               316 /  331         49.8          20.1       8.7X
+    Parquet Vectorized                            3048 / 3150          5.2         193.8       1.0X
+    Parquet Vectorized (Pushdown)                  326 /  341         48.3          20.7       9.4X
+    Native ORC Vectorized                         4979 / 5008          3.2         316.5       0.6X
+    Native ORC Vectorized (Pushdown)               396 /  401         39.7          25.2       7.7X
 
 
     Select 1 distinct string row
     ('100' <= value <= '100'):               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            2906 / 2917          5.4         184.8       1.0X
-    Parquet Vectorized (Pushdown)                 2819 / 2886          5.6         179.2       1.0X
-    Native ORC Vectorized                         4025 / 4102          3.9         255.9       0.7X
-    Native ORC Vectorized (Pushdown)               325 /  341         48.4          20.7       8.9X
+    Parquet Vectorized                            3123 / 3213          5.0         198.5       1.0X
+    Parquet Vectorized (Pushdown)                  337 /  352         46.7          21.4       9.3X
+    Native ORC Vectorized                         5211 / 5247          3.0         331.3       0.6X
+    Native ORC Vectorized (Pushdown)               402 /  412         39.1          25.6       7.8X
 
 
     Select all distinct string rows
     (value IS NOT NULL):                     Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     ------------------------------------------------------------------------------------------------
-    Parquet Vectorized                            7582 / 7942          2.1         482.0       1.0X
-    Parquet Vectorized (Pushdown)                 7450 / 7916          2.1         473.6       1.0X
-    Native ORC Vectorized                         9497 / 9784          1.7         603.8       0.8X
-    Native ORC Vectorized (Pushdown)              9423 / 9646          1.7         599.1       0.8X
+    Parquet Vectorized                            7995 / 8324          2.0         508.3       1.0X
+    Parquet Vectorized (Pushdown)                 8094 / 8333          1.9         514.6       1.0X
+    Native ORC Vectorized                       11501 / 11872          1.4         731.2       0.7X
+    Native ORC Vectorized (Pushdown)            11436 / 11904          1.4         727.1       0.7X
     */
 
     benchmark.run()


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr added benchmark code `FilterPushdownBenchmark` for string pushdown and updated performance results on the AWS `r3.xlarge`.

## How was this patch tested?
N/A