### PR TITLE
[SPARK-24240] Add a config to control whether InMemoryFileIndex should update cache when refresh.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1238,6 +1238,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val UPDATE_CACHE_WHEN_REFRESH_MEMORY_FILE_INDEX =
+    buildConf("spark.sql.updateCacheWhenRefreshMemoryFileIndex")
+      .internal()
+      .doc("When true, InMemoryFileIndex will update cache when refresh," +
+        " otherwise only mark the cache as outdated.")
+      .booleanConf
+      .createWithDefault(true)
+
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"
   }
@@ -1405,6 +1413,9 @@ class SQLConf extends Serializable with Logging {
   def stringRedationPattern: Option[Regex] = SQL_STRING_REDACTION_PATTERN.readFrom(reader)
 
   def sortBeforeRepartition: Boolean = getConf(SORT_BEFORE_REPARTITION)
+
+  def updateCacheWhenRefreshMemoryFileIndex: Boolean =
+    getConf(UPDATE_CACHE_WHEN_REFRESH_MEMORY_FILE_INDEX)
 
   /**
    * Returns the [[Resolver]] for the current configuration, which can be used to determine if two

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -104,7 +104,13 @@ class InMemoryFileIndex(
     }
   }
 
-  private def refresh0(): Unit = {
+  // Exposed for testing.
+  def ifCacheOutDated(): Boolean = {
+    cacheOutDated
+  }
+
+  // Exposed for testing.
+  protected def refresh0(): Unit = {
     val files = listLeafFiles(rootPaths)
     cachedLeafFiles =
       new mutable.LinkedHashMap[Path, FileStatus]() ++= files.map(f => f.getPath -> f)


### PR DESCRIPTION
## What changes were proposed in this pull request?
In current code(https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala#L172), after data is inserted, spark will always refresh file index and update the cache, which costs extra overhead if the updated cache is not used any more.

This pr proposes to add a config -- `spark.sql.updateCacheWhenRefreshMemoryFileIndex`. When it's false, Spark only marks cache as outdated and do lazy cache-update when list the files.

## How was this patch tested?
Added a test.
