### PR TITLE
[SPARK-24241][Submit]Do not fail fast when dynamic resource allocation enabled with 0 executor

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -277,7 +277,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     if (totalExecutorCores != null && Try(totalExecutorCores.toInt).getOrElse(-1) <= 0) {
       error("Total executor cores must be a positive number")
     }
-    if (dynamicAllocationEnabled.toLowerCase != "true" &&
+    if (!"true".equalsIgnoreCase(dynamicAllocationEnabled) &&
       numExecutors != null && Try(numExecutors.toInt).getOrElse(-1) <= 0) {
       error("Number of executors must be a positive number")
     }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -36,7 +36,6 @@ import org.apache.spark.launcher.SparkSubmitArgumentsParser
 import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
-
 /**
  * Parses and encapsulates arguments from the spark-submit script.
  * The env argument is used for testing.
@@ -76,6 +75,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
   var proxyUser: String = null
   var principal: String = null
   var keytab: String = null
+  var dynamicAllocationEnabled: String = null
 
   // Standalone cluster mode only
   var supervise: Boolean = false
@@ -198,6 +198,9 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     queue = Option(queue).orElse(sparkProperties.get("spark.yarn.queue")).orNull
     keytab = Option(keytab).orElse(sparkProperties.get("spark.yarn.keytab")).orNull
     principal = Option(principal).orElse(sparkProperties.get("spark.yarn.principal")).orNull
+    dynamicAllocationEnabled = Option(dynamicAllocationEnabled)
+      .orElse(sparkProperties.get("spark.dynamicAllocation.enabled"))
+      .orNull
 
     // Try to set main class from JAR if no --class argument is given
     if (mainClass == null && !isPython && !isR && primaryResource != null) {
@@ -274,7 +277,8 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     if (totalExecutorCores != null && Try(totalExecutorCores.toInt).getOrElse(-1) <= 0) {
       error("Total executor cores must be a positive number")
     }
-    if (numExecutors != null && Try(numExecutors.toInt).getOrElse(-1) <= 0) {
+    if (dynamicAllocationEnabled.toLowerCase != "true" &&
+      numExecutors != null && Try(numExecutors.toInt).getOrElse(-1) <= 0) {
       error("Number of executors must be a positive number")
     }
     if (pyFiles != null && !isPython) {

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -75,7 +75,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
   var proxyUser: String = null
   var principal: String = null
   var keytab: String = null
-  var dynamicAllocationEnabled: String = null
+  private var dynamicAllocationEnabled: String = null
 
   // Standalone cluster mode only
   var supervise: Boolean = false

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -75,7 +75,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
   var proxyUser: String = null
   var principal: String = null
   var keytab: String = null
-  private var dynamicAllocationEnabled: String = null
+  private var dynamicAllocationEnabled: Boolean = false
 
   // Standalone cluster mode only
   var supervise: Boolean = false
@@ -198,9 +198,8 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     queue = Option(queue).orElse(sparkProperties.get("spark.yarn.queue")).orNull
     keytab = Option(keytab).orElse(sparkProperties.get("spark.yarn.keytab")).orNull
     principal = Option(principal).orElse(sparkProperties.get("spark.yarn.principal")).orNull
-    dynamicAllocationEnabled = Option(dynamicAllocationEnabled)
-      .orElse(sparkProperties.get("spark.dynamicAllocation.enabled"))
-      .orNull
+    dynamicAllocationEnabled =
+      sparkProperties.get("spark.dynamicAllocation.enabled").exists("true".equalsIgnoreCase)
 
     // Try to set main class from JAR if no --class argument is given
     if (mainClass == null && !isPython && !isR && primaryResource != null) {
@@ -277,7 +276,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     if (totalExecutorCores != null && Try(totalExecutorCores.toInt).getOrElse(-1) <= 0) {
       error("Total executor cores must be a positive number")
     }
-    if (!"true".equalsIgnoreCase(dynamicAllocationEnabled) &&
+    if (!dynamicAllocationEnabled &&
       numExecutors != null && Try(numExecutors.toInt).getOrElse(-1) <= 0) {
       error("Number of executors must be a positive number")
     }

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -180,15 +180,14 @@ class SparkSubmitSuite
     appArgs.toString should include ("thequeue")
   }
 
-  test("SPARK-24241: not fail fast when executor num is 0 and dynamic allocation enabled") {
+  test("SPARK-24241: do not fail fast if executor num is 0 when dynamic allocation is enabled") {
     val clArgs1 = Seq(
       "--name", "myApp",
       "--class", "Foo",
       "--num-executors", "0",
       "--conf", "spark.dynamicAllocation.enabled=true",
       "thejar.jar")
-    val appArgs = new SparkSubmitArguments(clArgs1)
-    appArgs.dynamicAllocationEnabled should be ("true")
+    new SparkSubmitArguments(clArgs1)
 
     val clArgs2 = Seq(
       "--name", "myApp",
@@ -196,7 +195,9 @@ class SparkSubmitSuite
       "--num-executors", "0",
       "--conf", "spark.dynamicAllocation.enabled=false",
       "thejar.jar")
-    intercept[SparkException](new SparkSubmitArguments(clArgs2))
+
+    val e = intercept[SparkException](new SparkSubmitArguments(clArgs2))
+    assert(e.getMessage.contains("Number of executors must be a positive number"))
   }
 
   test("specify deploy mode through configuration") {

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -303,6 +303,23 @@ class SparkSubmitSuite
     sys.props("SPARK_SUBMIT") should be ("true")
   }
 
+  test("SPARK-24241: not fail fast when executor num is 0 and dynamic allocation enabled") {
+    val clArgs1 = Seq(
+      "--name", "myApp",
+      "--num-executors", "0",
+      "--conf", "spark.dynamicAllocation.enabled=true",
+      "thejar.jar")
+    val appArgs = new SparkSubmitArguments(clArgs1)
+    appArgs.dynamicAllocationEnabled should be ("true")
+
+    val clArgs2 = Seq(
+      "--name", "myApp",
+      "--num-executors", "0",
+      "--conf", "spark.dynamicAllocation.enabled=false",
+      "thejar.jar")
+    intercept[SparkException](new SparkSubmitArguments(clArgs2))
+  }
+
   test("handles standalone cluster mode") {
     testStandaloneCluster(useRest = true)
   }

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -180,6 +180,25 @@ class SparkSubmitSuite
     appArgs.toString should include ("thequeue")
   }
 
+  test("SPARK-24241: not fail fast when executor num is 0 and dynamic allocation enabled") {
+    val clArgs1 = Seq(
+      "--name", "myApp",
+      "--class", "Foo",
+      "--num-executors", "0",
+      "--conf", "spark.dynamicAllocation.enabled=true",
+      "thejar.jar")
+    val appArgs = new SparkSubmitArguments(clArgs1)
+    appArgs.dynamicAllocationEnabled should be ("true")
+
+    val clArgs2 = Seq(
+      "--name", "myApp",
+      "--class", "Foo",
+      "--num-executors", "0",
+      "--conf", "spark.dynamicAllocation.enabled=false",
+      "thejar.jar")
+    intercept[SparkException](new SparkSubmitArguments(clArgs2))
+  }
+
   test("specify deploy mode through configuration") {
     val clArgs = Seq(
       "--master", "yarn",
@@ -301,23 +320,6 @@ class SparkSubmitSuite
       regex (".*one.jar,.*two.jar,.*three.jar,.*thejar.jar")
     conf.get("spark.ui.enabled") should be ("false")
     sys.props("SPARK_SUBMIT") should be ("true")
-  }
-
-  test("SPARK-24241: not fail fast when executor num is 0 and dynamic allocation enabled") {
-    val clArgs1 = Seq(
-      "--name", "myApp",
-      "--num-executors", "0",
-      "--conf", "spark.dynamicAllocation.enabled=true",
-      "thejar.jar")
-    val appArgs = new SparkSubmitArguments(clArgs1)
-    appArgs.dynamicAllocationEnabled should be ("true")
-
-    val clArgs2 = Seq(
-      "--name", "myApp",
-      "--num-executors", "0",
-      "--conf", "spark.dynamicAllocation.enabled=false",
-      "thejar.jar")
-    intercept[SparkException](new SparkSubmitArguments(clArgs2))
   }
 
   test("handles standalone cluster mode") {


### PR DESCRIPTION
## What changes were proposed in this pull request?
```
~/spark-2.3.0-bin-hadoop2.7$ bin/spark-sql --num-executors 0 --conf spark.dynamicAllocation.enabled=true
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option PermSize=1024m; support was removed in 8.0
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=1024m; support was removed in 8.0
Error: Number of executors must be a positive number
Run with --help for usage help or --verbose for debug output
```

Actually, we could start up with min executor number with 0 before if dynamically

## How was this patch tested?

ut added
