### PR TITLE
[SPARK-24237][SS] Continuous shuffle dependency and map output tracker

### DIFF
--- a/core/src/main/scala/org/apache/spark/Dependency.scala
+++ b/core/src/main/scala/org/apache/spark/Dependency.scala
@@ -65,15 +65,17 @@ abstract class NarrowDependency[T](_rdd: RDD[T]) extends Dependency[T] {
  * @param keyOrdering key ordering for RDD's shuffles
  * @param aggregator map/reduce-side aggregator for RDD's shuffle
  * @param mapSideCombine whether to perform partial aggregation (also known as map-side combine)
+ * @param isContinuous mark the dependency is base for continuous processing or not
  */
 @DeveloperApi
 class ShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
-    @transient private val _rdd: RDD[_ <: Product2[K, V]],
+    @transient val _rdd: RDD[_ <: Product2[K, V]],
     val partitioner: Partitioner,
     val serializer: Serializer = SparkEnv.get.serializer,
     val keyOrdering: Option[Ordering[K]] = None,
     val aggregator: Option[Aggregator[K, V, C]] = None,
-    val mapSideCombine: Boolean = false)
+    val mapSideCombine: Boolean = false,
+    val isContinuous: Boolean = false)
   extends Dependency[Product2[K, V]] {
 
   if (mapSideCombine) {
@@ -88,37 +90,52 @@ class ShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
   private[spark] val combinerClassName: Option[String] =
     Option(reflect.classTag[C]).map(_.runtimeClass.getName)
 
-  val shuffleId: Int = _rdd.context.newShuffleId()
+  val shuffleId: Int = if (isContinuous) {
+    // This will not be reset in continuous processing, set an invalid value for now.
+    Int.MinValue
+  } else {
+    _rdd.context.newShuffleId()
+  }
 
-  val shuffleHandle: ShuffleHandle = _rdd.context.env.shuffleManager.registerShuffle(
-    shuffleId, _rdd.partitions.length, this)
+  val shuffleHandle: ShuffleHandle = if (isContinuous) {
+    null
+  } else {
+    _rdd.context.env.shuffleManager.registerShuffle(
+      shuffleId, _rdd.partitions.length, this)
+  }
 
-  _rdd.sparkContext.cleaner.foreach(_.registerShuffleForCleanup(this))
+  if (!isContinuous) {
+    _rdd.sparkContext.cleaner.foreach(_.registerShuffleForCleanup(this))
+  }
 }
 
 /**
  * :: DeveloperApi ::
  * Represents a dependency on the output of a shuffle stage of continuous type.
+ * Different with ShuffleDependency, the continuous dependency only create on Executor side,
+ * so the rdd in param is deserialized from taskBinary.
  */
 @DeveloperApi
 class ContinuousShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
-    dep: ShuffleDependency[K, V, C], continuousEpoch: Int, totalShuffleNum: Int)
+    rdd: RDD[_ <: Product2[K, V]],
+    dep: ShuffleDependency[K, V, C],
+    continuousEpoch: Int,
+    totalShuffleNum: Int,
+    shuffleNumMaps: Int)
   extends ShuffleDependency[K, V, C](
-    dep.rdd,
+    rdd,
     dep.partitioner,
     dep.serializer,
     dep.keyOrdering,
     dep.aggregator,
-    dep.mapSideCombine) {
+    dep.mapSideCombine, true) {
 
-  val baseShuffleId: Int = super.shuffleId
+  val baseShuffleId: Int = dep.shuffleId
 
   override val shuffleId: Int = continuousEpoch * totalShuffleNum + baseShuffleId
 
-  override val shuffleHandle: ShuffleHandle = dep.rdd.context.env.shuffleManager.registerShuffle(
-    shuffleId, dep.rdd.partitions.length, this)
-
-  dep.rdd.sparkContext.cleaner.foreach(_.registerShuffleForCleanup(this))
+  override val shuffleHandle: ShuffleHandle = SparkEnv.get.shuffleManager.registerShuffle(
+    shuffleId, shuffleNumMaps, this)
 }
 
 /**

--- a/core/src/main/scala/org/apache/spark/Dependency.scala
+++ b/core/src/main/scala/org/apache/spark/Dependency.scala
@@ -78,6 +78,12 @@ class ShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
     val isContinuous: Boolean = false)
   extends Dependency[Product2[K, V]] {
 
+  def this(rdd: RDD[_ <: Product2[K, V]], partitioner: Partitioner,
+    serializer: Serializer, keyOrdering: Option[Ordering[K]],
+    aggregator: Option[Aggregator[K, V, C]], mapSideCombine: Boolean) = {
+    this(rdd, partitioner, serializer, keyOrdering, aggregator, mapSideCombine, false)
+  }
+
   if (mapSideCombine) {
     require(aggregator.isDefined, "Map-side combine without Aggregator specified!")
   }

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -140,6 +140,7 @@ object SparkEnv extends Logging {
 
   private[spark] val driverSystemName = "sparkDriver"
   private[spark] val executorSystemName = "sparkExecutor"
+  private[spark] val START_EPOCH_KEY = "__continuous_start_epoch"
 
   def set(e: SparkEnv) {
     env = e
@@ -305,7 +306,7 @@ object SparkEnv extends Logging {
     val mapOutputTracker = if (isDriver) {
       new MapOutputTrackerMaster(conf, broadcastManager, isLocal)
     } else if (isContinuous) {
-      new ContinuousProcessingMapOutputTrackerWorker(conf)
+      new ContinuousMapOutputTrackerWorker(conf)
     } else {
       new MapOutputTrackerWorker(conf)
     }
@@ -319,7 +320,9 @@ object SparkEnv extends Logging {
     // Let the user specify short names for shuffle managers
     val shortShuffleMgrNames = Map(
       "sort" -> classOf[org.apache.spark.shuffle.sort.SortShuffleManager].getName,
-      "tungsten-sort" -> classOf[org.apache.spark.shuffle.sort.SortShuffleManager].getName)
+      "tungsten-sort" -> classOf[org.apache.spark.shuffle.sort.SortShuffleManager].getName,
+      "continuous" ->
+        classOf[org.apache.spark.sql.execution.streaming.continuous.ContinuousShuffleManager])
     val shuffleMgrName = conf.get("spark.shuffle.manager", "sort")
     val shuffleMgrClass =
       shortShuffleMgrNames.getOrElse(shuffleMgrName.toLowerCase(Locale.ROOT), shuffleMgrName)

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -320,9 +320,7 @@ object SparkEnv extends Logging {
     // Let the user specify short names for shuffle managers
     val shortShuffleMgrNames = Map(
       "sort" -> classOf[org.apache.spark.shuffle.sort.SortShuffleManager].getName,
-      "tungsten-sort" -> classOf[org.apache.spark.shuffle.sort.SortShuffleManager].getName,
-      "continuous" ->
-        classOf[org.apache.spark.sql.execution.streaming.continuous.ContinuousShuffleManager])
+      "tungsten-sort" -> classOf[org.apache.spark.shuffle.sort.SortShuffleManager].getName)
     val shuffleMgrName = conf.get("spark.shuffle.manager", "sort")
     val shuffleMgrClass =
       shortShuffleMgrNames.getOrElse(shuffleMgrName.toLowerCase(Locale.ROOT), shuffleMgrName)

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -227,6 +227,7 @@ object SparkEnv extends Logging {
       mockOutputCommitCoordinator: Option[OutputCommitCoordinator] = None): SparkEnv = {
 
     val isDriver = executorId == SparkContext.DRIVER_IDENTIFIER
+    val isContinuous = conf.getBoolean("spark.streaming.continuousMode", false)
 
     // Listener bus is only used on the driver
     if (isDriver) {
@@ -303,6 +304,8 @@ object SparkEnv extends Logging {
 
     val mapOutputTracker = if (isDriver) {
       new MapOutputTrackerMaster(conf, broadcastManager, isLocal)
+    } else if (isContinuous) {
+      new ContinuousProcessingMapOutputTrackerWorker(conf)
     } else {
       new MapOutputTrackerWorker(conf)
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/ContinuousShuffleMapTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ContinuousShuffleMapTask.scala
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler
+
+import java.lang.management.ManagementFactory
+import java.nio.ByteBuffer
+import java.util.Properties
+
+import scala.language.existentials
+
+import org.apache.spark._
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
+import org.apache.spark.shuffle.ShuffleWriter
+
+/**
+ * A ShuffleMapTask divides the elements of an RDD into multiple buckets (based on a partitioner
+ * specified in the ShuffleDependency).
+ *
+ * See [[org.apache.spark.scheduler.Task]] for more information.
+ *
+ * @param stageId id of the stage this task belongs to
+ * @param stageAttemptId attempt id of the stage this task belongs to
+ * @param taskBinary broadcast version of the RDD and the ShuffleDependency. Once deserialized,
+ *                   the type should be (RDD[_], ShuffleDependency[_, _, _]).
+ * @param partition partition of the RDD this task is associated with
+ * @param locs preferred task execution locations for locality scheduling
+ * @param localProperties copy of thread-local properties set by the user on the driver side.
+ * @param serializedTaskMetrics a `TaskMetrics` that is created and serialized on the driver side
+ *                              and sent to executor side.
+ * @param totalShuffleNum total shuffle number for current job.
+ *
+ * The parameters below are optional:
+ * @param jobId id of the job this task belongs to
+ * @param appId id of the app this task belongs to
+ * @param appAttemptId attempt id of the app this task belongs to
+ */
+private[spark] class ContinuousShuffleMapTask(
+    stageId: Int,
+    stageAttemptId: Int,
+    taskBinary: Broadcast[Array[Byte]],
+    partition: Partition,
+    @transient private var locs: Seq[TaskLocation],
+    localProperties: Properties,
+    serializedTaskMetrics: Array[Byte],
+    totalShuffleNum: Int,
+    jobId: Option[Int] = None,
+    appId: Option[String] = None,
+    appAttemptId: Option[String] = None)
+  extends Task[Unit](stageId, stageAttemptId, partition.index, localProperties,
+    serializedTaskMetrics, jobId, appId, appAttemptId)
+    with Logging {
+
+  /** A constructor used only in test suites. This does not require passing in an RDD. */
+  def this(partitionId: Int) {
+    this(0, 0, null, new Partition { override def index: Int = 0 }, null, new Properties, null)
+  }
+
+  @transient private val preferredLocs: Seq[TaskLocation] = {
+    if (locs == null) Nil else locs.toSet.toSeq
+  }
+
+  // TODO: Get current epoch from epoch coordinator while task restart, also epoch is Long, we
+  //       should deal with it.
+  var currentEpoch = context.getLocalProperty(SparkEnv.START_EPOCH_KEY).toInt
+
+  override def runTask(context: TaskContext): Unit = {
+    // Deserialize the RDD using the broadcast variable.
+    val threadMXBean = ManagementFactory.getThreadMXBean
+    val deserializeStartTime = System.currentTimeMillis()
+    val deserializeStartCpuTime = if (threadMXBean.isCurrentThreadCpuTimeSupported) {
+      threadMXBean.getCurrentThreadCpuTime
+    } else 0L
+    val ser = SparkEnv.get.closureSerializer.newInstance()
+    // TODO: rdd here should be a wrap of ShuffledRowRDD which never stop
+    val (rdd, dep) = ser.deserialize[(RDD[_], ShuffleDependency[_, _, _])](
+      ByteBuffer.wrap(taskBinary.value), Thread.currentThread.getContextClassLoader)
+    _executorDeserializeTime = System.currentTimeMillis() - deserializeStartTime
+    _executorDeserializeCpuTime = if (threadMXBean.isCurrentThreadCpuTimeSupported) {
+      threadMXBean.getCurrentThreadCpuTime - deserializeStartCpuTime
+    } else 0L
+
+    var writer: ShuffleWriter[Any, Any] = null
+    val manager = SparkEnv.get.shuffleManager
+    val mapOutputTracker = SparkEnv.get.mapOutputTracker
+      .asInstanceOf[ContinuousMapOutputTrackerWorker]
+
+    while (!context.isCompleted() || !context.isInterrupted()) {
+      try {
+        // Create a ContinuousShuffleDependency which has new shuffleId based on continuous epoch
+        val continuousDep = new ContinuousShuffleDependency(dep, currentEpoch, totalShuffleNum)
+        // Re-register the shuffle TO mapOutputTrackerMaster
+        mapOutputTracker.checkAndRegisterShuffle(continuousDep.shuffleId, rdd.partitions.length)
+        writer = manager.getWriter[Any, Any](continuousDep.shuffleHandle, partitionId, context)
+        writer.write(rdd.iterator(partition, context)
+          .asInstanceOf[Iterator[_ <: Product2[Any, Any]]])
+        val status = writer.stop(success = true).get
+        // Register map output in task cause the continuous task never success
+        mapOutputTracker.registerMapOutput(continuousDep.shuffleId, partitionId, status)
+        currentEpoch += 1
+      } catch {
+        case e: Exception =>
+          try {
+            if (writer != null) {
+              writer.stop(success = false)
+            }
+          } catch {
+            case e: Exception =>
+              log.debug("Could not stop writer", e)
+          }
+          throw e
+      }
+    }
+  }
+
+  override def preferredLocations: Seq[TaskLocation] = preferredLocs
+
+  override def toString: String = "ContinuousShuffleMapTask(%d, %d)".format(stageId, partitionId)
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

As our disscussion in [jira comment](https://issues.apache.org/jira/browse/SPARK-24036?focusedCommentId=16470067&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16470067) and [design comment](https://docs.google.com/document/d/1IL4kJoKrZWeyIhklKUJqsW-yEN7V7aL05MmM65AYOfE/edit?disco=AAAAB4X1H_E) and [design doc](https://docs.google.com/document/d/14cGJ75v9myznywtB35ytEqL9wHy9xfZRv06B6g2tUgI/edit#bookmark=id.2lfv2glj7ny0), this pr including the following changes:
1. Add ContinuousShuffleDependency support, which can allow shuffleId generated from epoch and re-register shuffleHandle with new shuffleId.
2. Add ContinuousMapOutputTrackerWorker, which can get shuffle status by a blocking way, and support register shuffle\map ouput in tracker worker.
3. Add ContinuousShuffleMapTask.

## How was this patch tested?

Add a new UT for ContinuousMapOutputTracker.
