### PR TITLE
[SPARK-24262][Python] Fix typo in UDF type match error message

### DIFF
--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -82,7 +82,7 @@ def wrap_scalar_pandas_udf(f, return_type):
     def verify_result_length(*a):
         result = f(*a)
         if not hasattr(result, "__len__"):
-            raise TypeError("Return type of the user-defined functon should be "
+            raise TypeError("Return type of the user-defined function should be "
                             "Pandas.Series, but is {}".format(type(result)))
         if len(result) != len(a[0]):
             raise RuntimeError("Result vector from pandas_udf was not the required length: "


### PR DESCRIPTION
## What changes were proposed in this pull request?

Updates `functon` to `function`. This was called out in @holdenk's PyCon 2018 conference talk. Didn't see any existing PR's for this.

@holdenk happy to fix the Pandas.Series bug too but will need a bit more guidance.
