### PR TITLE
[SPARK-24257][SQL]LongToUnsafeRowMap calculate the new size may be wrong

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -30,7 +30,6 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.physical.BroadcastMode
 import org.apache.spark.sql.types.LongType
 import org.apache.spark.unsafe.Platform
-import org.apache.spark.unsafe.array.ByteArrayMethods
 import org.apache.spark.unsafe.map.BytesToBytesMap
 import org.apache.spark.util.{KnownSizeEstimation, Utils}
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
@@ -266,9 +266,9 @@ class HashedRelationSuite extends SparkFunSuite with SharedSQLContext {
     val map = new LongToUnsafeRowMap(taskMemoryManager, 1)
 
     val key = 0L
-    // the page array is initialized with length 1 << 17,
-    // so here we need a value larger than 1 << 18
-    val bigStr = UTF8String.fromString("x" * 1024 * 1024 * 2)
+    // the page array is initialized with length 1 << 17 (1M bytes),
+    // so here we need a value larger than 1 << 18 (2M bytes),to trigger the bug
+    val bigStr = UTF8String.fromString("x" * (1 << 22))
 
     map.append(key, unsafeProj(InternalRow(bigStr)))
     map.optimize()


### PR DESCRIPTION
## What changes were proposed in this pull request?

LongToUnsafeRowMap
Calculate the new size simply by multiplying by 2
At this time, the size of the application may not be enough to store data
Some data is lost and the data read out is dirty

## How was this patch tested?
HashedRelationSuite
test("LongToUnsafeRowMap with big values")