### PR TITLE
[SPARK-24225][CORE] Support closing AutoClosable objects in MemoryStore

### DIFF
--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
@@ -238,6 +238,7 @@ private[spark] class TorrentBroadcast[T: ClassTag](obj: T, id: Long)
               // need to re-fetch it.
               val storageLevel = StorageLevel.MEMORY_AND_DISK
               if (!blockManager.putSingle(broadcastId, obj, storageLevel, tellMaster = false)) {
+                Utils.tryClose(obj)
                 throw new SparkException(s"Failed to store $broadcastId in BlockManager")
               }
 

--- a/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
@@ -388,13 +388,13 @@ private[spark] class MemoryStore(
   private def maybeReleaseResources(entry: MemoryEntry[_]): Unit = {
     entry match {
       case SerializedMemoryEntry(buffer, _, _) => buffer.dispose()
-      case DeserializedMemoryEntry(objs: Array[Any], _, _) => maybeCloseValues(objs)
+      case DeserializedMemoryEntry(values: Array[Any], _, _) => maybeCloseValues(values)
       case _ =>
     }
   }
 
-  private def maybeCloseValues(objs: Array[Any]): Unit = {
-    objs.foreach {
+  private def maybeCloseValues(values: Array[Any]): Unit = {
+    values.foreach {
       case closable: AutoCloseable =>
         safelyCloseValue(closable)
       case _ =>

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1930,6 +1930,18 @@ private[spark] object Utils extends Logging {
     }
   }
 
+  def tryClose(value: Any): Unit = {
+    value match {
+      case closable: AutoCloseable =>
+        try {
+          closable.close()
+        } catch {
+          case ex: Exception => logError(s"Failed to close AutoClosable $closable", ex)
+        }
+      case _ =>
+    }
+  }
+
   /** Returns true if the given exception was fatal. See docs for scala.util.control.NonFatal. */
   def isFatalError(e: Throwable): Boolean = {
     e match {

--- a/core/src/test/scala/org/apache/spark/storage/MemoryStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/MemoryStoreSuite.scala
@@ -539,6 +539,18 @@ class MemoryStoreSuite
     assert(tracker.getClosed())
   }
 
+  test("[SPARK-24225]: remove should not close object if it's not a broadcast variable") {
+
+    val (store, _) = makeMemoryStore(12000)
+
+    val id = "a1" // This will be a test variable
+    val tracker = new CloseTracker()
+    store.putIteratorAsValues(id, Iterator(tracker), ClassTag.Any)
+    assert(store.contains(id))
+    store.remove(id)
+    assert(!tracker.getClosed())
+  }
+
   test("[SPARK-24225]: remove should close AutoCloseable objects even if they throw exceptions") {
 
     val (store, _) = makeMemoryStore(12000)

--- a/core/src/test/scala/org/apache/spark/storage/MemoryStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/MemoryStoreSuite.scala
@@ -536,7 +536,7 @@ class MemoryStoreSuite
     store.putIteratorAsValues(id, Iterator(tracker), ClassTag.Any)
     assert(store.contains(id))
     store.remove(id)
-    assert(tracker.getClosed())
+    assert(tracker.getClosed)
   }
 
   test("[SPARK-24225]: remove should not close object if it's not a broadcast variable") {
@@ -548,7 +548,7 @@ class MemoryStoreSuite
     store.putIteratorAsValues(id, Iterator(tracker), ClassTag.Any)
     assert(store.contains(id))
     store.remove(id)
-    assert(!tracker.getClosed())
+    assert(!tracker.getClosed)
   }
 
   test("[SPARK-24225]: remove should close AutoCloseable objects even if they throw exceptions") {
@@ -560,7 +560,7 @@ class MemoryStoreSuite
     store.putIteratorAsValues(id, Iterator(tracker), ClassTag.Any)
     assert(store.contains(id))
     store.remove(id)
-    assert(tracker.getClosed())
+    assert(tracker.getClosed)
   }
 
   test("[SPARK-24225]: clear should close AutoCloseable objects") {
@@ -572,7 +572,7 @@ class MemoryStoreSuite
     store.putIteratorAsValues(id, Iterator(tracker), ClassTag.Any)
     assert(store.contains(id))
     store.clear()
-    assert(tracker.getClosed())
+    assert(tracker.getClosed)
   }
 
   test("[SPARK-24225]: clear should close all AutoCloseable objects put together in an iterator") {
@@ -585,8 +585,8 @@ class MemoryStoreSuite
     store.putIteratorAsValues(id1, Iterator(tracker1, tracker2), ClassTag.Any)
     assert(store.contains(id1))
     store.clear()
-    assert(tracker1.getClosed())
-    assert(tracker2.getClosed())
+    assert(tracker1.getClosed)
+    assert(tracker2.getClosed)
   }
 
   test("[SPARK-24225]: clear should close AutoCloseable objects even if they throw exceptions") {
@@ -602,20 +602,29 @@ class MemoryStoreSuite
     assert(store.contains(id1))
     assert(store.contains(id2))
     store.clear()
-    assert(tracker1.getClosed())
-    assert(tracker2.getClosed())
+    assert(tracker1.getClosed)
+    assert(tracker1.getExceptionThrown)
+    assert(tracker2.getClosed)
+    assert(tracker2.getExceptionThrown)
   }
 }
 
 private class CloseTracker (val throwsOnClosed: Boolean = false) extends AutoCloseable {
-  var closed = false
+  private var closed = false
+  private var exceptionThrown = false
+
   override def close(): Unit = {
     closed = true
     if (throwsOnClosed) {
+      exceptionThrown = true
       throw new RuntimeException("Throwing")
     }
   }
-  def getClosed(): Boolean = {
+  def getClosed: Boolean = {
     closed
+  }
+
+  def getExceptionThrown: Boolean = {
+    exceptionThrown
   }
 }


### PR DESCRIPTION
This allows Broadcast Variables can be released properly

## What changes were proposed in this pull request?

Broadcast variables, while usually used to broadcast data to executors, can also be used to control the scope and lifecycle of shared resources (e.g. connection pools). When creating and destroying those resources within a task is expensive, using a broadcast variable to keep them deserialized in memory for multiple tasks to share can make a huge difference in the efficiency of a Spark job.

In `MemoryStore`, check if any entries in a `DeserializedMemoryEntry` implement `AutoClosable` and, if so, call `close` on those resources. This occurs in two places:
- `remove` of an individual item
- `clear` of the MemoryStore

## How was this patch tested?

Added additional tests to `MemoryStoreSuite` in order to check that we properly close resources, and handle exceptions properly.