### PR TITLE
[SPARK-22234] Support distinct window functions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -104,8 +104,9 @@ trait CheckAnalysis extends PredicateHelper {
           case g: GroupingID =>
             failAnalysis("grouping_id() can only be used with GroupingSets/Cube/Rollup")
 
-          case w @ WindowExpression(AggregateExpression(_, _, true, _), _) =>
-            failAnalysis(s"Distinct window functions are not supported: $w")
+          case w @ WindowExpression(AggregateExpression(_, _, true, _), windowSpec)
+              if windowSpec.orderSpec.nonEmpty =>
+            failAnalysis(s"ORDER BY cannot be used with DISTINCT: $w")
 
           case w @ WindowExpression(_: OffsetWindowFunction,
             WindowSpecDefinition(_, order, frame: SpecifiedWindowFrame))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -152,25 +152,9 @@ class AnalysisErrorSuite extends AnalysisTest {
     "not supported within a window function" :: Nil)
 
   errorTest(
-    "distinct aggregate function in window",
-    testRelation2.select(
-      WindowExpression(
-        AggregateExpression(Count(UnresolvedAttribute("b")), Complete, isDistinct = true),
-        WindowSpecDefinition(
-          UnresolvedAttribute("a") :: Nil,
-          SortOrder(UnresolvedAttribute("b"), Ascending) :: Nil,
-          UnspecifiedFrame)).as('window)),
-    "Distinct window functions are not supported" :: Nil)
-
-  errorTest(
     "distinct function",
     CatalystSqlParser.parsePlan("SELECT hex(DISTINCT a) FROM TaBlE"),
     "hex does not support the modifier DISTINCT" :: Nil)
-
-  errorTest(
-    "distinct window function",
-    CatalystSqlParser.parsePlan("SELECT percent_rank(DISTINCT a) over () FROM TaBlE"),
-    "percent_rank does not support the modifier DISTINCT" :: Nil)
 
   errorTest(
     "nested aggregate functions",

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowFunctionFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowFunctionFrame.scala
@@ -231,6 +231,7 @@ private[window] final class SlidingWindowFunctionFrame(
 
     // Only recalculate and update when the buffer changes.
     if (bufferUpdated) {
+      previousRow = null
       processor.initialize(input.length)
       val iter = buffer.iterator()
       while (iter.hasNext) {
@@ -453,8 +454,10 @@ private[window] final class UnboundedFollowingWindowFunctionFrame(
     // Only recalculate and update when the buffer changes.
     if (bufferUpdated) {
       processor.initialize(input.length)
+      previousRow = null
       if (nextRow != null) {
         processor.update(nextRow)
+        previousRow = nextRow
       }
       while (iterator.hasNext) {
         val row = iterator.next()

--- a/sql/core/src/test/resources/sql-tests/inputs/window.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/window.sql
@@ -110,14 +110,58 @@ FROM testData
 WINDOW w AS ()
 ORDER BY cate, val;
 
--- sum(distinct)
+-- sum(distinct) for entire partition frame
 SELECT val, cate,
 sum(val) OVER (PARTITION BY cate) AS sum1,
 sum(DISTINCT val) OVER (PARTITION BY cate) AS sum2
-FROM testData;
+FROM testData
+ORDER BY cate, val;
 
--- count(distinct)
+-- count(distinct) for entire partition frame
 SELECT val, cate,
 count(val) OVER (PARTITION BY cate) AS cnt1,
 count(DISTINCT val) OVER (PARTITION BY cate) AS cnt2
-FROM testData;
+FROM testData
+ORDER BY cate, val;
+
+-- sum(distinct) for growing frame
+SELECT val, cate,
+sum(val) OVER (PARTITION BY cate ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS sum1,
+sum(DISTINCT val) OVER (PARTITION BY cate ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS sum2
+FROM testData
+ORDER BY cate, val;
+
+-- count(distinct) for growing frame
+SELECT val, cate,
+count(val) OVER (PARTITION BY cate ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS cnt1,
+count(DISTINCT val) OVER (PARTITION BY cate ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS cnt2
+FROM testData
+ORDER BY cate, val;
+
+-- sum(distinct) for shrinking frame
+SELECT val, cate,
+sum(val) OVER (PARTITION BY cate ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS sum1,
+sum(DISTINCT val) OVER (PARTITION BY cate ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS sum2
+FROM testData
+ORDER BY cate, val;
+
+-- count(distinct) for shrinking frame
+SELECT val, cate,
+count(val) OVER (PARTITION BY cate ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS cnt1,
+count(DISTINCT val) OVER (PARTITION BY cate ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS cnt2
+FROM testData
+ORDER BY cate, val;
+
+-- sum(distinct) for moving frame
+SELECT val, cate,
+sum(val) OVER (PARTITION BY cate ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS sum1,
+sum(DISTINCT val) OVER (PARTITION BY cate ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS sum2
+FROM testData
+ORDER BY cate, val;
+
+-- count(distinct) for moving frame
+SELECT val, cate,
+count(val) OVER (PARTITION BY cate ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS cnt1,
+count(DISTINCT val) OVER (PARTITION BY cate ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS cnt2
+FROM testData
+ORDER BY cate, val;

--- a/sql/core/src/test/resources/sql-tests/inputs/window.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/window.sql
@@ -109,3 +109,15 @@ last_value(false, false) OVER w AS last_value_contain_null
 FROM testData
 WINDOW w AS ()
 ORDER BY cate, val;
+
+-- sum(distinct)
+SELECT val, cate,
+sum(val) OVER (PARTITION BY cate) AS sum1,
+sum(DISTINCT val) OVER (PARTITION BY cate) AS sum2
+FROM testData;
+
+-- count(distinct)
+SELECT val, cate,
+count(val) OVER (PARTITION BY cate) AS cnt1,
+count(DISTINCT val) OVER (PARTITION BY cate) AS cnt2
+FROM testData;

--- a/sql/core/src/test/resources/sql-tests/results/window.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/window.sql.out
@@ -370,18 +370,19 @@ SELECT val, cate,
 sum(val) OVER (PARTITION BY cate) AS sum1,
 sum(DISTINCT val) OVER (PARTITION BY cate) AS sum2
 FROM testData
+ORDER BY cate, val
 -- !query 11 schema
 struct<val:int,cate:string,sum1:bigint,sum2:bigint>
 -- !query 11 output
-1	a	4	3
-1	a	4	3
-1	b	6	6
-2	a	4	3
-2	b	6	6
-3	NULL	3	3
-3	b	6	6
 NULL	NULL	3	3
+3	NULL	3	3
 NULL	a	4	3
+1	a	4	3
+1	a	4	3
+2	a	4	3
+1	b	6	6
+2	b	6	6
+3	b	6	6
 
 
 -- !query 12
@@ -389,15 +390,130 @@ SELECT val, cate,
 count(val) OVER (PARTITION BY cate) AS cnt1,
 count(DISTINCT val) OVER (PARTITION BY cate) AS cnt2
 FROM testData
+ORDER BY cate, val
 -- !query 12 schema
 struct<val:int,cate:string,cnt1:bigint,cnt2:bigint>
 -- !query 12 output
-1	a	3	2
-1	a	3	2
-1	b	3	3
-2	a	3	2
-2	b	3	3
-3	NULL	1	1
-3	b	3	3
 NULL	NULL	1	1
+3	NULL	1	1
 NULL	a	3	2
+1	a	3	2
+1	a	3	2
+2	a	3	2
+1	b	3	3
+2	b	3	3
+3	b	3	3
+
+-- !query13
+SELECT val, cate,
+sum(val) OVER (PARTITION BY cate ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS sum1,
+sum(DISTINCT val) OVER (PARTITION BY cate ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS sum2
+FROM testData
+ORDER BY cate, val
+-- !query 13 schema
+struct<val:int,cate:string,sum1:bigint,sum2:bigint>
+-- !query 13 output
+NULL	NULL	NULL	NULL
+3	NULL	3	3
+NULL	a	NULL	NULL
+1	a	1	1
+1	a	2	1
+2	a	4	3
+1	b	1	1
+2	b	3	3
+3	b	6	6
+
+-- !query14
+SELECT val, cate,
+count(val) OVER (PARTITION BY cate ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS cnt1,
+count(DISTINCT val) OVER (PARTITION BY cate ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS cnt2
+FROM testData
+ORDER BY cate, val
+-- !query 14 schema
+struct<val:int,cate:string,cnt1:bigint,cnt2:bigint>
+-- !query 14 output
+NULL	NULL	0	0
+3	NULL	1	1
+NULL	a	0	0
+1	a	1	1
+1	a	2	1
+2	a	3	2
+1	b	1	1
+2	b	2	2
+3	b	3	3
+
+-- !query15
+SELECT val, cate,
+sum(val) OVER (PARTITION BY cate ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS sum1,
+sum(DISTINCT val) OVER (PARTITION BY cate ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS sum2
+FROM testData
+ORDER BY cate, val
+-- !query 15 schema
+struct<val:int,cate:string,sum1:bigint,sum2:bigint>
+-- !query 15 output
+NULL	NULL	3	3
+3	NULL	3	3
+NULL	a	4	3
+1	a	4	3
+1	a	3	3
+2	a	2	2
+1	b	6	6
+2	b	5	5
+3	b	3	3
+
+-- !query16
+SELECT val, cate,
+count(val) OVER (PARTITION BY cate ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS cnt1,
+count(DISTINCT val) OVER (PARTITION BY cate ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS cnt2
+FROM testData
+ORDER BY cate, val
+-- !query 16 schema
+struct<val:int,cate:string,cnt1:bigint,cnt2:bigint>
+-- !query 16 output
+NULL	NULL	1	1
+3	NULL	1	1
+NULL	a	3	2
+1	a	3	2
+1	a	2	2
+2	a	1	1
+1	b	3	3
+2	b	2	2
+3	b	1	1
+
+-- !query17
+SELECT val, cate,
+sum(val) OVER (PARTITION BY cate ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS sum1,
+sum(DISTINCT val) OVER (PARTITION BY cate ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS sum2
+FROM testData
+ORDER BY cate, val
+-- !query 17 schema
+struct<val:int,cate:string,sum1:bigint,sum2:bigint>
+-- !query 17 output
+NULL	NULL	3	3
+3	NULL	3	3
+NULL	a	1	1
+1	a	2	1
+1	a	3	3
+2	a	2	2
+1	b	3	3
+2	b	5	5
+3	b	3	3
+
+-- !query18
+SELECT val, cate,
+count(val) OVER (PARTITION BY cate ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS cnt1,
+count(DISTINCT val) OVER (PARTITION BY cate ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS cnt2
+FROM testData
+ORDER BY cate, val
+-- !query 18 schema
+struct<val:int,cate:string,cnt1:bigint,cnt2:bigint>
+-- !query 18 output
+NULL	NULL	1	1
+3	NULL	1	1
+NULL	a	1	1
+1	a	2	1
+1	a	2	2
+2	a	1	1
+1	b	2	2
+2	b	2	2
+3	b	1	1

--- a/sql/core/src/test/resources/sql-tests/results/window.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/window.sql.out
@@ -363,3 +363,41 @@ NULL	a	false	true	false	false	true	false
 1	b	false	true	false	false	true	false
 2	b	false	true	false	false	true	false
 3	b	false	true	false	false	true	false
+
+
+-- !query 11
+SELECT val, cate,
+sum(val) OVER (PARTITION BY cate) AS sum1,
+sum(DISTINCT val) OVER (PARTITION BY cate) AS sum2
+FROM testData
+-- !query 11 schema
+struct<val:int,cate:string,sum1:bigint,sum2:bigint>
+-- !query 11 output
+1	a	4	3
+1	a	4	3
+1	b	6	6
+2	a	4	3
+2	b	6	6
+3	NULL	3	3
+3	b	6	6
+NULL	NULL	3	3
+NULL	a	4	3
+
+
+-- !query 12
+SELECT val, cate,
+count(val) OVER (PARTITION BY cate) AS cnt1,
+count(DISTINCT val) OVER (PARTITION BY cate) AS cnt2
+FROM testData
+-- !query 12 schema
+struct<val:int,cate:string,cnt1:bigint,cnt2:bigint>
+-- !query 12 output
+1	a	3	2
+1	a	3	2
+1	b	3	3
+2	a	3	2
+2	b	3	3
+3	NULL	1	1
+3	b	3	3
+NULL	NULL	1	1
+NULL	a	3	2

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
@@ -173,27 +173,6 @@ class SQLWindowFunctionSuite extends QueryTest with SharedSQLContext {
       ).map(i => Row(i._1, i._2, i._3, i._4)))
   }
 
-  test("window function: distinct should not be silently ignored") {
-    val data = Seq(
-      WindowData(1, "a", 5),
-      WindowData(2, "a", 6),
-      WindowData(3, "b", 7),
-      WindowData(4, "b", 8),
-      WindowData(5, "c", 9),
-      WindowData(6, "c", 10)
-    )
-    sparkContext.parallelize(data).toDF().createOrReplaceTempView("windowData")
-
-    val e = intercept[AnalysisException] {
-      sql(
-        """
-          |select month, area, product, sum(distinct product + 1) over (partition by 1 order by 2)
-          |from windowData
-        """.stripMargin)
-    }
-    assert(e.getMessage.contains("Distinct window functions are not supported"))
-  }
-
   test("window function: expressions in arguments of a window functions") {
     val data = Seq(
       WindowData(1, "a", 5),


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr proposes to support distinct window functions. After this change, query like below are supported:
```
SELECT val, cate,
sum(val) OVER (PARTITION BY cate) AS sum1,
sum(DISTINCT val) OVER (PARTITION BY cate) AS sum2
FROM testData
```
In this pr:
1. ORDER BY and distinct window function don't work at the same time due to performance concern and implementation requirement.
2. Insert distinct fields into the order by list, thus during counting, we only need to compare the current row against the previous row, i we ignore the current row if they have same projected values.

The behavior is inherited from hive.

## How was this patch tested?
Test added and more tests to be added.