### PR TITLE
[SPARK-24236][SS] Continuous replacement for ShuffleExchangeExec

### DIFF
--- a/core/src/main/scala/org/apache/spark/Dependency.scala
+++ b/core/src/main/scala/org/apache/spark/Dependency.scala
@@ -65,7 +65,7 @@ abstract class NarrowDependency[T](_rdd: RDD[T]) extends Dependency[T] {
  * @param keyOrdering key ordering for RDD's shuffles
  * @param aggregator map/reduce-side aggregator for RDD's shuffle
  * @param mapSideCombine whether to perform partial aggregation (also known as map-side combine)
- * @param baseForCp the dependency is base for continuous processing or not
+ * @param isContinuous the dependency is base for continuous processing or not
  */
 @DeveloperApi
 class ShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](

--- a/core/src/main/scala/org/apache/spark/Dependency.scala
+++ b/core/src/main/scala/org/apache/spark/Dependency.scala
@@ -78,6 +78,12 @@ class ShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
     val isContinuous: Boolean = false)
   extends Dependency[Product2[K, V]] {
 
+  def this(rdd: RDD[_ <: Product2[K, V]], partitioner: Partitioner,
+    serializer: Serializer, keyOrdering: Option[Ordering[K]],
+    aggregator: Option[Aggregator[K, V, C]], mapSideCombine: Boolean) = {
+    this(rdd, partitioner, serializer, keyOrdering, aggregator, mapSideCombine, false)
+  }
+
   if (mapSideCombine) {
     require(aggregator.isDefined, "Map-side combine without Aggregator specified!")
   }

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -140,6 +140,7 @@ object SparkEnv extends Logging {
 
   private[spark] val driverSystemName = "sparkDriver"
   private[spark] val executorSystemName = "sparkExecutor"
+  private[spark] val START_EPOCH_KEY = "__continuous_start_epoch"
 
   def set(e: SparkEnv) {
     env = e

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ContinuousShuffledRowRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ContinuousShuffledRowRDD.scala
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark._
+import org.apache.spark.sql.catalyst.InternalRow
+
+/**
+ * This is a specialized version of [[org.apache.spark.sql.execution.ShuffledRowRDD]] which is used
+ * for shuffle in continuous processing.
+ *
+ * This RDD takes a [[ShuffleDependency]] (`dependency`),
+ * an optional array of partition start indices as input arguments
+ * (`specifiedPartitionStartIndices`), and (`totalShuffleNum`) which specifies
+ * the total shuffle number in the job.
+ */
+class ContinuousShuffledRowRDD(
+    dependency: ShuffleDependency[Int, InternalRow, InternalRow],
+    specifiedPartitionStartIndices: Option[Array[Int]] = None, totalShuffleNum: Int)
+  extends ShuffledRowRDD(dependency, specifiedPartitionStartIndices) {
+
+  private val shuffleNumMaps = dependency.rdd.partitions.length
+
+  override def compute(split: Partition, context: TaskContext): Iterator[InternalRow] = {
+    val shuffledRowPartition = split.asInstanceOf[ShuffledRowRDDPartition]
+
+    new Iterator[InternalRow] {
+      private var currentIterator: Iterator[InternalRow] = null
+      private var currentRow: InternalRow = null
+
+      // TODO: Get current epoch from epoch coordinator while task restart, also epoch is Long, we
+      //       should deal with it.
+      private var currentEpoch = context.getLocalProperty(SparkEnv.START_EPOCH_KEY).toInt
+
+      override def hasNext(): Boolean = {
+        if (currentIterator == null) {
+          // Create a ContinuousShuffleDependency which has new shuffleId based on continuous epoch
+          val continuousDep = new ContinuousShuffleDependency(dependency._rdd,
+            dependency, currentEpoch, totalShuffleNum, shuffleNumMaps)
+          // The range of pre-shuffle partitions that we are fetching at here is
+          // [startPreShufflePartitionIndex, endPreShufflePartitionIndex - 1].
+          val reader =
+            SparkEnv.get.shuffleManager.getReader(
+              continuousDep.shuffleHandle,
+              shuffledRowPartition.startPreShufflePartitionIndex,
+              shuffledRowPartition.endPreShufflePartitionIndex,
+              context)
+          // The read method will be blocked until the shuffle data for current epoch is ready.
+          currentIterator =
+            reader.read().asInstanceOf[Iterator[Product2[Int, InternalRow]]].map(_._2)
+        }
+
+        val res = currentIterator.hasNext
+        if (res) {
+          currentRow = currentIterator.next()
+        } else {
+          currentIterator = null
+          currentEpoch += 1
+        }
+
+        res
+      }
+
+      override def next(): InternalRow = {
+        if (currentRow == null) throw new NoSuchElementException("No current row was set")
+        val res = currentRow
+        currentRow = null
+        res
+      }
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, ReturnAnswer}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.command.{DescribeTableCommand, ExecutedCommandExec, ShowTablesCommand}
-import org.apache.spark.sql.execution.exchange.{EnsureRequirements, ReuseExchange}
+import org.apache.spark.sql.execution.exchange.{ReplaceShuffleExchange, EnsureRequirements, ReuseExchange}
 import org.apache.spark.sql.types.{BinaryType, DateType, DecimalType, TimestampType, _}
 import org.apache.spark.util.Utils
 
@@ -94,7 +94,8 @@ class QueryExecution(val sparkSession: SparkSession, val logical: LogicalPlan) {
     EnsureRequirements(sparkSession.sessionState.conf),
     CollapseCodegenStages(sparkSession.sessionState.conf),
     ReuseExchange(sparkSession.sessionState.conf),
-    ReuseSubquery(sparkSession.sessionState.conf))
+    ReuseSubquery(sparkSession.sessionState.conf),
+    ReplaceShuffleExchange(sparkSession.sparkContext.conf))
 
   protected def stringOrError[A](f: => A): String =
     try f.toString catch { case e: AnalysisException => e.toString }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, ReturnAnswer}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.command.{DescribeTableCommand, ExecutedCommandExec, ShowTablesCommand}
-import org.apache.spark.sql.execution.exchange.{ReplaceShuffleExchange, EnsureRequirements, ReuseExchange}
+import org.apache.spark.sql.execution.exchange.{EnsureRequirements, ReplaceShuffleExchange, ReuseExchange}
 import org.apache.spark.sql.types.{BinaryType, DateType, DecimalType, TimestampType, _}
 import org.apache.spark.util.Utils
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ShuffledRowRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ShuffledRowRDD.scala
@@ -33,6 +33,8 @@ private final class ShuffledRowRDDPartition(
     val startPreShufflePartitionIndex: Int,
     val endPreShufflePartitionIndex: Int) extends Partition {
   override val index: Int = postShufflePartitionIndex
+
+  var lastEpoch : Int = Int.MinValue
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala
@@ -89,11 +89,11 @@ class ExchangeCoordinator(
   extends Logging {
 
   // The registered Exchange operators.
-  private[this] val exchanges = ArrayBuffer[BaseShuffleExchangeExec]()
+  private[this] val exchanges = ArrayBuffer[ShuffleExchangeExec]()
 
   // This map is used to lookup the post-shuffle ShuffledRowRDD for an Exchange operator.
-  private[this] val postShuffleRDDs: JMap[BaseShuffleExchangeExec, ShuffledRowRDD] =
-    new JHashMap[BaseShuffleExchangeExec, ShuffledRowRDD](numExchanges)
+  private[this] val postShuffleRDDs: JMap[ShuffleExchangeExec, ShuffledRowRDD] =
+    new JHashMap[ShuffleExchangeExec, ShuffledRowRDD](numExchanges)
 
   // A boolean that indicates if this coordinator has made decision on how to shuffle data.
   // This variable will only be updated by doEstimationIfNecessary, which is protected by
@@ -105,7 +105,7 @@ class ExchangeCoordinator(
    * to be called in the `doPrepare` method of a [[ShuffleExchangeExec]] operator.
    */
   @GuardedBy("this")
-  def registerExchange(exchange: BaseShuffleExchangeExec): Unit = synchronized {
+  def registerExchange(exchange: ShuffleExchangeExec): Unit = synchronized {
     exchanges += exchange
   }
 
@@ -200,7 +200,7 @@ class ExchangeCoordinator(
       // Make sure we have the expected number of registered Exchange operators.
       assert(exchanges.length == numExchanges)
 
-      val newPostShuffleRDDs = new JHashMap[BaseShuffleExchangeExec, ShuffledRowRDD](numExchanges)
+      val newPostShuffleRDDs = new JHashMap[ShuffleExchangeExec, ShuffledRowRDD](numExchanges)
 
       // Submit all map stages
       val shuffleDependencies = ArrayBuffer[ShuffleDependency[Int, InternalRow, InternalRow]]()
@@ -255,7 +255,7 @@ class ExchangeCoordinator(
     }
   }
 
-  def postShuffleRDD(exchange: BaseShuffleExchangeExec): ShuffledRowRDD = {
+  def postShuffleRDD(exchange: ShuffleExchangeExec): ShuffledRowRDD = {
     doEstimationIfNecessary()
 
     if (!postShuffleRDDs.containsKey(exchange)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala
@@ -89,11 +89,11 @@ class ExchangeCoordinator(
   extends Logging {
 
   // The registered Exchange operators.
-  private[this] val exchanges = ArrayBuffer[ShuffleExchangeExec]()
+  private[this] val exchanges = ArrayBuffer[BaseShuffleExchangeExec]()
 
   // This map is used to lookup the post-shuffle ShuffledRowRDD for an Exchange operator.
-  private[this] val postShuffleRDDs: JMap[ShuffleExchangeExec, ShuffledRowRDD] =
-    new JHashMap[ShuffleExchangeExec, ShuffledRowRDD](numExchanges)
+  private[this] val postShuffleRDDs: JMap[BaseShuffleExchangeExec, ShuffledRowRDD] =
+    new JHashMap[BaseShuffleExchangeExec, ShuffledRowRDD](numExchanges)
 
   // A boolean that indicates if this coordinator has made decision on how to shuffle data.
   // This variable will only be updated by doEstimationIfNecessary, which is protected by
@@ -105,7 +105,7 @@ class ExchangeCoordinator(
    * to be called in the `doPrepare` method of a [[ShuffleExchangeExec]] operator.
    */
   @GuardedBy("this")
-  def registerExchange(exchange: ShuffleExchangeExec): Unit = synchronized {
+  def registerExchange(exchange: BaseShuffleExchangeExec): Unit = synchronized {
     exchanges += exchange
   }
 
@@ -200,7 +200,7 @@ class ExchangeCoordinator(
       // Make sure we have the expected number of registered Exchange operators.
       assert(exchanges.length == numExchanges)
 
-      val newPostShuffleRDDs = new JHashMap[ShuffleExchangeExec, ShuffledRowRDD](numExchanges)
+      val newPostShuffleRDDs = new JHashMap[BaseShuffleExchangeExec, ShuffledRowRDD](numExchanges)
 
       // Submit all map stages
       val shuffleDependencies = ArrayBuffer[ShuffleDependency[Int, InternalRow, InternalRow]]()
@@ -255,7 +255,7 @@ class ExchangeCoordinator(
     }
   }
 
-  def postShuffleRDD(exchange: ShuffleExchangeExec): ShuffledRowRDD = {
+  def postShuffleRDD(exchange: BaseShuffleExchangeExec): ShuffledRowRDD = {
     doEstimationIfNecessary()
 
     if (!postShuffleRDDs.containsKey(exchange)) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. New RDD named ContinuousShuffleRowRDD
2. New case class ContinuousShuffleExchangeExec
3. The rule named ReplaceShuffleExchange to replace original ShuffleExchange to ContinuousShuffleExchangeExec

## How was this patch tested?

Existing UT. Add more UT later. 