### PR TITLE
[SPARK-24286][Documentation] DataFrameReader.csv - Add missing  alias…

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -521,7 +521,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    *
    * You can set the following CSV-specific options to deal with CSV files:
    * <ul>
-   * <li>`sep` (default `,`): sets a single character as a separator for each
+   * <li>`sep` or  `delimiter` (default `,`): sets a single character as a separator for each
    * field and value.</li>
    * <li>`encoding` (default `UTF-8`): decodes the CSV files by the given encoding
    * type.</li>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Documentation misses out on an alias option available for DataFrameReader.csv method. This issue will add the 'delimiter' as an alias option in the doc.

## How was this patch tested?
Doc change

Please review http://spark.apache.org/contributing.html before opening a pull request.
