### PR TITLE
[SPARK-24294] Throw SparkException when OOM in BroadcastExchangeExec

### DIFF
--- a/core/src/main/java/org/apache/spark/memory/SparkOutOfMemoryException.java
+++ b/core/src/main/java/org/apache/spark/memory/SparkOutOfMemoryException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.memory;
+
+import org.apache.spark.annotation.Private;
+
+/**
+ * SPARK-24294: To bypass scala bug: https://github.com/scala/bug/issues/9554, we catch
+ * {@link OutOfMemoryError} in {@link scala.concurrent.Future}'s body, and re-throw
+ * SparkOutOfMemoryException instead.
+ */
+@Private
+public final class SparkOutOfMemoryException extends Exception {
+
+  private OutOfMemoryError oe;
+
+  public SparkOutOfMemoryException(OutOfMemoryError e) {
+    oe = e;
+  }
+
+  public OutOfMemoryError getOOM(){
+    return oe;
+  }
+}

--- a/core/src/main/scala/org/apache/spark/util/SparkFatalException.scala
+++ b/core/src/main/scala/org/apache/spark/util/SparkFatalException.scala
@@ -14,25 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.memory;
-
-import org.apache.spark.annotation.Private;
+package org.apache.spark.util
 
 /**
  * SPARK-24294: To bypass scala bug: https://github.com/scala/bug/issues/9554, we catch
- * {@link OutOfMemoryError} in {@link scala.concurrent.Future}'s body, and re-throw
- * SparkOutOfMemoryException instead.
+ * fatal throwable in {@link scala.concurrent.Future}'s body, and re-throw
+ * SparkFatalException, which wraps the fatal throwable inside.
  */
-@Private
-public final class SparkOutOfMemoryException extends Exception {
-
-  private OutOfMemoryError oe;
-
-  public SparkOutOfMemoryException(OutOfMemoryError e) {
-    oe = e;
-  }
-
-  public OutOfMemoryError getOOM(){
-    return oe;
-  }
-}
+private[spark] final class SparkFatalException(val throwable: Throwable) extends Exception

--- a/core/src/main/scala/org/apache/spark/util/SparkFatalException.scala
+++ b/core/src/main/scala/org/apache/spark/util/SparkFatalException.scala
@@ -20,5 +20,8 @@ package org.apache.spark.util
  * SPARK-24294: To bypass scala bug: https://github.com/scala/bug/issues/9554, we catch
  * fatal throwable in {@link scala.concurrent.Future}'s body, and re-throw
  * SparkFatalException, which wraps the fatal throwable inside.
+ * Note that SparkFatalException should only be thrown from a {@link scala.concurrent.Future},
+ * which is run by using ThreadUtils.awaitResult. ThreadUtils.awaitResult will catch
+ * it and re-throw the original exception/error.
  */
 private[spark] final class SparkFatalException(val throwable: Throwable) extends Exception

--- a/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
@@ -27,6 +27,7 @@ import scala.util.control.NonFatal
 import com.google.common.util.concurrent.{MoreExecutors, ThreadFactoryBuilder}
 
 import org.apache.spark.SparkException
+import org.apache.spark.memory.SparkOutOfMemoryException
 
 private[spark] object ThreadUtils {
 
@@ -200,6 +201,8 @@ private[spark] object ThreadUtils {
       val awaitPermission = null.asInstanceOf[scala.concurrent.CanAwait]
       awaitable.result(atMost)(awaitPermission)
     } catch {
+      case e: SparkOutOfMemoryException =>
+        throw e.getOOM
       // TimeoutException is thrown in the current thread, so not need to warp the exception.
       case NonFatal(t) if !t.isInstanceOf[TimeoutException] =>
         throw new SparkException("Exception thrown in awaitResult: ", t)

--- a/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
@@ -27,7 +27,6 @@ import scala.util.control.NonFatal
 import com.google.common.util.concurrent.{MoreExecutors, ThreadFactoryBuilder}
 
 import org.apache.spark.SparkException
-import org.apache.spark.memory.SparkOutOfMemoryException
 
 private[spark] object ThreadUtils {
 
@@ -201,8 +200,8 @@ private[spark] object ThreadUtils {
       val awaitPermission = null.asInstanceOf[scala.concurrent.CanAwait]
       awaitable.result(atMost)(awaitPermission)
     } catch {
-      case e: SparkOutOfMemoryException =>
-        throw e.getOOM
+      case e: SparkFatalException =>
+        throw e.throwable
       // TimeoutException is thrown in the current thread, so not need to warp the exception.
       case NonFatal(t) if !t.isInstanceOf[TimeoutException] =>
         throw new SparkException("Exception thrown in awaitResult: ", t)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -112,11 +112,10 @@ case class BroadcastExchangeExec(
           broadcasted
         } catch {
           case oe: OutOfMemoryError =>
-            throw new OutOfMemoryError(s"Not enough memory to build and broadcast the table to " +
+            throw new SparkException(s"Not enough memory to build and broadcast the table to " +
               s"all worker nodes. As a workaround, you can either disable broadcast by setting " +
               s"${SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key} to -1 or increase the spark driver " +
-              s"memory by setting ${SparkLauncher.DRIVER_MEMORY} to a higher value")
-              .initCause(oe.getCause)
+              s"memory by setting ${SparkLauncher.DRIVER_MEMORY} to a higher value", oe)
         }
       }
     }(BroadcastExchangeExec.executionContext)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -19,10 +19,10 @@ package org.apache.spark.sql.execution.exchange
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
+import scala.util.control.NonFatal
 
 import org.apache.spark.{broadcast, SparkException}
 import org.apache.spark.launcher.SparkLauncher
-import org.apache.spark.memory.SparkOutOfMemoryException
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
@@ -31,7 +31,7 @@ import org.apache.spark.sql.execution.{SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.joins.HashedRelation
 import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.util.ThreadUtils
+import org.apache.spark.util.{SparkFatalException, ThreadUtils}
 
 /**
  * A [[BroadcastExchangeExec]] collects, transforms and finally broadcasts the result of
@@ -112,16 +112,18 @@ case class BroadcastExchangeExec(
           SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, metrics.values.toSeq)
           broadcasted
         } catch {
+          // SPARK-24294: To bypass scala bug: https://github.com/scala/bug/issues/9554, we throw
+          // SparkFatalException, which is a subclass of Exception. ThreadUtils.awaitResult
+          // will catch this exception and re-throw the wrapped fatal throwable.
           case oe: OutOfMemoryError =>
-            // SPARK-24294: To bypass scala bug: https://github.com/scala/bug/issues/9554, we throw
-            // SparkOutOfMemoryException, which is a subclass of Exception. ThreadUtils.awaitResult
-            // will catch this exception and re-throw the wrapped OutOfMemoryError.
-            throw new SparkOutOfMemoryException(
+            throw new SparkFatalException(
               new OutOfMemoryError(s"Not enough memory to build and broadcast the table to " +
               s"all worker nodes. As a workaround, you can either disable broadcast by setting " +
               s"${SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key} to -1 or increase the spark driver " +
               s"memory by setting ${SparkLauncher.DRIVER_MEMORY} to a higher value")
-              .initCause(oe.getCause).asInstanceOf[OutOfMemoryError])
+              .initCause(oe.getCause))
+          case e if !NonFatal(e) =>
+            throw new SparkFatalException(e)
         }
       }
     }(BroadcastExchangeExec.executionContext)


### PR DESCRIPTION
## What changes were proposed in this pull request?

When OutOfMemoryError thrown from BroadcastExchangeExec, scala.concurrent.Future will hit scala bug – https://github.com/scala/bug/issues/9554, and hang until future timeout:

We could wrap the OOM inside SparkException to resolve this issue.

## How was this patch tested?

Manually tested.