### PR TITLE
[SPARK-24309][CORE] AsyncEventQueue should stop on interrupt.

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
@@ -192,7 +192,7 @@ private class AsyncEventQueue(
 
   override def removeListenerOnError(listener: SparkListenerInterface): Unit = {
     // the listener failed in an unrecoverably way, we want to remove it from the entire
-    // LiveListenerBus (potentially stopping a queue if its empty)
+    // LiveListenerBus (potentially stopping a queue if it is empty)
     bus.removeListener(listener)
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
@@ -34,7 +34,10 @@ import org.apache.spark.util.Utils
  * Delivery will only begin when the `start()` method is called. The `stop()` method should be
  * called when no more events need to be delivered.
  */
-private class AsyncEventQueue(val name: String, conf: SparkConf, metrics: LiveListenerBusMetrics,
+private class AsyncEventQueue(
+    val name: String,
+    conf: SparkConf,
+    metrics: LiveListenerBusMetrics,
     bus: LiveListenerBus)
   extends SparkListenerBus
   with Logging {

--- a/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
@@ -34,7 +34,8 @@ import org.apache.spark.util.Utils
  * Delivery will only begin when the `start()` method is called. The `stop()` method should be
  * called when no more events need to be delivered.
  */
-private class AsyncEventQueue(val name: String, conf: SparkConf, metrics: LiveListenerBusMetrics)
+private class AsyncEventQueue(val name: String, conf: SparkConf, metrics: LiveListenerBusMetrics,
+    bus: LiveListenerBus)
   extends SparkListenerBus
   with Logging {
 
@@ -97,6 +98,11 @@ private class AsyncEventQueue(val name: String, conf: SparkConf, metrics: LiveLi
     } catch {
       case ie: InterruptedException =>
         logInfo(s"Stopping listener queue $name.", ie)
+        stopped.set(true)
+        bus.removeQueue(name)
+        // we're not going to process any more events in this queue, so might as well clear it
+        eventQueue.clear()
+        eventCount.set(0)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/LiveListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/LiveListenerBus.scala
@@ -102,12 +102,18 @@ private[spark] class LiveListenerBus(conf: SparkConf) {
         queue.addListener(listener)
 
       case None =>
-        val newQueue = new AsyncEventQueue(queue, conf, metrics)
+        val newQueue = new AsyncEventQueue(queue, conf, metrics, this)
         newQueue.addListener(listener)
         if (started.get()) {
           newQueue.start(sparkContext)
         }
         queues.add(newQueue)
+    }
+  }
+
+  private[scheduler] def removeQueue(queue: String): Unit = synchronized {
+    queues.asScala.find(_.name == queue).foreach { q =>
+      queues.remove(q)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/LiveListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/LiveListenerBus.scala
@@ -111,12 +111,6 @@ private[spark] class LiveListenerBus(conf: SparkConf) {
     }
   }
 
-  private[scheduler] def removeQueue(queue: String): Unit = synchronized {
-    queues.asScala.find(_.name == queue).foreach { q =>
-      queues.remove(q)
-    }
-  }
-
   def removeListener(listener: SparkListenerInterface): Unit = synchronized {
     // Remove listener from all queues it was added to, and stop queues that have become empty.
     queues.asScala

--- a/core/src/main/scala/org/apache/spark/util/ListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/util/ListenerBus.scala
@@ -90,9 +90,9 @@ private[spark] trait ListenerBus[L <: AnyRef, E] extends Logging {
       try {
         doPostEvent(listener, event)
         if (Thread.interrupted()) {
-          logError(s"Interrupted while posting to ${Utils.getFormattedClassName(listener)}.  " +
-            s"Removing that listener.")
-          removeListenerOnError(listener)
+          // We want to throw the InterruptedException right away so we can associate the interrupt
+          // with this listener, as opposed to waiting for a queue.take() etc. to detect it.
+          throw new InterruptedException()
         }
       } catch {
         case ie: InterruptedException =>

--- a/core/src/main/scala/org/apache/spark/util/ListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/util/ListenerBus.scala
@@ -95,6 +95,10 @@ private[spark] trait ListenerBus[L <: AnyRef, E] extends Logging {
           removeListenerOnError(listener)
         }
       } catch {
+        case ie: InterruptedException =>
+          logError(s"Interrupted while posting to ${Utils.getFormattedClassName(listener)}.  " +
+            s"Removing that listener.", ie)
+          removeListenerOnError(listener)
         case NonFatal(e) if !isIgnorableException(e) =>
           logError(s"Listener ${Utils.getFormattedClassName(listener)} threw an exception", e)
       } finally {

--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -489,6 +489,38 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     assert(bus.findListenersByClass[BasicJobCounter]().isEmpty)
   }
 
+  test("interrupt within listener is handled correctly") {
+    val conf = new SparkConf(false)
+      .set(LISTENER_BUS_EVENT_QUEUE_CAPACITY, 5)
+    val bus = new LiveListenerBus(conf)
+    val counter1 = new BasicJobCounter()
+    val counter2 = new BasicJobCounter()
+    val interruptingListener = new InterruptingListener
+    bus.addToSharedQueue(counter1)
+    bus.addToSharedQueue(interruptingListener)
+    bus.addToStatusQueue(counter2)
+    assert(bus.activeQueues() === Set(SHARED_QUEUE, APP_STATUS_QUEUE))
+    assert(bus.findListenersByClass[BasicJobCounter]().size === 2)
+
+    bus.start(mockSparkContext, mockMetricsSystem)
+
+    // after we post one event, the shared queue should get stopped because of the interrupt
+    bus.post(SparkListenerJobEnd(0, jobCompletionTime, JobSucceeded))
+    bus.waitUntilEmpty(WAIT_TIMEOUT_MILLIS)
+    assert(bus.activeQueues() === Set(APP_STATUS_QUEUE))
+    assert(bus.findListenersByClass[BasicJobCounter]().size === 1)
+    assert(counter2.count === 1)
+
+    // posting more events should be fine, they'll just get processed from the OK queue.
+    (0 until 5).foreach { _ => bus.post(SparkListenerJobEnd(0, jobCompletionTime, JobSucceeded)) }
+    bus.waitUntilEmpty(WAIT_TIMEOUT_MILLIS)
+    assert(counter2.count === 6)
+
+    // Make sure stopping works -- this requires putting a poison pill in all active queues, which
+    // would fail if our interrupted queue was still active, as its queue would be full.
+    bus.stop()
+  }
+
   /**
    * Assert that the given list of numbers has an average that is greater than zero.
    */
@@ -547,6 +579,14 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = { throw new Exception }
   }
 
+  /**
+   * A simple listener that interrupts on job end.
+   */
+  private class InterruptingListener extends SparkListener {
+    override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = {
+      Thread.currentThread().interrupt()
+    }
+  }
 }
 
 // These classes can't be declared inside of the SparkListenerSuite class because we don't want

--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -504,7 +504,7 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
 
     bus.start(mockSparkContext, mockMetricsSystem)
 
-    // after we post one event, the shared queue should get stopped because of the interrupt
+    // after we post one event, the shared queue should stop because of the interrupt
     bus.post(SparkListenerJobEnd(0, jobCompletionTime, JobSucceeded))
     bus.waitUntilEmpty(WAIT_TIMEOUT_MILLIS)
     assert(bus.activeQueues() === Set(APP_STATUS_QUEUE))

--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -489,43 +489,46 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     assert(bus.findListenersByClass[BasicJobCounter]().isEmpty)
   }
 
-  test("interrupt within listener is handled correctly") {
-    val conf = new SparkConf(false)
-      .set(LISTENER_BUS_EVENT_QUEUE_CAPACITY, 5)
-    val bus = new LiveListenerBus(conf)
-    val counter1 = new BasicJobCounter()
-    val counter2 = new BasicJobCounter()
-    val interruptingListener1 = new InterruptingListener
-    val interruptingListener2 = new InterruptingListener
-    bus.addToSharedQueue(counter1)
-    bus.addToSharedQueue(interruptingListener1)
-    bus.addToStatusQueue(counter2)
-    bus.addToEventLogQueue(interruptingListener2)
-    assert(bus.activeQueues() === Set(SHARED_QUEUE, APP_STATUS_QUEUE, EVENT_LOG_QUEUE))
-    assert(bus.findListenersByClass[BasicJobCounter]().size === 2)
-    assert(bus.findListenersByClass[InterruptingListener]().size === 2)
+  Seq(true, false).foreach { throwInterruptedException =>
+    val suffix = if (throwInterruptedException) "throw interrupt" else "set Thread interrupted"
+    test(s"interrupt within listener is handled correctly: $suffix") {
+      val conf = new SparkConf(false)
+        .set(LISTENER_BUS_EVENT_QUEUE_CAPACITY, 5)
+      val bus = new LiveListenerBus(conf)
+      val counter1 = new BasicJobCounter()
+      val counter2 = new BasicJobCounter()
+      val interruptingListener1 = new InterruptingListener(throwInterruptedException)
+      val interruptingListener2 = new InterruptingListener(throwInterruptedException)
+      bus.addToSharedQueue(counter1)
+      bus.addToSharedQueue(interruptingListener1)
+      bus.addToStatusQueue(counter2)
+      bus.addToEventLogQueue(interruptingListener2)
+      assert(bus.activeQueues() === Set(SHARED_QUEUE, APP_STATUS_QUEUE, EVENT_LOG_QUEUE))
+      assert(bus.findListenersByClass[BasicJobCounter]().size === 2)
+      assert(bus.findListenersByClass[InterruptingListener]().size === 2)
 
-    bus.start(mockSparkContext, mockMetricsSystem)
+      bus.start(mockSparkContext, mockMetricsSystem)
 
-    // after we post one event, both interrupting listeners should get removed, and the
-    // event log queue should be removed
-    bus.post(SparkListenerJobEnd(0, jobCompletionTime, JobSucceeded))
-    bus.waitUntilEmpty(WAIT_TIMEOUT_MILLIS)
-    assert(bus.activeQueues() === Set(SHARED_QUEUE, APP_STATUS_QUEUE))
-    assert(bus.findListenersByClass[BasicJobCounter]().size === 2)
-    assert(bus.findListenersByClass[InterruptingListener]().size === 0)
-    assert(counter1.count === 1)
-    assert(counter2.count === 1)
+      // after we post one event, both interrupting listeners should get removed, and the
+      // event log queue should be removed
+      bus.post(SparkListenerJobEnd(0, jobCompletionTime, JobSucceeded))
+      bus.waitUntilEmpty(WAIT_TIMEOUT_MILLIS)
+      assert(bus.activeQueues() === Set(SHARED_QUEUE, APP_STATUS_QUEUE))
+      assert(bus.findListenersByClass[BasicJobCounter]().size === 2)
+      assert(bus.findListenersByClass[InterruptingListener]().size === 0)
+      assert(counter1.count === 1)
+      assert(counter2.count === 1)
 
-    // posting more events should be fine, they'll just get processed from the OK queue.
-    (0 until 5).foreach { _ => bus.post(SparkListenerJobEnd(0, jobCompletionTime, JobSucceeded)) }
-    bus.waitUntilEmpty(WAIT_TIMEOUT_MILLIS)
-    assert(counter1.count === 6)
-    assert(counter2.count === 6)
+      // posting more events should be fine, they'll just get processed from the OK queue.
+      (0 until 5).foreach { _ => bus.post(SparkListenerJobEnd(0, jobCompletionTime, JobSucceeded)) }
+      bus.waitUntilEmpty(WAIT_TIMEOUT_MILLIS)
+      assert(counter1.count === 6)
+      assert(counter2.count === 6)
 
-    // Make sure stopping works -- this requires putting a poison pill in all active queues, which
-    // would fail if our interrupted queue was still active, as its queue would be full.
-    bus.stop()
+      // Make sure stopping works -- this requires putting a poison pill in all active queues, which
+      // would fail if our interrupted queue was still active, as its queue would be full.
+      bus.stop()
+    }
   }
 
   /**
@@ -589,9 +592,13 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
   /**
    * A simple listener that interrupts on job end.
    */
-  private class InterruptingListener extends SparkListener {
+  private class InterruptingListener(val throwInterruptedException: Boolean) extends SparkListener {
     override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = {
-      Thread.currentThread().interrupt()
+      if (throwInterruptedException) {
+        throw new InterruptedException("got interrupted")
+      } else {
+        Thread.currentThread().interrupt()
+      }
     }
   }
 }


### PR DESCRIPTION
EventListeners can interrupt the event queue thread.  In particular,
when the EventLoggingListener writes to hdfs, hdfs can interrupt the
thread.  When there is an interrupt, the queue should be removed and stop
accepting any more events.  Before this change, the queue would continue
to take more events (till it was full), and then would not stop when the
application was complete because the PoisonPill couldn't be added.

Added a unit test which failed before this change.