### PR TITLE
[SPARK-24288] Enable preventing predicate pushdown

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1122,7 +1122,7 @@ class Analyzer(
   object ResolveMissingReferences extends Rule[LogicalPlan] {
     def apply(plan: LogicalPlan): LogicalPlan = plan.transformUp {
       // Skip sort with aggregate. This will be handled in ResolveAggregateFunctions
-      case sa @ Sort(_, _, Barrier(child: Aggregate)) => sa
+      case sa @ Sort(_, _, Barrier(child: Aggregate, _)) => sa
       case sa @ Sort(_, _, child: Aggregate) => sa
 
       case s @ Sort(order, _, child) if !s.resolved && child.resolved =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -356,7 +356,7 @@ trait CheckAnalysis extends PredicateHelper {
     }
     extendedCheckRules.foreach(_(plan))
     plan.foreachUp {
-      case AnalysisBarrier(child) if !child.resolved => checkAnalysis(child)
+      case Barrier(child, _) if !child.resolved => checkAnalysis(child)
       case o if !o.resolved => failAnalysis(s"unresolved operator ${o.simpleString}")
       case _ =>
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -953,5 +953,9 @@ object Barrier {
 
   def unapply(b: Barrier): Option[(LogicalPlan, Boolean)] = Some((b.child, b.analysisOnly))
 
-  private case class BarrierImpl(child: LogicalPlan, analysisOnly: Boolean) extends Barrier { }
+  private case class BarrierImpl(child: LogicalPlan, analysisOnly: Boolean) extends Barrier {
+    override def simpleString: String = {
+      if (analysisOnly) "AnalysisBarrier" else "OptimizerBarrier"
+    }
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -548,13 +548,13 @@ class AnalysisSuite extends AnalysisTest with Matchers {
     // [[AnalysisBarrier]] will be removed after analysis
     checkAnalysis(
       Project(Seq(UnresolvedAttribute("tbl.a")),
-        AnalysisBarrier(SubqueryAlias("tbl", testRelation))),
+        Barrier(SubqueryAlias("tbl", testRelation), true)),
       Project(testRelation.output, SubqueryAlias("tbl", testRelation)))
 
     // Verify we won't go through a plan wrapped in a barrier.
     // Since we wrap an unresolved plan and analyzer won't go through it. It remains unresolved.
-    val barrier = AnalysisBarrier(Project(Seq(UnresolvedAttribute("tbl.b")),
-      SubqueryAlias("tbl", testRelation)))
+    val barrier = Barrier(Project(Seq(UnresolvedAttribute("tbl.b")),
+      SubqueryAlias("tbl", testRelation)), true)
     assertAnalysisError(barrier, Seq("cannot resolve '`tbl.b`'"))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/LogicalPlanSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/LogicalPlanSuite.scala
@@ -62,7 +62,7 @@ class LogicalPlanSuite extends SparkFunSuite {
 
   test("transformUp skips all ready resolved plans wrapped in analysis barrier") {
     invocationCount = 0
-    val plan = AnalysisBarrier(Project(Nil, Project(Nil, testRelation)))
+    val plan = Barrier(Project(Nil, Project(Nil, testRelation)), true)
     plan transformUp function
 
     assert(invocationCount === 0)
@@ -74,7 +74,7 @@ class LogicalPlanSuite extends SparkFunSuite {
 
   test("transformUp skips partially resolved plans wrapped in analysis barrier") {
     invocationCount = 0
-    val plan1 = AnalysisBarrier(Project(Nil, testRelation))
+    val plan1 = Barrier(Project(Nil, testRelation), true)
     val plan2 = Project(Nil, plan1)
     plan2 transformUp function
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -26,7 +26,7 @@ import org.apache.spark.annotation.InterfaceStability
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, UnresolvedRelation}
 import org.apache.spark.sql.catalyst.catalog._
-import org.apache.spark.sql.catalyst.plans.logical.{AnalysisBarrier, InsertIntoTable, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{Barrier, InsertIntoTable, LogicalPlan}
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.command.DDLUtils
 import org.apache.spark.sql.execution.datasources.{CreateTable, DataSource, LogicalRelation}
@@ -275,7 +275,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
         sparkSession = df.sparkSession,
         className = source,
         partitionColumns = partitioningColumns.getOrElse(Nil),
-        options = extraOptions.toMap).planForWriting(mode, AnalysisBarrier(df.logicalPlan))
+        options = extraOptions.toMap).planForWriting(mode, Barrier(df.logicalPlan, true))
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -574,6 +574,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
       case r: LogicalRDD =>
         RDDScanExec(r.output, r.rdd, "ExistingRDD", r.outputPartitioning, r.outputOrdering) :: Nil
       case h: ResolvedHint => planLater(h.child) :: Nil
+      case Barrier(child, false) => planLater(child) :: Nil
       case _ => Nil
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameOptimizerBarrierSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameOptimizerBarrierSuite.scala
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.execution.{FilterExec, SortExec, UnionExec}
+import org.apache.spark.sql.test.SharedSQLContext
+
+class DataFrameOptimizerBarrierSuite extends QueryTest with SharedSQLContext {
+  import testImplicits._
+
+  test("filter") {
+    val df1 = Seq((1, "1"), (2, "2"), (3, "3")).toDF("key", "value")
+    val dfBarrier = df1.where('key > 1).withOptimizerBarrier().where('value === "3")
+    val dfNoBarrier = df1.where('key > 1).where('value === "3")
+    // Filters not combined due to the barrier.
+    assert(dfBarrier.queryExecution.sparkPlan.collect {
+      case f: FilterExec => f }.size === 2)
+    assert(dfNoBarrier.queryExecution.sparkPlan.collect {
+      case f: FilterExec => f }.size === 1)
+    checkAnswer(dfBarrier, dfNoBarrier)
+  }
+
+  test("sort over project") {
+    val df1 = Seq((1, "1"), (2, "2"), (3, "3")).toDF("key", "value")
+    val dfBarrier = df1.select('value).withOptimizerBarrier().orderBy('key.desc)
+    val dfNoBarrier = df1.select('value).orderBy('key.desc)
+    checkAnswer(dfBarrier, dfNoBarrier)
+  }
+
+  test("sort over aggregate") {
+    val df1 = Seq((1, "1"), (2, "1"), (3, "3")).toDF("key", "value")
+    val dfBarrier = df1.groupBy('value).min("key")
+      .withOptimizerBarrier().orderBy($"min(key)".desc)
+    val dfNoBarrier = df1.groupBy('value).min("key").orderBy($"min(key)".desc)
+    checkAnswer(dfBarrier, dfNoBarrier)
+  }
+
+  test("filter over aggregate") {
+    val df1 = Seq((1, "1"), (2, "1"), (3, "3"), (4, "3")).toDF("key", "value")
+    val dfBarrier = df1.groupBy('value).min("key")
+      .withOptimizerBarrier().where("max(key) < 4")
+    val dfNoBarrier = df1.groupBy('value).min("key").where("max(key) < 4")
+    checkAnswer(dfBarrier, dfNoBarrier)
+  }
+
+  test("self-join") {
+    val df1 = Seq((1, "1"), (2, "2"), (3, "3")).toDF("key", "value")
+    val dfBarrier = df1.join(df1.withOptimizerBarrier(), "key")
+    val dfNoBarrier = df1.join(df1, "key")
+    checkAnswer(dfBarrier, dfNoBarrier)
+  }
+
+  test("union") {
+    val df1 = Seq((1, "1"), (2, "2"), (3, "3")).toDF("key1", "value1")
+    val df2 = Seq((4, "4"), (5, "5"), (6, "6")).toDF("key2", "value2")
+    val dfBarrier1 = df1.union(df2).union(df1.union(df2).withOptimizerBarrier())
+    val dfBarrier2 = df1.union(df2).withOptimizerBarrier().union(df1.union(df2))
+    val dfNoBarrier = df1.union(df2).union(df1.union(df2))
+    // Union nested within another Union will be flattened, but that under a barrier will not.
+    assert(dfBarrier1.queryExecution.sparkPlan.collect {
+      case u: UnionExec => u }.size === 2)
+    assert(dfBarrier2.queryExecution.sparkPlan.collect {
+      case u: UnionExec => u }.size === 2)
+    checkAnswer(dfBarrier1, dfNoBarrier)
+    checkAnswer(dfBarrier2, dfNoBarrier)
+  }
+
+  test("unionByName") {
+    val df1 = Seq((1, "1"), (2, "2"), (3, "3")).toDF("key", "value")
+    val df2 = Seq(("4", 4), ("5", 5), ("6", 6)).toDF("value", "key")
+    val dfBarrier1 = df1.unionByName(df2).unionByName(df1.unionByName(df2).withOptimizerBarrier())
+    val dfBarrier2 = df1.unionByName(df2).withOptimizerBarrier().unionByName(df1.unionByName(df2))
+    val dfNoBarrier = df1.unionByName(df2).unionByName(df1.unionByName(df2))
+    // Union nested within another Union will be flattened, but that under a barrier will not.
+    assert(dfBarrier1.queryExecution.sparkPlan.collect {
+      case u: UnionExec => u }.size === 2)
+    assert(dfBarrier2.queryExecution.sparkPlan.collect {
+      case u: UnionExec => u }.size === 2)
+    checkAnswer(dfBarrier1, dfNoBarrier)
+    checkAnswer(dfBarrier2, dfNoBarrier)
+  }
+
+  test("order preserving") {
+    val df1 = Seq((1, "1"), (2, "2"), (3, "3")).toDF("key", "value")
+    val dfBarrier = df1.orderBy('key.desc).withOptimizerBarrier().orderBy('key.desc)
+    val dfNoBarrier = df1.orderBy('key.desc).orderBy('key.desc)
+    // Barrier preserves the ordering, so the parent sort can be optimized out.
+    assert(dfBarrier.queryExecution.sparkPlan.collect {
+      case s: SortExec => s }.size === 1)
+    assert(dfNoBarrier.queryExecution.sparkPlan.collect {
+      case s: SortExec => s }.size === 1)
+    checkAnswer(dfBarrier, dfNoBarrier)
+  }
+
+  test("constraint preserving") {
+    val df1 = Seq((1, "1"), (2, "2"), (3, "3")).toDF("key", "value")
+    val df2 = Seq((1, 1), (2, 2), (3, 3)).toDF("key", "value")
+    val dfBarrier1 = df1.where('key > 1).withOptimizerBarrier().join(df2, "key")
+    val dfBarrier2 = df1.join(df2.where('key > 1).withOptimizerBarrier(), "key")
+    // Barrier preserves the child's constraints which can be propagated.
+    assert(dfBarrier1.queryExecution.sparkPlan.collect {
+      case f: FilterExec => f }.size === 2)
+    assert(dfBarrier2.queryExecution.sparkPlan.collect {
+      case f: FilterExec => f }.size === 2)
+    val dfNoBarrier = df1.where('key > 1).join(df2, "key")
+    checkAnswer(dfBarrier1, dfNoBarrier)
+    checkAnswer(dfBarrier2, dfNoBarrier)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -313,6 +313,10 @@ class JDBCSuite extends SparkFunSuite
     }
     assert(checkNotPushdown(sql("SELECT * FROM foobar WHERE (THEID + 1) < 2")).collect().size == 0)
     assert(checkNotPushdown(sql("SELECT * FROM foobar WHERE (THEID + 2) != 4")).collect().size == 2)
+
+    // SPARK-24288: Enable preventing predicate pushdown
+    val df3 = sql("SELECT * FROM foobar").withOptimizerBarrier().where("THEID = 1")
+    assert(checkNotPushdown(df3).collect().size == 1)
   }
 
   test("SELECT COUNT(1) WHERE (predicates)") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Add DataSet interface "withOptimizerBarrier()"
2. Modify AnalysisBarrier to accommodate two scenarios: 1) analysis-only barriers; and 2) optimizer barriers.
3. Add handling of Barrier in Optimizer (logical plan optimization).
4. Add handling of Barrier in SparkStrategies (logical-to-physical plan translation).

## How was this patch tested?

1. Add DataFrameOptimizerBarrierSuite to ensure:
    a) Barriers isolate optimization rule applications.
    b) Plans with optimization Barriers get resolved correctly, same as analysis-only Barriers.
    c) Barriers preserves ordering.
    d) Barriers preserves constraints.
2. Add one test in JDBCSuite to verify scenario raised by the user (avoid filter push-down to data source).