### PR TITLE
[SPARK-24317][SQL]Float-point numbers are displayed with different precision in ThriftServer2

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/Column.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/Column.java
@@ -349,7 +349,7 @@ public class Column extends AbstractList {
         break;
       case FLOAT_TYPE:
         nulls.set(size, field == null);
-        doubleVars()[size] = field == null ? 0 : ((Float)field).doubleValue();
+        doubleVars()[size] = field == null ? 0 : new Double(field.toString());
         break;
       case DOUBLE_TYPE:
         nulls.set(size, field == null);

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
@@ -170,6 +170,14 @@ class HiveThriftBinaryServerSuite extends HiveThriftJdbcTest {
     }
   }
 
+  test("JDBC query float-point number") {
+    withJdbcStatement() { statement =>
+      val resultSet = statement.executeQuery("SELECT CAST(1.23 AS FLOAT)")
+      resultSet.next()
+      assert(resultSet.getString(1) === "1.23")
+    }
+  }
+
   test("Checks Hive version") {
     withJdbcStatement() { statement =>
       val resultSet = statement.executeQuery("SET spark.sql.hive.version")


### PR DESCRIPTION
## What changes were proposed in this pull request?
When querying float-point numbers , the values displayed on beeline or jdbc are with different precision.
```
SELECT CAST(1.23 AS FLOAT)
Result:
1.2300000190734863
```
According to these two jira:
[HIVE-11802](https://issues.apache.org/jira/browse/HIVE-11802)
[HIVE-11832](https://issues.apache.org/jira/browse/HIVE-11832)
Make a slight modification to the spark hive thrift server.

## How was this patch tested?
HiveThriftBinaryServerSuite
test("JDBC query float-point number")
