### PR TITLE
[SPARK-24250][SQL][FollowUp] Fix compile error and flaky test

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -33,6 +33,7 @@ import org.apache.spark.internal.config._
 import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator
+import org.apache.spark.util.Utils
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // This file defines the configuration options for Spark SQL.

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
@@ -59,7 +59,8 @@ class ExecutorSideSQLConfSuite extends SparkFunSuite with SQLTestUtils {
         val pathString = path.getCanonicalPath
         spark.range(10).select('id.as("ID")).write.json(pathString)
         spark.range(10).write.mode("append").json(pathString)
-        assert(spark.read.json(pathString).columns.toSet == Set("id", "ID"))
+        val df = spark.read.option("samplingRatio", 1).json(pathString)
+        assert(df.columns.toSet == Set("id", "ID"))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
@@ -59,8 +59,7 @@ class ExecutorSideSQLConfSuite extends SparkFunSuite with SQLTestUtils {
         val pathString = path.getCanonicalPath
         spark.range(10).select('id.as("ID")).write.json(pathString)
         spark.range(10).write.mode("append").json(pathString)
-        val df = spark.read.option("samplingRatio", 1).json(pathString)
-        assert(df.columns.toSet == Set("id", "ID"))
+        assert(spark.read.json(pathString).columns.toSet == Set("id", "ID"))
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Two recent commits change SQLConf at the same time and accidentally make compile error in current code base. This patch goes to add necessary import back.

One added test by SPARK-24250 is flaky. This patch also fixes it.

## How was this patch tested?

N/A.

