### PR TITLE
[SPARK-24250][SQL][FOLLOWUP] Fix build failure

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -33,6 +33,7 @@ import org.apache.spark.internal.config._
 import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator
+import org.apache.spark.util.Utils
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // This file defines the configuration options for Spark SQL.


### PR DESCRIPTION
## What changes were proposed in this pull request?

SPARK-24250 is causing a build failure because it removed an import which was not used in that patch but was used in SPARK-23850, which was committed meanwhile.

## How was this patch tested?

building the project
