### PR TITLE
[SPARK-24329][SQL] Remove comments filtering before parsing of CSV files

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -504,7 +504,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
     val parsed = linesWithoutHeader.mapPartitions { iter =>
       val rawParser = new UnivocityParser(actualSchema, parsedOptions)
       val parser = new FailureSafeParser[String](
-        input => Seq(rawParser.parse(input)),
+        input => rawParser.parse(input),
         parsedOptions.parseMode,
         schema,
         parsedOptions.columnNameOfCorruptRecord)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/UnivocityParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/UnivocityParser.scala
@@ -302,14 +302,11 @@ private[csv] object UnivocityParser {
       lines
     }
 
-    val filteredLines: Iterator[String] = linesWithoutHeader
-      // CSVUtils.filterCommentAndEmpty(linesWithoutHeader, options)
-
     val safeParser = new FailureSafeParser[String](
       input => parser.parse(input),
       parser.options.parseMode,
       schema,
       parser.options.columnNameOfCorruptRecord)
-    filteredLines.flatMap(safeParser.parse)
+    linesWithoutHeader.flatMap(safeParser.parse)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Filtering of comments and whitespace has been performed by uniVocity parser already according to parser settings:
https://github.com/apache/spark/blob/branch-2.3/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVOptions.scala#L178-L180

There is no need to repeat the same before uniVocity parser. In this PR, I propose to remove filtering of whitespaces and comments (call of filterCommentAndEmpty) in the parseIterator method of the UnivocityParser object.

## How was this patch tested?

The changes were tested by CSVSuite
