### PR TITLE
[SPARK-23754][Python] Re-raising StopIteration in client code

### DIFF
--- a/python/pyspark/shuffle.py
+++ b/python/pyspark/shuffle.py
@@ -28,7 +28,7 @@ import sys
 import pyspark.heapq3 as heapq
 from pyspark.serializers import BatchedSerializer, PickleSerializer, FlattenedValuesSerializer, \
     CompressedSerializer, AutoBatchedSerializer
-from pyspark.util import fail_on_StopIteration
+from pyspark.util import fail_on_stopiteration
 
 
 try:
@@ -95,9 +95,9 @@ class Aggregator(object):
     """
 
     def __init__(self, createCombiner, mergeValue, mergeCombiners):
-        self.createCombiner = fail_on_StopIteration(createCombiner)
-        self.mergeValue = fail_on_StopIteration(mergeValue)
-        self.mergeCombiners = fail_on_StopIteration(mergeCombiners)
+        self.createCombiner = fail_on_stopiteration(createCombiner)
+        self.mergeValue = fail_on_stopiteration(mergeValue)
+        self.mergeCombiners = fail_on_stopiteration(mergeCombiners)
 
 
 class SimpleAggregator(Aggregator):

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -908,8 +908,14 @@ class SQLTests(ReusedSQLTestCase):
         def foo(x):
             raise StopIteration()
 
-        with self.assertRaises(Py4JJavaError):
+        with self.assertRaises(Py4JJavaError) as cm:
             self.spark.range(0, 1000).withColumn('v', udf(foo)('id')).show()
+
+        self.assertIn(
+            "Caught StopIteration thrown from user's code; failing the task",
+            cm.exception.java_exception.toString()
+        )
+
 
     def test_validate_column_types(self):
         from pyspark.sql.functions import udf, to_json

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -916,7 +916,6 @@ class SQLTests(ReusedSQLTestCase):
             cm.exception.java_exception.toString()
         )
 
-
     def test_validate_column_types(self):
         from pyspark.sql.functions import udf, to_json
         from pyspark.sql.column import _to_java_column

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -908,7 +908,7 @@ class SQLTests(ReusedSQLTestCase):
         def foo(x):
             raise StopIteration()
 
-        with self.assertRaises(Py4JJavaError) as cm:
+        with self.assertRaises(Py4JJavaError):
             self.spark.range(0, 1000).withColumn('v', udf(foo)).show()
 
     def test_validate_column_types(self):

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -900,6 +900,19 @@ class SQLTests(ReusedSQLTestCase):
         self.assertEqual(f, f_.func)
         self.assertEqual(return_type, f_.returnType)
 
+    def test_stopiteration_in_udf(self):
+        # test for SPARK-23754
+        from pyspark.sql.functions import udf
+        from py4j.protocol import Py4JJavaError
+
+        def foo(x):
+            raise StopIteration()
+
+        with self.assertRaises(Py4JJavaError) as cm:
+            self.spark.range(0, 1000).withColumn('v', udf(foo)).show()
+        self.assertIn('StopIteration in client code',
+                      cm.exception.java_exception.toString())
+
     def test_validate_column_types(self):
         from pyspark.sql.functions import udf, to_json
         from pyspark.sql.column import _to_java_column

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -909,7 +909,7 @@ class SQLTests(ReusedSQLTestCase):
             raise StopIteration()
 
         with self.assertRaises(Py4JJavaError):
-            self.spark.range(0, 1000).withColumn('v', udf(foo)).show()
+            self.spark.range(0, 1000).withColumn('v', udf(foo)('id')).show()
 
     def test_validate_column_types(self):
         from pyspark.sql.functions import udf, to_json

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -910,8 +910,6 @@ class SQLTests(ReusedSQLTestCase):
 
         with self.assertRaises(Py4JJavaError) as cm:
             self.spark.range(0, 1000).withColumn('v', udf(foo)).show()
-        self.assertIn('StopIteration in client code',
-                      cm.exception.java_exception.toString())
 
     def test_validate_column_types(self):
         from pyspark.sql.functions import udf, to_json

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -92,7 +92,7 @@ class UserDefinedFunction(object):
             raise TypeError(
                 "Invalid evalType: evalType should be an int but is {}".format(evalType))
 
-        self.func = fail_on_stopiteration(func)
+        self.func = func
         self._returnType = returnType
         # Stores UserDefinedPythonFunctions jobj, once initialized
         self._returnType_placeholder = None
@@ -157,7 +157,7 @@ class UserDefinedFunction(object):
         spark = SparkSession.builder.getOrCreate()
         sc = spark.sparkContext
 
-        wrapped_func = _wrap_function(sc, self.func, self.returnType)
+        wrapped_func = _wrap_function(sc, fail_on_stopiteration(self.func), self.returnType)
         jdt = spark._jsparkSession.parseDataType(self.returnType.json())
         judf = sc._jvm.org.apache.spark.sql.execution.python.UserDefinedPythonFunction(
             self._name, wrapped_func, jdt, self.evalType, self.deterministic)

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -25,7 +25,7 @@ from pyspark.rdd import _prepare_for_python_RDD, PythonEvalType, ignore_unicode_
 from pyspark.sql.column import Column, _to_java_column, _to_seq
 from pyspark.sql.types import StringType, DataType, StructType, _parse_datatype_string,\
     to_arrow_type, to_arrow_schema
-from pyspark.util import _get_argspec
+from pyspark.util import _get_argspec, fail_on_stopiteration
 
 __all__ = ["UDFRegistration"]
 
@@ -92,7 +92,7 @@ class UserDefinedFunction(object):
             raise TypeError(
                 "Invalid evalType: evalType should be an int but is {}".format(evalType))
 
-        self.func = func
+        self.func = fail_on_stopiteration(func)
         self._returnType = returnType
         # Stores UserDefinedPythonFunctions jobj, once initialized
         self._returnType_placeholder = None

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -159,13 +159,13 @@ class UserDefinedFunction(object):
 
         func = fail_on_stopiteration(self.func)
 
-        # prevent inspect to fail
-        # e.g. inspect.getargspec(sum) raises
-        # TypeError: <built-in function sum> is not a Python function
-        try:
+        # for pandas UDFs the worker needs to know if the function takes
+        # one or two arguments, but the signature is lost when wrapping with
+        # fail_on_stopiteration, so we store it here
+        if self.evalType in (PythonEvalType.SQL_SCALAR_PANDAS_UDF,
+                             PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF,
+                             PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF):
             func._argspec = _get_argspec(self.func)
-        except TypeError:
-            pass
 
         wrapped_func = _wrap_function(sc, func, self.returnType)
         jdt = spark._jsparkSession.parseDataType(self.returnType.json())

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -161,6 +161,46 @@ class MergerTests(unittest.TestCase):
             self.assertEqual(k, len(vs))
             self.assertEqual(list(range(k)), list(vs))
 
+    def test_stopiteration_is_raised(self):
+
+        def validate_exception(exc):
+            if isinstance(exc, RuntimeError):
+                self.assertEquals('StopIteration in client code', exc.args[0])
+            else:
+                self.assertIn('StopIteration in client code', exc.java_exception.toString())
+
+        def stopit(*args, **kwargs):
+            raise StopIteration()
+
+        def legit_create_combiner(x):
+            return [x]
+
+        def legit_merge_value(x, y):
+            return x.append(y) or x
+
+        def legit_merge_combiners(x, y):
+            return x.extend(y) or x
+
+        data = [(x % 2, x) for x in range(100)]
+
+        # wrong create combiner
+        m = ExternalMerger(Aggregator(stopit, legit_merge_value, legit_merge_combiners), 20)
+        with self.assertRaises((Py4JJavaError, RuntimeError)) as cm:
+            m.mergeValues(data)
+        validate_exception(cm.exception)
+
+        # wrong merge value
+        m = ExternalMerger(Aggregator(legit_create_combiner, stopit, legit_merge_combiners), 20)
+        with self.assertRaises((Py4JJavaError, RuntimeError)) as cm:
+            m.mergeValues(data)
+        validate_exception(cm.exception)
+
+        # wrong merge combiners
+        m = ExternalMerger(Aggregator(legit_create_combiner, legit_merge_value, stopit), 20)
+        with self.assertRaises((Py4JJavaError, RuntimeError)) as cm:
+            m.mergeCombiners(map(lambda x_y1: (x_y1[0], [x_y1[1]]), data))
+        validate_exception(cm.exception)
+
 
 class SorterTests(unittest.TestCase):
     def test_in_memory_sort(self):
@@ -1245,6 +1285,37 @@ class RDDTests(ReusedPySparkTestCase):
         rdd = self.sc.parallelize(data)
         result = rdd.pipe('cat').collect()
         self.assertEqual(data, result)
+
+    def test_stopiteration_in_client_code(self):
+
+        def a_rdd(keyed=False):
+            return self.sc.parallelize(
+                ((x % 2, x) if keyed else x)
+                for x in range(10)
+            )
+
+        def stopit(*x):
+            raise StopIteration()
+
+        def do_test(action, *args, **kwargs):
+            with self.assertRaises((Py4JJavaError, RuntimeError)) as cm:
+                action(*args, **kwargs)
+            if isinstance(cm.exception, RuntimeError):
+                self.assertEquals('StopIteration in client code',
+                                  cm.exception.args[0])
+            else:
+                self.assertIn('StopIteration in client code',
+                              cm.exception.java_exception.toString())
+
+        do_test(a_rdd().map(stopit).collect)
+        do_test(a_rdd().filter(stopit).collect)
+        do_test(a_rdd().cartesian(a_rdd()).flatMap(stopit).collect)
+        do_test(a_rdd().foreach, stopit)
+        do_test(a_rdd(keyed=True).reduceByKeyLocally, stopit)
+        do_test(a_rdd().reduce, stopit)
+        do_test(a_rdd().fold, 0, stopit)
+        do_test(a_rdd().aggregate, 0, stopit, lambda *x: 1)
+        do_test(a_rdd().aggregate, 0, lambda *x: 1, stopit)
 
 
 class ProfilerTests(PySparkTestCase):

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -1284,17 +1284,20 @@ class RDDTests(ReusedPySparkTestCase):
 
         seq_rdd = self.sc.parallelize(range(10))
         keyed_rdd = self.sc.parallelize((x % 2, x) for x in range(10))
-        exc = Py4JJavaError, RuntimeError
 
-        self.assertRaises(exc, seq_rdd.map(stopit).collect)
-        self.assertRaises(exc, seq_rdd.filter(stopit).collect)
-        self.assertRaises(exc, seq_rdd.cartesian(seq_rdd).flatMap(stopit).collect)
-        self.assertRaises(exc, seq_rdd.foreach, stopit)
-        self.assertRaises(exc, keyed_rdd.reduceByKeyLocally, stopit)
-        self.assertRaises(exc, seq_rdd.reduce, stopit)
-        self.assertRaises(exc, seq_rdd.fold, 0, stopit)
-        self.assertRaises(exc, seq_rdd.aggregate, 0, stopit, lambda *x: 1)
-        self.assertRaises(exc, seq_rdd.aggregate, 0, lambda *x: 1, stopit)
+        self.assertRaises(Py4JJavaError, seq_rdd.map(stopit).collect)
+        self.assertRaises(Py4JJavaError, seq_rdd.filter(stopit).collect)
+        self.assertRaises(Py4JJavaError, seq_rdd.cartesian(seq_rdd).flatMap(stopit).collect)
+        self.assertRaises(Py4JJavaError, seq_rdd.foreach, stopit)
+        self.assertRaises(Py4JJavaError, keyed_rdd.reduceByKeyLocally, stopit)
+        self.assertRaises(Py4JJavaError, seq_rdd.reduce, stopit)
+        self.assertRaises(Py4JJavaError, seq_rdd.fold, 0, stopit)
+
+        # the exception raised is non-deterministic
+        self.assertRaises((Py4JJavaError, RuntimeError),
+                          seq_rdd.aggregate, 0, stopit, lambda *x: 1)
+        self.assertRaises((Py4JJavaError, RuntimeError),
+                          seq_rdd.aggregate, 0, lambda *x: 1, stopit)
 
 
 class ProfilerTests(PySparkTestCase):

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -163,12 +163,6 @@ class MergerTests(unittest.TestCase):
 
     def test_stopiteration_is_raised(self):
 
-        def validate_exception(exc):
-            if isinstance(exc, RuntimeError):
-                self.assertEquals('StopIteration in client code', exc.args[0])
-            else:
-                self.assertIn('StopIteration in client code', exc.java_exception.toString())
-
         def stopit(*args, **kwargs):
             raise StopIteration()
 
@@ -187,19 +181,16 @@ class MergerTests(unittest.TestCase):
         m = ExternalMerger(Aggregator(stopit, legit_merge_value, legit_merge_combiners), 20)
         with self.assertRaises((Py4JJavaError, RuntimeError)) as cm:
             m.mergeValues(data)
-        validate_exception(cm.exception)
 
         # wrong merge value
         m = ExternalMerger(Aggregator(legit_create_combiner, stopit, legit_merge_combiners), 20)
         with self.assertRaises((Py4JJavaError, RuntimeError)) as cm:
             m.mergeValues(data)
-        validate_exception(cm.exception)
 
         # wrong merge combiners
         m = ExternalMerger(Aggregator(legit_create_combiner, legit_merge_value, stopit), 20)
         with self.assertRaises((Py4JJavaError, RuntimeError)) as cm:
             m.mergeCombiners(map(lambda x_y1: (x_y1[0], [x_y1[1]]), data))
-        validate_exception(cm.exception)
 
 
 class SorterTests(unittest.TestCase):
@@ -1300,12 +1291,6 @@ class RDDTests(ReusedPySparkTestCase):
         def do_test(action, *args, **kwargs):
             with self.assertRaises((Py4JJavaError, RuntimeError)) as cm:
                 action(*args, **kwargs)
-            if isinstance(cm.exception, RuntimeError):
-                self.assertEquals('StopIteration in client code',
-                                  cm.exception.args[0])
-            else:
-                self.assertIn('StopIteration in client code',
-                              cm.exception.java_exception.toString())
 
         do_test(a_rdd().map(stopit).collect)
         do_test(a_rdd().filter(stopit).collect)

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -89,15 +89,16 @@ class VersionUtils(object):
                              " version numbers.")
 
 
-def fail_on_StopIteration(f):
-    """ wraps f to make it safe (= does not lead to data loss) to use inside a for loop
-        make StopIteration's raised inside f explicit
+def fail_on_stopiteration(f):
+    """
+        Wraps the input function to fail on 'StopIteration' by raising a 'RuntimeError'
+        prevents silent loss of data when 'f' is used in a for loop
     """
     def wrapper(*args, **kwargs):
         try:
             return f(*args, **kwargs)
         except StopIteration as exc:
-            raise RuntimeError('StopIteration in client code', exc)
+            raise RuntimeError("Caught StopIteration thrown from user's code; failing the task", exc)
 
     return wrapper
 

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -98,7 +98,10 @@ def fail_on_stopiteration(f):
         try:
             return f(*args, **kwargs)
         except StopIteration as exc:
-            raise RuntimeError("Caught StopIteration thrown from user's code; failing the task", exc)
+            raise RuntimeError(
+                "Caught StopIteration thrown from user's code; failing the task",
+                exc
+            )
 
     return wrapper
 

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -89,6 +89,19 @@ class VersionUtils(object):
                              " version numbers.")
 
 
+def fail_on_StopIteration(f):
+    """ wraps f to make it safe (= does not lead to data loss) to use inside a for loop
+        make StopIteration's raised inside f explicit
+    """
+    def wrapper(*args, **kwargs):
+        try:
+            return f(*args, **kwargs)
+        except StopIteration as exc:
+            raise RuntimeError('StopIteration in client code', exc)
+
+    return wrapper
+
+
 if __name__ == "__main__":
     import doctest
     (failure_count, test_count) = doctest.testmod()

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -53,13 +53,16 @@ def _get_argspec(f):
     """
     Get argspec of a function. Supports both Python 2 and Python 3.
     """
-    # `getargspec` is deprecated since python3.0 (incompatible with function annotations).
-    # See SPARK-23569.
+
     if hasattr(f, '_argspec'):
+        # only used for pandas UDF: they wrap the user function, losing its signature
+        # workers need this signature, so UDF saves it here
         argspec = f._argspec
     elif sys.version_info[0] < 3:
         argspec = inspect.getargspec(f)
     else:
+        # `getargspec` is deprecated since python3.0 (incompatible with function annotations).
+        # See SPARK-23569.
         argspec = inspect.getfullargspec(f)
     return argspec
 

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -91,8 +91,8 @@ class VersionUtils(object):
 
 def fail_on_stopiteration(f):
     """
-        Wraps the input function to fail on 'StopIteration' by raising a 'RuntimeError'
-        prevents silent loss of data when 'f' is used in a for loop
+    Wraps the input function to fail on 'StopIteration' by raising a 'RuntimeError'
+    prevents silent loss of data when 'f' is used in a for loop
     """
     def wrapper(*args, **kwargs):
         try:

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -23,8 +23,6 @@ from py4j.protocol import Py4JJavaError
 
 __all__ = []
 
-WRAPPED_ARGSPEC_ATTR = '_wrapped_argspec'
-
 
 def _exception_message(excp):
     """Return the message from an exception as either a str or unicode object.  Supports both
@@ -57,8 +55,8 @@ def _get_argspec(f):
     """
     # `getargspec` is deprecated since python3.0 (incompatible with function annotations).
     # See SPARK-23569.
-    if hasattr(f, WRAPPED_ARGSPEC_ATTR):
-        argspec = getattr(f, WRAPPED_ARGSPEC_ATTR)
+    if hasattr(f, '_argspec'):
+        argspec = f._argspec
     elif sys.version_info[0] < 3:
         argspec = inspect.getargspec(f)
     else:
@@ -106,16 +104,6 @@ def fail_on_stopiteration(f):
                 "Caught StopIteration thrown from user's code; failing the task",
                 exc
             )
-
-    # prevent inspect to fail
-    # e.g. inspect.getargspec(sum) raises
-    # TypeError: <built-in function sum> is not a Python function
-    try:
-        argspec = _get_argspec(f)
-    except TypeError:
-        pass
-    else:
-        setattr(wrapper, WRAPPED_ARGSPEC_ATTR, _get_argspec(f))
 
     return wrapper
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make sure that `StopIteration`s raised in users' code do not silently interrupt processing by spark, but are raised as exceptions to the users. The users' functions are wrapped in `safe_iter` (in `shuffle.py`), which re-raises `StopIteration`s as `RuntimeError`s

## How was this patch tested?

Unit tests, making sure that the exceptions are indeed raised. I am not sure how to check whether a `Py4JJavaError` contains my exception, so I simply looked for the exception message in the java exception's `toString`. Can you propose a better way?

## License

This is my original work, licensed in the same way as spark