### PR TITLE
[SPARK-24336][SQL] Support 'pass through' transformation in BasicOperators

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -706,29 +706,29 @@ object ScalaReflection extends ScalaReflection {
   def getClassFromTypeHandleArray(tpe: Type): Class[_] = cleanUpReflectionObjects {
     tpe.dealias match {
       case ty if ty <:< localTypeOf[Array[_]] =>
-        def arrayClassFromType(tpe: `Type`): Class[_] =
-          ScalaReflection.cleanUpReflectionObjects {
-            tpe.dealias match {
-              case t if t <:< definitions.IntTpe => classOf[Array[Int]]
-              case t if t <:< definitions.LongTpe => classOf[Array[Long]]
-              case t if t <:< definitions.DoubleTpe => classOf[Array[Double]]
-              case t if t <:< definitions.FloatTpe => classOf[Array[Float]]
-              case t if t <:< definitions.ShortTpe => classOf[Array[Short]]
-              case t if t <:< definitions.ByteTpe => classOf[Array[Byte]]
-              case t if t <:< definitions.BooleanTpe => classOf[Array[Boolean]]
-              case _ =>
-                // There is probably a better way to do this, but I couldn't find it...
-                val elementType = getClassFromTypeHandleArray(tpe)
-                java.lang.reflect.Array.newInstance(elementType, 1).getClass
-            }
-          }
-
         val TypeRef(_, _, Seq(elementType)) = ty
         arrayClassFromType(elementType)
 
       case ty => getClassFromType(ty)
     }
   }
+
+  private def arrayClassFromType(tpe: Type): Class[_] =
+    ScalaReflection.cleanUpReflectionObjects {
+      tpe.dealias match {
+        case t if t <:< definitions.IntTpe => classOf[Array[Int]]
+        case t if t <:< definitions.LongTpe => classOf[Array[Long]]
+        case t if t <:< definitions.DoubleTpe => classOf[Array[Double]]
+        case t if t <:< definitions.FloatTpe => classOf[Array[Float]]
+        case t if t <:< definitions.ShortTpe => classOf[Array[Short]]
+        case t if t <:< definitions.ByteTpe => classOf[Array[Byte]]
+        case t if t <:< definitions.BooleanTpe => classOf[Array[Boolean]]
+        case _ =>
+          // There is probably a better way to do this, but I couldn't find it...
+          val elementType = getClassFromTypeHandleArray(tpe)
+          java.lang.reflect.Array.newInstance(elementType, 1).getClass
+      }
+    }
 
   case class Schema(dataType: DataType, nullable: Boolean)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -703,6 +703,33 @@ object ScalaReflection extends ScalaReflection {
    */
   def getClassFromType(tpe: Type): Class[_] = mirror.runtimeClass(tpe.dealias.typeSymbol.asClass)
 
+  def getClassFromTypeHandleArray(tpe: Type): Class[_] = cleanUpReflectionObjects {
+    tpe.dealias match {
+      case ty if ty <:< localTypeOf[Array[_]] =>
+        def arrayClassFromType(tpe: `Type`): Class[_] =
+          ScalaReflection.cleanUpReflectionObjects {
+            tpe.dealias match {
+              case t if t <:< definitions.IntTpe => classOf[Array[Int]]
+              case t if t <:< definitions.LongTpe => classOf[Array[Long]]
+              case t if t <:< definitions.DoubleTpe => classOf[Array[Double]]
+              case t if t <:< definitions.FloatTpe => classOf[Array[Float]]
+              case t if t <:< definitions.ShortTpe => classOf[Array[Short]]
+              case t if t <:< definitions.ByteTpe => classOf[Array[Byte]]
+              case t if t <:< definitions.BooleanTpe => classOf[Array[Boolean]]
+              case _ =>
+                // There is probably a better way to do this, but I couldn't find it...
+                val elementType = getClassFromTypeHandleArray(tpe)
+                java.lang.reflect.Array.newInstance(elementType, 1).getClass
+            }
+          }
+
+        val TypeRef(_, _, Seq(elementType)) = ty
+        arrayClassFromType(elementType)
+
+      case ty => getClassFromType(ty)
+    }
+  }
+
   case class Schema(dataType: DataType, nullable: Boolean)
 
   /** Returns a Sequence of attributes for the given case class type. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -578,9 +578,6 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
       case logical.MapPartitionsInR(f, p, b, is, os, objAttr, child) =>
         execution.MapPartitionsExec(
           execution.r.MapPartitionsRWrapper(f, p, b, is, os), objAttr, planLater(child)) :: Nil
-      case logical.FlatMapGroupsInR(f, p, b, is, os, key, value, grouping, data, objAttr, child) =>
-        execution.FlatMapGroupsInRExec(f, p, b, is, os, key, value, grouping,
-          data, objAttr, planLater(child)) :: Nil
       case logical.MapElements(f, _, _, objAttr, child) =>
         execution.MapElementsExec(f, objAttr, planLater(child)) :: Nil
       case logical.AppendColumns(f, _, _, in, out, child) =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable 'pass through' transformation in BasicOperators via reflection, so that every pairs of transformation which only requires converting LogicalPlan to SparkPlan via calling `planLater()` can be  transformed automatically. It just needs to add the pair of transformation in map.

## How was this patch tested?

Unit tests on existing tests.
