### PR TITLE
[SPARK-24063][SS] Control maximum epoch backlog for ContinuousExecution

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1274,8 +1274,8 @@ object SQLConf {
   val MAX_EPOCH_BACKLOG = buildConf("spark.sql.streaming.continuous.maxEpochBacklog")
     .internal()
     .doc("The max number of epochs to be stored in queue to wait for late epochs. " +
-      "To prevent OOM, if this parameter is exceeded by the size of the queue, " +
-      "an error is reported and further epochs are not remembered until queue size decreases.")
+      "If this parameter is exceeded by the size of the queue, stream is stopped with an error " +
+      "indicating too many epochs stacked up.")
     .intConf
     .createWithDefault(10000)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1271,6 +1271,14 @@ object SQLConf {
       .intConf
       .createWithDefault(Int.MaxValue)
 
+  val MAX_EPOCH_BACKLOG = buildConf("spark.sql.streaming.continuous.maxEpochBacklog")
+    .internal()
+    .doc("The max number of epochs to be stored in queue to wait for late epochs. " +
+      "To prevent OOM, if this parameter is exceeded by the size of the queue, " +
+      "an error is reported and further epochs are not remembered until queue size decreases.")
+    .intConf
+    .createWithDefault(10000)
+
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"
   }
@@ -1640,6 +1648,8 @@ class SQLConf extends Serializable with Logging {
 
   def partitionOverwriteMode: PartitionOverwriteMode.Value =
     PartitionOverwriteMode.withName(getConf(PARTITION_OVERWRITE_MODE))
+
+  def maxEpochBacklog: Int = getConf(MAX_EPOCH_BACKLOG)
 
   /** ********************** SQLConf functionality methods ************ */
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request adds maxEpochBacklog SQL configuration option. EpochCoordinator tracks if the length of the queue of waiting epochs has exceeded it. Upon this condition stream is stopped with an error indicating too many epochs stacked up

## How was this patch tested?

Existing unit tests
