### PR TITLE
[SPARK-24338][SQL] Fixed Hive CREATETABLE error in Sentry-secured cluster

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -231,14 +231,14 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     // to create the table directory and write out data before we create this table, to avoid
     // exposing a partial written table.
     //
-    // CDH-51334: when using a remote metastore, and if a managed table is being created with its
+    // When using a remote metastore, and if a managed table is being created with its
     // location explicitly set to the location where it would be created anyway, then do
     // not set its location explicitly. This avoids an issue with Sentry in secure clusters.
     // Otherwise, the above comment applies.
     //
     // This workaround is not done for embedded metastores because (i) there's no Sentry in that
     // case, and (ii) HiveSparkSubmitSuite has a unit test that relies on the behavior without
-    // the CDH change.
+    // this change.
     val tableLocation: Option[URI] = if (tableDefinition.tableType == MANAGED) {
       val metastoreURIs = client.getConf(HiveConf.ConfVars.METASTOREURIS.varname, "")
       if (metastoreURIs.nonEmpty && DDLUtils.isHiveTable(tableDefinition)) {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -25,11 +25,13 @@ import java.util.Locale
 
 import scala.collection.mutable
 import scala.util.control.NonFatal
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.ql.metadata.HiveException
 import org.apache.thrift.TException
+
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException


### PR DESCRIPTION
## What changes were proposed in this pull request?

As detailed in the JIRA [ticket](https://issues.apache.org/jira/browse/SPARK-24338), Hive "CREATE TABLE" statement would fail when Sentry is used to manage authorization. This PR fixed this bug by porting the Cloudera fix.

## How was this patch tested?

Tested that the table can be successfully created with the fix. 