### PR TITLE
[SPARK-18805][DStream] Avoid StackOverflowError while getting RDD during restore from checkpoints

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -342,7 +342,10 @@ abstract class DStream[T: ClassTag] (
             try {
               compute(time)
             } catch {
-              case _: StackOverflowError => None
+              case soe: StackOverflowError =>
+                logWarning(s"Getting or computing the RDD corresponding" +
+                  s" to the time $time was failed", soe)
+                None
             }
           }
         }

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -339,7 +339,11 @@ abstract class DStream[T: ClassTag] (
           // recovery; see SPARK-4835 for more details. We need to have this call here because
           // compute() might cause Spark jobs to be launched.
           SparkHadoopWriterUtils.disableOutputSpecValidation.withValue(true) {
-            compute(time)
+            try {
+              compute(time)
+            } catch {
+              case _: StackOverflowError => None
+            }
           }
         }
 


### PR DESCRIPTION
Added a hook for catching a StackOverflowErrors threw during the process of restore RDDs from checkpoints.