### PR TITLE
[Spark-24376][doc]Summary:compiling spark with scala-2.10 should use the -P parameter instead of -D

### DIFF
--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -92,10 +92,10 @@ like ZooKeeper and Hadoop itself.
     ./build/mvn -Pmesos -DskipTests clean package
 
 ## Building for Scala 2.10
-To produce a Spark package compiled with Scala 2.10, use the `-Dscala-2.10` property:
+To produce a Spark package compiled with Scala 2.10, use the `-Pscala-2.10` property:
 
     ./dev/change-scala-version.sh 2.10
-    ./build/mvn -Pyarn -Dscala-2.10 -DskipTests clean package
+    ./build/mvn -Pyarn -scala-2.10 -DskipTestsP clean package
 
 Note that support for Scala 2.10 is deprecated as of Spark 2.1.0 and may be removed in Spark 2.2.0.
 

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -95,7 +95,7 @@ like ZooKeeper and Hadoop itself.
 To produce a Spark package compiled with Scala 2.10, use the `-Pscala-2.10` property:
 
     ./dev/change-scala-version.sh 2.10
-    ./build/mvn -Pyarn -scala-2.10 -DskipTestsP clean package
+    ./build/mvn -Pyarn -Pscala-2.10 -DskipTests clean package
 
 Note that support for Scala 2.10 is deprecated as of Spark 2.1.0 and may be removed in Spark 2.2.0.
 


### PR DESCRIPTION

 What changes were proposed in this pull request?

compiling spark with scala-2.10 should use the -P parameter instead of -D



## How was this patch tested?
JIRA_ID:SPARK-24376
using build/mvn clean package install deploy -DskipTests -Pscala-2.10

Please review http://spark.apache.org/contributing.html before opening a pull request.
