### PR TITLE
[SPARK-24397][PYSPARK] Added TaskContext.getLocalProperty(key) in Python

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -183,6 +183,13 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
         dataOut.writeInt(context.partitionId())
         dataOut.writeInt(context.attemptNumber())
         dataOut.writeLong(context.taskAttemptId())
+        val localProps = context.asInstanceOf[TaskContextImpl].getLocalProperties.asScala
+        dataOut.writeInt(localProps.size)
+        localProps.foreach { case (k, v) =>
+          PythonRDD.writeUTF(k, dataOut)
+          PythonRDD.writeUTF(v, dataOut)
+        }
+
         // sparkFilesDir
         PythonRDD.writeUTF(SparkFiles.getRootDirectory(), dataOut)
         // Python includes (*.zip and *.egg files)

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -94,4 +94,4 @@ class TaskContext(object):
         """
         Get a local property set upstream in the driver, or None if it is missing.
         """
-        return self._localProperties[key]
+        return self._localProperties.get(key, default=None)

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -34,6 +34,7 @@ class TaskContext(object):
     _partitionId = None
     _stageId = None
     _taskAttemptId = None
+    _localProperties = None
 
     def __new__(cls):
         """Even if users construct TaskContext instead of using get, give them the singleton."""
@@ -88,3 +89,9 @@ class TaskContext(object):
         TaskAttemptID.
         """
         return self._taskAttemptId
+
+    def getLocalProperty(self, key):
+        """
+        Get a local property set upstream in the driver, or None if it is missing.
+        """
+        return self._localProperties[key]

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -94,4 +94,4 @@ class TaskContext(object):
         """
         Get a local property set upstream in the driver, or None if it is missing.
         """
-        return self._localProperties.get(key, default=None)
+        return self._localProperties.get(key, None)

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -543,6 +543,14 @@ class TaskContextTests(PySparkTestCase):
         tc = TaskContext.get()
         self.assertTrue(tc is None)
 
+    def test_get_local_property(self):
+        """Verify that local properties set on the driver are available in TaskContext."""
+        self.sc.setLocalProperty("testkey", "testvalue")
+        rdd = self.sc.parallelize(range(1), 1)
+        prop1 = rdd1.map(lambda x: TaskContext.get().getLocalProperty("testkey")).collect()[0]
+        self.assertEqual(prop1, "testkey")
+        prop2 = rdd1.map(lambda x: TaskContext.get().getLocalProperty("otherkey")).collect()[0]
+        self.assertTrue(prop2 is None)
 
 class RDDTests(ReusedPySparkTestCase):
 

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -555,6 +555,7 @@ class TaskContextTests(PySparkTestCase):
         finally:
             self.sc.setLocalProperty("testkey", None)
 
+
 class RDDTests(ReusedPySparkTestCase):
 
     def test_range(self):

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -545,13 +545,15 @@ class TaskContextTests(PySparkTestCase):
 
     def test_get_local_property(self):
         """Verify that local properties set on the driver are available in TaskContext."""
-        self.sc.setLocalProperty("testkey", "testvalue")
-        rdd = self.sc.parallelize(range(1), 1)
-        prop1 = rdd.map(lambda x: TaskContext.get().getLocalProperty("testkey")).collect()[0]
-        self.assertEqual(prop1, "testkey")
-        prop2 = rdd.map(lambda x: TaskContext.get().getLocalProperty("otherkey")).collect()[0]
-        self.assertTrue(prop2 is None)
-
+        try:
+            self.sc.setLocalProperty("testkey", "testvalue")
+            rdd = self.sc.parallelize(range(1), 1)
+            prop1 = rdd.map(lambda x: TaskContext.get().getLocalProperty("testkey")).collect()[0]
+            self.assertEqual(prop1, "testvalue")
+            prop2 = rdd.map(lambda x: TaskContext.get().getLocalProperty("otherkey")).collect()[0]
+            self.assertTrue(prop2 is None)
+        finally:
+            self.sc.setLocalProperty("testkey", None)
 
 class RDDTests(ReusedPySparkTestCase):
 

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -547,9 +547,9 @@ class TaskContextTests(PySparkTestCase):
         """Verify that local properties set on the driver are available in TaskContext."""
         self.sc.setLocalProperty("testkey", "testvalue")
         rdd = self.sc.parallelize(range(1), 1)
-        prop1 = rdd1.map(lambda x: TaskContext.get().getLocalProperty("testkey")).collect()[0]
+        prop1 = rdd.map(lambda x: TaskContext.get().getLocalProperty("testkey")).collect()[0]
         self.assertEqual(prop1, "testkey")
-        prop2 = rdd1.map(lambda x: TaskContext.get().getLocalProperty("otherkey")).collect()[0]
+        prop2 = rdd.map(lambda x: TaskContext.get().getLocalProperty("otherkey")).collect()[0]
         self.assertTrue(prop2 is None)
 
 class RDDTests(ReusedPySparkTestCase):

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -552,6 +552,7 @@ class TaskContextTests(PySparkTestCase):
         prop2 = rdd.map(lambda x: TaskContext.get().getLocalProperty("otherkey")).collect()[0]
         self.assertTrue(prop2 is None)
 
+
 class RDDTests(ReusedPySparkTestCase):
 
     def test_range(self):

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -545,15 +545,17 @@ class TaskContextTests(PySparkTestCase):
 
     def test_get_local_property(self):
         """Verify that local properties set on the driver are available in TaskContext."""
+        key = "testkey"
+        value = "testvalue"
+        self.sc.setLocalProperty(key, value)
         try:
-            self.sc.setLocalProperty("testkey", "testvalue")
             rdd = self.sc.parallelize(range(1), 1)
-            prop1 = rdd.map(lambda x: TaskContext.get().getLocalProperty("testkey")).collect()[0]
-            self.assertEqual(prop1, "testvalue")
+            prop1 = rdd.map(lambda x: TaskContext.get().getLocalProperty(key)).collect()[0]
+            self.assertEqual(prop1, value)
             prop2 = rdd.map(lambda x: TaskContext.get().getLocalProperty("otherkey")).collect()[0]
             self.assertTrue(prop2 is None)
         finally:
-            self.sc.setLocalProperty("testkey", None)
+            self.sc.setLocalProperty(key, None)
 
 
 class RDDTests(ReusedPySparkTestCase):

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -222,6 +222,12 @@ def main(infile, outfile):
         taskContext._partitionId = read_int(infile)
         taskContext._attemptNumber = read_int(infile)
         taskContext._taskAttemptId = read_long(infile)
+        taskContext._localProperties = dict()
+        for i in range(read_int(infile)):
+            k = utf8_deserializer.loads(infile)
+            v = utf8_deserializer.loads(infile)
+            taskContext._localProperties[k] = v
+
         shuffle.MemoryBytesSpilled = 0
         shuffle.DiskBytesSpilled = 0
         _accumulatorRegistry.clear()


### PR DESCRIPTION
## What changes were proposed in this pull request?

This adds a new API `TaskContext.getLocalProperty(key)` to the Python TaskContext. It mirrors the Java TaskContext API of returning a string value if the key exists, or None if the key does not exist.


## How was this patch tested?
New test added.