### PR TITLE
[SPARK-24398] [SQL] Improve SQLAppStatusListener.aggregateMetrics() too slow

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListener.scala
@@ -159,16 +159,15 @@ class SQLAppStatusListener(
   }
 
   private def aggregateMetrics(exec: LiveExecutionData): Map[Long, String] = {
-    val metricIds = exec.metrics.map(_.accumulatorId).sorted
+    val metricIds = exec.metrics.map(_.accumulatorId).toSet
     val metricTypes = exec.metrics.map { m => (m.accumulatorId, m.metricType) }.toMap
     val metrics = exec.stages.toSeq
       .flatMap { stageId => Option(stageMetrics.get(stageId)) }
       .flatMap(_.taskMetrics.values().asScala)
       .flatMap { metrics => metrics.ids.zip(metrics.values) }
 
-    val metricIdKeys = metricIds.toSet
     val aggregatedMetrics = (metrics ++ exec.driverAccumUpdates.toSeq)
-      .filter { case (id, _) => metricIdKeys.contains(id) }
+      .filter { case (id, _) => metricIds.contains(id) }
       .groupBy(_._1)
       .map { case (id, values) =>
         id -> SQLMetrics.stringValue(metricTypes(id), values.map(_._2).toSeq)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListener.scala
@@ -166,8 +166,9 @@ class SQLAppStatusListener(
       .flatMap(_.taskMetrics.values().asScala)
       .flatMap { metrics => metrics.ids.zip(metrics.values) }
 
+    val metricIdKeys = metricIds.toSet
     val aggregatedMetrics = (metrics ++ exec.driverAccumUpdates.toSeq)
-      .filter { case (id, _) => metricIds.contains(id) }
+      .filter { case (id, _) => metricIdKeys.contains(id) }
       .groupBy(_._1)
       .map { case (id, values) =>
         id -> SQLMetrics.stringValue(metricTypes(id), values.map(_._2).toSeq)


### PR DESCRIPTION
## What changes were proposed in this pull request?

JIRA Issue: https://issues.apache.org/jira/browse/SPARK-24398
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
