### PR TITLE
[SPARK-24339][SQL]Add project for transform/map/reduce sql to prune column

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -341,7 +341,7 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
         // Add project.
         val namedExpressions = expressions.map {
           case e: NamedExpression => e
-          case e: _ => UnresolvedAlias(e)
+          case e: Expression => UnresolvedAlias(e)
         }
         val withProject = if (namedExpressions.nonEmpty) {
           Project(namedExpressions, withFilter)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -341,7 +341,7 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
         // Add project.
         val namedExpressions = expressions.map {
           case e: NamedExpression => e
-          case e: Expression => UnresolvedAlias(e)
+          case e: _ => UnresolvedAlias(e)
         }
         val withProject = if (namedExpressions.nonEmpty) {
           Project(namedExpressions, withFilter)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala
@@ -265,11 +265,14 @@ class HiveDDLCommandSuite extends PlanTest with SQLTestUtils with TestHiveSingle
       "func", Seq.empty, plans.table("e"), null)
 
     comparePlans(plan1,
-      p.copy(child = p.child.where('f < 10), output = Seq('key.string, 'value.string)))
+      p.copy(child = p.child.where('f < 10).select(UnresolvedAttribute("a"), UnresolvedAttribute("b")),
+        output = Seq('key.string, 'value.string)))
     comparePlans(plan2,
-      p.copy(output = Seq('c.string, 'd.string)))
+      p.copy(child = p.child.select(UnresolvedAttribute("a"), UnresolvedAttribute("b")),
+        output = Seq('c.string, 'd.string)))
     comparePlans(plan3,
-      p.copy(output = Seq('c.int, 'd.decimal(10, 0))))
+      p.copy(child = p.child.select(UnresolvedAttribute("a"), UnresolvedAttribute("b")),
+        output = Seq('c.int, 'd.decimal(10, 0))))
   }
 
   test("use backticks in output of Script Transform") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala
@@ -265,7 +265,8 @@ class HiveDDLCommandSuite extends PlanTest with SQLTestUtils with TestHiveSingle
       "func", Seq.empty, plans.table("e"), null)
 
     comparePlans(plan1,
-      p.copy(child = p.child.where('f < 10).select(UnresolvedAttribute("a"), UnresolvedAttribute("b")),
+      p.copy(
+        child = p.child.where('f < 10).select(UnresolvedAttribute("a"), UnresolvedAttribute("b")),
         output = Seq('key.string, 'value.string)))
     comparePlans(plan2,
       p.copy(child = p.child.select(UnresolvedAttribute("a"), UnresolvedAttribute("b")),

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala
@@ -269,10 +269,12 @@ class HiveDDLCommandSuite extends PlanTest with SQLTestUtils with TestHiveSingle
         child = p.child.where('f < 10).select(UnresolvedAttribute("a"), UnresolvedAttribute("b")),
         output = Seq('key.string, 'value.string)))
     comparePlans(plan2,
-      p.copy(child = p.child.select(UnresolvedAttribute("a"), UnresolvedAttribute("b")),
+      p.copy(
+        child = p.child.select(UnresolvedAttribute("a"), UnresolvedAttribute("b")),
         output = Seq('c.string, 'd.string)))
     comparePlans(plan3,
-      p.copy(child = p.child.select(UnresolvedAttribute("a"), UnresolvedAttribute("b")),
+      p.copy(
+        child = p.child.select(UnresolvedAttribute("a"), UnresolvedAttribute("b")),
         output = Seq('c.int, 'd.decimal(10, 0))))
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Transform query do not have Project Node, query like:

` select transform(a, b) using 'func' from e` 

and it' logic plan is:

> 'ScriptTransformation['a, 'b], func, [key#0, value#0] 
        +- 'UnresolvedRelation `e` (PlanTest.scala:97)

so that it will scan all the column data of relation.

In this PR, I propose to add Project Node for transform query, so that it scan required data by prune columns, for above transform query,  it's logic plan will be:

> 'ScriptTransformation['a, 'b], func, [key#0, value#0] 
   +- 'Project ['a, 'b]    
        +- 'UnresolvedRelation `e`

it will scan only two column data of relation.

In summary, Add Project Node for transform query can reduce the time of scan and assemble data.(In our scenario, the relation(table) have 700 columns.)

## How was this patch tested?

Modify existing test ("transform query spec")
