### PR TITLE
[SPARK-24385][SQL] Resolve self-join condition ambiguity for all BinaryComparisons

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -332,7 +332,10 @@ class Analyzer(
         gid: Expression): Expression = {
       expr transform {
         case e: GroupingID =>
-          if (e.groupByExprs.isEmpty || e.groupByExprs == groupByExprs) {
+          def sameExprs = e.groupByExprs.zip(groupByExprs).forall {
+            case (e1, e2) => e1.semanticEquals(e2)
+          }
+          if (e.groupByExprs.isEmpty || sameExprs) {
             Alias(gid, toPrettySQL(e))()
           } else {
             throw new AnalysisException(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
@@ -144,7 +144,15 @@ package object expressions  {
     }
 
     private def unique[T](m: Map[T, Seq[Attribute]]): Map[T, Seq[Attribute]] = {
-      m.mapValues(_.distinct).map(identity)
+      m.mapValues { allAttrs =>
+        val buffer = new scala.collection.mutable.ListBuffer[Attribute]
+        allAttrs.foreach { a =>
+          if (!buffer.exists(_.semanticEquals(a))) {
+            buffer += a
+          }
+        }
+        buffer
+      }.map(identity)
     }
 
     /** Map to use for direct case insensitive attribute lookups. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1000,11 +1000,11 @@ class Dataset[T] private[sql](
     // By the time we get here, since we have already run analysis, all attributes should've been
     // resolved and become AttributeReference.
     val cond = plan.condition.map { _.transform {
-      case catalyst.expressions.EqualTo(a: AttributeReference, b: AttributeReference)
+      case e @ catalyst.expressions.BinaryComparison(a: AttributeReference, b: AttributeReference)
           if a.sameRef(b) =>
-        catalyst.expressions.EqualTo(
+        e.withNewChildren(Seq(
           withPlan(plan.left).resolve(a.name),
-          withPlan(plan.right).resolve(b.name))
+          withPlan(plan.right).resolve(b.name)))
     }}
 
     withPlan {

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -463,7 +463,8 @@ class Dataset[T] private[sql](
    * @group basic
    * @since 1.6.0
    */
-  def schema: StructType = queryExecution.analyzed.schema
+  def schema: StructType = StructType.removeMetadata(
+    Dataset.DATASET_ID, queryExecution.analyzed.schema).asInstanceOf[StructType]
 
   /**
    * Prints the schema to the console in a nice tree format.

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -240,7 +240,7 @@ class Dataset[T] private[sql](
 
   private[sql] def numericColumns: Seq[Expression] = {
     schema.fields.filter(_.dataType.isInstanceOf[NumericType]).map { n =>
-      queryExecution.analyzed.resolveQuoted(n.name, sparkSession.sessionState.analyzer.resolver).get
+      resolve(n.name)
     }
   }
 
@@ -2329,7 +2329,7 @@ class Dataset[T] private[sql](
     }
     val attrs = this.planWithBarrier.output
     val colsAfterDrop = attrs.filter { attr =>
-      attr != expression
+      !attr.semanticEquals(expression)
     }.map(attr => Column(attr))
     select(colsAfterDrop : _*)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
@@ -287,4 +287,16 @@ class DataFrameJoinSuite extends QueryTest with SharedSQLContext {
       dfOne.join(dfTwo, $"a" === $"b", "left").queryExecution.optimizedPlan
     }
   }
+
+  test("SPARK-24385: Resolve ambiguity in self-joins with operators different from EqualsTo") {
+    withSQLConf(SQLConf.CROSS_JOINS_ENABLED.key -> "false") {
+      val df = spark.range(10)
+      // these should not throw any exception
+      df.join(df, df("id") >= df("id")).queryExecution.optimizedPlan
+      df.join(df, df("id") <=> df("id")).queryExecution.optimizedPlan
+      df.join(df, df("id") <= df("id")).queryExecution.optimizedPlan
+      df.join(df, df("id") > df("id")).queryExecution.optimizedPlan
+      df.join(df, df("id") < df("id")).queryExecution.optimizedPlan
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -862,7 +862,7 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
           Row(id, name, age, salary)
       }.toSeq)
     assert(df.schema.map(_.name) === Seq("id", "name", "age", "salary"))
-    assert(df("id") == person("id"))
+    assert(df("id").expr.semanticEquals(person("id").expr))
   }
 
   test("drop top level columns that contains dot") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `Dataset.join` we have a small hack for resolving ambiguity in the column name for self-joins. The current code supports only `EqualTo`, but we may have other conditions involving columns on self joins: in general any `BinaryComparison` can be specified and faces the same issue.

The PR extends the fix to all `BinaryComparison`s.

## How was this patch tested?

added UT
