### PR TITLE
Test branch to see how Scala 2.11.12 performs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <commons.math3.version>3.4.1</commons.math3.version>
     <!-- managed up from 3.2.1 for SPARK-11652 -->
     <commons.collections.version>3.2.2</commons.collections.version>
-    <scala.version>2.11.8</scala.version>
+    <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
     <fasterxml.jackson.version>2.6.7</fasterxml.jackson.version>


### PR DESCRIPTION
This may be useful when Java 8 is no longer supported since
Scala 2.11.12 supports later versions of Java

## What changes were proposed in this pull request?

Change Scala Build Version to 2.11.12.

## How was this patch tested?

This PR is made to run 2.11.12 Scala through Jenkins to see whether or not it passes cleanly.

Please review http://spark.apache.org/contributing.html before opening a pull request.
