### PR TITLE
[SPARK-24093][DStream][Minor]Make some fields of KafkaStreamWriter/In…

### DIFF
--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaStreamWriter.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaStreamWriter.scala
@@ -41,7 +41,7 @@ case object KafkaWriterCommitMessage extends WriterCommitMessage
  * @param schema The schema of the input data.
  */
 class KafkaStreamWriter(
-    topic: Option[String], producerParams: Map[String, String], schema: StructType)
+    val topic: Option[String], producerParams: Map[String, String], schema: StructType)
   extends StreamWriter with SupportsWriteInternalRow {
 
   validateQuery(schema.toAttributes, producerParams.toMap[String, Object].asJava, topic)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/MicroBatchWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/MicroBatchWriter.scala
@@ -37,7 +37,7 @@ class MicroBatchWriter(batchId: Long, writer: StreamWriter) extends DataSourceWr
   override def createWriterFactory(): DataWriterFactory[Row] = writer.createWriterFactory()
 }
 
-class InternalRowMicroBatchWriter(batchId: Long, writer: StreamWriter)
+class InternalRowMicroBatchWriter(batchId: Long, val writer: StreamWriter)
   extends DataSourceWriter with SupportsWriteInternalRow {
   override def commit(messages: Array[WriterCommitMessage]): Unit = {
     writer.commit(batchId, messages)


### PR DESCRIPTION
…ternalRowMicroBatchWriter visible to outside of the classes

## What changes were proposed in this pull request?

This PR is created to make relevant fields of KafkaStreamWriter and InternalRowMicroBatchWriter visible to outside of the classes.

## How was this patch tested?
manual tests

