### PR TITLE
[SPARK-22151] : PYTHONPATH not picked up from the spark.yarn.appMaste…

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -811,7 +811,7 @@ private[spark] class Client(
 
     // Finally, update the Spark config to propagate PYTHONPATH to the AM and executors.
     if (pythonPath.nonEmpty) {
-      val pythonPathStr = (sys.env.get("PYTHONPATH") ++ pythonPath)
+      val pythonPathStr = (sys.env.get("PYTHONPATH") ++=: pythonPath)
         .mkString(ApplicationConstants.CLASS_PATH_SEPARATOR)
       val newValue =
         if (env.contains("PYTHONPATH")) {
@@ -820,7 +820,9 @@ private[spark] class Client(
           pythonPathStr
         }
       env("PYTHONPATH") = newValue
-      sparkConf.setExecutorEnv("PYTHONPATH", newValue)
+      if (!sparkConf.getExecutorEnv.toMap.contains("PYTHONPATH")) {
+        sparkConf.setExecutorEnv("PYTHONPATH", newValue)
+      }
     }
 
     if (isClusterMode) {

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -811,7 +811,7 @@ private[spark] class Client(
 
     // Finally, update the Spark config to propagate PYTHONPATH to the AM and executors.
     if (pythonPath.nonEmpty) {
-      val pythonPathStr = (sys.env.get("PYTHONPATH") ++=: pythonPath)
+      val pythonPathStr = (sys.env.get("PYTHONPATH") ++ pythonPath)
         .mkString(ApplicationConstants.CLASS_PATH_SEPARATOR)
       val newValue =
         if (env.contains("PYTHONPATH")) {
@@ -821,7 +821,11 @@ private[spark] class Client(
         }
       env("PYTHONPATH") = newValue
       if (!sparkConf.getExecutorEnv.toMap.contains("PYTHONPATH")) {
-        sparkConf.setExecutorEnv("PYTHONPATH", newValue)
+        sparkConf.setExecutorEnv("PYTHONPATH", pythonPathStr)
+      } else {
+        val pythonPathExecutorEnv = sparkConf.getExecutorEnv.toMap.get("PYTHONPATH").get +
+          ApplicationConstants.CLASS_PATH_SEPARATOR + pythonPathStr
+        sparkConf.setExecutorEnv("PYTHONPATH", pythonPathExecutorEnv)
       }
     }
 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -813,8 +813,14 @@ private[spark] class Client(
     if (pythonPath.nonEmpty) {
       val pythonPathStr = (sys.env.get("PYTHONPATH") ++ pythonPath)
         .mkString(ApplicationConstants.CLASS_PATH_SEPARATOR)
-      env("PYTHONPATH") = pythonPathStr
-      sparkConf.setExecutorEnv("PYTHONPATH", pythonPathStr)
+      val newValue =
+        if (env.contains("PYTHONPATH")) {
+          env("PYTHONPATH") + ApplicationConstants.CLASS_PATH_SEPARATOR  + pythonPathStr
+        } else {
+          pythonPathStr
+        }
+      env("PYTHONPATH") = newValue
+      sparkConf.setExecutorEnv("PYTHONPATH", newValue)
     }
 
     if (isClusterMode) {

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -820,13 +820,14 @@ private[spark] class Client(
           pythonPathStr
         }
       env("PYTHONPATH") = newValue
-      if (!sparkConf.getExecutorEnv.toMap.contains("PYTHONPATH")) {
-        sparkConf.setExecutorEnv("PYTHONPATH", pythonPathStr)
-      } else {
-        val pythonPathExecutorEnv = sparkConf.getExecutorEnv.toMap.get("PYTHONPATH").get +
-          ApplicationConstants.CLASS_PATH_SEPARATOR + pythonPathStr
-        sparkConf.setExecutorEnv("PYTHONPATH", pythonPathExecutorEnv)
-      }
+      val pythonPathExecutorEnv =
+        if (!sparkConf.getExecutorEnv.toMap.contains("PYTHONPATH")) {
+          pythonPathStr
+        } else {
+          sparkConf.getExecutorEnv.toMap.get("PYTHONPATH").get +
+            ApplicationConstants.CLASS_PATH_SEPARATOR + pythonPathStr
+        }
+      sparkConf.setExecutorEnv("PYTHONPATH", pythonPathExecutorEnv)
     }
 
     if (isClusterMode) {

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -811,22 +811,11 @@ private[spark] class Client(
 
     // Finally, update the Spark config to propagate PYTHONPATH to the AM and executors.
     if (pythonPath.nonEmpty) {
-      val pythonPathStr = (sys.env.get("PYTHONPATH") ++ pythonPath)
+      val pythonPathList = (sys.env.get("PYTHONPATH") ++ pythonPath)
+      env("PYTHONPATH") = (env.get("PYTHONPATH") ++ pythonPathList)
         .mkString(ApplicationConstants.CLASS_PATH_SEPARATOR)
-      val newValue =
-        if (env.contains("PYTHONPATH")) {
-          env("PYTHONPATH") + ApplicationConstants.CLASS_PATH_SEPARATOR  + pythonPathStr
-        } else {
-          pythonPathStr
-        }
-      env("PYTHONPATH") = newValue
-      val pythonPathExecutorEnv =
-        if (!sparkConf.getExecutorEnv.toMap.contains("PYTHONPATH")) {
-          pythonPathStr
-        } else {
-          sparkConf.getExecutorEnv.toMap.get("PYTHONPATH").get +
-            ApplicationConstants.CLASS_PATH_SEPARATOR + pythonPathStr
-        }
+      val pythonPathExecutorEnv = (sparkConf.getExecutorEnv.toMap.get("PYTHONPATH") ++
+        pythonPathList).mkString(ApplicationConstants.CLASS_PATH_SEPARATOR)
       sparkConf.setExecutorEnv("PYTHONPATH", pythonPathExecutorEnv)
     }
 


### PR DESCRIPTION
…rEnv properly

Running in yarn cluster mode and trying to set pythonpath via spark.yarn.appMasterEnv.PYTHONPATH doesn't work.

the yarn Client code looks at the env variables:
val pythonPathStr = (sys.env.get("PYTHONPATH") ++ pythonPath)
But when you set spark.yarn.appMasterEnv it puts it into the local env.

So the python path set in spark.yarn.appMasterEnv isn't properly set.

You can work around if you are running in cluster mode by setting it on the client like:

PYTHONPATH=./addon/python/ spark-submit

## What changes were proposed in this pull request?
In Client.scala, PYTHONPATH was being overridden, so changed code to append values to PYTHONPATH instead of overriding them.

## How was this patch tested?
Added log statements to ApplicationMaster.scala to check for environment variable PYTHONPATH, ran a spark job in cluster mode before the change and verified the issue. Performed the same test after the change and verified the fix. 
