### PR TITLE
[SPARK-24441][SS] Expose total estimated size of states in HDFSBackedStateStoreProvider

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
@@ -81,10 +81,10 @@ class SQLMetric(val metricType: String, initValue: Long = 0L) extends Accumulato
 }
 
 object SQLMetrics {
-  private val SUM_METRIC = "sum"
-  private val SIZE_METRIC = "size"
-  private val TIMING_METRIC = "timing"
-  private val AVERAGE_METRIC = "average"
+  val SUM_METRIC = "sum"
+  val SIZE_METRIC = "size"
+  val TIMING_METRIC = "timing"
+  val AVERAGE_METRIC = "average"
 
   private val baseForAvgMetric: Int = 10
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
@@ -81,10 +81,10 @@ class SQLMetric(val metricType: String, initValue: Long = 0L) extends Accumulato
 }
 
 object SQLMetrics {
-  val SUM_METRIC = "sum"
-  val SIZE_METRIC = "size"
-  val TIMING_METRIC = "timing"
-  val AVERAGE_METRIC = "average"
+  private val SUM_METRIC = "sum"
+  private val SIZE_METRIC = "size"
+  private val TIMING_METRIC = "timing"
+  private val AVERAGE_METRIC = "average"
 
   private val baseForAvgMetric: Int = 10
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -183,7 +183,6 @@ private[state] class HDFSBackedStateStoreProvider extends StateStoreProvider wit
 
   def getCustomMetricsForProvider(): Map[StateStoreCustomMetric, Long] = synchronized {
     Map(metricProviderLoaderMapSizeBytes -> SizeEstimator.estimate(loadedMaps),
-      metricProviderLoaderCountOfVersionsInMap -> loadedMaps.size,
       metricLoadedMapCacheHit -> loadedMapCacheHitCount.sum(),
       metricLoadedMapCacheMiss -> loadedMapCacheMissCount.sum())
   }
@@ -233,8 +232,7 @@ private[state] class HDFSBackedStateStoreProvider extends StateStoreProvider wit
   }
 
   override def supportedCustomMetrics: Seq[StateStoreCustomMetric] = {
-    metricProviderLoaderMapSizeBytes :: metricProviderLoaderCountOfVersionsInMap ::
-      metricLoadedMapCacheHit :: metricLoadedMapCacheMiss :: Nil
+    metricProviderLoaderMapSizeBytes :: metricLoadedMapCacheHit :: metricLoadedMapCacheMiss :: Nil
   }
 
   override def toString(): String = {
@@ -261,10 +259,6 @@ private[state] class HDFSBackedStateStoreProvider extends StateStoreProvider wit
   private lazy val metricProviderLoaderMapSizeBytes: StateStoreCustomSizeMetric =
     StateStoreCustomSizeMetric("providerLoadedMapSizeBytes",
       "estimated size of states cache in provider")
-
-  private lazy val metricProviderLoaderCountOfVersionsInMap: StateStoreCustomAverageMetric =
-    StateStoreCustomAverageMetric("providerLoadedMapCountOfVersions",
-      "count of versions in states cache in provider")
 
   private lazy val metricLoadedMapCacheHit: StateStoreCustomMetric =
     StateStoreCustomSumMetric("loadedMapCacheHitCount",

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -139,6 +139,7 @@ trait StateStoreCustomMetric {
   def desc: String
 }
 
+case class StateStoreCustomSumMetric(name: String, desc: String) extends StateStoreCustomMetric
 case class StateStoreCustomAverageMetric(name: String, desc: String) extends StateStoreCustomMetric
 case class StateStoreCustomSizeMetric(name: String, desc: String) extends StateStoreCustomMetric
 case class StateStoreCustomTimingMetric(name: String, desc: String) extends StateStoreCustomMetric

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -138,6 +138,8 @@ trait StateStoreCustomMetric {
   def name: String
   def desc: String
 }
+
+case class StateStoreCustomAverageMetric(name: String, desc: String) extends StateStoreCustomMetric
 case class StateStoreCustomSizeMetric(name: String, desc: String) extends StateStoreCustomMetric
 case class StateStoreCustomTimingMetric(name: String, desc: String) extends StateStoreCustomMetric
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -140,7 +140,6 @@ trait StateStoreCustomMetric {
 }
 
 case class StateStoreCustomSumMetric(name: String, desc: String) extends StateStoreCustomMetric
-case class StateStoreCustomAverageMetric(name: String, desc: String) extends StateStoreCustomMetric
 case class StateStoreCustomSizeMetric(name: String, desc: String) extends StateStoreCustomMetric
 case class StateStoreCustomTimingMetric(name: String, desc: String) extends StateStoreCustomMetric
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManager.scala
@@ -269,6 +269,8 @@ class SymmetricHashJoinStateManager(
       keyWithIndexToValueMetrics.numKeys,       // represent each buffered row only once
       keyToNumValuesMetrics.memoryUsedBytes + keyWithIndexToValueMetrics.memoryUsedBytes,
       keyWithIndexToValueMetrics.customMetrics.map {
+        case (s @ StateStoreCustomAverageMetric(_, desc), value) =>
+          s.copy(desc = newDesc(desc)) -> value
         case (s @ StateStoreCustomSizeMetric(_, desc), value) =>
           s.copy(desc = newDesc(desc)) -> value
         case (s @ StateStoreCustomTimingMetric(_, desc), value) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManager.scala
@@ -269,6 +269,8 @@ class SymmetricHashJoinStateManager(
       keyWithIndexToValueMetrics.numKeys,       // represent each buffered row only once
       keyToNumValuesMetrics.memoryUsedBytes + keyWithIndexToValueMetrics.memoryUsedBytes,
       keyWithIndexToValueMetrics.customMetrics.map {
+        case (s @ StateStoreCustomSumMetric(_, desc), value) =>
+          s.copy(desc = newDesc(desc)) -> value
         case (s @ StateStoreCustomAverageMetric(_, desc), value) =>
           s.copy(desc = newDesc(desc)) -> value
         case (s @ StateStoreCustomSizeMetric(_, desc), value) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManager.scala
@@ -271,8 +271,6 @@ class SymmetricHashJoinStateManager(
       keyWithIndexToValueMetrics.customMetrics.map {
         case (s @ StateStoreCustomSumMetric(_, desc), value) =>
           s.copy(desc = newDesc(desc)) -> value
-        case (s @ StateStoreCustomAverageMetric(_, desc), value) =>
-          s.copy(desc = newDesc(desc)) -> value
         case (s @ StateStoreCustomSizeMetric(_, desc), value) =>
           s.copy(desc = newDesc(desc)) -> value
         case (s @ StateStoreCustomTimingMetric(_, desc), value) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -128,6 +128,8 @@ trait StateStoreWriter extends StatefulOperator { self: SparkPlan =>
   private def stateStoreCustomMetrics: Map[String, SQLMetric] = {
     val provider = StateStoreProvider.create(sqlContext.conf.stateStoreProviderClass)
     provider.supportedCustomMetrics.map {
+      case StateStoreCustomSumMetric(name, desc) =>
+        name -> SQLMetrics.createMetric(sparkContext, desc)
       case StateStoreCustomAverageMetric(name, desc) =>
         name -> SQLMetrics.createAverageMetric(sparkContext, desc)
       case StateStoreCustomSizeMetric(name, desc) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -90,13 +90,11 @@ trait StateStoreWriter extends StatefulOperator { self: SparkPlan =>
    * the driver after this SparkPlan has been executed and metrics have been updated.
    */
   def getProgress(): StateOperatorProgress = {
-    // average metric is a bit tricky, so hard to aggregate: just exclude them to simplify issue
-    val avgExcludedCustomMetrics = stateStoreCustomMetrics
-      .filterNot(_._2.metricType == SQLMetrics.AVERAGE_METRIC)
+    val customMetrics = stateStoreCustomMetrics
       .map(entry => entry._1 -> longMetric(entry._1).value)
 
     val javaConvertedCustomMetrics: java.util.HashMap[String, java.lang.Long] =
-      new java.util.HashMap(avgExcludedCustomMetrics.mapValues(long2Long).asJava)
+      new java.util.HashMap(customMetrics.mapValues(long2Long).asJava)
 
     new StateOperatorProgress(
       numRowsTotal = longMetric("numTotalStateRows").value,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -118,9 +118,6 @@ trait StateStoreWriter extends StatefulOperator { self: SparkPlan =>
     longMetric("numTotalStateRows") += storeMetrics.numKeys
     longMetric("stateMemory") += storeMetrics.memoryUsedBytes
     storeMetrics.customMetrics.foreach {
-      case (metric: StateStoreCustomAverageMetric, value) =>
-        longMetric(metric.name).set(value * 1.0d)
-
       case (metric, value) => longMetric(metric.name) += value
     }
   }
@@ -130,8 +127,6 @@ trait StateStoreWriter extends StatefulOperator { self: SparkPlan =>
     provider.supportedCustomMetrics.map {
       case StateStoreCustomSumMetric(name, desc) =>
         name -> SQLMetrics.createMetric(sparkContext, desc)
-      case StateStoreCustomAverageMetric(name, desc) =>
-        name -> SQLMetrics.createAverageMetric(sparkContext, desc)
       case StateStoreCustomSizeMetric(name, desc) =>
         name -> SQLMetrics.createSizeMetric(sparkContext, desc)
       case StateStoreCustomTimingMetric(name, desc) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -117,8 +117,8 @@ trait StateStoreWriter extends StatefulOperator { self: SparkPlan =>
     val storeMetrics = store.metrics
     longMetric("numTotalStateRows") += storeMetrics.numKeys
     longMetric("stateMemory") += storeMetrics.memoryUsedBytes
-    storeMetrics.customMetrics.foreach {
-      case (metric, value) => longMetric(metric.name) += value
+    storeMetrics.customMetrics.foreach { case (metric, value) =>
+      longMetric(metric.name) += value
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/progress.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/progress.scala
@@ -38,7 +38,8 @@ import org.apache.spark.annotation.InterfaceStability
 class StateOperatorProgress private[sql](
     val numRowsTotal: Long,
     val numRowsUpdated: Long,
-    val memoryUsedBytes: Long
+    val memoryUsedBytes: Long,
+    val customMetrics: ju.Map[String, JLong] = new ju.HashMap()
   ) extends Serializable {
 
   /** The compact JSON representation of this progress. */
@@ -48,12 +49,24 @@ class StateOperatorProgress private[sql](
   def prettyJson: String = pretty(render(jsonValue))
 
   private[sql] def copy(newNumRowsUpdated: Long): StateOperatorProgress =
-    new StateOperatorProgress(numRowsTotal, newNumRowsUpdated, memoryUsedBytes)
+    new StateOperatorProgress(numRowsTotal, newNumRowsUpdated, memoryUsedBytes, customMetrics)
 
   private[sql] def jsonValue: JValue = {
-    ("numRowsTotal" -> JInt(numRowsTotal)) ~
-    ("numRowsUpdated" -> JInt(numRowsUpdated)) ~
-    ("memoryUsedBytes" -> JInt(memoryUsedBytes))
+    def safeMapToJValue[T](map: ju.Map[String, T], valueToJValue: T => JValue): JValue = {
+      if (map.isEmpty) return JNothing
+      val keys = map.keySet.asScala.toSeq.sorted
+      keys.map { k => k -> valueToJValue(map.get(k)) : JObject }.reduce(_ ~ _)
+    }
+
+    val jsonVal = ("numRowsTotal" -> JInt(numRowsTotal)) ~
+      ("numRowsUpdated" -> JInt(numRowsUpdated)) ~
+      ("memoryUsedBytes" -> JInt(memoryUsedBytes))
+
+    if (!customMetrics.isEmpty) {
+      jsonVal ~ ("customMetrics" -> safeMapToJValue[JLong](customMetrics, v => JInt(v.toLong)))
+    } else {
+      jsonVal
+    }
   }
 
   override def toString: String = prettyJson

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/progress.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/progress.scala
@@ -52,21 +52,17 @@ class StateOperatorProgress private[sql](
     new StateOperatorProgress(numRowsTotal, newNumRowsUpdated, memoryUsedBytes, customMetrics)
 
   private[sql] def jsonValue: JValue = {
-    def safeMapToJValue[T](map: ju.Map[String, T], valueToJValue: T => JValue): JValue = {
-      if (map.isEmpty) return JNothing
-      val keys = map.keySet.asScala.toSeq.sorted
-      keys.map { k => k -> valueToJValue(map.get(k)) : JObject }.reduce(_ ~ _)
-    }
-
-    val jsonVal = ("numRowsTotal" -> JInt(numRowsTotal)) ~
-      ("numRowsUpdated" -> JInt(numRowsUpdated)) ~
-      ("memoryUsedBytes" -> JInt(memoryUsedBytes))
-
-    if (!customMetrics.isEmpty) {
-      jsonVal ~ ("customMetrics" -> safeMapToJValue[JLong](customMetrics, v => JInt(v.toLong)))
-    } else {
-      jsonVal
-    }
+    ("numRowsTotal" -> JInt(numRowsTotal)) ~
+    ("numRowsUpdated" -> JInt(numRowsUpdated)) ~
+    ("memoryUsedBytes" -> JInt(memoryUsedBytes)) ~
+    ("customMetrics" -> {
+      if (!customMetrics.isEmpty) {
+        val keys = customMetrics.keySet.asScala.toSeq.sorted
+        keys.map { k => k -> JInt(customMetrics.get(k).toLong) : JObject }.reduce(_ ~ _)
+      } else {
+        JNothing
+      }
+    })
   }
 
   override def toString: String = prettyJson

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -507,6 +507,81 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
     assert(CreateAtomicTestManager.cancelCalledInCreateAtomic)
   }
 
+  test("expose metrics with custom metrics to StateStoreMetrics") {
+    val provider = newStoreProvider()
+
+    // Verify state before starting a new set of updates
+    assert(getLatestData(provider).isEmpty)
+
+    val store = provider.getStore(0)
+    assert(!store.hasCommitted)
+    assert(store.metrics.numKeys === 0)
+
+    assert(store.metrics.customMetrics.exists(_._1.name == "providerLoadedMapCountOfVersions"))
+    var loadedMapSize = store.metrics.customMetrics.find(_._1.name == "providerLoadedMapSizeBytes")
+    assert(loadedMapSize.isDefined)
+    val initialLoadedMapSize = loadedMapSize.get._2
+    assert(initialLoadedMapSize >= 0)
+
+    put(store, "a", 1)
+    assert(store.metrics.numKeys === 1)
+
+    put(store, "b", 2)
+    put(store, "aa", 3)
+    assert(store.metrics.numKeys === 3)
+    remove(store, _.startsWith("a"))
+    assert(store.metrics.numKeys === 1)
+    assert(store.commit() === 1)
+
+    assert(store.hasCommitted)
+
+    assert(store.metrics.customMetrics.exists(_._1.name == "providerLoadedMapCountOfVersions"))
+    loadedMapSize = store.metrics.customMetrics.find(_._1.name == "providerLoadedMapSizeBytes")
+    assert(loadedMapSize.isDefined)
+    val loadedMapSizeForVersion1 = loadedMapSize.get._2
+    assert(loadedMapSizeForVersion1 > initialLoadedMapSize)
+
+    val storeV2 = provider.getStore(1)
+    assert(!storeV2.hasCommitted)
+    assert(storeV2.metrics.numKeys === 1)
+
+    put(storeV2, "cc", 4)
+    assert(storeV2.metrics.numKeys === 2)
+    assert(storeV2.commit() === 2)
+
+    assert(storeV2.hasCommitted)
+
+    assert(storeV2.metrics.customMetrics.exists(_._1.name == "providerLoadedMapCountOfVersions"))
+    loadedMapSize = storeV2.metrics.customMetrics.find(_._1.name == "providerLoadedMapSizeBytes")
+    assert(loadedMapSize.isDefined)
+    val loadedMapSizeForVersion1And2 = loadedMapSize.get._2
+    assert(loadedMapSizeForVersion1And2 > loadedMapSizeForVersion1)
+
+    val reloadedProvider = newStoreProvider(store.id)
+    // intended to load version 2 instead of 1
+    // version 2 will not be loaded to the cache in provider
+    val reloadedStore = reloadedProvider.getStore(1)
+    assert(reloadedStore.metrics.numKeys === 1)
+
+    assert(reloadedStore.metrics.customMetrics
+      .exists(_._1.name == "providerLoadedMapCountOfVersions"))
+    loadedMapSize = reloadedStore.metrics.customMetrics
+      .find(_._1.name == "providerLoadedMapSizeBytes")
+    assert(loadedMapSize.isDefined)
+    assert(loadedMapSize.get._2 === loadedMapSizeForVersion1)
+
+    // now we are loading version 2
+    val reloadedStoreV2 = reloadedProvider.getStore(2)
+    assert(reloadedStoreV2.metrics.numKeys === 2)
+
+    assert(reloadedStoreV2.metrics.customMetrics
+      .exists(_._1.name == "providerLoadedMapCountOfVersions"))
+    loadedMapSize = reloadedStoreV2.metrics.customMetrics
+      .find(_._1.name == "providerLoadedMapSizeBytes")
+    assert(loadedMapSize.isDefined)
+    assert(loadedMapSize.get._2 > loadedMapSizeForVersion1)
+  }
+
   override def newStoreProvider(): HDFSBackedStateStoreProvider = {
     newStoreProvider(opId = Random.nextInt(), partition = 0)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -522,6 +522,12 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
     assert(loadedMapSize.isDefined)
     val initialLoadedMapSize = loadedMapSize.get._2
     assert(initialLoadedMapSize >= 0)
+    var cacheHitCount = store.metrics.customMetrics.find(_._1.name == "loadedMapCacheHitCount")
+    assert(cacheHitCount.isDefined)
+    assert(cacheHitCount.get._2 == 0)
+    var cacheMissCount = store.metrics.customMetrics.find(_._1.name == "loadedMapCacheMissCount")
+    assert(cacheMissCount.isDefined)
+    assert(cacheMissCount.get._2 == 0)
 
     put(store, "a", 1)
     assert(store.metrics.numKeys === 1)
@@ -540,6 +546,12 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
     assert(loadedMapSize.isDefined)
     val loadedMapSizeForVersion1 = loadedMapSize.get._2
     assert(loadedMapSizeForVersion1 > initialLoadedMapSize)
+    cacheHitCount = store.metrics.customMetrics.find(_._1.name == "loadedMapCacheHitCount")
+    assert(cacheHitCount.isDefined)
+    assert(cacheHitCount.get._2 == 0)
+    cacheMissCount = store.metrics.customMetrics.find(_._1.name == "loadedMapCacheMissCount")
+    assert(cacheMissCount.isDefined)
+    assert(cacheMissCount.get._2 == 0)
 
     val storeV2 = provider.getStore(1)
     assert(!storeV2.hasCommitted)
@@ -556,6 +568,12 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
     assert(loadedMapSize.isDefined)
     val loadedMapSizeForVersion1And2 = loadedMapSize.get._2
     assert(loadedMapSizeForVersion1And2 > loadedMapSizeForVersion1)
+    cacheHitCount = store.metrics.customMetrics.find(_._1.name == "loadedMapCacheHitCount")
+    assert(cacheHitCount.isDefined)
+    assert(cacheHitCount.get._2 == 1)
+    cacheMissCount = store.metrics.customMetrics.find(_._1.name == "loadedMapCacheMissCount")
+    assert(cacheMissCount.isDefined)
+    assert(cacheMissCount.get._2 == 0)
 
     val reloadedProvider = newStoreProvider(store.id)
     // intended to load version 2 instead of 1
@@ -569,6 +587,14 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
       .find(_._1.name == "providerLoadedMapSizeBytes")
     assert(loadedMapSize.isDefined)
     assert(loadedMapSize.get._2 === loadedMapSizeForVersion1)
+    cacheHitCount = reloadedStore.metrics.customMetrics
+      .find(_._1.name == "loadedMapCacheHitCount")
+    assert(cacheHitCount.isDefined)
+    assert(cacheHitCount.get._2 == 0)
+    cacheMissCount = reloadedStore.metrics.customMetrics
+      .find(_._1.name == "loadedMapCacheMissCount")
+    assert(cacheMissCount.isDefined)
+    assert(cacheMissCount.get._2 == 1)
 
     // now we are loading version 2
     val reloadedStoreV2 = reloadedProvider.getStore(2)
@@ -580,6 +606,14 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
       .find(_._1.name == "providerLoadedMapSizeBytes")
     assert(loadedMapSize.isDefined)
     assert(loadedMapSize.get._2 > loadedMapSizeForVersion1)
+    cacheHitCount = reloadedStoreV2.metrics.customMetrics
+      .find(_._1.name == "loadedMapCacheHitCount")
+    assert(cacheHitCount.isDefined)
+    assert(cacheHitCount.get._2 == 0)
+    cacheMissCount = reloadedStoreV2.metrics.customMetrics
+      .find(_._1.name == "loadedMapCacheMissCount")
+    assert(cacheMissCount.isDefined)
+    assert(cacheMissCount.get._2 == 2)
   }
 
   override def newStoreProvider(): HDFSBackedStateStoreProvider = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -517,7 +517,6 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
     assert(!store.hasCommitted)
     assert(store.metrics.numKeys === 0)
 
-    assert(store.metrics.customMetrics.exists(_._1.name == "providerLoadedMapCountOfVersions"))
     var loadedMapSize = store.metrics.customMetrics.find(_._1.name == "providerLoadedMapSizeBytes")
     assert(loadedMapSize.isDefined)
     val initialLoadedMapSize = loadedMapSize.get._2
@@ -541,7 +540,6 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
 
     assert(store.hasCommitted)
 
-    assert(store.metrics.customMetrics.exists(_._1.name == "providerLoadedMapCountOfVersions"))
     loadedMapSize = store.metrics.customMetrics.find(_._1.name == "providerLoadedMapSizeBytes")
     assert(loadedMapSize.isDefined)
     val loadedMapSizeForVersion1 = loadedMapSize.get._2
@@ -563,7 +561,6 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
 
     assert(storeV2.hasCommitted)
 
-    assert(storeV2.metrics.customMetrics.exists(_._1.name == "providerLoadedMapCountOfVersions"))
     loadedMapSize = storeV2.metrics.customMetrics.find(_._1.name == "providerLoadedMapSizeBytes")
     assert(loadedMapSize.isDefined)
     val loadedMapSizeForVersion1And2 = loadedMapSize.get._2
@@ -581,8 +578,6 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
     val reloadedStore = reloadedProvider.getStore(1)
     assert(reloadedStore.metrics.numKeys === 1)
 
-    assert(reloadedStore.metrics.customMetrics
-      .exists(_._1.name == "providerLoadedMapCountOfVersions"))
     loadedMapSize = reloadedStore.metrics.customMetrics
       .find(_._1.name == "providerLoadedMapSizeBytes")
     assert(loadedMapSize.isDefined)
@@ -600,8 +595,6 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
     val reloadedStoreV2 = reloadedProvider.getStore(2)
     assert(reloadedStoreV2.metrics.numKeys === 2)
 
-    assert(reloadedStoreV2.metrics.customMetrics
-      .exists(_._1.name == "providerLoadedMapCountOfVersions"))
     loadedMapSize = reloadedStoreV2.metrics.customMetrics
       .find(_._1.name == "providerLoadedMapSizeBytes")
     assert(loadedMapSize.isDefined)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -518,20 +518,14 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
       getCustomMetric(metrics, "providerLoadedMapSizeBytes")
     }
 
-    def getCacheHitCountMetric(metrics: StateStoreMetrics): Long = {
-      getCustomMetric(metrics, "loadedMapCacheHitCount")
-    }
-
-    def getCacheMissCountMetric(metrics: StateStoreMetrics): Long = {
-      getCustomMetric(metrics, "loadedMapCacheMissCount")
-    }
-
     def assertCacheHitAndMissMetrics(
         metrics: StateStoreMetrics,
         expectedCacheHitCount: Long,
         expectedCacheMissCount: Long): Unit = {
-      assert(getCacheHitCountMetric(metrics) === expectedCacheHitCount)
-      assert(getCacheMissCountMetric(metrics) === expectedCacheMissCount)
+      val cacheHitCount = getCustomMetric(metrics, "loadedMapCacheHitCount")
+      val cacheMissCount = getCustomMetric(metrics, "loadedMapCacheMissCount")
+      assert(cacheHitCount === expectedCacheHitCount)
+      assert(cacheMissCount === expectedCacheMissCount)
     }
 
     val provider = newStoreProvider()

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
@@ -231,7 +231,7 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
   test("event ordering") {
     val listener = new EventCollector
     withListenerAdded(listener) {
-      for (i <- 1 to 100) {
+      for (i <- 1 to 50) {
         listener.reset()
         require(listener.startEvent === null)
         testStream(MemoryStream[Int].toDS)(

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryStatusAndProgressSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryStatusAndProgressSuite.scala
@@ -58,7 +58,10 @@ class StreamingQueryStatusAndProgressSuite extends StreamTest with Eventually {
         |  "stateOperators" : [ {
         |    "numRowsTotal" : 0,
         |    "numRowsUpdated" : 1,
-        |    "memoryUsedBytes" : 2
+        |    "memoryUsedBytes" : 2,
+        |    "customMetrics" : {
+        |      "providerLoadedMapSizeBytes" : 3
+        |    }
         |  } ],
         |  "sources" : [ {
         |    "description" : "source",
@@ -230,7 +233,10 @@ object StreamingQueryStatusAndProgressSuite {
       "avg" -> "2016-12-05T20:54:20.827Z",
       "watermark" -> "2016-12-05T20:54:20.827Z").asJava),
     stateOperators = Array(new StateOperatorProgress(
-      numRowsTotal = 0, numRowsUpdated = 1, memoryUsedBytes = 2)),
+      numRowsTotal = 0, numRowsUpdated = 1, memoryUsedBytes = 2,
+      customMetrics = new java.util.HashMap(Map("providerLoadedMapSizeBytes" -> 3L)
+        .mapValues(long2Long).asJava)
+    )),
     sources = Array(
       new SourceProgress(
         description = "source",

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryStatusAndProgressSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryStatusAndProgressSuite.scala
@@ -60,6 +60,8 @@ class StreamingQueryStatusAndProgressSuite extends StreamTest with Eventually {
         |    "numRowsUpdated" : 1,
         |    "memoryUsedBytes" : 2,
         |    "customMetrics" : {
+        |      "loadedMapCacheHitCount" : 1,
+        |      "loadedMapCacheMissCount" : 0,
         |      "providerLoadedMapSizeBytes" : 3
         |    }
         |  } ],
@@ -234,7 +236,8 @@ object StreamingQueryStatusAndProgressSuite {
       "watermark" -> "2016-12-05T20:54:20.827Z").asJava),
     stateOperators = Array(new StateOperatorProgress(
       numRowsTotal = 0, numRowsUpdated = 1, memoryUsedBytes = 2,
-      customMetrics = new java.util.HashMap(Map("providerLoadedMapSizeBytes" -> 3L)
+      customMetrics = new java.util.HashMap(Map("providerLoadedMapSizeBytes" -> 3L,
+        "loadedMapCacheHitCount" -> 1L, "loadedMapCacheMissCount" -> 0L)
         .mapValues(long2Long).asJava)
     )),
     sources = Array(

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryStatusAndProgressSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryStatusAndProgressSuite.scala
@@ -58,11 +58,11 @@ class StreamingQueryStatusAndProgressSuite extends StreamTest with Eventually {
         |  "stateOperators" : [ {
         |    "numRowsTotal" : 0,
         |    "numRowsUpdated" : 1,
-        |    "memoryUsedBytes" : 2,
+        |    "memoryUsedBytes" : 3,
         |    "customMetrics" : {
         |      "loadedMapCacheHitCount" : 1,
         |      "loadedMapCacheMissCount" : 0,
-        |      "providerLoadedMapSizeBytes" : 3
+        |      "stateOnCurrentVersionSizeBytes" : 2
         |    }
         |  } ],
         |  "sources" : [ {
@@ -235,8 +235,8 @@ object StreamingQueryStatusAndProgressSuite {
       "avg" -> "2016-12-05T20:54:20.827Z",
       "watermark" -> "2016-12-05T20:54:20.827Z").asJava),
     stateOperators = Array(new StateOperatorProgress(
-      numRowsTotal = 0, numRowsUpdated = 1, memoryUsedBytes = 2,
-      customMetrics = new java.util.HashMap(Map("providerLoadedMapSizeBytes" -> 3L,
+      numRowsTotal = 0, numRowsUpdated = 1, memoryUsedBytes = 3,
+      customMetrics = new java.util.HashMap(Map("stateOnCurrentVersionSizeBytes" -> 2L,
         "loadedMapCacheHitCount" -> 1L, "loadedMapCacheMissCount" -> 0L)
         .mapValues(long2Long).asJava)
     )),


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch exposes the estimation of size of cache (loadedMaps) in HDFSBackedStateStoreProvider as a custom metric of StateStore.

The rationalize of the patch is that state backed by HDFSBackedStateStoreProvider will consume more memory than the number what we can get from query status due to caching multiple versions of states. The memory footprint to be much larger than query status reports in situations where the state store is getting a lot of updates: while shallow-copying map incurs additional small memory usages due to the size of map entities and references, but row objects will still be shared across the versions. If there're lots of updates between batches, less row objects will be shared and more row objects will exist in memory consuming much memory then what we expect. 

While HDFSBackedStateStore refers loadedMaps in HDFSBackedStateStoreProvider directly, there would be only one `StateStoreWriter` which refers a StateStoreProvider, so the value is not exposed as well as being aggregated multiple times. Current state metrics are safe to aggregate for the same reason.

## How was this patch tested?

Tested manually. Below is the snapshot of UI page which is reflected by the patch: 

<img width="601" alt="screen shot 2018-06-05 at 10 16 16 pm" src="https://user-images.githubusercontent.com/1317309/40978481-b46ad324-690e-11e8-9b0f-e80528612a62.png">

Please refer "estimated size of states cache in provider total" as well as "count of versions in state cache in provider".