### PR TITLE
[SPARK-24416] Fix configuration specification for killBlacklisted executors

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1630,7 +1630,8 @@ Apart from these, the following properties are also available, and may be useful
   <td>false</td>
   <td>
     (Experimental) If set to "true", allow Spark to automatically kill the
-    executors when they are blacklisted on fetch failure or stage completion.  
+    executors when they are blacklisted on fetch failure or blacklisted for the entire application, 
+    as controlled by spark.blacklist.application.*.  
     Note that, when an entire node is added to the blacklist,
     all of the executors on that node will be killed.
   </td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1629,8 +1629,9 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.blacklist.killBlacklistedExecutors</code></td>
   <td>false</td>
   <td>
-    (Experimental) If set to "true", allow Spark to automatically kill, and attempt to re-create,
-    executors when they are blacklisted.  Note that, when an entire node is added to the blacklist,
+    (Experimental) If set to "true", allow Spark to automatically kill the
+    executors when they are blacklisted on fetch failure or stage completion.  
+    Note that, when an entire node is added to the blacklist,
     all of the executors on that node will be killed.
   </td>
 </tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1629,11 +1629,10 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.blacklist.killBlacklistedExecutors</code></td>
   <td>false</td>
   <td>
-    (Experimental) If set to "true", allow Spark to automatically kill the
-    executors when they are blacklisted on fetch failure or blacklisted for the entire application, 
-    as controlled by spark.blacklist.application.*.  
-    Note that, when an entire node is added to the blacklist,
-    all of the executors on that node will be killed.
+    (Experimental) If set to "true", allow Spark to automatically kill the executors 
+    when they are blacklisted on fetch failure or blacklisted for the entire application, 
+    as controlled by spark.blacklist.application.*. Note that, when an entire node is added 
+    to the blacklist, all of the executors on that node will be killed.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
## What changes were proposed in this pull request?

spark.blacklist.killBlacklistedExecutors is defined as 

(Experimental) If set to "true", allow Spark to automatically kill, and attempt to re-create, executors when they are blacklisted. Note that, when an entire node is added to the blacklist, all of the executors on that node will be killed.

I presume the killing of blacklisted executors only happens after the stage completes successfully and all tasks have completed or on fetch failures (updateBlacklistForFetchFailure/updateBlacklistForSuccessfulTaskSet). It is confusing because the definition states that the executor will be attempted to be recreated as soon as it is blacklisted. This is not true while the stage is in progress and an executor is blacklisted, it will not attempt to cleanup until the stage finishes.