### PR TITLE
[SPARK-24462][SS] Initialize the offsets correctly when restarting a query with saved state

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/LongOffset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/LongOffset.scala
@@ -28,6 +28,8 @@ case class LongOffset(offset: Long) extends OffsetV2 {
 
   def +(increment: Long): LongOffset = new LongOffset(offset + increment)
   def -(decrement: Long): LongOffset = new LongOffset(offset - decrement)
+  def <(that: LongOffset): Boolean = this.offset < that.offset
+  def >(that: LongOffset): Boolean = this.offset > that.offset
 }
 
 object LongOffset {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/socket.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/socket.scala
@@ -117,6 +117,11 @@ class TextSocketMicroBatchReader(options: DataSourceOptions) extends MicroBatchR
 
   override def setOffsetRange(start: Optional[Offset], end: Optional[Offset]): Unit = synchronized {
     startOffset = start.orElse(LongOffset(-1L))
+    val startOffsetLong = LongOffset.convert(startOffset).get
+    if (currentOffset < startOffsetLong) {
+      currentOffset = startOffsetLong
+      lastOffsetCommitted = startOffsetLong
+    }
     endOffset = end.orElse(currentOffset)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Initialize the `currentOffset` and `lastOffsetCommitted` correctly when the query is restarted with saved state (startOffset has some value)

## How was this patch tested?

existing unit tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
