### PR TITLE
[SPARK-24418][Build] Upgrade Scala to 2.11.12 and 2.12.6

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -242,7 +242,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
      (BSD licence) ANTLR ST4 4.0.4 (org.antlr:ST4:4.0.4 - http://www.stringtemplate.org)
      (BSD licence) ANTLR StringTemplate (org.antlr:stringtemplate:3.2.1 - http://www.stringtemplate.org)
      (BSD License) Javolution (javolution:javolution:5.5.1 - http://javolution.org)
-     (BSD) JLine (jline:jline:0.9.94 - http://jline.sourceforge.net)
+     (BSD) JLine (jline:jline:2.14.3 - https://github.com/jline/jline2)
      (BSD) ParaNamer Core (com.thoughtworks.paranamer:paranamer:2.3 - http://paranamer.codehaus.org/paranamer)
      (BSD) ParaNamer Core (com.thoughtworks.paranamer:paranamer:2.6 - http://paranamer.codehaus.org/paranamer)
      (BSD 3 Clause) Scala (http://www.scala-lang.org/download/#License)

--- a/LICENSE
+++ b/LICENSE
@@ -249,11 +249,11 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
         (Interpreter classes (all .scala files in repl/src/main/scala
         except for Main.Scala, SparkHelper.scala and ExecutorClassLoader.scala),
         and for SerializableMapWrapper in JavaUtils.scala)
-     (BSD-like) Scala Actors library (org.scala-lang:scala-actors:2.11.8 - http://www.scala-lang.org/)
-     (BSD-like) Scala Compiler (org.scala-lang:scala-compiler:2.11.8 - http://www.scala-lang.org/)
-     (BSD-like) Scala Compiler (org.scala-lang:scala-reflect:2.11.8 - http://www.scala-lang.org/)
-     (BSD-like) Scala Library (org.scala-lang:scala-library:2.11.8 - http://www.scala-lang.org/)
-     (BSD-like) Scalap (org.scala-lang:scalap:2.11.8 - http://www.scala-lang.org/)
+     (BSD-like) Scala Actors library (org.scala-lang:scala-actors:2.11.12 - http://www.scala-lang.org/)
+     (BSD-like) Scala Compiler (org.scala-lang:scala-compiler:2.11.12 - http://www.scala-lang.org/)
+     (BSD-like) Scala Compiler (org.scala-lang:scala-reflect:2.11.12 - http://www.scala-lang.org/)
+     (BSD-like) Scala Library (org.scala-lang:scala-library:2.11.12 - http://www.scala-lang.org/)
+     (BSD-like) Scalap (org.scala-lang:scalap:2.11.12 - http://www.scala-lang.org/)
      (BSD-style) scalacheck (org.scalacheck:scalacheck_2.11:1.10.0 - http://www.scalacheck.org)
      (BSD-style) spire (org.spire-math:spire_2.11:0.7.1 - http://spire-math.org)
      (BSD-style) spire-macros (org.spire-math:spire-macros_2.11:0.7.1 - http://spire-math.org)

--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -172,10 +172,10 @@ parquet-jackson-1.10.0.jar
 protobuf-java-2.5.0.jar
 py4j-0.10.7.jar
 pyrolite-4.13.jar
-scala-compiler-2.11.8.jar
-scala-library-2.11.8.jar
+scala-compiler-2.11.12.jar
+scala-library-2.11.12.jar
 scala-parser-combinators_2.11-1.0.4.jar
-scala-reflect-2.11.8.jar
+scala-reflect-2.11.12.jar
 scala-xml_2.11-1.0.5.jar
 shapeless_2.11-2.3.2.jar
 slf4j-api-1.7.16.jar

--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -174,7 +174,7 @@ py4j-0.10.7.jar
 pyrolite-4.13.jar
 scala-compiler-2.11.12.jar
 scala-library-2.11.12.jar
-scala-parser-combinators_2.11-1.0.4.jar
+scala-parser-combinators_2.11-1.1.0.jar
 scala-reflect-2.11.12.jar
 scala-xml_2.11-1.0.5.jar
 shapeless_2.11-2.3.2.jar

--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -122,7 +122,7 @@ jersey-server-2.22.2.jar
 jets3t-0.9.4.jar
 jetty-6.1.26.jar
 jetty-util-6.1.26.jar
-jline-2.12.1.jar
+jline-2.14.3.jar
 joda-time-2.9.3.jar
 jodd-core-3.5.2.jar
 jpam-1.1.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -175,7 +175,7 @@ py4j-0.10.7.jar
 pyrolite-4.13.jar
 scala-compiler-2.11.12.jar
 scala-library-2.11.12.jar
-scala-parser-combinators_2.11-1.0.4.jar
+scala-parser-combinators_2.11-1.1.0.jar
 scala-reflect-2.11.12.jar
 scala-xml_2.11-1.0.5.jar
 shapeless_2.11-2.3.2.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -173,10 +173,10 @@ parquet-jackson-1.10.0.jar
 protobuf-java-2.5.0.jar
 py4j-0.10.7.jar
 pyrolite-4.13.jar
-scala-compiler-2.11.8.jar
-scala-library-2.11.8.jar
+scala-compiler-2.11.12.jar
+scala-library-2.11.12.jar
 scala-parser-combinators_2.11-1.0.4.jar
-scala-reflect-2.11.8.jar
+scala-reflect-2.11.12.jar
 scala-xml_2.11-1.0.5.jar
 shapeless_2.11-2.3.2.jar
 slf4j-api-1.7.16.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -122,7 +122,7 @@ jersey-server-2.22.2.jar
 jets3t-0.9.4.jar
 jetty-6.1.26.jar
 jetty-util-6.1.26.jar
-jline-2.12.1.jar
+jline-2.14.3.jar
 joda-time-2.9.3.jar
 jodd-core-3.5.2.jar
 jpam-1.1.jar

--- a/dev/deps/spark-deps-hadoop-3.1
+++ b/dev/deps/spark-deps-hadoop-3.1
@@ -192,10 +192,10 @@ protobuf-java-2.5.0.jar
 py4j-0.10.7.jar
 pyrolite-4.13.jar
 re2j-1.1.jar
-scala-compiler-2.11.8.jar
-scala-library-2.11.8.jar
+scala-compiler-2.11.12.jar
+scala-library-2.11.12.jar
 scala-parser-combinators_2.11-1.0.4.jar
-scala-reflect-2.11.8.jar
+scala-reflect-2.11.12.jar
 scala-xml_2.11-1.0.5.jar
 shapeless_2.11-2.3.2.jar
 slf4j-api-1.7.16.jar

--- a/dev/deps/spark-deps-hadoop-3.1
+++ b/dev/deps/spark-deps-hadoop-3.1
@@ -122,7 +122,7 @@ jersey-server-2.22.2.jar
 jets3t-0.9.4.jar
 jetty-webapp-9.3.20.v20170531.jar
 jetty-xml-9.3.20.v20170531.jar
-jline-2.12.1.jar
+jline-2.14.3.jar
 joda-time-2.9.3.jar
 jodd-core-3.5.2.jar
 jpam-1.1.jar

--- a/dev/deps/spark-deps-hadoop-3.1
+++ b/dev/deps/spark-deps-hadoop-3.1
@@ -194,7 +194,7 @@ pyrolite-4.13.jar
 re2j-1.1.jar
 scala-compiler-2.11.12.jar
 scala-library-2.11.12.jar
-scala-parser-combinators_2.11-1.0.4.jar
+scala-parser-combinators_2.11-1.1.0.jar
 scala-reflect-2.11.12.jar
 scala-xml_2.11-1.0.5.jar
 shapeless_2.11-2.3.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -740,7 +740,7 @@
       <dependency>
         <groupId>org.scala-lang.modules</groupId>
         <artifactId>scala-parser-combinators_${scala.binary.version}</artifactId>
-        <version>1.0.4</version>
+        <version>1.1.0</version>
       </dependency>
       <!-- SPARK-16770 affecting Scala 2.11.x -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <commons.math3.version>3.4.1</commons.math3.version>
     <!-- managed up from 3.2.1 for SPARK-11652 -->
     <commons.collections.version>3.2.2</commons.collections.version>
-    <scala.version>2.11.8</scala.version>
+    <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
     <fasterxml.jackson.version>2.6.7</fasterxml.jackson.version>
@@ -2748,7 +2748,7 @@
     <profile>
       <id>scala-2.12</id>
       <properties>
-        <scala.version>2.12.4</scala.version>
+        <scala.version>2.12.6</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
       </properties>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -746,7 +746,7 @@
       <dependency>
         <groupId>jline</groupId>
         <artifactId>jline</artifactId>
-        <version>2.12.1</version>
+        <version>2.14.3</version>
       </dependency>
       <dependency>
         <groupId>org.scalatest</groupId>

--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -87,11 +87,15 @@ class SparkILoop(in0: Option[BufferedReader], out: JPrintWriter)
 
   /** Print a welcome message */
   override def printWelcome() {
-    // Before Scala 2.11.9, `printWelcome()` will be the last thing to be called,
-    // so Scala REPL and Spark will be initialized before `printWelcome()`.
-    // After Scala 2.11.9, `printWelcome()` will be the first thing to be called,
-    // as a result, Scala REPL and Spark will be initialized in `printWelcome()`.
-    if (!isInitializeComplete) {
+    // Before Scala 2.11.9, `printWelcome()` will be called after Scala REPL and Spark
+    // are initialized, so we will not call `initializeSynchronous()` in `printWelcome()`.
+    //
+    // However, after Scala 2.11.9, `printWelcome()` will be the first thing to be called,
+    // so we initialize the Scala REPL and Spark here instead.
+    if (intp == null) {
+      createInterpreter()
+    }
+    if (!intp.isInitializeComplete) {
       intp.initializeSynchronous()
     }
 

--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -95,9 +95,13 @@ class SparkILoop(in0: Option[BufferedReader], out: JPrintWriter)
     if (intp == null) {
       createInterpreter()
     }
+    echo(s"DB printWelcome 1  ${intp.isInitializeComplete}" )
+
     if (!intp.isInitializeComplete) {
       intp.initializeSynchronous()
     }
+
+    echo(s"DB printWelcome 2  ${intp.isInitializeComplete}" )
 
     import org.apache.spark.SPARK_VERSION
     echo("""Welcome to

--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -36,7 +36,7 @@ class SparkILoop(in0: Option[BufferedReader], out: JPrintWriter)
   def this() = this(None, new JPrintWriter(Console.out, true))
 
   override def createInterpreter(): Unit = {
-    intp = new SparkILoopInterpreter(settings, out)
+    intp = new SparkILoopInterpreter(settings, out, initializeSpark)
   }
 
   val initializationCommands: Seq[String] = Seq(
@@ -73,12 +73,9 @@ class SparkILoop(in0: Option[BufferedReader], out: JPrintWriter)
     "import org.apache.spark.sql.functions._"
   )
 
-  def initializeSpark() {
-    intp.beQuietDuring {
-      savingReplayStack { // remove the commands from session history.
-        initializationCommands.foreach(processLine)
-      }
-    }
+  def initializeSpark(): Unit = savingReplayStack {
+    // `savingReplayStack` removes the commands from session history.
+    initializationCommands.foreach(intp quietRun _)
   }
 
   /** Print a welcome message */
@@ -100,16 +97,6 @@ class SparkILoop(in0: Option[BufferedReader], out: JPrintWriter)
 
   /** Available commands */
   override def commands: List[LoopCommand] = standardCommands
-
-  /**
-   * We override `loadFiles` because we need to initialize Spark *before* the REPL
-   * sees any files, so that the Spark context is visible in those files. This is a bit of a
-   * hack, but there isn't another hook available to us at this point.
-   */
-  override def loadFiles(settings: Settings): Unit = {
-    initializeSpark()
-    super.loadFiles(settings)
-  }
 
   override def resetCommand(line: String): Unit = {
     super.resetCommand(line)

--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -87,22 +87,6 @@ class SparkILoop(in0: Option[BufferedReader], out: JPrintWriter)
 
   /** Print a welcome message */
   override def printWelcome() {
-    // Before Scala 2.11.9, `printWelcome()` will be called after Scala REPL and Spark
-    // are initialized, so we will not call `initializeSynchronous()` in `printWelcome()`.
-    //
-    // However, after Scala 2.11.9, `printWelcome()` will be the first thing to be called,
-    // so we initialize the Scala REPL and Spark here instead.
-    if (intp == null) {
-      createInterpreter()
-    }
-    echo(s"DB printWelcome 1  ${intp.isInitializeComplete}" )
-
-    if (!intp.isInitializeComplete) {
-      intp.initializeSynchronous()
-    }
-
-    echo(s"DB printWelcome 2  ${intp.isInitializeComplete}" )
-
     import org.apache.spark.SPARK_VERSION
     echo("""Welcome to
       ____              __

--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoopInterpreter.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoopInterpreter.scala
@@ -34,6 +34,10 @@ class SparkILoopInterpreter(settings: Settings, out: JPrintWriter, initializeSpa
    * See the discussion in Scala community https://github.com/scala/bug/issues/10913 for detail.
    */
   override def initializeSynchronous(): Unit = {
+    // scalastyle:off println
+    println(s"DB initializeSynchronous  ${isInitializeComplete}" )
+    // scalastyle:on println
+
     if (!isInitializeComplete) {
       super.initializeSynchronous()
       initializeSpark()

--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoopInterpreter.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoopInterpreter.scala
@@ -22,7 +22,7 @@ import scala.tools.nsc.Settings
 import scala.tools.nsc.interpreter._
 
 class SparkILoopInterpreter(settings: Settings, out: JPrintWriter, initializeSpark: () => Unit)
-  extends IMain(settings, out) { self =>
+    extends IMain(settings, out) { self =>
 
   /**
    * We override `initializeSynchronous` to initialize Spark *after* `intp` is properly initialized
@@ -34,8 +34,10 @@ class SparkILoopInterpreter(settings: Settings, out: JPrintWriter, initializeSpa
    * See the discussion in Scala community https://github.com/scala/bug/issues/10913 for detail.
    */
   override def initializeSynchronous(): Unit = {
-    super.initializeSynchronous()
-    initializeSpark()
+    if (!isInitializeComplete) {
+      super.initializeSynchronous()
+      initializeSpark()
+    }
   }
 
   override lazy val memberHandlers = new {

--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoopInterpreter.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoopInterpreter.scala
@@ -22,7 +22,7 @@ import scala.tools.nsc.Settings
 import scala.tools.nsc.interpreter._
 
 class SparkILoopInterpreter(settings: Settings, out: JPrintWriter, initializeSpark: () => Unit)
-    extends IMain(settings, out) { self =>
+  extends IMain(settings, out) { self =>
 
   /**
    * We override `initializeSynchronous` to initialize Spark *after* `intp` is properly initialized

--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoopInterpreter.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoopInterpreter.scala
@@ -34,14 +34,8 @@ class SparkILoopInterpreter(settings: Settings, out: JPrintWriter, initializeSpa
    * See the discussion in Scala community https://github.com/scala/bug/issues/10913 for detail.
    */
   override def initializeSynchronous(): Unit = {
-    // scalastyle:off println
-    println(s"DB initializeSynchronous  ${isInitializeComplete}" )
-    // scalastyle:on println
-
-    if (!isInitializeComplete) {
-      super.initializeSynchronous()
-      initializeSpark()
-    }
+    super.initializeSynchronous()
+    initializeSpark()
   }
 
   override lazy val memberHandlers = new {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Scala is upgraded to `2.11.12` and `2.12.6`. 

We used `loadFIles()` in `ILoop` as a hook to initialize the Spark before REPL sees any files in Scala `2.11.8`. However, it was a hack, and it was not intended to be a public API, so it was removed in Scala `2.11.12`.

From the discussion in Scala community, https://github.com/scala/bug/issues/10913 , we can use `initializeSynchronous` to initialize Spark instead. This PR implements the Spark initialization there.

However, in Scala `2.11.12`'s `ILoop.scala`, in function `def startup()`, the first thing it calls is `printWelcome()`. As a result, Scala will call `printWelcome()` and `splash` before calling `initializeSynchronous`. 

Thus, the Spark shell will allow users to type commends first, and then show the Spark UI URL. It's working, but it will change the Spark Shell interface as the following. 

```scala
➜  apache-spark git:(scala-2.11.12) ✗ ./bin/spark-shell 
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 2.4.0-SNAPSHOT
      /_/
         
Using Scala version 2.11.12 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_161)
Type in expressions to have them evaluated.
Type :help for more information.

scala> Spark context Web UI available at http://192.168.1.169:4040
Spark context available as 'sc' (master = local[*], app id = local-1528180279528).
Spark session available as 'spark'.


scala> 
```

It seems there is no easy way to inject the Spark initialization code in the proper place as Scala doesn't provide a hook. Maybe @som-snytt can comment on this.

The following command is used to update the dep files. 
```scala
./dev/test-dependencies.sh --replace-manifest
```
## How was this patch tested?

Existing tests