### PR TITLE
[SPARK-24410][SQL][Core] Optimization for Union outputPartitioning

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -910,6 +910,20 @@ abstract class RDD[T: ClassTag](
     zipPartitions(rdd2, rdd3, rdd4, preservesPartitioning = false)(f)
   }
 
+  /**
+   * Zip this RDD's partitions with one (or more) RDD(s) and return a new RDD by
+   * concatenating the zipped partitions. Assumes that all the RDDs have the
+   * *same number of partitions*, but does *not* require them to have the same number
+   * of elements in each partition.
+   */
+  private[spark] def zipRDDs(others: Seq[RDD[T]]): RDD[T] = withScope {
+    zipRDDs(others, preservesPartitioning = false)
+  }
+
+  private[spark] def zipRDDs(others: Seq[RDD[T]], preservesPartitioning: Boolean): RDD[T] =
+    withScope {
+      new ZippedPartitionsRDD(sc, Seq(this) ++ others, preservesPartitioning)
+    }
 
   // Actions (launch a job to return a value to the user program)
 

--- a/core/src/test/scala/org/apache/spark/rdd/ZippedPartitionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/ZippedPartitionsSuite.scala
@@ -38,4 +38,15 @@ class ZippedPartitionsSuite extends SparkFunSuite with SharedSparkContext {
     assert(obtainedSizes.size == 6)
     assert(obtainedSizes.zip(expectedSizes).forall(x => x._1 == x._2))
   }
+
+  test("RDD.zipRDDs") {
+    val data1 = sc.makeRDD(Array(1, 2, 3, 4), 2)
+    val data2 = sc.makeRDD(Array(1, 2, 3, 4, 5, 6), 2)
+    val data3 = sc.makeRDD(Array(1, 2), 2)
+
+    val zippedRDD = data1.zipRDDs(Seq(data2, data3))
+    val obtained = zippedRDD.collect()
+    val expected = Array(1, 2, 1, 2, 3, 1, 3, 4, 4, 5, 6, 2)
+    assert(obtained.zip(expected).forall(x => x._1 == x._2))
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1099,6 +1099,17 @@ object SQLConf {
       .intConf
       .createWithDefault(SHUFFLE_SPILL_NUM_ELEMENTS_FORCE_SPILL_THRESHOLD.defaultValue.get)
 
+  val UNION_IN_SAME_PARTITION =
+    buildConf("spark.sql.unionInSamePartition")
+      .internal()
+      .doc("When true, Union operator will union children results in the same corresponding " +
+        "partitions if they have same partitioning. This eliminates unnecessary shuffle in later " +
+        "operators like aggregation. Note that because non-deterministic functions such as " +
+        "monotonically_increasing_id are depended on partition id. By doing this, the values of " +
+        "those functions would be different than before Union.")
+      .booleanConf
+      .createWithDefault(false)
+
   val CARTESIAN_PRODUCT_EXEC_BUFFER_IN_MEMORY_THRESHOLD =
     buildConf("spark.sql.cartesianProductExec.buffer.in.memory.threshold")
       .internal()
@@ -1622,6 +1633,8 @@ class SQLConf extends Serializable with Logging {
 
   def sortMergeJoinExecBufferSpillThreshold: Int =
     getConf(SORT_MERGE_JOIN_EXEC_BUFFER_SPILL_THRESHOLD)
+
+  def unionInSamePartition: Boolean = getConf(UNION_IN_SAME_PARTITION)
 
   def cartesianProductExecBufferInMemoryThreshold: Int =
     getConf(CARTESIAN_PRODUCT_EXEC_BUFFER_IN_MEMORY_THRESHOLD)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.Duration
+import scala.util.Try
 
 import org.apache.spark.{InterruptibleIterator, Partition, SparkContext, TaskContext}
 import org.apache.spark.rdd.{EmptyRDD, PartitionwiseSampledRDD, RDD}
@@ -563,12 +564,71 @@ case class RangeExec(range: org.apache.spark.sql.catalyst.plans.logical.Range)
  * [[org.apache.spark.sql.catalyst.plans.logical.Union.maxRowsPerPartition]].
  */
 case class UnionExec(children: Seq[SparkPlan]) extends SparkPlan {
+
+  /**
+   * SPARK-24410: We can't use `sameResult` or `semanticEquals` to test if we can use children's
+   * `outputPartitioning`. We can use first child's `outputPartitioning` only if partitioning
+   * expressions have the same expressions and bounding same ordinal references.
+   */
+  override def outputPartitioning: Partitioning = Try {
+    val reducedPartitioning: Partitioning = children.map { child =>
+      // Bounding partition expressions to children's outputs.
+      child.outputPartitioning match {
+        case HashPartitioning(expr, num) =>
+          val bound = expr.map(BindReferences.bindReference(_,
+            child.output.map(_.withNullability(true))))
+          HashPartitioning(bound, num)
+        case RangePartitioning(ordering, num) =>
+          val bound = ordering.map(BindReferences.bindReference(_,
+            child.output.map(_.withNullability(true))))
+          RangePartitioning(bound, num)
+        case o => o
+      }
+    }.reduceLeft((left: Partitioning, right: Partitioning) => (left, right) match {
+      case (SinglePartition, SinglePartition) => SinglePartition
+      case (HashPartitioning(exprs1, p1), HashPartitioning(exprs2, p2)) if p1 == p2 =>
+        val matched = exprs1.length == exprs2.length && exprs1.zip(exprs2).forall {
+          case (l, r) => l.semanticEquals(r)
+        }
+
+        if (matched) {
+          HashPartitioning(exprs1, p1)
+        } else {
+          super.outputPartitioning
+        }
+      case (RangePartitioning(ordering1, p1), RangePartitioning(ordering2, p2)) if p1 == p2 =>
+        val minSize = Seq(ordering1.size, ordering2.size).min
+        if (ordering1.take(minSize) == ordering2.take(minSize)) {
+          RangePartitioning(ordering1.take(minSize), p1)
+        } else {
+          super.outputPartitioning
+        }
+      case _ => super.outputPartitioning
+    })
+
+    reducedPartitioning match {
+      case HashPartitioning(_, _) => children.head.outputPartitioning
+      case RangePartitioning(ordering, num) =>
+        val newOrdering = children.head.outputPartitioning
+          .asInstanceOf[RangePartitioning].ordering.take(ordering.size)
+        RangePartitioning(newOrdering, num)
+      case _ => reducedPartitioning
+    }
+    // We can hit exception when bounding partitioning expressions. In that cases, simply
+    // use default `outputPartitioning`.
+  }.getOrElse(super.outputPartitioning)
+
   override def output: Seq[Attribute] =
     children.map(_.output).transpose.map(attrs =>
       attrs.head.withNullability(attrs.exists(_.nullable)))
 
-  protected override def doExecute(): RDD[InternalRow] =
-    sparkContext.union(children.map(_.execute()))
+  protected override def doExecute(): RDD[InternalRow] = outputPartitioning match {
+    case UnknownPartitioning(_) => sparkContext.union(children.map(_.execute()))
+    case _ =>
+      // If we have known output partitioning, it means there is the same partitioning among
+      // union children. Simply zipping RDDs without shuffling.
+      children.head.execute().zipRDDs(children.tail.map(_.execute()), true)
+  }
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/UnionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/UnionSuite.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.{ExamplePoint, ExamplePointUDT, SharedSQLContext}
+
+class UnionSuite extends QueryTest with SharedSQLContext {
+  import testImplicits._
+
+  test("SPARK-24410: Missing optimization for Union on bucketed tables") {
+    val N = 10
+
+    withTable("t1", "t2") {
+      spark.range(N).selectExpr("id as key", "id % 2 as t1", "id % 3 as t2")
+        .repartition(col("key")).write.mode("overwrite")
+        .bucketBy(3, "key").sortBy("t1").saveAsTable("a1")
+
+      spark.range(N).selectExpr("id as key", "id % 2 as t1", "id % 3 as t2")
+        .repartition(col("key")).write.mode("overwrite")
+        .bucketBy(3, "key").sortBy("t1").saveAsTable("a2")
+
+      withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+        val df = sql("select key, count(*) from " +
+          "(select * from a1 union all select * from a2) z group by key")
+        val shuffles = df.queryExecution.executedPlan.collect {
+          case s: ShuffleExchangeExec => s
+        }
+        assert(shuffles.isEmpty)
+        checkAnswer(df.orderBy("key"), Row(0, 2) :: Row(1, 2) :: Row(2, 2) :: Row(3, 2) ::
+          Row(4, 2) :: Row(5, 2) :: Row(6, 2) :: Row(7, 2) :: Row(8, 2) :: Row(9, 2) :: Nil)
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/UnionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/UnionSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.{ExamplePoint, ExamplePointUDT, SharedSQLContext}
+import org.apache.spark.sql.test.SharedSQLContext
 
 class UnionSuite extends QueryTest with SharedSQLContext {
   import testImplicits._


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently `Union` has only unknown output partitioning. That said if the children are well partitioned (e.g., bucketed tables), we still run shuffling on the data on later operators such as aggregation.

This patch tries to better decide output partitioning for `Union` operator. So it can eliminate unnecessary shuffling, e.g.,

```scala
val N = 10

spark.range(N).selectExpr("id as key", "id % 2 as t1", "id % 3 as t2").repartition(col("key")).write.mode("overwrite").bucketBy(3, "key").sortBy("t1").saveAsTable("a1")
spark.range(N).selectExpr("id as key", "id % 2 as t1", "id % 3 as t2").repartition(col("key")).write.mode("overwrite").bucketBy(3, "key").sortBy("t1").saveAsTable("a2")
spark.conf.set("spark.sql.autoBroadcastJoinThreshold", -1)

val df = sql("select key,count(*) from (select * from a1 union all select * from a2)z group by key")
df.explain
```

```
== Physical Plan ==
*(3) HashAggregate(keys=[key#36L], functions=[count(1)])
+- *(3) HashAggregate(keys=[key#36L], functions=[partial_count(1)])
   +- Union
      :- *(1) Project [key#36L]
      :  +- *(1) FileScan parquet default.a1[key#36L] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/root/repos/spark-1/spark-warehouse/a1], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<key:bigint>
      +- *(2) Project [key#39L]
         +- *(2) FileScan parquet default.a2[key#39L] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/root/repos/spark-1/spark-warehouse/a2], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<key:bigint>
```


This patch adds a private API `zipRDDs` to `RDD`. Since `zipPartitions` asks a function to run on elements of rdds, it only supports fixed number of rdds. But for `Union`, the number of children is not fixed.

This optimization can be controlled by a SQL config `spark.sql.unionInSamePartition` which is false by default.

## How was this patch tested?

Added tests.