### PR TITLE
[SPARK-22575][SQL] Add destroy to Dataset

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -3199,6 +3199,21 @@ class Dataset[T] private[sql](
     files.toSet.toArray
   }
 
+  /**
+   * Frees resources which might be allocated by the Dataset.
+   * Calling this method is not necessary, but it can be useful to avoid resource leaking in
+   * long-running applications (especially if dynamic allocation is turned on).
+   *
+   * After calling this method, any attempt to use this Dataset or Datasets it was created from
+   * can lead to unexpected errors.
+   *
+   * @group basic
+   * @since 2.4.0
+   */
+  def destroy(): Unit = {
+    queryExecution.executedPlan.cleanUpResources()
+  }
+
   ////////////////////////////////////////////////////////////////////////////
   // For Python API
   ////////////////////////////////////////////////////////////////////////////

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -236,6 +236,19 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
   }
 
   /**
+   * The code to eventually free resources, such as deleting broadcast variables, etc.
+   */
+  final def cleanUpResources(): Unit = {
+    children.foreach(_.cleanUpResources)
+    doCleanUpResources
+  }
+
+  /**
+   * Frees resources allocated by this plan.
+   */
+  protected def doCleanUpResources: Unit = {}
+
+  /**
    * Packing the UnsafeRows into byte array for faster serialization.
    * The byte arrays are in the following format:
    * [size] [bytes of UnsafeRow] [size] [bytes of UnsafeRow] ... [-1]

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -20,8 +20,10 @@ package org.apache.spark.sql.execution.exchange
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
+import scala.util.Success
 
-import org.apache.spark.{broadcast, SparkException}
+import org.apache.spark.SparkException
+import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -64,7 +66,7 @@ case class BroadcastExchangeExec(
   }
 
   @transient
-  private lazy val relationFuture: Future[broadcast.Broadcast[Any]] = {
+  private lazy val relationFuture: Future[Broadcast[Any]] = {
     // broadcastFuture is used in "doExecute". Therefore we can get the execution id correctly here.
     val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
     Future {
@@ -139,8 +141,15 @@ case class BroadcastExchangeExec(
       "BroadcastExchange does not support the execute() code path.")
   }
 
-  override protected[sql] def doExecuteBroadcast[T](): broadcast.Broadcast[T] = {
-    ThreadUtils.awaitResult(relationFuture, timeout).asInstanceOf[broadcast.Broadcast[T]]
+  override protected[sql] def doExecuteBroadcast[T](): Broadcast[T] = {
+    ThreadUtils.awaitResult(relationFuture, timeout).asInstanceOf[Broadcast[T]]
+  }
+
+  override def doCleanUpResources: Unit = {
+    relationFuture.value match {
+      case Some(Success(broadcast)) => broadcast.destroy()
+      case _ =>
+    }
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -19,8 +19,8 @@ package org.apache.spark.sql.execution.exchange
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
-import scala.util.control.NonFatal
 import scala.util.Success
+import scala.util.control.NonFatal
 
 import org.apache.spark.SparkException
 import org.apache.spark.broadcast.Broadcast

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/BroadcastJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/BroadcastJoinSuite.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.execution.joins
 import scala.reflect.ClassTag
 
 import org.apache.spark.AccumulatorSuite
-import org.apache.spark.storage.BlockId
 import org.apache.spark.sql.{Dataset, QueryTest, Row, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.{BitwiseAnd, BitwiseOr, Cast, Literal, ShiftLeft}
 import org.apache.spark.sql.execution.{SparkPlan, WholeStageCodegenExec}
@@ -30,6 +29,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestUtils
 import org.apache.spark.sql.types.{LongType, ShortType}
+import org.apache.spark.storage.BlockId
 
 /**
  * Test various broadcast join operators.
@@ -156,9 +156,9 @@ class BroadcastJoinSuite extends QueryTest with SQLTestUtils {
   test("SPARK-22575: remove allocated blocks when they are not needed anymore") {
     val blockManager = sparkContext.env.blockManager
     def broadcastedBlockIds: Seq[BlockId] = {
-      blockManager.getMatchingBlockIds(blockId => {
+      blockManager.getMatchingBlockIds { blockId =>
         blockId.isBroadcast && blockManager.getStatus(blockId).get.storageLevel.deserialized
-      }).distinct
+      }.distinct
     }
     def isHashedRelationPresent(blockIds: Seq[BlockId]): Boolean = {
       val blockValues = blockIds.flatMap { id =>

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
@@ -288,6 +288,9 @@ private[hive] class SparkExecuteStatementOperation(
     if (statementId != null) {
       sqlContext.sparkContext.cancelJobGroup(statementId)
     }
+    if (result != null) {
+      result.destroy()
+    }
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the Dataset API we may acquire resources which we cannot deallocate. This happens for broadcast joins. The broadcasted object is never destroyed and we rely on the garbage collection of broadcasted object to free it. In a general use case, this is a safe assumption, but when dynamic allocation is enabled, the current approach can lead to resource leakage.

In particular, when a Spark application is submitted on YARN with dynamic allocation enabled, we may leak disk space. Indeed, in such a scenario, when query with a broadcast join is executed, it is likely that we ask for new containers. These containers are used for the execution of the query and then killed. They may be killed before the broadcast object is GCed. In this case, the files which have been written are never removed (as the container is not alive anymore to remove them and YARN removes them only when the application ends).

In order to solve the above-mentioned issue, the PR proposes to add a `destroy` method to the `Dataset` class, which can be used to free all the resources which have been acquired in the plan execution. Eagerly destroying the acquired resources, they are freed before the containers are killed, avoiding (or at least reducing considerably) the problem.

## How was this patch tested?

added UT
