### PR TITLE
[SPARK-24212][ML][doc] Add the example and user guide for ML PrefixSpan

### DIFF
--- a/docs/ml-frequent-pattern-mining.md
+++ b/docs/ml-frequent-pattern-mining.md
@@ -85,3 +85,48 @@ Refer to the [R API docs](api/R/spark.fpGrowth.html) for more details.
 </div>
 
 </div>
+
+## PrefixSpan
+
+PrefixSpan is a sequential pattern mining algorithm described in
+[Pei et al., Mining Sequential Patterns by Pattern-Growth: The
+PrefixSpan Approach](http://dx.doi.org/10.1109%2FTKDE.2004.77). We refer
+the reader to the referenced paper for formalizing the sequential
+pattern mining problem.
+
+`spark.ml`'s PrefixSpan takes the following parameters:
+
+* `minSupport`: the minimum support required to be considered a frequent
+  sequential pattern.
+* `maxPatternLength`: the maximum length of a frequent sequential
+  pattern. Any frequent pattern exceeding this length will not be
+  included in the results.
+* `maxLocalProjDBSize`: the maximum number of items allowed in a
+  prefix-projected database before local iterative processing of the
+  projected database begins. This parameter should be tuned with respect
+  to the size of your executors.
+
+**Examples**
+
+The following example illustrates PrefixSpan running on the sequences
+(using same notation as Pei et al):
+
+~~~
+  <(12)3>
+  <1(32)(12)>
+  <(12)5>
+  <6>
+~~~
+
+<div class="codetabs">
+<div data-lang="scala" markdown="1">
+
+[`ML PrefixSpan`](api/scala/index.html#org.apache.spark.ml.fpm.PrefixSpan) is a wrapper of [`MLlib PrefixSpan`](api/scala/index.html#org.apache.spark.mllib.fpm.PrefixSpan) which implements the algorithm.
+`PrefixSpan.findFrequentSequentialPatterns` would pass all parameters to [`MLlib PrefixSpan`](api/scala/index.html#org.apache.spark.mllib.fpm.PrefixSpan).
+
+Refer to the [`ML PrefixSpan  Scala docs` Scala docs](api/scala/index.html#org.apache.spark.ml.fpm.PrefixSpan), [`MLlib PrefixSpan  Scala docs`](api/scala/index.html#org.apache.spark.mllib.fpm.PrefixSpan) and [`MLlib PrefixSpanModel` Scala docs](api/scala/index.html#org.apache.spark.mllib.fpm.PrefixSpanModel) for details on the API.
+
+{% include_example scala/org/apache/spark/examples/ml/PrefixSpanExample.scala %}
+
+</div>
+</div>

--- a/examples/src/main/scala/org/apache/spark/examples/ml/PrefixSpanExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/PrefixSpanExample.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// scalastyle:off println
+package org.apache.spark.examples.ml
+
+// $example on$
+import org.apache.spark.ml.fpm.PrefixSpan
+// $example off$
+import org.apache.spark.sql.SparkSession
+/**
+ * An example for PrefixSpan.
+ * Run with
+ * {{{
+ * bin/run-example ml.PrefixSpanExample
+ * }}}
+ */
+object PrefixSpanExample {
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession
+      .builder
+      .appName("PrefixSpanExample")
+      .getOrCreate()
+
+    import spark.implicits._
+    // $example on$
+    val df = Seq(
+      Seq(Seq(1, 2), Seq(3)),
+      Seq(Seq(1), Seq(3, 2), Seq(1, 2)),
+      Seq(Seq(1, 2), Seq(5)),
+      Seq(Seq(6))).toDF("sequence")
+
+    val result = new PrefixSpan()
+      .setMinSupport(0.5)
+      .setMaxPatternLength(5)
+      .setMaxLocalProjDBSize(32000000)
+      .findFrequentSequentialPatterns(df)
+
+    result.show()
+    // $example off$
+    spark.stop()
+  }
+}
+// scalastyle:on println


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are no example and user guide for ML PrefixSpan (not MLlib PrefixSpan).

This PR adds an example and a user guide.

The user guide follows the user guide for MLlib PrefixSpan.

## How was this patch tested?

Generated the html file. See the screenshot.

<img width="812" alt="screenshot 2018-06-10 18 27 39" src="https://user-images.githubusercontent.com/2724786/41207516-3d5c137e-6cdd-11e8-8e8f-f713231cc4fd.png">
