### PR TITLE
[SPARK-24515][CORE] No need to warning when output commit coordination enabled

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -359,6 +359,8 @@ package object config {
 
   private[spark] val HADOOP_OUTPUTCOMMITCOORDINATION_ENABLED =
     ConfigBuilder("spark.hadoop.outputCommitCoordination.enabled")
+      .doc("when enabled, tasks will coordinate with the driver to make sure that," +
+        " for a certain partition, at most one task attempt can commit.")
       .booleanConf
       .createWithDefault(true)
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -357,6 +357,11 @@ package object config {
       .intConf
       .createWithDefault(256)
 
+  private[spark] val HADOOP_OUTPUTCOMMITCOORDINATION_ENABLED =
+    ConfigBuilder("spark.hadoop.outputCommitCoordination.enabled")
+      .booleanConf
+      .createWithDefault(true)
+
   private[spark] val NETWORK_AUTH_ENABLED =
     ConfigBuilder("spark.authenticate")
       .booleanConf

--- a/core/src/main/scala/org/apache/spark/mapred/SparkHadoopMapRedUtil.scala
+++ b/core/src/main/scala/org/apache/spark/mapred/SparkHadoopMapRedUtil.scala
@@ -25,6 +25,7 @@ import org.apache.hadoop.mapreduce.{OutputCommitter => MapReduceOutputCommitter}
 import org.apache.spark.{SparkEnv, TaskContext}
 import org.apache.spark.executor.CommitDeniedException
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config._
 
 object SparkHadoopMapRedUtil extends Logging {
   /**
@@ -33,7 +34,7 @@ object SparkHadoopMapRedUtil extends Logging {
    * the driver in order to determine whether this attempt can commit (please see SPARK-4879 for
    * details).
    *
-   * Output commit coordinator is only used when `spark.hadoop.outputCommitCoordination.enabled`
+   * Output commit coordinator is only used when [[HADOOP_OUTPUTCOMMITCOORDINATION_ENABLED]]
    * is set to true (which is the default).
    */
   def commitTask(
@@ -64,7 +65,7 @@ object SparkHadoopMapRedUtil extends Logging {
         // We only need to coordinate with the driver if there are concurrent task attempts.
         // Note that this could happen even when speculation is not enabled (e.g. see SPARK-8029).
         // This (undocumented) setting is an escape-hatch in case the commit code introduces bugs.
-        sparkConf.getBoolean("spark.hadoop.outputCommitCoordination.enabled", defaultValue = true)
+        sparkConf.get(HADOOP_OUTPUTCOMMITCOORDINATION_ENABLED)
       }
 
       if (shouldCoordinateWithDriver) {

--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -1053,7 +1053,10 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
     // users that they may loss data if they are using a direct output committer.
     val speculationEnabled = self.conf.getBoolean("spark.speculation", false)
     val outputCommitterClass = hadoopConf.get("mapred.output.committer.class", "")
-    if (speculationEnabled && outputCommitterClass.contains("Direct")) {
+    val outputCommitCoordinationEnabled = self.conf.getBoolean(
+      "spark.hadoop.outputCommitCoordination.enabled", true)
+    if (speculationEnabled && outputCommitterClass.contains("Direct")
+      && !outputCommitCoordinationEnabled) {
       val warningMessage =
         s"$outputCommitterClass may be an output committer that writes data directly to " +
           "the final location. Because speculation is enabled, this output committer may " +

--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -36,6 +36,7 @@ import org.apache.spark._
 import org.apache.spark.Partitioner.defaultPartitioner
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config._
 import org.apache.spark.internal.io._
 import org.apache.spark.partial.{BoundedDouble, PartialResult}
 import org.apache.spark.serializer.Serializer
@@ -1053,8 +1054,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
     // users that they may loss data if they are using a direct output committer.
     val speculationEnabled = self.conf.getBoolean("spark.speculation", false)
     val outputCommitterClass = hadoopConf.get("mapred.output.committer.class", "")
-    val outputCommitCoordinationEnabled = self.conf.getBoolean(
-      "spark.hadoop.outputCommitCoordination.enabled", true)
+    val outputCommitCoordinationEnabled = self.conf.get(HADOOP_OUTPUTCOMMITCOORDINATION_ENABLED)
     if (speculationEnabled && outputCommitterClass.contains("Direct")
       && !outputCommitCoordinationEnabled) {
       val warningMessage =

--- a/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorIntegrationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorIntegrationSuite.scala
@@ -22,6 +22,7 @@ import org.scalatest.concurrent.{Signaler, ThreadSignaler, TimeLimits}
 import org.scalatest.time.{Seconds, Span}
 
 import org.apache.spark.{LocalSparkContext, SparkConf, SparkContext, SparkFunSuite, TaskContext}
+import org.apache.spark.internal.config._
 import org.apache.spark.util.Utils
 
 /**
@@ -40,7 +41,7 @@ class OutputCommitCoordinatorIntegrationSuite
   override def beforeAll(): Unit = {
     super.beforeAll()
     val conf = new SparkConf()
-      .set("spark.hadoop.outputCommitCoordination.enabled", "true")
+      .set(HADOOP_OUTPUTCOMMITCOORDINATION_ENABLED.key, "true")
       .set("spark.hadoop.mapred.output.committer.class",
         classOf[ThrowExceptionOnFirstAttemptOutputCommitter].getCanonicalName)
     sc = new SparkContext("local[2, 4]", "test", conf)

--- a/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
@@ -33,6 +33,7 @@ import org.mockito.stubbing.Answer
 import org.scalatest.BeforeAndAfter
 
 import org.apache.spark._
+import org.apache.spark.internal.config._
 import org.apache.spark.internal.io.{FileCommitProtocol, HadoopMapRedCommitProtocol, SparkHadoopWriterUtils}
 import org.apache.spark.rdd.{FakeOutputCommitter, RDD}
 import org.apache.spark.util.{ThreadUtils, Utils}
@@ -79,7 +80,7 @@ class OutputCommitCoordinatorSuite extends SparkFunSuite with BeforeAndAfter {
     val conf = new SparkConf()
       .setMaster("local[4]")
       .setAppName(classOf[OutputCommitCoordinatorSuite].getSimpleName)
-      .set("spark.hadoop.outputCommitCoordination.enabled", "true")
+      .set(HADOOP_OUTPUTCOMMITCOORDINATION_ENABLED.key, "true")
     sc = new SparkContext(conf) {
       override private[spark] def createSparkEnv(
           conf: SparkConf,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveFileFormat.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveFileFormat.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.hive.execution
 
 import scala.collection.JavaConverters._
+
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.hive.ql.exec.Utilities
 import org.apache.hadoop.hive.ql.io.{HiveFileFormatUtils, HiveOutputFormat}
@@ -27,6 +28,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils.Object
 import org.apache.hadoop.io.Writable
 import org.apache.hadoop.mapred.{JobConf, Reporter}
 import org.apache.hadoop.mapreduce.{Job, TaskAttemptContext}
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.HADOOP_OUTPUTCOMMITCOORDINATION_ENABLED
 import org.apache.spark.sql.SparkSession


### PR DESCRIPTION
## What changes were proposed in this pull request?

No need to warning user when output commit coordination enabled
```
// When speculation is on and output committer class name contains "Direct", we should warn
// users that they may loss data if they are using a direct output committer.
val speculationEnabled = self.conf.getBoolean("spark.speculation", false)
val outputCommitterClass = hadoopConf.get("mapred.output.committer.class", "")
if (speculationEnabled && outputCommitterClass.contains("Direct")) {
 val warningMessage =
 s"$outputCommitterClass may be an output committer that writes data directly to " +
 "the final location. Because speculation is enabled, this output committer may " +
 "cause data loss (see the case in SPARK-10063). If possible, please use an output " +
 "committer that does not have this behavior (e.g. FileOutputCommitter)."
 logWarning(warningMessage)
}
```

## How was this patch tested?
UT
