### PR TITLE
[spark][pyspark][sql] Correcting code for Documentation Strings(PEP8)

### DIFF
--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -130,7 +130,6 @@ def _reverse_op(name, doc="binary operator"):
 
 
 class Column(object):
-
     """
     A column in a DataFrame.
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
 Just correcting an unnecessary interval on  [column.py] line 133.  It does not fit Documentation Strings(PEP8).

## How was this patch tested?

 Change is not affecting any other code. 

Please review http://spark.apache.org/contributing.html before opening a pull request.
