### PR TITLE
[SPARK-24521][SQL][TEST] Fix ineffective test in CachedTableSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -50,10 +50,6 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with SharedSQLContext
   }
 
   def rddIdOf(tableName: String): Int = {
-    rddIdOf(spark.table(tableName), tableName)
-  }
-
-  def rddIdOf(ds: Dataset[_], tableName: String = "unnamedTable"): Int = {
     val plan = ds.queryExecution.sparkPlan
     plan.collect {
       case InMemoryTableScanExec(_, _, relation) =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -50,7 +50,7 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with SharedSQLContext
   }
 
   def rddIdOf(tableName: String): Int = {
-    val plan = ds.queryExecution.sparkPlan
+    val plan = spark.table(tableName).queryExecution.sparkPlan
     plan.collect {
       case InMemoryTableScanExec(_, _, relation) =>
         relation.cacheBuilder.cachedColumnBuffers.id

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetCacheSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetCacheSuite.scala
@@ -102,7 +102,6 @@ class DatasetCacheSuite extends QueryTest with SharedSQLContext with TimeLimits 
 
   test("persist and then withColumn") {
     val df = Seq(("test", 1)).toDF("s", "i")
-    // We should not invalidate the cached DataFrame
     val df2 = df.withColumn("newColumn", lit(1))
 
     df.cache()
@@ -123,9 +122,9 @@ class DatasetCacheSuite extends QueryTest with SharedSQLContext with TimeLimits 
 
     df.cache()
     df.count()
-
     assertCached(df2)
 
+    // udf has been evaluated during caching, and thus should not be re-evaluated here
     failAfter(5 seconds) {
       df2.collect()
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

test("withColumn doesn't invalidate cached dataframe") in CachedTableSuite doesn't not work because:

The UDF is executed and test count incremented when "df.cache()" is called and the subsequent "df.collect()" has no effect on the test result. 

This PR fixed this test and add another test for caching UDF.

## How was this patch tested?

Add new tests.
