### PR TITLE
[SPARK-24538][SQL] ByteArrayDecimalType support push down to the data sources

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
+import java.math.{BigDecimal => JBigDecimal}
 import java.sql.Date
 
 import org.apache.parquet.filter2.predicate._
@@ -25,6 +26,7 @@ import org.apache.parquet.io.api.Binary
 
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.SQLDate
+import org.apache.spark.sql.execution.datasources.parquet.ParquetSchemaConverter.minBytesForPrecision
 import org.apache.spark.sql.sources
 import org.apache.spark.sql.types._
 
@@ -35,6 +37,23 @@ private[parquet] class ParquetFilters(pushDownDate: Boolean) {
 
   private def dateToDays(date: Date): SQLDate = {
     DateTimeUtils.fromJavaDate(date)
+  }
+
+  private def decimalToBinary(precision: Int, decimal: JBigDecimal): Binary = {
+    val numBytes = minBytesForPrecision(precision)
+    val bytes = decimal.unscaledValue().toByteArray
+    val decimalBuffer = new Array[Byte](minBytesForPrecision(DecimalType.MAX_PRECISION))
+
+    val fixedLengthBytes = if (bytes.length == numBytes) {
+      bytes
+    } else {
+      val signByte = if (bytes.head < 0) -1: Byte else 0: Byte
+      java.util.Arrays.fill(decimalBuffer, 0, numBytes - bytes.length, signByte)
+      System.arraycopy(bytes, 0, decimalBuffer, numBytes - bytes.length, bytes.length)
+      decimalBuffer
+    }
+
+    Binary.fromReusedByteArray(fixedLengthBytes, 0, numBytes)
   }
 
   private val makeEq: PartialFunction[DataType, (String, Any) => FilterPredicate] = {
@@ -62,11 +81,10 @@ private[parquet] class ParquetFilters(pushDownDate: Boolean) {
       (n: String, v: Any) => FilterApi.eq(
         intColumn(n),
         Option(v).map(date => dateToDays(date.asInstanceOf[Date]).asInstanceOf[Integer]).orNull)
-    case decimal: DecimalType if DecimalType.isByteArrayDecimalType(decimal) =>
+    case DecimalType.Fixed(p, s) if p > Decimal.MAX_LONG_DIGITS =>
       (n: String, v: Any) => FilterApi.eq(
         binaryColumn(n),
-        Option(v).map(d => Binary.fromReusedByteArray(new Array[Byte](8) ++
-          d.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
+        Option(v).map(d => decimalToBinary(p, d.asInstanceOf[JBigDecimal])).orNull)
   }
 
   private val makeNotEq: PartialFunction[DataType, (String, Any) => FilterPredicate] = {
@@ -93,11 +111,10 @@ private[parquet] class ParquetFilters(pushDownDate: Boolean) {
       (n: String, v: Any) => FilterApi.notEq(
         intColumn(n),
         Option(v).map(date => dateToDays(date.asInstanceOf[Date]).asInstanceOf[Integer]).orNull)
-    case decimal: DecimalType if DecimalType.isByteArrayDecimalType(decimal) =>
+    case DecimalType.Fixed(p, s) if p > Decimal.MAX_LONG_DIGITS =>
       (n: String, v: Any) => FilterApi.notEq(
         binaryColumn(n),
-        Option(v).map(d => Binary.fromReusedByteArray(new Array[Byte](8) ++
-          d.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
+        Option(v).map(d => decimalToBinary(p, d.asInstanceOf[JBigDecimal])).orNull)
   }
 
   private val makeLt: PartialFunction[DataType, (String, Any) => FilterPredicate] = {
@@ -121,11 +138,10 @@ private[parquet] class ParquetFilters(pushDownDate: Boolean) {
       (n: String, v: Any) => FilterApi.lt(
         intColumn(n),
         Option(v).map(date => dateToDays(date.asInstanceOf[Date]).asInstanceOf[Integer]).orNull)
-    case decimal: DecimalType if DecimalType.isByteArrayDecimalType(decimal) =>
+    case DecimalType.Fixed(p, s) if p > Decimal.MAX_LONG_DIGITS =>
       (n: String, v: Any) => FilterApi.lt(
         binaryColumn(n),
-        Option(v).map(d => Binary.fromReusedByteArray(new Array[Byte](8) ++
-          d.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
+        Option(v).map(d => decimalToBinary(p, d.asInstanceOf[JBigDecimal])).orNull)
   }
 
   private val makeLtEq: PartialFunction[DataType, (String, Any) => FilterPredicate] = {
@@ -149,11 +165,10 @@ private[parquet] class ParquetFilters(pushDownDate: Boolean) {
       (n: String, v: Any) => FilterApi.ltEq(
         intColumn(n),
         Option(v).map(date => dateToDays(date.asInstanceOf[Date]).asInstanceOf[Integer]).orNull)
-    case decimal: DecimalType if DecimalType.isByteArrayDecimalType(decimal) =>
+    case DecimalType.Fixed(p, s) if p > Decimal.MAX_LONG_DIGITS =>
       (n: String, v: Any) => FilterApi.ltEq(
         binaryColumn(n),
-        Option(v).map(d => Binary.fromReusedByteArray(new Array[Byte](8) ++
-          d.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
+        Option(v).map(d => decimalToBinary(p, d.asInstanceOf[JBigDecimal])).orNull)
   }
 
   private val makeGt: PartialFunction[DataType, (String, Any) => FilterPredicate] = {
@@ -177,11 +192,10 @@ private[parquet] class ParquetFilters(pushDownDate: Boolean) {
       (n: String, v: Any) => FilterApi.gt(
         intColumn(n),
         Option(v).map(date => dateToDays(date.asInstanceOf[Date]).asInstanceOf[Integer]).orNull)
-    case decimal: DecimalType if DecimalType.isByteArrayDecimalType(decimal) =>
+    case DecimalType.Fixed(p, s) if p > Decimal.MAX_LONG_DIGITS =>
       (n: String, v: Any) => FilterApi.gt(
         binaryColumn(n),
-        Option(v).map(d => Binary.fromReusedByteArray(new Array[Byte](8) ++
-          d.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
+        Option(v).map(d => decimalToBinary(p, d.asInstanceOf[JBigDecimal])).orNull)
   }
 
   private val makeGtEq: PartialFunction[DataType, (String, Any) => FilterPredicate] = {
@@ -205,11 +219,10 @@ private[parquet] class ParquetFilters(pushDownDate: Boolean) {
       (n: String, v: Any) => FilterApi.gtEq(
         intColumn(n),
         Option(v).map(date => dateToDays(date.asInstanceOf[Date]).asInstanceOf[Integer]).orNull)
-    case decimal: DecimalType if DecimalType.isByteArrayDecimalType(decimal) =>
+    case DecimalType.Fixed(p, s) if p > Decimal.MAX_LONG_DIGITS =>
       (n: String, v: Any) => FilterApi.gtEq(
         binaryColumn(n),
-        Option(v).map(d => Binary.fromReusedByteArray(new Array[Byte](8) ++
-          d.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
+        Option(v).map(d => decimalToBinary(p, d.asInstanceOf[JBigDecimal])).orNull)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
@@ -62,6 +62,11 @@ private[parquet] class ParquetFilters(pushDownDate: Boolean) {
       (n: String, v: Any) => FilterApi.eq(
         intColumn(n),
         Option(v).map(date => dateToDays(date.asInstanceOf[Date]).asInstanceOf[Integer]).orNull)
+    case decimal: DecimalType if DecimalType.isByteArrayDecimalType(decimal) =>
+      (n: String, v: Any) => FilterApi.eq(
+        binaryColumn(n),
+        Option(v).map(d => Binary.fromReusedByteArray(new Array[Byte](8) ++
+            v.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
   }
 
   private val makeNotEq: PartialFunction[DataType, (String, Any) => FilterPredicate] = {
@@ -88,6 +93,11 @@ private[parquet] class ParquetFilters(pushDownDate: Boolean) {
       (n: String, v: Any) => FilterApi.notEq(
         intColumn(n),
         Option(v).map(date => dateToDays(date.asInstanceOf[Date]).asInstanceOf[Integer]).orNull)
+    case decimal: DecimalType if DecimalType.isByteArrayDecimalType(decimal) =>
+      (n: String, v: Any) => FilterApi.notEq(
+        binaryColumn(n),
+        Option(v).map(d => Binary.fromReusedByteArray(new Array[Byte](8) ++
+          v.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
   }
 
   private val makeLt: PartialFunction[DataType, (String, Any) => FilterPredicate] = {
@@ -111,6 +121,11 @@ private[parquet] class ParquetFilters(pushDownDate: Boolean) {
       (n: String, v: Any) => FilterApi.lt(
         intColumn(n),
         Option(v).map(date => dateToDays(date.asInstanceOf[Date]).asInstanceOf[Integer]).orNull)
+    case decimal: DecimalType if DecimalType.isByteArrayDecimalType(decimal) =>
+      (n: String, v: Any) => FilterApi.lt(
+        binaryColumn(n),
+        Option(v).map(d => Binary.fromReusedByteArray(new Array[Byte](8) ++
+          v.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
   }
 
   private val makeLtEq: PartialFunction[DataType, (String, Any) => FilterPredicate] = {
@@ -134,6 +149,11 @@ private[parquet] class ParquetFilters(pushDownDate: Boolean) {
       (n: String, v: Any) => FilterApi.ltEq(
         intColumn(n),
         Option(v).map(date => dateToDays(date.asInstanceOf[Date]).asInstanceOf[Integer]).orNull)
+    case decimal: DecimalType if DecimalType.isByteArrayDecimalType(decimal) =>
+      (n: String, v: Any) => FilterApi.ltEq(
+        binaryColumn(n),
+        Option(v).map(d => Binary.fromReusedByteArray(new Array[Byte](8) ++
+          v.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
   }
 
   private val makeGt: PartialFunction[DataType, (String, Any) => FilterPredicate] = {
@@ -157,6 +177,11 @@ private[parquet] class ParquetFilters(pushDownDate: Boolean) {
       (n: String, v: Any) => FilterApi.gt(
         intColumn(n),
         Option(v).map(date => dateToDays(date.asInstanceOf[Date]).asInstanceOf[Integer]).orNull)
+    case decimal: DecimalType if DecimalType.isByteArrayDecimalType(decimal) =>
+      (n: String, v: Any) => FilterApi.gt(
+        binaryColumn(n),
+        Option(v).map(d => Binary.fromReusedByteArray(new Array[Byte](8) ++
+          v.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
   }
 
   private val makeGtEq: PartialFunction[DataType, (String, Any) => FilterPredicate] = {
@@ -180,6 +205,11 @@ private[parquet] class ParquetFilters(pushDownDate: Boolean) {
       (n: String, v: Any) => FilterApi.gtEq(
         intColumn(n),
         Option(v).map(date => dateToDays(date.asInstanceOf[Date]).asInstanceOf[Integer]).orNull)
+    case decimal: DecimalType if DecimalType.isByteArrayDecimalType(decimal) =>
+      (n: String, v: Any) => FilterApi.gtEq(
+        binaryColumn(n),
+        Option(v).map(d => Binary.fromReusedByteArray(new Array[Byte](8) ++
+          v.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
@@ -66,7 +66,7 @@ private[parquet] class ParquetFilters(pushDownDate: Boolean) {
       (n: String, v: Any) => FilterApi.eq(
         binaryColumn(n),
         Option(v).map(d => Binary.fromReusedByteArray(new Array[Byte](8) ++
-            v.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
+          d.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
   }
 
   private val makeNotEq: PartialFunction[DataType, (String, Any) => FilterPredicate] = {
@@ -97,7 +97,7 @@ private[parquet] class ParquetFilters(pushDownDate: Boolean) {
       (n: String, v: Any) => FilterApi.notEq(
         binaryColumn(n),
         Option(v).map(d => Binary.fromReusedByteArray(new Array[Byte](8) ++
-          v.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
+          d.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
   }
 
   private val makeLt: PartialFunction[DataType, (String, Any) => FilterPredicate] = {
@@ -125,7 +125,7 @@ private[parquet] class ParquetFilters(pushDownDate: Boolean) {
       (n: String, v: Any) => FilterApi.lt(
         binaryColumn(n),
         Option(v).map(d => Binary.fromReusedByteArray(new Array[Byte](8) ++
-          v.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
+          d.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
   }
 
   private val makeLtEq: PartialFunction[DataType, (String, Any) => FilterPredicate] = {
@@ -153,7 +153,7 @@ private[parquet] class ParquetFilters(pushDownDate: Boolean) {
       (n: String, v: Any) => FilterApi.ltEq(
         binaryColumn(n),
         Option(v).map(d => Binary.fromReusedByteArray(new Array[Byte](8) ++
-          v.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
+          d.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
   }
 
   private val makeGt: PartialFunction[DataType, (String, Any) => FilterPredicate] = {
@@ -181,7 +181,7 @@ private[parquet] class ParquetFilters(pushDownDate: Boolean) {
       (n: String, v: Any) => FilterApi.gt(
         binaryColumn(n),
         Option(v).map(d => Binary.fromReusedByteArray(new Array[Byte](8) ++
-          v.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
+          d.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
   }
 
   private val makeGtEq: PartialFunction[DataType, (String, Any) => FilterPredicate] = {
@@ -209,7 +209,7 @@ private[parquet] class ParquetFilters(pushDownDate: Boolean) {
       (n: String, v: Any) => FilterApi.gtEq(
         binaryColumn(n),
         Option(v).map(d => Binary.fromReusedByteArray(new Array[Byte](8) ++
-          v.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
+          d.asInstanceOf[java.math.BigDecimal].unscaledValue().toByteArray)).orNull)
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -17,13 +17,13 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
-import java.math.BigInteger
 import java.nio.charset.StandardCharsets
 import java.sql.Date
 
 import org.apache.parquet.filter2.predicate.{FilterPredicate, Operators}
 import org.apache.parquet.filter2.predicate.FilterApi._
 import org.apache.parquet.filter2.predicate.Operators.{Column => _, _}
+
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._


### PR DESCRIPTION
## What changes were proposed in this pull request?

[ByteArrayDecimalType](https://github.com/apache/spark/blob/e28eb431146bcdcaf02a6f6c406ca30920592a6a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalType.scala#L230) support push down to the data sources.

## How was this patch tested?
unit tests and manual tests.

**manual tests**:
```scala
spark.range(10000000).selectExpr("id", "cast(id as decimal(9)) as d1", "cast(id as decimal(9, 2)) as d2", "cast(id as decimal(18)) as d3", "cast(id as decimal(18, 4)) as d4", "cast(id as decimal(38)) as d5", "cast(id as decimal(38, 18)) as d6").coalesce(1).write.option("parquet.block.size", 1048576).parquet("/tmp/spark/parquet/decimal")
val df = spark.read.parquet("/tmp/spark/parquet/decimal/")
// Only read about 1 MB data
df.filter("d6 = 10000").show
spark.sql("set spark.sql.parquet.filterPushdown=false")
// Read 174.3 MB data
df.filter("d6 = 10000").show
```
