### PR TITLE
[SPARK-24556][SQL] Always rewrite output partitioning in ReusedExchangeExec and InMemoryTableScanExec

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.QueryPlan
-import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, RangePartitioning}
+import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution.{ColumnarBatchScan, LeafExecNode, SparkPlan, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.vectorized._
 import org.apache.spark.sql.types._

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.QueryPlan
-import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning}
+import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, RangePartitioning}
 import org.apache.spark.sql.execution.{ColumnarBatchScan, LeafExecNode, SparkPlan, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.vectorized._
 import org.apache.spark.sql.types._
@@ -170,6 +170,8 @@ case class InMemoryTableScanExec(
   override def outputPartitioning: Partitioning = {
     relation.cachedPlan.outputPartitioning match {
       case h: HashPartitioning => updateAttribute(h).asInstanceOf[HashPartitioning]
+      case r: RangePartitioning =>
+        r.copy(ordering = r.ordering.map(updateAttribute(_).asInstanceOf[SortOrder]))
       case _ => relation.cachedPlan.outputPartitioning
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
@@ -169,10 +169,8 @@ case class InMemoryTableScanExec(
   // But the cached version could alias output, so we need to replace output.
   override def outputPartitioning: Partitioning = {
     relation.cachedPlan.outputPartitioning match {
-      case h: HashPartitioning => updateAttribute(h).asInstanceOf[HashPartitioning]
-      case r: RangePartitioning =>
-        r.copy(ordering = r.ordering.map(updateAttribute(_).asInstanceOf[SortOrder]))
-      case _ => relation.cachedPlan.outputPartitioning
+      case e: Expression => updateAttribute(e).asInstanceOf[Partitioning]
+      case other => other
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
@@ -24,7 +24,7 @@ import org.apache.spark.broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, Expression, SortOrder}
-import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning}
+import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, RangePartitioning}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{LeafExecNode, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.internal.SQLConf
@@ -71,6 +71,8 @@ case class ReusedExchangeExec(override val output: Seq[Attribute], child: Exchan
 
   override def outputPartitioning: Partitioning = child.outputPartitioning match {
     case h: HashPartitioning => h.copy(expressions = h.expressions.map(updateAttr))
+    case r: RangePartitioning =>
+      r.copy(ordering = r.ordering.map(updateAttr(_).asInstanceOf[SortOrder]))
     case other => other
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
@@ -70,9 +70,7 @@ case class ReusedExchangeExec(override val output: Seq[Attribute], child: Exchan
   }
 
   override def outputPartitioning: Partitioning = child.outputPartitioning match {
-    case h: HashPartitioning => h.copy(expressions = h.expressions.map(updateAttr))
-    case r: RangePartitioning =>
-      r.copy(ordering = r.ordering.map(updateAttr(_).asInstanceOf[SortOrder]))
+    case e: Expression => updateAttr(e).asInstanceOf[Partitioning]
     case other => other
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
@@ -24,7 +24,7 @@ import org.apache.spark.broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, Expression, SortOrder}
-import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, RangePartitioning}
+import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{LeafExecNode, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.internal.SQLConf

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2270,15 +2270,4 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     val mapWithBinaryKey = map(lit(Array[Byte](1.toByte)), lit(1))
     checkAnswer(spark.range(1).select(mapWithBinaryKey.getItem(Array[Byte](1.toByte))), Row(1))
   }
-
-  test("SPARK-24556: ReusedExchange should rewrite output partitioning for RangePartitioning") {
-    val df = Seq(1 -> "a").toDF("i", "j")
-    val df1 = df.as("t1")
-    val df2 = df.as("t2")
-    val shuffles = df1.orderBy("j").join(df2.orderBy("j"), $"t1.i" === $"t2.i", "right")
-      .cache().orderBy($"t2.j").queryExecution.executedPlan.collect {
-      case e: ShuffleExchangeExec => e
-    }
-    assert(shuffles.isEmpty)
-  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -18,13 +18,13 @@
 package org.apache.spark.sql.execution
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{execution, Row}
+import org.apache.spark.sql.{execution, DataFrame, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Range, Repartition, Sort, Union}
 import org.apache.spark.sql.catalyst.plans.physical._
-import org.apache.spark.sql.execution.columnar.InMemoryRelation
+import org.apache.spark.sql.execution.columnar.{InMemoryRelation, InMemoryTableScanExec}
 import org.apache.spark.sql.execution.exchange.{EnsureRequirements, ReusedExchangeExec, ReuseExchange, ShuffleExchangeExec}
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, SortMergeJoinExec}
 import org.apache.spark.sql.functions._
@@ -685,6 +685,68 @@ class PlannerSuite extends SharedSQLContext {
       Range(1, 1, 1, 1),
       Range(1, 2, 1, 1)))
     df.queryExecution.executedPlan.execute()
+  }
+
+  test("SPARK-24556: always rewrite output partitioning in InMemoryTableScanExec" +
+    "and ReusedExchangeExec") {
+    def checkOutputPartitioningRewrite(
+        plans: Seq[SparkPlan],
+        expectedPartitioningClass: Class[_]): Unit = {
+      plans.foreach { plan =>
+        val partitioning = plan.outputPartitioning
+        assert(partitioning.getClass == expectedPartitioningClass)
+        val partitionedAttrs = partitioning.asInstanceOf[Expression].references
+        assert(partitionedAttrs.subsetOf(plan.outputSet))
+      }
+    }
+
+    def checkInMemoryTableScanOutputPartitioningRewrite(
+        df: DataFrame,
+        expectedPartitioningClass: Class[_]): Unit = {
+      val inMemoryScans = df.queryExecution.executedPlan.collect {
+        case m: InMemoryTableScanExec => m
+      }
+      checkOutputPartitioningRewrite(inMemoryScans, expectedPartitioningClass)
+    }
+
+    def checkReusedExchangeOutputPartitioningRewrite(
+        df: DataFrame,
+        expectedPartitioningClass: Class[_]): Unit = {
+      val reusedExchange = df.queryExecution.executedPlan.collect {
+        case r: ReusedExchangeExec => r
+      }
+      checkOutputPartitioningRewrite(reusedExchange, expectedPartitioningClass)
+    }
+
+    // InMemoryTableScan is HashPartitioning
+    val df1 = Seq(1 -> "a").toDF("i", "j").repartition($"i").persist()
+    val df2 = Seq(1 -> "a").toDF("i", "j").repartition($"i").persist()
+    checkInMemoryTableScanOutputPartitioningRewrite(df1.union(df2), classOf[HashPartitioning])
+
+    // InMemoryTableScan is RangePartitioning
+    val df3 = Seq(1 -> "a").toDF("i", "j").orderBy($"i").persist()
+    val df4 = Seq(1 -> "a").toDF("i", "j").orderBy($"i").persist()
+    checkInMemoryTableScanOutputPartitioningRewrite(df3.union(df4), classOf[RangePartitioning])
+
+    // InMemoryTableScan is PartitioningCollection
+    withSQLConf("spark.sql.autoBroadcastJoinThreshold" -> "0") {
+      val df5 =
+        Seq(1 -> "a").toDF("i", "j").join(Seq(1 -> "a").toDF("m", "n"), $"i" === $"m").persist()
+      val df6 =
+        Seq(1 -> "a").toDF("i", "j").join(Seq(1 -> "a").toDF("m", "n"), $"i" === $"m").persist()
+      checkInMemoryTableScanOutputPartitioningRewrite(
+        df5.union(df6), classOf[PartitioningCollection])
+    }
+
+    // ReusedExchange is HashPartitioning
+    val df7 = Seq(1 -> "a").toDF("i", "j").repartition($"i")
+    val df8 = Seq(1 -> "a").toDF("i", "j").repartition($"i")
+    checkReusedExchangeOutputPartitioningRewrite(df7.union(df8), classOf[HashPartitioning])
+
+    // ReusedExchange is RangePartitioning
+    val df9 = Seq(1 -> "a").toDF("i", "j").orderBy($"i")
+    val df10 = Seq(1 -> "a").toDF("i", "j").orderBy($"i")
+    checkReusedExchangeOutputPartitioningRewrite(df9.union(df10), classOf[RangePartitioning])
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -706,6 +706,7 @@ class PlannerSuite extends SharedSQLContext {
       val reusedExchange = df.queryExecution.executedPlan.collect {
         case r: ReusedExchangeExec => r
       }
+      assert(reusedExchange.size == 1)
       checkOutputPartitioningRewrite(reusedExchange, expectedPartitioningClass)
     }
 
@@ -715,6 +716,7 @@ class PlannerSuite extends SharedSQLContext {
       val inMemoryScans = df.queryExecution.executedPlan.collect {
         case m: InMemoryTableScanExec => m
       }
+      assert(inMemoryScans.size == 2)
       checkOutputPartitioningRewrite(inMemoryScans, expectedPartitioningClass)
     }
 
@@ -734,8 +736,8 @@ class PlannerSuite extends SharedSQLContext {
     checkInMemoryTableScanOutputPartitioningRewrite(df5.union(df6), classOf[HashPartitioning])
 
     // InMemoryTableScan is RangePartitioning
-    val df7 = df3.persist()
-    val df8 = df4.persist()
+    val df7 = spark.range(1, 100, 1, 10).toDF().persist()
+    val df8 = spark.range(1, 100, 1, 10).toDF().persist()
     checkInMemoryTableScanOutputPartitioningRewrite(df7.union(df8), classOf[RangePartitioning])
 
     // InMemoryTableScan is PartitioningCollection


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, ReusedExchange and InMemoryTableScanExec only rewrite output partitioning if child's partitioning is HashPartitioning and do nothing for other partitioning, e.g., RangePartitioning. We should always rewrite it, otherwise, unnecessary shuffle could be introduced like https://issues.apache.org/jira/browse/SPARK-24556.

## How was this patch tested?

Add new tests.
