### PR TITLE
[SPARK-24534][K8S] Bypass non spark-on-k8s commands

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
@@ -44,7 +44,7 @@ case "$SPARK_K8S_CMD" in
     "")
       ;;
     *)
-      echo "No SPARK_K8S_CMD provided: proceeding in pass-through mode..."
+      echo "Non-spark-on-k8s command provided, proceeding in pass-through mode..."
       exec /sbin/tini -s -- "$@"
       ;;
 esac

--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
@@ -38,10 +38,10 @@ fi
 
 SPARK_K8S_CMD="$1"
 if [ -z "$SPARK_K8S_CMD" ]; then
-  echo "No command to execute has been provided." 1>&2
-  exit 1
+  echo "No command to execute has been provided. Ignoring spark-on-k8s workflow..." 1>&2
+else
+  shift 1
 fi
-shift 1
 
 SPARK_CLASSPATH="$SPARK_CLASSPATH:${SPARK_HOME}/jars/*"
 env | grep SPARK_JAVA_OPT_ | sort -t_ -k4 -n | sed 's/[^=]*=\(.*\)/\1/g' > /tmp/java_opts.txt
@@ -110,8 +110,7 @@ case "$SPARK_K8S_CMD" in
     ;;
 
   *)
-    echo "Unknown command: $SPARK_K8S_CMD" 1>&2
-    exit 1
+    CMD=("$@")
 esac
 
 # Execute the container CMD under tini for better hygiene

--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
@@ -37,11 +37,17 @@ if [ -z "$uidentry" ] ; then
 fi
 
 SPARK_K8S_CMD="$1"
-if [ -z "$SPARK_K8S_CMD" ]; then
-  echo "No command to execute has been provided. Ignoring spark-on-k8s workflow..." 1>&2
-else
-  shift 1
-fi
+case "$SPARK_K8S_CMD" in
+    driver | driver-py | executor)
+      shift 1
+      ;;
+    "")
+      ;;
+    *)
+      echo "No SPARK_K8S_CMD provided: proceeding in pass-through mode..."
+      exec /sbin/tini -s -- "$@"
+      ;;
+esac
 
 SPARK_CLASSPATH="$SPARK_CLASSPATH:${SPARK_HOME}/jars/*"
 env | grep SPARK_JAVA_OPT_ | sort -t_ -k4 -n | sed 's/[^=]*=\(.*\)/\1/g' > /tmp/java_opts.txt
@@ -92,7 +98,6 @@ case "$SPARK_K8S_CMD" in
       "$@" $PYSPARK_PRIMARY $PYSPARK_ARGS
     )
     ;;
-
   executor)
     CMD=(
       ${JAVA_HOME}/bin/java
@@ -110,7 +115,8 @@ case "$SPARK_K8S_CMD" in
     ;;
 
   *)
-    CMD=("$@")
+    echo "Unknown command: $SPARK_K8S_CMD" 1>&2
+    exit 1
 esac
 
 # Execute the container CMD under tini for better hygiene


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR changes the entrypoint.sh to provide an option to run non spark-on-k8s commands (init, driver, executor) in order to let the user keep with the normal workflow without hacking the image to bypass the entrypoint

## How was this patch tested?
This patch was built manually in my local machine and I ran some tests with a combination of ```docker run``` commands.