### PR TITLE
[SPARK-24566][CORE] spark.storage.blockManagerSlaveTimeoutMs default config

### DIFF
--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -75,7 +75,8 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
   // "spark.network.timeout" uses "seconds", while `spark.storage.blockManagerSlaveTimeoutMs` uses
   // "milliseconds"
   private val slaveTimeoutMs =
-    sc.conf.getTimeAsMs("spark.storage.blockManagerSlaveTimeoutMs", "120s")
+    sc.conf.getTimeAsMs("spark.storage.blockManagerSlaveTimeoutMs",
+      s"${sc.conf.getTimeAsSeconds("spark.network.timeout", "120s") * 1000L}ms")
   private val executorTimeoutMs =
     sc.conf.getTimeAsSeconds("spark.network.timeout", s"${slaveTimeoutMs}ms") * 1000
 

--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -21,7 +21,6 @@ import java.util.concurrent.{ScheduledFuture, TimeUnit}
 
 import scala.collection.mutable
 import scala.concurrent.Future
-import scala.concurrent.duration._
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.rpc.{RpcCallContext, RpcEnv, ThreadSafeRpcEndpoint}
@@ -76,16 +75,15 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
   // "spark.network.timeout" uses "seconds", while `spark.storage.blockManagerSlaveTimeoutMs` uses
   // "milliseconds"
   private val executorTimeoutMs =
-    sc.conf.getTimeAsSeconds("spark.network.timeout",
-      s"${sc.conf.getTimeAsMs("spark.storage.blockManagerSlaveTimeoutMs",
-        "120s")}ms").seconds.toMillis
+    sc.conf.getTimeAsMs("spark.storage.blockManagerSlaveTimeoutMs",
+      s"${sc.conf.getTimeAsSeconds("spark.network.timeout", "120s")}s")
 
   // "spark.network.timeoutInterval" uses "seconds", while
   // "spark.storage.blockManagerTimeoutIntervalMs" uses "milliseconds"
+  private val timeoutIntervalMs =
+    sc.conf.getTimeAsMs("spark.storage.blockManagerTimeoutIntervalMs", "60s")
   private val checkTimeoutIntervalMs =
-    sc.conf.getTimeAsSeconds("spark.network.timeoutInterval",
-      s"${sc.conf.getTimeAsMs("spark.storage.blockManagerTimeoutIntervalMs",
-        "60s")}ms").seconds.toMillis
+    sc.conf.getTimeAsSeconds("spark.network.timeoutInterval", s"${timeoutIntervalMs}ms") * 1000
 
   private var timeoutCheckingTask: ScheduledFuture[_] = null
 

--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -20,8 +20,8 @@ package org.apache.spark
 import java.util.concurrent.{ScheduledFuture, TimeUnit}
 
 import scala.collection.mutable
-import scala.concurrent.duration._
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.rpc.{RpcCallContext, RpcEnv, ThreadSafeRpcEndpoint}
@@ -86,7 +86,8 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
   private val timeoutIntervalMs =
     sc.conf.getTimeAsMs("spark.storage.blockManagerTimeoutIntervalMs", "60s")
   private val checkTimeoutIntervalMs =
-    sc.conf.getTimeAsSeconds("spark.network.timeoutInterval", s"${timeoutIntervalMs}ms") * 1000
+    sc.conf.getTimeAsSeconds("spark.network.timeoutInterval",
+      s"${timeoutIntervalMs}ms").seconds.toMillis
 
   private var timeoutCheckingTask: ScheduledFuture[_] = null
 

--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -75,19 +75,17 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
 
   // "spark.network.timeout" uses "seconds", while `spark.storage.blockManagerSlaveTimeoutMs` uses
   // "milliseconds"
-  private val slaveTimeoutMs =
-    sc.conf.getTimeAsMs("spark.storage.blockManagerSlaveTimeoutMs",
-      s"${sc.conf.getTimeAsSeconds("spark.network.timeout", "120s").seconds.toMillis}ms")
   private val executorTimeoutMs =
-    sc.conf.getTimeAsSeconds("spark.network.timeout", s"${slaveTimeoutMs}ms").seconds.toMillis
+    sc.conf.getTimeAsSeconds("spark.network.timeout",
+      s"${sc.conf.getTimeAsMs("spark.storage.blockManagerSlaveTimeoutMs",
+        "120s")}ms").seconds.toMillis
 
   // "spark.network.timeoutInterval" uses "seconds", while
   // "spark.storage.blockManagerTimeoutIntervalMs" uses "milliseconds"
-  private val timeoutIntervalMs =
-    sc.conf.getTimeAsMs("spark.storage.blockManagerTimeoutIntervalMs", "60s")
   private val checkTimeoutIntervalMs =
     sc.conf.getTimeAsSeconds("spark.network.timeoutInterval",
-      s"${timeoutIntervalMs}ms").seconds.toMillis
+      s"${sc.conf.getTimeAsMs("spark.storage.blockManagerTimeoutIntervalMs",
+        "60s")}ms").seconds.toMillis
 
   private var timeoutCheckingTask: ScheduledFuture[_] = null
 

--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -20,6 +20,7 @@ package org.apache.spark
 import java.util.concurrent.{ScheduledFuture, TimeUnit}
 
 import scala.collection.mutable
+import scala.concurrent.duration._
 import scala.concurrent.Future
 
 import org.apache.spark.internal.Logging
@@ -76,9 +77,9 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
   // "milliseconds"
   private val slaveTimeoutMs =
     sc.conf.getTimeAsMs("spark.storage.blockManagerSlaveTimeoutMs",
-      s"${sc.conf.getTimeAsSeconds("spark.network.timeout", "120s") * 1000L}ms")
+      s"${sc.conf.getTimeAsSeconds("spark.network.timeout", "120s").seconds.toMillis}ms")
   private val executorTimeoutMs =
-    sc.conf.getTimeAsSeconds("spark.network.timeout", s"${slaveTimeoutMs}ms") * 1000
+    sc.conf.getTimeAsSeconds("spark.network.timeout", s"${slaveTimeoutMs}ms").seconds.toMillis
 
   // "spark.network.timeoutInterval" uses "seconds", while
   // "spark.storage.blockManagerTimeoutIntervalMs" uses "milliseconds"

--- a/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
@@ -374,25 +374,19 @@ class SparkConfSuite extends SparkFunSuite with LocalSparkContext with ResetSyst
 
   test("SPARK-24566") {
     val conf = new SparkConf()
-    conf.set("spark.network.timeout", "110")
-    val defaultSlaveTimeoutMs =
-      conf.getTimeAsMs("spark.storage.blockManagerSlaveTimeoutMs",
-        s"${conf.getTimeAsSeconds("spark.network.timeout", "120s").seconds.toMillis}ms")
-    assert(defaultSlaveTimeoutMs === 110000)
     conf.set("spark.storage.blockManagerSlaveTimeoutMs", "13000ms")
-    val slaveTimeoutMs =
-      conf.getTimeAsMs("spark.storage.blockManagerSlaveTimeoutMs",
-        s"${conf.getTimeAsSeconds("spark.network.timeout", "120s").seconds.toMillis}ms")
-    assert(slaveTimeoutMs === 13000)
-    conf.remove("spark.network.timeout")
+    conf.set("spark.storage.blockManagerTimeoutIntervalMs", "13000ms")
+
     val executorTimeoutMs =
-      conf.getTimeAsSeconds("spark.network.timeout", s"${slaveTimeoutMs}ms").seconds.toMillis
+      conf.getTimeAsSeconds("spark.network.timeout",
+        s"${conf.getTimeAsMs("spark.storage.blockManagerSlaveTimeoutMs",
+          "120s")}ms").seconds.toMillis
     assert(executorTimeoutMs === 13000)
-    val timeoutIntervalMs = 60000
-    conf.set("spark.network.timeoutInterval", "130")
-    val checkTimeoutIntervalMs = conf.getTimeAsSeconds("spark.network.timeoutInterval",
-      s"${timeoutIntervalMs}ms").seconds.toMillis
-    assert(checkTimeoutIntervalMs === 130000)
+    val checkTimeoutIntervalMs =
+      conf.getTimeAsSeconds("spark.network.timeoutInterval",
+        s"${conf.getTimeAsMs("spark.storage.blockManagerTimeoutIntervalMs",
+          "60s")}ms").seconds.toMillis
+    assert(checkTimeoutIntervalMs === 13000)
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
@@ -371,23 +371,6 @@ class SparkConfSuite extends SparkFunSuite with LocalSparkContext with ResetSyst
       assert(thrown.getMessage.contains(key))
     }
   }
-
-  test("SPARK-24566") {
-    val conf = new SparkConf()
-    conf.set("spark.storage.blockManagerSlaveTimeoutMs", "13000ms")
-    conf.set("spark.storage.blockManagerTimeoutIntervalMs", "13000ms")
-
-    val executorTimeoutMs =
-      conf.getTimeAsSeconds("spark.network.timeout",
-        s"${conf.getTimeAsMs("spark.storage.blockManagerSlaveTimeoutMs",
-          "120s")}ms").seconds.toMillis
-    assert(executorTimeoutMs === 13000)
-    val checkTimeoutIntervalMs =
-      conf.getTimeAsSeconds("spark.network.timeoutInterval",
-        s"${conf.getTimeAsMs("spark.storage.blockManagerTimeoutIntervalMs",
-          "60s")}ms").seconds.toMillis
-    assert(checkTimeoutIntervalMs === 13000)
-  }
 }
 
 class Class1 {}

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -634,7 +634,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
             slave.hostname,
             externalShufflePort,
             sc.conf.getTimeAsMs("spark.storage.blockManagerSlaveTimeoutMs",
-              s"${sc.conf.getTimeAsSeconds("spark.network.timeout", "120s") * 1000L}ms"),
+              s"${sc.conf.getTimeAsSeconds("spark.network.timeout", "120s")}s"),
             sc.conf.getTimeAsMs("spark.executor.heartbeatInterval", "10s"))
         slave.shuffleRegistered = true
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR use spark.network.timeout in place of spark.storage.blockManagerSlaveTimeoutMs when it is not configured, as configuration doc said

## How was this patch tested?
manual test
