### PR TITLE
[SPARK-24574][SQL] array_contains, array_position, array_remove and element_at functions deal with Column type

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3077,12 +3077,16 @@ object functions {
   //////////////////////////////////////////////////////////////////////////////////////////////
 
   /**
-   * Returns null if the array is null, true if the array contains `value`, and false otherwise.
+   * Returns null if the array is null, true if the array contains `value` or the content of
+   * `value` if it is of type Column, and false otherwise.
    * @group collection_funcs
    * @since 1.5.0
    */
   def array_contains(column: Column, value: Any): Column = withExpr {
-    ArrayContains(column.expr, Literal(value))
+    value match {
+      case c: Column => ArrayContains(column.expr, c.expr)
+      case _ => ArrayContains(column.expr, Literal(value))
+    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3182,7 +3182,10 @@ object functions {
    * @since 2.4.0
    */
   def array_remove(column: Column, element: Any): Column = withExpr {
-    ArrayRemove(column.expr, Literal(element))
+    element match {
+      case c: Column => ArrayRemove(column.expr, c.expr)
+      case _ => ArrayRemove(column.expr, Literal(element))
+    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3077,8 +3077,7 @@ object functions {
   //////////////////////////////////////////////////////////////////////////////////////////////
 
   /**
-   * Returns null if the array is null, true if the array contains `value` or the content of
-   * `value` if it is of type Column, and false otherwise.
+   * Returns null if the array is null, true if the array contains `value`, and false otherwise.
    * @group collection_funcs
    * @since 1.5.0
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3082,10 +3082,7 @@ object functions {
    * @since 1.5.0
    */
   def array_contains(column: Column, value: Any): Column = withExpr {
-    value match {
-      case c: Column => ArrayContains(column.expr, lit(c).expr)
-      case _ => ArrayContains(column.expr, Literal(value))
-    }
+    ArrayContains(column.expr, lit(value).expr)
   }
 
   /**
@@ -3149,10 +3146,7 @@ object functions {
    * @since 2.4.0
    */
   def array_position(column: Column, value: Any): Column = withExpr {
-    value match {
-      case c: Column => ArrayPosition(column.expr, lit(c).expr)
-      case _ => ArrayPosition(column.expr, Literal(value))
-    }
+    ArrayPosition(column.expr, lit(value).expr)
   }
 
   /**
@@ -3163,10 +3157,7 @@ object functions {
    * @since 2.4.0
    */
   def element_at(column: Column, value: Any): Column = withExpr {
-    value match {
-      case c: Column => ElementAt(column.expr, lit(c).expr)
-      case _ => ElementAt(column.expr, Literal(value))
-    }
+    ElementAt(column.expr, lit(value).expr)
   }
 
   /**
@@ -3184,10 +3175,7 @@ object functions {
    * @since 2.4.0
    */
   def array_remove(column: Column, element: Any): Column = withExpr {
-    element match {
-      case c: Column => ArrayRemove(column.expr, lit(c).expr)
-      case _ => ArrayRemove(column.expr, Literal(element))
-    }
+    ArrayRemove(column.expr, lit(element).expr)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3164,7 +3164,10 @@ object functions {
    * @since 2.4.0
    */
   def element_at(column: Column, value: Any): Column = withExpr {
-    ElementAt(column.expr, Literal(value))
+    value match {
+      case c: Column => ElementAt(column.expr, c.expr)
+      case _ => ElementAt(column.expr, Literal(value))
+    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3083,7 +3083,7 @@ object functions {
    */
   def array_contains(column: Column, value: Any): Column = withExpr {
     value match {
-      case c: Column => ArrayContains(column.expr, c.expr)
+      case c: Column => ArrayContains(column.expr, lit(c).expr)
       case _ => ArrayContains(column.expr, Literal(value))
     }
   }
@@ -3150,7 +3150,7 @@ object functions {
    */
   def array_position(column: Column, value: Any): Column = withExpr {
     value match {
-      case c: Column => ArrayPosition(column.expr, c.expr)
+      case c: Column => ArrayPosition(column.expr, lit(c).expr)
       case _ => ArrayPosition(column.expr, Literal(value))
     }
   }
@@ -3164,7 +3164,7 @@ object functions {
    */
   def element_at(column: Column, value: Any): Column = withExpr {
     value match {
-      case c: Column => ElementAt(column.expr, c.expr)
+      case c: Column => ElementAt(column.expr, lit(c).expr)
       case _ => ElementAt(column.expr, Literal(value))
     }
   }
@@ -3185,7 +3185,7 @@ object functions {
    */
   def array_remove(column: Column, element: Any): Column = withExpr {
     element match {
-      case c: Column => ArrayRemove(column.expr, c.expr)
+      case c: Column => ArrayRemove(column.expr, lit(c).expr)
       case _ => ArrayRemove(column.expr, Literal(element))
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3150,7 +3150,10 @@ object functions {
    * @since 2.4.0
    */
   def array_position(column: Column, value: Any): Column = withExpr {
-    ArrayPosition(column.expr, Literal(value))
+    value match {
+      case c: Column => ArrayPosition(column.expr, c.expr)
+      case _ => ArrayPosition(column.expr, Literal(value))
+    }
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -575,6 +575,10 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       df.select(array_contains(df("a"), df("c"))),
       Seq(Row(true), Row(false))
     )
+    checkAnswer(
+      df.selectExpr("array_contains(a, c)"),
+      Seq(Row(true), Row(false))
+    )
 
     // In hive, this errors because null has no type information
     intercept[AnalysisException] {
@@ -802,6 +806,10 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       Seq(Row(1L), Row(0L))
     )
     checkAnswer(
+      df.selectExpr("array_position(a, c)"),
+      Seq(Row(1L), Row(0L))
+    )
+    checkAnswer(
       df.select(array_position(df("a"), df("c"))),
       Seq(Row(1L), Row(0L))
     )
@@ -854,6 +862,10 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
     )
     checkAnswer(
       df.select(element_at(df("a"), df("b"))),
+      Seq(Row("1"), Row(""), Row(null))
+    )
+    checkAnswer(
+      df.selectExpr("element_at(a, b)"),
       Seq(Row("1"), Row(""), Row(null))
     )
 
@@ -1137,6 +1149,14 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
 
     checkAnswer(
       df.select(array_remove($"a", $"d")),
+      Seq(
+        Row(Seq(1, 3)),
+        Row(Seq.empty[Int]),
+        Row(null))
+    )
+
+    checkAnswer(
+      df.selectExpr("array_remove(a, d)"),
       Seq(
         Row(Seq(1, 3)),
         Row(Seq.empty[Int]),

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -789,9 +789,9 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
 
   test("array position function") {
     val df = Seq(
-      (Seq[Int](1, 2), "x"),
-      (Seq[Int](), "x")
-    ).toDF("a", "b")
+      (Seq[Int](1, 2), "x", 1),
+      (Seq[Int](), "x", 1)
+    ).toDF("a", "b", "c")
 
     checkAnswer(
       df.select(array_position(df("a"), 1)),
@@ -801,7 +801,10 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       df.selectExpr("array_position(a, 1)"),
       Seq(Row(1L), Row(0L))
     )
-
+    checkAnswer(
+      df.select(array_position(df("a"), df("c"))),
+      Seq(Row(1L), Row(0L))
+    )
     checkAnswer(
       df.select(array_position(df("a"), null)),
       Seq(Row(null), Row(null))

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -831,10 +831,10 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
 
   test("element_at function") {
     val df = Seq(
-      (Seq[String]("1", "2", "3")),
-      (Seq[String](null, "")),
-      (Seq[String]())
-    ).toDF("a")
+      (Seq[String]("1", "2", "3"), 1),
+      (Seq[String](null, ""), -1),
+      (Seq[String](), 2)
+    ).toDF("a", "b")
 
     intercept[Exception] {
       checkAnswer(
@@ -851,6 +851,10 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
     checkAnswer(
       df.select(element_at(df("a"), 4)),
       Seq(Row(null), Row(null), Row(null))
+    )
+    checkAnswer(
+      df.select(element_at(df("a"), df("b"))),
+      Seq(Row("1"), Row(""), Row(null))
     )
 
     checkAnswer(

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -558,9 +558,9 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
 
   test("array contains function") {
     val df = Seq(
-      (Seq[Int](1, 2), "x"),
-      (Seq[Int](), "x")
-    ).toDF("a", "b")
+      (Seq[Int](1, 2), "x", 1),
+      (Seq[Int](), "x", 1)
+    ).toDF("a", "b", "c")
 
     // Simple test cases
     checkAnswer(
@@ -569,6 +569,10 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
     )
     checkAnswer(
       df.selectExpr("array_contains(a, 1)"),
+      Seq(Row(true), Row(false))
+    )
+    checkAnswer(
+      df.select(array_contains(df("a"), df("c"))),
       Seq(Row(true), Row(false))
     )
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -1119,16 +1119,24 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
 
   test("array remove") {
     val df = Seq(
-      (Array[Int](2, 1, 2, 3), Array("a", "b", "c", "a"), Array("", "")),
-      (Array.empty[Int], Array.empty[String], Array.empty[String]),
-      (null, null, null)
-    ).toDF("a", "b", "c")
+      (Array[Int](2, 1, 2, 3), Array("a", "b", "c", "a"), Array("", ""), 2),
+      (Array.empty[Int], Array.empty[String], Array.empty[String], 2),
+      (null, null, null, 2)
+    ).toDF("a", "b", "c", "d")
     checkAnswer(
       df.select(array_remove($"a", 2), array_remove($"b", "a"), array_remove($"c", "")),
       Seq(
         Row(Seq(1, 3), Seq("b", "c"), Seq.empty[String]),
         Row(Seq.empty[Int], Seq.empty[String], Seq.empty[String]),
         Row(null, null, null))
+    )
+
+    checkAnswer(
+      df.select(array_remove($"a", $"d")),
+      Seq(
+        Row(Seq(1, 3)),
+        Row(Seq.empty[Int]),
+        Row(null))
     )
 
     checkAnswer(


### PR DESCRIPTION
## What changes were proposed in this pull request?

For the function ```def array_contains(column: Column, value: Any): Column ``` , if we pass the `value` parameter as a Column type, it will yield a runtime exception.

This PR proposes a pattern matching to detect if `value` is of type Column. If yes, it will use the .expr of the column, otherwise it will work as it used to.

Same thing for ```array_position, array_remove and element_at``` functions

## How was this patch tested?

Unit test modified to cover this code change.

Ping @ueshin 