### PR TITLE
[SPARK-24583][SQL] Wrong schema type in InsertIntoDataSourceCommand

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoDataSourceCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoDataSourceCommand.scala
@@ -38,7 +38,7 @@ case class InsertIntoDataSourceCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val relation = logicalRelation.relation.asInstanceOf[InsertableRelation]
     val data = Dataset.ofRows(sparkSession, query)
-    // Data should have been casted to the schema of the insert relation.
+    // Data has been casted to the target relation's schema by the PreprocessTableInsertion rule.
     relation.insert(data, overwrite)
 
     // Re-cache all cached plans(including this relation itself, if it's cached) that refer to this

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoDataSourceCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoDataSourceCommand.scala
@@ -39,7 +39,8 @@ case class InsertIntoDataSourceCommand(
     val relation = logicalRelation.relation.asInstanceOf[InsertableRelation]
     val data = Dataset.ofRows(sparkSession, query)
     // Apply the schema of the existing table to the new data.
-    val df = sparkSession.internalCreateDataFrame(data.queryExecution.toRdd, logicalRelation.schema)
+    val df = sparkSession.internalCreateDataFrame(
+      data.queryExecution.toRdd, logicalRelation.schema.asNullable)
     relation.insert(df, overwrite)
 
     // Re-cache all cached plans(including this relation itself, if it's cached) that refer to this

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoDataSourceCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoDataSourceCommand.scala
@@ -38,10 +38,8 @@ case class InsertIntoDataSourceCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val relation = logicalRelation.relation.asInstanceOf[InsertableRelation]
     val data = Dataset.ofRows(sparkSession, query)
-    // Apply the schema of the existing table to the new data.
-    val df = sparkSession.internalCreateDataFrame(
-      data.queryExecution.toRdd, logicalRelation.schema.asNullable)
-    relation.insert(df, overwrite)
+    // Data should have been casted to the schema of the insert relation.
+    relation.insert(data, overwrite)
 
     // Re-cache all cached plans(including this relation itself, if it's cached) that refer to this
     // data source relation.

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -31,9 +31,9 @@ import org.apache.spark.util.Utils
 
 class SimpleInsertSource extends SchemaRelationProvider {
   override def createRelation(
-    sqlContext: SQLContext,
-    parameters: Map[String, String],
-    schema: StructType): BaseRelation = {
+      sqlContext: SQLContext,
+      parameters: Map[String, String],
+      schema: StructType): BaseRelation = {
     SimpleInsert(schema)(sqlContext.sparkSession)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -561,7 +561,7 @@ class InsertSuite extends DataSourceTest with SharedSQLContext {
           compressed = false,
           properties = Map.empty),
         schema = schema,
-        provider = Some("org.apache.spark.sql.sources.SimpleInsertSource"))
+        provider = Some(classOf[SimpleInsertSource].getName))
 
       spark.sessionState.catalog.createTable(newTable, false)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change insert input schema type: "insertRelationType" -> "insertRelationType.asNullable", in order to avoid nullable being overridden.

## How was this patch tested?

Added one test in InsertSuite.