### PR TITLE
[SPARK-24578][Core] Avoid timeout at reading remote cache block

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/MessageWithHeader.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/MessageWithHeader.java
@@ -137,28 +137,11 @@ class MessageWithHeader extends AbstractFileRegion {
   }
 
   private int copyByteBuf(ByteBuf buf, WritableByteChannel target) throws IOException {
-    ByteBuffer buffer = buf.nioBuffer();
-    int written = (buffer.remaining() <= NIO_BUFFER_LIMIT) ?
-      target.write(buffer) : writeNioBuffer(target, buffer);
+    ByteBuffer buffer =
+      buf.nioBuffer(buf.readerIndex(), Math.min(buf.readableBytes(), NIO_BUFFER_LIMIT));
+    int written = target.write(buffer);
     buf.skipBytes(written);
     return written;
-  }
-
-  private int writeNioBuffer(
-      WritableByteChannel writeCh,
-      ByteBuffer buf) throws IOException {
-    int originalLimit = buf.limit();
-    int ret = 0;
-
-    try {
-      int ioSize = Math.min(buf.remaining(), NIO_BUFFER_LIMIT);
-      buf.limit(buf.position() + ioSize);
-      ret = writeCh.write(buf);
-    } finally {
-      buf.limit(originalLimit);
-    }
-
-    return ret;
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

In MessageWithHeader the copyByteBuf() method is called several times in case of huge byteBuf. If there is really huge CompositeByteBuf containing many small chunks then in the copyByteBuf method when the whole nioBuffer requested these small chunks are re-merged again and again. From this nioBuffer only just a smaller part is written to channel as there is additional buffering here.
This re-merging could took a considerable time which can cause a timeout at the client. As a result of the timeout the client closed the socket which at the sender lead to an "java.io.IOException: Broken pipe" exception.

In this PR only just the relevant nioBuffer parts are built.

## How was this patch tested?

With unit tests. 
