### PR TITLE
[SPARK-24629][SQL]thrift server memory leaks when Beeline session is closed

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -213,7 +213,7 @@ object HiveThriftServer2 extends Logging {
       } {
         onStatementCancel(statementId)
       }
-      sessionToRunningStatement.remove(sessionId)
+      runningStatement.remove(sessionId)
       onlineSessionNum -= 1
       trimSessionIfNecessary()
     }

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
@@ -251,6 +251,8 @@ private[hive] class SparkExecuteStatementOperation(
     } catch {
       case e: HiveSQLException =>
         if (getStatus().getState() == OperationState.CANCELED) {
+          setState(OperationState.CANCELED)
+          HiveThriftServer2.listener.onStatementCancel(statementId)
           return
         } else {
           setState(OperationState.ERROR)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Maintaining a running statement map.
When the session is closed, the relative statements should receive a cancel event. 

## How was this patch tested?
the attached UI show statements is successfully cancelled in UI.
<img width="1263" alt="3333" src="https://user-images.githubusercontent.com/2654887/41772001-94117874-7649-11e8-9701-6edf13593b9d.png">

Please review http://spark.apache.org/contributing.html before opening a pull request.
