### PR TITLE
[SPARK-20408][SQL] Get the glob path in parallel to reduce resolve relation time

### DIFF
--- a/core/src/main/java/org/apache/hadoop/fs/SparkGlobber.java
+++ b/core/src/main/java/org/apache/hadoop/fs/SparkGlobber.java
@@ -1,0 +1,295 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.logging.Log;
+
+/**
+ * This is based on hadoop-common-2.7.2
+ * {@link org.apache.hadoop.fs.Globber}.
+ * This class exposes globWithThreshold which can be used glob path in parallel.
+ */
+public class SparkGlobber {
+  public static final Log LOG = LogFactory.getLog(SparkGlobber.class.getName());
+
+  private final FileSystem fs;
+  private final FileContext fc;
+  private final Path pathPattern;
+
+  public SparkGlobber(FileSystem fs, Path pathPattern) {
+    this.fs = fs;
+    this.fc = null;
+    this.pathPattern = pathPattern;
+  }
+
+  public SparkGlobber(FileContext fc, Path pathPattern) {
+    this.fs = null;
+    this.fc = fc;
+    this.pathPattern = pathPattern;
+  }
+
+  private FileStatus getFileStatus(Path path) throws IOException {
+    try {
+      if (fs != null) {
+        return fs.getFileStatus(path);
+      } else {
+        return fc.getFileStatus(path);
+      }
+    } catch (FileNotFoundException e) {
+      return null;
+    }
+  }
+
+  private FileStatus[] listStatus(Path path) throws IOException {
+    try {
+      if (fs != null) {
+        return fs.listStatus(path);
+      } else {
+        return fc.util().listStatus(path);
+      }
+    } catch (FileNotFoundException e) {
+      return new FileStatus[0];
+    }
+  }
+
+  private Path fixRelativePart(Path path) {
+    if (fs != null) {
+      return fs.fixRelativePart(path);
+    } else {
+      return fc.fixRelativePart(path);
+    }
+  }
+
+  /**
+   * Convert a path component that contains backslash ecape sequences to a
+   * literal string.  This is necessary when you want to explicitly refer to a
+   * path that contains globber metacharacters.
+   */
+  private static String unescapePathComponent(String name) {
+    return name.replaceAll("\\\\(.)", "$1");
+  }
+
+  /**
+   * Translate an absolute path into a list of path components.
+   * We merge double slashes into a single slash here.
+   * POSIX root path, i.e. '/', does not get an entry in the list.
+   */
+  private static List<String> getPathComponents(String path)
+      throws IOException {
+    ArrayList<String> ret = new ArrayList<String>();
+    for (String component : path.split(Path.SEPARATOR)) {
+      if (!component.isEmpty()) {
+        ret.add(component);
+      }
+    }
+    return ret;
+  }
+
+  private String schemeFromPath(Path path) throws IOException {
+    String scheme = path.toUri().getScheme();
+    if (scheme == null) {
+      if (fs != null) {
+        scheme = fs.getUri().getScheme();
+      } else {
+        scheme = fc.getFSofPath(fc.fixRelativePart(path)).
+            getUri().getScheme();
+      }
+    }
+    return scheme;
+  }
+
+  private String authorityFromPath(Path path) throws IOException {
+    String authority = path.toUri().getAuthority();
+    if (authority == null) {
+      if (fs != null) {
+        authority = fs.getUri().getAuthority();
+      } else {
+        authority = fc.getFSofPath(fc.fixRelativePart(path)).
+            getUri().getAuthority();
+      }
+    }
+    return authority ;
+  }
+
+  public FileStatus[] globWithThreshold(int threshold) throws IOException {
+    // First we get the scheme and authority of the pattern that was passed
+    // in.
+    String scheme = schemeFromPath(pathPattern);
+    String authority = authorityFromPath(pathPattern);
+
+    // Next we strip off everything except the pathname itself, and expand all
+    // globs.  Expansion is a process which turns "grouping" clauses,
+    // expressed as brackets, into separate path patterns.
+    String pathPatternString = pathPattern.toUri().getPath();
+    List<String> flattenedPatterns = GlobExpander.expand(pathPatternString);
+
+    // Now loop over all flattened patterns.  In every case, we'll be trying to
+    // match them to entries in the filesystem.
+    ArrayList<FileStatus> results =
+        new ArrayList<FileStatus>(flattenedPatterns.size());
+    boolean sawWildcard = false;
+    for (String flatPattern : flattenedPatterns) {
+      // Get the absolute path for this flattened pattern.  We couldn't do
+      // this prior to flattening because of patterns like {/,a}, where which
+      // path you go down influences how the path must be made absolute.
+      Path absPattern = fixRelativePart(new Path(
+          flatPattern.isEmpty() ? Path.CUR_DIR : flatPattern));
+      // Now we break the flattened, absolute pattern into path components.
+      // For example, /a/*/c would be broken into the list [a, *, c]
+      List<String> components =
+          getPathComponents(absPattern.toUri().getPath());
+      // Starting out at the root of the filesystem, we try to match
+      // filesystem entries against pattern components.
+      ArrayList<FileStatus> candidates = new ArrayList<FileStatus>(1);
+      // To get the "real" FileStatus of root, we'd have to do an expensive
+      // RPC to the NameNode.  So we create a placeholder FileStatus which has
+      // the correct path, but defaults for the rest of the information.
+      // Later, if it turns out we actually want the FileStatus of root, we'll
+      // replace the placeholder with a real FileStatus obtained from the
+      // NameNode.
+      FileStatus rootPlaceholder;
+      if (Path.WINDOWS && !components.isEmpty()
+          && Path.isWindowsAbsolutePath(absPattern.toUri().getPath(), true)) {
+        // On Windows the path could begin with a drive letter, e.g. /E:/foo.
+        // We will skip matching the drive letter and start from listing the
+        // root of the filesystem on that drive.
+        String driveLetter = components.remove(0);
+        rootPlaceholder = new FileStatus(0, true, 0, 0, 0, new Path(scheme,
+            authority, Path.SEPARATOR + driveLetter + Path.SEPARATOR));
+      } else {
+        rootPlaceholder = new FileStatus(0, true, 0, 0, 0,
+            new Path(scheme, authority, Path.SEPARATOR));
+      }
+      candidates.add(rootPlaceholder);
+
+      for (int componentIdx = 0; componentIdx < components.size();
+         componentIdx++) {
+        ArrayList<FileStatus> newCandidates =
+            new ArrayList<FileStatus>(candidates.size());
+        GlobFilter globFilter = new GlobFilter(components.get(componentIdx));
+        String component = unescapePathComponent(components.get(componentIdx));
+        if (globFilter.hasPattern()) {
+          sawWildcard = true;
+        }
+        if (candidates.isEmpty() && sawWildcard) {
+          // Optimization: if there are no more candidates left, stop examining
+          // the path components.  We can only do this if we've already seen
+          // a wildcard component-- otherwise, we still need to visit all path
+          // components in case one of them is a wildcard.
+          break;
+        }
+        if ((componentIdx < components.size() - 1) &&
+            (!globFilter.hasPattern())) {
+          // Optimization: if this is not the terminal path component, and we
+          // are not matching against a glob, assume that it exists.  If it
+          // doesn't exist, we'll find out later when resolving a later glob
+          // or the terminal path component.
+          for (FileStatus candidate : candidates) {
+            candidate.setPath(new Path(candidate.getPath(), component));
+          }
+          continue;
+        }
+        for (FileStatus candidate : candidates) {
+          if (globFilter.hasPattern()) {
+            FileStatus[] children = listStatus(candidate.getPath());
+            if (children.length == 1) {
+              // If we get back only one result, this could be either a listing
+              // of a directory with one entry, or it could reflect the fact
+              // that what we listed resolved to a file.
+              //
+              // Unfortunately, we can't just compare the returned paths to
+              // figure this out.  Consider the case where you have /a/b, where
+              // b is a symlink to "..".  In that case, listing /a/b will give
+              // back "/a/b" again.  If we just went by returned pathname, we'd
+              // incorrectly conclude that /a/b was a file and should not match
+              // /a/*/*.  So we use getFileStatus of the path we just listed to
+              // disambiguate.
+              if (!getFileStatus(candidate.getPath()).isDirectory()) {
+                continue;
+              }
+            }
+            for (FileStatus child : children) {
+              if (componentIdx < components.size() - 1) {
+                // Don't try to recurse into non-directories.  See HADOOP-10957.
+                if (!child.isDirectory()) continue;
+              }
+              // Set the child path based on the parent path.
+              child.setPath(new Path(candidate.getPath(),
+                  child.getPath().getName()));
+              if (globFilter.accept(child.getPath())) {
+                newCandidates.add(child);
+              }
+            }
+          } else {
+            // When dealing with non-glob components, use getFileStatus
+            // instead of listStatus.  This is an optimization, but it also
+            // is necessary for correctness in HDFS, since there are some
+            // special HDFS directories like .reserved and .snapshot that are
+            // not visible to listStatus, but which do exist.  (See HADOOP-9877)
+            FileStatus childStatus = getFileStatus(
+                new Path(candidate.getPath(), component));
+            if (childStatus != null) {
+              newCandidates.add(childStatus);
+            }
+          }
+        }
+        candidates = newCandidates;
+        // When size of candidates has reached the threshold, stop expanding other
+        // components and add them to candidates.
+        if (candidates.size() >= threshold && componentIdx + 1 != components.size()) {
+          String restPath = StringUtils.join(
+              components.subList(componentIdx + 1, components.size()), "/");
+          for (FileStatus candidate : candidates) {
+            candidate.setPath(new Path(candidate.getPath(), restPath));
+          }
+          break;
+        }
+      }
+      for (FileStatus status : candidates) {
+        // Use object equality to see if this status is the root placeholder.
+        // See the explanation for rootPlaceholder above for more information.
+        if (status == rootPlaceholder) {
+          status = getFileStatus(rootPlaceholder.getPath());
+          if (status == null) continue;
+        }
+        results.add(status);
+      }
+    }
+    /*
+     * When the input pattern "looks" like just a simple filename, and we
+     * can't find it, we return null rather than an empty array.
+     * This is a special case which the shell relies on.
+     *
+     * To be more precise: if there were no results, AND there were no
+     * groupings (aka brackets), and no wildcards in the input (aka stars),
+     * we return null.
+     */
+    if ((!sawWildcard) && results.isEmpty() &&
+        (flattenedPatterns.size() <= 1)) {
+      return null;
+    }
+    return results.toArray(new FileStatus[0]);
+  }
+}

--- a/core/src/main/java/org/apache/hadoop/fs/SparkGlobber.java
+++ b/core/src/main/java/org/apache/hadoop/fs/SparkGlobber.java
@@ -113,8 +113,7 @@ public class SparkGlobber {
       if (fs != null) {
         scheme = fs.getUri().getScheme();
       } else {
-        scheme = fc.getFSofPath(fc.fixRelativePart(path)).
-            getUri().getScheme();
+        scheme = fc.getFSofPath(fc.fixRelativePart(path)).getUri().getScheme();
       }
     }
     return scheme;
@@ -126,8 +125,7 @@ public class SparkGlobber {
       if (fs != null) {
         authority = fs.getUri().getAuthority();
       } else {
-        authority = fc.getFSofPath(fc.fixRelativePart(path)).
-            getUri().getAuthority();
+        authority = fc.getFSofPath(fc.fixRelativePart(path)).getUri().getAuthority();
       }
     }
     return authority ;

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -255,6 +255,18 @@ class SparkHadoopUtil extends Logging {
     if (isGlobPath(pattern)) globPath(fs, pattern) else Seq(pattern)
   }
 
+  def expandGlobPath(fs: FileSystem, pattern: Path): Seq[String] = {
+    val arr = pattern.toString.split("/")
+    val firstIdx = arr.indexWhere(_.exists("{}[]*?\\".toSet.contains))
+    if (isGlobPath(pattern) && firstIdx != arr.length - 1) {
+      val parentPath = arr.slice(0, firstIdx + 1).mkString("/")
+      Option(fs.globStatus(new Path(parentPath))).map{ statuses =>
+        statuses.map(_.getPath.makeQualified(fs.getUri, fs.getWorkingDirectory).toString
+          + "/" + arr.slice(firstIdx + 1, arr.length).mkString("/")).toSeq
+      }.getOrElse(Seq.empty[String])
+    } else Seq(pattern.toString)
+  }
+
   /**
    * Lists all the files in a directory with the specified prefix, and does not end with the
    * given suffix. The returned {{FileStatus}} instances are sorted by the modification times of

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -256,10 +256,14 @@ class SparkHadoopUtil extends Logging {
   }
 
   def expandGlobPath(fs: FileSystem, pattern: Path, threshold: Int): Seq[Path] = {
-    val sparkGlobber = new SparkGlobber(fs, pattern)
-    Option(sparkGlobber.globWithThreshold(threshold)).map { statuses =>
-      statuses.map(_.getPath.makeQualified(fs.getUri, fs.getWorkingDirectory)).toSeq
-    }.getOrElse(Seq.empty[Path])
+    if (isGlobPath(pattern)) {
+      val sparkGlobber = new SparkGlobber(fs, pattern)
+      Option(sparkGlobber.globWithThreshold(threshold)).map { statuses =>
+        statuses.map(_.getPath.makeQualified(fs.getUri, fs.getWorkingDirectory)).toSeq
+      }.getOrElse(Seq.empty[Path])
+    } else {
+      Seq(pattern)
+    }
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
@@ -20,14 +20,13 @@ package org.apache.spark.deploy
 import java.io.File
 
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
-import org.apache.hadoop.fs.permission.{FsAction, FsPermission}
+import org.apache.hadoop.fs.{FileSystem, Path}
 import org.scalatest.Matchers
 
 import org.apache.spark.{LocalSparkContext, SparkFunSuite}
 import org.apache.spark.util.Utils
 
-class SparkHadoopUtilSuite extends SparkFunSuite with Matchers with LocalSparkContext{
+class SparkHadoopUtilSuite extends SparkFunSuite with Matchers with LocalSparkContext {
   test("test expanding glob path") {
     val tmpDir = Utils.createTempDir()
     val rootDir = tmpDir.getCanonicalPath
@@ -71,23 +70,5 @@ class SparkHadoopUtilSuite extends SparkFunSuite with Matchers with LocalSparkCo
       sparkHadoopUtil.expandGlobPath(fs, new Path(s"$rootDir/000[1-5]/*"), 10) should be(
         Seq.empty[Path])
     } finally Utils.deleteRecursively(tmpDir)
-  }
-
-  private def fileStatus(
-      owner: String,
-      group: String,
-      userAction: FsAction,
-      groupAction: FsAction,
-      otherAction: FsAction): FileStatus = {
-    new FileStatus(0L,
-      false,
-      0,
-      0L,
-      0L,
-      0L,
-      new FsPermission(userAction, groupAction, otherAction),
-      owner,
-      group,
-      null)
   }
 }

--- a/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
@@ -117,7 +117,7 @@ class SparkHadoopUtilSuite extends SparkFunSuite with Matchers with LocalSparkCo
 
       // test path is not globPath
       sparkHadoopUtil.expandGlobPath(fs, new Path(s"$rootDir/dir-0001/part-0001"), 10) should
-        be(Seq(new Path(s"file:$rootDir/dir-0001/part-0001")))
+        be(Seq(new Path(s"$rootDir/dir-0001/part-0001")))
 
       // test the wrong wild cast
       sparkHadoopUtil.expandGlobPath(fs, new Path(s"$rootDir/000[1-5]/*"), 10) should be(

--- a/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy
+
+import java.io.File
+import java.security.PrivilegedExceptionAction
+
+import scala.util.Random
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
+import org.apache.hadoop.fs.permission.{FsAction, FsPermission}
+import org.apache.hadoop.security.UserGroupInformation
+import org.scalatest.Matchers
+
+import org.apache.spark.{LocalSparkContext, SparkFunSuite}
+import org.apache.spark.util.Utils
+
+class SparkHadoopUtilSuite extends SparkFunSuite with Matchers with LocalSparkContext{
+  test("check file permission") {
+    import FsAction._
+    val testUser = s"user-${Random.nextInt(100)}"
+    val testGroups = Array(s"group-${Random.nextInt(100)}")
+    val testUgi = UserGroupInformation.createUserForTesting(testUser, testGroups)
+
+    testUgi.doAs(new PrivilegedExceptionAction[Void] {
+      override def run(): Void = {
+        val sparkHadoopUtil = new SparkHadoopUtil
+
+        // If file is owned by user and user has access permission
+        var status = fileStatus(testUser, testGroups.head, READ_WRITE, READ_WRITE, NONE)
+        sparkHadoopUtil.checkAccessPermission(status, READ) should be(true)
+        sparkHadoopUtil.checkAccessPermission(status, WRITE) should be(true)
+
+        // If file is owned by user but user has no access permission
+        status = fileStatus(testUser, testGroups.head, NONE, READ_WRITE, NONE)
+        sparkHadoopUtil.checkAccessPermission(status, READ) should be(false)
+        sparkHadoopUtil.checkAccessPermission(status, WRITE) should be(false)
+
+        val otherUser = s"test-${Random.nextInt(100)}"
+        val otherGroup = s"test-${Random.nextInt(100)}"
+
+        // If file is owned by user's group and user's group has access permission
+        status = fileStatus(otherUser, testGroups.head, NONE, READ_WRITE, NONE)
+        sparkHadoopUtil.checkAccessPermission(status, READ) should be(true)
+        sparkHadoopUtil.checkAccessPermission(status, WRITE) should be(true)
+
+        // If file is owned by user's group but user's group has no access permission
+        status = fileStatus(otherUser, testGroups.head, READ_WRITE, NONE, NONE)
+        sparkHadoopUtil.checkAccessPermission(status, READ) should be(false)
+        sparkHadoopUtil.checkAccessPermission(status, WRITE) should be(false)
+
+        // If file is owned by other user and this user has access permission
+        status = fileStatus(otherUser, otherGroup, READ_WRITE, READ_WRITE, READ_WRITE)
+        sparkHadoopUtil.checkAccessPermission(status, READ) should be(true)
+        sparkHadoopUtil.checkAccessPermission(status, WRITE) should be(true)
+
+        // If file is owned by other user but this user has no access permission
+        status = fileStatus(otherUser, otherGroup, READ_WRITE, READ_WRITE, NONE)
+        sparkHadoopUtil.checkAccessPermission(status, READ) should be(false)
+        sparkHadoopUtil.checkAccessPermission(status, WRITE) should be(false)
+
+        null
+      }
+    })
+  }
+
+  test("test expanding glob path") {
+    val tmpDir = Utils.createTempDir()
+    val rootDir = tmpDir.getCanonicalPath
+    try {
+      // Prepare nested dir env: /tmpPath/dir-${dirIndex}/part-${fileIndex}
+      for (i <- 1 to 10) {
+        val dirStr = new StringFormat(i.toString)
+        val curDir = rootDir + dirStr.formatted("/dir-%4s").replaceAll(" ", "0")
+        for (j <- 1 to 10) {
+          val fileStr = new StringFormat(j.toString)
+          val file = new File(curDir, fileStr.formatted("/part-%4s").replaceAll(" ", "0"))
+
+          file.getParentFile.exists() || file.getParentFile.mkdirs()
+          file.createNewFile()
+        }
+      }
+      val sparkHadoopUtil = new SparkHadoopUtil
+      val fs = FileSystem.getLocal(new Configuration())
+
+      // test partial match
+      sparkHadoopUtil.expandGlobPath(fs, new Path(s"${rootDir}/dir-000[1-5]/*")) should be(Seq(
+        s"file:${rootDir}/dir-0001/*",
+        s"file:${rootDir}/dir-0002/*",
+        s"file:${rootDir}/dir-0003/*",
+        s"file:${rootDir}/dir-0004/*",
+        s"file:${rootDir}/dir-0005/*"))
+      // test wild cast on the leaf files
+      sparkHadoopUtil.expandGlobPath(fs, new Path(s"${rootDir}/dir-0001/*")) should be(Seq(
+        s"${rootDir}/dir-0001/*"))
+      // test path is not globPath
+      sparkHadoopUtil.expandGlobPath(fs, new Path(s"${rootDir}/dir-0001/part-0001")) should be(Seq(
+        s"${rootDir}/dir-0001/part-0001"))
+      // test the wrong wild cast
+      sparkHadoopUtil.expandGlobPath(fs, new Path(s"${rootDir}/000[1-5]/*")) should be(
+        Seq.empty[String])
+    } finally Utils.deleteRecursively(tmpDir)
+  }
+
+  private def fileStatus(
+      owner: String,
+      group: String,
+      userAction: FsAction,
+      groupAction: FsAction,
+      otherAction: FsAction): FileStatus = {
+    new FileStatus(0L,
+      false,
+      0,
+      0L,
+      0L,
+      0L,
+      new FsPermission(userAction, groupAction, otherAction),
+      owner,
+      group,
+      null)
+  }
+}

--- a/examples/src/main/scala/org/apache/spark/examples/sql/SparkSQLExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/SparkSQLExample.scala
@@ -49,6 +49,9 @@ object SparkSQLExample {
     runInferSchemaExample(spark)
     runProgrammaticSchemaExample(spark)
 
+    val df = spark.read.json("examples/src/main/resources/a/b{0,1}/*/*")
+    df.show()
+
     spark.stop()
   }
 

--- a/examples/src/main/scala/org/apache/spark/examples/sql/SparkSQLExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/SparkSQLExample.scala
@@ -49,9 +49,6 @@ object SparkSQLExample {
     runInferSchemaExample(spark)
     runProgrammaticSchemaExample(spark)
 
-    val df = spark.read.json("examples/src/main/resources/a/b{0,1}/*/*")
-    df.show()
-
     spark.stop()
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1832,9 +1832,6 @@ class SQLConf extends Serializable with Logging {
   def parallelGetGlobbedPathNumThreads: Int =
     getConf(SQLConf.PARALLEL_GET_GLOBBED_PATH_NUM_THREADS)
 
-  def parallelGetGlobbedPathEnabled: Boolean =
-    parallelGetGlobbedPathNumThreads > 0
-
   def bucketingEnabled: Boolean = getConf(SQLConf.BUCKETING_ENABLED)
 
   def bucketingMaxBuckets: Int = getConf(SQLConf.BUCKETING_MAX_BUCKETS)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -737,6 +737,16 @@ object SQLConf {
       .intConf
       .createWithDefault(10000)
 
+  val PARALLEL_GET_GLOBBED_PATH_THRESHOLD =
+    buildConf("spark.sql.sources.parallelGetGlobbedPath.threshold")
+      .doc("The maximum number of subfiles or directories allowed after a globbed path " +
+        "expansion. If the number of paths exceeds this value during expansion, it tries to " +
+        "expand the globbed in parallel with multi-thread.")
+      .intConf
+      .checkValue(threshlod => threshlod >= 0, "The maximum number of subfiles or directories " +
+        "must not be negative")
+      .createWithDefault(32)
+
   val PARALLEL_GET_GLOBBED_PATH_PARALLELISM =
     buildConf("spark.sql.sources.parallelGetGlobbedPath.parallelism")
       .doc("The number of threads to get a collection of path in parallel. Set the " +
@@ -1815,6 +1825,9 @@ class SQLConf extends Serializable with Logging {
 
   def parallelPartitionDiscoveryParallelism: Int =
     getConf(SQLConf.PARALLEL_PARTITION_DISCOVERY_PARALLELISM)
+
+  def parallelGetGlobbedPathThreshold: Int =
+    getConf(SQLConf.PARALLEL_GET_GLOBBED_PATH_THRESHOLD)
 
   def parallelGetGlobbedPathParallelism: Int =
     getConf(SQLConf.PARALLEL_GET_GLOBBED_PATH_PARALLELISM)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -747,8 +747,8 @@ object SQLConf {
         "must not be negative")
       .createWithDefault(32)
 
-  val PARALLEL_GET_GLOBBED_PATH_PARALLELISM =
-    buildConf("spark.sql.sources.parallelGetGlobbedPath.parallelism")
+  val PARALLEL_GET_GLOBBED_PATH_NUM_THREADS =
+    buildConf("spark.sql.sources.parallelGetGlobbedPath.numThreads")
       .doc("The number of threads to get a collection of path in parallel. Set the " +
         "number to avoid generating too many threads.")
       .intConf
@@ -1829,8 +1829,8 @@ class SQLConf extends Serializable with Logging {
   def parallelGetGlobbedPathThreshold: Int =
     getConf(SQLConf.PARALLEL_GET_GLOBBED_PATH_THRESHOLD)
 
-  def parallelGetGlobbedPathParallelism: Int =
-    getConf(SQLConf.PARALLEL_GET_GLOBBED_PATH_PARALLELISM)
+  def parallelGetGlobbedPathNumThreads: Int =
+    getConf(SQLConf.PARALLEL_GET_GLOBBED_PATH_NUM_THREADS)
 
   def bucketingEnabled: Boolean = getConf(SQLConf.BUCKETING_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -737,6 +737,15 @@ object SQLConf {
       .intConf
       .createWithDefault(10000)
 
+  val PARALLEL_GET_GLOBBED_PATH_PARALLELISM =
+    buildConf("spark.sql.sources.parallelGetGlobbedPath.parallelism")
+      .doc("The number of threads to get a collection of path in parallel. Set the " +
+        "number to avoid generating too many threads.")
+      .intConf
+      .checkValue(parallel => parallel >= 0, "The maximum number of threads allowed for getting " +
+        "globbed paths at driver side must not be negative")
+      .createWithDefault(32)
+
   // Whether to automatically resolve ambiguity in join conditions for self-joins.
   // See SPARK-6231.
   val DATAFRAME_SELF_JOIN_AUTO_RESOLVE_AMBIGUITY =
@@ -1806,6 +1815,9 @@ class SQLConf extends Serializable with Logging {
 
   def parallelPartitionDiscoveryParallelism: Int =
     getConf(SQLConf.PARALLEL_PARTITION_DISCOVERY_PARALLELISM)
+
+  def parallelGetGlobbedPathParallelism: Int =
+    getConf(SQLConf.PARALLEL_GET_GLOBBED_PATH_PARALLELISM)
 
   def bucketingEnabled: Boolean = getConf(SQLConf.BUCKETING_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -740,21 +740,21 @@ object SQLConf {
   val PARALLEL_GET_GLOBBED_PATH_THRESHOLD =
     buildConf("spark.sql.sources.parallelGetGlobbedPath.threshold")
       .doc("The maximum number of subfiles or directories allowed after a globbed path " +
-        "expansion. If the number of paths exceeds this value during expansion, it tries to " +
-        "expand the globbed in parallel with multi-thread.")
+        "expansion.")
       .intConf
-      .checkValue(threshlod => threshlod >= 0, "The maximum number of subfiles or directories " +
+      .checkValue(threshold => threshold >= 0, "The maximum number of subfiles or directories " +
         "must not be negative")
       .createWithDefault(32)
 
   val PARALLEL_GET_GLOBBED_PATH_NUM_THREADS =
     buildConf("spark.sql.sources.parallelGetGlobbedPath.numThreads")
       .doc("The number of threads to get a collection of path in parallel. Set the " +
-        "number to avoid generating too many threads.")
+        "number to avoid generating too many threads. The default value 0 means the parallel" +
+        "mode is closed by default.")
       .intConf
       .checkValue(parallel => parallel >= 0, "The maximum number of threads allowed for getting " +
         "globbed paths at driver side must not be negative")
-      .createWithDefault(32)
+      .createWithDefault(0)
 
   // Whether to automatically resolve ambiguity in join conditions for self-joins.
   // See SPARK-6231.
@@ -1831,6 +1831,9 @@ class SQLConf extends Serializable with Logging {
 
   def parallelGetGlobbedPathNumThreads: Int =
     getConf(SQLConf.PARALLEL_GET_GLOBBED_PATH_NUM_THREADS)
+
+  def parallelGetGlobbedPathEnabled: Boolean =
+    parallelGetGlobbedPathNumThreads > 0
 
   def bucketingEnabled: Boolean = getConf(SQLConf.BUCKETING_ENABLED)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -543,7 +543,7 @@ case class DataSource(
       val hdfsPath = new Path(path)
       val fs = hdfsPath.getFileSystem(hadoopConf)
       val qualified = hdfsPath.makeQualified(fs.getUri, fs.getWorkingDirectory)
-      val globPath = dataSource.getGlobbedPaths(fs, qualified)
+      val globPath = DataSource.getGlobbedPaths(sparkSession, fs, hadoopConf, qualified)
 
       if (checkEmptyGlobPath && globPath.isEmpty) {
         throw new AnalysisException(s"Path does not exist: $qualified")
@@ -739,7 +739,11 @@ object DataSource extends Logging {
    * Return all paths represented by the wildcard string.
    * Follow [[InMemoryFileIndex]].bulkListLeafFile and reuse the conf.
    */
-  private def getGlobbedPaths(fs: FileSystem, qualified: Path): Seq[Path] = {
+  private def getGlobbedPaths(
+      sparkSession: SparkSession,
+      fs: FileSystem,
+      hadoopConf: SerializableConfiguration,
+      qualified: Path): Seq[Path] = {
     val paths = SparkHadoopUtil.get.expandGlobPath(fs, qualified)
     if (paths.size <= sparkSession.sessionState.conf.parallelPartitionDiscoveryThreshold) {
       SparkHadoopUtil.get.globPathIfNecessary(fs, qualified)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -750,11 +750,10 @@ object DataSource extends Logging {
     if (paths.size < getGlobbedPathThreshold) {
       SparkHadoopUtil.get.globPathIfNecessary(fs, qualified)
     } else {
-      val parallelGetGlobbedPathParallelism =
-        sparkSession.sessionState.conf.parallelGetGlobbedPathParallelism
-      val numParallelism = Math.min(paths.size, parallelGetGlobbedPathParallelism * 2)
+      val numThreads =
+        Math.min(paths.size, sparkSession.sessionState.conf.parallelGetGlobbedPathNumThreads)
       val threadPool = ThreadUtils.newDaemonCachedThreadPool(
-        "parallel-get-globbed-paths-thread-pool", numParallelism)
+        "parallel-get-globbed-paths-thread-pool", numThreads)
       val result = paths.map { path =>
         threadPool.submit(new Callable[Seq[Path]] {
           override def call(): Seq[Path] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.datasources
 
 import java.util.{Locale, ServiceConfigurationError, ServiceLoader}
+import java.util.concurrent.Callable
 
 import scala.collection.JavaConverters._
 import scala.language.{existentials, implicitConversions}
@@ -47,7 +48,7 @@ import org.apache.spark.sql.sources._
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types.{CalendarIntervalType, StructField, StructType}
 import org.apache.spark.sql.util.SchemaUtils
-import org.apache.spark.util.{SerializableConfiguration, Utils}
+import org.apache.spark.util.{ThreadUtils, Utils}
 
 /**
  * The main class responsible for representing a pluggable Data Source in Spark SQL. In addition to
@@ -737,26 +738,33 @@ object DataSource extends Logging {
 
   /**
    * Return all paths represented by the wildcard string.
-   * Follow [[InMemoryFileIndex]].bulkListLeafFile and reuse the conf.
+   * Use a local thread pool to do this while there's too many paths.
    */
   private def getGlobbedPaths(
       sparkSession: SparkSession,
       fs: FileSystem,
-      hadoopConf: SerializableConfiguration,
+      hadoopConf: Configuration,
       qualified: Path): Seq[Path] = {
     val paths = SparkHadoopUtil.get.expandGlobPath(fs, qualified)
-    if (paths.size <= sparkSession.sessionState.conf.parallelPartitionDiscoveryThreshold) {
+    if (paths.size < sparkSession.sessionState.conf.parallelGetGlobbedPathParallelism) {
       SparkHadoopUtil.get.globPathIfNecessary(fs, qualified)
     } else {
-      val parallelPartitionDiscoveryParallelism =
-        sparkSession.sessionState.conf.parallelPartitionDiscoveryParallelism
-      val numParallelism = Math.min(paths.size, parallelPartitionDiscoveryParallelism)
-      val expanded = sparkSession.sparkContext
-        .parallelize(paths, numParallelism)
-        .map { pathString =>
-          SparkHadoopUtil.get.globPathIfNecessary(fs, new Path(pathString)).map(_.toString)
-        }.collect()
-      expanded.flatMap(paths => paths.map(new Path(_))).toSeq
+      val parallelGetGlobbedPathParallelism =
+        sparkSession.sessionState.conf.parallelGetGlobbedPathParallelism
+      val numParallelism = Math.min(paths.size, parallelGetGlobbedPathParallelism * 2)
+      val threadPool = ThreadUtils.newDaemonCachedThreadPool(
+        "parallel-get-globbed-paths-thread-pool", numParallelism)
+      val result = paths.map { pathStr =>
+        threadPool.submit(new Callable[Seq[Path]] {
+          override def call(): Seq[Path] = {
+            val path = new Path(pathStr)
+            val fs = path.getFileSystem(hadoopConf)
+            SparkHadoopUtil.get.globPathIfNecessary(fs, path)
+          }
+        })
+      }.flatMap(_.get)
+      threadPool.shutdownNow()
+      result
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -47,7 +47,7 @@ import org.apache.spark.sql.sources._
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types.{CalendarIntervalType, StructField, StructType}
 import org.apache.spark.sql.util.SchemaUtils
-import org.apache.spark.util.Utils
+import org.apache.spark.util.{SerializableConfiguration, Utils}
 
 /**
  * The main class responsible for representing a pluggable Data Source in Spark SQL. In addition to
@@ -543,7 +543,7 @@ case class DataSource(
       val hdfsPath = new Path(path)
       val fs = hdfsPath.getFileSystem(hadoopConf)
       val qualified = hdfsPath.makeQualified(fs.getUri, fs.getWorkingDirectory)
-      val globPath = getGlobbedPaths(fs, qualified)
+      val globPath = dataSource.getGlobbedPaths(fs, qualified)
 
       if (checkEmptyGlobPath && globPath.isEmpty) {
         throw new AnalysisException(s"Path does not exist: $qualified")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR change the work of getting glob path in parallel, which can make complex wildcard path more quickly, the mainly changes in details:
1.Add new function getGlobbedPaths in DataSource, return all paths represented by the wildcard pattern, use a local thread pool to do this while the paths number expanded from patten lager than `spark.sql.sources.parallelGetGlobbedPath.threshold`. The local thread pool size controlled by `spark.sql.sources.parallelGetGlobbedPath.numThreads`
2.Add new function expandGlobPath in SparkHadoopUtil, to expand the dir represented by the patten, here we mainly reuse the logic in org.apache.hadoop.fs.Globber.glob().

## How was this patch tested?

Add UT in SparkHadoopUtilSuite.
