### PR TITLE
[SPARK-23776][DOC] Update instructions for running PySpark after building with SBT

### DIFF
--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -225,7 +225,7 @@ If you are building PySpark and wish to run the PySpark tests you will need to b
 If you are building PySpark with SBT and wish to run the PySpark tests, you will need to build Spark with Hive support and also build the test components:
 
     ./build/sbt -Phive clean package
-    ./build/sbt sql/test:compile
+    ./build/sbt test:compile
     ./python/run-tests
 
 The run-tests script also can be limited to a specific Python version or a specific module

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -215,18 +215,22 @@ If you are building Spark for use in a Python environment and you wish to pip in
 
 Alternatively, you can also run make-distribution with the --pip option.
 
-## PySpark Tests with Maven
+## PySpark Tests with Maven or SBT
 
 If you are building PySpark and wish to run the PySpark tests you will need to build Spark with Hive support.
 
     ./build/mvn -DskipTests clean package -Phive
     ./python/run-tests
 
+If you are building PySpark with SBT and wish to run the PySpark tests, you will need to build Spark with Hive support and also build the test components:
+
+    ./build/sbt -Phive clean package
+    ./build/sbt sql/test:compile
+    ./python/run-tests
+
 The run-tests script also can be limited to a specific Python version or a specific module
 
     ./python/run-tests --python-executables=python --modules=pyspark-sql
-
-**Note:** You can also run Python tests with an sbt build, provided you build Spark with Hive support.
 
 ## Running R Tests
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This update tells the reader how to build Spark with SBT such that pyspark-sql tests will succeed.

If you follow the current instructions for building Spark with SBT, pyspark/sql/udf.py fails with:
<pre>
AnalysisException: u'Can not load class test.org.apache.spark.sql.JavaStringLength, please make sure it is on the classpath;'
</pre>

## How was this patch tested?

I ran the doc build command (SKIP_API=1 jekyll build) and eyeballed the result.
