### PR TITLE
[SPARK-24648][SQL] SqlMetrics should be threadsafe

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -19,12 +19,12 @@ package org.apache.spark.sql.execution.metric
 
 import java.io.File
 
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 import scala.util.Random
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
-import org.apache.spark.sql.execution.ui.SQLAppStatusStore
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
@@ -503,5 +503,39 @@ class SQLMetricsSuite extends SparkFunSuite with SQLMetricsTestUtils with Shared
 
   test("writing data out metrics with dynamic partition: parquet") {
     testMetricsDynamicPartition("parquet", "parquet", "t1")
+  }
+
+  test("writing metrics from single thread") {
+    val nAdds = 10
+    val acc = new SQLMetric("test", -10)
+    assert(acc.isZero())
+    acc.set(0)
+    for (i <- 1 to nAdds) acc.add(1)
+    assert(!acc.isZero())
+    assert(nAdds === acc.value)
+    acc.reset()
+    assert(acc.isZero())
+  }
+
+  test("writing metrics from multiple threads") {
+    implicit val ec: ExecutionContextExecutor = ExecutionContext.global
+    val nThreads = 1000
+    val nAdds = 100
+    val acc = new SQLMetric("test", -10)
+    assert(acc.isZero() === true)
+    acc.set(0)
+    val l = for ( i <- 1 to nThreads ) yield {
+      Future {
+        for (j <- 1 to nAdds) acc.add(1)
+        i
+      }
+    }
+    for (futures <- Future.sequence(l)) {
+      assert(nThreads === futures.length)
+      assert(!acc.isZero())
+      assert(nThreads * nAdds === acc.value)
+      acc.reset()
+      assert(acc.isZero())
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -519,21 +519,21 @@ class SQLMetricsSuite extends SparkFunSuite with SQLMetricsTestUtils with Shared
 
   test("writing metrics from multiple threads") {
     implicit val ec: ExecutionContextExecutor = ExecutionContext.global
-    val nThreads = 1000
+    val nFutures = 1000
     val nAdds = 100
     val acc = new SQLMetric("test", -10)
     assert(acc.isZero() === true)
     acc.set(0)
-    val l = for ( i <- 1 to nThreads ) yield {
+    val l = for ( i <- 1 to nFutures ) yield {
       Future {
         for (j <- 1 to nAdds) acc.add(1)
         i
       }
     }
     for (futures <- Future.sequence(l)) {
-      assert(nThreads === futures.length)
+      assert(nFutures === futures.length)
       assert(!acc.isZero())
-      assert(nThreads * nAdds === acc.value)
+      assert(nFutures * nAdds === acc.value)
       acc.reset()
       assert(acc.isZero())
     }


### PR DESCRIPTION
Use LongAdder to make SQLMetrics thread safe.

## What changes were proposed in this pull request?
Replace += with LongAdder.add() for concurrent counting

## How was this patch tested?
Unit tests with local threads
