### PR TITLE
[SPARK-24624][SQL][PYTHON] Support mixture of Python UDF and Scalar Pandas UDF

### DIFF
--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -5051,7 +5051,7 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
 
     def test_mixed_udf(self):
         import pandas as pd
-        from pyspark.sql.functions import udf, pandas_udf
+        from pyspark.sql.functions import col, udf, pandas_udf
 
         df = self.spark.range(0, 1).toDF('v')
 
@@ -5078,55 +5078,58 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
             return x + 1000
 
         # Test mixed udfs in a single projection
-        df1 = df.withColumn('f1', f1(df['v']))
-        df1 = df1.withColumn('f2', f2(df1['v']))
-        df1 = df1.withColumn('f3', f3(df1['v']))
-        df1 = df1.withColumn('f4', f4(df1['v']))
-        df1 = df1.withColumn('f2_f1', f2(df1['f1']))
-        df1 = df1.withColumn('f3_f1', f3(df1['f1']))
-        df1 = df1.withColumn('f4_f1', f4(df1['f1']))
-        df1 = df1.withColumn('f3_f2', f3(df1['f2']))
-        df1 = df1.withColumn('f4_f2', f4(df1['f2']))
-        df1 = df1.withColumn('f4_f3', f4(df1['f3']))
-        df1 = df1.withColumn('f3_f2_f1', f3(df1['f2_f1']))
-        df1 = df1.withColumn('f4_f2_f1', f4(df1['f2_f1']))
-        df1 = df1.withColumn('f4_f3_f1', f4(df1['f3_f1']))
-        df1 = df1.withColumn('f4_f3_f2', f4(df1['f3_f2']))
-        df1 = df1.withColumn('f4_f3_f2_f1', f4(df1['f3_f2_f1']))
+        df1 = df \
+            .withColumn('f1', f1(col('v'))) \
+            .withColumn('f2', f2(col('v'))) \
+            .withColumn('f3', f3(col('v'))) \
+            .withColumn('f4', f4(col('v'))) \
+            .withColumn('f2_f1', f2(col('f1'))) \
+            .withColumn('f3_f1', f3(col('f1'))) \
+            .withColumn('f4_f1', f4(col('f1'))) \
+            .withColumn('f3_f2', f3(col('f2'))) \
+            .withColumn('f4_f2', f4(col('f2'))) \
+            .withColumn('f4_f3', f4(col('f3'))) \
+            .withColumn('f3_f2_f1', f3(col('f2_f1'))) \
+            .withColumn('f4_f2_f1', f4(col('f2_f1'))) \
+            .withColumn('f4_f3_f1', f4(col('f3_f1'))) \
+            .withColumn('f4_f3_f2', f4(col('f3_f2'))) \
+            .withColumn('f4_f3_f2_f1', f4(col('f3_f2_f1')))
 
         # Test mixed udfs in a single expression
-        df2 = df.withColumn('f1', f1(df['v']))
-        df2 = df2.withColumn('f2', f2(df['v']))
-        df2 = df2.withColumn('f3', f3(df['v']))
-        df2 = df2.withColumn('f4', f4(df['v']))
-        df2 = df2.withColumn('f2_f1', f2(f1(df['v'])))
-        df2 = df2.withColumn('f3_f1', f3(f1(df['v'])))
-        df2 = df2.withColumn('f4_f1', f4(f1(df['v'])))
-        df2 = df2.withColumn('f3_f2', f3(f2(df['v'])))
-        df2 = df2.withColumn('f4_f2', f4(f2(df['v'])))
-        df2 = df2.withColumn('f4_f3', f4(f3(df['v'])))
-        df2 = df2.withColumn('f3_f2_f1', f3(f2(f1(df['v']))))
-        df2 = df2.withColumn('f4_f2_f1', f4(f2(f1(df['v']))))
-        df2 = df2.withColumn('f4_f3_f1', f4(f3(f1(df['v']))))
-        df2 = df2.withColumn('f4_f3_f2', f4(f3(f2(df['v']))))
-        df2 = df2.withColumn('f4_f3_f2_f1', f4(f3(f2(f1(df['v'])))))
+        df2 = df \
+            .withColumn('f1', f1(col('v'))) \
+            .withColumn('f2', f2(col('v'))) \
+            .withColumn('f3', f3(col('v'))) \
+            .withColumn('f4', f4(col('v'))) \
+            .withColumn('f2_f1', f2(f1(col('v')))) \
+            .withColumn('f3_f1', f3(f1(col('v')))) \
+            .withColumn('f4_f1', f4(f1(col('v')))) \
+            .withColumn('f3_f2', f3(f2(col('v')))) \
+            .withColumn('f4_f2', f4(f2(col('v')))) \
+            .withColumn('f4_f3', f4(f3(col('v')))) \
+            .withColumn('f3_f2_f1', f3(f2(f1(col('v'))))) \
+            .withColumn('f4_f2_f1', f4(f2(f1(col('v'))))) \
+            .withColumn('f4_f3_f1', f4(f3(f1(col('v'))))) \
+            .withColumn('f4_f3_f2', f4(f3(f2(col('v'))))) \
+            .withColumn('f4_f3_f2_f1', f4(f3(f2(f1(col('v'))))))
 
         # expected result
-        df3 = df.withColumn('f1', df['v'] + 1)
-        df3 = df3.withColumn('f2', df['v'] + 10)
-        df3 = df3.withColumn('f3', df['v'] + 100)
-        df3 = df3.withColumn('f4', df['v'] + 1000)
-        df3 = df3.withColumn('f2_f1', df['v'] + 11)
-        df3 = df3.withColumn('f3_f1', df['v'] + 101)
-        df3 = df3.withColumn('f4_f1', df['v'] + 1001)
-        df3 = df3.withColumn('f3_f2', df['v'] + 110)
-        df3 = df3.withColumn('f4_f2', df['v'] + 1010)
-        df3 = df3.withColumn('f4_f3', df['v'] + 1100)
-        df3 = df3.withColumn('f3_f2_f1', df['v'] + 111)
-        df3 = df3.withColumn('f4_f2_f1', df['v'] + 1011)
-        df3 = df3.withColumn('f4_f3_f1', df['v'] + 1101)
-        df3 = df3.withColumn('f4_f3_f2', df['v'] + 1110)
-        df3 = df3.withColumn('f4_f3_f2_f1', df['v'] + 1111)
+        df3 = df \
+            .withColumn('f1', df['v'] + 1) \
+            .withColumn('f2', df['v'] + 10) \
+            .withColumn('f3', df['v'] + 100) \
+            .withColumn('f4', df['v'] + 1000) \
+            .withColumn('f2_f1', df['v'] + 11) \
+            .withColumn('f3_f1', df['v'] + 101) \
+            .withColumn('f4_f1', df['v'] + 1001) \
+            .withColumn('f3_f2', df['v'] + 110) \
+            .withColumn('f4_f2', df['v'] + 1010) \
+            .withColumn('f4_f3', df['v'] + 1100) \
+            .withColumn('f3_f2_f1', df['v'] + 111) \
+            .withColumn('f4_f2_f1', df['v'] + 1011) \
+            .withColumn('f4_f3_f1', df['v'] + 1101) \
+            .withColumn('f4_f3_f2', df['v'] + 1110) \
+            .withColumn('f4_f3_f2_f1', df['v'] + 1111)
 
         self.assertEquals(df3.collect(), df1.collect())
         self.assertEquals(df3.collect(), df2.collect())
@@ -5152,38 +5155,38 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
             assert type(x) == pd.Series
             return x + 100
 
-        df1 = df.withColumn('f1', f1(df['v']))
-        df1 = df1.withColumn('f2', f2(df['v']))
-        df1 = df1.withColumn('f3', f3(df['v']))
-        df1 = df1.withColumn('f1_f2', f1(f2(df['v'])))
-        df1 = df1.withColumn('f1_f3', f1(f3(df['v'])))
-        df1 = df1.withColumn('f2_f1', f2(f1(df['v'])))
-        df1 = df1.withColumn('f2_f3', f2(f3(df['v'])))
-        df1 = df1.withColumn('f3_f1', f3(f1(df['v'])))
-        df1 = df1.withColumn('f3_f2', f3(f2(df['v'])))
-        df1 = df1.withColumn('f1_f2_f3', f1(f2(f3(df['v']))))
-        df1 = df1.withColumn('f1_f3_f2', f1(f3(f2(df['v']))))
-        df1 = df1.withColumn('f2_f1_f3', f2(f1(f3(df['v']))))
-        df1 = df1.withColumn('f2_f3_f1', f2(f3(f1(df['v']))))
-        df1 = df1.withColumn('f3_f1_f2', f3(f1(f2(df['v']))))
-        df1 = df1.withColumn('f3_f2_f1', f3(f2(f1(df['v']))))
+        df1 = df.withColumn('f1', f1(df['v'])) \
+            .withColumn('f2', f2(df['v'])) \
+            .withColumn('f3', f3(df['v'])) \
+            .withColumn('f1_f2', f1(f2(df['v']))) \
+            .withColumn('f1_f3', f1(f3(df['v']))) \
+            .withColumn('f2_f1', f2(f1(df['v']))) \
+            .withColumn('f2_f3', f2(f3(df['v']))) \
+            .withColumn('f3_f1', f3(f1(df['v']))) \
+            .withColumn('f3_f2', f3(f2(df['v']))) \
+            .withColumn('f1_f2_f3', f1(f2(f3(df['v'])))) \
+            .withColumn('f1_f3_f2', f1(f3(f2(df['v'])))) \
+            .withColumn('f2_f1_f3', f2(f1(f3(df['v'])))) \
+            .withColumn('f2_f3_f1', f2(f3(f1(df['v'])))) \
+            .withColumn('f3_f1_f2', f3(f1(f2(df['v'])))) \
+            .withColumn('f3_f2_f1', f3(f2(f1(df['v']))))
 
         # expected result
-        df2 = df.withColumn('f1', df['v'] + 1)
-        df2 = df2.withColumn('f2', df['v'] + 10)
-        df2 = df2.withColumn('f3', df['v'] + 100)
-        df2 = df2.withColumn('f1_f2', df['v'] + 11)
-        df2 = df2.withColumn('f1_f3', df['v'] + 101)
-        df2 = df2.withColumn('f2_f1', df['v'] + 11)
-        df2 = df2.withColumn('f2_f3', df['v'] + 110)
-        df2 = df2.withColumn('f3_f1', df['v'] + 101)
-        df2 = df2.withColumn('f3_f2', df['v'] + 110)
-        df2 = df2.withColumn('f1_f2_f3', df['v'] + 111)
-        df2 = df2.withColumn('f1_f3_f2', df['v'] + 111)
-        df2 = df2.withColumn('f2_f1_f3', df['v'] + 111)
-        df2 = df2.withColumn('f2_f3_f1', df['v'] + 111)
-        df2 = df2.withColumn('f3_f1_f2', df['v'] + 111)
-        df2 = df2.withColumn('f3_f2_f1', df['v'] + 111)
+        df2 = df.withColumn('f1', df['v'] + 1) \
+            .withColumn('f2', df['v'] + 10) \
+            .withColumn('f3', df['v'] + 100) \
+            .withColumn('f1_f2', df['v'] + 11) \
+            .withColumn('f1_f3', df['v'] + 101) \
+            .withColumn('f2_f1', df['v'] + 11) \
+            .withColumn('f2_f3', df['v'] + 110) \
+            .withColumn('f3_f1', df['v'] + 101) \
+            .withColumn('f3_f2', df['v'] + 110) \
+            .withColumn('f1_f2_f3', df['v'] + 111) \
+            .withColumn('f1_f3_f2', df['v'] + 111) \
+            .withColumn('f2_f1_f3', df['v'] + 111) \
+            .withColumn('f2_f3_f1', df['v'] + 111) \
+            .withColumn('f3_f1_f2', df['v'] + 111) \
+            .withColumn('f3_f2_f1', df['v'] + 111)
 
         self.assertEquals(df2.collect(), df1.collect())
 
@@ -5614,14 +5617,14 @@ class GroupedMapPandasUDFTests(ReusedSQLTestCase):
                                                  F.col('temp0.key') == F.col('temp1.key'))
         self.assertEquals(res.count(), 5)
 
-    def test_mixed_udf(self):
+    def test_mixed_scalar_udfs_followed_by_grouby_apply(self):
         # Test Pandas UDF and scalar Python UDF followed by groupby apply
         from pyspark.sql.functions import udf, pandas_udf, PandasUDFType
         import pandas as pd
 
         df = self.spark.range(0, 10).toDF('v1')
-        df = df.withColumn('v2', udf(lambda x: x + 1, 'int')(df['v1']))
-        df = df.withColumn('v3', pandas_udf(lambda x: x + 2, 'int')(df['v1']))
+        df = df.withColumn('v2', udf(lambda x: x + 1, 'int')(df['v1'])) \
+            .withColumn('v3', pandas_udf(lambda x: x + 2, 'int')(df['v1']))
 
         result = df.groupby() \
             .apply(pandas_udf(lambda x: pd.DataFrame([x.sum().sum()]),

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -5055,6 +5055,8 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
 
         df = self.spark.range(0, 1).toDF('v')
 
+        # Test mixture of multiple UDFs and Pandas UDFs
+
         @udf('int')
         def f1(x):
             assert type(x) == int
@@ -5109,6 +5111,7 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
         df2 = df2.withColumn('f4_f3_f2', f4(f3(f2(df['v']))))
         df2 = df2.withColumn('f4_f3_f2_f1', f4(f3(f2(f1(df['v'])))))
 
+        # expected result
         df3 = df.withColumn('f1', df['v'] + 1)
         df3 = df3.withColumn('f2', df['v'] + 10)
         df3 = df3.withColumn('f3', df['v'] + 100)
@@ -5133,6 +5136,8 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
         from pyspark.sql.functions import udf, pandas_udf
 
         df = self.spark.range(0, 1).toDF('v')
+
+        # Test mixture of UDFs, Pandas UDFs and SQL expression.
 
         @udf('int')
         def f1(x):
@@ -5163,6 +5168,7 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
         df1 = df1.withColumn('f3_f1_f2', f3(f1(f2(df['v']))))
         df1 = df1.withColumn('f3_f2_f1', f3(f2(f1(df['v']))))
 
+        # expected result
         df2 = df.withColumn('f1', df['v'] + 1)
         df2 = df2.withColumn('f2', df['v'] + 10)
         df2 = df2.withColumn('f3', df['v'] + 100)

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -570,8 +570,7 @@ class SQLTests(ReusedSQLTestCase):
 
         my_filter = udf(lambda a: a < 2, BooleanType())
         sel = df.select(col("key"), col("value")).filter((my_filter(col("key"))) & (df.value < "2"))
-        sel.explain(True)
-        # self.assertEqual(sel.collect(), [Row(key=1, value='1')])
+        self.assertEqual(sel.collect(), [Row(key=1, value='1')])
 
     def test_udf_with_aggregate_function(self):
         df = self.spark.createDataFrame([(1, "1"), (2, "2"), (1, "2"), (1, "2")], ["key", "value"])

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -5125,8 +5125,8 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
         df3 = df3.withColumn('f4_f3_f2', df['v'] + 1110)
         df3 = df3.withColumn('f4_f3_f2_f1', df['v'] + 1111)
 
-        self.assertTrue(df3.collect() == df1.collect())
-        self.assertTrue(df3.collect() == df2.collect())
+        self.assertEquals(df3.collect(), df1.collect())
+        self.assertEquals(df3.collect(), df2.collect())
 
     def test_mixed_udf_and_sql(self):
         import pandas as pd
@@ -5177,9 +5177,9 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
         df2 = df2.withColumn('f2_f1_f3', df['v'] + 111)
         df2 = df2.withColumn('f2_f3_f1', df['v'] + 111)
         df2 = df2.withColumn('f3_f1_f2', df['v'] + 111)
-        df2 = df2.withColumn('f3_f2_f1', df['v'] + 110)
+        df2 = df2.withColumn('f3_f2_f1', df['v'] + 111)
 
-        self.assertTrue(df2.collect(), df1.collect())
+        self.assertEquals(df2.collect(), df1.collect())
 
 
 @unittest.skipIf(

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -5060,6 +5060,19 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
         df = self.spark.range(1).select(pandas_udf(f=_locals['noop'], returnType='bigint')('id'))
         self.assertEqual(df.first()[0], 0)
 
+    def test_mixed_udf(self):
+        from pyspark.sql.functions import udf, pandas_udf
+
+        df = self.spark.range(0, 10).toDF('a')
+
+        df = df.withColumn('b', udf(lambda x: x + 1, 'double')(df['a']))
+        df = df.withColumn('c', df['b'] + 2)
+        df = df.withColumn('d', udf(lambda x: x + 1, 'double')(df['c']))
+
+        df.explain(True)
+
+        #df.show()
+
 
 @unittest.skipIf(
     not _have_pandas or not _have_pyarrow,

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -5154,6 +5154,7 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
 
     def test_mixed_udf_and_sql(self):
         import pandas as pd
+        from pyspark.sql import Column
         from pyspark.sql.functions import udf, pandas_udf
 
         df = self.spark.range(0, 1).toDF('v')
@@ -5166,7 +5167,7 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
             return x + 1
 
         def f2(x):
-            assert type(x) == pyspark.sql.Column
+            assert type(x) == Column
             return x + 10
 
         @pandas_udf('int')

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
@@ -95,7 +95,7 @@ object ExtractPythonUDFFromAggregate extends Rule[LogicalPlan] {
  */
 object ExtractPythonUDFs extends Rule[SparkPlan] with PredicateHelper {
 
-  private case class EvalTypeHolder(var evalType: Int = -1) {
+  private case class EvalTypeHolder(private var evalType: Int = -1) {
 
     def isSet: Boolean = evalType >= 0
 
@@ -135,7 +135,7 @@ object ExtractPythonUDFs extends Rule[SparkPlan] with PredicateHelper {
     case udf: PythonUDF if PythonUDF.isScalarPythonUDF(udf)
       && (!firstEvalType.isSet || firstEvalType.get == udf.evalType)
       && canEvaluateInPython(udf) =>
-      firstEvalType.evalType = udf.evalType
+      firstEvalType.set(udf.evalType)
       Seq(udf)
     case e => e.children.flatMap(collectEvaluableUDFs(_, firstEvalType))
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
@@ -95,7 +95,7 @@ object ExtractPythonUDFFromAggregate extends Rule[LogicalPlan] {
  */
 object ExtractPythonUDFs extends Rule[SparkPlan] with PredicateHelper {
 
-  private case class LazyEvalType(var evalType: Int = -1) {
+  private case class EvalTypeHolder(var evalType: Int = -1) {
 
     def isSet: Boolean = evalType >= 0
 
@@ -120,57 +120,24 @@ object ExtractPythonUDFs extends Rule[SparkPlan] with PredicateHelper {
     e.find(PythonUDF.isScalarPythonUDF).isDefined
   }
 
-  /**
-   * Check whether a PythonUDF expression can be evaluated in Python.
-   *
-   * If the lazy eval type is not set, this method checks for either Batched Python UDF and Scalar
-   * Pandas UDF. If the lazy eval type is set, this method checks for the expression of the
-   * specified eval type.
-   *
-   * This method will also set the lazy eval type to be the type of the first evaluable expression,
-   * i.e., if lazy eval type is not set and we find a evaluable Python UDF expression, lazy eval
-   * type will be set to the eval type of the expression.
-   *
-   */
-  private def canEvaluateInPython(e: PythonUDF, lazyEvalType: LazyEvalType): Boolean = {
-    if (!lazyEvalType.isSet) {
-      e.children match {
-        // single PythonUDF child could be chained and evaluated in Python if eval type is the same
-        case Seq(u: PythonUDF) =>
-          // Need to recheck the eval type because lazy eval type will be set if child Python UDF is
-          // evaluable
-          canEvaluateInPython(u, lazyEvalType) && lazyEvalType.get == e.evalType
-        // Python UDF can't be evaluated directly in JVM
-        case children => if (!children.exists(hasScalarPythonUDF)) {
-          // We found the first evaluable expression, set lazy eval type to its eval type.
-          lazyEvalType.set(e.evalType)
-          true
-        } else {
-          false
-        }
-      }
-    } else {
-      if (e.evalType != lazyEvalType.get) {
-        false
-      } else {
-        e.children match {
-          case Seq(u: PythonUDF) => canEvaluateInPython(u, lazyEvalType)
-          case children => !children.exists(hasScalarPythonUDF)
-        }
-      }
+  private def canEvaluateInPython(e: PythonUDF): Boolean = {
+    e.children match {
+      // single PythonUDF child could be chained and evaluated in Python
+      case Seq(u: PythonUDF) => e.evalType == u.evalType && canEvaluateInPython(u)
+      // Python UDF can't be evaluated directly in JVM
+      case children => !children.exists(hasScalarPythonUDF)
     }
   }
 
   private def collectEvaluableUDFs(
       expr: Expression,
-      evalType: LazyEvalType
-  ): Seq[PythonUDF] = {
-    expr match {
-      case udf: PythonUDF if
-      PythonUDF.isScalarPythonUDF(udf) && canEvaluateInPython(udf, evalType) =>
-        Seq(udf)
-      case e => e.children.flatMap(collectEvaluableUDFs(_, evalType))
-    }
+      firstEvalType: EvalTypeHolder): Seq[PythonUDF] = expr match {
+    case udf: PythonUDF if PythonUDF.isScalarPythonUDF(udf)
+      && (!firstEvalType.isSet || firstEvalType.get == udf.evalType)
+      && canEvaluateInPython(udf) =>
+      firstEvalType.evalType = udf.evalType
+      Seq(udf)
+    case e => e.children.flatMap(collectEvaluableUDFs(_, firstEvalType))
   }
 
   def apply(plan: SparkPlan): SparkPlan = plan transformUp {
@@ -181,8 +148,8 @@ object ExtractPythonUDFs extends Rule[SparkPlan] with PredicateHelper {
    * Extract all the PythonUDFs from the current operator and evaluate them before the operator.
    */
   private def extract(plan: SparkPlan): SparkPlan = {
-    val lazyEvalType = new LazyEvalType
-    val udfs = plan.expressions.flatMap(collectEvaluableUDFs(_, lazyEvalType))
+    val firstEvalType = new EvalTypeHolder
+    val udfs = plan.expressions.flatMap(collectEvaluableUDFs(_, firstEvalType))
       // ignore the PythonUDF that come from second/third aggregate, which is not used
       .filter(udf => udf.references.subsetOf(plan.inputSet))
     if (udfs.isEmpty) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
@@ -150,7 +150,6 @@ object ExtractPythonUDFs extends Rule[SparkPlan] with PredicateHelper {
     val udfs = collectEvaluableUDFs(plan)
       // ignore the PythonUDF that come from second/third aggregate, which is not used
       .filter(udf => udf.references.subsetOf(plan.inputSet))
-
     if (udfs.isEmpty) {
       // If there aren't any, we are done.
       plan
@@ -215,7 +214,6 @@ object ExtractPythonUDFs extends Rule[SparkPlan] with PredicateHelper {
 
       // extract remaining python UDFs recursively
       val newPlan = extract(rewritten)
-
       if (newPlan.output != plan.output) {
         // Trim away the new UDF value if it was only used for filtering or something.
         ProjectExec(plan.output, newPlan)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
@@ -192,7 +192,7 @@ object ExtractPythonUDFs extends Rule[SparkPlan] with PredicateHelper {
               BatchEvalPythonExec(plainUdfs, child.output ++ resultAttrs, child)
             case _ =>
               throw new AnalysisException(
-                "Mixed Python and Scalar Pandas UDFs are not expected here")
+                "Expected either Scalar Pandas UDFs or Batched UDFs but got both")
           }
 
           attributeMap ++= validUdfs.zip(resultAttrs)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
@@ -190,7 +190,7 @@ object ExtractPythonUDFs extends Rule[SparkPlan] with PredicateHelper {
               ArrowEvalPythonExec(vectorizedUdfs, child.output ++ resultAttrs, child)
             case (vectorizedUdfs, plainUdfs) if vectorizedUdfs.isEmpty =>
               BatchEvalPythonExec(plainUdfs, child.output ++ resultAttrs, child)
-            case (vectorizedUdfs, plainUdfs) =>
+            case _ =>
               throw new AnalysisException(
                 "Mixed Python and Scalar Pandas UDFs are not expected here")
           }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
@@ -96,12 +96,11 @@ object ExtractPythonUDFFromAggregate extends Rule[LogicalPlan] {
 object ExtractPythonUDFs extends Rule[SparkPlan] with PredicateHelper {
 
   private case class EvalTypeHolder(private var evalType: Int = -1) {
-
     def isSet: Boolean = evalType >= 0
 
     def set(evalType: Int): Unit = {
-      if (isSet) {
-        throw new IllegalStateException("Eval type has already been set")
+      if (isSet && evalType != this.evalType) {
+        throw new IllegalStateException("Cannot reset eval type to a different value")
       } else {
         this.evalType = evalType
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.python
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
+
 import org.apache.spark.api.python.{PythonEvalType, PythonFunction}
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, GreaterThan, In}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
@@ -19,11 +19,11 @@ package org.apache.spark.sql.execution.python
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
-
 import org.apache.spark.api.python.{PythonEvalType, PythonFunction}
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, GreaterThan, In}
-import org.apache.spark.sql.execution.{FilterExec, InputAdapter, SparkPlanTest, WholeStageCodegenExec}
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types.BooleanType
 
@@ -31,13 +31,18 @@ class BatchEvalPythonExecSuite extends SparkPlanTest with SharedSQLContext {
   import testImplicits.newProductEncoder
   import testImplicits.localSeqToDatasetHolder
 
+  val pythonUDF = new MyDummyPythonUDF
+  val pandasUDF = new MyDummyScalarPandasUDF
+
   override def beforeAll(): Unit = {
     super.beforeAll()
-    spark.udf.registerPython("dummyPythonUDF", new MyDummyPythonUDF)
+    spark.udf.registerPython("dummyPythonUDF", pythonUDF)
+    spark.udf.registerPython("dummyScalarPandasUDF", pandasUDF)
   }
 
   override def afterAll(): Unit = {
     spark.sessionState.functionRegistry.dropFunction(FunctionIdentifier("dummyPythonUDF"))
+    spark.sessionState.functionRegistry.dropFunction(FunctionIdentifier("dummyScalarPandasUDF"))
     super.afterAll()
   }
 
@@ -97,6 +102,64 @@ class BatchEvalPythonExecSuite extends SparkPlanTest with SharedSQLContext {
     }
     assert(qualifiedPlanNodes.size == 1)
   }
+
+  private def collectPythonExec(spark: SparkPlan): Seq[BatchEvalPythonExec] = spark.collect {
+    case b: BatchEvalPythonExec => b
+  }
+
+  private def collectPandasExec(spark: SparkPlan): Seq[ArrowEvalPythonExec] = spark.collect {
+    case b: ArrowEvalPythonExec => b
+  }
+
+  test("Chained Python UDFs should be combined to a single physical node") {
+    val df = Seq(("Hello", 4)).toDF("a", "b")
+    val df2 = df.withColumn("c", pythonUDF(col("a"))).withColumn("d", pythonUDF(col("c")))
+    val pythonEvalNodes = collectPythonExec(df2.queryExecution.executedPlan)
+    assert(pythonEvalNodes.size == 1)
+  }
+
+  test("Chained Pandas UDFs should be combined to a single physical node") {
+    val df = Seq(("Hello", 4)).toDF("a", "b")
+    val df2 = df.withColumn("c", pandasUDF(col("a"))).withColumn("d", pandasUDF(col("c")))
+    val arrowEvalNodes = collectPandasExec(df2.queryExecution.executedPlan)
+    assert(arrowEvalNodes.size == 1)
+  }
+
+  test("Mixed Python UDFs and Pandas UDF should be separate physical node") {
+    val df = Seq(("Hello", 4)).toDF("a", "b")
+    val df2 = df.withColumn("c", pythonUDF(col("a"))).withColumn("d", pandasUDF(col("b")))
+
+    val pythonEvalNodes = collectPythonExec(df2.queryExecution.executedPlan)
+    val arrowEvalNodes = collectPandasExec(df2.queryExecution.executedPlan)
+    assert(pythonEvalNodes.size == 1)
+    assert(arrowEvalNodes.size == 1)
+  }
+
+  test("Independent Python UDFs and Pandas UDFs should be combined separately") {
+    val df = Seq(("Hello", 4)).toDF("a", "b")
+    val df2 = df.withColumn("c1", pythonUDF(col("a")))
+      .withColumn("c2", pythonUDF(col("c1")))
+      .withColumn("d1", pandasUDF(col("a")))
+      .withColumn("d2", pandasUDF(col("d1")))
+
+    val pythonEvalNodes = collectPythonExec(df2.queryExecution.executedPlan)
+    val arrowEvalNodes = collectPandasExec(df2.queryExecution.executedPlan)
+    assert(pythonEvalNodes.size == 1)
+    assert(arrowEvalNodes.size == 1)
+  }
+
+  test("Dependent Python UDFs and Pandas UDFs should not be combined") {
+    val df = Seq(("Hello", 4)).toDF("a", "b")
+    val df2 = df.withColumn("c1", pythonUDF(col("a")))
+      .withColumn("d1", pandasUDF(col("c1")))
+      .withColumn("c2", pythonUDF(col("d1")))
+      .withColumn("d2", pandasUDF(col("c2")))
+
+    val pythonEvalNodes = collectPythonExec(df2.queryExecution.executedPlan)
+    val arrowEvalNodes = collectPandasExec(df2.queryExecution.executedPlan)
+    assert(pythonEvalNodes.size == 2)
+    assert(arrowEvalNodes.size == 2)
+  }
 }
 
 // This Python UDF is dummy and just for testing. Unable to execute.
@@ -114,4 +177,11 @@ class MyDummyPythonUDF extends UserDefinedPythonFunction(
   func = new DummyUDF,
   dataType = BooleanType,
   pythonEvalType = PythonEvalType.SQL_BATCHED_UDF,
+  udfDeterministic = true)
+
+class MyDummyScalarPandasUDF extends UserDefinedPythonFunction(
+  name = "dummyPandasUDF",
+  func = new DummyUDF,
+  dataType = BooleanType,
+  pythonEvalType = PythonEvalType.SQL_SCALAR_PANDAS_UDF,
   udfDeterministic = true)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
@@ -23,7 +23,7 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.spark.api.python.{PythonEvalType, PythonFunction}
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, GreaterThan, In}
-import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.{FilterExec, InputAdapter, SparkPlanTest, WholeStageCodegenExec}
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types.BooleanType
 
@@ -31,11 +31,9 @@ class BatchEvalPythonExecSuite extends SparkPlanTest with SharedSQLContext {
   import testImplicits.newProductEncoder
   import testImplicits.localSeqToDatasetHolder
 
-  val pythonUDF = new MyDummyPythonUDF
-
   override def beforeAll(): Unit = {
     super.beforeAll()
-    spark.udf.registerPython("dummyPythonUDF", pythonUDF)
+    spark.udf.registerPython("dummyPythonUDF", new MyDummyPythonUDF)
   }
 
   override def afterAll(): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
@@ -24,7 +24,6 @@ import org.apache.spark.api.python.{PythonEvalType, PythonFunction}
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, GreaterThan, In}
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types.BooleanType
 
@@ -33,17 +32,14 @@ class BatchEvalPythonExecSuite extends SparkPlanTest with SharedSQLContext {
   import testImplicits.localSeqToDatasetHolder
 
   val pythonUDF = new MyDummyPythonUDF
-  val pandasUDF = new MyDummyScalarPandasUDF
 
   override def beforeAll(): Unit = {
     super.beforeAll()
     spark.udf.registerPython("dummyPythonUDF", pythonUDF)
-    spark.udf.registerPython("dummyScalarPandasUDF", pandasUDF)
   }
 
   override def afterAll(): Unit = {
     spark.sessionState.functionRegistry.dropFunction(FunctionIdentifier("dummyPythonUDF"))
-    spark.sessionState.functionRegistry.dropFunction(FunctionIdentifier("dummyScalarPandasUDF"))
     super.afterAll()
   }
 
@@ -103,64 +99,6 @@ class BatchEvalPythonExecSuite extends SparkPlanTest with SharedSQLContext {
     }
     assert(qualifiedPlanNodes.size == 1)
   }
-
-  private def collectPythonExec(plan: SparkPlan): Seq[BatchEvalPythonExec] = plan.collect {
-    case b: BatchEvalPythonExec => b
-  }
-
-  private def collectPandasExec(plan: SparkPlan): Seq[ArrowEvalPythonExec] = plan.collect {
-    case b: ArrowEvalPythonExec => b
-  }
-
-  test("Chained Python UDFs should be combined to a single physical node") {
-    val df = Seq(("Hello", 4)).toDF("a", "b")
-    val df2 = df.withColumn("c", pythonUDF(col("a"))).withColumn("d", pythonUDF(col("c")))
-    val pythonEvalNodes = collectPythonExec(df2.queryExecution.executedPlan)
-    assert(pythonEvalNodes.size == 1)
-  }
-
-  test("Chained Pandas UDFs should be combined to a single physical node") {
-    val df = Seq(("Hello", 4)).toDF("a", "b")
-    val df2 = df.withColumn("c", pandasUDF(col("a"))).withColumn("d", pandasUDF(col("c")))
-    val arrowEvalNodes = collectPandasExec(df2.queryExecution.executedPlan)
-    assert(arrowEvalNodes.size == 1)
-  }
-
-  test("Mixed Python UDFs and Pandas UDF should be separate physical node") {
-    val df = Seq(("Hello", 4)).toDF("a", "b")
-    val df2 = df.withColumn("c", pythonUDF(col("a"))).withColumn("d", pandasUDF(col("b")))
-
-    val pythonEvalNodes = collectPythonExec(df2.queryExecution.executedPlan)
-    val arrowEvalNodes = collectPandasExec(df2.queryExecution.executedPlan)
-    assert(pythonEvalNodes.size == 1)
-    assert(arrowEvalNodes.size == 1)
-  }
-
-  test("Independent Python UDFs and Pandas UDFs should be combined separately") {
-    val df = Seq(("Hello", 4)).toDF("a", "b")
-    val df2 = df.withColumn("c1", pythonUDF(col("a")))
-      .withColumn("c2", pythonUDF(col("c1")))
-      .withColumn("d1", pandasUDF(col("a")))
-      .withColumn("d2", pandasUDF(col("d1")))
-
-    val pythonEvalNodes = collectPythonExec(df2.queryExecution.executedPlan)
-    val arrowEvalNodes = collectPandasExec(df2.queryExecution.executedPlan)
-    assert(pythonEvalNodes.size == 1)
-    assert(arrowEvalNodes.size == 1)
-  }
-
-  test("Dependent Python UDFs and Pandas UDFs should not be combined") {
-    val df = Seq(("Hello", 4)).toDF("a", "b")
-    val df2 = df.withColumn("c1", pythonUDF(col("a")))
-      .withColumn("d1", pandasUDF(col("c1")))
-      .withColumn("c2", pythonUDF(col("d1")))
-      .withColumn("d2", pandasUDF(col("c2")))
-
-    val pythonEvalNodes = collectPythonExec(df2.queryExecution.executedPlan)
-    val arrowEvalNodes = collectPandasExec(df2.queryExecution.executedPlan)
-    assert(pythonEvalNodes.size == 2)
-    assert(arrowEvalNodes.size == 2)
-  }
 }
 
 // This Python UDF is dummy and just for testing. Unable to execute.
@@ -181,7 +119,7 @@ class MyDummyPythonUDF extends UserDefinedPythonFunction(
   udfDeterministic = true)
 
 class MyDummyScalarPandasUDF extends UserDefinedPythonFunction(
-  name = "dummyPandasUDF",
+  name = "dummyScalarPandasUDF",
   func = new DummyUDF,
   dataType = BooleanType,
   pythonEvalType = PythonEvalType.SQL_SCALAR_PANDAS_UDF,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
@@ -104,11 +104,11 @@ class BatchEvalPythonExecSuite extends SparkPlanTest with SharedSQLContext {
     assert(qualifiedPlanNodes.size == 1)
   }
 
-  private def collectPythonExec(spark: SparkPlan): Seq[BatchEvalPythonExec] = spark.collect {
+  private def collectPythonExec(plan: SparkPlan): Seq[BatchEvalPythonExec] = plan.collect {
     case b: BatchEvalPythonExec => b
   }
 
-  private def collectPandasExec(spark: SparkPlan): Seq[ArrowEvalPythonExec] = spark.collect {
+  private def collectPandasExec(plan: SparkPlan): Seq[ArrowEvalPythonExec] = plan.collect {
     case b: ArrowEvalPythonExec => b
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFsSuite.scala
@@ -90,4 +90,3 @@ class ExtractPythonUDFsSuite extends SparkPlanTest with SharedSQLContext {
   }
 }
 
-

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFsSuite.scala
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.python
+
+import org.apache.spark.sql.execution.{SparkPlan, SparkPlanTest}
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.test.SharedSQLContext
+
+class ExtractPythonUDFsSuite extends SparkPlanTest with SharedSQLContext {
+  import testImplicits.newProductEncoder
+  import testImplicits.localSeqToDatasetHolder
+
+  val batchedPythonUDF = new MyDummyPythonUDF
+  val scalarPandasUDF = new MyDummyScalarPandasUDF
+
+  private def collectBatchExec(plan: SparkPlan): Seq[BatchEvalPythonExec] = plan.collect {
+    case b: BatchEvalPythonExec => b
+  }
+
+  private def collectArrowExec(plan: SparkPlan): Seq[ArrowEvalPythonExec] = plan.collect {
+    case b: ArrowEvalPythonExec => b
+  }
+
+  test("Chained Batched Python UDFs should be combined to a single physical node") {
+    val df = Seq(("Hello", 4)).toDF("a", "b")
+    val df2 = df.withColumn("c", batchedPythonUDF(col("a")))
+      .withColumn("d", batchedPythonUDF(col("c")))
+    val pythonEvalNodes = collectBatchExec(df2.queryExecution.executedPlan)
+    assert(pythonEvalNodes.size == 1)
+  }
+
+  test("Chained Scalar Pandas UDFs should be combined to a single physical node") {
+    val df = Seq(("Hello", 4)).toDF("a", "b")
+    val df2 = df.withColumn("c", scalarPandasUDF(col("a")))
+      .withColumn("d", scalarPandasUDF(col("c")))
+    val arrowEvalNodes = collectArrowExec(df2.queryExecution.executedPlan)
+    assert(arrowEvalNodes.size == 1)
+  }
+
+  test("Mixed Batched Python UDFs and Pandas UDF should be separate physical node") {
+    val df = Seq(("Hello", 4)).toDF("a", "b")
+    val df2 = df.withColumn("c", batchedPythonUDF(col("a")))
+      .withColumn("d", scalarPandasUDF(col("b")))
+
+    val pythonEvalNodes = collectBatchExec(df2.queryExecution.executedPlan)
+    val arrowEvalNodes = collectArrowExec(df2.queryExecution.executedPlan)
+    assert(pythonEvalNodes.size == 1)
+    assert(arrowEvalNodes.size == 1)
+  }
+
+  test("Independent Batched Python UDFs and Scalar Pandas UDFs should be combined separately") {
+    val df = Seq(("Hello", 4)).toDF("a", "b")
+    val df2 = df.withColumn("c1", batchedPythonUDF(col("a")))
+      .withColumn("c2", batchedPythonUDF(col("c1")))
+      .withColumn("d1", scalarPandasUDF(col("a")))
+      .withColumn("d2", scalarPandasUDF(col("d1")))
+
+    val pythonEvalNodes = collectBatchExec(df2.queryExecution.executedPlan)
+    val arrowEvalNodes = collectArrowExec(df2.queryExecution.executedPlan)
+    assert(pythonEvalNodes.size == 1)
+    assert(arrowEvalNodes.size == 1)
+  }
+
+  test("Dependent Batched Python UDFs and Scalar Pandas UDFs should not be combined") {
+    val df = Seq(("Hello", 4)).toDF("a", "b")
+    val df2 = df.withColumn("c1", batchedPythonUDF(col("a")))
+      .withColumn("d1", scalarPandasUDF(col("c1")))
+      .withColumn("c2", batchedPythonUDF(col("d1")))
+      .withColumn("d2", scalarPandasUDF(col("c2")))
+
+    val pythonEvalNodes = collectBatchExec(df2.queryExecution.executedPlan)
+    val arrowEvalNodes = collectArrowExec(df2.queryExecution.executedPlan)
+    assert(pythonEvalNodes.size == 2)
+    assert(arrowEvalNodes.size == 2)
+  }
+}
+
+


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR add supports for using mixed Python UDF and Scalar Pandas UDF, in the following two cases:

(1)
```
from pyspark.sql.functions import udf, pandas_udf

@udf('int')
def f1(x):
    return x + 1

@pandas_udf('int')
def f2(x):
    return x + 1

df = spark.range(0, 1).toDF('v') \
    .withColumn('foo', f1(col('v'))) \
    .withColumn('bar', f2(col('v')))

```

QueryPlan:
```
>>> df.explain(True)
== Parsed Logical Plan ==
'Project [v#2L, foo#5, f2('v) AS bar#9]
+- AnalysisBarrier
      +- Project [v#2L, f1(v#2L) AS foo#5]
         +- Project [id#0L AS v#2L]
            +- Range (0, 1, step=1, splits=Some(4))

== Analyzed Logical Plan ==
v: bigint, foo: int, bar: int
Project [v#2L, foo#5, f2(v#2L) AS bar#9]
+- Project [v#2L, f1(v#2L) AS foo#5]
   +- Project [id#0L AS v#2L]
      +- Range (0, 1, step=1, splits=Some(4))

== Optimized Logical Plan ==
Project [id#0L AS v#2L, f1(id#0L) AS foo#5, f2(id#0L) AS bar#9]
+- Range (0, 1, step=1, splits=Some(4))

== Physical Plan ==
*(2) Project [id#0L AS v#2L, pythonUDF0#13 AS foo#5, pythonUDF0#14 AS bar#9]
+- ArrowEvalPython [f2(id#0L)], [id#0L, pythonUDF0#13, pythonUDF0#14]
   +- BatchEvalPython [f1(id#0L)], [id#0L, pythonUDF0#13]
      +- *(1) Range (0, 1, step=1, splits=4)
```

(2)
```
from pyspark.sql.functions import udf, pandas_udf
@udf('int')
def f1(x):
    return x + 1

@pandas_udf('int')
def f2(x):
    return x + 1

df = spark.range(0, 1).toDF('v')
df = df.withColumn('foo', f2(f1(df['v'])))
```

QueryPlan:
```
>>> df.explain(True)
== Parsed Logical Plan ==
Project [v#21L, f2(f1(v#21L)) AS foo#46]
+- AnalysisBarrier
      +- Project [v#21L, f1(f2(v#21L)) AS foo#39]
         +- Project [v#21L, <lambda>(<lambda>(v#21L)) AS foo#32]
            +- Project [v#21L, <lambda>(<lambda>(v#21L)) AS foo#25]
               +- Project [id#19L AS v#21L]
                  +- Range (0, 1, step=1, splits=Some(4))

== Analyzed Logical Plan ==
v: bigint, foo: int
Project [v#21L, f2(f1(v#21L)) AS foo#46]
+- Project [v#21L, f1(f2(v#21L)) AS foo#39]
   +- Project [v#21L, <lambda>(<lambda>(v#21L)) AS foo#32]
      +- Project [v#21L, <lambda>(<lambda>(v#21L)) AS foo#25]
         +- Project [id#19L AS v#21L]
            +- Range (0, 1, step=1, splits=Some(4))

== Optimized Logical Plan ==
Project [id#19L AS v#21L, f2(f1(id#19L)) AS foo#46]
+- Range (0, 1, step=1, splits=Some(4))

== Physical Plan ==
*(2) Project [id#19L AS v#21L, pythonUDF0#50 AS foo#46]
+- ArrowEvalPython [f2(pythonUDF0#49)], [id#19L, pythonUDF0#49, pythonUDF0#50]
   +- BatchEvalPython [f1(id#19L)], [id#19L, pythonUDF0#49]
      +- *(1) Range (0, 1, step=1, splits=4)
```

## How was this patch tested?

New tests are added to BatchEvalPythonExecSuite and ScalarPandasUDFTests
