### PR TITLE
[SPARK-18258] Sink need access to offset representation

### DIFF
--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSink.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSink.scala
@@ -21,6 +21,7 @@ import java.{util => ju}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DataFrame, SQLContext}
+import org.apache.spark.sql.execution.streaming.OffsetSeq
 import org.apache.spark.sql.execution.streaming.Sink
 
 private[kafka010] class KafkaSink(
@@ -31,12 +32,12 @@ private[kafka010] class KafkaSink(
 
   override def toString(): String = "KafkaSink"
 
-  override def addBatch(batchId: Long, data: DataFrame): Unit = {
+  override def addBatch(batchId: Long, data: DataFrame, start: OffsetSeq, end: OffsetSeq): Unit = {
     if (batchId <= latestBatchId) {
       logInfo(s"Skipping already committed batch $batchId")
     } else {
       KafkaWriter.write(sqlContext.sparkSession,
-        data.queryExecution, executorKafkaParams, topic)
+        data.queryExecution, executorKafkaParams, topic, start, end)
       latestBatchId = batchId
     }
   }

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
@@ -252,7 +252,7 @@ private[kafka010] class KafkaSourceProvider extends DataSourceRegister
     val topic = parameters.get(TOPIC_OPTION_KEY).map(_.trim)
     val specifiedKafkaParams = kafkaParamsForProducer(parameters)
     KafkaWriter.write(outerSQLContext.sparkSession, data.queryExecution,
-      new ju.HashMap[String, Object](specifiedKafkaParams.asJava), topic)
+      new ju.HashMap[String, Object](specifiedKafkaParams.asJava), topic, null, null)
 
     /* This method is suppose to return a relation that reads the data that was written.
      * We cannot support this for Kafka. Therefore, in order to make things consistent,

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaWriteTask.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaWriteTask.scala
@@ -23,6 +23,7 @@ import org.apache.kafka.clients.producer.{Callback, KafkaProducer, ProducerRecor
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Literal, UnsafeProjection}
+import org.apache.spark.sql.execution.streaming.OffsetSeq
 import org.apache.spark.sql.types.{BinaryType, StringType}
 
 /**
@@ -33,7 +34,9 @@ import org.apache.spark.sql.types.{BinaryType, StringType}
 private[kafka010] class KafkaWriteTask(
     producerConfiguration: ju.Map[String, Object],
     inputSchema: Seq[Attribute],
-    topic: Option[String]) extends KafkaRowWriter(inputSchema, topic) {
+    topic: Option[String],
+    start: OffsetSeq,  // not done
+    end: OffsetSeq) extends KafkaRowWriter(inputSchema, topic) {
   // used to synchronize with Kafka callbacks
   private var producer: KafkaProducer[Array[Byte], Array[Byte]] = _
 

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaWriter.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaWriter.scala
@@ -40,8 +40,6 @@ private[kafka010] object KafkaWriter extends Logging {
   val TOPIC_ATTRIBUTE_NAME: String = "topic"
   val KEY_ATTRIBUTE_NAME: String = "key"
   val VALUE_ATTRIBUTE_NAME: String = "value"
-  val START_OFFSETS_ATTRIBUTE_NAME: String = "startOffsets"
-  val END_OFFSETS_ATTRIBUTE_NAME: String = "endOffsets"
 
   override def toString: String = "KafkaWriter"
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
 import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils}
 import org.apache.spark.sql.execution.{SortExec, SparkPlan, SQLExecution}
+import org.apache.spark.sql.execution.streaming.OffsetSeq
 import org.apache.spark.util.{SerializableConfiguration, Utils}
 
 
@@ -72,7 +73,9 @@ object FileFormatWriter extends Logging {
       partitionColumns: Seq[Attribute],
       bucketSpec: Option[BucketSpec],
       statsTrackers: Seq[WriteJobStatsTracker],
-      options: Map[String, String])
+      options: Map[String, String],
+      start: OffsetSeq, // not done
+      end: OffsetSeq)
     : Set[String] = {
 
     val job = Job.getInstance(hadoopConf)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -162,7 +162,9 @@ case class InsertIntoHadoopFsRelationCommand(
           partitionColumns = partitionColumns,
           bucketSpec = bucketSpec,
           statsTrackers = Seq(basicWriteJobStatsTracker(hadoopConf)),
-          options = options)
+          options = options,
+          start = null,
+          end = null)
 
 
       // update metastore partition metadata

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSink.scala
@@ -103,7 +103,7 @@ class FileStreamSink(
     new BasicWriteJobStatsTracker(serializableHadoopConf, BasicWriteJobStatsTracker.metrics)
   }
 
-  override def addBatch(batchId: Long, data: DataFrame): Unit = {
+  override def addBatch(batchId: Long, data: DataFrame, start: OffsetSeq, end: OffsetSeq): Unit = {
     if (batchId <= fileLog.getLatest().map(_._1).getOrElse(-1L)) {
       logInfo(s"Skipping already committed batch $batchId")
     } else {
@@ -138,7 +138,9 @@ class FileStreamSink(
         partitionColumns = partitionColumns,
         bucketSpec = None,
         statsTrackers = Seq(basicWriteJobStatsTracker),
-        options = options)
+        options = options,
+        start = start,
+        end = end)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
@@ -302,7 +302,7 @@ class MicroBatchExecution(
    * Returns true if there is any new data available to be processed.
    */
   private def isNewDataAvailable: Boolean = {
-    availableOffsets.exists {
+    availableOffsets exists {
       case (source, available) =>
         committedOffsets
           .get(source)
@@ -522,7 +522,9 @@ class MicroBatchExecution(
     reportTimeTaken("addBatch") {
       SQLExecution.withNewExecutionId(sparkSessionToRunBatch, lastExecution) {
         sink match {
-          case s: Sink => s.addBatch(currentBatchId, nextBatch)
+          case s: Sink => s.addBatch(currentBatchId, nextBatch,
+            committedOffsets.toOffsetSeq(sources, offsetSeqMetadata),
+            availableOffsets.toOffsetSeq(sources, offsetSeqMetadata))
           case _: StreamWriteSupport =>
             // This doesn't accumulate any data - it just forces execution of the microbatch writer.
             nextBatch.collect()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
@@ -302,7 +302,7 @@ class MicroBatchExecution(
    * Returns true if there is any new data available to be processed.
    */
   private def isNewDataAvailable: Boolean = {
-    availableOffsets exists {
+    availableOffsets.exists {
       case (source, available) =>
         committedOffsets
           .get(source)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/Sink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/Sink.scala
@@ -37,5 +37,5 @@ trait Sink extends BaseStreamingSink {
    * Note 2: The method is supposed to be executed synchronously, i.e. the method should only return
    * after data is consumed by sink successfully.
    */
-  def addBatch(batchId: Long, data: DataFrame): Unit
+  def addBatch(batchId: Long, data: DataFrame, start: OffsetSeq, end: OffsetSeq): Unit
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/memory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/memory.scala
@@ -313,7 +313,7 @@ class MemorySink(val schema: StructType, outputMode: OutputMode, options: DataSo
     }.mkString("\n")
   }
 
-  override def addBatch(batchId: Long, data: DataFrame): Unit = {
+  override def addBatch(batchId: Long, data: DataFrame, start: OffsetSeq, end: OffsetSeq): Unit = { // not done
     val notCommitted = synchronized {
       latestBatchId.isEmpty || batchId > latestBatchId.get
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/ForeachBatchSink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/ForeachBatchSink.scala
@@ -20,13 +20,13 @@ package org.apache.spark.sql.execution.streaming.sources
 import org.apache.spark.api.python.PythonException
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
-import org.apache.spark.sql.execution.streaming.Sink
+import org.apache.spark.sql.execution.streaming.{OffsetSeq, Sink}
 import org.apache.spark.sql.streaming.DataStreamWriter
 
 class ForeachBatchSink[T](batchWriter: (Dataset[T], Long) => Unit, encoder: ExpressionEncoder[T])
   extends Sink {
 
-  override def addBatch(batchId: Long, data: DataFrame): Unit = {
+  override def addBatch(batchId: Long, data: DataFrame, start: OffsetSeq, end: OffsetSeq): Unit = { // not done
     val resolvedEncoder = encoder.resolveAndBind(
       data.logicalPlan.output,
       data.sparkSession.sessionState.analyzer)
@@ -55,4 +55,3 @@ object PythonForeachBatchHelper {
     dsw.foreachBatch(pythonFunc.call _)
   }
 }
-

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/MemorySinkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/MemorySinkSuite.scala
@@ -46,25 +46,25 @@ class MemorySinkSuite extends StreamTest with BeforeAndAfter {
     checkAnswer(sink.allData, Seq.empty)
 
     // Add batch 0 and check outputs
-    sink.addBatch(0, 1 to 3)
+    sink.addBatch(0, 1 to 3, OffsetSeq.fill(), OffsetSeq.fill())
     assert(sink.latestBatchId === Some(0))
     checkAnswer(sink.latestBatchData, 1 to 3)
     checkAnswer(sink.allData, 1 to 3)
 
     // Add batch 1 and check outputs
-    sink.addBatch(1, 4 to 6)
+    sink.addBatch(1, 4 to 6, OffsetSeq.fill(), OffsetSeq.fill())
     assert(sink.latestBatchId === Some(1))
     checkAnswer(sink.latestBatchData, 4 to 6)
     checkAnswer(sink.allData, 1 to 6)     // new data should get appended to old data
 
     // Re-add batch 1 with different data, should not be added and outputs should not be changed
-    sink.addBatch(1, 7 to 9)
+    sink.addBatch(1, 7 to 9, OffsetSeq.fill(), OffsetSeq.fill())
     assert(sink.latestBatchId === Some(1))
     checkAnswer(sink.latestBatchData, 4 to 6)
     checkAnswer(sink.allData, 1 to 6)
 
     // Add batch 2 and check outputs
-    sink.addBatch(2, 7 to 9)
+    sink.addBatch(2, 7 to 9, OffsetSeq.fill(), OffsetSeq.fill())
     assert(sink.latestBatchId === Some(2))
     checkAnswer(sink.latestBatchData, 7 to 9)
     checkAnswer(sink.allData, 1 to 9)
@@ -84,13 +84,13 @@ class MemorySinkSuite extends StreamTest with BeforeAndAfter {
     checkAnswer(sink.allData, Seq.empty)
 
     // Add batch 0 and check outputs
-    sink.addBatch(0, 1 to 3)
+    sink.addBatch(0, 1 to 3, OffsetSeq.fill(), OffsetSeq.fill())
     assert(sink.latestBatchId === Some(0))
     checkAnswer(sink.latestBatchData, 1 to 3)
     checkAnswer(sink.allData, 1 to 3)
 
     // Add batch 1 and check outputs
-    sink.addBatch(1, 4 to 6)
+    sink.addBatch(1, 4 to 6, OffsetSeq.fill(), OffsetSeq.fill())
     assert(sink.latestBatchId === Some(1))
     checkAnswer(sink.latestBatchData, 4 to 5)
     checkAnswer(sink.allData, 1 to 5)     // new data should not go over the limit
@@ -106,25 +106,25 @@ class MemorySinkSuite extends StreamTest with BeforeAndAfter {
     checkAnswer(sink.allData, Seq.empty)
 
     // Add batch 0 and check outputs
-    sink.addBatch(0, 1 to 3)
+    sink.addBatch(0, 1 to 3, OffsetSeq.fill(), OffsetSeq.fill())
     assert(sink.latestBatchId === Some(0))
     checkAnswer(sink.latestBatchData, 1 to 3)
     checkAnswer(sink.allData, 1 to 3)
 
     // Add batch 1 and check outputs
-    sink.addBatch(1, 4 to 6)
+    sink.addBatch(1, 4 to 6, OffsetSeq.fill(), OffsetSeq.fill())
     assert(sink.latestBatchId === Some(1))
     checkAnswer(sink.latestBatchData, 4 to 6)
     checkAnswer(sink.allData, 1 to 6) // new data should get appended to old data
 
     // Re-add batch 1 with different data, should not be added and outputs should not be changed
-    sink.addBatch(1, 7 to 9)
+    sink.addBatch(1, 7 to 9, OffsetSeq.fill(), OffsetSeq.fill())
     assert(sink.latestBatchId === Some(1))
     checkAnswer(sink.latestBatchData, 4 to 6)
     checkAnswer(sink.allData, 1 to 6)
 
     // Add batch 2 and check outputs
-    sink.addBatch(2, 7 to 9)
+    sink.addBatch(2, 7 to 9, OffsetSeq.fill(), OffsetSeq.fill())
     assert(sink.latestBatchId === Some(2))
     checkAnswer(sink.latestBatchData, 7 to 9)
     checkAnswer(sink.allData, 1 to 9)
@@ -140,25 +140,25 @@ class MemorySinkSuite extends StreamTest with BeforeAndAfter {
     checkAnswer(sink.allData, Seq.empty)
 
     // Add batch 0 and check outputs
-    sink.addBatch(0, 1 to 3)
+    sink.addBatch(0, 1 to 3, OffsetSeq.fill(), OffsetSeq.fill())
     assert(sink.latestBatchId === Some(0))
     checkAnswer(sink.latestBatchData, 1 to 3)
     checkAnswer(sink.allData, 1 to 3)
 
     // Add batch 1 and check outputs
-    sink.addBatch(1, 4 to 6)
+    sink.addBatch(1, 4 to 6, OffsetSeq.fill(), OffsetSeq.fill())
     assert(sink.latestBatchId === Some(1))
     checkAnswer(sink.latestBatchData, 4 to 6)
     checkAnswer(sink.allData, 4 to 6)     // new data should replace old data
 
     // Re-add batch 1 with different data, should not be added and outputs should not be changed
-    sink.addBatch(1, 7 to 9)
+    sink.addBatch(1, 7 to 9, OffsetSeq.fill(), OffsetSeq.fill())
     assert(sink.latestBatchId === Some(1))
     checkAnswer(sink.latestBatchData, 4 to 6)
     checkAnswer(sink.allData, 4 to 6)
 
     // Add batch 2 and check outputs
-    sink.addBatch(2, 7 to 9)
+    sink.addBatch(2, 7 to 9, OffsetSeq.fill(), OffsetSeq.fill())
     assert(sink.latestBatchId === Some(2))
     checkAnswer(sink.latestBatchData, 7 to 9)
     checkAnswer(sink.allData, 7 to 9)
@@ -178,13 +178,13 @@ class MemorySinkSuite extends StreamTest with BeforeAndAfter {
     checkAnswer(sink.allData, Seq.empty)
 
     // Add batch 0 and check outputs
-    sink.addBatch(0, 1 to 3)
+    sink.addBatch(0, 1 to 3, OffsetSeq.fill(), OffsetSeq.fill())
     assert(sink.latestBatchId === Some(0))
     checkAnswer(sink.latestBatchData, 1 to 3)
     checkAnswer(sink.allData, 1 to 3)
 
     // Add batch 1 and check outputs
-    sink.addBatch(1, 4 to 10)
+    sink.addBatch(1, 4 to 10, OffsetSeq.fill(), OffsetSeq.fill())
     assert(sink.latestBatchId === Some(1))
     checkAnswer(sink.latestBatchData, 4 to 8)
     checkAnswer(sink.allData, 4 to 8)     // new data should replace old data
@@ -272,11 +272,11 @@ class MemorySinkSuite extends StreamTest with BeforeAndAfter {
     checkAnswer(sink.allData, Seq.empty)
     assert(plan.stats.sizeInBytes === 0)
 
-    sink.addBatch(0, 1 to 3)
+    sink.addBatch(0, 1 to 3, OffsetSeq.fill(), OffsetSeq.fill())
     plan.invalidateStatsCache()
     assert(plan.stats.sizeInBytes === 36)
 
-    sink.addBatch(1, 4 to 6)
+    sink.addBatch(1, 4 to 6, OffsetSeq.fill(), OffsetSeq.fill())
     plan.invalidateStatsCache()
     assert(plan.stats.sizeInBytes === 72)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/sources/StreamingDataSourceV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/sources/StreamingDataSourceV2Suite.scala
@@ -21,7 +21,7 @@ import java.util.Optional
 
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.apache.spark.sql.execution.datasources.DataSource
-import org.apache.spark.sql.execution.streaming.{RateStreamOffset, Sink, StreamingQueryWrapper}
+import org.apache.spark.sql.execution.streaming.{OffsetSeq, RateStreamOffset, Sink, StreamingQueryWrapper}
 import org.apache.spark.sql.execution.streaming.continuous.ContinuousTrigger
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.{DataSourceRegister, StreamSinkProvider}
@@ -102,7 +102,8 @@ class FakeNoWrite extends DataSourceRegister {
 case class FakeWriteV1FallbackException() extends Exception
 
 class FakeSink extends Sink {
-  override def addBatch(batchId: Long, data: DataFrame): Unit = {}
+  override def addBatch(batchId: Long, data: DataFrame,
+                        start: OffsetSeq, end: OffsetSeq): Unit = {}
 }
 
 class FakeWriteV1Fallback extends DataSourceRegister

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamReaderWriterSuite.scala
@@ -104,7 +104,7 @@ class DefaultSource extends StreamSourceProvider with StreamSinkProvider {
     LastOptions.partitionColumns = partitionColumns
     LastOptions.mockStreamSinkProvider.createSink(spark, parameters, partitionColumns, outputMode)
     new Sink {
-      override def addBatch(batchId: Long, data: DataFrame): Unit = {}
+      override def addBatch(batchId: Long, data: DataFrame, start: OffsetSeq, end: OffsetSeq): Unit = {}
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/util/BlockingSource.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/util/BlockingSource.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.streaming.util
 import java.util.concurrent.CountDownLatch
 
 import org.apache.spark.sql.{SQLContext, _}
-import org.apache.spark.sql.execution.streaming.{LongOffset, Offset, Sink, Source}
+import org.apache.spark.sql.execution.streaming.{LongOffset, Offset, OffsetSeq, Sink, Source}
 import org.apache.spark.sql.sources.{StreamSinkProvider, StreamSourceProvider}
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
@@ -62,7 +62,8 @@ class BlockingSource extends StreamSourceProvider with StreamSinkProvider {
       partitionColumns: Seq[String],
       outputMode: OutputMode): Sink = {
     new Sink {
-      override def addBatch(batchId: Long, data: DataFrame): Unit = {}
+      override def addBatch(batchId: Long, data: DataFrame,
+                            start: OffsetSeq, end: OffsetSeq): Unit = {}
     }
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/SaveAsHiveFile.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/SaveAsHiveFile.scala
@@ -95,7 +95,9 @@ private[hive] trait SaveAsHiveFile extends DataWritingCommand {
       partitionColumns = partitionAttributes,
       bucketSpec = None,
       statsTrackers = Seq(basicWriteJobStatsTracker(hadoopConf)),
-      options = Map.empty)
+      options = Map.empty,
+      start = null,
+      end = null)
   }
 
   protected def getExternalTmpPath(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, sinks only have access to the batchId and the data, not the actual offset representation.
The goal of this PR is to expose this representation to sinks via ```addBatch```. 

## How was this patch tested?

Existing unit tests (needs to be changed to also test for offsetSeqs)

Please review http://spark.apache.org/contributing.html before opening a pull request.
