### PR TITLE
[SPARK-24680][Deploy]Support spark.executorEnv.JAVA_HOME in Standalone mode

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -91,16 +91,18 @@ abstract class AbstractCommandBuilder {
    */
   List<String> buildJavaCommand(String extraClassPath) throws IOException {
     List<String> cmd = new ArrayList<>();
-    String envJavaHome;
 
-    if (javaHome != null) {
-      cmd.add(join(File.separator, javaHome, "bin", "java"));
-    } else if (childEnv.containsKey("JAVA_HOME")) {
-      cmd.add(join(File.separator, childEnv.get("JAVA_HOME"), "bin", "java"));
-    } else if ((envJavaHome = System.getenv("JAVA_HOME")) != null) {
-      cmd.add(join(File.separator, envJavaHome, "bin", "java"));
-    } else {
-      cmd.add(join(File.separator, System.getProperty("java.home"), "bin", "java"));
+    String[] candidateJavaHomes = new String[] {
+      javaHome,
+      childEnv.get("JAVA_HOME"),
+      System.getenv("JAVA_HOME"),
+      System.getProperty("java.home")
+    };
+    for (String javaHome : candidateJavaHomes) {
+      if (javaHome != null) {
+        cmd.add(join(File.separator, javaHome, "bin", "java"));
+        break;
+      }
     }
 
     // Load extra JAVA_OPTS from conf/java-opts, if it exists.

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -95,10 +95,12 @@ abstract class AbstractCommandBuilder {
 
     if (javaHome != null) {
       cmd.add(join(File.separator, javaHome, "bin", "java"));
+    } else if (childEnv.containsKey("JAVA_HOME")) {
+      cmd.add(join(File.separator, childEnv.get("JAVA_HOME"), "bin", "java"));
     } else if ((envJavaHome = System.getenv("JAVA_HOME")) != null) {
-        cmd.add(join(File.separator, envJavaHome, "bin", "java"));
+      cmd.add(join(File.separator, envJavaHome, "bin", "java"));
     } else {
-        cmd.add(join(File.separator, System.getProperty("java.home"), "bin", "java"));
+      cmd.add(join(File.separator, System.getProperty("java.home"), "bin", "java"));
     }
 
     // Load extra JAVA_OPTS from conf/java-opts, if it exists.


### PR DESCRIPTION
## What changes were proposed in this pull request?

spark.executorEnv.JAVA_HOME does not take effect when a Worker starting an Executor process in Standalone mode.

This PR fixed this.

## How was this patch tested?

Manual tests.