### PR TITLE
SPARK-24714 AnalysisSuite should use ClassTag to check the runtime in…

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.catalyst.analysis
 
 import java.util.TimeZone
 
+import scala.reflect.{classTag, ClassTag}
+
 import org.scalatest.Matchers
 
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -518,9 +520,10 @@ class AnalysisSuite extends AnalysisTest with Matchers {
   }
 
   test("SPARK-22614 RepartitionByExpression partitioning") {
-    def checkPartitioning[T <: Partitioning](numPartitions: Int, exprs: Expression*): Unit = {
+    def checkPartitioning[T <: Partitioning: ClassTag](numPartitions: Int,
+                                                       exprs: Expression*): Unit = {
       val partitioning = RepartitionByExpression(exprs, testRelation2, numPartitions).partitioning
-      assert(partitioning.isInstanceOf[T])
+      assert(classTag[T].runtimeClass.isInstance(partitioning))
     }
 
     checkPartitioning[HashPartitioning](numPartitions = 10, exprs = Literal(20))


### PR DESCRIPTION
…stance

## What changes were proposed in this pull request?

Use scala classTag to do the type check.

## How was this patch tested?

this PR is against test

Please review http://spark.apache.org/contributing.html before opening a pull request.
