### PR TITLE
[SPARK-5152][CORE] Read metrics config file from Hadoop compatible file system

### DIFF
--- a/core/src/main/scala/org/apache/spark/metrics/MetricsConfig.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsConfig.scala
@@ -20,13 +20,13 @@ package org.apache.spark.metrics
 import java.io.{FileInputStream, InputStream}
 import java.util.Properties
 
-import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.matching.Regex
 
 import org.apache.spark.SparkConf
+import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
 import org.apache.spark.util.Utils
 
@@ -133,7 +133,7 @@ private[spark] class MetricsConfig(conf: SparkConf) extends Logging {
       is = path match {
         case Some(f) =>
           val hadoopPath = new Path(Utils.resolveURI(f))
-          Utils.getHadoopFileSystem(hadoopPath.toUri, new Configuration()).open(hadoopPath)
+          Utils.getHadoopFileSystem(hadoopPath.toUri, SparkHadoopUtil.get.conf).open(hadoopPath)
         case None =>
           Utils.getSparkClassLoader.getResourceAsStream(DEFAULT_METRICS_CONF_FILENAME)
       }

--- a/core/src/main/scala/org/apache/spark/metrics/MetricsConfig.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsConfig.scala
@@ -20,6 +20,8 @@ package org.apache.spark.metrics
 import java.io.{FileInputStream, InputStream}
 import java.util.Properties
 
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.matching.Regex
@@ -129,8 +131,11 @@ private[spark] class MetricsConfig(conf: SparkConf) extends Logging {
     var is: InputStream = null
     try {
       is = path match {
-        case Some(f) => new FileInputStream(f)
-        case None => Utils.getSparkClassLoader.getResourceAsStream(DEFAULT_METRICS_CONF_FILENAME)
+        case Some(f) =>
+          val hadoopPath = new Path(Utils.resolveURI(f))
+          Utils.getHadoopFileSystem(hadoopPath.toUri, new Configuration()).open(hadoopPath)
+        case None =>
+          Utils.getSparkClassLoader.getResourceAsStream(DEFAULT_METRICS_CONF_FILENAME)
       }
 
       if (is != null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable metrics config file to be read directly from Hadoop compatible file system.
```
spark-submit --conf spark.metrics.conf=hdfs://<nn>:8020/config/spark-metrics.properties
spark-submit --conf spark.metrics.conf=s3a://<bucket>/config/spark-metrics.properties
```

There is no need to distribute the config file if a distributed file system is used.

If no URI scheme is specified, assume local file system. This ensures backwards compatibility.

## How was this patch tested?

Unit tests:
- MetricsSystemSuite
- MetricsConfigSuite
- TaskContextSuite

Manual tests:
- Local file without URI scheme
- Local file with file://
- HDFS file path
- S3 file path

Author: John Zhuge <jzhuge@apache.org>