### PR TITLE
[SPARK-24737][SQL] Type coercion between StructTypes.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -185,6 +185,15 @@ object TypeCoercion {
               MapType(kt, vt, valueContainsNull1 || valueContainsNull2)
             }
           }
+        case (StructType(fields1), StructType(fields2)) if fields1.length == fields2.length =>
+          val resolver = SQLConf.get.resolver
+          fields1.zip(fields2).foldLeft(Option(new StructType())) {
+            case (Some(struct), (field1, field2)) if resolver(field1.name, field2.name) =>
+              findWiderTypeForTwo(field1.dataType, field2.dataType).map {
+                dt => struct.add(field1.name, dt, field1.nullable || field2.nullable)
+              }
+            case _ => None
+          }
         case _ => None
       })
   }
@@ -231,6 +240,15 @@ object TypeCoercion {
             findWiderTypeWithoutStringPromotionForTwo(vt1, vt2).map { vt =>
               MapType(kt, vt, valueContainsNull1 || valueContainsNull2)
             }
+          }
+        case (StructType(fields1), StructType(fields2)) if fields1.length == fields2.length =>
+          val resolver = SQLConf.get.resolver
+          fields1.zip(fields2).foldLeft(Option(new StructType())) {
+            case (Some(struct), (field1, field2)) if resolver(field1.name, field2.name) =>
+              findWiderTypeWithoutStringPromotionForTwo(field1.dataType, field2.dataType).map {
+                dt => struct.add(field1.name, dt, field1.nullable || field2.nullable)
+              }
+            case _ => None
           }
         case _ => None
       })

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -166,7 +166,7 @@ object TypeCoercion {
     case (l, r) => None
   }
 
-  private def mergeComplexTypes(
+  private def findWiderTypeForComplex(
       t1: DataType,
       t2: DataType,
       mergeFunc: (DataType, DataType) => Option[DataType]): Option[DataType] = (t1, t2) match {
@@ -200,7 +200,7 @@ object TypeCoercion {
     findTightestCommonType(t1, t2)
       .orElse(findWiderTypeForDecimal(t1, t2))
       .orElse(stringPromotion(t1, t2))
-      .orElse(mergeComplexTypes(t1, t2, findWiderTypeForTwo))
+      .orElse(findWiderTypeForComplex(t1, t2, findWiderTypeForTwo))
   }
 
   /**
@@ -236,7 +236,7 @@ object TypeCoercion {
       t2: DataType): Option[DataType] = {
     findTightestCommonType(t1, t2)
       .orElse(findWiderTypeForDecimal(t1, t2))
-      .orElse(mergeComplexTypes(t1, t2, findWiderTypeWithoutStringPromotionForTwo))
+      .orElse(findWiderTypeForComplex(t1, t2, findWiderTypeWithoutStringPromotionForTwo))
   }
 
   def findWiderTypeWithoutStringPromotion(types: Seq[DataType]): Option[DataType] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -102,25 +102,7 @@ object TypeCoercion {
     case (_: TimestampType, _: DateType) | (_: DateType, _: TimestampType) =>
       Some(TimestampType)
 
-    case (t1 @ StructType(fields1), t2 @ StructType(fields2)) if t1.sameType(t2) =>
-      Some(StructType(fields1.zip(fields2).map { case (f1, f2) =>
-        // Since `t1.sameType(t2)` is true, two StructTypes have the same DataType
-        // except `name` (in case of `spark.sql.caseSensitive=false`) and `nullable`.
-        // - Different names: use f1.name
-        // - Different nullabilities: `nullable` is true iff one of them is nullable.
-        val dataType = findTightestCommonType(f1.dataType, f2.dataType).get
-        StructField(f1.name, dataType, nullable = f1.nullable || f2.nullable)
-      }))
-
-    case (a1 @ ArrayType(et1, hasNull1), a2 @ ArrayType(et2, hasNull2)) if a1.sameType(a2) =>
-      findTightestCommonType(et1, et2).map(ArrayType(_, hasNull1 || hasNull2))
-
-    case (m1 @ MapType(kt1, vt1, hasNull1), m2 @ MapType(kt2, vt2, hasNull2)) if m1.sameType(m2) =>
-      val keyType = findTightestCommonType(kt1, kt2)
-      val valueType = findTightestCommonType(vt1, vt2)
-      Some(MapType(keyType.get, valueType.get, hasNull1 || hasNull2))
-
-    case _ => None
+    case (t1, t2) => findTypeForComplex(t1, t2, findTightestCommonType)
   }
 
   /** Promotes all the way to StringType. */
@@ -166,15 +148,15 @@ object TypeCoercion {
     case (l, r) => None
   }
 
-  private def findWiderTypeForComplex(
+  private def findTypeForComplex(
       t1: DataType,
       t2: DataType,
-      mergeFunc: (DataType, DataType) => Option[DataType]): Option[DataType] = (t1, t2) match {
+      findTypeFunc: (DataType, DataType) => Option[DataType]): Option[DataType] = (t1, t2) match {
     case (ArrayType(et1, containsNull1), ArrayType(et2, containsNull2)) =>
-      mergeFunc(et1, et2).map(ArrayType(_, containsNull1 || containsNull2))
+      findTypeFunc(et1, et2).map(ArrayType(_, containsNull1 || containsNull2))
     case (MapType(kt1, vt1, valueContainsNull1), MapType(kt2, vt2, valueContainsNull2)) =>
-      mergeFunc(kt1, kt2).flatMap { kt =>
-        mergeFunc(vt1, vt2).map { vt =>
+      findTypeFunc(kt1, kt2).flatMap { kt =>
+        findTypeFunc(vt1, vt2).map { vt =>
           MapType(kt, vt, valueContainsNull1 || valueContainsNull2)
         }
       }
@@ -182,7 +164,7 @@ object TypeCoercion {
       val resolver = SQLConf.get.resolver
       fields1.zip(fields2).foldLeft(Option(new StructType())) {
         case (Some(struct), (field1, field2)) if resolver(field1.name, field2.name) =>
-          mergeFunc(field1.dataType, field2.dataType).map {
+          findTypeFunc(field1.dataType, field2.dataType).map {
             dt => struct.add(field1.name, dt, field1.nullable || field2.nullable)
           }
         case _ => None
@@ -200,7 +182,7 @@ object TypeCoercion {
     findTightestCommonType(t1, t2)
       .orElse(findWiderTypeForDecimal(t1, t2))
       .orElse(stringPromotion(t1, t2))
-      .orElse(findWiderTypeForComplex(t1, t2, findWiderTypeForTwo))
+      .orElse(findTypeForComplex(t1, t2, findWiderTypeForTwo))
   }
 
   /**
@@ -236,7 +218,7 @@ object TypeCoercion {
       t2: DataType): Option[DataType] = {
     findTightestCommonType(t1, t2)
       .orElse(findWiderTypeForDecimal(t1, t2))
-      .orElse(findWiderTypeForComplex(t1, t2, findWiderTypeWithoutStringPromotionForTwo))
+      .orElse(findTypeForComplex(t1, t2, findWiderTypeWithoutStringPromotionForTwo))
   }
 
   def findWiderTypeWithoutStringPromotion(types: Seq[DataType]): Option[DataType] = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -397,7 +397,7 @@ class TypeCoercionSuite extends AnalysisTest {
     widenTest(
       StructType(Seq(StructField("a", IntegerType, nullable = false))),
       StructType(Seq(StructField("a", DoubleType, nullable = false))),
-      None)
+      Some(StructType(Seq(StructField("a", DoubleType, nullable = false)))))
 
     widenTest(
       StructType(Seq(StructField("a", IntegerType, nullable = false))),


### PR DESCRIPTION
## What changes were proposed in this pull request?

We can support type coercion between `StructType`s where all the internal types are compatible.

## How was this patch tested?

Added tests.