### PR TITLE
[SPARK-24744][STRUCTRURED STREAMING] Set the SparkSession configurati…

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/OffsetSeq.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/OffsetSeq.scala
@@ -107,11 +107,14 @@ object OffsetSeqMetadata extends Logging {
         case Some(valueInMetadata) =>
           // Config value exists in the metadata, update the session config with this value
           val optionalValueInSession = sessionConf.getOption(confKey)
+
           if (optionalValueInSession.isDefined && optionalValueInSession.get != valueInMetadata) {
+            sessionConf.set(confKey, optionalValueInSession.get)
+          } else {
             logWarning(s"Updating the value of conf '$confKey' in current session from " +
               s"'${optionalValueInSession.get}' to '$valueInMetadata'.")
+            sessionConf.set(confKey, valueInMetadata)
           }
-          sessionConf.set(confKey, valueInMetadata)
 
         case None =>
           // For backward compatibility, if a config was not recorded in the offset log,


### PR DESCRIPTION
# Background
When I use structured streaming to construct my application, there is something odd! The application always set option [spark.sql.shuffle.partitions] to default value [200]. Even though, I set [spark.sql.shuffle.partitions] to other value by SparkConf or --conf spark.sql.shuffle.partitions=100,  but it doesn't work. The option value is default value as before.
# Analyse
I review the relevant code. The relevant code is in [org.apache.spark.sql.execution.streaming.OffsetSeqMetadata].

```scala
/** Set the SparkSession configuration with the values in the metadata */
  def setSessionConf(metadata: OffsetSeqMetadata, sessionConf: RuntimeConfig): Unit = {
    OffsetSeqMetadata.relevantSQLConfs.map(_.key).foreach { confKey =>

      metadata.conf.get(confKey) match {

        case Some(valueInMetadata) =>
          // Config value exists in the metadata, update the session config with this value
          val optionalValueInSession = sessionConf.getOption(confKey)
          if (optionalValueInSession.isDefined && optionalValueInSession.get != valueInMetadata) {
            logWarning(s"Updating the value of conf '$confKey' in current session from " +
              s"'${optionalValueInSession.get}' to '$valueInMetadata'.")
          }
          sessionConf.set(confKey, valueInMetadata)

        case None =>
          // For backward compatibility, if a config was not recorded in the offset log,
          // then log it, and let the existing conf value in SparkSession prevail.
          logWarning (s"Conf '$confKey' was not found in the offset log, using existing value")
      }
    }
  }
```
In this code, we can find it always set some option in metadata value. But as user, we want to those option can set by user. So I changed this code.

```scala
/** Set the SparkSession configuration with the values in the metadata */
  def setSessionConf(metadata: OffsetSeqMetadata, sessionConf: RuntimeConfig): Unit = {
    OffsetSeqMetadata.relevantSQLConfs.map(_.key).foreach { confKey =>

      metadata.conf.get(confKey) match {

        case Some(valueInMetadata) =>
          // Config value exists in the metadata, update the session config with this value
          val optionalValueInSession = sessionConf.getOption(confKey)

          if (optionalValueInSession.isDefined && optionalValueInSession.get != valueInMetadata) {
            sessionConf.set(confKey, optionalValueInSession.get)
          } else {
            logWarning(s"Updating the value of conf '$confKey' in current session from " +
              s"'${optionalValueInSession.get}' to '$valueInMetadata'.")
            sessionConf.set(confKey, valueInMetadata)
          }

        case None =>
          // For backward compatibility, if a config was not recorded in the offset log,
          // then log it, and let the existing conf value in SparkSession prevail.
          logWarning (s"Conf '$confKey' was not found in the offset log, using existing value")
      }
    }
  }
```

