### PR TITLE
[SPARK-24761][SQL] Adding of isModifiable() to RuntimeConfig

### DIFF
--- a/python/pyspark/sql/conf.py
+++ b/python/pyspark/sql/conf.py
@@ -63,6 +63,12 @@ class RuntimeConfig(object):
             raise TypeError("expected %s '%s' to be a string (was '%s')" %
                             (identifier, obj, type(obj).__name__))
 
+    @ignore_unicode_prefix
+    @since(2.4)
+    def isModifiable(self, key):
+        """Is the configuration property modifiable or not."""
+        return self._jconf.isModifiable(key)
+
 
 def _test():
     import os

--- a/python/pyspark/sql/conf.py
+++ b/python/pyspark/sql/conf.py
@@ -66,7 +66,9 @@ class RuntimeConfig(object):
     @ignore_unicode_prefix
     @since(2.4)
     def isModifiable(self, key):
-        """Is the configuration property modifiable or not."""
+        """Indicates whether the configuration property with the given key
+        is modifiable in the current session.
+        """
         return self._jconf.isModifiable(key)
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1892,4 +1892,8 @@ class SQLConf extends Serializable with Logging {
     }
     cloned
   }
+
+  def isModifiable(key: String): Boolean = {
+    sqlConfEntries.containsKey(key) && !staticConfKeys.contains(key)
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/RuntimeConfig.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RuntimeConfig.scala
@@ -133,6 +133,13 @@ class RuntimeConfig private[sql](sqlConf: SQLConf = new SQLConf) {
   }
 
   /**
+   * Can the configuration property be modified at runtime.
+   *
+   * @since 2.4.0
+   */
+  def isModifiable(key: String): Boolean = sqlConf.isModifiable(key)
+
+  /**
    * Returns whether a particular key is set.
    */
   protected[sql] def contains(key: String): Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/RuntimeConfig.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RuntimeConfig.scala
@@ -133,7 +133,8 @@ class RuntimeConfig private[sql](sqlConf: SQLConf = new SQLConf) {
   }
 
   /**
-   * Can the configuration property be modified at runtime.
+   * Indicates whether the configuration property with the given key
+   * is modifiable in the current session.
    *
    * @since 2.4.0
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/RuntimeConfig.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RuntimeConfig.scala
@@ -136,6 +136,9 @@ class RuntimeConfig private[sql](sqlConf: SQLConf = new SQLConf) {
    * Indicates whether the configuration property with the given key
    * is modifiable in the current session.
    *
+   * @return `true` if the configuration property is modifiable. For static SQL, Spark Core,
+   *         invalid (not existing) and other non-modifiable configuration properties,
+   *         the returned value is `false`.
    * @since 2.4.0
    */
   def isModifiable(key: String): Boolean = sqlConf.isModifiable(key)

--- a/sql/core/src/test/scala/org/apache/spark/sql/RuntimeConfigSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/RuntimeConfigSuite.scala
@@ -54,4 +54,15 @@ class RuntimeConfigSuite extends SparkFunSuite {
       conf.get("k1")
     }
   }
+
+  test("is a config parameter modifiable") {
+    val conf = newConf()
+
+    // SQL configs
+    assert(!conf.isModifiable("spark.sql.sources.schemaStringLengthThreshold"))
+    assert(conf.isModifiable("spark.sql.streaming.checkpointLocation"))
+    // Core configs
+    assert(!conf.isModifiable("spark.task.cpus"))
+    assert(!conf.isModifiable("spark.executor.cores"))
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/RuntimeConfigSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/RuntimeConfigSuite.scala
@@ -55,7 +55,7 @@ class RuntimeConfigSuite extends SparkFunSuite {
     }
   }
 
-  test("is a config parameter modifiable") {
+  test("SPARK-24761: is a config parameter modifiable") {
     val conf = newConf()
 
     // SQL configs

--- a/sql/core/src/test/scala/org/apache/spark/sql/RuntimeConfigSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/RuntimeConfigSuite.scala
@@ -64,5 +64,8 @@ class RuntimeConfigSuite extends SparkFunSuite {
     // Core configs
     assert(!conf.isModifiable("spark.task.cpus"))
     assert(!conf.isModifiable("spark.executor.cores"))
+    // Invalid config parameters
+    assert(!conf.isModifiable(""))
+    assert(!conf.isModifiable("invalid config parameter"))
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the PR, I propose to extend `RuntimeConfig` by new method `isModifiable()` which returns `true` if a config parameter can be modified at runtime (for current session state). For static SQL and core parameters, the method returns `false`.

## How was this patch tested?

Added new test to `RuntimeConfigSuite` for checking Spark core and SQL parameters.
