### PR TITLE
Update example to work locally

### DIFF
--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaNaiveBayesExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaNaiveBayesExample.java
@@ -32,6 +32,7 @@ import org.apache.spark.SparkConf;
 public class JavaNaiveBayesExample {
   public static void main(String[] args) {
     SparkConf sparkConf = new SparkConf().setAppName("JavaNaiveBayesExample");
+    sparkConf.setMaster("local");
     JavaSparkContext jsc = new JavaSparkContext(sparkConf);
     // $example on$
     String path = "data/mllib/sample_libsvm_data.txt";


### PR DESCRIPTION
Without setting Master to "local" the example throws a SparkException "A master URL must be set in your configuration"

## What changes were proposed in this pull request?

explicitly set SparkConf master to "local"

## How was this patch tested?

Running the main method using Spark 2.3.1 without the change produces an exception. With the change, the main method executes without error.

Please review http://spark.apache.org/contributing.html before opening a pull request.
