### PR TITLE
[SPARK-18230][MLLib]Throw a better exception, if the user or product doesn't exist

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModelSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModelSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.mllib.recommendation
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkException, SparkFunSuite}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.rdd.RDD
@@ -70,6 +70,22 @@ class MatrixFactorizationModelSuite extends SparkFunSuite with MLlibTestSparkCon
     } finally {
       Utils.deleteRecursively(tempDir)
     }
+  }
+
+  test("invalid user and product") {
+    val model = new MatrixFactorizationModel(rank, userFeatures, prodFeatures)
+    assert(intercept[SparkException] {
+      model.predict(5, 2)
+    }.getMessage.contains("UserId: 5 not found in the model"))
+    assert(intercept[SparkException] {
+      model.predict(0, 5)
+   }.getMessage.contains("ProductId: 5 not found in the model"))
+    assert(intercept[SparkException] {
+      model.recommendProducts(5, 2)
+    }.getMessage.contains("UserId: 5 not found in the model"))
+    assert(intercept[SparkException] {
+      model.recommendUsers(5, 2)
+    }.getMessage.contains("ProductId: 5 not found in the model"))
   }
 
   test("batch predict API recommendProductsForUsers") {

--- a/mllib/src/test/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModelSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModelSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.mllib.recommendation
 
-import org.apache.spark.{SparkException, SparkFunSuite}
+import org.apache.spark.SparkFunSuite
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.rdd.RDD
@@ -74,18 +74,23 @@ class MatrixFactorizationModelSuite extends SparkFunSuite with MLlibTestSparkCon
 
   test("invalid user and product") {
     val model = new MatrixFactorizationModel(rank, userFeatures, prodFeatures)
-    assert(intercept[SparkException] {
+
+    intercept[IllegalArgumentException] {
+      // invalid user
       model.predict(5, 2)
-    }.getMessage.contains("UserId: 5 not found in the model"))
-    assert(intercept[SparkException] {
+    }
+    intercept[IllegalArgumentException] {
+      // invalid product
       model.predict(0, 5)
-   }.getMessage.contains("ProductId: 5 not found in the model"))
-    assert(intercept[SparkException] {
+    }
+    intercept[IllegalArgumentException] {
+      // invalid user
       model.recommendProducts(5, 2)
-    }.getMessage.contains("UserId: 5 not found in the model"))
-    assert(intercept[SparkException] {
+    }
+    intercept[IllegalArgumentException] {
+      // invalid product
       model.recommendUsers(5, 2)
-    }.getMessage.contains("ProductId: 5 not found in the model"))
+    }
   }
 
   test("batch predict API recommendProductsForUsers") {


### PR DESCRIPTION
When invoking MatrixFactorizationModel.recommendProducts(Int, Int) with a non-existing user, a java.util.NoSuchElementException is thrown:

> java.util.NoSuchElementException: next on empty iterator
	at scala.collection.Iterator$$anon$2.next(Iterator.scala:39)
	at scala.collection.Iterator$$anon$2.next(Iterator.scala:37)
	at scala.collection.IndexedSeqLike$Elements.next(IndexedSeqLike.scala:63)
	at scala.collection.IterableLike$class.head(IterableLike.scala:107)
	at scala.collection.mutable.WrappedArray.scala$collection$IndexedSeqOptimized$$super$head(WrappedArray.scala:35)
	at scala.collection.IndexedSeqOptimized$class.head(IndexedSeqOptimized.scala:126)
	at scala.collection.mutable.WrappedArray.head(WrappedArray.scala:35)
	at org.apache.spark.mllib.recommendation.MatrixFactorizationModel.recommendProducts(MatrixFactorizationModel.scala:169)

## What changes were proposed in this pull request?
Throw a better exception, like "user-id/product-id doesn't found in the model", for a non-existent user/product

## How was this patch tested?
Added UT
