### PR TITLE
[SPARK-24788][SQL] fixed UnresolvedException when toString an unresolved grouping expression

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -470,8 +470,11 @@ class RelationalGroupedDataset protected[sql](
   override def toString: String = {
     val builder = new StringBuilder
     builder.append("RelationalGroupedDataset: [grouping expressions: [")
-    val kFields = groupingExprs.map(_.asInstanceOf[NamedExpression]).map {
-      case f => s"${f.name}: ${f.dataType.simpleString(2)}"
+    val kFields = groupingExprs.collect {
+      case expr: NamedExpression if expr.resolved =>
+        s"${expr.name}: ${expr.dataType.simpleString(2)}"
+      case expr: NamedExpression =>
+        expr.name
     }
     builder.append(kFields.take(2).mkString(", "))
     if (kFields.length > 2) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql
 
 import scala.util.Random
 
-import org.scalatest.Matchers
+import org.scalatest.Matchers.the
 
 import org.apache.spark.sql.execution.WholeStageCodegenExec
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
@@ -33,7 +33,7 @@ import org.apache.spark.sql.types.DecimalType
 
 case class Fact(date: Int, hour: Int, minute: Int, room_name: String, temp: Double)
 
-class DataFrameAggregateSuite extends QueryTest with SharedSQLContext with Matchers {
+class DataFrameAggregateSuite extends QueryTest with SharedSQLContext {
   import testImplicits._
 
   val absTol = 1e-8
@@ -718,6 +718,8 @@ class DataFrameAggregateSuite extends QueryTest with SharedSQLContext with Match
   }
 
   test("SPARK-24788: toString with unresolved expressions should not throw") {
-    noException should be thrownBy testData.groupBy('key).toString
+    // these should not raise exceptions
+    testData.groupBy('key).toString
+    testData.groupBy(col("key")).toString
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql
 
 import scala.util.Random
 
-import org.scalatest.Matchers.the
+import org.scalatest.Matchers
 
 import org.apache.spark.sql.execution.WholeStageCodegenExec
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
@@ -33,7 +33,7 @@ import org.apache.spark.sql.types.DecimalType
 
 case class Fact(date: Int, hour: Int, minute: Int, room_name: String, temp: Double)
 
-class DataFrameAggregateSuite extends QueryTest with SharedSQLContext {
+class DataFrameAggregateSuite extends QueryTest with SharedSQLContext with Matchers {
   import testImplicits._
 
   val absTol = 1e-8
@@ -715,6 +715,11 @@ class DataFrameAggregateSuite extends QueryTest with SharedSQLContext {
     checkAnswer(
       sql("SELECT a, MAX(b), RANK() OVER(ORDER BY a) FROM testData2 GROUP BY a HAVING SUM(b) = 3"),
       Row(1, 2, 1) :: Row(2, 2, 2) :: Row(3, 2, 3) :: Nil)
+  }
+
+  test("SPARK-24788: RelationalGroupedDataset.toString " +
+    "with unresolved grouping expressions should not throw an exception") {
+    noException should be thrownBy testData.groupBy('key).toString
   }
 
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -717,9 +717,7 @@ class DataFrameAggregateSuite extends QueryTest with SharedSQLContext with Match
       Row(1, 2, 1) :: Row(2, 2, 2) :: Row(3, 2, 3) :: Nil)
   }
 
-  test("SPARK-24788: RelationalGroupedDataset.toString " +
-    "with unresolved grouping expressions should not throw an exception") {
+  test("SPARK-24788: toString with unresolved expressions should not throw") {
     noException should be thrownBy testData.groupBy('key).toString
   }
-
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://issues.apache.org/jira/browse/SPARK-24788

Add a special case for unresolved expressions when constructing toString for `RelationalGroupedDataset`.

----

The `.toString` method on `RelationalGroupedDataset` currently accesses the datatype of all of the grouping expressions.

When these are anonymous references (ie. `col("name")` or `'name`) they are created as `UnresolvedAttribute`.

This causes an exception due to this implementation of `NamedAttribute`:
https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala#L105

My fix skips the datatype part of the string representation and just appends the name.


This bug does not impact most applications because they do not call `toString`, however on the shell something as simple as `spark.range(1).groupBy('id)` causes the error because the repl loop calls `toString`.


## How was this patch tested?

Unit test provided.