### PR TITLE
[SPARK-24705][SQL] ExchangeCoordinator broken when duplicate exchanges reused

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -82,7 +82,6 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
       if (adaptiveExecutionEnabled && supportsCoordinator) {
         val coordinator =
           new ExchangeCoordinator(
-            children.length,
             targetPostShuffleInputSize,
             minNumPostShufflePartitions)
         children.zip(requiredChildDistributions).map {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
@@ -52,14 +52,6 @@ case class ReusedExchangeExec(override val output: Seq[Attribute], child: Exchan
   // Ignore this wrapper for canonicalizing.
   override def doCanonicalize(): SparkPlan = child.canonicalized
 
-  override protected def doPrepare(): Unit = {
-    child match {
-      case shuffleExchange @ ShuffleExchangeExec(_, _, Some(coordinator)) =>
-        coordinator.registerExchange(shuffleExchange)
-      case _ =>
-    }
-  }
-
   def doExecute(): RDD[InternalRow] = {
     child.execute()
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala
@@ -90,6 +90,10 @@ class ExchangeCoordinator(
   // The registered Exchange operators.
   private[this] val exchanges = ArrayBuffer[ShuffleExchangeExec]()
 
+  // `lazy val` is used here so that we could notice the wrong use of this class, e.g., all the
+  // exchanges should be registered before `postShuffleRDD` called first time. If a new exchange is
+  // registered after the `postShuffleRDD` call, `assert(exchanges.length == numExchanges)` fails
+  // in `doEstimationIfNecessary`.
   private[this] lazy val numExchanges = exchanges.size
 
   // This map is used to lookup the post-shuffle ShuffledRowRDD for an Exchange operator.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeCoordinatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeCoordinatorSuite.scala
@@ -58,7 +58,7 @@ class ExchangeCoordinatorSuite extends SparkFunSuite with BeforeAndAfterAll {
   }
 
   test("test estimatePartitionStartIndices - 1 Exchange") {
-    val coordinator = new ExchangeCoordinator(1, 100L)
+    val coordinator = new ExchangeCoordinator(100L)
 
     {
       // All bytes per partition are 0.
@@ -105,7 +105,7 @@ class ExchangeCoordinatorSuite extends SparkFunSuite with BeforeAndAfterAll {
   }
 
   test("test estimatePartitionStartIndices - 2 Exchanges") {
-    val coordinator = new ExchangeCoordinator(2, 100L)
+    val coordinator = new ExchangeCoordinator(100L)
 
     {
       // If there are multiple values of the number of pre-shuffle partitions,
@@ -199,7 +199,7 @@ class ExchangeCoordinatorSuite extends SparkFunSuite with BeforeAndAfterAll {
   }
 
   test("test estimatePartitionStartIndices and enforce minimal number of reducers") {
-    val coordinator = new ExchangeCoordinator(2, 100L, Some(2))
+    val coordinator = new ExchangeCoordinator(100L, Some(2))
 
     {
       // The minimal number of post-shuffle partitions is not enforced because

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeCoordinatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeCoordinatorSuite.scala
@@ -500,34 +500,10 @@ class ExchangeCoordinatorSuite extends SparkFunSuite with BeforeAndAfterAll {
     }
   }
 
-  test("SPARK-24705 adaptive query execution works when plan having duplicate exchanges") {
+  test("SPARK-24705 adaptive query execution works correctly when exchange reuse enabled") {
     withSparkSession(SQLConf.EXCHANGE_REUSE_ENABLED.key -> "true") { spark =>
       val df = spark.range(1).selectExpr("id AS key", "id AS value")
       val resultDf = df.join(df, "key").join(df, "key")
-      // If both adaptive execution and exchange reuse enabled, Spark tries to reuse exchanges
-      // in the same coordinator group. In this test, `resultDf` joins the same three input (`df`).
-      // In the first join, the exchange of one side input is reused because the other side
-      // exchange has the same coordinator. But, in the second join, the reuse doesn't happen
-      // because of a different coordinator group as follows;
-      //
-      // == Physical Plan ==
-      // *(9) Project [key#344L, value#345L, value#349L, value#354L]
-      // +- *(9) SortMergeJoin [key#344L], [key#353L], Inner
-      //    :- *(6) Sort [key#344L ASC NULLS FIRST], false, 0
-      //    :  +- Exchange(coordinator id: 738381688) hashpartitioning(key#344L, 5), ...
-      //    :     +- *(5) Project [key#344L, value#345L, value#349L]
-      //    :        +- *(5) SortMergeJoin [key#344L], [key#348L], Inner
-      //    :           :- *(2) Sort [key#344L ASC NULLS FIRST], false, 0
-      //    :           :  +- Exchange(coordinator id: 1048559742) ...
-      //    :           :     +- *(1) Project [id#342L AS key#344L, id#342L AS value#345L]
-      //    :           :        +- *(1) Range (0, 1, step=1, splits=4)
-      //    :           +- *(4) Sort [key#348L ASC NULLS FIRST], false, 0
-      //    :              +- ReusedExchange [key#348L, value#349L],
-      //                         Exchange(coordinator id: 1048559742) ...
-      //    +- *(8) Sort [key#353L ASC NULLS FIRST], false, 0
-      //       +- Exchange(coordinator id: 738381688) hashpartitioning(key#353L, 5), ...
-      //          +- *(7) Project [id#342L AS key#353L, id#342L AS value#354L]
-      //             +- *(7) Range (0, 1, step=1, splits=4)
       val sparkPlan = resultDf.queryExecution.executedPlan
       assert(sparkPlan.collect { case p: ReusedExchangeExec => p }.length == 1)
       assert(sparkPlan.collect { case p @ ShuffleExchangeExec(_, _, Some(c)) => p }.length == 3)


### PR DESCRIPTION
## What changes were proposed in this pull request?
In the current master, `EnsureRequirements` sets the number of exchanges in `ExchangeCoordinator` before `ReuseExchange`. Then, `ReuseExchange` removes some duplicate exchange and the actual number of registered exchanges changes. Finally, the assertion in `ExchangeCoordinator` fails because the logical number of exchanges and the actual number of registered exchanges become different;
https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala#L201

This pr fixed the issue and the code to reproduce this is as follows;
```
scala> sql("SET spark.sql.adaptive.enabled=true")
scala> sql("SET spark.sql.autoBroadcastJoinThreshold=-1")
scala> val df = spark.range(1).selectExpr("id AS key", "id AS value")
scala> val resultDf = df.join(df, "key").join(df, "key")
scala> resultDf.show
...
  at org.apache.spark.sql.execution.exchange.ShuffleExchangeExec$$anonfun$doExecute$1.apply(ShuffleExchangeExec.scala:119)
  at org.apache.spark.sql.catalyst.errors.package$.attachTree(package.scala:52)
  ... 101 more
Caused by: java.lang.AssertionError: assertion failed
  at scala.Predef$.assert(Predef.scala:156)
  at org.apache.spark.sql.execution.exchange.ExchangeCoordinator.doEstimationIfNecessary(ExchangeCoordinator.scala:201)
  at org.apache.spark.sql.execution.exchange.ExchangeCoordinator.postShuffleRDD(ExchangeCoordinator.scala:259)
  at org.apache.spark.sql.execution.exchange.ShuffleExchangeExec$$anonfun$doExecute$1.apply(ShuffleExchangeExec.scala:124)
  at org.apache.spark.sql.execution.exchange.ShuffleExchangeExec$$anonfun$doExecute$1.apply(ShuffleExchangeExec.scala:119)
  at org.apache.spark.sql.catalyst.errors.package$.attachTree(package.scala:52)
...
```

## How was this patch tested?
Added tests in `ExchangeCoordinatorSuite`.