### PR TITLE
[SPARK-24797] [SQL] respect spark.sql.hive.convertMetastoreOrc/Parquet when build…

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -820,6 +820,20 @@ object DDLUtils {
     table.provider.isDefined && table.provider.get.toLowerCase(Locale.ROOT) != HIVE_PROVIDER
   }
 
+  def convertSchema(table: CatalogTable, sparkSession: SparkSession): Boolean = {
+    val validProvider = table.provider.isDefined
+    if (validProvider &&
+      table.provider.get.toLowerCase(Locale.ROOT).contains("parquet")) {
+      sparkSession.sqlContext.conf.getConfString("spark.sql.hive.convertMetastoreParquet").
+        toBoolean
+    } else if (validProvider && table.provider.get.toLowerCase(Locale.ROOT).contains("orc")) {
+        sparkSession.sqlContext.conf.getConfString("spark.sql.hive.convertMetastoreOrc").
+          toBoolean
+    } else {
+      true
+    }
+  }
+
   /**
    * Throws a standard error for actions that require partitionProvider = hive.
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -254,13 +254,15 @@ class FindDataSourceTable(sparkSession: SparkSession) extends Rule[LogicalPlan] 
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan transform {
     case i @ InsertIntoTable(UnresolvedCatalogRelation(tableMeta), _, _, _, _)
-        if DDLUtils.isDatasourceTable(tableMeta) =>
+        if DDLUtils.isDatasourceTable(tableMeta) &&
+          DDLUtils.convertSchema(tableMeta, sparkSession) =>
       i.copy(table = readDataSourceTable(tableMeta))
 
     case i @ InsertIntoTable(UnresolvedCatalogRelation(tableMeta), _, _, _, _) =>
       i.copy(table = readHiveTable(tableMeta))
 
-    case UnresolvedCatalogRelation(tableMeta) if DDLUtils.isDatasourceTable(tableMeta) =>
+    case UnresolvedCatalogRelation(tableMeta) if DDLUtils.isDatasourceTable(tableMeta) &&
+      DDLUtils.convertSchema(tableMeta, sparkSession) =>
       readDataSourceTable(tableMeta)
 
     case UnresolvedCatalogRelation(tableMeta) =>


### PR DESCRIPTION

## What changes were proposed in this pull request?

the current code path ignore the value of spark.sql.hive.convertMetastoreParquet when building data source table 

 

https://github.com/apache/spark/blob/e0559f238009e02c40f65678fec691c07904e8c0/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala#L263

as a result, even I turned off spark.sql.hive.convertMetastoreParquet, Spark SQL still uses its own parquet reader to access table instead of delegate to serder

This PR checks the value of the configuration when building data source table

## How was this patch tested?

existing test