### PR TITLE
[SPARK-24803][SQL] add support for numeric

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1664,9 +1664,9 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
       case ("char", length :: Nil) => CharType(length.getText.toInt)
       case ("varchar", length :: Nil) => VarcharType(length.getText.toInt)
       case ("binary", Nil) => BinaryType
-      case ("decimal", Nil) => DecimalType.USER_DEFAULT
-      case ("decimal", precision :: Nil) => DecimalType(precision.getText.toInt, 0)
-      case ("decimal", precision :: scale :: Nil) =>
+      case ("decimal" | "numeric", Nil) => DecimalType.USER_DEFAULT
+      case ("decimal" | "numeric", precision :: Nil) => DecimalType(precision.getText.toInt, 0)
+      case ("decimal" | "numeric", precision :: scale :: Nil) =>
         DecimalType(precision.getText.toInt, scale.getText.toInt)
       case (dt, params) =>
         val dtStr = if (params.nonEmpty) s"$dt(${params.mkString(",")})" else dt


### PR DESCRIPTION
## What changes were proposed in this pull request?

numerical is as same with decimal. Spark has already  supported decimal，so i think we should add support for numeric to align SQL standards.

(Please fill in changes proposed in this fix)

## How was this patch tested?

already exist tests

Please review http://spark.apache.org/contributing.html before opening a pull request.