### PR TITLE
[SPARK-24806][SQL] Brush up generated code so that JDK compilers can handle it

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
@@ -31,7 +31,7 @@ import org.apache.spark.unsafe.array.ByteArrayMethods;
  * for each incoming record, we should call `reset` of BufferHolder instance before write the record
  * and reuse the data buffer.
  */
-final class BufferHolder {
+public final class BufferHolder {
 
   private static final int ARRAY_MAX = ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH;
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -897,7 +897,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
     case StringType =>
       val intOpt = ctx.freshVariable("intOpt", classOf[Option[Integer]])
       (c, evPrim, evNull) => code"""
-        scala.Option<Integer> $intOpt =
+        scala.Option<Object> $intOpt =
           org.apache.spark.sql.catalyst.util.DateTimeUtils.stringToDate($c);
         if ($intOpt.isDefined()) {
           $evPrim = ((Integer) $intOpt.get()).intValue();
@@ -990,8 +990,13 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
       val tz = JavaCode.global(ctx.addReferenceObj("timeZone", timeZone), timeZone.getClass)
       val longOpt = ctx.freshVariable("longOpt", classOf[Option[Long]])
       (c, evPrim, evNull) =>
+<<<<<<< HEAD
         code"""
           scala.Option<Long> $longOpt =
+=======
+        s"""
+          scala.Option<Object> $longOpt =
+>>>>>>> Fix
             org.apache.spark.sql.catalyst.util.DateTimeUtils.stringToTimestamp($c, $tz);
           if ($longOpt.isDefined()) {
             $evPrim = ((Long) $longOpt.get()).longValue();

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -990,13 +990,8 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
       val tz = JavaCode.global(ctx.addReferenceObj("timeZone", timeZone), timeZone.getClass)
       val longOpt = ctx.freshVariable("longOpt", classOf[Option[Long]])
       (c, evPrim, evNull) =>
-<<<<<<< HEAD
         code"""
-          scala.Option<Long> $longOpt =
-=======
-        s"""
           scala.Option<Object> $longOpt =
->>>>>>> Fix
             org.apache.spark.sql.catalyst.util.DateTimeUtils.stringToTimestamp($c, $tz);
           if ($longOpt.isDefined()) {
             $evPrim = ((Long) $longOpt.get()).longValue();

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
@@ -188,9 +188,9 @@ case class SortPrefix(child: SortOrder) extends UnaryExpression {
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val childCode = child.child.genCode(ctx)
     val input = childCode.value
-    val BinaryPrefixCmp = classOf[BinaryPrefixComparator].getName
-    val DoublePrefixCmp = classOf[DoublePrefixComparator].getName
-    val StringPrefixCmp = classOf[StringPrefixComparator].getName
+    val BinaryPrefixCmp = classOf[BinaryPrefixComparator].getCanonicalName
+    val DoublePrefixCmp = classOf[DoublePrefixComparator].getCanonicalName
+    val StringPrefixCmp = classOf[StringPrefixComparator].getCanonicalName
     val prefixCode = child.child.dataType match {
       case BooleanType =>
         s"$input ? 1L : 0L"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1606,10 +1606,9 @@ object CodeGenerator extends Logging {
 
   def getClassName(cls: Class[_]): String = {
     try {
-      return Option(cls.getCanonicalName).getOrElse(cls.getName)
+      Option(cls.getCanonicalName).getOrElse(cls.getName)
     } catch {
-      case err: InternalError =>
-        return cls.getName
+      case err: InternalError => cls.getName
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -133,7 +133,7 @@ class CodegenContext {
   def addReferenceObj(objName: String, obj: Any, className: String = null): String = {
     val idx = references.length
     references += obj
-    val clsName = Option(className).getOrElse(obj.getClass.getName)
+    val clsName = Option(className).getOrElse(obj.getClass.getCanonicalName)
     s"(($clsName) references[$idx] /* $objName */)"
   }
 
@@ -1624,7 +1624,7 @@ object CodeGenerator extends Logging {
     case _: MapType => "MapData"
     case udt: UserDefinedType[_] => javaType(udt.sqlType)
     case ObjectType(cls) if cls.isArray => s"${javaType(ObjectType(cls.getComponentType))}[]"
-    case ObjectType(cls) => cls.getName
+    case ObjectType(cls) => Option(cls.getCanonicalName).getOrElse(cls.getName)
     case _ => "Object"
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -133,7 +133,7 @@ class CodegenContext {
   def addReferenceObj(objName: String, obj: Any, className: String = null): String = {
     val idx = references.length
     references += obj
-    val clsName = Option(className).getOrElse(obj.getClass.getCanonicalName)
+    val clsName = Option(className).getOrElse(getClassName(obj.getClass))
     s"(($clsName) references[$idx] /* $objName */)"
   }
 
@@ -1604,6 +1604,15 @@ object CodeGenerator extends Logging {
 
   def primitiveTypeName(dt: DataType): String = primitiveTypeName(javaType(dt))
 
+  def getClassName(cls: Class[_]): String = {
+    try {
+      return Option(cls.getCanonicalName).getOrElse(cls.getName)
+    } catch {
+      case err: InternalError =>
+        return cls.getName
+    }
+  }
+
   /**
    * Returns the Java type for a DataType.
    */
@@ -1624,7 +1633,7 @@ object CodeGenerator extends Logging {
     case _: MapType => "MapData"
     case udt: UserDefinedType[_] => javaType(udt.sqlType)
     case ObjectType(cls) if cls.isArray => s"${javaType(ObjectType(cls.getComponentType))}[]"
-    case ObjectType(cls) => Option(cls.getCanonicalName).getOrElse(cls.getName)
+    case ObjectType(cls) => getClassName(cls)
     case _ => "Object"
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -1619,7 +1619,7 @@ case class ArraysOverlap(left: Expression, right: Expression)
     val getFromSmaller = CodeGenerator.getValue(smaller, elementType, i)
     val getFromBigger = CodeGenerator.getValue(bigger, elementType, i)
     val javaElementClass = CodeGenerator.boxedType(elementType)
-    val javaSet = classOf[java.util.HashSet[_]].getName
+    val javaSet = classOf[java.util.HashSet[_]].getCanonicalName
     val set = ctx.freshName("set")
     val addToSetFromSmallerCode = nullSafeElementCodegen(
       smaller, i, s"$set.add($getFromSmaller);", s"${ev.isNull} = true;")
@@ -2826,7 +2826,7 @@ case class Sequence(
       val arr = ctx.freshName("arr")
       val arrElemType = CodeGenerator.javaType(dataType.elementType)
       s"""
-         |final $arrElemType[] $arr = null;
+         |$arrElemType[] $arr = null;
          |${impl.genCode(ctx, startGen.value, stopGen.value, stepGen.value, arr, arrElemType)}
          |${ev.value} = UnsafeArrayData.fromPrimitiveArray($arr);
        """.stripMargin

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -1619,7 +1619,7 @@ case class ArraysOverlap(left: Expression, right: Expression)
     val getFromSmaller = CodeGenerator.getValue(smaller, elementType, i)
     val getFromBigger = CodeGenerator.getValue(bigger, elementType, i)
     val javaElementClass = CodeGenerator.boxedType(elementType)
-    val javaSet = classOf[java.util.HashSet[_]].getCanonicalName
+    val javaSet = classOf[java.util.HashSet[_]].getName
     val set = ctx.freshName("set")
     val addToSetFromSmallerCode = nullSafeElementCodegen(
       smaller, i, s"$set.add($getFromSmaller);", s"${ev.isNull} = true;")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -1048,7 +1048,7 @@ case class StringToTimestampWithoutTimezone(child: Expression, timeZoneId: Optio
        |${CodeGenerator.JAVA_BOOLEAN} ${ev.isNull} = true;
        |${CodeGenerator.JAVA_LONG} ${ev.value} = ${CodeGenerator.defaultValue(TimestampType)};
        |if (!${eval.isNull}) {
-       |  scala.Option<Long> $longOpt = $dtu.stringToTimestamp(${eval.value}, $tz, true);
+       |  scala.Option<Object> $longOpt = $dtu.stringToTimestamp(${eval.value}, $tz, true);
        |  if ($longOpt.isDefined()) {
        |    ${ev.value} = ((Long) $longOpt.get()).longValue();
        |    ${ev.isNull} = false;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -1585,7 +1585,7 @@ case class InitializeJavaBean(beanInstance: Expression, setters: Map[String, Exp
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     // Resolves setters before compilation
-    require(resolvedSetters.nonEmpty)
+    require(setters.isEmpty || resolvedSetters.nonEmpty)
 
     val instanceGen = beanInstance.genCode(ctx)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -36,7 +36,6 @@ import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData, GenericArrayData, MapData}
 import org.apache.spark.sql.types._
-import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 import org.apache.spark.util.Utils
 
 /**
@@ -434,7 +433,7 @@ case class NewInstance(
     propagateNull: Boolean,
     dataType: DataType,
     outerPointer: Option[() => AnyRef]) extends InvokeLike {
-  private val className = cls.getCanonicalName
+  private val className = CodeGenerator.getClassName(cls)
 
   override def nullable: Boolean = needNullCheck
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -219,8 +219,8 @@ case class StaticInvoke(
     propagateNull: Boolean = true,
     returnNullable: Boolean = true) extends InvokeLike {
 
-  val objectName = staticObject.getName.stripSuffix("$")
-  val cls = if (staticObject.getName == objectName) {
+  val objectName = staticObject.getCanonicalName.stripSuffix("$")
+  val cls = if (staticObject.getCanonicalName == objectName) {
     staticObject
   } else {
     Utils.classForName(objectName)
@@ -434,7 +434,7 @@ case class NewInstance(
     propagateNull: Boolean,
     dataType: DataType,
     outerPointer: Option[() => AnyRef]) extends InvokeLike {
-  private val className = cls.getName
+  private val className = cls.getCanonicalName
 
   override def nullable: Boolean = needNullCheck
 
@@ -1335,7 +1335,7 @@ case class ExternalMapToCatalyst private(
     val (defineEntries, defineKeyValue) = child.dataType match {
       case ObjectType(cls) if classOf[java.util.Map[_, _]].isAssignableFrom(cls) =>
         val javaIteratorCls = classOf[java.util.Iterator[_]].getName
-        val javaMapEntryCls = classOf[java.util.Map.Entry[_, _]].getName
+        val javaMapEntryCls = classOf[java.util.Map.Entry[_, _]].getCanonicalName
 
         val defineEntries =
           s"final $javaIteratorCls $entries = ${inputMap.value}.entrySet().iterator();"
@@ -1585,6 +1585,9 @@ case class InitializeJavaBean(beanInstance: Expression, setters: Map[String, Exp
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    // Resolves setters before compilation
+    require(resolvedSetters.nonEmpty)
+
     val instanceGen = beanInstance.genCode(ctx)
 
     val javaBeanInstance = ctx.freshName("javaBean")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -318,7 +318,8 @@ case class SampleExec(
         v => s"""
           | $v = new $samplerClass<UnsafeRow>($lowerBound, $upperBound, false);
           | $v.setSeed(${seed}L + partitionIndex);
-         """.stripMargin.trim)
+         """.stripMargin.trim,
+        forceInline = true)
 
       s"""
          | if ($sampler.sample() != 0) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
@@ -79,7 +79,7 @@ case class LocalLimitExec(limit: Int, child: SparkPlan) extends UnaryExecNode wi
 
     ctx.addNewFunction("stopEarly", s"""
       @Override
-      protected boolean stopEarly() {
+      public boolean stopEarly() {
         return $stopEarly;
       }
     """, inlineToOuterClass = true)


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr brushed up code so that JDK compilers can handle it because the master sometimes generates Java code that only janino can compile it. This is the issue I found when working on SPARK-24498.

## How was this patch tested?
Existing tests.