### PR TITLE
[SPARK-24809] [SQL] Serializing LongToUnsafeRowMap in executor may result in data error

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -726,10 +726,9 @@ private[execution] final class LongToUnsafeRowMap(val mm: TaskMemoryManager, cap
 
     writeLong(array.length)
     writeLongArray(writeBuffer, array, array.length)
-
-    val usedWordsNumber = ((cursor - Platform.LONG_ARRAY_OFFSET) / 8).toInt
-    writeLong(usedWordsNumber)
-    writeLongArray(writeBuffer, page, usedWordsNumber)
+    val used = ((cursor - Platform.LONG_ARRAY_OFFSET) / 8).toInt
+    writeLong(used)
+    writeLongArray(writeBuffer, page, used)
   }
 
   override def writeExternal(output: ObjectOutput): Unit = {
@@ -771,10 +770,10 @@ private[execution] final class LongToUnsafeRowMap(val mm: TaskMemoryManager, cap
     val length = readLong().toInt
     mask = length - 2
     array = readLongArray(readBuffer, length)
-    val usedWordsNumber = readLong().toInt
+    val pageLength = readLong().toInt
+    page = readLongArray(readBuffer, pageLength)
     // Set cursor because cursor is used in write function.
-    cursor = usedWordsNumber * 8 + Platform.LONG_ARRAY_OFFSET
-    page = readLongArray(readBuffer, usedWordsNumber)
+    cursor = pageLength * 8 + Platform.LONG_ARRAY_OFFSET
   }
 
   override def readExternal(in: ObjectInput): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -772,7 +772,7 @@ private[execution] final class LongToUnsafeRowMap(val mm: TaskMemoryManager, cap
     array = readLongArray(readBuffer, length)
     val pageLength = readLong().toInt
     page = readLongArray(readBuffer, pageLength)
-    // Set cursor because cursor is used in write function.
+    // Restore cursor variable to make this map able to be serialized again on executors.
     cursor = pageLength * 8 + Platform.LONG_ARRAY_OFFSET
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -726,8 +726,9 @@ private[execution] final class LongToUnsafeRowMap(val mm: TaskMemoryManager, cap
 
     writeLong(array.length)
     writeLongArray(writeBuffer, array, array.length)
-    val used = ((cursor - Platform.LONG_ARRAY_OFFSET) / 8).toInt
-    writeLong(used)
+    val cursorFlag = cursor - Platform.LONG_ARRAY_OFFSET
+    writeLong(cursorFlag)
+    val used = (cursorFlag / 8).toInt
     writeLongArray(writeBuffer, page, used)
   }
 
@@ -770,7 +771,9 @@ private[execution] final class LongToUnsafeRowMap(val mm: TaskMemoryManager, cap
     val length = readLong().toInt
     mask = length - 2
     array = readLongArray(readBuffer, length)
-    val pageLength = readLong().toInt
+    val cursorFlag = readLong()
+    cursor = cursorFlag + Platform.LONG_ARRAY_OFFSET
+    val pageLength = (cursorFlag / 8).toInt
     page = readLongArray(readBuffer, pageLength)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -726,10 +726,10 @@ private[execution] final class LongToUnsafeRowMap(val mm: TaskMemoryManager, cap
 
     writeLong(array.length)
     writeLongArray(writeBuffer, array, array.length)
-    val cursorFlag = cursor - Platform.LONG_ARRAY_OFFSET
-    writeLong(cursorFlag)
-    val used = (cursorFlag / 8).toInt
-    writeLongArray(writeBuffer, page, used)
+
+    val usedWordsNumber = ((cursor - Platform.LONG_ARRAY_OFFSET) / 8).toInt
+    writeLong(usedWordsNumber)
+    writeLongArray(writeBuffer, page, usedWordsNumber)
   }
 
   override def writeExternal(output: ObjectOutput): Unit = {
@@ -771,10 +771,10 @@ private[execution] final class LongToUnsafeRowMap(val mm: TaskMemoryManager, cap
     val length = readLong().toInt
     mask = length - 2
     array = readLongArray(readBuffer, length)
-    val cursorFlag = readLong()
-    cursor = cursorFlag + Platform.LONG_ARRAY_OFFSET
-    val pageLength = (cursorFlag / 8).toInt
-    page = readLongArray(readBuffer, pageLength)
+    val usedWordsNumber = readLong().toInt
+    // Set cursor because cursor is used in write function.
+    cursor = usedWordsNumber * 8 + Platform.LONG_ARRAY_OFFSET
+    page = readLongArray(readBuffer, usedWordsNumber)
   }
 
   override def readExternal(in: ObjectInput): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
@@ -292,8 +292,7 @@ class HashedRelationSuite extends SparkFunSuite with SharedSQLContext {
     originalMap.append(key2, unsafeProj(InternalRow(value2)))
     originalMap.optimize()
 
-    val ser = new KryoSerializer(
-            (new SparkConf).set("spark.kryo.referenceTracking", "false")).newInstance()
+    val ser = sparkContext.env.serializer.newInstance()
     // Simulate serialize/deserialize twice on driver and executor
     val firstTimeSerialized = ser.deserialize[LongToUnsafeRowMap](ser.serialize(originalMap))
     val secondTimeSerialized =


### PR DESCRIPTION
When join key is long or int in broadcast join, Spark will use `LongToUnsafeRowMap` to store key-values of the table witch will be broadcasted. But, when `LongToUnsafeRowMap` is broadcasted to executors, and it is too big to hold in memory, it will be stored in disk. At that time, because `write` uses a variable `cursor` to determine how many bytes in `page` of `LongToUnsafeRowMap` will be write out and the `cursor` was not restore when deserializing, executor will write out nothing from page into disk.

## What changes were proposed in this pull request?
Restore cursor value when deserializing.

