### PR TITLE
[WIP][SPARK-24498][SQL] Add JDK compiler for runtime codegen

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
@@ -188,9 +188,9 @@ case class SortPrefix(child: SortOrder) extends UnaryExpression {
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val childCode = child.child.genCode(ctx)
     val input = childCode.value
-    val BinaryPrefixCmp = classOf[BinaryPrefixComparator].getName
-    val DoublePrefixCmp = classOf[DoublePrefixComparator].getName
-    val StringPrefixCmp = classOf[StringPrefixComparator].getName
+    val BinaryPrefixCmp = classOf[BinaryPrefixComparator].getCanonicalName
+    val DoublePrefixCmp = classOf[DoublePrefixComparator].getCanonicalName
+    val StringPrefixCmp = classOf[StringPrefixComparator].getCanonicalName
     val prefixCode = child.child.dataType match {
       case BooleanType =>
         s"$input ? 1L : 0L"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -32,7 +32,7 @@ import org.apache.spark.metrics.source.CodegenMetrics
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
-import org.apache.spark.sql.catalyst.expressions.codegen.compiler.{CompilerBase, JaninoCompiler, JdkCompiler}
+import org.apache.spark.sql.catalyst.expressions.codegen.compiler._
 import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateMutableProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateMutableProjection.scala
@@ -127,8 +127,10 @@ object GenerateMutableProjection extends CodeGenerator[Seq[Expression], MutableP
           return (InternalRow) mutableRow;
         }
 
-        public java.lang.Object apply(java.lang.Object _i) {
-          InternalRow ${ctx.INPUT_ROW} = (InternalRow) _i;
+        $janinoCompatibilityCode
+
+        public InternalRow apply(InternalRow _i) {
+          InternalRow ${ctx.INPUT_ROW} = _i;
           $evalSubexpr
           $allProjections
           // copy all the results into MutableRow

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateSafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateSafeProjection.scala
@@ -187,8 +187,10 @@ object GenerateSafeProjection extends CodeGenerator[Seq[Expression], Projection]
           ${ctx.initPartition()}
         }
 
-        public java.lang.Object apply(java.lang.Object _i) {
-          InternalRow ${ctx.INPUT_ROW} = (InternalRow) _i;
+        $janinoCompatibilityCode
+
+        public InternalRow apply(InternalRow _i) {
+          InternalRow ${ctx.INPUT_ROW} = _i;
           $allExpressions
           return mutableRow;
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
@@ -355,10 +355,7 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
          |    ${ctx.initPartition()}
          |  }
          |
-         |  // Scala.Function1 need this
-         |  public java.lang.Object apply(java.lang.Object row) {
-         |    return apply((InternalRow) row);
-         |  }
+         |  $janinoCompatibilityCode
          |
          |  public UnsafeRow apply(InternalRow ${ctx.INPUT_ROW}) {
          |    ${eval.code}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/compiler/CompilerBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/compiler/CompilerBase.scala
@@ -15,26 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.spark.util
+package org.apache.spark.sql.catalyst.expressions.codegen.compiler
 
-/**
- * A class loader which makes some protected methods in ClassLoader accessible.
- */
-private[spark] class ParentClassLoader(parent: ClassLoader) extends ClassLoader(parent) {
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodeAndComment, GeneratedClass}
 
-  override def findClass(name: String): Class[_] = {
-    super.findClass(name)
-  }
 
-  override def loadClass(name: String): Class[_] = {
-    super.loadClass(name)
-  }
+abstract class CompilerBase {
 
-  override def loadClass(name: String, resolve: Boolean): Class[_] = {
-    super.loadClass(name, resolve)
-  }
-
-  def loadClass(name: String, b: Array[Byte], off: Int, length: Int): Class[_] = {
-    super.defineClass(name, b, off, length)
-  }
+  def compile (code: CodeAndComment): (GeneratedClass, Int)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/compiler/JaninoCompiler.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/compiler/JaninoCompiler.scala
@@ -59,7 +59,7 @@ object JaninoCompiler extends CompilerBase {
     evaluator.setParentClassLoader(parentClassLoader)
     // Cannot be under package codegen, or fail with java.lang.InstantiationException
     evaluator.setClassName(className)
-    evaluator.setDefaultImports(importClassNames.toArray)
+    importClassNames.map(evaluator.setDefaultImports(_))
     evaluator.setExtendedClass(extendedClass)
 
     logDebug({

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/compiler/JaninoCompiler.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/compiler/JaninoCompiler.scala
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions.codegen.compiler
+
+import java.io.ByteArrayInputStream
+import java.util.{Map => JavaMap}
+
+import scala.collection.JavaConverters._
+import scala.language.existentials
+import scala.util.control.NonFatal
+
+import org.codehaus.commons.compiler.CompileException
+import org.codehaus.janino.{ByteArrayClassLoader, ClassBodyEvaluator, InternalCompilerException, SimpleCompiler}
+import org.codehaus.janino.util.ClassFile
+
+import org.apache.spark.{TaskContext, TaskKilledException}
+import org.apache.spark.executor.InputMetrics
+import org.apache.spark.internal.Logging
+import org.apache.spark.metrics.source.CodegenMetrics
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodeAndComment, CodeFormatter, GeneratedClass}
+import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.Platform
+import org.apache.spark.unsafe.types._
+import org.apache.spark.util.{ParentClassLoader, Utils}
+
+
+object JaninoCompiler extends CompilerBase with Logging {
+
+  /**
+   * Returns the max bytecode size of the generated functions by inspecting janino private fields.
+   * Also, this method updates the metrics information.
+   */
+  private def updateAndGetCompilationStats(evaluator: ClassBodyEvaluator): Int = {
+    // First retrieve the generated classes.
+    val classes = {
+      val resultField = classOf[SimpleCompiler].getDeclaredField("result")
+      resultField.setAccessible(true)
+      val loader = resultField.get(evaluator).asInstanceOf[ByteArrayClassLoader]
+      val classesField = loader.getClass.getDeclaredField("classes")
+      classesField.setAccessible(true)
+      classesField.get(loader).asInstanceOf[JavaMap[String, Array[Byte]]].asScala
+    }
+
+    // Then walk the classes to get at the method bytecode.
+    val codeAttr = Utils.classForName("org.codehaus.janino.util.ClassFile$CodeAttribute")
+    val codeAttrField = codeAttr.getDeclaredField("code")
+    codeAttrField.setAccessible(true)
+    val codeSizes = classes.flatMap { case (_, classBytes) =>
+      CodegenMetrics.METRIC_GENERATED_CLASS_BYTECODE_SIZE.update(classBytes.length)
+      try {
+        val cf = new ClassFile(new ByteArrayInputStream(classBytes))
+        val stats = cf.methodInfos.asScala.flatMap { method =>
+          method.getAttributes().filter(_.getClass.getName == codeAttr.getName).map { a =>
+            val byteCodeSize = codeAttrField.get(a).asInstanceOf[Array[Byte]].length
+            CodegenMetrics.METRIC_GENERATED_METHOD_BYTECODE_SIZE.update(byteCodeSize)
+            byteCodeSize
+          }
+        }
+        Some(stats)
+      } catch {
+        case NonFatal(e) =>
+          logWarning("Error calculating stats of compiled class.", e)
+          None
+      }
+    }.flatten
+
+    codeSizes.max
+  }
+
+  override def compile(code: CodeAndComment): (GeneratedClass, Int) = {
+    val evaluator = new ClassBodyEvaluator()
+
+    // A special classloader used to wrap the actual parent classloader of
+    // [[org.codehaus.janino.ClassBodyEvaluator]] (see CodeGenerator.doCompile). This classloader
+    // does not throw a ClassNotFoundException with a cause set (i.e. exception.getCause returns
+    // a null). This classloader is needed because janino will throw the exception directly if
+    // the parent classloader throws a ClassNotFoundException with cause set instead of trying to
+    // find other possible classes (see org.codehaus.janinoClassLoaderIClassLoader's
+    // findIClass method). Please also see https://issues.apache.org/jira/browse/SPARK-15622 and
+    // https://issues.apache.org/jira/browse/SPARK-11636.
+    val parentClassLoader = new ParentClassLoader(Utils.getContextOrSparkClassLoader)
+    evaluator.setParentClassLoader(parentClassLoader)
+    // Cannot be under package codegen, or fail with java.lang.InstantiationException
+    evaluator.setClassName("org.apache.spark.sql.catalyst.expressions.GeneratedClass")
+    evaluator.setDefaultImports(Array(
+      classOf[Platform].getName,
+      classOf[InternalRow].getName,
+      classOf[UnsafeRow].getName,
+      classOf[UTF8String].getName,
+      classOf[Decimal].getName,
+      classOf[CalendarInterval].getName,
+      classOf[ArrayData].getName,
+      classOf[UnsafeArrayData].getName,
+      classOf[MapData].getName,
+      classOf[UnsafeMapData].getName,
+      classOf[Expression].getName,
+      classOf[TaskContext].getName,
+      classOf[TaskKilledException].getName,
+      classOf[InputMetrics].getName
+    ))
+    evaluator.setExtendedClass(classOf[GeneratedClass])
+
+    logDebug({
+      // Only add extra debugging info to byte code when we are going to print the source code.
+      evaluator.setDebuggingInformation(true, true, false)
+      s"\n${CodeFormatter.format(code)}"
+    })
+
+    val maxCodeSize = try {
+      evaluator.cook("generated.java", code.body)
+      updateAndGetCompilationStats(evaluator)
+    } catch {
+      case e: InternalCompilerException =>
+        val msg = s"failed to compile: $e"
+        logError(msg, e)
+        val maxLines = SQLConf.get.loggingMaxLinesForCodegen
+        logInfo(s"\n${CodeFormatter.format(code, maxLines)}")
+        throw new InternalCompilerException(msg, e)
+      case e: CompileException =>
+        val msg = s"failed to compile: $e"
+        logError(msg, e)
+        val maxLines = SQLConf.get.loggingMaxLinesForCodegen
+        logInfo(s"\n${CodeFormatter.format(code, maxLines)}")
+        throw new CompileException(msg, e.getLocation)
+    }
+
+    (evaluator.getClazz().newInstance().asInstanceOf[GeneratedClass], maxCodeSize)
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/compiler/JdkCompiler.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/compiler/JdkCompiler.scala
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions.codegen.compiler
+
+import java.io.{ByteArrayOutputStream, OutputStream, Reader, StringReader}
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.util.{Arrays, Locale}
+import javax.tools._
+import javax.tools.JavaFileManager.Location
+import javax.tools.JavaFileObject.Kind
+
+import scala.collection.mutable
+
+import com.sun.org.apache.xalan.internal.xsltc.compiler.CompilerException
+import org.codehaus.commons.compiler.CompileException
+
+import org.apache.spark.{TaskContext, TaskKilledException}
+import org.apache.spark.executor.InputMetrics
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst._
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.UnsafeProjection
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodeAndComment, GeneratedClass}
+import org.apache.spark.sql.catalyst.util._
+import org.apache.spark.sql.types.Decimal
+import org.apache.spark.unsafe.Platform
+import org.apache.spark.unsafe.types._
+import org.apache.spark.util.ParentClassLoader
+import org.apache.spark.util.collection.unsafe.sort.PrefixComparators
+
+
+class JavaCodeManager(fileManager: JavaFileManager)
+    extends ForwardingJavaFileManager[JavaFileManager](fileManager) with Logging {
+
+  // Holds a map between class names and `JavaCode`s (it has all the inner classes)
+  private val objects = mutable.Map[String, JavaCode]()
+
+  private val classLoader = new ClassLoader(null) {
+
+    // Loads a compile class into a current context class loader
+    val parentLoader = new ParentClassLoader(Thread.currentThread().getContextClassLoader)
+
+    private def loadAllObjects(): Unit = {
+      objects.foreach { case (className, javaCode) =>
+        try {
+          parentLoader.loadClass(className)
+        } catch {
+          case _: ClassNotFoundException =>
+            val bytecode = javaCode.getBytecode
+            parentLoader.loadClass(className, bytecode, 0, bytecode.length)
+        }
+      }
+    }
+
+    override def findClass(name: String): Class[_] = {
+      try {
+        parentLoader.loadClass(name)
+      } catch {
+        case _: ClassNotFoundException =>
+          loadAllObjects()
+          parentLoader.loadClass(name)
+      }
+    }
+  }
+
+  override def getClassLoader(location: Location): ClassLoader = {
+    classLoader
+  }
+
+  override def getJavaFileForOutput(
+      location: Location,
+      className: String,
+      kind: Kind,
+      sibling: FileObject): JavaFileObject = sibling match {
+    case code: JavaCode =>
+      logDebug(s"getJavaFileForOutput called: className=$className sibling=${code.className}")
+      val javaCode = if (code.className != className) JavaCode(className) else code
+      objects += className -> javaCode
+      javaCode
+    case unknown =>
+      throw new CompilerException(s"Unknown source file found: $unknown")
+  }
+}
+
+case class JavaCode(className: String, code: Option[String] = None)
+    extends SimpleJavaFileObject(
+      URI.create(s"string:///${className.replace('.', '/')}${Kind.SOURCE.extension}"),
+      Kind.SOURCE) {
+
+  // Holds compiled bytecode
+  private val outputStream = new ByteArrayOutputStream()
+
+  def getBytecode: Array[Byte] = outputStream.toByteArray
+
+  override def getCharContent(ignoreEncodingErrors: Boolean): CharSequence = code.getOrElse("")
+
+  override def openReader(ignoreEncodingErrors: Boolean): Reader = {
+    code.map { c => new StringReader(c) }.getOrElse {
+      throw new CompilerException(s"Failed to open a reader for $className")
+    }
+  }
+
+  override def openOutputStream(): OutputStream = {
+    outputStream
+  }
+}
+
+object JdkCompiler extends CompilerBase {
+
+  private val javaCompiler = {
+    val compiler = ToolProvider.getSystemJavaCompiler
+    if (compiler == null) {
+      throw new RuntimeException(
+        "JDK Java compiler not available - probably you're running Drill with a JRE and not a JDK")
+    }
+    compiler
+  }
+
+  private def javaCodeManager() = {
+    val fm = javaCompiler.getStandardFileManager(null, Locale.ROOT, StandardCharsets.UTF_8)
+    new JavaCodeManager(fm)
+  }
+
+  private val compilerOptions = Arrays.asList("-classpath", System.getProperty("java.class.path"))
+
+  override def compile(code: CodeAndComment): (GeneratedClass, Int) = {
+    val clazzName = "GeneratedIterator"
+    val codeWithImports =
+      s"""import ${classOf[Platform].getName};
+         |import ${classOf[InternalRow].getName};
+         |import ${classOf[UnsafeRow].getName};
+         |import ${classOf[UnsafeProjection].getName};
+         |import ${classOf[UTF8String].getName};
+         |import ${classOf[Decimal].getName};
+         |import ${classOf[CalendarInterval].getName};
+         |import ${classOf[ArrayData].getName};
+         |import ${classOf[PrefixComparators].getName};
+         |import ${classOf[UnsafeArrayData].getName};
+         |import ${classOf[MapData].getName};
+         |import ${classOf[UnsafeMapData].getName};
+         |import ${classOf[Expression].getName};
+         |import ${classOf[TaskContext].getName};
+         |import ${classOf[TaskKilledException].getName};
+         |import ${classOf[InputMetrics].getName};
+         |
+         |public class $clazzName extends ${classOf[GeneratedClass].getName} {
+         |${code.body}
+         |}
+       """.stripMargin
+
+    val javaCode = JavaCode(clazzName, Some(codeWithImports))
+    val fileManager = javaCodeManager()
+    val task = javaCompiler.getTask(
+      null, fileManager, null, compilerOptions, null, Arrays.asList(javaCode))
+    if (!task.call()) {
+      throw new CompileException("Compilation failed", null)
+    }
+    val clazz = fileManager.getClassLoader(null).loadClass(clazzName)
+    (clazz.newInstance().asInstanceOf[GeneratedClass], 0)
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -1551,7 +1551,7 @@ case class ArraysOverlap(left: Expression, right: Expression)
     val getFromSmaller = CodeGenerator.getValue(smaller, elementType, i)
     val getFromBigger = CodeGenerator.getValue(bigger, elementType, i)
     val javaElementClass = CodeGenerator.boxedType(elementType)
-    val javaSet = classOf[java.util.HashSet[_]].getName
+    val javaSet = classOf[java.util.HashSet[_]].getCanonicalName
     val set = ctx.freshName("set")
     val addToSetFromSmallerCode = nullSafeElementCodegen(
       smaller, i, s"$set.add($getFromSmaller);", s"${ev.isNull} = true;")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1740,6 +1740,10 @@ class SQLConf extends Serializable with Logging {
 
   def codegenCacheMaxEntries: Int = getConf(StaticSQLConf.CODEGEN_CACHE_MAX_ENTRIES)
 
+  def javaCompiler: String = getConf(StaticSQLConf.CODEGEN_JAVA_COMPILER)
+
+  def jdkCompilerOptions: String = getConf(StaticSQLConf.CODEGEN_JDK_JAVA_COMPILER_OPTION)
+
   def exchangeReuseEnabled: Boolean = getConf(EXCHANGE_REUSE_ENABLED)
 
   def caseSensitiveAnalysis: Boolean = getConf(SQLConf.CASE_SENSITIVE)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -82,6 +82,22 @@ object StaticSQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val CODEGEN_JAVA_COMPILER = buildStaticConf("spark.sql.codegen.javaCompiler")
+      .internal()
+      .doc("Sets the Java bytecode compiler for compiling Java methods for DataFrame or Dataset " +
+        "program. Acceptable values include: jdk or janino")
+      .stringConf
+      .checkValues(Set("jdk", "janino"))
+      .createWithDefault("jdk")
+
+  val CODEGEN_JDK_JAVA_COMPILER_OPTION =
+    buildStaticConf("spark.sql.codegen.javaCompiler.jdkOption")
+      .internal()
+      .doc("Sets compiler options for JDK Java bytecode compiler. This is ignored when janino is" +
+        "is selected")
+      .stringConf
+      .createWithDefault("")
+
   // When enabling the debug, Spark SQL internal table properties are not filtered out; however,
   // some related DDL commands (e.g., ANALYZE TABLE and CREATE TABLE LIKE) might not work properly.
   val DEBUG_MODE = buildStaticConf("spark.sql.debug")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR allow a user to select Javac bytecode compiler to compile a DataFrame/Dataset program.
Details will be filled later.

This PR is based on @maropu's implementation.

## How was this patch tested?

Added `CompilerSuite`