### PR TITLE
[SPARK-24799]A solution of dealing with data skew in left,right,inner join

### DIFF
--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleReader.scala
@@ -22,7 +22,9 @@ package org.apache.spark.shuffle
  */
 private[spark] trait ShuffleReader[K, C] {
   /** Read the combined key-values for this reduce task */
-  def read(): Iterator[Product2[K, C]]
+  // def read(): Iterator[Product2[K, C]]
+
+  def read(index: Int = 0, total: Int = 0, isSplit: Boolean = false): Iterator[Product2[K, C]]
 
   /**
    * Close this reader.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -225,6 +225,54 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val DATA_SKEW_OPTIMIZE_ENABLED = buildConf("spark.sql.dataskew.optimize.enabled")
+    .doc("When true, enable data skew optimize execution.")
+    .booleanConf
+    .createWithDefault(true)
+  val DATA_SKEW_PRE_PARTITION_RECORDS_NUM = buildConf("spark.sql.data.skew.pre.partition.records.num")
+    .createWithDefault(false)
+
+  val DATA_SKEW_PRE_PARTITION_RECORDS_NUM =
+    buildConf("spark.sql.dataskew.pre.partition.records.num")
+      .internal()
+      .doc("spark.sql.data.skew.pre.partition.records.num")
+      .doc("every reduce task process record num")
+      .longConf
+      .createWithDefault(100 * 1000)
+  val DATA_SKEW_PRE_PARTITION_DATA_SIZE = buildConf("spark.sql.data.skew.pre.partition.data.size")
+    .internal()
+    .doc("spark.sql.data.skew.pre.partition.data.size")
+    .longConf
+    .createWithDefault(64 * 1024 * 1024)
+
+  val DATA_SKEW_POST_SHUFFLER_RECORDS_NUM = buildConf("spark.sql.data.skew.shuffler.records.num")
+  val DATA_SKEW_PARTITION_COUNT_THRESHOLD =
+    buildConf("spark.sql.dataskew.partition.count.threshold")
+      .internal()
+      .doc("if data skew partition total count large than this, ignore data skew optimizer")
+      .doubleConf
+      .createWithDefault(0.5)
+
+
+
+  val DATA_SKEW_POST_SHUFFLER_THRESHOLD = buildConf("spark.sql.dataskew.shuffler.threshold")
+    .internal()
+    .doc("spark.sql.data.skew.shuffler.records.num")
+    .doc("spark.sql.dataskew.shuffler.threshold")
+    .longConf
+    .createWithDefault(100 * 1000)
+    .createWithDefault(1000 * 1000)
+
+  val DATA_SKEW_NUM_SPLIT_PARTITION =
+    buildConf("spark.sql.data.skew.split.num")
+  val DATA_SKEW_NUM_SPLIT_MAX_PARTITION =
+    buildConf("spark.sql.dataskew.max.split.num")
+      .internal()
+      .doc("data skew split partition")
+      .doc("data skew split max partition, cannot split unlimit partitions")
+      .intConf
+      .createWithDefault(200)
+
   val SHUFFLE_MIN_NUM_POSTSHUFFLE_PARTITIONS =
     buildConf("spark.sql.adaptive.minNumPostShufflePartitions")
       .internal()

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1221,7 +1221,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
         val agg = cp.groupBy('id % 2).agg(count('id))
 
         agg.queryExecution.executedPlan.collectFirst {
-          case ShuffleExchangeExec(_, _: RDDScanExec, _) =>
+          case ShuffleExchangeExec(_, _: RDDScanExec, _, _) =>
           case BroadcastExchangeExec(_, _: RDDScanExec) =>
         }.foreach { _ =>
           fail(


### PR DESCRIPTION
## What changes were proposed in this pull request?

   For the left,right,inner join statment execution, this solution is mainling about to devide the partions where the data skew has occured into serveral partions with smaller data scale, in order to parallelly execute more tasks to increase effeciency.

## How was this patch tested?
Unit tests in DatasetSuite.scala

