### PR TITLE
[SPARK-24568] Code refactoring for DataType equalsXXX methods

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -237,21 +237,6 @@ object DataType {
    * Compares two types, ignoring nullability of ArrayType, MapType, StructType.
    */
   private[types] def equalsIgnoreNullability(left: DataType, right: DataType): Boolean = {
-    /*
-    (left, right) match {
-      case (ArrayType(leftElementType, _), ArrayType(rightElementType, _)) =>
-        equalsIgnoreNullability(leftElementType, rightElementType)
-      case (MapType(leftKeyType, leftValueType, _), MapType(rightKeyType, rightValueType, _)) =>
-        equalsIgnoreNullability(leftKeyType, rightKeyType) &&
-          equalsIgnoreNullability(leftValueType, rightValueType)
-      case (StructType(leftFields), StructType(rightFields)) =>
-        leftFields.length == rightFields.length &&
-          leftFields.zip(rightFields).forall { case (l, r) =>
-            l.name == r.name && equalsIgnoreNullability(l.dataType, r.dataType)
-          }
-      case (l, r) => l == r
-    }
-    */
     equalsDataTypes(left, right, CaseSensitiveNameCheck, NoNullabilityCheck)
   }
 
@@ -270,27 +255,6 @@ object DataType {
    *   of `fromField.nullable` and `toField.nullable` are false.
    */
   private[sql] def equalsIgnoreCompatibleNullability(from: DataType, to: DataType): Boolean = {
-    /*
-    (from, to) match {
-      case (ArrayType(fromElement, fn), ArrayType(toElement, tn)) =>
-        (tn || !fn) && equalsIgnoreCompatibleNullability(fromElement, toElement)
-
-      case (MapType(fromKey, fromValue, fn), MapType(toKey, toValue, tn)) =>
-        (tn || !fn) &&
-          equalsIgnoreCompatibleNullability(fromKey, toKey) &&
-          equalsIgnoreCompatibleNullability(fromValue, toValue)
-
-      case (StructType(fromFields), StructType(toFields)) =>
-        fromFields.length == toFields.length &&
-          fromFields.zip(toFields).forall { case (fromField, toField) =>
-            fromField.name == toField.name &&
-              (toField.nullable || !fromField.nullable) &&
-              equalsIgnoreCompatibleNullability(fromField.dataType, toField.dataType)
-          }
-
-      case (fromDataType, toDataType) => fromDataType == toDataType
-    }
-    */
     equalsDataTypes(from, to, CaseSensitiveNameCheck, CompatibleNullabilityCheck)
   }
 
@@ -299,25 +263,6 @@ object DataType {
    * sensitivity of field names in StructType.
    */
   private[sql] def equalsIgnoreCaseAndNullability(from: DataType, to: DataType): Boolean = {
-    /*
-    (from, to) match {
-      case (ArrayType(fromElement, _), ArrayType(toElement, _)) =>
-        equalsIgnoreCaseAndNullability(fromElement, toElement)
-
-      case (MapType(fromKey, fromValue, _), MapType(toKey, toValue, _)) =>
-        equalsIgnoreCaseAndNullability(fromKey, toKey) &&
-          equalsIgnoreCaseAndNullability(fromValue, toValue)
-
-      case (StructType(fromFields), StructType(toFields)) =>
-        fromFields.length == toFields.length &&
-          fromFields.zip(toFields).forall { case (l, r) =>
-            l.name.equalsIgnoreCase(r.name) &&
-              equalsIgnoreCaseAndNullability(l.dataType, r.dataType)
-          }
-
-      case (fromDataType, toDataType) => fromDataType == toDataType
-    }
-    */
     equalsDataTypes(from, to, CaseInsensitiveNameCheck, NoNullabilityCheck)
   }
 
@@ -331,28 +276,6 @@ object DataType {
       from: DataType,
       to: DataType,
       ignoreNullability: Boolean = false): Boolean = {
-    /*
-    (from, to) match {
-      case (left: ArrayType, right: ArrayType) =>
-        equalsStructurally(left.elementType, right.elementType) &&
-          (ignoreNullability || left.containsNull == right.containsNull)
-
-      case (left: MapType, right: MapType) =>
-        equalsStructurally(left.keyType, right.keyType) &&
-          equalsStructurally(left.valueType, right.valueType) &&
-          (ignoreNullability || left.valueContainsNull == right.valueContainsNull)
-
-      case (StructType(fromFields), StructType(toFields)) =>
-        fromFields.length == toFields.length &&
-          fromFields.zip(toFields)
-            .forall { case (l, r) =>
-              equalsStructurally(l.dataType, r.dataType) &&
-                (ignoreNullability || l.nullable == r.nullable)
-            }
-
-      case (fromDataType, toDataType) => fromDataType == toDataType
-    }
-    */
     if (ignoreNullability) {
       equalsDataTypes(from, to, NoNameCheck, NoNullabilityCheck)
     } else {
@@ -360,6 +283,7 @@ object DataType {
     }
   }
 
+  /** Given the fieldNames compare for equality based on nameCheckType */
   private def isSameFieldName(left: String, right: String, nameCheckType: Int): Boolean = {
     nameCheckType match {
       case NoNameCheck => true
@@ -368,6 +292,7 @@ object DataType {
     }
   }
 
+  /** Given the nullability of two datatypes compare for equality based on nullabilityCheckType */
   private def isSameNullability(
       leftNullability: Boolean,
       rightNullability: Boolean,
@@ -379,11 +304,21 @@ object DataType {
     }
   }
 
+  /**
+   * Compare two dataTypes based on -
+   * nameCheckType - (NoNameCheck, CaseSensitiveNameCheck, CaseInsensitiveNameCheck)
+   * nullabilityCheckType - (NoNullabilityCheck, NullabilityCheck, CompatibleNullabilityCheck)
+   * @param left
+   * @param right
+   * @param nameCheckType
+   * @param nullabilityCheckType
+   * @return
+   */
   private def equalsDataTypes(
       left: DataType,
       right: DataType,
-      nameCheckType: Int, // 0: noCheck, 1: withCaseCheck, 2: ignoreCaseCheck
-      nullabilityCheckType: Int // 0: noCheck, 1: exactCheck, 2: compatibleCheck
+      nameCheckType: Int,
+      nullabilityCheckType: Int
       ): Boolean = {
     (left, right) match {
       case (left: ArrayType, right: ArrayType) =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -310,6 +310,88 @@ class DataTypeSuite extends SparkFunSuite {
   checkDefaultSize(MapType(IntegerType, ArrayType(DoubleType), false), 12)
   checkDefaultSize(structType, 20)
 
+  def checkEqualsIgnoreNullability(
+      from: DataType,
+      to: DataType,
+      expected: Boolean): Unit = {
+    val testName =
+      s"equalsIgnoreNullability: (from: $from, to: $to)"
+    test(testName) {
+      assert(DataType.equalsIgnoreNullability(from, to) === expected)
+    }
+  }
+
+  checkEqualsIgnoreNullability(
+    from = ArrayType(DoubleType, containsNull = false),
+    to = ArrayType(DoubleType, containsNull = true),
+    expected = true)
+  checkEqualsIgnoreNullability(
+    from = StructType(
+      StructField("a", DoubleType, nullable = false)::
+      StructField("b", ArrayType(DoubleType, containsNull = false), nullable = true):: Nil
+    ),
+    to = StructType(
+      StructField("a", DoubleType, nullable = false)::
+      StructField("b", ArrayType(DoubleType, containsNull = false), nullable = false):: Nil
+    ),
+    expected = true)
+  checkEqualsIgnoreNullability(
+    from = StructType(
+      StructField("a", DoubleType, nullable = false)::
+      StructField("b", ArrayType(DoubleType, containsNull = false), nullable = true):: Nil
+    ),
+    to = StructType(
+      StructField("a", DoubleType, nullable = false)::
+      StructField("c", ArrayType(DoubleType, containsNull = false), nullable = false):: Nil
+    ),
+    expected = false)
+  checkEqualsIgnoreNullability(
+    from = StructType(
+      StructField("a", DoubleType, nullable = false)::
+        StructField("b", ArrayType(DoubleType, containsNull = false), nullable = true):: Nil
+    ),
+    to = StructType(
+      StructField("a", DoubleType, nullable = false)::
+        StructField("B", ArrayType(DoubleType, containsNull = false), nullable = true):: Nil
+    ),
+    expected = false)
+  checkEqualsIgnoreNullability(
+    from = StructType(
+      StructField("a", DoubleType, nullable = false)::
+      StructField("b", ArrayType(MapType(StringType, StringType, valueContainsNull = false),
+        containsNull = false), nullable = true):: Nil
+    ),
+    to = StructType(
+      StructField("a", DoubleType, nullable = false)::
+      StructField("b", ArrayType(MapType(StringType, StringType, valueContainsNull = false),
+       containsNull = false), nullable = true):: Nil
+    ),
+    expected = true)
+
+  def checkEqualsIgnoreCaseAndNullability(
+                                    from: DataType,
+                                    to: DataType,
+                                    expected: Boolean): Unit = {
+    val testName =
+      s"equalsIgnoreCaseAndNullability: (from: $from, to: $to)"
+    test(testName) {
+      assert(DataType.equalsIgnoreCaseAndNullability(from, to) === expected)
+    }
+  }
+
+  checkEqualsIgnoreCaseAndNullability(
+    from = StructType(
+      StructField("a", DoubleType, nullable = false)::
+      StructField("b", ArrayType(MapType(IntegerType, StringType, valueContainsNull = false),
+        containsNull = false), nullable = true):: Nil
+    ),
+    to = StructType(
+      StructField("a", DoubleType, nullable = false)::
+      StructField("B", ArrayType(MapType(IntegerType, StringType, valueContainsNull = false),
+        containsNull = false), nullable = true):: Nil
+    ),
+    expected = true)
+
   def checkEqualsIgnoreCompatibleNullability(
       from: DataType,
       to: DataType,
@@ -392,6 +474,30 @@ class DataTypeSuite extends SparkFunSuite {
       StructField("a", StringType, nullable = false) ::
       StructField("b", StringType, nullable = false) :: Nil),
     expected = false)
+  checkEqualsIgnoreCompatibleNullability(
+    from = StructType(
+      StructField("a", DoubleType, nullable = false)::
+      StructField("b", ArrayType(MapType(IntegerType, StringType, valueContainsNull = false),
+        containsNull = false), nullable = true):: Nil
+    ),
+    to = StructType(
+      StructField("a", DoubleType, nullable = false)::
+      StructField("B", ArrayType(MapType(IntegerType, StringType, valueContainsNull = true),
+        containsNull = false), nullable = false):: Nil
+    ),
+    expected = false)
+  checkEqualsIgnoreCompatibleNullability(
+    from = StructType(
+      StructField("a", DoubleType, nullable = false)::
+      StructField("b", ArrayType(MapType(IntegerType, StringType, valueContainsNull = false),
+        containsNull = false), nullable = false):: Nil
+    ),
+    to = StructType(
+      StructField("a", DoubleType, nullable = false)::
+      StructField("b", ArrayType(MapType(IntegerType, StringType, valueContainsNull = true),
+        containsNull = false), nullable = true):: Nil
+    ),
+    expected = true)
 
   def checkCatalogString(dt: DataType): Unit = {
     test(s"catalogString: $dt") {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, DataType equals* methods has lot of code duplication. This PR adds - 
1. Helper function that removes code duplication and makes it easier to understand. 
2. It makes adding new variations of equals* methods easy by simply choosing right parameter combinations of helper function.

## Current functionality -
DataTypes are matched on three factors - (fieldName, dataType, nullability)
Current APIs

> 1. equalsIgnoreNullability - (fieldNameCheck: Yes, dataType: Yes, nullability: No)
> 2. equalsIgnoreCompatibleNullability - (fieldNameCheck: Yes, dataType: Yes, nullability: Compatible)
> 3. equalsIgnoreCaseAndNullability - (fieldNameCheck: Yes(case insensitive), dataType: Yes, nullability: No)
> 4. equalsStructurally - (fieldNameCheck: No, dataType: Yes, nullability: Yes/No)

Same API contracts are maintained but just new helper functions equalsDataTypes, isSameFieldName, isSameNullability added to give more flexibility & code centralization.
Additional private vals are added to set behavior of helper functions.
  ```
private val NoNameCheck = 0
  private val CaseSensitiveNameCheck = 1
  private val CaseInsensitiveNameCheck = 2
  private val NoNullabilityCheck = 0
  private val NullabilityCheck = 1
  private val CompatibleNullabilityCheck = 2
```
Any combination of above variables can be generated in future to add new equals* APIs. For instance, 

> equalsIgnoreCaseCompatibleNullability

 can easily be generated by calling -

> equalsDataTypes(left, right, CaseInsensitiveNameCheck, CompatibleNullabilityCheck)

New scalatests added to test missing API unit testing as well.

## How was this patch tested?

Code was tested with existing scalatests. New scalatests added for more robust testing of this functionality.
All tests were ran locally to make sure it doesn't affect elsewhere.

Please review http://spark.apache.org/contributing.html before opening a pull request.
