### PR TITLE
[SPARK-24925][SQL] input bytesRead metrics fluctuate from time to time

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
@@ -114,11 +114,13 @@ class FileScanRDD(
         // don't need to run this `if` for every record.
         if (nextElement.isInstanceOf[ColumnarBatch]) {
           inputMetrics.incRecordsRead(nextElement.asInstanceOf[ColumnarBatch].numRows())
+          updateBytesRead()
         } else {
           inputMetrics.incRecordsRead(1)
-        }
-        if (inputMetrics.recordsRead % SparkHadoopUtil.UPDATE_INPUT_METRICS_INTERVAL_RECORDS == 0) {
-          updateBytesRead()
+          if (inputMetrics.recordsRead %
+            SparkHadoopUtil.UPDATE_INPUT_METRICS_INTERVAL_RECORDS == 0) {
+            updateBytesRead()
+          }
         }
         nextElement
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, ColumnarBatch's bytesRead needs to be updated every 4096 * 1000 rows, which makes the metrics out of date. This PR makes it update at each batch.

## How was this patch tested?

Existing UTs.
