### PR TITLE
[SPARK-24840][SQL] do not use dummy filter to switch codegen on/of

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -507,8 +507,6 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
   }
 
   test("map_entries") {
-    val dummyFilter = (c: Column) => c.isNotNull || c.isNull
-
     // Primitive-type elements
     val idf = Seq(
       Map[Int, Int](1 -> 100, 2 -> 200, 3 -> 300),
@@ -521,15 +519,18 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(null)
     )
 
-    checkAnswer(idf.select(map_entries('m)), iExpected)
-    checkAnswer(idf.selectExpr("map_entries(m)"), iExpected)
-    checkAnswer(idf.filter(dummyFilter('m)).select(map_entries('m)), iExpected)
-    checkAnswer(
-      spark.range(1).selectExpr("map_entries(map(1, null, 2, null))"),
-      Seq(Row(Seq(Row(1, null), Row(2, null)))))
-    checkAnswer(
-      spark.range(1).filter(dummyFilter('id)).selectExpr("map_entries(map(1, null, 2, null))"),
-      Seq(Row(Seq(Row(1, null), Row(2, null)))))
+    def checkResult(): Unit = {
+      checkAnswer(idf.select(map_entries('m)), iExpected)
+      checkAnswer(idf.selectExpr("map_entries(m)"), iExpected)
+      checkAnswer(idf.selectExpr("map_entries(map(1, null, 2, null))"),
+        Seq.fill(iExpected.length)(Row(Seq(Row(1, null), Row(2, null)))))
+    }
+
+    // Test with local relation, the Project will be evaluated without codegen
+    checkResult()
+    // Test with cached relation, the Project will be evaluated with codegen
+    idf.cache()
+    checkResult()
 
     // Non-primitive-type elements
     val sdf = Seq(
@@ -545,9 +546,16 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(null)
     )
 
-    checkAnswer(sdf.select(map_entries('m)), sExpected)
-    checkAnswer(sdf.selectExpr("map_entries(m)"), sExpected)
-    checkAnswer(sdf.filter(dummyFilter('m)).select(map_entries('m)), sExpected)
+    def checkResult2(): Unit = {
+      checkAnswer(sdf.select(map_entries('m)), sExpected)
+      checkAnswer(sdf.selectExpr("map_entries(m)"), sExpected)
+    }
+
+    // Test with local relation, the Project will be evaluated without codegen
+    checkResult2()
+    // Test with cached relation, the Project will be evaluated with codegen
+    sdf.cache()
+    checkResult2()
   }
 
   test("map_concat function") {
@@ -629,9 +637,6 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
   }
 
   test("map_from_entries function") {
-    def dummyFilter(c: Column): Column = c.isNull || c.isNotNull
-    val oneRowDF = Seq(3215).toDF("i")
-
     // Test cases with primitive-type keys and values
     val idf = Seq(
       Seq((1, 10), (2, 20), (3, 10)),
@@ -645,18 +650,18 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(Map.empty),
       Row(null))
 
-    checkAnswer(idf.select(map_from_entries('a)), iExpected)
-    checkAnswer(idf.selectExpr("map_from_entries(a)"), iExpected)
-    checkAnswer(idf.filter(dummyFilter('a)).select(map_from_entries('a)), iExpected)
-    checkAnswer(
-      oneRowDF.selectExpr("map_from_entries(array(struct(1, null), struct(2, null)))"),
-      Seq(Row(Map(1 -> null, 2 -> null)))
-    )
-    checkAnswer(
-      oneRowDF.filter(dummyFilter('i))
-        .selectExpr("map_from_entries(array(struct(1, null), struct(2, null)))"),
-      Seq(Row(Map(1 -> null, 2 -> null)))
-    )
+    def checkResult(): Unit = {
+      checkAnswer(idf.select(map_from_entries('a)), iExpected)
+      checkAnswer(idf.selectExpr("map_from_entries(a)"), iExpected)
+      checkAnswer(idf.selectExpr("map_from_entries(array(struct(1, null), struct(2, null)))"),
+        Seq.fill(iExpected.length)(Row(Map(1 -> null, 2 -> null))))
+    }
+
+    // Test with local relation, the Project will be evaluated without codegen
+    checkResult()
+    // Test with cached relation, the Project will be evaluated with codegen
+    idf.cache()
+    checkResult()
 
     // Test cases with non-primitive-type keys and values
     val sdf = Seq(
@@ -673,9 +678,16 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(Map.empty),
       Row(null))
 
-    checkAnswer(sdf.select(map_from_entries('a)), sExpected)
-    checkAnswer(sdf.selectExpr("map_from_entries(a)"), sExpected)
-    checkAnswer(sdf.filter(dummyFilter('a)).select(map_from_entries('a)), sExpected)
+    def checkResult2(): Unit = {
+      checkAnswer(sdf.select(map_from_entries('a)), sExpected)
+      checkAnswer(sdf.selectExpr("map_from_entries(a)"), sExpected)
+    }
+
+    // Test with local relation, the Project will be evaluated without codegen
+    checkResult2()
+    // Test with cached relation, the Project will be evaluated with codegen
+    sdf.cache()
+    checkResult2()
   }
 
   test("array contains function") {
@@ -890,31 +902,21 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
   }
 
   test("reverse function") {
-    val dummyFilter = (c: Column) => c.isNull || c.isNotNull // switch codegen on
-
     // String test cases
     val oneRowDF = Seq(("Spark", 3215)).toDF("s", "i")
+    def checkResult(): Unit = {
+      checkAnswer(oneRowDF.select(reverse('s)), Seq(Row("krapS")))
+      checkAnswer(oneRowDF.selectExpr("reverse(s)"), Seq(Row("krapS")))
+      checkAnswer(oneRowDF.select(reverse('i)), Seq(Row("5123")))
+      checkAnswer(oneRowDF.selectExpr("reverse(i)"), Seq(Row("5123")))
+      checkAnswer(oneRowDF.selectExpr("reverse(null)"), Seq(Row(null)))
+    }
 
-    checkAnswer(
-      oneRowDF.select(reverse('s)),
-      Seq(Row("krapS"))
-    )
-    checkAnswer(
-      oneRowDF.selectExpr("reverse(s)"),
-      Seq(Row("krapS"))
-    )
-    checkAnswer(
-      oneRowDF.select(reverse('i)),
-      Seq(Row("5123"))
-    )
-    checkAnswer(
-      oneRowDF.selectExpr("reverse(i)"),
-      Seq(Row("5123"))
-    )
-    checkAnswer(
-      oneRowDF.selectExpr("reverse(null)"),
-      Seq(Row(null))
-    )
+    // Test with local relation, the Project will be evaluated without codegen
+    checkResult()
+    // Test with cached relation, the Project will be evaluated with codegen
+    oneRowDF.cache()
+    checkResult()
 
     // Array test cases (primitive-type elements)
     val idf = Seq(
@@ -924,26 +926,26 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       null
     ).toDF("i")
 
-    checkAnswer(
-      idf.select(reverse('i)),
-      Seq(Row(Seq(7, 8, 9, 1)), Row(Seq(2, 7, 9, 8, 5)), Row(Seq.empty), Row(null))
-    )
-    checkAnswer(
-      idf.filter(dummyFilter('i)).select(reverse('i)),
-      Seq(Row(Seq(7, 8, 9, 1)), Row(Seq(2, 7, 9, 8, 5)), Row(Seq.empty), Row(null))
-    )
-    checkAnswer(
-      idf.selectExpr("reverse(i)"),
-      Seq(Row(Seq(7, 8, 9, 1)), Row(Seq(2, 7, 9, 8, 5)), Row(Seq.empty), Row(null))
-    )
-    checkAnswer(
-      oneRowDF.selectExpr("reverse(array(1, null, 2, null))"),
-      Seq(Row(Seq(null, 2, null, 1)))
-    )
-    checkAnswer(
-      oneRowDF.filter(dummyFilter('i)).selectExpr("reverse(array(1, null, 2, null))"),
-      Seq(Row(Seq(null, 2, null, 1)))
-    )
+    def checkResult2(): Unit = {
+      checkAnswer(
+        idf.select(reverse('i)),
+        Seq(Row(Seq(7, 8, 9, 1)), Row(Seq(2, 7, 9, 8, 5)), Row(Seq.empty), Row(null))
+      )
+      checkAnswer(
+        idf.selectExpr("reverse(i)"),
+        Seq(Row(Seq(7, 8, 9, 1)), Row(Seq(2, 7, 9, 8, 5)), Row(Seq.empty), Row(null))
+      )
+      checkAnswer(
+        idf.selectExpr("reverse(array(1, null, 2, null))"),
+        Seq.fill(idf.count().toInt)(Row(Seq(null, 2, null, 1)))
+      )
+    }
+
+    // Test with local relation, the Project will be evaluated without codegen
+    checkResult2()
+    // Test with cached relation, the Project will be evaluated with codegen
+    idf.cache()
+    checkResult2()
 
     // Array test cases (non-primitive-type elements)
     val sdf = Seq(
@@ -953,26 +955,26 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       null
     ).toDF("s")
 
-    checkAnswer(
-      sdf.select(reverse('s)),
-      Seq(Row(Seq("b", "a", "c")), Row(Seq(null, "c", null, "b")), Row(Seq.empty), Row(null))
-    )
-    checkAnswer(
-      sdf.filter(dummyFilter('s)).select(reverse('s)),
-      Seq(Row(Seq("b", "a", "c")), Row(Seq(null, "c", null, "b")), Row(Seq.empty), Row(null))
-    )
-    checkAnswer(
-      sdf.selectExpr("reverse(s)"),
-      Seq(Row(Seq("b", "a", "c")), Row(Seq(null, "c", null, "b")), Row(Seq.empty), Row(null))
-    )
-    checkAnswer(
-      oneRowDF.selectExpr("reverse(array(array(1, 2), array(3, 4)))"),
-      Seq(Row(Seq(Seq(3, 4), Seq(1, 2))))
-    )
-    checkAnswer(
-      oneRowDF.filter(dummyFilter('s)).selectExpr("reverse(array(array(1, 2), array(3, 4)))"),
-      Seq(Row(Seq(Seq(3, 4), Seq(1, 2))))
-    )
+    def checkResult3(): Unit = {
+      checkAnswer(
+        sdf.select(reverse('s)),
+        Seq(Row(Seq("b", "a", "c")), Row(Seq(null, "c", null, "b")), Row(Seq.empty), Row(null))
+      )
+      checkAnswer(
+        sdf.selectExpr("reverse(s)"),
+        Seq(Row(Seq("b", "a", "c")), Row(Seq(null, "c", null, "b")), Row(Seq.empty), Row(null))
+      )
+      checkAnswer(
+        sdf.selectExpr("reverse(array(array(1, 2), array(3, 4)))"),
+        Seq.fill(sdf.count().toInt)(Row(Seq(Seq(3, 4), Seq(1, 2))))
+      )
+    }
+
+    // Test with local relation, the Project will be evaluated without codegen
+    checkResult3()
+    // Test with cached relation, the Project will be evaluated with codegen
+    sdf.cache()
+    checkResult3()
 
     // Error test cases
     intercept[AnalysisException] {
@@ -1147,65 +1149,66 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
     val nseqi : Seq[Int] = null
     val nseqs : Seq[String] = null
     val df = Seq(
-
       (Seq(1), Seq(2, 3), Seq(5L, 6L), nseqi, Seq("a", "b", "c"), Seq("d", "e"), Seq("f"), nseqs),
       (Seq(1, 0), Seq.empty[Int], Seq(2L), nseqi, Seq("a"), Seq.empty[String], Seq(null), nseqs)
     ).toDF("i1", "i2", "i3", "in", "s1", "s2", "s3", "sn")
 
-    val dummyFilter = (c: Column) => c.isNull || c.isNotNull // switch codeGen on
-
     // Simple test cases
-    checkAnswer(
-      df.selectExpr("array(1, 2, 3L)"),
-      Seq(Row(Seq(1L, 2L, 3L)), Row(Seq(1L, 2L, 3L)))
-    )
+    def checkResult(): Unit = {
+      checkAnswer (
+        df.select(concat($"i1", $"s1")),
+        Seq(Row(Seq("1", "a", "b", "c")), Row(Seq("1", "0", "a")))
+      )
+      checkAnswer(
+        df.select(concat($"i1", $"i2", $"i3")),
+        Seq(Row(Seq(1, 2, 3, 5, 6)), Row(Seq(1, 0, 2)))
+      )
+      checkAnswer(
+        df.selectExpr("concat(array(1, null), i2, i3)"),
+        Seq(Row(Seq(1, null, 2, 3, 5, 6)), Row(Seq(1, null, 2)))
+      )
+      checkAnswer(
+        df.select(concat($"s1", $"s2", $"s3")),
+        Seq(Row(Seq("a", "b", "c", "d", "e", "f")), Row(Seq("a", null)))
+      )
+      checkAnswer(
+        df.selectExpr("concat(s1, s2, s3)"),
+        Seq(Row(Seq("a", "b", "c", "d", "e", "f")), Row(Seq("a", null)))
+      )
+    }
 
-    checkAnswer (
-      df.select(concat($"i1", $"s1")),
-      Seq(Row(Seq("1", "a", "b", "c")), Row(Seq("1", "0", "a")))
-    )
-    checkAnswer(
-      df.select(concat($"i1", $"i2", $"i3")),
-      Seq(Row(Seq(1, 2, 3, 5, 6)), Row(Seq(1, 0, 2)))
-    )
-    checkAnswer(
-      df.filter(dummyFilter($"i1")).select(concat($"i1", $"i2", $"i3")),
-      Seq(Row(Seq(1, 2, 3, 5, 6)), Row(Seq(1, 0, 2)))
-    )
-    checkAnswer(
-      df.selectExpr("concat(array(1, null), i2, i3)"),
-      Seq(Row(Seq(1, null, 2, 3, 5, 6)), Row(Seq(1, null, 2)))
-    )
-    checkAnswer(
-      df.select(concat($"s1", $"s2", $"s3")),
-      Seq(Row(Seq("a", "b", "c", "d", "e", "f")), Row(Seq("a", null)))
-    )
-    checkAnswer(
-      df.selectExpr("concat(s1, s2, s3)"),
-      Seq(Row(Seq("a", "b", "c", "d", "e", "f")), Row(Seq("a", null)))
-    )
-    checkAnswer(
-      df.filter(dummyFilter($"s1"))select(concat($"s1", $"s2", $"s3")),
-      Seq(Row(Seq("a", "b", "c", "d", "e", "f")), Row(Seq("a", null)))
-    )
+    // Test with local relation, the Project will be evaluated without codegen
+    checkResult()
+    // Test with cached relation, the Project will be evaluated with codegen
+    df.cache()
+    checkResult()
 
     // Null test cases
-    checkAnswer(
-      df.select(concat($"i1", $"in")),
-      Seq(Row(null), Row(null))
-    )
-    checkAnswer(
-      df.select(concat($"in", $"i1")),
-      Seq(Row(null), Row(null))
-    )
-    checkAnswer(
-      df.select(concat($"s1", $"sn")),
-      Seq(Row(null), Row(null))
-    )
-    checkAnswer(
-      df.select(concat($"sn", $"s1")),
-      Seq(Row(null), Row(null))
-    )
+    def checkResult2(): Unit = {
+      checkAnswer(
+        df.select(concat($"i1", $"in")),
+        Seq(Row(null), Row(null))
+      )
+      checkAnswer(
+        df.select(concat($"in", $"i1")),
+        Seq(Row(null), Row(null))
+      )
+      checkAnswer(
+        df.select(concat($"s1", $"sn")),
+        Seq(Row(null), Row(null))
+      )
+      checkAnswer(
+        df.select(concat($"sn", $"s1")),
+        Seq(Row(null), Row(null))
+      )
+    }
+
+    // Test with local relation, the Project will be evaluated without codegen
+    df.unpersist()
+    checkResult2()
+    // Test with cached relation, the Project will be evaluated with codegen
+    df.cache()
+    checkResult2()
 
     // Type error test cases
     intercept[AnalysisException] {
@@ -1223,9 +1226,6 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
   }
 
   test("flatten function") {
-    val dummyFilter = (c: Column) => c.isNull || c.isNotNull // to switch codeGen on
-    val oneRowDF = Seq((1, "a", Seq(1, 2, 3))).toDF("i", "s", "arr")
-
     // Test cases with a primitive type
     val intDF = Seq(
       (Seq(Seq(1, 2, 3), Seq(4, 5), Seq(6))),
@@ -1248,12 +1248,16 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(null),
       Row(null))
 
-    checkAnswer(intDF.select(flatten($"i")), intDFResult)
-    checkAnswer(intDF.filter(dummyFilter($"i"))select(flatten($"i")), intDFResult)
-    checkAnswer(intDF.selectExpr("flatten(i)"), intDFResult)
-    checkAnswer(
-      oneRowDF.selectExpr("flatten(array(arr, array(null, 5), array(6, null)))"),
-      Seq(Row(Seq(1, 2, 3, null, 5, 6, null))))
+    def checkResult(): Unit = {
+      checkAnswer(intDF.select(flatten($"i")), intDFResult)
+      checkAnswer(intDF.selectExpr("flatten(i)"), intDFResult)
+    }
+
+    // Test with local relation, the Project will be evaluated without codegen
+    checkResult()
+    // Test with cached relation, the Project will be evaluated with codegen
+    intDF.cache()
+    checkResult()
 
     // Test cases with non-primitive types
     val strDF = Seq(
@@ -1279,14 +1283,36 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(null),
       Row(null))
 
-    checkAnswer(strDF.select(flatten($"s")), strDFResult)
-    checkAnswer(strDF.filter(dummyFilter($"s")).select(flatten($"s")), strDFResult)
-    checkAnswer(strDF.selectExpr("flatten(s)"), strDFResult)
-    checkAnswer(
-      oneRowDF.selectExpr("flatten(array(array(arr, arr), array(arr)))"),
-      Seq(Row(Seq(Seq(1, 2, 3), Seq(1, 2, 3), Seq(1, 2, 3)))))
+    def checkResult2(): Unit = {
+      checkAnswer(strDF.select(flatten($"s")), strDFResult)
+      checkAnswer(strDF.selectExpr("flatten(s)"), strDFResult)
+    }
+
+    // Test with local relation, the Project will be evaluated without codegen
+    checkResult2()
+    // Test with cached relation, the Project will be evaluated with codegen
+    strDF.cache()
+    checkResult2()
+
+    val arrDF = Seq((1, "a", Seq(1, 2, 3))).toDF("i", "s", "arr")
+
+    def checkResult3(): Unit = {
+      checkAnswer(
+        arrDF.selectExpr("flatten(array(arr, array(null, 5), array(6, null)))"),
+        Seq(Row(Seq(1, 2, 3, null, 5, 6, null))))
+      checkAnswer(
+        arrDF.selectExpr("flatten(array(array(arr, arr), array(arr)))"),
+        Seq(Row(Seq(Seq(1, 2, 3), Seq(1, 2, 3), Seq(1, 2, 3)))))
+    }
+
+    // Test with local relation, the Project will be evaluated without codegen
+    checkResult3()
+    // Test with cached relation, the Project will be evaluated with codegen
+    arrDF.cache()
+    checkResult3()
 
     // Error test cases
+    val oneRowDF = Seq((1, "a", Seq(1, 2, 3))).toDF("i", "s", "arr")
     intercept[AnalysisException] {
       oneRowDF.select(flatten($"arr"))
     }
@@ -1302,7 +1328,6 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
   }
 
   test("array_repeat function") {
-    val dummyFilter = (c: Column) => c.isNull || c.isNotNull // to switch codeGen on
     val strDF = Seq(
       ("hi", 2),
       (null, 2)
@@ -1313,12 +1338,18 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(Seq(null, null))
     )
 
-    checkAnswer(strDF.select(array_repeat($"a", 2)), strDFTwiceResult)
-    checkAnswer(strDF.filter(dummyFilter($"a")).select(array_repeat($"a", 2)), strDFTwiceResult)
-    checkAnswer(strDF.select(array_repeat($"a", $"b")), strDFTwiceResult)
-    checkAnswer(strDF.filter(dummyFilter($"a")).select(array_repeat($"a", $"b")), strDFTwiceResult)
-    checkAnswer(strDF.selectExpr("array_repeat(a, 2)"), strDFTwiceResult)
-    checkAnswer(strDF.selectExpr("array_repeat(a, b)"), strDFTwiceResult)
+    def checkResult(): Unit = {
+      checkAnswer(strDF.select(array_repeat($"a", 2)), strDFTwiceResult)
+      checkAnswer(strDF.select(array_repeat($"a", $"b")), strDFTwiceResult)
+      checkAnswer(strDF.selectExpr("array_repeat(a, 2)"), strDFTwiceResult)
+      checkAnswer(strDF.selectExpr("array_repeat(a, b)"), strDFTwiceResult)
+    }
+
+    // Test with local relation, the Project will be evaluated without codegen
+    checkResult()
+    // Test with cached relation, the Project will be evaluated with codegen
+    strDF.cache()
+    checkResult()
 
     val intDF = {
       val schema = StructType(Seq(
@@ -1336,12 +1367,18 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(Seq(null, null))
     )
 
-    checkAnswer(intDF.select(array_repeat($"a", 2)), intDFTwiceResult)
-    checkAnswer(intDF.filter(dummyFilter($"a")).select(array_repeat($"a", 2)), intDFTwiceResult)
-    checkAnswer(intDF.select(array_repeat($"a", $"b")), intDFTwiceResult)
-    checkAnswer(intDF.filter(dummyFilter($"a")).select(array_repeat($"a", $"b")), intDFTwiceResult)
-    checkAnswer(intDF.selectExpr("array_repeat(a, 2)"), intDFTwiceResult)
-    checkAnswer(intDF.selectExpr("array_repeat(a, b)"), intDFTwiceResult)
+    def checkResult2(): Unit = {
+      checkAnswer(intDF.select(array_repeat($"a", 2)), intDFTwiceResult)
+      checkAnswer(intDF.select(array_repeat($"a", $"b")), intDFTwiceResult)
+      checkAnswer(intDF.selectExpr("array_repeat(a, 2)"), intDFTwiceResult)
+      checkAnswer(intDF.selectExpr("array_repeat(a, b)"), intDFTwiceResult)
+    }
+
+    // Test with local relation, the Project will be evaluated without codegen
+    checkResult2()
+    // Test with cached relation, the Project will be evaluated with codegen
+    intDF.cache()
+    checkResult2()
 
     val nullCountDF = {
       val schema = StructType(Seq(
@@ -1354,13 +1391,18 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
     }
 
-    checkAnswer(
-      nullCountDF.select(array_repeat($"a", $"b")),
-      Seq(
-        Row(null),
-        Row(null)
+    def checkResult3(): Unit = {
+      checkAnswer(
+        nullCountDF.select(array_repeat($"a", $"b")),
+        Seq(Row(null), Row(null))
       )
-    )
+    }
+
+    // Test with local relation, the Project will be evaluated without codegen
+    checkResult3()
+    // Test with cached relation, the Project will be evaluated with codegen
+    nullCountDF.cache()
+    checkResult3()
 
     // Error test cases
     val invalidTypeDF = Seq(("hi", "1")).toDF("a", "b")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -519,7 +519,7 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(null)
     )
 
-    def checkResult(): Unit = {
+    def testPrimitiveType(): Unit = {
       checkAnswer(idf.select(map_entries('m)), iExpected)
       checkAnswer(idf.selectExpr("map_entries(m)"), iExpected)
       checkAnswer(idf.selectExpr("map_entries(map(1, null, 2, null))"),
@@ -527,10 +527,10 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
     }
 
     // Test with local relation, the Project will be evaluated without codegen
-    checkResult()
+    testPrimitiveType()
     // Test with cached relation, the Project will be evaluated with codegen
     idf.cache()
-    checkResult()
+    testPrimitiveType()
 
     // Non-primitive-type elements
     val sdf = Seq(
@@ -546,16 +546,16 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(null)
     )
 
-    def checkResult2(): Unit = {
+    def testNonPrimitiveType(): Unit = {
       checkAnswer(sdf.select(map_entries('m)), sExpected)
       checkAnswer(sdf.selectExpr("map_entries(m)"), sExpected)
     }
 
     // Test with local relation, the Project will be evaluated without codegen
-    checkResult2()
+    testNonPrimitiveType()
     // Test with cached relation, the Project will be evaluated with codegen
     sdf.cache()
-    checkResult2()
+    testNonPrimitiveType()
   }
 
   test("map_concat function") {
@@ -650,7 +650,7 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(Map.empty),
       Row(null))
 
-    def checkResult(): Unit = {
+    def testPrimitiveType(): Unit = {
       checkAnswer(idf.select(map_from_entries('a)), iExpected)
       checkAnswer(idf.selectExpr("map_from_entries(a)"), iExpected)
       checkAnswer(idf.selectExpr("map_from_entries(array(struct(1, null), struct(2, null)))"),
@@ -658,10 +658,10 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
     }
 
     // Test with local relation, the Project will be evaluated without codegen
-    checkResult()
+    testPrimitiveType()
     // Test with cached relation, the Project will be evaluated with codegen
     idf.cache()
-    checkResult()
+    testPrimitiveType()
 
     // Test cases with non-primitive-type keys and values
     val sdf = Seq(
@@ -678,16 +678,16 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(Map.empty),
       Row(null))
 
-    def checkResult2(): Unit = {
+    def testNonPrimitiveType(): Unit = {
       checkAnswer(sdf.select(map_from_entries('a)), sExpected)
       checkAnswer(sdf.selectExpr("map_from_entries(a)"), sExpected)
     }
 
     // Test with local relation, the Project will be evaluated without codegen
-    checkResult2()
+    testNonPrimitiveType()
     // Test with cached relation, the Project will be evaluated with codegen
     sdf.cache()
-    checkResult2()
+    testNonPrimitiveType()
   }
 
   test("array contains function") {
@@ -904,7 +904,7 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
   test("reverse function") {
     // String test cases
     val oneRowDF = Seq(("Spark", 3215)).toDF("s", "i")
-    def checkResult(): Unit = {
+    def testString(): Unit = {
       checkAnswer(oneRowDF.select(reverse('s)), Seq(Row("krapS")))
       checkAnswer(oneRowDF.selectExpr("reverse(s)"), Seq(Row("krapS")))
       checkAnswer(oneRowDF.select(reverse('i)), Seq(Row("5123")))
@@ -913,10 +913,10 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
     }
 
     // Test with local relation, the Project will be evaluated without codegen
-    checkResult()
+    testString()
     // Test with cached relation, the Project will be evaluated with codegen
     oneRowDF.cache()
-    checkResult()
+    testString()
 
     // Array test cases (primitive-type elements)
     val idf = Seq(
@@ -926,7 +926,7 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       null
     ).toDF("i")
 
-    def checkResult2(): Unit = {
+    def testArray(): Unit = {
       checkAnswer(
         idf.select(reverse('i)),
         Seq(Row(Seq(7, 8, 9, 1)), Row(Seq(2, 7, 9, 8, 5)), Row(Seq.empty), Row(null))
@@ -942,10 +942,10 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
     }
 
     // Test with local relation, the Project will be evaluated without codegen
-    checkResult2()
+    testArray()
     // Test with cached relation, the Project will be evaluated with codegen
     idf.cache()
-    checkResult2()
+    testArray()
 
     // Array test cases (non-primitive-type elements)
     val sdf = Seq(
@@ -955,7 +955,7 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       null
     ).toDF("s")
 
-    def checkResult3(): Unit = {
+    def testArrayOfNonPrimitiveType(): Unit = {
       checkAnswer(
         sdf.select(reverse('s)),
         Seq(Row(Seq("b", "a", "c")), Row(Seq(null, "c", null, "b")), Row(Seq.empty), Row(null))
@@ -971,10 +971,10 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
     }
 
     // Test with local relation, the Project will be evaluated without codegen
-    checkResult3()
+    testArrayOfNonPrimitiveType()
     // Test with cached relation, the Project will be evaluated with codegen
     sdf.cache()
-    checkResult3()
+    testArrayOfNonPrimitiveType()
 
     // Error test cases
     intercept[AnalysisException] {
@@ -1154,7 +1154,7 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
     ).toDF("i1", "i2", "i3", "in", "s1", "s2", "s3", "sn")
 
     // Simple test cases
-    def checkResult(): Unit = {
+    def simpleTest(): Unit = {
       checkAnswer (
         df.select(concat($"i1", $"s1")),
         Seq(Row(Seq("1", "a", "b", "c")), Row(Seq("1", "0", "a")))
@@ -1178,13 +1178,13 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
     }
 
     // Test with local relation, the Project will be evaluated without codegen
-    checkResult()
+    simpleTest()
     // Test with cached relation, the Project will be evaluated with codegen
     df.cache()
-    checkResult()
+    simpleTest()
 
     // Null test cases
-    def checkResult2(): Unit = {
+    def nullTest(): Unit = {
       checkAnswer(
         df.select(concat($"i1", $"in")),
         Seq(Row(null), Row(null))
@@ -1205,10 +1205,10 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
 
     // Test with local relation, the Project will be evaluated without codegen
     df.unpersist()
-    checkResult2()
+    nullTest()
     // Test with cached relation, the Project will be evaluated with codegen
     df.cache()
-    checkResult2()
+    nullTest()
 
     // Type error test cases
     intercept[AnalysisException] {
@@ -1248,16 +1248,16 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(null),
       Row(null))
 
-    def checkResult(): Unit = {
+    def testInt(): Unit = {
       checkAnswer(intDF.select(flatten($"i")), intDFResult)
       checkAnswer(intDF.selectExpr("flatten(i)"), intDFResult)
     }
 
     // Test with local relation, the Project will be evaluated without codegen
-    checkResult()
+    testInt()
     // Test with cached relation, the Project will be evaluated with codegen
     intDF.cache()
-    checkResult()
+    testInt()
 
     // Test cases with non-primitive types
     val strDF = Seq(
@@ -1283,20 +1283,20 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(null),
       Row(null))
 
-    def checkResult2(): Unit = {
+    def testString(): Unit = {
       checkAnswer(strDF.select(flatten($"s")), strDFResult)
       checkAnswer(strDF.selectExpr("flatten(s)"), strDFResult)
     }
 
     // Test with local relation, the Project will be evaluated without codegen
-    checkResult2()
+    testString()
     // Test with cached relation, the Project will be evaluated with codegen
     strDF.cache()
-    checkResult2()
+    testString()
 
     val arrDF = Seq((1, "a", Seq(1, 2, 3))).toDF("i", "s", "arr")
 
-    def checkResult3(): Unit = {
+    def testArray(): Unit = {
       checkAnswer(
         arrDF.selectExpr("flatten(array(arr, array(null, 5), array(6, null)))"),
         Seq(Row(Seq(1, 2, 3, null, 5, 6, null))))
@@ -1306,10 +1306,10 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
     }
 
     // Test with local relation, the Project will be evaluated without codegen
-    checkResult3()
+    testArray()
     // Test with cached relation, the Project will be evaluated with codegen
     arrDF.cache()
-    checkResult3()
+    testArray()
 
     // Error test cases
     val oneRowDF = Seq((1, "a", Seq(1, 2, 3))).toDF("i", "s", "arr")
@@ -1338,7 +1338,7 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(Seq(null, null))
     )
 
-    def checkResult(): Unit = {
+    def testString(): Unit = {
       checkAnswer(strDF.select(array_repeat($"a", 2)), strDFTwiceResult)
       checkAnswer(strDF.select(array_repeat($"a", $"b")), strDFTwiceResult)
       checkAnswer(strDF.selectExpr("array_repeat(a, 2)"), strDFTwiceResult)
@@ -1346,10 +1346,10 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
     }
 
     // Test with local relation, the Project will be evaluated without codegen
-    checkResult()
+    testString()
     // Test with cached relation, the Project will be evaluated with codegen
     strDF.cache()
-    checkResult()
+    testString()
 
     val intDF = {
       val schema = StructType(Seq(
@@ -1367,7 +1367,7 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(Seq(null, null))
     )
 
-    def checkResult2(): Unit = {
+    def testInt(): Unit = {
       checkAnswer(intDF.select(array_repeat($"a", 2)), intDFTwiceResult)
       checkAnswer(intDF.select(array_repeat($"a", $"b")), intDFTwiceResult)
       checkAnswer(intDF.selectExpr("array_repeat(a, 2)"), intDFTwiceResult)
@@ -1375,10 +1375,10 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
     }
 
     // Test with local relation, the Project will be evaluated without codegen
-    checkResult2()
+    testInt()
     // Test with cached relation, the Project will be evaluated with codegen
     intDF.cache()
-    checkResult2()
+    testInt()
 
     val nullCountDF = {
       val schema = StructType(Seq(
@@ -1391,7 +1391,7 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
     }
 
-    def checkResult3(): Unit = {
+    def testNull(): Unit = {
       checkAnswer(
         nullCountDF.select(array_repeat($"a", $"b")),
         Seq(Row(null), Row(null))
@@ -1399,10 +1399,10 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
     }
 
     // Test with local relation, the Project will be evaluated without codegen
-    checkResult3()
+    testNull()
     // Test with cached relation, the Project will be evaluated with codegen
     nullCountDF.cache()
-    checkResult3()
+    testNull()
 
     // Error test cases
     val invalidTypeDF = Seq(("hi", "1")).toDF("a", "b")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2336,46 +2336,40 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
 
     val sourceDF = spark.createDataFrame(rows, schema)
 
-    val structWhenDF = sourceDF
+    def structWhenDF: DataFrame = sourceDF
       .select(when('cond, struct(lit("a").as("val1"), lit(10).as("val2"))).otherwise('s) as "res")
       .select('res.getField("val1"))
-    val arrayWhenDF = sourceDF
+    def arrayWhenDF: DataFrame = sourceDF
       .select(when('cond, array(lit("a"), lit("b"))).otherwise('a) as "res")
       .select('res.getItem(0))
-    val mapWhenDF = sourceDF
+    def mapWhenDF: DataFrame = sourceDF
       .select(when('cond, map(lit(0), lit("a"))).otherwise('m) as "res")
       .select('res.getItem(0))
 
-    val structIfDF = sourceDF
+    def structIfDF: DataFrame = sourceDF
       .select(expr("if(cond, struct('a' as val1, 10 as val2), s)") as "res")
       .select('res.getField("val1"))
-    val arrayIfDF = sourceDF
+    def arrayIfDF: DataFrame = sourceDF
       .select(expr("if(cond, array('a', 'b'), a)") as "res")
       .select('res.getItem(0))
-    val mapIfDF = sourceDF
+    def mapIfDF: DataFrame = sourceDF
       .select(expr("if(cond, map(0, 'a'), m)") as "res")
       .select('res.getItem(0))
 
-    def checkResult(df: DataFrame, codegenExpected: Boolean): Unit = {
-      assert(df.queryExecution.executedPlan.isInstanceOf[WholeStageCodegenExec] == codegenExpected)
-      checkAnswer(df, Seq(Row("a"), Row(null)))
+    def checkResult(): Unit = {
+      checkAnswer(structWhenDF, Seq(Row("a"), Row(null)))
+      checkAnswer(arrayWhenDF, Seq(Row("a"), Row(null)))
+      checkAnswer(mapWhenDF, Seq(Row("a"), Row(null)))
+      checkAnswer(structIfDF, Seq(Row("a"), Row(null)))
+      checkAnswer(arrayIfDF, Seq(Row("a"), Row(null)))
+      checkAnswer(mapIfDF, Seq(Row("a"), Row(null)))
     }
 
-    // without codegen
-    checkResult(structWhenDF, false)
-    checkResult(arrayWhenDF, false)
-    checkResult(mapWhenDF, false)
-    checkResult(structIfDF, false)
-    checkResult(arrayIfDF, false)
-    checkResult(mapIfDF, false)
-
-    // with codegen
-    checkResult(structWhenDF.filter('cond.isNotNull), true)
-    checkResult(arrayWhenDF.filter('cond.isNotNull), true)
-    checkResult(mapWhenDF.filter('cond.isNotNull), true)
-    checkResult(structIfDF.filter('cond.isNotNull), true)
-    checkResult(arrayIfDF.filter('cond.isNotNull), true)
-    checkResult(mapIfDF.filter('cond.isNotNull), true)
+    // Test with local relation, the Project will be evaluated without codegen
+    checkResult()
+    sourceDF.cache()
+    // Test with cached relation, the Project will be evaluated with codegen
+    checkResult()
   }
 
   test("Uuid expressions should produce same results at retries in the same DataFrame") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2367,8 +2367,8 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
 
     // Test with local relation, the Project will be evaluated without codegen
     checkResult()
-    sourceDF.cache()
     // Test with cached relation, the Project will be evaluated with codegen
+    sourceDF.cache()
     checkResult()
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

It's a little tricky and fragile to use a dummy filter to switch codegen on/off. For now we should use local/cached relation to switch. In the future when we are able to use a config to turn off codegen, we shall use that.

## How was this patch tested?

test only PR.