### PR TITLE
[SPARK-24846][SQL] Made hashCode ExprId independent of jvmId

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -40,7 +40,16 @@ object NamedExpression {
  *
  * The `id` field is unique within a given JVM, while the `uuid` is used to uniquely identify JVMs.
  */
-case class ExprId(id: Long, jvmId: UUID)
+case class ExprId(id: Long, jvmId: UUID) {
+
+  override def equals(other: Any): Boolean = other match {
+    case ExprId(id, jvmId) => this.id == id && this.jvmId == jvmId
+    case _ => false
+  }
+
+  override def hashCode(): Int = id.hashCode()
+
+}
 
 object ExprId {
   def apply(id: Long): ExprId = ExprId(id, NamedExpression.jvmId)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExprIdSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExprIdSuite.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import java.util.UUID
+
+import org.apache.spark.SparkFunSuite
+
+class ExprIdSuite extends SparkFunSuite {
+
+  private val jvmId = UUID.randomUUID()
+  private val otherJvmId = UUID.randomUUID()
+
+  test("hashcode independent of jvmId") {
+    val exprId1 = ExprId(12, jvmId)
+    val exprId2 = ExprId(12, otherJvmId)
+    assert(exprId1 != exprId2)
+    assert(exprId1.hashCode() == exprId2.hashCode())
+  }
+
+  test("equality should depend on both id and jvmId") {
+    val exprId1 = ExprId(1, jvmId)
+    val exprId2 = ExprId(1, jvmId)
+    assert(exprId1 == exprId2)
+
+    val exprId3 = ExprId(1, jvmId)
+    val exprId4 = ExprId(2, jvmId)
+    assert(exprId3 != exprId4)
+
+    val exprId5 = ExprId(1, jvmId)
+    val exprId6 = ExprId(1, otherJvmId)
+    assert(exprId5 != exprId6)
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Made ExprId hashCode independent of jvmId to make canonicalization independent of JVM, by overriding hashCode (and necessarily also equality) to depend on id only

## How was this patch tested?
Created a unit test ExprIdSuite
Ran all unit tests of sql/catalyst
