### PR TITLE
[SPARK-24851][UI] Map a Stage ID to it's Associated Job ID

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
@@ -117,8 +117,7 @@ private[spark] class AppStatusStore(
     val stageKey = Array(stageId, stageAttemptId)
     val stageDataWrapper = store.read(classOf[StageDataWrapper], stageKey)
     val stage = if (details) stageWithDetails(stageDataWrapper.info) else stageDataWrapper.info
-    val jobIds = stageDataWrapper.jobIds
-    (stage, jobIds.toSeq)
+    (stage, stageDataWrapper.jobIds.toSeq)
   }
 
   def taskCount(stageId: Int, stageAttemptId: Int): Long = {

--- a/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
@@ -113,13 +113,12 @@ private[spark] class AppStatusStore(
   }
 
   def stageAttempt(stageId: Int, stageAttemptId: Int,
-    details: Boolean = false): StageDataWrapper = {
+    details: Boolean = false): (v1.StageData, Seq[Int]) = {
     val stageKey = Array(stageId, stageAttemptId)
     val stageDataWrapper: StageDataWrapper = store.read(classOf[StageDataWrapper], stageKey)
     val stage = if (details) stageWithDetails(stageDataWrapper.info) else stageDataWrapper.info
     val jobIds = stageDataWrapper.jobIds
-    val returnStageDataWrapper: StageDataWrapper = new StageDataWrapper(stage, jobIds, null)
-    returnStageDataWrapper
+    (stage, jobIds.toSeq)
   }
 
   def taskCount(stageId: Int, stageAttemptId: Int): Long = {

--- a/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
@@ -112,7 +112,8 @@ private[spark] class AppStatusStore(
     }
   }
 
-  def stageAttempt(stageId: Int, stageAttemptId: Int, details: Boolean = false): StageDataWrapper = {
+  def stageAttempt(stageId: Int, stageAttemptId: Int,
+    details: Boolean = false): StageDataWrapper = {
     val stageKey = Array(stageId, stageAttemptId)
     val stageDataWrapper: StageDataWrapper = store.read(classOf[StageDataWrapper], stageKey)
     val stage = if (details) stageWithDetails(stageDataWrapper.info) else stageDataWrapper.info

--- a/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
@@ -113,9 +113,9 @@ private[spark] class AppStatusStore(
   }
 
   def stageAttempt(stageId: Int, stageAttemptId: Int,
-    details: Boolean = false): (v1.StageData, Seq[Int]) = {
+      details: Boolean = false): (v1.StageData, Seq[Int]) = {
     val stageKey = Array(stageId, stageAttemptId)
-    val stageDataWrapper: StageDataWrapper = store.read(classOf[StageDataWrapper], stageKey)
+    val stageDataWrapper = store.read(classOf[StageDataWrapper], stageKey)
     val stage = if (details) stageWithDetails(stageDataWrapper.info) else stageDataWrapper.info
     val jobIds = stageDataWrapper.jobIds
     (stage, jobIds.toSeq)

--- a/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
@@ -94,6 +94,13 @@ private[spark] class AppStatusStore(
       }.toSeq
   }
 
+  def getJobIdsAssociatedWithStage(stageId: Int): Seq[Set[Int]] = {
+    store.view(classOf[StageDataWrapper]).index("stageId").first(stageId).last(stageId)
+      .asScala.map { s =>
+        s.jobIds
+    }.toSeq
+  }
+
   def lastStageAttempt(stageId: Int): v1.StageData = {
     val it = store.view(classOf[StageDataWrapper])
       .index("stageId")

--- a/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
@@ -94,11 +94,10 @@ private[spark] class AppStatusStore(
       }.toSeq
   }
 
-  def getJobIdsAssociatedWithStage(stageId: Int): Seq[Set[Int]] = {
-    store.view(classOf[StageDataWrapper]).index("stageId").first(stageId).last(stageId)
-      .asScala.map { s =>
-        s.jobIds
-    }.toSeq
+  def getJobIdsAssociatedWithStage(stageId: Int, stageAttemptId: Int): Seq[Int] = {
+    val stageKey = Array(stageId, stageAttemptId)
+    val jobIds = store.read(classOf[StageDataWrapper], stageKey).jobIds.toSeq
+    jobIds
   }
 
   def lastStageAttempt(stageId: Int): v1.StageData = {

--- a/core/src/main/scala/org/apache/spark/status/api/v1/StagesResource.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/StagesResource.scala
@@ -56,7 +56,7 @@ private[v1] class StagesResource extends BaseAppResource {
       @PathParam("stageAttemptId") stageAttemptId: Int,
       @QueryParam("details") @DefaultValue("true") details: Boolean): StageData = withUI { ui =>
     try {
-      ui.store.stageAttempt(stageId, stageAttemptId, details = details).info
+      ui.store.stageAttempt(stageId, stageAttemptId, details = details)._1
     } catch {
       case _: NoSuchElementException =>
         // Change the message depending on whether there are any attempts for the requested stage.

--- a/core/src/main/scala/org/apache/spark/status/api/v1/StagesResource.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/StagesResource.scala
@@ -56,7 +56,7 @@ private[v1] class StagesResource extends BaseAppResource {
       @PathParam("stageAttemptId") stageAttemptId: Int,
       @QueryParam("details") @DefaultValue("true") details: Boolean): StageData = withUI { ui =>
     try {
-      ui.store.stageAttempt(stageId, stageAttemptId, details = details)
+      ui.store.stageAttempt(stageId, stageAttemptId, details = details).info
     } catch {
       case _: NoSuchElementException =>
         // Change the message depending on whether there are any attempts for the requested stage.

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -188,7 +188,7 @@ private[ui] class StagePage(parent: StagesTab, store: AppStatusStore) extends We
           {if (!stageJobIds.isEmpty) {
             <li>
               <strong>Associated Job Ids: </strong>
-              {for(jobId <- stageJobIds) yield {val detailUrl = "%s/jobs/job/?id=%s".format(
+              {for (jobId <- stageJobIds) yield {val detailUrl = "%s/jobs/job/?id=%s".format(
                 UIUtils.prependBaseUri(request, parent.basePath), jobId)
               <a href={s"${detailUrl}"}>{s"${jobId}"} &nbsp;&nbsp;</a>
               }}

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -105,28 +105,29 @@ private[ui] class StagePage(parent: StagesTab, store: AppStatusStore) extends We
     val stageAttemptId = parameterAttempt.toInt
 
     val stageHeader = s"Details for Stage $stageId (Attempt $stageAttemptId)"
-    var stageDataTuple: Tuple2[StageData, Seq[Int]] = null
-    try {
-      stageDataTuple = parent.store.stageAttempt(stageId, stageAttemptId, details = false)
+    var stageDataTuple: Option[Tuple2[StageData, Seq[Int]]] = try {
+      Some(parent.store.stageAttempt(stageId, stageAttemptId, details = false))
     } catch {
       case e: NoSuchElementException => e.getMessage
+      None
     }
     var stageData: StageData = null
     var stageJobIds: Seq[Int] = null
-    if (stageDataTuple == null) {
-      stageData = {
-        val content =
-          <div id="no-info">
-            <p>No information to display for Stage
-              {stageId}
-              (Attempt
-              {stageAttemptId})</p>
-          </div>
-        return UIUtils.headerSparkPage(request, stageHeader, content, parent)
-      }
-    } else {
-      stageData = stageDataTuple._1
-      stageJobIds = stageDataTuple._2
+    stageDataTuple match {
+      case Some(stageTuple) =>
+        stageData = stageTuple._1
+        stageJobIds = stageTuple._2
+      case None =>
+        stageData = {
+          val content =
+            <div id="no-info">
+              <p>No information to display for Stage
+                {stageId}
+                (Attempt
+                {stageAttemptId})</p>
+            </div>
+          return UIUtils.headerSparkPage(request, stageHeader, content, parent)
+        }
     }
 
     val localitySummary = store.localitySummary(stageData.stageId, stageData.attemptId)

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -115,6 +115,8 @@ private[ui] class StagePage(parent: StagesTab, store: AppStatusStore) extends We
         return UIUtils.headerSparkPage(request, stageHeader, content, parent)
       }
 
+    val stageJobIds = parent.store.getJobIdsAssociatedWithStage(stageId)
+
     val localitySummary = store.localitySummary(stageData.stageId, stageData.attemptId)
 
     val totalTasks = taskCount(stageData)
@@ -180,6 +182,12 @@ private[ui] class StagePage(parent: StagesTab, store: AppStatusStore) extends We
             <li>
               <strong>Shuffle Spill (Disk): </strong>
               {Utils.bytesToString(stageData.diskBytesSpilled)}
+            </li>
+          }}
+          {if (!stageJobIds.isEmpty) {
+            <li>
+              <strong>Associated Job Ids: </strong>
+              {stageJobIds}
             </li>
           }}
         </ul>

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -115,7 +115,7 @@ private[ui] class StagePage(parent: StagesTab, store: AppStatusStore) extends We
         return UIUtils.headerSparkPage(request, stageHeader, content, parent)
       }
 
-    val stageJobIds = parent.store.getJobIdsAssociatedWithStage(stageId)
+    val stageJobIds = parent.store.getJobIdsAssociatedWithStage(stageId, stageAttemptId)
 
     val localitySummary = store.localitySummary(stageData.stageId, stageData.attemptId)
 


### PR DESCRIPTION
It would be nice to have a field in Stage Page UI which would show mapping of the current stage id to the job id's to which that stage belongs to. 

## What changes were proposed in this pull request?

Added a field in Stage UI to display the corresponding job id for that particular stage.

## How was this patch tested?

<img width="448" alt="screen shot 2018-07-25 at 1 33 07 pm" src="https://user-images.githubusercontent.com/22228190/43220447-a8e94f80-900f-11e8-8a20-a235bbd5a369.png">


