### PR TITLE
[SPARK-24870][SQL]Cache can't work normally if there are case letters in SQL

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -237,7 +237,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]] extends TreeNode[PlanT
         // Top level `AttributeReference` may also be used for output like `Alias`, we should
         // normalize the epxrId too.
         id += 1
-        ar.withExprId(ExprId(id)).withName("").canonicalized
+        ar.withExprId(ExprId(id)).canonicalized
 
       case other => QueryPlan.normalizeExprId(other, allAttributes)
     }.withNewChildren(canonicalizedChildren)
@@ -282,9 +282,9 @@ object QueryPlan extends PredicateHelper {
       case ar: AttributeReference =>
         val ordinal = input.indexOf(ar.exprId)
         if (ordinal == -1) {
-          ar.withName("")
+          ar.canonicalized
         } else {
-          ar.withExprId(ExprId(ordinal)).withName("")
+          ar.withExprId(ExprId(ordinal)).canonicalized
         }
     }.canonicalized.asInstanceOf[T]
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -239,7 +239,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]] extends TreeNode[PlanT
         // Top level `AttributeReference` may also be used for output like `Alias`, we should
         // normalize the epxrId too.
         id += 1
-        ar.withExprId(ExprId(id)).withName(ar.name.toLowerCase(Locale.ROOT)).canonicalized
+        ar.withExprId(ExprId(id)).withName("").canonicalized
 
       case other => QueryPlan.normalizeExprId(other, allAttributes)
     }.withNewChildren(canonicalizedChildren)
@@ -284,9 +284,9 @@ object QueryPlan extends PredicateHelper {
       case ar: AttributeReference =>
         val ordinal = input.indexOf(ar.exprId)
         if (ordinal == -1) {
-          ar.withName(ar.name.toLowerCase(Locale.ROOT))
+          ar.withName("")
         } else {
-          ar.withExprId(ExprId(ordinal)).withName(ar.name.toLowerCase(Locale.ROOT))
+          ar.withExprId(ExprId(ordinal)).withName("")
         }
     }.canonicalized.asInstanceOf[T]
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.catalyst.plans
 
-import java.util.Locale
-
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, TreeNode}
 import org.apache.spark.sql.internal.SQLConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.plans
 
+import java.util.Locale
+
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, TreeNode}
 import org.apache.spark.sql.internal.SQLConf
@@ -237,7 +239,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]] extends TreeNode[PlanT
         // Top level `AttributeReference` may also be used for output like `Alias`, we should
         // normalize the epxrId too.
         id += 1
-        ar.withExprId(ExprId(id)).canonicalized
+        ar.withExprId(ExprId(id)).withName(ar.name.toLowerCase(Locale.ROOT)).canonicalized
 
       case other => QueryPlan.normalizeExprId(other, allAttributes)
     }.withNewChildren(canonicalizedChildren)
@@ -282,9 +284,9 @@ object QueryPlan extends PredicateHelper {
       case ar: AttributeReference =>
         val ordinal = input.indexOf(ar.exprId)
         if (ordinal == -1) {
-          ar
+          ar.withName(ar.name.toLowerCase(Locale.ROOT))
         } else {
-          ar.withExprId(ExprId(ordinal))
+          ar.withExprId(ExprId(ordinal)).withName(ar.name.toLowerCase(Locale.ROOT))
         }
     }.canonicalized.asInstanceOf[T]
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -282,7 +282,7 @@ object QueryPlan extends PredicateHelper {
       case ar: AttributeReference =>
         val ordinal = input.indexOf(ar.exprId)
         if (ordinal == -1) {
-          ar.canonicalized
+          ar
         } else {
           ar.withExprId(ExprId(ordinal)).canonicalized
         }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CanonicalizeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CanonicalizeSuite.scala
@@ -18,10 +18,8 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
-import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LocalRelation, Range}
-import org.apache.spark.sql.types.LongType
+import org.apache.spark.sql.catalyst.plans.logical.Range
 
 class CanonicalizeSuite extends SparkFunSuite {
 
@@ -51,31 +49,5 @@ class CanonicalizeSuite extends SparkFunSuite {
 
     assert(range.where(arrays1).sameResult(range.where(arrays2)))
     assert(!range.where(arrays1).sameResult(range.where(arrays3)))
-  }
-
-  test("Canonicalized result is not case-insensitive") {
-    val u1 = 'A.string.at(0)
-    val u2 = 'B.string.at(1)
-    val u3 = 'C.string.at(2)
-    val caseA = CaseWhen(Seq((u1, u2)), u3)
-    val otherA = AttributeReference("D", LongType)(exprId = ExprId(3))
-    val aliases = Alias(sum(caseA), "E")() :: Nil
-    val planUppercase = Aggregate(
-      Nil,
-      aliases,
-      LocalRelation(otherA))
-
-    val l1 = 'a.string.at(0)
-    val l2 = 'b.string.at(1)
-    val l3 = 'c.string.at(2)
-    val caseALower = CaseWhen(Seq((l1, l2)), l3)
-    val otherALower = AttributeReference("d", LongType)(exprId = ExprId(3))
-    val aliasesLower = Alias(sum(caseALower), "e")() :: Nil
-    val planLowercase = Aggregate(
-      Nil,
-      aliasesLower,
-      LocalRelation(otherALower))
-
-    assert(planUppercase.canonicalized == planLowercase.canonicalized)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SameResultSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SameResultSuite.scala
@@ -62,7 +62,7 @@ class SameResultSuite extends QueryTest with SharedSQLContext {
     assert(df3.queryExecution.executedPlan.sameResult(df4.queryExecution.executedPlan))
   }
 
-  test("Canonicalized result is not case-insensitive") {
+  test("Canonicalized result is case-insensitive") {
     val a = AttributeReference("A", IntegerType)()
     val b = AttributeReference("B", IntegerType)()
     val planUppercase = Project(Seq(a), LocalRelation(a, b))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SameResultSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SameResultSuite.scala
@@ -65,11 +65,11 @@ class SameResultSuite extends QueryTest with SharedSQLContext {
   test("Canonicalized result is not case-insensitive") {
     val a = AttributeReference("A", IntegerType)()
     val b = AttributeReference("B", IntegerType)()
-    val planUppercase = Project(Seq(a, b), LocalRelation(a))
+    val planUppercase = Project(Seq(a), LocalRelation(a, b))
 
     val c = AttributeReference("a", IntegerType)()
     val d = AttributeReference("b", IntegerType)()
-    val planLowercase = Project(Seq(c, d), LocalRelation(c))
+    val planLowercase = Project(Seq(c), LocalRelation(c, d))
 
     assert(planUppercase.sameResult(planLowercase))
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Modified the canonicalized to not case-insensitive.
Before the PR, cache can't work normally if there are case letters in SQL, 
for example:
     sql("CREATE TABLE IF NOT EXISTS src (key INT, value STRING) USING hive")

    sql("select key, sum(case when Key > 0 then 1 else 0 end) as positiveNum " +
      "from src group by key").cache().createOrReplaceTempView("src_cache")
    sql(
      s"""select a.key
           from
           (select key from src_cache where positiveNum = 1)a
           left join
           (select key from src_cache )b
           on a.key=b.key
        """).explain

The physical plan of the sql is:
![image](https://user-images.githubusercontent.com/26834091/42979518-3decf0fa-8c05-11e8-9837-d5e4c334cb1f.png)

The subquery "select key from src_cache where positiveNum = 1" on the left of join can use the cache data, but the subquery "select key from src_cache" on the right of join cannot use the cache data.

## How was this patch tested?

new added test
