### PR TITLE
[SPARK-24872] Replace taking the $symbol with $sqlOperator in BinaryOperator's toString method

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -572,7 +572,7 @@ abstract class BinaryOperator extends BinaryExpression with ExpectsInputTypes {
 
   def sqlOperator: String = symbol
 
-  override def toString: String = s"($left $symbol $right)"
+  override def toString: String = s"($left $sqlOperator $right)"
 
   override def inputTypes: Seq[AbstractDataType] = Seq(inputType, inputType)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -442,7 +442,7 @@ case class Or(left: Expression, right: Expression) extends BinaryOperator with P
 
   override def inputType: AbstractDataType = BooleanType
 
-  override def symbol: String = "or"
+  override def symbol: String = "||"
 
   override def sqlOperator: String = "OR"
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -442,6 +442,8 @@ case class Or(left: Expression, right: Expression) extends BinaryOperator with P
 
   override def inputType: AbstractDataType = BooleanType
 
+  override def symbol: String = "or"
+
   override def sqlOperator: String = "OR"
 
   override def eval(input: InternalRow): Any = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -442,8 +442,6 @@ case class Or(left: Expression, right: Expression) extends BinaryOperator with P
 
   override def inputType: AbstractDataType = BooleanType
 
-  override def symbol: String = "||"
-
   override def sqlOperator: String = "OR"
 
   override def eval(input: InternalRow): Any = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/PredicateSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/PredicateSuite.scala
@@ -457,9 +457,10 @@ class PredicateSuite extends SparkFunSuite with ExpressionEvalHelper {
     assert(interpreted.eval(new UnsafeRow()))
   }
 
-  test("SPARK-24872: Replace the symbol '||' of Or operator with 'or'") {
+  test("SPARK-24872: Replace taking the $symbol with $sqlOperator in BinaryOperator's" +
+    " toString method") {
     val expression = CatalystSqlParser.parseExpression("id=1 or id=2").toString()
-    val expected = "(('id = 1) or ('id = 2))"
+    val expected = "(('id = 1) OR ('id = 2))"
     assert(expression == expected)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/PredicateSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/PredicateSuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.RandomDataGenerator
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.encoders.ExamplePointUDT
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData}
 import org.apache.spark.sql.types._
 
@@ -454,5 +455,11 @@ class PredicateSuite extends SparkFunSuite with ExpressionEvalHelper {
     val interpreted = InterpretedPredicate.create(LessThan(Rand(7), Literal(1.0)))
     interpreted.initialize(0)
     assert(interpreted.eval(new UnsafeRow()))
+  }
+
+  test("[SPARK-24872] Replace the symbol '||' of Or operator with 'or'") {
+    val expression = CatalystSqlParser.parseExpression("id=1 or id=2").toString()
+    val expected = "(('id = 1) or ('id = 2))"
+    assert(expression == expected)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/PredicateSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/PredicateSuite.scala
@@ -457,7 +457,7 @@ class PredicateSuite extends SparkFunSuite with ExpressionEvalHelper {
     assert(interpreted.eval(new UnsafeRow()))
   }
 
-  test("[SPARK-24872] Replace the symbol '||' of Or operator with 'or'") {
+  test("SPARK-24872: Replace the symbol '||' of Or operator with 'or'") {
     val expression = CatalystSqlParser.parseExpression("id=1 or id=2").toString()
     val expected = "(('id = 1) or ('id = 2))"
     assert(expression == expected)


### PR DESCRIPTION
## What changes were proposed in this pull request?

For BinaryOperator's toString method, it's better to use `$sqlOperator` instead of `$symbol`.

## How was this patch tested?

We can test this patch  with unit tests.

Please review http://spark.apache.org/contributing.html before opening a pull request.
