### PR TITLE
[SQL][HIVE] Correct an assert message in function makeRDDForTable

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -110,9 +110,9 @@ class HadoopTableReader(
       deserializerClass: Class[_ <: Deserializer],
       filterOpt: Option[PathFilter]): RDD[InternalRow] = {
 
-    assert(!hiveTable.isPartitioned, 
-      "makeRDDForTable() cannot be called on a partitioned table, since input formats may differ " + 
-      "across partitions. Use makeRDDForPartitionedTable() instead.")
+    assert(!hiveTable.isPartitioned,
+      "makeRDDForTable() cannot be called on a partitioned table, since input formats may " +
+      "differ across partitions. Use makeRDDForPartitionedTable() instead.")
 
     // Create local references to member variables, so that the entire `this` object won't be
     // serialized in the closure below.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -111,7 +111,8 @@ class HadoopTableReader(
       filterOpt: Option[PathFilter]): RDD[InternalRow] = {
 
     assert(!hiveTable.isPartitioned, """makeRDDForTable() cannot be called on a partitioned table,
-      since input formats may differ across partitions. Use makeRDDForPartitionedTable() instead.""")
+      since input formats may differ across partitions. Use makeRDDForPartitionedTable() 
+      instead.""")
 
     // Create local references to member variables, so that the entire `this` object won't be
     // serialized in the closure below.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -111,7 +111,7 @@ class HadoopTableReader(
       filterOpt: Option[PathFilter]): RDD[InternalRow] = {
 
     assert(!hiveTable.isPartitioned, """makeRDDForTable() cannot be called on a partitioned table,
-      since input formats may differ across partitions. Use makeRDDForTablePartitions() instead.""")
+      since input formats may differ across partitions. Use makeRDDForPartitionedTable() instead.""")
 
     // Create local references to member variables, so that the entire `this` object won't be
     // serialized in the closure below.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -110,9 +110,9 @@ class HadoopTableReader(
       deserializerClass: Class[_ <: Deserializer],
       filterOpt: Option[PathFilter]): RDD[InternalRow] = {
 
-    assert(!hiveTable.isPartitioned, """makeRDDForTable() cannot be called on a partitioned table,
-      since input formats may differ across partitions. Use makeRDDForPartitionedTable() 
-      instead.""")
+    assert(!hiveTable.isPartitioned, 
+      "makeRDDForTable() cannot be called on a partitioned table, since input formats may differ " + 
+      "across partitions. Use makeRDDForPartitionedTable() instead.")
 
     // Create local references to member variables, so that the entire `this` object won't be
     // serialized in the closure below.


### PR DESCRIPTION
## What changes were proposed in this pull request?
according to the context, "makeRDDForTablePartitions" in assert message should be "makeRDDForPartitionedTable", because "makeRDDForTablePartitions" does't exist in spark code.


## How was this patch tested?
unit tests


Please review http://spark.apache.org/contributing.html before opening a pull request.
