### PR TITLE
[WIP] New copy() method for Column of StructType

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
@@ -1234,6 +1234,8 @@ class Column(val expr: Expression) extends Logging {
    */
   def over(): Column = over(Window.spec)
 
+  def copy(field: String, value: Column): Column = withExpr(StructCopy(expr, field, value.expr))
+
 }
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -1565,6 +1565,24 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
     }
     assert(ex.getMessage.contains("Cannot use null as map key"))
   }
+
+  test("copy") {
+    val input = spark.range(1, 10, 1)
+    val df = input.selectExpr("id",
+      """named_struct(
+        |'c0', id - 1,
+        |'c1', named_struct(
+        |   'c11', id+1,
+        |   'c12', 2*id
+        |)) as s""".stripMargin)
+
+    df.printSchema()
+    df.show(false)
+    val res = df.withColumn("s",
+      $"s".copy("c1", $"s.c1".copy("c12", $"id"*3))
+    )
+    res.show(false)
+  }
 }
 
 object DataFrameFunctionsSuite {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the PR, I propose new method for columns of `StructType` - `.copy()`. The method should copy all field of a struct except a specified column. For the specified column, it should put new value. You can think of it as the `.copy()` method of case classes in Scala.

## How was this patch tested?

By new unit tests
