### PR TITLE
[SPARK-24886][INFRA] Fix the testing script to increase timeout for Jenkins build (from 300m to 340m)

### DIFF
--- a/dev/run-tests-jenkins.py
+++ b/dev/run-tests-jenkins.py
@@ -182,7 +182,7 @@ def main():
 
     # format: http://linux.die.net/man/1/timeout
     # must be less than the timeout configured on Jenkins (currently 361m)
-    tests_timeout = "350m"
+    tests_timeout = "330m"
 
     # Array to capture all test names to run on the pull request. These tests are represented
     # by their file equivalents in the dev/tests/ directory.

--- a/dev/run-tests-jenkins.py
+++ b/dev/run-tests-jenkins.py
@@ -181,8 +181,8 @@ def main():
     short_commit_hash = ghprb_actual_commit[0:7]
 
     # format: http://linux.die.net/man/1/timeout
-    # must be less than the timeout configured on Jenkins (currently 350m)
-    tests_timeout = "300m"
+    # must be less than the timeout configured on Jenkins (currently 361m)
+    tests_timeout = "350m"
 
     # Array to capture all test names to run on the pull request. These tests are represented
     # by their file equivalents in the dev/tests/ directory.

--- a/dev/run-tests-jenkins.py
+++ b/dev/run-tests-jenkins.py
@@ -181,7 +181,7 @@ def main():
     short_commit_hash = ghprb_actual_commit[0:7]
 
     # format: http://linux.die.net/man/1/timeout
-    # must be less than the timeout configured on Jenkins (currently 361m)
+    # must be less than the timeout configured on Jenkins (currently 400m)
     tests_timeout = "330m"
 
     # Array to capture all test names to run on the pull request. These tests are represented

--- a/dev/run-tests-jenkins.py
+++ b/dev/run-tests-jenkins.py
@@ -182,7 +182,7 @@ def main():
 
     # format: http://linux.die.net/man/1/timeout
     # must be less than the timeout configured on Jenkins (currently 400m)
-    tests_timeout = "330m"
+    tests_timeout = "340m"
 
     # Array to capture all test names to run on the pull request. These tests are represented
     # by their file equivalents in the dev/tests/ directory.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, looks we hit the time limit time to time. Looks better increasing the time a bit.

For instance, please see https://github.com/apache/spark/pull/21822

For clarification, current Jenkins timeout is 400m. This PR just proposes to fix the test script to increase it correspondingly.

*This PR does not target to change the build configuration*

## How was this patch tested?

Jenkins tests.