### PR TITLE
[SPARK-24892] [SQL] Simplify `CaseWhen` to `If` when there is only one branch

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -505,6 +505,9 @@ object SimplifyConditionals extends Rule[LogicalPlan] with PredicateHelper {
         } else {
           e.copy(branches = branches.take(i).map(branch => (branch._1, elseValue)))
         }
+
+      case CaseWhen(Seq((cond, trueValue)), elseValue) =>
+        If(cond, trueValue, elseValue.getOrElse(Literal(null, trueValue.dataType)))
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceNullWithFalseInPredicateSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceNullWithFalseInPredicateSuite.scala
@@ -200,13 +200,15 @@ class ReplaceNullWithFalseInPredicateSuite extends PlanTest {
 
   test("inability to replace null in non-boolean values of CaseWhen") {
     val nestedCaseWhen = CaseWhen(
-      Seq((UnresolvedAttribute("i") > Literal(20)) -> Literal(2)),
+      Seq((UnresolvedAttribute("i") > Literal(20)) -> Literal(2),
+        (UnresolvedAttribute("i") > Literal(25)) -> Literal(3)),
       Literal(null, IntegerType))
     val branchValue = If(
       Literal(2) === nestedCaseWhen,
       TrueLiteral,
       FalseLiteral)
-    val branches = Seq((UnresolvedAttribute("i") > Literal(10)) -> branchValue)
+    val branches = Seq((UnresolvedAttribute("i") > Literal(10)) -> branchValue,
+      UnresolvedAttribute("b").isNull -> TrueLiteral)
     val condition = CaseWhen(branches)
     testFilter(originalCond = condition, expectedCond = condition)
     testJoin(originalCond = condition, expectedCond = condition)
@@ -304,7 +306,8 @@ class ReplaceNullWithFalseInPredicateSuite extends PlanTest {
     val condition = GreaterThan(
       UnresolvedAttribute("i"),
       If(UnresolvedAttribute("b"), Literal(null, IntegerType), Literal(4)))
-    val column = CaseWhen(Seq(condition -> Literal(5)), Literal(2)).as("out")
+    val column = CaseWhen(Seq(condition -> Literal(5),
+      UnresolvedAttribute("b").isNotNull -> Literal(5)), Literal(2)).as("out")
     testProjection(originalExpr = column, expectedExpr = column)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SimplifyConditionalSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SimplifyConditionalSuite.scala
@@ -44,7 +44,8 @@ class SimplifyConditionalSuite extends PlanTest with PredicateHelper {
   }
 
   private val trueBranch = (TrueLiteral, Literal(5))
-  private val normalBranch = (NonFoldableLiteral(true), Literal(10))
+  private val normalBranch1 = (NonFoldableLiteral(true), Literal(10))
+  private val normalBranch2 = (NonFoldableLiteral(false), Literal(3))
   private val unreachableBranch = (FalseLiteral, Literal(20))
   private val nullBranch = (Literal.create(null, BooleanType), Literal(30))
 
@@ -82,8 +83,23 @@ class SimplifyConditionalSuite extends PlanTest with PredicateHelper {
   test("remove unreachable branches") {
     // i.e. removing branches whose conditions are always false
     assertEquivalent(
-      CaseWhen(unreachableBranch :: normalBranch :: unreachableBranch :: nullBranch :: Nil, None),
-      CaseWhen(normalBranch :: Nil, None))
+      CaseWhen(unreachableBranch :: normalBranch1 :: unreachableBranch ::
+        normalBranch2 :: nullBranch :: Nil, None),
+      CaseWhen(normalBranch1 :: normalBranch2 :: Nil, None))
+  }
+
+  test("simplify CaseWhen to If when there is only one branch") {
+    assertEquivalent(
+      CaseWhen(normalBranch1 :: Nil, Some(Literal(30))),
+      If(normalBranch1._1, normalBranch1._2, Literal(30)))
+
+    assertEquivalent(
+      CaseWhen(normalBranch1 :: Nil, None),
+      If(normalBranch1._1, normalBranch1._2, Literal(null, normalBranch1._2.dataType)))
+
+    assertEquivalent(
+      CaseWhen(unreachableBranch :: normalBranch1 :: unreachableBranch :: nullBranch :: Nil, None),
+      If(normalBranch1._1, normalBranch1._2, Literal(null, normalBranch1._2.dataType)))
   }
 
   test("remove entire CaseWhen if only the else branch is reachable") {
@@ -98,29 +114,29 @@ class SimplifyConditionalSuite extends PlanTest with PredicateHelper {
 
   test("remove entire CaseWhen if the first branch is always true") {
     assertEquivalent(
-      CaseWhen(trueBranch :: normalBranch :: nullBranch :: Nil, None),
+      CaseWhen(trueBranch :: normalBranch1 :: nullBranch :: Nil, None),
       Literal(5))
 
     // Test branch elimination and simplification in combination
     assertEquivalent(
-      CaseWhen(unreachableBranch :: unreachableBranch :: nullBranch :: trueBranch :: normalBranch
+      CaseWhen(unreachableBranch :: unreachableBranch :: nullBranch :: trueBranch :: normalBranch1
         :: Nil, None),
       Literal(5))
 
     // Make sure this doesn't trigger if there is a non-foldable branch before the true branch
     assertEquivalent(
-      CaseWhen(normalBranch :: trueBranch :: normalBranch :: Nil, None),
-      CaseWhen(normalBranch :: trueBranch :: Nil, None))
+      CaseWhen(normalBranch1 :: trueBranch :: normalBranch1 :: Nil, None),
+      CaseWhen(normalBranch1 :: trueBranch :: Nil, None))
   }
 
   test("simplify CaseWhen, prune branches following a definite true") {
     assertEquivalent(
-      CaseWhen(normalBranch :: unreachableBranch ::
+      CaseWhen(normalBranch1 :: unreachableBranch ::
         unreachableBranch :: nullBranch ::
-        trueBranch :: normalBranch ::
+        trueBranch :: normalBranch1 ::
         Nil,
         None),
-      CaseWhen(normalBranch :: trueBranch :: Nil, None))
+      CaseWhen(normalBranch1 :: trueBranch :: Nil, None))
   }
 
   test("simplify CaseWhen if all the outputs are semantic equivalence") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

After the rule of removing the unreachable branches, it could be only one branch left. In this situation, `CaseWhen` can be converted to `If` to do further optimization.

## How was this patch tested?

Tests added.