### PR TITLE
[SPARK-24738] [HistoryServer] FsHistoryProvider clean outdated event …

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/config.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/config.scala
@@ -64,4 +64,9 @@ private[spark] object config {
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("1m")
 
+  val HISTORY_CLEANER_AT_START_ENABLED = ConfigBuilder("spark.history.cleaner.cleanAtStart.enabled")
+    .doc("Specifies whether the History Server should clean outdated logs at start " +
+      "when `spark.history.fs.cleaner.enabled` is on, no need to wait replay all events")
+    .booleanConf
+    .createWithDefault(false)
 }


### PR DESCRIPTION
Now FsHistoryProvider's policy :

1. FsHistoryProvider create checkEvent thread and cleanLog thread, they share one thread pool to avoid conflicts;
2. `checkThread` replay all event logs first;
3. `cleanThread` iterators all events to check the outdated events and remove about it;
 

Why check thread at step2 not clean the outdated eventLogs at start, so no need replay the outdated logs to save times ?



## How was this patch tested?
TODO
(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
