### PR TITLE
[SPARK-24906][SQL] Adaptively enlarge split / partition size for Parq…

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -36,6 +36,7 @@ import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
 import org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator
+import org.apache.spark.sql.types.StringType
 import org.apache.spark.util.Utils
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -458,6 +459,29 @@ object SQLConf {
       "be carefully chosen to minimize overhead and avoid OOMs in reading data.")
     .intConf
     .createWithDefault(4096)
+
+  val IS_PARQUET_PARTITION_ADAPTIVE_ENABLED = buildConf("spark.sql.parquet.adaptiveFileSplit")
+    .doc("For columnar file format (e.g., Parquet), it's possible that only few (not all) " +
+      "columns are needed. So, it's better to make sure that the total size of the selected " +
+      "columns is about 128 MB "
+    )
+    .booleanConf
+    .createWithDefault(false)
+
+  val PARQUET_STRUCT_LENGTH = buildConf("spark.sql.parquet.struct.length")
+    .doc("Set the default size of struct column")
+    .intConf
+    .createWithDefault(StringType.defaultSize)
+
+  val PARQUET_MAP_LENGTH = buildConf("spark.sql.parquet.map.length")
+    .doc("Set the default size of map column")
+    .intConf
+    .createWithDefault(StringType.defaultSize)
+
+  val PARQUET_ARRAY_LENGTH = buildConf("spark.sql.parquet.array.length")
+    .doc("Set the default size of array column")
+    .intConf
+    .createWithDefault(StringType.defaultSize)
 
   val ORC_COMPRESSION = buildConf("spark.sql.orc.compression.codec")
     .doc("Sets the compression codec used when writing ORC files. If either `compression` or " +
@@ -1713,6 +1737,14 @@ class SQLConf extends Serializable with Logging {
   def writeLegacyParquetFormat: Boolean = getConf(PARQUET_WRITE_LEGACY_FORMAT)
 
   def parquetRecordFilterEnabled: Boolean = getConf(PARQUET_RECORD_FILTER_ENABLED)
+
+  def isParquetSizeAdaptiveEnabled: Boolean = getConf(IS_PARQUET_PARTITION_ADAPTIVE_ENABLED)
+
+  def parquetStructTypeLength: Int = getConf(PARQUET_STRUCT_LENGTH)
+
+  def parquetMapTypeLength: Int = getConf(PARQUET_MAP_LENGTH)
+
+  def parquetArrayTypeLength: Int = getConf(PARQUET_ARRAY_LENGTH)
 
   def inMemoryPartitionPruning: Boolean = getConf(IN_MEMORY_PARTITION_PRUNING)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -460,25 +460,32 @@ object SQLConf {
     .intConf
     .createWithDefault(4096)
 
-  val IS_PARQUET_PARTITION_ADAPTIVE_ENABLED = buildConf("spark.sql.parquet.adaptiveFileSplit")
-    .doc("For columnar file format (e.g., Parquet), it's possible that only few (not all) " +
-      "columns are needed. So, it's better to make sure that the total size of the selected " +
-      "columns is about 128 MB "
-    )
+  val IS_COLUMNAR_PARTITION_ADAPTIVE_ENABLED = buildConf("spark.sql.columnar.adaptiveFileSplit")
+    .doc("When this is enabled, the partition size will adaptively enlarged when reading " +
+      "from columnar storage to make sure the actual input bytes of each task is close to " +
+      "the a proper partition size. When a user set spark.sql.files.maxPartitionBytes, he " +
+      "may think that is the upper bound of a single partition and each task will read at " +
+      "most this amount of data. For row based files, that is right. But for columnar storage, " +
+      "such as Parquet OR ORC, each task may read much less data because of column pruning." +
+      "For example, a 1024 MB file may contains of 10 columns, 5 of which are integer while " +
+      "another 5 are long. If this is a row based file, there will be 8 tasks, each of which " +
+      "will read 128MB. If this is a Parquet or ORC file and the Job only read a single " +
+      "column in long, there will be also 8 tasks, but each task will read much less than " +
+      "128 MB because of column pruning.")
     .booleanConf
     .createWithDefault(false)
 
-  val PARQUET_STRUCT_LENGTH = buildConf("spark.sql.parquet.struct.length")
+  val COLUMNAR_STRUCT_LENGTH = buildConf("spark.sql.columnar.struct.length")
     .doc("Set the default size of struct column")
     .intConf
     .createWithDefault(StringType.defaultSize)
 
-  val PARQUET_MAP_LENGTH = buildConf("spark.sql.parquet.map.length")
+  val COLUMNAR_MAP_LENGTH = buildConf("spark.sql.columnar.map.length")
     .doc("Set the default size of map column")
     .intConf
     .createWithDefault(StringType.defaultSize)
 
-  val PARQUET_ARRAY_LENGTH = buildConf("spark.sql.parquet.array.length")
+  val COLUMNAR_ARRAY_LENGTH = buildConf("spark.sql.columnar.array.length")
     .doc("Set the default size of array column")
     .intConf
     .createWithDefault(StringType.defaultSize)
@@ -1738,13 +1745,14 @@ class SQLConf extends Serializable with Logging {
 
   def parquetRecordFilterEnabled: Boolean = getConf(PARQUET_RECORD_FILTER_ENABLED)
 
-  def isParquetSizeAdaptiveEnabled: Boolean = getConf(IS_PARQUET_PARTITION_ADAPTIVE_ENABLED)
+  def isColumnarStorageSplitSizeAdaptiveEnabled: Boolean =
+    getConf(IS_COLUMNAR_PARTITION_ADAPTIVE_ENABLED)
 
-  def parquetStructTypeLength: Int = getConf(PARQUET_STRUCT_LENGTH)
+  def columnarStructTypeLength: Int = getConf(COLUMNAR_STRUCT_LENGTH)
 
-  def parquetMapTypeLength: Int = getConf(PARQUET_MAP_LENGTH)
+  def columnarMapTypeLength: Int = getConf(COLUMNAR_MAP_LENGTH)
 
-  def parquetArrayTypeLength: Int = getConf(PARQUET_ARRAY_LENGTH)
+  def columnarArrayTypeLength: Int = getConf(COLUMNAR_ARRAY_LENGTH)
 
   def inMemoryPartitionPruning: Boolean = getConf(IN_MEMORY_PARTITION_PRUNING)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -433,7 +433,7 @@ case class FileSourceScanExec(
 
     var maxSplitBytes = Math.min(defaultMaxSplitBytes, Math.max(openCostInBytes, bytesPerCore))
 
-    if(fsRelation.sparkSession.sessionState.conf.isParquetSizeAdaptiveEnabled &&
+    if(fsRelation.sparkSession.sessionState.conf.isColumnarStorageSplitSizeAdaptiveEnabled &&
       (fsRelation.fileFormat.isInstanceOf[ParquetSource] ||
         fsRelation.fileFormat.isInstanceOf[OrcFileFormat])) {
       if (relation.dataSchema.map(_.dataType).forall(dataType =>
@@ -443,11 +443,11 @@ case class FileSourceScanExec(
 
         def getTypeLength(dataType: DataType): Int = {
           if (dataType.isInstanceOf[StructType]) {
-            fsRelation.sparkSession.sessionState.conf.parquetStructTypeLength
+            fsRelation.sparkSession.sessionState.conf.columnarStructTypeLength
           } else if (dataType.isInstanceOf[ArrayType]) {
-            fsRelation.sparkSession.sessionState.conf.parquetArrayTypeLength
+            fsRelation.sparkSession.sessionState.conf.columnarArrayTypeLength
           } else if (dataType.isInstanceOf[MapType]) {
-            fsRelation.sparkSession.sessionState.conf.parquetMapTypeLength
+            fsRelation.sparkSession.sessionState.conf.columnarMapTypeLength
           } else {
             dataType.defaultSize
           }


### PR DESCRIPTION
Please refer to https://issues.apache.org/jira/browse/SPARK-24906 for more detail and test

For columnar file, such as, when spark sql read the table, each split will be 128 MB by default since spark.sql.files.maxPartitionBytes is default to 128MB. Even when user set it to a large value, such as 512MB, the task may read only few MB or even hundreds of KB. Because the table (Parquet) may consists of dozens of columns while the SQL only need few columns. And spark will prune the unnecessary columns.

In this case, spark DataSourceScanExec can enlarge maxPartitionBytes adaptively. 

For example, there is 40 columns , 20 are integer while another 20 are long. When use query on an integer type column and an long type column, the maxPartitionBytes should be 20 times larger. (20*4+20*8) /  (4+8) = 20. 

 With this optimization, the number of task will be smaller and the job will run faster. More importantly, for a very large cluster (more the 10 thousand nodes), it will relieve RM's schedule pressure.

 Here is the test

 The table named test2 has more than 40 columns and there are more than 5 TB data each hour.

When we issue a very simple query 

` select count(device_id) from test2 where date=20180708 and hour='23'`
 
There are 72176 tasks and the duration of the job is 4.8 minutes

Most tasks last less than 1 second and read less than 1.5 MB data


After the optimization, there are only 1615 tasks and the job last only 30 seconds. It almost 10 times faster.

The median of read data is 44.2MB. 

https://issues.apache.org/jira/browse/SPARK-24906
