### PR TITLE
[SPARK-24930][SQL] Improve exception information when using LOAD DATA LOCAL INPATH

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -337,7 +337,11 @@ case class LoadDataCommand(
           new File(file.getAbsolutePath).exists()
         }
         if (!exists) {
-          throw new AnalysisException(s"LOAD DATA input path does not exist: $path")
+          // If user have no permission to access the given input path, `File.exists()` return false
+          // , `LOAD DATA input path does not exist` can confuse users.
+          throw new AnalysisException(s"LOAD DATA input path does not exist: `$path` or current " +
+            s"user ${Utils.getCurrentUserName()} have no permission to access the input path: " +
+            s"`$path`, please check it.")
         }
         uri
       } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. root user create a test.txt file contains a record '123'  in /root/ directory
2. switch mr user to execute spark-shell --master local

```
scala> spark.version
res2: String = 2.2.1

scala> spark.sql("create table t1(id int) partitioned by(area string)");
2018-07-26 17:20:37,523 WARN org.apache.hadoop.hive.metastore.HiveMetaStore: Location: hdfs://nameservice/spark/t1 specified for non-external table:t1
res4: org.apache.spark.sql.DataFrame = []

scala> spark.sql("load data local inpath '/root/test.txt' into table t1 partition(area ='025')")
org.apache.spark.sql.AnalysisException: LOAD DATA input path does not exist: /root/test.txt;
 at org.apache.spark.sql.execution.command.LoadDataCommand.run(tables.scala:339)
 at org.apache.spark.sql.execution.command.ExecutedCommandExec.sideEffectResult$lzycompute(commands.scala:58)
 at org.apache.spark.sql.execution.command.ExecutedCommandExec.sideEffectResult(commands.scala:56)
 at org.apache.spark.sql.execution.command.ExecutedCommandExec.executeCollect(commands.scala:67)
 at org.apache.spark.sql.Dataset.<init>(Dataset.scala:183)
 at org.apache.spark.sql.Dataset$.ofRows(Dataset.scala:68)
 at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:639)
 ... 48 elided

scala>
```

In fact, the input path exists, but the mr user does not have permission to access the directory `/root/` ,so the message throwed by `AnalysisException` can confuse user.

## How was this patch tested?
existing test case

Please review http://spark.apache.org/contributing.html before opening a pull request.
