### PR TITLE
[SPARK-24937][SQL] Datasource partition table should load empty static partitions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -166,8 +166,8 @@ case class InsertIntoHadoopFsRelationCommand(
 
 
       // update metastore partition metadata
-      if (staticPartitions.nonEmpty) {
-        // Avoid empty partition can't loaded.
+      if (staticPartitions.nonEmpty && updatedPartitionPaths.isEmpty) {
+        // Avoid empty static partition can't loaded to datasource table.
         refreshUpdatedPartitions(Set(PartitioningUtils.getPathFragment(staticPartitions)))
       } else {
         refreshUpdatedPartitions(updatedPartitionPaths)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -166,7 +166,12 @@ case class InsertIntoHadoopFsRelationCommand(
 
 
       // update metastore partition metadata
-      refreshUpdatedPartitions(updatedPartitionPaths)
+      if (staticPartitions.nonEmpty) {
+        // Avoid empty partition can't loaded.
+        refreshUpdatedPartitions(Set(PartitioningUtils.getPathFragment(staticPartitions)))
+      } else {
+        refreshUpdatedPartitions(updatedPartitionPaths)
+      }
 
       // refresh cached files in FileIndex
       fileIndex.foreach(_.refresh())

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -166,7 +166,8 @@ case class InsertIntoHadoopFsRelationCommand(
 
 
       // update metastore partition metadata
-      if (staticPartitions.nonEmpty && updatedPartitionPaths.isEmpty) {
+      if (updatedPartitionPaths.isEmpty && staticPartitions.nonEmpty
+        && partitionColumns.length == staticPartitions.size) {
         // Avoid empty static partition can't loaded to datasource table.
         refreshUpdatedPartitions(Set(PartitioningUtils.getPathFragment(staticPartitions)))
       } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -169,7 +169,9 @@ case class InsertIntoHadoopFsRelationCommand(
       if (updatedPartitionPaths.isEmpty && staticPartitions.nonEmpty
         && partitionColumns.length == staticPartitions.size) {
         // Avoid empty static partition can't loaded to datasource table.
-        refreshUpdatedPartitions(Set(PartitioningUtils.getPathFragment(staticPartitions)))
+        val staticPathFragment =
+          PartitioningUtils.getPathFragment(staticPartitions, partitionColumns)
+        refreshUpdatedPartitions(Set(staticPathFragment))
       } else {
         refreshUpdatedPartitions(updatedPartitionPaths)
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{Resolver, TypeCoercion}
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
-import org.apache.spark.sql.catalyst.expressions.{Cast, Literal}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Literal}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.SchemaUtils
@@ -284,10 +284,9 @@ object PartitioningUtils {
     }.mkString("/")
   }
 
-  def getPathFragment(partitions: TablePartitionSpec): String = partitions.map {
-    case (k, v) =>
-      escapePathName(k) + "=" + escapePathName(v)
-  }.mkString("/")
+  def getPathFragment(spec: TablePartitionSpec, partitionColumns: Seq[Attribute]): String = {
+    getPathFragment(spec, StructType.fromAttributes(partitionColumns))
+  }
 
   /**
    * Normalize the column names in partition specification, w.r.t. the real partition column names

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -284,6 +284,11 @@ object PartitioningUtils {
     }.mkString("/")
   }
 
+  def getPathFragment(partitions: TablePartitionSpec): String = partitions.map {
+    case (k, v) =>
+      escapePathName(k) + "=" + escapePathName(v)
+  }.mkString("/")
+
   /**
    * Normalize the column names in partition specification, w.r.t. the real partition column names
    * and case sensitivity. e.g., if the partition spec has a column named `monTh`, and there is a

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2254,8 +2254,8 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
     withTable("t", "t1") {
       withTempPath { dir =>
         spark.sql("CREATE TABLE t(a int) USING parquet")
-        spark.sql("CREATE TABLE t1(a int, b string, c string) " +
-          s"USING parquet PARTITIONED BY(b, c) LOCATION '${dir.toURI}'")
+        spark.sql("CREATE TABLE t1(a int, c string, b string) " +
+          s"USING parquet PARTITIONED BY(c, b) LOCATION '${dir.toURI}'")
 
         val table = spark.sessionState.catalog.getTableMetadata(TableIdentifier("t1"))
         assert(table.location == makeQualifiedPath(dir.getAbsolutePath))
@@ -2266,7 +2266,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
 
         assert(spark.sql("SHOW PARTITIONS t1").count() == 1)
 
-        assert(new File(dir, "b=b/c=c").exists())
+        assert(new File(dir, "c=c/b=b").exists())
 
         checkAnswer(spark.table("t1"), Nil)
       }
@@ -2277,18 +2277,18 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
       withTempPath { dir =>
         spark.sql("CREATE TABLE t(a int) USING parquet")
         spark.sql("CREATE TABLE t1(a int, b string, c string) " +
-          s"USING parquet PARTITIONED BY(b, c) LOCATION '${dir.toURI}'")
+          s"USING parquet PARTITIONED BY(c, b) LOCATION '${dir.toURI}'")
 
         val table = spark.sessionState.catalog.getTableMetadata(TableIdentifier("t1"))
         assert(table.location == makeQualifiedPath(dir.getAbsolutePath))
 
         assert(spark.sql("SHOW PARTITIONS t1").count() == 0)
 
-        spark.sql("INSERT INTO TABLE t1 PARTITION(b='b', c) SELECT *, 'c' FROM t WHERE 1 = 0")
+        spark.sql("INSERT INTO TABLE t1 PARTITION(c='c', b) SELECT *, 'b' FROM t WHERE 1 = 0")
 
         assert(spark.sql("SHOW PARTITIONS t1").count() == 0)
 
-        assert(!new File(dir, "b=b/c=c").exists())
+        assert(!new File(dir, "c=c/b=b").exists())
 
         checkAnswer(spark.table("t1"), Nil)
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

How to reproduce:
```sql
spark-sql> CREATE TABLE tbl AS SELECT 1;
spark-sql> CREATE TABLE tbl1 (c1 BIGINT, day STRING, hour STRING)
         > USING parquet
         > PARTITIONED BY (day, hour);
spark-sql> INSERT INTO TABLE tbl1 PARTITION (day = '2018-07-25', hour='01') SELECT * FROM tbl where 1=0;
spark-sql> SHOW PARTITIONS tbl1;
spark-sql> CREATE TABLE tbl2 (c1 BIGINT)
         > PARTITIONED BY (day STRING, hour STRING);
spark-sql> INSERT INTO TABLE tbl2 PARTITION (day = '2018-07-25', hour='01') SELECT * FROM tbl where 1=0;
spark-sql> SHOW PARTITIONS tbl2;
day=2018-07-25/hour=01
spark-sql> 
```
1. Users will be confused about whether the partition data of `tbl1` is generated.
2. Inconsistent with Hive table behavior.

This pr fix this issues.


## How was this patch tested?

unit tests
