### PR TITLE
[SPARK-24932] Allow update mode for streaming queries with join

### DIFF
--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -1687,9 +1687,9 @@ Here is the compatibility matrix.
   </tr>
   <tr>
       <td colspan="2" style="vertical-align: middle;">Queries with <code>joins</code></td>
-      <td style="vertical-align: middle;">Append</td>
+      <td style="vertical-align: middle;">Append, Update</td>
       <td style="vertical-align: middle;">
-        Update and Complete mode not supported yet. See the
+        Complete mode not supported yet. See the
         <a href="#support-matrix-for-joins-in-streaming-queries">support matrix in the Join Operations section</a>
          for more details on what types of joins are supported.
       </td>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -235,9 +235,9 @@ object UnsupportedOperationChecker {
 
             case _: InnerLike =>
               if (left.isStreaming && right.isStreaming &&
-                outputMode != InternalOutputModes.Append) {
+                outputMode == InternalOutputModes.Complete) {
                 throwError("Inner join between two streaming DataFrames/Datasets is not supported" +
-                  s" in ${outputMode} output mode, only in Append output mode")
+                  s" in ${outputMode} output mode, only in Append or Update output mode")
               }
 
             case FullOuter =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -384,7 +384,7 @@ class UnsupportedOperationsSuite extends SparkFunSuite {
     outputMode = Append
   )
 
-  // Inner joins: Multiple stream-stream joins supported only in append mode
+  // Inner joins: Multiple stream-stream joins supported only in append or update mode
   testBinaryOperationInStreamingPlan(
     "single inner join in append mode",
     _.join(_, joinType = Inner),
@@ -403,7 +403,7 @@ class UnsupportedOperationsSuite extends SparkFunSuite {
     "inner join in update mode",
     _.join(_, joinType = Inner),
     outputMode = Update,
-    streamStreamSupported = false,
+    streamStreamSupported = true,
     expectedMsg = "inner join")
 
   // Full outer joins: only batch-batch is allowed


### PR DESCRIPTION
## Motivation

In SPARK-19140 we supported *update* output mode for non-aggregation streaming queries by letting it behaves exactly same as *append* mode. This should also be applied to streaming join, which is added after SPARK-19140, to keep semantic consistent.

## What changes were proposed in this pull request?

When using *update* output mode in streaming join query, the JOIN operator will works exactly same as *append* mode. 

For example, this will allow user to run an aggregation-after-join query in *update* mode in order to get a more real-time result output.

## How was this patch tested?

See changes in `UnsupportedOperationsSuite`.

