### PR TITLE
[SPARK-24912][SQL] Don't obscure source of OOM during broadcast join

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -120,15 +120,16 @@ case class BroadcastExchangeExec(
           // will catch this exception and re-throw the wrapped fatal throwable.
           case oe: OutOfMemoryError =>
             val sizeMessage = if (dataSize != -1) {
-              s"; Size of table is $dataSize"
+              s"${SparkLauncher.DRIVER_MEMORY} by at least the estimated size of the " +
+                s"relation ($dataSize bytes)"
             } else {
-              ""
+              s"the spark driver memory by setting ${SparkLauncher.DRIVER_MEMORY} " +
+                "to a higher value"
             }
             val oome =
               new OutOfMemoryError(s"Not enough memory to build and broadcast the table to " +
               s"all worker nodes. As a workaround, you can either disable broadcast by setting " +
-              s"${SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key} to -1 or increase the spark driver " +
-              s"memory by setting ${SparkLauncher.DRIVER_MEMORY} to a higher value$sizeMessage")
+              s"${SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key} to -1 or increase $sizeMessage.")
               .initCause(oe.getCause)
             oome.setStackTrace(oe.getStackTrace)
             throw new SparkFatalException(oome)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR shows the stack trace of the original OutOfMemoryError that occurs while building or broadcasting a HashedRelation, rather than the stack trace of the newly created OutOfMemoryError that's created during error handling.

Currently, when an OOM occurs while broadcasting a table, the stack trace points to a line in the error handling:
<pre>
java.lang.OutOfMemoryError: Not enough memory to build and broadcast the table to all worker nodes. As a workaround, you can either disable broadcast by setting spark.sql.autoBroadcastJoinThreshold to -1 or increase the spark driver memory by setting spark.driver.memory to a higher value
  at org.apache.spark.sql.execution.exchange.BroadcastExchangeExec$$anonfun$relationFuture$1$$anonfun$apply$1.apply(BroadcastExchangeExec.scala:122)
  at org.apache.spark.sql.execution.exchange.BroadcastExchangeExec$$anonfun$relationFuture$1$$anonfun$apply$1.apply(BroadcastExchangeExec.scala:76)
  at org.apache.spark.sql.execution.SQLExecution$$anonfun$withExecutionId$1.apply(SQLExecution.scala:101)
</pre>
With this PR, it shows the original stack trace.
<pre>
java.lang.OutOfMemoryError: Not enough memory to build and broadcast the table to all worker nodes. As a workaround, you can either disable broadcast by setting spark.sql.autoBroadcastJoinThreshold to -1 or increase the spark driver memory by setting spark.driver.memory to a higher value.
  at org.apache.spark.sql.execution.joins.LongToUnsafeRowMap.grow(HashedRelation.scala:628)
  at org.apache.spark.sql.execution.joins.LongToUnsafeRowMap.append(HashedRelation.scala:570)
  at org.apache.spark.sql.execution.joins.LongHashedRelation$.apply(HashedRelation.scala:865)
</pre>
In addition, when the error occurs during broadcast, rather then construction of the relation, the message includes the estimated size of the relation:
<pre>
java.lang.OutOfMemoryError: Not enough memory to build and broadcast the table to all worker nodes. As a workaround, you can either disable broadcast by setting spark.sql.autoBroadcastJoinThreshold to -1 or increase spark.driver.memory by at least the estimated size of the relation (96468992 bytes).
  at java.nio.HeapByteBuffer.<init>(HeapByteBuffer.java:57)
  at java.nio.ByteBuffer.allocate(ByteBuffer.java:335)
  at org.apache.spark.broadcast.TorrentBroadcast$$anonfun$3.apply(TorrentBroadcast.scala:286)
  at org.apache.spark.broadcast.TorrentBroadcast$$anonfun$3.apply(TorrentBroadcast.scala:286)
</pre>

While sometimes the line on which is the exception is thrown is just a victim, sometimes it is a participant in the problem, as was the case in the above exception.

## How was this patch tested?

Manually tested case where broadcast join caused an OOM, and a case where it did not.
