### PR TITLE
[SPARK-24953] [SQL] Prune a branch in `CaseWhen` if previously seen

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -416,6 +416,29 @@ object SimplifyConditionals extends Rule[LogicalPlan] with PredicateHelper {
         // these branches can be pruned away
         val (h, t) = branches.span(_._1 != TrueLiteral)
         CaseWhen( h :+ t.head, None)
+
+      case e @ CaseWhen(branches, _) =>
+        val newBranches = branches.foldLeft(List[(Expression, Expression)]()) {
+          case (newBranches, branch) =>
+            if (newBranches.exists(_._1.semanticEquals(branch._1))) {
+              // If a condition in a branch is previously seen, this branch can be pruned.
+              // TODO: In fact, if a condition is a sub-condition of the previous one,
+              // TODO: it can be pruned. This is less strict and can be implemented
+              // TODO: by decomposing seen conditions.
+              newBranches
+            } else if (newBranches.nonEmpty && newBranches.last._2.semanticEquals(branch._2)) {
+              // If the outputs of two adjacent branches are the same, two branches can be combined.
+              newBranches.take(newBranches.length - 1)
+                .:+((Or(newBranches.last._1, branch._1), newBranches.last._2))
+            } else {
+              newBranches.:+(branch)
+            }
+        }
+        if (newBranches.length < branches.length) {
+          e.copy(branches = newBranches)
+        } else {
+          e
+        }
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SimplifyConditionalSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SimplifyConditionalSuite.scala
@@ -156,7 +156,7 @@ class SimplifyConditionalSuite extends PlanTest with PredicateHelper {
         Nil,
         None),
       CaseWhen((Or(GreaterThan(Rand(0), Literal(0.5)), NonFoldableLiteral(true)), Literal(1)) ::
-        (Or(LessThan(Rand(1), Literal(0.5)), NonFoldableLiteral(true)), Literal(3)) ::
+        (LessThan(Rand(1), Literal(0.5)), Literal(3)) ::
         (NonFoldableLiteral(false), Literal(4)) ::
         Nil,
         None)


### PR DESCRIPTION
## What changes were proposed in this pull request?

If a condition in a branch is previously seen, this branch can be pruned.

If the outputs of two adjacent branches are the same, two branches can be combined.

## How was this patch tested?

Tests added.