### PR TITLE
[SPARK-24962][SQL] Refactor CodeGenerator.createUnsafeArray, ArraySetLike, and ArrayDistinct

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeArrayData.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeArrayData.java
@@ -452,7 +452,7 @@ public final class UnsafeArrayData extends ArrayData {
 
   public static UnsafeArrayData fromPrimitiveArray(
        Object arr, int offset, int length, int elementSize) {
-    UnsafeArrayData result = forPrimitiveArray(length, elementSize);
+    UnsafeArrayData result = createFreshArray(length, elementSize);
     final long headerInBytes = calculateHeaderPortionInBytes(length);
     final long valueRegionInBytes = (long)elementSize * length;
     final Object data = result.getBaseObject();
@@ -461,7 +461,7 @@ public final class UnsafeArrayData extends ArrayData {
     return result;
   }
 
-  public static UnsafeArrayData forPrimitiveArray(int length, int elementSize) {
+  public static UnsafeArrayData createFreshArray(int length, int elementSize) {
     final long headerInBytes = calculateHeaderPortionInBytes(length);
     final long valueRegionInBytes = (long)elementSize * length;
     final long totalSizeInLongs = (headerInBytes + valueRegionInBytes + 7) / 8;

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeArrayData.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeArrayData.java
@@ -477,9 +477,9 @@ public final class UnsafeArrayData extends ArrayData {
     return fromPrimitiveArray(null, offset, length, elementSize);
   }
 
-  public static boolean shouldUseGenericArrayData(int elementSize, int length) {
+  public static boolean shouldUseGenericArrayData(int elementSize, long length) {
     final long headerInBytes = calculateHeaderPortionInBytes(length);
-    final long valueRegionInBytes = (long)elementSize * length;
+    final long valueRegionInBytes = elementSize * length;
     final long totalSizeInLongs = (headerInBytes + valueRegionInBytes + 7) / 8;
     return totalSizeInLongs > Integer.MAX_VALUE / 8;
   }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeArrayData.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeArrayData.java
@@ -473,8 +473,8 @@ public final class UnsafeArrayData extends ArrayData {
     return result;
   }
 
-  public static UnsafeArrayData forPrimitiveArray(int offset, int length, int elementSize) {
-    return fromPrimitiveArray(null, offset, length, elementSize);
+  public static UnsafeArrayData forPrimitiveArray(int length, int elementSize) {
+    return fromPrimitiveArray(null, 0, length, elementSize);
   }
 
   public static boolean shouldUseGenericArrayData(int elementSize, long length) {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeArrayData.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeArrayData.java
@@ -463,8 +463,10 @@ public final class UnsafeArrayData extends ArrayData {
     final long[] data = new long[(int)totalSizeInLongs];
 
     Platform.putLong(data, Platform.LONG_ARRAY_OFFSET, length);
-    Platform.copyMemory(arr, offset, data,
-      Platform.LONG_ARRAY_OFFSET + headerInBytes, valueRegionInBytes);
+    if (arr != null) {
+      Platform.copyMemory(arr, offset, data,
+        Platform.LONG_ARRAY_OFFSET + headerInBytes, valueRegionInBytes);
+    }
 
     UnsafeArrayData result = new UnsafeArrayData();
     result.pointTo(data, Platform.LONG_ARRAY_OFFSET, (int)totalSizeInLongs * 8);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -783,10 +783,9 @@ class CodegenContext {
     } else {
       elementType.defaultSize
     }
-    val arrayData = classOf[ArrayData].getName
     val allocation =
       s"""
-         |ArrayData $arrayName = $arrayData$$.MODULE$$.allocateArrayData(
+         |ArrayData $arrayName = ArrayData.allocateArrayData(
          |  $elemSize, $numElements, $isPrimitiveType, "$additionalErrorMessage");
        """.stripMargin
 
@@ -801,8 +800,7 @@ class CodegenContext {
    * @param elementType data type of the elements in source array
    * @param srcArray code representing the number of elements the array should contain
    * @param setFunc string to include in the error message
-   * @param rhsValue an optionally specified expression for the right-hand side of the returning
-   *                 assignment
+   * @param rhsValue optional expression for the right-hand side of the returning assignment
    * @param checkForNull optional value which shows whether a nullcheck is required for
    *                     the returning assignment
    *
@@ -815,10 +813,10 @@ class CodegenContext {
       elementType: DataType,
       srcArray: String,
       setFunc: String,
-      rhsValue: String = null,
+      rhsValue: Option[String] = None,
       checkForNull: Option[Boolean] = None): (String, String) => String = {
-    val getValue = (srcLoopIndex: String) => if (rhsValue != null) {
-      rhsValue
+    val getValue = (srcLoopIndex: String) => if (rhsValue.isDefined) {
+      rhsValue.get
     } else {
       CodeGenerator.getValue(srcArray, elementType, srcLoopIndex)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1462,7 +1462,6 @@ object CodeGenerator extends Logging {
    * @param srcArray code representing the number of elements the array should contain
    * @param needNullCheck value which shows whether a nullcheck is required for the returning
    *                      assignment
-   * @param rhsValue optional expression for the right-hand side of the returning assignment
    *
    * @return code representing an assignment to each element of the [[ArrayData]], which requires
    *         a pair of destination and source loop index variables

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1462,6 +1462,8 @@ object CodeGenerator extends Logging {
    * @param srcArray code representing the number of elements the array should contain
    * @param needNullCheck value which shows whether a nullcheck is required for the returning
    *                      assignment
+   * @param dstArrayIndex an index variable to access each element of destination array
+   * @param srcArrayIndex an index variable to access each element of source array
    *
    * @return code representing an assignment to each element of the [[ArrayData]], which requires
    *         a pair of destination and source loop index variables
@@ -1470,11 +1472,12 @@ object CodeGenerator extends Logging {
       arrayName: String,
       elementType: DataType,
       srcArray: String,
-      needNullCheck: Boolean): (String, String) => String = {
-    (dstLoopIndex: String, srcLoopIndex: String) =>
-      CodeGenerator.setArrayElement(arrayName, elementType, dstLoopIndex,
-        CodeGenerator.getValue(srcArray, elementType, srcLoopIndex),
-        if (needNullCheck) Some(s"$srcArray.isNullAt($srcLoopIndex)") else None)
+      dstArrayIndex: String,
+      srcArrayIndex: String,
+      needNullCheck: Boolean): String = {
+    CodeGenerator.setArrayElement(arrayName, elementType, dstArrayIndex,
+      CodeGenerator.getValue(srcArray, elementType, srcArrayIndex),
+      if (needNullCheck) Some(s"$srcArray.isNullAt($srcArrayIndex)") else None)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1451,7 +1451,6 @@ object CodeGenerator extends Logging {
    *                    [[UnsafeArrayData]] or [[GenericArrayData]]
    *
    * @return code representing the allocation of [[ArrayData]]
-   *         code representing a setter of an assignment for the generated array
    */
   def createArrayData(
       arrayName: String,
@@ -1472,7 +1471,7 @@ object CodeGenerator extends Logging {
   }
 
   /**
-   * Generates assignment code for a [[ArrayData]]
+   * Generates assignment code for an [[ArrayData]]
    *
    * @param arrayName name of the array to create
    * @param elementType data type of the elements in destination and source arrays

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1439,10 +1439,14 @@ object CodeGenerator extends Logging {
       elementType: DataType,
       numElements: String,
       additionalErrorMessage: String): String = {
-    val isPrimitiveType = CodeGenerator.isPrimitiveType(elementType)
+    val elementSize = if (CodeGenerator.isPrimitiveType(elementType)) {
+      elementType.defaultSize
+    } else {
+      -1
+    }
     s"""
        |ArrayData $arrayName = ArrayData.allocateArrayData(
-       |  ${elementType.defaultSize}, $numElements, $isPrimitiveType, "$additionalErrorMessage");
+       |  $elementSize, $numElements, "$additionalErrorMessage");
      """.stripMargin
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -397,13 +397,13 @@ case class MapEntries(child: Expression) extends UnaryExpression with ExpectsInp
       val (isPrimitive, elementSize) = if (isKeyPrimitive && isValuePrimitive) {
         (true, structSize + wordSize)
       } else {
-        (false, childDataType.keyType.defaultSize)
+        (false, -1)
       }
 
       val allocation =
         s"""
            |ArrayData $arrayData = ArrayData.allocateArrayData(
-           |  $elementSize, $numElements, $isPrimitive, " $prettyName failed.");
+           |  $elementSize, $numElements, " $prettyName failed.");
          """.stripMargin
 
       val code = if (isPrimitive) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -3156,8 +3156,8 @@ case class ArrayRemove(left: Expression, right: Expression)
  * and [[ArrayExcept]].
  */
 trait ArraySetLike {
-  val dt: DataType
-  val et: DataType
+  @transient protected lazy val dt: DataType = NullType
+  @transient protected lazy val et: DataType = NullType
 
   @transient protected lazy val canUseSpecializedHashSet = et match {
     case ByteType | ShortType | IntegerType | LongType | FloatType | DoubleType => true
@@ -3259,8 +3259,8 @@ case class ArrayDistinct(child: Expression)
 
   @transient private lazy val elementType: DataType = dataType.asInstanceOf[ArrayType].elementType
 
-  override val dt = dataType
-  override val et = elementType
+  @transient lazy override val dt = dataType
+  @transient lazy override val et = elementType
 
   override def checkInputDataTypes(): TypeCheckResult = {
     super.checkInputDataTypes() match {
@@ -3390,8 +3390,8 @@ case class ArrayDistinct(child: Expression)
  * Will become common base class for [[ArrayUnion]], [[ArrayIntersect]], and [[ArrayExcept]].
  */
 trait ArrayBinaryLike extends BinaryArrayExpressionWithImplicitCast with ArraySetLike {
-  override val dt = dataType
-  override val et = elementType
+  @transient lazy override val dt = dataType
+  @transient lazy override val et = elementType
 
   override def checkInputDataTypes(): TypeCheckResult = {
     val typeCheckResult = super.checkInputDataTypes()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -1317,7 +1317,7 @@ case class Reverse(child: Expression) extends UnaryExpression with ImplicitCastI
     val (initialization, setFunc) =
       ctx.createArrayData(arrayData, elementType, numElements, s" $prettyName failed.")
     val assignment =
-      ctx.createArrayAssignment(arrayData, dataType, elementType,  childName, setFunc)
+      ctx.createArrayAssignment(arrayData, dataType, elementType, childName, setFunc)
 
     s"""
        |final int $numElements = $childName.numElements();
@@ -3031,7 +3031,7 @@ case class ArrayRepeat(left: Expression, right: Expression)
     val (allocation, setFunc) =
       ctx.createArrayData(tempArrayDataName, elementType, numElemName, s" $prettyName failed.")
     val assignment = ctx.createArrayAssignment(tempArrayDataName, dataType, elementType, "",
-      setFunc, rhsValue = element, checkForNull = Some(false))
+      setFunc, rhsValue = Some(element), checkForNull = Some(false))
 
     s"""
        |$numElemCode

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -3031,7 +3031,7 @@ case class ArrayRepeat(left: Expression, right: Expression)
     val allocation = CodeGenerator.createArrayData(
       tempArrayDataName, elementType, numElemName, s" $prettyName failed.")
     val assignment = CodeGenerator.createArrayAssignment(
-      tempArrayDataName, elementType, "",false, rhsValue = Some(element))
+      tempArrayDataName, elementType, "", false, rhsValue = Some(element))
 
     s"""
        |$numElemCode

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -397,7 +397,7 @@ case class MapEntries(child: Expression) extends UnaryExpression with ExpectsInp
       val (isPrimitive, elementSize) = if (isKeyPrimitive && isValuePrimitive) {
         (true, structSize + wordSize)
       } else {
-        (isKeyPrimitive, childDataType.keyType.defaultSize)
+        (false, childDataType.keyType.defaultSize)
       }
 
       val allocation =
@@ -406,7 +406,7 @@ case class MapEntries(child: Expression) extends UnaryExpression with ExpectsInp
            |  $elementSize, $numElements, $isPrimitive, " $prettyName failed.");
          """.stripMargin
 
-      val code = if (isKeyPrimitive && isValuePrimitive) {
+      val code = if (isPrimitive) {
         val genCodeForPrimitive = genCodeForPrimitiveElements(
           ctx, arrayData, keys, values, ev.value, numElements, structSize)
         s"""

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -3276,8 +3276,8 @@ case class ArrayDistinct(child: Expression)
 
   @transient private lazy val elementType: DataType = dataType.asInstanceOf[ArrayType].elementType
 
-  override def dt = dataType
-  override def et = elementType
+  override protected def dt: DataType = dataType
+  override protected def et: DataType = elementType
 
   override def checkInputDataTypes(): TypeCheckResult = {
     super.checkInputDataTypes() match {
@@ -3407,8 +3407,8 @@ case class ArrayDistinct(child: Expression)
  * Will become common base class for [[ArrayUnion]], [[ArrayIntersect]], and [[ArrayExcept]].
  */
 trait ArrayBinaryLike extends BinaryArrayExpressionWithImplicitCast with ArraySetLike {
-  override def dt = dataType
-  override def et = elementType
+  override protected def dt: DataType = dataType
+  override protected def et: DataType = elementType
 
   override def checkInputDataTypes(): TypeCheckResult = {
     val typeCheckResult = super.checkInputDataTypes()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2374,7 +2374,8 @@ case class Concat(children: Seq[Expression]) extends ComplexTypeMergingExpressio
     val initialization = CodeGenerator.createArrayData(
       arrayData, elementType, numElemName, s" $prettyName failed.")
     val assignment = CodeGenerator.createArrayAssignment(
-      arrayData, elementType, s"args[$y]", counter, z, dataType.asInstanceOf[ArrayType].containsNull)
+      arrayData, elementType, s"args[$y]", counter, z,
+      dataType.asInstanceOf[ArrayType].containsNull)
 
     val concat = ctx.freshName("concat")
     val concatDef =
@@ -2491,7 +2492,8 @@ case class Flatten(child: Expression) extends UnaryExpression {
     val allocation = CodeGenerator.createArrayData(
       tempArrayDataName, elementType, numElemName, s" $prettyName failed.")
     val assignment = CodeGenerator.createArrayAssignment(
-      tempArrayDataName, elementType, arr, counter, l, dataType.asInstanceOf[ArrayType].containsNull)
+      tempArrayDataName, elementType, arr, counter, l,
+      dataType.asInstanceOf[ArrayType].containsNull)
 
     s"""
     |$numElemCode

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayData.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayData.scala
@@ -41,17 +41,16 @@ object ArrayData {
   /**
    * Allocate [[UnsafeArrayData]] or [[GenericArrayData]] based on given parameters.
    *
-   * @param elementSize a size of an element in bytes
+   * @param elementSize a size of an element in bytes. If less than zero, the type of an element is
+   *                    non-primitive type
    * @param numElements the number of elements the array should contain
-   * @param isPrimitiveType whether the type of an element is primitive type
    * @param additionalErrorMessage string to include in the error message
    */
   def allocateArrayData(
       elementSize: Int,
       numElements: Long,
-      isPrimitiveType: Boolean,
       additionalErrorMessage: String): ArrayData = {
-    if (isPrimitiveType && !UnsafeArrayData.shouldUseGenericArrayData(elementSize, numElements)) {
+    if (elementSize >= 0 && !UnsafeArrayData.shouldUseGenericArrayData(elementSize, numElements)) {
       UnsafeArrayData.createFreshArray(numElements.toInt, elementSize)
     } else if (numElements <= ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH.toLong) {
       new GenericArrayData(new Array[Any](numElements.toInt))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayData.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayData.scala
@@ -51,20 +51,15 @@ object ArrayData {
       numElements : Long,
       isPrimitiveType: Boolean,
       additionalErrorMessage: String) : ArrayData = {
-    val arraySize = UnsafeArrayData.calculateSizeOfUnderlyingByteArray(numElements, elementSize)
     if (isPrimitiveType && !UnsafeArrayData.shouldUseGenericArrayData(elementSize, numElements)) {
-      val arrayBytes = new Array[Byte](arraySize.toInt)
-      val arrayName = new UnsafeArrayData()
-      Platform.putLong(arrayBytes, Platform.BYTE_ARRAY_OFFSET, numElements)
-      arrayName.pointTo(arrayBytes, Platform.BYTE_ARRAY_OFFSET, arraySize.toInt)
-      arrayName
+      UnsafeArrayData.forPrimitiveArray(Platform.BYTE_ARRAY_OFFSET, numElements.toInt, elementSize)
     } else if (numElements <= ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH.toLong) {
       new GenericArrayData(new Array[Any](numElements.toInt))
     } else {
       throw new RuntimeException(s"Cannot create array with $numElements " +
         "elements of data due to exceeding the limit " +
-        s"${ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH} elements for ArrayData." +
-        s"$additionalErrorMessage")
+        s"${ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH} elements for ArrayData. " +
+        additionalErrorMessage)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayData.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayData.scala
@@ -48,11 +48,11 @@ object ArrayData {
    */
   def allocateArrayData(
       elementSize: Int,
-      numElements : Long,
+      numElements: Long,
       isPrimitiveType: Boolean,
-      additionalErrorMessage: String) : ArrayData = {
+      additionalErrorMessage: String): ArrayData = {
     if (isPrimitiveType && !UnsafeArrayData.shouldUseGenericArrayData(elementSize, numElements)) {
-      UnsafeArrayData.forPrimitiveArray(Platform.BYTE_ARRAY_OFFSET, numElements.toInt, elementSize)
+      UnsafeArrayData.forPrimitiveArray(numElements.toInt, elementSize)
     } else if (numElements <= ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH.toLong) {
       new GenericArrayData(new Array[Any](numElements.toInt))
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayData.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayData.scala
@@ -52,7 +52,7 @@ object ArrayData {
       isPrimitiveType: Boolean,
       additionalErrorMessage: String): ArrayData = {
     if (isPrimitiveType && !UnsafeArrayData.shouldUseGenericArrayData(elementSize, numElements)) {
-      UnsafeArrayData.forPrimitiveArray(numElements.toInt, elementSize)
+      UnsafeArrayData.createFreshArray(numElements.toInt, elementSize)
     } else if (numElements <= ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH.toLong) {
       new GenericArrayData(new Array[Any](numElements.toInt))
     } else {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -1314,9 +1314,9 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
   }
 
   test("Array Distinct") {
-    val a0 = Literal.create(Seq(2, 1, 2, 3, 4, 4, 5), ArrayType(IntegerType, false))
+    val a0 = Literal.create(Seq(2, 1, 2, 3, 4, 4, 5), ArrayType(IntegerType))
     val a1 = Literal.create(Seq.empty[Integer], ArrayType(IntegerType))
-    val a2 = Literal.create(Seq("b", "a", "a", "c", "b"), ArrayType(StringType, false))
+    val a2 = Literal.create(Seq("b", "a", "a", "c", "b"), ArrayType(StringType))
     val a3 = Literal.create(Seq("b", null, "a", null, "a", null), ArrayType(StringType))
     val a4 = Literal.create(Seq(null, null, null), ArrayType(NullType))
     val a5 = Literal.create(Seq(true, false, false, true), ArrayType(BooleanType))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -1314,9 +1314,9 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
   }
 
   test("Array Distinct") {
-    val a0 = Literal.create(Seq(2, 1, 2, 3, 4, 4, 5), ArrayType(IntegerType))
+    val a0 = Literal.create(Seq(2, 1, 2, 3, 4, 4, 5), ArrayType(IntegerType, false))
     val a1 = Literal.create(Seq.empty[Integer], ArrayType(IntegerType))
-    val a2 = Literal.create(Seq("b", "a", "a", "c", "b"), ArrayType(StringType))
+    val a2 = Literal.create(Seq("b", "a", "a", "c", "b"), ArrayType(StringType, false))
     val a3 = Literal.create(Seq("b", null, "a", null, "a", null), ArrayType(StringType))
     val a4 = Literal.create(Seq(null, null, null), ArrayType(NullType))
     val a5 = Literal.create(Seq(true, false, false, true), ArrayType(BooleanType))


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR integrates handling of `UnsafeArrayData` and `GenericArrayData` into one. The current `CodeGenerator.createUnsafeArray` handles only allocation of `UnsafeArrayData`.
This PR introduces a new method `createArrayData` that returns a code to allocate `UnsafeArrayData` or `GenericArrayData` and to assign a value into the allocated array.

This PR also reduce the size of generated code by calling a runtime helper.

This PR replaced `createArrayData` with `createUnsafeArray`. This PR also refactor `ArraySetLike` that can be used for `ArrayDistinct`, too.
This PR also refactors`ArrayDistinct` to use `ArraryBuilder`.

## How was this patch tested?

Existing tests