### PR TITLE
[SPARK-24917][CORE] make chunk size configurable

### DIFF
--- a/core/src/main/scala/org/apache/spark/serializer/SerializerManager.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/SerializerManager.scala
@@ -71,7 +71,7 @@ private[spark] class SerializerManager(
   // Whether to compress shuffle output temporarily spilled to disk
   private[this] val compressShuffleSpill = conf.getBoolean("spark.shuffle.spill.compress", true)
   // Size of the chunks to be used in the ChunkedByteBuffer
-  private[this] val chunkSizeMb = conf.getSizeAsMb("spark.memory.chunkSize", "4m").toInt
+  private[this] val chunkSizeMb = conf.getSizeAsMb("spark.memory.serializer.chunkSize", "4m").toInt
 
   /* The compression codec to use. Note that the "lazy" val is necessary because we want to delay
    * the initialization of the compression codec until it is first used. The reason is that a Spark


### PR DESCRIPTION
Add an option in Spark configuration to change the chunk size (which is by default 4 Mb).

This would allow to bypass the issue mentionned in SPARK-24917 by allowing users to define larger chunks.
Explanation:
currently, using netty < 4.1.28 (before this patch https://github.com/netty/netty/commit/9b95b8ee628983e3e4434da93fffb893edff4aa2), sending a ChunkedByteBuffer with more than 16 chunks over the network will trigger a "merge" of all the blocks into one big transient array that is then sent over the network. This is problematic as the total memory for all chunks can be high (2GB) and this would then trigger an allocation of 2GB to merge everything, which will create  OOM errors.
A possibility to bypass this netty behavior is to make sure that they data is never split into more than 16 chunks. One way to do this is to create bigger chunks, which is currently fixed to 4MB. In this commit I'm allowing users to define bigger chunk sizes for their job, which allowed us to bypass this OOM error.

## What changes were proposed in this pull request?
I'm introducing a configuration parameter to define the chunk size

## How was this patch tested?
Tested on several spark jobs, the changes actually work and generates "chunks" of the indicated size