### PR TITLE
[SPARK-24981][Core] ShutdownHook timeout causes job to fail when succeeded when SparkContext stop() not called by user program

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -575,7 +575,7 @@ class SparkContext(config: SparkConf) extends Logging {
         stop()
       } catch {
         case e: Throwable =>
-          logWarning("Ignoring Exception while stopping SparkContext", e)
+          logWarning("Ignoring Exception while stopping SparkContext from shutdownhook", e)
       }
     }
   } catch {

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -571,7 +571,12 @@ class SparkContext(config: SparkConf) extends Logging {
     _shutdownHookRef = ShutdownHookManager.addShutdownHook(
       ShutdownHookManager.SPARK_CONTEXT_SHUTDOWN_PRIORITY) { () =>
       logInfo("Invoking stop() from shutdown hook")
-      stop()
+      try {
+        stop()
+      } catch {
+        case e: Throwable =>
+          logWarning("Ignoring Exception while stoping SparkContext. Exception: " + e)
+      }
     }
   } catch {
     case NonFatal(e) =>

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -575,7 +575,7 @@ class SparkContext(config: SparkConf) extends Logging {
         stop()
       } catch {
         case e: Throwable =>
-          logWarning("Ignoring Exception while stopping SparkContext from shutdownhook", e)
+          logWarning("Ignoring Exception while stopping SparkContext from shutdown hook", e)
       }
     }
   } catch {

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -575,7 +575,7 @@ class SparkContext(config: SparkConf) extends Logging {
         stop()
       } catch {
         case e: Throwable =>
-          logWarning("Ignoring Exception while stoping SparkContext. Exception: " + e)
+          logWarning("Ignoring Exception while stopping SparkContext", e)
       }
     }
   } catch {


### PR DESCRIPTION
**Description**
The issue is described in [SPARK-24981](https://issues.apache.org/jira/browse/SPARK-24981). 

**How does this PR fix the issue?**
This PR catch the Exception that is thrown while the Sparkcontext.stop() is running (when it is called by the ShutdownHookManager).

**How was this patch tested?**
I manually tested it by adding delay (60s) inside the stop(). This make the shutdownHookManger interrupt the thread that is running stop(). The Interrupted Exception was catched and the job succeed.
