### PR TITLE
[SPARK-24982][SQL] UDAF resolution should not throw AssertionError

### DIFF
--- a/sql/core/src/test/resources/sql-tests/results/udaf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udaf.sql.out
@@ -33,8 +33,8 @@ SELECT default.myDoubleAvg(int_col1, 3) as my_avg from t1
 -- !query 3 schema
 struct<>
 -- !query 3 output
-java.lang.AssertionError
-assertion failed: Incorrect number of children
+org.apache.spark.sql.AnalysisException
+Invalid number of arguments for function default.myDoubleAvg. Expected: 1; Found: 2; line 1 pos 7
 
 
 -- !query 4


### PR DESCRIPTION
## What changes were proposed in this pull request?
When user calls anUDAF with the wrong number of arguments, Spark previously throws an AssertionError, which is not supposed to be a user-facing exception.  This patch updates it to throw AnalysisException instead, so it is consistent with a regular UDF.

## How was this patch tested?
Updated test case udaf.sql.
