### PR TITLE
[SPARK-24283][ML] Make ml.StandardScaler skip conversion of Spar…

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
@@ -180,8 +180,7 @@ class StandardScalerModel private[ml] (
     * @return Standardized vector. If the std of a column is zero, it will return default `0.0`
     *         for the column with zero std.
     */
-  @Since("2.3.0")
-  def transform(vector: Vector): Vector = {
+  private[spark] def transform(vector: Vector): Vector = {
     require(mean.size == vector.size)
     if ($(withMean)) {
       /**


### PR DESCRIPTION
…k ml vectors to mllib vectors

## What changes were proposed in this pull request?
Currently, ml.StandardScaler converts Spark  ml vectors to mllib vectors during transform operation. This PR makes changes to skip this step.

## How was this patch tested?
Existing tests in StandardScalerSuite
