### PR TITLE
[SPARK-24988][SQL]Add a castBySchema method which casts all the values of a DataFrame based on the DataTypes of a StructType

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1368,6 +1368,22 @@ class Dataset[T] private[sql](
   }
 
   /**
+   * Casts all the values of the current Dataset following the types of a specific StructType.
+   * This method works also with nested structTypes.
+   *
+   *  @group typedrel
+   *  @since 2.4.0
+   */
+  def castBySchema(schema: StructType): DataFrame = {
+    assert(schema.fields.map(_.name).toList.sameElements(this.schema.fields.map(_.name).toList),
+      "schema should have the same fields as the original schema")
+
+    selectExpr(schema.map(
+      field => s"CAST ( ${field.name} As ${field.dataType.sql}) ${field.name}"
+    ): _*)
+  }
+
+  /**
    * :: Experimental ::
    * Returns a new Dataset by computing the given [[Column]] expression for each element.
    *


### PR DESCRIPTION
## What changes were proposed in this pull request?

The main goal of this Pull Request is to extend the Dataframe methods in order to add a method which casts all the values of a Dataframe, based on the DataTypes of a StructType.

This feature can be useful when we have a large dataframe, and that we need to make multiple casts. In that case, we won't have to cast each value independently, all we have to do is to pass a StructType to the method castBySchema with the types we need (In real world examples, this schema is generally provided by the client, which was my case).

Here's an example here on how we can apply this method (let's say that we have a dataframe of strings, and that we want to cast the values of the second columns to Int) : 
```
// We start by creating the dataframe
val df = Seq(("test1", "0"), ("test2", "1")).toDF("name", "id")

// we prepare the StructType of the casted Dataframe that we'll obtain:
val schema = StructType( Seq( StructField("name", StringType, true), StructField("id", IntegerType, true)))

// and then, we simply use the method castBySchema :
val castedDf = df.castBySchema(schema) 
```


## How was this patch tested?

I modified DataFrameSuite in order to test the new added method (castBySchema).
I first tested the method on a simple dataframe with a simple schema, then I tested it on Dataframes with a complex schemas (Nested StructTypes for example).


