### PR TITLE
[SPARK-24914][SQL] Add configuration to avoid OOM during broadcast join (and other negative side effects of incorrect table sizing)

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -262,6 +262,37 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val ENABLE_FALL_BACK_TO_HDFS_FOR_STATS =
+    buildConf("spark.sql.statistics.fallBackToHdfs")
+    .doc("If the table statistics are not available from table metadata enable fall back to hdfs." +
+      " This is useful in determining if a table is small enough to use auto broadcast joins.")
+    .booleanConf
+    .createWithDefault(false)
+
+  val SIZE_DESER_FACTOR = buildConf("spark.sql.statistics.deserialization.factor")
+    .doc("In the absence of uncompressed/raw data size, total file size will be used for " +
+      "statistics annotation. But the file may be compressed, encoded and serialized which may " +
+      "be lesser in size than the actual uncompressed/raw data size. This factor will be " +
+      "multiplied to file size to estimate the raw data size. ")
+    .doubleConf
+    .createWithDefault(1.0)
+
+  val IGNORE_RAWDATASIZE = buildConf("spark.sql.statistics.ignoreRawDataSize")
+    .doc("Currently, the rawDataSize property of Hive tables is incorrect due to HIVE-20079. " +
+      "When this setting is true, Spark will not use the rawDataSize property when calculating " +
+      "the size of a table")
+    .booleanConf
+    .createWithDefault(false)
+
+  val DEFAULT_SIZE_IN_BYTES = buildConf("spark.sql.defaultSizeInBytes")
+    .internal()
+    .doc("The default table size used in query planning. By default, it is set to Long.MaxValue " +
+      "which is larger than `spark.sql.autoBroadcastJoinThreshold` to be more conservative. " +
+      "That is to say by default the optimizer will not choose to broadcast a table unless it " +
+      "knows for sure its size is small enough.")
+    .longConf
+    .createWithDefault(Long.MaxValue)
+
   val SHUFFLE_PARTITIONS = buildConf("spark.sql.shuffle.partitions")
     .doc("The default number of partitions to use when shuffling data for joins or aggregations.")
     .intConf
@@ -1988,6 +2019,10 @@ class SQLConf extends Serializable with Logging {
   def setOpsPrecedenceEnforced: Boolean = getConf(SQLConf.LEGACY_SETOPS_PRECEDENCE_ENABLED)
 
   def integralDivideReturnLong: Boolean = getConf(SQLConf.LEGACY_INTEGRALDIVIDE_RETURN_LONG)
+
+  def sizeDeserializationFactor: Double = getConf(SQLConf.SIZE_DESER_FACTOR)
+
+  def ignoreRawDataSize: Boolean = getConf(SQLConf.IGNORE_RAWDATASIZE)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -262,28 +262,12 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
-  val ENABLE_FALL_BACK_TO_HDFS_FOR_STATS =
-    buildConf("spark.sql.statistics.fallBackToHdfs")
-    .doc("If the table statistics are not available from table metadata enable fall back to hdfs." +
-      " This is useful in determining if a table is small enough to use auto broadcast joins.")
-    .booleanConf
-    .createWithDefault(false)
-
   val IGNORE_RAWDATASIZE = buildConf("spark.sql.statistics.ignoreRawDataSize")
     .doc("Currently, the rawDataSize property of Hive tables is incorrect due to HIVE-20079. " +
       "When this setting is true, Spark will not use the rawDataSize property when calculating " +
       "the size of a table")
     .booleanConf
     .createWithDefault(false)
-
-  val DEFAULT_SIZE_IN_BYTES = buildConf("spark.sql.defaultSizeInBytes")
-    .internal()
-    .doc("The default table size used in query planning. By default, it is set to Long.MaxValue " +
-      "which is larger than `spark.sql.autoBroadcastJoinThreshold` to be more conservative. " +
-      "That is to say by default the optimizer will not choose to broadcast a table unless it " +
-      "knows for sure its size is small enough.")
-    .longConf
-    .createWithDefault(Long.MaxValue)
 
   val SHUFFLE_PARTITIONS = buildConf("spark.sql.shuffle.partitions")
     .doc("The default number of partitions to use when shuffling data for joins or aggregations.")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -269,14 +269,6 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
-  val SIZE_DESER_FACTOR = buildConf("spark.sql.statistics.deserialization.factor")
-    .doc("In the absence of uncompressed/raw data size, total file size will be used for " +
-      "statistics annotation. But the file may be compressed, encoded and serialized which may " +
-      "be lesser in size than the actual uncompressed/raw data size. This factor will be " +
-      "multiplied to file size to estimate the raw data size. ")
-    .doubleConf
-    .createWithDefault(1.0)
-
   val IGNORE_RAWDATASIZE = buildConf("spark.sql.statistics.ignoreRawDataSize")
     .doc("Currently, the rawDataSize property of Hive tables is incorrect due to HIVE-20079. " +
       "When this setting is true, Spark will not use the rawDataSize property when calculating " +
@@ -2019,8 +2011,6 @@ class SQLConf extends Serializable with Logging {
   def setOpsPrecedenceEnforced: Boolean = getConf(SQLConf.LEGACY_SETOPS_PRECEDENCE_ENABLED)
 
   def integralDivideReturnLong: Boolean = getConf(SQLConf.LEGACY_INTEGRALDIVIDE_RETURN_LONG)
-
-  def sizeDeserializationFactor: Double = getConf(SQLConf.SIZE_DESER_FACTOR)
 
   def ignoreRawDataSize: Boolean = getConf(SQLConf.IGNORE_RAWDATASIZE)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources
 
+import org.apache.commons.lang3.math.NumberUtils
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.AnalysisException
@@ -58,5 +59,10 @@ object DataSourceUtils {
   private[sql] def isDataPath(path: Path): Boolean = {
     val name = path.getName
     !(name.startsWith("_") || name.startsWith("."))
+  }
+
+  def calcDataSize(properties: Map[String, String], sizeInBytes: Long): Long = {
+    val factor = NumberUtils.toDouble(properties.get("deserFactor").getOrElse("1.0"), 1.0)
+    (sizeInBytes * factor).toLong
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
@@ -61,8 +61,8 @@ object DataSourceUtils {
     !(name.startsWith("_") || name.startsWith("."))
   }
 
-  def calcDataSize(properties: Map[String, String], sizeInBytes: Long): Long = {
-    val factor = NumberUtils.toDouble(properties.get("deserFactor").getOrElse("1.0"), 1.0)
-    (sizeInBytes * factor).toLong
+  def calcDataSize(properties: Map[String, String], sizeInBytes: BigInt): BigInt = {
+    val factor = NumberUtils.toInt(properties.get("deserFactor").getOrElse("1"), 1)
+    sizeInBytes * factor
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -68,7 +68,7 @@ private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
         // Change table stats based on the sizeInBytes of pruned files
         val withStats = logicalRelation.catalogTable.map(_.copy(
           stats = Some(CatalogStatistics(sizeInBytes =
-            BigInt(calcPartSize(logicalRelation.catalogTable, prunedFileIndex.sizeInBytes))))))
+            calcPartSize(logicalRelation.catalogTable, prunedFileIndex.sizeInBytes)))))
         val prunedLogicalRelation = logicalRelation.copy(
           relation = prunedFsRelation, catalogTable = withStats)
         // Keep partition-pruning predicates so that they are visible in physical planning
@@ -80,11 +80,11 @@ private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
       }
   }
 
-  private def calcPartSize(catalogTable: Option[CatalogTable], sizeInBytes: Long): Long = {
+  private def calcPartSize(catalogTable: Option[CatalogTable], sizeInBytes: Long): BigInt = {
     if (catalogTable.isDefined) {
-      DataSourceUtils.calcDataSize(catalogTable.get.properties, BigInt(sizeInBytes)).toLong
+      DataSourceUtils.calcDataSize(catalogTable.get.properties, BigInt(sizeInBytes))
     } else {
-      sizeInBytes
+      BigInt(sizeInBytes)
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -86,6 +86,6 @@ private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
     } else {
       1.0
     }
-    (sizeInBytes.toLong * factor).toLong
+    (sizeInBytes * factor).toLong
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -81,11 +81,10 @@ private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
   }
 
   private def calcPartSize(catalogTable: Option[CatalogTable], sizeInBytes: Long): Long = {
-    val factor = if (catalogTable.isDefined) {
-      NumberUtils.toDouble(catalogTable.get.properties.get("deserFactor").getOrElse("1.0"), 1.0)
+    if (catalogTable.isDefined) {
+      DataSourceUtils.calcDataSize(catalogTable.get.properties, sizeInBytes)
     } else {
-      1.0
+      sizeInBytes
     }
-    (sizeInBytes * factor).toLong
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.datasources
 
+import org.apache.commons.lang3.math.NumberUtils
+
 import org.apache.spark.sql.catalyst.catalog.{CatalogStatistics, CatalogTable}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
@@ -80,7 +82,7 @@ private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
 
   private def calcPartSize(catalogTable: Option[CatalogTable], sizeInBytes: Long): Long = {
     val factor = if (catalogTable.isDefined) {
-      catalogTable.get.properties.get("deserFactor").getOrElse("1.0").toDouble
+      NumberUtils.toDouble(catalogTable.get.properties.get("deserFactor").getOrElse("1.0"), 1.0)
     } else {
       1.0
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -82,7 +82,7 @@ private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
 
   private def calcPartSize(catalogTable: Option[CatalogTable], sizeInBytes: Long): Long = {
     if (catalogTable.isDefined) {
-      DataSourceUtils.calcDataSize(catalogTable.get.properties, sizeInBytes)
+      DataSourceUtils.calcDataSize(catalogTable.get.properties, BigInt(sizeInBytes)).toLong
     } else {
       sizeInBytes
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -22,7 +22,6 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.internal.SQLConf
 
 private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = plan transformDown {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -1056,6 +1056,11 @@ private[hive] object HiveClientImpl {
     // When table is external, `totalSize` is always zero, which will influence join strategy.
     // So when `totalSize` is zero, use `rawDataSize` instead. When `rawDataSize` is also zero,
     // return None.
+    // If a table has a deserialization factor, the table owner expects the in-memory
+    // representation of the table to be larger than the table's totalSize value. In that case,
+    // multiply totalSize by the deserialization factor and use that number instead.
+    // If the user has set spark.sql.statistics.ignoreRawDataSize to true (because of HIVE-20079,
+    // for example), don't use rawDataSize.
     // In Hive, when statistics gathering is disabled, `rawDataSize` and `numRows` is always
     // zero after INSERT command. So they are used here only if they are larger than zero.
     val factor = NumberUtils.toDouble(properties.get("deserFactor").getOrElse("1.0"), 1.0)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -466,7 +466,7 @@ private[hive] class HiveClientImpl(
         // For EXTERNAL_TABLE, the table properties has a particular field "EXTERNAL". This is added
         // in the function toHiveTable.
         properties = filteredProperties,
-        stats = readHiveStats(properties, Option(h.getSerializationLib)),
+        stats = readHiveStats(properties),
         comment = comment,
         // In older versions of Spark(before 2.2.0), we expand the view original text and
         // store that into `viewExpandedText`, that should be used in view resolution.
@@ -1035,17 +1035,14 @@ private[hive] object HiveClientImpl {
       createTime = apiPartition.getCreateTime.toLong * 1000,
       lastAccessTime = apiPartition.getLastAccessTime.toLong * 1000,
       parameters = properties,
-      stats = readHiveStats(properties,
-        Option(apiPartition.getSd.getSerdeInfo.getSerializationLib)))
+      stats = readHiveStats(properties))
   }
 
   /**
    * Reads statistics from Hive.
    * Note that this statistics could be overridden by Spark's statistics if that's available.
    */
-  private def readHiveStats(
-          properties: Map[String, String],
-          serde: Option[String] = None): Option[CatalogStatistics] = {
+  private def readHiveStats(properties: Map[String, String]): Option[CatalogStatistics] = {
     val totalSize = properties.get(StatsSetupConst.TOTAL_SIZE).map(BigInt(_))
     val rawDataSize = properties.get(StatsSetupConst.RAW_DATA_SIZE).map(BigInt(_))
     val rowCount = properties.get(StatsSetupConst.ROW_COUNT).map(BigInt(_))

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -25,6 +25,7 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
+import org.apache.commons.lang3.math.NumberUtils
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.hive.common.StatsSetupConst
 import org.apache.hadoop.hive.conf.HiveConf
@@ -1057,7 +1058,7 @@ private[hive] object HiveClientImpl {
     // return None.
     // In Hive, when statistics gathering is disabled, `rawDataSize` and `numRows` is always
     // zero after INSERT command. So they are used here only if they are larger than zero.
-    val factor = properties.get("deserFactor").getOrElse("1.0").toDouble
+    val factor = NumberUtils.toDouble(properties.get("deserFactor").getOrElse("1.0"), 1.0)
     val adjustedSize = if (totalSize.isDefined && factor != 1.0D) {
       Some(BigInt((totalSize.get.toLong * factor).toLong))
     } else {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -25,7 +25,6 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.commons.lang3.math.NumberUtils
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.hive.common.StatsSetupConst
 import org.apache.hadoop.hive.conf.HiveConf
@@ -1063,7 +1062,11 @@ private[hive] object HiveClientImpl {
     // for example), don't use rawDataSize.
     // In Hive, when statistics gathering is disabled, `rawDataSize` and `numRows` is always
     // zero after INSERT command. So they are used here only if they are larger than zero.
-    val factor = NumberUtils.toDouble(properties.get("deserFactor").getOrElse("1.0"), 1.0)
+    val factor = try {
+        properties.get("deserFactor").getOrElse("1.0").toDouble
+      } catch {
+        case _: NumberFormatException => 1.0
+      }
     val adjustedSize = if (totalSize.isDefined && factor != 1.0D) {
       Some(BigInt((totalSize.get.toLong * factor).toLong))
     } else {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -1063,8 +1063,7 @@ private[hive] object HiveClientImpl {
     // for example), don't use rawDataSize.
     // In Hive, when statistics gathering is disabled, `rawDataSize` and `numRows` is always
     // zero after INSERT command. So they are used here only if they are larger than zero.
-    val adjustedSize = BigInt(DataSourceUtils.calcDataSize(properties,
-      totalSize.getOrElse(BigInt(0)).toLong))
+    val adjustedSize = DataSourceUtils.calcDataSize(properties, totalSize.getOrElse(BigInt(0)))
     val sqlConf = SQLConf.get
     if (adjustedSize > 0L) {
       Some(CatalogStatistics(sizeInBytes = adjustedSize, rowCount = rowCount.filter(_ > 0)))

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -1382,7 +1382,7 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
     }
   }
 
-  test("Test deserialization factor") {
+  test("test deserialization factor") {
     val factor = 10
     val tableName = s"sizeTest"
     val tableNameAdj = s"${tableName}Adj"

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruneFileSourcePartitionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruneFileSourcePartitionsSuite.scala
@@ -100,7 +100,6 @@ class PruneFileSourcePartitionsSuite extends QueryTest with SQLTestUtils with Te
       sql(s"ANALYZE TABLE tbl COMPUTE STATISTICS")
 
       val df1 = sql("SELECT * FROM tbl WHERE p = 1")
-
       val sizes1 = df1.queryExecution.optimizedPlan.collect {
         case relation: LogicalRelation => relation.catalogTable.get.stats.get.sizeInBytes
       }
@@ -110,7 +109,6 @@ class PruneFileSourcePartitionsSuite extends QueryTest with SQLTestUtils with Te
       sql("REFRESH TABLE TBL")
 
       val df2 = sql("SELECT * FROM tbl WHERE p = 1")
-
       val sizes2 = df2.queryExecution.optimizedPlan.collect {
         case relation: LogicalRelation => relation.catalogTable.get.stats.get.sizeInBytes
       }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruneFileSourcePartitionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruneFileSourcePartitionsSuite.scala
@@ -103,7 +103,7 @@ class PruneFileSourcePartitionsSuite extends QueryTest with SQLTestUtils with Te
       val sizes1 = df1.queryExecution.optimizedPlan.collect {
         case relation: LogicalRelation => relation.catalogTable.get.stats.get.sizeInBytes
       }
-      assert(sizes1 != 0)
+      assert(sizes1(0) != 0)
 
       sql(s"ALTER TABLE tbl SET TBLPROPERTIES('deserFactor'='$factor')")
       sql("REFRESH TABLE TBL")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruneFileSourcePartitionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruneFileSourcePartitionsSuite.scala
@@ -94,33 +94,27 @@ class PruneFileSourcePartitionsSuite extends QueryTest with SQLTestUtils with Te
 
   test("Test deserialization factor against partition") {
     val factor = 10
-    val formats = Seq("parquet", "orc", "csv")
-    formats.foreach { format =>
-      withTable("tbl") {
-        spark.range(10).selectExpr("id", "id % 3 as p").write.format(format)
-          .partitionBy("p").saveAsTable("tbl")
-        sql(s"ANALYZE TABLE tbl COMPUTE STATISTICS")
+    withTable("tbl") {
+      spark.range(10).selectExpr("id", "id % 3 as p").write.format("parquet")
+        .partitionBy("p").saveAsTable("tbl")
+      sql(s"ANALYZE TABLE tbl COMPUTE STATISTICS")
 
-        val df1 = sql("SELECT * FROM tbl WHERE p = 1")
+      val df1 = sql("SELECT * FROM tbl WHERE p = 1")
 
-        val sizes1 = df1.queryExecution.optimizedPlan.collect {
-          case relation: LogicalRelation => relation.catalogTable.get.stats.get.sizeInBytes
-        }
-
-        withSQLConf("spark.sql.statistics.deserialization.factor" -> factor.toString) {
-          val df2 = sql("SELECT * FROM tbl WHERE p = 1")
-
-          val sizes2 = df2.queryExecution.optimizedPlan.collect {
-            case relation: LogicalRelation => relation.catalogTable.get.stats.get.sizeInBytes
-          }
-
-          if (format == "csv") {
-            assert(sizes2(0) == sizes1(0))
-          } else {
-            assert(sizes2(0) == (sizes1(0) * factor))
-          }
-        }
+      val sizes1 = df1.queryExecution.optimizedPlan.collect {
+        case relation: LogicalRelation => relation.catalogTable.get.stats.get.sizeInBytes
       }
+      assert(sizes1 != 0)
+
+      sql(s"ALTER TABLE tbl SET TBLPROPERTIES('deserFactor'='$factor')")
+      sql("REFRESH TABLE TBL")
+
+      val df2 = sql("SELECT * FROM tbl WHERE p = 1")
+
+      val sizes2 = df2.queryExecution.optimizedPlan.collect {
+        case relation: LogicalRelation => relation.catalogTable.get.stats.get.sizeInBytes
+      }
+      assert(sizes2(0) == (sizes1(0) * factor))
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a configuration setting and table property to help avoid OOM errors during broadcast joins.

- Configuration setting to ignore rawDataSize: Due to HIVE-20079, rawDataSize is broken. This setting tells Spark to ignore rawDataSize when calculating the table's sizeInBytes.
- deser multiplication factor table property ("deserFactor"): Tell Spark to multiply totalSize times a specified factor. Spark will do this when calculating the table's sizeInBytes. This is modelled after Hive's hive.stats.deserialization.factor configuration setting (except that setting is global, and this one is per table).

One can partially simulate the deser multiplication factor without this change by decreasing the value in spark.sql.autoBroadcastJoinThreshold. However, that will affect all tables, not just the ones where the user recognizes a need.

## How was this patch tested?

Added unit tests.

Also, checked that I can avoid broadcast join OOM errors when using the deser multiplication factor on both my laptop and a cluster. Also checked that I can avoid OOM errors using the ignore rawDataSize flag on my laptop.
