### PR TITLE
[SPARK-24994][SQL] When the data type of the field is converted to other types, it can also support pushdown to parquet

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -269,7 +269,8 @@ case class FileSourceScanExec(
   }
 
   @transient
-  private val pushedDownFilters = dataFilters.flatMap(DataSourceStrategy.translateFilter)
+  private val pushedDownFilters = dataFilters.flatMap(DataSourceStrategy.
+    translateFilter(_, !relation.fileFormat.isInstanceOf[ParquetSource]))
   logInfo(s"Pushed Filters: ${pushedDownFilters.mkString(",")}")
 
   override lazy val metadata: Map[String, String] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
-import java.lang.{Boolean => JBoolean, Double => JDouble, Float => JFloat, Long => JLong}
+import java.lang.{Boolean => JBoolean, Byte => JByte, Double => JDouble, Float => JFloat, Integer => JInteger, Long => JLong, Short => JShort}
 import java.math.{BigDecimal => JBigDecimal}
 import java.sql.{Date, Timestamp}
 
@@ -383,7 +383,13 @@ private[parquet] class ParquetFilters(
     def valueCanMakeFilterOn(name: String, value: Any): Boolean = {
       value == null || (nameToType(name) match {
         case ParquetBooleanType => value.isInstanceOf[JBoolean]
-        case ParquetByteType | ParquetShortType | ParquetIntegerType => value.isInstanceOf[Number]
+        case ParquetByteType => value.isInstanceOf[JByte] ||
+          (value.isInstanceOf[JInteger] && value.asInstanceOf[JInteger].toByte.toInt ==
+            value.asInstanceOf[JInteger])
+        case ParquetShortType => value.isInstanceOf[JShort] ||
+          (value.isInstanceOf[JInteger] && value.asInstanceOf[JInteger].toShort.toInt ==
+            value.asInstanceOf[JInteger])
+        case ParquetIntegerType => value.isInstanceOf[JInteger]
         case ParquetLongType => value.isInstanceOf[JLong]
         case ParquetFloatType => value.isInstanceOf[JFloat]
         case ParquetDoubleType => value.isInstanceOf[JDouble]


### PR DESCRIPTION
## What changes were proposed in this pull request?
For this statement: select * from table1 where a = 100;
the data type of `a` is `smallint` , because the defaut data type of 100 is `int` ,so `a` is converted to `int`.
In this case, it does not support push down to parquet.

In our business, for our SQL statements, and we generally do not convert 100 to `smallint`, this pr can support push down to parquet for this situation.

## How was this patch tested?
added unit tests