### PR TITLE
[SPARK-23698]  Define xrange() for Python 3 in dumpdata_script.py

### DIFF
--- a/sql/hive/src/test/resources/data/scripts/dumpdata_script.py
+++ b/sql/hive/src/test/resources/data/scripts/dumpdata_script.py
@@ -18,6 +18,9 @@
 #
 import sys
 
+if sys.version_info[0] >= 3:
+    xrange = range
+
 for i in xrange(50):
     for j in xrange(5):
         for k in xrange(20022):


### PR DESCRIPTION
__xrange()__ was removed in Python 3 in favor of __range()__.  This simple change resolves three Undefined Names was originally suggested in #20838 which is currently mired in 50+ comments on unrelated modifications.  @HyukjinKwon @holdenk

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
