### PR TITLE
[SPARK-23698] Remove unused definitions of long and unicode

### DIFF
--- a/python/pyspark/sql/streaming.py
+++ b/python/pyspark/sql/streaming.py
@@ -19,10 +19,7 @@ import sys
 import json
 
 if sys.version >= '3':
-    intlike = int
-    basestring = unicode = str
-else:
-    intlike = (int, long)
+    basestring = str
 
 from py4j.java_gateway import java_import
 


### PR DESCRIPTION
__intlike__ and __unicode__ were defined but not used in the existing code.  __basestring()__ was removed in Python 3 in favor of __str()__ because all str are Unicode.  This simple change resolves an Undefined Name (__long__) and was originally suggested in #20838 which is currently mired in 50+ comments on unrelated modifications.  @HyukjinKwon @holdenk

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
