### PR TITLE
[SPARK-24947] [Core] aggregateAsync and foldAsync

### DIFF
--- a/core/src/test/scala/org/apache/spark/rdd/AsyncRDDActionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/AsyncRDDActionsSuite.scala
@@ -65,6 +65,17 @@ class AsyncRDDActionsSuite extends SparkFunSuite with BeforeAndAfterAll with Tim
     assert(collected === (1 to 1000))
   }
 
+  test("aggregateAsync") {
+    assert(zeroPartRdd.aggregateAsync(0)((acc, _) => acc + 1, _ + _).get() === 0)
+    val aggregated = sc.parallelize(1 to 10000, 5).aggregateAsync(0)((acc, _) => acc + 1, _ + _)
+    assert(aggregated.get() === 10000)
+  }
+
+  test("foldAsync") {
+    assert(zeroPartRdd.foldAsync(0)(_ + _).get() === 0)
+    assert(sc.parallelize(1 to 1000, 5).foldAsync(0)(_ + _).get() === 500500)
+  }
+
   test("foreachAsync") {
     zeroPartRdd.foreachAsync(i => Unit).get()
 


### PR DESCRIPTION
See the description in the [Jira ticket](https://issues.apache.org/jira/browse/SPARK-24947).

This contribution is my original work (inspired by similar methods in
the Spark code) and I license this work to Spark under the Apache
License 2.0.

## What changes were proposed in this pull request?

Add `aggregateAsync` and `foldAsync` methods to `AsyncRDDActions`.

## How was this patch tested?

Unit tests (included in PR).
