### PR TITLE
[SPARK-25010][SQL] Rand/Randn should produce different values for each execution in streaming query

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.util.RandomUUIDGenerator
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
-import org.apache.spark.util.Utils
 
 /**
  * Print the result of an expression to stderr (used for debugging codegen).
@@ -132,7 +131,7 @@ case class Uuid(randomSeed: Option[Long] = None) extends LeafExpression with Sta
 
   def this() = this(None)
 
-  override def withNewSeed(): Uuid = Uuid(Some(Utils.random.nextLong()))
+  override def withNewSeed(seed: Long): Uuid = Uuid(Some(seed))
 
   override lazy val resolved: Boolean = randomSeed.isDefined
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.util.RandomUUIDGenerator
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.util.Utils
 
 /**
  * Print the result of an expression to stderr (used for debugging codegen).
@@ -126,9 +127,12 @@ case class CurrentDatabase() extends LeafExpression with Unevaluable {
   """,
   note = "The function is non-deterministic.")
 // scalastyle:on line.size.limit
-case class Uuid(randomSeed: Option[Long] = None) extends LeafExpression with Stateful {
+case class Uuid(randomSeed: Option[Long] = None) extends LeafExpression with Stateful
+    with ExpressionWithRandomSeed {
 
   def this() = this(None)
+
+  override def withNewSeed(): Uuid = Uuid(Some(Utils.random.nextLong()))
 
   override lazy val resolved: Boolean = randomSeed.isDefined
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
@@ -57,6 +57,14 @@ abstract class RDG extends UnaryExpression with ExpectsInputTypes with Stateful 
   override def inputTypes: Seq[AbstractDataType] = Seq(TypeCollection(IntegerType, LongType))
 }
 
+/**
+ * Represents the behavior of expressions which have a random seed and can renew the seed.
+ * Usually the random seed needs to be renewed at each execution under streaming queries.
+ */
+trait ExpressionWithRandomSeed {
+  def withNewSeed(): Expression
+}
+
 /** Generate a random column with i.i.d. uniformly distributed values in [0, 1). */
 // scalastyle:off line.size.limit
 @ExpressionDescription(
@@ -72,9 +80,11 @@ abstract class RDG extends UnaryExpression with ExpectsInputTypes with Stateful 
   """,
   note = "The function is non-deterministic in general case.")
 // scalastyle:on line.size.limit
-case class Rand(child: Expression) extends RDG {
+case class Rand(child: Expression) extends RDG with ExpressionWithRandomSeed {
 
   def this() = this(Literal(Utils.random.nextLong(), LongType))
+
+  override def withNewSeed(): Rand = Rand(Literal(Utils.random.nextLong(), LongType))
 
   override protected def evalInternal(input: InternalRow): Double = rng.nextDouble()
 
@@ -110,9 +120,11 @@ object Rand {
   """,
   note = "The function is non-deterministic in general case.")
 // scalastyle:on line.size.limit
-case class Randn(child: Expression) extends RDG {
+case class Randn(child: Expression) extends RDG with ExpressionWithRandomSeed {
 
   def this() = this(Literal(Utils.random.nextLong(), LongType))
+
+  override def withNewSeed(): Randn = Randn(Literal(Utils.random.nextLong(), LongType))
 
   override protected def evalInternal(input: InternalRow): Double = rng.nextGaussian()
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
@@ -62,7 +62,7 @@ abstract class RDG extends UnaryExpression with ExpectsInputTypes with Stateful 
  * Usually the random seed needs to be renewed at each execution under streaming queries.
  */
 trait ExpressionWithRandomSeed {
-  def withNewSeed(): Expression
+  def withNewSeed(seed: Long): Expression
 }
 
 /** Generate a random column with i.i.d. uniformly distributed values in [0, 1). */
@@ -84,7 +84,7 @@ case class Rand(child: Expression) extends RDG with ExpressionWithRandomSeed {
 
   def this() = this(Literal(Utils.random.nextLong(), LongType))
 
-  override def withNewSeed(): Rand = Rand(Literal(Utils.random.nextLong(), LongType))
+  override def withNewSeed(seed: Long): Rand = Rand(Literal(seed, LongType))
 
   override protected def evalInternal(input: InternalRow): Double = rng.nextDouble()
 
@@ -124,7 +124,7 @@ case class Randn(child: Expression) extends RDG with ExpressionWithRandomSeed {
 
   def this() = this(Literal(Utils.random.nextLong(), LongType))
 
-  override def withNewSeed(): Randn = Randn(Literal(Utils.random.nextLong(), LongType))
+  override def withNewSeed(seed: Long): Randn = Randn(Literal(seed, LongType))
 
   override protected def evalInternal(input: InternalRow): Double = rng.nextGaussian()
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.execution.{QueryExecution, SparkPlan, SparkPlanner, 
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.OutputMode
-import org.apache.spark.sql.types.LongType
+import org.apache.spark.util.Utils
 
 /**
  * A variant of [[QueryExecution]] that allows the execution of the given [[LogicalPlan]]
@@ -78,7 +78,7 @@ class IncrementalExecution(
       case ts @ CurrentBatchTimestamp(timestamp, _, _) =>
         logInfo(s"Current batch timestamp = $timestamp")
         ts.toLiteral
-      case e: ExpressionWithRandomSeed => e.withNewSeed
+      case e: ExpressionWithRandomSeed => e.withNewSeed(Utils.random.nextLong())
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -20,11 +20,9 @@ package org.apache.spark.sql.execution.streaming
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 
-import scala.util.Random
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{AnalysisException, SparkSession, Strategy}
-import org.apache.spark.sql.catalyst.expressions.{CurrentBatchTimestamp, Uuid}
+import org.apache.spark.sql.catalyst.expressions.{CurrentBatchTimestamp, Literal, Rand, Randn, Uuid}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, ClusteredDistribution, HashPartitioning, SinglePartition}
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -32,6 +30,8 @@ import org.apache.spark.sql.execution.{QueryExecution, SparkPlan, SparkPlanner, 
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.OutputMode
+import org.apache.spark.sql.types.LongType
+import org.apache.spark.util.Utils
 
 /**
  * A variant of [[QueryExecution]] that allows the execution of the given [[LogicalPlan]]
@@ -75,14 +75,15 @@ class IncrementalExecution(
    * with the desired literal
    */
   override lazy val optimizedPlan: LogicalPlan = {
-    val random = new Random()
-
     sparkSession.sessionState.optimizer.execute(withCachedData) transformAllExpressions {
       case ts @ CurrentBatchTimestamp(timestamp, _, _) =>
         logInfo(s"Current batch timestamp = $timestamp")
         ts.toLiteral
       // SPARK-24896: Set the seed for random number generation in Uuid expressions.
-      case _: Uuid => Uuid(Some(random.nextLong()))
+      case _: Uuid => Uuid(Some(Utils.random.nextLong()))
+      // SPARK-25010: Set the seed for random number generation in rand/randn expressions.
+      case _: Rand => Rand(Literal(Utils.random.nextLong(), LongType))
+      case _: Randn => Randn(Literal(Utils.random.nextLong(), LongType))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -854,7 +854,7 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
     assert(uuids.distinct.size == 2)
   }
 
-  test("Rand/Randn in streaming query should not produce results in each execution") {
+  test("Rand/Randn in streaming query should not produce same results in each execution") {
     val rands = mutable.ArrayBuffer[Double]()
     def collectRand: Seq[Row] => Unit = { rows: Seq[Row] =>
       rows.foreach { r =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Column, DataFrame, Dataset, Row}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.Uuid
+import org.apache.spark.sql.catalyst.expressions.{Rand, Randn, Uuid}
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.execution.streaming.sources.TestForeachWriter
 import org.apache.spark.sql.functions._
@@ -852,6 +852,26 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
       CheckAnswer(collectUuid)
     )
     assert(uuids.distinct.size == 2)
+  }
+
+  test("Rand/Randn in streaming query should not produce results in each execution") {
+    val rands = mutable.ArrayBuffer[Double]()
+    def collectRand: Seq[Row] => Unit = { rows: Seq[Row] =>
+      rows.foreach { r =>
+        rands += r.getDouble(0)
+        rands += r.getDouble(1)
+      }
+    }
+
+    val stream = MemoryStream[Int]
+    val df = stream.toDF().select(new Column(new Rand()), new Column(new Randn()))
+    testStream(df)(
+      AddData(stream, 1),
+      CheckAnswer(collectRand),
+      AddData(stream, 2),
+      CheckAnswer(collectRand)
+    )
+    assert(rands.distinct.size == 4)
   }
 
   test("StreamingRelationV2/StreamingExecutionRelation/ContinuousExecutionRelation.toJSON " +


### PR DESCRIPTION
## What changes were proposed in this pull request?

Like Uuid in SPARK-24896, Rand and Randn expressions now produce the same results for each execution in streaming query. It doesn't make too much sense for streaming queries. We should make them produce different results as Uuid.

In this change, similar to Uuid, we assign new random seeds to Rand/Randn when returning optimized plan from `IncrementalExecution`.

Note: Different to Uuid, Rand/Randn can be created with initial seed. Because we replace this initial seed at `IncrementalExecution`, it doesn't use the initial seed anymore. For now it seems to me not a big issue for streaming query. But need to confirm with others. cc @zsxwing @cloud-fan 

## How was this patch tested?

Added test.
