### PR TITLE
[SPARK-24983][Catalyst] Add configuration for maximum number of leaf expressions in collapsed projects

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -143,12 +143,12 @@ object SQLConf {
     .intConf
     .createWithDefault(100)
 
-  val OPTIMIZER_MAX_NUM_OF_LEAF_EXPRESSIONS_IN_COLLAPSED_PROJECTS =
-    buildConf("spark.sql.optimizer.maxNumOfLeafExpressionsInCollapsedProjects")
+  val OPTIMIZER_MAX_NUM_OF_LEAF_EXPRESSIONS_IN_COLLAPSED_PROJECT =
+    buildConf("spark.sql.optimizer.maxNumOfLeafExpressionsInCollapsedProject")
       .internal()
-      .doc("Sets the maximum number of leaf expressions that a project statements is allowed to " +
-        "have after collapsing. If the collapsed project statement would have more leaf " +
-        "expressions then the optimizer won't collapse. Set to -1 to disable.")
+      .doc("Sets the maximum number of leaf expressions that a project is allowed to " +
+        "have after collapsing. If the collapsed project would have more leaf expressions " +
+        "than this number then the optimizer won't collapse. Set to -1 to disable.")
       .longConf
       .createWithDefault(10000)
 
@@ -1486,8 +1486,8 @@ class SQLConf extends Serializable with Logging {
 
   def optimizerMaxIterations: Int = getConf(OPTIMIZER_MAX_ITERATIONS)
 
-  def optimizerMaxNumOfLeafExpressionsInCollapsedProjects: Long =
-    getConf(OPTIMIZER_MAX_NUM_OF_LEAF_EXPRESSIONS_IN_COLLAPSED_PROJECTS)
+  def optimizerMaxNumOfLeafExpressionsInCollapsedProject: Long =
+    getConf(OPTIMIZER_MAX_NUM_OF_LEAF_EXPRESSIONS_IN_COLLAPSED_PROJECT)
 
   def optimizerInSetConversionThreshold: Int = getConf(OPTIMIZER_INSET_CONVERSION_THRESHOLD)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -143,6 +143,15 @@ object SQLConf {
     .intConf
     .createWithDefault(100)
 
+  val OPTIMIZER_MAX_NUM_OF_LEAF_EXPRESSIONS_IN_COLLAPSED_PROJECTS =
+    buildConf("spark.sql.optimizer.maxNumOfLeafExpressionsInCollapsedProjects")
+      .internal()
+      .doc("Sets the maximum number of leaf expressions that a project statements is allowed to " +
+        "have after collapsing. If the collapsed project statement would have more leaf " +
+        "expressions then the optimizer won't collapse. Set to -1 to disable.")
+      .longConf
+      .createWithDefault(10000)
+
   val OPTIMIZER_INSET_CONVERSION_THRESHOLD =
     buildConf("spark.sql.optimizer.inSetConversionThreshold")
       .internal()
@@ -1476,6 +1485,9 @@ class SQLConf extends Serializable with Logging {
   def optimizerExcludedRules: Option[String] = getConf(OPTIMIZER_EXCLUDED_RULES)
 
   def optimizerMaxIterations: Int = getConf(OPTIMIZER_MAX_ITERATIONS)
+
+  def optimizerMaxNumOfLeafExpressionsInCollapsedProjects: Long =
+    getConf(OPTIMIZER_MAX_NUM_OF_LEAF_EXPRESSIONS_IN_COLLAPSED_PROJECTS)
 
   def optimizerInSetConversionThreshold: Int = getConf(OPTIMIZER_INSET_CONVERSION_THRESHOLD)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CollapseProjectSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CollapseProjectSuite.scala
@@ -138,4 +138,16 @@ class CollapseProjectSuite extends PlanTest {
     assert(projects.size === 1)
     assert(hasMetadata(optimized))
   }
+
+  test("do not collapse if number of leave expressions would be too big") {
+    var query: LogicalPlan = testRelation
+    for( a <- 1 to 13) {
+      // after n iterations the number of leaf expressions will be 2^{n+1}
+      // => after 13 iterations we would end up with more than 10000 leaf expressions
+      query = query.select(('a + 'b).as('a), ('a - 'b).as('b))
+    }
+
+    val projects = Optimize.execute(query.analyze).collect { case p: Project => p }
+    assert(projects.size === 2) // everything should be collapsed except the last one
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a configuration option for the maximum number of leaf expressions in collapsed project nodes. If a collapsed project node (result of the `CollapseProject` optimizer rule) would have more leaf expressions than the configured maximum number we don't collapse. This is to protect against an exponentially exploding number of leaf expressions when collapsing many (binary) expression that refer to the same columns (see https://issues.apache.org/jira/browse/SPARK-24983).

## How was this patch tested?
Add a new unit test.
