### PR TITLE
[SPARK-24529][Build][test-maven][follow-up] Add spotbugs 3.1.6 into maven build process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2609,6 +2609,28 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>3.1.6</version>
+        <configuration>
+          <classFilesDirectory>${basedir}/target/scala-${scala.binary.version}/classes</classFilesDirectory>
+          <testClassFilesDirectory>${basedir}/target/scala-${scala.binary.version}/test-classes</testClassFilesDirectory>
+          <effort>Max</effort>
+          <threshold>Low</threshold>
+          <xmlOutput>true</xmlOutput>
+          <visitors>FindPuzzlers</visitors>
+          <fork>true</fork>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>compile</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR tries to add spotbugs after [upgrading mvn](https://issues.apache.org/jira/browse/SPARK-24956). This is because we met [a problem](https://issues.apache.org/jira/browse/SPARK-24895) with old mvn.

## How was this patch tested?

existing UTs