### PR TITLE
[SPARK-24888][CORE] spark-submit --master spark://host:port --status/kill driver-id does not give any status/update

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -98,8 +98,7 @@ private[spark] class SparkSubmit extends Logging {
    * Kill an existing submission using the REST protocol. Standalone and Mesos cluster mode only.
    */
   private def kill(args: SparkSubmitArguments): Unit = {
-    new RestSubmissionClient(args.master)
-      .killSubmission(args.submissionToKill)
+    createRestSubmissionClient(args).killSubmission(args.submissionToKill)
   }
 
   /**
@@ -107,8 +106,16 @@ private[spark] class SparkSubmit extends Logging {
    * Standalone and Mesos cluster mode only.
    */
   private def requestStatus(args: SparkSubmitArguments): Unit = {
-    new RestSubmissionClient(args.master)
-      .requestSubmissionStatus(args.submissionToRequestStatusFor)
+    createRestSubmissionClient(args).requestSubmissionStatus(args.submissionToRequestStatusFor)
+  }
+
+  /**
+   * Creates RestSubmissionClient with overridden logInfo()
+   */
+  private def createRestSubmissionClient(args: SparkSubmitArguments): RestSubmissionClient = {
+    new RestSubmissionClient(args.master) {
+      override protected def logInfo(msg: => String): Unit = printMessage(msg)
+    }
   }
 
   /** Print version information to the log. */


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `SparkSubmit.scala` (`val uninitLog = initializeLogIfNecessary(true, silent = true)`)  -> `Logging.scala` (`val replLevel = Option(replLogger.getLevel()).getOrElse(Level.WARN)`), the log level for `rootLogger ` is overiri to `WARN ` but the status of the driver and kill driver commands status have been logging with `INFO ` log level, so there is nothing printing on the console for status and kill commands. This PR overrides the `logInfo()` for `RestSubmissionClient` and redirects the msg to `printStream`.


## How was this patch tested?

I verified it manually by running status and kill commands, these are the results with and without the PR change.

- Without the PR change

```
[user1@user1-work-pc bin]$ ./spark-submit --master spark://user1-work-pc:6066 --status driver-20180803165641-0000
[user1@user1-work-pc bin]$ ./spark-submit --master spark://user1-work-pc:6066 --kill driver-20180803165641-0000
```


- With the PR change

```
[user1@user1-work-pc bin]$ ./spark-submit --master spark://user1-work-pc:6066 --kill driver-20180803165641-0000
Submitting a request to kill submission driver-20180803165641-0000 in spark://user1-work-pc:6066.
Server responded with KillSubmissionResponse:
{
  "action" : "KillSubmissionResponse",
  "message" : "Driver driver-20180803165641-0000 has already finished or does not exist",
  "serverSparkVersion" : "2.4.0-SNAPSHOT",
  "submissionId" : "driver-20180803165641-0000",
  "success" : false
}

[user1@user1-work-pc bin]$ ./spark-submit --master spark://user1-work-pc:6066 --status driver-20180803165641-0000
Submitting a request for the status of submission driver-20180803165641-0000 in spark://user1-work-pc:6066.
Server responded with SubmissionStatusResponse:
{
  "action" : "SubmissionStatusResponse",
  "driverState" : "FINISHED",
  "serverSparkVersion" : "2.4.0-SNAPSHOT",
  "submissionId" : "driver-20180803165641-0000",
  "success" : true,
  "workerHostPort" : "xx.x.xx.xxx:42040",
  "workerId" : "worker-20180803165615-10.3.66.149-42040"
}
```
