### PR TITLE
[SPARK-24928][SQL] Optimize cross join according to stats

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -673,6 +673,10 @@ abstract class RDD[T: ClassTag](
   /**
    * Return the Cartesian product of this RDD and another one, that is, the RDD of all pairs of
    * elements (a, b) where a is in `this` and b is in `other`.
+   *
+   * @note This operation performs a nested loop. The order of the operands can affect performance,
+   *       if the two [[RDD]]s involved have very different size. Thus it is recommended to call
+   *       the method on the smaller [[RDD]] and use the bigger as an argument.
    */
   def cartesian[U: ClassTag](other: RDD[U]): RDD[(T, U)] = withScope {
     new CartesianRDD(sc, this, other)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReorderCrossJoinOperandsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReorderCrossJoinOperandsSuite.scala
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.AttributeMap
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.catalyst.statsEstimation.{StatsEstimationTestBase, StatsTestPlan}
+import org.apache.spark.sql.internal.SQLConf.CBO_ENABLED
+
+class ReorderCrossJoinOperandsSuite extends PlanTest with StatsEstimationTestBase {
+
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches = Batch("Optimize Cartesian Products", Once, ReorderCrossJoinOperands) :: Nil
+  }
+
+  var originalConfCBOEnabled = false
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    originalConfCBOEnabled = conf.cboEnabled
+    conf.setConf(CBO_ENABLED, true)
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      conf.setConf(CBO_ENABLED, originalConfCBOEnabled)
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  private val t1 = StatsTestPlan(
+    outputList = Seq('t1_c1.int, 't1_c2.int),
+    rowCount = 50,
+    size = Some(3000),
+    attributeStats = AttributeMap[ColumnStat](Seq.empty))
+
+  private val t2 = StatsTestPlan(
+    outputList = Seq('t2_c1.int, 't2_c2.int),
+    rowCount = 10,
+    size = Some(3000),
+    attributeStats = AttributeMap[ColumnStat](Seq.empty))
+
+  private val t3 = StatsTestPlan(
+    outputList = Seq('t1_c1.int, 't1_c2.int),
+    rowCount = 50,
+    size = Some(3000),
+    attributeStats = AttributeMap[ColumnStat](Seq.empty))
+
+  private val noStatsTable = LocalRelation('a.int)
+
+  test("Reorder sides when left is bigger than right") {
+    val analyzedPlan = t1.join(t2, Cross, None).analyze
+    val optimizedPlan = Optimize.execute(analyzedPlan)
+    val correctAnswer = t2.join(t1, Cross, None).analyze
+    comparePlans(optimizedPlan, correctAnswer)
+  }
+
+  test("Do not reorder when left is not bigger") {
+    // The number of rows is the same so the plan should not be changed
+    val analyzedPlan = t1.join(t3, Cross, None).analyze
+    val optimizedPlan = Optimize.execute(analyzedPlan)
+    comparePlans(optimizedPlan, analyzedPlan)
+
+    // The number of rows is lower for left, so no changes here too
+    val analyzedPlan2 = t2.join(t3, Cross, None).analyze
+    val optimizedPlan2 = Optimize.execute(analyzedPlan2)
+    comparePlans(optimizedPlan2, analyzedPlan2)
+  }
+
+  test("Do nothing if stats are not collected") {
+    val analyzedPlan = t1.join(noStatsTable, Cross, None).analyze
+    val optimizedPlan = Optimize.execute(analyzedPlan)
+    comparePlans(optimizedPlan, analyzedPlan)
+  }
+
+  test("Optimize also if it is an implicit cartesian") {
+    Seq(Inner, LeftOuter, RightOuter, FullOuter).foreach { joinType =>
+      val analyzedPlan = t1.join(t2, joinType, None).analyze
+      val optimizedPlan = Optimize.execute(analyzedPlan)
+      val correctAnswer = t2.join(t1, joinType, None).analyze
+      comparePlans(optimizedPlan, correctAnswer)
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

The cartesian product of 2 RDDs perform a nested loop. This means that the iterator for the inner RDD is built as many times as the number of rows of the outer one. If the two RDDs have a very different size, the performance difference can be huge.

As there is no way to know which is the best RDD to choose as outer one (since we don't know the sizes), this cannot be addressed at RDD level. Only a comment has been added to warn/help the user to be careful about how they write their code.

The PR proposed to add an optimizer rule which uses statistics collected on tables in order to change the sides of the cartesian product so that the outer table is the smaller one.

## How was this patch tested?

added test suite