### PR TITLE
[SPARK-25034][CORE] Remove allocations in onBlockFetchSuccess

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/buffer/NettyManagedBuffer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/buffer/NettyManagedBuffer.java
@@ -45,6 +45,10 @@ public class NettyManagedBuffer extends ManagedBuffer {
     return buf.nioBuffer();
   }
 
+  public ByteBuffer[] nioByteBuffers() {
+    return buf.nioBuffers();
+  }
+
   @Override
   public InputStream createInputStream() throws IOException {
     return new ByteBufInputStream(buf);

--- a/core/src/main/scala/org/apache/spark/network/BlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/BlockTransferService.scala
@@ -101,15 +101,7 @@ abstract class BlockTransferService extends ShuffleClient with Closeable with Lo
           result.failure(exception)
         }
         override def onBlockFetchSuccess(blockId: String, data: ManagedBuffer): Unit = {
-          data match {
-            case f: FileSegmentManagedBuffer =>
-              result.success(f)
-            case _ =>
-              val ret = ByteBuffer.allocate(data.size.toInt)
-              ret.put(data.nioByteBuffer())
-              ret.flip()
-              result.success(new NioManagedBuffer(ret))
-          }
+          result.success(data.retain())
         }
       }, tempFileManager)
     ThreadUtils.awaitResult(result.future, Duration.Inf)


### PR DESCRIPTION
This method is only transferring a ManagedBuffer to the caller,
so there is no reason why it should allocate 2 (!) intermediate data
buffers in order to do so.

In this commit I'm removing the conversion from any kind of managed buffer
besides FileSegment to a NioManagedBuffer.
However if you check the only calling method getRemoteBytes(), you will
see that here we either:
 - do a memory-map if we have a FileSegmentManagedBuffer
 - try again to call the nioByteBuffer() method otherwise

So in any case the conversion will occur later.

## What changes were proposed in this pull request?
Remove needless temporary allocations

## How was this patch tested?
Tested this change with a few jobs
