### PR TITLE
[SPARK-25048][SQL] Pivoting by multiple columns in Scala/Java

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -373,6 +373,12 @@ class RelationalGroupedDataset protected[sql](
    *   df.groupBy($"year").pivot($"course").sum($"earnings");
    * }}}
    *
+   * For pivoting by multiple columns, use the `struct` function to combine the columns:
+   *
+   * {{{
+   *   df.groupBy($"year").pivot(struct($"course", $"training")).agg(sum($"earnings"))
+   * }}}
+   *
    * @param pivotColumn he column to pivot.
    * @since 2.4.0
    */
@@ -410,6 +416,15 @@ class RelationalGroupedDataset protected[sql](
    * {{{
    *   // Compute the sum of earnings for each year by course with each course as a separate column
    *   df.groupBy($"year").pivot($"course", Seq(lit("dotNET"), lit("Java"))).sum($"earnings")
+   * }}}
+   *
+   * For pivoting by multiple columns, use the `struct` function to combine the columns and values:
+   *
+   * {{{
+   *   df
+   *     .groupBy($"year")
+   *     .pivot(struct($"course", $"training"), Seq(struct(lit("java"), lit("Experts"))))
+   *     .agg(sum($"earnings"))
    * }}}
    *
    * @param pivotColumn the column to pivot.

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
@@ -306,6 +306,22 @@ public class JavaDataFrameSuite {
     Assert.assertEquals(30000.0, actual.get(1).getDouble(2), 0.01);
   }
 
+  @Test
+  public void pivotColumnValues() {
+    Dataset<Row> df = spark.table("courseSales");
+    List<Row> actual = df.groupBy("year")
+            .pivot(col("course"), Arrays.asList(lit("dotNET"), lit("Java")))
+            .agg(sum("earnings")).orderBy("year").collectAsList();
+
+    Assert.assertEquals(2012, actual.get(0).getInt(0));
+    Assert.assertEquals(15000.0, actual.get(0).getDouble(1), 0.01);
+    Assert.assertEquals(20000.0, actual.get(0).getDouble(2), 0.01);
+
+    Assert.assertEquals(2013, actual.get(1).getInt(0));
+    Assert.assertEquals(48000.0, actual.get(1).getDouble(1), 0.01);
+    Assert.assertEquals(30000.0, actual.get(1).getDouble(2), 0.01);
+  }
+
   private String getResource(String resource) {
     try {
       // The following "getResource" has different behaviors in SBT and Maven.

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
@@ -33,7 +33,7 @@ class DataFramePivotSuite extends QueryTest with SharedSQLContext {
         .agg(sum($"earnings")),
       expected)
     checkAnswer(
-      courseSales.groupBy($"year").pivot($"course", Seq("dotNET", "Java"))
+      courseSales.groupBy($"year").pivot($"course", Seq(lit("dotNET"), lit("Java")))
         .agg(sum($"earnings")),
       expected)
   }
@@ -44,7 +44,10 @@ class DataFramePivotSuite extends QueryTest with SharedSQLContext {
       courseSales.groupBy("course").pivot("year", Seq(2012, 2013)).agg(sum($"earnings")),
       expected)
     checkAnswer(
-      courseSales.groupBy('course).pivot('year, Seq(2012, 2013)).agg(sum('earnings)),
+      courseSales
+        .groupBy('course)
+        .pivot('year, Seq(lit(2012), lit(2013)))
+        .agg(sum('earnings)),
       expected)
   }
 
@@ -58,7 +61,7 @@ class DataFramePivotSuite extends QueryTest with SharedSQLContext {
       expected)
     checkAnswer(
       courseSales.groupBy($"year")
-        .pivot($"course", Seq("dotNET", "Java"))
+        .pivot($"course", Seq(lit("dotNET"), lit("Java")))
         .agg(sum($"earnings"), avg($"earnings")),
       expected)
   }
@@ -204,7 +207,7 @@ class DataFramePivotSuite extends QueryTest with SharedSQLContext {
       complexData.groupBy().pivot("b", Seq(true, false)).agg(max("a")),
       expected)
     checkAnswer(
-      complexData.groupBy().pivot('b, Seq(true, false)).agg(max('a)),
+      complexData.groupBy().pivot('b, Seq(lit(true), lit(false))).agg(max('a)),
       expected)
   }
 
@@ -272,7 +275,7 @@ class DataFramePivotSuite extends QueryTest with SharedSQLContext {
     val expected = Row(2012, 15000.0, 20000.0) :: Row(2013, 48000.0, 30000.0) :: Nil
     val df = trainingSales
       .groupBy($"sales.year")
-      .pivot(lower($"sales.course"), Seq("dotNet", "Java").map(_.toLowerCase))
+      .pivot(lower($"sales.course"), Seq("dotNet", "Java").map(_.toLowerCase).map(lit))
       .agg(sum($"sales.earnings"))
 
     checkAnswer(df, expected)
@@ -282,7 +285,7 @@ class DataFramePivotSuite extends QueryTest with SharedSQLContext {
     val expected = Row(2012, 10000.0) :: Row(2013, 48000.0) :: Nil
     val df = trainingSales
       .groupBy($"sales.year")
-      .pivot(concat_ws("-", $"training", $"sales.course"), Seq("Experts-dotNET"))
+      .pivot(concat_ws("-", $"training", $"sales.course"), Seq(lit("Experts-dotNET")))
       .agg(sum($"sales.earnings"))
 
     checkAnswer(df, expected)
@@ -292,7 +295,7 @@ class DataFramePivotSuite extends QueryTest with SharedSQLContext {
     val expected = Row(2012, 35000.0) :: Row(2013, 78000.0) :: Nil
     val df1 = trainingSales
       .groupBy($"sales.year")
-      .pivot(lit(123), Seq(123))
+      .pivot(lit(123), Seq(lit(123)))
       .agg(sum($"sales.earnings"))
 
     checkAnswer(df1, expected)
@@ -302,7 +305,7 @@ class DataFramePivotSuite extends QueryTest with SharedSQLContext {
     val exception = intercept[AnalysisException] {
       trainingSales
         .groupBy($"sales.year")
-        .pivot(min($"training"), Seq("Experts"))
+        .pivot(min($"training"), Seq(lit("Experts")))
         .agg(sum($"sales.earnings"))
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
@@ -311,4 +311,28 @@ class DataFramePivotSuite extends QueryTest with SharedSQLContext {
 
     assert(exception.getMessage.contains("aggregate functions are not allowed"))
   }
+
+  test("pivoting column list with values") {
+    val expected = Row(2012, 10000.0, null) :: Row(2013, 48000.0, 30000.0) :: Nil
+    val df = trainingSales
+      .groupBy($"sales.year")
+      .pivot(struct(lower($"sales.course"), $"training"), Seq(
+        struct(lit("dotnet"), lit("Experts")),
+        struct(lit("java"), lit("Dummies")))
+      ).agg(sum($"sales.earnings"))
+
+    checkAnswer(df, expected)
+  }
+
+  test("pivoting column list") {
+    val expected = Seq(
+      Row(2012, 5000.0, 10000.0, null, 20000.0),
+      Row(2013, null, 48000.0, 30000.0, null))
+    val df = trainingSales
+      .groupBy($"sales.year")
+      .pivot(struct(lower($"sales.course"), $"training"))
+      .agg(sum($"sales.earnings"))
+
+    checkAnswer(df, expected)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the PR, I propose to change signature of the `pivot()` method and make type of values more specific. The method
```
def pivot(pivotColumn: Column, values: Seq[Any]): RelationalGroupedDataset
```
is replaced by:
```
def pivot(pivotColumn: Column, values: Seq[Column]): RelationalGroupedDataset
```

This changes allow to combine literal values to structure and perform pivoting by multiple columns.

## How was this patch tested?

I added two tests with and without values specification.
