### PR TITLE
[SPARK-25054][CORE] Enable MetricsServlet sink for Executor

### DIFF
--- a/conf/metrics.properties.template
+++ b/conf/metrics.properties.template
@@ -60,6 +60,7 @@
 #    5. The MetricsServlet sink is added by default as a sink in the master,
 #    worker and driver, and you can send HTTP requests to the "/metrics/json"
 #    endpoint to get a snapshot of all the registered metrics in JSON format.
+#    For executor, it added when spark.executor.ui.enabled is set to true.
 #    For master, requests to the "/metrics/master/json" and
 #    "/metrics/applications/json" endpoints can be sent separately to get
 #    metrics snapshots of the master instance and applications. This

--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -53,6 +53,8 @@ private case class ExecutorRemoved(executorId: String)
 
 private[spark] case class HeartbeatResponse(reregisterBlockManager: Boolean)
 
+private[spark] case class ReportExecutorWebUrl(executorId: String, webUrl: String)
+
 /**
  * Lives in the driver to receive heartbeats from executors..
  */
@@ -146,6 +148,9 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
         logWarning(s"Dropping $heartbeat because TaskScheduler is not ready yet")
         context.reply(HeartbeatResponse(reregisterBlockManager = true))
       }
+    case ReportExecutorWebUrl(executorId, webUrl) =>
+      sc.executorToWebUrl(executorId) = webUrl
+      context.reply(true)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -276,6 +276,10 @@ class SparkContext(config: SparkConf) extends Logging {
 
   def uiWebUrl: Option[String] = _ui.map(_.webUrl)
 
+  private[spark] val executorToWebUrl = HashMap[String, String]()
+
+  def executorWebUrl(execId: String): Option[String] = executorToWebUrl.get(execId)
+
   /**
    * A default Hadoop Configuration for the Hadoop code (e.g. file systems) that we reuse.
    *

--- a/core/src/main/scala/org/apache/spark/executor/ui/ExecutorWebUI.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ui/ExecutorWebUI.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.executor.ui
+
+import org.apache.spark.{SecurityManager, SparkConf}
+import org.apache.spark.internal.Logging
+import org.apache.spark.ui.WebUI
+
+/**
+ * Web UI server for the executor.
+ * Without this, executor MetricsServlet sink can not be enabled in executor.
+ */
+private[executor] class ExecutorWebUI(
+    conf: SparkConf,
+    securityManager: SecurityManager,
+    port: Int)
+  extends WebUI(securityManager,
+    securityManager.getSSLOptions("executor"),
+    port, conf, name = "ExecutorUI") with Logging {
+
+  initialize()
+
+  /**
+   * In furture, maybe we need more information from this UI.
+   * Now we just leave everything empty.
+   */
+  def initialize(): Unit = {}
+}

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -116,8 +116,6 @@ private[spark] class TaskSchedulerImpl(
 
   protected val executorIdToHost = new HashMap[String, String]
 
-  protected val executorIdToHttpPort = new HashMap[String, Option[Int]]
-
   // Listener object to pass upcalls into
   var dagScheduler: DAGScheduler = null
 

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -116,6 +116,8 @@ private[spark] class TaskSchedulerImpl(
 
   protected val executorIdToHost = new HashMap[String, String]
 
+  protected val executorIdToHttpPort = new HashMap[String, Option[Int]]
+
   // Listener object to pass upcalls into
   var dagScheduler: DAGScheduler = null
 

--- a/core/src/test/scala/org/apache/spark/HeartbeatReceiverSuite.scala
+++ b/core/src/test/scala/org/apache/spark/HeartbeatReceiverSuite.scala
@@ -207,6 +207,17 @@ class HeartbeatReceiverSuite
     assert(fakeClusterManager.getExecutorIdsToKill === Set(executorId1, executorId2))
   }
 
+  test("report executor webUrl") {
+    val webUrl1 = "http://hostname1:12345"
+    val webUrl2 = "http://hostname2:12345"
+    heartbeatReceiverRef.askSync[Boolean](
+      ReportExecutorWebUrl(executorId1, webUrl1))
+    heartbeatReceiverRef.askSync[Boolean](
+      ReportExecutorWebUrl(executorId2, webUrl2))
+    assert(sc.executorWebUrl(executorId1).get === webUrl1)
+    assert(sc.executorWebUrl(executorId2).get === webUrl2)
+  }
+
   /** Manually send a heartbeat and return the response. */
   private def triggerHeartbeat(
       executorId: String,


### PR DESCRIPTION
## What changes were proposed in this pull request?

The MetricsServlet sink is added by default as a sink in the master. But there is no way to query the Executor metrics via Servlet. This ticket offers a way to enable the MetricsServlet Sink in Executor side when spark.executor.ui.enabled is set to true.

## How was this patch tested?

Unit tests
