### PR TITLE
[SPARK-25077][SQL] Delete unused variable in WindowExec

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowExec.scala
@@ -323,8 +323,6 @@ case class WindowExec(
         fetchNextRow()
 
         // Manage the current partition.
-        val inputFields = child.output.length
-
         val buffer: ExternalAppendOnlyUnsafeRowArray =
           new ExternalAppendOnlyUnsafeRowArray(inMemoryThreshold, spillThreshold)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Just delete the unused variable `inputFields` in WindowExec, avoid making others confused while reading the code.

## How was this patch tested?

Existing UT.