### PR TITLE
[SPARK-25036][SQL][FOLLOW-UP] Avoid match may not be exhaustive in Scala-2.12.

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/evaluation/ClusteringEvaluator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/evaluation/ClusteringEvaluator.scala
@@ -120,7 +120,7 @@ class ClusteringEvaluator @Since("2.3.0") (@Since("2.3.0") override val uid: Str
       case ("silhouette", "cosine") =>
         CosineSilhouette.computeSilhouetteScore(df, $(predictionCol), $(featuresCol))
       case (mn, dm) =>
-        throw new IllegalArgumentException(s"($mn, $dm) is not matched in evaluate")
+        throw new IllegalArgumentException(s"No support for metric $mn, distance $dm")
     }
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/evaluation/ClusteringEvaluator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/evaluation/ClusteringEvaluator.scala
@@ -119,6 +119,9 @@ class ClusteringEvaluator @Since("2.3.0") (@Since("2.3.0") override val uid: Str
           df, $(predictionCol), $(featuresCol))
       case ("silhouette", "cosine") =>
         CosineSilhouette.computeSilhouetteScore(df, $(predictionCol), $(featuresCol))
+      case (mn, dm) =>
+        throw new IllegalArgumentException(
+          s"($mn, $dm) is not matched in evaluate")
     }
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/evaluation/ClusteringEvaluator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/evaluation/ClusteringEvaluator.scala
@@ -120,8 +120,7 @@ class ClusteringEvaluator @Since("2.3.0") (@Since("2.3.0") override val uid: Str
       case ("silhouette", "cosine") =>
         CosineSilhouette.computeSilhouetteScore(df, $(predictionCol), $(featuresCol))
       case (mn, dm) =>
-        throw new IllegalArgumentException(
-          s"($mn, $dm) is not matched in evaluate")
+        throw new IllegalArgumentException(s"($mn, $dm) is not matched in evaluate")
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a follow-up pr of #22014 and #22039

We still have some more compilation errors in mllib with scala-2.12 with sbt:

```
[error] [warn] /home/ishizaki/Spark/PR/scala212/spark/mllib/src/main/scala/org/apache/spark/ml/evaluation/ClusteringEvaluator.scala:116: match may not be exhaustive.
[error] It would fail on the following inputs: ("silhouette", _), (_, "cosine"), (_, "squaredEuclidean"), (_, String()), (_, _)
[error] [warn]     ($(metricName), $(distanceMeasure)) match {
[error] [warn] 
```

## How was this patch tested?

Existing UTs