### PR TITLE
[DO NOT MERGE][TEST ONLY] Add once-policy rule check

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -115,6 +115,8 @@ class Analyzer(
     }
   }
 
+  override def verifyOnceStrategyIdempotence: Boolean = true
+
   override def execute(plan: LogicalPlan): LogicalPlan = {
     AnalysisContext.reset()
     try {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
@@ -69,7 +69,9 @@ abstract class RuleExecutor[TreeType <: TreeNode[_]] extends Logging {
   protected def verifyOnceStrategyIdempotence: Boolean = false
 
   private val knownUnstableBatches = Seq(
-    ("UDF", "org.apache.spark.ml.feature.StringIndexerSuite.transform")
+    ("UDF", "org.apache.spark.ml.feature.StringIndexerSuite.transform"),
+    ("View", "org.apache.spark.sql.hive.execution.HiveCatalogedDDLSuite." +
+      "SPARK-22431: view with nested type")
   )
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Rules like `HandleNullInputsForUDF` (https://issues.apache.org/jira/browse/SPARK-24891) do not stabilize (can apply new changes to a plan indefinitely) and can cause problems like SQL cache mismatching.
Ideally, all rules whether in a once-policy batch or a fixed-point-policy batch should stabilize after the number of runs specified. Once-policy should be considered a performance improvement, a assumption that the rule can stabilize after just one run rather than an assumption that the rule won't be applied more than once. Those once-policy rules should be able to run fine with fixed-point policy rule as well.
Currently we already have a check for fixed-point and throws an exception if maximum number of runs is reached and the plan is still changing. Here, in this PR, a similar check is added for once-policy and throws an exception if the plan changes between the first run and the second run of a once-policy rule.

From this test result, we can find out which of the analysis rules break this check so we can fix them later.

## How was this patch tested?

N/A
