### PR TITLE
[SPARK-25095][PySpark] Python support for BarrierTaskContext

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -113,7 +113,10 @@ private[spark] object PythonRDD extends Logging {
   private val workerBroadcasts = new mutable.WeakHashMap[Socket, mutable.Set[Long]]()
 
   // Authentication helper used when serving iterator data.
-  private lazy val authHelper = new SocketAuthHelper(SparkEnv.get.conf)
+  private lazy val authHelper = {
+    val conf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf())
+    new SocketAuthHelper(conf)
+  }
 
   def getWorkerBroadcasts(worker: Socket): mutable.Set[Long] = {
     synchronized {

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -113,10 +113,7 @@ private[spark] object PythonRDD extends Logging {
   private val workerBroadcasts = new mutable.WeakHashMap[Socket, mutable.Set[Long]]()
 
   // Authentication helper used when serving iterator data.
-  private lazy val authHelper = {
-    val conf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf())
-    new SocketAuthHelper(conf)
-  }
+  private lazy val authHelper = new SocketAuthHelper(SparkEnv.get.conf)
 
   def getWorkerBroadcasts(worker: Socket): mutable.Set[Long] = {
     synchronized {

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -195,6 +195,8 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
             .entryPoint(context.asInstanceOf[BarrierTaskContext])
             .authToken(secret)
             .javaPort(0)
+            // TODO We do not have requests from Java to Python, find a better approach other than
+            // filling in DEFAULT_PYTHON_PORT here.
             .callbackClient(GatewayServer.DEFAULT_PYTHON_PORT, GatewayServer.defaultAddress(),
               secret)
             .build())
@@ -210,7 +212,7 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
           val message = "GatewayServer to port BarrierTaskContext failed to bind to Java side."
           logError(message)
           throw new SparkException(message)
-        } else {
+        } else if (isBarrier) {
           logDebug(s"Started GatewayServer to port BarrierTaskContext on port $boundPort.")
         }
         // Write out the TaskContextInfo

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -82,10 +82,7 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
   private[spark] var serverSocket: Option[ServerSocket] = None
 
   // Authentication helper used when serving method calls via socket from Python side.
-  private lazy val authHelper = {
-    val conf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf())
-    new SocketAuthHelper(conf)
-  }
+  private lazy val authHelper = new SocketAuthHelper(SparkEnv.get.conf)
 
   def compute(
       inputIterator: Iterator[IN],

--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -713,6 +713,13 @@ def write_int(value, stream):
     stream.write(struct.pack("!i", value))
 
 
+def read_bool(stream):
+    length = stream.read(1)
+    if not length:
+        raise EOFError
+    return struct.unpack("!?", length)[0]
+
+
 def write_with_length(obj, stream):
     write_int(len(obj), stream)
     stream.write(obj)

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -203,12 +203,12 @@ class BarrierTaskContext(TaskContext):
 
         .. versionadded:: 2.4.0
         """
-        if self._barrierContext is None:
+        if self._port is None or self._secret is None:
             raise Exception("Not supported to call getTaskInfos() before initialize " +
                             "BarrierTaskContext.")
         else:
-            java_list = self._barrierContext.getTaskInfos()
-            return [BarrierTaskInfo(h) for h in java_list]
+            addresses = self._localProperties.get("addresses", "")
+            return [BarrierTaskInfo(h.strip()) for h in addresses.split(",")]
 
 
 class BarrierTaskInfo(object):
@@ -220,5 +220,5 @@ class BarrierTaskInfo(object):
     .. versionadded:: 2.4.0
     """
 
-    def __init__(self, jobj):
-        self.address = jobj.address()
+    def __init__(self, address):
+        self.address = address

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -182,5 +182,5 @@ class BarrierTaskInfo(object):
     .. versionadded:: 2.4.0
     """
 
-    def __init__(self, info):
-        self.address = info.address
+    def __init__(self, jobj):
+        self.address = jobj.address()

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 import socket
 
 from pyspark.java_gateway import do_server_auth
-from pyspark.serializers import UTF8Deserializer
+from pyspark.serializers import write_with_length, UTF8Deserializer
 
 
 class TaskContext(object):
@@ -125,6 +125,8 @@ def _load_from_socket(port, auth_secret):
         raise Exception("could not open socket")
 
     sockfile = sock.makefile("rwb", 65536)
+    write_with_length("run".encode("utf-8"), sockfile)
+    sockfile.flush()
     do_server_auth(sockfile, auth_secret)
 
     # The socket will be automatically closed when garbage-collected.

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -29,6 +29,7 @@ class TaskContext(object):
     """
 
     _taskContext = None
+    _javaContext = None
 
     _attemptNumber = None
     _partitionId = None
@@ -95,3 +96,33 @@ class TaskContext(object):
         Get a local property set upstream in the driver, or None if it is missing.
         """
         return self._localProperties.get(key, None)
+
+    def barrier(self):
+        """
+        .. note:: Experimental
+
+        Sets a global barrier and waits until all tasks in this stage hit this barrier.
+        Note this method is only allowed for a BarrierTaskContext.
+
+        .. versionadded:: 2.4.0
+        """
+        if self._javaContext is None:
+            raise Exception("Not supported to call barrier() inside a non-barrier task.")
+        else:
+            self._javaContext.barrier()
+
+    def getTaskInfos(self):
+        """
+        .. note:: Experimental
+
+        Returns the all task infos in this barrier stage, the task infos are ordered by
+        partitionId.
+        Note this method is only allowed for a BarrierTaskContext.
+
+        .. versionadded:: 2.4.0
+        """
+        if self._javaContext is None:
+            raise Exception("Not supported to call getTaskInfos() inside a non-barrier task.")
+        else:
+            java_list = self._javaContext.getTaskInfos()
+            return [h for h in java_list]

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -70,7 +70,7 @@ from pyspark.serializers import read_int, BatchedSerializer, MarshalSerializer, 
 from pyspark.shuffle import Aggregator, ExternalMerger, ExternalSorter
 from pyspark import shuffle
 from pyspark.profiler import BasicProfiler
-from pyspark.taskcontext import TaskContext
+from pyspark.taskcontext import BarrierTaskContext, TaskContext
 
 _have_scipy = False
 _have_numpy = False
@@ -587,6 +587,25 @@ class TaskContextTests(PySparkTestCase):
             self.assertTrue(prop2 is None)
         finally:
             self.sc.setLocalProperty(key, None)
+
+    def test_barrier(self):
+        """
+        Verify that BarrierTaskContext.barrier() performs global sync among all barrier tasks
+        within a stage.
+        """
+        rdd = self.sc.parallelize(range(10), 4)
+
+        def f(iterator):
+            yield sum(iterator)
+
+        def context_barrier(x):
+            tc = BarrierTaskContext.get()
+            time.sleep(random.randint(1, 10))
+            tc.barrier()
+            return time.time()
+
+        times = rdd.barrier().mapPartitions(f).map(context_barrier).collect()
+        self.assertTrue(max(times) - min(times) < 1)
 
 
 class RDDTests(ReusedPySparkTestCase):

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -607,6 +607,21 @@ class TaskContextTests(PySparkTestCase):
         times = rdd.barrier().mapPartitions(f).map(context_barrier).collect()
         self.assertTrue(max(times) - min(times) < 1)
 
+    def test_barrier_infos(self):
+        """
+        Verify that BarrierTaskContext.getTaskInfos() returns a list of all task infos in the
+        barrier stage.
+        """
+        rdd = self.sc.parallelize(range(10), 4)
+
+        def f(iterator):
+            yield sum(iterator)
+
+        taskInfos = rdd.barrier().mapPartitions(f).map(lambda x: BarrierTaskContext.get()
+                                                       .getTaskInfos()).collect()
+        self.assertTrue(len(taskInfos) == 4)
+        self.assertTrue(len(taskInfos[0]) == 4)
+
 
 class RDDTests(ReusedPySparkTestCase):
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -30,7 +30,7 @@ from py4j.java_gateway import JavaGateway, GatewayParameters
 from pyspark.accumulators import _accumulatorRegistry
 from pyspark.broadcast import Broadcast, _broadcastRegistry
 from pyspark.java_gateway import do_server_auth
-from pyspark.taskcontext import TaskContext
+from pyspark.taskcontext import BarrierTaskContext, TaskContext
 from pyspark.files import SparkFiles
 from pyspark.rdd import PythonEvalType
 from pyspark.serializers import write_with_length, write_int, read_long, read_bool, \
@@ -261,11 +261,20 @@ def main(infile, outfile):
                              "PYSPARK_DRIVER_PYTHON are correctly set.") %
                             ("%d.%d" % sys.version_info[:2], version))
 
-        # initialize global state
-        taskContext = TaskContext._getOrCreate()
+        # read inputs only for a barrier task
         isBarrier = read_bool(infile)
         boundPort = read_int(infile)
         secret = UTF8Deserializer().loads(infile)
+        # initialize global state
+        taskContext = None
+        if isBarrier:
+            taskContext = BarrierTaskContext._getOrCreate()
+            params = GatewayParameters(port=boundPort, auth_token=secret, auto_convert=True)
+            barrierContext = JavaGateway(gateway_parameters=params).entry_point
+            BarrierTaskContext._initialize(barrierContext)
+        else:
+            taskContext = TaskContext._getOrCreate()
+        # read inputs for TaskContext info
         taskContext._stageId = read_int(infile)
         taskContext._partitionId = read_int(infile)
         taskContext._attemptNumber = read_int(infile)
@@ -279,10 +288,6 @@ def main(infile, outfile):
         shuffle.MemoryBytesSpilled = 0
         shuffle.DiskBytesSpilled = 0
         _accumulatorRegistry.clear()
-
-        if isBarrier:
-            paras = GatewayParameters(port=boundPort, auth_token=secret, auto_convert=True)
-            taskContext._javaContext = JavaGateway(gateway_parameters=paras).entry_point
 
         # fetch name of workdir
         spark_files_dir = utf8_deserializer.loads(infile)

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -25,8 +25,6 @@ import time
 import socket
 import traceback
 
-from py4j.java_gateway import JavaGateway, GatewayParameters
-
 from pyspark.accumulators import _accumulatorRegistry
 from pyspark.broadcast import Broadcast, _broadcastRegistry
 from pyspark.java_gateway import do_server_auth

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -269,9 +269,7 @@ def main(infile, outfile):
         taskContext = None
         if isBarrier:
             taskContext = BarrierTaskContext._getOrCreate()
-            params = GatewayParameters(port=boundPort, auth_token=secret, auto_convert=True)
-            barrierContext = JavaGateway(gateway_parameters=params).entry_point
-            BarrierTaskContext._initialize(barrierContext)
+            BarrierTaskContext._initialize(boundPort, secret)
         else:
             taskContext = TaskContext._getOrCreate()
         # read inputs for TaskContext info


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add method `barrier()` and `getTaskInfos()` in python TaskContext, these two methods are only allowed for barrier tasks.

## How was this patch tested?

Add new tests in `tests.py`
