### PR TITLE
[SPARK-24931][CORE]CoarseGrainedExecutorBackend send wrong 'Reason' w…

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -32,7 +32,7 @@ import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.worker.WorkerWatcher
 import org.apache.spark.internal.Logging
 import org.apache.spark.rpc._
-import org.apache.spark.scheduler.{ExecutorLossReason, TaskDescription}
+import org.apache.spark.scheduler.{ExecutorExited, TaskDescription}
 import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages._
 import org.apache.spark.serializer.SerializerInstance
 import org.apache.spark.util.{ThreadUtils, Utils}
@@ -165,7 +165,7 @@ private[spark] class CoarseGrainedExecutorBackend(
     }
 
     if (notifyDriver && driver.nonEmpty) {
-      driver.get.send(RemoveExecutor(executorId, new ExecutorLossReason(reason)))
+      driver.get.send(RemoveExecutor(executorId, new ExecutorExited(code, false, reason)))
     }
 
     System.exit(code)


### PR DESCRIPTION
## What changes were proposed in this pull request?

When CoarseGrainedExecutorBackend find the executor not available, it will send a "RemoveExecutor" message of "ExecutorExited" instead "ExecutorLossReason". So it call tell driver whether is the executor "exitCausedByApp" which should be false. So when dirver(TaskSetManager) can "handleFailedTask" correctly to avoid task failed time up to the "maxTaskFailures" and finally cause job failed.


## How was this patch tested?

tested in my own cluster
