### PR TITLE
[SPARK-25098][SQL]‘Cast’ will return NULL when input string starts/en…

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -350,7 +350,8 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
   // TimestampConverter
   private[this] def castToTimestamp(from: DataType): Any => Any = from match {
     case StringType =>
-      buildCast[UTF8String](_, utfs => DateTimeUtils.stringToTimestamp(utfs, timeZone).orNull)
+      buildCast[UTF8String](_, utfs => DateTimeUtils.stringToTimestamp(
+        UTF8String.fromString(utfs.toString.trim), timeZone).orNull)
     case BooleanType =>
       buildCast[Boolean](_, b => if (b) 1L else 0)
     case LongType =>
@@ -393,7 +394,9 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
   // DateConverter
   private[this] def castToDate(from: DataType): Any => Any = from match {
     case StringType =>
-      buildCast[UTF8String](_, s => DateTimeUtils.stringToDate(s).orNull)
+      buildCast[UTF8String](_, s => DateTimeUtils.stringToDate(
+        UTF8String.fromString(s.toString.trim)
+      ).orNull)
     case TimestampType =>
       // throw valid precision more than seconds, according to Hive.
       // Timestamp.nanos is in 0 to 999,999,999, no more than a second.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -98,6 +98,7 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
     c.set(Calendar.MILLISECOND, 0)
     checkEvaluation(Cast(Literal("2015-03-18"), DateType), new Date(c.getTimeInMillis))
     checkEvaluation(Cast(Literal("2015-03-18 "), DateType), new Date(c.getTimeInMillis))
+    checkEvaluation(Cast(Literal(" 2015-03-18"), DateType), new Date(c.getTimeInMillis))
     checkEvaluation(Cast(Literal("2015-03-18 123142"), DateType), new Date(c.getTimeInMillis))
     checkEvaluation(Cast(Literal("2015-03-18T123123"), DateType), new Date(c.getTimeInMillis))
     checkEvaluation(Cast(Literal("2015-03-18T"), DateType), new Date(c.getTimeInMillis))
@@ -130,6 +131,7 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
       c.set(Calendar.MILLISECOND, 0)
       checkCastStringToTimestamp("2015-03-18", new Timestamp(c.getTimeInMillis))
       checkCastStringToTimestamp("2015-03-18 ", new Timestamp(c.getTimeInMillis))
+      checkCastStringToTimestamp(" 2015-03-18", new Timestamp(c.getTimeInMillis))
       checkCastStringToTimestamp("2015-03-18T", new Timestamp(c.getTimeInMillis))
 
       c = Calendar.getInstance(tz)


### PR DESCRIPTION
## What changes were proposed in this pull request?

UDF ‘Cast’ will return NULL when input string starts/ends with special character, but hive doesn't.
For examle, we get hour from a string ends with a blank :
hive：
```
hive> SELECT CAST(' 2018-08-13' AS DATE);//starts with a blank
OK 
2018-08-13
hive> SELECT HOUR('2018-08-13 17:20:07 );//ends with a blank
OK
17
```
spark-sql:
```
spark-sql> SELECT CAST(' 2018-08-13' AS DATE);//starts with a blank
NULL
spark-sql> SELECT HOUR('2018-08-13 17:20:07 );//ends with a blank
NULL
```
All of the following UDFs will be affected:
```
year
month
day
hour
minute
second
date_add
date_sub
```

## How was this patch tested?
Add test cases
