### PR TITLE
[SPARK-25101][CORE]Creating leaderLatch with id for getting info abou…

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/ZooKeeperLeaderElectionAgent.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ZooKeeperLeaderElectionAgent.scala
@@ -19,7 +19,6 @@ package org.apache.spark.deploy.master
 
 import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.framework.recipes.leader.{LeaderLatch, LeaderLatchListener}
-
 import org.apache.spark.SparkConf
 import org.apache.spark.deploy.SparkCuratorUtil
 import org.apache.spark.internal.Logging
@@ -38,7 +37,7 @@ private[master] class ZooKeeperLeaderElectionAgent(val masterInstance: LeaderEle
   private def start() {
     logInfo("Starting ZooKeeper LeaderElection agent")
     zk = SparkCuratorUtil.newClient(conf)
-    leaderLatch = new LeaderLatch(zk, WORKING_DIR)
+    leaderLatch = new LeaderLatch(zk, WORKING_DIR, conf.get("spark.master.leader.id", ""))
     leaderLatch.addListener(this)
     leaderLatch.start()
   }


### PR DESCRIPTION
…t spark master nodes from zk

## What changes were proposed in this pull request?

This PR proposes add id to LeaderLatch, because in special cases developers need monitor zk for presence leaderLatch for spark master node (sometimes master nodes start before zk and all of them are in STANDBY status). For prevent this cases I want monitor zk and if master hasn't leaderLatch I will restart it.

## How was this patch tested?
running all tests in spark project (mvn test)

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
