### PR TITLE
[SPARK-25100][CORE] Fix no registering TaskCommitMessage bug

### DIFF
--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -38,6 +38,7 @@ import org.roaringbitmap.RoaringBitmap
 import org.apache.spark._
 import org.apache.spark.api.python.PythonBroadcast
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.io.FileCommitProtocol._
 import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.scheduler.{CompressedMapStatus, HighlyCompressedMapStatus}
 import org.apache.spark.storage._
@@ -177,6 +178,7 @@ class KryoSerializer(conf: SparkConf)
     kryo.register(Nil.getClass)
     kryo.register(Utils.classForName("scala.collection.immutable.$colon$colon"))
     kryo.register(Utils.classForName("scala.collection.immutable.Map$EmptyMap$"))
+    kryo.register(Utils.classForName("scala.collection.immutable.Set$EmptySet$"))
     kryo.register(classOf[ArrayBuffer[Any]])
 
     // We can't load those class directly in order to avoid unnecessary jar dependencies.
@@ -430,7 +432,8 @@ private[serializer] object KryoSerializer {
     classOf[Array[String]],
     classOf[Array[Array[String]]],
     classOf[BoundedPriorityQueue[_]],
-    classOf[SparkConf]
+    classOf[SparkConf],
+    classOf[TaskCommitMessage]
   )
 
   private val toRegisterSerializer = Map[Class[_], KryoClassSerializer[_]](

--- a/core/src/test/scala/org/apache/spark/FileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FileSuite.scala
@@ -444,7 +444,6 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
     val conf = new SparkConf(false).setMaster("local").
         set("spark.kryo.registrationRequired", "true").setAppName("test")
     conf.set("spark.serializer", classOf[KryoSerializer].getName)
-    conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
     
     val jobConf = new JobConf()
     jobConf.setOutputKeyClass(classOf[IntWritable])


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the bug when invoking saveAsNewAPIHadoopDataset to store data, the job will fail because the class TaskCommitMessage hasn't be registered if serializer is KryoSerializer and spark.kryo.registrationRequired is true

## How was this patch tested?

Run all the test in project