### PR TITLE
[SPARK-25105][PySpark] [SQL]Include PandasUDFType in the import all of pyspark.sql.functions 

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2926,8 +2926,8 @@ def pandas_udf(f=None, returnType=None, functionType=None):
 blacklist = ['map', 'since', 'ignore_unicode_prefix']
 __all__ = [k for k, v in globals().items()
            if not k.startswith('_') and k[0].islower() and callable(v) and k not in blacklist]
-__all__.sort()
 __all__ += ["PandasUDFType"]
+__all__.sort()
 
 
 def _test():

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2927,7 +2927,7 @@ blacklist = ['map', 'since', 'ignore_unicode_prefix']
 __all__ = [k for k, v in globals().items()
            if not k.startswith('_') and k[0].islower() and callable(v) and k not in blacklist]
 __all__.sort()
-
+__all__ += ["PandasUDFType"]
 
 def _test():
     import doctest

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2929,6 +2929,7 @@ __all__ = [k for k, v in globals().items()
 __all__.sort()
 __all__ += ["PandasUDFType"]
 
+
 def _test():
     import doctest
     from pyspark.sql import Row, SparkSession

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -4360,7 +4360,7 @@ class ArrowTests(ReusedSQLTestCase):
 class PandasUDFTests(ReusedSQLTestCase):
     def test_pandas_udf_basic(self):
         from pyspark.rdd import PythonEvalType
-        from pyspark.sql.functions import pandas_udf, PandasUDFType
+        from pyspark.sql.functions import *
 
         udf = pandas_udf(lambda x: x, DoubleType())
         self.assertEqual(udf.returnType, DoubleType())

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -4360,7 +4360,7 @@ class ArrowTests(ReusedSQLTestCase):
 class PandasUDFTests(ReusedSQLTestCase):
     def test_pandas_udf_basic(self):
         from pyspark.rdd import PythonEvalType
-        from pyspark.sql.functions import *
+        from pyspark.sql.functions import pandas_udf, PandasUDFType
 
         udf = pandas_udf(lambda x: x, DoubleType())
         self.assertEqual(udf.returnType, DoubleType())


### PR DESCRIPTION
## What changes were proposed in this pull request?

Include PandasUDFType in the import all of pyspark.sql.functions 

## How was this patch tested?

Run the test case from the pyspark shell from the jira [spark-25105](https://jira.apache.org/jira/browse/SPARK-25105?jql=project%20%3D%20SPARK%20AND%20component%20in%20(ML%2C%20PySpark%2C%20SQL%2C%20%22Structured%20Streaming%22))
I manually test on pyspark-shell:
before:
`
>>> from pyspark.sql.functions import *
>>> foo = pandas_udf(lambda x: x, 'v int', PandasUDFType.GROUPED_MAP)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'PandasUDFType' is not defined
>>> 
`
after:
`
>>> from pyspark.sql.functions import *
>>> foo = pandas_udf(lambda x: x, 'v int', PandasUDFType.GROUPED_MAP)
>>> 
`
Please review http://spark.apache.org/contributing.html before opening a pull request.
