### PR TITLE
[SPARK-25123][SQL] Use Block to track code in SimpleExprValue

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -762,8 +762,8 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
     val keyToStringFunc = dataToStringFunc("keyToString", kt)
     val valueToStringFunc = dataToStringFunc("valueToString", vt)
     val loopIndex = ctx.freshVariable("loopIndex", IntegerType)
-    val mapKeyArray = JavaCode.expression(s"$map.keyArray()", classOf[ArrayData])
-    val mapValueArray = JavaCode.expression(s"$map.valueArray()", classOf[ArrayData])
+    val mapKeyArray = JavaCode.expression(code"$map.keyArray()", classOf[ArrayData])
+    val mapValueArray = JavaCode.expression(code"$map.valueArray()", classOf[ArrayData])
     val getMapFirstKey = CodeGenerator.getValue(mapKeyArray, kt, JavaCode.literal("0", IntegerType))
     val getMapFirstValue = CodeGenerator.getValue(mapValueArray, vt,
       JavaCode.literal("0", IntegerType))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -432,7 +432,7 @@ abstract class UnaryExpression extends Expression {
   protected def nullSafeCodeGen(
       ctx: CodegenContext,
       ev: ExprCode,
-      f: String => String): ExprCode = {
+      f: ExprValue => String): ExprCode = {
     val childGen = child.genCode(ctx)
     val resultCode = f(childGen.value)
 
@@ -521,7 +521,7 @@ abstract class BinaryExpression extends Expression {
   protected def nullSafeCodeGen(
       ctx: CodegenContext,
       ev: ExprCode,
-      f: (String, String) => String): ExprCode = {
+      f: (ExprValue, ExprValue) => String): ExprCode = {
     val leftGen = left.genCode(ctx)
     val rightGen = right.genCode(ctx)
     val resultCode = f(leftGen.value, rightGen.value)
@@ -661,7 +661,7 @@ abstract class TernaryExpression extends Expression {
   protected def nullSafeCodeGen(
     ctx: CodegenContext,
     ev: ExprCode,
-    f: (String, String, String) => String): ExprCode = {
+    f: (ExprValue, ExprValue, ExprValue) => String): ExprCode = {
     val leftGen = children(0).genCode(ctx)
     val midGen = children(1).genCode(ctx)
     val rightGen = children(2).genCode(ctx)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateSafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateSafeProjection.scala
@@ -57,7 +57,7 @@ object GenerateSafeProjection extends CodeGenerator[Seq[Expression], Projection]
     val fieldWriters = schema.map(_.dataType).zipWithIndex.map { case (dt, i) =>
       val converter = convertToSafe(
         ctx,
-        JavaCode.expression(CodeGenerator.getValue(tmpInput, dt, i.toString), dt),
+        CodeGenerator.getValue(JavaCode.variable(tmpInput, classOf[InternalRow]), dt, i.toString),
         dt)
       s"""
         if (!$tmpInput.isNullAt($i)) {
@@ -96,7 +96,7 @@ object GenerateSafeProjection extends CodeGenerator[Seq[Expression], Projection]
 
     val elementConverter = convertToSafe(
       ctx,
-      JavaCode.expression(CodeGenerator.getValue(tmpInput, elementType, index), elementType),
+      CodeGenerator.getValue(JavaCode.variable(tmpInput, classOf[ArrayData]), elementType, index),
       elementType)
     val code = code"""
       final ArrayData $tmpInput = $input;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
@@ -279,8 +279,8 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
     }
 
     val rowWriterClass = classOf[UnsafeRowWriter]
-    val rowWriter = ctx.addMutableState(rowWriterClass.toString, "rowWriter",
-      v => s"$v = new $rowWriterClass(${expressions.length}, ${numVarLenFields * 32});")
+    val rowWriter = ctx.addMutableState(rowWriterClass.getName, "rowWriter",
+      v => s"$v = new ${rowWriterClass.getName}(${expressions.length}, ${numVarLenFields * 32});")
     val rowWriterExpr = JavaCode.global(rowWriter, rowWriterClass)
     // Evaluate all the subexpression.
     val evalSubexpr = ctx.subexprFunctions.mkString("\n")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/javaCode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/javaCode.scala
@@ -97,21 +97,21 @@ object JavaCode {
   /**
    * Create an expression fragment.
    */
-  def expression(code: String, dataType: DataType): SimpleExprValue = {
+  def expression(code: Block, dataType: DataType): SimpleExprValue = {
     expression(code, CodeGenerator.javaClass(dataType))
   }
 
   /**
    * Create an expression fragment.
    */
-  def expression(code: String, javaClass: Class[_]): SimpleExprValue = {
+  def expression(code: Block, javaClass: Class[_]): SimpleExprValue = {
     SimpleExprValue(code, javaClass)
   }
 
   /**
    * Create a isNull expression fragment.
    */
-  def isNullExpression(code: String): SimpleExprValue = {
+  def isNullExpression(code: Block): SimpleExprValue = {
     expression(code, BooleanType)
   }
 
@@ -317,7 +317,7 @@ object ExprValue {
 /**
  * A java expression fragment.
  */
-case class SimpleExprValue(expr: String, javaType: Class[_]) extends ExprValue {
+case class SimpleExprValue(expr: Block, javaType: Class[_]) extends ExprValue {
   override def code: String = s"($expr)"
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis._
-import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode, JavaCode}
 import org.apache.spark.sql.catalyst.util.{quoteIdentifier, ArrayData, GenericArrayData, MapData, TypeUtils}
 import org.apache.spark.sql.types._
 
@@ -185,7 +185,7 @@ case class GetArrayStructFields(
       val n = ctx.freshName("n")
       val values = ctx.freshName("values")
       val j = ctx.freshName("j")
-      val row = ctx.freshName("row")
+      val row = JavaCode.variable(ctx.freshName("row"), classOf[InternalRow])
       val nullSafeEval = if (field.nullable) {
         s"""
          if ($row.isNullAt($ordinal)) {
@@ -299,10 +299,10 @@ abstract class GetMapValueUtil extends BinaryExpression with ImplicitCastInputTy
   def doGetValueGenCode(ctx: CodegenContext, ev: ExprCode, mapType: MapType): ExprCode = {
     val index = ctx.freshName("index")
     val length = ctx.freshName("length")
-    val keys = ctx.freshName("keys")
+    val keys = JavaCode.variable(ctx.freshName("keys"), classOf[ArrayData])
     val found = ctx.freshName("found")
     val key = ctx.freshName("key")
-    val values = ctx.freshName("values")
+    val values = JavaCode.variable(ctx.freshName("values"), classOf[ArrayData])
     val keyType = mapType.keyType
     val nullCheck = if (mapType.valueContainsNull) {
       s" || $values.isNullAt($index)"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -312,7 +312,8 @@ case class Literal (value: Any, dataType: DataType) extends LeafExpression {
               toExprCode(s"${value}D")
           }
         case ByteType | ShortType =>
-          ExprCode.forNonNullValue(JavaCode.expression(code"($javaType)$value", dataType))
+          ExprCode.forNonNullValue(
+            JavaCode.expression(code"($javaType)${value.toString}", dataType))
         case TimestampType | LongType =>
           toExprCode(s"${value}L")
         case _ =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -40,6 +40,7 @@ import org.json4s.JsonAST._
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow, ScalaReflection}
 import org.apache.spark.sql.catalyst.expressions.codegen._
+import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types._
@@ -311,7 +312,7 @@ case class Literal (value: Any, dataType: DataType) extends LeafExpression {
               toExprCode(s"${value}D")
           }
         case ByteType | ShortType =>
-          ExprCode.forNonNullValue(JavaCode.expression(s"($javaType)$value", dataType))
+          ExprCode.forNonNullValue(JavaCode.expression(code"($javaType)$value", dataType))
         case TimestampType | LongType =>
           toExprCode(s"${value}L")
         case _ =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -348,7 +348,7 @@ case class IsNotNull(child: Expression) extends UnaryExpression with Predicate {
     val value = eval.isNull match {
       case TrueLiteral => FalseLiteral
       case FalseLiteral => TrueLiteral
-      case v => JavaCode.isNullExpression(s"!$v")
+      case v => JavaCode.isNullExpression(code"!$v")
     }
     ExprCode(code = eval.code, isNull = FalseLiteral, value = value)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -1091,8 +1091,8 @@ case class CatalystToExternalMap private(
 
     val getLength = s"${genInputData.value}.numElements()"
 
-    val keyArray = ctx.freshName("keyArray")
-    val valueArray = ctx.freshName("valueArray")
+    val keyArray = JavaCode.variable(ctx.freshName("keyArray"), classOf[ArrayData])
+    val valueArray = JavaCode.variable(ctx.freshName("valueArray"), classOf[ArrayData])
     val getKeyArray =
       s"${classOf[ArrayData].getName} $keyArray = ${genInputData.value}.keyArray();"
     val getKeyLoopVar = CodeGenerator.getValue(keyArray, inputDataType(mapType.keyType), loopIndex)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/VectorizedHashMapGenerator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/VectorizedHashMapGenerator.scala
@@ -19,7 +19,8 @@ package org.apache.spark.sql.execution.aggregate
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
-import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, JavaCode}
+import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.execution.vectorized.{MutableColumnarRow, OnHeapColumnVector}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -127,7 +128,8 @@ class VectorizedHashMapGenerator(
 
     def genEqualsForKeys(groupingKeys: Seq[Buffer]): String = {
       groupingKeys.zipWithIndex.map { case (key: Buffer, ordinal: Int) =>
-        val value = CodeGenerator.getValueFromVector(s"vectors[$ordinal]", key.dataType,
+        val expr = JavaCode.expression(code"vectors[$ordinal]", classOf[OnHeapColumnVector])
+        val value = CodeGenerator.getValueFromVector(expr, key.dataType,
           "buckets[idx]")
         s"(${ctx.genEqual(key.dataType, value, key.name)})"
       }.mkString(" && ")


### PR DESCRIPTION
## What changes were proposed in this pull request?

`SimpleExprValue` carries some java code which is a rvalue. Now the code is represented by a String. If the code references a variable, this means that we are loosing track of its usage.

This is particularly important as the `value` of an `ExprCode` is (correctly) a `ExprValue`. Thus, if we have current code referencing a variable in it, we are loosing track of the referenced variable.

So the PR proposes to represent the code in `SimpleExprValue` using a `Block`, in order not to loose eventual references present in the generated code.

## How was this patch tested?

added UT/existing UTs
