### PR TITLE
[SPARK-25126] Lazily create Reader for orc files

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileOperator.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileOperator.scala
@@ -70,7 +70,7 @@ private[hive] object OrcFileOperator extends Logging {
       hdfsPath.getFileSystem(conf)
     }
 
-    listOrcFiles(basePath, conf).iterator.map { path =>
+    listOrcFiles(basePath, conf).view.map { path =>
       val reader = try {
         Some(OrcFile.createReader(fs, path))
       } catch {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently Reader is created for every orc file under the directory and then the first one
with non-empty schema is returned. Using `view` lazily creates Reader instead.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
