### PR TITLE
[SPARK-25131]Event logs missing applicationAttemptId for SparkListenerApplicationStart

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -62,6 +62,10 @@ private[spark] class YarnClientSchedulerBackend(
     super.start()
     waitForApplication()
 
+    // set the attemptId as its available now
+    this.attemptId = Option(client.getApplicationReport(this.appId.get)
+      .getCurrentApplicationAttemptId())
+
     monitorThread = asyncMonitorApplication()
     monitorThread.start()
   }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -67,7 +67,7 @@ private[spark] abstract class YarnSchedulerBackend(
   protected var appId: Option[ApplicationId] = None
 
   /** Attempt ID. This is unset for client-mode schedulers */
-  private var attemptId: Option[ApplicationAttemptId] = None
+  protected var attemptId: Option[ApplicationAttemptId] = None
 
   /** Scheduler extension services. */
   private val services: SchedulerExtensionServices = new SchedulerExtensionServices()


### PR DESCRIPTION
When master=yarn and deploy-mode=client, event logs do not contain applicationAttemptId for SparkListenerApplicationStart. This is caused at org.apache.spark.scheduler.cluster.YarnClientSchedulerBackend#start where we do bindToYarn(client.submitApplication(), None) which sets appAttemptId to None. We can however, get the appAttemptId after waitForApplication() and set it


This i have tested manually and verified