### PR TITLE
[SPARK-24665][PySpark][FollowUp] Use SQLConf in PySpark to manage all sql configs

### DIFF
--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -177,8 +177,7 @@ class Catalog(object):
         if path is not None:
             options["path"] = path
         if source is None:
-            source = self._sparkSession.conf.get(
-                "spark.sql.sources.default", "org.apache.spark.sql.parquet")
+            source = self._sparkSession._wrapped._conf.defaultDataSourceName()
         if schema is None:
             df = self._jcatalog.createTable(tableName, source, options)
         else:

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -678,9 +678,8 @@ class SparkSession(object):
             from pyspark.sql.utils import require_minimum_pandas_version
             require_minimum_pandas_version()
 
-            if self.conf.get("spark.sql.execution.pandas.respectSessionTimeZone").lower() \
-               == "true":
-                timezone = self.conf.get("spark.sql.session.timeZone")
+            if self._wrapped._conf.pandasRespectSessionTimeZone():
+                timezone = self._wrapped._conf.sessionLocalTimeZone()
             else:
                 timezone = None
 
@@ -690,15 +689,13 @@ class SparkSession(object):
                           (x.encode('utf-8') if not isinstance(x, str) else x)
                           for x in data.columns]
 
-            if self.conf.get("spark.sql.execution.arrow.enabled", "false").lower() == "true" \
-                    and len(data) > 0:
+            if self._wrapped._conf.arrowEnabled() and len(data) > 0:
                 try:
                     return self._create_from_pandas_with_arrow(data, schema, timezone)
                 except Exception as e:
                     from pyspark.util import _exception_message
 
-                    if self.conf.get("spark.sql.execution.arrow.fallback.enabled", "true") \
-                            .lower() == "true":
+                    if self._wrapped._conf.arrowFallbackEnabled():
                         msg = (
                             "createDataFrame attempted Arrow optimization because "
                             "'spark.sql.execution.arrow.enabled' is set to true; however, "


### PR DESCRIPTION
## What changes were proposed in this pull request?

Follow up for SPARK-24665, find some others hard code during code review.

## How was this patch tested?

Existing UT.