### PR TITLE
[DOCS] Fix cloud-integration.md Typo

### DIFF
--- a/docs/cloud-integration.md
+++ b/docs/cloud-integration.md
@@ -104,7 +104,7 @@ Spark jobs must authenticate with the object stores to access data within them.
 and `AWS_SESSION_TOKEN` environment variables and sets the associated authentication options
 for the `s3n` and `s3a` connectors to Amazon S3.
 1. In a Hadoop cluster, settings may be set in the `core-site.xml` file.
-1. Authentication details may be manually added to the Spark configuration in `spark-default.conf`
+1. Authentication details may be manually added to the Spark configuration in `spark-defaults.conf`
 1. Alternatively, they can be programmatically set in the `SparkConf` instance used to configure 
 the application's `SparkContext`.
 


### PR DESCRIPTION
Corrected typo; changed spark-default.conf to spark-defaults.conf
