### PR TITLE
[SPARK-25032][SQL] fix drop database issue

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -218,6 +218,10 @@ class SessionCatalog(
       throw new AnalysisException(s"Can not drop default database")
     }
     externalCatalog.dropDatabase(dbName, ignoreIfNotExists, cascade)
+    // if the current database is deleted, the default database will be selected
+    if (dbName == currentDb) {
+      setCurrentDatabase(DEFAULT_DATABASE)
+    }
   }
 
   def alterDatabase(dbDefinition: CatalogDatabase): Unit = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -185,6 +185,19 @@ abstract class SessionCatalogSuite extends AnalysisTest {
     }
   }
 
+  test("after drop the current database, switch the current database to default") {
+    withBasicCatalog { catalog =>
+      catalog.setCurrentDatabase("db1")
+      catalog.dropDatabase("db1", ignoreIfNotExists = true, cascade = true)
+      assert(catalog.getCurrentDatabase == "default")
+
+      // drop the database other than itself will not change the current database
+      catalog.setCurrentDatabase("db2")
+      catalog.dropDatabase("db3", ignoreIfNotExists = true, cascade = true)
+      assert(catalog.getCurrentDatabase == "db2")
+    }
+  }
+
   test("drop current database and drop default database") {
     withBasicCatalog { catalog =>
       catalog.setCurrentDatabase("db1")


### PR DESCRIPTION
## What changes were proposed in this pull request?
When user tries to drop the current database (other than default database), after the database is deleted, we should set the database to default. 

## How was this patch tested?
A new test case is added to cover this scenario.