### PR TITLE
Add test_slice() to streaming BasicOperations

### DIFF
--- a/python/pyspark/streaming/tests.py
+++ b/python/pyspark/streaming/tests.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import datetime as dt
 import glob
 import os
 import sys
@@ -204,6 +205,21 @@ class BasicOperationTests(PySparkStreamingTestCase):
         def func(dstream):
             return dstream.count()
         expected = [[len(x)] for x in input]
+        self._test_func(input, func, expected)
+
+    def test_slice(self):
+        """Basic operation test for DStream.slice."""
+        eol_python2 = dt.datetime(2020, 1, 1)
+        five_secs = dt.timedelta(seconds=5)
+        input = [eol_python2 - five_secs, eol_python2]
+        def func(dstream):
+            return dstream.slice()
+        expected = [[dt.datetime(2019, 12, 31, 23, 55)],
+                    [dt.datetime(2019, 12, 31, 23, 56)],
+                    [dt.datetime(2019, 12, 31, 23, 57)],
+                    [dt.datetime(2019, 12, 31, 23, 58)],
+                    [dt.datetime(2019, 12, 31, 23, 59)],
+                    [dt.datetime(2020, 1, 1)]]
         self._test_func(input, func, expected)
 
     def test_reduce(self):


### PR DESCRIPTION
As suggested in https://github.com/apache/spark/pull/20838#pullrequestreview-139118618

## What changes were proposed in this pull request?
Add a test for slice operations on streams.

(Please fill in changes proposed in this fix)

## How was this patch tested?
It is a new test being added to the automated test suite.

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
