### PR TITLE
[SPARK-25129][SQL]Make the mapping of com.databricks.spark.avro to built-in module configurable

### DIFF
--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -84,7 +84,7 @@ class AvroSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
         classOf[org.apache.spark.sql.avro.AvroFileFormat])
     }
 
-    withSQLConf(SQLConf.ENABLE_AVRO_BACKWARD_COMPATIBILITY.key -> "false") {
+    withSQLConf(SQLConf.LEGACY_REPLACE_DATABRICKS_SPARK_AVRO_ENABLED.key -> "false") {
       val message = intercept[AnalysisException] {
         DataSource.lookupDataSource(databricksAvro, spark.sessionState.conf)
       }.getMessage

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -79,7 +79,7 @@ class AvroSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
   test("resolve avro data source") {
     val databricksAvro = "com.databricks.spark.avro"
     // By default the backward compatibility for com.databricks.spark.avro is enabled.
-    Seq("avro", "org.apache.spark.sql.avro", databricksAvro).foreach { provider =>
+    Seq("avro", "org.apache.spark.sql.avro.AvroFileFormat", databricksAvro).foreach { provider =>
       assert(DataSource.lookupDataSource(provider, spark.sessionState.conf) ===
         classOf[org.apache.spark.sql.avro.AvroFileFormat])
     }

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -77,9 +77,18 @@ class AvroSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
   }
 
   test("resolve avro data source") {
-    Seq("avro", "com.databricks.spark.avro").foreach { provider =>
+    val databricksAvro = "com.databricks.spark.avro"
+    // By default the backward compatibility for com.databricks.spark.avro is enabled.
+    Seq("avro", "org.apache.spark.sql.avro", databricksAvro).foreach { provider =>
       assert(DataSource.lookupDataSource(provider, spark.sessionState.conf) ===
         classOf[org.apache.spark.sql.avro.AvroFileFormat])
+    }
+
+    withSQLConf(SQLConf.ENABLE_AVRO_BACKWARD_COMPATIBILITY.key -> "false") {
+      val message = intercept[AnalysisException] {
+        DataSource.lookupDataSource(databricksAvro, spark.sessionState.conf)
+      }.getMessage
+      assert(message.contains(s"Failed to find data source: $databricksAvro"))
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1459,11 +1459,12 @@ object SQLConf {
     .checkValues((1 to 9).toSet + Deflater.DEFAULT_COMPRESSION)
     .createWithDefault(Deflater.DEFAULT_COMPRESSION)
 
-  val ENABLE_AVRO_BACKWARD_COMPATIBILITY = buildConf("spark.sql.avro.backwardCompatibility")
-    .doc("If it is set to true, the data source provider com.databricks.spark.avro is mapped " +
-    "to the built-in module org.apache.spark.sql.avro for backward compatibility.")
-    .booleanConf
-    .createWithDefault(true)
+  val LEGACY_REPLACE_DATABRICKS_SPARK_AVRO_ENABLED =
+    buildConf("spark.sql.legacy.replaceDatabricksSparkAvro.enabled")
+      .doc("If it is set to true, the data source provider com.databricks.spark.avro is mapped " +
+        "to the built-in Avro data source module for backward compatibility.")
+      .booleanConf
+      .createWithDefault(true)
 
   val LEGACY_SETOPS_PRECEDENCE_ENABLED =
     buildConf("spark.sql.legacy.setopsPrecedence.enabled")
@@ -1877,7 +1878,8 @@ class SQLConf extends Serializable with Logging {
 
   def avroDeflateLevel: Int = getConf(SQLConf.AVRO_DEFLATE_LEVEL)
 
-  def enableAvroBackwardCompatibility: Boolean = getConf(SQLConf.ENABLE_AVRO_BACKWARD_COMPATIBILITY)
+  def replaceDatabricksSparkAvroEnabled: Boolean =
+    getConf(SQLConf.LEGACY_REPLACE_DATABRICKS_SPARK_AVRO_ENABLED)
 
   def setOpsPrecedenceEnforced: Boolean = getConf(SQLConf.LEGACY_SETOPS_PRECEDENCE_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1459,6 +1459,12 @@ object SQLConf {
     .checkValues((1 to 9).toSet + Deflater.DEFAULT_COMPRESSION)
     .createWithDefault(Deflater.DEFAULT_COMPRESSION)
 
+  val ENABLE_AVRO_BACKWARD_COMPATIBILITY = buildConf("spark.sql.avro.backwardCompatibility")
+    .doc("If it is set to true, the data source provider com.databricks.spark.avro is mapped " +
+    "to the built-in module org.apache.spark.sql.avro for backward compatibility.")
+    .booleanConf
+    .createWithDefault(true)
+
   val LEGACY_SETOPS_PRECEDENCE_ENABLED =
     buildConf("spark.sql.legacy.setopsPrecedence.enabled")
       .internal()
@@ -1870,6 +1876,8 @@ class SQLConf extends Serializable with Logging {
   def avroCompressionCodec: String = getConf(SQLConf.AVRO_COMPRESSION_CODEC)
 
   def avroDeflateLevel: Int = getConf(SQLConf.AVRO_DEFLATE_LEVEL)
+
+  def enableAvroBackwardCompatibility: Boolean = getConf(SQLConf.ENABLE_AVRO_BACKWARD_COMPATIBILITY)
 
   def setOpsPrecedenceEnforced: Boolean = getConf(SQLConf.LEGACY_SETOPS_PRECEDENCE_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1462,7 +1462,7 @@ object SQLConf {
   val LEGACY_REPLACE_DATABRICKS_SPARK_AVRO_ENABLED =
     buildConf("spark.sql.legacy.replaceDatabricksSparkAvro.enabled")
       .doc("If it is set to true, the data source provider com.databricks.spark.avro is mapped " +
-        "to the built-in Avro data source module for backward compatibility.")
+        "to the built-in external Avro data source module for backward compatibility.")
       .booleanConf
       .createWithDefault(true)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1462,7 +1462,7 @@ object SQLConf {
   val LEGACY_REPLACE_DATABRICKS_SPARK_AVRO_ENABLED =
     buildConf("spark.sql.legacy.replaceDatabricksSparkAvro.enabled")
       .doc("If it is set to true, the data source provider com.databricks.spark.avro is mapped " +
-        "to the built-in external Avro data source module for backward compatibility.")
+        "to the built-in but external Avro data source module for backward compatibility.")
       .booleanConf
       .createWithDefault(true)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -642,8 +642,8 @@ object DataSource extends Logging {
                   provider1 == "com.databricks.spark.avro" ||
                   provider1 == "org.apache.spark.sql.avro") {
                   throw new AnalysisException(
-                    s"Failed to find data source: $provider1. Avro is built-in data source since " +
-                    "Spark 2.4. Please deploy the application as per " +
+                    s"Failed to find data source: $provider1. Avro is built-in but external data " +
+                    "source module since Spark 2.4. Please deploy the application as per " +
                     s"$latestDocsURL/avro-data-source-guide.html#deploying")
                 } else if (provider1.toLowerCase(Locale.ROOT) == "kafka") {
                   throw new AnalysisException(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -626,7 +626,6 @@ object DataSource extends Logging {
       serviceLoader.asScala.filter(_.shortName().equalsIgnoreCase(provider1)).toList match {
         // the provider format did not match any given registered aliases
         case Nil =>
-          val latestDocsURL = "https://spark.apache.org/docs/latest"
           try {
             Try(loader.loadClass(provider1)).orElse(Try(loader.loadClass(provider2))) match {
               case Success(dataSource) =>
@@ -644,11 +643,12 @@ object DataSource extends Logging {
                   throw new AnalysisException(
                     s"Failed to find data source: $provider1. Avro is built-in but external data " +
                     "source module since Spark 2.4. Please deploy the application as per " +
-                    s"$latestDocsURL/avro-data-source-guide.html#deploying")
+                    "the deployment section of \"Apache Avro Data Source Guide\".")
                 } else if (provider1.toLowerCase(Locale.ROOT) == "kafka") {
                   throw new AnalysisException(
-                    s"Failed to find data source: $provider1. Please deploy the application as" +
-                    s"per $latestDocsURL/structured-streaming-kafka-integration.html#deploying")
+                    s"Failed to find data source: $provider1. Please deploy the application as " +
+                    "per the deployment section of " +
+                    "\"Structured Streaming + Kafka Integration Guide\".")
                 } else {
                   throw new ClassNotFoundException(
                     s"Failed to find data source: $provider1. Please find packages at " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -614,7 +614,7 @@ object DataSource extends Logging {
       case name if name.equalsIgnoreCase("orc") &&
           conf.getConf(SQLConf.ORC_IMPLEMENTATION) == "hive" =>
         "org.apache.spark.sql.hive.orc.OrcFileFormat"
-      case "com.databricks.spark.avro" if conf.enableAvroBackwardCompatibility =>
+      case "com.databricks.spark.avro" if conf.replaceDatabricksSparkAvroEnabled =>
         "org.apache.spark.sql.avro.AvroFileFormat"
       case name => name
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/ResolvedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/ResolvedDataSourceSuite.scala
@@ -76,6 +76,24 @@ class ResolvedDataSourceSuite extends SparkFunSuite with SharedSQLContext {
         classOf[org.apache.spark.sql.execution.datasources.csv.CSVFileFormat])
   }
 
+  test("avro: show deploy guide for loading the external avro module") {
+    Seq("avro", "org.apache.spark.sql.avro").foreach { provider =>
+      val message = intercept[AnalysisException] {
+        getProvidingClass(provider)
+      }.getMessage
+      assert(message.contains(s"Failed to find data source: $provider"))
+      assert(message.contains("avro-data-source-guide.html#deploying"))
+    }
+  }
+
+  test("kafka: show deploy guide for loading the external kafka module") {
+    val message = intercept[AnalysisException] {
+      getProvidingClass("kafka")
+    }.getMessage
+    assert(message.contains("Failed to find data source: kafka"))
+    assert(message.contains("structured-streaming-kafka-integration.html#deploying"))
+  }
+
   test("error message for unknown data sources") {
     val error = intercept[ClassNotFoundException] {
       getProvidingClass("asfdwefasdfasdf")

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/ResolvedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/ResolvedDataSourceSuite.scala
@@ -82,7 +82,7 @@ class ResolvedDataSourceSuite extends SparkFunSuite with SharedSQLContext {
         getProvidingClass(provider)
       }.getMessage
       assert(message.contains(s"Failed to find data source: $provider"))
-      assert(message.contains("avro-data-source-guide.html#deploying"))
+      assert(message.contains("Please deploy the application as per the deployment section of"))
     }
   }
 
@@ -91,7 +91,7 @@ class ResolvedDataSourceSuite extends SparkFunSuite with SharedSQLContext {
       getProvidingClass("kafka")
     }.getMessage
     assert(message.contains("Failed to find data source: kafka"))
-    assert(message.contains("structured-streaming-kafka-integration.html#deploying"))
+    assert(message.contains("Please deploy the application as per the deployment section of"))
   }
 
   test("error message for unknown data sources") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In https://issues.apache.org/jira/browse/SPARK-24924, the data source provider com.databricks.spark.avro is mapped to the new package org.apache.spark.sql.avro .

As per the discussion in the [Jira](https://issues.apache.org/jira/browse/SPARK-24924) and PR #22119, we should make the mapping configurable.

This PR also improve the error message when data source of Avro/Kafka is not found.

## How was this patch tested?

Unit test
