### PR TITLE
[SPARK-25124][ML]VectorSizeHint setSize and getSize don't return values

### DIFF
--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -3843,12 +3843,12 @@ class VectorSizeHint(JavaTransformer, HasInputCol, HasHandleInvalid, JavaMLReada
     @since("2.3.0")
     def getSize(self):
         """ Gets size param, the size of vectors in `inputCol`."""
-        self.getOrDefault(self.size)
+        return self.getOrDefault(self.size)
 
     @since("2.3.0")
     def setSize(self, value):
         """ Sets size param, the size of vectors in `inputCol`."""
-        self._set(size=value)
+        return self._set(size=value)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -844,6 +844,28 @@ class FeatureTests(SparkSessionTestCase):
             .select(model_default.getOrDefault(model_default.outputCol)).collect()
         self.assertEqual(len(transformed_list), 5)
 
+    def test_vector_size_hint(self):
+        df = self.spark.createDataFrame(
+            [(0, Vectors.dense([0.0, 10.0, 0.5])),
+             (1, Vectors.dense([1.0, 11.0, 0.5, 0.6])),
+             (2, Vectors.dense([2.0, 12.0]))],
+            ["id", "vector"])
+
+        sizeHint = VectorSizeHint(
+            inputCol="vector",
+            handleInvalid="skip",
+            size=3)
+
+        assembler = VectorAssembler(
+            inputCols=["id", "vector"],
+            outputCol="features")
+
+        pipeline = Pipeline(stages=[sizeHint, assembler])
+        pipelineModel = pipeline.fit(df)
+        output = pipelineModel.transform(df).head().features
+        expected = DenseVector([0.0, 0.0, 10.0, 0.5])
+        self.assertEqual(output, expected)
+
 
 class HasInducedError(Params):
 

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -853,17 +853,12 @@ class FeatureTests(SparkSessionTestCase):
 
         sizeHint = VectorSizeHint(
             inputCol="vector",
-            handleInvalid="skip",
-            size=3)
+            handleInvalid="skip")
+        sizeHint.setSize(3)
+        self.assertEqual(sizeHint.getSize(), 3)
 
-        assembler = VectorAssembler(
-            inputCols=["id", "vector"],
-            outputCol="features")
-
-        pipeline = Pipeline(stages=[sizeHint, assembler])
-        pipelineModel = pipeline.fit(df)
-        output = pipelineModel.transform(df).head().features
-        expected = DenseVector([0.0, 0.0, 10.0, 0.5])
+        output = sizeHint.transform(df).head().vector
+        expected = DenseVector([0.0, 10.0, 0.5])
         self.assertEqual(output, expected)
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In feature.py, VectorSizeHint setSize and getSize don't return value. Add return. 

## How was this patch tested?

I tested the changes on my local. 
