### PR TITLE
[SPARK-24647][SS] Report KafkaStreamWriter's written min and max offs…

### DIFF
--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaWriterCustomMetricsSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaWriterCustomMetricsSuite.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.kafka010
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.sources.v2.writer.WriterCommitMessage
+
+class KafkaWriterCustomMetricsSuite extends SparkFunSuite {
+
+  test("collate messages") {
+    val minOffset1 = KafkaSourceOffset(("topic1", 1, 2), ("topic1", 2, 3))
+    val maxOffset1 = KafkaSourceOffset(("topic1", 1, 2), ("topic1", 2, 5))
+    val minOffset2 = KafkaSourceOffset(("topic1", 1, 0), ("topic1", 2, 3))
+    val maxOffset2 = KafkaSourceOffset(("topic1", 1, 0), ("topic1", 2, 7))
+    val messages: Array[WriterCommitMessage] = Array(
+      KafkaWriterCommitMessage(minOffset1, maxOffset1),
+      KafkaWriterCommitMessage(minOffset2, maxOffset2))
+    val metrics = KafkaWriterCustomMetrics(messages)
+    assert(metrics.minOffset === KafkaSourceOffset(("topic1", 1, 0), ("topic1", 2, 3)))
+    assert(metrics.maxOffset === KafkaSourceOffset(("topic1", 1, 2), ("topic1", 2, 7)))
+  }
+}


### PR DESCRIPTION
…ets via CustomMetrics.

## What changes were proposed in this pull request?

Report KafkaStreamWriter's written min and max offsets via CustomMetrics. This is important for data lineage projects like Spline. Related issue: https://issues.apache.org/jira/browse/SPARK-24647

To be able to track data lineage for Structured Streaming (I intend to implement this to Open Source Project Spline), the monitoring needs to be able to not only to track where the data was read from but also where results were written to. This could be to my knowledge best implemented using monitoring StreamingQueryProgress. However currently written data offsets are not available on Sink or StreamWriter interface. Implementing as proposed would also bring symmetry to StreamingQueryProgress fields sources and sink.

## How was this patch tested?

Unit tests.

Please review http://spark.apache.org/contributing.html before opening a pull request.
