### PR TITLE
[SPARK-24935][SQL] : Problem with Executing Hive UDF's from Spark 2.2 Onwards

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 /** The mode of an [[AggregateFunction]]. */
@@ -182,6 +183,11 @@ abstract class AggregateFunction extends Expression {
    * These attributes are created automatically by cloning the [[aggBufferAttributes]].
    */
   def inputAggBufferAttributes: Seq[AttributeReference]
+
+  /**
+  * Indicates if this function supports partial aggregation.
+  */
+  def supportsPartial: Boolean = true
 
   /**
    * Result of the aggregate function when the input is empty. This is currently only used for the

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/windowExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/windowExpressions.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.analysis.{TypeCheckResult, UnresolvedExcept
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.{TypeCheckFailure, TypeCheckSuccess}
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateFunction, DeclarativeAggregate, NoOp}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 /**
@@ -466,6 +467,7 @@ abstract class AggregateWindowFunction extends DeclarativeAggregate with WindowF
   override val frame = SpecifiedWindowFrame(RowFrame, UnboundedPreceding, CurrentRow)
   override def dataType: DataType = IntegerType
   override def nullable: Boolean = true
+  override def supportsPartial: Boolean = SQLConf.get.supportPartialAggregationWindowFunctionUDAF
   override lazy val mergeExpressions =
     throw new UnsupportedOperationException("Window Functions do not support merging.")
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -971,6 +971,12 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val SUPPORT_PARTIAL_AGGREGATION = buildConf("spark.sql.execution.supportPartialAggregation")
+    .internal()
+    .doc("Decides whether partial aggregation is supported or not by the UDAF")
+    .booleanConf
+    .createWithDefault(true)
+
   val FILE_SINK_LOG_DELETION = buildConf("spark.sql.streaming.fileSink.log.deletion")
     .internal()
     .doc("Whether to delete the expired log files in file stream sink.")
@@ -1769,6 +1775,8 @@ class SQLConf extends Serializable with Logging {
   def enableTwoLevelAggMap: Boolean = getConf(ENABLE_TWOLEVEL_AGG_MAP)
 
   def useObjectHashAggregation: Boolean = getConf(USE_OBJECT_HASH_AGG)
+
+  def supportPartialAggregation: Boolean = getConf(SUPPORT_PARTIAL_AGGREGATION)
 
   def objectAggSortBasedFallbackThreshold: Int = getConf(OBJECT_AGG_SORT_BASED_FALLBACK_THRESHOLD)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -971,9 +971,17 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
-  val SUPPORT_PARTIAL_AGGREGATION = buildConf("spark.sql.execution.supportPartialAggregation")
+  val SUPPORT_PARTIAL_AGGREGATION_HIVE_UDAF =
+    buildConf("spark.sql.execution.supportPartialAggregationHiveUDAF")
     .internal()
-    .doc("Decides whether partial aggregation is supported or not by the UDAF")
+    .doc("Decides whether partial aggregation is supported or not by the hive UDAF")
+    .booleanConf
+    .createWithDefault(true)
+
+  val SUPPORT_PARTIAL_AGGREGATION_WINDOW_FUNCTION_UDAF =
+    buildConf("spark.sql.execution.supportPartialAggregationWindowFunctionUDAF")
+    .internal()
+    .doc("Decides whether partial aggregation is supported or not by the window function UDAF")
     .booleanConf
     .createWithDefault(true)
 
@@ -1776,7 +1784,10 @@ class SQLConf extends Serializable with Logging {
 
   def useObjectHashAggregation: Boolean = getConf(USE_OBJECT_HASH_AGG)
 
-  def supportPartialAggregation: Boolean = getConf(SUPPORT_PARTIAL_AGGREGATION)
+  def supportPartialAggregationHiveUDAF: Boolean = getConf(SUPPORT_PARTIAL_AGGREGATION_HIVE_UDAF)
+
+  def supportPartialAggregationWindowFunctionUDAF: Boolean =
+    getConf(SUPPORT_PARTIAL_AGGREGATION_WINDOW_FUNCTION_UDAF)
 
   def objectAggSortBasedFallbackThreshold: Int = getConf(OBJECT_AGG_SORT_BASED_FALLBACK_THRESHOLD)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -411,7 +411,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         }
 
         val aggregateOperator =
-          if (!child.conf.supportPartialAggregation) {
+          if (aggregateExpressions.map(_.aggregateFunction).exists(!_.supportsPartial)) {
             if (functionsWithDistinct.nonEmpty) {
               sys.error("Distinct columns cannot exist in Aggregate operator containing " +
                 "aggregate functions which don't support partial aggregation.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -411,7 +411,18 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         }
 
         val aggregateOperator =
-          if (functionsWithDistinct.isEmpty) {
+          if (!child.conf.supportPartialAggregation) {
+            if (functionsWithDistinct.nonEmpty) {
+              sys.error("Distinct columns cannot exist in Aggregate operator containing " +
+                "aggregate functions which don't support partial aggregation.")
+            } else {
+              aggregate.AggUtils.planAggregateWithoutPartial(
+                groupingExpressions,
+                aggregateExpressions,
+                resultExpressions,
+                planLater(child))
+            }
+          } else if (functionsWithDistinct.isEmpty) {
             aggregate.AggUtils.planAggregateWithoutDistinct(
               groupingExpressions,
               aggregateExpressions,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala
@@ -27,6 +27,25 @@ import org.apache.spark.sql.internal.SQLConf
  * Utility functions used by the query planner to convert our plan to new aggregation code path.
  */
 object AggUtils {
+
+  def planAggregateWithoutPartial(
+    groupingExpressions: Seq[NamedExpression],
+    aggregateExpressions: Seq[AggregateExpression],
+    resultExpressions: Seq[NamedExpression],
+    child: SparkPlan): Seq[SparkPlan] = {
+    val completeAggregateExpressions = aggregateExpressions.map(_.copy(mode = Complete))
+    val completeAggregateAttributes = completeAggregateExpressions.map(_.resultAttribute)
+    SortAggregateExec(
+      requiredChildDistributionExpressions = Some(groupingExpressions),
+      groupingExpressions = groupingExpressions,
+      aggregateExpressions = completeAggregateExpressions,
+      aggregateAttributes = completeAggregateAttributes,
+      initialInputBufferOffset = 0,
+      resultExpressions = resultExpressions,
+      child = child
+    ) :: Nil
+  }
+
   private def createAggregate(
       requiredChildDistributionExpressions: Option[Seq[Expression]] = None,
       groupingExpressions: Seq[NamedExpression] = Nil,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.hive.HiveShim._
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 
@@ -390,6 +391,8 @@ private[hive] case class HiveUDAFFunction(
   private lazy val aggBufferSerDe: AggregationBufferSerDe = new AggregationBufferSerDe
 
   override def nullable: Boolean = true
+
+  override def supportsPartial: Boolean = SQLConf.get.supportPartialAggregationHiveUDAF
 
   override lazy val dataType: DataType = inspectorToDataType(returnInspector)
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/TestingTypedCount.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/TestingTypedCount.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{ImperativeAggregate, TypedImperativeAggregate}
 import org.apache.spark.sql.hive.execution.TestingTypedCount.State
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 @ExpressionDescription(
@@ -41,6 +42,8 @@ case class TestingTypedCount(
   override def dataType: DataType = LongType
 
   override def nullable: Boolean = false
+
+  override val supportsPartial: Boolean = true
 
   override def createAggregationBuffer(): State = TestingTypedCount.State(0L)
 


### PR DESCRIPTION
A user of sketches library(https://github.com/DataSketches/sketches-hive) reported an issue with HLL Sketch Hive UDAF that seems to be a bug in Spark or Hive. Their code runs fine in 2.1 but has an issue from 2.2 onwards. For more details on the issue, you can refer to the discussion in the sketches-user list:
https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/sketches-user/GmH4-OlHP9g/MW-J7Hg4BwAJ

 
On further debugging, we figured out that from 2.2 onwards, Spark hive UDAF provides support for partial aggregation, and has removed the functionality that supported complete mode aggregation(Refer https://issues.apache.org/jira/browse/SPARK-19060 and https://issues.apache.org/jira/browse/SPARK-18186). Thus, instead of expecting update method to be called, merge method is called here (https://github.com/DataSketches/sketches-hive/blob/master/src/main/java/com/yahoo/sketches/hive/hll/SketchEvaluator.java#L56) which throws the exception as described in the forums above.

## What changes were proposed in this pull request?

Added two new configs, **spark.sql.execution.supportPartialAggregationHiveUDAF** and **spark.sql.execution.supportPartialAggregationWindowFunctionUDAF** that is true by default but can be set to false when using UDAF's which do not support partial aggregation.

## How was this patch tested?

The steps to reproduce the above issue have been stated in the google group link posted above but will repeat them here for convenience:
**1. Download the following three jars from the maven repository in https://datasketches.github.io/docs/downloads.html.**
 -sketches-core
 -sketches-hive
 -memory

**2. Launch spark-shell by adding the above jars in the driver as well as executor classpath and run the following commands:**
scala> def randId=scala.util.Random.nextInt(10000)+1

scala> def randomStringFromCharList(length: Int, chars: Seq[Char]): String = {
     |     val sb = new StringBuilder
     |     for (i <- 1 to length) {
     |       val randomNum = util.Random.nextInt(chars.length)
     |       sb.append(chars(randomNum))
     |     }
     |     sb.toString
     |   }

scala> def randomAlphaNumericString(length: Int): String = {
     |     val chars = ('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9')
     |     randomStringFromCharList(length, chars)
     |   }


scala> val df = sc.parallelize(
     | Seq.fill(1000000){(randId,randomAlphaNumericString(64))}
     | ).toDF("id","value")

scala> spark.sql("CREATE TEMPORARY FUNCTION data2sketch AS 'com.yahoo.sketches.hive.hll.DataToSketchUDAF'")

scala> val nDf=df.groupBy("id").agg(expr("data2sketch(value, 21, 'HLL_4') as hll")).select(col("id"),col("hll"))
nDf: org.apache.spark.sql.DataFrame = [id: int, hll: binary]

scala> nDf.show(10,false)


**3. You will see the following exception below:**

[Stage 0:>                                                          (0 + 2) / 2]18/08/19 00:47:24 WARN TaskSetManager: Lost task 0.0 in stage 0.0 (TID 0, gsrd259n31.red.ygrid.yahoo.com, executor 2): java.lang.ClassCastException: com.yahoo.sketches.hive.hll.SketchState cannot be cast to com.yahoo.sketches.hive.hll.UnionState
	at com.yahoo.sketches.hive.hll.SketchEvaluator.merge(SketchEvaluator.java:56)
	at com.yahoo.sketches.hive.hll.DataToSketchUDAF$DataToSketchEvaluator.merge(DataToSketchUDAF.java:100)
	at org.apache.spark.sql.hive.HiveUDAFFunction.merge(hiveUDFs.scala:420)
	at org.apache.spark.sql.hive.HiveUDAFFunction.merge(hiveUDFs.scala:307)
	at org.apache.spark.sql.catalyst.expressions.aggregate.TypedImperativeAggregate.merge(interfaces.scala:541)
	at org.apache.spark.sql.execution.aggregate.AggregationIterator$$anonfun$1$$anonfun$applyOrElse$2.apply(AggregationIterator.scala:174)
	at org.apache.spark.sql.execution.aggregate.AggregationIterator$$anonfun$1$$anonfun$applyOrElse$2.apply(AggregationIterator.scala:174)
	at org.apache.spark.sql.execution.aggregate.AggregationIterator$$anonfun$generateProcessRow$1.apply(AggregationIterator.scala:188)
	at org.apache.spark.sql.execution.aggregate.AggregationIterator$$anonfun$generateProcessRow$1.apply(AggregationIterator.scala:182)
	at org.apache.spark.sql.execution.aggregate.SortBasedAggregator$$anon$1.findNextSortedGroup(ObjectAggregationIterator.scala:275)
	at org.apache.spark.sql.execution.aggregate.SortBasedAggregator$$anon$1.hasNext(ObjectAggregationIterator.scala:247)
	at org.apache.spark.sql.execution.aggregate.ObjectAggregationIterator.hasNext(ObjectAggregationIterator.scala:81)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:409)
	at org.apache.spark.shuffle.sort.BypassMergeSortShuffleWriter.write(BypassMergeSortShuffleWriter.java:148)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:96)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:53)
	at org.apache.spark.scheduler.Task.run(Task.scala:109)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:367)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)

**4. Run the same bunch of commands by setting --conf spark.sql.execution.supportPartialAggregationHiveUDAF=false and check that the code works.**