### PR TITLE
[SPARK-23711][SPARK-25140][SQL] Catch correct exceptions when expr codegen fails

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CodeGeneratorWithInterpretedFallback.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CodeGeneratorWithInterpretedFallback.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
+import scala.util.control.NonFatal
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.Utils
@@ -49,7 +51,7 @@ abstract class CodeGeneratorWithInterpretedFallback[IN, OUT] extends Logging {
         try {
           createCodeGeneratedObject(in)
         } catch {
-          case _: Exception =>
+          case NonFatal(_) =>
             // We should have already seen the error message in `CodeGenerator`
             logWarning("Expr codegen error and falling back to interpreter mode")
             createInterpretedObject(in)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CodeGeneratorWithInterpretedFallback.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CodeGeneratorWithInterpretedFallback.scala
@@ -51,7 +51,7 @@ abstract class CodeGeneratorWithInterpretedFallback[IN, OUT] extends Logging {
         } catch {
           case _: Exception =>
             // We should have already see error message in `CodeGenerator`
-            logError("Expr codegen disabled and falls back to the interpreter mode")
+            logWarning("Expr codegen error and falls back to interpreter mode")
             createInterpretedObject(in)
         }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CodeGeneratorWithInterpretedFallback.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CodeGeneratorWithInterpretedFallback.scala
@@ -50,8 +50,8 @@ abstract class CodeGeneratorWithInterpretedFallback[IN, OUT] extends Logging {
           createCodeGeneratedObject(in)
         } catch {
           case _: Exception =>
-            // We should have already see error message in `CodeGenerator`
-            logWarning("Expr codegen error and falls back to interpreter mode")
+            // We should have already seen the error message in `CodeGenerator`
+            logWarning("Expr codegen error and falling back to interpreter mode")
             createInterpretedObject(in)
         }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Projection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Projection.scala
@@ -182,7 +182,7 @@ object UnsafeProjection
     } catch {
       case _: Exception =>
         // We should have already see error message in `CodeGenerator`
-        logError("Expr codegen error and falls back to interpreter mode")
+        logWarning("Expr codegen error and falls back to interpreter mode")
         InterpretedUnsafeProjection.createProjection(unsafeExprs)
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Projection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Projection.scala
@@ -180,7 +180,10 @@ object UnsafeProjection
     try {
       GenerateUnsafeProjection.generate(unsafeExprs, subexpressionEliminationEnabled)
     } catch {
-      case CodegenError(_) => InterpretedUnsafeProjection.createProjection(unsafeExprs)
+      case _: Exception =>
+        // We should have already see error message in `CodeGenerator`
+        logError("Expr codegen disabled and falls back to the interpreter mode")
+        InterpretedUnsafeProjection.createProjection(unsafeExprs)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Projection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Projection.scala
@@ -182,7 +182,7 @@ object UnsafeProjection
     } catch {
       case _: Exception =>
         // We should have already see error message in `CodeGenerator`
-        logError("Expr codegen disabled and falls back to the interpreter mode")
+        logError("Expr codegen error and falls back to interpreter mode")
         InterpretedUnsafeProjection.createProjection(unsafeExprs)
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Projection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Projection.scala
@@ -181,8 +181,8 @@ object UnsafeProjection
       GenerateUnsafeProjection.generate(unsafeExprs, subexpressionEliminationEnabled)
     } catch {
       case _: Exception =>
-        // We should have already see error message in `CodeGenerator`
-        logWarning("Expr codegen error and falls back to interpreter mode")
+        // We should have already seen the error message in `CodeGenerator`
+        logWarning("Expr codegen error and falling back to interpreter mode")
         InterpretedUnsafeProjection.createProjection(unsafeExprs)
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Projection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Projection.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
+import scala.util.control.NonFatal
+
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.{GenerateSafeProjection, GenerateUnsafeProjection}
 import org.apache.spark.sql.types.{DataType, StructType}
@@ -180,7 +182,7 @@ object UnsafeProjection
     try {
       GenerateUnsafeProjection.generate(unsafeExprs, subexpressionEliminationEnabled)
     } catch {
-      case _: Exception =>
+      case NonFatal(_) =>
         // We should have already seen the error message in `CodeGenerator`
         logWarning("Expr codegen error and falling back to interpreter mode")
         InterpretedUnsafeProjection.createProjection(unsafeExprs)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGeneratorWithInterpretedFallbackSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGeneratorWithInterpretedFallbackSuite.scala
@@ -17,11 +17,13 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
+import java.util.concurrent.ExecutionException
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodeAndComment, CodeGenerator}
 import org.apache.spark.sql.catalyst.plans.PlanTestBase
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{IntegerType, LongType}
+import org.apache.spark.sql.types.IntegerType
 
 class CodeGeneratorWithInterpretedFallbackSuite extends SparkFunSuite with PlanTestBase {
 
@@ -41,9 +43,7 @@ class CodeGeneratorWithInterpretedFallbackSuite extends SparkFunSuite with PlanT
   }
 
   test("UnsafeProjection with codegen factory mode") {
-    val input = Seq(IntegerType).zipWithIndex.map { case (tpe, ordinal) =>
-      BoundReference(ordinal, tpe, nullable = true)
-    }
+    val input = Seq(BoundReference(0, IntegerType, nullable = true))
     val codegenOnly = CodegenObjectFactoryMode.CODEGEN_ONLY.toString
     withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key -> codegenOnly) {
       val obj = UnsafeProjection.createObject(input)
@@ -64,5 +64,16 @@ class CodeGeneratorWithInterpretedFallbackSuite extends SparkFunSuite with PlanT
       val obj = FailedCodegenProjection.createObject(input)
       assert(obj.isInstanceOf[InterpretedUnsafeProjection])
     }
+  }
+
+  test("codegen failures in the CODEGEN_ONLY mode") {
+    val errMsg = intercept[ExecutionException] {
+      val input = Seq(BoundReference(0, IntegerType, nullable = true))
+      val codegenOnly = CodegenObjectFactoryMode.CODEGEN_ONLY.toString
+      withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key -> codegenOnly) {
+        FailedCodegenProjection.createObject(input)
+      }
+    }.getMessage
+    assert(errMsg.contains("failed to compile: org.codehaus.commons.compiler.CompileException:"))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -21,6 +21,7 @@ import java.util.Locale
 import java.util.function.Supplier
 
 import scala.collection.mutable
+import scala.util.control.NonFatal
 
 import org.apache.spark.broadcast
 import org.apache.spark.rdd.RDD
@@ -582,7 +583,7 @@ case class WholeStageCodegenExec(child: SparkPlan)(val codegenStageId: Int)
     val (_, maxCodeSize) = try {
       CodeGenerator.compile(cleanedSource)
     } catch {
-      case _: Exception if !Utils.isTesting && sqlContext.conf.codegenFallback =>
+      case NonFatal(_) if !Utils.isTesting && sqlContext.conf.codegenFallback =>
         // We should already saw the error message
         logWarning(s"Whole-stage codegen disabled for plan (id=$codegenStageId):\n $treeString")
         return child.execute()


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr is to fix bugs when expr codegen fails; we need to catch `java.util.concurrent.ExecutionException` instead of `InternalCompilerException` and `CompileException` . This handling is the same with the `WholeStageCodegenExec ` one: https://github.com/apache/spark/blob/60af2501e1afc00192c779f2736a4e3de12428fa/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala#L585

## How was this patch tested?
Added tests in `CodeGeneratorWithInterpretedFallbackSuite`
