### PR TITLE
[SPARK-25166][CORE]Reduce the number of write operations for shuffle write.

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockObjectWriter.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockObjectWriter.scala
@@ -265,6 +265,19 @@ private[spark] class DiskBlockObjectWriter(
   }
 
   /**
+   * Notify the writer that n record(s) worth of bytes has been written with OutputStream#write.
+   */
+  def recordWritten(n: Int): Unit = {
+    val preNumRecordsWritten = numRecordsWritten
+    numRecordsWritten += n
+    writeMetrics.incRecordsWritten(n)
+
+    if (numRecordsWritten / 16384 != preNumRecordsWritten / 16384) {
+      updateBytesWritten()
+    }
+  }
+
+  /**
    * Report the number of bytes written in this writer's shuffle write metrics.
    * Note that this is only valid before the underlying streams are closed.
    */


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, only one record is written to a buffer each time, which increases the number of copies.
I think we should write as many records as possible each time.

## How was this patch tested?
Existed  unit tests in `UnsafeShuffleWriterSuite`
