### PR TITLE
[SPARK-25017][Core] Add test suite for ContextBarrierState

### DIFF
--- a/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
@@ -101,7 +101,7 @@ private[spark] class BarrierCoordinator(
     // There may be multiple barrier() calls from a barrier stage attempt, `barrierEpoch` is used
     // to identify each barrier() call. It shall get increased when a barrier() call succeeds, or
     // reset when a barrier() call fails due to timeout.
-    private[spark] var barrierEpoch: Int = 0
+    private var barrierEpoch: Int = 0
 
     // An array of RPCCallContexts for barrier tasks that are waiting for reply of a barrier()
     // call.
@@ -194,6 +194,9 @@ private[spark] class BarrierCoordinator(
 
     // Check for clearing internal data, visible for test only.
     private[spark] def cleanCheck(): Boolean = requesters.isEmpty && timerTask == null
+
+    // Get currently barrier epoch, visible for test only.
+    private[spark] def getBarrierEpoch(): Int = barrierEpoch
   }
 
   // Clean up the [[ContextBarrierState]] that correspond to a specific stage attempt.

--- a/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
@@ -192,8 +192,8 @@ private[spark] class BarrierCoordinator(
       cancelTimerTask()
     }
 
-    // Check for clearing internal data, visible for test only.
-    private[spark] def cleanCheck(): Boolean = requesters.isEmpty && timerTask == null
+    // Check for internal state clear, visible for test only.
+    private[spark] def isInternalStateClear(): Boolean = requesters.isEmpty && timerTask == null
 
     // Get currently barrier epoch, visible for test only.
     private[spark] def getBarrierEpoch(): Int = barrierEpoch

--- a/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
@@ -145,7 +145,7 @@ private[spark] class BarrierCoordinator(
       logInfo(s"Current barrier epoch for $barrierId is $barrierEpoch.")
       if (epoch != barrierEpoch) {
         requester.sendFailure(new SparkException(s"The request to sync of $barrierId with " +
-          s"barrier epoch $barrierEpoch has already finished. Maybe task $taskId is not " +
+          s"barrier epoch $epoch has already finished. Maybe task $taskId is not " +
           "properly killed."))
       } else {
         // If this is the first sync message received for a barrier() call, start timer to ensure

--- a/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
@@ -32,7 +32,7 @@ import org.apache.spark.scheduler.{LiveListenerBus, SparkListener, SparkListener
  * we can use (stageId, stageAttemptId) to identify the stage attempt where the barrier() call is
  * from.
  */
-private case class ContextBarrierId(stageId: Int, stageAttemptId: Int) {
+private[spark] case class ContextBarrierId(stageId: Int, stageAttemptId: Int) {
   override def toString: String = s"Stage $stageId (Attempt $stageAttemptId)"
 }
 
@@ -63,13 +63,9 @@ private[spark] class BarrierCoordinator(
     }
   }
 
-  /**
-   * Record all active stage attempts that make barrier() call(s), and the corresponding internal
-   * state.
-   *
-   * Visible for testing.
-   */
-  private[spark] val states = new ConcurrentHashMap[ContextBarrierId, ContextBarrierState]
+  // Record all active stage attempts that make barrier() call(s), and the corresponding internal
+  // state.
+  private val states = new ConcurrentHashMap[ContextBarrierId, ContextBarrierState]
 
   override def onStart(): Unit = {
     super.onStart()
@@ -225,7 +221,7 @@ private[spark] class BarrierCoordinator(
   }
 }
 
-private[spark] sealed trait BarrierCoordinatorMessage extends Serializable
+private sealed trait BarrierCoordinatorMessage extends Serializable
 
 /**
  * A global sync request message from BarrierTaskContext, by `barrier()` call. Each request is

--- a/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
@@ -63,8 +63,12 @@ private[spark] class BarrierCoordinator(
     }
   }
 
-  // Record all active stage attempts that make barrier() call(s), and the corresponding internal
-  // state.
+  /**
+   * Record all active stage attempts that make barrier() call(s), and the corresponding internal
+   * state.
+   *
+   * Visible for testing.
+   */
   private[spark] val states = new ConcurrentHashMap[ContextBarrierId, ContextBarrierState]
 
   override def onStart(): Unit = {
@@ -84,7 +88,7 @@ private[spark] class BarrierCoordinator(
 
   /**
    * Provide the current state of a barrier() call. A state is created when a new stage attempt
-   * sends out a barrier() call, and recycled on stage completed.
+   * sends out a barrier() call, and recycled on stage completed. Visible for testing.
    *
    * @param barrierId Identifier of the barrier stage that make a barrier() call.
    * @param numTasks Number of tasks of the barrier stage, all barrier() calls from the stage shall
@@ -187,6 +191,9 @@ private[spark] class BarrierCoordinator(
       requesters.clear()
       cancelTimerTask()
     }
+
+    // Check for clearing internal data, visible for test only.
+    private[spark] def cleanCheck(): Boolean = requesters.isEmpty && timerTask == null
   }
 
   // Clean up the [[ContextBarrierState]] that correspond to a specific stage attempt.

--- a/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
@@ -65,7 +65,7 @@ private[spark] class BarrierCoordinator(
 
   // Record all active stage attempts that make barrier() call(s), and the corresponding internal
   // state.
-  private val states = new ConcurrentHashMap[ContextBarrierId, ContextBarrierState]
+  private[spark] val states = new ConcurrentHashMap[ContextBarrierId, ContextBarrierState]
 
   override def onStart(): Unit = {
     super.onStart()
@@ -90,14 +90,14 @@ private[spark] class BarrierCoordinator(
    * @param numTasks Number of tasks of the barrier stage, all barrier() calls from the stage shall
    *                 collect `numTasks` requests to succeed.
    */
-  private class ContextBarrierState(
+  private[spark] class ContextBarrierState(
       val barrierId: ContextBarrierId,
       val numTasks: Int) {
 
     // There may be multiple barrier() calls from a barrier stage attempt, `barrierEpoch` is used
     // to identify each barrier() call. It shall get increased when a barrier() call succeeds, or
     // reset when a barrier() call fails due to timeout.
-    private var barrierEpoch: Int = 0
+    private[spark] var barrierEpoch: Int = 0
 
     // An array of RPCCallContexts for barrier tasks that are waiting for reply of a barrier()
     // call.

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierCoordinatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierCoordinatorSuite.scala
@@ -53,7 +53,7 @@ class BarrierCoordinatorSuite extends SparkFunSuite with LocalSparkContext with 
     eventually(timeout(10.seconds)) {
       // Ensure barrierEpoch value have been changed.
       val barrierState = getBarrierState(stageId, stageAttemptNumber, barrierCoordinator)
-      assert(barrierState.barrierEpoch == 1)
+      assert(barrierState.getBarrierEpoch() == 1)
       assert(barrierState.cleanCheck())
     }
   }
@@ -81,7 +81,7 @@ class BarrierCoordinatorSuite extends SparkFunSuite with LocalSparkContext with 
     eventually(timeout(10.seconds)) {
       // Ensure barrierEpoch value have been changed.
       val barrierState = getBarrierState(stageId, stageAttemptNumber, barrierCoordinator)
-      assert(barrierState.barrierEpoch == 1)
+      assert(barrierState.getBarrierEpoch() == 1)
       assert(barrierState.cleanCheck())
     }
   }
@@ -124,7 +124,7 @@ class BarrierCoordinatorSuite extends SparkFunSuite with LocalSparkContext with 
     eventually(timeout(10.seconds)) {
       // Ensure barrierEpoch value have been changed.
       val barrierState = getBarrierState(stageId, stageAttemptNumber, barrierCoordinator)
-      assert(barrierState.barrierEpoch == 1)
+      assert(barrierState.getBarrierEpoch() == 1)
       assert(barrierState.cleanCheck())
     }
     intercept[SparkException](

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierCoordinatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierCoordinatorSuite.scala
@@ -63,7 +63,7 @@ class BarrierCoordinatorSuite extends SparkFunSuite with LocalSparkContext with 
     // Ensure barrierEpoch value have been changed.
     val barrierState = getBarrierState(stageId, stageAttemptNumber, barrierCoordinator)
     assert(barrierState.getBarrierEpoch() == 1)
-    assert(barrierState.cleanCheck())
+    assert(barrierState.isInternalStateClear())
   }
 
   test("normal test for multi tasks") {
@@ -85,7 +85,7 @@ class BarrierCoordinatorSuite extends SparkFunSuite with LocalSparkContext with 
     // Ensure barrierEpoch value have been changed.
     val barrierState = getBarrierState(stageId, stageAttemptNumber, barrierCoordinator)
     assert(barrierState.getBarrierEpoch() == 1)
-    assert(barrierState.cleanCheck())
+    assert(barrierState.isInternalStateClear())
   }
 
   test("abnormal test for syncing with illegal barrierId") {
@@ -133,7 +133,7 @@ class BarrierCoordinatorSuite extends SparkFunSuite with LocalSparkContext with 
     // Ensure barrierEpoch value have been changed.
     val barrierState = getBarrierState(stageId, stageAttemptNumber, barrierCoordinator)
     assert(barrierState.getBarrierEpoch() == 1)
-    assert(barrierState.cleanCheck())
+    assert(barrierState.isInternalStateClear())
     barrierCoordinator.receiveAndReply(rpcCallContext)(
       RequestToSync(
         numTasks,

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierCoordinatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierCoordinatorSuite.scala
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler
+
+import java.util.concurrent.TimeoutException
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+import org.apache.spark._
+import org.apache.spark.rpc.RpcTimeout
+
+class BarrierCoordinatorSuite extends SparkFunSuite with LocalSparkContext {
+
+  /**
+   * Get the current barrierEpoch from barrierCoordinator.states by ContextBarrierId
+   */
+  def getCurrentBarrierEpoch(
+      stageId: Int, stageAttemptId: Int, barrierCoordinator: BarrierCoordinator): Int = {
+    val barrierId = ContextBarrierId(stageId, stageAttemptId)
+    barrierCoordinator.states.get(barrierId).barrierEpoch
+  }
+
+  test("normal test for single task") {
+    sc = new SparkContext("local", "test")
+    val barrierCoordinator = new BarrierCoordinator(5, sc.listenerBus, sc.env.rpcEnv)
+    val rpcEndpointRef = sc.env.rpcEnv.setupEndpoint("barrierCoordinator", barrierCoordinator)
+    val stageId = 0
+    val stageAttemptNumber = 0
+    rpcEndpointRef.askSync[Unit](
+      message = RequestToSync(numTasks = 1, stageId, stageAttemptNumber, taskAttemptId = 0,
+        barrierEpoch = 0),
+      timeout = new RpcTimeout(5 seconds, "rpcTimeOut"))
+    // sleep for waiting barrierEpoch value change
+    Thread.sleep(500)
+    assert(getCurrentBarrierEpoch(stageId, stageAttemptNumber, barrierCoordinator) == 1)
+  }
+
+  test("normal test for multi tasks") {
+    sc = new SparkContext("local", "test")
+    val barrierCoordinator = new BarrierCoordinator(5, sc.listenerBus, sc.env.rpcEnv)
+    val rpcEndpointRef = sc.env.rpcEnv.setupEndpoint("barrierCoordinator", barrierCoordinator)
+    val numTasks = 3
+    val stageId = 0
+    val stageAttemptNumber = 0
+    val rpcTimeOut = new RpcTimeout(5 seconds, "rpcTimeOut")
+    // sync request from 3 tasks
+    (0 until numTasks).foreach { taskId =>
+      new Thread(s"task-$taskId-thread") {
+        setDaemon(true)
+        override def run(): Unit = {
+          rpcEndpointRef.askSync[Unit](
+            message = RequestToSync(numTasks, stageId, stageAttemptNumber, taskAttemptId = taskId,
+              barrierEpoch = 0),
+            timeout = rpcTimeOut)
+        }
+      }.start()
+    }
+    // sleep for waiting barrierEpoch value change
+    Thread.sleep(500)
+    assert(getCurrentBarrierEpoch(stageId, stageAttemptNumber, barrierCoordinator) == 1)
+  }
+
+  test("abnormal test for syncing with illegal barrierId") {
+    sc = new SparkContext("local", "test")
+    val barrierCoordinator = new BarrierCoordinator(5, sc.listenerBus, sc.env.rpcEnv)
+    val rpcEndpointRef = sc.env.rpcEnv.setupEndpoint("barrierCoordinator", barrierCoordinator)
+    val numTasks = 3
+    val stageId = 0
+    val stageAttemptNumber = 0
+    val rpcTimeOut = new RpcTimeout(5 seconds, "rpcTimeOut")
+    intercept[SparkException](
+      rpcEndpointRef.askSync[Unit](
+        message = RequestToSync(numTasks, stageId, stageAttemptNumber, taskAttemptId = 0,
+          barrierEpoch = -1), // illegal barrierId = -1
+        timeout = rpcTimeOut))
+  }
+
+  test("abnormal test for syncing with old barrierId") {
+    sc = new SparkContext("local", "test")
+    val barrierCoordinator = new BarrierCoordinator(5, sc.listenerBus, sc.env.rpcEnv)
+    val rpcEndpointRef = sc.env.rpcEnv.setupEndpoint("barrierCoordinator", barrierCoordinator)
+    val numTasks = 3
+    val stageId = 0
+    val stageAttemptNumber = 0
+    val rpcTimeOut = new RpcTimeout(5 seconds, "rpcTimeOut")
+    // sync request from 3 tasks
+    (0 until numTasks).foreach { taskId =>
+      new Thread(s"task-$taskId-thread") {
+        setDaemon(true)
+        override def run(): Unit = {
+          rpcEndpointRef.askSync[Unit](
+            message = RequestToSync(numTasks, stageId, stageAttemptNumber, taskAttemptId = taskId,
+              barrierEpoch = 0),
+            timeout = rpcTimeOut)
+        }
+      }.start()
+    }
+    // sleep for waiting barrierEpoch value change
+    Thread.sleep(500)
+    assert(getCurrentBarrierEpoch(stageId, stageAttemptNumber, barrierCoordinator) == 1)
+    intercept[SparkException](
+      rpcEndpointRef.askSync[Unit](
+        message = RequestToSync(numTasks, stageId, stageAttemptNumber, taskAttemptId = 0,
+        barrierEpoch = 0),
+        timeout = rpcTimeOut))
+  }
+
+  test("abnormal test for timeout when rpcTimeOut < barrierTimeOut") {
+    sc = new SparkContext("local", "test")
+    val barrierCoordinator = new BarrierCoordinator(2, sc.listenerBus, sc.env.rpcEnv)
+    val rpcEndpointRef = sc.env.rpcEnv.setupEndpoint("barrierCoordinator", barrierCoordinator)
+    val numTasks = 3
+    val stageId = 0
+    val stageAttemptNumber = 0
+    val rpcTimeOut = new RpcTimeout(1 seconds, "rpcTimeOut")
+    intercept[TimeoutException](
+      rpcEndpointRef.askSync[Unit](
+        message = RequestToSync(numTasks, stageId, stageAttemptNumber, taskAttemptId = 0,
+          barrierEpoch = 0),
+        timeout = rpcTimeOut))
+  }
+
+  test("abnormal test for timeout when rpcTimeOut > barrierTimeOut") {
+    sc = new SparkContext("local", "test")
+    val barrierCoordinator = new BarrierCoordinator(2, sc.listenerBus, sc.env.rpcEnv)
+    val rpcEndpointRef = sc.env.rpcEnv.setupEndpoint("barrierCoordinator", barrierCoordinator)
+    val numTasks = 3
+    val stageId = 0
+    val stageAttemptNumber = 0
+    val rpcTimeOut = new RpcTimeout(4 seconds, "rpcTimeOut")
+    intercept[SparkException](
+      rpcEndpointRef.askSync[Unit](
+        message = RequestToSync(numTasks, stageId, stageAttemptNumber, taskAttemptId = 0,
+          barrierEpoch = 0),
+        timeout = rpcTimeOut))
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently `ContextBarrierState` is only covered by end-to-end test in `BarrierTaskContextSuite`, add BarrierCoordinatorSuite to test both classes.

## How was this patch tested?

UT newly added in ContextBarrierStateSuite.
