### PR TITLE
[SPARK-24355] Spark external shuffle server improvement to better handle block fetch requests.

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
@@ -103,11 +103,10 @@ public class TransportContext {
    * @param conf TransportConf
    * @param rpcHandler RpcHandler responsible for handling requests and responses.
    * @param closeIdleConnections Close idle connections if it is set to true.
-   * @param isClientOnly This config is more important when external shuffle is enabled.
+   * @param isClientOnly This config indicates the TransportContext is only used by a client.
+   *                     This config is more important when external shuffle is enabled.
    *                     It stops creating extra event loop and subsequent thread pool
    *                     for shuffle clients to handle chunked fetch requests.
-   *                     In the case when external shuffle is disabled, the executors are both
-   *                     client and server so both share the same event loop which is trivial.
    */
   public TransportContext(
       TransportConf conf,

--- a/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
@@ -101,7 +101,8 @@ public class TransportContext {
     synchronized(TransportContext.class) {
       if (chunkFetchWorkers == null &&
           conf.getModuleName() != null &&
-          conf.getModuleName().equalsIgnoreCase("shuffle")) {
+          conf.getModuleName().equalsIgnoreCase("shuffle") &&
+          !conf.shuffleClient()) {
         chunkFetchWorkers = NettyUtils.createEventLoop(
             IOMode.valueOf(conf.ioMode()),
             conf.chunkFetchHandlerThreads(),
@@ -176,7 +177,9 @@ public class TransportContext {
         // would require more logic to guarantee if this were not part of the same event loop.
         .addLast("handler", channelHandler);
       // Use a separate EventLoopGroup to handle ChunkFetchRequest messages for shuffle rpcs.
-      if (conf.getModuleName() != null && conf.getModuleName().equalsIgnoreCase("shuffle")) {
+      if (conf.getModuleName() != null &&
+          conf.getModuleName().equalsIgnoreCase("shuffle")
+          && !conf.shuffleClient()) {
         pipeline.addLast(chunkFetchWorkers, "chunkFetchHandler", chunkFetchHandler);
       }
       return channelHandler;

--- a/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
@@ -98,17 +98,17 @@ public class TransportContext {
     this(conf, rpcHandler, closeIdleConnections, false);
   }
 
-    /**
-     *
-     * @param conf TransportConf
-     * @param rpcHandler RpcHandler responsible for handling requests and responses.
-     * @param closeIdleConnections Close idle connections if it is set to true.
-     * @param isClientOnly This config is more important when external shuffle is enabled.
-     *                     It stops creating extra event loop and subsequent thread pool
-     *                     for shuffle clients to handle chunked fetch requests.
-     *                     In the case when external shuffle is disabled, the executors are both
-     *                     client and server so both share the same event loop which is trivial.
-     */
+  /**
+   *
+   * @param conf TransportConf
+   * @param rpcHandler RpcHandler responsible for handling requests and responses.
+   * @param closeIdleConnections Close idle connections if it is set to true.
+   * @param isClientOnly This config is more important when external shuffle is enabled.
+   *                     It stops creating extra event loop and subsequent thread pool
+   *                     for shuffle clients to handle chunked fetch requests.
+   *                     In the case when external shuffle is disabled, the executors are both
+   *                     client and server so both share the same event loop which is trivial.
+   */
   public TransportContext(
       TransportConf conf,
       RpcHandler rpcHandler,

--- a/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
@@ -102,7 +102,7 @@ public class TransportContext {
      *
      * @param conf TransportConf
      * @param rpcHandler RpcHandler responsible for handling requests and responses.
-     * @param closeIdleConnections Close idle connections if is set to true.
+     * @param closeIdleConnections Close idle connections if it is set to true.
      * @param isClientOnly This config is more important when external shuffle is enabled.
      *                     It stops creating extra event loop and subsequent thread pool
      *                     for shuffle clients to handle chunked fetch requests.

--- a/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
@@ -99,6 +99,7 @@ public class TransportContext {
   }
 
   /**
+   * Enables TransportContext initialization for underlying client and server.
    *
    * @param conf TransportConf
    * @param rpcHandler RpcHandler responsible for handling requests and responses.

--- a/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
@@ -219,7 +219,7 @@ public class TransportContext {
   private ChunkFetchRequestHandler createChunkFetchHandler(TransportChannelHandler channelHandler,
       RpcHandler rpcHandler) {
     return new ChunkFetchRequestHandler(channelHandler.getClient(),
-        rpcHandler.getStreamManager(), conf.maxChunksBeingTransferred());
+      rpcHandler.getStreamManager(), conf.maxChunksBeingTransferred());
   }
 
   public TransportConf getConf() { return conf; }

--- a/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
@@ -99,7 +99,8 @@ public class TransportContext {
     this.closeIdleConnections = closeIdleConnections;
 
     synchronized(this.getClass()) {
-      if (chunkFetchWorkers == null && conf.getModuleName().equalsIgnoreCase("shuffle")) {
+      if (chunkFetchWorkers == null && conf.getModuleName() != null &&
+              conf.getModuleName().equalsIgnoreCase("shuffle")) {
         chunkFetchWorkers = NettyUtils.createEventLoop(
             IOMode.valueOf(conf.ioMode()),
             conf.chunkFetchHandlerThreads(),
@@ -172,7 +173,7 @@ public class TransportContext {
         // would require more logic to guarantee if this were not part of the same event loop.
         .addLast("handler", channelHandler);
       // Use a separate EventLoopGroup to handle ChunkFetchRequest messages for shuffle rpcs.
-      if (conf.getModuleName().equalsIgnoreCase("shuffle")) {
+      if (conf.getModuleName() != null && conf.getModuleName().equalsIgnoreCase("shuffle")) {
         pipeline.addLast(chunkFetchWorkers, "chunkFetchHandler", chunkFetchHandler);
       }
       return channelHandler;

--- a/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
@@ -163,12 +163,14 @@ public class TransportContext {
       RpcHandler channelRpcHandler) {
     try {
       TransportChannelHandler channelHandler = createChannelHandler(channel, channelRpcHandler);
-      ChunkFetchRequestHandler chunkFetchHandler = createChunkFetchHandler(channelHandler, channelRpcHandler);
+      ChunkFetchRequestHandler chunkFetchHandler =
+              createChunkFetchHandler(channelHandler, channelRpcHandler);
       ChannelPipeline pipeline = channel.pipeline()
         .addLast("encoder", ENCODER)
         .addLast(TransportFrameDecoder.HANDLER_NAME, NettyUtils.createFrameDecoder())
         .addLast("decoder", DECODER)
-        .addLast("idleStateHandler", new IdleStateHandler(0, 0, conf.connectionTimeoutMs() / 1000))
+        .addLast("idleStateHandler",
+                new IdleStateHandler(0, 0, conf.connectionTimeoutMs() / 1000))
         // NOTE: Chunks are currently guaranteed to be returned in the order of request, but this
         // would require more logic to guarantee if this were not part of the same event loop.
         .addLast("handler", channelHandler);

--- a/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.server;
+
+import java.net.SocketAddress;
+
+import com.google.common.base.Throwables;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.spark.network.buffer.ManagedBuffer;
+import org.apache.spark.network.client.TransportClient;
+import org.apache.spark.network.protocol.ChunkFetchFailure;
+import org.apache.spark.network.protocol.ChunkFetchRequest;
+import org.apache.spark.network.protocol.ChunkFetchSuccess;
+import org.apache.spark.network.protocol.Encodable;
+
+import static org.apache.spark.network.util.NettyUtils.*;
+
+
+/**
+ * A dedicated ChannelHandler for processing ChunkFetchRequest messages. When sending response
+ * of ChunkFetchRequest messages to the clients, the thread performing the I/O on the underlying
+ * channel could potentially be blocked due to disk contentions. If several hundreds of clients
+ * send ChunkFetchRequest to the server at the same time, it could potentially occupying all
+ * threads from TransportServer's default EventLoopGroup for waiting for disk reads before it
+ * can send the block data back to the client as part of the ChunkFetchSuccess messages. As a
+ * result, it would leave no threads left to process other RPC messages, which takes much less
+ * time to process, and could lead to client timing out on either performing SASL authentication,
+ * registering executors, or waiting for response for an OpenBlocks messages.
+ */
+public class ChunkFetchRequestHandler extends SimpleChannelInboundHandler<ChunkFetchRequest> {
+  private static final Logger logger = LoggerFactory.getLogger(ChunkFetchRequestHandler.class);
+
+  private final TransportClient client;
+  private final StreamManager streamManager;
+  /** The max number of chunks being transferred and not finished yet. */
+  private final long maxChunksBeingTransferred;
+
+  public ChunkFetchRequestHandler(
+      TransportClient client,
+      StreamManager streamManager,
+      Long maxChunksBeingTransferred) {
+    this.client = client;
+    this.streamManager = streamManager;
+    this.maxChunksBeingTransferred = maxChunksBeingTransferred;
+  }
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    logger.warn("Exception in connection from " + getRemoteAddress(ctx.channel()),
+        cause);
+    ctx.close();
+  }
+
+  @Override
+  protected void channelRead0(ChannelHandlerContext ctx, final ChunkFetchRequest msg) throws Exception {
+    Channel channel = ctx.channel();
+    if (logger.isTraceEnabled()) {
+      logger.trace("Received req from {} to fetch block {}", getRemoteAddress(channel),
+          msg.streamChunkId);
+    }
+    long chunksBeingTransferred = streamManager.chunksBeingTransferred();
+    if (chunksBeingTransferred >= maxChunksBeingTransferred) {
+      logger.warn("The number of chunks being transferred {} is above {}, close the connection.",
+          chunksBeingTransferred, maxChunksBeingTransferred);
+      channel.close();
+      return;
+    }
+    ManagedBuffer buf;
+    try {
+      streamManager.checkAuthorization(client, msg.streamChunkId.streamId);
+      streamManager.registerChannel(channel, msg.streamChunkId.streamId);
+      buf = streamManager.getChunk(msg.streamChunkId.streamId, msg.streamChunkId.chunkIndex);
+    } catch (Exception e) {
+      logger.error(String.format("Error opening block %s for request from %s",
+          msg.streamChunkId, getRemoteAddress(channel)), e);
+      respond(channel, new ChunkFetchFailure(msg.streamChunkId, Throwables.getStackTraceAsString(e)));
+      return;
+    }
+
+    streamManager.chunkBeingSent(msg.streamChunkId.streamId);
+    respond(channel, new ChunkFetchSuccess(msg.streamChunkId, buf)).addListener(
+        (ChannelFutureListener) future -> streamManager.chunkSent(msg.streamChunkId.streamId));
+  }
+
+  /**
+   * The invocation to channel.writeAndFlush is async, and the actual I/O on the channel will be handled
+   * by the EventLoop the channel is registered to. So even though we are processing the ChunkFetchRequest
+   * in a separate thread pool, the actual I/O, which is the potentially blocking call that could deplete
+   * server handler threads, is still being processed by TransportServer's default EventLoopGroup. In order
+   * to throttle the max number of threads that channel I/O for sending response to ChunkFetchRequest,
+   * the thread calling channel.writeAndFlush will wait for the completion of sending response back to client
+   * by invoking sync(). This will throttle the rate at which threads from ChunkFetchRequest dedicated
+   * EventLoopGroup submit channel I/O requests to TransportServer's default EventLoopGroup, thus making sure
+   * that we can reserve some threads in TransportServer's default EventLoopGroup for handling other RPC
+   * messages.
+   */
+  private ChannelFuture respond(final Channel channel, final Encodable result) throws InterruptedException {
+    final SocketAddress remoteAddress = channel.remoteAddress();
+    return channel.writeAndFlush(result).sync().addListener((ChannelFutureListener) future -> {
+      if (future.isSuccess()) {
+        logger.trace("Sent result {} to client {}", result, remoteAddress);
+      } else {
+        logger.error(String.format("Error sending result %s to %s; closing connection",
+            result, remoteAddress), future.cause());
+        channel.close();
+      }
+    });
+  }
+}

--- a/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
@@ -37,7 +37,6 @@ import org.apache.spark.network.protocol.Encodable;
 
 import static org.apache.spark.network.util.NettyUtils.*;
 
-
 /**
  * A dedicated ChannelHandler for processing ChunkFetchRequest messages. When sending response
  * of ChunkFetchRequest messages to the clients, the thread performing the I/O on the underlying

--- a/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
@@ -113,7 +113,7 @@ public class ChunkFetchRequestHandler extends SimpleChannelInboundHandler<ChunkF
    * being processed by TransportServer's default EventLoopGroup. In order to throttle the max
    * number of threads that channel I/O for sending response to ChunkFetchRequest, the thread
    * calling channel.writeAndFlush will wait for the completion of sending response back to
-   * client by invoking sync(). This will throttle the rate at which threads from
+   * client by invoking await(). This will throttle the rate at which threads from
    * ChunkFetchRequest dedicated EventLoopGroup submit channel I/O requests to TransportServer's
    * default EventLoopGroup, thus making sure that we can reserve some threads in
    * TransportServer's default EventLoopGroup for handling other RPC messages.

--- a/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
@@ -68,23 +68,22 @@ public class ChunkFetchRequestHandler extends SimpleChannelInboundHandler<ChunkF
 
   @Override
   public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-    logger.warn("Exception in connection from " + getRemoteAddress(ctx.channel()),
-        cause);
+    logger.warn("Exception in connection from " + getRemoteAddress(ctx.channel()), cause);
     ctx.close();
   }
 
   @Override
-  protected void channelRead0(ChannelHandlerContext ctx,
-                              final ChunkFetchRequest msg) throws Exception {
+  protected void channelRead0(ChannelHandlerContext ctx, final ChunkFetchRequest msg)
+    throws Exception {
     Channel channel = ctx.channel();
     if (logger.isTraceEnabled()) {
       logger.trace("Received req from {} to fetch block {}", getRemoteAddress(channel),
-          msg.streamChunkId);
+        msg.streamChunkId);
     }
     long chunksBeingTransferred = streamManager.chunksBeingTransferred();
     if (chunksBeingTransferred >= maxChunksBeingTransferred) {
       logger.warn("The number of chunks being transferred {} is above {}, close the connection.",
-          chunksBeingTransferred, maxChunksBeingTransferred);
+        chunksBeingTransferred, maxChunksBeingTransferred);
       channel.close();
       return;
     }
@@ -95,16 +94,15 @@ public class ChunkFetchRequestHandler extends SimpleChannelInboundHandler<ChunkF
       buf = streamManager.getChunk(msg.streamChunkId.streamId, msg.streamChunkId.chunkIndex);
     } catch (Exception e) {
       logger.error(String.format("Error opening block %s for request from %s",
-          msg.streamChunkId, getRemoteAddress(channel)), e);
-      respond(channel,
-              new ChunkFetchFailure(msg.streamChunkId,
-              Throwables.getStackTraceAsString(e)));
+        msg.streamChunkId, getRemoteAddress(channel)), e);
+      respond(channel, new ChunkFetchFailure(msg.streamChunkId,
+        Throwables.getStackTraceAsString(e)));
       return;
     }
 
     streamManager.chunkBeingSent(msg.streamChunkId.streamId);
     respond(channel, new ChunkFetchSuccess(msg.streamChunkId, buf)).addListener(
-        (ChannelFutureListener) future -> streamManager.chunkSent(msg.streamChunkId.streamId));
+      (ChannelFutureListener) future -> streamManager.chunkSent(msg.streamChunkId.streamId));
   }
 
   /**
@@ -128,7 +126,7 @@ public class ChunkFetchRequestHandler extends SimpleChannelInboundHandler<ChunkF
         logger.trace("Sent result {} to client {}", result, remoteAddress);
       } else {
         logger.error(String.format("Error sending result %s to %s; closing connection",
-            result, remoteAddress), future.cause());
+          result, remoteAddress), future.cause());
         channel.close();
       }
     });

--- a/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
@@ -121,7 +121,7 @@ public class ChunkFetchRequestHandler extends SimpleChannelInboundHandler<ChunkF
   private ChannelFuture respond(final Channel channel,
                                 final Encodable result) throws InterruptedException {
     final SocketAddress remoteAddress = channel.remoteAddress();
-    return channel.writeAndFlush(result).sync().addListener((ChannelFutureListener) future -> {
+    return channel.writeAndFlush(result).await().addListener((ChannelFutureListener) future -> {
       if (future.isSuccess()) {
         logger.trace("Sent result {} to client {}", result, remoteAddress);
       } else {

--- a/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
@@ -73,8 +73,9 @@ public class ChunkFetchRequestHandler extends SimpleChannelInboundHandler<ChunkF
   }
 
   @Override
-  protected void channelRead0(ChannelHandlerContext ctx, final ChunkFetchRequest msg)
-    throws Exception {
+  protected void channelRead0(
+      ChannelHandlerContext ctx,
+      final ChunkFetchRequest msg) throws Exception {
     Channel channel = ctx.channel();
     if (logger.isTraceEnabled()) {
       logger.trace("Received req from {} to fetch block {}", getRemoteAddress(channel),
@@ -118,8 +119,9 @@ public class ChunkFetchRequestHandler extends SimpleChannelInboundHandler<ChunkF
    * default EventLoopGroup, thus making sure that we can reserve some threads in
    * TransportServer's default EventLoopGroup for handling other RPC messages.
    */
-  private ChannelFuture respond(final Channel channel,
-                                final Encodable result) throws InterruptedException {
+  private ChannelFuture respond(
+      final Channel channel,
+      final Encodable result) throws InterruptedException {
     final SocketAddress remoteAddress = channel.remoteAddress();
     return channel.writeAndFlush(result).await().addListener((ChannelFutureListener) future -> {
       if (future.isSuccess()) {

--- a/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
@@ -120,7 +120,8 @@ public class ChunkFetchRequestHandler extends SimpleChannelInboundHandler<ChunkF
    * default EventLoopGroup, thus making sure that we can reserve some threads in
    * TransportServer's default EventLoopGroup for handling other RPC messages.
    */
-  private ChannelFuture respond(final Channel channel, final Encodable result) throws InterruptedException {
+  private ChannelFuture respond(final Channel channel,
+                                final Encodable result) throws InterruptedException {
     final SocketAddress remoteAddress = channel.remoteAddress();
     return channel.writeAndFlush(result).sync().addListener((ChannelFutureListener) future -> {
       if (future.isSuccess()) {

--- a/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
@@ -74,7 +74,8 @@ public class ChunkFetchRequestHandler extends SimpleChannelInboundHandler<ChunkF
   }
 
   @Override
-  protected void channelRead0(ChannelHandlerContext ctx, final ChunkFetchRequest msg) throws Exception {
+  protected void channelRead0(ChannelHandlerContext ctx,
+                              final ChunkFetchRequest msg) throws Exception {
     Channel channel = ctx.channel();
     if (logger.isTraceEnabled()) {
       logger.trace("Received req from {} to fetch block {}", getRemoteAddress(channel),
@@ -95,7 +96,9 @@ public class ChunkFetchRequestHandler extends SimpleChannelInboundHandler<ChunkF
     } catch (Exception e) {
       logger.error(String.format("Error opening block %s for request from %s",
           msg.streamChunkId, getRemoteAddress(channel)), e);
-      respond(channel, new ChunkFetchFailure(msg.streamChunkId, Throwables.getStackTraceAsString(e)));
+      respond(channel,
+              new ChunkFetchFailure(msg.streamChunkId,
+              Throwables.getStackTraceAsString(e)));
       return;
     }
 
@@ -105,16 +108,17 @@ public class ChunkFetchRequestHandler extends SimpleChannelInboundHandler<ChunkF
   }
 
   /**
-   * The invocation to channel.writeAndFlush is async, and the actual I/O on the channel will be handled
-   * by the EventLoop the channel is registered to. So even though we are processing the ChunkFetchRequest
-   * in a separate thread pool, the actual I/O, which is the potentially blocking call that could deplete
-   * server handler threads, is still being processed by TransportServer's default EventLoopGroup. In order
-   * to throttle the max number of threads that channel I/O for sending response to ChunkFetchRequest,
-   * the thread calling channel.writeAndFlush will wait for the completion of sending response back to client
-   * by invoking sync(). This will throttle the rate at which threads from ChunkFetchRequest dedicated
-   * EventLoopGroup submit channel I/O requests to TransportServer's default EventLoopGroup, thus making sure
-   * that we can reserve some threads in TransportServer's default EventLoopGroup for handling other RPC
-   * messages.
+   * The invocation to channel.writeAndFlush is async, and the actual I/O on the
+   * channel will be handled by the EventLoop the channel is registered to. So even
+   * though we are processing the ChunkFetchRequest in a separate thread pool, the actual I/O,
+   * which is the potentially blocking call that could deplete server handler threads, is still
+   * being processed by TransportServer's default EventLoopGroup. In order to throttle the max
+   * number of threads that channel I/O for sending response to ChunkFetchRequest, the thread
+   * calling channel.writeAndFlush will wait for the completion of sending response back to
+   * client by invoking sync(). This will throttle the rate at which threads from
+   * ChunkFetchRequest dedicated EventLoopGroup submit channel I/O requests to TransportServer's
+   * default EventLoopGroup, thus making sure that we can reserve some threads in
+   * TransportServer's default EventLoopGroup for handling other RPC messages.
    */
   private ChannelFuture respond(final Channel channel, final Encodable result) throws InterruptedException {
     final SocketAddress remoteAddress = channel.remoteAddress();

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportChannelHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportChannelHandler.java
@@ -19,6 +19,7 @@ package org.apache.spark.network.server;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 import org.slf4j.Logger;
@@ -26,6 +27,8 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.spark.network.client.TransportClient;
 import org.apache.spark.network.client.TransportResponseHandler;
+import org.apache.spark.network.protocol.ChunkFetchRequest;
+import org.apache.spark.network.protocol.Message;
 import org.apache.spark.network.protocol.RequestMessage;
 import org.apache.spark.network.protocol.ResponseMessage;
 import static org.apache.spark.network.util.NettyUtils.getRemoteAddress;
@@ -47,7 +50,7 @@ import static org.apache.spark.network.util.NettyUtils.getRemoteAddress;
  * on the channel for at least `requestTimeoutMs`. Note that this is duplex traffic; we will not
  * timeout if the client is continuously sending but getting no responses, for simplicity.
  */
-public class TransportChannelHandler extends ChannelInboundHandlerAdapter {
+public class TransportChannelHandler extends SimpleChannelInboundHandler<Message> {
   private static final Logger logger = LoggerFactory.getLogger(TransportChannelHandler.class);
 
   private final TransportClient client;
@@ -112,8 +115,21 @@ public class TransportChannelHandler extends ChannelInboundHandlerAdapter {
     super.channelInactive(ctx);
   }
 
+  /**
+   * Overwrite acceptInboundMessage to properly delegate ChunkFetchRequest messages
+   * to ChunkFetchRequestHandler.
+   */
   @Override
-  public void channelRead(ChannelHandlerContext ctx, Object request) throws Exception {
+  public boolean acceptInboundMessage(Object msg) throws Exception {
+    if (msg instanceof ChunkFetchRequest) {
+      return false;
+    } else {
+      return super.acceptInboundMessage(msg);
+    }
+  }
+
+  @Override
+  public void channelRead0(ChannelHandlerContext ctx, Message request) throws Exception {
     if (request instanceof RequestMessage) {
       requestHandler.handle((RequestMessage) request);
     } else if (request instanceof ResponseMessage) {

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportChannelHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportChannelHandler.java
@@ -18,7 +18,6 @@
 package org.apache.spark.network.server;
 
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
@@ -25,18 +25,7 @@ import com.google.common.base.Throwables;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import org.apache.spark.network.buffer.ManagedBuffer;
-import org.apache.spark.network.buffer.NioManagedBuffer;
-import org.apache.spark.network.client.RpcResponseCallback;
-import org.apache.spark.network.client.TransportClient;
-import org.apache.spark.network.client.StreamCallbackWithID;
-import org.apache.spark.network.client.StreamInterceptor;
-import org.apache.spark.network.protocol.Encodable;
 import org.apache.spark.network.protocol.OneWayMessage;
-import org.apache.spark.network.protocol.RequestMessage;
 import org.apache.spark.network.protocol.RpcFailure;
 import org.apache.spark.network.protocol.RpcRequest;
 import org.apache.spark.network.protocol.RpcResponse;
@@ -44,6 +33,13 @@ import org.apache.spark.network.protocol.StreamFailure;
 import org.apache.spark.network.protocol.StreamRequest;
 import org.apache.spark.network.protocol.StreamResponse;
 import org.apache.spark.network.protocol.UploadStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.spark.network.buffer.ManagedBuffer;
+import org.apache.spark.network.buffer.NioManagedBuffer;
+import org.apache.spark.network.client.*;
+import org.apache.spark.network.protocol.*;
 import org.apache.spark.network.util.TransportFrameDecoder;
 import static org.apache.spark.network.util.NettyUtils.getRemoteAddress;
 

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
@@ -25,14 +25,6 @@ import com.google.common.base.Throwables;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 
-import org.apache.spark.network.protocol.OneWayMessage;
-import org.apache.spark.network.protocol.RpcFailure;
-import org.apache.spark.network.protocol.RpcRequest;
-import org.apache.spark.network.protocol.RpcResponse;
-import org.apache.spark.network.protocol.StreamFailure;
-import org.apache.spark.network.protocol.StreamRequest;
-import org.apache.spark.network.protocol.StreamResponse;
-import org.apache.spark.network.protocol.UploadStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +33,7 @@ import org.apache.spark.network.buffer.NioManagedBuffer;
 import org.apache.spark.network.client.*;
 import org.apache.spark.network.protocol.*;
 import org.apache.spark.network.util.TransportFrameDecoder;
+
 import static org.apache.spark.network.util.NettyUtils.getRemoteAddress;
 
 /**

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer;
 import com.google.common.base.Throwables;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +32,8 @@ import org.apache.spark.network.buffer.ManagedBuffer;
 import org.apache.spark.network.buffer.NioManagedBuffer;
 import org.apache.spark.network.client.RpcResponseCallback;
 import org.apache.spark.network.client.TransportClient;
+import org.apache.spark.network.client.StreamCallbackWithID;
+import org.apache.spark.network.client.StreamInterceptor;
 import org.apache.spark.network.protocol.Encodable;
 import org.apache.spark.network.protocol.OneWayMessage;
 import org.apache.spark.network.protocol.RequestMessage;
@@ -40,6 +43,8 @@ import org.apache.spark.network.protocol.RpcResponse;
 import org.apache.spark.network.protocol.StreamFailure;
 import org.apache.spark.network.protocol.StreamRequest;
 import org.apache.spark.network.protocol.StreamResponse;
+import org.apache.spark.network.protocol.UploadStream;
+import org.apache.spark.network.util.TransportFrameDecoder;
 import static org.apache.spark.network.util.NettyUtils.getRemoteAddress;
 
 /**

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
@@ -29,10 +29,17 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.spark.network.buffer.ManagedBuffer;
 import org.apache.spark.network.buffer.NioManagedBuffer;
-import org.apache.spark.network.client.*;
-import org.apache.spark.network.protocol.*;
-import org.apache.spark.network.util.TransportFrameDecoder;
-
+import org.apache.spark.network.client.RpcResponseCallback;
+import org.apache.spark.network.client.TransportClient;
+import org.apache.spark.network.protocol.Encodable;
+import org.apache.spark.network.protocol.OneWayMessage;
+import org.apache.spark.network.protocol.RequestMessage;
+import org.apache.spark.network.protocol.RpcFailure;
+import org.apache.spark.network.protocol.RpcRequest;
+import org.apache.spark.network.protocol.RpcResponse;
+import org.apache.spark.network.protocol.StreamFailure;
+import org.apache.spark.network.protocol.StreamRequest;
+import org.apache.spark.network.protocol.StreamResponse;
 import static org.apache.spark.network.util.NettyUtils.getRemoteAddress;
 
 /**
@@ -97,9 +104,7 @@ public class TransportRequestHandler extends MessageHandler<RequestMessage> {
 
   @Override
   public void handle(RequestMessage request) {
-    if (request instanceof ChunkFetchRequest) {
-      processFetchRequest((ChunkFetchRequest) request);
-    } else if (request instanceof RpcRequest) {
+    if (request instanceof RpcRequest) {
       processRpcRequest((RpcRequest) request);
     } else if (request instanceof OneWayMessage) {
       processOneWayMessage((OneWayMessage) request);
@@ -110,36 +115,6 @@ public class TransportRequestHandler extends MessageHandler<RequestMessage> {
     } else {
       throw new IllegalArgumentException("Unknown request type: " + request);
     }
-  }
-
-  private void processFetchRequest(final ChunkFetchRequest req) {
-    if (logger.isTraceEnabled()) {
-      logger.trace("Received req from {} to fetch block {}", getRemoteAddress(channel),
-        req.streamChunkId);
-    }
-    long chunksBeingTransferred = streamManager.chunksBeingTransferred();
-    if (chunksBeingTransferred >= maxChunksBeingTransferred) {
-      logger.warn("The number of chunks being transferred {} is above {}, close the connection.",
-        chunksBeingTransferred, maxChunksBeingTransferred);
-      channel.close();
-      return;
-    }
-    ManagedBuffer buf;
-    try {
-      streamManager.checkAuthorization(reverseClient, req.streamChunkId.streamId);
-      streamManager.registerChannel(channel, req.streamChunkId.streamId);
-      buf = streamManager.getChunk(req.streamChunkId.streamId, req.streamChunkId.chunkIndex);
-    } catch (Exception e) {
-      logger.error(String.format("Error opening block %s for request from %s",
-        req.streamChunkId, getRemoteAddress(channel)), e);
-      respond(new ChunkFetchFailure(req.streamChunkId, Throwables.getStackTraceAsString(e)));
-      return;
-    }
-
-    streamManager.chunkBeingSent(req.streamChunkId.streamId);
-    respond(new ChunkFetchSuccess(req.streamChunkId, buf)).addListener(future -> {
-      streamManager.chunkSent(req.streamChunkId.streamId);
-    });
   }
 
   private void processStreamRequest(final StreamRequest req) {

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -281,4 +281,23 @@ public class TransportConf {
   public long maxChunksBeingTransferred() {
     return conf.getLong("spark.shuffle.maxChunksBeingTransferred", Long.MAX_VALUE);
   }
+
+  /**
+   * Number of threads to process ChunkFetchRequest. Shuffle server will use a separate
+   * EventLoopGroup to process ChunkFetchRequest messages. Although when calling the
+   * async writeAndFlush on the underlying channel to send response back to client,
+   * the I/O on the channel is still being handled by
+   * {@link org.apache.spark.network.server.TransportServer}'s default EventLoopGroup
+   * that's registered with the Channel, by waiting inside the ChunkFetchRequest handler
+   * threads for the completion of sending back responses, we are able to put a limit on
+   * the max number of threads from TransportServer's default EventLoopGroup that are
+   * going to be consumed by writing response to ChunkFetchRequest, which are I/O intensive
+   * and could take long time to process due to disk contentions. By configuring a slightly
+   * higher number of shuffler server threads, we are able to reserve some threads for
+   * handling other RPC messages, thus making the Client less likely to experience timeout
+   * when sending RPC messages to the shuffle server. Default to 0, which is 2*#cores.
+   */
+  public int chunkFetchHandlerThreads() {
+    return conf.getInt("spark.shuffle.server.chunkFetchHandlerThreads", 0);
+  }
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -47,8 +47,6 @@ public class TransportConf {
 
   private final String module;
 
-  private boolean isShuffleClient;
-
   public TransportConf(String module, ConfigProvider conf) {
     this.module = module;
     this.conf = conf;
@@ -283,19 +281,6 @@ public class TransportConf {
    */
   public long maxChunksBeingTransferred() {
     return conf.getLong("spark.shuffle.maxChunksBeingTransferred", Long.MAX_VALUE);
-  }
-
-  /**
-   * Check if it is a shuffle client
-   * and avoid creating unnecessary event loops
-   * in the TransportChannelHandler
-   */
-  public boolean shuffleClient() {
-    return this.isShuffleClient;
-  }
-
-  public void setShuffleClient(boolean isShuffleClient) {
-    this.isShuffleClient = isShuffleClient;
   }
 
   /**

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -288,7 +288,7 @@ public class TransportConf {
   /**
    * Check if it is a shuffle client
    * and avoid creating unnecessary event loops
-   * in the TransportClientHandler
+   * in the TransportChannelHandler
    */
   public boolean shuffleClient() {
     return this.isShuffleClient;

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -320,8 +320,8 @@ public class TransportConf {
       return 0;
     }
     int chunkFetchHandlerThreadsPercent =
-            conf.getInt("spark.shuffle.server.chunkFetchHandlerThreadsPercent", 0);
+      conf.getInt("spark.shuffle.server.chunkFetchHandlerThreadsPercent", 0);
     return this.serverThreads() > 0 ? (this.serverThreads() * chunkFetchHandlerThreadsPercent)/100:
-            (2 * NettyRuntime.availableProcessors() * chunkFetchHandlerThreadsPercent)/100;
+      (2 * NettyRuntime.availableProcessors() * chunkFetchHandlerThreadsPercent)/100;
   }
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -47,6 +47,8 @@ public class TransportConf {
 
   private final String module;
 
+  private boolean isShuffleClient;
+
   public TransportConf(String module, ConfigProvider conf) {
     this.module = module;
     this.conf = conf;
@@ -281,6 +283,19 @@ public class TransportConf {
    */
   public long maxChunksBeingTransferred() {
     return conf.getLong("spark.shuffle.maxChunksBeingTransferred", Long.MAX_VALUE);
+  }
+
+  /**
+   * Check if it is a shuffle client
+   * and avoid creating unnecessary event loops
+   * in the TransportClientHandler
+   */
+  public boolean shuffleClient() {
+    return this.isShuffleClient;
+  }
+
+  public void setShuffleClient(boolean isShuffleClient) {
+    this.isShuffleClient = isShuffleClient;
   }
 
   /**

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -297,16 +297,16 @@ public class TransportConf {
    * higher number of shuffler server threads, we are able to reserve some threads for
    * handling other RPC messages, thus making the Client less likely to experience timeout
    * when sending RPC messages to the shuffle server. Default to 0, which is 2*#cores
-   * or io.serverThreads. 10 would mean 10% of 2*#cores or 10% of io.serverThreads
-   * which equals 0.1 * 2*#cores or 0.1 * io.serverThreads.
+   * or io.serverThreads. 90 would mean 90% of 2*#cores or 90% of io.serverThreads
+   * which equals 0.9 * 2*#cores or 0.9 * io.serverThreads.
    */
   public int chunkFetchHandlerThreads() {
-    if(!this.getModuleName().equalsIgnoreCase("shuffle")) {
+    if (!this.getModuleName().equalsIgnoreCase("shuffle")) {
       return 0;
     }
     int chunkFetchHandlerThreadsPercent =
             conf.getInt("spark.shuffle.server.chunkFetchHandlerThreadsPercent", 0);
-    return this.serverThreads() > 0? (this.serverThreads() * chunkFetchHandlerThreadsPercent)/100:
-            (2* NettyRuntime.availableProcessors() * chunkFetchHandlerThreadsPercent)/100;
+    return this.serverThreads() > 0 ? (this.serverThreads() * chunkFetchHandlerThreadsPercent)/100:
+            (2 * NettyRuntime.availableProcessors() * chunkFetchHandlerThreadsPercent)/100;
   }
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -304,7 +304,8 @@ public class TransportConf {
     if(!this.getModuleName().equalsIgnoreCase("shuffle")) {
       return 0;
     }
-    int chunkFetchHandlerThreadsPercent = conf.getInt("spark.shuffle.server.chunkFetchHandlerThreadsPercent", 0);
+    int chunkFetchHandlerThreadsPercent =
+            conf.getInt("spark.shuffle.server.chunkFetchHandlerThreadsPercent", 0);
     return this.serverThreads() > 0? (this.serverThreads() * chunkFetchHandlerThreadsPercent)/100:
             (2* NettyRuntime.availableProcessors() * chunkFetchHandlerThreadsPercent)/100;
   }

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -21,6 +21,7 @@ import java.util.Locale;
 import java.util.Properties;
 
 import com.google.common.primitives.Ints;
+import io.netty.util.NettyRuntime;
 
 /**
  * A central location that tracks all the settings we expose to users.
@@ -283,10 +284,10 @@ public class TransportConf {
   }
 
   /**
-   * Number of threads to process ChunkFetchRequest. Shuffle server will use a separate
-   * EventLoopGroup to process ChunkFetchRequest messages. Although when calling the
-   * async writeAndFlush on the underlying channel to send response back to client,
-   * the I/O on the channel is still being handled by
+   * Percentage of io.serverThreads used by netty to process ChunkFetchRequest.
+   * Shuffle server will use a separate EventLoopGroup to process ChunkFetchRequest messages.
+   * Although when calling the async writeAndFlush on the underlying channel to send
+   * response back to client, the I/O on the channel is still being handled by
    * {@link org.apache.spark.network.server.TransportServer}'s default EventLoopGroup
    * that's registered with the Channel, by waiting inside the ChunkFetchRequest handler
    * threads for the completion of sending back responses, we are able to put a limit on
@@ -295,9 +296,16 @@ public class TransportConf {
    * and could take long time to process due to disk contentions. By configuring a slightly
    * higher number of shuffler server threads, we are able to reserve some threads for
    * handling other RPC messages, thus making the Client less likely to experience timeout
-   * when sending RPC messages to the shuffle server. Default to 0, which is 2*#cores.
+   * when sending RPC messages to the shuffle server. Default to 0, which is 2*#cores
+   * or io.serverThreads. 10 would mean 10% of 2*#cores or 10% of io.serverThreads
+   * which equals 0.1 * 2*#cores or 0.1 * io.serverThreads.
    */
   public int chunkFetchHandlerThreads() {
-    return conf.getInt("spark.shuffle.server.chunkFetchHandlerThreads", 0);
+    if(!this.getModuleName().equalsIgnoreCase("shuffle")) {
+      return 0;
+    }
+    int chunkFetchHandlerThreadsPercent = conf.getInt("spark.shuffle.server.chunkFetchHandlerThreadsPercent", 0);
+    return this.serverThreads() > 0? (this.serverThreads() * chunkFetchHandlerThreadsPercent)/100:
+            (2* NettyRuntime.availableProcessors() * chunkFetchHandlerThreadsPercent)/100;
   }
 }

--- a/common/network-common/src/test/java/org/apache/spark/network/ChunkFetchRequestHandlerSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/ChunkFetchRequestHandlerSuite.java
@@ -45,18 +45,18 @@ public class ChunkFetchRequestHandlerSuite {
     Channel channel = mock(Channel.class);
     ChannelHandlerContext context = mock(ChannelHandlerContext.class);
     when(context.channel())
-        .thenAnswer(invocationOnMock0 -> {
-          return channel;
-        });
+      .thenAnswer(invocationOnMock0 -> {
+        return channel;
+      });
     List<Pair<Object, ExtendedChannelPromise>> responseAndPromisePairs =
-        new ArrayList<>();
+      new ArrayList<>();
     when(channel.writeAndFlush(any()))
-        .thenAnswer(invocationOnMock0 -> {
-          Object response = invocationOnMock0.getArguments()[0];
-          ExtendedChannelPromise channelFuture = new ExtendedChannelPromise(channel);
-          responseAndPromisePairs.add(ImmutablePair.of(response, channelFuture));
-          return channelFuture;
-        });
+      .thenAnswer(invocationOnMock0 -> {
+        Object response = invocationOnMock0.getArguments()[0];
+        ExtendedChannelPromise channelFuture = new ExtendedChannelPromise(channel);
+        responseAndPromisePairs.add(ImmutablePair.of(response, channelFuture));
+        return channelFuture;
+      });
 
     // Prepare the stream.
     List<ManagedBuffer> managedBuffers = new ArrayList<>();
@@ -68,21 +68,21 @@ public class ChunkFetchRequestHandlerSuite {
     streamManager.registerChannel(channel, streamId);
     TransportClient reverseClient = mock(TransportClient.class);
     ChunkFetchRequestHandler requestHandler = new ChunkFetchRequestHandler(reverseClient,
-        rpcHandler.getStreamManager(), 2L);
+      rpcHandler.getStreamManager(), 2L);
 
     RequestMessage request0 = new ChunkFetchRequest(new StreamChunkId(streamId, 0));
     requestHandler.channelRead(context, request0);
     assert responseAndPromisePairs.size() == 1;
     assert responseAndPromisePairs.get(0).getLeft() instanceof ChunkFetchSuccess;
     assert ((ChunkFetchSuccess) (responseAndPromisePairs.get(0).getLeft())).body() ==
-        managedBuffers.get(0);
+      managedBuffers.get(0);
 
     RequestMessage request1 = new ChunkFetchRequest(new StreamChunkId(streamId, 1));
     requestHandler.channelRead(context, request1);
     assert responseAndPromisePairs.size() == 2;
     assert responseAndPromisePairs.get(1).getLeft() instanceof ChunkFetchSuccess;
     assert ((ChunkFetchSuccess) (responseAndPromisePairs.get(1).getLeft())).body() ==
-        managedBuffers.get(1);
+      managedBuffers.get(1);
 
     // Finish flushing the response for request0.
     responseAndPromisePairs.get(0).getRight().finish(true);
@@ -92,7 +92,7 @@ public class ChunkFetchRequestHandlerSuite {
     assert responseAndPromisePairs.size() == 3;
     assert responseAndPromisePairs.get(2).getLeft() instanceof ChunkFetchSuccess;
     assert ((ChunkFetchSuccess) (responseAndPromisePairs.get(2).getLeft())).body() ==
-        managedBuffers.get(2);
+      managedBuffers.get(2);
 
     RequestMessage request3 = new ChunkFetchRequest(new StreamChunkId(streamId, 3));
     requestHandler.channelRead(context, request3);

--- a/common/network-common/src/test/java/org/apache/spark/network/ExtendedChannelPromise.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/ExtendedChannelPromise.java
@@ -1,0 +1,53 @@
+package org.apache.spark.network;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+
+
+class ExtendedChannelPromise extends DefaultChannelPromise {
+
+  private List<GenericFutureListener<Future<Void>>> listeners = new ArrayList<>();
+  private boolean success;
+
+  ExtendedChannelPromise(Channel channel) {
+    super(channel);
+    success = false;
+  }
+
+  @Override
+  public ChannelPromise addListener(
+      GenericFutureListener<? extends Future<? super Void>> listener) {
+    @SuppressWarnings("unchecked")
+    GenericFutureListener<Future<Void>> gfListener =
+        (GenericFutureListener<Future<Void>>) listener;
+    listeners.add(gfListener);
+    return super.addListener(listener);
+  }
+
+  @Override
+  public boolean isSuccess() {
+    return success;
+  }
+
+  @Override
+  public ChannelPromise sync() throws InterruptedException {
+    return this;
+  }
+
+  public void finish(boolean success) {
+    this.success = success;
+    listeners.forEach(listener -> {
+      try {
+        listener.operationComplete(this);
+      } catch (Exception e) {
+        // do nothing
+      }
+    });
+  }
+}

--- a/common/network-common/src/test/java/org/apache/spark/network/ExtendedChannelPromise.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/ExtendedChannelPromise.java
@@ -52,7 +52,7 @@ class ExtendedChannelPromise extends DefaultChannelPromise {
   }
 
   @Override
-  public ChannelPromise sync() throws InterruptedException {
+  public ChannelPromise await() throws InterruptedException {
     return this;
   }
 

--- a/common/network-common/src/test/java/org/apache/spark/network/ExtendedChannelPromise.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/ExtendedChannelPromise.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.network;
 
 import java.util.ArrayList;

--- a/common/network-common/src/test/java/org/apache/spark/network/ExtendedChannelPromise.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/ExtendedChannelPromise.java
@@ -26,7 +26,6 @@ import io.netty.channel.DefaultChannelPromise;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 
-
 class ExtendedChannelPromise extends DefaultChannelPromise {
 
   private List<GenericFutureListener<Future<Void>>> listeners = new ArrayList<>();

--- a/common/network-common/src/test/java/org/apache/spark/network/TransportRequestHandlerSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/TransportRequestHandlerSuite.java
@@ -69,14 +69,14 @@ public class TransportRequestHandlerSuite {
     assert responseAndPromisePairs.size() == 1;
     assert responseAndPromisePairs.get(0).getLeft() instanceof StreamResponse;
     assert ((StreamResponse) (responseAndPromisePairs.get(0).getLeft())).body() ==
-        managedBuffers.get(0);
+      managedBuffers.get(0);
 
     RequestMessage request1 = new StreamRequest(String.format("%d_%d", streamId, 1));
     requestHandler.handle(request1);
     assert responseAndPromisePairs.size() == 2;
     assert responseAndPromisePairs.get(1).getLeft() instanceof StreamResponse;
     assert ((StreamResponse) (responseAndPromisePairs.get(1).getLeft())).body() ==
-        managedBuffers.get(1);
+      managedBuffers.get(1);
 
     // Finish flushing the response for request0.
     responseAndPromisePairs.get(0).getRight().finish(true);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleClient.java
@@ -76,7 +76,7 @@ public class ExternalShuffleClient extends ShuffleClient {
   @Override
   public void init(String appId) {
     this.appId = appId;
-    TransportContext context = new TransportContext(conf, new NoOpRpcHandler(), true);
+    TransportContext context = new TransportContext(conf, new NoOpRpcHandler(), true, true);
     List<TransportClientBootstrap> bootstraps = Lists.newArrayList();
     if (authEnabled) {
       bootstraps.add(new AuthClientBootstrap(conf, appId, secretKeyHolder));

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -185,7 +185,6 @@ private[spark] class BlockManager(
   // standard BlockTransferService to directly connect to other Executors.
   private[spark] val shuffleClient = if (externalShuffleServiceEnabled) {
     val transConf = SparkTransportConf.fromSparkConf(conf, "shuffle", numUsableCores)
-    transConf.setShuffleClient(true);
     new ExternalShuffleClient(transConf, securityManager,
       securityManager.isAuthenticationEnabled(), conf.get(config.SHUFFLE_REGISTRATION_TIMEOUT))
   } else {

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -185,6 +185,7 @@ private[spark] class BlockManager(
   // standard BlockTransferService to directly connect to other Executors.
   private[spark] val shuffleClient = if (externalShuffleServiceEnabled) {
     val transConf = SparkTransportConf.fromSparkConf(conf, "shuffle", numUsableCores)
+    transConf.setShuffleClient(true);
     new ExternalShuffleClient(transConf, securityManager,
       securityManager.isAuthenticationEnabled(), conf.get(config.SHUFFLE_REGISTRATION_TIMEOUT))
   } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Description:
Right now, the default server side netty handler threads is 2 * # cores, and can be further configured with parameter spark.shuffle.io.serverThreads.
In order to process a client request, it would require one available server netty handler thread.
However, when the server netty handler threads start to process ChunkFetchRequests, they will be blocked on disk I/O, mostly due to disk contentions from the random read operations initiated by all the ChunkFetchRequests received from clients.
As a result, when the shuffle server is serving many concurrent ChunkFetchRequests, the server side netty handler threads could all be blocked on reading shuffle files, thus leaving no handler thread available to process other types of requests which should all be very quick to process.

This issue could potentially be fixed by limiting the number of netty handler threads that could get blocked when processing ChunkFetchRequest. We have a patch to do this by using a separate EventLoopGroup with a dedicated ChannelHandler to process ChunkFetchRequest. This enables shuffle server to reserve netty handler threads for non-ChunkFetchRequest, thus enabling consistent processing time for these requests which are fast to process. After deploying the patch in our infrastructure, we no longer see timeout issues with either executor registration with local shuffle server or shuffle client establishing connection with remote shuffle server.
(Please fill in changes proposed in this fix)

For Original PR please refer here
https://github.com/apache/spark/pull/21402

## How was this patch tested?

Unit tests and stress testing.
(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
