### PR TITLE
[SPARK-22779][SQL] Fallback config defaults should behave like scalar defaults

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1954,14 +1954,7 @@ class SQLConf extends Serializable with Logging {
         entry.valueConverter(defaultValue)
       }
     }
-    Option(settings.get(key)).getOrElse {
-      // If the key is not set, need to check whether the config entry is registered and is
-      // a fallback conf, so that we can check its parent.
-      sqlConfEntries.get(key) match {
-        case e: FallbackConfigEntry[_] => getConfString(e.fallback.key, defaultValue)
-        case _ => defaultValue
-      }
-    }
+    Option(settings.get(key)).getOrElse(defaultValue)
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -282,32 +282,49 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
   }
 
   test("SPARK-22779: correctly compute default value for fallback configs") {
-    val fallback = SQLConf.buildConf("spark.sql.__test__.spark_22779")
-      .fallbackConf(SQLConf.PARQUET_COMPRESSION)
+    val parent = SQLConf.buildConf("spark.example.parent")
+      .booleanConf
+      .createWithDefault(false)
+    val child = SQLConf.buildConf("spark.example.child")
+      .fallbackConf(parent)
 
-    assert(spark.sessionState.conf.getConfString(fallback.key) ===
-      SQLConf.PARQUET_COMPRESSION.defaultValue.get)
-    assert(spark.sessionState.conf.getConfString(fallback.key, "lzo") === "lzo")
+    // explicitParentVal is Some(v) if we have called spark.conf.set(parent.key, v) or None if we
+    // have not called explicitly set a conf value for parent.key
+    def testCorrectValues(explicitParentVal: Option[Boolean]): Unit = {
+      // The order of precedence should be:
+      // 1. Explicit value if one was set
+      // 2. Otherwise, client default if one was provided
+      // 3. Otherwise, builder default (either scalar default or a fallback conf default)
+      val explicitParentString = explicitParentVal.map(_.toString)
 
-    val displayValue = spark.sessionState.conf.getAllDefinedConfs
-      .find { case (key, _, _) => key == fallback.key }
-      .map { case (_, v, _) => v }
-      .get
-    assert(displayValue === fallback.defaultValueString)
+      // Using the ConfigBuilder directly should use the builder default
+      assert(spark.conf.get(parent) == explicitParentVal.getOrElse(false))
+      assert(spark.conf.get(child) == explicitParentVal.getOrElse(false))
 
-    spark.sessionState.conf.setConf(SQLConf.PARQUET_COMPRESSION, "gzip")
-    assert(spark.sessionState.conf.getConfString(fallback.key) === "gzip")
+      // Using the ConfigBuilder's key with no client default should use the builder default
+      assert(spark.conf.get(parent.key) == explicitParentString.getOrElse("false"))
+      assert(spark.conf.get(child.key) == explicitParentString.getOrElse("false"))
 
-    spark.sessionState.conf.setConf(fallback, "lzo")
-    assert(spark.sessionState.conf.getConfString(fallback.key) === "lzo")
+      // Using the ConfigBuilder's key with a client default should use the client default
+      assert(spark.conf.get(parent.key, "false") == explicitParentString.getOrElse("false"))
+      assert(spark.conf.get(parent.key, "true") == explicitParentString.getOrElse("true"))
+      assert(spark.conf.get(child.key, "false") == "false")
+      assert(spark.conf.get(child.key, "true") == "true")
+    }
 
-    val newDisplayValue = spark.sessionState.conf.getAllDefinedConfs
-      .find { case (key, _, _) => key == fallback.key }
-      .map { case (_, v, _) => v }
-      .get
-    assert(newDisplayValue === "lzo")
+    // When the parent is not explicitly set
+    testCorrectValues(None)
 
-    SQLConf.unregister(fallback)
+    try {
+      // When the parent is explicitly set to false
+      spark.conf.set(parent.key, false)
+      testCorrectValues(Some(false))
+
+      // When the parent is explicitly set to true
+      spark.conf.set(parent.key, true)
+      testCorrectValues(Some(true))
+    } finally {
+      spark.conf.unset(parent.key)
+    }
   }
-
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -291,11 +291,12 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
     // explicitParentVal is Some(v) if we have called spark.conf.set(parent.key, v) or None if we
     // have not called explicitly set a conf value for parent.key
     def testCorrectValues(explicitParentVal: Option[Boolean]): Unit = {
+      val explicitParentString = explicitParentVal.map(_.toString)
+
       // The order of precedence should be:
       // 1. Explicit value if one was set
       // 2. Otherwise, client default if one was provided
       // 3. Otherwise, builder default (either scalar default or a fallback conf default)
-      val explicitParentString = explicitParentVal.map(_.toString)
 
       // Using the ConfigBuilder directly should use the builder default
       assert(spark.conf.get(parent) == explicitParentVal.getOrElse(false))


### PR DESCRIPTION
## What changes were proposed in this pull request?
The value returned by a call to `spark.conf.get(key)` may be specified in one of 3 different ways:
1. By explicitly setting the value of `key` via e.g. `spark.conf.set(key, value)`
1. By the client providing a default value at call-time via e.g. `spark.conf.get(key, clientDefault)`
1. By the ConfigBuilder providing a default value when it is declared via e.g. `SQLConf.buildConf(key).createWithDefault(builderDefault)`

Currently, the order of precedence among these different sources of value is:
1. Explicit value if one was set
1. Otherwise, client default if one was provided
1. Otherwise, builder default

There is currently one exception to this rule: if the builder happened to be declared with a default that is another ConfigBuilder (via e.g. `SQLConf.buildConf(key).fallbackConf(parentConfigBuilder)`), then we check the builder default first (in this case the parent conf and potentially the parent's parent and so on) and then only use the client default if none of the fallback confs had explicit values defined.

From a user perspective, this means that the client default may or may not be used depending on whether the config in question was declared with a scalar default or a fallback conf default, which is usually not obvious. In the case of a fallback conf default, the value returned by `spark.conf.get` may depend on an arbitrary number of parent confs, which seems like it will lead to particularly difficult to diagnose errors.

This PR removes that exception and adds a test to guarantee that the precedence order listed above is applied to all conf types. Note that this is an explicit change from the previous implementation in https://github.com/apache/spark/pull/19974

## How was this patch tested?
Unit test to verify the precedence order for confs with both scalar and fallback conf defaults.