### PR TITLE
[SPARK-25119][Web UI] stages in wrong order within job page DAG chart

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
@@ -18,18 +18,18 @@
 package org.apache.spark.ui.jobs
 
 import java.util.Locale
+
 import javax.servlet.http.HttpServletRequest
 
 import scala.collection.mutable.{Buffer, ListBuffer}
 import scala.xml.{Node, NodeSeq, Unparsed, Utility}
-
 import org.apache.commons.lang3.StringEscapeUtils
-
 import org.apache.spark.JobExecutionStatus
 import org.apache.spark.scheduler._
 import org.apache.spark.status.AppStatusStore
 import org.apache.spark.status.api.v1
 import org.apache.spark.ui._
+import org.apache.spark.ui.scope.RDDOperationGraph
 
 /** Page showing statistics and stage list for a given job */
 private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIPage("job") {
@@ -337,7 +337,9 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
       store.executorList(false), appStartTime)
 
     val operationGraphContent = store.asOption(store.operationGraphForJob(jobId)) match {
-      case Some(operationGraph) => UIUtils.showDagVizForJob(jobId, operationGraph)
+      case Some(operationGraph) => UIUtils.showDagVizForJob(jobId, operationGraph.sortWith(
+        _.rootCluster.id.replaceAll(RDDOperationGraph.STAGE_CLUSTER_PREFIX, "").toInt
+          < _.rootCluster.id.replaceAll(RDDOperationGraph.STAGE_CLUSTER_PREFIX, "").toInt))
       case None =>
         <div id="no-info">
           <p>No DAG visualization information to display for job {jobId}</p>


### PR DESCRIPTION
if spark job contains multiple tasks , the order in DAG chart might be incorrect.
sample and screen snapshot can be found in jira ticket https://issues.apache.org/jira/browse/SPARK-25119

to fix this issue, just sort RDDOperationGraph Array on "task id" before UIUtils.showDagVizForJob()

## How was this patch tested?
packaging with all existing UT passed. 
run complex query in Spark-sql console with the new jars
check the DAG chart in job page. 
