### PR TITLE
[MINOR] Fix build failure due to non-direct conflict: removing import affects others

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -20,6 +20,8 @@ package org.apache.spark.sql.execution.streaming
 import java.util.UUID
 import java.util.concurrent.TimeUnit._
 
+import scala.collection.JavaConverters._
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.errors._


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the build failure on master branch: #21733 removed import which #21469 referred to. They were not making direct conflict so cannot find the issue until running build after merging twos.

## How was this patch tested?

Ran `maven clean install -DskipTests`. For tests I'd like to defer to CI build cause it will take hours.