### PR TITLE
[SPARK-25183][SQL] Spark HiveServer2 to use Spark ShutdownHookManager

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/server/HiveServer2.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/server/HiveServer2.java
@@ -20,6 +20,9 @@ package org.apache.hive.service.server;
 
 import java.util.Properties;
 
+import scala.runtime.AbstractFunction0;
+import scala.runtime.BoxedUnit;
+
 import org.apache.commons.cli.GnuParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
@@ -38,6 +41,7 @@ import org.apache.hive.service.cli.CLIService;
 import org.apache.hive.service.cli.thrift.ThriftBinaryCLIService;
 import org.apache.hive.service.cli.thrift.ThriftCLIService;
 import org.apache.hive.service.cli.thrift.ThriftHttpCLIService;
+
 import org.apache.spark.util.ShutdownHookManager;
 
 /**
@@ -70,14 +74,20 @@ public class HiveServer2 extends CompositeService {
     // Add a shutdown hook for catching SIGTERM & SIGINT
     // this must be higher than the Hadoop Filesystem priority of 10,
     // which the default priority is.
+    // The signature of the callback must match that of a scala () -> Unit
+    // function
     ShutdownHookManager.addShutdownHook(
-        () -> {
-          try {
-            stop();
-          } catch (Throwable e) {
-            LOG.warn("Ignoring Exception while stopping Hive Server from shutdown hook", e);
+        new AbstractFunction0<BoxedUnit>() {
+          public BoxedUnit apply() {
+            try {
+              LOG.info("Hive Server Shutdown hook invoked");
+              stop();
+            } catch (Throwable e) {
+              LOG.warn("Ignoring Exception while stopping Hive Server from shutdown hook",
+                  e);
+            }
+            return BoxedUnit.UNIT;
           }
-          return null;
         });
   }
 
@@ -100,7 +110,6 @@ public class HiveServer2 extends CompositeService {
   @Override
   public synchronized void stop() {
     LOG.info("Shutting down HiveServer2");
-    HiveConf hiveConf = this.getHiveConf();
     super.stop();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Switch `org.apache.hive.service.server.HiveServer2` to register its shutdown callback with Spark's `ShutdownHookManager`, rather than direct with the Java Runtime callback.

This avoids race conditions in shutdown where the filesystem is shutdown before the flush/write/rename of the event log is completed, particularly on object stores where the write and rename can be slow.

## How was this patch tested?

There's no explicit unit for test this, which is consistent with every other shutdown hook in the codebase.

* There's an implicit test when the scalatest process is halted.
* More manual/integration testing is needed.

HADOOP-15679 has added the ability to explicitly execute the hadoop shutdown hook sequence which spark uses; that could be stabilized for testing if desired, after which all the spark hooks could be tested. Until then: external system tests only.