### PR TITLE
[SPARK-25188][SQL] Add WriteConfig to v2 write API.

### DIFF
--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
@@ -269,8 +269,6 @@ private[kafka010] class KafkaSourceProvider extends DataSourceRegister
 
   override def createStreamingWriteSupport(
       queryId: String,
-      schema: StructType,
-      mode: OutputMode,
       options: DataSourceOptions): StreamingWriteSupport = {
     import scala.collection.JavaConverters._
 
@@ -279,10 +277,7 @@ private[kafka010] class KafkaSourceProvider extends DataSourceRegister
     // We convert the options argument from V2 -> Java map -> scala mutable -> scala immutable.
     val producerParams = kafkaParamsForProducer(options.asMap.asScala.toMap)
 
-    KafkaWriter.validateQuery(
-      schema.toAttributes, new java.util.HashMap[String, Object](producerParams.asJava), topic)
-
-    new KafkaStreamingWriteSupport(topic, producerParams, schema)
+    new KafkaStreamingWriteSupport(topic, producerParams)
   }
 
   private def strategy(caseInsensitiveParams: Map[String, String]) =

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/BatchWriteSupportProvider.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/BatchWriteSupportProvider.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import org.apache.spark.annotation.InterfaceStability;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.sources.v2.writer.BatchWriteSupport;
-import org.apache.spark.sql.types.StructType;
 
 /**
  * A mix-in interface for {@link DataSourceV2}. Data sources can implement this interface to
@@ -35,25 +34,18 @@ import org.apache.spark.sql.types.StructType;
 public interface BatchWriteSupportProvider extends DataSourceV2 {
 
   /**
-   * Creates an optional {@link BatchWriteSupport} instance to save the data to this data source,
-   * which is called by Spark at the beginning of each batch query.
+   * Creates a {@link BatchWriteSupport} instance to save the data to a data source. Called by
+   * Spark at the beginning of each batch query.
    *
    * Data sources can return None if there is no writing needed to be done according to the save
    * mode.
    *
-   * @param queryId A unique string for the writing query. It's possible that there are many
-   *                writing queries running at the same time, and the returned
-   *                {@link BatchWriteSupport} can use this id to distinguish itself from others.
-   * @param schema the schema of the data to be written.
    * @param mode the save mode which determines what to do when the data are already in this data
    *             source, please refer to {@link SaveMode} for more details.
    * @param options the options for the returned data source writer, which is an immutable
    *                case-insensitive string-to-string map.
    * @return a write support to write data to this data source.
    */
-  Optional<BatchWriteSupport> createBatchWriteSupport(
-      String queryId,
-      StructType schema,
-      SaveMode mode,
-      DataSourceOptions options);
+  // TODO: remove SaveMode
+  Optional<BatchWriteSupport> createBatchWriteSupport(SaveMode mode, DataSourceOptions options);
 }

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/StreamingWriteSupportProvider.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/StreamingWriteSupportProvider.java
@@ -20,8 +20,6 @@ package org.apache.spark.sql.sources.v2;
 import org.apache.spark.annotation.InterfaceStability;
 import org.apache.spark.sql.execution.streaming.BaseStreamingSink;
 import org.apache.spark.sql.sources.v2.writer.streaming.StreamingWriteSupport;
-import org.apache.spark.sql.streaming.OutputMode;
-import org.apache.spark.sql.types.StructType;
 
 /**
  * A mix-in interface for {@link DataSourceV2}. Data sources can implement this interface to
@@ -40,15 +38,10 @@ public interface StreamingWriteSupportProvider extends DataSourceV2, BaseStreami
    * @param queryId A unique string for the writing query. It's possible that there are many
    *                writing queries running at the same time, and the returned
    *                {@link StreamingWriteSupport} can use this id to distinguish itself from others.
-   * @param schema the schema of the data to be written.
-   * @param mode the output mode which determines what successive epoch output means to this
-   *             sink, please refer to {@link OutputMode} for more details.
    * @param options the options for the returned data source writer, which is an immutable
    *                case-insensitive string-to-string map.
    */
   StreamingWriteSupport createStreamingWriteSupport(
       String queryId,
-      StructType schema,
-      OutputMode mode,
       DataSourceOptions options);
 }

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/BatchOverwriteSupport.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/BatchOverwriteSupport.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.sources.v2.writer;
+
+import org.apache.spark.sql.catalyst.plans.logical.Filter;
+import org.apache.spark.sql.sources.v2.DataSourceOptions;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * An interface that adds support to {@link BatchWriteSupport} for a replace data operation that
+ * replaces a subset of the output table with the output of a write operation. The subset removed is
+ * determined by a set of filter expressions.
+ * <p>
+ * Data source implementations can implement this interface in addition to {@link BatchWriteSupport}
+ * to support idempotent write operations that replace data matched by a set of delete filters with
+ * the result of the write operation.
+ * <p>
+ * This is used to build idempotent writes. For example, a query that produces a daily summary
+ * may be run several times as new data arrives. Each run should replace the output of the last
+ * run for a particular day in the partitioned output table. Such a job would write using this
+ * WriteSupport and would pass a filter matching the previous job's output, like
+ * <code>$"day" === '2018-08-22'</code>, to remove that data and commit the replacement data at
+ * the same time.
+ */
+public interface BatchOverwriteSupport extends BatchWriteSupport {
+  /**
+   * Creates a {@link WriteConfig} for a batch overwrite operation, where the data written replaces
+   * the data matching the delete filters.
+   * <p>
+   * Implementations may reject the delete filters if the delete isn't possible without significant
+   * effort. For example, partitioned data sources may reject deletes that do not filter by
+   * partition columns because the filter may require rewriting files without deleted records.
+   * To reject a delete implementations should throw {@link IllegalArgumentException} with a clear
+   * error message that identifies which expression was rejected.
+   *
+   * @param schema schema of the data that will be written
+   * @param options options to configure the write operation
+   * @param deleteFilters filters that match data to be replaced by the data written
+   * @return a new WriteConfig for the replace data (overwrite) operation
+   * @throws IllegalArgumentException If the delete is rejected due to required effort
+   */
+  // TODO: replace DataSourceOptions with CaseInsensitiveStringMap
+  WriteConfig createOverwriteConfig(StructType schema,
+                                    DataSourceOptions options,
+                                    Filter[] deleteFilters);
+}

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/BatchPartitionOverwriteSupport.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/BatchPartitionOverwriteSupport.java
@@ -30,7 +30,7 @@ import org.apache.spark.sql.types.StructType;
  * <p>
  * This is used to implement INSERT OVERWRITE ... PARTITIONS.
  */
-public interface BatchPartitionOverwriteSupport {
+public interface BatchPartitionOverwriteSupport extends BatchWriteSupport {
   /**
    * Creates a {@link WriteConfig} for a batch overwrite operation, where the data partitions
    * written by the job replace any partitions that already exist in the output table.

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/BatchPartitionOverwriteSupport.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/BatchPartitionOverwriteSupport.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.sources.v2.writer;
+
+import org.apache.spark.sql.sources.v2.DataSourceOptions;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * An interface that adds support to {@link BatchWriteSupport} for a replace data operation that
+ * replaces partitions dynamically with the output of a write operation.
+ * <p>
+ * Data source implementations can implement this interface in addition to {@link BatchWriteSupport}
+ * to support write operations that replace all partitions in the output table that are present
+ * in the write's output data.
+ * <p>
+ * This is used to implement INSERT OVERWRITE ... PARTITIONS.
+ */
+public interface BatchPartitionOverwriteSupport {
+  /**
+   * Creates a {@link WriteConfig} for a batch overwrite operation, where the data partitions
+   * written by the job replace any partitions that already exist in the output table.
+   *
+   * @param schema schema of the data that will be written
+   * @param options options to configure the write operation
+   * @return a new WriteConfig for the dynamic partition overwrite operation
+   */
+  // TODO: replace DataSourceOptions with CaseInsensitiveStringMap
+  WriteConfig createDynamicOverwriteConfig(StructType schema, DataSourceOptions options);
+}

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/BatchWriteSupport.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/BatchWriteSupport.java
@@ -18,19 +18,21 @@
 package org.apache.spark.sql.sources.v2.writer;
 
 import org.apache.spark.annotation.InterfaceStability;
+import org.apache.spark.sql.sources.v2.DataSourceOptions;
+import org.apache.spark.sql.types.StructType;
 
 /**
  * An interface that defines how to write the data to data source for batch processing.
  *
  * The writing procedure is:
- *   1. Create a writer factory by {@link #createBatchWriterFactory()}, serialize and send it to all
- *      the partitions of the input data(RDD).
+ *   1. Create a writer factory by {@link #createBatchWriterFactory(WriteConfig)}, serialize and
+ *      send it to all the partitions of the input data(RDD).
  *   2. For each partition, create the data writer, and write the data of the partition with this
  *      writer. If all the data are written successfully, call {@link DataWriter#commit()}. If
  *      exception happens during the writing, call {@link DataWriter#abort()}.
- *   3. If all writers are successfully committed, call {@link #commit(WriterCommitMessage[])}. If
- *      some writers are aborted, or the job failed with an unknown reason, call
- *      {@link #abort(WriterCommitMessage[])}.
+ *   3. If all writers are successfully committed, call
+ *      {@link #commit(WriteConfig,WriterCommitMessage[])}. If some writers are aborted, or the job
+ *      failed with an unknown reason, call {@link #abort(WriteConfig, WriterCommitMessage[])}.
  *
  * While Spark will retry failed writing tasks, Spark won't retry failed writing jobs. Users should
  * do it manually in their Spark applications if they want to retry.
@@ -41,12 +43,22 @@ import org.apache.spark.annotation.InterfaceStability;
 public interface BatchWriteSupport {
 
   /**
+   * Creates a {@link WriteConfig} for a batch write operation.
+   *
+   * @param schema schema of the data that will be written
+   * @param options options to configure the write operation
+   * @return a new WriteConfig
+   */
+  // TODO: replace DataSourceOptions with CaseInsensitiveStringMap
+  WriteConfig createWriteConfig(StructType schema, DataSourceOptions options);
+
+  /**
    * Creates a writer factory which will be serialized and sent to executors.
    *
    * If this method fails (by throwing an exception), the action will fail and no Spark job will be
    * submitted.
    */
-  DataWriterFactory createBatchWriterFactory();
+  DataWriterFactory createBatchWriterFactory(WriteConfig config);
 
   /**
    * Returns whether Spark should use the commit coordinator to ensure that at most one task for
@@ -54,7 +66,7 @@ public interface BatchWriteSupport {
    *
    * @return true if commit coordinator should be used, false otherwise.
    */
-  default boolean useCommitCoordinator() {
+  default boolean useCommitCoordinator(WriteConfig config) {
     return true;
   }
 
@@ -62,31 +74,32 @@ public interface BatchWriteSupport {
    * Handles a commit message on receiving from a successful data writer.
    *
    * If this method fails (by throwing an exception), this writing job is considered to to have been
-   * failed, and {@link #abort(WriterCommitMessage[])} would be called.
+   * failed, and {@link #abort(WriteConfig, WriterCommitMessage[])} would be called.
    */
-  default void onDataWriterCommit(WriterCommitMessage message) {}
+  default void onDataWriterCommit(WriteConfig config, WriterCommitMessage message) {}
 
   /**
    * Commits this writing job with a list of commit messages. The commit messages are collected from
    * successful data writers and are produced by {@link DataWriter#commit()}.
    *
    * If this method fails (by throwing an exception), this writing job is considered to to have been
-   * failed, and {@link #abort(WriterCommitMessage[])} would be called. The state of the destination
-   * is undefined and @{@link #abort(WriterCommitMessage[])} may not be able to deal with it.
+   * failed, and {@link #abort(WriteConfig, WriterCommitMessage[])} would be called. The state of
+   * the destination is undefined and @{@link #abort(WriteConfig, WriterCommitMessage[])} may not be
+   * able to deal with it.
    *
    * Note that speculative execution may cause multiple tasks to run for a partition. By default,
    * Spark uses the commit coordinator to allow at most one task to commit. Implementations can
-   * disable this behavior by overriding {@link #useCommitCoordinator()}. If disabled, multiple
-   * tasks may have committed successfully and one successful commit message per task will be
-   * passed to this commit method. The remaining commit messages are ignored by Spark.
+   * disable this behavior by overriding {@link #useCommitCoordinator(WriteConfig)}. If disabled,
+   * multiple tasks may have committed successfully and one successful commit message per task will
+   * be passed to this commit method. The remaining commit messages are ignored by Spark.
    */
-  void commit(WriterCommitMessage[] messages);
+  void commit(WriteConfig config, WriterCommitMessage[] messages);
 
   /**
    * Aborts this writing job because some data writers are failed and keep failing when retry,
    * or the Spark job fails with some unknown reasons,
-   * or {@link #onDataWriterCommit(WriterCommitMessage)} fails,
-   * or {@link #commit(WriterCommitMessage[])} fails.
+   * or {@link #onDataWriterCommit(WriteConfig,WriterCommitMessage)} fails,
+   * or {@link #commit(WriteConfig,WriterCommitMessage[])} fails.
    *
    * If this method fails (by throwing an exception), the underlying data source may require manual
    * cleanup.
@@ -97,5 +110,5 @@ public interface BatchWriteSupport {
    * driver when the abort is triggered. So this is just a "best effort" for data sources to
    * clean up the data left by data writers.
    */
-  void abort(WriterCommitMessage[] messages);
+  void abort(WriteConfig config, WriterCommitMessage[] messages);
 }

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataWriter.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataWriter.java
@@ -36,11 +36,11 @@ import org.apache.spark.annotation.InterfaceStability;
  *
  * If this data writer succeeds(all records are successfully written and {@link #commit()}
  * succeeds), a {@link WriterCommitMessage} will be sent to the driver side and pass to
- * {@link BatchWriteSupport#commit(WriterCommitMessage[])} with commit messages from other data
- * writers. If this data writer fails(one record fails to write or {@link #commit()} fails), an
- * exception will be sent to the driver side, and Spark may retry this writing task a few times.
- * In each retry, {@link DataWriterFactory#createWriter(int, long)} will receive a
- * different `taskId`. Spark will call {@link BatchWriteSupport#abort(WriterCommitMessage[])}
+ * {@link BatchWriteSupport#commit(WriteConfig,WriterCommitMessage[])} with commit messages from
+ * other data writers. If this data writer fails(one record fails to write or {@link #commit()}
+ * fails), an exception will be sent to the driver side, and Spark may retry this writing task a few
+ * times. In each retry, {@link DataWriterFactory#createWriter(int, long)} will receive a different
+ * `taskId`. Spark will call {@link BatchWriteSupport#abort(WriteConfig,WriterCommitMessage[])}
  * when the configured number of retries is exhausted.
  *
  * Besides the retry mechanism, Spark may launch speculative tasks if the existing writing task
@@ -71,12 +71,12 @@ public interface DataWriter<T> {
   /**
    * Commits this writer after all records are written successfully, returns a commit message which
    * will be sent back to driver side and passed to
-   * {@link BatchWriteSupport#commit(WriterCommitMessage[])}.
+   * {@link BatchWriteSupport#commit(WriteConfig, WriterCommitMessage[])}.
    *
    * The written data should only be visible to data source readers after
-   * {@link BatchWriteSupport#commit(WriterCommitMessage[])} succeeds, which means this method
-   * should still "hide" the written data and ask the {@link BatchWriteSupport} at driver side to
-   * do the final commit via {@link WriterCommitMessage}.
+   * {@link BatchWriteSupport#commit(WriteConfig, WriterCommitMessage[])} succeeds, which means this
+   * method should still "hide" the written data and ask the {@link BatchWriteSupport} at driver
+   * side to do the final commit via {@link WriterCommitMessage}.
    *
    * If this method fails (by throwing an exception), {@link #abort()} will be called and this
    * data writer is considered to have been failed.
@@ -93,8 +93,8 @@ public interface DataWriter<T> {
    * failed.
    *
    * If this method fails(by throwing an exception), the underlying data source may have garbage
-   * that need to be cleaned by {@link BatchWriteSupport#abort(WriterCommitMessage[])} or manually,
-   * but these garbage should not be visible to data source readers.
+   * that need to be cleaned by {@link BatchWriteSupport#abort(WriteConfig, WriterCommitMessage[])}
+   * or manually, but these garbage should not be visible to data source readers.
    *
    * @throws IOException if failure happens during disk/network IO like writing files.
    */

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataWriterFactory.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/DataWriterFactory.java
@@ -24,7 +24,8 @@ import org.apache.spark.annotation.InterfaceStability;
 import org.apache.spark.sql.catalyst.InternalRow;
 
 /**
- * A factory of {@link DataWriter} returned by {@link BatchWriteSupport#createBatchWriterFactory()},
+ * A factory of {@link DataWriter} returned by
+ * {@link BatchWriteSupport#createBatchWriterFactory(WriteConfig)},
  * which is responsible for creating and initializing the actual data writer at executor side.
  *
  * Note that, the writer factory will be serialized and sent to executors, then the data writer

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/WriteConfig.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/WriteConfig.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.sources.v2.writer;
+
+import org.apache.spark.annotation.InterfaceStability;
+import org.apache.spark.sql.catalyst.plans.logical.Filter;
+import org.apache.spark.sql.sources.v2.DataSourceOptions;
+import org.apache.spark.sql.sources.v2.writer.streaming.StreamingWriteSupport;
+import org.apache.spark.sql.streaming.OutputMode;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * WriteConfig carries configuration specific to a write operation for a table.
+ * <p>
+ * WriteConfig is created when Spark initializes a v2 write operation using factory methods provided
+ * by the write support instance for the query type:
+ * <ul>
+ * <li>
+ * {@link BatchWriteSupport#createWriteConfig(StructType, DataSourceOptions)}
+ * </li>
+ * <li>
+ * {@link BatchOverwriteSupport#createOverwriteConfig(StructType, DataSourceOptions, Filter[])}
+ * </li>
+ * <li>
+ * {@link BatchPartitionOverwriteSupport#createDynamicOverwriteConfig(StructType,DataSourceOptions)}
+ * </li>
+ * <li>
+ * {@link StreamingWriteSupport#createWriteConfig(StructType, OutputMode, DataSourceOptions)}
+ * </li>
+ * </ul>
+ * <p>
+ * This class is passed to create a {@link DataWriterFactory} and is passed to commit and abort.
+ */
+@InterfaceStability.Evolving
+public interface WriteConfig {
+  /**
+   * The schema of rows that will be written.
+   */
+  StructType writeSchema();
+
+  /**
+   * Options to configure the write.
+   */
+  DataSourceOptions writeOptions();
+}

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/WriterCommitMessage.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/WriterCommitMessage.java
@@ -19,13 +19,14 @@ package org.apache.spark.sql.sources.v2.writer;
 
 import java.io.Serializable;
 
+import org.apache.spark.sql.sources.v2.writer.streaming.StreamingWriteConfig;
 import org.apache.spark.sql.sources.v2.writer.streaming.StreamingWriteSupport;
 import org.apache.spark.annotation.InterfaceStability;
 
 /**
  * A commit message returned by {@link DataWriter#commit()} and will be sent back to the driver side
  * as the input parameter of {@link BatchWriteSupport#commit(WriteConfig,WriterCommitMessage[])} or
- * {@link StreamingWriteSupport#commit(WriteConfig, long, WriterCommitMessage[])}.
+ * {@link StreamingWriteSupport#commit(StreamingWriteConfig, long, WriterCommitMessage[])}.
  *
  * This is an empty interface, data sources should define their own message class and use it when
  * generating messages at executor side and handling the messages at driver side.

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/WriterCommitMessage.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/WriterCommitMessage.java
@@ -24,8 +24,8 @@ import org.apache.spark.annotation.InterfaceStability;
 
 /**
  * A commit message returned by {@link DataWriter#commit()} and will be sent back to the driver side
- * as the input parameter of {@link BatchWriteSupport#commit(WriterCommitMessage[])} or
- * {@link StreamingWriteSupport#commit(long, WriterCommitMessage[])}.
+ * as the input parameter of {@link BatchWriteSupport#commit(WriteConfig,WriterCommitMessage[])} or
+ * {@link StreamingWriteSupport#commit(WriteConfig, long, WriterCommitMessage[])}.
  *
  * This is an empty interface, data sources should define their own message class and use it when
  * generating messages at executor side and handling the messages at driver side.

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/streaming/StreamingDataWriterFactory.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/streaming/StreamingDataWriterFactory.java
@@ -23,12 +23,11 @@ import org.apache.spark.TaskContext;
 import org.apache.spark.annotation.InterfaceStability;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.sources.v2.writer.DataWriter;
-import org.apache.spark.sql.sources.v2.writer.WriteConfig;
 
 /**
  * A factory of {@link DataWriter} returned by
- * {@link StreamingWriteSupport#createStreamingWriterFactory(WriteConfig)}, which is responsible for
- * creating and initializing the actual data writer at executor side.
+ * {@link StreamingWriteSupport#createStreamingWriterFactory(StreamingWriteConfig)}, which is
+ * responsible for creating and initializing the actual data writer at executor side.
  *
  * Note that, the writer factory will be serialized and sent to executors, then the data writer
  * will be created on executors and do the actual writing. So this interface must be

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/streaming/StreamingDataWriterFactory.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/streaming/StreamingDataWriterFactory.java
@@ -23,11 +23,12 @@ import org.apache.spark.TaskContext;
 import org.apache.spark.annotation.InterfaceStability;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.sources.v2.writer.DataWriter;
+import org.apache.spark.sql.sources.v2.writer.WriteConfig;
 
 /**
  * A factory of {@link DataWriter} returned by
- * {@link StreamingWriteSupport#createStreamingWriterFactory()}, which is responsible for creating
- * and initializing the actual data writer at executor side.
+ * {@link StreamingWriteSupport#createStreamingWriterFactory(WriteConfig)}, which is responsible for
+ * creating and initializing the actual data writer at executor side.
  *
  * Note that, the writer factory will be serialized and sent to executors, then the data writer
  * will be created on executors and do the actual writing. So this interface must be

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/streaming/StreamingWriteConfig.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/streaming/StreamingWriteConfig.java
@@ -15,19 +15,17 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.execution.streaming.continuous
+package org.apache.spark.sql.sources.v2.writer.streaming;
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.sources.v2.writer.streaming.{StreamingWriteConfig, StreamingWriteSupport}
+import org.apache.spark.sql.sources.v2.writer.WriteConfig;
+import org.apache.spark.sql.streaming.OutputMode;
 
 /**
- * The logical plan for writing data in a continuous stream.
+ * A {@link WriteConfig} for streaming writes.
  */
-case class WriteToContinuousDataSource(
-    writeSupport: StreamingWriteSupport,
-    config: StreamingWriteConfig,
-    query: LogicalPlan) extends LogicalPlan {
-  override def children: Seq[LogicalPlan] = Seq(query)
-  override def output: Seq[Attribute] = Nil
+public interface StreamingWriteConfig extends WriteConfig {
+  /**
+   * Returns the streaming output mode for this write.
+   */
+  OutputMode outputMode();
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchWriteConfig.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchWriteConfig.scala
@@ -15,19 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.execution.streaming.continuous
+package org.apache.spark.sql.execution.datasources.v2
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.sources.v2.writer.streaming.{StreamingWriteConfig, StreamingWriteSupport}
+import org.apache.spark.sql.sources.v2.DataSourceOptions
+import org.apache.spark.sql.sources.v2.writer.WriteConfig
+import org.apache.spark.sql.types.StructType
 
 /**
- * The logical plan for writing data in a continuous stream.
+ * A generic [[WriteConfig]] implementation for batch writer implementations.
  */
-case class WriteToContinuousDataSource(
-    writeSupport: StreamingWriteSupport,
-    config: StreamingWriteConfig,
-    query: LogicalPlan) extends LogicalPlan {
-  override def children: Seq[LogicalPlan] = Seq(query)
-  override def output: Seq[Attribute] = Nil
-}
+case class BatchWriteConfig(writeSchema: StructType, writeOptions: DataSourceOptions)
+    extends WriteConfig

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
-import java.util.UUID
-
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.{AnalysisException, SaveMode}
@@ -58,7 +56,7 @@ case class DataSourceV2Relation(
 
   override def simpleString: String = "RelationV2 " + metadataString
 
-  def newWriteSupport(): BatchWriteSupport = source.createWriteSupport(options, schema)
+  def newWriteSupport(): BatchWriteSupport = source.createWriteSupport(options)
 
   override def computeStats(): Statistics = readSupport match {
     case r: SupportsReportStatistics =>
@@ -158,12 +156,8 @@ object DataSourceV2Relation {
       }
     }
 
-    def createWriteSupport(
-        options: Map[String, String],
-        schema: StructType): BatchWriteSupport = {
+    def createWriteSupport(options: Map[String, String]): BatchWriteSupport = {
       asWriteSupportProvider.createBatchWriteSupport(
-        UUID.randomUUID().toString,
-        schema,
         SaveMode.Append,
         new DataSourceOptions(options.asJava)).get
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{EventTimeWatermark, LogicalP
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2ScanExec, WriteToDataSourceV2Exec}
-import org.apache.spark.sql.execution.streaming.sources.MicroBatchWritSupport
+import org.apache.spark.sql.execution.streaming.sources.MicroBatchWriteSupport
 import org.apache.spark.sql.sources.v2.CustomMetrics
 import org.apache.spark.sql.sources.v2.reader.streaming.{MicroBatchReadSupport, SupportsCustomReaderMetrics}
 import org.apache.spark.sql.sources.v2.writer.streaming.{StreamingWriteSupport, SupportsCustomWriterMetrics}
@@ -242,7 +242,7 @@ trait ProgressReporter extends Logging {
       case p if p.isInstanceOf[WriteToDataSourceV2Exec] =>
         p.asInstanceOf[WriteToDataSourceV2Exec].writeSupport
     }.headOption match {
-      case Some(w: MicroBatchWritSupport) => Some(w.writeSupport)
+      case Some(w: MicroBatchWriteSupport) => Some(w.writeSupport)
       case _ => None
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/console.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/console.scala
@@ -22,7 +22,6 @@ import org.apache.spark.sql.execution.streaming.sources.ConsoleWriteSupport
 import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, DataSourceRegister}
 import org.apache.spark.sql.sources.v2.{DataSourceOptions, DataSourceV2, StreamingWriteSupportProvider}
 import org.apache.spark.sql.sources.v2.writer.streaming.StreamingWriteSupport
-import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types.StructType
 
 case class ConsoleRelation(override val sqlContext: SQLContext, data: DataFrame)
@@ -37,10 +36,8 @@ class ConsoleSinkProvider extends DataSourceV2
 
   override def createStreamingWriteSupport(
       queryId: String,
-      schema: StructType,
-      mode: OutputMode,
       options: DataSourceOptions): StreamingWriteSupport = {
-    new ConsoleWriteSupport(schema, options)
+    new ConsoleWriteSupport(options)
   }
 
   def createRelation(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/WriteToContinuousDataSourceExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/WriteToContinuousDataSourceExec.scala
@@ -26,18 +26,21 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.streaming.StreamExecution
-import org.apache.spark.sql.sources.v2.writer.streaming.StreamingWriteSupport
+import org.apache.spark.sql.sources.v2.writer.streaming.{StreamingWriteConfig, StreamingWriteSupport}
 
 /**
  * The physical plan for writing data into a continuous processing [[StreamingWriteSupport]].
  */
-case class WriteToContinuousDataSourceExec(writeSupport: StreamingWriteSupport, query: SparkPlan)
+case class WriteToContinuousDataSourceExec(
+    writeSupport: StreamingWriteSupport,
+    writeConfig: StreamingWriteConfig,
+    query: SparkPlan)
     extends SparkPlan with Logging {
   override def children: Seq[SparkPlan] = Seq(query)
   override def output: Seq[Attribute] = Nil
 
   override protected def doExecute(): RDD[InternalRow] = {
-    val writerFactory = writeSupport.createStreamingWriterFactory()
+    val writerFactory = writeSupport.createStreamingWriterFactory(writeConfig)
     val rdd = new ContinuousWriteRDD(query.execute(), writerFactory)
 
     logInfo(s"Start processing data source write support: $writeSupport. " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/StreamWriteConfig.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/StreamWriteConfig.scala
@@ -15,19 +15,17 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.execution.streaming.continuous
+package org.apache.spark.sql.execution.streaming.sources
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.sources.v2.writer.streaming.{StreamingWriteConfig, StreamingWriteSupport}
+import org.apache.spark.sql.sources.v2.DataSourceOptions
+import org.apache.spark.sql.sources.v2.writer.streaming.StreamingWriteConfig
+import org.apache.spark.sql.streaming.OutputMode
+import org.apache.spark.sql.types.StructType
 
 /**
- * The logical plan for writing data in a continuous stream.
+ * A generic [[StreamingWriteConfig]] implementation for streaming writer implementations.
  */
-case class WriteToContinuousDataSource(
-    writeSupport: StreamingWriteSupport,
-    config: StreamingWriteConfig,
-    query: LogicalPlan) extends LogicalPlan {
-  override def children: Seq[LogicalPlan] = Seq(query)
-  override def output: Seq[Attribute] = Nil
-}
+case class StreamWriteConfig(
+    writeSchema: StructType,
+    outputMode: OutputMode,
+    writeOptions: DataSourceOptions) extends StreamingWriteConfig

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousQueuedDataReaderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousQueuedDataReaderSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.execution.streaming.continuous._
 import org.apache.spark.sql.sources.v2.reader.streaming.{ContinuousPartitionReader, ContinuousReadSupport, PartitionOffset}
-import org.apache.spark.sql.sources.v2.writer.streaming.StreamingWriteSupport
+import org.apache.spark.sql.sources.v2.writer.streaming.{StreamingWriteConfig, StreamingWriteSupport}
 import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.types.{DataType, IntegerType, StructType}
 
@@ -44,6 +44,7 @@ class ContinuousQueuedDataReaderSuite extends StreamTest with MockitoSugar {
     super.beforeEach()
     epochEndpoint = EpochCoordinatorRef.create(
       mock[StreamingWriteSupport],
+      mock[StreamingWriteConfig],
       mock[ContinuousReadSupport],
       mock[ContinuousExecution],
       coordinatorId,

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/sources/StreamingDataSourceV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/sources/StreamingDataSourceV2Suite.scala
@@ -68,8 +68,6 @@ trait FakeContinuousReadSupportProvider extends ContinuousReadSupportProvider {
 trait FakeStreamingWriteSupportProvider extends StreamingWriteSupportProvider {
   override def createStreamingWriteSupport(
       queryId: String,
-      schema: StructType,
-      mode: OutputMode,
       options: DataSourceOptions): StreamingWriteSupport = {
     throw new IllegalStateException("fake sink - cannot actually write")
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This updates the v2 write path to a similar structure as the v2 read path. Individual writes are configured and tracked using `WriteConfig` (analogous to `ScanConfig`) and this config is passed to the methods of `WriteSupport` that are specific to a single write, like `commit` and `abort`.

This new config will be used to communicate overwrite options to data sources that implement new support classes, `BatchOverwriteSupport` and `BatchPartitionOverwriteSupport`. The new config could also be used by implementations to get and hold locks to make operations atomic.

Streaming is also updated to use a `StreamingWriteConfig`. Options that are specific to a write, like schema, output mode, and write options.

## How was this patch tested?

This is primarily an API change and should pass existing tests.
