### PR TITLE
[SPARK-25121][SQL] Supports multi-part table names for broadcast hint resolution

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -146,7 +146,7 @@ class Analyzer(
 
   lazy val batches: Seq[Batch] = Seq(
     Batch("Hints", fixedPoint,
-      new ResolveHints.ResolveBroadcastHints(conf),
+      new ResolveHints.ResolveBroadcastHints(conf, catalog),
       ResolveHints.ResolveCoalesceHints,
       ResolveHints.RemoveAllHints),
     Batch("Simple Sanity Check", Once,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
@@ -62,15 +62,11 @@ object ResolveHints {
       }
     }
 
-    private def formatDatabaseName(name: String): String = {
-      if (conf.caseSensitiveAnalysis) name else name.toLowerCase(Locale.ROOT)
-    }
-
     private def matchedTableIdentifier(
         nameParts: Seq[String],
         tableIdent: IdentifierWithDatabase): Boolean = {
       tableIdent.database match {
-        case Some(db) if catalog.globalTempViewManager.database == formatDatabaseName(db) =>
+        case Some(db) if resolver(catalog.globalTempViewManager.database, db) =>
           val identifierList = db :: tableIdent.identifier :: Nil
           namePartsWithDatabase(nameParts, catalog.globalTempViewManager.database)
             .corresponds(identifierList)(resolver)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
@@ -70,6 +70,8 @@ object ResolveHints {
           val identifierList = db :: tableIdent.identifier :: Nil
           namePartsWithDatabase(nameParts, catalog.globalTempViewManager.database)
             .corresponds(identifierList)(resolver)
+        case None if catalog.getTempView(tableIdent.identifier).isDefined =>
+          nameParts.size == 1 && resolver(nameParts.head, tableIdent.identifier)
         case _ =>
           val db = tableIdent.database.getOrElse(catalog.getCurrentDatabase)
           val identifierList = db :: tableIdent.identifier :: Nil

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
@@ -168,7 +168,7 @@ package object expressions  {
       // For example, consider an example where "db1" is the database name, "a" is the table name
       // and "b" is the column name and "c" is the struct field name.
       // If the name parts is db1.a.b.c, then Attribute will match
-      // Attribute(b, qualifier("db1,"a")) and List("c") will be the second element
+      // Attribute(b, qualifier("db1","a")) and List("c") will be the second element
       var matches: (Seq[Attribute], Seq[String]) = nameParts match {
         case dbPart +: tblPart +: name +: nestedFields =>
           val key = (dbPart.toLowerCase(Locale.ROOT),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisTest.scala
@@ -41,6 +41,8 @@ trait AnalysisTest extends PlanTest {
     catalog.createTempView("TaBlE", TestRelations.testRelation, overrideIfExists = true)
     catalog.createTempView("TaBlE2", TestRelations.testRelation2, overrideIfExists = true)
     catalog.createTempView("TaBlE3", TestRelations.testRelation3, overrideIfExists = true)
+    catalog.createGlobalTempView("TaBlE4", TestRelations.testRelation4, overrideIfExists = true)
+    catalog.createGlobalTempView("TaBlE5", TestRelations.testRelation5, overrideIfExists = true)
     new Analyzer(catalog, conf) {
       override val extendedResolutionRules = EliminateSubqueryAliases :: Nil
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
@@ -157,17 +157,32 @@ class ResolveHintsSuite extends AnalysisTest {
   }
 
   test("Supports multi-part table names for broadcast hint resolution") {
+    // local temp table
     checkAnalysis(
-      UnresolvedHint("MAPJOIN", Seq("default.table", "default.table2"),
+      UnresolvedHint("MAPJOIN", Seq("table", "table2"),
         table("table").join(table("table2"))),
       Join(ResolvedHint(testRelation, HintInfo(broadcast = true)),
         ResolvedHint(testRelation2, HintInfo(broadcast = true)), Inner, None),
       caseSensitive = false)
 
     checkAnalysis(
-      UnresolvedHint("MAPJOIN", Seq("default.TaBlE", "default.table2", "DEfault.TaBlE2"),
+      UnresolvedHint("MAPJOIN", Seq("TaBlE", "table2"),
         table("TaBlE").join(table("TaBlE2"))),
       Join(ResolvedHint(testRelation, HintInfo(broadcast = true)), testRelation2, Inner, None),
+      caseSensitive = true)
+
+    // global temp table
+    checkAnalysis(
+      UnresolvedHint("MAPJOIN", Seq("global_temp.table4", "GlOBal_TeMP.table5"),
+        table("global_temp", "table4").join(table("global_temp", "table5"))),
+      Join(ResolvedHint(testRelation4, HintInfo(broadcast = true)),
+        ResolvedHint(testRelation5, HintInfo(broadcast = true)), Inner, None),
+      caseSensitive = false)
+
+    checkAnalysis(
+      UnresolvedHint("MAPJOIN", Seq("global_temp.TaBlE4", "table5"),
+        table("global_temp", "TaBlE4").join(table("global_temp", "TaBlE5"))),
+      Join(ResolvedHint(testRelation4, HintInfo(broadcast = true)), testRelation5, Inner, None),
       caseSensitive = true)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
@@ -163,5 +163,11 @@ class ResolveHintsSuite extends AnalysisTest {
       Join(ResolvedHint(testRelation, HintInfo(broadcast = true)),
         ResolvedHint(testRelation2, HintInfo(broadcast = true)), Inner, None),
       caseSensitive = false)
+
+    checkAnalysis(
+      UnresolvedHint("MAPJOIN", Seq("default.TaBlE", "default.table2", "DEfault.TaBlE2"),
+        table("TaBlE").join(table("TaBlE2"))),
+      Join(ResolvedHint(testRelation, HintInfo(broadcast = true)), testRelation2, Inner, None),
+      caseSensitive = true)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
@@ -161,28 +161,46 @@ class ResolveHintsSuite extends AnalysisTest {
     checkAnalysis(
       UnresolvedHint("MAPJOIN", Seq("table", "table2"),
         table("table").join(table("table2"))),
-      Join(ResolvedHint(testRelation, HintInfo(broadcast = true)),
-        ResolvedHint(testRelation2, HintInfo(broadcast = true)), Inner, None),
+      Join(
+        ResolvedHint(testRelation, HintInfo(broadcast = true)),
+        ResolvedHint(testRelation2, HintInfo(broadcast = true)),
+        Inner,
+        None,
+        JoinHint(None, None)),
       caseSensitive = false)
 
     checkAnalysis(
       UnresolvedHint("MAPJOIN", Seq("TaBlE", "table2"),
         table("TaBlE").join(table("TaBlE2"))),
-      Join(ResolvedHint(testRelation, HintInfo(broadcast = true)), testRelation2, Inner, None),
+      Join(
+        ResolvedHint(testRelation, HintInfo(broadcast = true)),
+        testRelation2,
+        Inner,
+        None,
+        JoinHint(None, None)),
       caseSensitive = true)
 
     // global temp table
     checkAnalysis(
       UnresolvedHint("MAPJOIN", Seq("global_temp.table4", "GlOBal_TeMP.table5"),
         table("global_temp", "table4").join(table("global_temp", "table5"))),
-      Join(ResolvedHint(testRelation4, HintInfo(broadcast = true)),
-        ResolvedHint(testRelation5, HintInfo(broadcast = true)), Inner, None),
+      Join(
+        ResolvedHint(testRelation4, HintInfo(broadcast = true)),
+        ResolvedHint(testRelation5, HintInfo(broadcast = true)),
+        Inner,
+        None,
+        JoinHint(None, None)),
       caseSensitive = false)
 
     checkAnalysis(
       UnresolvedHint("MAPJOIN", Seq("global_temp.TaBlE4", "table5"),
         table("global_temp", "TaBlE4").join(table("global_temp", "TaBlE5"))),
-      Join(ResolvedHint(testRelation4, HintInfo(broadcast = true)), testRelation5, Inner, None),
+      Join(
+        ResolvedHint(testRelation4, HintInfo(broadcast = true)),
+        testRelation5,
+        Inner,
+        None,
+        JoinHint(None, None)),
       caseSensitive = true)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
@@ -155,4 +155,13 @@ class ResolveHintsSuite extends AnalysisTest {
       UnresolvedHint("REPARTITION", Seq(Literal(true)), table("TaBlE")),
       Seq(errMsgRepa))
   }
+
+  test("Supports multi-part table names for broadcast hint resolution") {
+    checkAnalysis(
+      UnresolvedHint("MAPJOIN", Seq("default.table", "default.table2"),
+        table("table").join(table("table2"))),
+      Join(ResolvedHint(testRelation, HintInfo(broadcast = true)),
+        ResolvedHint(testRelation2, HintInfo(broadcast = true)), Inner, None),
+      caseSensitive = false)
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
@@ -156,7 +156,7 @@ class ResolveHintsSuite extends AnalysisTest {
       Seq(errMsgRepa))
   }
 
-  test("Supports multi-part table names for broadcast hint resolution") {
+  test("supports multi-part table names for broadcast hint resolution") {
     // local temp table
     checkAnalysis(
       UnresolvedHint("MAPJOIN", Seq("table", "table2"),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TestRelations.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TestRelations.scala
@@ -44,6 +44,8 @@ object TestRelations {
     AttributeReference("g", StringType)(),
     AttributeReference("h", MapType(IntegerType, IntegerType))())
 
+  val testRelation5 = LocalRelation(AttributeReference("i", StringType)())
+
   val nestedRelation = LocalRelation(
     AttributeReference("top", StructType(
       StructField("duplicateField", StringType) ::

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
@@ -199,7 +199,7 @@ class DataFrameJoinSuite extends QueryTest with SharedSQLContext {
     val (table1Name, table2Name) = ("t1", "t2")
     withTempDatabase { dbName =>
       withTable(table1Name, table2Name) {
-        withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0") {
+        withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
           spark.range(50).write.saveAsTable(s"$dbName.$table1Name")
           spark.range(100).write.saveAsTable(s"$dbName.$table2Name")
           // First, makes sure a join is not broadcastable

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
@@ -210,7 +210,7 @@ class DataFrameJoinSuite extends QueryTest with SharedSQLContext {
 
           // Uses multi-part table names for broadcast hints
           def checkIfHintApplied(tableName: String, hintTableName: String): Unit = {
-            val p = sql(s"SELECT /*+ BROADCASTJOIN($tableName) */ * " +
+            val p = sql(s"SELECT /*+ BROADCASTJOIN($hintTableName) */ * " +
                 s"FROM $tableName, $dbName.$table2Name " +
                 s"WHERE $tableName.id = $table2Name.id")
               .queryExecution.executedPlan

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/GlobalTempViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/GlobalTempViewSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.catalog.Table
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.plans.logical.{Join, ResolvedHint}
+import org.apache.spark.sql.catalyst.plans.logical.{Join, JoinHint}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types.StructType
@@ -169,9 +169,10 @@ class GlobalTempViewSuite extends QueryTest with SharedSQLContext {
             "SELECT /*+ MAPJOIN(v1) */ * FROM global_temp.v1, v2 WHERE v1.id = v2.id",
             "SELECT /*+ MAPJOIN(global_temp.v1) */ * FROM global_temp.v1, v2 WHERE v1.id = v2.id"
           ).foreach { statement =>
-            val plan = sql(statement).queryExecution.optimizedPlan
-            assert(plan.asInstanceOf[Join].left.isInstanceOf[ResolvedHint])
-            assert(!plan.asInstanceOf[Join].right.isInstanceOf[ResolvedHint])
+            sql(statement).queryExecution.optimizedPlan match {
+              case Join(_, _, _, _, JoinHint(Some(leftHint), None)) => assert(leftHint.broadcast)
+              case _ => fail("broadcast hint not found in a left-side table")
+            }
           }
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -738,8 +738,8 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
           assert(broadcastData.head.identifier === "tv")
 
           val sparkPlan = df.queryExecution.executedPlan
-          val broadcastHashJoin = sparkPlan.collect { case p: BroadcastHashJoinExec => p }
-          assert(broadcastHashJoin.size == 1)
+          val broadcastHashJoins = sparkPlan.collect { case p: BroadcastHashJoinExec => p }
+          assert(broadcastHashJoins.size == 1)
         }
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr fixed code to respect a database name for broadcast table hint resolution.
Currently, spark ignores a database name in multi-part names;
```
scala> sql("CREATE DATABASE testDb")
scala> spark.range(10).write.saveAsTable("testDb.t")

// without this patch
scala> spark.range(10).join(spark.table("testDb.t"), "id").hint("broadcast", "testDb.t").explain
== Physical Plan ==
*(2) Project [id#24L]
+- *(2) BroadcastHashJoin [id#24L], [id#26L], Inner, BuildLeft
   :- BroadcastExchange HashedRelationBroadcastMode(List(input[0, bigint, false]))
   :  +- *(1) Range (0, 10, step=1, splits=4)
   +- *(2) Project [id#26L]
      +- *(2) Filter isnotnull(id#26L)
         +- *(2) FileScan parquet testdb.t[id#26L] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/Users/maropu/Repositories/spark/spark-2.3.1-bin-hadoop2.7/spark-warehouse..., PartitionFilters: [], PushedFilters: [IsNotNull(id)], ReadSchema: struct<id:bigint>

// with this patch
scala> spark.range(10).join(spark.table("testDb.t"), "id").hint("broadcast", "testDb.t").explain
== Physical Plan ==
*(2) Project [id#3L]
+- *(2) BroadcastHashJoin [id#3L], [id#5L], Inner, BuildRight
   :- *(2) Range (0, 10, step=1, splits=4)
   +- BroadcastExchange HashedRelationBroadcastMode(List(input[0, bigint, true]))
      +- *(1) Project [id#5L]
         +- *(1) Filter isnotnull(id#5L)
            +- *(1) FileScan parquet testdb.t[id#5L] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/Users/maropu/Repositories/spark/spark-master/spark-warehouse/testdb.db/t], PartitionFilters: [], PushedFilters: [IsNotNull(id)], ReadSchema: struct<id:bigint>
```

## How was this patch tested?
Added tests in `DataFrameJoinSuite`.