### PR TITLE
[SPARK-25211][Core] speculation and fetch failed result in hang of job

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1402,7 +1402,7 @@ private[spark] class DAGScheduler(
               shuffleStage.pendingPartitions -= task.partitionId
             }
 
-            if (runningStages.contains(shuffleStage) && shuffleStage.pendingPartitions.isEmpty) {
+            if (shuffleStage.pendingPartitions.isEmpty) {
               markStageAsFinished(shuffleStage)
               logInfo("looking for newly runnable stages")
               logInfo("running: " + runningStages)

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1221,7 +1221,6 @@ private[spark] class DAGScheduler(
               s"(available: ${stage.isAvailable}," +
               s"available outputs: ${stage.numAvailableOutputs}," +
               s"partitions: ${stage.numPartitions})")
-          markMapStageJobsAsFinished(stage)
         case stage : ResultStage =>
           logDebug(s"Stage ${stage} is actually done; (partitions: ${stage.numPartitions})")
       }

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -2247,58 +2247,6 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     assertDataStructuresEmpty()
   }
 
-  test("Trigger mapstage's job listener in submitMissingTasks") {
-    val rdd1 = new MyRDD(sc, 2, Nil)
-    val dep1 = new ShuffleDependency(rdd1, new HashPartitioner(2))
-    val rdd2 = new MyRDD(sc, 2, List(dep1), tracker = mapOutputTracker)
-    val dep2 = new ShuffleDependency(rdd2, new HashPartitioner(2))
-
-    val listener1 = new SimpleListener
-    val listener2 = new SimpleListener
-
-    submitMapStage(dep1, listener1)
-    submitMapStage(dep2, listener2)
-
-    // Complete the stage0.
-    assert(taskSets(0).stageId === 0)
-    complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostA", rdd1.partitions.length)),
-      (Success, makeMapStatus("hostB", rdd1.partitions.length))))
-    assert(mapOutputTracker.getMapSizesByExecutorId(dep1.shuffleId, 0).map(_._1).toSet ===
-        HashSet(makeBlockManagerId("hostA"), makeBlockManagerId("hostB")))
-    assert(listener1.results.size === 1)
-
-    // When attempting stage1, trigger a fetch failure.
-    assert(taskSets(1).stageId === 1)
-    complete(taskSets(1), Seq(
-      (Success, makeMapStatus("hostC", rdd2.partitions.length)),
-      (FetchFailed(makeBlockManagerId("hostA"), dep1.shuffleId, 0, 0, "ignored"), null)))
-    scheduler.resubmitFailedStages()
-    // Stage1 listener should not have a result yet
-    assert(listener2.results.size === 0)
-
-    // Speculative task succeeded in stage1.
-    runEvent(makeCompletionEvent(
-      taskSets(1).tasks(1),
-      Success,
-      makeMapStatus("hostD", rdd2.partitions.length)))
-    // stage1 listener still should not have a result, though there's no missing partitions
-    // in it. Because stage1 has been failed and is not inside `runningStages` at this moment.
-    assert(listener2.results.size === 0)
-
-    // Stage0 should now be running as task set 2; make its task succeed
-    assert(taskSets(2).stageId === 0)
-    complete(taskSets(2), Seq(
-      (Success, makeMapStatus("hostC", rdd2.partitions.length))))
-    assert(mapOutputTracker.getMapSizesByExecutorId(dep1.shuffleId, 0).map(_._1).toSet ===
-        Set(makeBlockManagerId("hostC"), makeBlockManagerId("hostB")))
-
-    // After stage0 is finished, stage1 will be submitted and found there is no missing
-    // partitions in it. Then listener got triggered.
-    assert(listener2.results.size === 1)
-    assertDataStructuresEmpty()
-  }
-
   /**
    * In this test, we run a map stage where one of the executors fails but we still receive a
    * "zombie" complete message from that executor. We want to make sure the stage is not reported


### PR DESCRIPTION
## What changes were proposed in this pull request?

In current `DAGScheduler.handleTaskCompletion` code, when a shuffleMapStage with job not in runningStages and its `pendingPartitions` is empty, the job of this shuffleMapStage will never complete.

*Think about below*

1. Stage 0 runs and generates shuffle output data.

2. Stage 1 reads the output from stage 0 and generates more shuffle data. It has two tasks with the same partition: ShuffleMapTask0 and ShuffleMapTask0.1(speculation).

3. ShuffleMapTask0 fails to fetch blocks and sends a FetchFailed to the driver. The driver resubmits stage 0 and stage 1. The driver will place stage 0 in runningStages and place stage 1 in waitingStages.

4. ShuffleMapTask0.1 successfully finishes and sends Success back to driver. The driver will add the mapstatus to the set of output locations of stage 1. because of stage 1 not in runningStages, the job will not complete.

5. stage 0 completes and the driver will run stage 1. But, because the output sets of stage 1 is complete, the drive will not submit any tasks and make stage 1 complte right now. Because the job complete relay on the `CompletionEvent` and there will never a `CompletionEvent` come, the job will hang.

## How was this patch tested?

UT