### PR TITLE
[SPARK-25216][SQL] Improve error message when a column containing dot cannot be resolved

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -23,6 +23,7 @@ import java.sql.{Date, Timestamp}
 import scala.collection.JavaConverters._
 import scala.language.implicitConversions
 import scala.reflect.runtime.universe.TypeTag
+import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
 import org.apache.commons.lang3.StringUtils
@@ -217,17 +218,25 @@ class Dataset[T] private[sql](
     val resolver = sparkSession.sessionState.analyzer.resolver
     queryExecution.analyzed.resolveQuoted(colName, resolver)
       .getOrElse {
-        if (queryExecution.analyzed.resolveQuoted(s"`$colName`", resolver).isDefined) {
-          throw new AnalysisException(
-            s"""Cannot resolve column name "$colName" among (${schema.fieldNames.mkString(", ")}).
-               | Try adding backticks to the column name, i.e., `$colName`,
-               | if "$colName" is the name of the whole column"""
-              .stripMargin.replaceAll("\n", ""))
-        } else {
-          throw new AnalysisException(
-            s"""Cannot resolve column name "$colName" among (${schema.fieldNames.mkString(", ")})"""
-              .stripMargin)
+        val defaultMessage =
+          s"""Cannot resolve column name "$colName" among (${schema.fieldNames.mkString(", ")})"""
+            .stripMargin
+
+        val improvedMessage =
+          s"""Cannot resolve column name "$colName" among (${schema.fieldNames.mkString(", ")}).
+             | Try adding backticks to the column name, i.e., `$colName`,
+             | if "$colName" is the name of the whole column"""
+            .stripMargin.replaceAll("\n", "")
+
+        // Try to resolve colName with backticks and give a better exception message if the
+        // colName can be resolved with backticks. If this fails, return the default
+        // error message
+        val message = Try(queryExecution.analyzed.resolveQuoted(s"`$colName`", resolver)) match {
+          case Success(result) => if (result.isDefined) improvedMessage else defaultMessage
+          case Failure(_) => defaultMessage
         }
+
+        throw new AnalysisException(message)
       }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -216,8 +216,16 @@ class Dataset[T] private[sql](
   private[sql] def resolve(colName: String): NamedExpression = {
     queryExecution.analyzed.resolveQuoted(colName, sparkSession.sessionState.analyzer.resolver)
       .getOrElse {
-        throw new AnalysisException(
-          s"""Cannot resolve column name "$colName" among (${schema.fieldNames.mkString(", ")})""")
+        if (schema.fieldNames.contains(colName)) {
+          throw new AnalysisException(
+            s"""Cannot resolve column name "$colName" among (${schema.fieldNames.mkString(", ")}).
+               | Try adding backticks to the column name, i.e., `$colName`"""
+              .stripMargin.replaceAll("\n", ""))
+        } else {
+          throw new AnalysisException(
+            s"""Cannot resolve column name "$colName" among (${schema.fieldNames.mkString(", ")}"""
+              .stripMargin)
+        }
       }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current error message is  often confusing to a new Spark user that a column containing "." needs backticks quote. 

For example, consider the following code:
```
spark.range(0, 1).toDF('a.b')['a.b']
```

the current message looks like this and is confusing:

```
Cannot resolve column name "a.b" among (a.b)
```
This PR improves the error message to, 

```
Cannot resolve column name "a.b" among (a.b). Try adding backticks to the column name, i.e., `a.b`;
``` 

## How was this patch tested?

Manual test in shell
