### PR TITLE
[SPARK-25221][DEPLOY] Consistent trailing whitespace treatment of conf values

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2062,8 +2062,10 @@ private[spark] object Utils extends Logging {
     try {
       val properties = new Properties()
       properties.load(inReader)
-      properties.stringPropertyNames().asScala.map(
-        k => (k, properties.getProperty(k).trim)).toMap
+      properties.stringPropertyNames().asScala
+        .map(k => (k, properties.getProperty(k)))
+        .toMap
+
     } catch {
       case e: IOException =>
         throw new SparkException(s"Failed when loading Spark properties from $filename", e)

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2052,13 +2052,16 @@ private[spark] object Utils extends Logging {
   }
 
 
-  private[this] val nonSpaceOrNaturalLineDelimiter: Char => Boolean = { ch => ch > ' ' || ch == '\r' || ch == '\n' }
+  private[this] val nonSpaceOrNaturalLineDelimiter: Char => Boolean = {
+    ch => ch > ' ' || ch == '\r' || ch == '\n'
+  }
 
   /**
-   * Implements the same logic as JDK java.lang.String#trim by removing leading and trailing non-printable characters
-   * less or equal to '\u0020' (SPACE) but preserves natural line delimiters according to
-   * [[java.util.Properties]] load method. The natural line delimiters are removed by JDK during load.
-   * Therefore any remaining ones have been specifically provided and escaped by the user, and must not be ignored
+   * Implements the same logic as JDK java.lang.String#trim by removing leading and trailing
+   * non-printable characters less or equal to '\u0020' (SPACE) but preserves natural line
+   * delimiters according to [[java.util.Properties]] load method. The natural line delimiters are
+   * removed by JDK during load. Therefore any remaining ones have been specifically provided and
+   * escaped by the user, and must not be ignored
    *
    * @param str
    * @return the trimmed value of str

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2051,11 +2051,6 @@ private[spark] object Utils extends Logging {
     }
   }
 
-
-  private[this] val nonSpaceOrNaturalLineDelimiter: Char => Boolean = {
-    ch => ch > ' ' || ch == '\r' || ch == '\n'
-  }
-
   /**
    * Implements the same logic as JDK java.lang.String#trim by removing leading and trailing
    * non-printable characters less or equal to '\u0020' (SPACE) but preserves natural line
@@ -2067,6 +2062,10 @@ private[spark] object Utils extends Logging {
    * @return the trimmed value of str
    */
   private[util] def trimExceptCRLF(str: String): String = {
+    val nonSpaceOrNaturalLineDelimiter: Char => Boolean = { ch =>
+      ch > ' ' || ch == '\r' || ch == '\n'
+    }
+
     val firstPos = str.indexWhere(nonSpaceOrNaturalLineDelimiter)
     val lastPos = str.lastIndexWhere(nonSpaceOrNaturalLineDelimiter)
     if (firstPos >= 0 && lastPos >= 0) {
@@ -2087,7 +2086,7 @@ private[spark] object Utils extends Logging {
       val properties = new Properties()
       properties.load(inReader)
       properties.stringPropertyNames().asScala
-        .map(k => (k, trimExceptCRLF(properties.getProperty(k))))
+        .map { k => (k, trimExceptCRLF(properties.getProperty(k))) }
         .toMap
 
     } catch {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -19,7 +19,6 @@ package org.apache.spark.util
 
 import java.io._
 import java.lang.{Byte => JByte}
-import java.lang.InternalError
 import java.lang.management.{LockInfo, ManagementFactory, MonitorInfo, ThreadInfo}
 import java.lang.reflect.InvocationTargetException
 import java.math.{MathContext, RoundingMode}
@@ -2052,6 +2051,28 @@ private[spark] object Utils extends Logging {
     }
   }
 
+
+  private[this] val nonSpaceOrNaturalLineDelimiter: Char => Boolean = { ch => ch > ' ' || ch == '\r' || ch == '\n' }
+
+  /**
+   * Implements the same logic as JDK java.lang.String#trim by removing leading and trailing non-printable characters
+   * less or equal to '\u0020' (SPACE) but preserves natural line delimiters according to
+   * [[java.util.Properties]] load method. The natural line delimiters are removed by JDK during load.
+   * Therefore any remaining ones have been specifically provided and escaped by the user, and must not be ignored
+   *
+   * @param str
+   * @return the trimmed value of str
+   */
+  def trimExceptCRLF(str: String): String = {
+    val firstPos = str.indexWhere(nonSpaceOrNaturalLineDelimiter)
+    val lastPos = str.lastIndexWhere(nonSpaceOrNaturalLineDelimiter)
+    if (firstPos >= 0 && lastPos >= 0) {
+      str.substring(firstPos, lastPos + 1)
+    } else {
+      ""
+    }
+  }
+
   /** Load properties present in the given file. */
   def getPropertiesFromFile(filename: String): Map[String, String] = {
     val file = new File(filename)
@@ -2063,7 +2084,7 @@ private[spark] object Utils extends Logging {
       val properties = new Properties()
       properties.load(inReader)
       properties.stringPropertyNames().asScala
-        .map(k => (k, properties.getProperty(k)))
+        .map(k => (k, trimExceptCRLF(properties.getProperty(k))))
         .toMap
 
     } catch {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2063,7 +2063,7 @@ private[spark] object Utils extends Logging {
    * @param str
    * @return the trimmed value of str
    */
-  def trimExceptCRLF(str: String): String = {
+  private[util] def trimExceptCRLF(str: String): String = {
     val firstPos = str.indexWhere(nonSpaceOrNaturalLineDelimiter)
     val lastPos = str.lastIndexWhere(nonSpaceOrNaturalLineDelimiter)
     if (firstPos >= 0 && lastPos >= 0) {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2052,7 +2052,7 @@ private[spark] object Utils extends Logging {
   }
 
   /**
-   * Implements the same logic as JDK java.lang.String#trim by removing leading and trailing
+   * Implements the same logic as JDK `java.lang.String#trim` by removing leading and trailing
    * non-printable characters less or equal to '\u0020' (SPACE) but preserves natural line
    * delimiters according to [[java.util.Properties]] load method. The natural line delimiters are
    * removed by JDK during load. Therefore any remaining ones have been specifically provided and

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -1150,6 +1150,7 @@ class SparkSubmitSuite
     val LF = "\n"
     val CR = "\r"
 
+    val lineFeedFromCommandLine = s"${delimKey}lineFeedFromCommandLine" -> LF
     val leadingDelimKeyFromFile = s"${delimKey}leadingDelimKeyFromFile" -> s"${LF}blah"
     val trailingDelimKeyFromFile = s"${delimKey}trailingDelimKeyFromFile" -> s"blah${CR}"
     val infixDelimFromFile = s"${delimKey}infixDelimFromFile" -> s"${CR}blah${LF}"
@@ -1171,7 +1172,7 @@ class SparkSubmitSuite
 
     val clArgs = Seq(
       "--class", "org.SomeClass",
-      "--conf", s"${delimKey}=$LF",
+      "--conf", s"${lineFeedFromCommandLine._1}=${lineFeedFromCommandLine._2}",
       "--conf", "spark.master=yarn",
       "--properties-file", propsFile.getPath,
       "thejar.jar")
@@ -1179,10 +1180,14 @@ class SparkSubmitSuite
     val appArgs = new SparkSubmitArguments(clArgs)
     val (_, _, conf, _) = submit.prepareSubmitEnvironment(appArgs)
 
-    Seq((delimKey -> LF), leadingDelimKeyFromFile, trailingDelimKeyFromFile, infixDelimFromFile)
-      .foreach {
-        case (k, v) => conf.get(k) should be (v)
-      }
+    Seq(
+      lineFeedFromCommandLine,
+      leadingDelimKeyFromFile,
+      trailingDelimKeyFromFile,
+      infixDelimFromFile
+    ).foreach { case (k, v) =>
+      conf.get(k) should be (v)
+    }
 
     conf.get(nonDelimSpaceFromFile._1) should be ("blah")
   }

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -1155,10 +1155,12 @@ class SparkSubmitSuite
     val infixDelimFromFile = s"${delimKey}infixDelimFromFile" -> s"${CR}blah${LF}"
     val nonDelimSpaceFromFile = s"${delimKey}nonDelimSpaceFromFile" -> " blah\f"
 
-    val testProps = Seq(leadingDelimKeyFromFile, trailingDelimKeyFromFile, infixDelimFromFile, nonDelimSpaceFromFile)
+    val testProps = Seq(leadingDelimKeyFromFile, trailingDelimKeyFromFile, infixDelimFromFile,
+      nonDelimSpaceFromFile)
 
     val props = new java.util.Properties()
-    val propsFile = File.createTempFile("test-spark-conf", ".properties", Utils.createTempDir())
+    val propsFile = File.createTempFile("test-spark-conf", ".properties",
+      Utils.createTempDir())
     val propsOutputStream = new FileOutputStream(propsFile)
     try {
       testProps.foreach { case (k, v) => props.put(k, v) }

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -1205,6 +1205,39 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     assert(Utils.stringHalfWidth("\u0967\u0968\u0969") == 3)
     // scalastyle:on nonascii
   }
+
+  test("trimExceptCRLF standalone") {
+    val crlfSet = Set("\r", "\n")
+    val nonPrintableButCRLF =
+      (0 to 32).map(_.toChar.toString).toSet -- crlfSet
+
+    // identity for CRLF
+    crlfSet
+      .foreach(s => Utils.trimExceptCRLF(s) === s)
+
+    // empty for other non-printables
+    nonPrintableButCRLF
+      .foreach(s => assert(Utils.trimExceptCRLF(s) === ""))
+
+    // identity for a printable string
+    assert(Utils.trimExceptCRLF("a") === "a")
+
+    // identity for strings with CRLF
+    crlfSet
+      .foreach { s =>
+        assert(Utils.trimExceptCRLF(s"${s}a") === s"${s}a")
+        assert(Utils.trimExceptCRLF(s"a${s}") === s"a${s}")
+        assert(Utils.trimExceptCRLF(s"b${s}b") === s"b${s}b")
+      }
+
+    // trim nonPrintableButCRLF except when inside a string
+    nonPrintableButCRLF
+      .foreach { s =>
+        assert(Utils.trimExceptCRLF(s"${s}a") === "a")
+        assert(Utils.trimExceptCRLF(s"a${s}") === "a")
+        assert(Utils.trimExceptCRLF(s"b${s}b") === s"b${s}b")
+      }
+  }
 }
 
 private class SimpleExtension

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -1212,31 +1212,27 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
       (0 to 32).map(_.toChar.toString).toSet -- crlfSet
 
     // identity for CRLF
-    crlfSet
-      .foreach(s => Utils.trimExceptCRLF(s) === s)
+    crlfSet.foreach { s => Utils.trimExceptCRLF(s) === s }
 
     // empty for other non-printables
-    nonPrintableButCRLF
-      .foreach(s => assert(Utils.trimExceptCRLF(s) === ""))
+    nonPrintableButCRLF.foreach { s => assert(Utils.trimExceptCRLF(s) === "") }
 
     // identity for a printable string
     assert(Utils.trimExceptCRLF("a") === "a")
 
     // identity for strings with CRLF
-    crlfSet
-      .foreach { s =>
-        assert(Utils.trimExceptCRLF(s"${s}a") === s"${s}a")
-        assert(Utils.trimExceptCRLF(s"a${s}") === s"a${s}")
-        assert(Utils.trimExceptCRLF(s"b${s}b") === s"b${s}b")
-      }
+    crlfSet.foreach { s =>
+      assert(Utils.trimExceptCRLF(s"${s}a") === s"${s}a")
+      assert(Utils.trimExceptCRLF(s"a${s}") === s"a${s}")
+      assert(Utils.trimExceptCRLF(s"b${s}b") === s"b${s}b")
+    }
 
     // trim nonPrintableButCRLF except when inside a string
-    nonPrintableButCRLF
-      .foreach { s =>
-        assert(Utils.trimExceptCRLF(s"${s}a") === "a")
-        assert(Utils.trimExceptCRLF(s"a${s}") === "a")
-        assert(Utils.trimExceptCRLF(s"b${s}b") === s"b${s}b")
-      }
+    nonPrintableButCRLF.foreach { s =>
+      assert(Utils.trimExceptCRLF(s"${s}a") === "a")
+      assert(Utils.trimExceptCRLF(s"a${s}") === "a")
+      assert(Utils.trimExceptCRLF(s"b${s}b") === s"b${s}b")
+    }
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -1208,8 +1208,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
 
   test("trimExceptCRLF standalone") {
     val crlfSet = Set("\r", "\n")
-    val nonPrintableButCRLF =
-      (0 to 32).map(_.toChar.toString).toSet -- crlfSet
+    val nonPrintableButCRLF = (0 to 32).map(_.toChar.toString).toSet -- crlfSet
 
     // identity for CRLF
     crlfSet.foreach { s => Utils.trimExceptCRLF(s) === s }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Stop trimming values of properties loaded from a file

## How was this patch tested?

Added unit test demonstrating the issue hit in production.