### PR TITLE
[SPARK-23698][Python] Avoid 'undefined name' by defining __version__

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -28,6 +28,7 @@ if sys.version_info < (2, 7):
           file=sys.stderr)
     sys.exit(-1)
 
+__version__ = "Unknown"  # Prevent linters from raising 'undefined name'
 try:
     exec(open('pyspark/version.py').read())
 except IOError:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Prevent linters from raising __undefined name '\_\_version\_\_'__ by initializing the variable before setting it via a call to __exec()__.  This is the last remaining issue related to the work done in #20838

## How was this patch tested?
* $ __python2 -m flake8 . --count --select=E9,F82 --show-source --statistics__
* $ __python3 -m flake8 . --count --select=E9,F82 --show-source --statistics__

Please review http://spark.apache.org/contributing.html before opening a pull request.
