### PR TITLE
[SPARK-25228][CORE]Add executor CPU time metric.

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/ExecutorSource.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorSource.scala
@@ -86,12 +86,8 @@ class ExecutorSource(threadPool: ThreadPoolExecutor, executorId: String) extends
     val name = new ObjectName("java.lang", "type", "OperatingSystem")
     override def getValue: Long = {
       try {
-        val attribute = mBean.getAttribute(name, "ProcessCpuTime")
-        if (attribute != null) {
-          attribute.asInstanceOf[Long]
-        } else {
-          -1L
-        }
+        // return JVM process CPU time if the ProcessCpuTime method is available
+        mBean.getAttribute(name, "ProcessCpuTime").asInstanceOf[Long]
       } catch {
         case NonFatal(_) => -1L
       }

--- a/core/src/main/scala/org/apache/spark/executor/ExecutorSource.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorSource.scala
@@ -29,8 +29,6 @@ import org.apache.hadoop.fs.FileSystem
 
 import org.apache.spark.metrics.source.Source
 
-
-
 private[spark]
 class ExecutorSource(threadPool: ThreadPoolExecutor, executorId: String) extends Source {
 

--- a/core/src/main/scala/org/apache/spark/executor/ExecutorSource.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorSource.scala
@@ -82,9 +82,9 @@ class ExecutorSource(threadPool: ThreadPoolExecutor, executorId: String) extends
   // It will use proprietary extensions such as com.sun.management.OperatingSystemMXBean or
   // com.ibm.lang.management.OperatingSystemMXBean, if available.
   metricRegistry.register(MetricRegistry.name("jvmCpuTime"), new Gauge[Long] {
+    val mBean: MBeanServer = ManagementFactory.getPlatformMBeanServer
+    val name = new ObjectName("java.lang", "type", "OperatingSystem")
     override def getValue: Long = {
-      val mBean: MBeanServer = ManagementFactory.getPlatformMBeanServer
-      val name = new ObjectName("java.lang", "type", "OperatingSystem")
       try {
         val attribute = mBean.getAttribute(name, "ProcessCpuTime")
         if (attribute != null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a new metric to measure the executor's process (JVM) CPU time.

## How was this patch tested?

Manually tested on a Spark cluster (see SPARK-25228 for an example screenshot).