### PR TITLE
[SPARK-25224][SQL] Improvement of Spark SQL ThriftServer memory management

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -640,6 +640,16 @@ object SQLConf {
     .intConf
     .createWithDefault(200)
 
+  val THRIFTSERVER_BATCH_DESERIALIZE_LIMIT =
+    buildConf("spark.sql.thriftServer.batchDeserializeLimit")
+      .doc("The maximum number of result rows that can be deserialized at one time. " +
+        "If the number of result rows exceeds this value, the Thrift Server will only use " +
+        "'memory of serialized rows' + 'memory of the deserialized rows being fetched to the " +
+        "client'. Only valid if spark.sql.thriftServer.incrementalCollect is false. " +
+        "Default is no limit.")
+      .longConf
+      .createWithDefault(Long.MaxValue)
+
   // This is used to set the default data source
   val DEFAULT_DATA_SOURCE_NAME = buildConf("spark.sql.sources.default")
     .doc("The default data source to use in input/output.")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -640,15 +640,15 @@ object SQLConf {
     .intConf
     .createWithDefault(200)
 
-  val THRIFTSERVER_BATCH_DESERIALIZE_LIMIT =
-    buildConf("spark.sql.thriftServer.batchDeserializeLimit")
-      .doc("The maximum number of result rows that can be deserialized at one time. " +
-        "If the number of result rows exceeds this value, the Thrift Server will only use " +
+  val THRIFTSERVER_INCREMENTAL_DESERIALIZE =
+    buildConf("spark.sql.thriftServer.incrementalDeserialize")
+      .doc("When true, Thrift Server will deserialize result rows incrementally." +
+        "This feature only has an effect on collection phase, and does not affect scheduling of " +
+        "partitions. By deserialzing incrementally, the driver of Thrift Server will only use " +
         "'memory of serialized rows' + 'memory of the deserialized rows being fetched to the " +
-        "client'. Only valid if spark.sql.thriftServer.incrementalCollect is false. " +
-        "Default is no limit.")
-      .longConf
-      .createWithDefault(Long.MaxValue)
+        s"client'. Only valid if ${THRIFTSERVER_INCREMENTAL_COLLECT.key} is false.")
+      .booleanConf
+      .createWithDefault(false)
 
   // This is used to set the default data source
   val DEFAULT_DATA_SOURCE_NAME = buildConf("spark.sql.sources.default")

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -21,7 +21,6 @@ import java.io.{ByteArrayOutputStream, CharArrayWriter, DataOutputStream}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
-import scala.collection.SeqView
 import scala.language.implicitConversions
 import scala.util.control.NonFatal
 
@@ -219,7 +218,7 @@ class Dataset[T] private[sql](
 
   // The deserializer expression which can be used to build a projection and turn rows to objects
   // of type T, after collecting rows to the driver side.
-  private lazy val deserializer =
+  private[sql] lazy val deserializer =
     exprEnc.resolveAndBind(logicalPlan.output, sparkSession.sessionState.analyzer).deserializer
 
   private implicit def classTag = exprEnc.clsTag
@@ -3163,29 +3162,6 @@ class Dataset[T] private[sql](
     }.flatten
     files.toSet.toArray
   }
-
-  /**
-   * Returns the tuple of the row count and an SeqView that contains all rows in this Dataset.
-   *
-   * The SeqView` will consume as much memory as the total size of serialized results which can be
-   * limited with the config 'spark.driver.maxResultSize'. Rows are deserialized when iterating rows
-   * with iterator of returned SeqView. Whether to collect all deserialized rows or to iterate them
-   * incrementally can be decided with considering total rows count and driver memory.
-   */
-  private[sql] def collectCountAndSeqView(): (Long, SeqView[T, Array[T]]) =
-    withAction("collectCountAndSeqView", queryExecution) { plan =>
-      // This projection writes output to a `InternalRow`, which means applying this projection is
-      // not thread-safe. Here we create the projection inside this method to make `Dataset`
-      // thread-safe.
-      val objProj = GenerateSafeProjection.generate(deserializer :: Nil)
-      val (totalRowCount, internalRowsView) = plan.executeCollectSeqView()
-      (totalRowCount, internalRowsView.map { row =>
-        // The row returned by SafeProjection is `SpecificInternalRow`, which ignore the data type
-        // parameter of its `get` method, so it's safe to use null here.
-        objProj(row).get(0, null).asInstanceOf[T]
-      }.asInstanceOf[SeqView[T, Array[T]]])
-    }
-
   ////////////////////////////////////////////////////////////////////////////
   // For Python API
   ////////////////////////////////////////////////////////////////////////////
@@ -3365,7 +3341,7 @@ class Dataset[T] private[sql](
    * Wrap a Dataset action to track the QueryExecution and time cost, then report to the
    * user-registered callback functions.
    */
-  private def withAction[U](name: String, qe: QueryExecution)(action: SparkPlan => U) = {
+  private[sql] def withAction[U](name: String, qe: QueryExecution)(action: SparkPlan => U) = {
     SQLExecution.withNewExecutionId(sparkSession, qe, Some(name)) {
       qe.executedPlan.foreach { plan =>
         plan.resetMetrics()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -331,17 +331,19 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
    *
    * This is modeled after `RDD.take` but never runs any job locally on the driver.
    */
-  def executeTake(n: Int): Array[InternalRow] = {
+  def executeTake(n: Int): Array[InternalRow] = executeTakeIterator(n)._2.toArray
+
+  private[spark] def executeTakeIterator(n: Int): (Long, Iterator[InternalRow]) = {
     if (n == 0) {
-      return new Array[InternalRow](0)
+      return (0, Iterator.empty)
     }
 
-    val childRDD = getByteArrayRdd(n).map(_._2)
-
-    val buf = new ArrayBuffer[InternalRow]
+    val childRDD = getByteArrayRdd(n)
+    val encodedBuf = new ArrayBuffer[Array[Byte]]
     val totalParts = childRDD.partitions.length
+    var scannedRowCount = 0L
     var partsScanned = 0
-    while (buf.size < n && partsScanned < totalParts) {
+    while (scannedRowCount < n && partsScanned < totalParts) {
       // The number of partitions to try in this iteration. It is ok for this number to be
       // greater than totalParts because we actually cap it at totalParts in runJob.
       var numPartsToTry = 1L
@@ -350,30 +352,30 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
         // Otherwise, interpolate the number of partitions we need to try, but overestimate
         // it by 50%. We also cap the estimation in the end.
         val limitScaleUpFactor = Math.max(sqlContext.conf.limitScaleUpFactor, 2)
-        if (buf.isEmpty) {
+        if (scannedRowCount == 0) {
           numPartsToTry = partsScanned * limitScaleUpFactor
         } else {
-          val left = n - buf.size
+          val left = n - scannedRowCount
           // As left > 0, numPartsToTry is always >= 1
-          numPartsToTry = Math.ceil(1.5 * left * partsScanned / buf.size).toInt
+          numPartsToTry = Math.ceil(1.5 * left * partsScanned / scannedRowCount).toInt
           numPartsToTry = Math.min(numPartsToTry, partsScanned * limitScaleUpFactor)
         }
       }
 
       val p = partsScanned.until(math.min(partsScanned + numPartsToTry, totalParts).toInt)
       val sc = sqlContext.sparkContext
-      val res = sc.runJob(childRDD,
-        (it: Iterator[Array[Byte]]) => if (it.hasNext) it.next() else Array.empty[Byte], p)
+      val res = sc.runJob(childRDD, (it: Iterator[(Long, Array[Byte])]) =>
+        if (it.hasNext) it.next() else (0L, Array.empty[Byte]), p)
 
-      buf ++= res.flatMap(decodeUnsafeRows)
-
+      encodedBuf ++= res.map(_._2)
+      scannedRowCount += res.map(_._1).sum
       partsScanned += p.size
     }
 
-    if (buf.size > n) {
-      buf.take(n).toArray
+    if (scannedRowCount > n) {
+      (n, encodedBuf.toIterator.flatMap(decodeUnsafeRows).take(n))
     } else {
-      buf.toArray
+      (scannedRowCount, encodedBuf.toIterator.flatMap(decodeUnsafeRows))
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
@@ -80,11 +80,8 @@ case class ExecutedCommandExec(cmd: RunnableCommand) extends LeafExecNode {
 
   override def executeCollect(): Array[InternalRow] = sideEffectResult.toArray
 
-  override private[spark] def executeCollectSeqView(): (Long,
-    SeqView[InternalRow, Array[InternalRow]]) = {
-    val result = executeCollect()
-    (result.length, result.view)
-  }
+  override private[spark] def executeCollectSeqView(): SeqView[InternalRow, Array[InternalRow]] =
+    executeCollect().view
 
   override def executeToIterator: Iterator[InternalRow] = sideEffectResult.toIterator
 
@@ -123,11 +120,8 @@ case class DataWritingCommandExec(cmd: DataWritingCommand, child: SparkPlan)
 
   override def executeCollect(): Array[InternalRow] = sideEffectResult.toArray
 
-  override private[spark] def executeCollectSeqView(): (Long,
-    SeqView[InternalRow, Array[InternalRow]]) = {
-    val result = executeCollect()
-    (result.length, result.view)
-  }
+  override private[spark] def executeCollectSeqView(): SeqView[InternalRow, Array[InternalRow]] =
+    executeCollect().view
 
   override def executeToIterator: Iterator[InternalRow] = sideEffectResult.toIterator
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.execution.command
 
 import java.util.UUID
 
+import scala.collection.SeqView
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
@@ -78,6 +80,12 @@ case class ExecutedCommandExec(cmd: RunnableCommand) extends LeafExecNode {
 
   override def executeCollect(): Array[InternalRow] = sideEffectResult.toArray
 
+  override private[spark] def executeCollectSeqView(): (Long,
+    SeqView[InternalRow, Array[InternalRow]]) = {
+    val result = executeCollect()
+    (result.length, result.view)
+  }
+
   override def executeToIterator: Iterator[InternalRow] = sideEffectResult.toIterator
 
   override def executeTake(limit: Int): Array[InternalRow] = sideEffectResult.take(limit).toArray
@@ -114,6 +122,12 @@ case class DataWritingCommandExec(cmd: DataWritingCommand, child: SparkPlan)
   override def argString(maxFields: Int): String = cmd.argString(maxFields)
 
   override def executeCollect(): Array[InternalRow] = sideEffectResult.toArray
+
+  override private[spark] def executeCollectSeqView(): (Long,
+    SeqView[InternalRow, Array[InternalRow]]) = {
+    val result = executeCollect()
+    (result.length, result.view)
+  }
 
   override def executeToIterator: Iterator[InternalRow] = sideEffectResult.toIterator
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
@@ -39,8 +39,8 @@ case class CollectLimitExec(limit: Int, child: SparkPlan) extends UnaryExecNode 
   override def output: Seq[Attribute] = child.output
   override def outputPartitioning: Partitioning = SinglePartition
   override def executeCollect(): Array[InternalRow] = child.executeTake(limit)
-  override private[spark] def executeCollectSeqView(): (Long,
-    SeqView[InternalRow, Array[InternalRow]]) = child.executeTakeSeqView(limit)
+  override private[spark] def executeCollectSeqView(): SeqView[InternalRow, Array[InternalRow]] =
+    child.executeTakeSeqView(limit)
   private val serializer: Serializer = new UnsafeRowSerializer(child.output.size)
   private lazy val writeMetrics =
     SQLShuffleWriteMetricsReporter.createShuffleWriteMetrics(sparkContext)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution
 
+import scala.collection.SeqView
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.sql.catalyst.InternalRow
@@ -37,6 +39,8 @@ case class CollectLimitExec(limit: Int, child: SparkPlan) extends UnaryExecNode 
   override def output: Seq[Attribute] = child.output
   override def outputPartitioning: Partitioning = SinglePartition
   override def executeCollect(): Array[InternalRow] = child.executeTake(limit)
+  override private[spark] def executeCollectSeqView(): (Long,
+    SeqView[InternalRow, Array[InternalRow]]) = child.executeTakeSeqView(limit)
   private val serializer: Serializer = new UnsafeRowSerializer(child.output.size)
   private lazy val writeMetrics =
     SQLShuffleWriteMetricsReporter.createShuffleWriteMetrics(sparkContext)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1580,24 +1580,6 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     checkDataset(ds1.select("_2._2"), ds2.select("_2._2").collect(): _*)
   }
 
-  test("SPARK-25224: collectCountAndSeqView does not deserialize result in it") {
-    implicit val nonDeserializableEncoder = Encoders.javaSerialization[NonDeserializableJavaData]
-    val dsWithDeserializeError = spark.createDataset(Seq(new NonDeserializableJavaData(1),
-      new NonDeserializableJavaData(2), new NonDeserializableJavaData(3)))
-    val (rowCount1, resultView) = dsWithDeserializeError.collectCountAndSeqView()
-    assert(rowCount1 == 3)
-    intercept[UnsupportedOperationException] {
-      resultView.force
-    }
-
-    implicit val deserializableEncoder = Encoders.javaSerialization[JavaData]
-    val normalDS = spark.createDataset(Seq(JavaData(1), JavaData(2), JavaData(3)))
-    val (rowCount2, resultView2) = normalDS.collectCountAndSeqView()
-    val collected = resultView2.force
-    assert(rowCount2 == collected.length)
-    assert(normalDS.collect() sameElements collected)
-  }
-
   test("SPARK-24571: filtering of string values by char literal") {
     val df = Seq("Amsterdam", "San Francisco", "X").toDF("city")
     checkAnswer(df.where('city === 'X'), Seq(Row("X")))
@@ -1848,9 +1830,3 @@ case class CircularReferenceClassD(map: Map[String, CircularReferenceClassE])
 case class CircularReferenceClassE(id: String, list: List[CircularReferenceClassD])
 
 case class SpecialCharClass(`field.1`: String, `field 2`: String)
-
-class NonDeserializableJavaData(a: Int) extends JavaData(a) {
-  private def readObject(in: java.io.ObjectInputStream): Unit = {
-    throw new UnsupportedOperationException
-  }
-}

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
@@ -691,6 +691,16 @@ class HiveThriftBinaryServerSuite extends HiveThriftJdbcTest {
 
           rows_first.numRows()
         }
+
+        statement.execute(s"SET ${SQLConf.THRIFTSERVER_INCREMENTAL_DESERIALIZE.key}=true")
+        statement.setFetchSize(2)
+        val rs = statement.executeQuery("SELECT * FROM test_25224 WHERE key IS NOT NULL LIMIT 3")
+        Seq(238, 311, 255).foreach { key =>
+          rs.next()
+          assert(rs.getInt(1) === key)
+        }
+        assert(!rs.next())
+        rs.close()
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spark SQL only have two options for managing thriftserver memory - enable spark.sql.thriftServer.incrementalCollect or not

### The case of enabling spark.sql.thriftServer.incrementalCollects
   - Pros
        - thriftserver can handle large output without OOM.
   - Cons
        - Performance degradation because of executing task partition by partition.
        - Handle queries with count-limit inefficiently because of executing all partitions.
        - Does not cache result for FETCH_FIRST

### The case of disabling spark.sql.thriftServer.incrementalCollects
   - Pros
        - Good performance for small output
   - Cons
        - Memory peak usage is too large because allocating decompressed & deserialized rows in "batch" manner, and OOM could occur for large output.
        - It is difficult to measure memory peak usage of Query, so configuring spark.driver.maxResultSize is very difficult.
        - If decompressed & deserialized rows fills up eden area of JVM Heap, they moves to old Gen and could increase possibility of "Full GC" that stops the world.
 
### The improvement idea of solving these problems is below.
   - DataSet does not decompress & deserialize result, and just return total row count & iterator to SQL-Executor. By doing that, only compressed data reside in memory, so that the memory usage is not only much lower than before but can be controlled with spark.driver.maxResultSize config.

   - After SQL-Executor get total row count & iterator from DataSet, SQL-Executor could decide whether deserializing them collectively or iteratively with considering returned row count.

## How was this patch tested?
Add test cases.
