### PR TITLE
[SPARK-25229][SQL] Partition fields are uniformly processed into lowercase

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
@@ -494,6 +494,11 @@ abstract class ExternalCatalogSuite extends SparkFunSuite with BeforeAndAfterEac
           throw new AnalysisException(ex.getMessage)
       }
     }
+
+    val m = intercept[AnalysisException] {
+      checkAnswer(tbl2, Seq('A.int === 1 && 'b.string === "2"), Set(part1))
+    }.getMessage
+    assert(m.contains("Expected only partition pruning predicates"))
   }
 
   test("drop partitions") {


### PR DESCRIPTION
## What changes were proposed in this pull request?
```
scala> spark.version
res0: String = 2.3.0

scala> spark.sql("create table t(id int,name string) partitioned by(aA string)")

res1: org.apache.spark.sql.DataFrame = []

scala> spark.sql("insert into table t values(1,'Donahue','US')")

res2: org.apache.spark.sql.DataFrame = []

scala> spark.sql("select id,name from t where aA = 'US'").show(1)
org.apache.spark.sql.AnalysisException: Expected only partition pruning predicates: List(isnotnull(aA#25), (aA#25 = US));
at org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils$.prunePartitionsByFilter(ExternalCatalogUtils.scala:145)
at org.apache.spark.sql.hive.MetastoreRelation.getHiveQlPartitions(MetastoreRelation.scala:158)
at org.apache.spark.sql.hive.execution.HiveTableScanExec$$anonfun$10.apply(HiveTableScanExec.scala:151)
at org.apache.spark.sql.hive.execution.HiveTableScanExec$$anonfun$10.apply(HiveTableScanExec.scala:150)
at org.apache.spark.util.Utils$.withDummyCallSite(Utils.scala:2393)
at org.apache.spark.sql.hive.execution.HiveTableScanExec.doExecute(HiveTableScanExec.scala:149)
at org.apache.spark.sql.execution.SparkPlan$$anonfun$execute$1.apply(SparkPlan.scala:115)
at org.apache.spark.sql.execution.SparkPlan$$anonfun$execute$1.apply(SparkPlan.scala:115)
at org.apache.spark.sql.execution.SparkPlan$$anonfun$executeQuery$1.apply(SparkPlan.scala:136)
at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
at org.apache.spark.sql.execution.SparkPlan.executeQuery(SparkPlan.scala:133)
at org.apache.spark.sql.execution.SparkPlan.execute(SparkPlan.scala:114)
at org.apache.spark.sql.execution.SparkPlan.getByteArrayRdd(SparkPlan.scala:240)
at org.apache.spark.sql.execution.SparkPlan.executeTake(SparkPlan.scala:323)
at org.apache.spark.sql.execution.CollectLimitExec.executeCollect(limit.scala:39)
at org.apache.spark.sql.Dataset$$anonfun$org$apache$spark$sql$Dataset$$execute$1$1.apply(Dataset.scala:2194)
at org.apache.spark.sql.execution.SQLExecution$.withNewExecutionId(SQLExecution.scala:57)
at org.apache.spark.sql.Dataset.withNewExecutionId(Dataset.scala:2547)
at org.apache.spark.sql.Dataset.org$apache$spark$sql$Dataset$$execute$1(Dataset.scala:2193)
at org.apache.spark.sql.Dataset.org$apache$spark$sql$Dataset$$collect(Dataset.scala:2200)
at org.apache.spark.sql.Dataset$$anonfun$head$1.apply(Dataset.scala:1936)
at org.apache.spark.sql.Dataset$$anonfun$head$1.apply(Dataset.scala:1935)
at org.apache.spark.sql.Dataset.withTypedCallback(Dataset.scala:2577)
at org.apache.spark.sql.Dataset.head(Dataset.scala:1935)
at org.apache.spark.sql.Dataset.take(Dataset.scala:2150)
at org.apache.spark.sql.Dataset.showString(Dataset.scala:240)
at org.apache.spark.sql.Dataset.show(Dataset.scala:527)
at org.apache.spark.sql.Dataset.show(Dataset.scala:487)
... 48 elided
```


## How was this patch tested?
update existing test case

Please review http://spark.apache.org/contributing.html before opening a pull request.
