### PR TITLE
[SPARK-25083][SQL] Remove the type erasure hack in data source scan

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarBatchScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarBatchScan.scala
@@ -34,7 +34,7 @@ private[sql] trait ColumnarBatchScan extends CodegenSupport {
 
   def vectorTypes: Option[Seq[String]] = None
 
-  protected def supportsBatch: Boolean = true
+  override def supportsBatch: Boolean = true
 
   protected def needsUnsafeRowConversion: Boolean = true
 
@@ -55,15 +55,13 @@ private[sql] trait ColumnarBatchScan extends CodegenSupport {
   /**
    * Get input RDD depends on supportsBatch.
    */
-  final def getInputRDDs(): Seq[RDD[InternalRow]] = {
+  override def inputRDDs(): Seq[RDD[_]] = {
     if (supportsBatch) {
-      inputBatchRDDs().asInstanceOf[Seq[RDD[InternalRow]]]
+      inputBatchRDDs()
     } else {
       inputRowRDDs()
     }
   }
-
-  override def inputRDDs(): Seq[RDD[InternalRow]] = getInputRDDs()
 
   /**
    * Generate [[ColumnVector]] expressions for our parent to consume as rows.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -308,7 +308,7 @@ case class FileSourceScanExec(
     withSelectedBucketsCount
   }
 
-  private lazy val inputRDD: RDD[Object] = {
+  private lazy val inputRDD: RDD[_] = {
     val readFile: (PartitionedFile) => Iterator[InternalRow] =
       relation.fileFormat.buildReaderWithPartitionValues(
         sparkSession = relation.sparkSession,
@@ -387,7 +387,7 @@ case class FileSourceScanExec(
       bucketSpec: BucketSpec,
       readFile: (PartitionedFile) => Iterator[InternalRow],
       selectedPartitions: Seq[PartitionDirectory],
-      fsRelation: HadoopFsRelation): RDD[Object] = {
+      fsRelation: HadoopFsRelation): RDD[_] = {
     logInfo(s"Planning with ${bucketSpec.numBuckets} buckets")
     val filesGroupedToBuckets =
       selectedPartitions.flatMap { p =>
@@ -428,7 +428,7 @@ case class FileSourceScanExec(
   private def createNonBucketedReadRDD(
       readFile: (PartitionedFile) => Iterator[InternalRow],
       selectedPartitions: Seq[PartitionDirectory],
-      fsRelation: HadoopFsRelation): RDD[Object] = {
+      fsRelation: HadoopFsRelation): RDD[_] = {
     val defaultMaxSplitBytes =
       fsRelation.sparkSession.sessionState.conf.filesMaxPartitionBytes
     val openCostInBytes = fsRelation.sparkSession.sessionState.conf.filesOpenCostInBytes

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExpandExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExpandExec.scala
@@ -86,7 +86,7 @@ case class ExpandExec(
     }
   }
 
-  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+  override def inputRDDs(): Seq[RDD[_]] = {
     child.asInstanceOf[CodegenSupport].inputRDDs()
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/GenerateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/GenerateExec.scala
@@ -126,7 +126,7 @@ case class GenerateExec(
 
   override def supportCodegen: Boolean = false
 
-  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+  override def inputRDDs(): Seq[RDD[_]] = {
     child.asInstanceOf[CodegenSupport].inputRDDs()
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
@@ -117,7 +117,7 @@ case class SortExec(
 
   override def usedInputs: AttributeSet = AttributeSet(Seq.empty)
 
-  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+  override def inputRDDs(): Seq[RDD[_]] = {
     child.asInstanceOf[CodegenSupport].inputRDDs()
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -147,7 +147,7 @@ case class HashAggregateExec(
     !aggregateExpressions.exists(_.aggregateFunction.isInstanceOf[ImperativeAggregate])
   }
 
-  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+  override def inputRDDs(): Seq[RDD[_]] = {
     child.asInstanceOf[CodegenSupport].inputRDDs()
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -37,7 +37,7 @@ case class ProjectExec(projectList: Seq[NamedExpression], child: SparkPlan)
 
   override def output: Seq[Attribute] = projectList.map(_.toAttribute)
 
-  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+  override def inputRDDs(): Seq[RDD[_]] = {
     child.asInstanceOf[CodegenSupport].inputRDDs()
   }
 
@@ -117,7 +117,7 @@ case class FilterExec(condition: Expression, child: SparkPlan)
   override lazy val metrics = Map(
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))
 
-  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+  override def inputRDDs(): Seq[RDD[_]] = {
     child.asInstanceOf[CodegenSupport].inputRDDs()
   }
 
@@ -267,7 +267,7 @@ case class SampleExec(
   // to the parent operator.
   override def usedInputs: AttributeSet = AttributeSet.empty
 
-  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+  override def inputRDDs(): Seq[RDD[_]] = {
     child.asInstanceOf[CodegenSupport].inputRDDs()
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
@@ -66,12 +66,12 @@ class FileScanRDD(
     @transient private val sparkSession: SparkSession,
     readFunction: (PartitionedFile) => Iterator[InternalRow],
     @transient val filePartitions: Seq[FilePartition])
-  extends RDD[InternalRow](sparkSession.sparkContext, Nil) {
+  extends RDD[Object](sparkSession.sparkContext, Nil) {
 
   private val ignoreCorruptFiles = sparkSession.sessionState.conf.ignoreCorruptFiles
   private val ignoreMissingFiles = sparkSession.sessionState.conf.ignoreMissingFiles
 
-  override def compute(split: RDDPartition, context: TaskContext): Iterator[InternalRow] = {
+  override def compute(split: RDDPartition, context: TaskContext): Iterator[Object] = {
     val iterator = new Iterator[Object] with AutoCloseable {
       private val inputMetrics = context.taskMetrics().inputMetrics
       private val existingBytesRead = inputMetrics.bytesRead
@@ -216,7 +216,7 @@ class FileScanRDD(
     // Register an on-task-completion callback to close the input stream.
     context.addTaskCompletionListener[Unit](_ => iterator.close())
 
-    iterator.asInstanceOf[Iterator[InternalRow]] // This is an erasure hack.
+    iterator
   }
 
   override protected def getPartitions: Array[RDDPartition] = filePartitions.toArray

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
@@ -238,7 +238,7 @@ package object debug {
 
     override def outputPartitioning: Partitioning = child.outputPartitioning
 
-    override def inputRDDs(): Seq[RDD[InternalRow]] = {
+    override def inputRDDs(): Seq[RDD[_]] = {
       child.asInstanceOf[CodegenSupport].inputRDDs()
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinExec.scala
@@ -73,7 +73,7 @@ case class BroadcastHashJoinExec(
     }
   }
 
-  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+  override def inputRDDs(): Seq[RDD[_]] = {
     streamedPlan.asInstanceOf[CodegenSupport].inputRDDs()
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
@@ -61,7 +61,7 @@ case class LocalLimitExec(limit: Int, child: SparkPlan) extends UnaryExecNode wi
     iter.take(limit)
   }
 
-  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+  override def inputRDDs(): Seq[RDD[_]] = {
     child.asInstanceOf[CodegenSupport].inputRDDs()
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
@@ -72,7 +72,7 @@ case class DeserializeToObjectExec(
 
   override def outputPartitioning: Partitioning = child.outputPartitioning
 
-  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+  override def inputRDDs(): Seq[RDD[_]] = {
     child.asInstanceOf[CodegenSupport].inputRDDs()
   }
 
@@ -106,7 +106,7 @@ case class SerializeFromObjectExec(
 
   override def outputPartitioning: Partitioning = child.outputPartitioning
 
-  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+  override def inputRDDs(): Seq[RDD[_]] = {
     child.asInstanceOf[CodegenSupport].inputRDDs()
   }
 
@@ -203,7 +203,7 @@ case class MapElementsExec(
     child: SparkPlan)
   extends ObjectConsumerExec with ObjectProducerExec with CodegenSupport {
 
-  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+  override def inputRDDs(): Seq[RDD[_]] = {
     child.asInstanceOf[CodegenSupport].inputRDDs()
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Add function `inputBatchRDDs` and `inputRowRDDs` in `ColumnarBatchScan`.
2. Rewrite the 2 functions in physical nodes which extend `ColumnarBatchScan`.
3. Remove hack alert in `InMemoryTableScanExec` and `FileScanRDD`.
https://github.com/apache/spark/blob/ab33028957443189efc4106afd9d65dddf8f9c98/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala#L108-L109
https://github.com/apache/spark/blob/ab33028957443189efc4106afd9d65dddf8f9c98/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala#L219
4. Remove TODOs in `DataSourceRDD`.
https://github.com/apache/spark/blob/ab33028957443189efc4106afd9d65dddf8f9c98/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceRDD.scala#L28-L29
https://github.com/apache/spark/blob/ab33028957443189efc4106afd9d65dddf8f9c98/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceRDD.scala#L75

## How was this patch tested?

Existing UT.
