### PR TITLE
[SPARK-25233][Streaming] Give the user the option of specifying a minimum message per partition per batch when using kafka direct API with backpressure

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1926,6 +1926,14 @@ showDF(properties, numRows = 200, truncate = FALSE)
   </td>
 </tr>
 <tr>
+  <td><code>spark.streaming.backpressure.fixedMinMessagePerPartition</code></td>
+  <td>1</td>
+  <td>
+    This sets a fixed minimum message per partition per batch when the backpressure mechanism is enabled. The
+    default value is 1.
+  </td>
+</tr>
+<tr>
   <td><code>spark.streaming.blockInterval</code></td>
   <td>200ms</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1926,14 +1926,6 @@ showDF(properties, numRows = 200, truncate = FALSE)
   </td>
 </tr>
 <tr>
-  <td><code>spark.streaming.backpressure.fixedMinMessagePerPartition</code></td>
-  <td>1</td>
-  <td>
-    This sets a fixed minimum message per partition per batch when the backpressure mechanism is enabled. The
-    default value is 1.
-  </td>
-</tr>
-<tr>
   <td><code>spark.streaming.blockInterval</code></td>
   <td>200ms</td>
   <td>
@@ -1992,6 +1984,14 @@ showDF(properties, numRows = 200, truncate = FALSE)
     <a href="streaming-kafka-integration.html">Kafka Integration guide</a>
     for more details.
   </td>
+</tr>
+<tr>
+    <td><code>spark.streaming.kafka.minRatePerPartition</code></td>
+    <td>1</td>
+    <td>
+      Minimum rate (number of records per second) at which data will be read from each Kafka
+      partition when using the new Kafka direct stream API.
+    </td>
 </tr>
 <tr>
   <td><code>spark.streaming.kafka.maxRetries</code></td>

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
@@ -141,6 +141,7 @@ private[spark] class DirectKafkaInputDStream[K, V](
           tp -> Math.max(offset - currentOffsets(tp), 0)
         }
         val totalLag = lagPerPartition.values.sum
+
         lagPerPartition.map { case (tp, lag) =>
           val maxRateLimitPerPartition = ppc.maxRatePerPartition(tp)
           val backpressureRate = lag / totalLag.toDouble * rate
@@ -154,7 +155,7 @@ private[spark] class DirectKafkaInputDStream[K, V](
       val secsPerBatch = context.graph.batchDuration.milliseconds.toDouble / 1000
       Some(effectiveRateLimitPerPartition.map {
         case (tp, limit) => tp -> Math.max((secsPerBatch * limit).toLong,
-          Math.max(ppc.minRatePerPartition(tp), 1L))
+          ppc.minRatePerPartition(tp))
       })
     } else {
       None

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/PerPartitionConfig.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/PerPartitionConfig.scala
@@ -34,6 +34,7 @@ abstract class PerPartitionConfig extends Serializable {
    *  from each Kafka partition.
    */
   def maxRatePerPartition(topicPartition: TopicPartition): Long
+  def minRatePerPartition(topicPartition: TopicPartition): Long
 }
 
 /**
@@ -42,6 +43,8 @@ abstract class PerPartitionConfig extends Serializable {
 private class DefaultPerPartitionConfig(conf: SparkConf)
     extends PerPartitionConfig {
   val maxRate = conf.getLong("spark.streaming.kafka.maxRatePerPartition", 0)
-
+  val minRate = conf.getLong("spark.streaming.kafka.minRatePerPartition", 1)
+  
   def maxRatePerPartition(topicPartition: TopicPartition): Long = maxRate
+  def minRatePerPartition(topicPartition: TopicPartition): Long = minRate
 }

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/PerPartitionConfig.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/PerPartitionConfig.scala
@@ -34,7 +34,7 @@ abstract class PerPartitionConfig extends Serializable {
    *  from each Kafka partition.
    */
   def maxRatePerPartition(topicPartition: TopicPartition): Long
-  def minRatePerPartition(topicPartition: TopicPartition): Long
+  def minRatePerPartition(topicPartition: TopicPartition): Long = 1
 }
 
 /**
@@ -46,5 +46,5 @@ private class DefaultPerPartitionConfig(conf: SparkConf)
   val minRate = conf.getLong("spark.streaming.kafka.minRatePerPartition", 1)
 
   def maxRatePerPartition(topicPartition: TopicPartition): Long = maxRate
-  def minRatePerPartition(topicPartition: TopicPartition): Long = minRate
+  override def minRatePerPartition(topicPartition: TopicPartition): Long = minRate
 }

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/PerPartitionConfig.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/PerPartitionConfig.scala
@@ -44,7 +44,7 @@ private class DefaultPerPartitionConfig(conf: SparkConf)
     extends PerPartitionConfig {
   val maxRate = conf.getLong("spark.streaming.kafka.maxRatePerPartition", 0)
   val minRate = conf.getLong("spark.streaming.kafka.minRatePerPartition", 1)
-  
+
   def maxRatePerPartition(topicPartition: TopicPartition): Long = maxRate
   def minRatePerPartition(topicPartition: TopicPartition): Long = minRate
 }

--- a/external/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
+++ b/external/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
@@ -543,6 +543,7 @@ class DirectKafkaStreamSuite
         } else {
           100
         }
+      def minRatePerPartition(tp: TopicPartition) = 1
     })
     val kafkaStream = getDirectKafkaStream(topic, rateController, ppc)
 
@@ -675,7 +676,7 @@ class DirectKafkaStreamSuite
       .setMaster("local[1]")
       .setAppName(this.getClass.getSimpleName)
       .set("spark.streaming.kafka.maxRatePerPartition", "100")
-      .set("spark.streaming.backpressure.fixedMinMessagePerPartition", "5")
+      .set("spark.streaming.kafka.minRatePerPartition", "5")
 
 
     // Setup the streaming context

--- a/external/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
+++ b/external/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
@@ -543,7 +543,6 @@ class DirectKafkaStreamSuite
         } else {
           100
         }
-      def minRatePerPartition(tp: TopicPartition) = 1
     })
     val kafkaStream = getDirectKafkaStream(topic, rateController, ppc)
 

--- a/external/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
+++ b/external/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
@@ -664,7 +664,8 @@ class DirectKafkaStreamSuite
     kafkaStream.stop()
   }
 
-  test("maxMessagesPerPartition with zero offset and rate equal to one") {
+  test("maxMessagesPerPartition with zero offset and rate equal to the specified" +
+    " minimum with default 1") {
     val topic = "backpressure"
     val kafkaParams = getKafkaParams()
     val batchIntervalMilliseconds = 60000
@@ -674,6 +675,8 @@ class DirectKafkaStreamSuite
       .setMaster("local[1]")
       .setAppName(this.getClass.getSimpleName)
       .set("spark.streaming.kafka.maxRatePerPartition", "100")
+      .set("spark.streaming.backpressure.fixedMinMessagePerPartition", "5")
+
 
     // Setup the streaming context
     ssc = new StreamingContext(sparkConf, Milliseconds(batchIntervalMilliseconds))
@@ -704,12 +707,13 @@ class DirectKafkaStreamSuite
     )
     val result = kafkaStream.maxMessagesPerPartition(offsets)
     val expected = Map(
-      new TopicPartition(topic, 0) -> 1L,
+      new TopicPartition(topic, 0) -> 5L,
       new TopicPartition(topic, 1) -> 10L,
       new TopicPartition(topic, 2) -> 20L,
       new TopicPartition(topic, 3) -> 30L
     )
-    assert(result.contains(expected), s"Number of messages per partition must be at least 1")
+    assert(result.contains(expected), s"Number of messages per partition must be at least equal" +
+      s" to the specified minimum")
   }
 
   /** Get the generated offset ranges from the DirectKafkaStream */


### PR DESCRIPTION
After SPARK-18371, it is guaranteed that there would be at least one message per partition per batch using direct kafka API when new messages exist in the topics. This change will give the user the option of setting the minimum instead of just a hard coded 1 limit
The related unit test is updated and some internal tests verified that the topic partitions with new messages will be progressed by the specified minimum.