### PR TITLE
[SPARK-25237][SQL]remove updateBytesReadWithFileSize because we use Hadoop FileSystem s…

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
@@ -89,14 +89,6 @@ class FileScanRDD(
         inputMetrics.setBytesRead(existingBytesRead + getBytesReadCallback())
       }
 
-      // If we can't get the bytes read from the FS stats, fall back to the file size,
-      // which may be inaccurate.
-      private def updateBytesReadWithFileSize(): Unit = {
-        if (currentFile != null) {
-          inputMetrics.incBytesRead(currentFile.length)
-        }
-      }
-
       private[this] val files = split.asInstanceOf[FilePartition].files.toIterator
       private[this] var currentFile: PartitionedFile = null
       private[this] var currentIterator: Iterator[Object] = null
@@ -139,7 +131,6 @@ class FileScanRDD(
 
       /** Advances to the next file. Returns true if a new non-empty iterator is available. */
       private def nextIterator(): Boolean = {
-        updateBytesReadWithFileSize()
         if (files.hasNext) {
           currentFile = files.next()
           logInfo(s"Reading File $currentFile")
@@ -208,7 +199,6 @@ class FileScanRDD(
 
       override def close(): Unit = {
         updateBytesRead()
-        updateBytesReadWithFileSize()
         InputFileBlockHolder.unset()
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceSuite.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.scheduler.{SparkListener, SparkListenerTaskEnd}
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.expressions.PredicateHelper
+import org.apache.spark.sql.test.SharedSQLContext
+
+
+class FileSourceSuite extends QueryTest with SharedSQLContext with PredicateHelper {
+
+  test("[SPARK-25237] remove updateBytesReadWithFileSize in FileScanRdd") {
+    withTempPath { p =>
+      val path = p.getAbsolutePath
+      spark.range(1000).selectExpr("id AS c0", "rand() AS c1").repartition(10).write.csv(path)
+
+      val bytesReads = new ArrayBuffer[Long]()
+      val bytesReadListener = new SparkListener() {
+        override def onTaskEnd(taskEnd: SparkListenerTaskEnd) {
+          bytesReads += taskEnd.taskMetrics.inputMetrics.bytesRead
+        }
+      }
+      // Avoid receiving earlier taskEnd events
+      spark.sparkContext.listenerBus.waitUntilEmpty(500)
+
+      spark.sparkContext.addSparkListener(bytesReadListener)
+
+      spark.read.csv(path).limit(1).collect()
+
+      spark.sparkContext.listenerBus.waitUntilEmpty(500)
+      spark.sparkContext.removeSparkListener(bytesReadListener)
+
+      assert(bytesReads.sum < 5000)
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceSuite.scala
@@ -31,6 +31,7 @@ class FileSourceSuite extends QueryTest with SharedSQLContext with PredicateHelp
     withTempPath { p =>
       val path = p.getAbsolutePath
       spark.range(1000).selectExpr("id AS c0", "rand() AS c1").repartition(10).write.csv(path)
+      val df = spark.read.csv(path).limit(1)
 
       val bytesReads = new ArrayBuffer[Long]()
       val bytesReadListener = new SparkListener() {
@@ -43,12 +44,12 @@ class FileSourceSuite extends QueryTest with SharedSQLContext with PredicateHelp
 
       spark.sparkContext.addSparkListener(bytesReadListener)
 
-      spark.read.csv(path).limit(1).collect()
+      df.collect()
 
       spark.sparkContext.listenerBus.waitUntilEmpty(500)
       spark.sparkContext.removeSparkListener(bytesReadListener)
 
-      assert(bytesReads.sum < 5000)
+      assert(bytesReads.sum < 3000)
     }
   }
 }


### PR DESCRIPTION
…tatistics to update the inputMetrics

## What changes were proposed in this pull request?

In FileScanRdd, we will update inputMetrics's bytesRead using updateBytesRead  every 1000 rows or when close the iterator.

but when close the iterator,  we will invoke updateBytesReadWithFileSize to increase the inputMetrics's bytesRead with file's length.

this will result in the inputMetrics's bytesRead is wrong when run the query with limit such as select * from table limit 1.

because we do not support for Hadoop 2.5 and earlier now, we always get the bytesRead from  Hadoop FileSystem statistics other than files's length.

## How was this patch tested?

manual test

