### PR TITLE
[SPARK-25243][SQL] Use FailureSafeParser in from_json

### DIFF
--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -1694,7 +1694,7 @@ test_that("column functions", {
   df <- as.DataFrame(list(list("col" = "{\"date\":\"21/10/2014\"}")))
   schema2 <- structType(structField("date", "date"))
   s <- collect(select(df, from_json(df$col, schema2)))
-  expect_equal(s[[1]][[1]], NA)
+  expect_equal(s[[1]][[1]]$date, NA)
   s <- collect(select(df, from_json(df$col, schema2, dateFormat = "dd/MM/yyyy")))
   expect_is(s[[1]][[1]]$date, "Date")
   expect_equal(as.character(s[[1]][[1]]$date), "2014-10-21")

--- a/docs/sql-migration-guide-upgrade.md
+++ b/docs/sql-migration-guide-upgrade.md
@@ -13,6 +13,8 @@ displayTitle: Spark SQL Upgrading Guide
 
   - In Spark version 2.4 and earlier, the parser of JSON data source treats empty strings as null for some data types such as `IntegerType`. For `FloatType` and `DoubleType`, it fails on empty strings and throws exceptions. Since Spark 3.0, we disallow empty strings and will throw exceptions for data types except for `StringType` and `BinaryType`.
 
+  - Since Spark 3.0, the `from_json` functions supports two modes - `PERMISSIVE` and `FAILFAST`. The modes can be set via the `mode` option. The default mode became `PERMISSIVE`. In previous versions, behavior of `from_json` did not conform to either `PERMISSIVE` nor `FAILFAST`, especially in processing of malformed JSON records. For example, the JSON string `{"a" 1}` with the schema `a INT` is converted to `null` by previous versions but Spark 3.0 converts it to `Row(null)`.
+
 ## Upgrading From Spark SQL 2.3 to 2.4
 
   - In Spark version 2.3 and earlier, the second parameter to array_contains function is implicitly promoted to the element type of first array type parameter. This type promotion can be lossy and may cause `array_contains` function to return wrong result. This problem has been addressed in 2.4 by employing a safer type promotion mechanism. This can cause some change in behavior and are illustrated in the table below.

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2305,7 +2305,7 @@ def from_json(col, schema, options={}):
     [Row(json=[Row(a=1)])]
     >>> schema = schema_of_json(lit('''{"a": 0}'''))
     >>> df.select(from_json(df.value, schema).alias("json")).collect()
-    [Row(json=Row(a=1))]
+    [Row(json=Row(a=None))]
     >>> data = [(1, '''[1, 2, 3]''')]
     >>> schema = ArrayType(IntegerType())
     >>> df = spark.createDataFrame(data, ("key", "value"))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -564,8 +564,10 @@ case class JsonToStructs(
   @transient lazy val parser = {
     val parsedOptions = new JSONOptions(options, timeZoneId.get)
     val mode = parsedOptions.parseMode
-    require(mode == PermissiveMode || mode == FailFastMode,
-      s"The functions supports only the ${PermissiveMode.name} and ${FailFastMode.name} modes.")
+    if (mode != PermissiveMode && mode != FailFastMode) {
+      throw new AnalysisException(s"from_json() doesn't support the ${mode.name} mode. " +
+        s"Acceptable modes are ${PermissiveMode.name} and ${FailFastMode.name}.")
+    }
     val rawParser = new JacksonParser(nullableSchema, parsedOptions)
     val createParser = CreateJacksonParser.utf8String _
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -568,7 +568,7 @@ case class JsonToStructs(
       throw new IllegalArgumentException(s"from_json() doesn't support the ${mode.name} mode. " +
         s"Acceptable modes are ${PermissiveMode.name} and ${FailFastMode.name}.")
     }
-    val rawParser = new JacksonParser(nullableSchema, parsedOptions, explodeArray = false)
+    val rawParser = new JacksonParser(nullableSchema, parsedOptions, allowArrayAsStructs = false)
     val createParser = CreateJacksonParser.utf8String _
 
     new FailureSafeParser[UTF8String](

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -561,8 +561,9 @@ case class JsonToStructs(
       (rows: Iterator[InternalRow]) => if (rows.hasNext) rows.next().getMap(0) else null
   }
 
+  val nameOfCorruptRecord = SQLConf.get.getConf(SQLConf.COLUMN_NAME_OF_CORRUPT_RECORD)
   @transient lazy val parser = {
-    val parsedOptions = new JSONOptions(options, timeZoneId.get)
+    val parsedOptions = new JSONOptions(options, timeZoneId.get, nameOfCorruptRecord)
     val mode = parsedOptions.parseMode
     if (mode != PermissiveMode && mode != FailFastMode) {
       throw new IllegalArgumentException(s"from_json() doesn't support the ${mode.name} mode. " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -553,7 +553,7 @@ case class JsonToStructs(
   // This converts parsed rows to the desired output by the given schema.
   @transient
   lazy val converter = nullableSchema match {
-    case st: StructType =>
+    case _: StructType =>
       (rows: Iterator[InternalRow]) => if (rows.hasNext) rows.next() else null
     case _: ArrayType =>
       (rows: Iterator[InternalRow]) => if (rows.hasNext) rows.next().getArray(0) else null

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -572,10 +572,15 @@ case class JsonToStructs(
     val rawParser = new JacksonParser(nullableSchema, parsedOptions, allowArrayAsStructs = false)
     val createParser = CreateJacksonParser.utf8String _
 
+    val parserSchema = nullableSchema match {
+      case s: StructType => s
+      case other => StructType(StructField("value", other) :: Nil)
+    }
+
     new FailureSafeParser[UTF8String](
       input => rawParser.parse(input, createParser, identity[UTF8String]),
       mode,
-      schema,
+      parserSchema,
       parsedOptions.columnNameOfCorruptRecord,
       parsedOptions.multiLine)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -561,15 +561,18 @@ case class JsonToStructs(
       (rows: Iterator[InternalRow]) => if (rows.hasNext) rows.next().getMap(0) else null
   }
 
-  @transient lazy val parsedOptions = new JSONOptions(options, timeZoneId.get)
-  @transient lazy val rawParser = new JacksonParser(nullableSchema, parsedOptions)
-  @transient lazy val createParser = CreateJacksonParser.utf8String _
-  @transient lazy val parser = new FailureSafeParser[UTF8String](
-    input => rawParser.parse(input, createParser, identity[UTF8String]),
-    parsedOptions.parseMode,
-    schema,
-    parsedOptions.columnNameOfCorruptRecord,
-    parsedOptions.multiLine)
+  @transient lazy val parser = {
+    val parsedOptions = new JSONOptions(options, timeZoneId.get)
+    val rawParser = new JacksonParser(nullableSchema, parsedOptions)
+    val createParser = CreateJacksonParser.utf8String _
+
+    new FailureSafeParser[UTF8String](
+      input => rawParser.parse(input, createParser, identity[UTF8String]),
+      parsedOptions.parseMode,
+      schema,
+      parsedOptions.columnNameOfCorruptRecord,
+      parsedOptions.multiLine)
+  }
 
   override def dataType: DataType = nullableSchema
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -585,27 +585,6 @@ case class JsonToStructs(
     copy(timeZoneId = Option(timeZoneId))
 
   override def nullSafeEval(json: Any): Any = {
-    // When input is,
-    //   - `null`: `null`.
-    //   - invalid json: `null`.
-    //   - empty string: `null`.
-    //
-    // When the schema is array,
-    //   - json array: `Array(Row(...), ...)`
-    //   - json object: `Array(Row(...))`
-    //   - empty json array: `Array()`.
-    //   - empty json object: `Array(Row(null))`.
-    //
-    // When the schema is a struct,
-    //   - json object/array with single element: `Row(...)`
-    //   - json array with multiple elements: `null`
-    //   - empty json array: `null`.
-    //   - empty json object: `Row(null)`.
-
-    // We need `null` if the input string is an empty string. `JacksonParser` can
-    // deal with this but produces `Nil`.
-    if (json.toString.trim.isEmpty) return null
-
     converter(parser.parse(json.asInstanceOf[UTF8String]))
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -565,7 +565,7 @@ case class JsonToStructs(
     val parsedOptions = new JSONOptions(options, timeZoneId.get)
     val mode = parsedOptions.parseMode
     if (mode != PermissiveMode && mode != FailFastMode) {
-      throw new AnalysisException(s"from_json() doesn't support the ${mode.name} mode. " +
+      throw new IllegalArgumentException(s"from_json() doesn't support the ${mode.name} mode. " +
         s"Acceptable modes are ${PermissiveMode.name} and ${FailFastMode.name}.")
     }
     val rawParser = new JacksonParser(nullableSchema, parsedOptions)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -606,11 +606,7 @@ case class JsonToStructs(
     // deal with this but produces `Nil`.
     if (json.toString.trim.isEmpty) return null
 
-    try {
-      converter(parser.parse(json.asInstanceOf[UTF8String]))
-    } catch {
-      case _: BadRecordException => null
-    }
+    converter(parser.parse(json.asInstanceOf[UTF8String]))
   }
 
   override def inputTypes: Seq[AbstractDataType] = StringType :: Nil

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -563,12 +563,15 @@ case class JsonToStructs(
 
   @transient lazy val parser = {
     val parsedOptions = new JSONOptions(options, timeZoneId.get)
+    val mode = parsedOptions.parseMode
+    require(mode == PermissiveMode || mode == FailFastMode,
+      s"The functions supports only the ${PermissiveMode.name} and ${FailFastMode.name} modes.")
     val rawParser = new JacksonParser(nullableSchema, parsedOptions)
     val createParser = CreateJacksonParser.utf8String _
 
     new FailureSafeParser[UTF8String](
       input => rawParser.parse(input, createParser, identity[UTF8String]),
-      parsedOptions.parseMode,
+      mode,
       schema,
       parsedOptions.columnNameOfCorruptRecord,
       parsedOptions.multiLine)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -568,7 +568,7 @@ case class JsonToStructs(
       throw new IllegalArgumentException(s"from_json() doesn't support the ${mode.name} mode. " +
         s"Acceptable modes are ${PermissiveMode.name} and ${FailFastMode.name}.")
     }
-    val rawParser = new JacksonParser(nullableSchema, parsedOptions)
+    val rawParser = new JacksonParser(nullableSchema, parsedOptions, explodeArray = false)
     val createParser = CreateJacksonParser.utf8String _
 
     new FailureSafeParser[UTF8String](

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -38,7 +38,8 @@ import org.apache.spark.util.Utils
  */
 class JacksonParser(
     schema: DataType,
-    val options: JSONOptions) extends Logging {
+    val options: JSONOptions,
+    explodeArray: Boolean) extends Logging {
 
   import JacksonUtils._
   import com.fasterxml.jackson.core.JsonToken._
@@ -90,6 +91,10 @@ class JacksonParser(
         // in such an array as a row, this case is possible.
         if (array.numElements() == 0) {
           Nil
+        } else if (array.numElements() > 1 && !explodeArray) {
+          throw new RuntimeException("Found an array with more than one element for " +
+            s"the specified schema ${st.catalogString}. " +
+            s"The array cannot be converted to the type.")
         } else {
           array.toArray[InternalRow](schema).toSeq
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/FailureSafeParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/FailureSafeParser.scala
@@ -36,10 +36,9 @@ class FailureSafeParser[IN](
   private val toResultRow: (Option[InternalRow], () => UTF8String) => InternalRow = schema match {
     case struct: StructType =>
       val corruptFieldIndex = struct.getFieldIndex(columnNameOfCorruptRecord)
-      val actualSchema = StructType(struct.filterNot(_.name == columnNameOfCorruptRecord))
-      val resultRow = new GenericInternalRow(struct.length)
-      val nullResult = new GenericInternalRow(struct.length)
       if (corruptFieldIndex.isDefined) {
+        val actualSchema = StructType(struct.filterNot(_.name == columnNameOfCorruptRecord))
+        val resultRow = new GenericInternalRow(struct.length)
         (row, badRecord) => {
           var i = 0
           while (i < actualSchema.length) {
@@ -51,6 +50,7 @@ class FailureSafeParser[IN](
           resultRow
         }
       } else {
+        val nullResult = new GenericInternalRow(struct.length)
         (row, _) => row.getOrElse(nullResult)
       }
     case _ => (row, _) => row.getOrElse(new GenericInternalRow(1))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/FailureSafeParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/FailureSafeParser.scala
@@ -33,26 +33,32 @@ class FailureSafeParser[IN](
   // schema doesn't contain a field for corrupted record, we just return the partial result or a
   // row with all fields null. If the given schema contains a field for corrupted record, we will
   // set the bad record to this field, and set other fields according to the partial result or null.
-  private val toResultRow: (Option[InternalRow], () => UTF8String) => InternalRow = dataType match {
-    case struct: StructType =>
-      val corruptFieldIndex = struct.getFieldIndex(columnNameOfCorruptRecord)
-      if (corruptFieldIndex.isDefined) {
-        val actualSchema = StructType(struct.filterNot(_.name == columnNameOfCorruptRecord))
-        val resultRow = new GenericInternalRow(struct.length)
-        (row, badRecord) => {
-          var i = 0
-          while (i < actualSchema.length) {
-            val from = actualSchema(i)
-            resultRow(struct.fieldIndex(from.name)) = row.map(_.get(i, from.dataType)).orNull
-            i += 1
-          }
-          resultRow(corruptFieldIndex.get) = badRecord()
-          resultRow
+  private def structToResultRow(
+      struct: StructType)
+    : (Option[InternalRow], () => UTF8String) => InternalRow = {
+    val corruptFieldIndex = struct.getFieldIndex(columnNameOfCorruptRecord)
+
+    if (corruptFieldIndex.isDefined) {
+      val actualSchema = StructType(struct.filterNot(_.name == columnNameOfCorruptRecord))
+      val resultRow = new GenericInternalRow(struct.length)
+      (row, badRecord) => {
+        var i = 0
+        while (i < actualSchema.length) {
+          val from = actualSchema(i)
+          resultRow(struct.fieldIndex(from.name)) = row.map(_.get(i, from.dataType)).orNull
+          i += 1
         }
-      } else {
-        val nullResult = new GenericInternalRow(struct.length)
-        (row, _) => row.getOrElse(nullResult)
+        resultRow(corruptFieldIndex.get) = badRecord()
+        resultRow
       }
+    } else {
+      val nullResult = new GenericInternalRow(struct.length)
+      (row, _) => row.getOrElse(nullResult)
+    }
+  }
+
+  private val toResultRow: (Option[InternalRow], () => UTF8String) => InternalRow = dataType match {
+    case struct: StructType => structToResultRow(struct)
     case _ => (row, _) => row.getOrElse(new GenericInternalRow(1))
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/FailureSafeParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/FailureSafeParser.scala
@@ -26,14 +26,14 @@ import org.apache.spark.unsafe.types.UTF8String
 class FailureSafeParser[IN](
     rawParser: IN => Seq[InternalRow],
     mode: ParseMode,
-    schema: DataType,
+    dataType: DataType,
     columnNameOfCorruptRecord: String,
     isMultiLine: Boolean) {
   // This function takes 2 parameters: an optional partial result, and the bad record. If the given
   // schema doesn't contain a field for corrupted record, we just return the partial result or a
   // row with all fields null. If the given schema contains a field for corrupted record, we will
   // set the bad record to this field, and set other fields according to the partial result or null.
-  private val toResultRow: (Option[InternalRow], () => UTF8String) => InternalRow = schema match {
+  private val toResultRow: (Option[InternalRow], () => UTF8String) => InternalRow = dataType match {
     case struct: StructType =>
       val corruptFieldIndex = struct.getFieldIndex(columnNameOfCorruptRecord)
       if (corruptFieldIndex.isDefined) {
@@ -56,7 +56,7 @@ class FailureSafeParser[IN](
     case _ => (row, _) => row.getOrElse(new GenericInternalRow(1))
   }
 
-  private val skipParsing = !isMultiLine && mode == PermissiveMode && (schema match {
+  private val skipParsing = !isMultiLine && mode == PermissiveMode && (dataType match {
     case struct: StructType => struct.isEmpty
     case _ => false
   })

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
@@ -464,13 +464,12 @@ class JsonExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper with 
     val input = """[{"a": 1}, {"a": 2}]"""
     val corrupted = "corrupted"
     val schema = new StructType().add("a", IntegerType).add(corrupted, StringType)
-    StructType(StructField("a", IntegerType) :: Nil)
     val output = InternalRow(null, UTF8String.fromString(input))
     val options = Map("columnNameOfCorruptRecord" -> corrupted)
     checkEvaluation(JsonToStructs(schema, options, Literal(input), gmtId), output)
   }
 
-  test("from_json - input=empty array, schema=struct, output=null") {
+  test("from_json - input=empty array, schema=struct, output=single row with null") {
     val input = """[]"""
     val schema = StructType(StructField("a", IntegerType) :: Nil)
     val output = InternalRow(null)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
@@ -462,9 +462,12 @@ class JsonExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper with 
 
   test("from_json - input=array, schema=struct, output=single row") {
     val input = """[{"a": 1}, {"a": 2}]"""
-    val schema = StructType(StructField("a", IntegerType) :: Nil)
-    val output = InternalRow(1)
-    checkEvaluation(JsonToStructs(schema, Map.empty, Literal(input), gmtId), output)
+    val corrupted = "corrupted"
+    val schema = new StructType().add("a", IntegerType).add(corrupted, StringType)
+    StructType(StructField("a", IntegerType) :: Nil)
+    val output = InternalRow(null, UTF8String.fromString(input))
+    val options = Map("columnNameOfCorruptRecord" -> corrupted)
+    checkEvaluation(JsonToStructs(schema, options, Literal(input), gmtId), output)
   }
 
   test("from_json - input=empty array, schema=struct, output=null") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.catalyst.expressions
 
 import java.util.Calendar
 
+import org.scalatest.exceptions.TestFailedException
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.errors.TreeNodeException
@@ -412,11 +414,13 @@ class JsonExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper with 
       InternalRow(null)
     )
 
-    // Other modes should still return `null`.
-    checkEvaluation(
-      JsonToStructs(schema, Map("mode" -> PermissiveMode.name), Literal(jsonData), gmtId),
-      InternalRow(null)
-    )
+    val msg = intercept[TestFailedException] {
+      checkEvaluation(
+        JsonToStructs(schema, Map("mode" -> FailFastMode.name), Literal(jsonData), gmtId),
+        InternalRow(null)
+      )
+    }.getCause.getMessage
+    assert(msg.contains("Malformed records are detected in record parsing. Parse Mode: FAILFAST"))
   }
 
   test("from_json - input=array, schema=array, output=array") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
@@ -460,7 +460,7 @@ class JsonExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper with 
     checkEvaluation(JsonToStructs(schema, Map.empty, Literal(input), gmtId), output)
   }
 
-  test("from_json - input=array, schema=struct, output=null") {
+  test("from_json - input=array, schema=struct, output=single row") {
     val input = """[{"a": 1}, {"a": 2}]"""
     val schema = StructType(StructField("a", IntegerType) :: Nil)
     val output = InternalRow(1)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
@@ -456,7 +456,7 @@ class JsonExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper with 
   test("from_json - input=array of single object, schema=struct, output=single row") {
     val input = """[{"a": 1}]"""
     val schema = StructType(StructField("a", IntegerType) :: Nil)
-    val output = InternalRow(1)
+    val output = InternalRow(null)
     checkEvaluation(JsonToStructs(schema, Map.empty, Literal(input), gmtId), output)
   }
 
@@ -473,7 +473,7 @@ class JsonExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper with 
   test("from_json - input=empty array, schema=struct, output=null") {
     val input = """[]"""
     val schema = StructType(StructField("a", IntegerType) :: Nil)
-    val output = null
+    val output = InternalRow(null)
     checkEvaluation(JsonToStructs(schema, Map.empty, Literal(input), gmtId), output)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
@@ -409,13 +409,13 @@ class JsonExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper with 
     val schema = StructType(StructField("a", IntegerType) :: Nil)
     checkEvaluation(
       JsonToStructs(schema, Map.empty, Literal(jsonData), gmtId),
-      null
+      InternalRow(null)
     )
 
     // Other modes should still return `null`.
     checkEvaluation(
       JsonToStructs(schema, Map("mode" -> PermissiveMode.name), Literal(jsonData), gmtId),
-      null
+      InternalRow(null)
     )
   }
 
@@ -457,7 +457,7 @@ class JsonExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper with 
   test("from_json - input=array, schema=struct, output=null") {
     val input = """[{"a": 1}, {"a": 2}]"""
     val schema = StructType(StructField("a", IntegerType) :: Nil)
-    val output = null
+    val output = InternalRow(1)
     checkEvaluation(JsonToStructs(schema, Map.empty, Literal(input), gmtId), output)
   }
 
@@ -487,7 +487,7 @@ class JsonExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper with 
     val schema = StructType(StructField("a", IntegerType) :: Nil)
     checkEvaluation(
       JsonToStructs(schema, Map.empty, Literal(badJson), gmtId),
-      null)
+      InternalRow(null))
   }
 
   test("from_json with timestamp") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
@@ -21,7 +21,7 @@ import java.util.Calendar
 
 import org.scalatest.exceptions.TestFailedException
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkException, SparkFunSuite}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.errors.TreeNodeException
 import org.apache.spark.sql.catalyst.plans.PlanTestBase
@@ -414,13 +414,15 @@ class JsonExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper with 
       InternalRow(null)
     )
 
-    val msg = intercept[TestFailedException] {
+    val exception = intercept[TestFailedException] {
       checkEvaluation(
         JsonToStructs(schema, Map("mode" -> FailFastMode.name), Literal(jsonData), gmtId),
         InternalRow(null)
       )
-    }.getCause.getMessage
-    assert(msg.contains("Malformed records are detected in record parsing. Parse Mode: FAILFAST"))
+    }.getCause
+    assert(exception.isInstanceOf[SparkException])
+    assert(exception.getMessage.contains(
+      "Malformed records are detected in record parsing. Parse Mode: FAILFAST"))
   }
 
   test("from_json - input=array, schema=array, output=array") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -446,7 +446,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
 
     val createParser = CreateJacksonParser.string _
     val parsed = jsonDataset.rdd.mapPartitions { iter =>
-      val rawParser = new JacksonParser(actualSchema, parsedOptions)
+      val rawParser = new JacksonParser(actualSchema, parsedOptions, explodeArray = true)
       val parser = new FailureSafeParser[String](
         input => rawParser.parse(input, createParser, UTF8String.fromString),
         parsedOptions.parseMode,

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -446,7 +446,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
 
     val createParser = CreateJacksonParser.string _
     val parsed = jsonDataset.rdd.mapPartitions { iter =>
-      val rawParser = new JacksonParser(actualSchema, parsedOptions, explodeArray = true)
+      val rawParser = new JacksonParser(actualSchema, parsedOptions, allowArrayAsStructs = true)
       val parser = new FailureSafeParser[String](
         input => rawParser.parse(input, createParser, UTF8String.fromString),
         parsedOptions.parseMode,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -130,7 +130,7 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
     }
 
     (file: PartitionedFile) => {
-      val parser = new JacksonParser(actualSchema, parsedOptions)
+      val parser = new JacksonParser(actualSchema, parsedOptions, explodeArray = true)
       JsonDataSource(parsedOptions).readFile(
         broadcastedHadoopConf.value.value,
         file,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -130,7 +130,7 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
     }
 
     (file: PartitionedFile) => {
-      val parser = new JacksonParser(actualSchema, parsedOptions, explodeArray = true)
+      val parser = new JacksonParser(actualSchema, parsedOptions, allowArrayAsStructs = true)
       JsonDataSource(parsedOptions).readFile(
         broadcastedHadoopConf.value.value,
         file,

--- a/sql/core/src/test/resources/sql-tests/results/typeCoercion/native/stringCastAndExpressions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/typeCoercion/native/stringCastAndExpressions.sql.out
@@ -258,4 +258,4 @@ select from_json(a, 'a INT') from t
 -- !query 31 schema
 struct<from_json(a):struct<a:int>>
 -- !query 31 output
-NULL
+{"a":null}

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -563,9 +563,9 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
     assert(exception1.contains(
       "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))
 
-    val exception2 = intercept[AnalysisException] {
+    val exception2 = intercept[SparkException] {
       df.select(from_json($"value", schema, Map("mode" -> "DROPMALFORMED")))
-        .queryExecution.executedPlan
+        .collect()
     }.getMessage
     assert(exception2.contains(
       "from_json() doesn't support the DROPMALFORMED mode. " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -132,7 +132,7 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
 
     checkAnswer(
       df.select(from_json($"value", schema)),
-      Row(null) :: Nil)
+      Row(Row(null)) :: Nil)
   }
 
   test("from_json - json doesn't conform to the array type") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -563,10 +563,11 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
     assert(exception1.contains(
       "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))
 
-    val exception2 = intercept[IllegalArgumentException] {
+    val exception2 = intercept[AnalysisException] {
       df.select(from_json($"value", schema, Map("mode" -> "DROPMALFORMED"))).collect()
     }.getMessage
     assert(exception2.contains(
-      "The functions supports only the PERMISSIVE and FAILFAST modes."))
+      "from_json() doesn't support the DROPMALFORMED mode. " +
+      "Acceptable modes are PERMISSIVE and FAILFAST."))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -557,14 +557,16 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
       df.select(from_json($"value", schema, Map("mode" -> "PERMISSIVE"))),
       Row(Row(null)) :: Row(Row(2)) :: Nil)
 
-    val exceptionOne = intercept[SparkException] {
+    val exception1 = intercept[SparkException] {
       df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))).collect()
     }.getMessage
-    assert(exceptionOne.contains(
+    assert(exception1.contains(
       "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))
 
-    checkAnswer(
-      df.select(from_json($"value", schema, Map("mode" -> "DROPMALFORMED"))),
-      Row(null) :: Row(Row(2)) :: Nil)
+    val exception2 = intercept[IllegalArgumentException] {
+      df.select(from_json($"value", schema, Map("mode" -> "DROPMALFORMED"))).collect()
+    }.getMessage
+    assert(exception2.contains(
+      "The functions supports only the PERMISSIVE and FAILFAST modes."))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -564,7 +564,8 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
       "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))
 
     val exception2 = intercept[AnalysisException] {
-      df.select(from_json($"value", schema, Map("mode" -> "DROPMALFORMED"))).collect()
+      df.select(from_json($"value", schema, Map("mode" -> "DROPMALFORMED")))
+        .queryExecution.executedPlan
     }.getMessage
     assert(exception2.contains(
       "from_json() doesn't support the DROPMALFORMED mode. " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -21,6 +21,7 @@ import collection.JavaConverters._
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types._
 
@@ -550,25 +551,31 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
   }
 
   test("from_json invalid json - check modes") {
-    val df = Seq("""{"a" 1}""", """{"a": 2}""").toDS()
-    val schema = new StructType().add("a", IntegerType)
+    withSQLConf(SQLConf.COLUMN_NAME_OF_CORRUPT_RECORD.key -> "_unparsed") {
+      val schema = new StructType()
+        .add("a", IntegerType)
+        .add("b", IntegerType)
+        .add("_unparsed", StringType)
+      val badRec = """{"a" 1, "b": 11}"""
+      val df = Seq(badRec, """{"a": 2, "b": 12}""").toDS()
 
-    checkAnswer(
-      df.select(from_json($"value", schema, Map("mode" -> "PERMISSIVE"))),
-      Row(Row(null)) :: Row(Row(2)) :: Nil)
+      checkAnswer(
+        df.select(from_json($"value", schema, Map("mode" -> "PERMISSIVE"))),
+        Row(Row(null, null, badRec)) :: Row(Row(2, 12, null)) :: Nil)
 
-    val exception1 = intercept[SparkException] {
-      df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))).collect()
-    }.getMessage
-    assert(exception1.contains(
-      "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))
+      val exception1 = intercept[SparkException] {
+        df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))).collect()
+      }.getMessage
+      assert(exception1.contains(
+        "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))
 
-    val exception2 = intercept[SparkException] {
-      df.select(from_json($"value", schema, Map("mode" -> "DROPMALFORMED")))
-        .collect()
-    }.getMessage
-    assert(exception2.contains(
-      "from_json() doesn't support the DROPMALFORMED mode. " +
-      "Acceptable modes are PERMISSIVE and FAILFAST."))
+      val exception2 = intercept[SparkException] {
+        df.select(from_json($"value", schema, Map("mode" -> "DROPMALFORMED")))
+          .collect()
+      }.getMessage
+      assert(exception2.contains(
+        "from_json() doesn't support the DROPMALFORMED mode. " +
+          "Acceptable modes are PERMISSIVE and FAILFAST."))
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -558,9 +558,7 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
       Row(Row(null)) :: Row(Row(2)) :: Nil)
 
     val exceptionOne = intercept[SparkException] {
-      checkAnswer(
-        df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))),
-        Row(Row(2)) :: Nil)
+      df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))).collect()
     }.getMessage
     assert(exceptionOne.contains(
       "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -67,7 +67,7 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
 
       val dummyOption = new JSONOptions(Map.empty[String, String], "GMT")
       val dummySchema = StructType(Seq.empty)
-      val parser = new JacksonParser(dummySchema, dummyOption, explodeArray = true)
+      val parser = new JacksonParser(dummySchema, dummyOption, allowArrayAsStructs = true)
 
       Utils.tryWithResource(factory.createParser(writer.toString)) { jsonParser =>
         jsonParser.nextToken()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -67,7 +67,7 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
 
       val dummyOption = new JSONOptions(Map.empty[String, String], "GMT")
       val dummySchema = StructType(Seq.empty)
-      val parser = new JacksonParser(dummySchema, dummyOption)
+      val parser = new JacksonParser(dummySchema, dummyOption, explodeArray = true)
 
       Utils.tryWithResource(factory.createParser(writer.toString)) { jsonParser =>
         jsonParser.nextToken()


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the PR, I propose to switch `from_json` on `FailureSafeParser`, and to make the function compatible to `PERMISSIVE` mode by default, and to support the `FAILFAST` mode as well. The `DROPMALFORMED` mode is not supported by `from_json`.

## How was this patch tested?

It was tested by existing `JsonSuite`/`CSVSuite`, `JsonFunctionsSuite` and `JsonExpressionsSuite` as well as new tests for `from_json` which checks different modes.
