### PR TITLE
[MINOR] Avoid code duplication for nullable in Higher Order function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
@@ -90,6 +90,8 @@ object LambdaFunction {
  */
 trait HigherOrderFunction extends Expression with ExpectsInputTypes {
 
+  override def nullable: Boolean = arguments.exists(_.nullable)
+
   override def children: Seq[Expression] = arguments ++ functions
 
   /**
@@ -154,8 +156,6 @@ trait HigherOrderFunction extends Expression with ExpectsInputTypes {
  * Trait for functions having as input one argument and one function.
  */
 trait SimpleHigherOrderFunction extends HigherOrderFunction  {
-
-  override def nullable: Boolean = argument.nullable
 
   def argument: Expression
 
@@ -628,8 +628,6 @@ case class MapZipWith(left: Expression, right: Expression, function: Expression)
 
   override def functionTypes: Seq[AbstractDataType] = AnyDataType :: Nil
 
-  override def nullable: Boolean = left.nullable || right.nullable
-
   override def dataType: DataType = MapType(keyType, function.dataType, function.nullable)
 
   override def bind(f: (Expression, Seq[(DataType, Boolean)]) => LambdaFunction): MapZipWith = {
@@ -799,8 +797,6 @@ case class ZipWith(left: Expression, right: Expression, function: Expression)
   override def functions: Seq[Expression] = List(function)
 
   override def functionTypes: Seq[AbstractDataType] = AnyDataType :: Nil
-
-  override def nullable: Boolean = left.nullable || right.nullable
 
   override def dataType: ArrayType = ArrayType(function.dataType, function.nullable)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
@@ -155,6 +155,8 @@ trait HigherOrderFunction extends Expression with ExpectsInputTypes {
  */
 trait SimpleHigherOrderFunction extends HigherOrderFunction  {
 
+  override def nullable: Boolean = argument.nullable
+
   def argument: Expression
 
   override def arguments: Seq[Expression] = argument :: Nil
@@ -216,8 +218,6 @@ case class ArrayTransform(
     argument: Expression,
     function: Expression)
   extends ArrayBasedSimpleHigherOrderFunction with CodegenFallback {
-
-  override def nullable: Boolean = argument.nullable
 
   override def dataType: ArrayType = ArrayType(function.dataType, function.nullable)
 
@@ -287,8 +287,6 @@ case class MapFilter(
     copy(function = f(function, (keyType, false) :: (valueType, valueContainsNull) :: Nil))
   }
 
-  override def nullable: Boolean = argument.nullable
-
   override def nullSafeEval(inputRow: InternalRow, argumentValue: Any): Any = {
     val m = argumentValue.asInstanceOf[MapData]
     val f = functionForEval
@@ -327,8 +325,6 @@ case class ArrayFilter(
     argument: Expression,
     function: Expression)
   extends ArrayBasedSimpleHigherOrderFunction with CodegenFallback {
-
-  override def nullable: Boolean = argument.nullable
 
   override def dataType: DataType = argument.dataType
 
@@ -374,8 +370,6 @@ case class ArrayExists(
     argument: Expression,
     function: Expression)
   extends ArrayBasedSimpleHigherOrderFunction with CodegenFallback {
-
-  override def nullable: Boolean = argument.nullable
 
   override def dataType: DataType = BooleanType
 
@@ -516,8 +510,6 @@ case class TransformKeys(
     function: Expression)
   extends MapBasedSimpleHigherOrderFunction with CodegenFallback {
 
-  override def nullable: Boolean = argument.nullable
-
   @transient lazy val MapType(keyType, valueType, valueContainsNull) = argument.dataType
 
   override def dataType: DataType = MapType(function.dataType, valueType, valueContainsNull)
@@ -567,8 +559,6 @@ case class TransformValues(
     argument: Expression,
     function: Expression)
   extends MapBasedSimpleHigherOrderFunction with CodegenFallback {
-
-  override def nullable: Boolean = argument.nullable
 
   @transient lazy val MapType(keyType, valueType, valueContainsNull) = argument.dataType
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Most of  `HigherOrderFunction`s have the same `nullable` definition, ie. they are nullable when one of their arguments is nullable. The PR refactors it in order to avoid code duplication.

## How was this patch tested?

NA
