### PR TITLE
[SPARK-16281][SQL][FOLLOW-UP] Add parse_url to functions.scala

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2460,6 +2460,26 @@ object functions {
   }
 
   /**
+    * Extracts a part from a URL.
+    *
+    * @group string_funcs
+    * @since 2.4.0
+    */
+  def parse_url(url: Column, partToExtract: String): Column = withExpr {
+    ParseUrl(url, Literal(partToExtract))
+  }
+
+  /**
+    * Extracts a part from a URL.
+    *
+    * @group string_funcs
+    * @since 2.4.0
+    */
+  def parse_url(url: Column, partToExtract: String, key: String): Column = withExpr {
+    ParseUrl(url, Literal(partToExtract), Literal(key))
+  }
+
+  /**
    * Extract a specific group matched by a Java regex, from the specified string column.
    * If the regex did not match, or the specified group did not match, an empty string is returned.
    *

--- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
@@ -261,6 +261,13 @@ class StringFunctionsSuite extends QueryTest with SharedSQLContext {
         "parse_url(url, 'PROTOCOL')", "parse_url(url, 'FILE')",
         "parse_url(url, 'AUTHORITY')", "parse_url(url, 'USERINFO')",
         "parse_url(url, 'QUERY', 'query')"), expected)
+
+      checkAnswer(Seq[String]((url)).toDF("url").select(
+        parse_url('url, "HOST"), parse_url('url, "PATH"),
+        parse_url('url, "QUERY"), parse_url('url, "REF"),
+        parse_url('url, "PROTOCOL"), parse_url('url, "FILE"),
+        parse_url('url, "AUTHORITY"), parse_url('url, "USERINFO"),
+        parse_url('url, "QUERY", "query"), expected)
     }
 
     testUrl(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `parse_url` function to `functions.scala`. This will allow users to use this functions without calling `selectExpr` or `spark.sql`

## How was this patch tested?

`testUrl` function was changed to test also this change

Please review http://spark.apache.org/contributing.html before opening a pull request.
