### PR TITLE
[CATALYST] Add a call to apply method explicitly in combineFilterFunction

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/objects.scala
@@ -87,7 +87,7 @@ object CombineTypedFilters extends Rule[LogicalPlan] {
           f2.asInstanceOf[FilterFunction[Any]].call(input)
       case (f1: FilterFunction[_], f2) =>
         input => f1.asInstanceOf[FilterFunction[Any]].call(input) &&
-          f2.asInstanceOf[Any => Boolean](input)
+          f2.asInstanceOf[Any => Boolean].apply(input)
       case (f1, f2: FilterFunction[_]) =>
         input => f1.asInstanceOf[Any => Boolean].apply(input) &&
           f2.asInstanceOf[FilterFunction[Any]].call(input)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR do:
add an apply method explicitly for consistency with other CASE branches in the same function of combineFilterFunction.
maybe improve code readability.

## How was this patch tested?

Existing unit tests.

