### PR TITLE
[SPARK-25262][K8S] Better support configurability of Spark scratch space when using Kubernetes

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -215,6 +215,22 @@ spark.kubernetes.driver.volumes.persistentVolumeClaim.checkpointpvc.options.clai
 
 The configuration properties for mounting volumes into the executor pods use prefix `spark.kubernetes.executor.` instead of `spark.kubernetes.driver.`. For a complete list of available options for each supported type of volumes, please refer to the [Spark Properties](#spark-properties) section below. 
 
+## Local Storage
+
+Spark uses temporary scratch space to spill data to disk during shuffles and other operations.  When using Kubernetes as the resource manager the pods will be created with an [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) volume mounted for each directory listed in `SPARK_LOCAL_DIRS`.  If no directories are explicitly specified then a default directory is created and configured appropriately.
+
+`emptyDir` volumes use the ephemeral storage feature of Kubernetes and do not persist beyond the life of the pod.
+
+### Using RAM for local storage
+
+As `emptyDir` volumes use the nodes backing storage for ephemeral storage this default behaviour may not be appropriate for some compute environments.  For example if you have diskless nodes with remote storage mounted over a network having lots of executors doing IO to this remote storage may actually degrade performance.
+
+In this case it may be desirable to set `spark.kubernetes.local.dirs.tmpfs=true` in your configuration which will cause the `emptyDir` volumes to be configured as `tmpfs` i.e. RAM backed volumes.  When configured like this Sparks local storage usage will count towards your pods memory usage therefore you may wish to increase your memory requests via the normal `spark.driver.memory` and `spark.executor.memory` configuration properties.
+
+### Using arbitrary volumes for local storage
+
+Alternatively if using the pod template feature you can provide a volume named `spark-local-dirs-N`, where N is a 1 based index to the entires in your `SPARK_LOCAL_DIRS` variable, in your specification and that will be used for local storage.  This enables you to use a volume type that is appropriate to your compute environment.
+
 ## Introspection and Debugging
 
 These are the different ways in which you can investigate a running/completed Spark application, monitor progress, and

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -225,6 +225,15 @@ private[spark] object Config extends Logging {
         "Ensure that major Python version is either Python2 or Python3")
       .createWithDefault("2")
 
+  val KUBERNETES_LOCAL_DIRS_TMPFS =
+    ConfigBuilder("spark.kubernetes.local.dirs.tmpfs")
+      .doc("If set to true then emptyDir volumes created to back spark.local.dirs will have their " +
+        "medium set to Memory so that they will be created as tmpfs (i.e. RAM) backed volumes. " +
+        "This may improve performance but scratch space usage will count towards your pods memory " +
+        "limit so you may wish to request more memory.")
+    .booleanConf
+    .createWithDefault(false)
+
   val KUBERNETES_AUTH_SUBMISSION_CONF_PREFIX =
     "spark.kubernetes.authenticate.submission"
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -227,10 +227,10 @@ private[spark] object Config extends Logging {
 
   val KUBERNETES_LOCAL_DIRS_TMPFS =
     ConfigBuilder("spark.kubernetes.local.dirs.tmpfs")
-      .doc("If set to true then emptyDir volumes created to back spark.local.dirs will have their " +
-        "medium set to Memory so that they will be created as tmpfs (i.e. RAM) backed volumes. " +
-        "This may improve performance but scratch space usage will count towards your pods memory " +
-        "limit so you may wish to request more memory.")
+      .doc("If set to true then emptyDir volumes created to back spark.local.dirs will have " +
+        "their medium set to Memory so that they will be created as tmpfs (i.e. RAM) backed " +
+        "volumes. This may improve performance but scratch space usage will count towards " +
+        "your pods memory limit so you may wish to request more memory.")
     .booleanConf
     .createWithDefault(false)
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStep.scala
@@ -20,11 +20,11 @@ import java.nio.file.Paths
 import java.util.UUID
 
 import collection.JavaConverters._
+import io.fabric8.kubernetes.api.model.{ContainerBuilder, HasMetadata, PodBuilder, VolumeBuilder, VolumeMount, VolumeMountBuilder}
 
-import io.fabric8.kubernetes.api.model.{ContainerBuilder, HasMetadata, PodBuilder, VolumeBuilder, VolumeMountBuilder}
-
-import org.apache.spark.deploy.k8s.Config._
+import org.apache.spark.SparkException
 import org.apache.spark.deploy.k8s.{KubernetesConf, KubernetesDriverSpecificConf, KubernetesRoleSpecificConf, SparkPod}
+import org.apache.spark.deploy.k8s.Config._
 
 private[spark] class LocalDirsFeatureStep(
     conf: KubernetesConf[_ <: KubernetesRoleSpecificConf],
@@ -70,14 +70,34 @@ private[spark] class LocalDirsFeatureStep(
     val localDirVolumeMounts = localDirVolumes
       .zip(resolvedLocalDirs)
       .map { case (localDirVolume, localDirPath) =>
-        new VolumeMountBuilder()
-          .withName(localDirVolume.getName)
-          .withMountPath(localDirPath)
-          .build()
+        hasVolumeMount(pod, localDirVolume.getName, localDirPath) match {
+          case true =>
+            // For pre-existing volume mounts just re-use the mount
+            pod.container.getVolumeMounts().asScala
+              .find(m => m.getName.equals(localDirVolume.getName)
+                         && m.getMountPath.equals(localDirPath))
+              .get
+          case false =>
+            // Create new volume mount
+            new VolumeMountBuilder()
+              .withName (localDirVolume.getName)
+              .withMountPath (localDirPath)
+              .build()
+        }
       }
+
+    // Check for conflicting volume mounts
+    for (m: VolumeMount <- localDirVolumeMounts) {
+      if (hasConflictingVolumeMount(pod, m.getName, m.getMountPath).size > 0) {
+        throw new SparkException(s"Conflicting volume mounts defined, pod template attempted to " +
+          "mount SPARK_LOCAL_DIRS volume ${m.getName} multiple times or at an alternative path " +
+          "then the expected ${m.getPath}")
+      }
+    }
+
     val podWithLocalDirVolumes = new PodBuilder(pod.pod)
       .editSpec()
-         // Don't want to re-add volume mounts that already existed in the incoming spec
+         // Don't want to re-add volumes that already existed in the incoming spec
          // as duplicate definitions will lead to K8S API errors
         .addToVolumes(localDirVolumes.filter(v => !hasVolume(pod, v.getName)): _*)
         .endSpec()
@@ -87,7 +107,10 @@ private[spark] class LocalDirsFeatureStep(
         .withName("SPARK_LOCAL_DIRS")
         .withValue(resolvedLocalDirs.mkString(","))
         .endEnv()
-      .addToVolumeMounts(localDirVolumeMounts: _*)
+      // Don't want to re-add volume mounts that already existed in the incoming spec
+      // as duplicate definitions will lead to K8S API errors
+      .addToVolumeMounts(localDirVolumeMounts
+                         .filter(m => !hasVolumeMount(pod, m.getName, m.getMountPath)): _*)
       .build()
     SparkPod(podWithLocalDirVolumes, containerWithLocalDirVolumeMounts)
   }
@@ -98,5 +121,18 @@ private[spark] class LocalDirsFeatureStep(
 
   def hasVolume(pod: SparkPod, name: String): Boolean = {
     pod.pod.getSpec().getVolumes().asScala.exists(v => v.getName.equals(name))
+  }
+
+  def hasVolumeMount(pod: SparkPod, name: String, path: String): Boolean = {
+    pod.container.getVolumeMounts().asScala
+      .exists(m => m.getName.equals(name) && m.getMountPath.equals(path))
+  }
+
+  def hasConflictingVolumeMount(pod: SparkPod, name: String, path: String): Seq[VolumeMount] = {
+    // A volume mount is considered conflicting if it matches one, and only one of, the name/path
+    // of a volume mount we are creating
+    pod.container.getVolumeMounts().asScala
+      .filter(m => (m.getName.equals(name) && !m.getMountPath.equals(path)) ||
+                   (m.getMountPath.equals(path) && !m.getName.equals(name)))
   }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStepSuite.scala
@@ -18,9 +18,11 @@ package org.apache.spark.deploy.k8s.features
 
 import io.fabric8.kubernetes.api.model.{ContainerBuilder, EnvVarBuilder, PodBuilder, VolumeBuilder, VolumeMountBuilder}
 import org.mockito.Mockito
+import org.scalatest._
 import org.scalatest.BeforeAndAfter
+import Matchers._
 
-import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.{SparkConf, SparkException, SparkFunSuite}
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.{KubernetesConf, KubernetesDriverSpecificConf, KubernetesRoleSpecificConf, SparkPod}
 
@@ -151,6 +153,80 @@ class LocalDirsFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
         .withName("SPARK_LOCAL_DIRS")
         .withValue(defaultLocalDir)
         .build())
+  }
+
+  test("Use predefined volume and mount for local dirs") {
+    Mockito.doReturn(null).when(sparkConf).get("spark.local.dir")
+    Mockito.doReturn(null).when(sparkConf).getenv("SPARK_LOCAL_DIRS")
+    val stepUnderTest = new LocalDirsFeatureStep(kubernetesConf, defaultLocalDir)
+    val initialPod =
+      new PodBuilder(SparkPod.initialPod().pod)
+        .editSpec()
+        .addToVolumes(new VolumeBuilder()
+          .withName("spark-local-dir-1")
+          .withNewConfigMap()
+          .withName("foo")
+          .endConfigMap()
+          .build())
+        .endSpec()
+        .build()
+    val initialContainer =
+      new ContainerBuilder()
+        .withVolumeMounts(new VolumeMountBuilder()
+          .withName("spark-local-dir-1")
+          .withMountPath(defaultLocalDir)
+          .build())
+        .build()
+
+    val configuredPod = stepUnderTest.configurePod(new SparkPod(initialPod,
+      initialContainer))
+    assert(configuredPod.pod.getSpec.getVolumes.size === 1)
+    assert(configuredPod.pod.getSpec.getVolumes.get(0) ===
+      new VolumeBuilder()
+        .withName(s"spark-local-dir-1")
+        .withNewConfigMap()
+        .withName("foo")
+        .endConfigMap()
+        .build())
+    assert(configuredPod.container.getVolumeMounts.size === 1)
+    assert(configuredPod.container.getVolumeMounts.get(0) ===
+      new VolumeMountBuilder()
+        .withName(s"spark-local-dir-1")
+        .withMountPath(defaultLocalDir)
+        .build())
+    assert(configuredPod.container.getEnv.size === 1)
+    assert(configuredPod.container.getEnv.get(0) ===
+      new EnvVarBuilder()
+        .withName("SPARK_LOCAL_DIRS")
+        .withValue(defaultLocalDir)
+        .build())
+  }
+
+  test("Using conflicting volume mount for local dirs should error") {
+    Mockito.doReturn(null).when(sparkConf).get("spark.local.dir")
+    Mockito.doReturn(null).when(sparkConf).getenv("SPARK_LOCAL_DIRS")
+    val stepUnderTest = new LocalDirsFeatureStep(kubernetesConf, defaultLocalDir)
+    val initialPod =
+      new PodBuilder(SparkPod.initialPod().pod)
+        .editSpec()
+        .addToVolumes(new VolumeBuilder()
+          .withName("spark-local-dir-1")
+          .withNewConfigMap()
+          .withName("foo")
+          .endConfigMap()
+          .build())
+        .endSpec()
+        .build()
+    val initialContainer =
+      new ContainerBuilder()
+        .withVolumeMounts(new VolumeMountBuilder()
+          .withName("spark-local-dir-1")
+          .withMountPath("/bad/path")
+          .build())
+        .build()
+
+    an [SparkException] should be thrownBy stepUnderTest.configurePod(new SparkPod(initialPod,
+      initialContainer))
   }
 
   test("Use tmpfs to back default local dir") {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStepSuite.scala
@@ -19,12 +19,12 @@ package org.apache.spark.deploy.k8s.features
 import io.fabric8.kubernetes.api.model.{ContainerBuilder, EnvVarBuilder, PodBuilder, VolumeBuilder, VolumeMountBuilder}
 import org.mockito.Mockito
 import org.scalatest._
-import org.scalatest.BeforeAndAfter
 import Matchers._
+import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.{SparkConf, SparkException, SparkFunSuite}
-import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.{KubernetesConf, KubernetesDriverSpecificConf, KubernetesRoleSpecificConf, SparkPod}
+import org.apache.spark.deploy.k8s.Config._
 
 class LocalDirsFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
   private val defaultLocalDir = "/var/data/default-local-dir"


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change improves how Spark on Kubernetes creates the local directories used for Spark scratch space i.e. `SPARK_LOCAL_DIRS`/`spark.local.dirs`

Currently Spark on Kubernetes creates each defined local directory, or a single default directory if none defined, as a Kubernetes `emptyDir` volume mounted into the containers.  The problem is that `emptyDir` directories are backed by the node storage and so for some compute environments e.g. diskless any "local" storage is actually provided by some remote file system that may actually harm performance when jobs use it heavily.

Kubernetes provides the option to have `emptyDir` volumes backed by `tmpfs` i.e. RAM on the nodes so we introduce a boolean `spark.kubernetes.local.dirs.tmpfs` option that when true causes the created `emptyDir` volumes to use memory.

A second related problem is that because Spark on Kubernetes always generates `emptyDir` volumes users have no way to use alternative volume types that may be available in their cluster.

No new options specific to this problem are introduced but the code is modified to detect when the pod spec already defines an appropriately named volume and to avoid creating `emptyDir` volumes in this case.  This uses the convention of the existing code that volumes for scratch space are named `spark-local-dirs-N` numbered from 1-N based on the number of entries defined in the `SPARK_LOCAL_DIRS`/`spark.local.dirs` setting.  This is done in anticipation of the pod template feature form SPARK-24434 (PR #22146) being merged since that will allow users to define custom volumes more easily.

Tasks:

- [x] Support using `tmpfs` volumes
- [x] Support using pre-existing volumes
- [x] Unit tests
- [x] Documentation

## How was this patch tested?

Unit tests added to the relevant feature step to exercise the new configuration option and to check that pre-existing volumes are used.  Plan to add further unit tests to check some other corner cases.