### PR TITLE
[SPARK-25269][SQL] SQL interface support specify StorageLevel when cache table

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -162,8 +162,8 @@ statement
         tableIdentifier partitionSpec? describeColName?                #describeTable
     | REFRESH TABLE tableIdentifier                                    #refreshTable
     | REFRESH (STRING | .*?)                                           #refreshResource
-    | CACHE LAZY? storageLevel=identifier? TABLE
-        tableIdentifier (AS? query)?                                   #cacheTable
+    | CACHE LAZY? TABLE tableIdentifier
+        (OPTIONS options=tablePropertyList)? (AS? query)?              #cacheTable
     | UNCACHE TABLE (IF EXISTS)? tableIdentifier                       #uncacheTable
     | CLEAR CACHE                                                      #clearCache
     | LOAD DATA LOCAL? INPATH path=STRING OVERWRITE? INTO TABLE

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -162,7 +162,8 @@ statement
         tableIdentifier partitionSpec? describeColName?                #describeTable
     | REFRESH TABLE tableIdentifier                                    #refreshTable
     | REFRESH (STRING | .*?)                                           #refreshResource
-    | CACHE LAZY? TABLE tableIdentifier (AS? query)?                   #cacheTable
+    | CACHE LAZY? storageLevel=identifier? TABLE
+        tableIdentifier (AS? query)?                                   #cacheTable
     | UNCACHE TABLE (IF EXISTS)? tableIdentifier                       #uncacheTable
     | CLEAR CACHE                                                      #clearCache
     | LOAD DATA LOCAL? INPATH path=STRING OVERWRITE? INTO TABLE

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -272,8 +272,8 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
       throw new ParseException(s"It is not allowed to add database prefix `$database` to " +
         s"the table name in CACHE TABLE AS SELECT", ctx)
     }
-    CacheTableCommand(tableIdent, query, ctx.LAZY != null,
-      Option(ctx.storageLevel).map(_.getText.toUpperCase(Locale.ROOT)))
+    val options = Option(ctx.options).map(visitPropertyKeyValues).getOrElse(Map.empty)
+    CacheTableCommand(tableIdent, query, ctx.LAZY != null, options)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -272,7 +272,8 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
       throw new ParseException(s"It is not allowed to add database prefix `$database` to " +
         s"the table name in CACHE TABLE AS SELECT", ctx)
     }
-    CacheTableCommand(tableIdent, query, ctx.LAZY != null, Option(ctx.storageLevel).map(source))
+    CacheTableCommand(tableIdent, query, ctx.LAZY != null,
+      Option(ctx.storageLevel).map(_.getText.toUpperCase(Locale.ROOT)))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -272,7 +272,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
       throw new ParseException(s"It is not allowed to add database prefix `$database` to " +
         s"the table name in CACHE TABLE AS SELECT", ctx)
     }
-    CacheTableCommand(tableIdent, query, ctx.LAZY != null)
+    CacheTableCommand(tableIdent, query, ctx.LAZY != null, Option(ctx.storageLevel).map(source))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/cache.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/cache.scala
@@ -17,10 +17,9 @@
 
 package org.apache.spark.sql.execution.command
 
-import java.util.Locale
-
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.storage.StorageLevel
@@ -43,7 +42,7 @@ case class CacheTableCommand(
     if (storageLevel.nonEmpty) {
       sparkSession.catalog.cacheTable(
         tableIdent.quotedString,
-        StorageLevel.fromString(storageLevel.get.toUpperCase(Locale.ROOT)))
+        StorageLevel.fromString(storageLevel.get))
     } else {
       sparkSession.catalog.cacheTable(tableIdent.quotedString)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -304,11 +304,13 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with SharedSQLContext
     assert(isExpectStorageLevel(rddId, Disk))
   }
 
-  test("SQL interface select from table support storageLevel(DISK_ONLY)") {
-    sql("CACHE TABLE testSelect OPTIONS('storageLevel' 'DISK_ONLY') SELECT * FROM testData")
-    assertCached(spark.table("testSelect"))
-    val rddId = rddIdOf("testSelect")
-    assert(isExpectStorageLevel(rddId, Disk))
+  test("SQL interface cache SELECT ... support storageLevel(DISK_ONLY)") {
+    withTempView("testCacheSelect") {
+      sql("CACHE TABLE testCacheSelect OPTIONS('storageLevel' 'DISK_ONLY') SELECT * FROM testData")
+      assertCached(spark.table("testCacheSelect"))
+      val rddId = rddIdOf("testCacheSelect")
+      assert(isExpectStorageLevel(rddId, Disk))
+    }
   }
 
   test("SQL interface support storageLevel(DISK_ONLY) with invalid options") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -325,6 +325,21 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with SharedSQLContext
     assert(isExpectStorageLevel(rddId, Memory))
   }
 
+  test("SQL interface support storageLevel(Invalid StorageLevel)") {
+    val message = intercept[IllegalArgumentException] {
+      sql("CACHE TABLE testData OPTIONS('storageLevel' 'invalid_storage_level')")
+    }.getMessage
+    assert(message.contains("Invalid StorageLevel: INVALID_STORAGE_LEVEL"))
+  }
+
+  test("SQL interface support storageLevel(with LAZY)") {
+    sql("CACHE LAZY TABLE testData OPTIONS('storageLevel' 'disk_only')")
+    assertCached(spark.table("testData"))
+    val rddId = rddIdOf("testData")
+    sql("SELECT COUNT(*) FROM testData").collect()
+    assert(isExpectStorageLevel(rddId, Disk))
+  }
+
   test("InMemoryRelation statistics") {
     sql("CACHE TABLE testData")
     spark.table("testData").queryExecution.withCachedData.collect {

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -352,6 +352,7 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with SharedSQLContext
     assert(
       isMaterialized(rddId),
       "Lazily cached in-memory table should have been materialized")
+    assert(isExpectStorageLevel(rddId, Disk))
 
     spark.catalog.uncacheTable("testData")
     eventually(timeout(10 seconds)) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -302,16 +302,14 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with SharedSQLContext
     assertCached(spark.table("testData"))
     val rddId = rddIdOf("testData")
     assert(isExpectStorageLevel(rddId, Disk))
-    assert(!isExpectStorageLevel(rddId, Memory))
     spark.catalog.uncacheTable("testData")
   }
 
   test("SQL interface select from table support storageLevel(DISK_ONLY)") {
-    sql("CACHE TABLE testSelect OPTIONS('storageLevel' 'DISK_ONLY') select * from testData")
+    sql("CACHE TABLE testSelect OPTIONS('storageLevel' 'DISK_ONLY') SELECT * FROM testData")
     assertCached(spark.table("testSelect"))
     val rddId = rddIdOf("testSelect")
     assert(isExpectStorageLevel(rddId, Disk))
-    assert(!isExpectStorageLevel(rddId, Memory))
     spark.catalog.uncacheTable("testSelect")
   }
 
@@ -320,7 +318,6 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with SharedSQLContext
     assertCached(spark.table("testData"))
     val rddId = rddIdOf("testData")
     assert(isExpectStorageLevel(rddId, Disk))
-    assert(!isExpectStorageLevel(rddId, Memory))
     spark.catalog.uncacheTable("testData")
   }
 
@@ -328,7 +325,6 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with SharedSQLContext
     sql("CACHE TABLE testData OPTIONS('storageLevel' 'MEMORY_ONLY')")
     assertCached(spark.table("testData"))
     val rddId = rddIdOf("testData")
-    assert(!isExpectStorageLevel(rddId, Disk))
     assert(isExpectStorageLevel(rddId, Memory))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -302,7 +302,6 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with SharedSQLContext
     assertCached(spark.table("testData"))
     val rddId = rddIdOf("testData")
     assert(isExpectStorageLevel(rddId, Disk))
-    spark.catalog.uncacheTable("testData")
   }
 
   test("SQL interface select from table support storageLevel(DISK_ONLY)") {
@@ -310,7 +309,6 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with SharedSQLContext
     assertCached(spark.table("testSelect"))
     val rddId = rddIdOf("testSelect")
     assert(isExpectStorageLevel(rddId, Disk))
-    spark.catalog.uncacheTable("testSelect")
   }
 
   test("SQL interface support storageLevel(DISK_ONLY) with invalid options") {
@@ -318,7 +316,6 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with SharedSQLContext
     assertCached(spark.table("testData"))
     val rddId = rddIdOf("testData")
     assert(isExpectStorageLevel(rddId, Disk))
-    spark.catalog.uncacheTable("testData")
   }
 
   test("SQL interface support storageLevel(MEMORY_ONLY)") {
@@ -326,34 +323,6 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with SharedSQLContext
     assertCached(spark.table("testData"))
     val rddId = rddIdOf("testData")
     assert(isExpectStorageLevel(rddId, Memory))
-  }
-
-  test("SQL interface support storageLevel(Invalid StorageLevel)") {
-    val message = intercept[IllegalArgumentException] {
-      sql("CACHE TABLE testData OPTIONS('storageLevel' 'invalid_storage_level')")
-    }.getMessage
-    assert(message.contains("Invalid StorageLevel: INVALID_STORAGE_LEVEL"))
-  }
-
-  test("SQL interface support storageLevel(with LAZY)") {
-    sql("CACHE LAZY TABLE testData OPTIONS('storageLevel' 'disk_only')")
-    assertCached(spark.table("testData"))
-
-    val rddId = rddIdOf("testData")
-    assert(
-      !isMaterialized(rddId),
-      "Lazily cached in-memory table shouldn't be materialized eagerly")
-
-    sql("SELECT COUNT(*) FROM testData").collect()
-    assert(
-      isMaterialized(rddId),
-      "Lazily cached in-memory table should have been materialized")
-    assert(isExpectStorageLevel(rddId, Disk))
-
-    spark.catalog.uncacheTable("testData")
-    eventually(timeout(10 seconds)) {
-      assert(!isMaterialized(rddId), "Uncached in-memory table should have been unpersisted")
-    }
   }
 
   test("InMemoryRelation statistics") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -70,7 +70,7 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with SharedSQLContext
     val maybeBlock = sparkContext.env.blockManager.get(RDDBlockId(rddId, 0))
     val isExpectLevel = maybeBlock.forall(_.readMethod === level)
     maybeBlock.foreach(_ => sparkContext.env.blockManager.releaseLock(RDDBlockId(rddId, 0)))
-    isExpectLevel
+    maybeBlock.nonEmpty && isExpectLevel
   }
 
   private def getNumInMemoryRelations(ds: Dataset[_]): Int = {
@@ -301,7 +301,6 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with SharedSQLContext
     sql("CACHE DISK_ONLY TABLE testData")
     assertCached(spark.table("testData"))
     val rddId = rddIdOf("testData")
-    assert(isMaterialized(rddId))
     assert(isExpectStorageLevel(rddId, Disk))
     assert(!isExpectStorageLevel(rddId, Memory))
     spark.catalog.uncacheTable("testData")
@@ -311,7 +310,6 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with SharedSQLContext
     sql("CACHE MEMORY_ONLY TABLE testData")
     assertCached(spark.table("testData"))
     val rddId = rddIdOf("testData")
-    assert(isMaterialized(rddId))
     assert(!isExpectStorageLevel(rddId, Disk))
     assert(isExpectStorageLevel(rddId, Memory))
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -565,7 +565,7 @@ private[hive] class TestHiveQueryExecution(
 
   override lazy val analyzed: LogicalPlan = {
     val describedTables = logical match {
-      case CacheTableCommand(tbl, _, _) => tbl.table :: Nil
+      case CacheTableCommand(tbl, _, _, _) => tbl.table :: Nil
       case _ => Nil
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

SQL interface support specify `StorageLevel` when cache table. The semantic is:
```sql
CACHE TABLE tableName OPTIONS('storageLevel' 'DISK_ONLY');
```
All supported `StorageLevel` are:
https://github.com/apache/spark/blob/eefdf9f9dd8afde49ad7d4e230e2735eb817ab0a/core/src/main/scala/org/apache/spark/storage/StorageLevel.scala#L172-L183

## How was this patch tested?

unit tests and manual tests.

manual tests configuration:
```
--executor-memory 15G --executor-cores 5 --num-executors 50
```
Data:
Input Size / Records: 1037.7 GB / 11732805788

Result:
![image](https://user-images.githubusercontent.com/5399861/47213362-56a1c980-d3cd-11e8-82e7-28d7abc5923e.png)


