### PR TITLE
[SPARK-25270] lint-python: Add flake8 to find syntax errors and undefined names

### DIFF
--- a/dev/lint-python
+++ b/dev/lint-python
@@ -82,6 +82,26 @@ else
     rm "$PYCODESTYLE_REPORT_PATH"
 fi
 
+python -m pip install flake8
+# stop the build if there are Python syntax errors or undefined names
+flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+flake8_status="${PIPESTATUS[0]}"
+# exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+if [ "$flake8_status" -eq 0 ]; then
+    lint_status=0
+else
+    lint_status=1
+fi
+
+if [ "$lint_status" -ne 0 ]; then
+    echo "flake8 checks failed."
+    exit "$lint_status"
+else
+    echo "flake8 checks passed."
+fi
+
 # Check that the documentation builds acceptably, skip check if sphinx is not installed.
 if hash "$SPHINXBUILD" 2> /dev/null; then
   cd python/docs

--- a/dev/lint-python
+++ b/dev/lint-python
@@ -83,10 +83,8 @@ else
 fi
 
 # stop the build if there are Python syntax errors or undefined names
-flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+flake8 . --count --select=E901,E999,F821,F822,F823 --max-line-length=100 --show-source --statistics
 flake8_status="${PIPESTATUS[0]}"
-# exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
 if [ "$flake8_status" -eq 0 ]; then
     lint_status=0

--- a/dev/lint-python
+++ b/dev/lint-python
@@ -82,7 +82,6 @@ else
     rm "$PYCODESTYLE_REPORT_PATH"
 fi
 
-python -m pip install flake8
 # stop the build if there are Python syntax errors or undefined names
 flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
 flake8_status="${PIPESTATUS[0]}"

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,3 +1,4 @@
+flake8==3.5.0
 jira==1.0.3
 PyGithub==1.26.0
 Unidecode==0.04.19


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add [flake8](http://flake8.pycqa.org) tests to find Python syntax errors and undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree

## How was this patch tested?

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
$ __flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics__

Please review http://spark.apache.org/contributing.html before opening a pull request.
