### PR TITLE
[SPARK-24716][TESTS][FOLLOW-UP] Test Hive metastore schema and parquet schema are in different letter cases

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -1021,18 +1021,6 @@ class ParquetFilterSuite extends QueryTest with ParquetTest with SharedSQLContex
       }
     }
   }
-
-  test("SPARK-25206: wrong records are returned when Hive metastore schema and parquet schema " +
-    "are in different letter cases") {
-    withTempPath { path =>
-      val data = spark.range(1, 10).toDF("id")
-      data.write.parquet(path.getCanonicalPath)
-      withTable("SPARK_25206") {
-        sql(s"CREATE TABLE SPARK_25206 (ID LONG) USING parquet LOCATION '${path.getCanonicalPath}'")
-        checkAnswer(sql("select id from SPARK_25206 where id > 0"), data)
-      }
-    }
-  }
 }
 
 class NumRowGroupsAcc extends AccumulatorV2[Integer, Integer] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -1021,6 +1021,18 @@ class ParquetFilterSuite extends QueryTest with ParquetTest with SharedSQLContex
       }
     }
   }
+
+  test("SPARK-25206: wrong records are returned when Hive metastore schema and parquet schema " +
+    "are in different letter cases") {
+    withTempPath { path =>
+      val data = spark.range(1, 10).toDF("id")
+      data.write.parquet(path.getCanonicalPath)
+      withTable("SPARK_25206") {
+        sql(s"CREATE TABLE SPARK_25206 (ID LONG) USING parquet LOCATION '${path.getCanonicalPath}'")
+        checkAnswer(sql("select id from SPARK_25206 where id > 0"), data)
+      }
+    }
+  }
 }
 
 class NumRowGroupsAcc extends AccumulatorV2[Integer, Integer] {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.hive
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetTest
 import org.apache.spark.sql.hive.test.TestHiveSingleton
+import org.apache.spark.sql.internal.SQLConf
 
 case class Cases(lower: String, UPPER: String)
 
@@ -72,6 +73,21 @@ class HiveParquetSuite extends QueryTest with ParquetTest with TestHiveSingleton
           sql("INSERT OVERWRITE TABLE p SELECT * FROM t")
           sql("INSERT OVERWRITE TABLE p SELECT * FROM t")
           checkAnswer(sql("SELECT * FROM p"), sql("SELECT * FROM t").collect().toSeq)
+        }
+      }
+    }
+  }
+
+  test("SPARK-25206: wrong records are returned by filter pushdown " +
+    "when Hive metastore schema and parquet schema are in different letter cases") {
+    withSQLConf(SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> true.toString) {
+      withTempPath { path =>
+        val data = spark.range(1, 10).toDF("id")
+        data.write.parquet(path.getCanonicalPath)
+        withTable("SPARK_25206") {
+          sql("CREATE TABLE SPARK_25206 (ID LONG) USING parquet LOCATION " +
+            s"'${path.getCanonicalPath}'")
+          checkAnswer(sql("select id from SPARK_25206 where id > 0"), data)
         }
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since https://github.com/apache/spark/pull/21696. Spark uses Parquet schema instead of Hive metastore schema to do pushdown.
That change can avoid wrong records returned when Hive metastore schema and parquet schema are in different letter cases. This pr add a test case for it.

More details:
https://issues.apache.org/jira/browse/SPARK-25206

## How was this patch tested?

unit tests
