### PR TITLE
[SPARK-25242][SQL] make sql config setting fluent

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/RuntimeConfig.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RuntimeConfig.scala
@@ -37,9 +37,10 @@ class RuntimeConfig private[sql](sqlConf: SQLConf = new SQLConf) {
    *
    * @since 2.0.0
    */
-  def set(key: String, value: String): Unit = {
+  def set(key: String, value: String): RuntimeConfig = {
     requireNonStaticConf(key)
     sqlConf.setConfString(key, value)
+    this
   }
 
   /**
@@ -47,9 +48,10 @@ class RuntimeConfig private[sql](sqlConf: SQLConf = new SQLConf) {
    *
    * @since 2.0.0
    */
-  def set(key: String, value: Boolean): Unit = {
+  def set(key: String, value: Boolean): RuntimeConfig = {
     requireNonStaticConf(key)
     set(key, value.toString)
+    this
   }
 
   /**
@@ -57,9 +59,10 @@ class RuntimeConfig private[sql](sqlConf: SQLConf = new SQLConf) {
    *
    * @since 2.0.0
    */
-  def set(key: String, value: Long): Unit = {
+  def set(key: String, value: Long): RuntimeConfig = {
     requireNonStaticConf(key)
     set(key, value.toString)
+    this
   }
 
   /**
@@ -127,9 +130,10 @@ class RuntimeConfig private[sql](sqlConf: SQLConf = new SQLConf) {
    *
    * @since 2.0.0
    */
-  def unset(key: String): Unit = {
+  def unset(key: String): RuntimeConfig = {
     requireNonStaticConf(key)
     sqlConf.unsetConf(key)
+    this
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/RuntimeConfigSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/RuntimeConfigSuite.scala
@@ -36,6 +36,11 @@ class RuntimeConfigSuite extends SparkFunSuite {
     intercept[NoSuchElementException] {
       conf.get("notset")
     }
+
+    conf.set("k4", "v4").set("k5", 5).set("k6", value = true)
+    assert(conf.get("k4") == "v4")
+    assert(conf.get("k5") == "5")
+    assert(conf.get("k6") == "true")
   }
 
   test("getOption") {
@@ -52,6 +57,10 @@ class RuntimeConfigSuite extends SparkFunSuite {
     conf.unset("k1")
     intercept[NoSuchElementException] {
       conf.get("k1")
+    }
+
+    intercept[NoSuchElementException] {
+      conf.set("k2", "v2").unset("k2").get("k2")
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

User can now set conf more easily by doing this:
```
sparkSession.conf.set(...).set(...).unset(...)
```

## How was this patch tested?

More tests for those writings are added to the existing test cases.