### PR TITLE
emphasize deprecation [documentation tweak]

### DIFF
--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -499,7 +499,7 @@ setMethod("createOrReplaceTempView",
 
 #' (Deprecated) Register Temporary Table
 #'
-#' Registers a SparkDataFrame as a Temporary Table in the SparkSession
+#' (Deprecated) Registers a SparkDataFrame as a Temporary Table in the SparkSession
 #' @param x A SparkDataFrame
 #' @param tableName A character vector containing the name of the table
 #'


### PR DESCRIPTION
Was poking around documentation for `formals` of this method as I'd seen it recommended and completely missed the `Deprecated` tag; even after seeing elsewhere it's deprecated, I stared at the documentation for far too long before noticing the existing tag.

So, adding this to emphasize further