### PR TITLE
[SPARK-25280][SQL] Add support for USING syntax for DataSourceV2

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
@@ -106,13 +106,11 @@ object MLUtils extends Logging {
 
   private[spark] def parseLibSVMFile(
       sparkSession: SparkSession, paths: Seq[String]): RDD[(Double, Array[Int], Array[Double])] = {
-    val lines = sparkSession.baseRelationToDataFrame(
-      DataSource.apply(
-        sparkSession,
-        paths = paths,
-        className = classOf[TextFileFormat].getName
-      ).resolveRelation(checkFilesExist = false))
-      .select("value")
+    val lines = DataSource.apply(
+      sparkSession,
+      paths = paths,
+      className = classOf[TextFileFormat].getName
+    ).resolveRelation(checkFilesExist = false).toDataFrame(sparkSession).select("value")
 
     import lines.sqlContext.implicits._
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -384,15 +384,15 @@ case class DataSource(
           format,
           caseInsensitiveOptions)(sparkSession)
 
-      case (datasourceV2: DataSourceV2, _) if datasourceV2.isInstanceOf[BatchReadSupportProvider] =>
+      case (dataSourceV2: DataSourceV2, _) if dataSourceV2.isInstanceOf[BatchReadSupportProvider] =>
         val sessionOptions = DataSourceV2Utils.extractSessionConfigs(
-          ds = datasourceV2, conf = sparkSession.sessionState.conf)
+          ds = dataSourceV2, conf = sparkSession.sessionState.conf)
         val pathsOption = {
           val objectMapper = new ObjectMapper()
           DataSourceOptions.PATHS_KEY -> objectMapper.writeValueAsString(paths.toArray)
         }
         DataSourceV2Relation.create(
-          datasourceV2, caseInsensitiveOptions ++ sessionOptions + pathsOption,
+          dataSourceV2, caseInsensitiveOptions ++ sessionOptions + pathsOption,
           userSpecifiedSchema = userSpecifiedSchema)
 
       case _ =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceRelation.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.sources.BaseRelation
+import org.apache.spark.sql.types.StructType
+
+
+/**
+ * A trait that should be mixed into a data source. It provides a set of methods and fields
+ * to convert the data source to be analyzed, for example, from a data source to
+ * `DataFrame` or [[LogicalPlan]].
+ *
+ * @note fields and methods here are intentionally `private[spark]` to prevent
+ * access from inherited interface.
+ */
+trait DataSourceRelation {
+  import DataSourceRelation._
+
+  /**
+   * Convert a data source created for external data sources into a `DataFrame`.
+   */
+  private[spark] final def toDataFrame(sparkSession: SparkSession): DataFrame = this match {
+    case dsV1: DataSourceV1Relation => sparkSession.baseRelationToDataFrame(dsV1)
+    case dsV2: DataSourceV2Relation => Dataset.ofRows(sparkSession, dsV2)
+    case _ => throw new AnalysisException(s"Unexpected relation $this.")
+  }
+
+  /**
+   * Convert a data source created for external data sources into a [[LogicalPlan]].
+   */
+  private[spark] final def toLogicalPlan: LogicalPlan = this match {
+    case dsV1: DataSourceV1Relation => LogicalRelation(dsV1)
+    case dsV2: DataSourceV2Relation => dsV2
+    case _ => throw new AnalysisException(s"Unexpected relation $this.")
+  }
+
+  private[spark] final def toLogicalPlan(isStreaming: Boolean): LogicalPlan = this match {
+    case dsV1: DataSourceV1Relation if isStreaming => LogicalRelation(dsV1, isStreaming)
+    // TODO: Add StreamingDataSourceV2Relation as well.
+    case _ => toLogicalPlan
+  }
+
+  private[spark] final def toLogicalPlan(table: Option[CatalogTable]): LogicalPlan = {
+    this match {
+      case dsV1: DataSourceV1Relation if table.isDefined => LogicalRelation(dsV1, table.get)
+      case dsV2: DataSourceV2Relation if table.isDefined =>
+        dsV2.copy(tableIdent = table.map(_.identifier))
+      case _ => toLogicalPlan
+    }
+  }
+
+  private[spark] final val sourceSchema: StructType = this match {
+    case dsV1: DataSourceV1Relation => dsV1.schema
+    case dsV2: DataSourceV2Relation => dsV2.schema
+    case _ => throw new AnalysisException(s"Unexpected relation $this.")
+  }
+}
+
+object DataSourceRelation {
+  private type DataSourceV1Relation = BaseRelation
+
+  def newOutputCopy(plan: LogicalPlan, newOutput: Seq[AttributeReference]): LogicalPlan = {
+    plan match {
+      case relationV1: LogicalRelation => relationV1.copy(output = newOutput)
+      case relationV2: DataSourceV2Relation => relationV2.copy(output = newOutput)
+      case _ => throw new AnalysisException(s"Unexpected relation $plan.")
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceRelation.scala
@@ -70,7 +70,7 @@ trait DataSourceRelation {
     }
   }
 
-  private[spark] final val sourceSchema: StructType = this match {
+  private[spark] final def sourceSchema: StructType = this match {
     case dsV1: DataSourceV1Relation => dsV1.schema
     case dsV2: DataSourceV2Relation => dsV2.schema
     case _ => throw new AnalysisException(s"Unexpected relation $this.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{RowDataSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.command._
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
@@ -239,7 +240,7 @@ class FindDataSourceTable(sparkSession: SparkSession) extends Rule[LogicalPlan] 
             options = table.storage.properties ++ pathOption,
             catalogTable = Some(table))
 
-        LogicalRelation(dataSource.resolveRelation(checkFilesExist = false), table)
+        dataSource.resolveRelation(checkFilesExist = false).toLogicalPlan(Some(table))
       }
     })
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
@@ -265,14 +265,13 @@ object TextInputCSVDataSource extends CSVDataSource {
       options: CSVOptions): Dataset[String] = {
     val paths = inputPaths.map(_.getPath.toString)
     if (Charset.forName(options.charset) == StandardCharsets.UTF_8) {
-      sparkSession.baseRelationToDataFrame(
-        DataSource.apply(
-          sparkSession,
-          paths = paths,
-          className = classOf[TextFileFormat].getName,
-          options = options.parameters
-        ).resolveRelation(checkFilesExist = false))
-        .select("value").as[String](Encoders.STRING)
+      DataSource.apply(
+        sparkSession,
+        paths = paths,
+        className = classOf[TextFileFormat].getName,
+        options = options.parameters
+      ).resolveRelation(checkFilesExist = false).toDataFrame(sparkSession)
+      .select("value").as[String](Encoders.STRING)
     } else {
       val charset = options.charset
       val rdd = sparkSession.sparkContext

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ddl.scala
@@ -90,7 +90,7 @@ case class CreateTempViewUsing(
 
     val catalog = sparkSession.sessionState.catalog
     val viewDefinition = Dataset.ofRows(
-      sparkSession, LogicalRelation(dataSource.resolveRelation())).logicalPlan
+      sparkSession, dataSource.resolveRelation().toLogicalPlan).logicalPlan
 
     if (global) {
       catalog.createGlobalTempView(tableIdent.table, viewDefinition, replace)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonDataSource.scala
@@ -114,14 +114,13 @@ object TextInputJsonDataSource extends JsonDataSource {
       sparkSession: SparkSession,
       inputPaths: Seq[FileStatus],
       parsedOptions: JSONOptions): Dataset[String] = {
-    sparkSession.baseRelationToDataFrame(
-      DataSource.apply(
-        sparkSession,
-        paths = inputPaths.map(_.getPath.toString),
-        className = classOf[TextFileFormat].getName,
-        options = parsedOptions.parameters
-      ).resolveRelation(checkFilesExist = false))
-      .select("value").as(Encoders.STRING)
+    DataSource.apply(
+      sparkSession,
+      paths = inputPaths.map(_.getPath.toString),
+      className = classOf[TextFileFormat].getName,
+      options = parsedOptions.parameters
+    ).resolveRelation(checkFilesExist = false).toDataFrame(sparkSession)
+    .select("value").as[String](Encoders.STRING)
   }
 
   override def readFile(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -56,7 +56,7 @@ class ResolveSQLOnFile(sparkSession: SparkSession) extends Rule[LogicalPlan] {
           throw new AnalysisException("Unsupported data source type for direct query on files: " +
             s"${u.tableIdentifier.database.get}")
         }
-        LogicalRelation(dataSource.resolveRelation())
+        dataSource.resolveRelation().toLogicalPlan
       } catch {
         case _: ClassNotFoundException => u
         case e: Exception =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{MultiInstanceRelation, NamedRelation}
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression}
 import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan, Statistics}
+import org.apache.spark.sql.execution.datasources.DataSourceRelation
 import org.apache.spark.sql.sources.DataSourceRegister
 import org.apache.spark.sql.sources.v2.{BatchReadSupportProvider, BatchWriteSupportProvider, DataSourceOptions, DataSourceV2}
 import org.apache.spark.sql.sources.v2.reader.{BatchReadSupport, ReadSupport, ScanConfigBuilder, SupportsReportStatistics}
@@ -46,7 +47,11 @@ case class DataSourceV2Relation(
     options: Map[String, String],
     tableIdent: Option[TableIdentifier] = None,
     userSpecifiedSchema: Option[StructType] = None)
-  extends LeafNode with MultiInstanceRelation with NamedRelation with DataSourceV2StringFormat {
+  extends LeafNode
+  with MultiInstanceRelation
+  with NamedRelation
+  with DataSourceV2StringFormat
+  with DataSourceRelation {
 
   import DataSourceV2Relation._
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
@@ -171,8 +171,9 @@ class FileStreamSource(
         partitionColumns = partitionColumns,
         className = fileFormatClassName,
         options = optionsWithPartitionBasePath)
-    Dataset.ofRows(sparkSession, LogicalRelation(newDataSource.resolveRelation(
-      checkFilesExist = false), isStreaming = true))
+    val logicalPlan =
+      newDataSource.resolveRelation(checkFilesExist = false).toLogicalPlan(isStreaming = true)
+    Dataset.ofRows(sparkSession, logicalPlan)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -22,6 +22,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.execution.datasources.DataSourceRelation
 import org.apache.spark.sql.execution.streaming.{Sink, Source}
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types.StructType
@@ -193,7 +194,7 @@ trait CreatableRelationProvider {
  * @since 1.3.0
  */
 @InterfaceStability.Stable
-abstract class BaseRelation {
+abstract class BaseRelation extends DataSourceRelation {
   def sqlContext: SQLContext
   def schema: StructType
 

--- a/sql/core/src/test/java/test/org/apache/spark/sql/sources/v2/JavaAdvancedDataSourceV2.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/sources/v2/JavaAdvancedDataSourceV2.java
@@ -171,4 +171,9 @@ public class JavaAdvancedDataSourceV2 implements DataSourceV2, BatchReadSupportP
   public BatchReadSupport createBatchReadSupport(DataSourceOptions options) {
     return new ReadSupport();
   }
+
+  @Override
+  public BatchReadSupport createBatchReadSupport(StructType schema, DataSourceOptions options) {
+    return createBatchReadSupport(options);
+  }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/sources/v2/JavaColumnarDataSourceV2.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/sources/v2/JavaColumnarDataSourceV2.java
@@ -26,6 +26,7 @@ import org.apache.spark.sql.sources.v2.DataSourceOptions;
 import org.apache.spark.sql.sources.v2.DataSourceV2;
 import org.apache.spark.sql.sources.v2.reader.*;
 import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 
@@ -110,5 +111,10 @@ public class JavaColumnarDataSourceV2 implements DataSourceV2, BatchReadSupportP
   @Override
   public BatchReadSupport createBatchReadSupport(DataSourceOptions options) {
     return new ReadSupport();
+  }
+
+  @Override
+  public BatchReadSupport createBatchReadSupport(StructType schema, DataSourceOptions options) {
+    return createBatchReadSupport(options);
   }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/sources/v2/JavaPartitionAwareDataSource.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/sources/v2/JavaPartitionAwareDataSource.java
@@ -27,6 +27,7 @@ import org.apache.spark.sql.sources.v2.reader.*;
 import org.apache.spark.sql.sources.v2.reader.partitioning.ClusteredDistribution;
 import org.apache.spark.sql.sources.v2.reader.partitioning.Distribution;
 import org.apache.spark.sql.sources.v2.reader.partitioning.Partitioning;
+import org.apache.spark.sql.types.StructType;
 
 public class JavaPartitionAwareDataSource implements DataSourceV2, BatchReadSupportProvider {
 
@@ -110,5 +111,10 @@ public class JavaPartitionAwareDataSource implements DataSourceV2, BatchReadSupp
   @Override
   public BatchReadSupport createBatchReadSupport(DataSourceOptions options) {
     return new ReadSupport();
+  }
+
+  @Override
+  public BatchReadSupport createBatchReadSupport(StructType schema, DataSourceOptions options) {
+    return createBatchReadSupport(options);
   }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/sources/v2/JavaSimpleDataSourceV2.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/sources/v2/JavaSimpleDataSourceV2.java
@@ -21,6 +21,7 @@ import org.apache.spark.sql.sources.v2.BatchReadSupportProvider;
 import org.apache.spark.sql.sources.v2.DataSourceV2;
 import org.apache.spark.sql.sources.v2.DataSourceOptions;
 import org.apache.spark.sql.sources.v2.reader.*;
+import org.apache.spark.sql.types.StructType;
 
 public class JavaSimpleDataSourceV2 implements DataSourceV2, BatchReadSupportProvider {
 
@@ -38,5 +39,10 @@ public class JavaSimpleDataSourceV2 implements DataSourceV2, BatchReadSupportPro
   @Override
   public BatchReadSupport createBatchReadSupport(DataSourceOptions options) {
     return new ReadSupport();
+  }
+
+  @Override
+  public BatchReadSupport createBatchReadSupport(StructType schema, DataSourceOptions options) {
+    return createBatchReadSupport(options);
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -194,7 +194,7 @@ case class RelationConversions(
   private def isParquetProperty(key: String) =
     key.startsWith("parquet.") || key.contains(".parquet.")
 
-  private def convert(relation: HiveTableRelation): LogicalRelation = {
+  private def convert(relation: HiveTableRelation): LogicalPlan = {
     val serde = relation.tableMeta.storage.serde.getOrElse("").toLowerCase(Locale.ROOT)
 
     // Consider table and storage properties. For properties existing in both sides, storage


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR targets for DataSource V2 to have `USING` syntax support mainly. 

Currently, 

```scala
spark.sql(s"CREATE TABLE tableB USING ${classOf[SimpleDataSourceV2].getCanonicalName}")
```

produces an error:

```
org.apache.spark.sql.sources.v2.SimpleDataSourceV2 is not a valid Spark SQL Data Source.;
org.apache.spark.sql.AnalysisException: org.apache.spark.sql.sources.v2.SimpleDataSourceV2 is not a valid Spark SQL Data Source.;
	at org.apache.spark.sql.execution.datasources.DataSource.resolveRelation(DataSource.scala:385)
	at org.apache.spark.sql.execution.command.CreateDataSourceTableCommand.run(createDataSourceTables.scala:78)
	at org.apache.spark.sql.execution.command.ExecutedCommandExec.sideEffectResult$lzycompute(commands.scala:70)
	at org.apache.spark.sql.execution.command.ExecutedCommandExec.sideEffectResult(commands.scala:68)
	at org.apache.spark.sql.execution.command.ExecutedCommandExec.executeCollect(commands.scala:79)
```

So that developers (Datasource V1) can easily migrate and their users can smoothly change their codes using `USING` syntax from Datasource v1, we better support this case as well.

There's a discussion thread about this here as well - http://apache-spark-developers-list.1001551.n3.nabble.com/DISCUSS-USING-syntax-for-Datasource-V2-td24754.html

For this one, looks we can proceed orthogonally with multiple catalog support.

The approach taken here is basically introduce `DataSourceRelation` trait which connects DataSourceV1 and DataSourceV2 so that the changes can be minimised. For extendability, this uses a pattern match so that, for instance, newer DataSource can be added in the (far) future.

For `StreamingDataSourceV2Relation` and `BatchWriteSupportProvider`, it is not handled here.

## How was this patch tested?

Unit tests were added.