### PR TITLE
[SPARK-25283][CORE] Fix for a deadlock in UnionRDD

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/UnionRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/UnionRDD.scala
@@ -20,13 +20,12 @@ package org.apache.spark.rdd
 import java.io.{IOException, ObjectOutputStream}
 
 import scala.collection.mutable.ArrayBuffer
-import scala.concurrent.ExecutionContext
+import scala.collection.parallel.ForkJoinTaskSupport
 import scala.concurrent.forkjoin.ForkJoinPool
 import scala.reflect.ClassTag
 
 import org.apache.spark.{Dependency, Partition, RangeDependency, SparkContext, TaskContext}
 import org.apache.spark.annotation.DeveloperApi
-import org.apache.spark.util.ThreadUtils.parmap
 import org.apache.spark.util.Utils
 
 /**
@@ -60,7 +59,8 @@ private[spark] class UnionPartition[T: ClassTag](
 }
 
 object UnionRDD {
-  private[spark] lazy val threadPool = new ForkJoinPool(8)
+  private[spark] lazy val partitionEvalTaskSupport =
+    new ForkJoinTaskSupport(new ForkJoinPool(8))
 }
 
 @DeveloperApi
@@ -74,13 +74,14 @@ class UnionRDD[T: ClassTag](
     rdds.length > conf.getInt("spark.rdd.parallelListingThreshold", 10)
 
   override def getPartitions: Array[Partition] = {
-    val partitionLengths = if (isPartitionListingParallel) {
-      implicit val ec = ExecutionContext.fromExecutor(UnionRDD.threadPool)
-      parmap(rdds)(_.partitions.length)
+    val parRDDs = if (isPartitionListingParallel) {
+      val parArray = rdds.par
+      parArray.tasksupport = UnionRDD.partitionEvalTaskSupport
+      parArray
     } else {
-      rdds.map(_.partitions.length)
+      rdds
     }
-    val array = new Array[Partition](partitionLengths.sum)
+    val array = new Array[Partition](parRDDs.map(_.partitions.length).seq.sum)
     var pos = 0
     for ((rdd, rddIndex) <- rdds.zipWithIndex; split <- rdd.partitions) {
       array(pos) = new UnionPartition(pos, rdd, rddIndex, split.index)

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -1220,16 +1220,16 @@ class RDDSuite extends SparkFunSuite with SharedSparkContext {
   test("deadlock in UnionRDD") {
     val wide = 20
     def unionRDD(num: Int): UnionRDD[Int] = {
-      val rdds = (0 to 20).map(_ => sc.parallelize(1 to 10, 1))
+      val rdds = (0 until num).map(_ => sc.parallelize(1 to 10, 1))
       new UnionRDD(sc, rdds)
     }
-    val level0 = (0 to wide).map { i =>
-      val level1 = (0 to wide).map(_ => unionRDD(wide))
+    val level0 = (0 until wide).map { _ =>
+      val level1 = (0 until wide).map(_ => unionRDD(wide))
       new UnionRDD(sc, level1)
     }
     val rdd = new UnionRDD(sc, level0)
 
-    assert(rdd.partitions.length == (wide * wide))
+    assert(rdd.partitions.length == (wide * wide * wide))
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The commit https://github.com/apache/spark/commit/131ca146ed390cd0109cd6e8c95b61e418507080 replaced Scala parallel collections in `UnionRDD` by `parmap`. The changes cause a deadlock in the `partitions` method if the method is called recursively and number of unions of the top level union is bigger than maximum size of the thread pool used in `UnionRDD`. In the PR, I propose to revert Scala parallel collections back since they support nested calls even on fixed thread pools.

## How was this patch tested?

I added a test which creates 2 levels of unionRDDs wider than fixed thread pool.
