### PR TITLE
[SPARK-25284] Spark UI: make sure skipped stages are updated onJobEnd

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -354,7 +354,7 @@ private[spark] class AppStatusListener(
           job.skippedStages += stage.info.stageId
           job.skippedTasks += stage.info.numTasks
           it.remove()
-          update(stage, now)
+          update(stage, now, last = true)
         }
       }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Tiny bug in onJobEnd, not forcing the refresh of skipped stages it removes.

## How was this patch tested?

YOLO