### PR TITLE
[SPARK-25135][SQL] FileFormatWriter should respect the schema of Hive

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DataWritingCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DataWritingCommand.scala
@@ -39,7 +39,7 @@ trait DataWritingCommand extends Command {
    */
   def query: LogicalPlan
 
-  override final def children: Seq[LogicalPlan] = query :: Nil
+  override final def innerChildren: Seq[LogicalPlan] = query :: Nil
 
   // Output columns of the analyzed input query plan
   def outputColumns: Seq[Attribute]

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -2252,6 +2252,38 @@ class HiveDDLSuite
     }
   }
 
+  test("SPARK-25135: FileFormatWriter should respect the input query schema in HIVE") {
+    withTempPath { dir =>
+      val path = dir.getCanonicalPath
+      val cnt = 30
+      val table1Path = s"$path/table1"
+      val table2Path = s"$path/table2"
+      val table3Path = s"$path/table3"
+      val data =
+        spark.range(cnt).selectExpr("cast(id as bigint) as col1", "cast(id % 3 as bigint) as col2")
+      data.write.mode(SaveMode.Overwrite).parquet(table1Path)
+      withTable("table1", "table2", "table3") {
+        spark.sql(
+          s"CREATE TABLE table1(col1 bigint, col2 bigint) using parquet location '$table1Path'")
+        spark.sql(
+          s"CREATE TABLE table2(COL1 bigint, COL2 bigint) using parquet location '$table2Path'")
+        spark.sql("CREATE TABLE table3(COL1 bigint, COL2 bigint) using parquet " +
+          "PARTITIONED BY (COL2) " +
+          s"CLUSTERED BY (COL1) INTO 2 BUCKETS location '$table3Path'")
+
+        withView("view1") {
+          spark.sql("CREATE VIEW view1 as select col1, col2 from table1 where col1 > -20")
+          spark.sql("INSERT OVERWRITE TABLE table2 select COL1, COL2 from view1")
+          checkAnswer(spark.table("table2"), data)
+          assert(spark.read.parquet(table2Path).schema === spark.table("table2").schema)
+
+          spark.sql("INSERT OVERWRITE TABLE table3 select COL1, COL2 from view1 CLUSTER BY COL1")
+          checkAnswer(spark.table("table3"), data)
+        }
+      }
+    }
+  }
+
   test("SPARK-24812: desc formatted table for last access verification") {
     withTable("t1") {
       sql(


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr fix `FileFormatWriter's dataSchema`  should respect the schema of Hive. Otherwise there will be two issues. 

1.  Throwing an exception(This can be reproduce by added test case):
```scala
java.util.NoSuchElementException: None.get
	at scala.None$.get(Option.scala:347)
	at scala.None$.get(Option.scala:345)
	at org.apache.spark.sql.execution.datasources.FileFormatWriter$$anonfun$3$$anonfun$4.apply(FileFormatWriter.scala:87)
	at org.apache.spark.sql.execution.datasources.FileFormatWriter$$anonfun$3$$anonfun$4.apply(FileFormatWriter.scala:87)
```
2. The schema of the Hive table is not the same as the schema of the parquet file.

## How was this patch tested?

- Unit tests for FileFormatWriter should respect the schema of Hive.
- Manual tests for didn't break UI issues fixed by [SPARK-22834](https://issues.apache.org/jira/browse/SPARK-22834):
![image](https://user-images.githubusercontent.com/5399861/44870021-94ce1700-acc1-11e8-8ef7-d7a8ba3c435d.png)

