### PR TITLE
[SPARK-25285][CORE] Add startedTasks and finishedTasks to the metrics system in the executor instance

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -556,8 +556,7 @@ private[spark] class Executor(
           }
         }
 
-        // update metric counting the number of tasks finished
-        executorSource.FINISHED_TASKS.inc(1L)
+        executorSource.SUCCEEDED_TASKS.inc(1L)
         setTaskFinishedAndClearInterruptStatus()
         execBackend.statusUpdate(taskId, TaskState.FINISHED, serializedResult)
 

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -488,7 +488,6 @@ private[spark] class Executor(
 
         // Expose task metrics using the Dropwizard metrics system.
         // Update task metrics counters
-        executorSource.SUCCESSFUL_TASKS.inc(1L)
         executorSource.METRIC_CPU_TIME.inc(task.metrics.executorCpuTime)
         executorSource.METRIC_RUN_TIME.inc(task.metrics.executorRunTime)
         executorSource.METRIC_JVM_GC_TIME.inc(task.metrics.jvmGCTime)
@@ -557,6 +556,8 @@ private[spark] class Executor(
           }
         }
 
+        // update metric counting the number of tasks finished
+        executorSource.FINISHED_TASKS.inc(1L)
         setTaskFinishedAndClearInterruptStatus()
         execBackend.statusUpdate(taskId, TaskState.FINISHED, serializedResult)
 

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -488,6 +488,7 @@ private[spark] class Executor(
 
         // Expose task metrics using the Dropwizard metrics system.
         // Update task metrics counters
+        executorSource.SUCCESSFUL_TASKS.inc(1L)
         executorSource.METRIC_CPU_TIME.inc(task.metrics.executorCpuTime)
         executorSource.METRIC_RUN_TIME.inc(task.metrics.executorRunTime)
         executorSource.METRIC_JVM_GC_TIME.inc(task.metrics.jvmGCTime)

--- a/core/src/main/scala/org/apache/spark/executor/ExecutorSource.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorSource.scala
@@ -101,7 +101,7 @@ class ExecutorSource(threadPool: ThreadPoolExecutor, executorId: String) extends
 
   // Expose executor task metrics using the Dropwizard metrics system.
   // The list of available Task metrics can be found in TaskMetrics.scala
-  val FINISHED_TASKS = metricRegistry.counter(MetricRegistry.name("finishedTasks"))
+  val SUCCEEDED_TASKS = metricRegistry.counter(MetricRegistry.name("succeededTasks"))
   val METRIC_CPU_TIME = metricRegistry.counter(MetricRegistry.name("cpuTime"))
   val METRIC_RUN_TIME = metricRegistry.counter(MetricRegistry.name("runTime"))
   val METRIC_JVM_GC_TIME = metricRegistry.counter(MetricRegistry.name("jvmGCTime"))

--- a/core/src/main/scala/org/apache/spark/executor/ExecutorSource.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorSource.scala
@@ -100,8 +100,8 @@ class ExecutorSource(threadPool: ThreadPoolExecutor, executorId: String) extends
   })
 
   // Expose executor task metrics using the Dropwizard metrics system.
-  // The list is taken from TaskMetrics.scala
-  val SUCCESSFUL_TASKS = metricRegistry.counter(MetricRegistry.name("successfulTasks"))
+  // The list of available Task metrics is available in TaskMetrics.scala
+  val FINISHED_TASKS = metricRegistry.counter(MetricRegistry.name("finishedTasks"))
   val METRIC_CPU_TIME = metricRegistry.counter(MetricRegistry.name("cpuTime"))
   val METRIC_RUN_TIME = metricRegistry.counter(MetricRegistry.name("runTime"))
   val METRIC_JVM_GC_TIME = metricRegistry.counter(MetricRegistry.name("jvmGCTime"))

--- a/core/src/main/scala/org/apache/spark/executor/ExecutorSource.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorSource.scala
@@ -56,7 +56,7 @@ class ExecutorSource(threadPool: ThreadPoolExecutor, executorId: String) extends
     override def getValue: Long = threadPool.getCompletedTaskCount()
   })
 
-  // Gauge for executor, number of threads started
+  // Gauge for executor, number of tasks started
   metricRegistry.register(MetricRegistry.name("threadpool", "startedTasks"), new Gauge[Long] {
     override def getValue: Long = threadPool.getTaskCount()
   })
@@ -100,7 +100,7 @@ class ExecutorSource(threadPool: ThreadPoolExecutor, executorId: String) extends
   })
 
   // Expose executor task metrics using the Dropwizard metrics system.
-  // The list of available Task metrics is available in TaskMetrics.scala
+  // The list of available Task metrics can be found in TaskMetrics.scala
   val FINISHED_TASKS = metricRegistry.counter(MetricRegistry.name("finishedTasks"))
   val METRIC_CPU_TIME = metricRegistry.counter(MetricRegistry.name("cpuTime"))
   val METRIC_RUN_TIME = metricRegistry.counter(MetricRegistry.name("runTime"))

--- a/core/src/main/scala/org/apache/spark/executor/ExecutorSource.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorSource.scala
@@ -56,6 +56,11 @@ class ExecutorSource(threadPool: ThreadPoolExecutor, executorId: String) extends
     override def getValue: Long = threadPool.getCompletedTaskCount()
   })
 
+  // Gauge for executor, number of threads started
+  metricRegistry.register(MetricRegistry.name("threadpool", "startedTasks"), new Gauge[Long] {
+    override def getValue: Long = threadPool.getTaskCount()
+  })
+
   // Gauge for executor thread pool's current number of threads
   metricRegistry.register(MetricRegistry.name("threadpool", "currentPool_size"), new Gauge[Int] {
     override def getValue: Int = threadPool.getPoolSize()
@@ -96,6 +101,7 @@ class ExecutorSource(threadPool: ThreadPoolExecutor, executorId: String) extends
 
   // Expose executor task metrics using the Dropwizard metrics system.
   // The list is taken from TaskMetrics.scala
+  val SUCCESSFUL_TASKS = metricRegistry.counter(MetricRegistry.name("successfulTasks"))
   val METRIC_CPU_TIME = metricRegistry.counter(MetricRegistry.name("cpuTime"))
   val METRIC_RUN_TIME = metricRegistry.counter(MetricRegistry.name("runTime"))
   val METRIC_JVM_GC_TIME = metricRegistry.counter(MetricRegistry.name("jvmGCTime"))

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -853,7 +853,7 @@ when running in local mode.
   - shuffleRemoteBytesReadToDisk.count
   - shuffleTotalBytesRead.count
   - shuffleWriteTime.count
-  - finishedTasks.count
+  - succeddedTasks.count
   - threadpool.activeTasks
   - threadpool.completeTasks
   - threadpool.currentPool_size

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -853,7 +853,7 @@ when running in local mode.
   - shuffleRemoteBytesReadToDisk.count
   - shuffleTotalBytesRead.count
   - shuffleWriteTime.count
-  - succeddedTasks.count
+  - succeededTasks.count
   - threadpool.activeTasks
   - threadpool.completeTasks
   - threadpool.currentPool_size

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -853,10 +853,12 @@ when running in local mode.
   - shuffleRemoteBytesReadToDisk.count
   - shuffleTotalBytesRead.count
   - shuffleWriteTime.count
+  - finishedTasks.count
   - threadpool.activeTasks
   - threadpool.completeTasks
   - threadpool.currentPool_size
   - threadpool.maxPool_size
+  - threadpool.startedTasks
 
 - namespace=NettyBlockTransfer
   - shuffle-client.usedDirectMemory


### PR DESCRIPTION
## What changes were proposed in this pull request?

The motivation for these additional metrics is to help in troubleshooting and monitoring task execution workload when running on a cluster. Currently available metrics include executor threadpool metrics for task completed and for active tasks. The addition of threadpool taskStarted metric will allow for example to collect info on the (approximate) number of failed tasks by computing the difference thread started – (active threads + completed tasks and/or successfully finished tasks).
The proposed metric finishedTasks is also intended for this type of troubleshooting. The difference between finshedTasks and threadpool.completeTasks, is that the latter is a (dropwizard library) gauge taken from the threadpool, while the former is a (dropwizard) counter computed in the [[Executor]] class, when a task successfully finishes, together with several other task metrics counters.
Note, there are similarities with some of the metrics introduced in SPARK-24398, however there are key differences, coming from the fact that this PR concerns the executor source, therefore providing metric values per executor + metric values do not require to pass through the listerner bus in this case.

## How was this patch tested?

Manually tested on a YARN cluster