### PR TITLE
[SPARK-24748][SS][FOLLOWUP] Switch custom metrics to Unstable APIs

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/CustomMetrics.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/CustomMetrics.java
@@ -22,7 +22,7 @@ import org.apache.spark.annotation.InterfaceStability;
 /**
  * An interface for reporting custom metrics from streaming sources and sinks
  */
-@InterfaceStability.Evolving
+@InterfaceStability.Unstable
 public interface CustomMetrics {
   /**
    * Returns a JSON serialized representation of custom metrics

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/reader/streaming/SupportsCustomReaderMetrics.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/reader/streaming/SupportsCustomReaderMetrics.java
@@ -25,7 +25,7 @@ import org.apache.spark.sql.sources.v2.CustomMetrics;
  * to report custom metrics that gets reported under the
  * {@link org.apache.spark.sql.streaming.SourceProgress}
  */
-@InterfaceStability.Evolving
+@InterfaceStability.Unstable
 public interface SupportsCustomReaderMetrics extends StreamingReadSupport {
 
   /**

--- a/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/streaming/SupportsCustomWriterMetrics.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/sources/v2/writer/streaming/SupportsCustomWriterMetrics.java
@@ -25,7 +25,7 @@ import org.apache.spark.sql.sources.v2.CustomMetrics;
  * to report custom metrics that gets reported under the
  * {@link org.apache.spark.sql.streaming.SinkProgress}
  */
-@InterfaceStability.Evolving
+@InterfaceStability.Unstable
 public interface SupportsCustomWriterMetrics extends StreamingWriteSupport {
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to switch the api stability from `Evolving` to `Unstable` given the discussion in the original PR for now.

## How was this patch tested?

N/A