### PR TITLE
[SPARK-21786][SQL][FOLLOWUP] Add compressionCodec test for CTAS

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/CompressionCodecSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/CompressionCodecSuite.scala
@@ -122,7 +122,7 @@ class CompressionCodecSuite extends TestHiveSingleton with ParquetTest with Befo
       """.stripMargin)
   }
 
-  private def writeDateToTableUsingCTAS(
+  private def writeDataToTableUsingCTAS(
       rootDir: File,
       tableName: String,
       partitionValue: Option[String],
@@ -152,7 +152,7 @@ class CompressionCodecSuite extends TestHiveSingleton with ParquetTest with Befo
       usingCTAS: Boolean): String = {
     val partitionValue = if (isPartitioned) Some("test") else None
     if (usingCTAS) {
-      writeDateToTableUsingCTAS(tmpDir, tableName, partitionValue, format, compressionCodec)
+      writeDataToTableUsingCTAS(tmpDir, tableName, partitionValue, format, compressionCodec)
     } else {
       createTable(tmpDir, tableName, isPartitioned, format, compressionCodec)
       writeDataToTable(tableName, partitionValue)
@@ -258,8 +258,7 @@ class CompressionCodecSuite extends TestHiveSingleton with ParquetTest with Befo
   def checkForTableWithCompressProp(format: String, compressCodecs: List[String]): Unit = {
     Seq(true, false).foreach { isPartitioned =>
       Seq(true, false).foreach { convertMetastore =>
-        // TODO: Also verify CTAS(usingCTAS=true) cases when the bug(SPARK-22926) is fixed.
-        Seq(false).foreach { usingCTAS =>
+        Seq(true, false).foreach { usingCTAS =>
           checkTableCompressionCodecForCodecs(
             format,
             isPartitioned,
@@ -281,8 +280,7 @@ class CompressionCodecSuite extends TestHiveSingleton with ParquetTest with Befo
   def checkForTableWithoutCompressProp(format: String, compressCodecs: List[String]): Unit = {
     Seq(true, false).foreach { isPartitioned =>
       Seq(true, false).foreach { convertMetastore =>
-        // TODO: Also verify CTAS(usingCTAS=true) cases when the bug(SPARK-22926) is fixed.
-        Seq(false).foreach { usingCTAS =>
+        Seq(true, false).foreach { usingCTAS =>
           checkTableCompressionCodecForCodecs(
             format,
             isPartitioned,


### PR DESCRIPTION
## What changes were proposed in this pull request?
Before Apache Spark 2.3, table properties were ignored when writing data to a hive table(created with STORED AS PARQUET/ORC syntax), because the compression configurations were not passed to the FileFormatWriter in hadoopConf. Then it was fixed in #20087. But actually for CTAS with USING PARQUET/ORC syntax, table properties were ignored too when convertMastore, so the test case for CTAS not supported. 

Now it has been fixed  in #20522 , the test case should be enabled too.

## How was this patch tested?
This only re-enables the test cases of previous PR.