### PR TITLE
[SPARK-25297][Streaming][Test] Fix blocking unit tests for Scala 2.12

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/util/FileBasedWriteAheadLog.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/util/FileBasedWriteAheadLog.scala
@@ -65,7 +65,8 @@ private[streaming] class FileBasedWriteAheadLog(
     "WriteAheadLogManager" + callerName.map(c => s" for $c").getOrElse("")
   }
   private val forkJoinPool = ThreadUtils.newForkJoinPool(threadpoolName, 20)
-  private val executionContext = ExecutionContext.fromExecutorService(forkJoinPool)
+  private val executionContext = ExecutionContext
+    .fromExecutorService(forkJoinPool, { e: Throwable => throw e })
 
   override protected def logName = {
     getClass.getName.stripSuffix("$") +


### PR DESCRIPTION
## What changes were proposed in this pull request?

Customize ExecutorContext's reporter to fix blocking unit tests for Scala 2.12

## How was this patch tested?
```
./dev/change-scala-version.sh 2.12
$ sbt -Dscala-2.12
> ++2.12.6
> project streaming
> testOnly *FileBasedWriteAheadLogWithFileCloseAfterWriteSuite
```