### PR TITLE
[SPARK-25301][SQL] When a view uses an UDF from a non default database, Spark analyser throws AnalysisException

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1311,7 +1311,10 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
   protected def visitFunctionName(ctx: QualifiedNameContext): FunctionIdentifier = {
     ctx.identifier().asScala.map(_.getText) match {
       case Seq(db, fn) => FunctionIdentifier(fn, Option(db))
-      case Seq(fn) => FunctionIdentifier(fn, None)
+      case Seq(fn) => fn.split('.').toSeq match {
+        case Seq(d, f) => FunctionIdentifier(f, Option(d))
+        case _ => FunctionIdentifier(fn, None)
+      }
       case other => throw new ParseException(s"Unsupported function name '${ctx.getText}'", ctx)
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -2281,4 +2281,23 @@ class HiveDDLSuite
       }
     }
   }
+
+  test("SPARK-25301: checks view with udf from non default database") {
+    val db = "d1"
+    withDatabase(db) {
+      spark.sql(s"CREATE DATABASE $db")
+      val table = "t1"
+      withTable(s"$db.$table") {
+        spark.sql(s"CREATE TABLE $db.$table AS SELECT 'abcd' c1, 'xyz' c2")
+        val functionNameUpper = "udfUpper"
+        withUserDefinedFunction(s"$db.$functionNameUpper" -> false) {
+          val functionClass =
+            classOf[org.apache.hadoop.hive.ql.udf.generic.GenericUDFUpper].getCanonicalName
+          sql(s"CREATE FUNCTION $db.$functionNameUpper AS '$functionClass'")
+          val ds = sql(s"SELECT `$db.$functionNameUpper`(`$table`.`c1`)  FROM `$db`.`$table`")
+          checkAnswer(ds, Row("ABCD"))
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
When a hive view uses an UDF from a non default database, Spark analyser throws AnalysisException

Steps to simulate this issue
-----------------------------
Step 1: Run following statements in Hive
--------
```sql
CREATE TABLE emp AS SELECT 'user' AS name, 'address' as address;
CREATE DATABASE d100;
CREATE FUNCTION d100.udf100 as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFUpper'; // Note: udf100 is created in d100
CREATE VIEW d100.v100 AS SELECT d100.udf100(name) FROM default.emp; 
SELECT * FROM d100.v100; // query on view d100.v100 gives correct result
```
Step2 : Run following statement in Spark-shell 
-------------
```scala
spark.sql("SELECT * FROM d100.v100").show
```
throws 
```
org.apache.spark.sql.AnalysisException: Undefined function: 'd100.udf100'. This function is neither a registered temporary function nor a permanent function registered in the database 'default'
```

This is because, while parsing the SQL statement of the View 
``` 'select `d100.udf100`(`emp`.`name`) from `default`.`emp`' ``` , spark parser fails to split database name and udf name and hence Spark function registry tries to load the UDF 'd100.udf100' from 'default' database.

To solve this issue, before creating 'FunctionIdentifier' ,  try to  get  actual database name and then create FunctionIdentifier using  that database name and function name 

## How was this patch tested?
Added 1 unit test 