### PR TITLE
[SPARK-20384][SQL] Support value class in schema of Dataset

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -189,7 +189,10 @@ object ScalaReflection extends ScalaReflection {
    * @param tpe The `Type` of deserialized object.
    * @param path The expression which can be used to extract serialized value.
    * @param walkedTypePath The paths from top to bottom to access current field when deserializing.
-   * @param instantiateValueClass If `true`, create an instance for Scala value class
+   * @param instantiateValueClass If `true`, create an instance for Scala value class.
+   *                              This is needed in case value class is top-level or it is
+   *                              the type of collection elements. Please refer to the comment in
+   *                              value class case for more details.
    */
   private def deserializerFor(
       tpe: `Type`,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -399,7 +399,7 @@ object ScalaReflection extends ScalaReflection {
         // Nested value class is treated as its underlying type
         // because the compiler will convert value class in the schema to
         // its underlying type.
-        // However, for value class that is top-level or array element,
+        // However, for value class that is top-level or collection element or
         // if it is used as another type (e.g. as its parent trait or generic),
         // the compiler keeps the class so we must provide an instance of the
         // class too. In other cases, the compiler will handle wrapping/unwrapping

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -174,7 +174,7 @@ object ScalaReflection extends ScalaReflection {
     val input = upCastToExpectedType(
       GetColumnByOrdinal(0, dataType), dataType, walkedTypePath)
 
-    val expr = deserializerFor(tpe, input, walkedTypePath)
+    val expr = deserializerFor(tpe, input, walkedTypePath, lastType = None)
     if (nullable) {
       expr
     } else {
@@ -193,7 +193,8 @@ object ScalaReflection extends ScalaReflection {
   private def deserializerFor(
       tpe: `Type`,
       path: Expression,
-      walkedTypePath: Seq[String]): Expression = cleanUpReflectionObjects {
+      walkedTypePath: Seq[String],
+      lastType: Option[Type]): Expression = cleanUpReflectionObjects {
 
     /** Returns the current path with a sub-field extracted. */
     def addToPath(part: String, dataType: DataType, walkedTypePath: Seq[String]): Expression = {
@@ -217,7 +218,7 @@ object ScalaReflection extends ScalaReflection {
         val TypeRef(_, _, Seq(optType)) = t
         val className = getClassNameFromType(optType)
         val newTypePath = s"""- option value class: "$className"""" +: walkedTypePath
-        WrapOption(deserializerFor(optType, path, newTypePath), dataTypeFor(optType))
+        WrapOption(deserializerFor(optType, path, newTypePath, Some(t)), dataTypeFor(optType))
 
       case t if t <:< localTypeOf[java.lang.Integer] =>
         val boxedType = classOf[java.lang.Integer]
@@ -297,7 +298,7 @@ object ScalaReflection extends ScalaReflection {
         val mapFunction: Expression => Expression = element => {
           // upcast the array element to the data type the encoder expected.
           val casted = upCastToExpectedType(element, dataType, newTypePath)
-          val converter = deserializerFor(elementType, casted, newTypePath)
+          val converter = deserializerFor(elementType, casted, newTypePath, Some(t))
           if (elementNullable) {
             converter
           } else {
@@ -337,7 +338,7 @@ object ScalaReflection extends ScalaReflection {
         val mapFunction: Expression => Expression = element => {
           // upcast the array element to the data type the encoder expected.
           val casted = upCastToExpectedType(element, dataType, newTypePath)
-          val converter = deserializerFor(elementType, casted, newTypePath)
+          val converter = deserializerFor(elementType, casted, newTypePath, Some(t))
           if (elementNullable) {
             converter
           } else {
@@ -360,8 +361,8 @@ object ScalaReflection extends ScalaReflection {
 
         UnresolvedCatalystToExternalMap(
           path,
-          p => deserializerFor(keyType, p, walkedTypePath),
-          p => deserializerFor(valueType, p, walkedTypePath),
+          p => deserializerFor(keyType, p, walkedTypePath, Some(t)),
+          p => deserializerFor(valueType, p, walkedTypePath, Some(t)),
           mirror.runtimeClass(t.typeSymbol.asClass)
         )
 
@@ -397,8 +398,11 @@ object ScalaReflection extends ScalaReflection {
         // the compiler keeps the class so we must provide an instance of the
         // class too. In other cases, the compiler will handle wrapping/unwrapping
         // for us automatically.
-        val arg = deserializerFor(underlyingType, path, newTypePath)
-        if (walkedTypePath.length == 1 || walkedTypePath.head.contains("array element")) {
+        val arg = deserializerFor(underlyingType, path, newTypePath, Some(t))
+        val isCollectionElement = lastType.exists { lt =>
+          lt <:< localTypeOf[Array[_]] || lt <:< localTypeOf[Seq[_]]
+        }
+        if (lastType.isEmpty || isCollectionElement) {
           val cls = getClassFromType(t)
           NewInstance(cls, Seq(arg), ObjectType(cls), propagateNull = false)
         } else {
@@ -419,12 +423,14 @@ object ScalaReflection extends ScalaReflection {
             deserializerFor(
               fieldType,
               addToPathOrdinal(i, dataType, newTypePath),
-              newTypePath)
+              newTypePath,
+              Some(t))
           } else {
             deserializerFor(
               fieldType,
               addToPath(fieldName, dataType, newTypePath),
-              newTypePath)
+              newTypePath,
+              Some(t))
           }
 
           if (!nullable) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -367,8 +367,8 @@ object ScalaReflection extends ScalaReflection {
 
         UnresolvedCatalystToExternalMap(
           path,
-          p => deserializerFor(keyType, p, walkedTypePath),
-          p => deserializerFor(valueType, p, walkedTypePath),
+          p => deserializerFor(keyType, p, walkedTypePath, instantiateValueClass = true),
+          p => deserializerFor(valueType, p, walkedTypePath, instantiateValueClass = true),
           mirror.runtimeClass(t.typeSymbol.asClass)
         )
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -388,7 +388,7 @@ object ScalaReflection extends ScalaReflection {
         // top level value class must be treated as a product
         val underlyingType = getUnderlyingTypeOf(t)
         val underlyingClsName = getClassNameFromType(underlyingType)
-        val clsName = t.typeSymbol.asClass.fullName
+        val clsName = getUnerasedClassNameFromType(t)
         val newTypePath = s"""- Scala value class: $clsName($underlyingClsName)""" +:
           walkedTypePath
 
@@ -647,7 +647,7 @@ object ScalaReflection extends ScalaReflection {
       case t if definedByConstructorParams(t) && isValueClass(t) =>
         val (name, underlyingType) = getConstructorParameters(t).head
         val underlyingClsName = getClassNameFromType(underlyingType)
-        val clsName = t.typeSymbol.asClass.fullName
+        val clsName = getUnerasedClassNameFromType(t)
         val newPath = s"""- Scala value class: $clsName($underlyingClsName)""" +: walkedTypePath
         val getArg = Invoke(inputObject, name, dataTypeFor(underlyingType))
         serializerFor(getArg, underlyingType, newPath)
@@ -972,6 +972,13 @@ trait ScalaReflection extends Logging {
    */
   def getClassNameFromType(tpe: `Type`): String = {
     tpe.dealias.erasure.typeSymbol.asClass.fullName
+  }
+
+  /**
+   * Same as `getClassNameFromType` but returns the class name before erasure.
+   */
+  def getUnerasedClassNameFromType(tpe: `Type`): String = {
+    tpe.dealias.typeSymbol.asClass.fullName
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -672,7 +672,7 @@ object ScalaReflection extends ScalaReflection {
 
           val fieldValue = Invoke(
             AssertNotNull(inputObject, walkedTypePath), fieldName, dataTypeFor(trueFieldType),
-            returnNullable = !fieldType.typeSymbol.asClass.isPrimitive)
+            returnNullable = !trueFieldType.typeSymbol.asClass.isPrimitive)
           val clsName = getClassNameFromType(trueFieldType)
           val newPath = s"""- field (class: "$clsName", name: "$fieldName")""" +: walkedTypePath
           expressions.Literal(fieldName) ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -129,7 +129,8 @@ object ScalaReflection extends ScalaReflection {
   }
 
   def isValueClass(tpe: `Type`): Boolean = {
-    definedByConstructorParams(tpe) && tpe <:< localTypeOf[AnyVal]
+    val notNull = !(tpe <:< localTypeOf[Null])
+    notNull && definedByConstructorParams(tpe) && tpe <:< localTypeOf[AnyVal]
   }
 
   /** Returns the underlying type of value class `cls`. */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -384,14 +384,19 @@ object ScalaReflection extends ScalaReflection {
         Invoke(obj, "deserialize", ObjectType(udt.userClass), path :: Nil)
 
       case t if isValueClass(t) =>
-        // nested value class is treated as its underlying type
-        // top level value class must be treated as a product
         val underlyingType = getUnderlyingTypeOf(t)
         val underlyingClsName = getClassNameFromType(underlyingType)
         val clsName = getUnerasedClassNameFromType(t)
         val newTypePath = s"""- Scala value class: $clsName($underlyingClsName)""" +:
           walkedTypePath
 
+        // Nested value class is treated as its underlying type
+        // because the compiler will convert value class in the schema to
+        // its underlying type.
+        // However, for top-level value class, if it is used as another type
+        // (e.g. as its parent trait or generic), the compiler keeps the class
+        // so we must provide an instance of the class too. In other cases,
+        // the compiler will handle wrapping/unwrapping for us automatically.
         val arg = deserializerFor(underlyingType, path, newTypePath)
         if (path.isDefined) {
           arg

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -397,7 +397,7 @@ object ScalaReflection extends ScalaReflection {
         // so we must provide an instance of the class too. In other cases,
         // the compiler will handle wrapping/unwrapping for us automatically.
         val arg = deserializerFor(underlyingType, path, newTypePath)
-        if (path.isDefined) {
+        if (walkedTypePath.length > 1) {
           arg
         } else {
           val cls = getClassFromType(t)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -115,9 +115,9 @@ object TestingValueClass {
 
   case class ValueClassData(
     intField: Int,
-    wrappedInt: IntWrapper,
+    wrappedInt: IntWrapper, // an int column
     strField: String,
-    wrappedStr: StrWrapper)
+    wrappedStr: StrWrapper) // a string column
 }
 
 class ScalaReflectionSuite extends SparkFunSuite {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -122,6 +122,7 @@ object TestingValueClass {
 
 class ScalaReflectionSuite extends SparkFunSuite {
   import org.apache.spark.sql.catalyst.ScalaReflection._
+  import TestingValueClass._
 
   // A helper method used to test `ScalaReflection.serializerForType`.
   private def serializerFor[T: TypeTag]: Expression =
@@ -374,12 +375,12 @@ class ScalaReflectionSuite extends SparkFunSuite {
   }
 
   test("schema for case class that is a value class") {
-    val schema = schemaFor[TestingValueClass.IntWrapper]
+    val schema = schemaFor[IntWrapper]
     assert(schema === Schema(IntegerType, nullable = false))
   }
 
   test("schema for case class that contains value class fields") {
-    val schema = schemaFor[TestingValueClass.ValueClassData]
+    val schema = schemaFor[ValueClassData]
     assert(schema === Schema(
       StructType(Seq(
         StructField("intField", IntegerType, nullable = false),
@@ -390,9 +391,16 @@ class ScalaReflectionSuite extends SparkFunSuite {
   }
 
   test("schema for array of value class") {
-    val schema = schemaFor[Array[TestingValueClass.IntWrapper]]
+    val schema = schemaFor[Array[IntWrapper]]
     assert(schema === Schema(
       ArrayType(IntegerType, containsNull = false),
+      nullable = true))
+  }
+
+  test("schema for map of value class") {
+    val schema = schemaFor[Map[IntWrapper, StrWrapper]]
+    assert(schema === Schema(
+      MapType(IntegerType, StringType, valueContainsNull = true),
       nullable = true))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -110,7 +110,7 @@ object TestingUDT {
 }
 
 object TestingValueClass {
-  case class IntWrapper(i: Int) extends AnyVal
+  class IntWrapper(val i: Int) extends AnyVal
   case class StrWrapper(s: String) extends AnyVal
 
   case class ValueClassData(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -109,6 +109,16 @@ object TestingUDT {
   }
 }
 
+object TestingValueClass {
+  case class IntWrapper(i: Int) extends AnyVal
+  case class StrWrapper(s: String) extends AnyVal
+
+  case class ValueClassData(
+    intField: Int,
+    wrappedInt: IntWrapper,
+    strField: String,
+    wrappedStr: StrWrapper)
+}
 
 class ScalaReflectionSuite extends SparkFunSuite {
   import org.apache.spark.sql.catalyst.ScalaReflection._
@@ -361,5 +371,21 @@ class ScalaReflectionSuite extends SparkFunSuite {
     assert(numberOfCheckedArguments(deserializerFor[(Double, Double)]) == 2)
     assert(numberOfCheckedArguments(deserializerFor[(java.lang.Double, Int)]) == 1)
     assert(numberOfCheckedArguments(deserializerFor[(java.lang.Integer, java.lang.Integer)]) == 0)
+  }
+
+  test("schema for case class that is a value class") {
+    val schema = schemaFor[TestingValueClass.IntWrapper]
+    assert(schema === Schema(IntegerType, nullable = false))
+  }
+
+  test("schema for case class that contains value class fields") {
+    val schema = schemaFor[TestingValueClass.ValueClassData]
+    assert(schema === Schema(
+      StructType(Seq(
+        StructField("intField", IntegerType, nullable = false),
+        StructField("wrappedInt", IntegerType, nullable = false),
+        StructField("strField", StringType, nullable = true),
+        StructField("wrappedStr", StringType, nullable = true))),
+      nullable = true))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -388,4 +388,11 @@ class ScalaReflectionSuite extends SparkFunSuite {
         StructField("wrappedStr", StringType, nullable = true))),
       nullable = true))
   }
+
+  test("schema for array of value class") {
+    val schema = schemaFor[Array[TestingValueClass.IntWrapper]]
+    assert(schema === Schema(
+      ArrayType(IntegerType, containsNull = false),
+      nullable = true))
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -112,6 +112,10 @@ object ReferenceValueClass {
   case class Container(data: Int)
 }
 
+case class StringWrapper(s: String) extends AnyVal
+case class ValueContainer(a: Int, b: StringWrapper)
+case class ComplexValueClassContainer(a: Int, b: ValueContainer)
+
 class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTest {
   OuterScopes.addOuterScope(this)
 
@@ -297,11 +301,16 @@ class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTes
     ExpressionEncoder.tuple(intEnc, ExpressionEncoder.tuple(intEnc, longEnc))
   }
 
+  // test for Scala value class
   encodeDecodeTest(
     PrimitiveValueClass(42), "primitive value class")
-
   encodeDecodeTest(
     ReferenceValueClass(ReferenceValueClass.Container(1)), "reference value class")
+  encodeDecodeTest(StringWrapper("a"), "value class string")
+  encodeDecodeTest(ValueContainer(1, StringWrapper("b")), "value class nested")
+  encodeDecodeTest(
+    ComplexValueClassContainer(1, ValueContainer(2, StringWrapper("b"))),
+    "value class complex")
 
   encodeDecodeTest(Option(31), "option of int")
   encodeDecodeTest(Option.empty[Int], "empty option of int")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -116,7 +116,11 @@ case class StringWrapper(s: String) extends AnyVal
 case class ValueContainer(
   a: Int,
   b: StringWrapper) // a string column
-case class ComplexValueClassContainer(a: Int, b: ValueContainer)
+class IntWrapper(val i: Int) extends AnyVal // child column doesn't need to be case class
+case class ComplexValueClassContainer(
+  a: Int,
+  b: ValueContainer,
+  c: IntWrapper) // an int column
 
 class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTest {
   OuterScopes.addOuterScope(this)
@@ -311,7 +315,7 @@ class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTes
   encodeDecodeTest(StringWrapper("a"), "value class string")
   encodeDecodeTest(ValueContainer(1, StringWrapper("b")), "value class nested")
   encodeDecodeTest(
-    ComplexValueClassContainer(1, ValueContainer(2, StringWrapper("b"))),
+    ComplexValueClassContainer(1, ValueContainer(2, StringWrapper("b")), new IntWrapper(3)),
     "value class complex")
 
   encodeDecodeTest(Option(31), "option of int")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -321,11 +321,11 @@ class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTes
   encodeDecodeTest(
     Array(new IntWrapper(1), new IntWrapper(2), new IntWrapper(3)),
     "array of value class")
-  encodeDecodeTest(Array.empty[StringWrapper], "empty array of value class")
+  encodeDecodeTest(Array.empty[IntWrapper], "empty array of value class")
   encodeDecodeTest(
     Seq(new IntWrapper(1), new IntWrapper(2), new IntWrapper(3)),
     "seq of value class")
-  encodeDecodeTest(Seq.empty[StringWrapper], "empty seq of value class")
+  encodeDecodeTest(Seq.empty[IntWrapper], "empty seq of value class")
 
   encodeDecodeTest(Option(31), "option of int")
   encodeDecodeTest(Option.empty[Int], "empty option of int")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -326,6 +326,9 @@ class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTes
     Seq(new IntWrapper(1), new IntWrapper(2), new IntWrapper(3)),
     "seq of value class")
   encodeDecodeTest(Seq.empty[IntWrapper], "empty seq of value class")
+  encodeDecodeTest(
+    Map(new IntWrapper(1) -> StringWrapper("a"), new IntWrapper(2) -> StringWrapper("b")),
+    "map with value class")
 
   encodeDecodeTest(Option(31), "option of int")
   encodeDecodeTest(Option.empty[Int], "empty option of int")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -318,6 +318,14 @@ class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTes
   encodeDecodeTest(
     ComplexValueClassContainer(1, ValueContainer(2, StringWrapper("b")), new IntWrapper(3)),
     "complex value class")
+  encodeDecodeTest(
+    Array(new IntWrapper(1), new IntWrapper(2), new IntWrapper(3)),
+    "array of value class")
+  encodeDecodeTest(Array.empty[StringWrapper], "empty array of value class")
+  encodeDecodeTest(
+    Seq(new IntWrapper(1), new IntWrapper(2), new IntWrapper(3)),
+    "seq of value class")
+  encodeDecodeTest(Seq.empty[StringWrapper], "empty seq of value class")
 
   encodeDecodeTest(Option(31), "option of int")
   encodeDecodeTest(Option.empty[Int], "empty option of int")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -314,6 +314,7 @@ class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTes
     ReferenceValueClass(ReferenceValueClass.Container(1)), "reference value class")
   encodeDecodeTest(StringWrapper("a"), "string value class")
   encodeDecodeTest(ValueContainer(1, StringWrapper("b")), "nested value class")
+  encodeDecodeTest(ValueContainer(1, StringWrapper(null)), "nested value class with null")
   encodeDecodeTest(
     ComplexValueClassContainer(1, ValueContainer(2, StringWrapper("b")), new IntWrapper(3)),
     "complex value class")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -312,11 +312,11 @@ class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTes
     PrimitiveValueClass(42), "primitive value class")
   encodeDecodeTest(
     ReferenceValueClass(ReferenceValueClass.Container(1)), "reference value class")
-  encodeDecodeTest(StringWrapper("a"), "value class string")
-  encodeDecodeTest(ValueContainer(1, StringWrapper("b")), "value class nested")
+  encodeDecodeTest(StringWrapper("a"), "string value class")
+  encodeDecodeTest(ValueContainer(1, StringWrapper("b")), "nested value class")
   encodeDecodeTest(
     ComplexValueClassContainer(1, ValueContainer(2, StringWrapper("b")), new IntWrapper(3)),
-    "value class complex")
+    "complex value class")
 
   encodeDecodeTest(Option(31), "option of int")
   encodeDecodeTest(Option.empty[Int], "empty option of int")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -113,7 +113,9 @@ object ReferenceValueClass {
 }
 
 case class StringWrapper(s: String) extends AnyVal
-case class ValueContainer(a: Int, b: StringWrapper)
+case class ValueContainer(
+  a: Int,
+  b: StringWrapper) // a string column
 case class ComplexValueClassContainer(a: Int, b: ValueContainer)
 
 class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTest {


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR adds support for [Scala value class][1] in schema of Datasets (as both top level class and nested field). 
The idea is to treat  value class as its underlying type at run time. For example:
```scala
case class Id(get: Int) extends AnyVal
case class User(id: Id) // field `id` will be treated as Int
```
However, if the value class is top-level (e.g. `Dataset[Id]`) then it must be treated like a boxed type and must be instantiated. I'm not sure why it behaves this way but I suspect it is related to the [expansion of value class][2] when we do casting (e.g. `asInstanceOf[T]`)

Actually, this feature is addressed before in [SPARK-17368][3] but the patch only supports top-level case. Hence we see the error when value class is nested as in [SPARK-19741][4] and [SPARK-20384][5]

[1]: https://docs.scala-lang.org/sips/value-classes.html
[2]: https://docs.scala-lang.org/sips/value-classes.html#example-1
[3]: https://issues.apache.org/jira/browse/SPARK-17368
[4]: https://issues.apache.org/jira/browse/SPARK-19741
[5]: https://issues.apache.org/jira/browse/SPARK-20384

## How was this patch tested?
I added unit tests for top-level and nested case.
