### PR TITLE
[SPARK-17916][SQL] Fix new behavior when quote is set and fix old behavior when quote is unset

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVOptions.scala
@@ -173,7 +173,11 @@ class CSVOptions(
     writerSettings.setIgnoreLeadingWhitespaces(ignoreLeadingWhiteSpaceFlagInWrite)
     writerSettings.setIgnoreTrailingWhitespaces(ignoreTrailingWhiteSpaceFlagInWrite)
     writerSettings.setNullValue(nullValue)
-    writerSettings.setEmptyValue("\"\"")
+    if (quote == '\u0000') {
+      writerSettings.setEmptyValue(nullValue)
+    } else {
+      writerSettings.setEmptyValue(s"${quote}${quote}")
+    }
     writerSettings.setSkipEmptyLines(true)
     writerSettings.setQuoteAllFields(quoteAll)
     writerSettings.setQuoteEscapingEnabled(escapeQuotes)
@@ -194,7 +198,11 @@ class CSVOptions(
     settings.setInputBufferSize(inputBufferSize)
     settings.setMaxColumns(maxColumns)
     settings.setNullValue(nullValue)
-    settings.setEmptyValue("")
+    if (quote == '\u0000') {
+      settings.setEmptyValue(null)
+    } else {
+      settings.setEmptyValue("")
+    }
     settings.setMaxCharsPerColumn(maxCharsPerColumn)
     settings.setUnescapedQuoteHandling(UnescapedQuoteHandling.STOP_AT_DELIMITER)
     settings

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVOptions.scala
@@ -173,7 +173,7 @@ class CSVOptions(
     writerSettings.setIgnoreLeadingWhitespaces(ignoreLeadingWhiteSpaceFlagInWrite)
     writerSettings.setIgnoreTrailingWhitespaces(ignoreTrailingWhiteSpaceFlagInWrite)
     writerSettings.setNullValue(nullValue)
-    if (quote == '\u0000') {
+    if (nullValue == "" || quote == '\u0000') {
       writerSettings.setEmptyValue(nullValue)
     } else {
       writerSettings.setEmptyValue(s"${quote}${quote}")
@@ -198,11 +198,7 @@ class CSVOptions(
     settings.setInputBufferSize(inputBufferSize)
     settings.setMaxColumns(maxColumns)
     settings.setNullValue(nullValue)
-    if (quote == '\u0000') {
-      settings.setEmptyValue(null)
-    } else {
-      settings.setEmptyValue("")
-    }
+    settings.setEmptyValue("")
     settings.setMaxCharsPerColumn(maxCharsPerColumn)
     settings.setUnescapedQuoteHandling(UnescapedQuoteHandling.STOP_AT_DELIMITER)
     settings


### PR DESCRIPTION
## What changes were proposed in this pull request?

1) Set nullValue to quoted empty string respecting quote value
2) Fall back to old behavior of unquoted null if quote is not set

## How was this patch tested?

Two new tests that will fail without these fixes

Please review http://spark.apache.org/contributing.html before opening a pull request.
