### PR TITLE
[SPARK-25308][SQL] ArrayContains function may return a error in the code generation phase.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -1464,25 +1464,33 @@ case class ArrayContains(left: Expression, right: Expression)
     nullSafeCodeGen(ctx, ev, (arr, value) => {
       val i = ctx.freshName("i")
       val getValue = CodeGenerator.getValue(arr, right.dataType, i)
-      val checkAndSetIsNullCode = if (nullable) {
-        s"""
-           |if ($arr.isNullAt($i)) {
-           |    ${ev.isNull} = true;
-           |} else
+      def checkAndSetIsNullCode(body: String) = {
+        if (nullable) {
+          s"""
+             |if ($arr.isNullAt($i)) {
+             |    ${ev.isNull} = true;
+             |} else {
+             |  $body
+             |}
          """.stripMargin
-      } else {
-        ""
+        } else {
+          body
+        }
       }
       val unsetIsNullCode = if (nullable) s"${ev.isNull} = false;" else ""
+      val code = checkAndSetIsNullCode(
+        s"""
+           |if (${ctx.genEqual(right.dataType, value, getValue)}) {
+           |  $unsetIsNullCode
+           |  ${ev.value} = true;
+           |  break;
+           |}
+         """.stripMargin
+      )
 
       s"""
          |for (int $i = 0; $i < $arr.numElements(); $i ++) {
-         |  $checkAndSetIsNullCode
-         |  if (${ctx.genEqual(right.dataType, value, getValue)}) {
-         |    $unsetIsNullCode
-         |    ${ev.value} = true;
-         |    break;
-         |  }
+         |  $code
          |}
        """.stripMargin
     })

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -1469,7 +1469,6 @@ case class ArrayContains(left: Expression, right: Expression)
            |if ($arr.isNullAt($i)) {
            |    ${ev.isNull} = true;
            |} else
-           |
          """.stripMargin
       } else {
         ""

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -1464,18 +1464,16 @@ case class ArrayContains(left: Expression, right: Expression)
     nullSafeCodeGen(ctx, ev, (arr, value) => {
       val i = ctx.freshName("i")
       val getValue = CodeGenerator.getValue(arr, right.dataType, i)
-      def checkAndSetIsNullCode(body: String) = {
-        if (nullable) {
-          s"""
-             |if ($arr.isNullAt($i)) {
-             |    ${ev.isNull} = true;
-             |} else {
-             |  $body
-             |}
+      def checkAndSetIsNullCode(body: String) = if (nullable) {
+        s"""
+           |if ($arr.isNullAt($i)) {
+           |    ${ev.isNull} = true;
+           |} else {
+           |  $body
+           |}
          """.stripMargin
-        } else {
-          body
-        }
+      } else {
+        body
       }
       val unsetIsNullCode = if (nullable) s"${ev.isNull} = false;" else ""
       val code = checkAndSetIsNullCode(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -383,10 +383,13 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
     val a3 = Literal.create(null, ArrayType(StringType))
     val a4 = Literal.create(Seq(create_row(1)), ArrayType(StructType(Seq(
       StructField("a", IntegerType, true)))))
+    // Explicitly mark the array type not nullable (spark-xxxxx)
+    val a5 = Literal.create(Seq(1, 2, 3), ArrayType(IntegerType, false))
 
     checkEvaluation(ArrayContains(a0, Literal(1)), true)
     checkEvaluation(ArrayContains(a0, Literal(0)), false)
     checkEvaluation(ArrayContains(a0, Literal.create(null, IntegerType)), null)
+    checkEvaluation(ArrayContains(a5, Literal(1)), true)
 
     checkEvaluation(ArrayContains(a1, Literal("")), true)
     checkEvaluation(ArrayContains(a1, Literal("a")), null)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -383,7 +383,7 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
     val a3 = Literal.create(null, ArrayType(StringType))
     val a4 = Literal.create(Seq(create_row(1)), ArrayType(StructType(Seq(
       StructField("a", IntegerType, true)))))
-    // Explicitly mark the array type not nullable (spark-xxxxx)
+    // Explicitly mark the array type not nullable (spark-25308)
     val a5 = Literal.create(Seq(1, 2, 3), ArrayType(IntegerType, false))
 
     checkEvaluation(ArrayContains(a0, Literal(1)), true)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -384,7 +384,7 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
     val a4 = Literal.create(Seq(create_row(1)), ArrayType(StructType(Seq(
       StructField("a", IntegerType, true)))))
     // Explicitly mark the array type not nullable (spark-25308)
-    val a5 = Literal.create(Seq(1, 2, 3), ArrayType(IntegerType, false))
+    val a5 = Literal.create(Seq(1, 2, 3), ArrayType(IntegerType, containsNull = false))
 
     checkEvaluation(ArrayContains(a0, Literal(1)), true)
     checkEvaluation(ArrayContains(a0, Literal(0)), false)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Invoking ArrayContains function with non nullable array type throws the following error in the code generation phase. Below is the error snippet.
```SQL
Code generation of array_contains([1,2,3], 1) failed:
java.util.concurrent.ExecutionException: org.codehaus.commons.compiler.CompileException: File 'generated.java', Line 40, Column 11: failed to compile: org.codehaus.commons.compiler.CompileException: File 'generated.java', Line 40, Column 11: Expression "isNull_0" is not an rvalue
java.util.concurrent.ExecutionException: org.codehaus.commons.compiler.CompileException: File 'generated.java', Line 40, Column 11: failed to compile: org.codehaus.commons.compiler.CompileException: File 'generated.java', Line 40, Column 11: Expression "isNull_0" is not an rvalue
	at com.google.common.util.concurrent.AbstractFuture$Sync.getValue(AbstractFuture.java:306)
	at com.google.common.util.concurrent.AbstractFuture$Sync.get(AbstractFuture.java:293)
	at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:116)
	at com.google.common.util.concurrent.Uninterruptibles.getUninterruptibly(Uninterruptibles.java:135)
	at com.google.common.cache.LocalCache$Segment.getAndRecordStats(LocalCache.java:2410)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2380)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2342)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2257)
	at com.google.common.cache.LocalCache.get(LocalCache.java:4000)
	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4004)
	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4874)
	at org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator$.compile(CodeGenerator.scala:1305)

```
## How was this patch tested?
Added test in CollectionExpressionSuite.