### PR TITLE
[SPARK-25150][SQL] Rewrite condition when deduplicate Join

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -755,6 +755,8 @@ class Analyzer(
    */
   object ResolveReferences extends Rule[LogicalPlan] {
 
+    private val emptyAttrMap = new AttributeMap[Attribute](Map.empty)
+
     /**
      * Generate a new logical plan for the right child with different expression IDs
      * for all conflicting attributes.
@@ -808,7 +810,7 @@ class Analyzer(
            * that this rule cannot handle. When that is the case, there must be another rule
            * that resolves these conflicts. Otherwise, the analysis will fail.
            */
-          (right, AttributeMap.empty)
+          (right, emptyAttrMap)
         case Some((oldRelation, newRelation)) =>
           val attributeRewrites = AttributeMap(oldRelation.output.zip(newRelation.output))
           val newRight = right transformUp {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -755,8 +755,6 @@ class Analyzer(
    */
   object ResolveReferences extends Rule[LogicalPlan] {
 
-    private val emptyAttrMap = new AttributeMap[Attribute](Map.empty)
-
     /**
      * Generate a new logical plan for the right child with different expression IDs
      * for all conflicting attributes.
@@ -810,7 +808,7 @@ class Analyzer(
            * that this rule cannot handle. When that is the case, there must be another rule
            * that resolves these conflicts. Otherwise, the analysis will fail.
            */
-          (right, emptyAttrMap)
+          (right, AttributeMap.empty)
         case Some((oldRelation, newRelation)) =>
           val attributeRewrites = AttributeMap(oldRelation.output.zip(newRelation.output))
           val newRight = right transformUp {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -754,7 +754,6 @@ class Analyzer(
    * a logical plan node's children.
    */
   object ResolveReferences extends Rule[LogicalPlan] {
-
     /**
      * Generate a new logical plan for the right child with different expression IDs
      * for all conflicting attributes.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -754,7 +754,6 @@ class Analyzer(
    * a logical plan node's children.
    */
   object ResolveReferences extends Rule[LogicalPlan] {
-
     private val emptyAttrMap = new AttributeMap[Attribute](Map.empty)
 
     /**
@@ -930,7 +929,7 @@ class Analyzer(
       case j @ Join(left, right, _, condition) if !j.duplicateResolved =>
         val (dedupedRight, attributeRewrites) = dedupRight(left, right)
         val changedCondition = condition.map(_.transform {
-          case attr: Attribute if attr.resolved => attributeRewrites.getOrElse(attr, attr)
+          case attr: Attribute if attr.resolved => dedupAttr(attr, attributeRewrites)
         })
         j.copy(right = dedupedRight, condition = changedCondition)
       case i @ Intersect(left, right, _) if !i.duplicateResolved =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -754,6 +754,7 @@ class Analyzer(
    * a logical plan node's children.
    */
   object ResolveReferences extends Rule[LogicalPlan] {
+
     /**
      * Generate a new logical plan for the right child with different expression IDs
      * for all conflicting attributes.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -754,6 +754,9 @@ class Analyzer(
    * a logical plan node's children.
    */
   object ResolveReferences extends Rule[LogicalPlan] {
+
+    private val emptyAttrMap = new AttributeMap[Attribute](Map.empty)
+
     /**
      * Generate a new logical plan for the right child with different expression IDs
      * for all conflicting attributes.
@@ -807,10 +810,10 @@ class Analyzer(
            * that this rule cannot handle. When that is the case, there must be another rule
            * that resolves these conflicts. Otherwise, the analysis will fail.
            */
-          (right, AttributeMap.empty[Attribute])
+          (right, emptyAttrMap)
         case Some((oldRelation, newRelation)) =>
           val attributeRewrites = AttributeMap(oldRelation.output.zip(newRelation.output))
-          (right transformUp {
+          val newRight = right transformUp {
             case r if r == oldRelation => newRelation
           } transformUp {
             case other => other transformExpressions {
@@ -819,7 +822,8 @@ class Analyzer(
               case s: SubqueryExpression =>
                 s.withNewPlan(dedupOuterReferencesInSubquery(s.plan, attributeRewrites))
             }
-          }, attributeRewrites)
+          }
+          (newRight, attributeRewrites)
       }
     }
 
@@ -897,13 +901,6 @@ class Analyzer(
       case _ => e.mapChildren(resolve(_, q))
     }
 
-    private def rewriteJoinCondition(
-        e: Expression,
-        attributeRewrites: AttributeMap[Attribute]): Expression = e match {
-      case a: Attribute => attributeRewrites.getOrElse(a, a)
-      case _ => e.mapChildren(rewriteJoinCondition(_, attributeRewrites))
-    }
-
     def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsUp {
       case p: LogicalPlan if !p.childrenResolved => p
 
@@ -932,7 +929,9 @@ class Analyzer(
       // To resolve duplicate expression IDs for Join and Intersect
       case j @ Join(left, right, _, condition) if !j.duplicateResolved =>
         val (dedupedRight, attributeRewrites) = dedupRight(left, right)
-        val changedCondition = condition.map(rewriteJoinCondition(_, attributeRewrites))
+        val changedCondition = condition.map(_.transform {
+          case attr: Attribute if attr.resolved => attributeRewrites.getOrElse(attr, attr)
+        })
         j.copy(right = dedupedRight, condition = changedCondition)
       case i @ Intersect(left, right, _) if !i.duplicateResolved =>
         val (dedupedRight, _) = dedupRight(left, right)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AttributeMap.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AttributeMap.scala
@@ -26,8 +26,6 @@ object AttributeMap {
   def apply[A](kvs: Seq[(Attribute, A)]): AttributeMap[A] = {
     new AttributeMap(kvs.map(kv => (kv._1.exprId, kv)).toMap)
   }
-
-  def empty[A](): AttributeMap[A] = new AttributeMap(Map.empty)
 }
 
 class AttributeMap[A](val baseMap: Map[ExprId, (Attribute, A)])

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AttributeMap.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AttributeMap.scala
@@ -23,7 +23,7 @@ package org.apache.spark.sql.catalyst.expressions
  * of the name, or the expected nullability).
  */
 object AttributeMap {
-  val empty = new AttributeMap(Map.empty)
+  var empty = new AttributeMap(Map.empty)
 
   def apply[A](kvs: Seq[(Attribute, A)]): AttributeMap[A] = {
     new AttributeMap(kvs.map(kv => (kv._1.exprId, kv)).toMap)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AttributeMap.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AttributeMap.scala
@@ -23,12 +23,14 @@ package org.apache.spark.sql.catalyst.expressions
  * of the name, or the expected nullability).
  */
 object AttributeMap {
+  var empty = new AttributeMap(Map.empty)
+
   def apply[A](kvs: Seq[(Attribute, A)]): AttributeMap[A] = {
     new AttributeMap(kvs.map(kv => (kv._1.exprId, kv)).toMap)
   }
 }
 
-class AttributeMap[A](val baseMap: Map[ExprId, (Attribute, A)])
+class AttributeMap[+A](val baseMap: Map[ExprId, (Attribute, A)])
   extends Map[Attribute, A] with Serializable {
 
   override def get(k: Attribute): Option[A] = baseMap.get(k.exprId).map(_._2)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AttributeMap.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AttributeMap.scala
@@ -23,7 +23,7 @@ package org.apache.spark.sql.catalyst.expressions
  * of the name, or the expected nullability).
  */
 object AttributeMap {
-  var empty = new AttributeMap(Map.empty)
+  val empty = new AttributeMap(Map.empty)
 
   def apply[A](kvs: Seq[(Attribute, A)]): AttributeMap[A] = {
     new AttributeMap(kvs.map(kv => (kv._1.exprId, kv)).toMap)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AttributeMap.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AttributeMap.scala
@@ -23,14 +23,12 @@ package org.apache.spark.sql.catalyst.expressions
  * of the name, or the expected nullability).
  */
 object AttributeMap {
-  var empty = new AttributeMap(Map.empty)
-
   def apply[A](kvs: Seq[(Attribute, A)]): AttributeMap[A] = {
     new AttributeMap(kvs.map(kv => (kv._1.exprId, kv)).toMap)
   }
 }
 
-class AttributeMap[+A](val baseMap: Map[ExprId, (Attribute, A)])
+class AttributeMap[A](val baseMap: Map[ExprId, (Attribute, A)])
   extends Map[Attribute, A] with Serializable {
 
   override def get(k: Attribute): Option[A] = baseMap.get(k.exprId).map(_._2)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AttributeMap.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AttributeMap.scala
@@ -26,6 +26,8 @@ object AttributeMap {
   def apply[A](kvs: Seq[(Attribute, A)]): AttributeMap[A] = {
     new AttributeMap(kvs.map(kv => (kv._1.exprId, kv)).toMap)
   }
+
+  def empty[A](): AttributeMap[A] = new AttributeMap(Map.empty)
 }
 
 class AttributeMap[A](val baseMap: Map[ExprId, (Attribute, A)])

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
@@ -297,15 +297,12 @@ class DataFrameJoinSuite extends QueryTest with SharedSQLContext {
   }
 
   test("SPARK-25150: Attribute deduplication handles attributes in join condition properly") {
-    withSQLConf(SQLConf.CROSS_JOINS_ENABLED.key -> "false") {
-      val a = spark.range(1, 5)
-      val b = spark.range(10)
-      val c = b.filter($"id" % 2 === 0)
+    val a = spark.range(1, 5)
+    val b = spark.range(10)
+    val c = b.filter($"id" % 2 === 0)
 
-      val r = a.join(b, a("id") === b("id"), "inner").join(c, a("id") === c("id"), "inner")
+    val r = a.join(b, a("id") === b("id"), "inner").join(c, a("id") === c("id"), "inner")
 
-      checkAnswer(r, Row(2, 2, 2) :: Row(4, 4, 4) :: Nil)
-    }
+    checkAnswer(r, Row(2, 2, 2) :: Row(4, 4, 4) :: Nil)
   }
-
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

ResolveReferences rule modifies (deduplicates) conflicting AttributeReferences in left and right side of a Join. It changes the right side to avoid conflicts but it forgot to change the references in the condition of the join. Solution is to rewrite the condition too.

Details:

With this PR, if any of the resolved attributes in a join condition refer to an attribute that is replaced during the deduplication (`dedupRight()`) then the join condition is modified to reflect the change.
The modification is done regardless whether the reference is on the left or the right side of the condition.

This PR has no effect on unresolved attributes. Those attributes are resolved later by different rules. 

This PR helps in those cases where same origin dataframes (`b`, `c`) are joined to a different origin one (`a`): 
```
val a = spark.range(1, 5)
val b = spark.range(10)
val c = b.filter($"id" % 2 === 0)
val r = a.join(b, a("id") === b("id"), "inner").join(c, a("id") === c("id"), "inner")
```
Here the result of `a join b` contains an `id` attribute coming from `b`. That attribute conflicts with the `id` attribute of `c` in the second join so `c("id")` is deduplicated to let's say `X` and the join condition `a("id") === c("id")` needs to be modified to `a("id") === X` to get correct results.

I believe it is also worth explaining some situations where this PR does't help (but also does no harm). In cases where same origin dataframes are joined to each other:
```
val b = spark.range(10)
val c = b.filter($"id" % 2 === 0)
val r = b.join(c, b("id") === c("id"), "inner")
```
In this latter case the deduplication is applied as both `b` and `c` have an `id` attribute (that actually refer to the same resolved attribute (have the same `ExprId`)). Deduplication results `c("id")` to be changed to let's say `X`. So in this case both `b("id")` and `c("id")` in the join condition are modified to `X` by the changes introduced in this PR. The reason why the result will be correct with this PR (and is correct without this PR) is that the current implementation of Spark contains a "hack" in `Dataframe` that fixes `EqualTo` and `EqualNullSafe` type of conditions with identical references on both sides. The hack rewrites these join conditions by re-resolving the attributes with the name of the attribute on both the left and right sides.

Please note that until a resolved attribute doesn't contain some kind of reference to it's dataframe not all  cases of join can be handled properly. Such an initiative can be found in https://github.com/apache/spark/pull/21449.

## How was this patch tested?

Added unit test.

Please review http://spark.apache.org/contributing.html before opening a pull request.
