### PR TITLE
[SPARK-25333][SQL] Ability add new columns in Dataset in a user-defined position

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2226,16 +2226,18 @@ class Dataset[T] private[sql](
     * `column`'s expression must only refer to attributes supplied by this Dataset. It is an
     * error to add a column that refers to some other Dataset.
     *
-    * The position of the new column start from 0, and a negative position means at the end (default behavior).
+    * The position of the new column starts at 0. Any negative position means to add the column at the end.
+    *
+    * @since 2.4.0
     */
   def withColumn(colName: String, col: Column, atPosition: Int): DataFrame =
     withColumns(Seq(colName), Seq(col), atPosition)
 
   /**
-   * Returns a new Dataset by adding columns or replacing the existing columns that has
+   * Returns a new Dataset by adding columns or replacing the existing columns that have
    * the same names.
    *
-   * The position of new columns start from 0, and a negative position means at the end (default behavior).
+   * The position of new columns starts at 0. Any negative position means to add the column at the end.
    */
   private[spark] def withColumns(colNames: Seq[String], cols: Seq[Column], atPosition: Int = -1): DataFrame = {
     require(colNames.size == cols.size,

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -830,22 +830,35 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
         Row(key, value, key + 1)
       }.toSeq)
     assert(df.schema.map(_.name) === Seq("key", "value", "newCol"))
+  }
 
-    val df2 = testData.toDF().withColumn("newCol", col("key") + 1, 0)
+  test("SPARK-25333 withColumn: with a user-defined position") {
+    val df = testData.toDF().withColumn("newCol", col("key") + 1, 0)
+    checkAnswer(
+      df,
+      testData.collect().map { case Row(key: Int, value: String) =>
+        Row(key + 1, key, value)
+      }.toSeq)
+    assert(df.schema.map(_.name) === Seq("newCol", "key", "value"))
+
+    val df2 = testData.toDF().withColumn("newCol", col("key") + 1, 1)
     checkAnswer(
       df2,
       testData.collect().map { case Row(key: Int, value: String) =>
-        Row(key, value, key + 1)
+        Row(key, key + 1, value)
       }.toSeq)
-    assert(df2.schema.map(_.name) === Seq("newCol", "key", "value"))
+    assert(df2.schema.map(_.name) === Seq("key", "newCol", "value"))
 
-    val df3 = testData.toDF().withColumn("newCol", col("key") + 1, 1)
-    checkAnswer(
-      df3,
-      testData.collect().map { case Row(key: Int, value: String) =>
-        Row(key, value, key + 1)
-      }.toSeq)
-    assert(df3.schema.map(_.name) === Seq("key", "newCol", "value"))
+    val atPosition = Seq(2, -4, 15)
+    atPosition.foreach { position =>
+      val df3 = testData.toDF().withColumn("newCol", col("key") + 1, position)
+      checkAnswer(
+        df3,
+        testData.collect().map { case Row(key: Int, value: String) =>
+          Row(key, value, key + 1)
+        }.toSeq)
+      assert(df3.schema.map(_.name) === Seq("key", "value", "newCol"))
+    }
   }
 
   test("withColumns") {
@@ -857,24 +870,6 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
         Row(key, value, key + 1, key + 2)
       }.toSeq)
     assert(df.schema.map(_.name) === Seq("key", "value", "newCol1", "newCol2"))
-
-    val df2 = testData.toDF().withColumns(Seq("newCol1", "newCol2"),
-      Seq(col("key") + 1, col("key") + 2), 0)
-    checkAnswer(
-      df2,
-      testData.collect().map { case Row(key: Int, value: String) =>
-        Row(key, value, key + 1, key + 2)
-      }.toSeq)
-    assert(df2.schema.map(_.name) === Seq("newCol1", "newCol2", "key", "value"))
-
-    val df3 = testData.toDF().withColumns(Seq("newCol1", "newCol2"),
-      Seq(col("key") + 1, col("key") + 2), 0)
-    checkAnswer(
-      df3,
-      testData.collect().map { case Row(key: Int, value: String) =>
-        Row(key, value, key + 1, key + 2)
-      }.toSeq)
-    assert(df3.schema.map(_.name) === Seq("key", "newCol1", "newCol2", "value"))
 
     val err = intercept[IllegalArgumentException] {
       testData.toDF().withColumns(Seq("newCol1"),
@@ -888,6 +883,38 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
         Seq(col("key") + 1, col("key") + 2))
     }
     assert(err2.getMessage.contains("Found duplicate column(s)"))
+  }
+
+  test("SPARK-25333 withColumns: with a user-defined position") {
+    val df = testData.toDF().withColumns(Seq("newCol1", "newCol2"),
+      Seq(col("key") + 1, col("key") + 2), 0)
+    checkAnswer(
+      df,
+      testData.collect().map { case Row(key: Int, value: String) =>
+        Row(key + 1, key + 2, key, value)
+      }.toSeq)
+    assert(df.schema.map(_.name) === Seq("newCol1", "newCol2", "key", "value"))
+
+    val df2 = testData.toDF().withColumns(Seq("newCol1", "newCol2"),
+      Seq(col("key") + 1, col("key") + 2), 1)
+    checkAnswer(
+      df2,
+      testData.collect().map { case Row(key: Int, value: String) =>
+        Row(key, key + 1, key + 2, value)
+      }.toSeq)
+    assert(df2.schema.map(_.name) === Seq("key", "newCol1", "newCol2", "value"))
+
+    val atPosition = Seq(2, -4, 15)
+    atPosition.foreach { position =>
+      val df3 = testData.toDF().withColumns(Seq("newCol1", "newCol2"),
+        Seq(col("key") + 1, col("key") + 2), position)
+      checkAnswer(
+        df3,
+        testData.collect().map { case Row(key: Int, value: String) =>
+          Row(key, value, key + 1, key + 2)
+        }.toSeq)
+      assert(df3.schema.map(_.name) === Seq("key", "value", "newCol1", "newCol2"))
+    }
   }
 
   test("withColumns: case sensitive") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -831,13 +831,21 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
       }.toSeq)
     assert(df.schema.map(_.name) === Seq("key", "value", "newCol"))
 
-    val df2 = testData.toDF().withColumn("newCol", col("key") + 1, false)
+    val df2 = testData.toDF().withColumn("newCol", col("key") + 1, 0)
     checkAnswer(
       df2,
       testData.collect().map { case Row(key: Int, value: String) =>
         Row(key, value, key + 1)
       }.toSeq)
     assert(df2.schema.map(_.name) === Seq("newCol", "key", "value"))
+
+    val df3 = testData.toDF().withColumn("newCol", col("key") + 1, 1)
+    checkAnswer(
+      df3,
+      testData.collect().map { case Row(key: Int, value: String) =>
+        Row(key, value, key + 1)
+      }.toSeq)
+    assert(df3.schema.map(_.name) === Seq("key", "newCol", "value"))
   }
 
   test("withColumns") {
@@ -851,13 +859,22 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     assert(df.schema.map(_.name) === Seq("key", "value", "newCol1", "newCol2"))
 
     val df2 = testData.toDF().withColumns(Seq("newCol1", "newCol2"),
-      Seq(col("key") + 1, col("key") + 2), false)
+      Seq(col("key") + 1, col("key") + 2), 0)
     checkAnswer(
       df2,
       testData.collect().map { case Row(key: Int, value: String) =>
         Row(key, value, key + 1, key + 2)
       }.toSeq)
     assert(df2.schema.map(_.name) === Seq("newCol1", "newCol2", "key", "value"))
+
+    val df3 = testData.toDF().withColumns(Seq("newCol1", "newCol2"),
+      Seq(col("key") + 1, col("key") + 2), 0)
+    checkAnswer(
+      df3,
+      testData.collect().map { case Row(key: Int, value: String) =>
+        Row(key, value, key + 1, key + 2)
+      }.toSeq)
+    assert(df3.schema.map(_.name) === Seq("key", "newCol1", "newCol2", "value"))
 
     val err = intercept[IllegalArgumentException] {
       testData.toDF().withColumns(Seq("newCol1"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -830,6 +830,14 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
         Row(key, value, key + 1)
       }.toSeq)
     assert(df.schema.map(_.name) === Seq("key", "value", "newCol"))
+
+    val df2 = testData.toDF().withColumn("newCol", col("key") + 1, false)
+    checkAnswer(
+      df2,
+      testData.collect().map { case Row(key: Int, value: String) =>
+        Row(key, value, key + 1)
+      }.toSeq)
+    assert(df2.schema.map(_.name) === Seq("newCol", "key", "value"))
   }
 
   test("withColumns") {
@@ -841,6 +849,15 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
         Row(key, value, key + 1, key + 2)
       }.toSeq)
     assert(df.schema.map(_.name) === Seq("key", "value", "newCol1", "newCol2"))
+
+    val df2 = testData.toDF().withColumns(Seq("newCol1", "newCol2"),
+      Seq(col("key") + 1, col("key") + 2), false)
+    checkAnswer(
+      df2,
+      testData.collect().map { case Row(key: Int, value: String) =>
+        Row(key, value, key + 1, key + 2)
+      }.toSeq)
+    assert(df2.schema.map(_.name) === Seq("newCol1", "newCol2", "key", "value"))
 
     val err = intercept[IllegalArgumentException] {
       testData.toDF().withColumns(Seq("newCol1"),


### PR DESCRIPTION
## What changes were proposed in this pull request?

When we add new columns in a Dataset, they are added automatically at the end of the Dataset.
Generally users want to add new columns either at the end, in the beginning or in a defined position, depends on use cases.
In my case for example, we add technical columns in the beginning of a Dataset and we add business columns at the end.

This pull request, add the ability to add new columns in a user-defined position of a Dataset, using an optional parameter **atPosition** that should start from 0: 
- negative value (default behavior) means add the column at the end
- a position greater than the columns number means add the column at the end

This change is backward compatible with old versions.

Consider this data frame with two columns:

```
val df = sc.parallelize(Seq(1, 2, 3)).toDF.withColumn("newCol1", col("value") + 1)
df.printSchema

root
 |-- value: integer (nullable = true)
 |-- newCol1: integer (nullable = true)
```

So we can:

1- add a new column without using the parameter **atPosition** (default behavior):

```
val newDf = df.withColumn("newCol2", col("value") + 2)
newDf.printSchema

root
 |-- value: integer (nullable = true)
 |-- newCol1: integer (nullable = true)
 |-- newCol2: integer (nullable = true)
```

2- add a new column using the parameter **atPosition** with different values:

```
val newDf = df.withColumn("newColumn", col("value") + 2, 2)
newDf.printSchema

root
 |-- value: integer (nullable = true)
 |-- newCol1: integer (nullable = true)
 |-- newCol2: integer (nullable = true)
```

```
val newDf = df.withColumn("newColumn", col("value") + 2, 0)
newDf.printSchema

root
 |-- newCol2: integer (nullable = true)
 |-- value: integer (nullable = true)
 |-- newCol1: integer (nullable = true)
```

```
val newDf = df.withColumn("newColumn", col("value") + 2, 1)
newDf.printSchema

root
 |-- value: integer (nullable = true)
 |-- newCol2: integer (nullable = true)
 |-- newCol1: integer (nullable = true)
```

=> with negative position

```
val newDf = df.withColumn("newColumn", col("value") + 2, -2)
newDf.printSchema

root
 |-- value: integer (nullable = true)
 |-- newCol1: integer (nullable = true)
 |-- newCol2: integer (nullable = true)
```

=> with a position greater than the columns number
 
```
val newDf = df.withColumn("newColumn", col("value") + 2, 15)
newDf.printSchema

root
 |-- value: integer (nullable = true)
 |-- newCol1: integer (nullable = true)
 |-- newCol2: integer (nullable = true)
```


## How was this patch tested?

This patch is tested with unit tests.
