### PR TITLE
[SPARK-25391][SQL] Make behaviors consistent when converting parquet hive table to parquet data source

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -300,6 +300,8 @@ class ParquetFileFormat
       filters: Seq[Filter],
       options: Map[String, String],
       hadoopConf: Configuration): (PartitionedFile) => Iterator[InternalRow] = {
+    val parquetOptions = new ParquetOptions(options, sparkSession.sessionState.conf)
+
     hadoopConf.set(ParquetInputFormat.READ_SUPPORT_CLASS, classOf[ParquetReadSupport].getName)
     hadoopConf.set(
       ParquetReadSupport.SPARK_ROW_REQUESTED_SCHEMA,
@@ -313,6 +315,10 @@ class ParquetFileFormat
     hadoopConf.setBoolean(
       SQLConf.CASE_SENSITIVE.key,
       sparkSession.sessionState.conf.caseSensitiveAnalysis)
+    hadoopConf.set(
+      ParquetOptions.DUPLICATED_FIELDS_RESOLUTION_MODE,
+      parquetOptions.duplicatedFieldsResolutionMode
+    )
 
     ParquetWriteSupport.setSchema(requiredSchema, hadoopConf)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetOptions.scala
@@ -69,11 +69,24 @@ class ParquetOptions(
     .get(MERGE_SCHEMA)
     .map(_.toBoolean)
     .getOrElse(sqlConf.isParquetSchemaMergingEnabled)
+
+  /**
+   * How to resolve duplicated field names. By default, parquet data source fails when hitting
+   * duplicated field names in case-insensitive mode. When converting hive parquet table to parquet
+   * data source, we need to ask parquet data source to pick the first matched field - the same
+   * behavior as hive parquet table - to keep behaviors consistent.
+   */
+  val duplicatedFieldsResolutionMode: String = {
+    parameters.getOrElse(DUPLICATED_FIELDS_RESOLUTION_MODE,
+      ParquetDuplicatedFieldsResolutionMode.FAIL.toString)
+  }
 }
 
 
 object ParquetOptions {
   val MERGE_SCHEMA = "mergeSchema"
+
+  val DUPLICATED_FIELDS_RESOLUTION_MODE = "duplicatedFieldsResolutionMode"
 
   // The parquet compression short names
   private val shortParquetCompressionCodecNames = Map(
@@ -89,4 +102,8 @@ object ParquetOptions {
   def getParquetCompressionCodecName(name: String): String = {
     shortParquetCompressionCodecNames(name).name()
   }
+}
+
+object ParquetDuplicatedFieldsResolutionMode extends Enumeration {
+  val FAIL, FIRST_MATCH = Value
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
parquet data source tables and hive parquet tables have different behaviors about parquet field resolution. So, when `spark.sql.hive.convertMetastoreParquet` is true, users might face inconsistent behaviors. The differences are:
* Whether respect spark.sql.caseSensitive. Without #22148, both data source tables and hive tables do NOT respect spark.sql.caseSensitive. However data source tables always do case-sensitive parquet field resolution, while hive tables always do case-insensitive parquet field resolution no matter whether spark.sql.caseSensitive is set to true or false. #22148 let data source tables respect spark.sql.caseSensitive while hive serde table behavior is not changed.
* How to resolve ambiguity in case-insensitive mode. Without #22148, data source tables do case-sensitive resolution and return columns with the corresponding letter cases, while hive tables always return the first matched column ignoring cases. #22148 let data source tables throw exception when there is ambiguity while hive table behavior is not changed.

This PR aims to make behaviors consistent when converting hive table to data source table.
* The behavior must be consistent to do the conversion, so we skip the conversion in case-sensitive mode because hive parquet table always do case-insensitive field resolution.
* In case-insensitive mode, when converting hive parquet table to parquet data source, we switch the duplicated fields resolution mode to ask parquet data source to pick the first matched field - the same behavior as hive parquet table - to keep behaviors consistent.

## How was this patch tested?
Unit tests added.