### PR TITLE
[SPARK-25353][SQL] executeTake in SparkPlan is modified to avoid unnecessary decoding.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -445,9 +445,9 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
     }
 
     if (scannedRowCount > n) {
-      buf.toArray.view.flatMap(decodeUnsafeRows).take(n).force
+      buf.iterator.flatMap(decodeUnsafeRows).take(n).toArray
     } else {
-      buf.toArray.view.flatMap(decodeUnsafeRows).force
+      buf.flatMap(decodeUnsafeRows).toArray
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
In some cases, executeTake in SparkPlan could decode more than necessary.

For example, in case of below odd/even number partitioning, total row's count from partitions will be 100, although it is limited with 51. And 'executeTake' in SparkPlan decodes all of them, "49" rows of which are unnecessarily decoded.

```scala
spark.sparkContext.parallelize((0 until 100).map(i => (i, 1))).toDF()
      .repartitionByRange(2, $"_1" % 2).limit(51).collect()
```

By using a iterator of the scalar collection, we can make ensure that at most n rows are decoded.

## How was this patch tested?
Existing unit tests that call limit function of DataFrame.

testOnly *SQLQuerySuite
testOnly *DataFrameSuite
