### PR TITLE
[SPARK-25356][SQL]Add Parquet block size  option to SparkSQL configuration

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -404,6 +404,11 @@ object SQLConf {
     .checkValues(Set("none", "uncompressed", "snappy", "gzip", "lzo", "lz4", "brotli", "zstd"))
     .createWithDefault("snappy")
 
+  val PARQUET_BLOCK_SIZE = buildConf("spark.sql.parquet.block.size")
+    .doc("Sets the block size of parquet when operating Parquet files.")
+    .intConf
+    .createWithDefault(128 * 1024 *1024)
+
   val PARQUET_FILTER_PUSHDOWN_ENABLED = buildConf("spark.sql.parquet.filterPushdown")
     .doc("Enables Parquet filter push-down optimization when set to true.")
     .booleanConf
@@ -1625,6 +1630,8 @@ class SQLConf extends Serializable with Logging {
   def orcVectorizedReaderBatchSize: Int = getConf(ORC_VECTORIZED_READER_BATCH_SIZE)
 
   def parquetCompressionCodec: String = getConf(PARQUET_COMPRESSION)
+
+  def parquetBlockSize: Int = getConf(PARQUET_BLOCK_SIZE)
 
   def parquetVectorizedReaderEnabled: Boolean = getConf(PARQUET_VECTORIZED_READER_ENABLED)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -123,6 +123,9 @@ class ParquetFileFormat
     // Sets compression scheme
     conf.set(ParquetOutputFormat.COMPRESSION, parquetOptions.compressionCodecClassName)
 
+    // Sets Parquet block size
+    conf.setInt(ParquetOutputFormat.BLOCK_SIZE, sparkSession.sessionState.conf.parquetBlockSize)
+
     // SPARK-15719: Disables writing Parquet summary files by default.
     if (conf.get(ParquetOutputFormat.JOB_SUMMARY_LEVEL) == null
       && conf.get(ParquetOutputFormat.ENABLE_JOB_SUMMARY) == null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?


I think we should configure the Parquet buffer size when using Parquet format.
Because for HDFS, `dfs.block.size` is configurable, sometimes we hope the block size of parquet to be consistent with it.
And  whether this parameter `spark.sql.files.maxPartitionBytes` is best consistent with the Parquet  block size when using Parquet format?
Also we may want to shrink Parquet block size in some tests.

## How was this patch tested?
N/A
