### PR TITLE
[SPARK-25375][SQL][TEST] Reenable qualified perm. function checks in UDFSuite

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/UDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/UDFSuite.scala
@@ -141,11 +141,10 @@ class UDFSuite
     withTempDatabase { dbName =>
       withUserDefinedFunction(functionName -> false) {
         sql(s"CREATE FUNCTION $dbName.$functionName AS '$functionClass'")
-        // TODO: Re-enable it after can distinguish qualified and unqualified function name
-        // checkAnswer(
-        //  sql(s"SELECT $dbName.myuPPer(value) from $testTableName"),
-        //  expectedDF
-        // )
+        checkAnswer(
+          sql(s"SELECT $dbName.$functionName(value) from $testTableName"),
+          expectedDF
+        )
 
         checkAnswer(
           sql(s"SHOW FUNCTIONS like $dbName.$functionNameUpper"),
@@ -174,11 +173,10 @@ class UDFSuite
       // For this block, drop function command uses default.functionName as the function name.
       withUserDefinedFunction(s"$dbName.$functionNameUpper" -> false) {
         sql(s"CREATE FUNCTION $dbName.$functionName AS '$functionClass'")
-        // TODO: Re-enable it after can distinguish qualified and unqualified function name
-        // checkAnswer(
-        //  sql(s"SELECT $dbName.myupper(value) from $testTableName"),
-        //  expectedDF
-        // )
+        checkAnswer(
+          sql(s"SELECT $dbName.$functionName(value) from $testTableName"),
+          expectedDF
+        )
 
         sql(s"USE $dbName")
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

At Spark 2.0.0, SPARK-14335 adds some [commented-out test coverages](https://github.com/apache/spark/pull/12117/files#diff-dd4b39a56fac28b1ced6184453a47358R177
). This PR enables them because it's supported since 2.0.0.

## How was this patch tested?

Pass the Jenkins with re-enabled test coverage.