### PR TITLE
[SPARK-25404][SQL] Staging path may not on the expected place when table path contains the stagingDir string

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/SaveAsHiveFile.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/SaveAsHiveFile.scala
@@ -217,12 +217,7 @@ private[hive] trait SaveAsHiveFile extends DataWritingCommand {
     val inputPathUri: URI = inputPath.toUri
     val inputPathName: String = inputPathUri.getPath
     val fs: FileSystem = inputPath.getFileSystem(hadoopConf)
-    var stagingPathName: String =
-      if (inputPathName.indexOf(stagingDir) == -1) {
-        new Path(inputPathName, stagingDir).toString
-      } else {
-        inputPathName.substring(0, inputPathName.indexOf(stagingDir) + stagingDir.length)
-      }
+    var stagingPathName: String = new Path(inputPathName, stagingDir).toString
 
     // SPARK-20594: This is a walk-around fix to resolve a Hive bug. Hive requires that the
     // staging directory needs to avoid being deleted when users set hive.exec.stagingdir


### PR DESCRIPTION
## What changes were proposed in this pull request?
As described in [#SPARK-25404](https://issues.apache.org/jira/browse/SPARK-25404),  staging path may not on the right place we expect. I'm not quiet sure  in which case the `inputPathName` contains the `stagingDir`, but it seems `new Path(inputPathName, stagingDir).toString`  is enough.
```scala
    var stagingPathName: String =
      if (inputPathName.indexOf(stagingDir) == -1) {
        new Path(inputPathName, stagingDir).toString
      } else {
        inputPathName.substring(0, inputPathName.indexOf(stagingDir) + stagingDir.length)
      }
```

## How was this patch tested?
Manually test with debug mode, and check the staging files on right path.

