### PR TITLE
[SPARK-25302][STREAMING] Checkpoint the reducedStream in ReducedWindo…

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/ReducedWindowedDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/ReducedWindowedDStream.scala
@@ -54,6 +54,10 @@ class ReducedWindowedDStream[K: ClassTag, V: ClassTag](
   super.persist(StorageLevel.MEMORY_ONLY_SER)
   reducedStream.persist(StorageLevel.MEMORY_ONLY_SER)
 
+  // Checkpoint the reducedStream per slideDuration by default.
+  super.checkpoint(slideDuration)
+  reducedStream.checkpoint(slideDuration)
+
   def windowDuration: Duration = _windowDuration
 
   override def dependencies: List[DStream[_]] = List(reducedStream)
@@ -72,7 +76,7 @@ class ReducedWindowedDStream[K: ClassTag, V: ClassTag](
 
   override def checkpoint(interval: Duration): DStream[(K, V)] = {
     super.checkpoint(interval)
-    // reducedStream.checkpoint(interval)
+    reducedStream.checkpoint(interval)
     this
   }
 

--- a/streaming/src/test/scala/org/apache/spark/streaming/DStreamScopeSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/DStreamScopeSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
 import org.apache.spark.rdd.{RDD, RDDOperationScope}
 import org.apache.spark.streaming.dstream.DStream
 import org.apache.spark.streaming.ui.UIUtils
-import org.apache.spark.util.ManualClock
+import org.apache.spark.util.{ManualClock, Utils}
 
 /**
  * Tests whether scope information is passed from DStream operations to RDDs correctly.
@@ -39,6 +39,9 @@ class DStreamScopeSuite extends SparkFunSuite with BeforeAndAfter with BeforeAnd
     val conf = new SparkConf().setMaster("local").setAppName("test")
     conf.set("spark.streaming.clock", classOf[ManualClock].getName())
     ssc = new StreamingContext(new SparkContext(conf), batchDuration)
+    val checkpointDir = Utils.createTempDir(namePrefix = this.getClass.getSimpleName()).toString
+    logDebug(s"Using checkpoint directory $checkpointDir")
+    ssc.checkpoint(checkpointDir)
   }
 
   override def afterAll(): Unit = {

--- a/streaming/src/test/scala/org/apache/spark/streaming/TestSuiteBase.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/TestSuiteBase.scala
@@ -39,7 +39,8 @@ import org.apache.spark.util.{ManualClock, Utils}
 /**
  * A dummy stream that does absolutely nothing.
  */
-private[streaming] class DummyDStream(ssc: StreamingContext) extends DStream[Int](ssc) {
+private[streaming] class DummyDStream(@transient ssc: StreamingContext)
+  extends DStream[Int](ssc) {
   override def dependencies: List[DStream[Int]] = List.empty
   override def slideDuration: Duration = Seconds(1)
   override def compute(time: Time): Option[RDD[Int]] = Some(ssc.sc.emptyRDD[Int])
@@ -48,7 +49,8 @@ private[streaming] class DummyDStream(ssc: StreamingContext) extends DStream[Int
 /**
  * A dummy input stream that does absolutely nothing.
  */
-private[streaming] class DummyInputDStream(ssc: StreamingContext) extends InputDStream[Int](ssc) {
+private[streaming] class DummyInputDStream(@transient ssc: StreamingContext)
+  extends InputDStream[Int](ssc) {
   override def start(): Unit = { }
   override def stop(): Unit = { }
   override def compute(time: Time): Option[RDD[Int]] = Some(ssc.sc.emptyRDD[Int])


### PR DESCRIPTION
…wDStream so as to cut the lineage completely to parent

  ## What changes were proposed in this pull request?

  Dstream.reduceByKeyAndWindow() with inverse reduce functions eventually creates
  a ReducedWindowDStream but did not checkpoint it.
  When combined with the issue described in SPARK-25303,
  it results in the problem described in the post here:

  http://apache-spark-user-list.1001560.n3.nabble.com/DStream-reduceByKeyAndWindow-not-using-checkpointed-data-for-inverse-reducing-old-data-td33332.html

  This change will checkpoint reducedStream inside to cut the lineage.
  A separate patch is being created for the issue in SPARK-25303

  ## How was this patch tested?

  Running the existing Unit tests. A couple of existing unit test classes were
  written assuming they will not be used in serialization. Had to declare
  SparkContext as transient like other tests in order to make them work
  due to new checkpointing causing serialization to occur.

  ## What improvement does this patch make?

  Cuts the lineage to the parent DStream. When combined with the fix
  in SPARK-25303, unpersits the intermediate RDDs and Input DStreams that
  were being remembered for too long, resulting in much lower memory usage
  on the Executors after the fixes. Observed from the DAG chart differences and
  data from the Storage tab on the Driver UI.

