### PR TITLE
[SPARK-25303][STREAMING] For checkpointed DStreams, remove the parent…

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -108,7 +108,8 @@ abstract class DStream[T: ClassTag] (
   private[streaming] def isInitialized = zeroTime != null
 
   // Duration for which the DStream requires its parent DStream to remember each RDD created
-  private[streaming] def parentRememberDuration = rememberDuration
+  private[streaming] def parentRememberDuration =
+    if (checkpointDuration == null) rememberDuration else null
 
   /** Return the StreamingContext associated with this DStream */
   def context: StreamingContext = ssc


### PR DESCRIPTION
…RemeberDuration - this will be recalculated to a minimum value

        ## How was this patch tested?


## What changes were proposed in this pull request?

When a DStream gets checkpointed, there is no need to remember
        parentRDDs (unless indicated by other DStreams from that parent).
        This change sets the parentRememberDuration to null for checkpointed
        DStreams. Please note that this does get recalculated during validation
        to a minimum value in the parent as expected for any DStream as usual.
        Before this change, even after the fix for SPARK-25302 that cut the
        lineage to the parent, the parentDStreams and all the ones before that
        were being remembered for long durations. This was unnecessary and
        resulted in input RDDs being persisted for much longer than needed.

        Please see post below for original issue and a reply to it about
        resolution

        http://apache-spark-user-list.1001560.n3.nabble.com/DStream-reduceByKeyAndWindow-not-using-checkpointed-data-for-inverse-reducing-old-data-td33332.html

        A separate patch is being created for the issue in SPARK-25302

## How was this patch tested?

        Running the existing Unit tests.

## What improvement does this patch make?

        When combined with the fix in SPARK-25302,
        unpersits the intermediate RDDs and Input DStreams that
        were being remembered for too long, resulting in much lower memory usage
        on the Executors after the fixes were applied. Observed from the DAG chart differences and
        data from the Storage tab on the Driver UI.

