### PR TITLE
[SPARK-25430][SQL] Add map parameter for withColumnRenamed

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2311,7 +2311,7 @@ class Dataset[T] private[sql](
    * }}}
    *
    * @group untypedrel
-   * @since 2.4.0
+   * @since 3.0.0
    */
   def withColumnRenamed(columnMap: Map[String, String]): DataFrame = {
     val resolver = sparkSession.sessionState.analyzer.resolver

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1021,6 +1021,18 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     assert(df.schema.map(_.name) === Seq("key", "valueRenamed", "newCol"))
   }
 
+  test("SPARK-25430: Add map parameter for withColumnRenamed") {
+    val df = testData.toDF().withColumn("newCol", col("key") + 1)
+      .withColumnRenamed(Map("value"->"valueRenamed", "newCol"->"newColRenamed",
+        "newCol2"->"newColRenamed2"))
+    checkAnswer(
+      df,
+      testData.collect().map { case Row(key: Int, value: String) =>
+        Row(key, value, key + 1)
+      }.toSeq)
+    assert(df.schema.map(_.name) === Seq("key", "valueRenamed", "newColRenamed"))
+  }
+
   private lazy val person2: DataFrame = Seq(
     ("Bob", 16, 176),
     ("Alice", 32, 164),


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR allows withColumnRenamed with a map input argument

## How was this patch tested?
unit tests