### PR TITLE
[SPARK-25442][SQL][K8S] Support STS to run in k8s deployments with spark deployment mode as cluster.

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -292,7 +292,7 @@ private[spark] class SparkSubmit extends Logging {
         error("Cluster deploy mode is not applicable to Spark shells.")
       case (_, CLUSTER) if isSqlShell(args.mainClass) =>
         error("Cluster deploy mode is not applicable to Spark SQL shell.")
-      case (_, CLUSTER) if isThriftServer(args.mainClass) =>
+      case (_, CLUSTER) if (clusterManager != KUBERNETES) && isThriftServer(args.mainClass) =>
         error("Cluster deploy mode is not applicable to Spark Thrift server.")
       case _ =>
     }

--- a/sbin/start-thriftserver.sh
+++ b/sbin/start-thriftserver.sh
@@ -53,4 +53,4 @@ fi
 
 export SUBMIT_USAGE_FUNCTION=usage
 
-exec "${SPARK_HOME}"/sbin/spark-daemon.sh submit $CLASS 1 --name "Thrift JDBC/ODBC Server" "$@"
+exec "${SPARK_HOME}"/sbin/spark-daemon.sh submit $CLASS 1 --name "Thrift-JDBC-ODBC-Server" "$@"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Code is enhanced to allow the STS run in kubernetes deployment with spark deploy mode of cluster.

  

## How was this patch tested?

Started the sts in cluster mode in K8S deployment and was able to run some queries using the beeline client.