### PR TITLE
[SPARK-24685][BUILD][FOLLOWUP] Fix the nonexist profile name in release script

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -271,7 +271,7 @@ if [[ "$1" == "package" ]]; then
   BINARY_PKGS_ARGS["hadoop2.7"]="-Phadoop-2.7 $HIVE_PROFILES"
   if ! is_dry_run; then
     BINARY_PKGS_ARGS["hadoop2.6"]="-Phadoop-2.6 $HIVE_PROFILES"
-    BINARY_PKGS_ARGS["without-hadoop"]="-Pwithout-hadoop"
+    BINARY_PKGS_ARGS["without-hadoop"]="-Phadoop-provided"
     if [[ $SPARK_VERSION < "2.2." ]]; then
       BINARY_PKGS_ARGS["hadoop2.4"]="-Phadoop-2.4 $HIVE_PROFILES"
       BINARY_PKGS_ARGS["hadoop2.3"]="-Phadoop-2.3 $HIVE_PROFILES"


### PR DESCRIPTION
## What changes were proposed in this pull request?

`without-hadoop` profile doesn't exist in Maven, instead the name should be `hadoop-provided`, this is a regression introduced by SPARK-24685. So here fix it.

## How was this patch tested?

Local test.

