### PR TITLE
[SPARK-25444][SQL] Refactor GenArrayData.genCodeToCreateArrayData method

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
@@ -100,7 +100,7 @@ private [sql] object GenArrayData {
       val setArrayElement = CodeGenerator.setArrayElement(
         arrayDataName, elementType, i.toString, eval.value)
 
-      val assignment = if (!expr.nullable || eval.isNull == FalseLiteral) {
+      val assignment = if (!expr.nullable) {
         setArrayElement
       } else {
         val isNullAssignment = if (!isMapKey) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR makes `GenArrayData.genCodeToCreateArrayData` method simple by using `ArrayData.createArrayData` method.

Before this PR, `genCodeToCreateArrayData` method was complicated
* Generated a temporary Java array to create `ArrayData`
* Had separate code generation path to assign values for `GenericArrayData` and `UnsafeArrayData`

After this PR, the method
* Directly generates `GenericArrayData` or `UnsafeArrayData` without a temporary array
* Has only code generation path to assign values

## How was this patch tested?

Existing UTs
