### PR TITLE
[SPARK-25339][TEST] Refactor FilterPushdownBenchmark

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/BenchmarkBase.scala
+++ b/core/src/main/scala/org/apache/spark/util/BenchmarkBase.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+import java.io.{File, FileOutputStream, OutputStream}
+
+/**
+ * A base class for generate benchmark results to a file.
+ */
+abstract class BenchmarkBase {
+  var output: Option[OutputStream] = None
+
+  def benchmark(): Unit
+
+  final def runBenchmark(benchmarkName: String)(func: => Any): Unit = {
+    val separator = "=" * 96
+    val testHeader = (separator + '\n' + benchmarkName + '\n' + separator + '\n' + '\n').getBytes
+    output.foreach(_.write(testHeader))
+    func
+    output.foreach(_.write('\n'))
+  }
+
+  def main(args: Array[String]): Unit = {
+    val regenerateBenchmarkFiles: Boolean = System.getenv("SPARK_GENERATE_BENCHMARK_FILES") == "1"
+    if (regenerateBenchmarkFiles) {
+      val resultFileName = s"${this.getClass.getSimpleName.replace("$", "")}-results.txt"
+      val file = new File(s"benchmarks/$resultFileName")
+      if (!file.exists()) {
+        file.createNewFile()
+      }
+      output = Some(new FileOutputStream(file))
+    }
+
+    benchmark()
+
+    output.foreach { o =>
+      if (o != null) {
+        o.close()
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/FilterPushdownBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/FilterPushdownBenchmark.scala
@@ -32,10 +32,10 @@ import org.apache.spark.util.{Benchmark, BenchmarkBase => FileBenchmarkBase, Uti
 /**
  * Benchmark to measure read performance with Filter pushdown.
  * To run this benchmark:
- *  1. without sbt: bin/spark-submit --class <this class> <spark sql test jar>
- *  2. build/sbt "sql/test:runMain <this class>"
- *  3. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain <this class>"
- *     Results will be written to "benchmarks/FilterPushdownBenchmark-results.txt".
+ * 1. without sbt: bin/spark-submit --class <this class> <spark sql test jar>
+ * 2. build/sbt "sql/test:runMain <this class>"
+ * 3. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain <this class>"
+ *    Results will be written to "benchmarks/FilterPushdownBenchmark-results.txt".
  */
 object FilterPushdownBenchmark extends FileBenchmarkBase {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/FilterPushdownBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/FilterPushdownBenchmark.scala
@@ -17,29 +17,28 @@
 
 package org.apache.spark.sql.execution.benchmark
 
-import java.io.{File, FileOutputStream, OutputStream}
+import java.io.File
 
 import scala.util.{Random, Try}
 
-import org.scalatest.{BeforeAndAfterEachTestData, Suite, TestData}
-
 import org.apache.spark.SparkConf
-import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.functions.monotonically_increasing_id
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.ParquetOutputTimestampType
 import org.apache.spark.sql.types.{ByteType, Decimal, DecimalType, TimestampType}
-import org.apache.spark.util.{Benchmark, Utils}
+import org.apache.spark.util.{Benchmark, BenchmarkBase => FileBenchmarkBase, Utils}
 
 /**
  * Benchmark to measure read performance with Filter pushdown.
- * To run this:
- *  build/sbt "sql/test-only *FilterPushdownBenchmark"
- *
- * Results will be written to "benchmarks/FilterPushdownBenchmark-results.txt".
+ * To run this benchmark:
+ *  1. without sbt: bin/spark-submit --class <this class> <spark sql test jar>
+ *  2. build/sbt "sql/test:runMain <this class>"
+ *  3. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain <this class>"
+ *     Results will be written to "benchmarks/FilterPushdownBenchmark-results.txt".
  */
-class FilterPushdownBenchmark extends SparkFunSuite with BenchmarkBeforeAndAfterEachTest {
+object FilterPushdownBenchmark extends FileBenchmarkBase {
+
   private val conf = new SparkConf()
     .setAppName(this.getClass.getSimpleName)
     // Since `spark.master` always exists, overrides this value
@@ -50,40 +49,13 @@ class FilterPushdownBenchmark extends SparkFunSuite with BenchmarkBeforeAndAfter
     .setIfMissing("orc.compression", "snappy")
     .setIfMissing("spark.sql.parquet.compression.codec", "snappy")
 
-  private val numRows = 1024 * 1024 * 15
+  private val numRows = 1024
   private val width = 5
   private val mid = numRows / 2
   // For Parquet/ORC, we will use the same value for block size and compression size
   private val blockSize = org.apache.parquet.hadoop.ParquetWriter.DEFAULT_PAGE_SIZE
 
   private val spark = SparkSession.builder().config(conf).getOrCreate()
-
-  private var out: OutputStream = _
-
-  override def beforeAll() {
-    super.beforeAll()
-    out = new FileOutputStream(new File("benchmarks/FilterPushdownBenchmark-results.txt"))
-  }
-
-  override def beforeEach(td: TestData) {
-    super.beforeEach(td)
-    val separator = "=" * 96
-    val testHeader = (separator + '\n' + td.name + '\n' + separator + '\n' + '\n').getBytes
-    out.write(testHeader)
-  }
-
-  override def afterEach(td: TestData) {
-    out.write('\n')
-    super.afterEach(td)
-  }
-
-  override def afterAll() {
-    try {
-      out.close()
-    } finally {
-      super.afterAll()
-    }
-  }
 
   def withTempPath(f: File => Unit): Unit = {
     val path = Utils.createTempDir()
@@ -154,7 +126,7 @@ class FilterPushdownBenchmark extends SparkFunSuite with BenchmarkBeforeAndAfter
       title: String,
       whereExpr: String,
       selectExpr: String = "*"): Unit = {
-    val benchmark = new Benchmark(title, values, minNumIters = 5, output = Some(out))
+    val benchmark = new Benchmark(title, values, minNumIters = 5, output = output)
 
     Seq(false, true).foreach { pushDownEnabled =>
       val name = s"Parquet Vectorized ${if (pushDownEnabled) s"(Pushdown)" else ""}"
@@ -241,191 +213,184 @@ class FilterPushdownBenchmark extends SparkFunSuite with BenchmarkBeforeAndAfter
     }
   }
 
-  ignore("Pushdown for many distinct value case") {
-    withTempPath { dir =>
-      withTempTable("orcTable", "parquetTable") {
-        Seq(true, false).foreach { useStringForValue =>
-          prepareTable(dir, numRows, width, useStringForValue)
-          if (useStringForValue) {
-            runStringBenchmark(numRows, width, mid, "string")
-          } else {
-            runIntBenchmark(numRows, width, mid)
+  override def benchmark(): Unit = {
+    runBenchmark("Pushdown for many distinct value case") {
+      withTempPath { dir =>
+        withTempTable("orcTable", "parquetTable") {
+          Seq(true, false).foreach { useStringForValue =>
+            prepareTable(dir, numRows, width, useStringForValue)
+            if (useStringForValue) {
+              runStringBenchmark(numRows, width, mid, "string")
+            } else {
+              runIntBenchmark(numRows, width, mid)
+            }
           }
         }
       }
     }
-  }
 
-  ignore("Pushdown for few distinct value case (use dictionary encoding)") {
-    withTempPath { dir =>
-      val numDistinctValues = 200
+    runBenchmark("Pushdown for few distinct value case (use dictionary encoding)") {
+      withTempPath { dir =>
+        val numDistinctValues = 200
 
-      withTempTable("orcTable", "parquetTable") {
-        prepareStringDictTable(dir, numRows, numDistinctValues, width)
-        runStringBenchmark(numRows, width, numDistinctValues / 2, "distinct string")
+        withTempTable("orcTable", "parquetTable") {
+          prepareStringDictTable(dir, numRows, numDistinctValues, width)
+          runStringBenchmark(numRows, width, numDistinctValues / 2, "distinct string")
+        }
       }
     }
-  }
 
-  ignore("Pushdown benchmark for StringStartsWith") {
-    withTempPath { dir =>
-      withTempTable("orcTable", "parquetTable") {
-        prepareTable(dir, numRows, width, true)
+    runBenchmark("Pushdown benchmark for StringStartsWith") {
+      withTempPath { dir =>
+        withTempTable("orcTable", "parquetTable") {
+          prepareTable(dir, numRows, width, true)
+          Seq(
+            "value like '10%'",
+            "value like '1000%'",
+            s"value like '${mid.toString.substring(0, mid.toString.length - 1)}%'"
+          ).foreach { whereExpr =>
+            val title = s"StringStartsWith filter: ($whereExpr)"
+            filterPushDownBenchmark(numRows, title, whereExpr)
+          }
+        }
+      }
+    }
+
+    runBenchmark(s"Pushdown benchmark for ${DecimalType.simpleString}") {
+      withTempPath { dir =>
         Seq(
-          "value like '10%'",
-          "value like '1000%'",
-          s"value like '${mid.toString.substring(0, mid.toString.length - 1)}%'"
-        ).foreach { whereExpr =>
-          val title = s"StringStartsWith filter: ($whereExpr)"
-          filterPushDownBenchmark(numRows, title, whereExpr)
+          s"decimal(${Decimal.MAX_INT_DIGITS}, 2)",
+          s"decimal(${Decimal.MAX_LONG_DIGITS}, 2)",
+          s"decimal(${DecimalType.MAX_PRECISION}, 2)"
+        ).foreach { dt =>
+          val columns = (1 to width).map(i => s"CAST(id AS string) c$i")
+          val valueCol = if (dt.equalsIgnoreCase(s"decimal(${Decimal.MAX_INT_DIGITS}, 2)")) {
+            monotonically_increasing_id() % 9999999
+          } else {
+            monotonically_increasing_id()
+          }
+          val df = spark.range(numRows)
+            .selectExpr(columns: _*).withColumn("value", valueCol.cast(dt))
+          withTempTable("orcTable", "parquetTable") {
+            saveAsTable(df, dir)
+
+            Seq(s"value = $mid").foreach { whereExpr =>
+              val title = s"Select 1 $dt row ($whereExpr)".replace("value AND value", "value")
+              filterPushDownBenchmark(numRows, title, whereExpr)
+            }
+
+            val selectExpr = (1 to width).map(i => s"MAX(c$i)").mkString("", ",", ", MAX(value)")
+            Seq(10, 50, 90).foreach { percent =>
+              filterPushDownBenchmark(
+                numRows,
+                s"Select $percent% $dt rows (value < ${numRows * percent / 100})",
+                s"value < ${numRows * percent / 100}",
+                selectExpr
+              )
+            }
+          }
         }
       }
     }
-  }
 
-  ignore(s"Pushdown benchmark for ${DecimalType.simpleString}") {
-    withTempPath { dir =>
-      Seq(
-        s"decimal(${Decimal.MAX_INT_DIGITS}, 2)",
-        s"decimal(${Decimal.MAX_LONG_DIGITS}, 2)",
-        s"decimal(${DecimalType.MAX_PRECISION}, 2)"
-      ).foreach { dt =>
-        val columns = (1 to width).map(i => s"CAST(id AS string) c$i")
-        val valueCol = if (dt.equalsIgnoreCase(s"decimal(${Decimal.MAX_INT_DIGITS}, 2)")) {
-          monotonically_increasing_id() % 9999999
-        } else {
-          monotonically_increasing_id()
+    runBenchmark("Pushdown benchmark for InSet -> InFilters") {
+      withTempPath { dir =>
+        withTempTable("orcTable", "parquetTable") {
+          prepareTable(dir, numRows, width, false)
+          Seq(5, 10, 50, 100).foreach { count =>
+            Seq(10, 50, 90).foreach { distribution =>
+              val filter =
+                Range(0, count).map(r => scala.util.Random.nextInt(numRows * distribution / 100))
+              val whereExpr = s"value in(${filter.mkString(",")})"
+              val title = s"InSet -> InFilters (values count: $count, distribution: $distribution)"
+              filterPushDownBenchmark(numRows, title, whereExpr)
+            }
+          }
         }
-        val df = spark.range(numRows).selectExpr(columns: _*).withColumn("value", valueCol.cast(dt))
+      }
+    }
+
+    runBenchmark(s"Pushdown benchmark for ${ByteType.simpleString}") {
+      withTempPath { dir =>
+        val columns = (1 to width).map(i => s"CAST(id AS string) c$i")
+        val df = spark.range(numRows).selectExpr(columns: _*)
+          .withColumn("value", (monotonically_increasing_id() % Byte.MaxValue).cast(ByteType))
+          .orderBy("value")
         withTempTable("orcTable", "parquetTable") {
           saveAsTable(df, dir)
 
-          Seq(s"value = $mid").foreach { whereExpr =>
-            val title = s"Select 1 $dt row ($whereExpr)".replace("value AND value", "value")
-            filterPushDownBenchmark(numRows, title, whereExpr)
-          }
+          Seq(s"value = CAST(${Byte.MaxValue / 2} AS ${ByteType.simpleString})")
+            .foreach { whereExpr =>
+              val title = s"Select 1 ${ByteType.simpleString} row ($whereExpr)"
+                .replace("value AND value", "value")
+              filterPushDownBenchmark(numRows, title, whereExpr)
+            }
 
           val selectExpr = (1 to width).map(i => s"MAX(c$i)").mkString("", ",", ", MAX(value)")
           Seq(10, 50, 90).foreach { percent =>
             filterPushDownBenchmark(
               numRows,
-              s"Select $percent% $dt rows (value < ${numRows * percent / 100})",
-              s"value < ${numRows * percent / 100}",
+              s"Select $percent% ${ByteType.simpleString} rows " +
+                s"(value < CAST(${Byte.MaxValue * percent / 100} AS ${ByteType.simpleString}))",
+              s"value < CAST(${Byte.MaxValue * percent / 100} AS ${ByteType.simpleString})",
               selectExpr
             )
           }
         }
       }
     }
-  }
 
-  ignore("Pushdown benchmark for InSet -> InFilters") {
-    withTempPath { dir =>
-      withTempTable("orcTable", "parquetTable") {
-        prepareTable(dir, numRows, width, false)
-        Seq(5, 10, 50, 100).foreach { count =>
-          Seq(10, 50, 90).foreach { distribution =>
-            val filter =
-              Range(0, count).map(r => scala.util.Random.nextInt(numRows * distribution / 100))
-            val whereExpr = s"value in(${filter.mkString(",")})"
-            val title = s"InSet -> InFilters (values count: $count, distribution: $distribution)"
-            filterPushDownBenchmark(numRows, title, whereExpr)
-          }
-        }
-      }
-    }
-  }
+    runBenchmark(s"Pushdown benchmark for Timestamp") {
+      withTempPath { dir =>
+        withSQLConf(SQLConf.PARQUET_FILTER_PUSHDOWN_TIMESTAMP_ENABLED.key -> true.toString) {
+          ParquetOutputTimestampType.values.toSeq.map(_.toString).foreach { fileType =>
+            withSQLConf(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key -> fileType) {
+              val columns = (1 to width).map(i => s"CAST(id AS string) c$i")
+              val df = spark.range(numRows).selectExpr(columns: _*)
+                .withColumn("value", monotonically_increasing_id().cast(TimestampType))
+              withTempTable("orcTable", "parquetTable") {
+                saveAsTable(df, dir)
 
-  ignore(s"Pushdown benchmark for ${ByteType.simpleString}") {
-    withTempPath { dir =>
-      val columns = (1 to width).map(i => s"CAST(id AS string) c$i")
-      val df = spark.range(numRows).selectExpr(columns: _*)
-        .withColumn("value", (monotonically_increasing_id() % Byte.MaxValue).cast(ByteType))
-        .orderBy("value")
-      withTempTable("orcTable", "parquetTable") {
-        saveAsTable(df, dir)
+                Seq(s"value = CAST($mid AS timestamp)").foreach { whereExpr =>
+                  val title = s"Select 1 timestamp stored as $fileType row ($whereExpr)"
+                    .replace("value AND value", "value")
+                  filterPushDownBenchmark(numRows, title, whereExpr)
+                }
 
-        Seq(s"value = CAST(${Byte.MaxValue / 2} AS ${ByteType.simpleString})")
-          .foreach { whereExpr =>
-            val title = s"Select 1 ${ByteType.simpleString} row ($whereExpr)"
-              .replace("value AND value", "value")
-            filterPushDownBenchmark(numRows, title, whereExpr)
-          }
-
-        val selectExpr = (1 to width).map(i => s"MAX(c$i)").mkString("", ",", ", MAX(value)")
-        Seq(10, 50, 90).foreach { percent =>
-          filterPushDownBenchmark(
-            numRows,
-            s"Select $percent% ${ByteType.simpleString} rows " +
-              s"(value < CAST(${Byte.MaxValue * percent / 100} AS ${ByteType.simpleString}))",
-            s"value < CAST(${Byte.MaxValue * percent / 100} AS ${ByteType.simpleString})",
-            selectExpr
-          )
-        }
-      }
-    }
-  }
-
-  ignore(s"Pushdown benchmark for Timestamp") {
-    withTempPath { dir =>
-      withSQLConf(SQLConf.PARQUET_FILTER_PUSHDOWN_TIMESTAMP_ENABLED.key -> true.toString) {
-        ParquetOutputTimestampType.values.toSeq.map(_.toString).foreach { fileType =>
-          withSQLConf(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key -> fileType) {
-            val columns = (1 to width).map(i => s"CAST(id AS string) c$i")
-            val df = spark.range(numRows).selectExpr(columns: _*)
-              .withColumn("value", monotonically_increasing_id().cast(TimestampType))
-            withTempTable("orcTable", "parquetTable") {
-              saveAsTable(df, dir)
-
-              Seq(s"value = CAST($mid AS timestamp)").foreach { whereExpr =>
-                val title = s"Select 1 timestamp stored as $fileType row ($whereExpr)"
-                  .replace("value AND value", "value")
-                filterPushDownBenchmark(numRows, title, whereExpr)
-              }
-
-              val selectExpr = (1 to width).map(i => s"MAX(c$i)").mkString("", ",", ", MAX(value)")
-              Seq(10, 50, 90).foreach { percent =>
-                filterPushDownBenchmark(
-                  numRows,
-                  s"Select $percent% timestamp stored as $fileType rows " +
-                    s"(value < CAST(${numRows * percent / 100} AS timestamp))",
-                  s"value < CAST(${numRows * percent / 100} as timestamp)",
-                  selectExpr
-                )
+                val selectExpr = (1 to width)
+                  .map(i => s"MAX(c$i)").mkString("", ",", ", MAX(value)")
+                Seq(10, 50, 90).foreach { percent =>
+                  filterPushDownBenchmark(
+                    numRows,
+                    s"Select $percent% timestamp stored as $fileType rows " +
+                      s"(value < CAST(${numRows * percent / 100} AS timestamp))",
+                    s"value < CAST(${numRows * percent / 100} as timestamp)",
+                    selectExpr
+                  )
+                }
               }
             }
           }
         }
       }
     }
-  }
 
-  ignore(s"Pushdown benchmark with many filters") {
-    val numRows = 1
-    val width = 500
+    runBenchmark(s"Pushdown benchmark with many filters") {
+      val numRows = 1
+      val width = 500
 
-    withTempPath { dir =>
-      val columns = (1 to width).map(i => s"id c$i")
-      val df = spark.range(1).selectExpr(columns: _*)
-      withTempTable("orcTable", "parquetTable") {
-        saveAsTable(df, dir)
-        Seq(1, 250, 500).foreach { numFilter =>
-          val whereExpr = (1 to numFilter).map(i => s"c$i = 0").mkString(" and ")
-          // Note: InferFiltersFromConstraints will add more filters to this given filters
-          filterPushDownBenchmark(numRows, s"Select 1 row with $numFilter filters", whereExpr)
+      withTempPath { dir =>
+        val columns = (1 to width).map(i => s"id c$i")
+        val df = spark.range(1).selectExpr(columns: _*)
+        withTempTable("orcTable", "parquetTable") {
+          saveAsTable(df, dir)
+          Seq(1, 250, 500).foreach { numFilter =>
+            val whereExpr = (1 to numFilter).map(i => s"c$i = 0").mkString(" and ")
+            // Note: InferFiltersFromConstraints will add more filters to this given filters
+            filterPushDownBenchmark(numRows, s"Select 1 row with $numFilter filters", whereExpr)
+          }
         }
       }
     }
-  }
-}
-
-trait BenchmarkBeforeAndAfterEachTest extends BeforeAndAfterEachTestData { this: Suite =>
-
-  override def beforeEach(td: TestData) {
-    super.beforeEach(td)
-  }
-
-  override def afterEach(td: TestData) {
-    super.afterEach(td)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/FilterPushdownBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/FilterPushdownBenchmark.scala
@@ -49,7 +49,7 @@ object FilterPushdownBenchmark extends FileBenchmarkBase {
     .setIfMissing("orc.compression", "snappy")
     .setIfMissing("spark.sql.parquet.compression.codec", "snappy")
 
-  private val numRows = 1024
+  private val numRows = 1024 * 1024 * 15
   private val width = 5
   private val mid = numRows / 2
   // For Parquet/ORC, we will use the same value for block size and compression size


### PR DESCRIPTION
## What changes were proposed in this pull request?

Refactor `FilterPushdownBenchmark` use `main` method. we can use 3 ways to run this test now:

1. bin/spark-submit --class org.apache.spark.sql.execution.benchmark.FilterPushdownBenchmark spark-sql_2.11-2.5.0-SNAPSHOT-tests.jar
2. build/sbt "sql/test:runMain org.apache.spark.sql.execution.benchmark.FilterPushdownBenchmark"
3. SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain org.apache.spark.sql.execution.benchmark.FilterPushdownBenchmark"

The method 2 and the method 3 do not need to compile the `spark-sql_*-tests.jar` package. So these two methods are mainly for developers to quickly do benchmark.


## How was this patch tested?

manual tests
