### PR TITLE
[SPARK-25409][Core]Speed up Spark History loading via incremental loading and adding a flag to load incomplete or not

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/config.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/config.scala
@@ -64,4 +64,13 @@ private[spark] object config {
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("1m")
 
+  val HISTORY_APP_REFRESH_NUM = ConfigBuilder("spark.history.fs.appRefreshNum")
+    .doc("APP number to refresh each scan")
+    .intConf
+    .createWithDefault(3000)
+
+  val HISTORY_APP_LOAD_INCOMPLETE = ConfigBuilder("spark.history.fs.load.incomplete")
+    .doc("Show incomplete APP's information or not")
+    .booleanConf
+    .createWithDefault(true)
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

1.  Instead of loading all event logs in every loading, load only a certain amount of event logs. That is because if there are tens of thousands of event logs, loading all of them take long time. 
2.  If we run Spark on Yarn, Spark jobs information can be obtained by Yarn Application master, this is no need to load incomplete applications, so add a flag not to load them. 

## How was this patch tested?
This is tested manually in our production cluster.
