### PR TITLE
[SPARK-22666][ML][FOLLOW-UP] Improve testcase to tolerate different schema representation

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/source/image/ImageFileFormatSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/source/image/ImageFileFormatSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.ml.source.image
 
+import java.net.URI
 import java.nio.file.Paths
 
 import org.apache.spark.SparkFunSuite
@@ -58,8 +59,15 @@ class ImageFileFormatSuite extends SparkFunSuite with MLlibTestSparkContext {
       .load(filePath)
     assert(df2.count() === 1)
     val result = df2.head()
-    assert(result === invalidImageRow(
-      Paths.get(filePath).toAbsolutePath().normalize().toUri().toString))
+
+    val resultOrigin = result.getStruct(0).getString(0)
+    // covert `origin` to `java.net.URI` object and then compare.
+    // because `file:/path` and `file:///path` are both valid URI-ifications
+    assert(new URI(resultOrigin) ===
+      new URI(Paths.get(filePath).toAbsolutePath().normalize().toString))
+
+    // Compare other columns in the row to be the same with the `invalidImageRow`
+    assert(result === invalidImageRow(resultOrigin))
   }
 
   test("image datasource partition test") {

--- a/mllib/src/test/scala/org/apache/spark/ml/source/image/ImageFileFormatSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/source/image/ImageFileFormatSuite.scala
@@ -63,8 +63,7 @@ class ImageFileFormatSuite extends SparkFunSuite with MLlibTestSparkContext {
     val resultOrigin = result.getStruct(0).getString(0)
     // covert `origin` to `java.net.URI` object and then compare.
     // because `file:/path` and `file:///path` are both valid URI-ifications
-    assert(new URI(resultOrigin) ===
-      new URI(Paths.get(filePath).toAbsolutePath().normalize().toString))
+    assert(new URI(resultOrigin) === Paths.get(filePath).toAbsolutePath().normalize().toUri())
 
     // Compare other columns in the row to be the same with the `invalidImageRow`
     assert(result === invalidImageRow(resultOrigin))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Improve testcase "image datasource test: read non image" to tolerate different schema representation.
Because file:/path and file:///path are both valid URI-ifications so in some environment the testcase will fail.

## How was this patch tested?

Manual.
