### PR TITLE
[SPARK-25445][BUILD][FOLLOWUP] Resolve issues in release-build.sh for publishing scala-2.12 build

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -192,6 +192,7 @@ if [[ "$1" == "package" ]]; then
     NAME=$1
     FLAGS="$MVN_EXTRA_OPTS -B $BASE_RELEASE_PROFILES $2"
     BUILD_PACKAGE=$3
+    SCALA_VERSION=$4
 
     # We increment the Zinc port each time to avoid OOM's and other craziness if multiple builds
     # share the same Zinc server.
@@ -200,6 +201,10 @@ if [[ "$1" == "package" ]]; then
     echo "Building binary dist $NAME"
     cp -r spark spark-$SPARK_VERSION-bin-$NAME
     cd spark-$SPARK_VERSION-bin-$NAME
+
+    if [[ "$SCALA_VERSION" != "2.11" ]]; then
+      ./dev/change-scala-version.sh $SCALA_VERSION
+    fi
 
     export ZINC_PORT=$ZINC_PORT
     echo "Creating distribution: $NAME ($FLAGS)"
@@ -290,20 +295,18 @@ if [[ "$1" == "package" ]]; then
   for key in ${!BINARY_PKGS_ARGS[@]}; do
     args=${BINARY_PKGS_ARGS[$key]}
     extra=${BINARY_PKGS_EXTRA[$key]}
-    if ! make_binary_release "$key" "$SCALA_2_11_PROFILES $args" "$extra"; then
+    if ! make_binary_release "$key" "$SCALA_2_11_PROFILES $args" "$extra" "2.11"; then
       error "Failed to build $key package. Check logs for details."
     fi
   done
 
   if [[ $PUBLISH_SCALA_2_12 = 1 ]]; then
-    ./spark/dev/change-scala-version.sh 2.12
     key="without-hadoop-scala-2.12"
     args="-Phadoop-provided"
     extra=""
-    if ! make_binary_release "$key" "$SCALA_2_12_PROFILES $args" "$extra"; then
+    if ! make_binary_release "$key" "$SCALA_2_12_PROFILES $args" "$extra" "2.12"; then
       error "Failed to build $key package. Check logs for details."
     fi
-    ./spark/dev/change-scala-version.sh 2.11
   fi
 
   rm -rf spark-$SPARK_VERSION-bin-*/

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -121,7 +121,7 @@ else
 fi
 
 PUBLISH_SCALA_2_12=0
-SCALA_2_12_PROFILES="-Pscala-2.12 -Pkafka-0-8"
+SCALA_2_12_PROFILES="-Pscala-2.12"
 if [[ $SPARK_VERSION > "2.4" ]]; then
   PUBLISH_SCALA_2_12=1
 fi
@@ -431,6 +431,8 @@ if [[ "$1" == "publish-release" ]]; then
 
   # Clean-up Zinc nailgun process
   $LSOF -P |grep $ZINC_PORT | grep LISTEN | awk '{ print $2; }' | xargs kill
+
+  ./dev/change-scala-version.sh 2.11
 
   pushd $tmp_repo/org/apache/spark
 

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -111,19 +111,19 @@ fi
 # different versions of Scala are supported.
 BASE_PROFILES="-Pmesos -Pyarn"
 PUBLISH_SCALA_2_10=0
-PUBLISH_SCALA_2_12=0
 SCALA_2_10_PROFILES="-Pscala-2.10"
 SCALA_2_11_PROFILES=
-SCALA_2_12_PROFILES="-Pscala-2.12 -Pkafka-0-8"
-
 if [[ $SPARK_VERSION > "2.3" ]]; then
   BASE_PROFILES="$BASE_PROFILES -Pkubernetes -Pflume"
   SCALA_2_11_PROFILES="-Pkafka-0-8"
-  if [[ $SPARK_VERSION > "2.4" ]]; then
-    PUBLISH_SCALA_2_12=1
-  fi
 else
   PUBLISH_SCALA_2_10=1
+fi
+
+PUBLISH_SCALA_2_12=0
+SCALA_2_12_PROFILES="-Pscala-2.12 -Pkafka-0-8"
+if [[ $SPARK_VERSION > "2.4" ]]; then
+  PUBLISH_SCALA_2_12=1
 fi
 
 # Hive-specific profiles for some builds
@@ -190,17 +190,8 @@ if [[ "$1" == "package" ]]; then
   # Updated for each binary build
   make_binary_release() {
     NAME=$1
-    SCALA_VERSION=$2
-    SCALA_PROFILES=
-    if [[ SCALA_VERSION == "2.10" ]]; then
-      SCALA_PROFILES="$SCALA_2_10_PROFILES"
-    elif [[ SCALA_VERSION == "2.12" ]]; then
-      SCALA_PROFILES="$SCALA_2_12_PROFILES"
-    else
-      SCALA_PROFILES="$SCALA_2_11_PROFILES"
-    fi
-    FLAGS="$MVN_EXTRA_OPTS -B $SCALA_PROFILES $BASE_RELEASE_PROFILES $3"
-    BUILD_PACKAGE=$4
+    FLAGS="$MVN_EXTRA_OPTS -B $BASE_RELEASE_PROFILES $2"
+    BUILD_PACKAGE=$3
 
     # We increment the Zinc port each time to avoid OOM's and other craziness if multiple builds
     # share the same Zinc server.
@@ -209,12 +200,6 @@ if [[ "$1" == "package" ]]; then
     echo "Building binary dist $NAME"
     cp -r spark spark-$SPARK_VERSION-bin-$NAME
     cd spark-$SPARK_VERSION-bin-$NAME
-
-    if [[ SCALA_VERSION == "2.10" ]]; then
-      ./dev/change-scala-version.sh 2.10
-    elif [[ SCALA_VERSION == "2.12" ]]; then
-      ./dev/change-scala-version.sh 2.12
-    fi
 
     export ZINC_PORT=$ZINC_PORT
     echo "Creating distribution: $NAME ($FLAGS)"
@@ -305,16 +290,17 @@ if [[ "$1" == "package" ]]; then
   for key in ${!BINARY_PKGS_ARGS[@]}; do
     args=${BINARY_PKGS_ARGS[$key]}
     extra=${BINARY_PKGS_EXTRA[$key]}
-    if ! make_binary_release "$key" "2.11" "$args" "$extra"; then
+    if ! make_binary_release "$key" "$SCALA_2_11_PROFILES $args" "$extra"; then
       error "Failed to build $key package. Check logs for details."
     fi
   done
 
   if [[ $PUBLISH_SCALA_2_12 = 1 ]]; then
+    ./dev/change-scala-version.sh 2.12
     key="without-hadoop-scala-2.12"
     args="-Phadoop-provided"
     extra=""
-    if ! make_binary_release "$key" "2.12" "$args" "$extra"; then
+    if ! make_binary_release "$key" "$SCALA_2_12_PROFILES $args" "$extra"; then
       error "Failed to build $key package. Check logs for details."
     fi
   fi

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -303,6 +303,7 @@ if [[ "$1" == "package" ]]; then
     if ! make_binary_release "$key" "$SCALA_2_12_PROFILES $args" "$extra"; then
       error "Failed to build $key package. Check logs for details."
     fi
+    ./dev/change-scala-version.sh 2.11
   fi
 
   rm -rf spark-$SPARK_VERSION-bin-*/

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -296,14 +296,14 @@ if [[ "$1" == "package" ]]; then
   done
 
   if [[ $PUBLISH_SCALA_2_12 = 1 ]]; then
-    ./dev/change-scala-version.sh 2.12
+    ./spark/dev/change-scala-version.sh 2.12
     key="without-hadoop-scala-2.12"
     args="-Phadoop-provided"
     extra=""
     if ! make_binary_release "$key" "$SCALA_2_12_PROFILES $args" "$extra"; then
       error "Failed to build $key package. Check logs for details."
     fi
-    ./dev/change-scala-version.sh 2.11
+    ./spark/dev/change-scala-version.sh 2.11
   fi
 
   rm -rf spark-$SPARK_VERSION-bin-*/


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a follow up for #22441.

1. Remove flag "-Pkafka-0-8" for Scala 2.12 build.
2. Clean up the script, simpler logic.
3. Switch to Scala version to 2.11 before script exit.

## How was this patch tested?

Manual test.