### PR TITLE
[SPARK-19355][SQL] Fix variable names numberOfOutput -> numRecords

### DIFF
--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -534,7 +534,7 @@ private[spark] class MapOutputTrackerMaster(
           for (i <- 0 until totalSizes.length) {
             totalSizes(i) += s.getSizeForBlock(i)
           }
-          recordsByMapTask(index) = s.numberOfOutput
+          recordsByMapTask(index) = s.numRecords
         }
       } else {
         val threadPool = ThreadUtils.newDaemonFixedThreadPool(parallelism, "map-output-aggregate")
@@ -552,7 +552,7 @@ private[spark] class MapOutputTrackerMaster(
           threadPool.shutdown()
         }
         statuses.zipWithIndex.foreach { case (s, index) =>
-          recordsByMapTask(index) = s.numberOfOutput
+          recordsByMapTask(index) = s.numRecords
         }
       }
       new MapOutputStatistics(dep.shuffleId, totalSizes, recordsByMapTask)

--- a/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
+++ b/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
@@ -233,7 +233,7 @@ public class UnsafeShuffleWriterSuite {
     writer.write(Iterators.emptyIterator());
     final Option<MapStatus> mapStatus = writer.stop(true);
     assertTrue(mapStatus.isDefined());
-    assertEquals(0, mapStatus.get().numberOfOutput());
+    assertEquals(0, mapStatus.get().numRecords());
     assertTrue(mergedOutputFile.exists());
     assertArrayEquals(new long[NUM_PARTITITONS], partitionSizesInMergedFile);
     assertEquals(0, taskMetrics.shuffleWriteMetrics().recordsWritten());
@@ -253,7 +253,7 @@ public class UnsafeShuffleWriterSuite {
     writer.write(dataToWrite.iterator());
     final Option<MapStatus> mapStatus = writer.stop(true);
     assertTrue(mapStatus.isDefined());
-    assertEquals(NUM_PARTITITONS, mapStatus.get().numberOfOutput());
+    assertEquals(NUM_PARTITITONS, mapStatus.get().numRecords());
     assertTrue(mergedOutputFile.exists());
 
     long sumOfPartitionSizes = 0;

--- a/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
@@ -391,7 +391,7 @@ abstract class ShuffleSuite extends SparkFunSuite with Matchers with LocalSparkC
     assert(mapOutput2.isDefined)
     assert(mapOutput1.get.location === mapOutput2.get.location)
     assert(mapOutput1.get.getSizeForBlock(0) === mapOutput1.get.getSizeForBlock(0))
-    assert(mapOutput1.get.numberOfOutput === mapOutput2.get.numberOfOutput)
+    assert(mapOutput1.get.numRecords === mapOutput2.get.numRecords)
 
     // register one of the map outputs -- doesn't matter which one
     mapOutput1.foreach { case mapStatus =>


### PR DESCRIPTION
## What changes were proposed in this pull request?
SPARK-19355 introduced a variable / method called numberOfOutput, which is a really bad name because it is unclear whether it is a block, or a row. This patch renamed it numRecords, and also changed couple other places to make them consistent.

## How was this patch tested?
Should be covered by existing tests.