### PR TITLE
[SPARK-25464][SQL] Create Database to the location,only if it is empty or does not exists.

### DIFF
--- a/docs/sql-migration-guide-upgrade.md
+++ b/docs/sql-migration-guide-upgrade.md
@@ -31,6 +31,8 @@ license: |
 
   - In Spark version 2.4 and earlier, SQL queries such as `FROM <table>` or `FROM <table> UNION ALL FROM <table>` are supported by accident. In hive-style `FROM <table> SELECT <expr>`, the `SELECT` clause is not negligible. Neither Hive nor Presto support this syntax. Therefore we will treat these queries as invalid since Spark 3.0.
 
+  - Since Spark 3.0, creating a database with nonempty location is not allowed. An exception is thrown when attempting to create a database with nonempty location. 
+
   - Since Spark 3.0, the Dataset and DataFrame API `unionAll` is not deprecated any more. It is an alias for `union`.
 
   - In PySpark, when creating a `SparkSession` with `SparkSession.builder.getOrCreate()`, if there is an existing `SparkContext`, the builder was trying to update the `SparkConf` of the existing `SparkContext` with configurations specified to the builder, but the `SparkContext` is shared by all `SparkSession`s, so we should not update them. Since 3.0, the builder comes to not update the configurations. This is the same behavior as Java/Scala API in 2.3 and above. If you want to update them, you need to update them prior to creating a `SparkSession`.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -214,7 +214,7 @@ class SessionCatalog(
     if (!externalCatalog.databaseExists(dbName) && fs.exists(dbPath)
       && fs.listStatus(dbPath).nonEmpty) {
       throw new AnalysisException(
-        s"Cannot create database at location $dbPath because the path is not empty.")
+        s"Cannot create database at location $dbPath as the path already exists.")
     }
     val qualifiedPath = makeQualifiedPath(dbDefinition.locationUri)
     externalCatalog.createDatabase(

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
@@ -416,6 +416,7 @@ class HiveThriftBinaryServerSuite extends HiveThriftJdbcTest {
         statement.execute("USE db1")
         // access test_map2
         statement.executeQuery("SELECT key from test_map2")
+        statement.execute("DROP DATABASE db1 CASCADE")
       }
     )
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -2521,8 +2521,7 @@ class HiveDDLSuite
     val dbName = "dbwithcustomlocation"
     withTempDir { tmpDir =>
       val parentDir = tmpDir.getParent
-      val expectedMsg = s"Cannot create database at location $parentDir because the path is not " +
-        "empty."
+      val expectedMsg = s"Cannot create database at location $parentDir as the path already exists."
       val e = intercept[AnalysisException] {
         sql(s"CREATE DATABASE $dbName Location '$parentDir' ")
       }.getMessage

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -2516,4 +2516,17 @@ class HiveDDLSuite
       }
     }
   }
+
+  test("SPARK-25464 create a database with a non empty location") {
+    val dbName = "dbwithcustomlocation"
+    withTempDir { tmpDir =>
+      val parentDir = tmpDir.getParent
+      val expectedMsg = s"Cannot create database at location $parentDir because the path is not " +
+        "empty."
+      val e = intercept[AnalysisException] {
+        sql(s"CREATE DATABASE $dbName Location '$parentDir' ")
+      }.getMessage
+      assert(e.contains(expectedMsg))
+    }
+  }
 }


### PR DESCRIPTION
Modification content:If the database is created with location URI then should be empty/should not exists

 What changes were proposed in this pull request?

If the user specifies the location while creating the Database then location should be empty or should not exists

for e.g create database db1 location '/user/hive/warehouse';
this command will be passed only if 'user/hive/warehouse' is empty or should not exists.

 How was this patch tested?
Added testcases and also manually verified in the cluster
