### PR TITLE
[SPARK-25469][SQL] Eval methods of Concat, Reverse and ElementAt should use pattern matching only once

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2274,21 +2274,21 @@ case class Concat(children: Seq[Expression]) extends ComplexTypeMergingExpressio
 
   override def foldable: Boolean = children.forall(_.foldable)
 
-  override def eval(input: InternalRow): Any = evalFunction(input)
+  override def eval(input: InternalRow): Any = doConcat(input)
 
-  @transient private lazy val evalFunction: InternalRow => Any = dataType match {
+  @transient private lazy val doConcat: InternalRow => Any = dataType match {
     case BinaryType =>
-      (input) => {
+      input => {
         val inputs = children.map(_.eval(input).asInstanceOf[Array[Byte]])
         ByteArray.concat(inputs: _*)
       }
     case StringType =>
-      (input) => {
+      input => {
         val inputs = children.map(_.eval(input).asInstanceOf[UTF8String])
         UTF8String.concat(inputs: _*)
       }
     case ArrayType(elementType, _) =>
-      (input) => {
+      input => {
         val inputs = children.toStream.map(_.eval(input))
         if (inputs.contains(null)) {
           null


### PR DESCRIPTION
## What changes were proposed in this pull request?

The PR proposes to avoid usage of pattern matching for each call of ```eval``` method within:
- ```Concat```
- ```Reverse```
- ```ElementAt```

## How was this patch tested?

Run the existing tests for ```Concat```, ```Reverse``` and  ```ElementAt``` expression classes.

