### PR TITLE
[SPARK-25477] “INSERT OVERWRITE LOCAL DIRECTORY”， the data files allo…

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveDirCommand.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveDirCommand.scala
@@ -118,8 +118,13 @@ case class InsertIntoHiveDirCommand(
         }
       }
 
-      fs.listStatus(tmpPath).foreach {
-        tmpFile => fs.rename(tmpFile.getPath, writeToPath)
+      val tmpFs = tmpPath.getFileSystem(hadoopConf)
+      tmpFs.listStatus(tmpPath).foreach { tmpFile =>
+        if (writeToPath.toUri.getScheme == "file") {
+          tmpFs.copyToLocalFile(tmpFile.getPath, writeToPath)
+        } else {
+          tmpFs.rename(tmpFile.getPath, writeToPath)
+        }
       }
     } catch {
       case e: Throwable =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/SaveAsHiveFile.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/SaveAsHiveFile.scala
@@ -159,10 +159,7 @@ private[hive] trait SaveAsHiveFile extends DataWritingCommand {
       scratchDir: String): Path = {
     val extURI: URI = path.toUri
     val scratchPath = new Path(scratchDir, executionId)
-    var dirPath = new Path(
-      extURI.getScheme,
-      extURI.getAuthority,
-      scratchPath.toUri.getPath + "-" + TaskRunner.getTaskRunnerID())
+    var dirPath = new Path(scratchPath.toUri.getPath + "-" + TaskRunner.getTaskRunnerID())
 
     try {
       val fs: FileSystem = dirPath.getFileSystem(hadoopConf)
@@ -205,7 +202,7 @@ private[hive] trait SaveAsHiveFile extends DataWritingCommand {
       hadoopConf: Configuration,
       stagingDir: String): Path = {
     getStagingDir(
-      new Path(extURI.getScheme, extURI.getAuthority, extURI.getPath),
+      new Path(extURI.getPath),
       hadoopConf,
       stagingDir)
   }


### PR DESCRIPTION
…cated on the non-driver node will not be written to the specified output directory

## What changes were proposed in this pull request?
As  The "INSERT OVERWRITE LOCAL DIRECTORY" features use the local staging directory to load data into the specified output directory , the data files allocated on the non-driver node will not be written to the specified output directory. 
In saveAsHiveFile.scala, the code is based on the output directory to determine whether to use the local staging directory or the distributed staging directory. I change the getStagingDir() method. Modify the first parameter from 
" new Path(extURI.getScheme, extURI.getAuthority, extURI.getPath) " to "new Path(extURI.getPath)"

If spark depends on the distributed storage system, then it will be used first. If it is not, it will be used locally. You can directly adjust it to let it be automatically selected instead of specifying it according to the output directory.

## How was this patch tested?
manual tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
