### PR TITLE
[SPARK-25481][SQL][TEST] Refactor ColumnarBatchBenchmark to use main method

### DIFF
--- a/sql/core/benchmarks/ColumnarBatchBenchmark-results.txt
+++ b/sql/core/benchmarks/ColumnarBatchBenchmark-results.txt
@@ -1,0 +1,63 @@
+================================================================================================
+int access benchmark
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_162-b12 on Mac OS X 10.13.6
+Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
+
+Int Read/Write:                          Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+Java Array                                     190 /  194       1725.7           0.6       1.0X
+ByteBuffer Unsafe                              319 /  324       1028.7           1.0       0.6X
+ByteBuffer API                                1363 / 1366        240.4           4.2       0.1X
+DirectByteBuffer                               532 /  542        615.5           1.6       0.4X
+Unsafe Buffer                                  186 /  190       1758.7           0.6       1.0X
+Column(on heap)                                186 /  192       1758.6           0.6       1.0X
+Column(off heap)                               372 /  375        881.5           1.1       0.5X
+Column(off heap direct)                        185 /  191       1769.8           0.6       1.0X
+UnsafeRow (on heap)                            378 /  384        865.9           1.2       0.5X
+UnsafeRow (off heap)                           402 /  406        815.3           1.2       0.5X
+Column On Heap Append                          324 /  332       1012.8           1.0       0.6X
+
+
+================================================================================================
+boolean access benchmark
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_162-b12 on Mac OS X 10.13.6
+Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
+
+Boolean Read/Write:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+Bitset                                         730 /  736        459.6           2.2       1.0X
+Byte Array                                     462 /  469        725.8           1.4       1.6X
+
+
+================================================================================================
+string access benchmark
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_162-b12 on Mac OS X 10.13.6
+Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
+
+String Read/Write:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+On Heap                                        364 /  369         45.0          22.2       1.0X
+Off Heap                                       485 /  490         33.8          29.6       0.8X
+
+
+================================================================================================
+array access benchmark
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_162-b12 on Mac OS X 10.13.6
+Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
+
+Array Vector Read:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+On Heap Read Size Only                         500 /  500        327.8           3.1       1.0X
+Off Heap Read Size Only                        541 /  552        302.6           3.3       0.9X
+On Heap Read Elements                         2956 / 2975         55.4          18.0       0.2X
+Off Heap Read Elements                        3854 / 3854         42.5          23.5       0.1X
+
+

--- a/sql/core/benchmarks/ColumnarBatchBenchmark-results.txt
+++ b/sql/core/benchmarks/ColumnarBatchBenchmark-results.txt
@@ -1,5 +1,5 @@
 ================================================================================================
-int access benchmark
+Int Read/Write
 ================================================================================================
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_162-b12 on Mac OS X 10.13.6
@@ -7,21 +7,21 @@ Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
 
 Int Read/Write:                          Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-Java Array                                     190 /  194       1725.7           0.6       1.0X
-ByteBuffer Unsafe                              319 /  324       1028.7           1.0       0.6X
-ByteBuffer API                                1363 / 1366        240.4           4.2       0.1X
-DirectByteBuffer                               532 /  542        615.5           1.6       0.4X
-Unsafe Buffer                                  186 /  190       1758.7           0.6       1.0X
-Column(on heap)                                186 /  192       1758.6           0.6       1.0X
-Column(off heap)                               372 /  375        881.5           1.1       0.5X
-Column(off heap direct)                        185 /  191       1769.8           0.6       1.0X
-UnsafeRow (on heap)                            378 /  384        865.9           1.2       0.5X
-UnsafeRow (off heap)                           402 /  406        815.3           1.2       0.5X
-Column On Heap Append                          324 /  332       1012.8           1.0       0.6X
+Java Array                                     197 /  201       1667.2           0.6       1.0X
+ByteBuffer Unsafe                              336 /  339        974.3           1.0       0.6X
+ByteBuffer API                                1419 / 1423        231.0           4.3       0.1X
+DirectByteBuffer                               557 /  561        588.3           1.7       0.4X
+Unsafe Buffer                                  194 /  200       1687.0           0.6       1.0X
+Column(on heap)                                193 /  199       1700.6           0.6       1.0X
+Column(off heap)                               374 /  387        876.8           1.1       0.5X
+Column(off heap direct)                        191 /  201       1711.8           0.6       1.0X
+UnsafeRow (on heap)                            386 /  395        849.5           1.2       0.5X
+UnsafeRow (off heap)                           411 /  417        796.7           1.3       0.5X
+Column On Heap Append                          341 /  347        959.6           1.0       0.6X
 
 
 ================================================================================================
-boolean access benchmark
+Boolean Read/Write
 ================================================================================================
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_162-b12 on Mac OS X 10.13.6
@@ -29,12 +29,12 @@ Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
 
 Boolean Read/Write:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-Bitset                                         730 /  736        459.6           2.2       1.0X
-Byte Array                                     462 /  469        725.8           1.4       1.6X
+Bitset                                         750 /  755        447.2           2.2       1.0X
+Byte Array                                     470 /  482        713.5           1.4       1.6X
 
 
 ================================================================================================
-string access benchmark
+String Read/Write
 ================================================================================================
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_162-b12 on Mac OS X 10.13.6
@@ -42,12 +42,12 @@ Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
 
 String Read/Write:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-On Heap                                        364 /  369         45.0          22.2       1.0X
-Off Heap                                       485 /  490         33.8          29.6       0.8X
+On Heap                                        379 /  385         43.2          23.1       1.0X
+Off Heap                                       501 /  504         32.7          30.6       0.8X
 
 
 ================================================================================================
-array access benchmark
+Array Vector Read
 ================================================================================================
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_162-b12 on Mac OS X 10.13.6
@@ -55,9 +55,9 @@ Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
 
 Array Vector Read:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-On Heap Read Size Only                         500 /  500        327.8           3.1       1.0X
-Off Heap Read Size Only                        541 /  552        302.6           3.3       0.9X
-On Heap Read Elements                         2956 / 2975         55.4          18.0       0.2X
-Off Heap Read Elements                        3854 / 3854         42.5          23.5       0.1X
+On Heap Read Size Only                         513 /  523        319.2           3.1       1.0X
+Off Heap Read Size Only                        568 /  576        288.6           3.5       0.9X
+On Heap Read Elements                         3107 / 3109         52.7          19.0       0.2X
+Off Heap Read Elements                        3964 / 3966         41.3          24.2       0.1X
 
 

--- a/sql/core/benchmarks/ColumnarBatchBenchmark-results.txt
+++ b/sql/core/benchmarks/ColumnarBatchBenchmark-results.txt
@@ -2,62 +2,58 @@
 Int Read/Write
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_162-b12 on Mac OS X 10.13.6
-Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
-
+OpenJDK 64-Bit Server VM 1.8.0_181-b13 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Int Read/Write:                          Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-Java Array                                     197 /  201       1667.2           0.6       1.0X
-ByteBuffer Unsafe                              336 /  339        974.3           1.0       0.6X
-ByteBuffer API                                1419 / 1423        231.0           4.3       0.1X
-DirectByteBuffer                               557 /  561        588.3           1.7       0.4X
-Unsafe Buffer                                  194 /  200       1687.0           0.6       1.0X
-Column(on heap)                                193 /  199       1700.6           0.6       1.0X
-Column(off heap)                               374 /  387        876.8           1.1       0.5X
-Column(off heap direct)                        191 /  201       1711.8           0.6       1.0X
-UnsafeRow (on heap)                            386 /  395        849.5           1.2       0.5X
-UnsafeRow (off heap)                           411 /  417        796.7           1.3       0.5X
-Column On Heap Append                          341 /  347        959.6           1.0       0.6X
+Java Array                                     244 /  244       1342.3           0.7       1.0X
+ByteBuffer Unsafe                              445 /  445        736.5           1.4       0.5X
+ByteBuffer API                                2124 / 2125        154.3           6.5       0.1X
+DirectByteBuffer                               750 /  750        437.2           2.3       0.3X
+Unsafe Buffer                                  234 /  236       1401.3           0.7       1.0X
+Column(on heap)                                245 /  245       1335.6           0.7       1.0X
+Column(off heap)                               489 /  489        670.3           1.5       0.5X
+Column(off heap direct)                        236 /  236       1388.1           0.7       1.0X
+UnsafeRow (on heap)                            532 /  534        616.0           1.6       0.5X
+UnsafeRow (off heap)                           564 /  565        580.7           1.7       0.4X
+Column On Heap Append                          489 /  489        670.6           1.5       0.5X
 
 
 ================================================================================================
 Boolean Read/Write
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_162-b12 on Mac OS X 10.13.6
-Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
-
+OpenJDK 64-Bit Server VM 1.8.0_181-b13 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Boolean Read/Write:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-Bitset                                         750 /  755        447.2           2.2       1.0X
-Byte Array                                     470 /  482        713.5           1.4       1.6X
+Bitset                                         879 /  879        381.9           2.6       1.0X
+Byte Array                                     794 /  794        422.6           2.4       1.1X
 
 
 ================================================================================================
 String Read/Write
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_162-b12 on Mac OS X 10.13.6
-Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
-
+OpenJDK 64-Bit Server VM 1.8.0_181-b13 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 String Read/Write:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-On Heap                                        379 /  385         43.2          23.1       1.0X
-Off Heap                                       501 /  504         32.7          30.6       0.8X
+On Heap                                        449 /  449         36.5          27.4       1.0X
+Off Heap                                       679 /  679         24.1          41.4       0.7X
 
 
 ================================================================================================
 Array Vector Read
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_162-b12 on Mac OS X 10.13.6
-Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
-
+OpenJDK 64-Bit Server VM 1.8.0_181-b13 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Array Vector Read:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-On Heap Read Size Only                         513 /  523        319.2           3.1       1.0X
-Off Heap Read Size Only                        568 /  576        288.6           3.5       0.9X
-On Heap Read Elements                         3107 / 3109         52.7          19.0       0.2X
-Off Heap Read Elements                        3964 / 3966         41.3          24.2       0.1X
+On Heap Read Size Only                         713 /  713        229.8           4.4       1.0X
+Off Heap Read Size Only                        757 /  757        216.5           4.6       0.9X
+On Heap Read Elements                         3648 / 3650         44.9          22.3       0.2X
+Off Heap Read Elements                        5263 / 5265         31.1          32.1       0.1X
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchBenchmark.scala
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets
 
 import scala.util.Random
 
-import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
 import org.apache.spark.memory.MemoryMode
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.types.{ArrayType, BinaryType, IntegerType}
@@ -30,8 +30,13 @@ import org.apache.spark.util.collection.BitSet
 
 /**
  * Benchmark to low level memory access using different ways to manage buffers.
+ * To run this benchmark:
+ * 1. without sbt: bin/spark-submit --class <this class> <spark sql test jar>
+ * 2. build/sbt "sql/test:runMain <this class>"
+ * 3. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain <this class>"
+ *    Results will be written to "benchmarks/<this class>-results.txt".
  */
-object ColumnarBatchBenchmark {
+object ColumnarBatchBenchmark extends BenchmarkBase {
   // This benchmark reads and writes an array of ints.
   // TODO: there is a big (2x) penalty for a random access API for off heap.
   // Note: carefully if modifying this code. It's hard to reason about the JIT.
@@ -260,25 +265,7 @@ object ColumnarBatchBenchmark {
       col.close
     }
 
-    /*
-    Java HotSpot(TM) 64-Bit Server VM 1.8.0_60-b27 on Mac OS X 10.13.1
-    Intel(R) Core(TM) i7-4960HQ CPU @ 2.60GHz
-
-    Int Read/Write:                          Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-    ------------------------------------------------------------------------------------------------
-    Java Array                                     177 /  183       1851.1           0.5       1.0X
-    ByteBuffer Unsafe                              314 /  330       1043.7           1.0       0.6X
-    ByteBuffer API                                1298 / 1307        252.4           4.0       0.1X
-    DirectByteBuffer                               465 /  483        704.2           1.4       0.4X
-    Unsafe Buffer                                  179 /  183       1835.5           0.5       1.0X
-    Column(on heap)                                181 /  186       1815.2           0.6       1.0X
-    Column(off heap)                               344 /  349        951.7           1.1       0.5X
-    Column(off heap direct)                        178 /  186       1838.6           0.5       1.0X
-    UnsafeRow (on heap)                            388 /  394        844.8           1.2       0.5X
-    UnsafeRow (off heap)                           400 /  403        819.4           1.2       0.4X
-    Column On Heap Append                          315 /  325       1041.8           1.0       0.6X
-    */
-    val benchmark = new Benchmark("Int Read/Write", count * iters)
+    val benchmark = new Benchmark("Int Read/Write", count * iters, output = output)
     benchmark.addCase("Java Array")(javaArray)
     benchmark.addCase("ByteBuffer Unsafe")(byteBufferUnsafe)
     benchmark.addCase("ByteBuffer API")(byteBufferApi)
@@ -295,7 +282,7 @@ object ColumnarBatchBenchmark {
 
   def booleanAccess(iters: Int): Unit = {
     val count = 8 * 1024
-    val benchmark = new Benchmark("Boolean Read/Write", iters * count.toLong)
+    val benchmark = new Benchmark("Boolean Read/Write", iters * count.toLong, output = output)
     benchmark.addCase("Bitset") { i: Int => {
       val b = new BitSet(count)
       var sum = 0L
@@ -329,15 +316,6 @@ object ColumnarBatchBenchmark {
         }
       }
     }}
-    /*
-    Java HotSpot(TM) 64-Bit Server VM 1.8.0_60-b27 on Mac OS X 10.13.1
-    Intel(R) Core(TM) i7-4960HQ CPU @ 2.60GHz
-
-    Boolean Read/Write:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-    ------------------------------------------------------------------------------------------------
-    Bitset                                         741 /  747        452.6           2.2       1.0X
-    Byte Array                                     531 /  542        631.6           1.6       1.4X
-    */
     benchmark.run()
   }
 
@@ -386,16 +364,7 @@ object ColumnarBatchBenchmark {
       }
     }
 
-    /*
-    Java HotSpot(TM) 64-Bit Server VM 1.8.0_60-b27 on Mac OS X 10.13.1
-    Intel(R) Core(TM) i7-4960HQ CPU @ 2.60GHz
-
-    String Read/Write:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-    ------------------------------------------------------------------------------------------------
-    On Heap                                        351 /  362         46.6          21.4       1.0X
-    Off Heap                                       456 /  466         35.9          27.8       0.8X
-    */
-    val benchmark = new Benchmark("String Read/Write", count * iters)
+    val benchmark = new Benchmark("String Read/Write", count * iters, output = output)
     benchmark.addCase("On Heap")(column(MemoryMode.ON_HEAP))
     benchmark.addCase("Off Heap")(column(MemoryMode.OFF_HEAP))
     benchmark.run
@@ -463,30 +432,27 @@ object ColumnarBatchBenchmark {
       }
     }
 
-    val benchmark = new Benchmark("Array Vector Read", count * iters)
+    val benchmark = new Benchmark("Array Vector Read", count * iters, output = output)
     benchmark.addCase("On Heap Read Size Only") { _ => readArrays(true) }
     benchmark.addCase("Off Heap Read Size Only") { _ => readArrays(false) }
     benchmark.addCase("On Heap Read Elements") { _ => readArrayElements(true) }
     benchmark.addCase("Off Heap Read Elements") { _ => readArrayElements(false) }
 
-    /*
-    Java HotSpot(TM) 64-Bit Server VM 1.8.0_60-b27 on Mac OS X 10.13.1
-    Intel(R) Core(TM) i7-4960HQ CPU @ 2.60GHz
-
-    Array Vector Read:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-    ------------------------------------------------------------------------------------------------
-    On Heap Read Size Only                         426 /  437        384.9           2.6       1.0X
-    Off Heap Read Size Only                        406 /  421        404.0           2.5       1.0X
-    On Heap Read Elements                         2636 / 2642         62.2          16.1       0.2X
-    Off Heap Read Elements                        3770 / 3774         43.5          23.0       0.1X
-    */
     benchmark.run
   }
 
-  def main(args: Array[String]): Unit = {
-    intAccess(1024 * 40)
-    booleanAccess(1024 * 40)
-    stringAccess(1024 * 4)
-    arrayAccess(1024 * 40)
+  override def benchmark(): Unit = {
+    runBenchmark("int access benchmark") {
+      intAccess(1024 * 40)
+    }
+    runBenchmark("boolean access benchmark") {
+      booleanAccess(1024 * 40)
+    }
+    runBenchmark("string access benchmark") {
+      stringAccess(1024 * 4)
+    }
+    runBenchmark("array access benchmark") {
+      arrayAccess(1024 * 40)
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchBenchmark.scala
@@ -35,7 +35,7 @@ import org.apache.spark.util.collection.BitSet
  *   1. without sbt: bin/spark-submit --class <this class> <spark sql test jar>
  *   2. build/sbt "sql/test:runMain <this class>"
  *   3. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain <this class>"
- *      Results will be written to "benchmarks/<this class>-results.txt".
+ *      Results will be written to "benchmarks/ColumnarBatchBenchmark-results.txt".
  * }}}
  */
 object ColumnarBatchBenchmark extends BenchmarkBase {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchBenchmark.scala
@@ -31,10 +31,12 @@ import org.apache.spark.util.collection.BitSet
 /**
  * Benchmark to low level memory access using different ways to manage buffers.
  * To run this benchmark:
- * 1. without sbt: bin/spark-submit --class <this class> <spark sql test jar>
- * 2. build/sbt "sql/test:runMain <this class>"
- * 3. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain <this class>"
- *    Results will be written to "benchmarks/<this class>-results.txt".
+ * {{{
+ *   1. without sbt: bin/spark-submit --class <this class> <spark sql test jar>
+ *   2. build/sbt "sql/test:runMain <this class>"
+ *   3. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain <this class>"
+ *      Results will be written to "benchmarks/<this class>-results.txt".
+ * }}}
  */
 object ColumnarBatchBenchmark extends BenchmarkBase {
   // This benchmark reads and writes an array of ints.
@@ -442,16 +444,16 @@ object ColumnarBatchBenchmark extends BenchmarkBase {
   }
 
   override def benchmark(): Unit = {
-    runBenchmark("int access benchmark") {
+    runBenchmark("Int Read/Write") {
       intAccess(1024 * 40)
     }
-    runBenchmark("boolean access benchmark") {
+    runBenchmark("Boolean Read/Write") {
       booleanAccess(1024 * 40)
     }
-    runBenchmark("string access benchmark") {
+    runBenchmark("String Read/Write") {
       stringAccess(1024 * 4)
     }
-    runBenchmark("array access benchmark") {
+    runBenchmark("Array Vector Read") {
       arrayAccess(1024 * 40)
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Refactor `ColumnarBatchBenchmark` to use main method.
Generate benchmark result:
```
SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain org.apache.spark.sql.execution.vectorized.ColumnarBatchBenchmark"
```

## How was this patch tested?

manual tests
