### PR TITLE
[SPARK-25118][Submit] Persist Driver Logs in Client mode to Hdfs

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1871,6 +1871,9 @@ class SparkContext(config: SparkConf) extends Logging {
       postApplicationEnd()
     }
     Utils.tryLogNonFatalError {
+      _driverLogger.foreach(_.stop())
+    }
+    Utils.tryLogNonFatalError {
       _ui.foreach(_.stop())
     }
     if (env != null) {
@@ -2361,7 +2364,6 @@ class SparkContext(config: SparkConf) extends Logging {
   /** Post the application end event */
   private def postApplicationEnd() {
     listenerBus.post(SparkListenerApplicationEnd(System.currentTimeMillis))
-    _driverLogger.foreach(_.stop())
   }
 
   /** Post the environment update event once the task scheduler is ready */

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2355,13 +2355,13 @@ class SparkContext(config: SparkConf) extends Logging {
     // the cluster manager to get an application ID (in case the cluster manager provides one).
     listenerBus.post(SparkListenerApplicationStart(appName, Some(applicationId),
       startTime, sparkUser, applicationAttemptId, schedulerBackend.getDriverLogUrls))
-    _driverLogger.map(_.startSync(_hadoopConfiguration))
+    _driverLogger.foreach(_.startSync(_hadoopConfiguration))
   }
 
   /** Post the application end event */
   private def postApplicationEnd() {
     listenerBus.post(SparkListenerApplicationEnd(System.currentTimeMillis))
-    _driverLogger.map(_.stop())
+    _driverLogger.foreach(_.stop())
   }
 
   /** Post the environment update event once the task scheduler is ready */

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -206,8 +206,7 @@ class SparkContext(config: SparkConf) extends Logging {
   private var _applicationId: String = _
   private var _applicationAttemptId: Option[String] = None
   private var _eventLogger: Option[EventLoggingListener] = None
-  // Visible for testing
-  private[spark] var _driverLogger: Option[DriverLogger] = None
+  private var _driverLogger: Option[DriverLogger] = None
   private var _executorAllocationManager: Option[ExecutorAllocationManager] = None
   private var _cleaner: Option[ContextCleaner] = None
   private var _listenerBusStarted: Boolean = false

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -206,7 +206,8 @@ class SparkContext(config: SparkConf) extends Logging {
   private var _applicationId: String = _
   private var _applicationAttemptId: Option[String] = None
   private var _eventLogger: Option[EventLoggingListener] = None
-  private var _driverLogger: Option[DriverLogger] = None
+  // Visible for testing
+  private[spark] var _driverLogger: Option[DriverLogger] = None
   private var _executorAllocationManager: Option[ExecutorAllocationManager] = None
   private var _cleaner: Option[ContextCleaner] = None
   private var _listenerBusStarted: Boolean = false

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -58,6 +58,7 @@ import org.apache.spark.storage._
 import org.apache.spark.storage.BlockManagerMessages.TriggerThreadDump
 import org.apache.spark.ui.{ConsoleProgressBar, SparkUI}
 import org.apache.spark.util._
+import org.apache.spark.util.logging.DriverLogger
 
 /**
  * Main entry point for Spark functionality. A SparkContext represents the connection to a Spark
@@ -205,6 +206,7 @@ class SparkContext(config: SparkConf) extends Logging {
   private var _applicationId: String = _
   private var _applicationAttemptId: Option[String] = None
   private var _eventLogger: Option[EventLoggingListener] = None
+  private var _driverLogger: Option[DriverLogger] = None
   private var _executorAllocationManager: Option[ExecutorAllocationManager] = None
   private var _cleaner: Option[ContextCleaner] = None
   private var _listenerBusStarted: Boolean = false
@@ -370,6 +372,8 @@ class SparkContext(config: SparkConf) extends Logging {
     if (!_conf.contains("spark.app.name")) {
       throw new SparkException("An application name must be set in your configuration")
     }
+
+    _driverLogger = DriverLogger(_conf)
 
     // log out spark.app.name in the Spark driver logs
     logInfo(s"Submitted application: $appName")
@@ -2351,11 +2355,13 @@ class SparkContext(config: SparkConf) extends Logging {
     // the cluster manager to get an application ID (in case the cluster manager provides one).
     listenerBus.post(SparkListenerApplicationStart(appName, Some(applicationId),
       startTime, sparkUser, applicationAttemptId, schedulerBackend.getDriverLogUrls))
+    _driverLogger.map(_.startSync(_hadoopConfiguration))
   }
 
   /** Post the application end event */
   private def postApplicationEnd() {
     listenerBus.post(SparkListenerApplicationEnd(System.currentTimeMillis))
+    _driverLogger.map(_.stop())
   }
 
   /** Post the environment update event once the task scheduler is ready */

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -865,8 +865,8 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         } catch {
           case e: NoSuchElementException =>
             // For every new driver log file discovered, create a new entry in listing
-            listing.write(LogInfo(f.getPath().toString(), currentTime, LogType.DriverLogs, None, None,
-              f.getLen()))
+            listing.write(LogInfo(f.getPath().toString(), currentTime, LogType.DriverLogs, None,
+              None, f.getLen()))
           false
         }
       if (deleteFile) {

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -824,7 +824,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
       .reverse()
       .first(maxTime)
       .asScala
-      .filter(l => l.logType == LogType.EventLogs)
+      .filter { l => l.logType == null || l.logType == LogType.EventLogs }
       .toList
     stale.foreach { log =>
       if (log.appId.isEmpty) {
@@ -883,7 +883,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
       .reverse()
       .first(maxTime)
       .asScala
-      .filter(i => i.logType == LogType.DriverLogs)
+      .filter { l => l.logType != null && l.logType == LogType.DriverLogs }
       .toList
     stale.foreach { log =>
       logInfo(s"Deleting invalid driver log ${log.logPath}")

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -42,12 +42,9 @@ import org.fusesource.leveldbjni.internal.NativeDB
 import org.apache.spark.{SecurityManager, SparkConf, SparkException}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
-<<<<<<< HEAD
+import org.apache.spark.internal.config.DRIVER_LOG_DFS_DIR
 import org.apache.spark.internal.config.History._
 import org.apache.spark.internal.config.Status._
-=======
-import org.apache.spark.internal.config.DRIVER_LOG_DFS_DIR
->>>>>>> Review Comments: Minor refactoring
 import org.apache.spark.io.CompressionCodec
 import org.apache.spark.scheduler._
 import org.apache.spark.scheduler.ReplayListenerBus._

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -284,7 +284,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
           getRunner(() => cleanLogs()), 0, CLEAN_INTERVAL_S, TimeUnit.SECONDS)
       }
 
-      if (conf.get(DRIVER_LOG_DFS_DIR).isDefined && conf.get(DRIVER_LOG_CLEANER_ENABLED)) {
+      if (conf.contains(DRIVER_LOG_DFS_DIR) && conf.get(DRIVER_LOG_CLEANER_ENABLED)) {
         pool.scheduleWithFixedDelay(getRunner(() => cleanDriverLogs()),
           0,
           conf.get(DRIVER_LOG_CLEANER_INTERVAL),

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -860,7 +860,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         logFiles.foreach { f =>
           try {
             val info = listing.read(classOf[LogInfo], f.getPath().toString())
-            if (info.fileSize < f.getLen()) {
+            if (info.fileSize < f.getLen() || info.lastProcessed < f.getModificationTime()) {
               listing.write(info.copy(f.getPath().toString(), currentTime, None, None, f.getLen()))
               deleteDir = false
             } else if (info.lastProcessed > maxTime) {

--- a/core/src/main/scala/org/apache/spark/internal/Logging.scala
+++ b/core/src/main/scala/org/apache/spark/internal/Logging.scala
@@ -154,19 +154,17 @@ trait Logging {
             System.err.println("To adjust logging level use sc.setLogLevel(newLevel). " +
               "For SparkR, use setLogLevel(newLevel).")
           }
-          rootLogger.getAllAppenders().asScala.foreach { tmp =>
-            tmp match {
-              case ca: ConsoleAppender =>
-                Option(ca.getThreshold()) match {
-                  case Some(t) =>
-                    Logging.consoleAppenderToThreshold.put(ca, t)
-                    if (!t.isGreaterOrEqual(replLevel)) {
-                      ca.setThreshold(replLevel)
-                    }
-                  case None => ca.setThreshold(replLevel)
-                }
-              case _ => // no-op
-            }
+          rootLogger.getAllAppenders().asScala.foreach {
+            case ca: ConsoleAppender =>
+              Option(ca.getThreshold()) match {
+                case Some(t) =>
+                  Logging.consoleAppenderToThreshold.put(ca, t)
+                  if (!t.isGreaterOrEqual(replLevel)) {
+                    ca.setThreshold(replLevel)
+                  }
+                case None => ca.setThreshold(replLevel)
+              }
+            case _ => // no-op
           }
         }
       }
@@ -184,7 +182,7 @@ private[spark] object Logging {
   @volatile private var initialized = false
   @volatile private var defaultRootLevel: Level = null
   @volatile private var defaultSparkLog4jConfig = false
-  val consoleAppenderToThreshold = new ConcurrentHashMap[ConsoleAppender, Priority]()
+  private val consoleAppenderToThreshold = new ConcurrentHashMap[ConsoleAppender, Priority]()
 
   val initLock = new Object()
   try {
@@ -213,12 +211,10 @@ private[spark] object Logging {
       } else {
         val rootLogger = LogManager.getRootLogger()
         rootLogger.setLevel(defaultRootLevel)
-        rootLogger.getAllAppenders().asScala.foreach { tmp =>
-          tmp match {
-            case ca: ConsoleAppender =>
-              ca.setThreshold(consoleAppenderToThreshold.get(ca))
-            case _ => // no-op
-          }
+        rootLogger.getAllAppenders().asScala.foreach {
+          case ca: ConsoleAppender =>
+            ca.setThreshold(consoleAppenderToThreshold.get(ca))
+          case _ => // no-op
         }
       }
     }

--- a/core/src/main/scala/org/apache/spark/internal/config/History.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/History.scala
@@ -62,4 +62,16 @@ private[spark] object History {
         "parts of event log files. It can be disabled by setting this config to 0.")
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("1m")
+
+  val DRIVER_LOG_CLEANER_ENABLED = ConfigBuilder("spark.history.fs.driverlog.cleaner.enabled")
+    .booleanConf
+    .createOptional
+
+  val DRIVER_LOG_CLEANER_INTERVAL = ConfigBuilder("spark.history.fs.driverlog.cleaner.interval")
+    .timeConf(TimeUnit.SECONDS)
+    .createOptional
+
+  val MAX_DRIVER_LOG_AGE_S = ConfigBuilder("spark.history.fs.driverlog.cleaner.maxAge")
+    .timeConf(TimeUnit.SECONDS)
+    .createOptional
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/History.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/History.scala
@@ -29,6 +29,14 @@ private[spark] object History {
     .stringConf
     .createWithDefault(DEFAULT_LOG_DIR)
 
+  val CLEANER_ENABLED = ConfigBuilder("spark.history.fs.cleaner.enabled")
+    .booleanConf
+    .createWithDefault(false)
+
+  val CLEANER_INTERVAL_S = ConfigBuilder("spark.history.fs.cleaner.interval")
+    .timeConf(TimeUnit.SECONDS)
+    .createWithDefaultString("1d")
+
   val MAX_LOG_AGE_S = ConfigBuilder("spark.history.fs.cleaner.maxAge")
     .timeConf(TimeUnit.SECONDS)
     .createWithDefaultString("7d")
@@ -64,14 +72,11 @@ private[spark] object History {
       .createWithDefaultString("1m")
 
   val DRIVER_LOG_CLEANER_ENABLED = ConfigBuilder("spark.history.fs.driverlog.cleaner.enabled")
-    .booleanConf
-    .createOptional
+    .fallbackConf(CLEANER_ENABLED)
 
   val DRIVER_LOG_CLEANER_INTERVAL = ConfigBuilder("spark.history.fs.driverlog.cleaner.interval")
-    .timeConf(TimeUnit.SECONDS)
-    .createOptional
+    .fallbackConf(CLEANER_INTERVAL_S)
 
   val MAX_DRIVER_LOG_AGE_S = ConfigBuilder("spark.history.fs.driverlog.cleaner.maxAge")
-    .timeConf(TimeUnit.SECONDS)
-    .createOptional
+    .fallbackConf(MAX_LOG_AGE_S)
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -62,11 +62,6 @@ package object config {
       .booleanConf
       .createWithDefault(false)
 
-  private[spark] val DRIVER_LOG_SYNCTOYARN =
-    ConfigBuilder("spark.driver.log.syncToYarn.enabled")
-      .booleanConf
-      .createWithDefault(false)
-
   private[spark] val EVENT_LOG_COMPRESS =
     ConfigBuilder("spark.eventLog.compress")
       .booleanConf

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -49,6 +49,24 @@ package object config {
     .bytesConf(ByteUnit.MiB)
     .createOptional
 
+  private[spark] val DRIVER_LOG_DFS_DIR =
+    ConfigBuilder("spark.driver.log.dfsDir").stringConf.createOptional
+
+  private[spark] val DRIVER_LOG_LAYOUT =
+    ConfigBuilder("spark.driver.log.layout")
+      .stringConf
+      .createWithDefault("%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n")
+
+  private[spark] val DRIVER_LOG_SYNCTODFS =
+    ConfigBuilder("spark.driver.log.syncToDfs.enabled")
+      .booleanConf
+      .createWithDefault(false)
+
+  private[spark] val DRIVER_LOG_SYNCTOYARN =
+    ConfigBuilder("spark.driver.log.syncToYarn.enabled")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val EVENT_LOG_COMPRESS =
     ConfigBuilder("spark.eventLog.compress")
       .booleanConf

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -57,8 +57,8 @@ package object config {
       .stringConf
       .createWithDefault("%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n")
 
-  private[spark] val DRIVER_LOG_SYNCTODFS =
-    ConfigBuilder("spark.driver.log.syncToDfs.enabled")
+  private[spark] val DRIVER_LOG_PERSISTTODFS =
+    ConfigBuilder("spark.driver.log.persistToDfs.enabled")
       .booleanConf
       .createWithDefault(false)
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -55,7 +55,7 @@ package object config {
   private[spark] val DRIVER_LOG_LAYOUT =
     ConfigBuilder("spark.driver.log.layout")
       .stringConf
-      .createWithDefault("%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n")
+      .createOptional
 
   private[spark] val DRIVER_LOG_PERSISTTODFS =
     ConfigBuilder("spark.driver.log.persistToDfs.enabled")

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -382,17 +382,13 @@ private[spark] object EventLoggingListener extends Logging {
       appId: String,
       appAttemptId: Option[String],
       compressionCodecName: Option[String] = None): String = {
-    val base = new Path(logBaseDir).toString.stripSuffix("/") + "/" + sanitize(appId)
+    val base = new Path(logBaseDir).toString.stripSuffix("/") + "/" + Utils.sanitizeDirName(appId)
     val codec = compressionCodecName.map("." + _).getOrElse("")
     if (appAttemptId.isDefined) {
-      base + "_" + sanitize(appAttemptId.get) + codec
+      base + "_" + Utils.sanitizeDirName(appAttemptId.get) + codec
     } else {
       base + codec
     }
-  }
-
-  private def sanitize(str: String): String = {
-    str.replaceAll("[ :/]", "-").replaceAll("[.${}'\"]", "_").toLowerCase(Locale.ROOT)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2330,11 +2330,9 @@ private[spark] object Utils extends Logging {
   def setLogLevel(l: org.apache.log4j.Level) {
     val rootLogger = org.apache.log4j.Logger.getRootLogger()
     rootLogger.setLevel(l)
-    rootLogger.getAllAppenders().asScala.foreach { tmp =>
-      tmp match {
-        case ca: org.apache.log4j.ConsoleAppender => ca.setThreshold(l)
-        case _ => // no-op
-      }
+    rootLogger.getAllAppenders().asScala.foreach {
+      case ca: org.apache.log4j.ConsoleAppender => ca.setThreshold(l)
+      case _ => // no-op
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2330,9 +2330,7 @@ private[spark] object Utils extends Logging {
   def setLogLevel(l: org.apache.log4j.Level) {
     val rootLogger = org.apache.log4j.Logger.getRootLogger()
     rootLogger.setLevel(l)
-    val appenders = rootLogger.getAllAppenders
-    while (appenders.hasMoreElements()) {
-      val tmp = appenders.nextElement()
+    rootLogger.getAllAppenders().asScala.foreach { tmp =>
       tmp match {
         case ca: org.apache.log4j.ConsoleAppender => ca.setThreshold(l)
         case _ => // no-op

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2871,11 +2871,11 @@ private[spark] object Utils extends Logging {
     if (str == null) 0 else str.length + fullWidthRegex.findAllIn(str).size
   }
 
-  private[spark] def sanitizeDirName(str: String): String = {
+  def sanitizeDirName(str: String): String = {
     str.replaceAll("[ :/]", "-").replaceAll("[.${}'\"]", "_").toLowerCase(Locale.ROOT)
   }
 
-  private[spark] def isClientMode(conf: SparkConf): Boolean = {
+  def isClientMode(conf: SparkConf): Boolean = {
     "client".equals(conf.get(SparkLauncher.DEPLOY_MODE, "client"))
   }
 }

--- a/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
+++ b/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util.logging
+
+import java.io._
+import java.util.concurrent.TimeUnit
+
+import scala.util.{Failure, Try}
+
+import org.apache.commons.io.FileUtils
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, FSDataOutputStream, Path}
+import org.apache.hadoop.fs.permission.FsPermission
+import org.apache.hadoop.security.{AccessControlException, UserGroupInformation}
+import org.apache.hadoop.yarn.conf.YarnConfiguration
+import org.apache.log4j.{FileAppender => Log4jFileAppender, _}
+
+import org.apache.spark.SparkConf
+import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config._
+import org.apache.spark.network.util.JavaUtils
+import org.apache.spark.util.{ThreadUtils, Utils}
+
+private[spark] class DriverLogger(conf: SparkConf)
+    extends Logging {
+
+  private val UPLOAD_CHUNK_SIZE = 1024 * 1024
+  private val UPLOAD_INTERVAL_IN_SECS = 5
+  private val DRIVER_LOG_FILE = "driver.log"
+  private val LOG_FILE_PERMISSIONS = new FsPermission(Integer.parseInt("770", 8).toShort)
+
+  private var localLogFile: String = FileUtils.getFile(
+    Utils.getLocalDir(conf), "driver_logs", DRIVER_LOG_FILE).getAbsolutePath()
+  private var hdfsLogFile: String = _
+  private var writer: Option[HdfsAsyncWriter] = None
+  private var hadoopConfiguration: Configuration = _
+  private var fileSystem: FileSystem = _
+
+  private val syncToDfs: Boolean = conf.get(DRIVER_LOG_SYNCTODFS)
+  private val syncToYarn: Boolean = conf.get(DRIVER_LOG_SYNCTOYARN)
+
+  addLogAppender()
+
+  private def addLogAppender(): Unit = {
+    val appenders = LogManager.getRootLogger().getAllAppenders()
+    val layout = if (appenders.hasMoreElements()) {
+      appenders.nextElement().asInstanceOf[Appender].getLayout()
+    } else {
+      new PatternLayout(conf.get(DRIVER_LOG_LAYOUT))
+    }
+    val fa = new Log4jFileAppender(layout, localLogFile)
+    fa.setName(DriverLogger.APPENDER_NAME)
+    LogManager.getRootLogger().addAppender(fa)
+    logInfo(s"Added a local log appender at: ${localLogFile}")
+  }
+
+  def startSync(hadoopConf: Configuration): Unit = {
+    try {
+      val appId = Utils.sanitizeDirName(conf.getAppId)
+      hdfsLogFile = {
+        val rootDir = conf.get(DRIVER_LOG_DFS_DIR.key,
+          "/tmp/driver_logs").split(",").head
+        FileUtils.getFile(rootDir, appId, DRIVER_LOG_FILE).getAbsolutePath()
+      }
+      hadoopConfiguration = hadoopConf
+      fileSystem = FileSystem.get(hadoopConf)
+
+      // Setup a writer which moves the local file to hdfs continuously
+      if (syncToDfs) {
+        writer = Some(new HdfsAsyncWriter())
+        logInfo(s"The local driver log file is being synced to spark dfs at: ${hdfsLogFile}")
+      }
+    } catch {
+      case e: Exception =>
+        logError(s"Could not sync driver logs to spark dfs", e)
+    }
+  }
+
+  def stop(): Unit = {
+    try {
+      writer.map(_.closeWriter())
+      if (syncToYarn) {
+        moveToYarnAppDir()
+      }
+    } catch {
+      case e: Exception =>
+        logError(s"Error in persisting driver logs", e)
+    } finally {
+      try {
+        JavaUtils.deleteRecursively(FileUtils.getFile(localLogFile).getParentFile())
+      } catch {
+        case e: Exception =>
+          logError(s"Error in deleting local driver log dir", e)
+      }
+    }
+  }
+
+  private def moveToYarnAppDir(): Unit = {
+    try {
+      val appId = Utils.sanitizeDirName(conf.getAppId)
+      val yarnConf = new YarnConfiguration(hadoopConfiguration)
+      val rootDir = yarnConf.get(YarnConfiguration.NM_REMOTE_APP_LOG_DIR)
+      if (rootDir != null && !rootDir.isEmpty()) {
+        var parentDir = if (UserGroupInformation.getCurrentUser() != null) {
+          FileUtils.getFile(
+            rootDir,
+            UserGroupInformation.getCurrentUser().getShortUserName(),
+            "logs",
+            appId)
+        } else {
+          FileUtils.getFile(rootDir, "logs", appId)
+        }
+        if (syncToDfs) {
+          fileSystem.rename(new Path(hdfsLogFile), new Path(parentDir.getAbsolutePath()))
+          fileSystem.delete(new Path(FileUtils.getFile(hdfsLogFile).getParent()), true)
+          logInfo(
+            s"Moved the driver log file to: ${parentDir.getAbsolutePath()}")
+        } else {
+          fileSystem.copyFromLocalFile(true,
+            new Path(localLogFile),
+            new Path(parentDir.getAbsolutePath()))
+          logInfo(
+            s"Moved the local driver log file to spark dfs at: ${parentDir.getAbsolutePath()}")
+        }
+      }
+    } catch {
+      case nse: NoSuchElementException => logWarning("Couldn't move driver log" +
+        " to YARN application dir as no appId defined")
+      case ace: AccessControlException =>
+        if (!syncToDfs) {
+          logWarning(s"Couldn't move local driver log to YARN application dir," +
+            s" trying Spark application dir now")
+          moveToDfs()
+        } else {
+          logError(s"Couldn't move driver log to YARN application dir", ace)
+        }
+      case e: Exception =>
+        logError(s"Couldn't move driver log to YARN application dir", e)
+    }
+  }
+
+  private def moveToDfs(): Unit = {
+    try {
+      fileSystem.copyFromLocalFile(true,
+        new Path(localLogFile),
+        new Path(hdfsLogFile))
+      fileSystem.setPermission(new Path(hdfsLogFile), LOG_FILE_PERMISSIONS)
+      logInfo(
+        s"Moved the local driver log file to spark dfs at: ${hdfsLogFile}")
+    } catch {
+      case e: Exception =>
+        logError(s"Could not move local driver log to spark dfs", e)
+    }
+  }
+
+  private class HdfsAsyncWriter extends Runnable with Logging {
+
+    private var streamClosed = false
+    private val inStream = new BufferedInputStream(new FileInputStream(localLogFile))
+    private val outputStream: FSDataOutputStream = fileSystem.create(new Path(hdfsLogFile), true)
+    fileSystem.setPermission(new Path(hdfsLogFile), LOG_FILE_PERMISSIONS)
+    private val tmpBuffer = new Array[Byte](UPLOAD_CHUNK_SIZE)
+    private val threadpool = ThreadUtils.newDaemonSingleThreadScheduledExecutor("dfsSyncThread")
+    threadpool.scheduleWithFixedDelay(this, UPLOAD_INTERVAL_IN_SECS, UPLOAD_INTERVAL_IN_SECS,
+      TimeUnit.SECONDS)
+
+    def run(): Unit = {
+      if (streamClosed) {
+        return
+      }
+      try {
+        var remaining = inStream.available()
+        while (remaining > 0) {
+          val read = inStream.read(tmpBuffer, 0, math.min(remaining, UPLOAD_CHUNK_SIZE))
+          outputStream.write(tmpBuffer, 0, read)
+          remaining -= read
+        }
+        outputStream.hflush()
+      } catch {
+        case e: Exception => logError("Failed to write to spark dfs", e)
+      }
+    }
+
+    def close(): Unit = {
+      try {
+        // Write all remaining bytes
+        run()
+      } catch {
+        case e: Exception => logError("Failed to write to spark dfs", e)
+      } finally {
+        inStream.close()
+        outputStream.close()
+        streamClosed = true
+      }
+    }
+
+    def closeWriter(): Unit = {
+      try {
+        threadpool.execute(new Runnable() {
+          def run(): Unit = HdfsAsyncWriter.this.close()
+        })
+        threadpool.shutdown()
+        threadpool.awaitTermination(1, TimeUnit.MINUTES)
+      } catch {
+        case e: Exception =>
+          logError("Error in closing driver log input/output stream", e)
+      }
+    }
+  }
+
+}
+
+private[spark] object DriverLogger extends Logging {
+  val APPENDER_NAME = "_DriverLogAppender"
+
+  def apply(conf: SparkConf): Option[DriverLogger] = {
+    if ((conf.get(DRIVER_LOG_SYNCTODFS) || conf.get(DRIVER_LOG_SYNCTOYARN))
+      && Utils.isClientMode(conf)) {
+      Try[DriverLogger] { new DriverLogger(conf) }
+        .recoverWith { case t: Throwable => logError("Could not add driver logger", t); Failure(t) }
+        .toOption
+    } else {
+      None
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
+++ b/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
@@ -130,9 +130,14 @@ private[spark] class DriverLogger(conf: SparkConf) extends Logging {
         // Write all remaining bytes
         run()
       } finally {
-        inStream.close()
-        outputStream.close()
-        streamClosed = true
+        try {
+          streamClosed = true
+          inStream.close()
+          outputStream.close()
+        } catch {
+          case t: Throwable =>
+            logError("Error in closing driver log input/output stream", t)
+        }
       }
     }
 
@@ -145,7 +150,7 @@ private[spark] class DriverLogger(conf: SparkConf) extends Logging {
         threadpool.awaitTermination(1, TimeUnit.MINUTES)
       } catch {
         case e: Exception =>
-          logError("Error in closing driver log input/output stream", e)
+          logError("Error in shutting down threadpool", e)
       }
     }
   }

--- a/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
+++ b/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
@@ -115,12 +115,8 @@ private[spark] class DriverLogger(conf: SparkConf) extends Logging {
         fileSystem.setPermission(new Path(dfsLogFile), LOG_FILE_PERMISSIONS)
       } catch {
         case e: Exception =>
-          if (inStream != null) {
-            Utils.tryLogNonFatalError(inStream.close())
-          }
-          if (outputStream != null) {
-            Utils.tryLogNonFatalError(outputStream.close())
-          }
+          JavaUtils.closeQuietly(inStream)
+          JavaUtils.closeQuietly(outputStream)
           throw e
       }
       threadpool = ThreadUtils.newDaemonSingleThreadScheduledExecutor("dfsSyncThread")

--- a/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
+++ b/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
@@ -43,7 +43,8 @@ private[spark] class DriverLogger(conf: SparkConf) extends Logging {
 
   private var localLogFile: String = FileUtils.getFile(
     Utils.getLocalDir(conf), "driver_logs", DRIVER_LOG_FILE).getAbsolutePath()
-  private var writer: Option[DfsAsyncWriter] = None
+  // Visible for testing
+  private[spark] var writer: Option[DfsAsyncWriter] = None
 
   addLogAppender()
 
@@ -86,7 +87,8 @@ private[spark] class DriverLogger(conf: SparkConf) extends Logging {
     }
   }
 
-  private class DfsAsyncWriter(appId: String, hadoopConf: Configuration) extends Runnable
+  // Visible for testing
+  private[spark] class DfsAsyncWriter(appId: String, hadoopConf: Configuration) extends Runnable
     with Logging {
 
     private var streamClosed = false

--- a/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
+++ b/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
@@ -90,7 +90,7 @@ private[spark] class DriverLogger(conf: SparkConf) extends Logging {
 
   // Visible for testing
   private[spark] class DfsAsyncWriter(appId: String, hadoopConf: Configuration) extends Runnable
-    with Logging {
+      with Logging {
 
     private var streamClosed = false
     private val fileSystem: FileSystem = FileSystem.get(hadoopConf)
@@ -137,7 +137,7 @@ private[spark] class DriverLogger(conf: SparkConf) extends Logging {
         }
         outputStream.hflush()
       } catch {
-        case e: Exception => logError("Failed to write to spark dfs", e)
+        case e: Exception => logError("Failed writing driver logs to dfs", e)
       }
     }
 
@@ -182,7 +182,7 @@ private[spark] object DriverLogger extends Logging {
   def apply(conf: SparkConf): Option[DriverLogger] = {
     if (conf.get(DRIVER_LOG_SYNCTODFS)
         && conf.get(DRIVER_LOG_DFS_DIR).isDefined
-      && Utils.isClientMode(conf)) {
+        && Utils.isClientMode(conf)) {
       Try[DriverLogger] { new DriverLogger(conf) }
         .recoverWith {
           case t: Throwable =>

--- a/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
+++ b/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
@@ -114,7 +114,7 @@ private[spark] class DriverLogger(conf: SparkConf) extends Logging {
       val yarnConf = new YarnConfiguration(hadoopConfiguration)
       val rootDir = yarnConf.get(YarnConfiguration.NM_REMOTE_APP_LOG_DIR)
       if (rootDir != null && !rootDir.isEmpty()) {
-        var parentDir = FileUtils.getFile(
+        val parentDir = FileUtils.getFile(
             rootDir,
             UserGroupInformation.getCurrentUser().getShortUserName(),
             "logs",

--- a/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
+++ b/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
@@ -102,7 +102,7 @@ private[spark] class DriverLogger(conf: SparkConf) extends Logging {
         throw new RuntimeException(s"${rootDir} does not exist." +
           s" Please create this dir in order to persist driver logs")
       }
-      FileUtils.getFile(rootDir, appId, DriverLogger.DRIVER_LOG_FILE).getAbsolutePath()
+      FileUtils.getFile(rootDir, appId + DriverLogger.DRIVER_LOG_FILE_SUFFIX).getAbsolutePath()
     }
     private var inStream: InputStream = null
     private var outputStream: FSDataOutputStream = null
@@ -181,6 +181,7 @@ private[spark] class DriverLogger(conf: SparkConf) extends Logging {
 private[spark] object DriverLogger extends Logging {
   val DRIVER_LOG_DIR = "__driver_logs__"
   val DRIVER_LOG_FILE = "driver.log"
+  val DRIVER_LOG_FILE_SUFFIX = "_" + DRIVER_LOG_FILE
   val APPENDER_NAME = "_DriverLogAppender"
 
   def apply(conf: SparkConf): Option[DriverLogger] = {

--- a/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
+++ b/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
@@ -49,7 +49,7 @@ private[spark] class DriverLogger(conf: SparkConf) extends Logging {
 
   private def addLogAppender(): Unit = {
     val appenders = LogManager.getRootLogger().getAllAppenders()
-    val layout = if (conf.get(DRIVER_LOG_LAYOUT).isDefined) {
+    val layout = if (conf.contains(DRIVER_LOG_LAYOUT)) {
       new PatternLayout(conf.get(DRIVER_LOG_LAYOUT).get)
     } else if (appenders.hasMoreElements()) {
       appenders.nextElement().asInstanceOf[Appender].getLayout()
@@ -189,7 +189,7 @@ private[spark] object DriverLogger extends Logging {
 
   def apply(conf: SparkConf): Option[DriverLogger] = {
     if (conf.get(DRIVER_LOG_PERSISTTODFS) && Utils.isClientMode(conf)) {
-      if (conf.get(DRIVER_LOG_DFS_DIR).isDefined) {
+      if (conf.contains(DRIVER_LOG_DFS_DIR)) {
         try {
           Some(new DriverLogger(conf))
         } catch {

--- a/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
+++ b/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
@@ -83,8 +83,9 @@ private[spark] class DriverLogger(conf: SparkConf) extends Logging {
       case e: Exception =>
         logError(s"Error in persisting driver logs", e)
     } finally {
-      Utils.tryLogNonFatalError(JavaUtils.deleteRecursively(
-        FileUtils.getFile(localLogFile).getParentFile()))
+      Utils.tryLogNonFatalError {
+        JavaUtils.deleteRecursively(FileUtils.getFile(localLogFile).getParentFile())
+      }
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -23,10 +23,12 @@ import java.util.{Date, Locale}
 import java.util.concurrent.TimeUnit
 import java.util.zip.{ZipInputStream, ZipOutputStream}
 
+import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
 import com.google.common.io.{ByteStreams, Files}
+import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.{FileStatus, FileSystem, FSDataInputStream, Path}
 import org.apache.hadoop.hdfs.{DFSInputStream, DistributedFileSystem}
 import org.apache.hadoop.security.AccessControlException
@@ -40,6 +42,7 @@ import org.scalatest.concurrent.Eventually._
 
 import org.apache.spark.{SecurityManager, SparkConf, SparkFunSuite}
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.DRIVER_LOG_DFS_DIR
 import org.apache.spark.internal.config.History._
 import org.apache.spark.io._
 import org.apache.spark.scheduler._
@@ -47,6 +50,7 @@ import org.apache.spark.security.GroupMappingServiceProvider
 import org.apache.spark.status.AppStatusStore
 import org.apache.spark.status.api.v1.{ApplicationAttemptInfo, ApplicationInfo}
 import org.apache.spark.util.{Clock, JsonProtocol, ManualClock, Utils}
+import org.apache.spark.util.logging.DriverLogger
 
 class FsHistoryProviderSuite extends SparkFunSuite with BeforeAndAfter with Matchers with Logging {
 
@@ -411,6 +415,68 @@ class FsHistoryProviderSuite extends SparkFunSuite with BeforeAndAfter with Matc
       totalEntries should be (1)
       inputStream.close()
     }
+  }
+
+  test("driver log cleaner") {
+    val firstFileModifiedTime = TimeUnit.SECONDS.toMillis(10)
+    val secondFileModifiedTime = TimeUnit.SECONDS.toMillis(20)
+    val maxAge = TimeUnit.SECONDS.toSeconds(40)
+    val clock = new ManualClock(0)
+    val testConf = new SparkConf()
+    testConf.set("spark.history.fs.logDirectory",
+      Utils.createTempDir(namePrefix = "eventLog").getAbsolutePath())
+    testConf.set(DRIVER_LOG_DFS_DIR, testDir.getAbsolutePath())
+    testConf.set(DRIVER_LOG_CLEANER_ENABLED, true)
+    testConf.set(DRIVER_LOG_CLEANER_INTERVAL, maxAge / 4)
+    testConf.set(MAX_DRIVER_LOG_AGE_S, maxAge)
+    val provider = new FsHistoryProvider(testConf, clock)
+
+    val log1 = FileUtils.getFile(testDir, "1" + DriverLogger.DRIVER_LOG_FILE_SUFFIX)
+    createEmptyFile(log1)
+    val modTime1 = System.currentTimeMillis()
+
+    clock.setTime(modTime1 + firstFileModifiedTime)
+    provider.cleanDriverLogs()
+
+    val log2 = FileUtils.getFile(testDir, "2" + DriverLogger.DRIVER_LOG_FILE_SUFFIX)
+    createEmptyFile(log2)
+    val log3 = FileUtils.getFile(testDir, "3" + DriverLogger.DRIVER_LOG_FILE_SUFFIX)
+    createEmptyFile(log3)
+    val modTime2 = System.currentTimeMillis()
+
+    clock.setTime(modTime1 + secondFileModifiedTime)
+    provider.cleanDriverLogs()
+
+    // This should not trigger any cleanup
+    provider.listing.view(classOf[LogInfo]).iterator().asScala.toSeq.size should be(3)
+
+    // Should trigger cleanup for first file but not second one
+    clock.setTime(modTime1 + firstFileModifiedTime + TimeUnit.SECONDS.toMillis(maxAge) + 1)
+    provider.cleanDriverLogs()
+    provider.listing.view(classOf[LogInfo]).iterator().asScala.toSeq.size should be(2)
+    assert(!log1.exists())
+    assert(log2.exists())
+    assert(log3.exists())
+
+    // Should cleanup the second file but not the third file, as filelength changed.
+    val writer = new OutputStreamWriter(new BufferedOutputStream(new FileOutputStream(log3)))
+    Utils.tryWithSafeFinally {
+      writer.append("Add logs to file")
+    } {
+      writer.close()
+    }
+    clock.setTime(modTime2 + secondFileModifiedTime + TimeUnit.SECONDS.toMillis(maxAge) + 1)
+    provider.cleanDriverLogs()
+    provider.listing.view(classOf[LogInfo]).iterator().asScala.toSeq.size should be(1)
+    assert(!log1.exists())
+    assert(!log2.exists())
+    assert(log3.exists())
+
+    // Should cleanup the third file as well.
+    clock.setTime(modTime2 + secondFileModifiedTime + 2 * TimeUnit.SECONDS.toMillis(maxAge) + 2)
+    provider.cleanDriverLogs()
+    provider.listing.view(classOf[LogInfo]).iterator().asScala.toSeq.size should be(0)
+    assert(!log3.exists())
   }
 
   test("SPARK-8372: new logs with no app ID are ignored") {

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -444,9 +444,8 @@ class FsHistoryProviderSuite extends SparkFunSuite with BeforeAndAfter with Matc
     clock.setTime(secondFileModifiedTime)
     log2.setLastModified(clock.getTimeMillis())
     log3.setLastModified(clock.getTimeMillis())
-    provider.cleanDriverLogs()
-
     // This should not trigger any cleanup
+    provider.cleanDriverLogs()
     provider.listing.view(classOf[LogInfo]).iterator().asScala.toSeq.size should be(3)
 
     // Should trigger cleanup for first file but not second one
@@ -458,9 +457,7 @@ class FsHistoryProviderSuite extends SparkFunSuite with BeforeAndAfter with Matc
     assert(log3.exists())
 
     // Update the third file length while keeping the original modified time
-    Utils.tryLogNonFatalError {
-      Files.write("Add logs to file".getBytes(), log3)
-    }
+    Files.write("Add logs to file".getBytes(), log3)
     log3.setLastModified(secondFileModifiedTime)
     // Should cleanup the second file but not the third file, as filelength changed.
     clock.setTime(secondFileModifiedTime + TimeUnit.SECONDS.toMillis(maxAge) + 1)

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -933,16 +933,19 @@ class FsHistoryProviderSuite extends SparkFunSuite with BeforeAndAfter with Matc
     when(dfsIn.getFileLength).thenReturn(200)
     // FileStatus.getLen is more than logInfo fileSize
     var fileStatus = new FileStatus(200, false, 0, 0, 0, path)
-    var logInfo = new LogInfo(path.toString, 0, Some("appId"), Some("attemptId"), 100)
+    var logInfo = new LogInfo(path.toString, 0, LogType.EventLogs, Some("appId"),
+      Some("attemptId"), 100)
     assert(mockedProvider.shouldReloadLog(logInfo, fileStatus))
 
     fileStatus = new FileStatus()
     fileStatus.setPath(path)
     // DFSInputStream.getFileLength is more than logInfo fileSize
-    logInfo = new LogInfo(path.toString, 0, Some("appId"), Some("attemptId"), 100)
+    logInfo = new LogInfo(path.toString, 0, LogType.EventLogs, Some("appId"),
+      Some("attemptId"), 100)
     assert(mockedProvider.shouldReloadLog(logInfo, fileStatus))
     // DFSInputStream.getFileLength is equal to logInfo fileSize
-    logInfo = new LogInfo(path.toString, 0, Some("appId"), Some("attemptId"), 200)
+    logInfo = new LogInfo(path.toString, 0, LogType.EventLogs, Some("appId"),
+      Some("attemptId"), 200)
     assert(!mockedProvider.shouldReloadLog(logInfo, fileStatus))
     // in.getWrappedStream returns other than DFSInputStream
     val bin = mock(classOf[BufferedInputStream])

--- a/core/src/test/scala/org/apache/spark/util/logging/DriverLoggerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/logging/DriverLoggerSuite.scala
@@ -84,8 +84,8 @@ class DriverLoggerSuite extends SparkFunSuite with LocalSparkContext {
       logInfo("Log enough data to log file so that it can be flushed")
     }
 
-    // After 5 secs, file contents are synced to Hdfs (which is a local dir for this test)
-    Thread.sleep(6000)
+    // Sync the driver logs manually instead of waiting for scheduler
+    sc._driverLogger.foreach(_.writer.foreach(_.run()))
     val hdfsDir = FileUtils.getFile(sc.getConf.get(DRIVER_LOG_DFS_DIR).get, app_id)
     assert(hdfsDir.exists())
     val hdfsFiles = hdfsDir.listFiles()

--- a/core/src/test/scala/org/apache/spark/util/logging/DriverLoggerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/logging/DriverLoggerSuite.scala
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util.logging
+
+import java.io.{BufferedInputStream, FileInputStream}
+
+import org.apache.commons.io.FileUtils
+
+import org.apache.spark._
+import org.apache.spark.{SparkContext, SparkFunSuite}
+import org.apache.spark.internal.config._
+import org.apache.spark.launcher.SparkLauncher
+import org.apache.spark.network.util.JavaUtils
+import org.apache.spark.util.Utils
+
+class DriverLoggerSuite extends SparkFunSuite {
+
+  test("driver logs are persisted") {
+    val sc = getSparkContext()
+    // Wait for application to start
+    Thread.sleep(1000)
+
+    val app_id = sc.applicationId
+    // Run a simple spark application
+    sc.parallelize(1 to 1000).count()
+
+    // Assert driver log file exists
+    val rootDir = Utils.getLocalDir(sc.getConf)
+    val driverLogsDir = FileUtils.getFile(rootDir, "driver_logs")
+    assert(driverLogsDir.exists())
+    val files = driverLogsDir.listFiles()
+    assert(files.length === 1)
+    assert(files(0).getName.equals("driver.log"))
+
+    sc.stop()
+    // On application end, file is moved to Hdfs (which is a local dir for this test)
+    assert(!driverLogsDir.exists())
+    val hdfsDir = FileUtils.getFile("/tmp/hdfs_logs/", app_id)
+    assert(hdfsDir.exists())
+    val hdfsFiles = hdfsDir.listFiles()
+    assert(hdfsFiles.length > 0)
+    JavaUtils.deleteRecursively(hdfsDir)
+    assert(!hdfsDir.exists())
+  }
+
+  test("driver logs are synced to hdfs continuously") {
+    val sc = getSparkContext()
+    // Wait for application to start
+    Thread.sleep(1000)
+
+    val app_id = sc.applicationId
+    // Run a simple spark application
+    sc.parallelize(1 to 1000).count()
+
+    // Assert driver log file exists
+    val rootDir = Utils.getLocalDir(sc.getConf)
+    val driverLogsDir = FileUtils.getFile(rootDir, "driver_logs")
+    assert(driverLogsDir.exists())
+    val files = driverLogsDir.listFiles()
+    assert(files.length === 1)
+    assert(files(0).getName.equals("driver.log"))
+    for (i <- 1 to 1000) {
+      logInfo("Log enough data to log file so that it can be flushed")
+    }
+
+    // After 5 secs, file contents are synced to Hdfs (which is a local dir for this test)
+    Thread.sleep(6000)
+    val hdfsDir = FileUtils.getFile("/tmp/hdfs_logs/", app_id)
+    assert(hdfsDir.exists())
+    val hdfsFiles = hdfsDir.listFiles()
+    assert(hdfsFiles.length > 0)
+    val driverLogFile = hdfsFiles.filter(f => f.getName.equals("driver.log")).head
+    val hdfsIS = new BufferedInputStream(new FileInputStream(driverLogFile))
+    assert(hdfsIS.available() > 0)
+
+    sc.stop()
+    // Ensure that the local file is deleted on application end
+    assert(!driverLogsDir.exists())
+    JavaUtils.deleteRecursively(hdfsDir)
+    assert(!hdfsDir.exists())
+  }
+
+  private def getSparkContext(): SparkContext = {
+    val conf = new SparkConf()
+    conf.set("spark.local.dir", "/tmp")
+    conf.set(DRIVER_LOG_DFS_DIR, "/tmp/hdfs_logs")
+    conf.set(DRIVER_LOG_SYNCTODFS, true)
+    conf.set(SparkLauncher.SPARK_MASTER, "local")
+    conf.set(SparkLauncher.DEPLOY_MODE, "client")
+    new SparkContext("local", "DriverLogTest", conf)
+  }
+
+}
+

--- a/core/src/test/scala/org/apache/spark/util/logging/DriverLoggerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/logging/DriverLoggerSuite.scala
@@ -59,10 +59,10 @@ class DriverLoggerSuite extends SparkFunSuite with LocalSparkContext {
 
     sc.stop()
     assert(!driverLogsDir.exists())
-    val dfsDir = FileUtils.getFile(sc.getConf.get(DRIVER_LOG_DFS_DIR).get, app_id)
-    assert(dfsDir.exists())
-    val dfsFiles = dfsDir.listFiles()
-    dfsFiles.exists{ f => f.getName().equals(DriverLogger.DRIVER_LOG_FILE) && f.length() > 0 }
+    val dfsFile = FileUtils.getFile(sc.getConf.get(DRIVER_LOG_DFS_DIR).get,
+      app_id + DriverLogger.DRIVER_LOG_FILE_SUFFIX)
+    assert(dfsFile.exists())
+    assert(dfsFile.length() > 0)
   }
 
   private def getSparkContext(): SparkContext = {

--- a/core/src/test/scala/org/apache/spark/util/logging/DriverLoggerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/logging/DriverLoggerSuite.scala
@@ -72,7 +72,7 @@ class DriverLoggerSuite extends SparkFunSuite with LocalSparkContext {
   private def getSparkContext(): SparkContext = {
     val conf = new SparkConf()
     conf.set(DRIVER_LOG_DFS_DIR, rootHdfsDir.getAbsolutePath())
-    conf.set(DRIVER_LOG_SYNCTODFS, true)
+    conf.set(DRIVER_LOG_PERSISTTODFS, true)
     conf.set(SparkLauncher.SPARK_MASTER, "local")
     conf.set(SparkLauncher.DEPLOY_MODE, "client")
     sc = new SparkContext("local", "DriverLogTest", conf)

--- a/core/src/test/scala/org/apache/spark/util/logging/DriverLoggerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/logging/DriverLoggerSuite.scala
@@ -30,6 +30,16 @@ import org.apache.spark.util.Utils
 
 class DriverLoggerSuite extends SparkFunSuite with LocalSparkContext {
 
+  private val DRIVER_LOG_DIR_DEFAULT = "/tmp/hdfs_logs"
+
+  override def beforeAll(): Unit = {
+    FileUtils.forceMkdir(FileUtils.getFile(DRIVER_LOG_DIR_DEFAULT))
+  }
+
+  override def afterAll(): Unit = {
+    JavaUtils.deleteRecursively(FileUtils.getFile(DRIVER_LOG_DIR_DEFAULT))
+  }
+
   test("driver logs are persisted") {
     val sc = getSparkContext()
 
@@ -94,7 +104,7 @@ class DriverLoggerSuite extends SparkFunSuite with LocalSparkContext {
   private def getSparkContext(): SparkContext = {
     val conf = new SparkConf()
     conf.set("spark.local.dir", "/tmp")
-    conf.set(DRIVER_LOG_DFS_DIR, "/tmp/hdfs_logs")
+    conf.set(DRIVER_LOG_DFS_DIR, DRIVER_LOG_DIR_DEFAULT)
     conf.set(DRIVER_LOG_SYNCTODFS, true)
     conf.set(SparkLauncher.SPARK_MASTER, "local")
     conf.set(SparkLauncher.DEPLOY_MODE, "client")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -280,11 +280,11 @@ of the most common options to set are:
   </td>
 </tr>
 <tr>
-  <td><code>spark.driver.log.syncToDfs.enabled</code></td>
+  <td><code>spark.driver.log.persistToDfs.enabled</code></td>
   <td>false</td>
   <td>
-    If true, spark application running in client mode will sync driver logs to a persistent storage, configured
-    in spark.driver.log.dfsDir. If spark.driver.log.dfsDir is not configured, driver logs will not be synced.
+    If true, spark application running in client mode will write driver logs to a persistent storage, configured
+    in spark.driver.log.dfsDir. If spark.driver.log.dfsDir is not configured, driver logs will not be persisted.
     Additionally, enable the cleaner by setting spark.history.fs.driverlog.cleaner.enabled to true.
   </td>
 </tr>
@@ -292,7 +292,7 @@ of the most common options to set are:
   <td><code>spark.driver.log.layout</code></td>
   <td>%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n</td>
   <td>
-    The layout for the driver logs that are synced to spark.driver.log.dfsDir. If spark.driver.log.syncToDfs.enabled
+    The layout for the driver logs that are synced to spark.driver.log.dfsDir. If spark.driver.log.persistToDfs.enabled
     is true and this configuration is used. If this is not configured, it uses the layout for the first appender defined
     in log4j.properties. If that is also not configured, driver logs use the default layout.
   </td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -270,13 +270,14 @@ of the most common options to set are:
   <td><code>spark.driver.log.dfsDir</code></td>
   <td>(none)</td>
   <td>
-    Base directory in which Spark driver logs are synced, if spark.driver.log.persistToDfs.enabled is true.
-    Within this base directory, Spark creates a sub-directory for each application, and logs the driver logs
-    specific to the application in this directory. Users may want to set this to a unified location like an
-    HDFS directory so driver log files can be persisted for later usage. This directory should allow any spark
-    user to read/write files and the spark history server user to delete files. Additionally, older logs from
-    this directory are cleaned by Spark History Server if spark.history.fs.driverlog.cleaner.enabled is true.
-    They are cleaned if they are older than max age configured at spark.history.fs.driverlog.cleaner.maxAge.
+    Base directory in which Spark driver logs are synced, if <code>spark.driver.log.persistToDfs.enabled</code>
+    is true. Within this base directory, Spark creates a sub-directory for each application, and logs the driver
+    logs specific to the application in this directory. Users may want to set this to a unified location like an
+    HDFS directory so driver log files can be persisted for later usage. This directory should allow any Spark
+    user to read/write files and the Spark History Server user to delete files. Additionally, older logs from
+    this directory are cleaned by Spark History Server if <code>spark.history.fs.driverlog.cleaner.enabled</code>
+    is true. They are cleaned if they are older than max age configured at
+    <code>spark.history.fs.driverlog.cleaner.maxAge</code>.
   </td>
 </tr>
 <tr>
@@ -284,17 +285,19 @@ of the most common options to set are:
   <td>false</td>
   <td>
     If true, spark application running in client mode will write driver logs to a persistent storage, configured
-    in spark.driver.log.dfsDir. If spark.driver.log.dfsDir is not configured, driver logs will not be persisted.
-    Additionally, enable the cleaner by setting spark.history.fs.driverlog.cleaner.enabled to true.
+    in <code>spark.driver.log.dfsDir</code>. If <code>spark.driver.log.dfsDir</code> is not configured, driver logs
+    will not be persisted. Additionally, enable the cleaner by setting <code>spark.history.fs.driverlog.cleaner.enabled</code>
+    to true.
   </td>
 </tr>
 <tr>
   <td><code>spark.driver.log.layout</code></td>
   <td>%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n</td>
   <td>
-    The layout for the driver logs that are synced to spark.driver.log.dfsDir. If spark.driver.log.persistToDfs.enabled
-    is true and this configuration is used. If this is not configured, it uses the layout for the first appender defined
-    in log4j.properties. If that is also not configured, driver logs use the default layout.
+    The layout for the driver logs that are synced to <code>spark.driver.log.dfsDir</code>. If 
+    <code>spark.driver.log.persistToDfs.enabled</code> is true and this configuration is used. If this is not configured,
+    it uses the layout for the first appender defined in log4j.properties. If that is also not configured, driver logs
+    use the default layout.
   </td>
 </tr>
 </table>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -274,10 +274,10 @@ of the most common options to set are:
     is true. Within this base directory, each application logs the driver logs to an application specific file.
     Users may want to set this to a unified location like an HDFS directory so driver log files can be persisted
     for later usage. This directory should allow any Spark user to read/write files and the Spark History Server
-    user to delete files. Additionally, older logs from this directory are cleaned by
-    <a href="monitoring.html#spark-history-server-configuration-options"> Spark History Server</a>  if
+    user to delete files. Additionally, older logs from this directory are cleaned by the
+    <a href="monitoring.html#spark-history-server-configuration-options">Spark History Server</a> if
     <code>spark.history.fs.driverlog.cleaner.enabled</code> is true and, if they are older than max age configured
-    at <code>spark.history.fs.driverlog.cleaner.maxAge</code>.
+    by setting <code>spark.history.fs.driverlog.cleaner.maxAge</code>.
   </td>
 </tr>
 <tr>
@@ -287,15 +287,14 @@ of the most common options to set are:
     If true, spark application running in client mode will write driver logs to a persistent storage, configured
     in <code>spark.driver.log.dfsDir</code>. If <code>spark.driver.log.dfsDir</code> is not configured, driver logs
     will not be persisted. Additionally, enable the cleaner by setting <code>spark.history.fs.driverlog.cleaner.enabled</code>
-    to true in <a href="monitoring.html#spark-history-server-configuration-options"> Spark History Server</a>.
+    to true in <a href="monitoring.html#spark-history-server-configuration-options">Spark History Server</a>.
   </td>
 </tr>
 <tr>
   <td><code>spark.driver.log.layout</code></td>
   <td>%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n</td>
   <td>
-    The layout for the driver logs that are synced to <code>spark.driver.log.dfsDir</code>. If 
-    <code>spark.driver.log.persistToDfs.enabled</code> is true and this configuration is used. If this is not configured,
+    The layout for the driver logs that are synced to <code>spark.driver.log.dfsDir</code>. If this is not configured,
     it uses the layout for the first appender defined in log4j.properties. If that is also not configured, driver logs
     use the default layout.
   </td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -266,6 +266,36 @@ of the most common options to set are:
     Only has effect in Spark standalone mode or Mesos cluster deploy mode.
   </td>
 </tr>
+<tr>
+  <td><code>spark.driver.log.dfsDir</code></td>
+  <td>(none)</td>
+  <td>
+    Base directory in which Spark driver logs are synced, if spark.driver.log.syncToDfs.enabled is true.
+    Within this base directory, Spark creates a sub-directory for each application, and logs the driver logs
+    specific to the application in this directory. Users may want to set this to a unified location like an
+    HDFS directory so driver log files can be persisted for later usage. This directory should allow any spark
+    user to read/write files and the spark history server user to delete files. Additionally, older logs from
+    this directory are cleaned by Spark History Server if spark.history.fs.cleaner.enabled is true. They are
+    cleaned if they are older than max age configured at spark.history.fs.cleaner.maxAge.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.driver.log.syncToDfs.enabled</code></td>
+  <td>false</td>
+  <td>
+    If true, spark application running in client mode will sync driver logs to a persistent storage, configured
+    in spark.driver.log.dfsDir. If spark.driver.log.dfsDir is not configured, driver logs will not be synced.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.driver.log.layout</code></td>
+  <td>%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n</td>
+  <td>
+    The layout for the driver logs that are synced to spark.driver.log.dfsDir. If spark.driver.log.syncToDfs.enabled
+    is true and this configuration is used. If this is not configured, it uses the layout for the first appender defined
+    in log4j.properties. If that is also not configured, driver logs use the default layout.
+  </td>
+</tr>
 </table>
 
 Apart from these, the following properties are also available, and may be useful in some situations:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -270,7 +270,7 @@ of the most common options to set are:
   <td><code>spark.driver.log.dfsDir</code></td>
   <td>(none)</td>
   <td>
-    Base directory in which Spark driver logs are synced, if spark.driver.log.syncToDfs.enabled is true.
+    Base directory in which Spark driver logs are synced, if spark.driver.log.persistToDfs.enabled is true.
     Within this base directory, Spark creates a sub-directory for each application, and logs the driver logs
     specific to the application in this directory. Users may want to set this to a unified location like an
     HDFS directory so driver log files can be persisted for later usage. This directory should allow any spark

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -275,8 +275,8 @@ of the most common options to set are:
     specific to the application in this directory. Users may want to set this to a unified location like an
     HDFS directory so driver log files can be persisted for later usage. This directory should allow any spark
     user to read/write files and the spark history server user to delete files. Additionally, older logs from
-    this directory are cleaned by Spark History Server if spark.history.fs.cleaner.enabled is true. They are
-    cleaned if they are older than max age configured at spark.history.fs.cleaner.maxAge.
+    this directory are cleaned by Spark History Server if spark.history.fs.driverlog.cleaner.enabled is true.
+    They are cleaned if they are older than max age configured at spark.history.fs.driverlog.cleaner.maxAge.
   </td>
 </tr>
 <tr>
@@ -285,6 +285,7 @@ of the most common options to set are:
   <td>
     If true, spark application running in client mode will sync driver logs to a persistent storage, configured
     in spark.driver.log.dfsDir. If spark.driver.log.dfsDir is not configured, driver logs will not be synced.
+    Additionally, enable the cleaner by setting spark.history.fs.driverlog.cleaner.enabled to true.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -271,14 +271,13 @@ of the most common options to set are:
   <td>(none)</td>
   <td>
     Base directory in which Spark driver logs are synced, if <code>spark.driver.log.persistToDfs.enabled</code>
-    is true. Within this base directory, Spark creates a sub-directory for each application, and logs the driver
-    logs specific to the application in this directory. Users may want to set this to a unified location like an
-    HDFS directory so driver log files can be persisted for later usage. This directory should allow any Spark
-    user to read/write files and the Spark History Server user to delete files. Additionally, older logs from
-    this directory are cleaned by Spark History Server if <code>spark.history.fs.driverlog.cleaner.enabled</code>
-    is true or if not configured, falling back to <code>spark.history.fs.cleaner.enabled</code>. They are cleaned
-    if they are older than max age configured at <code>spark.history.fs.driverlog.cleaner.maxAge</code> or if not
-    configured, falling back to <code>spark.history.fs.cleaner.maxAge</code>.
+    is true. Within this base directory, each application logs the driver logs to an application specific file.
+    Users may want to set this to a unified location like an HDFS directory so driver log files can be persisted
+    for later usage. This directory should allow any Spark user to read/write files and the Spark History Server
+    user to delete files. Additionally, older logs from this directory are cleaned by
+    <a href="monitoring.html#spark-history-server-configuration-options"> Spark History Server</a>  if
+    <code>spark.history.fs.driverlog.cleaner.enabled</code> is true and, if they are older than max age configured
+    at <code>spark.history.fs.driverlog.cleaner.maxAge</code>.
   </td>
 </tr>
 <tr>
@@ -288,7 +287,7 @@ of the most common options to set are:
     If true, spark application running in client mode will write driver logs to a persistent storage, configured
     in <code>spark.driver.log.dfsDir</code>. If <code>spark.driver.log.dfsDir</code> is not configured, driver logs
     will not be persisted. Additionally, enable the cleaner by setting <code>spark.history.fs.driverlog.cleaner.enabled</code>
-    to true.
+    to true in <a href="monitoring.html#spark-history-server-configuration-options"> Spark History Server</a>.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -276,8 +276,9 @@ of the most common options to set are:
     HDFS directory so driver log files can be persisted for later usage. This directory should allow any Spark
     user to read/write files and the Spark History Server user to delete files. Additionally, older logs from
     this directory are cleaned by Spark History Server if <code>spark.history.fs.driverlog.cleaner.enabled</code>
-    is true. They are cleaned if they are older than max age configured at
-    <code>spark.history.fs.driverlog.cleaner.maxAge</code>.
+    is true or if not configured, falling back to <code>spark.history.fs.cleaner.enabled</code>. They are cleaned
+    if they are older than max age configured at <code>spark.history.fs.driverlog.cleaner.maxAge</code> or if not
+    configured, falling back to <code>spark.history.fs.cleaner.maxAge</code>.
   </td>
 </tr>
 <tr>

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -213,7 +213,7 @@ Security options for the Spark History Server are covered more detail in the
     <td>spark.history.fs.driverlog.cleaner.interval</td>
     <td><code>spark.history.fs.cleaner.interval</code></td>
     <td>
-      How often the filesystem driver log history cleaner checks for files to delete.
+      How often the filesystem driver log cleaner checks for files to delete.
       Files are only deleted if they are older than <code>spark.history.fs.driverlog.cleaner.maxAge</code>
     </td>
   </tr>

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -203,6 +203,28 @@ Security options for the Spark History Server are covered more detail in the
     </td>
   </tr>
   <tr>
+    <td>spark.history.fs.driverlog.cleaner.enabled</td>
+    <td><code>spark.history.fs.cleaner.enabled</code></td>
+    <td>
+      Specifies whether the History Server should periodically clean up driver logs from storage.
+    </td>
+  </tr>
+  <tr>
+    <td>spark.history.fs.driverlog.cleaner.interval</td>
+    <td><code>spark.history.fs.cleaner.interval</code></td>
+    <td>
+      How often the filesystem driver log history cleaner checks for files to delete.
+      Files are only deleted if they are older than <code>spark.history.fs.driverlog.cleaner.maxAge</code>
+    </td>
+  </tr>
+  <tr>
+    <td>spark.history.fs.driverlog.cleaner.maxAge</td>
+    <td><code>spark.history.fs.cleaner.maxAge</code></td>
+    <td>
+      Driver log files older than this will be deleted when the driver log cleaner runs.
+    </td>
+  </tr>
+  <tr>
     <td>spark.history.fs.numReplayThreads</td>
     <td>25% of available cores</td>
     <td>

--- a/docs/security.md
+++ b/docs/security.md
@@ -821,3 +821,14 @@ should correspond to the super user who is running the Spark History Server.
 This will allow all users to write to the directory but will prevent unprivileged users from
 reading, removing or renaming a file unless they own it. The event log files will be created by
 Spark with permissions such that only the user and group have read and write access.
+
+# Persisting driver logs in client mode
+
+If your applications persist driver logs in client mode by enabling `spark.driver.log.persistToDfs.enabled`,
+the directory where the driver logs go (`spark.driver.log.dfsDir`) should be manually created with proper
+permissions. To secure the log files, the directory permissions should be set to `drwxrwxrwxt`. The owner
+and group of the directory should correspond to the super user who is running the Spark History Server.
+
+This will allow all users to write to the directory but will prevent unprivileged users from
+reading, removing or renaming a file unless they own it. The driver log files will be created by
+Spark with permissions such that only the user and group have read and write access.


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, we do not have a mechanism to collect driver logs if a user chooses
to run their application in client mode. This is a big issue as admin teams need
to create their own mechanisms to capture driver logs.

This commit adds a logger which, if enabled, adds a local log appender to the
root logger and asynchronously syncs it an application specific log file on hdfs
(Spark Driver Log Dir).

Additionally, this collects spark-shell driver logs at INFO level by default.
The change is that instead of setting root logger level to WARN, we will set the
consoleAppender threshold to WARN, in case of spark-shell. This ensures that
only WARN logs are printed on CONSOLE but other log appenders still capture INFO
(or the default log level logs).

## How was this patch tested?
1. Verified that logs are written to local and remote dir
2. Added a unit test case
3. Verified this for spark-shell, client mode and pyspark.
4. Verified in both non-kerberos and kerberos environment
5. Verified with following unexpected termination conditions: Ctrl + C, Driver
OOM, Large Log Files
6. Ran an application in spark-shell and ensured that driver logs were
captured at INFO level
7. Started the application at WARN level, programmatically changed the level to
INFO and ensured that logs on console were printed at INFO level