### PR TITLE
[SPARK-25513][SQL] Read zipped CSV and JSON

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/CodecStreams.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/CodecStreams.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.datasources
 import java.io.{InputStream, OutputStream, OutputStreamWriter}
 import java.nio.charset.{Charset, StandardCharsets}
 
+import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.compress._
@@ -41,7 +42,12 @@ object CodecStreams {
 
     getDecompressionCodec(config, file)
       .map(codec => codec.createInputStream(inputStream))
-      .getOrElse(inputStream)
+      .orElse {
+        if (file.getName.endsWith(".zip")) {
+          val zip = new ZipArchiveInputStream(inputStream)
+          if (zip.getNextEntry != null) Some(zip) else None
+        } else None
+      }.getOrElse(inputStream)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/CodecStreams.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/CodecStreams.scala
@@ -43,7 +43,7 @@ object CodecStreams {
     getDecompressionCodec(config, file)
       .map(codec => codec.createInputStream(inputStream))
       .orElse {
-        if (file.getName.endsWith(".zip")) {
+        if (file.getName.toLowerCase.endsWith(".zip")) {
           val zip = new ZipArchiveInputStream(inputStream)
           if (zip.getNextEntry != null) Some(zip) else None
         } else None

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -1824,8 +1824,8 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
 
   test("read zip archive containing one CSV file") {
     withTempDir { path =>
-      val zipCSV = new File(path.getAbsolutePath, "test.csv.zip")
-      val out = new ZipOutputStream(new FileOutputStream(zipCSV));
+      val zippedCSV = new File(path.getAbsolutePath, "test.csv.zip")
+      val out = new ZipOutputStream(new FileOutputStream(zippedCSV));
       val entry = new ZipEntry("test.csv")
       out.putNextEntry(entry)
       val content = "1,2\n3,4".getBytes()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -33,9 +33,8 @@ import org.apache.hadoop.io.SequenceFile.CompressionType
 import org.apache.hadoop.io.compress.GzipCodec
 import org.apache.log4j.{AppenderSkeleton, LogManager}
 import org.apache.log4j.spi.LoggingEvent
-import org.apache.spark.SparkException
-import sun.nio.cs.StandardCharsets
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.SQLConf

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.datasources.csv
 
 import java.io.{File, FileOutputStream}
-import java.nio.charset.{Charset, UnsupportedCharsetException}
+import java.nio.charset.{Charset, StandardCharsets, UnsupportedCharsetException}
 import java.nio.file.Files
 import java.sql.{Date, Timestamp}
 import java.text.SimpleDateFormat
@@ -1828,7 +1828,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
       val out = new ZipOutputStream(new FileOutputStream(zippedCSV));
       val entry = new ZipEntry("test.csv")
       out.putNextEntry(entry)
-      val content = "1,2\n3,4".getBytes()
+      val content = "1,2\n3,4".getBytes(StandardCharsets.UTF_8)
       out.write(content, 0, content.length)
       out.close()
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the PR, I propose to support reading of zip archives containing **one** CSV or JSON file in the multi-line mode. 

## How was this patch tested?

Added tests for CSV and JSON where zip archives are created by Java library.
