### PR TITLE
[SPARK-25500][K8s]Specify configmap and secrets in Spark driver and executor pods in Kubernetes

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -192,7 +192,6 @@ Starting with Spark 2.4.0, users can mount the following types of Kubernetes [vo
 * [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir): an initially empty volume created when a pod is assigned to a node.
 * [persistentVolumeClaim](https://kubernetes.io/docs/concepts/storage/volumes/#persistentvolumeclaim): used to mount a `PersistentVolume` into a pod.
 * [configMap](https://kubernetes.io/docs/concepts/storage/volumes/#configmap): used to mount a `configMap` into a pod.
-* [secret](https://kubernetes.io/docs/concepts/storage/volumes/#secret): used to mount a `secret` into a pod.
 
 To mount a volume of any of the types above into the driver pod, use the following configuration property:
 
@@ -201,7 +200,7 @@ To mount a volume of any of the types above into the driver pod, use the followi
 --conf spark.kubernetes.driver.volumes.[VolumeType].[VolumeName].mount.readOnly=<true|false>
 ``` 
 
-Specifically, `VolumeType` can be one of the following values: `hostPath`, `emptyDir`, `persistentVolumeClaim`, `configMap` and `secret`. `VolumeName` is the name you want to use for the volume under the `volumes` field in the pod specification.
+Specifically, `VolumeType` can be one of the following values: `hostPath`, `emptyDir`, `persistentVolumeClaim` and `configMap`. `VolumeName` is the name you want to use for the volume under the `volumes` field in the pod specification.
 
 Each supported type of volumes may have some specific configuration options, which can be specified using configuration properties of the following form:
 

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -191,6 +191,8 @@ Starting with Spark 2.4.0, users can mount the following types of Kubernetes [vo
 * [hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath): mounts a file or directory from the host node’s filesystem into a pod.
 * [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir): an initially empty volume created when a pod is assigned to a node.
 * [persistentVolumeClaim](https://kubernetes.io/docs/concepts/storage/volumes/#persistentvolumeclaim): used to mount a `PersistentVolume` into a pod.
+* [configMap](https://kubernetes.io/docs/concepts/storage/volumes/#configmap): used to mount a `configMap` into a pod.
+* [secret](https://kubernetes.io/docs/concepts/storage/volumes/#secret): used to mount a `secret` into a pod.
 
 To mount a volume of any of the types above into the driver pod, use the following configuration property:
 
@@ -199,7 +201,7 @@ To mount a volume of any of the types above into the driver pod, use the followi
 --conf spark.kubernetes.driver.volumes.[VolumeType].[VolumeName].mount.readOnly=<true|false>
 ``` 
 
-Specifically, `VolumeType` can be one of the following values: `hostPath`, `emptyDir`, and `persistentVolumeClaim`. `VolumeName` is the name you want to use for the volume under the `volumes` field in the pod specification.
+Specifically, `VolumeType` can be one of the following values: `hostPath`, `emptyDir`, `persistentVolumeClaim`, `configMap` and `secret`. `VolumeName` is the name you want to use for the volume under the `volumes` field in the pod specification.
 
 Each supported type of volumes may have some specific configuration options, which can be specified using configuration properties of the following form:
 
@@ -211,6 +213,12 @@ For example, the claim name of a `persistentVolumeClaim` with volume name `check
 
 ```
 spark.kubernetes.driver.volumes.persistentVolumeClaim.checkpointpvc.options.claimName=check-point-pvc-claim
+```
+
+The configMap name with volume name `configvolume` can be specified using the following property:
+
+```
+spark.kubernetes.driver.volumes.configMap.configvolume.options.name=test-configmap
 ```
 
 The configuration properties for mounting volumes into the executor pods use prefix `spark.kubernetes.executor.` instead of `spark.kubernetes.driver.`. For a complete list of available options for each supported type of volumes, please refer to the [Spark Properties](#spark-properties) section below. 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -261,12 +261,15 @@ private[spark] object Config extends Logging {
   val KUBERNETES_VOLUMES_HOSTPATH_TYPE = "hostPath"
   val KUBERNETES_VOLUMES_PVC_TYPE = "persistentVolumeClaim"
   val KUBERNETES_VOLUMES_EMPTYDIR_TYPE = "emptyDir"
+  val KUBERNETES_VOLUMES_CONFIGMAP_TYPE = "configMap"
+  val KUBERNETES_VOLUMES_SECRET_TYPE = "secret"
   val KUBERNETES_VOLUMES_MOUNT_PATH_KEY = "mount.path"
   val KUBERNETES_VOLUMES_MOUNT_READONLY_KEY = "mount.readOnly"
   val KUBERNETES_VOLUMES_OPTIONS_PATH_KEY = "options.path"
   val KUBERNETES_VOLUMES_OPTIONS_CLAIM_NAME_KEY = "options.claimName"
   val KUBERNETES_VOLUMES_OPTIONS_MEDIUM_KEY = "options.medium"
   val KUBERNETES_VOLUMES_OPTIONS_SIZE_LIMIT_KEY = "options.sizeLimit"
+  val KUBERNETES_VOLUMES_OPTIONS_NAME_KEY = "options.name"
 
   val KUBERNETES_DRIVER_ENV_PREFIX = "spark.kubernetes.driverEnv."
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -262,7 +262,6 @@ private[spark] object Config extends Logging {
   val KUBERNETES_VOLUMES_PVC_TYPE = "persistentVolumeClaim"
   val KUBERNETES_VOLUMES_EMPTYDIR_TYPE = "emptyDir"
   val KUBERNETES_VOLUMES_CONFIGMAP_TYPE = "configMap"
-  val KUBERNETES_VOLUMES_SECRET_TYPE = "secret"
   val KUBERNETES_VOLUMES_MOUNT_PATH_KEY = "mount.path"
   val KUBERNETES_VOLUMES_MOUNT_READONLY_KEY = "mount.readOnly"
   val KUBERNETES_VOLUMES_OPTIONS_PATH_KEY = "options.path"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesVolumeSpec.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesVolumeSpec.scala
@@ -35,10 +35,6 @@ private[spark] case class KubernetesConfigmapVolumeConf(
     configMapName: String)
   extends KubernetesVolumeSpecificConf
 
-private[spark] case class KubernetesSecretVolumeConf(
-    secretName: String)
-  extends KubernetesVolumeSpecificConf
-
 private[spark] case class KubernetesVolumeSpec[T <: KubernetesVolumeSpecificConf](
     volumeName: String,
     mountPath: String,

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesVolumeSpec.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesVolumeSpec.scala
@@ -31,6 +31,14 @@ private[spark] case class KubernetesEmptyDirVolumeConf(
     sizeLimit: Option[String])
   extends KubernetesVolumeSpecificConf
 
+private[spark] case class KubernetesConfigmapVolumeConf(
+    configMapName: String)
+  extends KubernetesVolumeSpecificConf
+
+private[spark] case class KubernetesSecretVolumeConf(
+    secretName: String)
+  extends KubernetesVolumeSpecificConf
+
 private[spark] case class KubernetesVolumeSpec[T <: KubernetesVolumeSpecificConf](
     volumeName: String,
     mountPath: String,

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesVolumeUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesVolumeUtils.scala
@@ -98,12 +98,6 @@ private[spark] object KubernetesVolumeUtils {
           path <- options.getTry(nameKey)
         } yield KubernetesConfigmapVolumeConf(path)
 
-      case KUBERNETES_VOLUMES_SECRET_TYPE =>
-        val nameKey = s"$volumeType.$volumeName.$KUBERNETES_VOLUMES_OPTIONS_NAME_KEY"
-        for {
-          path <- options.getTry(nameKey)
-        } yield KubernetesSecretVolumeConf(path)
-
       case _ =>
         Failure(new RuntimeException(s"Kubernetes Volume type `$volumeType` is not supported"))
     }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesVolumeUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesVolumeUtils.scala
@@ -92,6 +92,18 @@ private[spark] object KubernetesVolumeUtils {
         val sizeLimitKey = s"$volumeType.$volumeName.$KUBERNETES_VOLUMES_OPTIONS_SIZE_LIMIT_KEY"
         Success(KubernetesEmptyDirVolumeConf(options.get(mediumKey), options.get(sizeLimitKey)))
 
+      case KUBERNETES_VOLUMES_CONFIGMAP_TYPE =>
+        val nameKey = s"$volumeType.$volumeName.$KUBERNETES_VOLUMES_OPTIONS_NAME_KEY"
+        for {
+          path <- options.getTry(nameKey)
+        } yield KubernetesConfigmapVolumeConf(path)
+
+      case KUBERNETES_VOLUMES_SECRET_TYPE =>
+        val nameKey = s"$volumeType.$volumeName.$KUBERNETES_VOLUMES_OPTIONS_NAME_KEY"
+        for {
+          path <- options.getTry(nameKey)
+        } yield KubernetesSecretVolumeConf(path)
+
       case _ =>
         Failure(new RuntimeException(s"Kubernetes Volume type `$volumeType` is not supported"))
     }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/MountVolumesFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/MountVolumesFeatureStep.scala
@@ -74,10 +74,6 @@ private[spark] class MountVolumesFeatureStep(
           new VolumeBuilder()
             .withConfigMap(new ConfigMapVolumeSourceBuilder()
                            .withName(configMapName).build)
-
-        case KubernetesSecretVolumeConf(secretName) =>
-          new VolumeBuilder()
-            .withNewSecret().withSecretName(secretName).endSecret()
       }
 
       val volume = volumeBuilder.withName(spec.volumeName).build()

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/MountVolumesFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/MountVolumesFeatureStep.scala
@@ -69,6 +69,15 @@ private[spark] class MountVolumesFeatureStep(
             .withEmptyDir(
               new EmptyDirVolumeSource(medium.getOrElse(""),
               new Quantity(sizeLimit.orNull)))
+
+        case KubernetesConfigmapVolumeConf(configMapName) =>
+          new VolumeBuilder()
+            .withConfigMap(new ConfigMapVolumeSourceBuilder()
+                           .withName(configMapName).build)
+
+        case KubernetesSecretVolumeConf(secretName) =>
+          new VolumeBuilder()
+            .withNewSecret().withSecretName(secretName).endSecret()
       }
 
       val volume = volumeBuilder.withName(spec.volumeName).build()

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesVolumeUtilsSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesVolumeUtilsSuite.scala
@@ -125,27 +125,4 @@ class KubernetesVolumeUtilsSuite extends SparkFunSuite {
     assert(volumeSpec.isFailure === true)
     assert(volumeSpec.failed.get.getMessage === "configMap.volumeName.options.path")
   }
-
-  test("Parses secret volumes correctly") {
-    val sparkConf = new SparkConf(false)
-    sparkConf.set("test.secret.volumeName.mount.path", "/path")
-    sparkConf.set("test.secret.volumeName.options.name", "secret")
-
-    val volumeSpec = KubernetesVolumeUtils.parseVolumesWithPrefix(sparkConf, "test.").head.get
-    assert(volumeSpec.volumeName === "volumeName")
-    assert(volumeSpec.mountPath === "/path")
-    assert(volumeSpec.volumeConf.asInstanceOf[KubernetesEmptyDirVolumeConf] ===
-      KubernetesSecretVolumeConf("secret"))
-  }
-
-  test("Gracefully fails on missing option key for secret") {
-    val sparkConf = new SparkConf(false)
-    sparkConf.set("test.secret.volumeName.mount.path", "/path")
-    sparkConf.set("test.secret.volumeName.options.ame", "secret")
-
-    val volumeSpec = KubernetesVolumeUtils.parseVolumesWithPrefix(sparkConf, "test.").head
-    assert(volumeSpec.isFailure === true)
-    assert(volumeSpec.failed.get.getMessage === "secret.volumeName.options.path")
-  }
-
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesVolumeUtilsSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesVolumeUtilsSuite.scala
@@ -103,4 +103,49 @@ class KubernetesVolumeUtilsSuite extends SparkFunSuite {
     assert(volumeSpec.isFailure === true)
     assert(volumeSpec.failed.get.getMessage === "hostPath.volumeName.options.path")
   }
+
+  test("Parses configMap volumes correctly") {
+    val sparkConf = new SparkConf(false)
+    sparkConf.set("test.configMap.volumeName.mount.path", "/path")
+    sparkConf.set("test.configMap.volumeName.options.name", "configmap")
+
+    val volumeSpec = KubernetesVolumeUtils.parseVolumesWithPrefix(sparkConf, "test.").head.get
+    assert(volumeSpec.volumeName === "volumeName")
+    assert(volumeSpec.mountPath === "/path")
+    assert(volumeSpec.volumeConf.asInstanceOf[KubernetesEmptyDirVolumeConf] ===
+      KubernetesConfigmapVolumeConf("configmap"))
+  }
+
+  test("Gracefully fails on missing option key for configmap") {
+    val sparkConf = new SparkConf(false)
+    sparkConf.set("test.configMap.volumeName.mount.path", "/path")
+    sparkConf.set("test.configMap.volumeName.options.ame", "configmap")
+
+    val volumeSpec = KubernetesVolumeUtils.parseVolumesWithPrefix(sparkConf, "test.").head
+    assert(volumeSpec.isFailure === true)
+    assert(volumeSpec.failed.get.getMessage === "configMap.volumeName.options.path")
+  }
+
+  test("Parses secret volumes correctly") {
+    val sparkConf = new SparkConf(false)
+    sparkConf.set("test.secret.volumeName.mount.path", "/path")
+    sparkConf.set("test.secret.volumeName.options.name", "secret")
+
+    val volumeSpec = KubernetesVolumeUtils.parseVolumesWithPrefix(sparkConf, "test.").head.get
+    assert(volumeSpec.volumeName === "volumeName")
+    assert(volumeSpec.mountPath === "/path")
+    assert(volumeSpec.volumeConf.asInstanceOf[KubernetesEmptyDirVolumeConf] ===
+      KubernetesSecretVolumeConf("secret"))
+  }
+
+  test("Gracefully fails on missing option key for secret") {
+    val sparkConf = new SparkConf(false)
+    sparkConf.set("test.secret.volumeName.mount.path", "/path")
+    sparkConf.set("test.secret.volumeName.options.ame", "secret")
+
+    val volumeSpec = KubernetesVolumeUtils.parseVolumesWithPrefix(sparkConf, "test.").head
+    assert(volumeSpec.isFailure === true)
+    assert(volumeSpec.failed.get.getMessage === "secret.volumeName.options.path")
+  }
+
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/MountVolumesFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/MountVolumesFeatureStepSuite.scala
@@ -141,4 +141,42 @@ class MountVolumesFeatureStepSuite extends SparkFunSuite {
     assert(configuredPod.pod.getSpec.getVolumes.size() === 2)
     assert(configuredPod.container.getVolumeMounts.size() === 2)
   }
+
+  test("Mounts configMap") {
+    val volumeConf = KubernetesVolumeSpec(
+      "testVolume",
+      "/tmp",
+      false,
+      KubernetesConfigmapVolumeConf("configMap")
+    )
+    val kubernetesConf = emptyKubernetesConf.copy(roleVolumes = volumeConf :: Nil)
+    val step = new MountVolumesFeatureStep(kubernetesConf)
+    val configuredPod = step.configurePod(SparkPod.initialPod())
+
+    assert(configuredPod.pod.getSpec.getVolumes.size() === 1)
+    val configMap = configuredPod.pod.getSpec.getVolumes.get(0).getConfigMap
+    assert(configMap.getName === "configMap")
+    assert(configuredPod.container.getVolumeMounts.size() === 1)
+    assert(configuredPod.container.getVolumeMounts.get(0).getMountPath === "/tmp")
+    assert(configuredPod.container.getVolumeMounts.get(0).getName === "testVolume")
+  }
+
+  test("Mounts Secrets") {
+    val volumeConf = KubernetesVolumeSpec(
+      "testVolume",
+      "/tmp",
+      false,
+      KubernetesConfigmapVolumeConf("secret")
+    )
+    val kubernetesConf = emptyKubernetesConf.copy(roleVolumes = volumeConf :: Nil)
+    val step = new MountVolumesFeatureStep(kubernetesConf)
+    val configuredPod = step.configurePod(SparkPod.initialPod())
+
+    assert(configuredPod.pod.getSpec.getVolumes.size() === 1)
+    val secret = configuredPod.pod.getSpec.getVolumes.get(0).getSecret
+    assert(secret.getSecretName === "secret")
+    assert(configuredPod.container.getVolumeMounts.size() === 1)
+    assert(configuredPod.container.getVolumeMounts.get(0).getMountPath === "/tmp")
+    assert(configuredPod.container.getVolumeMounts.get(0).getName === "testVolume")
+  }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/MountVolumesFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/MountVolumesFeatureStepSuite.scala
@@ -160,23 +160,4 @@ class MountVolumesFeatureStepSuite extends SparkFunSuite {
     assert(configuredPod.container.getVolumeMounts.get(0).getMountPath === "/tmp")
     assert(configuredPod.container.getVolumeMounts.get(0).getName === "testVolume")
   }
-
-  test("Mounts Secrets") {
-    val volumeConf = KubernetesVolumeSpec(
-      "testVolume",
-      "/tmp",
-      false,
-      KubernetesConfigmapVolumeConf("secret")
-    )
-    val kubernetesConf = emptyKubernetesConf.copy(roleVolumes = volumeConf :: Nil)
-    val step = new MountVolumesFeatureStep(kubernetesConf)
-    val configuredPod = step.configurePod(SparkPod.initialPod())
-
-    assert(configuredPod.pod.getSpec.getVolumes.size() === 1)
-    val secret = configuredPod.pod.getSpec.getVolumes.get(0).getSecret
-    assert(secret.getSecretName === "secret")
-    assert(configuredPod.container.getVolumeMounts.size() === 1)
-    assert(configuredPod.container.getVolumeMounts.get(0).getMountPath === "/tmp")
-    assert(configuredPod.container.getVolumeMounts.get(0).getName === "testVolume")
-  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR introduces support for specifying configmap as spark-configuration.
Using PR #22146, the above functionality can be achieved by passing template file. However, for spark properties (like log4j.properties, fairscheduler.xml and metrics.properties), we are proposing this approach as this is native to other configuration options specifications in spark.

The configmaps has to be pre-created before using this as spark configuration.

(Please fill in changes proposed in this fix)
Add the following parameters while doing spark-submit

spark.kubernetes.driver.volumes.configMap.<volume-name>.mount.path=<mount location inside pod>
spark.kubernetes.driver.volumes.configMap.<volume-name>.options.name=<configmap name>

Using these properties, mount the configmap to spark-driver and spark-executor pods.
Changes are required in the `KubernetesVolumeSpec` and `MountVolumesFeatureStep` .

## How was this patch tested?
Manual testing on a k8s cluster. Unit tests added to `KubernetesVolumeUtilsSuite` and `MountVolumesFeatureStepSuite`