### PR TITLE
[SPARK-25516][k8s]Utilities needed for spark-history and spark-shuffle-service

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -29,7 +29,7 @@ ARG img_path=kubernetes/dockerfiles
 
 RUN set -ex && \
     apk upgrade --no-cache && \
-    apk add --no-cache bash tini libc6-compat linux-pam && \
+    apk add --no-cache bash tini libc6-compat linux-pam procps coreutils && \
     mkdir -p /opt/spark && \
     mkdir -p /opt/spark/work-dir && \
     touch /opt/spark/RELEASE && \


### PR DESCRIPTION
## Summary
When attempting to run ./sbin/start-shuffle-service.sh the image errors with the following output:
`ps: unrecognized option: p`
Adding the `procps` package fixes this issue.
After correcting the issue with `ps`, the code will then error with:
`nohup: can't execute '--': No such file or directory`
This is remedied with the inclusion of `coreutils` to the apk add statement.

The ./sbin/start-history-server.sh also requires the added packages to successfully start.

## What changes were proposed in this pull request?

Adding procps and coreutils to enable this image to execute the spark-history and spark-shuffle-service shell scripts.

## How was this patch tested?

Tested via docker manually 
