### PR TITLE
[SPARK-25517][SQL] Detect/Infer date type in CSV file

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVInferSchema.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVInferSchema.scala
@@ -149,6 +149,8 @@ private[csv] object CSVInferSchema {
     // This case infers a custom `dataFormat` is set.
     if ((allCatch opt options.timestampFormat.parse(field)).isDefined) {
       TimestampType
+    } else if ((allCatch opt options.dateFormat.parse(field)).isDefined) {
+      DateType
     } else if ((allCatch opt DateTimeUtils.stringToTime(field)).isDefined) {
       // We keep this for backwards compatibility.
       TimestampType


### PR DESCRIPTION
This fix is with reference to the below JIRA Issue which I've created just hours before:

[SPARK-25517](https://issues.apache.org/jira/browse/SPARK-25517)

This is about spark.read.format("csv").option("inferSchema", "true").option("dateFormat", "MM/dd/yyyy").load(/path/to/csvfile). Assume /path/to/csvfile has a column which contains just date information such as employee joining date, for example:- 02/22/2018 which is 22nd of feb 2018, is a **date** but the spark always incorrectly reads this joining_date column as **string**, whereas the same analogy works perfectly fine with timestampFormat or the timestamp column values in csv.

## What changes were proposed in this pull request?

to support for detecting date type from the csv files,

## How was this patch tested?

manual test

Please review http://spark.apache.org/contributing.html before opening a pull request.
