### PR TITLE
[SPARK-25522][SQL] Improve type promotion for input arguments of elementAt function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -977,12 +977,13 @@ object TypeCoercion {
         // Implicit cast between Map types.
         // Follows the same semantics of implicit casting between two array types.
         // Refer to documentation above.
-        case (MapType(fromKeyType, fromValueType, fn), MapType(toKeyType, toValueType, true)) =>
-          val newFromType = implicitCast(fromKeyType, toKeyType).orNull
+        case (MapType(fromKeyType, fromValueType, fn), MapType(toKeyType, toValueType, true))
+          if !Cast.forceNullable(fromKeyType, toKeyType) =>
+          val newKeyType = implicitCast(fromKeyType, toKeyType).orNull
           val newValueType = implicitCast(fromValueType, toValueType).orNull
-          if (newFromType != null && newValueType != null
-            && (!newFromType.sameType(fromKeyType) || !newValueType.sameType(fromValueType))) {
-            MapType(newFromType, newValueType, true)
+          if (newKeyType != null && newValueType != null
+            && (!newKeyType.sameType(fromKeyType) || !newValueType.sameType(fromValueType))) {
+            MapType(newKeyType, newValueType, true)
           } else {
             null
           }
@@ -991,12 +992,13 @@ object TypeCoercion {
          null
 
         case (MapType(fromKeyType, fromValueType, false), MapType(toKeyType, toValueType, false))
-          if !Cast.forceNullable(fromValueType, toValueType) =>
-          val newFromType = implicitCast(fromKeyType, toKeyType).orNull
+          if (!(Cast.forceNullable(fromKeyType, toKeyType) ||
+            Cast.forceNullable(fromValueType, toValueType))) =>
+          val newKeyType = implicitCast(fromKeyType, toKeyType).orNull
           val newValueType = implicitCast(fromValueType, toValueType).orNull
-          if (newFromType != null && newValueType != null
-            && (!newFromType.sameType(fromKeyType) || !newValueType.sameType(fromValueType))) {
-            MapType(newFromType, newValueType, false)
+          if (newKeyType != null && newValueType != null
+            && (!newKeyType.sameType(fromKeyType) || !newValueType.sameType(fromValueType))) {
+            MapType(newKeyType, newValueType, false)
           } else {
             null
           }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -977,7 +977,7 @@ object TypeCoercion {
         // Implicit cast between Map types.
         // Follows the same semantics of implicit casting between two array types.
         // Refer to documentation above. Make sure that both key and values
-        // can not by null after the implicit cast operation by calling forceNullable
+        // can not be null after the implicit cast operation by calling forceNullable
         // method.
         case (MapType(fromKeyType, fromValueType, fn), MapType(toKeyType, toValueType, tn))
             if !Cast.forceNullable(fromKeyType, toKeyType) && Cast.resolvableNullability(fn, tn) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -971,18 +971,17 @@ object TypeCoercion {
         case (ArrayType(fromType, true), ArrayType(toType: DataType, false)) => null
 
         case (ArrayType(fromType, false), ArrayType(toType: DataType, false))
-          if !Cast.forceNullable(fromType, toType) =>
+            if !Cast.forceNullable(fromType, toType) =>
           implicitCast(fromType, toType).map(ArrayType(_, false)).orNull
 
         // Implicit cast between Map types.
         // Follows the same semantics of implicit casting between two array types.
         // Refer to documentation above.
         case (MapType(fromKeyType, fromValueType, fn), MapType(toKeyType, toValueType, true))
-          if !Cast.forceNullable(fromKeyType, toKeyType) =>
+            if !Cast.forceNullable(fromKeyType, toKeyType) =>
           val newKeyType = implicitCast(fromKeyType, toKeyType).orNull
           val newValueType = implicitCast(fromValueType, toValueType).orNull
-          if (newKeyType != null && newValueType != null
-            && (!newKeyType.sameType(fromKeyType) || !newValueType.sameType(fromValueType))) {
+          if (newKeyType != null && newValueType != null) {
             MapType(newKeyType, newValueType, true)
           } else {
             null
@@ -992,12 +991,11 @@ object TypeCoercion {
          null
 
         case (MapType(fromKeyType, fromValueType, false), MapType(toKeyType, toValueType, false))
-          if (!(Cast.forceNullable(fromKeyType, toKeyType) ||
-            Cast.forceNullable(fromValueType, toValueType))) =>
+            if (!(Cast.forceNullable(fromKeyType, toKeyType) ||
+              Cast.forceNullable(fromValueType, toValueType))) =>
           val newKeyType = implicitCast(fromKeyType, toKeyType).orNull
           val newValueType = implicitCast(fromValueType, toValueType).orNull
-          if (newKeyType != null && newValueType != null
-            && (!newKeyType.sameType(fromKeyType) || !newValueType.sameType(fromValueType))) {
+          if (newKeyType != null && newValueType != null) {
             MapType(newKeyType, newValueType, false)
           } else {
             null

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -976,29 +976,21 @@ object TypeCoercion {
 
         // Implicit cast between Map types.
         // Follows the same semantics of implicit casting between two array types.
-        // Refer to documentation above.
-        case (MapType(fromKeyType, fromValueType, fn), MapType(toKeyType, toValueType, true))
-            if !Cast.forceNullable(fromKeyType, toKeyType) =>
-          val newKeyType = implicitCast(fromKeyType, toKeyType).orNull
-          val newValueType = implicitCast(fromValueType, toValueType).orNull
-          if (newKeyType != null && newValueType != null) {
-            MapType(newKeyType, newValueType, true)
-          } else {
+        // Refer to documentation above. Make sure that both key and values
+        // can not by null after the implicit cast operation by calling forceNullable
+        // method.
+        case (MapType(fromKeyType, fromValueType, fn), MapType(toKeyType, toValueType, tn))
+            if !Cast.forceNullable(fromKeyType, toKeyType) && Cast.resolvableNullability(fn, tn) =>
+          if (Cast.forceNullable(fromValueType, toValueType) && !tn) {
             null
-          }
-
-        case (MapType(fromKeyType, fromValueType, true), MapType(toKeyType, toValueType, false)) =>
-         null
-
-        case (MapType(fromKeyType, fromValueType, false), MapType(toKeyType, toValueType, false))
-            if (!(Cast.forceNullable(fromKeyType, toKeyType) ||
-              Cast.forceNullable(fromValueType, toValueType))) =>
-          val newKeyType = implicitCast(fromKeyType, toKeyType).orNull
-          val newValueType = implicitCast(fromValueType, toValueType).orNull
-          if (newKeyType != null && newValueType != null) {
-            MapType(newKeyType, newValueType, false)
           } else {
-            null
+            val newKeyType = implicitCast(fromKeyType, toKeyType).orNull
+            val newValueType = implicitCast(fromValueType, toValueType).orNull
+            if (newKeyType != null && newValueType != null) {
+              MapType(newKeyType, newValueType, tn)
+            } else {
+              null
+            }
           }
 
         case _ => null

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -971,8 +971,35 @@ object TypeCoercion {
         case (ArrayType(fromType, true), ArrayType(toType: DataType, false)) => null
 
         case (ArrayType(fromType, false), ArrayType(toType: DataType, false))
-            if !Cast.forceNullable(fromType, toType) =>
+          if !Cast.forceNullable(fromType, toType) =>
           implicitCast(fromType, toType).map(ArrayType(_, false)).orNull
+
+        // Implicit cast between Map types.
+        // Follows the same semantics of implicit casting between two array types.
+        // Refer to documentation above.
+        case (MapType(fromKeyType, fromValueType, fn), MapType(toKeyType, toValueType, true)) =>
+          val newFromType = implicitCast(fromKeyType, toKeyType).orNull
+          val newValueType = implicitCast(fromValueType, toValueType).orNull
+          if (newFromType != null && newValueType != null
+            && (!newFromType.sameType(fromKeyType) || !newValueType.sameType(fromValueType))) {
+            MapType(newFromType, newValueType, true)
+          } else {
+            null
+          }
+
+        case (MapType(fromKeyType, fromValueType, true), MapType(toKeyType, toValueType, false)) =>
+         null
+
+        case (MapType(fromKeyType, fromValueType, false), MapType(toKeyType, toValueType, false))
+          if !Cast.forceNullable(fromValueType, toValueType) =>
+          val newFromType = implicitCast(fromKeyType, toKeyType).orNull
+          val newValueType = implicitCast(fromValueType, toValueType).orNull
+          if (newFromType != null && newValueType != null
+            && (!newFromType.sameType(fromKeyType) || !newValueType.sameType(fromValueType))) {
+            MapType(newFromType, newValueType, false)
+          } else {
+            null
+          }
 
         case _ => null
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -183,7 +183,7 @@ object Cast {
     case _ => false
   }
 
-  private def resolvableNullability(from: Boolean, to: Boolean) = !from || to
+  def resolvableNullability(from: Boolean, to: Boolean): Boolean = !from || to
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2141,8 +2141,8 @@ case class ElementAt(left: Expression, right: Expression) extends GetMapValueUti
 
   override def inputTypes: Seq[AbstractDataType] = {
     (left.dataType, right.dataType) match {
-      case (ArrayType(e1, hasNull), e2: IntegralType) if (e2 != LongType) =>
-        Seq(ArrayType(e1, hasNull), IntegerType)
+      case (arr: ArrayType, e2: IntegralType) if (e2 != LongType) =>
+        Seq(arr, IntegerType)
       case (MapType(keyType, valueType, hasNull), e2) =>
         TypeCoercion.findTightestCommonType(keyType, e2) match {
           case Some(dt) => Seq(MapType(dt, valueType, hasNull), dt)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2140,21 +2140,34 @@ case class ElementAt(left: Expression, right: Expression) extends GetMapValueUti
   }
 
   override def inputTypes: Seq[AbstractDataType] = {
-    Seq(TypeCollection(ArrayType, MapType),
-      left.dataType match {
-        case _: ArrayType => IntegerType
-        case _: MapType => mapKeyType
-        case _ => AnyDataType // no match for a wrong 'left' expression type
-      }
-    )
+    (left.dataType, right.dataType) match {
+      case (ArrayType(e1, hasNull), e2: IntegralType) if (e2 != LongType) =>
+        Seq(ArrayType(e1, hasNull), IntegerType)
+      case (MapType(keyType, valueType, hasNull), e2) =>
+        TypeCoercion.findTightestCommonType(keyType, e2) match {
+          case Some(dt) => Seq(MapType(dt, valueType, hasNull), dt)
+          case _ => Seq.empty
+        }
+      case (l, r) => Seq.empty
+
+    }
   }
 
   override def checkInputDataTypes(): TypeCheckResult = {
-    super.checkInputDataTypes() match {
-      case f: TypeCheckResult.TypeCheckFailure => f
-      case TypeCheckResult.TypeCheckSuccess if left.dataType.isInstanceOf[MapType] =>
-        TypeUtils.checkForOrderingExpr(mapKeyType, s"function $prettyName")
-      case TypeCheckResult.TypeCheckSuccess => TypeCheckResult.TypeCheckSuccess
+    (left.dataType, right.dataType) match {
+      case (ArrayType(e1, _), e2) if e2 != IntegerType =>
+        TypeCheckResult.TypeCheckFailure(s"Input to function $prettyName should have " +
+          s"been ${ArrayType.simpleString} followed by a ${IntegerType.simpleString}, but it's " +
+          s"[${left.dataType.catalogString}, ${right.dataType.catalogString}].")
+      case (MapType(e1, _, _), e2) if (!e2.sameType(e1)) =>
+        TypeCheckResult.TypeCheckFailure(s"Input to function $prettyName should have " +
+          s"been ${MapType.simpleString} followed by a value of same key type, but it's " +
+          s"[${left.dataType.catalogString}, ${right.dataType.catalogString}].")
+      case (e1, _) if (!e1.isInstanceOf[MapType] && !e1.isInstanceOf[ArrayType]) =>
+        TypeCheckResult.TypeCheckFailure(s"The first argument to function $prettyName should " +
+          s"have been ${ArrayType.simpleString} or ${MapType.simpleString} type, but its " +
+          s"${left.dataType.catalogString} type.")
+      case _ => TypeCheckResult.TypeCheckSuccess
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2155,7 +2155,7 @@ case class ElementAt(left: Expression, right: Expression) extends GetMapValueUti
 
   override def checkInputDataTypes(): TypeCheckResult = {
     (left.dataType, right.dataType) match {
-      case (ArrayType(e1, _), e2) if e2 != IntegerType =>
+      case (_: ArrayType, e2) if e2 != IntegerType =>
         TypeCheckResult.TypeCheckFailure(s"Input to function $prettyName should have " +
           s"been ${ArrayType.simpleString} followed by a ${IntegerType.simpleString}, but it's " +
           s"[${left.dataType.catalogString}, ${right.dataType.catalogString}].")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -257,9 +257,15 @@ class TypeCoercionSuite extends AnalysisTest {
     shouldNotCast(checkedType, IntegralType)
   }
 
-  test("implicit type cast - MapType(StringType, StringType)") {
+  test("implicit type cast between two Map types") {
     val checkedType = MapType(StringType, StringType)
-    checkTypeCasting(checkedType, castableTypes = Seq(checkedType))
+    val nonCastableTypes =
+      complexTypes ++ Seq(BooleanType, NullType, CalendarIntervalType)
+    checkTypeCasting(checkedType,
+      castableTypes = allTypes.filterNot(nonCastableTypes.contains).map(dt => MapType(dt, dt)))
+    nonCastableTypes.map(dt => MapType(dt, dt)).foreach(shouldNotCast(checkedType, _))
+    shouldNotCast(MapType(DoubleType, DoubleType, valueContainsNull = false),
+      MapType(LongType, LongType, valueContainsNull = false))
     shouldNotCast(checkedType, DecimalType)
     shouldNotCast(checkedType, NumericType)
     shouldNotCast(checkedType, IntegralType)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -289,16 +289,11 @@ class TypeCoercionSuite extends AnalysisTest {
       CreateMap(Seq(Literal.default(sourceType.keyType),
         Literal.create(null, sourceType.valueType)))
     targetNotNullableTypes.foreach { targetType =>
-      val x = 10
       val castDefault =
         TypeCoercion.ImplicitTypeCasts.implicitCast(sourceMapExprWithValueNull, targetType)
       assert(castDefault.isEmpty,
-        s"Should not be able to cast $sourceType to $sourceType, but got $castDefault")
+        s"Should not be able to cast $sourceType to $targetType, but got $castDefault")
     }
-
-    shouldNotCast(MapType(DoubleType, DoubleType, valueContainsNull = false),
-      CalendarIntervalType)
-
   }
 
   test("implicit type cast - StructType().add(\"a1\", StringType)") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -26,6 +26,7 @@ import scala.util.Random
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
@@ -1115,11 +1116,80 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       Seq(Row("3"), Row(""), Row(null))
     )
 
-    val e = intercept[AnalysisException] {
+    val e1 = intercept[AnalysisException] {
       Seq(("a string element", 1)).toDF().selectExpr("element_at(_1, _2)")
     }
-    assert(e.message.contains(
-      "argument 1 requires (array or map) type, however, '`_1`' is of string type"))
+    val errorMsg1 =
+      s"""
+         |The first argument to function element_at should have been array or map type, but
+         |its string type.
+       """.stripMargin.replace("\n", " ").trim()
+    assert(e1.message.contains(errorMsg1))
+
+    checkAnswer(
+      OneRowRelation().selectExpr("element_at(array(2, 1), 2S)"),
+      Seq(Row(1))
+    )
+
+    checkAnswer(
+      OneRowRelation().selectExpr("element_at(array('a', 'b'), 1Y)"),
+      Seq(Row("a"))
+    )
+
+    checkAnswer(
+      OneRowRelation().selectExpr("element_at(array(1, 2, 3), 3)"),
+      Seq(Row(3))
+    )
+
+    val e2 = intercept[AnalysisException] {
+      OneRowRelation().selectExpr("element_at(array('a', 'b'), 1L)")
+    }
+    val errorMsg2 =
+      s"""
+         |Input to function element_at should have been array followed by a int, but it's
+         |[array<string>, bigint].
+       """.stripMargin.replace("\n", " ").trim()
+    assert(e2.message.contains(errorMsg2))
+
+    checkAnswer(
+      OneRowRelation().selectExpr("element_at(map(1, 'a', 2, 'b'), 2Y)"),
+      Seq(Row("b"))
+    )
+
+    checkAnswer(
+      OneRowRelation().selectExpr("element_at(map(1, 'a', 2, 'b'), 1S)"),
+      Seq(Row("a"))
+    )
+
+    checkAnswer(
+      OneRowRelation().selectExpr("element_at(map(1, 'a', 2, 'b'), 2)"),
+      Seq(Row("b"))
+    )
+
+    checkAnswer(
+      OneRowRelation().selectExpr("element_at(map(1, 'a', 2, 'b'), 2L)"),
+      Seq(Row("b"))
+    )
+
+    checkAnswer(
+      OneRowRelation().selectExpr("element_at(map(1, 'a', 2, 'b'), 1.0D)"),
+      Seq(Row("a"))
+    )
+
+    checkAnswer(
+      OneRowRelation().selectExpr("element_at(map(1, 'a', 2, 'b'), 1.23D)"),
+      Seq(Row(null))
+    )
+
+    val e3 = intercept[AnalysisException] {
+      OneRowRelation().selectExpr("element_at(map(1, 'a', 2, 'b'), '1')")
+    }
+    val errorMsg3 =
+      s"""
+         |Input to function element_at should have been map followed by a value of same
+         |key type, but it's [map<int,string>, string].
+       """.stripMargin.replace("\n", " ").trim()
+    assert(e3.message.contains(errorMsg3))
   }
 
   test("array_union functions") {


### PR DESCRIPTION
## What changes were proposed in this pull request?
In ElementAt, when first argument is MapType, we should coerce the key type and the second argument based on findTightestCommonType. This is not happening currently. We may produce wrong output as we will incorrectly downcast the right hand side double expression to int.

```SQL
spark-sql> select element_at(map(1,"one", 2, "two"), 2.2);

two
```

Also, when the first argument is ArrayType, the second argument should be an integer type or a smaller integral type that can be safely casted to an integer type. Currently we may do an unsafe cast. In the following case, we should fail with an error as 2.2 is not a integer index. But instead we down cast it to int currently and return a result instead.

```SQL
spark-sql> select element_at(array(1,2), 1.24D);

1
```
This PR also supports implicit cast between two MapTypes. I have followed similar logic that exists today to do implicit casts between two array types.
## How was this patch tested?
Added new tests in DataFrameFunctionSuite, TypeCoercionSuite.