### PR TITLE
[SPARK-25541][SQL] CaseInsensitiveMap should be serializable after '-' or 'filterKeys'

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CaseInsensitiveMap.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CaseInsensitiveMap.scala
@@ -42,7 +42,11 @@ class CaseInsensitiveMap[T] private (val originalMap: Map[String, T]) extends Ma
   override def iterator: Iterator[(String, T)] = keyLowerCasedMap.iterator
 
   override def -(key: String): Map[String, T] = {
-    new CaseInsensitiveMap(originalMap.filterKeys(!_.equalsIgnoreCase(key)))
+    new CaseInsensitiveMap(originalMap.filter(!_._1.equalsIgnoreCase(key)))
+  }
+
+  override def filterKeys(p: (String) => Boolean): Map[String, T] = {
+    new CaseInsensitiveMap(originalMap.filter(kv => p(kv._1)))
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/CaseInsensitiveMapSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/CaseInsensitiveMapSuite.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.util
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.serializer.JavaSerializer
+
+class CaseInsensitiveMapSuite extends SparkFunSuite {
+  test("Keys are case insensitive") {
+    val m = CaseInsensitiveMap(Map("a" -> "b", "foO" -> "bar"))
+    assert(m("FOO") == "bar")
+    assert(m("fOo") == "bar")
+    assert(m("A") == "b")
+  }
+
+  test("CaseInsensitiveMap should be serializable after '-' operator") {
+    val m = CaseInsensitiveMap(Map("a" -> "b", "foo" -> "bar")) - "a"
+    assert(m == Map("foo" -> "bar"))
+    new JavaSerializer(new SparkConf()).newInstance().serialize(m)
+  }
+
+  test("CaseInsensitiveMap should be serializable after '+' operator") {
+    val m = CaseInsensitiveMap(Map("a" -> "b", "foo" -> "bar")) + ("x" -> "y")
+    assert(m == Map("a" -> "b", "foo" -> "bar", "x" -> "y"))
+    new JavaSerializer(new SparkConf()).newInstance().serialize(m)
+  }
+
+  test("CaseInsensitiveMap should be serializable after 'filterKeys' method") {
+    val m = CaseInsensitiveMap(Map("a" -> "b", "foo" -> "bar")).filterKeys(_ == "foo")
+    assert(m == Map("foo" -> "bar"))
+    new JavaSerializer(new SparkConf()).newInstance().serialize(m)
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/CaseInsensitiveMapSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/CaseInsensitiveMapSuite.scala
@@ -21,28 +21,33 @@ import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.serializer.JavaSerializer
 
 class CaseInsensitiveMapSuite extends SparkFunSuite {
+  private def shouldBeSerializable(m: Map[String, String]): Unit = {
+    new JavaSerializer(new SparkConf()).newInstance().serialize(m)
+  }
+
   test("Keys are case insensitive") {
     val m = CaseInsensitiveMap(Map("a" -> "b", "foO" -> "bar"))
     assert(m("FOO") == "bar")
     assert(m("fOo") == "bar")
     assert(m("A") == "b")
+    shouldBeSerializable(m)
   }
 
   test("CaseInsensitiveMap should be serializable after '-' operator") {
     val m = CaseInsensitiveMap(Map("a" -> "b", "foo" -> "bar")) - "a"
     assert(m == Map("foo" -> "bar"))
-    new JavaSerializer(new SparkConf()).newInstance().serialize(m)
+    shouldBeSerializable(m)
   }
 
   test("CaseInsensitiveMap should be serializable after '+' operator") {
     val m = CaseInsensitiveMap(Map("a" -> "b", "foo" -> "bar")) + ("x" -> "y")
     assert(m == Map("a" -> "b", "foo" -> "bar", "x" -> "y"))
-    new JavaSerializer(new SparkConf()).newInstance().serialize(m)
+    shouldBeSerializable(m)
   }
 
   test("CaseInsensitiveMap should be serializable after 'filterKeys' method") {
     val m = CaseInsensitiveMap(Map("a" -> "b", "foo" -> "bar")).filterKeys(_ == "foo")
     assert(m == Map("foo" -> "bar"))
-    new JavaSerializer(new SparkConf()).newInstance().serialize(m)
+    shouldBeSerializable(m)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`CaseInsensitiveMap` is declared as Serializable. However, it is no serializable after `-` operator or `filterKeys` method.

This PR fix the issue by  overriding the operator `-` and method `filterKeys`. So the we can avoid potential `NotSerializableException` on using `CaseInsensitiveMap`.

## How was this patch tested?

New test suite.
