### PR TITLE
[WIP][SPARK-23622] Add javax.jdo to barrierPrefixes to fix HiveClientSuites Flaky Test

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -129,7 +129,7 @@ private[spark] object HiveUtils extends Logging {
       "declared in a prefix that typically would be shared (i.e. <code>org.apache.spark.*</code>).")
     .stringConf
     .toSequence
-    .createWithDefault(Nil)
+    .createWithDefault(Seq("javax.jdo"))
 
   val HIVE_THRIFT_SERVER_ASYNC = buildConf("spark.sql.hive.thriftServer.async")
     .doc("When set to true, Hive Thrift server executes SQL queries in an asynchronous way.")

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
@@ -189,6 +189,7 @@ private[hive] class IsolatedClientLoader(
     (name.startsWith("com.google") && !name.startsWith("com.google.cloud")) ||
     name.startsWith("java.lang.") ||
     name.startsWith("java.net") ||
+    name.startsWith("javax.jdo") ||
     sharedPrefixes.exists(name.startsWith)
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
@@ -189,7 +189,6 @@ private[hive] class IsolatedClientLoader(
     (name.startsWith("com.google") && !name.startsWith("com.google.cloud")) ||
     name.startsWith("java.lang.") ||
     name.startsWith("java.net") ||
-    name.startsWith("javax.jdo") ||
     sharedPrefixes.exists(name.startsWith)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR try to fix `HiveClientSuites` Flaky Test by add `javax.jdo` to barrierPrefixes.
I think it safe as Hive and Spark use the same `jdo-api-3.0.1.jar`:
![image](https://user-images.githubusercontent.com/5399861/46062317-0358a480-c19c-11e8-88a9-0a0e955d8d0a.png)

## How was this patch tested?

 manual tests
