### PR TITLE
[SPARK-25548][SQL]In the PruneFileSourcePartitions optimizer, replace the nonPartitionOps field with true in the And(partitionOps, nonPartitionOps) to make the partition can be pruned

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -55,12 +55,12 @@ private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
             a.withName(logicalRelation.output.find(_.semanticEquals(a)).get.name)
           // Replace the nonPartitionOps field with true in the And(partitionOps, nonPartitionOps)
           // to make the partition can be pruned
-          case and @And(left, right) =>
+          case and @ And(left, right) =>
             val leftPartition = left.references.filter(partitionSet.contains(_))
             val rightPartition = right.references.filter(partitionSet.contains(_))
-            if (leftPartition.size == left.references.size && rightPartition.size == 0) {
+            if (leftPartition.size == left.references.size && rightPartition.isEmpty) {
               and.withNewChildren(Seq(left, Literal(true, BooleanType)))
-            } else if (leftPartition.size == 0 && rightPartition.size == right.references.size) {
+            } else if (leftPartition.isEmpty && rightPartition.size == right.references.size) {
               and.withNewChildren(Seq(Literal(true, BooleanType), right))
             } else and
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?
In the PruneFileSourcePartitions optimizer, the partition files will not be pruned if we use partition filter and non partition filter together, for example:

    sql("CREATE TABLE IF NOT EXISTS src_par (key INT, value STRING) partitioned by(p_d int) stored as parquet ")
    sql("insert overwrite table src_par partition(p_d=2) select 2 as key, '4' as value")
    sql("insert overwrite table src_par partition(p_d=3) select 3 as key, '4' as value")
    sql("insert overwrite table src_par partition(p_d=4) select 4 as key, '4' as value")

Before this PR, the sql below will scan all the partition files, in which, the partition **p_d=4** should be pruned.

    sql("select * from src_par where (p_d=2 and key=2) or (p_d=3 and key=3)").show

After this PR, the partition **p_d=4** will be pruned

## How was this patch tested?
exist test
