### PR TITLE
[SPARK-25542][Core][Test] Move flaky test in OpenHashMapSuite to OpenHashSetSuite and make it against OpenHashSet

### DIFF
--- a/core/src/test/scala/org/apache/spark/util/collection/OpenHashMapSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/OpenHashMapSuite.scala
@@ -185,16 +185,6 @@ class OpenHashMapSuite extends SparkFunSuite with Matchers {
     assert(map.contains(null))
   }
 
-  test("support for more than 12M items") {
-    val cnt = 12000000 // 12M
-    val map = new OpenHashMap[Int, Int](cnt)
-    for (i <- 0 until cnt) {
-      map(i) = 1
-    }
-    val numInvalidValues = map.iterator.count(_._2 == 0)
-    assertResult(0)(numInvalidValues)
-  }
-
   test("distinguish between the 0/0.0/0L and null") {
     val specializedMap1 = new OpenHashMap[String, Long]
     specializedMap1("a") = null.asInstanceOf[Long]

--- a/core/src/test/scala/org/apache/spark/util/collection/OpenHashSetSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/OpenHashSetSuite.scala
@@ -263,8 +263,8 @@ class OpenHashSetSuite extends SparkFunSuite with Matchers {
       set.add(i)
       assert(set.contains(i))
 
-      val pos1 = set.addWithoutResize(i) & OpenHashSet.POSITION_MASK
-      val pos2 = set.getPos(i)
+      val pos1 = set.getPos(i)
+      val pos2 = set.addWithoutResize(i) & OpenHashSet.POSITION_MASK
       assert(pos1 == pos2)
     }
   }

--- a/core/src/test/scala/org/apache/spark/util/collection/OpenHashSetSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/OpenHashSetSuite.scala
@@ -255,4 +255,16 @@ class OpenHashSetSuite extends SparkFunSuite with Matchers {
     val set = new OpenHashSet[Long](0)
     assert(set.size === 0)
   }
+
+  test("support for more than 12M items") {
+    val cnt = 12000000 // 12M
+    val set = new OpenHashSet[Int](cnt)
+    for (i <- 0 until cnt) {
+      set.add(i)
+
+      val pos1 = set.addWithoutResize(i) & OpenHashSet.POSITION_MASK
+      val pos2 = set.getPos(i)
+      assert(pos1 == pos2)
+    }
+  }
 }

--- a/core/src/test/scala/org/apache/spark/util/collection/OpenHashSetSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/OpenHashSetSuite.scala
@@ -261,6 +261,7 @@ class OpenHashSetSuite extends SparkFunSuite with Matchers {
     val set = new OpenHashSet[Int](cnt)
     for (i <- 0 until cnt) {
       set.add(i)
+      assert(set.contains(i))
 
       val pos1 = set.addWithoutResize(i) & OpenHashSet.POSITION_MASK
       val pos2 = set.getPos(i)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The specified test in OpenHashMapSuite to test large items is somehow flaky to throw OOM.
By considering the original work #6763 that added this test, the test can be against OpenHashSetSuite. And by doing this should be to save memory because OpenHashMap allocates two more arrays when growing the map/set.

## How was this patch tested?

Existing tests.