### PR TITLE
[SPARK-25392][Spark Job History]Inconsistent behaviour for pool details in spark web UI and history server page 

### DIFF
--- a/core/src/main/java/org/apache/spark/SparkFirehoseListener.java
+++ b/core/src/main/java/org/apache/spark/SparkFirehoseListener.java
@@ -163,6 +163,11 @@ public class SparkFirehoseListener implements SparkListenerInterface {
   }
 
   @Override
+  public void onPoolInformationEvent(SparkListenerPoolInformation poolInfo){
+    onEvent(poolInfo);
+  }
+
+  @Override
   public void onOtherEvent(SparkListenerEvent event) {
     onEvent(event);
   }

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -561,6 +561,7 @@ class SparkContext(config: SparkConf) extends Logging {
     setupAndStartListenerBus()
     postEnvironmentUpdate()
     postApplicationStart()
+    postPoolInformation()
 
     // Post init
     _taskScheduler.postStartHook()
@@ -2447,6 +2448,13 @@ class SparkContext(config: SparkConf) extends Logging {
     val accumUpdates = new Array[(Long, Int, Int, Seq[AccumulableInfo])](0)
     listenerBus.post(SparkListenerExecutorMetricsUpdate("driver", accumUpdates,
       Some(driverUpdates)))
+  }
+
+  private def postPoolInformation(): Unit = {
+    // SPARK-25392 pool Information should be stored in the event
+    val poolInformation = getAllPools.map { it => (it.name, it) }
+    val poolDetails = SparkListenerPoolInformation(poolInformation)
+    listenerBus.post(poolDetails)
   }
 
   // In order to prevent multiple SparkContexts from being active at the same time, mark this

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -279,6 +279,10 @@ private[spark] class EventLoggingListener(
     }
   }
 
+  override def onPoolInformationEvent(event: SparkListenerPoolInformation): Unit = {
+    logEvent(event, true)
+  }
+
   override def onOtherEvent(event: SparkListenerEvent): Unit = {
     if (event.logEvent) {
       logEvent(event, flushLogger = true)

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -204,6 +204,13 @@ case class SparkListenerApplicationEnd(time: Long) extends SparkListenerEvent
 case class SparkListenerLogStart(sparkVersion: String) extends SparkListenerEvent
 
 /**
+ *  Class which holds the Pool Information
+ */
+@DeveloperApi
+case class SparkListenerPoolInformation(
+    poolDetails: Seq[(String, Schedulable)]) extends SparkListenerEvent
+
+/**
  * Interface for listening to events from the Spark scheduler. Most applications should probably
  * extend SparkListener or SparkFirehoseListener directly, rather than implementing this class.
  *
@@ -341,6 +348,11 @@ private[spark] trait SparkListenerInterface {
   def onSpeculativeTaskSubmitted(speculativeTask: SparkListenerSpeculativeTaskSubmitted): Unit
 
   /**
+   * Called when the schedular is ready
+   */
+  def onPoolInformationEvent(poolDetails: SparkListenerPoolInformation): Unit
+
+  /**
    * Called when other events like SQL-specific events are posted.
    */
   def onOtherEvent(event: SparkListenerEvent): Unit
@@ -415,6 +427,8 @@ abstract class SparkListener extends SparkListenerInterface {
 
   override def onSpeculativeTaskSubmitted(
       speculativeTask: SparkListenerSpeculativeTaskSubmitted): Unit = { }
+
+  override def onPoolInformationEvent(poolDetails: SparkListenerPoolInformation): Unit = {}
 
   override def onOtherEvent(event: SparkListenerEvent): Unit = { }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListenerBus.scala
@@ -79,6 +79,8 @@ private[spark] trait SparkListenerBus
         listener.onBlockUpdated(blockUpdated)
       case speculativeTaskSubmitted: SparkListenerSpeculativeTaskSubmitted =>
         listener.onSpeculativeTaskSubmitted(speculativeTaskSubmitted)
+      case poolDetails: SparkListenerPoolInformation =>
+        listener.onPoolInformationEvent(poolDetails)
       case _ => listener.onOtherEvent(event)
     }
   }

--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -250,6 +250,10 @@ private[spark] class AppStatusListener(
     }
   }
 
+  override def onPoolInformationEvent(event: SparkListenerPoolInformation): Unit = {
+    kvstore.write(new PoolInformationWrapper(event.poolDetails))
+  }
+
   private def addBlackListedStageTo(exec: LiveExecutor, stageId: Int, now: Long): Unit = {
     exec.blacklistedInStages += stageId
     liveUpdate(exec, now)

--- a/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
@@ -22,6 +22,7 @@ import java.util.{List => JList}
 import scala.collection.JavaConverters._
 
 import org.apache.spark.{JobExecutionStatus, SparkConf}
+import org.apache.spark.scheduler.Schedulable
 import org.apache.spark.status.api.v1
 import org.apache.spark.ui.scope._
 import org.apache.spark.util.{Distribution, Utils}
@@ -488,6 +489,11 @@ private[spark] class AppStatusStore(
 
   def appSummary(): AppSummary = {
     store.read(classOf[AppSummary], classOf[AppSummary].getName())
+  }
+
+  def getPoolInfo(): Map[String, Schedulable] = {
+    val cls = classOf[PoolInformationWrapper]
+    store.read(cls, cls.getName).poolDetails.toMap
   }
 
   def close(): Unit = {

--- a/core/src/main/scala/org/apache/spark/status/storeTypes.scala
+++ b/core/src/main/scala/org/apache/spark/status/storeTypes.scala
@@ -23,6 +23,7 @@ import java.util.Date
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 
+import org.apache.spark.scheduler.Schedulable
 import org.apache.spark.status.KVUtils._
 import org.apache.spark.status.api.v1._
 import org.apache.spark.ui.scope._
@@ -46,6 +47,11 @@ private[spark] class ApplicationEnvironmentInfoWrapper(val info: ApplicationEnvi
   @JsonIgnore @KVIndex
   def id: String = classOf[ApplicationEnvironmentInfoWrapper].getName()
 
+}
+
+private[spark] class PoolInformationWrapper(val poolDetails: Seq[(String, Schedulable)]) {
+  @JsonIgnore  @KVIndex
+  def id: String = classOf[PoolInformationWrapper].getName()
 }
 
 private[spark] class ExecutorSummaryWrapper(val info: ExecutorSummary) {

--- a/core/src/main/scala/org/apache/spark/ui/jobs/PoolPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/PoolPage.scala
@@ -36,9 +36,14 @@ private[ui] class PoolPage(parent: StagesTab) extends WebUIPage("pool") {
       throw new IllegalArgumentException(s"Missing poolname parameter")
     }
 
-    // For now, pool information is only accessible in live UIs
-    val pool = parent.sc.flatMap(_.getPoolForName(poolName)).getOrElse {
-      throw new IllegalArgumentException(s"Unknown pool: $poolName")
+    val pool = if (parent.sc.isDefined) {
+      parent.sc.flatMap(_.getPoolForName(poolName)).getOrElse {
+        throw new IllegalArgumentException(s"Unknown pool: $poolName")
+      }
+    } else {
+      parent.store.getPoolInfo().getOrElse(poolName,
+        throw new IllegalArgumentException(s"Unknown pool: $poolName")
+      )
     }
 
     val uiPool = parent.store.asOption(parent.store.pool(poolName)).getOrElse(


### PR DESCRIPTION
## What changes were proposed in this pull request?

1.Added the new SparkListenerEvent **SparkListenerPoolInformation** which holds the pool Information as Map of (poolName -> Pool)

2.AppStatusListener reads this events and stores in kvstore

3.EventLoggingListener overrides the onPoolInformationEvent API and logs the event in Json Format,so History server can replay these events on start up

4, PoolInformation is visible in two pages: one is AllStagesPage, and the other is PoolPage,both will fetch the pool Details from kvstore and display accordingly

In summary, added the new ListenerEvent SparkListenerPoolInformation which holds the pool information, AppStatusListener writes this event to kvstore and AllStagesPage, Poolpage gets details from kvstore and display the information accordingly 

## How was this patch tested?

Added Testcases and also verified manually in the cluster

