### PR TITLE
[SPARK-25568][Core]Continue to update the remaining accumulators when failing to update one accumulator

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1267,7 +1267,7 @@ private[spark] class DAGScheduler(
           // Log the class name to make it easy to find the bad implementation
           val accumClassName = AccumulatorContext.get(id) match {
             case Some(accum) => accum.getClass.getName
-            case None => ""
+            case None => "Unknown class"
           }
           logError(
             s"Failed to update accumulator $id ($accumClassName) for task ${task.partitionId}",

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1254,7 +1254,12 @@ private[spark] class DAGScheduler(
           case None =>
             throw new SparkException(s"attempted to access non-existent accumulator $id")
         }
-        acc.merge(updates.asInstanceOf[AccumulatorV2[Any, Any]])
+        try {
+          acc.merge(updates.asInstanceOf[AccumulatorV2[Any, Any]])
+        } catch {
+          case NonFatal(e) =>
+            logError(s"Failed to update accumulator ${acc.id} for task ${task.partitionId}", e)
+        }
         // To avoid UI cruft, ignore cases where value wasn't updated
         if (acc.name.isDefined && !updates.isZero) {
           stage.latestInfo.accumulables(id) = acc.toInfo(None, Some(acc.value))

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1264,7 +1264,14 @@ private[spark] class DAGScheduler(
         }
       } catch {
         case NonFatal(e) =>
-          logError(s"Failed to update accumulator $id for task ${task.partitionId}", e)
+          // Log the class name to make it easy to find the bad implementation
+          val accumClassName = AccumulatorContext.get(id) match {
+            case Some(accum) => accum.getClass.getName
+            case None => ""
+          }
+          logError(
+            s"Failed to update accumulator $id ($accumClassName) for task ${task.partitionId}",
+            e)
       }
     }
   }

--- a/docs/rdd-programming-guide.md
+++ b/docs/rdd-programming-guide.md
@@ -1465,6 +1465,10 @@ jsc.sc().register(myVectorAcc, "MyVectorAcc1");
 
 Note that, when programmers define their own type of AccumulatorV2, the resulting type can be different than that of the elements added.
 
+*Warning*: When a Spark task finishes, Spark will try to merge the accumulated updates in this task to an accumulator.
+If it fails, Spark will ignore the failure and still mark the task successful and continue to run other tasks. Hence,
+a buggy accumulator will not impact a Spark job but it will not get updated even if a Spark job is successful.
+
 </div>
 
 <div data-lang="python"  markdown="1">

--- a/docs/rdd-programming-guide.md
+++ b/docs/rdd-programming-guide.md
@@ -1467,7 +1467,7 @@ Note that, when programmers define their own type of AccumulatorV2, the resultin
 
 *Warning*: When a Spark task finishes, Spark will try to merge the accumulated updates in this task to an accumulator.
 If it fails, Spark will ignore the failure and still mark the task successful and continue to run other tasks. Hence,
-a buggy accumulator will not impact a Spark job but it will not get updated even if a Spark job is successful.
+a buggy accumulator will not impact a Spark job, but it may not get updated correctly although a Spark job is successful.
 
 </div>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since we don't fail a job when `AccumulatorV2.merge` fails, we should try to update the remaining accumulators so that they can still report correct values.

## How was this patch tested?

The new unit test.