### PR TITLE
[SPARK-25574][SQL]Add an option `keepQuotes` for parsing csv file

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -191,6 +191,10 @@ class CSVOptions(
    * The value is used instead of an empty string in write. Default value is `""`
    */
   val emptyValueInWrite = emptyValue.getOrElse("\"\"")
+  /**
+   * This option only effects on quotes which are on the begin and end.
+   */
+  val keepQuotes = getBool("keepQuotes", false)
 
   /**
    * A string between two consecutive JSON records.
@@ -249,6 +253,7 @@ class CSVOptions(
     lineSeparatorInRead.foreach { _ =>
       settings.setNormalizeLineEndingsWithinQuotes(!multiLine)
     }
+    settings.setKeepQuotes(keepQuotes)
 
     settings
   }

--- a/sql/core/src/test/resources/test-data/keep-quotes.csv
+++ b/sql/core/src/test/resources/test-data/keep-quotes.csv
@@ -1,0 +1,2 @@
+"a"b,ccc,"",ddd
+ab,cc,,"c,ddd"


### PR DESCRIPTION
## What changes were proposed in this pull request?

In this PR, I added a new option for csv file - `keepQuotes`.
In our project, when we read the CSV file, we hope to keep quotes.

For example:
We have such a record in the CSV file.:
`ab,cc,,"c,ddd"`

We hope it displays like this:
+----+---+----+---+
| _c0 | _c1 | _c2  |   _c3 |
+---+---+----+----+
|  ab  |  cc   |  null     | `"c,ddd"` |

Not like this:
+----+---+----+----+
| _c0 |  _c1  | _c2 |   _c3  |
+---+----+----+----+
|  ab   |  cc   |  null   | c,ddd |
+----+---+----+---+



## How was this patch tested?
Added a unit test.
