### PR TITLE
[SPARK-25575][WEBUI][SQL] SQL tab in the spark UI support hide tables, to make it consistent with other tabs.

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/webui.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.js
@@ -83,4 +83,7 @@ $(function() {
   collapseTablePageLoad('collapse-aggregated-rdds','aggregated-rdds');
   collapseTablePageLoad('collapse-aggregated-activeBatches','aggregated-activeBatches');
   collapseTablePageLoad('collapse-aggregated-completedBatches','aggregated-completedBatches');
+  collapseTablePageLoad('collapse-aggregated-runningExecutions','runningExecutions');
+  collapseTablePageLoad('collapse-aggregated-completedExecutions','completedExecutions');
+  collapseTablePageLoad('collapse-aggregated-failedExecutions','failedExecutions');
 });

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/AllExecutionsPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/AllExecutionsPage.scala
@@ -55,24 +55,57 @@ private[ui] class AllExecutionsPage(parent: SQLTab) extends WebUIPage("") with L
       val _content = mutable.ListBuffer[Node]()
 
       if (running.nonEmpty) {
+        val runningPageTable = new RunningExecutionTable(
+          parent, currentTime, running.sortBy(_.submissionTime).reverse).toNodeSeq(request)
+
         _content ++=
-          new RunningExecutionTable(
-            parent, s"Running Queries (${running.size})", currentTime,
-            running.sortBy(_.submissionTime).reverse).toNodeSeq(request)
+          <span id="running" class="collapse-aggregated-runningExecutions collapse-table"
+                onClick="collapseTable('collapse-aggregated-runningExecutions',
+                'aggregated-runningExecutions')">
+            <h4>
+              <span class="collapse-table-arrow arrow-open"></span>
+              <a>Running Queries ({running.size})</a>
+            </h4>
+          </span> ++
+            <div class="aggregated-runningExecutions collapsible-table">
+              {runningPageTable}
+            </div>
       }
 
       if (completed.nonEmpty) {
+        val completedPageTable = new CompletedExecutionTable(
+          parent, currentTime, completed.sortBy(_.submissionTime).reverse).toNodeSeq(request)
+
         _content ++=
-          new CompletedExecutionTable(
-            parent, s"Completed Queries (${completed.size})", currentTime,
-            completed.sortBy(_.submissionTime).reverse).toNodeSeq(request)
+          <span id="completed" class="collapse-aggregated-completedExecutions collapse-table"
+                onClick="collapseTable('collapse-aggregated-completedExecutions',
+                'aggregated-completedExecutions')">
+            <h4>
+              <span class="collapse-table-arrow arrow-open"></span>
+              <a>Completed Queries ({completed.size})</a>
+            </h4>
+          </span> ++
+            <div class="aggregated-completedExecutions collapsible-table">
+              {completedPageTable}
+            </div>
       }
 
       if (failed.nonEmpty) {
+        val failedPageTable = new FailedExecutionTable(
+          parent, currentTime, failed.sortBy(_.submissionTime).reverse).toNodeSeq(request)
+
         _content ++=
-          new FailedExecutionTable(
-            parent, s"Failed Queries (${failed.size})", currentTime,
-            failed.sortBy(_.submissionTime).reverse).toNodeSeq(request)
+          <span id="failed" class="collapse-aggregated-failedExecutions collapse-table"
+                onClick="collapseTable('collapse-aggregated-failedExecutions',
+                'aggregated-failedExecutions')">
+            <h4>
+              <span class="collapse-table-arrow arrow-open"></span>
+              <a>Failed Queries ({failed.size})</a>
+            </h4>
+          </span> ++
+            <div class="aggregated-failedExecutions collapsible-table">
+              {failedPageTable}
+            </div>
       }
       _content
     }
@@ -118,7 +151,6 @@ private[ui] class AllExecutionsPage(parent: SQLTab) extends WebUIPage("") with L
 private[ui] abstract class ExecutionTable(
     parent: SQLTab,
     tableId: String,
-    tableName: String,
     currentTime: Long,
     executionUIDatas: Seq[SQLExecutionUIData],
     showRunningJobs: Boolean,
@@ -206,11 +238,8 @@ private[ui] abstract class ExecutionTable(
   }
 
   def toNodeSeq(request: HttpServletRequest): Seq[Node] = {
-    <div>
-      <h4>{tableName}</h4>
-      {UIUtils.listingTable[SQLExecutionUIData](
-        header, row(request, currentTime, _), executionUIDatas, id = Some(tableId))}
-    </div>
+    UIUtils.listingTable[SQLExecutionUIData](
+      header, row(request, currentTime, _), executionUIDatas, id = Some(tableId))
   }
 
   private def jobURL(request: HttpServletRequest, jobId: Long): String =
@@ -223,13 +252,11 @@ private[ui] abstract class ExecutionTable(
 
 private[ui] class RunningExecutionTable(
     parent: SQLTab,
-    tableName: String,
     currentTime: Long,
     executionUIDatas: Seq[SQLExecutionUIData])
   extends ExecutionTable(
     parent,
     "running-execution-table",
-    tableName,
     currentTime,
     executionUIDatas,
     showRunningJobs = true,
@@ -242,13 +269,11 @@ private[ui] class RunningExecutionTable(
 
 private[ui] class CompletedExecutionTable(
     parent: SQLTab,
-    tableName: String,
     currentTime: Long,
     executionUIDatas: Seq[SQLExecutionUIData])
   extends ExecutionTable(
     parent,
     "completed-execution-table",
-    tableName,
     currentTime,
     executionUIDatas,
     showRunningJobs = false,
@@ -260,13 +285,11 @@ private[ui] class CompletedExecutionTable(
 
 private[ui] class FailedExecutionTable(
     parent: SQLTab,
-    tableName: String,
     currentTime: Long,
     executionUIDatas: Seq[SQLExecutionUIData])
   extends ExecutionTable(
     parent,
     "failed-execution-table",
-    tableName,
     currentTime,
     executionUIDatas,
     showRunningJobs = false,


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, SQL tab in the WEBUI doesn't support hiding table. Other tabs in the web ui like, Jobs, stages etc supports hiding table (refer SPARK-23024 https://github.com/apache/spark/pull/20216). 
In this PR, added the support for hide table in the sql tab also.


## How was this patch tested?
bin/spark-shell
```
sql("create table a (id int)")
for(i <- 1 to 100) sql(s"insert into a values ($i)")
```
Open SQL tab in the web UI

**Before fix:**
 
![image](https://user-images.githubusercontent.com/23054875/46249137-f5c44880-c441-11e8-953a-a811e33ac24d.png)

**After fix:** Consistent with the other tabs.

![screenshot from 2018-09-30 00-11-28](https://user-images.githubusercontent.com/23054875/46249354-75074b80-c445-11e8-9417-28751fd8628a.png)


(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
