### PR TITLE
[SPARK-25586][MLlib][Core] Replace toString method with summarize m…

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -1501,7 +1501,7 @@ class GeneralizedLinearRegressionTrainingSummary private[regression] (
     }
   }
 
-  override def toString: String = {
+  def summarize(): String = {
     if (isNormalSolver) {
 
       def round(x: Double): String = {


### PR DESCRIPTION
…ethod in GeneralizedLinearRegressionTrainingSummary

## What changes were proposed in this pull request?

After the change in SPARK-25118 (not submitted yet), which enables spark-shell to run with default
log level, test_glr_summary started failing with StackOverflow error.

Cause: ClosureCleaner calls logDebug on various objects and when it is called
for GeneralizedLinearRegressionTrainingSummary, it starts a spark job which runs
into infinite loop and fails with the below exception.

Fix: Remove toString method and move the existing logic to a new method
"summarize". This follows the general guideline as other summary objects do not
have a toString method as well.

## How was this patch tested?

Ran the python "mllib" and scala/junit tests for this module