### PR TITLE
[SPARK-25561][SQL] Implement a new config to control partition pruning fallback (if partition push-down to Hive fails)

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -544,14 +544,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
-  val HIVE_METASTORE_PARTITION_PRUNING_FALLBACK =
-    buildConf("spark.sql.hive.metastorePartitionPruningFallback")
+  val HIVE_METASTORE_PARTITION_PRUNING_FALLBACK_ENABLED =
+    buildConf("spark.sql.hive.metastorePartitionPruning.fallback.enabled")
       .doc("When true, enable fallback to fetch all partitions if Hive metastore partition " +
            "push down fails. This is applicable only if partition pruning is enabled (see " +
            s" ${HIVE_METASTORE_PARTITION_PRUNING.key}). Enabling this may degrade performance " +
            "if there are a large number of partitions." )
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   val HIVE_MANAGE_FILESOURCE_PARTITIONS =
     buildConf("spark.sql.hive.manageFilesourcePartitions")
@@ -1707,7 +1707,7 @@ class SQLConf extends Serializable with Logging {
   def metastorePartitionPruning: Boolean = getConf(HIVE_METASTORE_PARTITION_PRUNING)
 
   def metastorePartitionPruningFallback: Boolean =
-    getConf(HIVE_METASTORE_PARTITION_PRUNING_FALLBACK)
+    getConf(HIVE_METASTORE_PARTITION_PRUNING_FALLBACK_ENABLED)
 
   def manageFilesourcePartitions: Boolean = getConf(HIVE_MANAGE_FILESOURCE_PARTITIONS)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -549,7 +549,7 @@ object SQLConf {
       .doc("When true, enable fallback to fetch all partitions if Hive metastore partition " +
            "push down fails. This is applicable only if partition pruning is enabled (see " +
            s" ${HIVE_METASTORE_PARTITION_PRUNING.key}). Enabling this may degrade performance " +
-           "if there are a large number of partitions." )
+           "if there is a large number of partitions." )
       .booleanConf
       .createWithDefault(false)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -544,6 +544,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val HIVE_METASTORE_PARTITION_PRUNING_FALLBACK =
+    buildConf("spark.sql.hive.metastorePartitionPruningFallback")
+      .doc("When true, enable fallback to fetch all partitions if Hive metastore partition " +
+           "push down fails. This is applicable only if partition pruning is enabled (see " +
+           s" ${HIVE_METASTORE_PARTITION_PRUNING.key}). Enabling this may degrade performance " +
+           "if there are a large number of partitions." )
+      .booleanConf
+      .createWithDefault(true)
+
   val HIVE_MANAGE_FILESOURCE_PARTITIONS =
     buildConf("spark.sql.hive.manageFilesourcePartitions")
       .doc("When true, enable metastore partition management for file source tables as well. " +
@@ -1696,6 +1705,9 @@ class SQLConf extends Serializable with Logging {
   def verifyPartitionPath: Boolean = getConf(HIVE_VERIFY_PARTITION_PATH)
 
   def metastorePartitionPruning: Boolean = getConf(HIVE_METASTORE_PARTITION_PRUNING)
+
+  def metastorePartitionPruningFallback: Boolean =
+    getConf(HIVE_METASTORE_PARTITION_PRUNING_FALLBACK)
 
   def manageFilesourcePartitions: Boolean = getConf(HIVE_MANAGE_FILESOURCE_PARTITIONS)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -746,6 +746,7 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
         getAllPartitionsMethod.invoke(hive, table).asInstanceOf[JSet[Partition]]
       } else {
         logDebug(s"Hive metastore filter is '$filter'.")
+        val shouldFallback = SQLConf.get.metastorePartitionPruningFallback
         val tryDirectSqlConfVar = HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL
         // We should get this config value from the metaStore. otherwise hit SPARK-18681.
         // To be compatible with hive-0.12 and hive-0.13, In the future we can achieve this by:
@@ -759,24 +760,33 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
             .asInstanceOf[JArrayList[Partition]]
         } catch {
           case ex: InvocationTargetException if ex.getCause.isInstanceOf[MetaException] =>
-            if (!tryDirectSql) {
-              logWarning("Caught Hive MetaException attempting to get partition metadata by " +
-                "filter from Hive. Falling back to fetching all partition metadata, which will " +
-                "degrade performance. Modifying your Hive metastore configuration to set " +
-                s"${tryDirectSqlConfVar.varname} to true may resolve this problem.")
+            if (shouldFallback) {
+              if (!tryDirectSql) {
+                logWarning("Caught Hive MetaException attempting to get partition metadata by " +
+                  "filter from Hive. Falling back to fetching all partition metadata, which will " +
+                  "degrade performance. Modifying your Hive metastore configuration to set " +
+                  s"${tryDirectSqlConfVar.varname} to true may resolve this problem.")
+              } else {
+                logWarning("Caught Hive MetaException attempting to get partition metadata " +
+                  "by filter from Hive. Hive metastore's direct SQL feature has been enabled, " +
+                  "but it is an optimistic optimization and not guaranteed to work. Falling back " +
+                  "to fetching all partition metadata, which will degrade performance (for the " +
+                  "current query). If you see this error consistently, you can set the Spark " +
+                  s"configuration setting ${SQLConf.HIVE_MANAGE_FILESOURCE_PARTITIONS.key} to " +
+                  "false as a work around, however this will result in degraded performance. " +
+                  "Please report a bug to Hive stating that direct SQL is failing consistently " +
+                  "for the specified query: https://issues.apache.org/jira/browse/HIVE")
+              }
+              // HiveShim clients are expected to handle a superset of the requested partitions
+              getAllPartitionsMethod.invoke(hive, table).asInstanceOf[JSet[Partition]]
             } else {
-              logWarning("Caught Hive MetaException attempting to get partition metadata by " +
-                "filter from Hive. Hive metastore's direct SQL feature has been enabled, but it " +
-                "is an optimistic optimization and not guaranteed to work. Falling back to " +
-                "fetching all partition metadata, which will degrade performance (for the " +
-                "current query). If you see this error consistently, you can set the Spark " +
-                s"configuration setting ${SQLConf.HIVE_MANAGE_FILESOURCE_PARTITIONS.key} to " +
-                "false as a work around, however this will result in degraded performance. " +
-                "Please report a bug to Hive stating that direct SQL is failing consistently for " +
-                "the specified query: https://issues.apache.org/jira/browse/HIVE")
+              // Fallback mode has been disabled. Rethrow exception.
+              throw new RuntimeException("Caught Hive MetaException attempting to get partition " +
+                "metadata from Hive. Fallback mechanism is not enabled. You can set " +
+                s"${SQLConf.HIVE_METASTORE_PARTITION_PRUNING_FALLBACK} to true to fetch all " +
+                "partition metadata as a fallback mechanism, however this may result in degraded " +
+                "performance.", ex)
             }
-            // HiveShim clients are expected to handle a superset of the requested partitions
-            getAllPartitionsMethod.invoke(hive, table).asInstanceOf[JSet[Partition]]
         }
       }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -783,9 +783,9 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
               // Fallback mode has been disabled. Rethrow exception.
               throw new RuntimeException("Caught Hive MetaException attempting to get partition " +
                 "metadata from Hive. Fallback mechanism is not enabled. You can set " +
-                s"${SQLConf.HIVE_METASTORE_PARTITION_PRUNING_FALLBACK} to true to fetch all " +
-                "partition metadata as a fallback mechanism, however this may result in degraded " +
-                "performance.", ex)
+                s"${SQLConf.HIVE_METASTORE_PARTITION_PRUNING_FALLBACK_ENABLED} to true to fetch " +
+                "all partition metadata as a fallback mechanism, however this may result in " +
+                "degraded performance.", ex)
             }
         }
       }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -754,8 +754,6 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
         val tryDirectSql = hive.getMSC.getConfigValue(tryDirectSqlConfVar.varname,
           tryDirectSqlConfVar.defaultBoolVal.toString).toBoolean
         try {
-          // Hive may throw an exception when calling this method in some circumstances, such as
-          // when filtering on a non-string partition column.
           getPartitionsByFilterMethod.invoke(hive, table, filter)
             .asInstanceOf[JArrayList[Partition]]
         } catch {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -746,34 +746,20 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
         getAllPartitionsMethod.invoke(hive, table).asInstanceOf[JSet[Partition]]
       } else {
         logDebug(s"Hive metastore filter is '$filter'.")
-        val tryDirectSqlConfVar = HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL
-        // We should get this config value from the metaStore. otherwise hit SPARK-18681.
-        // To be compatible with hive-0.12 and hive-0.13, In the future we can achieve this by:
-        // val tryDirectSql = hive.getMetaConf(tryDirectSqlConfVar.varname).toBoolean
-        val tryDirectSql = hive.getMSC.getConfigValue(tryDirectSqlConfVar.varname,
-          tryDirectSqlConfVar.defaultBoolVal.toString).toBoolean
         try {
           // Hive may throw an exception when calling this method in some circumstances, such as
-          // when filtering on a non-string partition column when the hive config key
-          // hive.metastore.try.direct.sql is false
+          // when filtering on a non-string partition column.
           getPartitionsByFilterMethod.invoke(hive, table, filter)
             .asInstanceOf[JArrayList[Partition]]
         } catch {
-          case ex: InvocationTargetException if ex.getCause.isInstanceOf[MetaException] &&
-              !tryDirectSql =>
+          case ex: InvocationTargetException if ex.getCause.isInstanceOf[MetaException] =>
             logWarning("Caught Hive MetaException attempting to get partition metadata by " +
               "filter from Hive. Falling back to fetching all partition metadata, which will " +
-              "degrade performance. Modifying your Hive metastore configuration to set " +
-              s"${tryDirectSqlConfVar.varname} to true may resolve this problem.", ex)
+              "degrade performance. Enable direct SQL mode in hive metastore to attempt " +
+              "to improve performance. However, Hive's direct SQL mode is an optimistic " +
+              "optimization and does not guarantee improved performance.")
             // HiveShim clients are expected to handle a superset of the requested partitions
             getAllPartitionsMethod.invoke(hive, table).asInstanceOf[JSet[Partition]]
-          case ex: InvocationTargetException if ex.getCause.isInstanceOf[MetaException] &&
-              tryDirectSql =>
-            throw new RuntimeException("Caught Hive MetaException attempting to get partition " +
-              "metadata by filter from Hive. You can set the Spark configuration setting " +
-              s"${SQLConf.HIVE_MANAGE_FILESOURCE_PARTITIONS.key} to false to work around this " +
-              "problem, however this will result in degraded performance. Please report a bug: " +
-              "https://issues.apache.org/jira/browse/SPARK", ex)
         }
       }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When using partition filter pushdown to Hive Metastore, the pushdown might fail (depending on the type of partition and if direct SQL mode is enabled in HMS). This change implements a new config option in Spark SQL to decide what to do when a partition filter pushdown fails. The fallback behavior would be to fetch all partitions instead. This might degrade performance depending on the total number of partitions and warnings are added as appropriate.

## How was this patch tested?

New unit tests were added to confirm behavior of the new config. All Unit tests on the Spark SQL component were run successfully.

