### PR TITLE
[SPARK-25636][CORE] spark-submit cuts off the failure reason when there is an error connecting to master

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -843,6 +843,8 @@ private[spark] class SparkSubmit extends Logging {
         if (e.getCause() != null) findCause(e.getCause()) else e
       case e: InvocationTargetException =>
         if (e.getCause() != null) findCause(e.getCause()) else e
+      case e: SparkException =>
+        if (e.getCause() != null) findCause(e.getCause()) else e
       case e: Throwable =>
         e
     }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -843,8 +843,6 @@ private[spark] class SparkSubmit extends Logging {
         if (e.getCause() != null) findCause(e.getCause()) else e
       case e: InvocationTargetException =>
         if (e.getCause() != null) findCause(e.getCause()) else e
-      case e: SparkException =>
-        if (e.getCause() != null) findCause(e.getCause()) else e
       case e: Throwable =>
         e
     }
@@ -929,8 +927,6 @@ object SparkSubmit extends CommandLineUtils with Logging {
         } catch {
           case e: SparkUserAppException =>
             exitFn(e.exitCode)
-          case e: SparkException =>
-            printErrorAndExit(e.getMessage())
         }
       }
 

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -87,7 +87,7 @@ trait TestPrematureExit {
     thread.join()
     if (exitedCleanly) {
       val joined = printStream.lineBuffer.mkString("\n")
-      assert(joined.contains(searchString), s"Search string '$searchString' not found in $joined")
+      assert(joined.contains(searchString))
     } else {
       assert(exception != null)
       if (!exception.getMessage.contains(searchString)) {

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -74,20 +74,26 @@ trait TestPrematureExit {
     @volatile var exitedCleanly = false
     mainObject.exitFn = (_) => exitedCleanly = true
 
+    var message: String = null
     val thread = new Thread {
       override def run() = try {
         mainObject.main(input)
       } catch {
         // If exceptions occur after the "exit" has happened, fine to ignore them.
         // These represent code paths not reachable during normal execution.
-        case e: Exception => if (!exitedCleanly) throw e
+        case e: Exception =>
+          message = e.getMessage
+          if (!(exitedCleanly || message.contains(searchString))) {
+            throw e
+          }
       }
     }
     thread.start()
     thread.join()
     val joined = printStream.lineBuffer.mkString("\n")
-    if (!joined.contains(searchString)) {
-      fail(s"Search string '$searchString' not found in $joined")
+    if (!(joined.contains(searchString) ||
+      (message != null && message.contains(searchString)))) {
+      fail(s"Search string '$searchString' not found in $joined or in $message")
     }
   }
 }

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -83,13 +83,13 @@ trait TestPrematureExit {
     }
     thread.start()
     thread.join()
-    val joined = printStream.lineBuffer.mkString("\n")
     if (exception != null) {
       if (!exception.getMessage.contains(searchString)) {
         throw exception
       }
-    } else if (!joined.contains(searchString)) {
-      fail(s"Search string '$searchString' not found in $joined")
+    } else {
+      val joined = printStream.lineBuffer.mkString("\n")
+      assert(joined.contains(searchString), s"Search string '$searchString' not found in $joined")
     }
   }
 }

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -88,11 +88,12 @@ trait TestPrematureExit {
     thread.join()
     val joined = printStream.lineBuffer.mkString("\n")
     val searchStrContainsInEx = exception != null && exception.getMessage.contains(searchString)
-    if(!searchStrContainsInEx){
-      if(!exitedCleanly){
-        // throw the exception when the exception message doesn't contain searchString and not exitedCleanly.
+    if (!searchStrContainsInEx) {
+      if (!exitedCleanly) {
+        // throw the exception when the exception message doesn't contain
+        // searchString and not exitedCleanly.
         throw exception
-      } else if(!joined.contains(searchString)){
+      } else if (!joined.contains(searchString)) {
         fail(s"Search string '$searchString' not found in $joined")
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Cause of the error is wrapped with SparkException, now finding the cause from the wrapped exception and throwing the cause instead of the wrapped exception.

## How was this patch tested?
Verified it manually by checking the cause of the error, it gives the error as shown below.

### Without the PR change

```
[apache-spark]$ ./bin/spark-submit --verbose --master spark://******
....
Error: Exception thrown in awaitResult:
Run with --help for usage help or --verbose for debug output

```

### With the PR change


```
[apache-spark]$ ./bin/spark-submit --verbose --master spark://******
....
Exception in thread "main" org.apache.spark.SparkException: Exception thrown in awaitResult:
        at org.apache.spark.util.ThreadUtils$.awaitResult(ThreadUtils.scala:226)
        at org.apache.spark.rpc.RpcTimeout.awaitResult(RpcTimeout.scala:75)
        ....
        at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
Caused by: java.io.IOException: Failed to connect to devaraj-pc1/10.3.66.65:7077
        at org.apache.spark.network.client.TransportClientFactory.createClient(TransportClientFactory.java:245)
       ....
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: devaraj-pc1/10.3.66.65:7077
        at sun.nio.ch.SocketChannelImpl.checkConnect(Native Method)
        ....
        at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:138)
        ... 1 more
Caused by: java.net.ConnectException: Connection refused
        ... 11 more

```