### PR TITLE
[SPARK-25591][PySpark][SQL] Avoid overwriting deserialized accumulator

### DIFF
--- a/python/pyspark/accumulators.py
+++ b/python/pyspark/accumulators.py
@@ -109,10 +109,14 @@ _accumulatorRegistry = {}
 
 def _deserialize_accumulator(aid, zero_value, accum_param):
     from pyspark.accumulators import _accumulatorRegistry
-    accum = Accumulator(aid, zero_value, accum_param)
-    accum._deserialized = True
-    _accumulatorRegistry[aid] = accum
-    return accum
+    # If this certain accumulator was deserialized, don't overwrite it.
+    if aid in _accumulatorRegistry:
+        return _accumulatorRegistry[aid]
+    else:
+        accum = Accumulator(aid, zero_value, accum_param)
+        accum._deserialized = True
+        _accumulatorRegistry[aid] = accum
+        return accum
 
 
 class Accumulator(object):

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3607,22 +3607,22 @@ class SQLTests(ReusedSQLTestCase):
     def test_same_accumulator_in_udfs(self):
         from pyspark.sql.functions import udf
 
-        data_schema = StructType([StructField("a", DoubleType(), True),
-                                  StructField("b", DoubleType(), True)])
-        data = self.spark.createDataFrame([[1.0, 2.0]], schema=data_schema)
+        data_schema = StructType([StructField("a", IntegerType(), True),
+                                  StructField("b", IntegerType(), True)])
+        data = self.spark.createDataFrame([[1, 2]], schema=data_schema)
 
-        test_accum = self.sc.accumulator(0.0)
+        test_accum = self.sc.accumulator(0)
 
         def first_udf(x):
-            test_accum.add(1.0)
+            test_accum.add(1)
             return x
 
         def second_udf(x):
-            test_accum.add(100.0)
+            test_accum.add(100)
             return x
 
-        func_udf = udf(first_udf, DoubleType())
-        func_udf2 = udf(second_udf, DoubleType())
+        func_udf = udf(first_udf, IntegerType())
+        func_udf2 = udf(second_udf, IntegerType())
         data = data.withColumn("out1", func_udf(data["a"]))
         data = data.withColumn("out2", func_udf2(data["b"]))
         data.collect()

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3603,6 +3603,31 @@ class SQLTests(ReusedSQLTestCase):
                     self.assertEquals(None, df._repr_html_())
                     self.assertEquals(expected, df.__repr__())
 
+    # SPARK-25591
+    def test_same_accumulator_in_udfs(self):
+        from pyspark.sql.functions import udf
+
+        data_schema = StructType([StructField("a", DoubleType(), True),
+                                  StructField("b", DoubleType(), True)])
+        data = self.spark.createDataFrame([[1.0, 2.0]], schema=data_schema)
+
+        test_accum = self.sc.accumulator(0.0)
+
+        def first_udf(x):
+            test_accum.add(1.0)
+            return x
+
+        def second_udf(x):
+            test_accum.add(100.0)
+            return x
+
+        func_udf = udf(first_udf, DoubleType())
+        func_udf2 = udf(second_udf, DoubleType())
+        data = data.withColumn("out1", func_udf(data["a"]))
+        data = data.withColumn("out2", func_udf2(data["b"]))
+        data.collect()
+        self.assertEqual(test_accum.value, 101)
+
 
 class HiveSparkSubmitTests(SparkSubmitTests):
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

If we use accumulators in more than one UDFs, it is possible to overwrite deserialized accumulators and its values. We should check if an accumulator was deserialized before overwriting it in accumulator registry.

## How was this patch tested?

Added test.