### PR TITLE
[SPARK-25611][SPARK-25612][SQL][TESTS] Improve test run time of CompressionCodecSuite

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/CompressionCodecSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/CompressionCodecSuite.scala
@@ -262,9 +262,9 @@ class CompressionCodecSuite extends TestHiveSingleton with ParquetTest with Befo
   }
 
   def checkForTableWithCompressProp(
-     format: String,
-     tableCompressCodecs: List[String],
-     sessionCompressCodecs: List[String]): Unit = {
+      format: String,
+      tableCompressCodecs: List[String],
+      sessionCompressCodecs: List[String]): Unit = {
     Seq(true, false).foreach { isPartitioned =>
       Seq(true, false).foreach { convertMetastore =>
         Seq(true, false).foreach { usingCTAS =>

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/CompressionCodecSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/CompressionCodecSuite.scala
@@ -21,6 +21,7 @@ import java.io.File
 import java.util.Locale
 
 import scala.collection.JavaConverters._
+import scala.util.Random
 
 import org.apache.hadoop.fs.Path
 import org.apache.orc.OrcConf.COMPRESS
@@ -229,8 +230,8 @@ class CompressionCodecSuite extends TestHiveSingleton with ParquetTest with Befo
       tableCompressionCodecs: List[String])
       (assertionCompressionCodec: (Option[String], String, String, Long) => Unit): Unit = {
     withSQLConf(getConvertMetastoreConfName(format) -> convertMetastore.toString) {
-      tableCompressionCodecs.foreach { tableCompression =>
-        compressionCodecs.foreach { sessionCompressionCodec =>
+      Random.shuffle(tableCompressionCodecs).take(1).foreach { tableCompression =>
+        Random.shuffle(compressionCodecs).take(1).foreach { sessionCompressionCodec =>
           withSQLConf(getSparkCompressionConfName(format) -> sessionCompressionCodec) {
             // 'tableCompression = null' means no table-level compression
             val compression = Option(tableCompression)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/CompressionCodecSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/CompressionCodecSuite.scala
@@ -229,8 +229,8 @@ class CompressionCodecSuite extends TestHiveSingleton with ParquetTest with Befo
       tableCompressionCodecs: List[String])
       (assertionCompressionCodec: (Option[String], String, String, Long) => Unit): Unit = {
     withSQLConf(getConvertMetastoreConfName(format) -> convertMetastore.toString) {
-      tableCompressionCodecs.foreach { tableCompression =>
-        compressionCodecs.filterNot(_ == tableCompression).foreach { sessionCompressionCodec =>
+      tableCompressionCodecs.zipAll(compressionCodecs, null, "SNAPPY").foreach {
+        case (tableCompression, sessionCompressionCodec) =>
           withSQLConf(getSparkCompressionConfName(format) -> sessionCompressionCodec) {
             // 'tableCompression = null' means no table-level compression
             val compression = Option(tableCompression)
@@ -240,7 +240,6 @@ class CompressionCodecSuite extends TestHiveSingleton with ParquetTest with Befo
                   compression, sessionCompressionCodec, realCompressionCodec, tableSize)
             }
           }
-        }
       }
     }
   }
@@ -262,7 +261,10 @@ class CompressionCodecSuite extends TestHiveSingleton with ParquetTest with Befo
     }
   }
 
-  def checkForTableWithCompressProp(format: String, compressCodecs: List[String]): Unit = {
+  def checkForTableWithCompressProp(
+     format: String,
+     tableCompressCodecs: List[String],
+     sessionCompressCodecs: List[String]): Unit = {
     Seq(true, false).foreach { isPartitioned =>
       Seq(true, false).foreach { convertMetastore =>
         Seq(true, false).foreach { usingCTAS =>
@@ -271,10 +273,10 @@ class CompressionCodecSuite extends TestHiveSingleton with ParquetTest with Befo
             isPartitioned,
             convertMetastore,
             usingCTAS,
-            compressionCodecs = compressCodecs,
-            tableCompressionCodecs = compressCodecs) {
+            compressionCodecs = sessionCompressCodecs,
+            tableCompressionCodecs = tableCompressCodecs) {
             case (tableCodec, sessionCodec, realCodec, tableSize) =>
-              val expectCodec = tableCodec.get
+              val expectCodec = if (tableCodec.isDefined) tableCodec.get else sessionCodec
               assert(expectCodec == realCodec)
               assert(checkTableSize(
                 format, expectCodec, isPartitioned, convertMetastore, usingCTAS, tableSize))
@@ -284,36 +286,22 @@ class CompressionCodecSuite extends TestHiveSingleton with ParquetTest with Befo
     }
   }
 
-  def checkForTableWithoutCompressProp(format: String, compressCodecs: List[String]): Unit = {
-    Seq(true, false).foreach { isPartitioned =>
-      Seq(true, false).foreach { convertMetastore =>
-        Seq(true, false).foreach { usingCTAS =>
-          checkTableCompressionCodecForCodecs(
-            format,
-            isPartitioned,
-            convertMetastore,
-            usingCTAS,
-            compressionCodecs = compressCodecs,
-            tableCompressionCodecs = List(null)) {
-            case (tableCodec, sessionCodec, realCodec, tableSize) =>
-              // Always expect session-level take effect
-              assert(sessionCodec == realCodec)
-              assert(checkTableSize(
-                format, sessionCodec, isPartitioned, convertMetastore, usingCTAS, tableSize))
-          }
-        }
-      }
-    }
-  }
-
   test("both table-level and session-level compression are set") {
-    checkForTableWithCompressProp("parquet", List("UNCOMPRESSED", "SNAPPY", "GZIP"))
-    checkForTableWithCompressProp("orc", List("NONE", "SNAPPY", "ZLIB"))
+    checkForTableWithCompressProp("parquet",
+      tableCompressCodecs = List("UNCOMPRESSED", "SNAPPY", "GZIP"),
+      sessionCompressCodecs = List("SNAPPY", "GZIP", "SNAPPY"))
+    checkForTableWithCompressProp("orc",
+      tableCompressCodecs = List("NONE", "SNAPPY", "ZLIB"),
+      sessionCompressCodecs = List("SNAPPY", "ZLIB", "SNAPPY"))
   }
 
   test("table-level compression is not set but session-level compressions is set ") {
-    checkForTableWithoutCompressProp("parquet", List("UNCOMPRESSED", "SNAPPY", "GZIP"))
-    checkForTableWithoutCompressProp("orc", List("NONE", "SNAPPY", "ZLIB"))
+    checkForTableWithCompressProp("parquet",
+      tableCompressCodecs = List.empty,
+      sessionCompressCodecs = List("UNCOMPRESSED", "SNAPPY", "GZIP"))
+    checkForTableWithCompressProp("orc",
+      tableCompressCodecs = List.empty,
+      sessionCompressCodecs = List("NONE", "SNAPPY", "ZLIB"))
   }
 
   def checkTableWriteWithCompressionCodecs(format: String, compressCodecs: List[String]): Unit = {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/CompressionCodecSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/CompressionCodecSuite.scala
@@ -276,7 +276,7 @@ class CompressionCodecSuite extends TestHiveSingleton with ParquetTest with Befo
             compressionCodecs = sessionCompressCodecs,
             tableCompressionCodecs = tableCompressCodecs) {
             case (tableCodec, sessionCodec, realCodec, tableSize) =>
-              val expectCodec = if (tableCodec.isDefined) tableCodec.get else sessionCodec
+              val expectCodec = tableCodec.getOrElse(sessionCodec)
               assert(expectCodec == realCodec)
               assert(checkTableSize(
                 format, expectCodec, isPartitioned, convertMetastore, usingCTAS, tableSize))

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/CompressionCodecSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/CompressionCodecSuite.scala
@@ -21,7 +21,6 @@ import java.io.File
 import java.util.Locale
 
 import scala.collection.JavaConverters._
-import scala.util.Random
 
 import org.apache.hadoop.fs.Path
 import org.apache.orc.OrcConf.COMPRESS
@@ -230,8 +229,8 @@ class CompressionCodecSuite extends TestHiveSingleton with ParquetTest with Befo
       tableCompressionCodecs: List[String])
       (assertionCompressionCodec: (Option[String], String, String, Long) => Unit): Unit = {
     withSQLConf(getConvertMetastoreConfName(format) -> convertMetastore.toString) {
-      Random.shuffle(tableCompressionCodecs).take(1).foreach { tableCompression =>
-        Random.shuffle(compressionCodecs).take(1).foreach { sessionCompressionCodec =>
+      tableCompressionCodecs.foreach { tableCompression =>
+        compressionCodecs.filterNot(_ == tableCompression).foreach { sessionCompressionCodec =>
           withSQLConf(getSparkCompressionConfName(format) -> sessionCompressionCodec) {
             // 'tableCompression = null' means no table-level compression
             val compression = Option(tableCompression)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Reduced the combination of codecs from 9 to 3 to improve the test runtime.

## How was this patch tested?
This is a test fix.