### PR TITLE
[SPARK-25627][TEST] Reduce test time for ContinuousStressSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousSuite.scala
@@ -241,10 +241,10 @@ class ContinuousStressSuite extends ContinuousSuiteBase {
     testStream(df, useV2Sink = true)(
       StartStream(longContinuousTrigger),
       AwaitEpoch(0),
-      Execute(waitForRateSourceTriggers(_, 201)),
+      Execute(waitForRateSourceTriggers(_, 10)),
       IncrementEpoch(),
       StopStream,
-      CheckAnswerRowsContains(scala.Range(0, 25000).map(Row(_)))
+      CheckAnswerRowsContains(scala.Range(0, 2500).map(Row(_)))
     )
   }
 
@@ -259,10 +259,10 @@ class ContinuousStressSuite extends ContinuousSuiteBase {
     testStream(df, useV2Sink = true)(
       StartStream(Trigger.Continuous(2012)),
       AwaitEpoch(0),
-      Execute(waitForRateSourceTriggers(_, 201)),
+      Execute(waitForRateSourceTriggers(_, 10)),
       IncrementEpoch(),
       StopStream,
-      CheckAnswerRowsContains(scala.Range(0, 25000).map(Row(_))))
+      CheckAnswerRowsContains(scala.Range(0, 2500).map(Row(_))))
   }
 
   test("restarts") {
@@ -274,27 +274,27 @@ class ContinuousStressSuite extends ContinuousSuiteBase {
       .select('value)
 
     testStream(df, useV2Sink = true)(
-      StartStream(Trigger.Continuous(2012)),
+      StartStream(Trigger.Continuous(1012)),
+      AwaitEpoch(2),
+      StopStream,
+      StartStream(Trigger.Continuous(1012)),
+      AwaitEpoch(4),
+      StopStream,
+      StartStream(Trigger.Continuous(1012)),
+      AwaitEpoch(5),
+      StopStream,
+      StartStream(Trigger.Continuous(1012)),
+      AwaitEpoch(6),
+      StopStream,
+      StartStream(Trigger.Continuous(1012)),
+      AwaitEpoch(8),
+      StopStream,
+      StartStream(Trigger.Continuous(1012)),
+      StopStream,
+      StartStream(Trigger.Continuous(1012)),
       AwaitEpoch(10),
       StopStream,
-      StartStream(Trigger.Continuous(2012)),
-      AwaitEpoch(20),
-      StopStream,
-      StartStream(Trigger.Continuous(2012)),
-      AwaitEpoch(21),
-      StopStream,
-      StartStream(Trigger.Continuous(2012)),
-      AwaitEpoch(22),
-      StopStream,
-      StartStream(Trigger.Continuous(2012)),
-      AwaitEpoch(25),
-      StopStream,
-      StartStream(Trigger.Continuous(2012)),
-      StopStream,
-      StartStream(Trigger.Continuous(2012)),
-      AwaitEpoch(50),
-      StopStream,
-      CheckAnswerRowsContains(scala.Range(0, 25000).map(Row(_))))
+      CheckAnswerRowsContains(scala.Range(0, 2500).map(Row(_))))
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousSuite.scala
@@ -292,7 +292,7 @@ class ContinuousStressSuite extends ContinuousSuiteBase {
       StartStream(Trigger.Continuous(1012)),
       StopStream,
       StartStream(Trigger.Continuous(1012)),
-      AwaitEpoch(10),
+      AwaitEpoch(15),
       StopStream,
       CheckAnswerRowsContains(scala.Range(0, 2500).map(Row(_))))
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This goes to reduce test time for ContinuousStressSuite - from 8 mins 13 sec to 43 seconds.

The approach taken by this is to reduce the triggers and epochs to wait and to reduce the expected rows accordingly.

## How was this patch tested?

Existing tests.