### PR TITLE
[SPARK-25615][SQL][TEST] Improve the test runtime of KafkaSinkSuite: streaming write to non-existing topic

### DIFF
--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSinkSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSinkSuite.scala
@@ -332,9 +332,7 @@ class KafkaSinkSuite extends StreamTest with SharedSQLContext with KafkaTest {
     var ex: Exception = null
     try {
       ex = intercept[StreamingQueryException] {
-        writer = createKafkaWriter(input.toDF(),
-          withTopic = Some(topic),
-          withOptions = Map("kafka.max.block.ms" -> "10000"))()
+        writer = createKafkaWriter(input.toDF(), withTopic = Some(topic))()
         input.addData("1", "2", "3", "4", "5")
         writer.processAllAvailable()
       }
@@ -429,6 +427,7 @@ class KafkaSinkSuite extends StreamTest with SharedSQLContext with KafkaTest {
         .format("kafka")
         .option("checkpointLocation", checkpointDir.getCanonicalPath)
         .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+        .option("kafka.max.block.ms", "5000")
         .queryName("kafkaStream")
       withTopic.foreach(stream.option("topic", _))
       withOutputMode.foreach(stream.outputMode(_))

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSinkSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSinkSuite.scala
@@ -332,7 +332,9 @@ class KafkaSinkSuite extends StreamTest with SharedSQLContext with KafkaTest {
     var ex: Exception = null
     try {
       ex = intercept[StreamingQueryException] {
-        writer = createKafkaWriter(input.toDF(), withTopic = Some(topic))()
+        writer = createKafkaWriter(input.toDF(),
+          withTopic = Some(topic),
+          withOptions = Map("kafka.max.block.ms" -> "10000"))()
         input.addData("1", "2", "3", "4", "5")
         writer.processAllAvailable()
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Specify `kafka.max.block.ms` to 10 seconds while creating the kafka writer. In the absence of this overridden config, by default it uses a default time out of 60 seconds.

With this change the test completes in close to 10 seconds as opposed to 1 minute.

## How was this patch tested?
This is a test fix.