### PR TITLE
[SPARK-20144] Allow reading files in order with spark.sql.files.allowReordering=false

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -835,6 +835,13 @@ object SQLConf {
     .longConf
     .createWithDefault(4 * 1024 * 1024)
 
+  val ALLOW_REORDERING_FILES = buildConf("spark.sql.files.allowReordering")
+    .internal()
+    .doc("If enabled, Spark is free to change the order of input files when trying to organize" +
+      " them into even-sized partitions for performance.")
+    .booleanConf
+    .createWithDefault(true)
+
   val IGNORE_CORRUPT_FILES = buildConf("spark.sql.files.ignoreCorruptFiles")
     .doc("Whether to ignore corrupt files. If true, the Spark jobs will continue to run when " +
       "encountering corrupted files and the contents that have been read will still be returned.")
@@ -1638,6 +1645,8 @@ class SQLConf extends Serializable with Logging {
   def filesMaxPartitionBytes: Long = getConf(FILES_MAX_PARTITION_BYTES)
 
   def filesOpenCostInBytes: Long = getConf(FILES_OPEN_COST_IN_BYTES)
+
+  def allowReorderingFiles: Boolean = getConf(ALLOW_REORDERING_FILES)
 
   def ignoreCorruptFiles: Boolean = getConf(IGNORE_CORRUPT_FILES)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -1368,6 +1368,17 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
     })
   }
 
+  test("SPARK-20144: Keep partition order if allowReordering=false.") {
+    withSQLConf(
+      "spark.sql.files.allowReordering" -> "false"
+    )(withTempPath { path =>
+      val df = spark.range(10).map(_.toString).toDF
+      df.write.csv(path.getAbsolutePath)
+      val readback = spark.read.csv(path.getCanonicalPath)
+      assert(readback.collect.toSeq == df.collect.toSeq)
+    })
+  }
+
   test("SPARK-23846: usage of samplingRatio while parsing a dataset of strings") {
     val ds = sampledTestData.coalesce(1)
     val readback = spark.read


### PR DESCRIPTION
## What changes were proposed in this pull request?

I'm adding `spark.sql.files.allowReordering`, defaulting to `true`. When set to `true` the behavior is as before. When set to `false`, the input files are read in alphabetical order. This means partitions are read in the `part-00001`, `part-00002`, `part-00003`... order, recovering the same ordering as before.

While [**SPARK-20144**](https://issues.apache.org/jira/browse/SPARK-20144) has been closed as "Not A Problem", I think this is still a valuable feature. Spark has been [touted](https://databricks.com/blog/2016/11/14/setting-new-world-record-apache-spark.html) as the best tool for sorting. It certainly can sort data. But without this change, it can not read back sorted data on the DataFrame API.

My practical use case is that we allow users to run their SQL expressions through our UI. We also allow them to ask for the results to be persisted to Parquet files. We noticed that if they do an `ORDER BY`, the ordering is lost if they also ask for persistence. For example they might want to rank data points by a score, so they can later get the top 10 or top 10,000,000 entries easily. With this change we could fulfill this use case.

Thanks for hearing me out! :blush: 

## How was this patch tested?

New unit test.