### PR TITLE
[SPARK-25685][BUILD] Allow running tests in Jenkins in enterprise Git repository

### DIFF
--- a/dev/run-tests-jenkins.py
+++ b/dev/run-tests-jenkins.py
@@ -39,7 +39,7 @@ def print_err(msg):
 def post_message_to_github(msg, ghprb_pull_id):
     print("Attempting to post to Github...")
 
-    api_url = os.getenv("GITHUB_SERVER_API_URL", "https://api.github.com/repos/apache/spark")
+    api_url = os.getenv("GITHUB_API_BASE", "https://api.github.com/repos/apache/spark")
     url = api_url + "/issues/" + ghprb_pull_id + "/comments"
     github_oauth_key = os.environ["GITHUB_OAUTH_KEY"]
 

--- a/dev/run-tests-jenkins.py
+++ b/dev/run-tests-jenkins.py
@@ -39,7 +39,8 @@ def print_err(msg):
 def post_message_to_github(msg, ghprb_pull_id):
     print("Attempting to post to Github...")
 
-    url = "https://api.github.com/repos/apache/spark/issues/" + ghprb_pull_id + "/comments"
+    api_url = os.getenv("GITHUB_SERVER_API_URL", "https://api.github.com/repos/apache/spark")
+    url = api_url + "/issues/" + ghprb_pull_id + "/comments"
     github_oauth_key = os.environ["GITHUB_OAUTH_KEY"]
 
     posted_message = json.dumps({"body": msg})
@@ -176,7 +177,8 @@ def main():
     build_display_name = os.environ["BUILD_DISPLAY_NAME"]
     build_url = os.environ["BUILD_URL"]
 
-    commit_url = "https://github.com/apache/spark/commit/" + ghprb_actual_commit
+    project_url = os.getenv("SPARK_PROJECT_URL", "https://github.com/apache/spark")
+    commit_url = project_url + "/commit/" + ghprb_actual_commit
 
     # GitHub doesn't auto-link short hashes when submitted via the API, unfortunately. :(
     short_commit_hash = ghprb_actual_commit[0:7]

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -296,7 +296,7 @@ If use an individual repository or an GitHub Enterprise, export below environmen
   <td><code>SPARK_PROJECT_URL</code></td>
   <td>https://github.com/apache/spark</td>
   <td>
-    The Spark project URL of (enterprise) GitHub.
+    The Spark project URL of GitHub Enterprise.
   </td>
 </tr>
 </table>

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -284,7 +284,7 @@ If use an individual repository or an enterprise GitHub, export below environmen
 ### Related environment variables
 
 <table class="table">
-<tr><th>variable Name</th><th>Default</th><th>Meaning</th></tr>
+<tr><th>Variable Name</th><th>Default</th><th>Meaning</th></tr>
 <tr>
   <td><code>GITHUB_API_BASE</code></td>
   <td>https://api.github.com/repos/apache/spark</td>

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -279,24 +279,24 @@ To run tests with Jenkins:
 
     ./dev/run-tests-jenkins
 
-If use an individual repository or an GitHub Enterprise, export below environment variables before running above command.
+If use an individual repository or a repository on GitHub Enterprise, export below environment variables before running above command.
 
 ### Related environment variables
 
 <table class="table">
 <tr><th>Variable Name</th><th>Default</th><th>Meaning</th></tr>
 <tr>
-  <td><code>GITHUB_API_BASE</code></td>
-  <td>https://api.github.com/repos/apache/spark</td>
-  <td>
-    The GitHub server API URL. It could be pointed to an GitHub Enterprise.
-  </td>
-</tr>
-<tr>
   <td><code>SPARK_PROJECT_URL</code></td>
   <td>https://github.com/apache/spark</td>
   <td>
     The Spark project URL of GitHub Enterprise.
+  </td>
+</tr>
+<tr>
+  <td><code>GITHUB_API_BASE</code></td>
+  <td>https://api.github.com/repos/apache/spark</td>
+  <td>
+    The Spark project API server URL of GitHub Enterprise.
   </td>
 </tr>
 </table>

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -272,3 +272,31 @@ For SBT, specify a complete scala version using (e.g. 2.12.6):
     ./build/sbt -Dscala.version=2.12.6
 
 Otherwise, the sbt-pom-reader plugin will use the `scala.version` specified in the spark-parent pom.
+
+## Running Jenkins tests with enterprise Github
+
+To run tests with Jenkins:
+
+    ./dev/run-tests-jenkins
+
+If you use an individual repository or an enterprise GitHub, you should export below environment variables before running above command.
+
+### Related environment variables
+
+<table class="table">
+<tr><th>variable Name</th><th>Default</th><th>Meaning</th></tr>
+<tr>
+  <td><code>GITHUB_API_BASE</code></td>
+  <td>https://api.github.com/repos/apache/spark</td>
+  <td>
+    The GitHub server API URL. It could be pointed to an enterprise GitHub.
+  </td>
+</tr>
+<tr>
+  <td><code>SPARK_PROJECT_URL</code></td>
+  <td>https://github.com/apache/spark</td>
+  <td>
+    The Spark project URL of (enterprise) GitHub.
+  </td>
+</tr>
+</table>

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -279,7 +279,7 @@ To run tests with Jenkins:
 
     ./dev/run-tests-jenkins
 
-If you use an individual repository or an enterprise GitHub, you should export below environment variables before running above command.
+If use an individual repository or an enterprise GitHub, export below environment variables before running above command.
 
 ### Related environment variables
 

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -273,13 +273,13 @@ For SBT, specify a complete scala version using (e.g. 2.12.6):
 
 Otherwise, the sbt-pom-reader plugin will use the `scala.version` specified in the spark-parent pom.
 
-## Running Jenkins tests with enterprise Github
+## Running Jenkins tests with Github Enterprise
 
 To run tests with Jenkins:
 
     ./dev/run-tests-jenkins
 
-If use an individual repository or an enterprise GitHub, export below environment variables before running above command.
+If use an individual repository or an GitHub Enterprise, export below environment variables before running above command.
 
 ### Related environment variables
 
@@ -289,7 +289,7 @@ If use an individual repository or an enterprise GitHub, export below environmen
   <td><code>GITHUB_API_BASE</code></td>
   <td>https://api.github.com/repos/apache/spark</td>
   <td>
-    The GitHub server API URL. It could be pointed to an enterprise GitHub.
+    The GitHub server API URL. It could be pointed to an GitHub Enterprise.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Many companies have their own enterprise GitHub to manage Spark code. To build and test in those repositories with Jenkins need to modify this script.
So I suggest to add some environment variables to allow regression testing in enterprise Jenkins instead of default Spark repository in GitHub.

## How was this patch tested?

Manually test.
