### PR TITLE
[SPARK-25702][SQL] Push down filters with `Not` operator in Parquet

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
@@ -534,6 +534,13 @@ private[parquet] class ParquetFilters(
             createFilterHelper(nameToParquetField, rhs, canPartialPushDownConjuncts = false)
         } yield FilterApi.or(lhsFilter, rhsFilter)
 
+      case sources.Not(sources.Or(lhs, rhs)) if canPartialPushDownConjuncts =>
+        createFilterHelper(nameToParquetField,
+          sources.And(sources.Not(lhs), sources.Not(rhs)), canPartialPushDownConjuncts = true)
+
+      case sources.Not(sources.Not(pred)) if canPartialPushDownConjuncts =>
+        createFilterHelper(nameToParquetField, pred, canPartialPushDownConjuncts = true)
+
       case sources.Not(pred) =>
         createFilterHelper(nameToParquetField, pred, canPartialPushDownConjuncts = false)
           .map(FilterApi.not)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, in ParquetFilters, predicates inside `Not` operator are considered as unable to perform partial push down.
However, the following cases is still possible for push down:
1. `Not(Or(left, right))` can be conversed as `And(Not(left), Not(right))`
2. `Not(Not(pred))` can be conversed as `pred`

Both cases should be quite trivial, since the `Not` operator should be pushed down by optimization rule `BooleanSimplification` already.
But I think it should be good to handle such cases in Parquet data source module as well.

## How was this patch tested?

New unit test.
