### PR TITLE
[SPARK-25681][K8S][WIP] Leverage a config to tune renewal time retrieval 

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala
@@ -127,8 +127,8 @@ private[deploy] class HadoopFSDelegationTokenProvider(fileSystems: Configuration
       filesystems: Set[FileSystem]): Option[Long] = {
     // In Yarn: you cannot use the tokens generated with renewer yarn. Trying to renew
     // those will fail with an access control issue. So we create new tokens with the logged in
-    // user as renewer. In Kubernetes: you may prefer to achieve the renewal interval, but
-    // you are not required to fetch a new DT, as does Yarn.
+    // user as renewer. In Kubernetes: you may prefer to retrieve the renewal interval, but
+    // you are not required to fetch a second DT, as does Yarn.
     val renewIntervals = sparkConf.get(KUBE_RENEWAL).map { boolConf =>
       if (boolConf) {
         getIntervalGivenCreds(hadoopConf, existingCreds)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -184,6 +184,10 @@ package object config {
     .toSequence
     .createWithDefault(Nil)
 
+  private[spark] val KUBE_RENEWAL = ConfigBuilder("spark.kubernetes.kerberos.tokenRenewer.enabled")
+    .booleanConf
+    .createOptional
+
   private[spark] val MAX_TASK_FAILURES =
     ConfigBuilder("spark.task.maxFailures")
       .intConf


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changes to core allow for a K8S to pass a SparkConf specifying whether the `obtainDelegationTokens()` logic fetches `renewalInterval` (as in some uses cases where the DT renewal may be external to Spark i.e. K8s Cluster Mode) and whether this renewal interval calculation is done by retrieving a second DT, as YARN does. 

## How was this patch tested?

- [ ] Unit Tests
- Integration Tests
   - [ ] Yarn 
   - [ ] K8S
