### PR TITLE
[SPARK-25720][WEBUI] Support auto refresh page for the WEBUI

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -240,6 +240,8 @@ private[spark] object UIUtils extends Logging {
         <link rel="shortcut icon"
               href={prependBaseUri(request, "/static/spark-logo-77x50px-hd.png")}></link>
         <title>{appName} - {title}</title>
+        {if (refreshInterval.isDefined) {
+          <meta http-equiv="refresh" content={(refreshInterval.get / 1000).toString}/>}}
       </head>
       <body>
         <div class="navbar navbar-static-top">


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently spark webui doesn't have an option of auto refresh page. Because of this, user has to reload
every time to see the updates in the page. 

For SQL page and Streaming page, currently we are passing the refresh interval, but it is not implemented in the 'headerSparkPage' method. This PR, added the refresh functionality to the webui.

![screenshot from 2018-10-13 23-18-06](https://user-images.githubusercontent.com/23054875/46908270-48bbf680-cf3e-11e8-8014-de4cf8393dd9.png)
![screenshot from 2018-10-13 23-17-51](https://user-images.githubusercontent.com/23054875/46908272-4f4a6e00-cf3e-11e8-8ad9-3c6c5228b62d.png)
![screenshot from 2018-10-13 23-17-40](https://user-images.githubusercontent.com/23054875/46908275-52455e80-cf3e-11e8-92c3-93ffd5c0aff3.png)


## How was this patch tested?
Manually verified.
Every 5 seconds the SQL page is refreshing. 

![screenshot from 2018-10-13 23-23-41](https://user-images.githubusercontent.com/23054875/46908342-11017e80-cf3f-11e8-8bd5-33087e7acedb.png)

![screenshot from 2018-10-13 23-24-27](https://user-images.githubusercontent.com/23054875/46908347-27a7d580-cf3f-11e8-8bc2-360fb9d5894f.png)





