### PR TITLE
[SPARK-25740][SQL] Refactor DetermineTableStats to invalidate cache when some configuration changed

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
@@ -42,11 +42,6 @@ case class SetCommand(kv: Option[(String, Option[String])]) extends RunnableComm
     schema.toAttributes
   }
 
-  val isInvalidateAllCachedTablesKeys = Set(
-    SQLConf.ENABLE_FALL_BACK_TO_HDFS_FOR_STATS.key,
-    SQLConf.DEFAULT_SIZE_IN_BYTES.key
-  )
-
   private val (_output, runFunc): (Seq[Attribute], SparkSession => Seq[Row]) = kv match {
     // Configures the deprecated "mapred.reduce.tasks" property.
     case Some((SQLConf.Deprecated.MAPRED_REDUCE_TASKS, Some(value))) =>
@@ -100,9 +95,6 @@ case class SetCommand(kv: Option[(String, Option[String])]) extends RunnableComm
             s"prefix spark.hadoop (e.g. spark.hadoop.$key) when starting a Spark application. " +
             "For details, see the link: https://spark.apache.org/docs/latest/configuration.html#" +
             "dynamically-loading-spark-properties.")
-        }
-        if (isInvalidateAllCachedTablesKeys.contains(key)) {
-          sparkSession.sessionState.catalog.invalidateAllCachedTables()
         }
         sparkSession.conf.set(key, value)
         Seq(Row(key, value))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
@@ -42,6 +42,11 @@ case class SetCommand(kv: Option[(String, Option[String])]) extends RunnableComm
     schema.toAttributes
   }
 
+  val isInvalidateAllCachedTablesKeys = Set(
+    SQLConf.ENABLE_FALL_BACK_TO_HDFS_FOR_STATS.key,
+    SQLConf.DEFAULT_SIZE_IN_BYTES.key
+  )
+
   private val (_output, runFunc): (Seq[Attribute], SparkSession => Seq[Row]) = kv match {
     // Configures the deprecated "mapred.reduce.tasks" property.
     case Some((SQLConf.Deprecated.MAPRED_REDUCE_TASKS, Some(value))) =>
@@ -95,6 +100,9 @@ case class SetCommand(kv: Option[(String, Option[String])]) extends RunnableComm
             s"prefix spark.hadoop (e.g. spark.hadoop.$key) when starting a Spark application. " +
             "For details, see the link: https://spark.apache.org/docs/latest/configuration.html#" +
             "dynamically-loading-spark-properties.")
+        }
+        if (isInvalidateAllCachedTablesKeys.contains(key)) {
+          sparkSession.sessionState.catalog.invalidateAllCachedTables()
         }
         sparkSession.conf.set(key, value)
         Seq(Row(key, value))

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveStrategiesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveStrategiesSuite.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive
+
+import org.apache.spark.sql.catalyst.QualifiedTableName
+import org.apache.spark.sql.catalyst.catalog.SessionCatalog
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.hive.test.TestHiveSingleton
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SQLTestUtils
+
+class HiveStrategiesSuite extends SQLTestUtils with TestHiveSingleton {
+
+  test("Test DetermineTableStats") {
+    def assertStatsNonEmpty(catalog: SessionCatalog, cachedRelation: LogicalPlan): Unit = {
+      assert(cachedRelation.isInstanceOf[LogicalRelation])
+      assert(cachedRelation.asInstanceOf[LogicalRelation].catalogTable.nonEmpty)
+      assert(cachedRelation.asInstanceOf[LogicalRelation].catalogTable.get.stats.nonEmpty)
+    }
+
+    withTable("t1") {
+      sql("CREATE TABLE t1 (c1 bigint) STORED AS PARQUET")
+      sql("INSERT INTO TABLE t1 VALUES (1)")
+      sql("REFRESH TABLE t1")
+
+      val catalog = spark.sessionState.catalog
+      val defaultSizeInBytesValue = spark.sessionState.conf.defaultSizeInBytes
+      val qualifiedTableName = QualifiedTableName(catalog.getCurrentDatabase, "t1")
+
+      Seq(true, false, true).foreach { enableFallBack =>
+        withSQLConf(SQLConf.ENABLE_FALL_BACK_TO_HDFS_FOR_STATS.key -> enableFallBack.toString) {
+          sql("SELECT * from t1").collect()
+          val cachedRelation = catalog.getCachedTable(qualifiedTableName)
+          assertStatsNonEmpty(catalog, cachedRelation)
+          val stats = cachedRelation.asInstanceOf[LogicalRelation].catalogTable.get.stats.get
+          if (enableFallBack) {
+            assert(stats.sizeInBytes !== defaultSizeInBytesValue)
+          } else {
+            assert(stats.sizeInBytes === defaultSizeInBytesValue)
+          }
+        }
+      }
+
+      Seq(Long.MaxValue, 10000, 10).foreach { defaultSizeInBytes =>
+        withSQLConf(SQLConf.DEFAULT_SIZE_IN_BYTES.key -> defaultSizeInBytes.toString) {
+          sql("SELECT * from t1").collect()
+          val cachedRelation = catalog.getCachedTable(qualifiedTableName)
+          assertStatsNonEmpty(catalog, cachedRelation)
+          val stats = cachedRelation.asInstanceOf[LogicalRelation].catalogTable.get.stats.get
+          assert(stats.sizeInBytes === defaultSizeInBytes)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
How to reproduce:
```sql
# spark-sql
create table t1 (a int) stored as parquet;
create table t2 (a int) stored as parquet;
insert into table t1 values (1);
insert into table t2 values (1);
-- clear cache
REFRESH TABLE t1;
REFRESH TABLE t2;

explain select * from t1, t2 where t1.a = t2.a;
-- SortMergeJoin
set spark.sql.statistics.fallBackToHdfs=true;
explain select * from t1, t2 where t1.a = t2.a;
-- SortMergeJoin, it should be BroadcastHashJoin

-- clear cache
REFRESH TABLE t1;
REFRESH TABLE t2;
explain select * from t1, t2 where t1.a = t2.a;
-- BroadcastHashJoin
```


This pr refactor `DetermineTableStats `to invalidate cache when `spark.sql.statistics.fallBackToHdfs` or `spark.sql.defaultSizeInBytes` changed.

## How was this patch tested?

unit tests
