### PR TITLE
[SPARK-20327][yarn] Follow up: fix resource request tests on Hadoop 3.

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ResourceRequestHelper.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ResourceRequestHelper.scala
@@ -29,7 +29,7 @@ import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.deploy.yarn.config._
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
-import org.apache.spark.util.Utils
+import org.apache.spark.util.{CausedBy, Utils}
 
 /**
  * This helper class uses some of Hadoop 3 methods from the YARN API,
@@ -121,6 +121,8 @@ private object ResourceRequestHelper extends Logging {
         case _: MatchError =>
           throw new IllegalArgumentException(s"Resource request for '$name' ('$rawAmount') " +
               s"does not match pattern $AMOUNT_AND_UNIT_REGEX.")
+        case CausedBy(e: IllegalArgumentException) =>
+          throw new IllegalArgumentException(s"Invalid request for $name: ${e.getMessage}")
         case e: InvocationTargetException if e.getCause != null => throw e.getCause
       }
     }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ResourceRequestTestHelper.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ResourceRequestTestHelper.scala
@@ -18,20 +18,18 @@
 package org.apache.spark.deploy.yarn
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable.ListBuffer
 
 import org.apache.hadoop.yarn.api.records.Resource
 
 import org.apache.spark.util.Utils
 
 object ResourceRequestTestHelper {
-  def initializeResourceTypes(resourceTypes: List[String]): Unit = {
+  def initializeResourceTypes(resourceTypes: Seq[String]): Unit = {
     if (!ResourceRequestHelper.isYarnResourceTypesAvailable()) {
       throw new IllegalStateException("This method should not be invoked " +
         "since YARN resource types is not available because of old Hadoop version!" )
     }
 
-    val allResourceTypes = new ListBuffer[AnyRef]
     // ResourceUtils.reinitializeResources() is the YARN-way
     // to specify resources for the execution of the tests.
     // This method should receive standard resources with names of memory-mb and vcores.
@@ -42,8 +40,7 @@ object ResourceRequestTestHelper {
       createResourceTypeInfo("memory-mb"),
       createResourceTypeInfo("vcores"))
     val customResourceTypes = resourceTypes.map(createResourceTypeInfo)
-    allResourceTypes ++= defaultResourceTypes
-    allResourceTypes ++= customResourceTypes
+    val allResourceTypes = defaultResourceTypes ++ customResourceTypes
 
     val resourceUtilsClass =
       Utils.classForName("org.apache.hadoop.yarn.util.resource.ResourceUtils")
@@ -58,8 +55,8 @@ object ResourceRequestTestHelper {
     resTypeInfoNewInstanceMethod.invoke(null, resourceName)
   }
 
-  def getResourceTypeValue(res: Resource, name: String): AnyRef = {
-    val resourceInformation = getResourceInformation(res, name)
+  def getRequestedValue(res: Resource, rtype: String): AnyRef = {
+    val resourceInformation = getResourceInformation(res, rtype)
     invokeMethod(resourceInformation, "getValue")
   }
 
@@ -88,5 +85,5 @@ object ResourceRequestTestHelper {
     getValueMethod.invoke(resourceInformation)
   }
 
-  case class ResourceInformation(name: String, value: Long, units: String)
+  case class ResourceInformation(name: String, value: Long, unit: String)
 }


### PR DESCRIPTION
The test fix is to allocate a `Resource` object only after the resource
types have been initialized. Otherwise the YARN classes get in a weird
state and throw a different exception than expected, because the resource
has a different view of the registered resources.

I also removed a test for a null resource since that seems unnecessary
and made the fix more complicated.

All the other changes are just cleanup; basically simplify the tests by
defining what is being tested and deriving the resource type registration
and the SparkConf from that data, instead of having redundant definitions
in the tests.

Ran tests with Hadoop 3 (and also without it).