### PR TITLE
[SPARK-25800][Build] Remove all instances of netty 3.x in code base.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -249,10 +249,6 @@
       <artifactId>netty-all</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.clearspring.analytics</groupId>
       <artifactId>stream</artifactId>
     </dependency>

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -148,7 +148,6 @@ metrics-graphite-3.1.5.jar
 metrics-json-3.1.5.jar
 metrics-jvm-3.1.5.jar
 minlog-1.3.0.jar
-netty-3.7.0.Final.jar
 netty-all-4.1.30.Final.jar
 objenesis-2.5.1.jar
 okhttp-3.8.1.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -148,7 +148,7 @@ metrics-graphite-3.1.5.jar
 metrics-json-3.1.5.jar
 metrics-jvm-3.1.5.jar
 minlog-1.3.0.jar
-netty-3.9.9.Final.jar
+netty-3.7.0.Final.jar
 netty-all-4.1.30.Final.jar
 objenesis-2.5.1.jar
 okhttp-3.8.1.jar

--- a/dev/deps/spark-deps-hadoop-3.1
+++ b/dev/deps/spark-deps-hadoop-3.1
@@ -164,7 +164,6 @@ metrics-json-3.1.5.jar
 metrics-jvm-3.1.5.jar
 minlog-1.3.0.jar
 mssql-jdbc-6.2.1.jre7.jar
-netty-3.10.5.Final.jar
 netty-all-4.1.30.Final.jar
 nimbus-jose-jwt-4.41.1.jar
 objenesis-2.5.1.jar

--- a/dev/deps/spark-deps-hadoop-3.1
+++ b/dev/deps/spark-deps-hadoop-3.1
@@ -164,7 +164,7 @@ metrics-json-3.1.5.jar
 metrics-jvm-3.1.5.jar
 minlog-1.3.0.jar
 mssql-jdbc-6.2.1.jre7.jar
-netty-3.9.9.Final.jar
+netty-3.10.5.Final.jar
 netty-all-4.1.30.Final.jar
 nimbus-jose-jwt-4.41.1.jar
 objenesis-2.5.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -867,6 +867,10 @@
             <artifactId>asm</artifactId>
           </exclusion>
           <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>org.jboss.netty</groupId>
             <artifactId>netty</artifactId>
           </exclusion>
@@ -1196,6 +1200,10 @@
         <version>${zookeeper.version}</version>
         <scope>${hadoop.deps.scope}</scope>
         <exclusions>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>org.jboss.netty</groupId>
             <artifactId>netty</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -584,11 +584,6 @@
         <version>4.1.30.Final</version>
       </dependency>
       <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty</artifactId>
-        <version>3.9.9.Final</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.derby</groupId>
         <artifactId>derby</artifactId>
         <version>${derby.version}</version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove all the dependencies of netty 3.x from pom.xml.

## How was this patch tested?

Manual tests.
./dev/make-distribution.sh --name custom_spark --tgz  -Phadoop-2.7 -Phive -Pyarn -Phive-thriftserver -Phadoop-provided