### PR TITLE
[SPARK-25665][SQL][TEST] Refactor ObjectHashAggregateExecBenchmark to…

### DIFF
--- a/sql/hive/benchmarks/ObjectHashAggregateExecBenchmark-results.txt
+++ b/sql/hive/benchmarks/ObjectHashAggregateExecBenchmark-results.txt
@@ -1,0 +1,45 @@
+================================================================================================
+Hive UDAF vs Spark AF
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_162-b12 on Mac OS X 10.13.6
+Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
+hive udaf vs spark af:                   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+hive udaf w/o group by                        4895 / 5020          0.0       74685.5       1.0X
+spark af w/o group by                           38 /   46          1.7         580.3     128.7X
+hive udaf w/ group by                         3309 / 3331          0.0       50491.1       1.5X
+spark af w/ group by w/o fallback               41 /   46          1.6         626.4     119.2X
+spark af w/ group by w/ fallback               111 /  115          0.6        1690.9      44.2X
+
+
+================================================================================================
+ObjectHashAggregateExec vs SortAggregateExec - typed_count
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_162-b12 on Mac OS X 10.13.6
+Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
+object agg v.s. sort agg:                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+sort agg w/ group by                        33760 / 34049          3.1         322.0       1.0X
+object agg w/ group by w/o fallback           7625 / 7877         13.8          72.7       4.4X
+object agg w/ group by w/ fallback          22695 / 22749          4.6         216.4       1.5X
+sort agg w/o group by                         4861 / 6473         21.6          46.4       6.9X
+object agg w/o group by w/o fallback          4143 / 4272         25.3          39.5       8.1X
+
+
+================================================================================================
+ObjectHashAggregateExec vs SortAggregateExec - percentile_approx
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_162-b12 on Mac OS X 10.13.6
+Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
+object agg v.s. sort agg:                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+sort agg w/ group by                           745 /  786          2.8         355.2       1.0X
+object agg w/ group by w/o fallback            596 /  626          3.5         284.3       1.2X
+object agg w/ group by w/ fallback             769 /  810          2.7         366.6       1.0X
+sort agg w/o group by                          564 /  589          3.7         268.7       1.3X
+object agg w/o group by w/o fallback           573 /  598          3.7         273.3       1.3X
+
+

--- a/sql/hive/benchmarks/ObjectHashAggregateExecBenchmark-results.txt
+++ b/sql/hive/benchmarks/ObjectHashAggregateExecBenchmark-results.txt
@@ -2,44 +2,44 @@
 Hive UDAF vs Spark AF
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_162-b12 on Mac OS X 10.13.6
-Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 hive udaf vs spark af:                   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-hive udaf w/o group by                        4895 / 5020          0.0       74685.5       1.0X
-spark af w/o group by                           38 /   46          1.7         580.3     128.7X
-hive udaf w/ group by                         3309 / 3331          0.0       50491.1       1.5X
-spark af w/ group by w/o fallback               41 /   46          1.6         626.4     119.2X
-spark af w/ group by w/ fallback               111 /  115          0.6        1690.9      44.2X
+hive udaf w/o group by                        6370 / 6400          0.0       97193.6       1.0X
+spark af w/o group by                           54 /   63          1.2         820.8     118.4X
+hive udaf w/ group by                         4492 / 4507          0.0       68539.5       1.4X
+spark af w/ group by w/o fallback               58 /   64          1.1         881.7     110.2X
+spark af w/ group by w/ fallback               136 /  142          0.5        2075.0      46.8X
 
 
 ================================================================================================
 ObjectHashAggregateExec vs SortAggregateExec - typed_count
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_162-b12 on Mac OS X 10.13.6
-Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 object agg v.s. sort agg:                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-sort agg w/ group by                        33760 / 34049          3.1         322.0       1.0X
-object agg w/ group by w/o fallback           7625 / 7877         13.8          72.7       4.4X
-object agg w/ group by w/ fallback          22695 / 22749          4.6         216.4       1.5X
-sort agg w/o group by                         4861 / 6473         21.6          46.4       6.9X
-object agg w/o group by w/o fallback          4143 / 4272         25.3          39.5       8.1X
+sort agg w/ group by                        41500 / 41630          2.5         395.8       1.0X
+object agg w/ group by w/o fallback         10075 / 10122         10.4          96.1       4.1X
+object agg w/ group by w/ fallback          28131 / 28205          3.7         268.3       1.5X
+sort agg w/o group by                         6182 / 6221         17.0          59.0       6.7X
+object agg w/o group by w/o fallback          5435 / 5468         19.3          51.8       7.6X
 
 
 ================================================================================================
 ObjectHashAggregateExec vs SortAggregateExec - percentile_approx
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_162-b12 on Mac OS X 10.13.6
-Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 object agg v.s. sort agg:                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-sort agg w/ group by                           745 /  786          2.8         355.2       1.0X
-object agg w/ group by w/o fallback            596 /  626          3.5         284.3       1.2X
-object agg w/ group by w/ fallback             769 /  810          2.7         366.6       1.0X
-sort agg w/o group by                          564 /  589          3.7         268.7       1.3X
-object agg w/o group by w/o fallback           573 /  598          3.7         273.3       1.3X
+sort agg w/ group by                           970 / 1025          2.2         462.5       1.0X
+object agg w/ group by w/o fallback            772 /  798          2.7         368.1       1.3X
+object agg w/ group by w/ fallback            1013 / 1044          2.1         483.1       1.0X
+sort agg w/o group by                          751 /  781          2.8         358.0       1.3X
+object agg w/o group by w/o fallback           772 /  814          2.7         368.0       1.3X
 
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/execution/benchmark/ObjectHashAggregateExecBenchmark.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/execution/benchmark/ObjectHashAggregateExecBenchmark.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.LongType
 
 /**
- * Benchmark to measure read performance with Filter pushdown.
+ * Benchmark to measure hash based aggregation.
  * To run this benchmark:
  * {{{
  *   1. without sbt: bin/spark-submit --class <this class>

--- a/sql/hive/src/test/scala/org/apache/spark/sql/execution/benchmark/ObjectHashAggregateExecBenchmark.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/execution/benchmark/ObjectHashAggregateExecBenchmark.scala
@@ -138,8 +138,7 @@ object ObjectHashAggregateExecBenchmark extends BenchmarkBase with SQLHelper {
     benchmark.addCase("object agg w/ group by w/ fallback") { _ =>
       withSQLConf(
         SQLConf.USE_OBJECT_HASH_AGG.key -> "true",
-        SQLConf.OBJECT_AGG_SORT_BASED_FALLBACK_THRESHOLD.key -> "2"
-      ) {
+        SQLConf.OBJECT_AGG_SORT_BASED_FALLBACK_THRESHOLD.key -> "2") {
         df.groupBy($"id" < (N / 2)).agg(typed_count($"id")).collect()
       }
     }
@@ -174,17 +173,13 @@ object ObjectHashAggregateExecBenchmark extends BenchmarkBase with SQLHelper {
 
     benchmark.addCase("sort agg w/ group by") { _ =>
       withSQLConf(SQLConf.USE_OBJECT_HASH_AGG.key -> "false") {
-        df.groupBy($"id" / (N / 4) cast LongType)
-          .agg(percentile_approx($"id", 0.5))
-          .collect()
+        df.groupBy($"id" / (N / 4) cast LongType).agg(percentile_approx($"id", 0.5)).collect()
       }
     }
 
     benchmark.addCase("object agg w/ group by w/o fallback") { _ =>
       withSQLConf(SQLConf.USE_OBJECT_HASH_AGG.key -> "true") {
-        df.groupBy($"id" / (N / 4) cast LongType)
-          .agg(percentile_approx($"id", 0.5))
-          .collect()
+        df.groupBy($"id" / (N / 4) cast LongType).agg(percentile_approx($"id", 0.5)).collect()
       }
     }
 
@@ -192,9 +187,7 @@ object ObjectHashAggregateExecBenchmark extends BenchmarkBase with SQLHelper {
       withSQLConf(
         SQLConf.USE_OBJECT_HASH_AGG.key -> "true",
         SQLConf.OBJECT_AGG_SORT_BASED_FALLBACK_THRESHOLD.key -> "2") {
-        df.groupBy($"id" / (N / 4) cast LongType)
-          .agg(percentile_approx($"id", 0.5))
-          .collect()
+        df.groupBy($"id" / (N / 4) cast LongType).agg(percentile_approx($"id", 0.5)).collect()
       }
     }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/execution/benchmark/ObjectHashAggregateExecBenchmark.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/execution/benchmark/ObjectHashAggregateExecBenchmark.scala
@@ -46,11 +46,11 @@ import org.apache.spark.sql.types.LongType
  */
 object ObjectHashAggregateExecBenchmark extends BenchmarkBase with SQLHelper {
 
-  val spark: SparkSession = TestHive.sparkSession
+  private val spark: SparkSession = TestHive.sparkSession
+  private val sql = spark.sql _
+  import spark.implicits._
 
-  private def hiveUDAFvsSparkAF(): Unit = {
-    val N = 2 << 15
-
+  private def hiveUDAFvsSparkAF(N: Int): Unit = {
     val benchmark = new Benchmark(
       name = "hive udaf vs spark af",
       valuesPerIteration = N,
@@ -61,7 +61,7 @@ object ObjectHashAggregateExecBenchmark extends BenchmarkBase with SQLHelper {
       output = output
     )
 
-    spark.sql(
+    sql(
       s"CREATE TEMPORARY FUNCTION hive_percentile_approx AS '" +
         s"${classOf[GenericUDAFPercentileApprox].getName}'"
     )
@@ -70,33 +70,27 @@ object ObjectHashAggregateExecBenchmark extends BenchmarkBase with SQLHelper {
 
     benchmark.addCase("hive udaf w/o group by") { _ =>
       withSQLConf(SQLConf.USE_OBJECT_HASH_AGG.key -> "false") {
-        spark.sql("SELECT hive_percentile_approx(id, 0.5) FROM t").collect()
+        sql("SELECT hive_percentile_approx(id, 0.5) FROM t").collect()
       }
     }
 
     benchmark.addCase("spark af w/o group by") { _ =>
       withSQLConf(SQLConf.USE_OBJECT_HASH_AGG.key -> "true") {
-        spark.sql("SELECT percentile_approx(id, 0.5) FROM t").collect()
+        sql("SELECT percentile_approx(id, 0.5) FROM t").collect()
       }
     }
 
     benchmark.addCase("hive udaf w/ group by") { _ =>
       withSQLConf(SQLConf.USE_OBJECT_HASH_AGG.key -> "false") {
-        spark
-          .sql(
-            s"SELECT hive_percentile_approx(id, 0.5) " +
-              s"FROM t GROUP BY CAST(id / ${N / 4} AS BIGINT)"
-          )
-          .collect()
+        sql(
+          s"SELECT hive_percentile_approx(id, 0.5) FROM t GROUP BY CAST(id / ${N / 4} AS BIGINT)"
+        ).collect()
       }
     }
 
     benchmark.addCase("spark af w/ group by w/o fallback") { _ =>
       withSQLConf(SQLConf.USE_OBJECT_HASH_AGG.key -> "true") {
-        spark
-          .sql(
-            s"SELECT percentile_approx(id, 0.5) FROM t GROUP BY CAST(id / ${N / 4} AS BIGINT)"
-          )
+        sql(s"SELECT percentile_approx(id, 0.5) FROM t GROUP BY CAST(id / ${N / 4} AS BIGINT)")
           .collect()
       }
     }
@@ -104,12 +98,8 @@ object ObjectHashAggregateExecBenchmark extends BenchmarkBase with SQLHelper {
     benchmark.addCase("spark af w/ group by w/ fallback") { _ =>
       withSQLConf(
         SQLConf.USE_OBJECT_HASH_AGG.key -> "true",
-        SQLConf.OBJECT_AGG_SORT_BASED_FALLBACK_THRESHOLD.key -> "2"
-      ) {
-        spark
-          .sql(
-            s"SELECT percentile_approx(id, 0.5) FROM t GROUP BY CAST(id / ${N / 4} AS BIGINT)"
-          )
+        SQLConf.OBJECT_AGG_SORT_BASED_FALLBACK_THRESHOLD.key -> "2") {
+        sql(s"SELECT percentile_approx(id, 0.5) FROM t GROUP BY CAST(id / ${N / 4} AS BIGINT)")
           .collect()
       }
     }
@@ -117,9 +107,7 @@ object ObjectHashAggregateExecBenchmark extends BenchmarkBase with SQLHelper {
     benchmark.run()
   }
 
-  private def objectHashAggregateExecVsSortAggregateExecUsingTypedCount(): Unit = {
-    val N: Long = 1024 * 1024 * 100
-
+  private def objectHashAggregateExecVsSortAggregateExecUsingTypedCount(N: Int): Unit = {
     val benchmark = new Benchmark(
       name = "object agg v.s. sort agg",
       valuesPerIteration = N,
@@ -129,8 +117,6 @@ object ObjectHashAggregateExecBenchmark extends BenchmarkBase with SQLHelper {
       outputPerIteration = true,
       output = output
     )
-
-    import spark.implicits._
 
     def typed_count(column: Column): Column =
       Column(TestingTypedCount(column.expr).toAggregateExpression())
@@ -173,9 +159,7 @@ object ObjectHashAggregateExecBenchmark extends BenchmarkBase with SQLHelper {
     benchmark.run()
   }
 
-  private def objectHashAggregateExecVsSortAggregateExecUsingPercentileApprox(): Unit = {
-    val N = 2 << 20
-
+  private def objectHashAggregateExecVsSortAggregateExecUsingPercentileApprox(N: Int): Unit = {
     val benchmark = new Benchmark(
       name = "object agg v.s. sort agg",
       valuesPerIteration = N,
@@ -185,8 +169,6 @@ object ObjectHashAggregateExecBenchmark extends BenchmarkBase with SQLHelper {
       outputPerIteration = true,
       output = output
     )
-
-    import spark.implicits._
 
     val df = spark.range(N).coalesce(1)
 
@@ -209,8 +191,7 @@ object ObjectHashAggregateExecBenchmark extends BenchmarkBase with SQLHelper {
     benchmark.addCase("object agg w/ group by w/ fallback") { _ =>
       withSQLConf(
         SQLConf.USE_OBJECT_HASH_AGG.key -> "true",
-        SQLConf.OBJECT_AGG_SORT_BASED_FALLBACK_THRESHOLD.key -> "2"
-      ) {
+        SQLConf.OBJECT_AGG_SORT_BASED_FALLBACK_THRESHOLD.key -> "2") {
         df.groupBy($"id" / (N / 4) cast LongType)
           .agg(percentile_approx($"id", 0.5))
           .collect()
@@ -240,15 +221,15 @@ object ObjectHashAggregateExecBenchmark extends BenchmarkBase with SQLHelper {
 
   override def runBenchmarkSuite(): Unit = {
     runBenchmark("Hive UDAF vs Spark AF") {
-      hiveUDAFvsSparkAF()
+      hiveUDAFvsSparkAF(2 << 15)
     }
 
     runBenchmark("ObjectHashAggregateExec vs SortAggregateExec - typed_count") {
-      objectHashAggregateExecVsSortAggregateExecUsingTypedCount
+      objectHashAggregateExecVsSortAggregateExecUsingTypedCount(1024 * 1024 * 100)
     }
 
     runBenchmark("ObjectHashAggregateExec vs SortAggregateExec - percentile_approx") {
-      objectHashAggregateExecVsSortAggregateExecUsingPercentileApprox
+      objectHashAggregateExecVsSortAggregateExecUsingPercentileApprox(2 << 20)
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/execution/benchmark/ObjectHashAggregateExecBenchmark.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/execution/benchmark/ObjectHashAggregateExecBenchmark.scala
@@ -21,207 +21,212 @@ import scala.concurrent.duration._
 
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFPercentileApprox
 
-import org.apache.spark.benchmark.Benchmark
-import org.apache.spark.sql.Column
-import org.apache.spark.sql.catalyst.FunctionIdentifier
-import org.apache.spark.sql.catalyst.catalog.CatalogFunction
+import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
+import org.apache.spark.sql.{Column, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile
-import org.apache.spark.sql.hive.HiveSessionCatalog
+import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.hive.execution.TestingTypedCount
-import org.apache.spark.sql.hive.test.TestHiveSingleton
+import org.apache.spark.sql.hive.test.TestHive
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.LongType
 
-class ObjectHashAggregateExecBenchmark extends BenchmarkWithCodegen with TestHiveSingleton {
-  ignore("Hive UDAF vs Spark AF") {
-    val N = 2 << 15
+/**
+ * Benchmark to measure read performance with Filter pushdown.
+ * To run this benchmark:
+ * {{{
+ *   1. without sbt: bin/spark-submit --class <this class>
+ *        --jars <spark catalyst test jar>,<spark core test jar>,<spark hive jar>
+ *        --packages org.spark-project.hive:hive-exec:1.2.1.spark2
+ *        <spark hive test jar>
+ *   2. build/sbt "hive/test:runMain <this class>"
+ *   3. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "hive/test:runMain <this class>"
+ *      Results will be written to "benchmarks/ObjectHashAggregateExecBenchmark-results.txt".
+ * }}}
+ */
+object ObjectHashAggregateExecBenchmark extends BenchmarkBase with SQLHelper {
 
-    val benchmark = new Benchmark(
-      name = "hive udaf vs spark af",
-      valuesPerIteration = N,
-      minNumIters = 5,
-      warmupTime = 5.seconds,
-      minTime = 10.seconds,
-      outputPerIteration = true
-    )
+  val spark: SparkSession = TestHive.sparkSession
 
-    registerHiveFunction("hive_percentile_approx", classOf[GenericUDAFPercentileApprox])
+  override def runBenchmarkSuite(): Unit = {
+    runBenchmark("Hive UDAF vs Spark AF") {
+      val N = 2 << 15
 
-    sparkSession.range(N).createOrReplaceTempView("t")
+      val benchmark = new Benchmark(
+        name = "hive udaf vs spark af",
+        valuesPerIteration = N,
+        minNumIters = 5,
+        warmupTime = 5.seconds,
+        minTime = 10.seconds,
+        outputPerIteration = true,
+        output = output
+      )
 
-    benchmark.addCase("hive udaf w/o group by") { _ =>
-      sparkSession.conf.set(SQLConf.USE_OBJECT_HASH_AGG.key, "false")
-      sparkSession.sql("SELECT hive_percentile_approx(id, 0.5) FROM t").collect()
+      spark.sql(s"CREATE TEMPORARY FUNCTION hive_percentile_approx AS '" +
+          s"${classOf[GenericUDAFPercentileApprox].getName}'")
+
+      spark.range(N).createOrReplaceTempView("t")
+
+      benchmark.addCase("hive udaf w/o group by") { _ =>
+        withSQLConf(SQLConf.USE_OBJECT_HASH_AGG.key -> "false") {
+          spark.sql("SELECT hive_percentile_approx(id, 0.5) FROM t").collect()
+        }
+      }
+
+      benchmark.addCase("spark af w/o group by") { _ =>
+        withSQLConf(SQLConf.USE_OBJECT_HASH_AGG.key -> "true") {
+          spark.sql("SELECT percentile_approx(id, 0.5) FROM t").collect()
+        }
+      }
+
+      benchmark.addCase("hive udaf w/ group by") { _ =>
+        withSQLConf(SQLConf.USE_OBJECT_HASH_AGG.key -> "false") {
+          spark
+            .sql(
+              s"SELECT hive_percentile_approx(id, 0.5) " +
+                s"FROM t GROUP BY CAST(id / ${N / 4} AS BIGINT)"
+            )
+            .collect()
+        }
+      }
+
+      benchmark.addCase("spark af w/ group by w/o fallback") { _ =>
+        withSQLConf(SQLConf.USE_OBJECT_HASH_AGG.key -> "true") {
+          spark
+            .sql(
+              s"SELECT percentile_approx(id, 0.5) FROM t GROUP BY CAST(id / ${N / 4} AS BIGINT)"
+            )
+            .collect()
+        }
+      }
+
+      benchmark.addCase("spark af w/ group by w/ fallback") { _ =>
+        withSQLConf(
+          SQLConf.USE_OBJECT_HASH_AGG.key -> "true",
+          SQLConf.OBJECT_AGG_SORT_BASED_FALLBACK_THRESHOLD.key -> "2") {
+            spark
+              .sql(
+                s"SELECT percentile_approx(id, 0.5) FROM t GROUP BY CAST(id / ${N / 4} AS BIGINT)"
+              )
+              .collect()
+          }
+      }
+
+      benchmark.run()
     }
 
-    benchmark.addCase("spark af w/o group by") { _ =>
-      sparkSession.conf.set(SQLConf.USE_OBJECT_HASH_AGG.key, "true")
-      sparkSession.sql("SELECT percentile_approx(id, 0.5) FROM t").collect()
+    runBenchmark("ObjectHashAggregateExec vs SortAggregateExec - typed_count") {
+      val N: Long = 1024 * 1024 * 100
+
+      val benchmark = new Benchmark(
+        name = "object agg v.s. sort agg",
+        valuesPerIteration = N,
+        minNumIters = 1,
+        warmupTime = 10.seconds,
+        minTime = 45.seconds,
+        outputPerIteration = true,
+        output = output
+      )
+
+      import spark.implicits._
+
+      def typed_count(column: Column): Column =
+        Column(TestingTypedCount(column.expr).toAggregateExpression())
+
+      val df = spark.range(N)
+
+      benchmark.addCase("sort agg w/ group by") { _ =>
+        withSQLConf(SQLConf.USE_OBJECT_HASH_AGG.key -> "false") {
+          df.groupBy($"id" < (N / 2)).agg(typed_count($"id")).collect()
+        }
+      }
+
+      benchmark.addCase("object agg w/ group by w/o fallback") { _ =>
+        withSQLConf(SQLConf.USE_OBJECT_HASH_AGG.key -> "true") {
+          df.groupBy($"id" < (N / 2)).agg(typed_count($"id")).collect()
+        }
+      }
+
+      benchmark.addCase("object agg w/ group by w/ fallback") { _ =>
+        withSQLConf(
+          SQLConf.USE_OBJECT_HASH_AGG.key -> "true",
+          SQLConf.OBJECT_AGG_SORT_BASED_FALLBACK_THRESHOLD.key -> "2") {
+            df.groupBy($"id" < (N / 2)).agg(typed_count($"id")).collect()
+          }
+      }
+
+      benchmark.addCase("sort agg w/o group by") { _ =>
+        withSQLConf(SQLConf.USE_OBJECT_HASH_AGG.key -> "false") {
+          df.select(typed_count($"id")).collect()
+        }
+      }
+
+      benchmark.addCase("object agg w/o group by w/o fallback") { _ =>
+        withSQLConf(SQLConf.USE_OBJECT_HASH_AGG.key -> "true") {
+          df.select(typed_count($"id")).collect()
+        }
+      }
+
+      benchmark.run()
     }
 
-    benchmark.addCase("hive udaf w/ group by") { _ =>
-      sparkSession.conf.set(SQLConf.USE_OBJECT_HASH_AGG.key, "false")
-      sparkSession.sql(
-        s"SELECT hive_percentile_approx(id, 0.5) FROM t GROUP BY CAST(id / ${N / 4} AS BIGINT)"
-      ).collect()
+    runBenchmark("ObjectHashAggregateExec vs SortAggregateExec - percentile_approx") {
+      val N = 2 << 20
+
+      val benchmark = new Benchmark(
+        name = "object agg v.s. sort agg",
+        valuesPerIteration = N,
+        minNumIters = 5,
+        warmupTime = 15.seconds,
+        minTime = 45.seconds,
+        outputPerIteration = true,
+        output = output
+      )
+
+      import spark.implicits._
+
+      val df = spark.range(N).coalesce(1)
+
+      benchmark.addCase("sort agg w/ group by") { _ =>
+        withSQLConf(SQLConf.USE_OBJECT_HASH_AGG.key -> "false") {
+          df.groupBy($"id" / (N / 4) cast LongType)
+            .agg(percentile_approx($"id", 0.5))
+            .collect()
+        }
+      }
+
+      benchmark.addCase("object agg w/ group by w/o fallback") { _ =>
+        withSQLConf(SQLConf.USE_OBJECT_HASH_AGG.key -> "true") {
+          df.groupBy($"id" / (N / 4) cast LongType)
+            .agg(percentile_approx($"id", 0.5))
+            .collect()
+        }
+      }
+
+      benchmark.addCase("object agg w/ group by w/ fallback") { _ =>
+        withSQLConf(
+          SQLConf.USE_OBJECT_HASH_AGG.key -> "true",
+          SQLConf.OBJECT_AGG_SORT_BASED_FALLBACK_THRESHOLD.key -> "2") {
+            df.groupBy($"id" / (N / 4) cast LongType)
+              .agg(percentile_approx($"id", 0.5))
+              .collect()
+          }
+      }
+
+      benchmark.addCase("sort agg w/o group by") { _ =>
+        withSQLConf(SQLConf.USE_OBJECT_HASH_AGG.key -> "false") {
+          df.select(percentile_approx($"id", 0.5)).collect()
+        }
+      }
+
+      benchmark.addCase("object agg w/o group by w/o fallback") { _ =>
+        withSQLConf(SQLConf.USE_OBJECT_HASH_AGG.key -> "true") {
+          df.select(percentile_approx($"id", 0.5)).collect()
+        }
+      }
+
+      benchmark.run()
     }
-
-    benchmark.addCase("spark af w/ group by w/o fallback") { _ =>
-      sparkSession.conf.set(SQLConf.USE_OBJECT_HASH_AGG.key, "true")
-      sparkSession.sql(
-        s"SELECT percentile_approx(id, 0.5) FROM t GROUP BY CAST(id / ${N / 4} AS BIGINT)"
-      ).collect()
-    }
-
-    benchmark.addCase("spark af w/ group by w/ fallback") { _ =>
-      sparkSession.conf.set(SQLConf.USE_OBJECT_HASH_AGG.key, "true")
-      sparkSession.conf.set(SQLConf.OBJECT_AGG_SORT_BASED_FALLBACK_THRESHOLD.key, "2")
-      sparkSession.sql(
-        s"SELECT percentile_approx(id, 0.5) FROM t GROUP BY CAST(id / ${N / 4} AS BIGINT)"
-      ).collect()
-    }
-
-    benchmark.run()
-
-    /*
-    Java HotSpot(TM) 64-Bit Server VM 1.8.0_92-b14 on Mac OS X 10.10.5
-    Intel(R) Core(TM) i7-4960HQ CPU @ 2.60GHz
-
-    hive udaf vs spark af:                   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-    ------------------------------------------------------------------------------------------------
-    hive udaf w/o group by                        5326 / 5408          0.0       81264.2       1.0X
-    spark af w/o group by                           93 /  111          0.7        1415.6      57.4X
-    hive udaf w/ group by                         3804 / 3946          0.0       58050.1       1.4X
-    spark af w/ group by w/o fallback               71 /   90          0.9        1085.7      74.8X
-    spark af w/ group by w/ fallback                98 /  111          0.7        1501.6      54.1X
-     */
-  }
-
-  ignore("ObjectHashAggregateExec vs SortAggregateExec - typed_count") {
-    val N: Long = 1024 * 1024 * 100
-
-    val benchmark = new Benchmark(
-      name = "object agg v.s. sort agg",
-      valuesPerIteration = N,
-      minNumIters = 1,
-      warmupTime = 10.seconds,
-      minTime = 45.seconds,
-      outputPerIteration = true
-    )
-
-    import sparkSession.implicits._
-
-    def typed_count(column: Column): Column =
-      Column(TestingTypedCount(column.expr).toAggregateExpression())
-
-    val df = sparkSession.range(N)
-
-    benchmark.addCase("sort agg w/ group by") { _ =>
-      sparkSession.conf.set(SQLConf.USE_OBJECT_HASH_AGG.key, "false")
-      df.groupBy($"id" < (N / 2)).agg(typed_count($"id")).collect()
-    }
-
-    benchmark.addCase("object agg w/ group by w/o fallback") { _ =>
-      sparkSession.conf.set(SQLConf.USE_OBJECT_HASH_AGG.key, "true")
-      df.groupBy($"id" < (N / 2)).agg(typed_count($"id")).collect()
-    }
-
-    benchmark.addCase("object agg w/ group by w/ fallback") { _ =>
-      sparkSession.conf.set(SQLConf.USE_OBJECT_HASH_AGG.key, "true")
-      sparkSession.conf.set(SQLConf.OBJECT_AGG_SORT_BASED_FALLBACK_THRESHOLD.key, "2")
-      df.groupBy($"id" < (N / 2)).agg(typed_count($"id")).collect()
-    }
-
-    benchmark.addCase("sort agg w/o group by") { _ =>
-      sparkSession.conf.set(SQLConf.USE_OBJECT_HASH_AGG.key, "false")
-      df.select(typed_count($"id")).collect()
-    }
-
-    benchmark.addCase("object agg w/o group by w/o fallback") { _ =>
-      sparkSession.conf.set(SQLConf.USE_OBJECT_HASH_AGG.key, "true")
-      df.select(typed_count($"id")).collect()
-    }
-
-    benchmark.run()
-
-    /*
-    Java HotSpot(TM) 64-Bit Server VM 1.8.0_92-b14 on Mac OS X 10.10.5
-    Intel(R) Core(TM) i7-4960HQ CPU @ 2.60GHz
-
-    object agg v.s. sort agg:                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-    ------------------------------------------------------------------------------------------------
-    sort agg w/ group by                        31251 / 31908          3.4         298.0       1.0X
-    object agg w/ group by w/o fallback           6903 / 7141         15.2          65.8       4.5X
-    object agg w/ group by w/ fallback          20945 / 21613          5.0         199.7       1.5X
-    sort agg w/o group by                         4734 / 5463         22.1          45.2       6.6X
-    object agg w/o group by w/o fallback          4310 / 4529         24.3          41.1       7.3X
-     */
-  }
-
-  ignore("ObjectHashAggregateExec vs SortAggregateExec - percentile_approx") {
-    val N = 2 << 20
-
-    val benchmark = new Benchmark(
-      name = "object agg v.s. sort agg",
-      valuesPerIteration = N,
-      minNumIters = 5,
-      warmupTime = 15.seconds,
-      minTime = 45.seconds,
-      outputPerIteration = true
-    )
-
-    import sparkSession.implicits._
-
-    val df = sparkSession.range(N).coalesce(1)
-
-    benchmark.addCase("sort agg w/ group by") { _ =>
-      sparkSession.conf.set(SQLConf.USE_OBJECT_HASH_AGG.key, "false")
-      df.groupBy($"id" / (N / 4) cast LongType).agg(percentile_approx($"id", 0.5)).collect()
-    }
-
-    benchmark.addCase("object agg w/ group by w/o fallback") { _ =>
-      sparkSession.conf.set(SQLConf.USE_OBJECT_HASH_AGG.key, "true")
-      df.groupBy($"id" / (N / 4) cast LongType).agg(percentile_approx($"id", 0.5)).collect()
-    }
-
-    benchmark.addCase("object agg w/ group by w/ fallback") { _ =>
-      sparkSession.conf.set(SQLConf.USE_OBJECT_HASH_AGG.key, "true")
-      sparkSession.conf.set(SQLConf.OBJECT_AGG_SORT_BASED_FALLBACK_THRESHOLD.key, "2")
-      df.groupBy($"id" / (N / 4) cast LongType).agg(percentile_approx($"id", 0.5)).collect()
-    }
-
-    benchmark.addCase("sort agg w/o group by") { _ =>
-      sparkSession.conf.set(SQLConf.USE_OBJECT_HASH_AGG.key, "false")
-      df.select(percentile_approx($"id", 0.5)).collect()
-    }
-
-    benchmark.addCase("object agg w/o group by w/o fallback") { _ =>
-      sparkSession.conf.set(SQLConf.USE_OBJECT_HASH_AGG.key, "true")
-      df.select(percentile_approx($"id", 0.5)).collect()
-    }
-
-    benchmark.run()
-
-    /*
-    Java HotSpot(TM) 64-Bit Server VM 1.8.0_92-b14 on Mac OS X 10.10.5
-    Intel(R) Core(TM) i7-4960HQ CPU @ 2.60GHz
-
-    object agg v.s. sort agg:                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-    ------------------------------------------------------------------------------------------------
-    sort agg w/ group by                          3418 / 3530          0.6        1630.0       1.0X
-    object agg w/ group by w/o fallback           3210 / 3314          0.7        1530.7       1.1X
-    object agg w/ group by w/ fallback            3419 / 3511          0.6        1630.1       1.0X
-    sort agg w/o group by                         4336 / 4499          0.5        2067.3       0.8X
-    object agg w/o group by w/o fallback          4271 / 4372          0.5        2036.7       0.8X
-     */
-  }
-
-  private def registerHiveFunction(functionName: String, clazz: Class[_]): Unit = {
-    val sessionCatalog = sparkSession.sessionState.catalog.asInstanceOf[HiveSessionCatalog]
-    val functionIdentifier = FunctionIdentifier(functionName, database = None)
-    val func = CatalogFunction(functionIdentifier, clazz.getName, resources = Nil)
-    sessionCatalog.registerFunction(func, overrideIfExists = false)
   }
 
   private def percentile_approx(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Refactor ObjectHashAggregateExecBenchmark to use main method

## How was this patch tested?

Manually tested:
```
bin/spark-submit --class org.apache.spark.sql.execution.benchmark.ObjectHashAggregateExecBenchmark --jars sql/catalyst/target/spark-catalyst_2.11-3.0.0-SNAPSHOT-tests.jar,core/target/spark-core_2.11-3.0.0-SNAPSHOT-tests.jar,sql/hive/target/spark-hive_2.11-3.0.0-SNAPSHOT.jar --packages org.spark-project.hive:hive-exec:1.2.1.spark2 sql/hive/target/spark-hive_2.11-3.0.0-SNAPSHOT-tests.jar
```
Generated results with:
```
SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "hive/test:runMain org.apache.spark.sql.execution.benchmark.ObjectHashAggregateExecBenchmark"
```

