### PR TITLE
[SPARK-25818][CORE] WorkDirCleanup should only remove the directory at the beginning of the app

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -462,7 +462,7 @@ private[deploy] class Worker(
           // when cleaning up
           val appIdFromDir = dir.getName
           val isAppStillRunning = appIds.contains(appIdFromDir)
-          dir.isDirectory && !isAppStillRunning &&
+          dir.isDirectory && !isAppStillRunning && appIdFromDir.startsWith("app-") &&
           !Utils.doesDirectoryContainAnyNewFiles(dir, APP_DATA_RETENTION_SECONDS)
         }.foreach { dir =>
           logInfo(s"Removing directory: ${dir.getPath}")


### PR DESCRIPTION
## What changes were proposed in this pull request?

The cleanup mechanism will clear all the eligible directories under SPARK_WORK_DIR. If the other configured paths are the same as the SPARK_WORK_DIR configuration, this will cause the file directories of other configuration items to be deleted by mistake. For example, the SPARK_LOCAL_DIRS and SPARK_WORK_DIR settings are the same.

We should add an another condition which start with 'app-'  when removing the expired app-* directories  in  SPARK_WORK_DIR


## How was this patch tested?
manual test
