### PR TITLE
[SPARK-25678] Requesting feedback regarding a prototype for adding PBS Professional as a cluster manager

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -149,6 +149,16 @@
       </dependencies>
     </profile>
     <profile>
+      <id>pbs</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-pbs_${scala.binary.version}</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>kubernetes</id>
       <dependencies>
         <dependency>

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -159,6 +159,7 @@ abstract class AbstractCommandBuilder {
         "repl",
         "resource-managers/mesos",
         "resource-managers/yarn",
+        "resource-managers/pbs",
         "sql/catalyst",
         "sql/core",
         "sql/hive",

--- a/pom.xml
+++ b/pom.xml
@@ -2723,6 +2723,13 @@
     </profile>
 
     <profile>
+      <id>pbs</id>
+      <modules>
+        <module>resource-managers/pbs</module>
+      </modules>
+    </profile>
+
+    <profile>
       <id>hive-thriftserver</id>
       <modules>
         <module>sql/hive-thriftserver</module>


### PR DESCRIPTION
## What changes were proposed in this pull request?
*From Spark [JIRA ticket](https://issues.apache.org/jira/browse/SPARK-25678):*  
  
[PBS (Portable Batch System) Professional](https://github.com/pbspro/pbspro) is an open sourced workload management system for HPC clusters. Many organizations using PBS for managing their cluster also use Spark for Big Data but they are forced to divide the cluster into Spark cluster and PBS cluster either physically dividing the cluster nodes into two groups or starting Spark Standalone cluster manager's Master and Slaves as PBS jobs, leading to underutilization of resources.

I am trying to add support in Spark to use PBS as a pluggable cluster manager. Going through the Spark codebase and looking at Mesos and Kubernetes integration, I found that we can get this working as follows:

- Extend `ExternalClusterManager`.
- Extend `CoarseGrainedSchedulerBackend`
  - This class can start `Executors` as PBS jobs.
  - The initial number of `Executors` are started `onStart`.
  - More `Executors` can be started as and when required using `doRequestTotalExecutors`.
  - `Executors` can be killed using `doKillExecutors`.
- Extend `SparkApplication` to start `Driver` as a PBS job in cluster deploy mode.
  - This extended class can submit the Spark application again as a PBS job with deploy mode = client, so that the application driver is started on a node in the cluster.


## How was this patch tested?
- Compiled with PBS support by sending `-Ppbs` flag to `build/mvn`.
- I was able to run a basic `SparkPi`Java application with client and cluster deploy modes using `bin/spark-submit`:
```bash
./bin/spark-submit --master pbs --deploy-mode cluster --class org.apache.spark.examples.SparkPi spark-examples.jar 1000000
```
- The TravisCI build seems to fail because of code lint/license comments


## I have a couple of questions:

- Does this seem like a good idea to do this or should we look at other options?
- What are the expectations from the initial prototype?
- Would Spark maintainers look forward to merging this or would they want it to be maintained as a fork?

CC: @sakshamgarg