### PR TITLE
[SPARK-25836][BUILD][K8S] For now disable kubernetes-integration-tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2656,8 +2656,13 @@
       <id>kubernetes</id>
       <modules>
         <module>resource-managers/kubernetes/core</module>
-        <!-- for now, don't automatically build and run the integration tests -->
-        <!-- <module>resource-managers/kubernetes/integration-tests</module> -->
+      </modules>
+    </profile>
+    <!-- generally not enabled for automated builds, but will run k8s tests -->
+    <profile>
+      <id>kubernetes-integration-tests</id>
+      <modules>
+        <module>resource-managers/kubernetes/integration-tests</module>
       </modules>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2656,7 +2656,8 @@
       <id>kubernetes</id>
       <modules>
         <module>resource-managers/kubernetes/core</module>
-        <module>resource-managers/kubernetes/integration-tests</module>
+        <!-- for now, don't automatically build and run the integration tests -->
+        <!-- <module>resource-managers/kubernetes/integration-tests</module> -->
       </modules>
     </profile>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

For now make building and running kubernetes-integration-tests manual.

## How was this patch tested?

N/A
