### PR TITLE
[SPARK-25850][SQL] Make the split threshold for the code generated function configurable

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.analysis.{TypeCheckResult, TypeCoercion}
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.trees.TreeNode
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
@@ -120,7 +121,8 @@ abstract class Expression extends TreeNode[Expression] {
 
   private def reduceCodeSize(ctx: CodegenContext, eval: ExprCode): Unit = {
     // TODO: support whole stage codegen too
-    if (eval.code.length > 1024 && ctx.INPUT_ROW != null && ctx.currentVars == null) {
+    val splitThreshold = SQLConf.get.methodSplitThreshold
+    if (eval.code.length > splitThreshold && ctx.INPUT_ROW != null && ctx.currentVars == null) {
       val setIsNull = if (!eval.isNull.isInstanceOf[LiteralValue]) {
         val globalIsNull = ctx.addMutableState(CodeGenerator.JAVA_BOOLEAN, "globalIsNull")
         val localIsNull = eval.isNull

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -910,12 +910,13 @@ class CodegenContext {
     val blocks = new ArrayBuffer[String]()
     val blockBuilder = new StringBuilder()
     var length = 0
+    val splitThreshold = SQLConf.get.methodSplitThreshold
     for (code <- expressions) {
       // We can't know how many bytecode will be generated, so use the length of source code
       // as metric. A method should not go beyond 8K, otherwise it will not be JITted, should
       // also not be too small, or it will have many function calls (for wide table), see the
       // results in BenchmarkWideTable.
-      if (length > 1024) {
+      if (length > splitThreshold) {
         blocks += blockBuilder.toString()
         blockBuilder.clear()
         length = 0

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -814,12 +814,12 @@ object SQLConf {
 
   val CODEGEN_METHOD_SPLIT_THRESHOLD = buildConf("spark.sql.codegen.methodSplitThreshold")
     .internal()
-    .doc("Splits the generated code of expressions into multiple functions by this threshold." +
-      "Each function's code length (without comments) is larger than but near to this value, " +
-      "except that the last one may be smaller. We can't know how many bytecode will be " +
-      "generated, so use the code length as split metric. A function's bytecode should not go " +
+    .doc("The threshold of source code length without comment of a single Java function by " +
+      "codegen to be split. When the generated Java function source code exceeds this threshold" +
+      ", it will be split into multiple small functions. We can't know how many bytecode will " +
+      "be generated, so use the code length as metric. A function's bytecode should not go " +
       "beyond 8KB, otherwise it will not be JITted; it also should not be too small, otherwise " +
-      "there will be many function calls. ")
+      "there will be many function calls.")
     .intConf
     .createWithDefault(1024)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -818,8 +818,8 @@ object SQLConf {
       "Each function's code length (without comments) is larger than but near to this value, " +
       "except that the last one may be smaller. We can't know how many bytecode will be " +
       "generated, so use the code length as split metric. A function's bytecode should not go " +
-      "beyond 8KB, otherwise it will not be JITed, should also not be too small, or we will " +
-      "have many function calls. ")
+      "beyond 8KB, otherwise it will not be JITted; it also should not be too small, otherwise " +
+      "there will be many function calls. ")
     .intConf
     .createWithDefault(1024)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -814,10 +814,10 @@ object SQLConf {
 
   val CODEGEN_METHOD_SPLIT_THRESHOLD = buildConf("spark.sql.codegen.methodSplitThreshold")
     .internal()
-    .doc("The threshold of source code length without comment of a single Java function by " +
-      "codegen to be split. When the generated Java function source code exceeds this threshold" +
-      ", it will be split into multiple small functions. We cannot know how many bytecode will " +
-      "be generated, so use the code length as metric. When running on HotSpot, a function's " +
+    .doc("The threshold of source-code splitting in the codegen. When the number of characters " +
+      "in a single JAVA function (without comment) exceeds the threshold, the function will be " +
+      "automatically split to multiple smaller ones. We cannot know how many bytecode will be " +
+      "generated, so use the code length as metric. When running on HotSpot, a function's " +
       "bytecode should not go beyond 8KB, otherwise it will not be JITted; it also should not " +
       "be too small, otherwise there will be many function calls.")
     .intConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -821,6 +821,7 @@ object SQLConf {
       "bytecode should not go beyond 8KB, otherwise it will not be JITted; it also should not " +
       "be too small, otherwise there will be many function calls.")
     .intConf
+    .checkValue(threshold => threshold > 0, "The threshold must be a positive integer.")
     .createWithDefault(1024)
 
   val WHOLESTAGE_SPLIT_CONSUME_FUNC_BY_OPERATOR =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -816,10 +816,10 @@ object SQLConf {
     .internal()
     .doc("The threshold of source code length without comment of a single Java function by " +
       "codegen to be split. When the generated Java function source code exceeds this threshold" +
-      ", it will be split into multiple small functions. We can't know how many bytecode will " +
-      "be generated, so use the code length as metric. A function's bytecode should not go " +
-      "beyond 8KB, otherwise it will not be JITted; it also should not be too small, otherwise " +
-      "there will be many function calls.")
+      ", it will be split into multiple small functions. We cannot know how many bytecode will " +
+      "be generated, so use the code length as metric. When running on HotSpot, a function's " +
+      "bytecode should not go beyond 8KB, otherwise it will not be JITted; it also should not " +
+      "be too small, otherwise there will be many function calls.")
     .intConf
     .createWithDefault(1024)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -814,12 +814,12 @@ object SQLConf {
 
   val CODEGEN_METHOD_SPLIT_THRESHOLD = buildConf("spark.sql.codegen.methodSplitThreshold")
     .internal()
-    .doc("The maximum source code length of a single Java function by codegen. When the " +
-      "generated Java function source code exceeds this threshold, it will be split into " +
-      "multiple small functions, each function length is spark.sql.codegen.methodSplitThreshold." +
-      " A function's bytecode should not go beyond 8KB, otherwise it will not be JITted, should " +
-      "also not be too small, or we will have many function calls. We can't know how many " +
-      "bytecode will be generated, so use the length of source code as metric.")
+    .doc("Splits the generated code of expressions into multiple functions by this threshold." +
+      "Each function's code length (without comments) is larger than but near to this value, " +
+      "except that the last one may be smaller. We can't know how many bytecode will be " +
+      "generated, so use the code length as split metric. A function's bytecode should not go " +
+      "beyond 8KB, otherwise it will not be JITed, should also not be too small, or we will " +
+      "have many function calls. ")
     .intConf
     .createWithDefault(1024)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -815,7 +815,7 @@ object SQLConf {
   val CODEGEN_METHOD_SPLIT_THRESHOLD = buildConf("spark.sql.codegen.methodSplitThreshold")
     .internal()
     .doc("The threshold of source-code splitting in the codegen. When the number of characters " +
-      "in a single JAVA function (without comment) exceeds the threshold, the function will be " +
+      "in a single Java function (without comment) exceeds the threshold, the function will be " +
       "automatically split to multiple smaller ones. We cannot know how many bytecode will be " +
       "generated, so use the code length as metric. When running on HotSpot, a function's " +
       "bytecode should not go beyond 8KB, otherwise it will not be JITted; it also should not " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -812,6 +812,17 @@ object SQLConf {
     .intConf
     .createWithDefault(65535)
 
+  val CODEGEN_METHOD_SPLIT_THRESHOLD = buildConf("spark.sql.codegen.methodSplitThreshold")
+    .internal()
+    .doc("The maximum source code length of a single Java function by codegen. When the " +
+      "generated Java function source code exceeds this threshold, it will be split into " +
+      "multiple small functions, each function length is spark.sql.codegen.methodSplitThreshold." +
+      " A function's bytecode should not go beyond 8KB, otherwise it will not be JITted, should " +
+      "also not be too small, or we will have many function calls. We can't know how many " +
+      "bytecode will be generated, so use the length of source code as metric.")
+    .intConf
+    .createWithDefault(1024)
+
   val WHOLESTAGE_SPLIT_CONSUME_FUNC_BY_OPERATOR =
     buildConf("spark.sql.codegen.splitConsumeFuncByOperator")
       .internal()
@@ -1732,6 +1743,8 @@ class SQLConf extends Serializable with Logging {
   def loggingMaxLinesForCodegen: Int = getConf(CODEGEN_LOGGING_MAX_LINES)
 
   def hugeMethodLimit: Int = getConf(WHOLESTAGE_HUGE_METHOD_LIMIT)
+
+  def methodSplitThreshold: Int = getConf(CODEGEN_METHOD_SPLIT_THRESHOLD)
 
   def wholeStageSplitConsumeFuncByOperator: Boolean =
     getConf(WHOLESTAGE_SPLIT_CONSUME_FUNC_BY_OPERATOR)


### PR DESCRIPTION
## What changes were proposed in this pull request?
As per the discussion in [#22823](https://github.com/apache/spark/pull/22823/files#r228400706), add a new configuration to make the split threshold for the code generated function configurable.

When the generated Java function source code exceeds `spark.sql.codegen.methodSplitThreshold`, it will be split into multiple small functions.

## How was this patch tested?
manual tests