### PR TITLE
[SPARK-25852][Core] we should filter the workOffers with freeCores>=CPUS_PER_TASK for better performance

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -240,7 +240,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
       val taskDescs = CoarseGrainedSchedulerBackend.this.synchronized {
         // Filter out executors under killing
         val activeExecutors = executorDataMap.filterKeys(executorIsAlive)
-        val workOffers = activeExecutors.map {
+        val workOffers = activeExecutors.filter(_._2.freeCores >= scheduler.CPUS_PER_TASK).map {
           case (id, executorData) =>
             new WorkerOffer(id, executorData.executorHost, executorData.freeCores,
               Some(executorData.executorAddress.hostPort))


### PR DESCRIPTION
## What changes were proposed in this pull request?

we should filter the workOffers with freeCores>CPUS_PER_TASK  for better performance

## How was this patch tested?
Exist tests
