### PR TITLE
[SPARK-25854][BUILD] fix `build/mvn` not to fail during Zinc server shutdown

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -166,16 +166,7 @@ echo "Using \`mvn\` from path: $MVN_BIN" 1>&2
 # call the `mvn` command as usual
 "${MVN_BIN}" -DzincPort=${ZINC_PORT} "$@"
 
-# check to see if zinc server is still running post-build
-"${ZINC_BIN}" -status -port ${ZINC_PORT} &> /dev/null
-ZINC_STATUS=$?
-
-# Try to shut down zinc explicitly if the server is still running
-if [ $ZINC_STATUS -eq 0 ]; then
-  # zinc is still running!
-  "${ZINC_BIN}" -shutdown -port ${ZINC_PORT}
-  exit 0
-else
-  # zinc is not running!  exit cleanly
-  exit 0
-fi
+# Try to shut down zinc explicitly if the server is still running.  if it's not running,
+# it's timed out and we'll still need to exit the script w/a 0 to keep the build from
+# failing.
+"${ZINC_BIN}" -shutdown -port ${ZINC_PORT} || true

--- a/build/mvn
+++ b/build/mvn
@@ -153,7 +153,7 @@ if [ -n "${ZINC_INSTALL_FLAG}" -o -z "`"${ZINC_BIN}" -status -port ${ZINC_PORT}`
   export ZINC_OPTS=${ZINC_OPTS:-"$_COMPILE_JVM_OPTS"}
   "${ZINC_BIN}" -shutdown -port ${ZINC_PORT}
   "${ZINC_BIN}" -start -port ${ZINC_PORT} \
-    -server 127.0.0.1 -idle-timeout 30m \
+    -server 127.0.0.1 -idle-timeout 3h \
     -scala-compiler "${SCALA_COMPILER}" \
     -scala-library "${SCALA_LIBRARY}" &>/dev/null
 fi
@@ -163,8 +163,19 @@ export MAVEN_OPTS=${MAVEN_OPTS:-"$_COMPILE_JVM_OPTS"}
 
 echo "Using \`mvn\` from path: $MVN_BIN" 1>&2
 
-# Last, call the `mvn` command as usual
+# call the `mvn` command as usual
 "${MVN_BIN}" -DzincPort=${ZINC_PORT} "$@"
 
-# Try to shut down zinc explicitly
-"${ZINC_BIN}" -shutdown -port ${ZINC_PORT}
+# check to see if zinc server is still running post-build
+"${ZINC_BIN}" -status -port ${ZINC_PORT} &> /dev/null
+ZINC_STATUS=$?
+
+# Try to shut down zinc explicitly if the server is still running
+if [ $ZINC_STATUS -eq 0 ]; then
+  # zinc is still running!
+  "${ZINC_BIN}" -shutdown -port ${ZINC_PORT}
+  exit 0
+else
+  # zinc is not running!  exit cleanly
+  exit 0
+fi

--- a/build/mvn
+++ b/build/mvn
@@ -164,13 +164,11 @@ export MAVEN_OPTS=${MAVEN_OPTS:-"$_COMPILE_JVM_OPTS"}
 echo "Using \`mvn\` from path: $MVN_BIN" 1>&2
 
 # call the `mvn` command as usual
+# SPARK-25854
 "${MVN_BIN}" -DzincPort=${ZINC_PORT} "$@"
 MVN_RETCODE=$?
 
-# SPARK-25854
-# Try to shut down zinc explicitly if the server is still running.  if it's not running,
-# it's timed out and we'll still need to exit the script w/a 0 to keep the build from
-# failing.
+# Try to shut down zinc explicitly if the server is still running.
 "${ZINC_BIN}" -shutdown -port ${ZINC_PORT}
 
 exit $MVN_RETCODE

--- a/build/mvn
+++ b/build/mvn
@@ -171,6 +171,6 @@ MVN_RETCODE=$?
 # Try to shut down zinc explicitly if the server is still running.  if it's not running,
 # it's timed out and we'll still need to exit the script w/a 0 to keep the build from
 # failing.
-"${ZINC_BIN}" -shutdown -port ${ZINC_PORT} || true
+"${ZINC_BIN}" -shutdown -port ${ZINC_PORT}
 
 exit $MVN_RETCODE

--- a/build/mvn
+++ b/build/mvn
@@ -166,6 +166,7 @@ echo "Using \`mvn\` from path: $MVN_BIN" 1>&2
 # call the `mvn` command as usual
 "${MVN_BIN}" -DzincPort=${ZINC_PORT} "$@"
 
+# SPARK-25854
 # Try to shut down zinc explicitly if the server is still running.  if it's not running,
 # it's timed out and we'll still need to exit the script w/a 0 to keep the build from
 # failing.

--- a/build/mvn
+++ b/build/mvn
@@ -165,9 +165,12 @@ echo "Using \`mvn\` from path: $MVN_BIN" 1>&2
 
 # call the `mvn` command as usual
 "${MVN_BIN}" -DzincPort=${ZINC_PORT} "$@"
+MVN_RETCODE=$?
 
 # SPARK-25854
 # Try to shut down zinc explicitly if the server is still running.  if it's not running,
 # it's timed out and we'll still need to exit the script w/a 0 to keep the build from
 # failing.
 "${ZINC_BIN}" -shutdown -port ${ZINC_PORT} || true
+
+exit $MVN_RETCODE


### PR DESCRIPTION
## What changes were proposed in this pull request?

the final line in the mvn helper script in build/ attempts to shut down the zinc server.  due to the zinc server being set up w/a 30min timeout, by the time the mvn test instantiation finishes, the server times out.

this means that when the mvn script tries to shut down zinc, it returns w/an exit code of 1.  this will then automatically fail the entire build (even if the build passes).

## How was this patch tested?

i set up a test build:
https://amplab.cs.berkeley.edu/jenkins/job/sknapp-testing-spark-branch-2.4-test-maven-hadoop-2.7/

