### PR TITLE
[SPARK-25869] [YARN] the original diagnostics is missing when job failed ma…

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -293,6 +293,9 @@ private[spark] class ApplicationMaster(args: ApplicationMasterArguments) extends
         }
 
         if (!unregistered) {
+          logInfo("Waiting for " + sparkConf.get("spark.yarn.report.interval", "1000").toInt +"ms to unregister am," +
+            " so the client can have the right diagnostics msg!")
+          Thread.sleep(sparkConf.get("spark.yarn.report.interval", "1000").toInt)
           // we only want to unregister if we don't want the RM to retry
           if (finalStatus == FinalApplicationStatus.SUCCEEDED || isLastAttempt) {
             unregister(finalStatus, finalMsg)


### PR DESCRIPTION
When submit spark on yarn jobs, the diagnostics message may be missing when job failed maxAppAttempts times

### **What changes were proposed in this pull request?**
When set configs in yarn as below:
yarn.scheduler.minimum-allocation-mb 50mb
yarn.scheduler.increment-allocation-mb 50mb
And submit spark on yarn job using the command below:
` spark-submit  --class org.apache.spark.examples.SparkPi     --master yarn     --deploy-mode cluster     --driver-memory 127m  --driver-cores 1   --executor-memory 2048m     --executor-cores 1    --num-executors 10  --queue root.mr --conf spark.testing.reservedMemory=1048576 --conf spark.yarn.executor.memoryOverhead=50 --conf spark.yarn.driver.memoryOverhead=50 /opt/ZDH/parcels/lib/spark/examples/jars/spark-examples* 10000`

In ApplicationMaster.scala, when a spark applicaiton failed in the LastAttempt, it will try to unregister itself from yarn resourcemanager. Normally, during **${spark.yarn.report.interval}**, the unregister event will be sent to resourcemanager before the failed container event, and overwrite the container failded diagnostics (out of memory) with "Shutdown hook called before final status was reported." 

### **How was this patch tested?**

manual test



