### PR TITLE
[SPARK-25837] [Core] Fix potential slowdown in AppStatusListener when cleaning up stages

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -1098,7 +1098,7 @@ private[spark] class AppStatusListener(
 
     // Delete tasks for all stages in one pass, as deleting them for each stage individually is slow
     val tasks = kvstore.view(classOf[TaskDataWrapper]).asScala
-    val keys = stages.map(s => (s.info.stageId, s.info.attemptId)).toSet
+    val keys = stages.map { s => (s.info.stageId, s.info.attemptId) }.toSet
     tasks.foreach { t =>
       if (keys.contains((t.stageId, t.stageAttemptId))) {
         kvstore.delete(t.getClass(), t.taskId)

--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -1097,7 +1097,7 @@ private[spark] class AppStatusListener(
     }
 
     // Delete tasks for all stages in one pass, as deleting them for each stage individually is slow
-    val tasks: Iterable[TaskDataWrapper] = kvstore.view(classOf[TaskDataWrapper]).asScala
+    val tasks = kvstore.view(classOf[TaskDataWrapper]).asScala
     val keys = stages.map(s => (s.info.stageId, s.info.attemptId)).toSet
     tasks.foreach { t =>
       if (keys.contains((t.stageId, t.stageAttemptId))) {

--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -1073,16 +1073,6 @@ private[spark] class AppStatusListener(
         kvstore.delete(e.getClass(), e.id)
       }
 
-      val tasks = kvstore.view(classOf[TaskDataWrapper])
-        .index("stage")
-        .first(key)
-        .last(key)
-        .asScala
-
-      tasks.foreach { t =>
-        kvstore.delete(t.getClass(), t.taskId)
-      }
-
       // Check whether there are remaining attempts for the same stage. If there aren't, then
       // also delete the RDD graph data.
       val remainingAttempts = kvstore.view(classOf[StageDataWrapper])
@@ -1104,6 +1094,15 @@ private[spark] class AppStatusListener(
       }
 
       cleanupCachedQuantiles(key)
+    }
+
+    // Delete tasks for all stages in one pass, as deleting them for each stage individually is slow
+    val tasks: Iterable[TaskDataWrapper] = kvstore.view(classOf[TaskDataWrapper]).asScala
+    val keys = stages.map(s => (s.info.stageId, s.info.attemptId)).toSet
+    tasks.foreach { t =>
+      if (keys.contains((t.stageId, t.stageAttemptId))) {
+        kvstore.delete(t.getClass(), t.taskId)
+      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Update `AppStatusListener` `cleanupStages` method to remove tasks for those stages in a single pass instead of 1 for each stage.
* This fixes an issue where the cleanupStages method would get backed up, causing a backup in the executor in ElementTrackingStore, resulting in stages and jobs not getting cleaned up properly.

Tasks seem most susceptible to this as there are a lot of them, however a similar issue could arise in other locations the `KVStore` `view` method is used. A broader fix might involve updates to `KVStoreView` and `InMemoryView` as it appears this interface and implementation can lead to multiple and inefficient traversals of the stored data.

## How was this patch tested?

Using existing tests in AppStatusListenerSuite


This is my original work and I license the work to the project under the project’s open source license.