### PR TITLE
[SPARK-25880][CORE] user set's hadoop conf should not overwrite by sparkcontext's conf

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -468,10 +468,7 @@ object SparkHadoopUtil {
   private def appendSparkHadoopConfigs(conf: SparkConf, hadoopConf: Configuration): Unit = {
     // Copy any "spark.hadoop.foo=bar" spark properties into conf as "foo=bar"
     for ((key, value) <- conf.getAll if key.startsWith("spark.hadoop.")) {
-      val hadoopKey = key.substring("spark.hadoop.".length)
-      if (hadoopConf.get(hadoopKey) == null) {
-        hadoopConf.set(hadoopKey, value)
-      }
+      hadoopConf.set(key.substring("spark.hadoop.".length), value)
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -468,7 +468,10 @@ object SparkHadoopUtil {
   private def appendSparkHadoopConfigs(conf: SparkConf, hadoopConf: Configuration): Unit = {
     // Copy any "spark.hadoop.foo=bar" spark properties into conf as "foo=bar"
     for ((key, value) <- conf.getAll if key.startsWith("spark.hadoop.")) {
-      hadoopConf.set(key.substring("spark.hadoop.".length), value)
+      val hadoopKey = key.substring("spark.hadoop.".length)
+      if (hadoopConf.get(hadoopKey) == null) {
+        hadoopConf.set(hadoopKey, value)
+      }
     }
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -85,6 +85,12 @@ class HadoopTableReader(
   SparkHadoopUtil.get.appendS3AndSparkHadoopConfigurations(
     sparkSession.sparkContext.conf, hadoopConf)
 
+  // User's configuration that through setCommand should update the hadoopConf
+  // but the key must start with 'spark.hadoop.'
+  for ((key, value) <- sparkSession.conf.getAll if key.startsWith("spark.hadoop.")) {
+    hadoopConf.set(key.substring("spark.hadoop.".length), value)
+  }
+
   private val _broadcastedHadoopConf =
     sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hadoop conf which is set by user which is use sparksql's set command should not overwrite by sparkContext's conf which is read from spark-default.conf.

## How was this patch tested?
manually verified with 2.2.0
