### PR TITLE
[SPARK-25886][SQL][Minor] Improve error message of `FailureSafeParser` and `from_avro` in FAILFAST mode

### DIFF
--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
@@ -100,12 +100,7 @@ case class AvroDataToCatalyst(
       case NonFatal(e) => parseMode match {
         case PermissiveMode => nullResultRow
         case FailFastMode =>
-          val msg = if (e.getMessage != null) {
-            e.getMessage + "\n"
-          } else {
-            ""
-          }
-          throw new SparkException(msg + "Malformed records are detected in record parsing. " +
+          throw new SparkException("Malformed records are detected in record parsing. " +
             s"Current parse Mode: ${FailFastMode.name}. To process malformed records as null " +
             "result, try setting the option 'mode' as 'PERMISSIVE'.", e)
         case _ =>

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
@@ -100,9 +100,14 @@ case class AvroDataToCatalyst(
       case NonFatal(e) => parseMode match {
         case PermissiveMode => nullResultRow
         case FailFastMode =>
-          throw new SparkException("Malformed records are detected in record parsing. " +
+          val msg = if (e.getMessage != null) {
+            e.getMessage + "\n"
+          } else {
+            ""
+          }
+          throw new SparkException(msg + "Malformed records are detected in record parsing. " +
             s"Current parse Mode: ${FailFastMode.name}. To process malformed records as null " +
-            "result, try setting the option 'mode' as 'PERMISSIVE'.", e.getCause)
+            "result, try setting the option 'mode' as 'PERMISSIVE'.", e)
         case _ =>
           throw new AnalysisException(unacceptableModeMessage(parseMode.name))
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/FailureSafeParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/FailureSafeParser.scala
@@ -72,8 +72,14 @@ class FailureSafeParser[IN](
         case DropMalformedMode =>
           Iterator.empty
         case FailFastMode =>
-          throw new SparkException("Malformed records are detected in record parsing. " +
-            s"Parse Mode: ${FailFastMode.name}.", e.cause)
+          val msg = if (e.getMessage != null) {
+            e.getMessage + "\n"
+          } else {
+            ""
+          }
+          throw new SparkException(msg + "Malformed records are detected in record parsing. " +
+            s"Parse Mode: ${FailFastMode.name}. To process malformed records as null " +
+            "result, try setting the option 'mode' as 'PERMISSIVE'.", e)
       }
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/FailureSafeParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/FailureSafeParser.scala
@@ -72,12 +72,7 @@ class FailureSafeParser[IN](
         case DropMalformedMode =>
           Iterator.empty
         case FailFastMode =>
-          val msg = if (e.getMessage != null) {
-            e.getMessage + "\n"
-          } else {
-            ""
-          }
-          throw new SparkException(msg + "Malformed records are detected in record parsing. " +
+          throw new SparkException("Malformed records are detected in record parsing. " +
             s"Parse Mode: ${FailFastMode.name}. To process malformed records as null " +
             "result, try setting the option 'mode' as 'PERMISSIVE'.", e)
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -567,6 +567,8 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
         df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))).collect()
       }.getMessage
       assert(exception1.contains(
+        "com.fasterxml.jackson.core.JsonParseException: Unexpected character"))
+      assert(exception1.contains(
         "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))
 
       val exception2 = intercept[SparkException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -567,8 +567,6 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
         df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))).collect()
       }.getMessage
       assert(exception1.contains(
-        "com.fasterxml.jackson.core.JsonParseException: Unexpected character"))
-      assert(exception1.contains(
         "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))
 
       val exception2 = intercept[SparkException] {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently in `FailureSafeParser` and `from_avro`, the exception is created with such code
```
throw new SparkException("Malformed records are detected in record parsing. " +
s"Parse Mode: ${FailFastMode.name}.", e.cause)
```

1. The cause part should be `e` instead of `e.cause`
2. If `e` contains non-null message, it should be shown in `from_json`/`from_csv`/`from_avro`, e.g. 
```
com.fasterxml.jackson.core.JsonParseException: Unexpected character ('1' (code 49)): was expecting a colon to separate field name and value
at [Source: (InputStreamReader); line: 1, column: 7]
```
3.Kindly show hint for trying PERMISSIVE in error message.

## How was this patch tested?
Unit test.

