### PR TITLE
[SPARK-25894][SQL] Add a ColumnarFileFormat type which returns the column count for a given schema

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -306,7 +306,15 @@ case class FileSourceScanExec(
       withOptPartitionCount
     }
 
-    withSelectedBucketsCount
+    val withOptColumnCount = relation.fileFormat match {
+      case columnar: ColumnarFileFormat =>
+        val sqlConf = relation.sparkSession.sessionState.conf
+        val columnCount = columnar.columnCountForSchema(sqlConf, requiredSchema)
+        withSelectedBucketsCount + ("ColumnCount" -> columnCount.toString)
+      case _ => withSelectedBucketsCount
+    }
+
+    withOptColumnCount
   }
 
   private lazy val inputRDD: RDD[InternalRow] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ColumnarFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ColumnarFileFormat.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.StructType
+
+/**
+ * An optional mix-in for columnar [[FileFormat]]s. This trait provides some helpful metadata when
+ * debugging a physical query plan.
+ */
+private[sql] trait ColumnarFileFormat {
+  _: FileFormat =>
+
+  /** Returns the number of columns required to satisfy the given schema. */
+  def columnCountForSchema(conf: SQLConf, schema: StructType): Int
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ColumnarFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ColumnarFileFormat.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.types.StructType
  * An optional mix-in for columnar [[FileFormat]]s. This trait provides some helpful metadata when
  * debugging a physical query plan.
  */
-private[datasources] trait ColumnarFileFormat {
+private[execution] trait ColumnarFileFormat {
   _: FileFormat =>
 
   /** Returns the number of columns required to satisfy the given schema. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ColumnarFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ColumnarFileFormat.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.types.StructType
  * An optional mix-in for columnar [[FileFormat]]s. This trait provides some helpful metadata when
  * debugging a physical query plan.
  */
-private[sql] trait ColumnarFileFormat {
+private[datasources] trait ColumnarFileFormat {
   _: FileFormat =>
 
   /** Returns the number of columns required to satisfy the given schema. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -55,6 +55,7 @@ import org.apache.spark.util.{SerializableConfiguration, ThreadUtils}
 
 class ParquetFileFormat
   extends FileFormat
+  with ColumnarFileFormat
   with DataSourceRegister
   with Logging
   with Serializable {
@@ -71,6 +72,12 @@ class ParquetFileFormat
   override def hashCode(): Int = getClass.hashCode()
 
   override def equals(other: Any): Boolean = other.isInstanceOf[ParquetFileFormat]
+
+  override def columnCountForSchema(conf: SQLConf, schema: StructType): Int = {
+    val converter = new SparkToParquetSchemaConverter(conf)
+    val parquetSchema = converter.convert(schema)
+    parquetSchema.getPaths.size
+  }
 
   override def prepareWrite(
       sparkSession: SparkSession,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruningSuite.scala
@@ -217,6 +217,19 @@ class ParquetSchemaPruningSuite
       Row("Y.") :: Nil)
   }
 
+  test("ColumnCount metadata value for pruned query should equal the number of columns read") {
+    withContacts {
+      val query = sql("select name.middle from contacts")
+      val fileSourceScans =
+        query.queryExecution.executedPlan.collect {
+          case scan: FileSourceScanExec => scan
+        }
+      assert(fileSourceScans.size === 1)
+      val contactsFileScan = fileSourceScans(0)
+      assert(contactsFileScan.metadata("ColumnCount") === "1")
+    }
+  }
+
   private def testSchemaPruning(testName: String)(testThunk: => Unit) {
     test(s"Spark vectorized reader - without partition data column - $testName") {
       withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "true") {


### PR DESCRIPTION
(link to Jira: https://issues.apache.org/jira/browse/SPARK-25894)

## What changes were proposed in this pull request?

Knowing the number of physical columns Spark will read from a columnar file format (such as Parquet) is extremely helpful (if not critical) in debugging poor query performance on a parquet table with a deeply nested schema. This PR adds a new metadata field for `FileSourceScanExec` which identifies the maximum number of columns Spark will read from that file source. (N.B. the actual number of columns read may be lower if the physical file Spark is reading is missing some of them. For example, this can occur in a large partitioned table with a wide schema with sparse data—some partitions may not have data for some columns.) This metadata is printed as part of a physical plan. For example, take a `contacts` table with the following schema:

```
root
 |-- id: integer (nullable = true)
 |-- name: struct (nullable = true)
 |    |-- first: string (nullable = true)
 |    |-- middle: string (nullable = true)
 |    |-- last: string (nullable = true)
 |-- address: string (nullable = true)
 |-- employer: struct (nullable = true)
 |    |-- id: integer (nullable = true)
 |    |-- company: struct (nullable = true)
 |    |    |-- name: string (nullable = true)
 |    |    |-- address: string (nullable = true)
```

With schema pruning, the following `explain` query

```
explain select name.first, employer.company.address from contacts
```

prints

```
== Physical Plan ==
*(1) Project [name#3726.first AS first#3742, employer#3728.company.address AS address#3743]
+- *(1) FileScan parquet [name#3726,employer#3728,p#3729] Batched: false, ColumnCount: 2,
        DataFilters: [], Format: Parquet, Location:
        InMemoryFileIndex[file:/blah/blah/spark/target/tmp/spark-686cac53-0...,
        PartitionCount: 2, PartitionFilters: [], PushedFilters: [], ReadSchema:
        struct<name:struct<first:string>,employer:struct<company:struct<address:string>>>
```

Note `ColumnCount: 2`. This tells us that schema pruning is working at planning time. Without schema pruning, that same query prints

```
== Physical Plan ==
*(1) Project [name#3726.first AS first#3742, employer#3728.company.address AS address#3743]
+- *(1) FileScan parquet [name#3726,employer#3728,p#3729] Batched: false, ColumnCount: 6,
        DataFilters: [], Format: Parquet, Location:
        InMemoryFileIndex[file:/blah/blah/spark/target/tmp/spark-947d2af3-8...,
        PartitionCount: 2, PartitionFilters: [], PushedFilters: [], ReadSchema:
        struct<name:struct<first:string,middle:string,last:string>,employer:struct<id:int,
        company:struct<...
```

Note `ColumnCount: 6`. This tells us either schema pruning is disabled or is not working as expected. If we've enabled schema pruning, this query plan gives us an obvious avenue for investigation of poor query performance.

## How was this patch tested?

A new test was added to `ParquetSchemaPruningSuite.scala`.