### PR TITLE
[SPARK-25896][CORE][WIP] Accumulator should only be updated once for each successful task in shuffle map stage

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapStage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapStage.scala
@@ -51,7 +51,7 @@ private[spark] class ShuffleMapStage(
    * Partitions that either haven't yet been computed, or that were computed on an executor
    * that has since been lost, so should be re-computed.  This variable is used by the
    * DAGScheduler to determine when a stage has completed. Task successes in both the active
-   * attempt for the stage or in earlier attempts for this stage can cause paritition ids to get
+   * attempt for the stage or in earlier attempts for this stage can cause partition ids to get
    * removed from pendingPartitions. As a result, this variable may be inconsistent with the pending
    * tasks in the TaskSetManager for the active attempt for the stage (the partitions stored here
    * will always be a subset of the partitions that the TaskSetManager thinks are pending).


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a followup of https://github.com/apache/spark/pull/19877

For the same reason, we should also update accumulator once for each successful task in shuffle map stage.

TODO:
1. `ShuffleMapStage` has `pendingPartitions` and `findMissingPartitions`, I'm not sure which one is the single source of truth
2. When we receive repeated successful shuffle map tasks, seems we will override the previous one. Need a double check.
3. add tests.

## How was this patch tested?

TODO