### PR TITLE
[MINOR][SQL] Replace all TreeNode's node name in the simpleString as their nodeName

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -558,7 +558,7 @@ case class Range(
   override def newInstance(): Range = copy(output = output.map(_.newInstance()))
 
   override def simpleString: String = {
-    s"Range ($start, $end, step=$step, splits=$numSlices)"
+    s"$nodeName ($start, $end, step=$step, splits=$numSlices)"
   }
 
   override def computeStats(): Statistics = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -932,12 +932,12 @@ case class HashAggregateExec(
         val functionString = Utils.truncatedString(allAggregateExpressions, "[", ", ", "]")
         val outputString = Utils.truncatedString(output, "[", ", ", "]")
         if (verbose) {
-          s"HashAggregate(keys=$keyString, functions=$functionString, output=$outputString)"
+          s"$nodeName(keys=$keyString, functions=$functionString, output=$outputString)"
         } else {
-          s"HashAggregate(keys=$keyString, functions=$functionString)"
+          s"$nodeName(keys=$keyString, functions=$functionString)"
         }
       case Some(fallbackStartsAt) =>
-        s"HashAggregateWithControlledFallback $groupingExpressions " +
+        s"${nodeName}WithControlledFallback $groupingExpressions " +
           s"$allAggregateExpressions $resultExpressions fallbackStartsAt=$fallbackStartsAt"
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
@@ -147,9 +147,9 @@ case class ObjectHashAggregateExec(
     val functionString = Utils.truncatedString(allAggregateExpressions, "[", ", ", "]")
     val outputString = Utils.truncatedString(output, "[", ", ", "]")
     if (verbose) {
-      s"ObjectHashAggregate(keys=$keyString, functions=$functionString, output=$outputString)"
+      s"$nodeName(keys=$keyString, functions=$functionString, output=$outputString)"
     } else {
-      s"ObjectHashAggregate(keys=$keyString, functions=$functionString)"
+      s"$nodeName(keys=$keyString, functions=$functionString)"
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
@@ -118,9 +118,9 @@ case class SortAggregateExec(
     val functionString = Utils.truncatedString(allAggregateExpressions, "[", ", ", "]")
     val outputString = Utils.truncatedString(output, "[", ", ", "]")
     if (verbose) {
-      s"SortAggregate(key=$keyString, functions=$functionString, output=$outputString)"
+      s"$nodeName(key=$keyString, functions=$functionString, output=$outputString)"
     } else {
-      s"SortAggregate(key=$keyString, functions=$functionString)"
+      s"$nodeName(key=$keyString, functions=$functionString)"
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -586,7 +586,7 @@ case class RangeExec(range: org.apache.spark.sql.catalyst.plans.logical.Range)
       }
   }
 
-  override def simpleString: String = s"Range ($start, $end, step=$step, splits=$numSlices)"
+  override def simpleString: String = s"$nodeName ($start, $end, step=$step, splits=$numSlices)"
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -209,5 +209,5 @@ case class InMemoryRelation(
   override protected def otherCopyArgs: Seq[AnyRef] = Seq(statsOfPlanToCache)
 
   override def simpleString: String =
-    s"InMemoryRelation [${Utils.truncatedString(output, ", ")}], ${cacheBuilder.storageLevel}"
+    s"$nodeName [${Utils.truncatedString(output, ", ")}], ${cacheBuilder.storageLevel}"
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/LogicalRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/LogicalRelation.scala
@@ -63,7 +63,7 @@ case class LogicalRelation(
     case _ =>  // Do nothing.
   }
 
-  override def simpleString: String = s"Relation[${Utils.truncatedString(output, ",")}] $relation"
+  override def simpleString: String = s"$nodeName[${Utils.truncatedString(output, ",")}] $relation"
 }
 
 object LogicalRelation {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommand.scala
@@ -50,6 +50,6 @@ case class SaveIntoDataSourceCommand(
 
   override def simpleString: String = {
     val redacted = SQLConf.get.redactOptions(options)
-    s"SaveIntoDataSourceCommand ${dataSource}, ${redacted}, ${mode}"
+    s"$nodeName ${dataSource}, ${redacted}, ${mode}"
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
@@ -56,7 +56,7 @@ case class DataSourceV2Relation(
 
   override def pushedFilters: Seq[Expression] = Seq.empty
 
-  override def simpleString: String = "RelationV2 " + metadataString
+  override def simpleString: String = s"$nodeName " + metadataString
 
   def newWriteSupport(): BatchWriteSupport = source.createWriteSupport(options, schema)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExec.scala
@@ -40,7 +40,7 @@ case class DataSourceV2ScanExec(
     @transient scanConfig: ScanConfig)
   extends LeafExecNode with DataSourceV2StringFormat with ColumnarBatchScan {
 
-  override def simpleString: String = "ScanV2 " + metadataString
+  override def simpleString: String = s"$nodeName " + metadataString
 
   // TODO: unify the equal/hashCode implementation for all data source v2 query plans.
   override def equals(other: Any): Boolean = other match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
@@ -180,6 +180,6 @@ case class TakeOrderedAndProjectExec(
     val orderByString = Utils.truncatedString(sortOrder, "[", ",", "]")
     val outputString = Utils.truncatedString(output, "[", ",", "]")
 
-    s"TakeOrderedAndProject(limit=$limit, orderBy=$orderByString, output=$outputString)"
+    s"$nodeName(limit=$limit, orderBy=$orderByString, output=$outputString)"
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -497,7 +497,7 @@ class StreamSuite extends StreamTest {
       // `extended = false` only displays the physical plan.
       assert("Streaming RelationV2 MemoryStreamDataSource".r
         .findAllMatchIn(explainWithoutExtended).size === 0)
-      assert("ScanV2 MemoryStreamDataSource".r
+      assert("DataSourceV2Scan MemoryStreamDataSource".r
         .findAllMatchIn(explainWithoutExtended).size === 1)
       // Use "StateStoreRestore" to verify that it does output a streaming physical plan
       assert(explainWithoutExtended.contains("StateStoreRestore"))
@@ -507,7 +507,7 @@ class StreamSuite extends StreamTest {
       // plan.
       assert("Streaming RelationV2 MemoryStreamDataSource".r
         .findAllMatchIn(explainWithExtended).size === 3)
-      assert("ScanV2 MemoryStreamDataSource".r
+      assert("DataSourceV2Scan MemoryStreamDataSource".r
         .findAllMatchIn(explainWithExtended).size === 1)
       // Use "StateStoreRestore" to verify that it does output a streaming physical plan
       assert(explainWithExtended.contains("StateStoreRestore"))
@@ -552,7 +552,7 @@ class StreamSuite extends StreamTest {
       // `extended = false` only displays the physical plan.
       assert("Streaming RelationV2 ContinuousMemoryStream".r
         .findAllMatchIn(explainWithoutExtended).size === 0)
-      assert("ScanV2 ContinuousMemoryStream".r
+      assert("DataSourceV2Scan ContinuousMemoryStream".r
         .findAllMatchIn(explainWithoutExtended).size === 1)
 
       val explainWithExtended = q.explainInternal(true)
@@ -560,7 +560,7 @@ class StreamSuite extends StreamTest {
       // plan.
       assert("Streaming RelationV2 ContinuousMemoryStream".r
         .findAllMatchIn(explainWithExtended).size === 3)
-      assert("ScanV2 ContinuousMemoryStream".r
+      assert("DataSourceV2Scan ContinuousMemoryStream".r
         .findAllMatchIn(explainWithExtended).size === 1)
     } finally {
       q.stop()


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr replace all `TreeNode`'s node name in the `simpleString()` as their `nodeName`.

## How was this patch tested?

N/A