### PR TITLE
[SPARK-25901][CORE] Use only one thread in BarrierTaskContext companion object 

### DIFF
--- a/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
@@ -41,13 +41,13 @@ import org.apache.spark.util._
 class BarrierTaskContext private[spark] (
     taskContext: TaskContext) extends TaskContext with Logging {
 
+  import BarrierTaskContext._
+
   // Find the driver side RPCEndpointRef of the coordinator that handles all the barrier() calls.
   private val barrierCoordinator: RpcEndpointRef = {
     val env = SparkEnv.get
     RpcUtils.makeDriverRef("barrierSync", env.conf, env.rpcEnv)
   }
-
-  private val timer = new Timer("Barrier task timer for barrier() calls.")
 
   // Local barrierEpoch that identify a barrier() call from current task, it shall be identical
   // with the driver side epoch.
@@ -234,4 +234,7 @@ object BarrierTaskContext {
   @Experimental
   @Since("2.4.0")
   def get(): BarrierTaskContext = TaskContext.get().asInstanceOf[BarrierTaskContext]
+
+  private val timer = new Timer("Barrier task timer for barrier() calls.")
+
 }

--- a/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
@@ -114,7 +114,7 @@ class BarrierTaskContext private[spark] (
       }
     }
     // Log the update of global sync every 60 seconds.
-    timer.schedule(timerTask, 1000, 1000)
+    timer.schedule(timerTask, 60000, 60000)
 
     try {
       barrierCoordinator.askSync[Unit](

--- a/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
@@ -114,7 +114,7 @@ class BarrierTaskContext private[spark] (
       }
     }
     // Log the update of global sync every 60 seconds.
-    timer.schedule(timerTask, 60000, 60000)
+    timer.schedule(timerTask, 1000, 1000)
 
     try {
       barrierCoordinator.askSync[Unit](


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now we use only one `timer` (and thus a backing thread) in `BarrierTaskContext` companion object, and the objects can add `timerTasks` to that `timer`.

## How was this patch tested?

This was tested manually by generating logs and seeing that they look the same as ones before, namely, that is, a partition waiting on another partition for 5seconds generates 4-5 log messages when the frequency of logging is set to 1second.


