### PR TITLE
[SPARK-25902][SQL] Add support for dates with milliseconds in Apache Arrow bindings

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
@@ -156,6 +156,8 @@ public final class ArrowColumnVector extends ColumnVector {
       accessor = new BinaryAccessor((VarBinaryVector) vector);
     } else if (vector instanceof DateDayVector) {
       accessor = new DateAccessor((DateDayVector) vector);
+    } else if (vector instanceof DateMilliVector) {
+      accessor = new DateMilliAccessor((DateMilliVector) vector);
     } else if (vector instanceof TimeStampMicroTZVector) {
       accessor = new TimestampAccessor((TimeStampMicroTZVector) vector);
     } else if (vector instanceof ListVector) {
@@ -411,6 +413,21 @@ public final class ArrowColumnVector extends ColumnVector {
     @Override
     final int getInt(int rowId) {
       return accessor.get(rowId);
+    }
+  }
+
+  private static class DateMilliAccessor extends ArrowVectorAccessor {
+
+    private final DateMilliVector accessor;
+
+    DateMilliAccessor(DateMilliVector vector) {
+      super(vector);
+      this.accessor = vector;
+    }
+
+    @Override
+    final long getLong(int rowId) {
+      return 1000 * accessor.get(rowId);
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowUtils.scala
@@ -71,6 +71,7 @@ object ArrowUtils {
     case d: ArrowType.Decimal => DecimalType(d.getPrecision, d.getScale)
     case date: ArrowType.Date if date.getUnit == DateUnit.DAY => DateType
     case ts: ArrowType.Timestamp if ts.getUnit == TimeUnit.MICROSECOND => TimestampType
+    case date: ArrowType.Date if date.getUnit == DateUnit.MILLISECOND => TimestampType
     case _ => throw new UnsupportedOperationException(s"Unsupported data type: $dt")
   }
 


### PR DESCRIPTION
Currently, the Apache Arrow bindings for Java only support `Date` with the metric set to `DateUnit.DAY`, see [ArrowUtils.scala#L72](https://github.com/apache/spark/blob/8c2edf46d0f89e5ec54968218d89f30a3f8190bc/sql/core/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowUtils.scala#L72).

However, the Spark Arrow bindings for `R` are adding support to map `POSIXct` to `Date` using `DateUnit.MILLISECOND`, see https://github.com/rstudio/sparklyr/issues/1733.

This PR does not change existing functionality but rather, adds support for the `DateUnit.MILLISECOND` metric in `Date` to avoid hitting a `java.lang.UnsupportedOperationException: Unsupported data type: Date(MILLISECOND)` exception while loading an Arrow stream to Spark.

This patch was tested with https://github.com/rstudio/sparklyr/issues/1733, by building Spark from source and then:

```r
devtools::install_github("apache/arrow", subdir = "r")
devtools::install_github("rstudio/sparklyr", ref = "feature/arrow")
Sys.setenv("SPARK_HOME_VERSION" = "2.3.2")

library(sparklyr)
library(arrow)
sc <- spark_connect(master = "local", spark_home = "<path-to-spark-sources>")

dates <- data.frame(dates = c(
  as.POSIXlt(Sys.time(), "GMT"),
  as.POSIXlt(Sys.time(), "EST"))
)

dates_tbl <- sdf_copy_to(sc, dates, overwrite = T)
```