### PR TITLE
[SPARK-25825][K8S][WIP] Enable token renewal for both --keytab and tokenSecret

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -335,7 +335,8 @@ private[spark] class SparkSubmit extends Logging {
     val targetDir = Utils.createTempDir()
 
     // assure a keytab is available from any place in a JVM
-    if (clusterManager == YARN || clusterManager == LOCAL || isMesosClient || isKubernetesCluster) {
+    if (clusterManager == YARN || clusterManager == LOCAL ||
+      clusterManager == KUBERNETES || isMesosClient) {
       if (args.principal != null) {
         if (args.keytab != null) {
           require(new File(args.keytab).exists(), s"Keytab file: ${args.keytab} does not exist")

--- a/core/src/main/scala/org/apache/spark/deploy/security/HadoopDelegationTokenManager.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/security/HadoopDelegationTokenManager.scala
@@ -70,8 +70,8 @@ private[spark] class HadoopDelegationTokenManager(
     "spark.yarn.security.credentials.%s.enabled")
   private val providerEnabledConfig = "spark.security.credentials.%s.enabled"
 
-  private val principal = sparkConf.get(PRINCIPAL).orNull
-  private val keytab = sparkConf.get(KEYTAB).orNull
+  protected val principal = sparkConf.get(PRINCIPAL).orNull
+  protected val keytab = sparkConf.get(KEYTAB).orNull
 
   require((principal == null) == (keytab == null),
     "Both principal and keytab must be defined, or neither.")
@@ -81,8 +81,8 @@ private[spark] class HadoopDelegationTokenManager(
   logDebug("Using the following builtin delegation token providers: " +
     s"${delegationTokenProviders.keys.mkString(", ")}.")
 
-  private var renewalExecutor: ScheduledExecutorService = _
-  private val driverRef = new AtomicReference[RpcEndpointRef]()
+  protected var renewalExecutor: ScheduledExecutorService = _
+  protected val driverRef = new AtomicReference[RpcEndpointRef]()
 
   /** Set the endpoint used to send tokens to the driver. */
   def setDriverRef(ref: RpcEndpointRef): Unit = {

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -884,7 +884,7 @@ specific to Spark on Kubernetes.
   <td>(none)</td>
   <td>
    Specify the local file that contains the driver [pod template](#pod-template). For example
-   <code>spark.kubernetes.driver.podTemplateFile=/path/to/driver-pod-template.yaml`</code>
+   <code>spark.kubernetes.driver.podTemplateFile=/path/to/driver-pod-template.yaml</code>
   </td>
 </tr>
 <tr>
@@ -892,7 +892,16 @@ specific to Spark on Kubernetes.
   <td>(none)</td>
   <td>
    Specify the local file that contains the executor [pod template](#pod-template). For example
-   <code>spark.kubernetes.executor.podTemplateFile=/path/to/executor-pod-template.yaml`</code>
+   <code>spark.kubernetes.executor.podTemplateFile=/path/to/executor-pod-template.yaml</code>
+  </td>
+</tr>
+<tr>
+  <td><code>spark.kubernetes.kerberos.tokenSecret.renewal</code></td>
+  <td>false</td>
+  <td>
+    Enabling the driver to watch the secret specified at
+    <code>spark.kubernetes.kerberos.tokenSecret.name</code> for updates so that the tokens can be 
+    propagated to the executors.
   </td>
 </tr>
 </table>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -262,6 +262,15 @@ private[spark] object Config extends Logging {
       .stringConf
       .createOptional
 
+  val KUBERNETES_KERBEROS_DT_SECRET_RENEWAL =
+    ConfigBuilder("spark.kubernetes.kerberos.tokenSecret.renewal")
+      .doc("Enabling the driver to watch the secret specified at " +
+        "spark.kubernetes.kerberos.tokenSecret.name for updates so that the " +
+        "tokens can be propagated to the executors.")
+      .booleanConf
+      .createWithDefault(false)
+
+
   val APP_RESOURCE_TYPE =
     ConfigBuilder("spark.kubernetes.resource.type")
       .doc("This sets the resource type internally")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
@@ -109,6 +109,7 @@ private[spark] object Constants {
   val KERBEROS_SPARK_USER_NAME =
     "spark.kubernetes.kerberos.spark-user-name"
   val KERBEROS_SECRET_KEY = "hadoop-tokens"
+  val SECRET_DATA_ITEM_PREFIX_TOKENS = "spark.kubernetes.dt-"
 
   // Hadoop credentials secrets for the Spark app.
   val SPARK_APP_HADOOP_CREDENTIALS_BASE_DIR = "/mnt/secrets/hadoop-credentials"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -78,7 +78,7 @@ private[spark] case class KubernetesConf[T <: KubernetesRoleSpecificConf](
   def krbConfigMapName: String = s"$appResourceNamePrefix-krb5-file"
 
   def tokenManager(conf: SparkConf, hConf: Configuration): KubernetesHadoopDelegationTokenManager =
-    new KubernetesHadoopDelegationTokenManager(conf, hConf)
+    new KubernetesHadoopDelegationTokenManager(conf, hConf, None)
 
   def namespace(): String = sparkConf.get(KUBERNETES_NAMESPACE)
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/security/KubernetesHadoopDelegationTokenManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/security/KubernetesHadoopDelegationTokenManager.scala
@@ -17,21 +17,105 @@
 
 package org.apache.spark.deploy.k8s.security
 
+import java.io.{ByteArrayInputStream, DataInputStream}
+import java.io.File
+
+import scala.collection.JavaConverters._
+
+import io.fabric8.kubernetes.api.model.Secret
+import io.fabric8.kubernetes.client.{KubernetesClientException, Watch, Watcher}
+import io.fabric8.kubernetes.client.KubernetesClient
+import io.fabric8.kubernetes.client.Watcher.Action
+import org.apache.commons.codec.binary.Base64
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.security.UserGroupInformation
+import org.apache.hadoop.security.{Credentials, UserGroupInformation}
 
 import org.apache.spark.SparkConf
+import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.deploy.k8s.Config._
+import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.deploy.security.HadoopDelegationTokenManager
+import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages.UpdateDelegationTokens
 
 /**
  * Adds Kubernetes-specific functionality to HadoopDelegationTokenManager.
  */
 private[spark] class KubernetesHadoopDelegationTokenManager(
     _sparkConf: SparkConf,
-    _hadoopConf: Configuration)
+    _hadoopConf: Configuration,
+    kubernetesClient: Option[KubernetesClient])
   extends HadoopDelegationTokenManager(_sparkConf, _hadoopConf) {
 
   def getCurrentUser: UserGroupInformation = UserGroupInformation.getCurrentUser
   def isSecurityEnabled: Boolean = UserGroupInformation.isSecurityEnabled
 
+  private val isTokenRenewalEnabled =
+    _sparkConf.get(KUBERNETES_KERBEROS_DT_SECRET_RENEWAL)
+
+  private val dtSecretName = _sparkConf.get(KUBERNETES_KERBEROS_DT_SECRET_NAME)
+
+  if (isTokenRenewalEnabled) {
+    require(dtSecretName.isDefined,
+      "Must specify the token secret which the driver must watch for updates")
+  }
+
+  private def deserialize(credentials: Credentials, data: Array[Byte]): Unit = {
+    val byteStream = new ByteArrayInputStream(data)
+    val dataStream = new DataInputStream(byteStream)
+    credentials.readTokenStorageStream(dataStream)
+  }
+
+  private var watch: Watch = _
+
+  /**
+   * As in HadoopDelegationTokenManager this starts the token renewer.
+   * Upon start, if a principal and keytab are defined, the renewer will:
+   *
+    * - log in the configured principal, and set up a task to keep that user's ticket renewed
+    * - obtain delegation tokens from all available providers
+    * - send the tokens to the driver, if it's already registered
+    * - schedule a periodic task to update the tokens when needed.
+   *
+   * In the case that the principal is NOT configured, one may still service a long running
+   * app by enabling the KERBEROS_SECRET_RENEWER config and relying on an external service
+   * to populate a secret with valid Delegation Tokens that the application will then use.
+   * This is possibly via the use of a Secret watcher which the driver will leverage to
+   * detect updates that happen to the secret so that it may retrieve that secret's contents
+   * and send it to all expiring executors
+   *
+   * @return The newly logged in user, or null
+   */
+  override def start(): UserGroupInformation = {
+    val driver = driverRef.get()
+    if (isTokenRenewalEnabled &&
+      kubernetesClient.isDefined && driver != null) {
+      watch = kubernetesClient.get
+        .secrets()
+        .inNamespace(_sparkConf.get(KUBERNETES_NAMESPACE))
+        .withName(dtSecretName.get)
+        .watch(new Watcher[Secret] {
+          override def onClose(cause: KubernetesClientException): Unit =
+            logInfo("Ending the watch of DT Secret")
+          override def eventReceived(action: Watcher.Action, resource: Secret): Unit = {
+            action match {
+              case Action.ADDED | Action.MODIFIED =>
+                logInfo("Secret update")
+                val dataItems = resource.getData.asScala.filterKeys(
+                  _.startsWith(SECRET_DATA_ITEM_PREFIX_TOKENS)).toSeq.sorted
+                val latestToken = if (dataItems.nonEmpty) Some(dataItems.max) else None
+                latestToken.foreach {
+                  case (_, data) =>
+                    val credentials = new Credentials
+                    deserialize(credentials, Base64.decodeBase64(data))
+                    val tokens = SparkHadoopUtil.get.serialize(credentials)
+                    driver.send(UpdateDelegationTokens(tokens))
+                }
+            }
+          }
+        })
+      null
+    } else {
+      super.start()
+    }
+  }
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
@@ -110,7 +110,7 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
 
     new KubernetesClusterSchedulerBackend(
       scheduler.asInstanceOf[TaskSchedulerImpl],
-      sc.env.rpcEnv,
+      sc,
       kubernetesClient,
       requestExecutorsService,
       snapshotsStore,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enabled token renewal when specifying `--keytab` or (`spark.kubernetes.kerberos.tokenSecret.renewal` + `spark.kubernetes.kerberos.tokenSecret.name`) for Kerberos on Kubernetes

## How was this patch tested?

Unit and Integration tests
