### PR TITLE
[SPARK-24869][SQL] Fix SaveIntoDataSourceCommand's input Dataset does not use cached data

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -518,7 +518,8 @@ case class DataSource(
 
     providingClass.newInstance() match {
       case dataSource: CreatableRelationProvider =>
-        SaveIntoDataSourceCommand(data, dataSource, caseInsensitiveOptions, mode)
+        SaveIntoDataSourceCommand(
+          data, dataSource, caseInsensitiveOptions, mode, data.output.map(_.name))
       case format: FileFormat =>
         DataSource.validateSchema(data.schema)
         planForWritingFileFormat(format, mode, data)

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/DataSourceTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/DataSourceTest.scala
@@ -87,3 +87,7 @@ case class SimpleDDLScan(
     }.asInstanceOf[RDD[Row]]
   }
 }
+
+case class FakeRelation(sqlContext: SQLContext) extends BaseRelation {
+  override def schema: StructType = StructType(Seq(StructField("a", StringType)))
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/FakeDataSourceStrategy.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/FakeDataSourceStrategy.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.test
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.EmptyRDD
+import org.apache.spark.sql.{execution, Strategy}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.CastSupport
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.RowDataSourceScanExec
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.sources.FakeRelation
+
+/**
+ * A Strategy for planning fake Relation.
+ */
+case class FakeDataSourceStrategy(conf: SQLConf) extends Strategy with Logging with CastSupport {
+
+  def apply(plan: LogicalPlan): Seq[execution.SparkPlan] = plan match {
+    case l @ LogicalRelation(relation: FakeRelation, _, _, _) =>
+      RowDataSourceScanExec(
+        l.output,
+        l.output.indices,
+        Set.empty,
+        Set.empty,
+        new EmptyRDD[InternalRow](relation.sqlContext.sparkContext),
+        relation,
+        None) :: Nil
+
+    case _ => Nil
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/TestSQLContext.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/TestSQLContext.scala
@@ -39,7 +39,10 @@ private[spark] class TestSparkSession(sc: SparkContext) extends SparkSession(sc)
 
   @transient
   override lazy val sessionState: SessionState = {
-    new TestSQLSessionStateBuilder(this, None).build()
+    val ss = new TestSQLSessionStateBuilder(this, None).build()
+    // Add FakeDataSourceStrategy to test FakeRelation, see SPARK-24869 for more details.
+    ss.experimentalMethods.extraStrategies = FakeDataSourceStrategy(ss.conf) :: Nil
+    ss
   }
 
   // Needed for Java tests


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fix 2 things:
1. Fix `SaveIntoDataSourceCommand`'s input Dataset does not use Cached Data.
2. Fix `SaveIntoDataSourceCommand`s web ui when writing data.

## How was this patch tested?
unit tests and  manual tests

Manual test web UI case 1:
```scala
 val df = spark.range(0, 3)
df.write.mode(SaveMode.Overwrite).jdbc(jdbcUrl, jdbcTable, new Properties)
```

 Before this PR                   | After this PR
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/5399861/47954021-345c9e00-dfc0-11e8-9317-0c06460ad2eb.png)  |  ![image](https://user-images.githubusercontent.com/5399861/47954625-f2832600-dfc6-11e8-9cc8-125b1a0187bb.png)



---

Manual test web UI case 2:
```scala
val udf1 = udf({ (x: Int, y: Int) => x + y })
val df = spark.range(0, 3).toDF("a").withColumn("b", udf1(col("a"), lit(10)))
df.cache
df.write.mode(SaveMode.Overwrite).jdbc(jdbcUrl, jdbcTable, new Properties)
```

 Before this PR                   | After this PR
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/5399861/47954236-d54c5880-dfc2-11e8-886b-1575ebd99563.png)  |  ![image](https://user-images.githubusercontent.com/5399861/47954643-3d04a280-dfc7-11e8-955b-949722761f8a.png)



