### PR TITLE
 [SPARK-25933][DOCUMENTATION] Fix pstats.Stats() reference in configuration.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -445,7 +445,7 @@ Apart from these, the following properties are also available, and may be useful
   <td>
     The directory which is used to dump the profile result before driver exiting.
     The results will be dumped as separated file for each RDD. They can be loaded
-    by ptats.Stats(). If this is specified, the profile result will not be displayed
+    by pstats.Stats(). If this is specified, the profile result will not be displayed
     automatically.
   </td>
 </tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -445,7 +445,7 @@ Apart from these, the following properties are also available, and may be useful
   <td>
     The directory which is used to dump the profile result before driver exiting.
     The results will be dumped as separated file for each RDD. They can be loaded
-    by pstats.Stats(). If this is specified, the profile result will not be displayed
+    by <code>pstats.Stats()</code>. If this is specified, the profile result will not be displayed
     automatically.
   </td>
 </tr>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change ptats.Stats() to pstats.Stats() for `spark.python.profile.dump` in configuration.md.

## How was this patch tested?

Doc test
