### PR TITLE
[SPARK-19799] Support WITH clause (CTE) in subqueries

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -372,7 +372,7 @@ queryPrimary
     : querySpecification                                                    #queryPrimaryDefault
     | TABLE tableIdentifier                                                 #table
     | inlineTable                                                           #inlineTableDefault1
-    | '(' queryNoWith  ')'                                                  #subquery
+    | '(' query  ')'                                                        #subquery
     ;
 
 sortItem
@@ -510,7 +510,7 @@ identifierComment
 
 relationPrimary
     : tableIdentifier sample? tableAlias      #tableName
-    | '(' queryNoWith ')' sample? tableAlias  #aliasedQuery
+    | '(' query ')' sample? tableAlias        #aliasedQuery
     | '(' relation ')' sample? tableAlias     #aliasedRelation
     | inlineTable                             #inlineTableDefault2
     | functionTable                           #tableValuedFunction

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -795,7 +795,7 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
    * Create a logical plan for a sub-query.
    */
   override def visitSubquery(ctx: SubqueryContext): LogicalPlan = withOrigin(ctx) {
-    plan(ctx.queryNoWith)
+    plan(ctx.query)
   }
 
   /**
@@ -883,7 +883,7 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
    * }}}
    */
   override def visitAliasedQuery(ctx: AliasedQueryContext): LogicalPlan = withOrigin(ctx) {
-    val relation = plan(ctx.queryNoWith).optionalMap(ctx.sample)(withSample)
+    val relation = plan(ctx.query).optionalMap(ctx.sample)(withSample)
     if (ctx.tableAlias.strictIdentifier == null) {
       // For un-aliased subqueries, use a default alias name that is not likely to conflict with
       // normal subquery names, so that parent operators can only access the columns in subquery by

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -542,7 +542,7 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
       sql("""
             |select avg(b) from (
             | with maxearnings as (
-            |   select course, year, max(earnings) as earnings FROM courseSales 
+            |   select course, year, max(earnings) as earnings FROM courseSales
             |     GROUP BY course, year
             |   )
             | select course, sum(earnings) as b FROM maxearnings GROUP BY course

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -542,7 +542,8 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
       sql("""
             |select avg(b) from (
             | with maxearnings as (
-            |   select course, year, max(earnings) as earnings FROM courseSales GROUP BY course, year
+            |   select course, year, max(earnings) as earnings FROM courseSales 
+            |     GROUP BY course, year
             |   )
             | select course, sum(earnings) as b FROM maxearnings GROUP BY course
             | )""".stripMargin),
@@ -555,8 +556,6 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
         "with q1 as (select * from testData) with q2 as (select * from q1) select * from q2")
     }
   }
-
-
 
   test("date row") {
     checkAnswer(sql(

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -535,7 +535,18 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
         |q2 as (select * from testData where key = '4')
         |select * from q1 union all select * from q2""".stripMargin),
       Row(5, "5") :: Row(4, "4") :: Nil)
+  }
 
+  test("SPARK-19799: Support WITH clause in subqueries") {
+    checkAnswer(
+      sql("""
+            |select avg(b) from (
+            | with maxearnings as (
+            |   select course, year, max(earnings) as earnings FROM courseSales GROUP BY course, year
+            |   )
+            | select course, sum(earnings) as b FROM maxearnings GROUP BY course
+            | )""".stripMargin),
+      Row(54000) :: Nil)
   }
 
   test("Allow only a single WITH clause per query") {
@@ -544,6 +555,8 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
         "with q1 as (select * from testData) with q2 as (select * from q1) select * from q2")
     }
   }
+
+
 
   test("date row") {
     checkAnswer(sql(


### PR DESCRIPTION
Because of SPARK-17590 support of WITH clause (CTE) in subqueries requires only grammar support.

Test for augmented syntax is provided.
