### PR TITLE
[MINOR][R] Rename SQLUtils name to RSQLUtils in R

### DIFF
--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -1178,7 +1178,7 @@ setMethod("collect",
               data.frame()
             } else {
               # listCols is a list of columns
-              listCols <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "dfToCols", x@sdf)
+              listCols <- callJStatic("org.apache.spark.sql.api.r.RSQLUtils", "dfToCols", x@sdf)
               stopifnot(length(listCols) == ncol)
 
               # An empty data.frame with 0 columns and number of rows as collected
@@ -1348,7 +1348,7 @@ setMethod("first",
 setMethod("toRDD",
           signature(x = "SparkDataFrame"),
           function(x) {
-            jrdd <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "dfToRowRDD", x@sdf)
+            jrdd <- callJStatic("org.apache.spark.sql.api.r.RSQLUtils", "dfToRowRDD", x@sdf)
             colNames <- callJMethod(x@sdf, "columns")
             rdd <- RDD(jrdd, serializedMode = "row")
             lapply(rdd, function(row) {
@@ -1438,7 +1438,7 @@ dapplyInternal <- function(x, func, schema) {
                          function(name) { get(name, .broadcastNames) })
 
   sdf <- callJStatic(
-           "org.apache.spark.sql.api.r.SQLUtils",
+           "org.apache.spark.sql.api.r.RSQLUtils",
            "dapply",
            x@sdf,
            serialize(cleanClosure(func), connection = NULL),

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -103,7 +103,7 @@ infer_type <- function(x) {
 sparkR.conf <- function(key, defaultValue) {
   sparkSession <- getSparkSession()
   if (missing(key)) {
-    m <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getSessionConf", sparkSession)
+    m <- callJStatic("org.apache.spark.sql.api.r.RSQLUtils", "getSessionConf", sparkSession)
     as.list(m, all.names = TRUE, sorted = TRUE)
   } else {
     conf <- callJMethod(sparkSession, "conf")
@@ -202,7 +202,7 @@ createDataFrame <- function(data, schema = NULL, samplingRatio = 1.0,
   }
 
   if (is.list(data)) {
-    sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
+    sc <- callJStatic("org.apache.spark.sql.api.r.RSQLUtils", "getJavaSparkContext", sparkSession)
     if (!is.null(numPartitions)) {
       rdd <- parallelize(sc, data, numSlices = numToInt(numPartitions))
     } else {
@@ -248,7 +248,7 @@ createDataFrame <- function(data, schema = NULL, samplingRatio = 1.0,
 
   jrdd <- getJRDD(lapply(rdd, function(x) x), "row")
   srdd <- callJMethod(jrdd, "rdd")
-  sdf <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "createDF",
+  sdf <- callJStatic("org.apache.spark.sql.api.r.RSQLUtils", "createDF",
                      srdd, schema$jobj, sparkSession)
   dataFrame(sdf)
 }

--- a/R/pkg/R/catalog.R
+++ b/R/pkg/R/catalog.R
@@ -192,7 +192,7 @@ tables <- function(databaseName = NULL) {
 #' @note tableNames since 1.4.0
 tableNames <- function(databaseName = NULL) {
   sparkSession <- getSparkSession()
-  callJStatic("org.apache.spark.sql.api.r.SQLUtils",
+  callJStatic("org.apache.spark.sql.api.r.RSQLUtils",
               "getTableNames",
               sparkSession,
               databaseName)

--- a/R/pkg/R/group.R
+++ b/R/pkg/R/group.R
@@ -234,7 +234,7 @@ gapplyInternal <- function(x, func, schema) {
   broadcastArr <- lapply(ls(.broadcastNames),
                     function(name) { get(name, .broadcastNames) })
   sdf <- callJStatic(
-           "org.apache.spark.sql.api.r.SQLUtils",
+           "org.apache.spark.sql.api.r.RSQLUtils",
            "gapply",
            x@sgd,
            serialize(cleanClosure(func), connection = NULL),

--- a/R/pkg/R/schema.R
+++ b/R/pkg/R/schema.R
@@ -65,7 +65,7 @@ structType.structField <- function(x, ...) {
   sfObjList <- lapply(fields, function(field) {
     field$jobj
   })
-  stObj <- callJStatic("org.apache.spark.sql.api.r.SQLUtils",
+  stObj <- callJStatic("org.apache.spark.sql.api.r.RSQLUtils",
                        "createStructType",
                        sfObjList)
   structType(stObj)
@@ -219,7 +219,7 @@ structField.character <- function(x, type, nullable = TRUE, ...) {
 
   checkType(type)
 
-  sfObj <- callJStatic("org.apache.spark.sql.api.r.SQLUtils",
+  sfObj <- callJStatic("org.apache.spark.sql.api.r.RSQLUtils",
                        "createStructField",
                        x,
                        type,

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -319,13 +319,13 @@ sparkR.session <- function(
     sparkSession <- get(".sparkRsession", envir = .sparkREnv)
     # Apply config to Spark Context and Spark Session if already there
     # Cannot change enableHiveSupport
-    callJStatic("org.apache.spark.sql.api.r.SQLUtils",
+    callJStatic("org.apache.spark.sql.api.r.RSQLUtils",
                 "setSparkContextSessionConf",
                 sparkSession,
                 sparkConfigMap)
   } else {
     jsc <- get(".sparkRjsc", envir = .sparkREnv)
-    sparkSession <- callJStatic("org.apache.spark.sql.api.r.SQLUtils",
+    sparkSession <- callJStatic("org.apache.spark.sql.api.r.RSQLUtils",
                                 "getOrCreateSparkSession",
                                 jsc,
                                 sparkConfigMap,

--- a/R/pkg/inst/profile/shell.R
+++ b/R/pkg/inst/profile/shell.R
@@ -26,7 +26,7 @@
 
   spark <- SparkR::sparkR.session()
   assign("spark", spark, envir = .GlobalEnv)
-  sc <- SparkR:::callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", spark)
+  sc <- SparkR:::callJStatic("org.apache.spark.sql.api.r.RSQLUtils", "getJavaSparkContext", spark)
   assign("sc", sc, envir = .GlobalEnv)
   sparkVer <- SparkR:::callJMethod(sc, "version")
   cat("\n Welcome to")

--- a/R/pkg/tests/fulltests/test_binaryFile.R
+++ b/R/pkg/tests/fulltests/test_binaryFile.R
@@ -19,7 +19,7 @@ context("functions on binary files")
 
 # JavaSparkContext handle
 sparkSession <- sparkR.session(master = sparkRTestMaster, enableHiveSupport = FALSE)
-sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
+sc <- callJStatic("org.apache.spark.sql.api.r.RSQLUtils", "getJavaSparkContext", sparkSession)
 
 mockFile <- c("Spark is pretty.", "Spark is awesome.")
 

--- a/R/pkg/tests/fulltests/test_binary_function.R
+++ b/R/pkg/tests/fulltests/test_binary_function.R
@@ -19,7 +19,7 @@ context("binary functions")
 
 # JavaSparkContext handle
 sparkSession <- sparkR.session(master = sparkRTestMaster, enableHiveSupport = FALSE)
-sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
+sc <- callJStatic("org.apache.spark.sql.api.r.RSQLUtils", "getJavaSparkContext", sparkSession)
 
 # Data
 nums <- 1:10

--- a/R/pkg/tests/fulltests/test_broadcast.R
+++ b/R/pkg/tests/fulltests/test_broadcast.R
@@ -19,7 +19,7 @@ context("broadcast variables")
 
 # JavaSparkContext handle
 sparkSession <- sparkR.session(master = sparkRTestMaster, enableHiveSupport = FALSE)
-sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
+sc <- callJStatic("org.apache.spark.sql.api.r.RSQLUtils", "getJavaSparkContext", sparkSession)
 
 # Partitioned data
 nums <- 1:2

--- a/R/pkg/tests/fulltests/test_includePackage.R
+++ b/R/pkg/tests/fulltests/test_includePackage.R
@@ -19,7 +19,7 @@ context("include R packages")
 
 # JavaSparkContext handle
 sparkSession <- sparkR.session(master = sparkRTestMaster, enableHiveSupport = FALSE)
-sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
+sc <- callJStatic("org.apache.spark.sql.api.r.RSQLUtils", "getJavaSparkContext", sparkSession)
 
 # Partitioned data
 nums <- 1:2

--- a/R/pkg/tests/fulltests/test_parallelize_collect.R
+++ b/R/pkg/tests/fulltests/test_parallelize_collect.R
@@ -34,7 +34,7 @@ strPairs <- list(list(strList, strList), list(strList, strList))
 
 # JavaSparkContext handle
 sparkSession <- sparkR.session(master = sparkRTestMaster, enableHiveSupport = FALSE)
-jsc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
+jsc <- callJStatic("org.apache.spark.sql.api.r.RSQLUtils", "getJavaSparkContext", sparkSession)
 
 # Tests
 

--- a/R/pkg/tests/fulltests/test_rdd.R
+++ b/R/pkg/tests/fulltests/test_rdd.R
@@ -19,7 +19,7 @@ context("basic RDD functions")
 
 # JavaSparkContext handle
 sparkSession <- sparkR.session(master = sparkRTestMaster, enableHiveSupport = FALSE)
-sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
+sc <- callJStatic("org.apache.spark.sql.api.r.RSQLUtils", "getJavaSparkContext", sparkSession)
 
 # Data
 nums <- 1:10

--- a/R/pkg/tests/fulltests/test_shuffle.R
+++ b/R/pkg/tests/fulltests/test_shuffle.R
@@ -19,7 +19,7 @@ context("partitionBy, groupByKey, reduceByKey etc.")
 
 # JavaSparkContext handle
 sparkSession <- sparkR.session(master = sparkRTestMaster, enableHiveSupport = FALSE)
-sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
+sc <- callJStatic("org.apache.spark.sql.api.r.RSQLUtils", "getJavaSparkContext", sparkSession)
 
 # Data
 intPairs <- list(list(1L, -1), list(2L, 100), list(2L, 1), list(1L, 200))

--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -66,7 +66,7 @@ sparkSession <- if (windows_with_hadoop()) {
   } else {
     sparkR.session(master = sparkRTestMaster, enableHiveSupport = FALSE)
   }
-sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
+sc <- callJStatic("org.apache.spark.sql.api.r.RSQLUtils", "getJavaSparkContext", sparkSession)
 # materialize the catalog implementation
 listTables()
 

--- a/R/pkg/tests/fulltests/test_take.R
+++ b/R/pkg/tests/fulltests/test_take.R
@@ -31,7 +31,7 @@ strList <- list("Dexter Morgan: Blood. Sometimes it sets my teeth on edge, ",
 
 # JavaSparkContext handle
 sparkSession <- sparkR.session(master = sparkRTestMaster, enableHiveSupport = FALSE)
-sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
+sc <- callJStatic("org.apache.spark.sql.api.r.RSQLUtils", "getJavaSparkContext", sparkSession)
 
 test_that("take() gives back the original elements in correct count and order", {
   numVectorRDD <- parallelize(sc, numVector, 10)

--- a/R/pkg/tests/fulltests/test_textFile.R
+++ b/R/pkg/tests/fulltests/test_textFile.R
@@ -19,7 +19,7 @@ context("the textFile() function")
 
 # JavaSparkContext handle
 sparkSession <- sparkR.session(master = sparkRTestMaster, enableHiveSupport = FALSE)
-sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
+sc <- callJStatic("org.apache.spark.sql.api.r.RSQLUtils", "getJavaSparkContext", sparkSession)
 
 mockFile <- c("Spark is pretty.", "Spark is awesome.")
 

--- a/R/pkg/tests/fulltests/test_utils.R
+++ b/R/pkg/tests/fulltests/test_utils.R
@@ -19,7 +19,7 @@ context("functions in utils.R")
 
 # JavaSparkContext handle
 sparkSession <- sparkR.session(master = sparkRTestMaster, enableHiveSupport = FALSE)
-sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
+sc <- callJStatic("org.apache.spark.sql.api.r.RSQLUtils", "getJavaSparkContext", sparkSession)
 
 test_that("convertJListToRList() gives back (deserializes) the original JLists
           of strings and integers", {
@@ -160,7 +160,7 @@ test_that("varargsToJProperties", {
 
 test_that("captureJVMException", {
   method <- "createStructField"
-  expect_error(tryCatch(callJStatic("org.apache.spark.sql.api.r.SQLUtils", method,
+  expect_error(tryCatch(callJStatic("org.apache.spark.sql.api.r.RSQLUtils", method,
                                     "col", "unknown", TRUE),
                         error = function(e) {
                           captureJVMException(e, method)

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/r/RSQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/r/RSQLUtils.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.execution.command.ShowTablesCommand
 import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
 import org.apache.spark.sql.types._
 
-private[sql] object SQLUtils extends Logging {
+private[sql] object RSQLUtils extends Logging {
   SerDe.setSQLReadObject(readSqlObject).setSQLWriteObject(writeSqlObject)
 
   private[this] def withHiveExternalCatalog(sc: SparkContext): SparkContext = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
@@ -24,7 +24,7 @@ import org.apache.spark.api.r._
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.api.r.SQLUtils._
+import org.apache.spark.sql.api.r.RSQLUtils._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen._

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/r/MapPartitionsRWrapper.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/r/MapPartitionsRWrapper.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.r
 import org.apache.spark.api.r._
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.api.r.SQLUtils._
+import org.apache.spark.sql.api.r.RSQLUtils._
 import org.apache.spark.sql.types.StructType
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/api/r/RSQLUtilsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/api/r/RSQLUtilsSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.api.r
 
 import org.apache.spark.sql.test.SharedSQLContext
 
-class SQLUtilsSuite extends SharedSQLContext {
+class RSQLUtilsSuite extends SharedSQLContext {
 
   import testImplicits._
 
@@ -28,7 +28,7 @@ class SQLUtilsSuite extends SharedSQLContext {
       (1, 2, 3),
       (4, 5, 6)
     ).toDF
-    assert(SQLUtils.dfToCols(df) === Array(
+    assert(RSQLUtils.dfToCols(df) === Array(
       Array(1, 4),
       Array(2, 5),
       Array(3, 6)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to rename `SQLUtils` name to `RSQLUtils` in R. This bugged me before but I didn't propose to change because of backporting worry. Since we're going to 3.0.0, the backporting concern is likely small. The name `SQLUtils` sounds quite confusing to me.

This basically targets to match with Python side utils:

`org.apache.spark.sql.api.python.PythonSQLUtils`
`org.apache.spark.api.python.PythonUtils`

**Before:**

`org.apache.spark.sql.api.r.SQLUtils`
`org.apache.spark.api.r.RUtils`

**After:**

`org.apache.spark.sql.api.r.RSQLUtils`
`org.apache.spark.api.r.RUtils`


## How was this patch tested?

Existing tests should cover.
