### PR TITLE
[SPARK-25936][SQL] Fix InsertIntoDataSourceCommand does not use Cached Data

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -143,7 +143,7 @@ case class DataSourceAnalysis(conf: SQLConf) extends Rule[LogicalPlan] with Cast
 
     case InsertIntoTable(l @ LogicalRelation(_: InsertableRelation, _, _, _),
         parts, query, overwrite, false) if parts.isEmpty =>
-      InsertIntoDataSourceCommand(l, query, overwrite)
+      InsertIntoDataSourceCommand(l, query, overwrite, query.output.map(_.name))
 
     case InsertIntoDir(_, storage, provider, query, overwrite)
       if provider.isDefined && provider.get.toLowerCase(Locale.ROOT) != DDLUtils.HIVE_PROVIDER =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

```java
spark.sql("""
  CREATE TABLE jdbcTable
  USING org.apache.spark.sql.jdbc
  OPTIONS (
    url "jdbc:mysql://localhost:3306/test",
    dbtable "test.InsertIntoDataSourceCommand",
    user "hive",
    password "hive"
  )""")

spark.range(2).createTempView("test_view")
spark.catalog.cacheTable("test_view")
spark.sql("INSERT INTO TABLE jdbcTable SELECT * FROM test_view").explain
```

Before this PR:
```
== Physical Plan ==                                                             
Execute InsertIntoDataSourceCommand
   +- InsertIntoDataSourceCommand
         +- Project
            +- SubqueryAlias
               +- Range (0, 2, step=1, splits=Some(8))
```

After this PR:
```
== Physical Plan ==                                                             
Execute InsertIntoDataSourceCommand InsertIntoDataSourceCommand Relation[id#8L] JDBCRelation(test.InsertIntoDataSourceCommand) [numPartitions=1], false, [id]
+- *(1) InMemoryTableScan [id#0L]
      +- InMemoryRelation [id#0L], StorageLevel(disk, memory, deserialized, 1 replicas)
            +- *(1) Range (0, 2, step=1, splits=8)
```

## How was this patch tested?

unit tests
