### PR TITLE
[SPARK-25943][SQL] Fail if mismatching nested struct fields when writing to datasource

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.command.DDLUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.InsertableRelation
-import org.apache.spark.sql.types.{ArrayType, DataType, AtomicType, MapType, StructType}
+import org.apache.spark.sql.types.{ArrayType, AtomicType, DataType, MapType, StructType}
 import org.apache.spark.sql.util.SchemaUtils
 
 /**


### PR DESCRIPTION
At present, Spark reorders mismatched columns when writing to
a datasource, but does not reorder nested structs.

This causes failure at present if the types do not match, but
not if the names do not match; this causes structs to get
silently mangled.

It's not obvious to me where I should add tests, so would
appreciate guidance on that!

## What changes were proposed in this pull request?

Unify DatasourcesV1 behaviour with DatasourcesV2, by throwing if the names are mismatched.

## How was this patch tested?

Nothing. I'd really appreciate a suggestion of where to put tests for this; I'm unfamiliar with the codebase and I couldn't find any obvious looking tests of that codepath.