### PR TITLE
[SPARK-24913][SQL] Make AssertNotNull and AssertTrue non-deterministic

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -367,12 +367,11 @@ trait CheckAnalysis extends PredicateHelper {
 
           case o if o.expressions.exists(!_.deterministic) &&
             !o.isInstanceOf[Project] && !o.isInstanceOf[Filter] &&
-            !o.isInstanceOf[Aggregate] && !o.isInstanceOf[Window] &&
-            !o.isInstanceOf[DeserializeToObject] =>
+            !o.isInstanceOf[Aggregate] && !o.isInstanceOf[Window] =>
             // The rule above is used to check Aggregate operator.
             failAnalysis(
               s"""nondeterministic expressions are only allowed in
-                 |Project, Filter, Aggregate, Window or DeserializeToObject, found:
+                 |Project, Filter, Aggregate or Window, found:
                  | ${o.expressions.map(_.sql).mkString(",")}
                  |in operator ${operator.simpleString}
                """.stripMargin)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -368,11 +368,11 @@ trait CheckAnalysis extends PredicateHelper {
           case o if o.expressions.exists(!_.deterministic) &&
             !o.isInstanceOf[Project] && !o.isInstanceOf[Filter] &&
             !o.isInstanceOf[Aggregate] && !o.isInstanceOf[Window] &&
-            !o.isInstanceOf[DeserializeToObject] && !o.isInstanceOf[SerializeFromObject] =>
+            !o.isInstanceOf[DeserializeToObject] =>
             // The rule above is used to check Aggregate operator.
             failAnalysis(
-              s"""nondeterministic expressions are only allowed in Project, Filter,
-                 | Aggregate, Window, SerializeFromObject or DeserializeToObject, found:
+              s"""nondeterministic expressions are only allowed in
+                 |Project, Filter, Aggregate, Window or DeserializeToObject, found:
                  | ${o.expressions.map(_.sql).mkString(",")}
                  |in operator ${operator.simpleString}
                """.stripMargin)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -368,11 +368,11 @@ trait CheckAnalysis extends PredicateHelper {
           case o if o.expressions.exists(!_.deterministic) &&
             !o.isInstanceOf[Project] && !o.isInstanceOf[Filter] &&
             !o.isInstanceOf[Aggregate] && !o.isInstanceOf[Window] &&
-            !o.isInstanceOf[DeserializeToObject] =>
+            !o.isInstanceOf[DeserializeToObject] && !o.isInstanceOf[SerializeFromObject] =>
             // The rule above is used to check Aggregate operator.
             failAnalysis(
-              s"""nondeterministic expressions are only allowed in
-                 |Project, Filter, Aggregate, Window or DeserializeToObject, found:
+              s"""nondeterministic expressions are only allowed in Project, Filter,
+                 | Aggregate, Window, SerializeFromObject or DeserializeToObject, found:
                  | ${o.expressions.map(_.sql).mkString(",")}
                  |in operator ${operator.simpleString}
                """.stripMargin)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -367,11 +367,12 @@ trait CheckAnalysis extends PredicateHelper {
 
           case o if o.expressions.exists(!_.deterministic) &&
             !o.isInstanceOf[Project] && !o.isInstanceOf[Filter] &&
-            !o.isInstanceOf[Aggregate] && !o.isInstanceOf[Window] =>
+            !o.isInstanceOf[Aggregate] && !o.isInstanceOf[Window] &&
+            !o.isInstanceOf[DeserializeToObject] =>
             // The rule above is used to check Aggregate operator.
             failAnalysis(
               s"""nondeterministic expressions are only allowed in
-                 |Project, Filter, Aggregate or Window, found:
+                 |Project, Filter, Aggregate, Window or DeserializeToObject, found:
                  | ${o.expressions.map(_.sql).mkString(",")}
                  |in operator ${operator.simpleString}
                """.stripMargin)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Canonicalize.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Canonicalize.scala
@@ -64,10 +64,10 @@ object Canonicalize {
     case m: Multiply => orderCommutative(m, { case Multiply(l, r) => Seq(l, r) }).reduce(Multiply)
 
     case o: Or =>
-      orderCommutative(o, { case Or(l, r) if l.deterministic && r.deterministic => Seq(l, r) })
+      orderCommutative(o, { case Or(l, r) if l.idempotent && r.idempotent => Seq(l, r) })
         .reduce(Or)
     case a: And =>
-      orderCommutative(a, { case And(l, r) if l.deterministic && r.deterministic => Seq(l, r)})
+      orderCommutative(a, { case And(l, r) if l.idempotent && r.idempotent => Seq(l, r)})
         .reduce(And)
 
     case EqualTo(l, r) if l.hashCode() > r.hashCode() => EqualTo(r, l)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -84,6 +84,15 @@ abstract class Expression extends TreeNode[Expression] {
    */
   lazy val deterministic: Boolean = children.forall(_.deterministic)
 
+  /**
+   * Returns true iff the current expression can produce other results apart from its evaluation.
+   * This is the case for expressions which throw exceptions in certain conditions.
+   * By default leaf expressions return false since Nil.exists(_.hasSideEffect) returns false.
+   */
+  lazy val hasSideEffect: Boolean = children.exists(_.hasSideEffect)
+
+  final def idempotent: Boolean = deterministic && !hasSideEffect
+
   def nullable: Boolean
 
   def references: AttributeSet = AttributeSet.fromAttributeSets(children.map(_.references))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -66,6 +66,8 @@ case class AssertTrue(child: Expression) extends UnaryExpression with ImplicitCa
 
   override def nullable: Boolean = true
 
+  override lazy val deterministic: Boolean = false
+
   override def inputTypes: Seq[DataType] = Seq(BooleanType)
 
   override def dataType: DataType = NullType

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -66,7 +66,7 @@ case class AssertTrue(child: Expression) extends UnaryExpression with ImplicitCa
 
   override def nullable: Boolean = true
 
-  override lazy val deterministic: Boolean = false
+  override lazy val hasSideEffect: Boolean = true
 
   override def inputTypes: Seq[DataType] = Seq(BooleanType)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -1632,6 +1632,8 @@ case class AssertNotNull(child: Expression, walkedTypePath: Seq[String] = Nil)
   override def foldable: Boolean = false
   override def nullable: Boolean = false
 
+  override lazy val deterministic: Boolean = false
+
   override def flatArguments: Iterator[Any] = Iterator(child)
 
   private val errMsg = "Null value appeared in non-nullable field:" +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -1632,7 +1632,7 @@ case class AssertNotNull(child: Expression, walkedTypePath: Seq[String] = Nil)
   override def foldable: Boolean = false
   override def nullable: Boolean = false
 
-  override lazy val deterministic: Boolean = false
+  override lazy val hasSideEffect: Boolean = true
 
   override def flatArguments: Iterator[Any] = Iterator(child)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -120,7 +120,7 @@ object EliminateOuterJoin extends Rule[LogicalPlan] with PredicateHelper {
    * Returns whether the expression returns null or false when all inputs are nulls.
    */
   private def canFilterOutNull(e: Expression): Boolean = {
-    if (!e.deterministic || SubqueryExpression.hasCorrelatedSubquery(e)) return false
+    if (!e.idempotent || SubqueryExpression.hasCorrelatedSubquery(e)) return false
     val attributes = e.references.toSeq
     val emptyRow = new GenericInternalRow(attributes.length)
     val boundE = BindReferences.bindReference(e, attributes)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -56,12 +56,12 @@ object PhysicalOperation extends PredicateHelper {
   private def collectProjectsAndFilters(plan: LogicalPlan):
       (Option[Seq[NamedExpression]], Seq[Expression], LogicalPlan, Map[Attribute, Expression]) =
     plan match {
-      case Project(fields, child) if fields.forall(_.deterministic) =>
+      case Project(fields, child) if fields.forall(_.idempotent) =>
         val (_, filters, other, aliases) = collectProjectsAndFilters(child)
         val substitutedFields = fields.map(substitute(aliases)).asInstanceOf[Seq[NamedExpression]]
         (Some(substitutedFields), filters, other, collectAliases(substitutedFields))
 
-      case Filter(condition, child) if condition.deterministic =>
+      case Filter(condition, child) if condition.idempotent =>
         val (fields, filters, other, aliases) = collectProjectsAndFilters(child)
         val substitutedCondition = substitute(aliases)(condition)
         (fields, filters ++ splitConjunctivePredicates(substitutedCondition), other, aliases)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
@@ -34,7 +34,7 @@ trait QueryPlanConstraints extends ConstraintHelper { self: LogicalPlan =>
           .union(inferAdditionalConstraints(validConstraints))
           .union(constructIsNotNullConstraints(validConstraints, output))
           .filter { c =>
-            c.references.nonEmpty && c.references.subsetOf(outputSet) && c.deterministic
+            c.references.nonEmpty && c.references.subsetOf(outputSet) && c.idempotent
           }
       )
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -58,10 +58,10 @@ case class ProjectExec(projectList: Seq[NamedExpression], child: SparkPlan)
   override def doConsume(ctx: CodegenContext, input: Seq[ExprCode], row: ExprCode): String = {
     val exprs = projectList.map(x => BindReferences.bindReference[Expression](x, child.output))
     val resultVars = exprs.map(_.genCode(ctx))
-    // Evaluation of non-deterministic expressions can't be deferred.
-    val nonDeterministicAttrs = projectList.filterNot(_.deterministic).map(_.toAttribute)
+    // Evaluation of non-idempotent expressions can't be deferred.
+    val nonIdempotentAttrs = projectList.filterNot(_.idempotent).map(_.toAttribute)
     s"""
-       |${evaluateRequiredVariables(output, resultVars, AttributeSet(nonDeterministicAttrs))}
+       |${evaluateRequiredVariables(output, resultVars, AttributeSet(nonIdempotentAttrs))}
        |${consume(ctx, resultVars)}
      """.stripMargin
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -248,7 +248,7 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
       rightKeys: Seq[Expression],
       leftPartitioning: Partitioning,
       rightPartitioning: Partitioning): (Seq[Expression], Seq[Expression]) = {
-    if (leftKeys.forall(_.deterministic) && rightKeys.forall(_.deterministic)) {
+    if (leftKeys.forall(_.idempotent) && rightKeys.forall(_.idempotent)) {
       leftPartitioning match {
         case HashPartitioning(leftExpressions, _)
           if leftExpressions.length == leftKeys.length &&

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
@@ -216,12 +216,12 @@ object ExtractPythonUDFs extends Rule[LogicalPlan] with PredicateHelper {
   }
 
   // Split the original FilterExec to two FilterExecs. Only push down the first few predicates
-  // that are all deterministic.
+  // that are all idempotent.
   private def trySplitFilter(plan: LogicalPlan): LogicalPlan = {
     plan match {
       case filter: Filter =>
         val (candidates, nonDeterministic) =
-          splitConjunctivePredicates(filter.condition).partition(_.deterministic)
+          splitConjunctivePredicates(filter.condition).partition(_.idempotent)
         val (pushDown, rest) = candidates.partition(!hasScalarPythonUDF(_))
         if (pushDown.nonEmpty) {
           val newChild = Filter(pushDown.reduceLeft(And), filter.child)


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://github.com/apache/spark/pull/21848 introduces an optimization which causes wrong behavior with `AssertNotNull` and `AssertTrue`. This PR makes the two mentioned expressions as non-deterministic in order to avoid skipping evaluating them.

## How was this patch tested?

added UT
