### PR TITLE
[SPARK-20568][SS] Provide option to clean up completed files in streaming query

### DIFF
--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -548,8 +548,8 @@ Here are the details of all the sources in Spark.
         "s3a://a/b/c/dataset.txt"<br/>
         <code>cleanSource</code>: option to clean up completed files after processing.<br/>
         Available options are "archive", "delete", "off". If the option is not provided, the default value is "off".<br/>
-        When "archive" is provided, additional option <code>sourceArchiveDir</code> must be provided as well. The value of "sourceArchiveDir" must have 2 subdirectories (so depth of directory is greater than 2). e.g. /archived/here This will ensure archived files are never included as new source files.<br/>
-        Spark will move source files respecting its own path. For example, if the path of source file is "/a/b/dataset.txt" and the path of archive directory is "/archived/here", file will be moved to "/archived/here/a/b/dataset.txt"<br/>
+        When "archive" is provided, additional option <code>sourceArchiveDir</code> must be provided as well. The value of "sourceArchiveDir" must have 2 subdirectories (so depth of directory is greater than 2). e.g. <code>/archived/here</code>. This will ensure archived files are never included as new source files.<br/>
+        Spark will move source files respecting their own path. For example, if the path of source file is <code>/a/b/dataset.txt</code> and the path of archive directory is <code>/archived/here</code>, file will be moved to <code>/archived/here/a/b/dataset.txt</code>.<br/>
         NOTE: Both archiving (via moving) or deleting completed files will introduce overhead (slow down) in each micro-batch, so you need to understand the cost for each operation in your file system before enabling this option. On the other hand, enabling this option will reduce the cost to list source files which can be an expensive operation.<br/>
         NOTE 2: The source path should not be used from multiple sources or queries when enabling this option.<br/>
         NOTE 3: Both delete and move actions are best effort. Failing to delete or move files will not fail the streaming query.

--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -548,7 +548,7 @@ Here are the details of all the sources in Spark.
         "s3a://a/b/c/dataset.txt"<br/>
         <code>cleanSource</code>: option to clean up completed files after processing.<br/>
         Available options are "archive", "delete", "off". If the option is not provided, the default value is "off".<br/>
-        When "archive" is provided, additional option <code>sourceArchiveDir</code> must be provided as well. The value of "sourceArchiveDir" must be outside of source path, to ensure archived files are never included as new source files.<br/>
+        When "archive" is provided, additional option <code>sourceArchiveDir</code> must be provided as well. The value of "sourceArchiveDir" must have 2 subdirectories (so depth of directory is greater than 2). e.g. /archived/here This will ensure archived files are never included as new source files.<br/>
         Spark will move source files respecting its own path. For example, if the path of source file is "/a/b/dataset.txt" and the path of archive directory is "/archived/here", file will be moved to "/archived/here/a/b/dataset.txt"<br/>
         NOTE: Both archiving (via moving) or deleting completed files will introduce overhead (slow down) in each micro-batch, so you need to understand the cost for each operation in your file system before enabling this option. On the other hand, enabling this option will reduce the cost to list source files which can be an expensive operation.<br/>
         NOTE 2: The source path should not be used from multiple sources or queries when enabling this option.<br/>

--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -546,6 +546,13 @@ Here are the details of all the sources in Spark.
         "s3://a/dataset.txt"<br/>
         "s3n://a/b/dataset.txt"<br/>
         "s3a://a/b/c/dataset.txt"<br/>
+        <code>cleanSource</code>: option to clean up completed files after processing.<br/>
+        Available options are "archive", "delete", "no_op". If the option is not provided, the default value is "no_op".<br/>
+        When "archive" is provided, additional option <code>sourceArchiveDir</code> must be provided as well. The value of "sourceArchiveDir" must be outside of source path, to ensure archived files are never included to new source files again.<br/>
+        Spark will move source files respecting its own path. For example, if the path of source file is "/a/b/dataset.txt" and the path of archive directory is "/archived/here", file will be moved to "/archived/here/a/b/dataset.txt"<br/>
+        NOTE: Both archiving (via moving) or deleting completed files would introduce overhead (slow down) in each micro-batch, so you need to understand the cost for each operation in your file system before enabling this option. On the other hand, enbling this option would reduce the cost to list source files which is considered as a heavy operation.<br/>
+        NOTE 2: The source path should not be used from multiple sources or queries when enabling this option, because source files will be moved or deleted which behavior may impact the other sources and queries.<br/>
+        NOTE 3: Both delete and move actions are best effort. Failing to delete or move files will not fail the streaming query.
         <br/><br/>
         For file-format-specific options, see the related methods in <code>DataStreamReader</code>
         (<a href="api/scala/index.html#org.apache.spark.sql.streaming.DataStreamReader">Scala</a>/<a href="api/java/org/apache/spark/sql/streaming/DataStreamReader.html">Java</a>/<a href="api/python/pyspark.sql.html#pyspark.sql.streaming.DataStreamReader">Python</a>/<a

--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -548,10 +548,10 @@ Here are the details of all the sources in Spark.
         "s3a://a/b/c/dataset.txt"<br/>
         <code>cleanSource</code>: option to clean up completed files after processing.<br/>
         Available options are "archive", "delete", "off". If the option is not provided, the default value is "off".<br/>
-        When "archive" is provided, additional option <code>sourceArchiveDir</code> must be provided as well. The value of "sourceArchiveDir" must be outside of source path, to ensure archived files are never included to new source files again.<br/>
+        When "archive" is provided, additional option <code>sourceArchiveDir</code> must be provided as well. The value of "sourceArchiveDir" must be outside of source path, to ensure archived files are never included as new source files.<br/>
         Spark will move source files respecting its own path. For example, if the path of source file is "/a/b/dataset.txt" and the path of archive directory is "/archived/here", file will be moved to "/archived/here/a/b/dataset.txt"<br/>
-        NOTE: Both archiving (via moving) or deleting completed files would introduce overhead (slow down) in each micro-batch, so you need to understand the cost for each operation in your file system before enabling this option. On the other hand, enabling this option will reduce the cost to list source files which is considered as a heavy operation.<br/>
-        NOTE 2: The source path should not be used from multiple sources or queries when enabling this option, because source files will be moved or deleted which behavior may impact the other sources and queries.<br/>
+        NOTE: Both archiving (via moving) or deleting completed files will introduce overhead (slow down) in each micro-batch, so you need to understand the cost for each operation in your file system before enabling this option. On the other hand, enabling this option will reduce the cost to list source files which can be an expensive operation.<br/>
+        NOTE 2: The source path should not be used from multiple sources or queries when enabling this option.<br/>
         NOTE 3: Both delete and move actions are best effort. Failing to delete or move files will not fail the streaming query.
         <br/><br/>
         For file-format-specific options, see the related methods in <code>DataStreamReader</code>

--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -550,7 +550,7 @@ Here are the details of all the sources in Spark.
         Available options are "archive", "delete", "no_op". If the option is not provided, the default value is "no_op".<br/>
         When "archive" is provided, additional option <code>sourceArchiveDir</code> must be provided as well. The value of "sourceArchiveDir" must be outside of source path, to ensure archived files are never included to new source files again.<br/>
         Spark will move source files respecting its own path. For example, if the path of source file is "/a/b/dataset.txt" and the path of archive directory is "/archived/here", file will be moved to "/archived/here/a/b/dataset.txt"<br/>
-        NOTE: Both archiving (via moving) or deleting completed files would introduce overhead (slow down) in each micro-batch, so you need to understand the cost for each operation in your file system before enabling this option. On the other hand, enbling this option would reduce the cost to list source files which is considered as a heavy operation.<br/>
+        NOTE: Both archiving (via moving) or deleting completed files would introduce overhead (slow down) in each micro-batch, so you need to understand the cost for each operation in your file system before enabling this option. On the other hand, enabling this option would reduce the cost to list source files which is considered as a heavy operation.<br/>
         NOTE 2: The source path should not be used from multiple sources or queries when enabling this option, because source files will be moved or deleted which behavior may impact the other sources and queries.<br/>
         NOTE 3: Both delete and move actions are best effort. Failing to delete or move files will not fail the streaming query.
         <br/><br/>

--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -547,10 +547,10 @@ Here are the details of all the sources in Spark.
         "s3n://a/b/dataset.txt"<br/>
         "s3a://a/b/c/dataset.txt"<br/>
         <code>cleanSource</code>: option to clean up completed files after processing.<br/>
-        Available options are "archive", "delete", "no_op". If the option is not provided, the default value is "no_op".<br/>
+        Available options are "archive", "delete", "off". If the option is not provided, the default value is "off".<br/>
         When "archive" is provided, additional option <code>sourceArchiveDir</code> must be provided as well. The value of "sourceArchiveDir" must be outside of source path, to ensure archived files are never included to new source files again.<br/>
         Spark will move source files respecting its own path. For example, if the path of source file is "/a/b/dataset.txt" and the path of archive directory is "/archived/here", file will be moved to "/archived/here/a/b/dataset.txt"<br/>
-        NOTE: Both archiving (via moving) or deleting completed files would introduce overhead (slow down) in each micro-batch, so you need to understand the cost for each operation in your file system before enabling this option. On the other hand, enabling this option would reduce the cost to list source files which is considered as a heavy operation.<br/>
+        NOTE: Both archiving (via moving) or deleting completed files would introduce overhead (slow down) in each micro-batch, so you need to understand the cost for each operation in your file system before enabling this option. On the other hand, enabling this option will reduce the cost to list source files which is considered as a heavy operation.<br/>
         NOTE 2: The source path should not be used from multiple sources or queries when enabling this option, because source files will be moved or deleted which behavior may impact the other sources and queries.<br/>
         NOTE 3: Both delete and move actions are best effort. Failing to delete or move files will not fail the streaming query.
         <br/><br/>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamOptions.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.streaming
 
+import java.util.Locale
+
 import scala.util.Try
 
 import org.apache.spark.internal.Logging
@@ -74,6 +76,30 @@ class FileStreamOptions(parameters: CaseInsensitiveMap[String]) extends Logging 
    */
   val fileNameOnly: Boolean = withBooleanParameter("fileNameOnly", false)
 
+  /**
+   * The archive directory to move completed files. The option will be only effective when
+   * "cleanSource" is set to "archive".
+   *
+   * Note that the completed file will be moved to this archive directory with respecting to
+   * its own path.
+   *
+   * For example, if the path of source file is "/a/b/dataset.txt", and the path of archive
+   * directory is "/archived/here", file will be moved to "/archived/here/a/b/dataset.txt".
+   */
+  val sourceArchiveDir: Option[String] = parameters.get("sourceArchiveDir")
+
+  /**
+   * Defines how to clean up completed files. Available options are "archive", "delete", "no_op".
+   */
+  val cleanSource: CleanSourceMode.Value = {
+    val matchedMode = CleanSourceMode.fromString(parameters.get("cleanSource"))
+    if (matchedMode == CleanSourceMode.ARCHIVE && sourceArchiveDir.isEmpty) {
+      throw new IllegalArgumentException("Archive mode must be used with 'sourceArchiveDir' " +
+        "option.")
+    }
+    matchedMode
+  }
+
   private def withBooleanParameter(name: String, default: Boolean) = {
     parameters.get(name).map { str =>
       try {
@@ -84,5 +110,25 @@ class FileStreamOptions(parameters: CaseInsensitiveMap[String]) extends Logging 
             s"Invalid value '$str' for option '$name', must be 'true' or 'false'")
       }
     }.getOrElse(default)
+  }
+}
+
+object CleanSourceMode extends Enumeration {
+  val ARCHIVE, DELETE, NO_OP = Value
+
+  def fromString(value: String): CleanSourceMode.Value = {
+    val matchedModeOpt = CleanSourceMode.values.find(_.toString == value.toUpperCase(Locale.ROOT))
+    matchedModeOpt match {
+      case None =>
+        throw new IllegalArgumentException(s"Invalid mode for clean source option $value." +
+          s" Must be one of ${CleanSourceMode.values.mkString(",")}")
+      case Some(matchedMode) =>
+        matchedMode
+    }
+  }
+
+  def fromString(value: Option[String]): CleanSourceMode.Value = value match {
+    case Some(mode) => fromString(mode)
+    case None => NO_OP
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamOptions.scala
@@ -89,7 +89,7 @@ class FileStreamOptions(parameters: CaseInsensitiveMap[String]) extends Logging 
   val sourceArchiveDir: Option[String] = parameters.get("sourceArchiveDir")
 
   /**
-   * Defines how to clean up completed files. Available options are "archive", "delete", "no_op".
+   * Defines how to clean up completed files. Available options are "archive", "delete", "off".
    */
   val cleanSource: CleanSourceMode.Value = {
     val matchedMode = CleanSourceMode.fromString(parameters.get("cleanSource"))
@@ -114,21 +114,12 @@ class FileStreamOptions(parameters: CaseInsensitiveMap[String]) extends Logging 
 }
 
 object CleanSourceMode extends Enumeration {
-  val ARCHIVE, DELETE, NO_OP = Value
+  val ARCHIVE, DELETE, OFF = Value
 
-  def fromString(value: String): CleanSourceMode.Value = {
-    val matchedModeOpt = CleanSourceMode.values.find(_.toString == value.toUpperCase(Locale.ROOT))
-    matchedModeOpt match {
-      case None =>
-        throw new IllegalArgumentException(s"Invalid mode for clean source option $value." +
-          s" Must be one of ${CleanSourceMode.values.mkString(",")}")
-      case Some(matchedMode) =>
-        matchedMode
-    }
-  }
-
-  def fromString(value: Option[String]): CleanSourceMode.Value = value match {
-    case Some(mode) => fromString(mode)
-    case None => NO_OP
-  }
+  def fromString(value: Option[String]): CleanSourceMode.Value = value.map { v =>
+    CleanSourceMode.values.find(_.toString == v.toUpperCase(Locale.ROOT))
+      .getOrElse(throw new IllegalArgumentException(
+        s"Invalid mode for clean source option $value." +
+        s" Must be one of ${CleanSourceMode.values.mkString(",")}"))
+  }.getOrElse(OFF)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
@@ -374,8 +374,8 @@ object FileStreamSource {
       require(baseArchiveFileSystem.isDefined == baseArchivePath.isDefined)
 
       baseArchiveFileSystem.foreach { fs =>
-        require(fileSystem.getUri == fs.getUri, "Base archive path is located to the different" +
-          s" filesystem with source, which is not supported. source path: $sourcePath" +
+        require(fileSystem.getUri == fs.getUri, "Base archive path is located on a different " +
+          s"file system than the source files. source path: $sourcePath" +
           s" / base archive path: ${baseArchivePath.get}")
       }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
@@ -275,7 +275,7 @@ class FileStreamSource(
           validFileEntities.foreach(sourceCleaner.archive)
 
         case CleanSourceMode.DELETE =>
-          validFileEntities.foreach(sourceCleaner.remove)
+          validFileEntities.foreach(sourceCleaner.delete)
 
         case _ =>
       }
@@ -379,7 +379,7 @@ object FileStreamSource {
       }
     }
 
-    def remove(entry: FileEntry): Unit = {
+    def delete(entry: FileEntry): Unit = {
       val curPath = new Path(new URI(entry.path))
       try {
         logDebug(s"Removing completed file $curPath")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
@@ -243,7 +243,6 @@ class FileStreamSource(
     val files = allFiles.sortBy(_.getModificationTime)(fileSortOrder).map { status =>
       (status.getPath.toUri.toString, status.getModificationTime)
     }
-
     val endTime = System.nanoTime
     val listingTimeMs = NANOSECONDS.toMillis(endTime - startTime)
     if (listingTimeMs > 2000) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
@@ -402,7 +402,7 @@ object FileStreamSource {
       require(baseArchivePath.isDefined)
 
       val curPath = new Path(new URI(entry.path))
-      val newPath = new Path(baseArchivePath.get, curPath.toUri.getPath.stripPrefix("/"))
+      val newPath = new Path(baseArchivePath.get.toString.stripSuffix("/") + curPath.toUri.getPath)
 
       try {
         logDebug(s"Creating directory if it doesn't exist ${newPath.getParent}")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
@@ -266,7 +266,7 @@ class FileStreamSource(
   override def commit(end: Offset): Unit = {
     val logOffset = FileStreamSourceOffset(end).logOffset
 
-    if (sourceOptions.cleanSource != CleanSourceMode.NO_OP) {
+    if (sourceOptions.cleanSource != CleanSourceMode.OFF) {
       val files = metadataLog.get(Some(logOffset), Some(logOffset)).flatMap(_._2)
       val validFileEntities = files.filter(_.batchId == logOffset)
       logDebug(s"completed file entries: ${validFileEntities.mkString(",")}")
@@ -408,14 +408,7 @@ object FileStreamSource {
 
     private def buildArchiveFilePath(pathUri: URI): Path = {
       require(baseArchivePathString.isDefined)
-      val baseArchivePathStr = baseArchivePathString.get
-      val normalizedBaseArchiveDirPath = if (baseArchivePathStr.endsWith("/")) {
-        baseArchivePathStr.substring(0, baseArchivePathStr.length - 1)
-      } else {
-        baseArchivePathStr
-      }
-
-      new Path(normalizedBaseArchiveDirPath + pathUri.getPath)
+      new Path(baseArchivePathString.get.stripSuffix("/") + pathUri.getPath)
     }
 
     private def isArchiveFileMatchedAgainstSourcePattern(archiveFile: Path): Boolean = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -1402,7 +1402,7 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
       firstBatch: String,
       secondBatch: String,
       maxFileAge: Option[String] = None,
-      cleanSource: CleanSourceMode.Value = CleanSourceMode.NO_OP,
+      cleanSource: CleanSourceMode.Value = CleanSourceMode.OFF,
       archiveDir: Option[String] = None): Unit = {
     val srcOptions = Map("latestFirst" -> latestFirst.toString, "maxFilesPerTrigger" -> "1") ++
       maxFileAge.map("maxFileAge" -> _) ++

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -1561,8 +1561,8 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
       val unioned = source1.union(source2)
 
       def addMultiTextFileData(
-                                source1Content: String,
-                                source2Content: String): StreamAction = {
+          source1Content: String,
+          source2Content: String): StreamAction = {
         val actions = Seq(
           AddTextFileData(source1Content, sourceDir1, tmp),
           AddTextFileData(source2Content, sourceDir2, tmp)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -1792,71 +1792,16 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
     override def getFileStatus(f: Path): FileStatus = throw new NotImplementedError
   }
 
-  test("FileStreamSourceCleaner - archive - destinations match against source pattern") {
+  test("FileStreamSourceCleaner - archive - base archive path depth <= 2") {
     val fakeFileSystem = new FakeFileSystem("fake")
 
     val sourcePatternPath = new Path("/hello*/h{e,f}ll?")
     val baseArchiveDirPath = new Path("/hello")
 
-    val sourceCleaner = new FileStreamSourceCleaner(fakeFileSystem, sourcePatternPath,
-      Some(fakeFileSystem), Some(baseArchiveDirPath))
-
-    // file 1: /hello/helln
-    // final destination = /hello/hello/helln
-    // parent directory of final destination matches source pattern
-    val sourcePath1 = new Path("/hello/helln")
-    sourceCleaner.archive(FileEntry(sourcePath1.toUri.getPath, 0, 0))
-
-    assertNoMove(fakeFileSystem)
-
-    fakeFileSystem.clearRecords()
-
-    // file 2: /hello/hfllo/spark
-    // final destination = /hello/hello/hfllo/spark
-    // no match
-    val sourcePath2 = new Path("/hello/hfllo/spark")
-    val expectedDestPath2 = new Path("/hello/hello/hfllo/spark")
-    sourceCleaner.archive(FileEntry(sourcePath2.toUri.getPath, 0, 0))
-
-    assertMoveFile(fakeFileSystem, sourcePath2, expectedDestPath2)
-
-    fakeFileSystem.clearRecords()
-
-    // file 3: /hello1/hflln
-    // final destination = /hello/hello1/hflln
-    // no match
-    val sourcePath3 = new Path("/hello1/hflln")
-    val expectedDestPath3 = new Path("/hello/hello1/hflln")
-    sourceCleaner.archive(FileEntry(sourcePath3.toUri.getPath, 0, 0))
-
-    assertMoveFile(fakeFileSystem, sourcePath3, expectedDestPath3)
-
-    fakeFileSystem.clearRecords()
-
-    // corner case: this should end up with all archive destinations to be
-    // matched against source pattern
-    val baseArchiveDirPath2 = new Path("/")
-
-    val sourceCleaner2 = new FileStreamSourceCleaner(fakeFileSystem, sourcePatternPath,
-      Some(fakeFileSystem), Some(baseArchiveDirPath2))
-
-    // file 4 (& final destination): /hello/helln
-    // final destination matches source pattern
-    val sourcePath4 = new Path("/hello/helln")
-    sourceCleaner2.archive(FileEntry(sourcePath4.toUri.getPath, 0, 0))
-
-    assertNoMove(fakeFileSystem)
-
-    fakeFileSystem.clearRecords()
-
-    // file 5 (& final destination): /hello/hfllo/spark
-    // final destination matches source pattern
-    val sourcePath5 = new Path("/hello/hfllo/spark")
-    sourceCleaner2.archive(FileEntry(sourcePath5.toUri.getPath, 0, 0))
-
-    assertNoMove(fakeFileSystem)
-
-    fakeFileSystem.clearRecords()
+    intercept[IllegalArgumentException] {
+      new FileStreamSourceCleaner(fakeFileSystem, sourcePatternPath,
+        Some(fakeFileSystem), Some(baseArchiveDirPath))
+    }
   }
 
   test("FileStreamSourceCleaner - archive - different filesystems between source and archive") {
@@ -1866,14 +1811,10 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
     val sourcePatternPath = new Path("/hello*/h{e,f}ll?")
     val baseArchiveDirPath = new Path("/hello")
 
-    val sourceCleaner = new FileStreamSourceCleaner(fakeFileSystem, sourcePatternPath,
-      Some(fakeFileSystem2), Some(baseArchiveDirPath))
-
-    val sourcePath = new Path("/hello/hfllo/spark")
-    sourceCleaner.archive(FileEntry(sourcePath.toUri.getPath, 0, 0))
-
-    assertNoMove(fakeFileSystem)
-    assertNoMove(fakeFileSystem2)
+    intercept[IllegalArgumentException] {
+      new FileStreamSourceCleaner(fakeFileSystem, sourcePatternPath,
+        Some(fakeFileSystem2), Some(baseArchiveDirPath))
+    }
   }
 
   private def assertNoMove(fs: FakeFileSystem): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch adds the option to clean up files which are completed in previous batch.

`cleanSource` -> "archive" / "delete" / "off"

The default value is "off", which Spark will do nothing.

If "delete" is specified, Spark will simply delete input files. If "archive" is specified, Spark will require additional config `sourceArchiveDir` which will be used to move input files to there. When archiving (via move) the path of input files are retained to the archived paths as sub-path.

Note that it is only applied to "micro-batch", since for batch all input files must be kept to get same result across multiple query executions.

## How was this patch tested?

Added UT. Manual test against local disk as well as HDFS.