### PR TITLE
[SPARK-25981][R] Enables Arrow optimization from R DataFrame to Spark DataFrame

### DIFF
--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -22,7 +22,8 @@ Suggests:
     rmarkdown,
     testthat,
     e1071,
-    survival
+    survival,
+    withr
 Collate:
     'schema.R'
     'generics.R'

--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -22,7 +22,9 @@ Suggests:
     rmarkdown,
     testthat,
     e1071,
-    survival
+    survival,
+    arrow,
+    withr
 Collate:
     'schema.R'
     'generics.R'

--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -22,9 +22,7 @@ Suggests:
     rmarkdown,
     testthat,
     e1071,
-    survival,
-    arrow,
-    withr
+    survival
 Collate:
     'schema.R'
     'generics.R'

--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -22,8 +22,7 @@ Suggests:
     rmarkdown,
     testthat,
     e1071,
-    survival,
-    withr
+    survival
 Collate:
     'schema.R'
     'generics.R'

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -247,19 +247,17 @@ createDataFrame <- function(data, schema = NULL, samplingRatio = 1.0,
 
   if (shouldUseArrow) {
     rdd <- jrddInArrow
-  } else {
-    if (is.list(data)) {
-      sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
-      if (!is.null(numPartitions)) {
-        rdd <- parallelize(sc, data, numSlices = numToInt(numPartitions))
-      } else {
-        rdd <- parallelize(sc, data, numSlices = 1)
-      }
-    } else if (inherits(data, "RDD")) {
-      rdd <- data
+  } else if (is.list(data)) {
+    sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sparkSession)
+    if (!is.null(numPartitions)) {
+      rdd <- parallelize(sc, data, numSlices = numToInt(numPartitions))
     } else {
-      stop(paste("unexpected type:", class(data)))
+      rdd <- parallelize(sc, data, numSlices = 1)
     }
+  } else if (inherits(data, "RDD")) {
+    rdd <- data
+  } else {
+    stop(paste("unexpected type:", class(data)))
   }
 
   if (is.null(schema) || (!inherits(schema, "structType") && is.null(names(schema)))) {

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -178,9 +178,6 @@ writeToFileInArrow <- function(fileName, rdf, numPartitions) {
       for (rdf_slice in rdf_slices) {
         batch <- record_batch(rdf_slice)
         if (is.null(stream_writer)) {
-          # We should avoid private calls like 'close_on_exit' (CRAN disallows) but looks
-          # there's no exposed API for it. Here's a workaround but ideally this should
-          # be removed.
           stream <- FileOutputStream(fileName)
           schema <- batch$schema
           stream_writer <- RecordBatchStreamWriter(stream, schema)

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -151,9 +151,12 @@ writeToTempFileInArrow <- function(rdf, numPartitions) {
   # For some reasons, Arrow R API requires to load 'defer_parent' which is from 'withr' package.
   # This is a workaround to avoid this error. Otherwise, we should directly load 'withr'
   # package, which CRAN complains about.
-  defer_parent <- function(x, ...) {
-    if (requireNamespace("withr", quietly = TRUE)) {
-      withr::defer_parent(x, ...)
+  defer_parent <- function(x, ...)
+    # requireNamespace complains in CRAN in Jenkins. We should fix.
+    requireNamespace1 <- requireNamespace
+    if (requireNamespace1("withr", quietly = TRUE)) {
+      defer_parent <- get("defer_parent", envir = asNamespace("withr"), inherits = FALSE)
+      defer_parent(x, ...)
     } else {
       stop("'withr' package should be installed.")
     }

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -148,10 +148,10 @@ getDefaultSqlSource <- function() {
 }
 
 writeToTempFileInArrow <- function(rdf, numPartitions) {
-  defer_parent <- function(x, ...){
-    # For some reasons, Arrow R API requires to load 'defer_parent', which is from 'withr' package.
-    # This is a workaround to avoid this error. Otherwise, we should directly load 'withr'
-    # package, which CRAN complains about.
+  # For some reasons, Arrow R API requires to load 'defer_parent' which is from 'withr' package.
+  # This is a workaround to avoid this error. Otherwise, we should directly load 'withr'
+  # package, which CRAN complains about.
+  defer_parent <- function(x, ...) {
     if (requireNamespace("withr", quietly = TRUE)) {
       withr::defer_parent(x, ...)
     } else {

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -150,11 +150,10 @@ getDefaultSqlSource <- function() {
 writeToFileInArrow <- function(fileName, rdf, numPartitions) {
   requireNamespace1 <- requireNamespace
 
-  # R API in Arrow is not yet released in CRAN (see ARROW-3204). CRAN requires to add the
+  # R API in Arrow is not yet released in CRAN. CRAN requires to add the
   # package in requireNamespace at DESCRIPTION. Later, CRAN checks if the package is available
   # or not. Therefore, it works around by avoiding direct requireNamespace.
-  # Currently, as of Arrow 0.12.0, it can be installed, for instance, by
-  # `Rscript -e 'remotes::install_github("apache/arrow@apache-arrow-0.12.0", subdir = "r")'`
+  # Currently, as of Arrow 0.12.0, it can be installed by install_github. See ARROW-3204.
   if (requireNamespace1("arrow", quietly = TRUE)) {
     record_batch <- get("record_batch", envir = asNamespace("arrow"), inherits = FALSE)
     RecordBatchStreamWriter <- get(

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -154,7 +154,7 @@ writeToTempFileInArrow <- function(rdf, numPartitions) {
   # This is a workaround to avoid this error. Otherwise, we should directly load 'withr'
   # package, which CRAN complains about.
   defer_parent <- function(x, ...) {
-  if (requireNamespace1("withr", quietly = TRUE)) {
+    if (requireNamespace1("withr", quietly = TRUE)) {
       defer_parent <- get("defer_parent", envir = asNamespace("withr"), inherits = FALSE)
       defer_parent(x, ...)
     } else {
@@ -209,7 +209,7 @@ writeToTempFileInArrow <- function(rdf, numPartitions) {
       }
     })
 
-    return(fileName)
+    fileName
   } else {
     stop("'arrow' package should be installed.")
   }
@@ -300,7 +300,7 @@ createDataFrame <- function(data, schema = NULL, samplingRatio = 1.0,
                        "'spark.sql.execution.arrow.enabled' is set to true; however, ",
                        "failed, attempting non-optimization. Reason: ",
                        e))
-        return(FALSE)
+        FALSE
       })
     }
 

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -153,10 +153,13 @@ writeToTempFileInArrow <- function(rdf, numPartitions) {
   # For some reasons, Arrow R API requires to load 'defer_parent' which is from 'withr' package.
   # This is a workaround to avoid this error. Otherwise, we should directly load 'withr'
   # package, which CRAN complains about.
+  defer_parent <- function(x, ...) {
   if (requireNamespace1("withr", quietly = TRUE)) {
-    defer_parent <- get("defer_parent", envir = asNamespace("withr"), inherits = FALSE)
-  } else {
-    stop("'withr' package should be installed.")
+      defer_parent <- get("defer_parent", envir = asNamespace("withr"), inherits = FALSE)
+      defer_parent(x, ...)
+    } else {
+      stop("'withr' package should be installed.")
+    }
   }
 
   # R API in Arrow is not yet released. CRAN requires to add the package in requireNamespace

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -148,7 +148,11 @@ getDefaultSqlSource <- function() {
 }
 
 writeToTempFileInArrow <- function(rdf, numPartitions) {
-  if (requireNamespace("arrow", quietly = TRUE)) {
+  # R API in Arrow is not yet released. CRAN requires to add the package in requireNamespace
+  # at DESCRIPTION. Later, CRAN checks if the package is available or not. Therefore, it works
+  # around by avoiding direct requireNamespace.
+  requireNamespace1 <- requireNamespace
+  if (requireNamespace1("arrow", quietly = TRUE)) {
     # Currently arrow requires withr; otherwise, write APIs don't work.
     # Direct 'require' is not recommended by CRAN. Here's a workaround.
     require1 <- require

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -148,24 +148,20 @@ getDefaultSqlSource <- function() {
 }
 
 writeToTempFileInArrow <- function(rdf, numPartitions) {
+  requireNamespace1 <- requireNamespace
+
   # For some reasons, Arrow R API requires to load 'defer_parent' which is from 'withr' package.
   # This is a workaround to avoid this error. Otherwise, we should directly load 'withr'
   # package, which CRAN complains about.
-  defer_parent <- function(x, ...)
-    # requireNamespace complains in CRAN in Jenkins. We should fix.
-    requireNamespace1 <- requireNamespace
-    if (requireNamespace1("withr", quietly = TRUE)) {
-      defer_parent <- get("defer_parent", envir = asNamespace("withr"), inherits = FALSE)
-      defer_parent(x, ...)
-    } else {
-      stop("'withr' package should be installed.")
-    }
+  if (requireNamespace1("withr", quietly = TRUE)) {
+    defer_parent <- get("defer_parent", envir = asNamespace("withr"), inherits = FALSE)
+  } else {
+    stop("'withr' package should be installed.")
   }
 
   # R API in Arrow is not yet released. CRAN requires to add the package in requireNamespace
   # at DESCRIPTION. Later, CRAN checks if the package is available or not. Therefore, it works
   # around by avoiding direct requireNamespace.
-  requireNamespace1 <- requireNamespace
   if (requireNamespace1("arrow", quietly = TRUE)) {
     record_batch <- get("record_batch", envir = asNamespace("arrow"), inherits = FALSE)
     record_batch_stream_writer <- get(

--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -310,9 +310,19 @@ test_that("create DataFrame from RDD", {
 test_that("createDataFrame Arrow optimization", {
   skip_if_not_installed("arrow")
   skip_if_not_installed("withr")
-  expected <- collect(createDataFrame(mtcars))
-  arrowEnabled <- sparkR.conf("spark.sql.execution.arrow.enabled")[[1]]
+
   conf <- callJMethod(sparkSession, "conf")
+  arrowEnabled <- sparkR.conf("spark.sql.execution.arrow.enabled")[[1]]
+
+  callJMethod(conf, "set", "spark.sql.execution.arrow.enabled", "false")
+  tryCatch({
+    expected <- collect(createDataFrame(mtcars))
+  },
+  finally = {
+    # Resetting the conf back to default value
+    callJMethod(conf, "set", "spark.sql.execution.arrow.enabled", arrowEnabled)
+  })
+
   callJMethod(conf, "set", "spark.sql.execution.arrow.enabled", "true")
   tryCatch({
     expect_equal(collect(createDataFrame(mtcars)), expected)
@@ -332,9 +342,19 @@ test_that("createDataFrame Arrow optimization - type specification", {
                               d = 1.1,
                               e = 1L,
                               g = as.Date("1990-02-24"))))
-  expected <- collect(createDataFrame(rdf))
+
   arrowEnabled <- sparkR.conf("spark.sql.execution.arrow.enabled")[[1]]
   conf <- callJMethod(sparkSession, "conf")
+
+  callJMethod(conf, "set", "spark.sql.execution.arrow.enabled", "false")
+  tryCatch({
+    expected <- collect(createDataFrame(rdf))
+  },
+  finally = {
+    # Resetting the conf back to default value
+    callJMethod(conf, "set", "spark.sql.execution.arrow.enabled", arrowEnabled)
+  })
+
   callJMethod(conf, "set", "spark.sql.execution.arrow.enabled", "true")
   tryCatch({
     expect_equal(collect(createDataFrame(rdf)), expected)

--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -309,7 +309,6 @@ test_that("create DataFrame from RDD", {
 
 test_that("createDataFrame Arrow optimization", {
   skip_if_not_installed("arrow")
-  skip_if_not_installed("withr")
 
   conf <- callJMethod(sparkSession, "conf")
   arrowEnabled <- sparkR.conf("spark.sql.execution.arrow.enabled")[[1]]
@@ -335,13 +334,13 @@ test_that("createDataFrame Arrow optimization", {
 
 test_that("createDataFrame Arrow optimization - type specification", {
   skip_if_not_installed("arrow")
-  skip_if_not_installed("withr")
   rdf <- data.frame(list(list(a = 1,
                               b = "a",
                               c = TRUE,
                               d = 1.1,
                               e = 1L,
-                              g = as.Date("1990-02-24"))))
+                              f = as.Date("1990-02-24"),
+                              g = as.POSIXct("1990-02-24 12:34:56"))))
 
   arrowEnabled <- sparkR.conf("spark.sql.execution.arrow.enabled")[[1]]
   conf <- callJMethod(sparkSession, "conf")

--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -311,8 +311,8 @@ test_that("createDataFrame Arrow optimization", {
   skip_if_not_installed("arrow")
   skip_if_not_installed("withr")
   expected <- collect(createDataFrame(mtcars))
+  arrowEnabled <- sparkR.conf("spark.sql.execution.arrow.enabled")[[1]]
   conf <- callJMethod(sparkSession, "conf")
-  arrowEnabled <- callJMethod(conf, "get", "spark.sql.execution.arrow.enabled")
   callJMethod(conf, "set", "spark.sql.execution.arrow.enabled", "true")
   tryCatch({
     expect_equal(collect(createDataFrame(mtcars)), expected)

--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -326,12 +326,12 @@ test_that("createDataFrame Arrow optimization", {
 test_that("createDataFrame Arrow optimization - type specification", {
   skip_if_not_installed("arrow")
   skip_if_not_installed("withr")
-  rdf <- data.frame(list(list(a=1,
-                              b="a",
-                              c=TRUE,
-                              d=1.1,
-                              e=1L,
-                              g=as.Date("1990-02-24"))))
+  rdf <- data.frame(list(list(a = 1,
+                              b = "a",
+                              c = TRUE,
+                              d = 1.1,
+                              e = 1L,
+                              g = as.Date("1990-02-24"))))
   expected <- collect(createDataFrame(rdf))
   arrowEnabled <- sparkR.conf("spark.sql.execution.arrow.enabled")[[1]]
   conf <- callJMethod(sparkSession, "conf")

--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -319,7 +319,7 @@ test_that("createDataFrame Arrow optimization", {
   },
   finally = {
     # Resetting the conf back to default value
-    callJMethod(conf, "set", "spark.sql.shuffle.partitions", arrowEnabled)
+    callJMethod(conf, "set", "spark.sql.execution.arrow.enabled", arrowEnabled)
   })
 })
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1286,7 +1286,7 @@ object SQLConf {
       .doc("When true, make use of Apache Arrow for columnar data transfers. Currently available " +
         "for use with pyspark.sql.DataFrame.toPandas, " +
         "pyspark.sql.SparkSession.createDataFrame when its input is a Pandas DataFrame," +
-        "and createDataFrame when its input is a R DataFrame. " +
+        "and createDataFrame when its input is an R DataFrame. " +
         "The following data types are unsupported: " +
         "BinaryType, MapType, ArrayType of TimestampType, and nested StructType.")
       .booleanConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1284,8 +1284,9 @@ object SQLConf {
   val ARROW_EXECUTION_ENABLED =
     buildConf("spark.sql.execution.arrow.enabled")
       .doc("When true, make use of Apache Arrow for columnar data transfers. Currently available " +
-        "for use with pyspark.sql.DataFrame.toPandas, and " +
-        "pyspark.sql.SparkSession.createDataFrame when its input is a Pandas DataFrame. " +
+        "for use with pyspark.sql.DataFrame.toPandas, " +
+        "pyspark.sql.SparkSession.createDataFrame when its input is a Pandas DataFrame," +
+        "and createDataFrame when its input is a R DataFrame. " +
         "The following data types are unsupported: " +
         "BinaryType, MapType, ArrayType of TimestampType, and nested StructType.")
       .booleanConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1285,7 +1285,7 @@ object SQLConf {
     buildConf("spark.sql.execution.arrow.enabled")
       .doc("When true, make use of Apache Arrow for columnar data transfers. Currently available " +
         "for use with pyspark.sql.DataFrame.toPandas, " +
-        "pyspark.sql.SparkSession.createDataFrame when its input is a Pandas DataFrame," +
+        "pyspark.sql.SparkSession.createDataFrame when its input is a Pandas DataFrame, " +
         "and createDataFrame when its input is an R DataFrame. " +
         "The following data types are unsupported: " +
         "BinaryType, MapType, ArrayType of TimestampType, and nested StructType.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/r/SQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/r/SQLUtils.scala
@@ -240,7 +240,7 @@ private[sql] object SQLUtils extends Logging {
   }
 
   /**
-   * R callable function to read a file in Arrow stream format and create a `RDD`
+   * R callable function to read a file in Arrow stream format and create an `RDD`
    * using each serialized ArrowRecordBatch as a partition.
    */
   def readArrowStreamFromFile(

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/r/SQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/r/SQLUtils.scala
@@ -32,6 +32,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.{ExprUtils, GenericRowWithSchema}
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
+import org.apache.spark.sql.execution.arrow.ArrowConverters
 import org.apache.spark.sql.execution.command.ShowTablesCommand
 import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
 import org.apache.spark.sql.types._
@@ -236,5 +237,26 @@ private[sql] object SQLUtils extends Logging {
 
   def createArrayType(column: Column): ArrayType = {
     new ArrayType(ExprUtils.evalTypeExpr(column.expr), true)
+  }
+
+  /**
+   * R callable function to read a file in Arrow stream format and create a [[RDD]]
+   * using each serialized ArrowRecordBatch as a partition.
+   */
+  def readArrowStreamFromFile(
+      sparkSession: SparkSession,
+      filename: String): JavaRDD[Array[Byte]] = {
+    ArrowConverters.readArrowStreamFromFile(sparkSession.sqlContext, filename)
+  }
+
+  /**
+   * R callable function to read a file in Arrow stream format and create a [[DataFrame]]
+   * from an RDD.
+   */
+  def toDataFrame(
+      arrowBatchRDD: JavaRDD[Array[Byte]],
+      schema: StructType,
+      sparkSession: SparkSession): DataFrame = {
+    ArrowConverters.toDataFrame(arrowBatchRDD, schema.json, sparkSession.sqlContext)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/r/SQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/r/SQLUtils.scala
@@ -250,8 +250,8 @@ private[sql] object SQLUtils extends Logging {
   }
 
   /**
-   * R callable function to read a file in Arrow stream format and create a `DataFrame`
-   * from an RDD.
+   * R callable function to create a `DataFrame` from a `JavaRDD` of serialized
+   * ArrowRecordBatches.
    */
   def toDataFrame(
       arrowBatchRDD: JavaRDD[Array[Byte]],

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/r/SQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/r/SQLUtils.scala
@@ -240,7 +240,7 @@ private[sql] object SQLUtils extends Logging {
   }
 
   /**
-   * R callable function to read a file in Arrow stream format and create a [[RDD]]
+   * R callable function to read a file in Arrow stream format and create a `RDD`
    * using each serialized ArrowRecordBatch as a partition.
    */
   def readArrowStreamFromFile(
@@ -250,7 +250,7 @@ private[sql] object SQLUtils extends Logging {
   }
 
   /**
-   * R callable function to read a file in Arrow stream format and create a [[DataFrame]]
+   * R callable function to read a file in Arrow stream format and create a `DataFrame`
    * from an RDD.
    */
   def toDataFrame(


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR targets to support Arrow optimization for conversion from R DataFrame to Spark DataFrame.
Like PySpark side, it falls back to non-optimization code path when it's unable to use Arrow optimization.

This can be tested as below:

```bash
$ ./bin/sparkR --conf spark.sql.execution.arrow.enabled=true
```

```r
collect(createDataFrame(mtcars))
```

### Requirements
  - R 3.5.x 
  - Arrow package 0.12+
    ```bash
    Rscript -e 'remotes::install_github("apache/arrow@apache-arrow-0.12.0", subdir = "r")'
    ```

**Note:** currently, Arrow R package is not in CRAN. Please take a look at ARROW-3204.
**Note:** currently, Arrow R package seems not supporting Windows. Please take a look at ARROW-3204.


### Benchmarks

**Shall**

```bash
sync && sudo purge
./bin/sparkR --conf spark.sql.execution.arrow.enabled=false
```

```bash
sync && sudo purge
./bin/sparkR --conf spark.sql.execution.arrow.enabled=true
```

**R code**

```r
createDataFrame(mtcars) # Initializes
rdf <- read.csv("500000.csv")

test <- function() {
  options(digits.secs = 6) # milliseconds
  start.time <- Sys.time()
  createDataFrame(rdf)
  end.time <- Sys.time()
  time.taken <- end.time - start.time
  print(time.taken)
}

test()
```

**Data (350 MB):**

```r
object.size(read.csv("500000.csv"))
350379504 bytes
```

"500000 Records"  http://eforexcel.com/wp/downloads-16-sample-csv-files-data-sets-for-testing/

**Results**

```
Time difference of 29.9468 secs
```

```
Time difference of 3.222129 secs
```

The performance improvement was around **950%**.
Actually, this PR improves around **1200%**+ because this PR includes a small optimization about regular R DataFrame -> Spark DatFrame. See https://github.com/apache/spark/pull/22954#discussion_r231847272

### Limitations:

For now, Arrow optimization with R does not support when the data is `raw`, and when user explicitly gives float type in the schema. They produce corrupt values.
In this case, we decide to fall back to non-optimization code path.

## How was this patch tested?

Small test was added.

I manually forced to set this optimization `true` for _all_ R tests and they were _all_ passed (with few of fallback warnings).

**TODOs:**
- [x] Draft codes
- [x] make the tests passed
- [x] make the CRAN check pass
- [x] Performance measurement
- [x] Supportability investigation (for instance types)
- [x] Wait for Arrow 0.12.0 release
- [x] Fix and match it to Arrow 0.12.0
