### PR TITLE
[SPARK-25921][PySpark] Fix barrier task run without BarrierTaskContext while python worker reuse

### DIFF
--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -144,20 +144,11 @@ class BarrierTaskContext(TaskContext):
         """Construct a BarrierTaskContext, use get instead"""
         pass
 
-    def __new__(cls):
-        """
-        Rewrite __new__ method to BarrierTaskContext for _getOrCreate called when _taskContext
-        is not instance of BarrierTaskContext.
-        """
-        if not isinstance(cls._taskContext, BarrierTaskContext):
-            cls._taskContext = object.__new__(cls)
-        return cls._taskContext
-
     @classmethod
     def _getOrCreate(cls):
         """Internal function to get or create global BarrierTaskContext."""
         if not isinstance(cls._taskContext, BarrierTaskContext):
-            cls._taskContext = BarrierTaskContext()
+            cls._taskContext = object.__new__(cls)
         return cls._taskContext
 
     @classmethod

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -144,10 +144,19 @@ class BarrierTaskContext(TaskContext):
         """Construct a BarrierTaskContext, use get instead"""
         pass
 
+    def __new__(cls):
+        """
+        Rewrite __new__ method to BarrierTaskContext for _getOrCreate called when _taskContext
+        is not instance of BarrierTaskContext.
+        """
+        if not isinstance(cls._taskContext, BarrierTaskContext):
+            cls._taskContext = object.__new__(cls)
+        return cls._taskContext
+
     @classmethod
     def _getOrCreate(cls):
         """Internal function to get or create global BarrierTaskContext."""
-        if cls._taskContext is None:
+        if not isinstance(cls._taskContext, BarrierTaskContext):
             cls._taskContext = BarrierTaskContext()
         return cls._taskContext
 

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -618,10 +618,13 @@ class TaskContextTests(PySparkTestCase):
         """
         Verify that BarrierTaskContext.barrier() with reused python worker.
         """
+        self.sc._conf.set("spark.python.work.reuse", "true")
         rdd = self.sc.parallelize(range(4), 4)
         # start a normal job first to start all worker
         result = rdd.map(lambda x: x ** 2).collect()
         self.assertEqual([0, 1, 4, 9], result)
+        # make sure `spark.python.work.reuse=true`
+        self.assertEqual(self.sc._conf.get("spark.python.work.reuse"), "true")
 
         # worker will be reused in this barrier job
         self.test_barrier()

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -614,6 +614,18 @@ class TaskContextTests(PySparkTestCase):
         times = rdd.barrier().mapPartitions(f).map(context_barrier).collect()
         self.assertTrue(max(times) - min(times) < 1)
 
+    def test_barrier_with_python_worker_reuse(self):
+        """
+        Verify that BarrierTaskContext.barrier() with reused python worker.
+        """
+        rdd = self.sc.parallelize(range(4), 4)
+        # start a normal job first to start all worker
+        result = rdd.map(lambda x: x ** 2).collect()
+        self.assertEqual([0, 1, 4, 9], result)
+
+        # worker will be reused in this barrier job
+        self.test_barrier()
+
     def test_barrier_infos(self):
         """
         Verify that BarrierTaskContext.getTaskInfos() returns a list of all task infos in the


### PR DESCRIPTION
## What changes were proposed in this pull request?

Running a barrier job after a normal spark job causes the barrier job to run without a BarrierTaskContext. This is because while python worker reuse, BarrierTaskContext._getOrCreate() will still return a TaskContext after firstly submit a normal spark job, we'll get a `AttributeError: 'TaskContext' object has no attribute 'barrier'`. Fix this by adding check logic in BarrierTaskContext._getOrCreate() and make sure it will return BarrierTaskContext in this scenario.

## How was this patch tested?

Add new UT in pyspark-core.