### PR TITLE
SPARK-25975 - Spark History does not display necessarily the incomplete applications when requested	

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -108,14 +108,13 @@ $(document).ready(function() {
     requestedIncomplete = getParameterByName("showIncomplete", searchString);
     requestedIncomplete = (requestedIncomplete == "true" ? true : false);
 
-    $.getJSON(uiRoot + "/api/v1/applications?limit=" + appLimit, function(response,status,jqXHR) {
+    status = requestedIncomplete ? 'RUNNING' : 'COMPLETED';
+
+    $.getJSON(uiRoot + "/api/v1/applications?limit=" + appLimit + "&status=" + status, function(response,status,jqXHR) {
       var array = [];
       var hasMultipleAttempts = false;
       for (i in response) {
         var app = response[i];
-        if (app["attempts"][0]["completed"] == requestedIncomplete) {
-          continue; // if we want to show for Incomplete, we skip the completed apps; otherwise skip incomplete ones.
-        }
         var id = app["id"];
         var name = app["name"];
         if (app["attempts"].length > 1) {


### PR DESCRIPTION
Filtering of incomplete applications is made in javascript against the response returned by the API. The problem is that if the returned result is not big enough (because of spark.history.ui.maxApplications), it might not contain incomplete applications. 
We can call the API with status RUNNING or COMPLETED depending on the view we want to fix this issue.
