### PR TITLE
[SPARK-25989][ML] OneVsRestModel handle empty outputCols incorrectly

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -215,8 +215,8 @@ final class OneVsRestModel private[ml] (
       newDataset.unpersist()
     }
 
-    var outputColNames = Seq.empty[String]
-    var outputColumns = Seq.empty[Column]
+    var predictionColNames = Seq.empty[String]
+    var predictionColumns = Seq.empty[Column]
 
     if (getRawPredictionCol != "") {
       val numClass = models.length
@@ -228,8 +228,8 @@ final class OneVsRestModel private[ml] (
         Vectors.dense(predArray)
       }
 
-      outputColNames = outputColNames :+ getRawPredictionCol
-      outputColumns = outputColumns :+ rawPredictionUDF(col(accColName))
+      predictionColNames = predictionColNames :+ getRawPredictionCol
+      predictionColumns = predictionColumns :+ rawPredictionUDF(col(accColName))
     }
 
     if (getPredictionCol != "") {
@@ -238,13 +238,13 @@ final class OneVsRestModel private[ml] (
         predictions.maxBy(_._2)._1.toDouble
       }
 
-      outputColNames = outputColNames :+ getPredictionCol
-      outputColumns = outputColumns :+ labelUDF(col(accColName))
+      predictionColNames = predictionColNames :+ getPredictionCol
+      predictionColumns = predictionColumns :+ labelUDF(col(accColName))
         .as(getPredictionCol, labelMetadata)
     }
 
     aggregatedDataset
-      .withColumns(outputColNames, outputColumns)
+      .withColumns(predictionColNames, predictionColumns)
       .drop(accColName)
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -22,10 +22,12 @@ import java.util.UUID
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.language.existentials
+
 import org.apache.hadoop.fs.Path
 import org.json4s.{DefaultFormats, JObject, _}
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods._
+
 import org.apache.spark.SparkContext
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml._

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
@@ -290,6 +290,32 @@ class OneVsRestSuite extends MLTest with DefaultReadWriteTest {
     checkModelData(ovaModel, newOvaModel)
   }
 
+  test("should ignore empty output cols") {
+    val lr = new LogisticRegression().setMaxIter(1)
+    val ovr = new OneVsRest().setClassifier(lr)
+    val ovrModel = ovr.fit(dataset)
+
+    val output1 = ovrModel.setPredictionCol("").setRawPredictionCol("")
+      .transform(dataset)
+    assert(output1.schema.fieldNames.toSet ===
+      Set("label", "features"))
+
+    val output2 = ovrModel.setPredictionCol("prediction").setRawPredictionCol("")
+      .transform(dataset)
+    assert(output2.schema.fieldNames.toSet ===
+      Set("label", "features", "prediction"))
+
+    val output3 = ovrModel.setPredictionCol("").setRawPredictionCol("rawPrediction")
+      .transform(dataset)
+    assert(output3.schema.fieldNames.toSet ===
+      Set("label", "features", "rawPrediction"))
+
+    val output4 = ovrModel.setPredictionCol("prediction").setRawPredictionCol("rawPrediction")
+      .transform(dataset)
+    assert(output4.schema.fieldNames.toSet ===
+      Set("label", "features", "prediction", "rawPrediction"))
+  }
+
   test("should support all NumericType labels and not support other types") {
     val ovr = new OneVsRest().setClassifier(new LogisticRegression().setMaxIter(1))
     MLTestingUtils.checkNumericTypes[OneVsRestModel, OneVsRest](


### PR DESCRIPTION
## What changes were proposed in this pull request?
ignore empty output columns

## How was this patch tested?
added tests