### PR TITLE
[SPARK-20319][SQL] Already quoted identifiers are getting wrapped with additional quotes

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -81,6 +81,10 @@ private case object OracleDialect extends JdbcDialect {
     case _ => None
   }
 
+  override def quoteIdentifier(colName: String): String = {
+    s""""${colName.stripPrefix("\"").stripSuffix("\"")}""""
+  }
+
   override def compileValue(value: Any): Any = value match {
     // The JDBC drivers support date literals in SQL statements written in the
     // format: {d 'yyyy-mm-dd'} and timestamp literals in SQL statements written


### PR DESCRIPTION
## What changes were proposed in this pull request?

Oracle JDBC Writer uses dialects to quote the field names but when the quotes are explicitly wrapped with the column names, JDBC driver fails to parse columns with two double quotes.
e.g. ```""columnName""```. 
This pr fix this issue.

## How was this patch tested?

unit tests

Closes https://github.com/apache/spark/pull/17631
