### PR TITLE
[SPARK-26006][mllib] unpersist 'dataInternalRepr' in the PrefixSpan

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/fpm/PrefixSpan.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/fpm/PrefixSpan.scala
@@ -174,6 +174,7 @@ class PrefixSpan private (
     val freqSequences = results.map { case (seq: Array[Int], count: Long) =>
       new FreqSequence(toPublicRepr(seq), count)
     }
+    dataInternalRepr.unpersist(false)
     new PrefixSpanModel(freqSequences)
   }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/fpm/PrefixSpan.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/fpm/PrefixSpan.scala
@@ -174,7 +174,10 @@ class PrefixSpan private (
     val freqSequences = results.map { case (seq: Array[Int], count: Long) =>
       new FreqSequence(toPublicRepr(seq), count)
     }
+    // Cache the final RDD to the same storage level as input
+    freqSequences.persist(data.getStorageLevel)
     dataInternalRepr.unpersist(false)
+
     new PrefixSpanModel(freqSequences)
   }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/fpm/PrefixSpan.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/fpm/PrefixSpan.scala
@@ -175,7 +175,10 @@ class PrefixSpan private (
       new FreqSequence(toPublicRepr(seq), count)
     }
     // Cache the final RDD to the same storage level as input
-    freqSequences.persist(data.getStorageLevel)
+    if (data.getStorageLevel != StorageLevel.NONE) {
+      freqSequences.persist(data.getStorageLevel)
+      freqSequences.count()
+    }
     dataInternalRepr.unpersist(false)
 
     new PrefixSpanModel(freqSequences)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Mllib's Prefixspan - run method - cached RDD stays in cache. After run is comlpeted , rdd remain in cache.
We need to unpersist the cached RDD after run method.


## How was this patch tested?
Existing tests
