### PR TITLE
[SPARK-26024][SQL]: Update documentation for repartitionByRange

### DIFF
--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -767,6 +767,14 @@ setMethod("repartition",
 #'                      using \code{spark.sql.shuffle.partitions} as number of partitions.}
 #'}
 #'
+#' At least one partition-by expression must be specified.
+#' When no explicit sort order is specified, "ascending nulls first" is assumed.
+#'
+#' Note that due to performance reasons this method uses sampling to estimate the ranges.
+#' Hence, the output may not be consistent, since sampling can return different values.
+#' The sample size can be controlled by the config
+#' \code{spark.sql.execution.rangeExchange.sampleSizePerPartition}.
+#'
 #' @param x a SparkDataFrame.
 #' @param numPartitions the number of partitions to use.
 #' @param col the column by which the range partitioning will be performed.

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -732,6 +732,11 @@ class DataFrame(object):
         At least one partition-by expression must be specified.
         When no explicit sort order is specified, "ascending nulls first" is assumed.
 
+        [SPARK-26024] Note that due to performance reasons this method uses sampling to
+        estimate the ranges. Hence, the output may not be consistent, since sampling can return
+        different values. The sample size can be controlled by setting the value of the parameter
+        `spark.sql.execution.rangeExchange.sampleSizePerPartition`.
+
         >>> df.repartitionByRange(2, "age").rdd.getNumPartitions()
         2
         >>> df.show()

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -734,7 +734,7 @@ class DataFrame(object):
 
         Note that due to performance reasons this method uses sampling to estimate the ranges.
         Hence, the output may not be consistent, since sampling can return different values.
-        The sample size can be controlled by setting the value of the parameter
+        The sample size can be controlled by the config
         `spark.sql.execution.rangeExchange.sampleSizePerPartition`.
 
         >>> df.repartitionByRange(2, "age").rdd.getNumPartitions()

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -732,9 +732,9 @@ class DataFrame(object):
         At least one partition-by expression must be specified.
         When no explicit sort order is specified, "ascending nulls first" is assumed.
 
-        [SPARK-26024] Note that due to performance reasons this method uses sampling to
-        estimate the ranges. Hence, the output may not be consistent, since sampling can return
-        different values. The sample size can be controlled by setting the value of the parameter
+        Note that due to performance reasons this method uses sampling to estimate the ranges.
+        Hence, the output may not be consistent, since sampling can return different values.
+        The sample size can be controlled by setting the value of the parameter
         `spark.sql.execution.rangeExchange.sampleSizePerPartition`.
 
         >>> df.repartitionByRange(2, "age").rdd.getNumPartitions()

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2789,6 +2789,12 @@ class Dataset[T] private[sql](
    * When no explicit sort order is specified, "ascending nulls first" is assumed.
    * Note, the rows are not sorted in each partition of the resulting Dataset.
    *
+   *
+   * [SPARK-26024] Note that due to performance reasons this method uses sampling to
+   * estimate the ranges. Hence, the output may not be consistent, since sampling can return
+   * different values. The sample size can be controlled by setting the value of the parameter
+   * {{spark.sql.execution.rangeExchange.sampleSizePerPartition}}.
+   *
    * @group typedrel
    * @since 2.3.0
    */
@@ -2812,6 +2818,11 @@ class Dataset[T] private[sql](
    * At least one partition-by expression must be specified.
    * When no explicit sort order is specified, "ascending nulls first" is assumed.
    * Note, the rows are not sorted in each partition of the resulting Dataset.
+   *
+   * [SPARK-26024] Note that due to performance reasons this method uses sampling to
+   * estimate the ranges. Hence, the output may not be consistent, since sampling can return
+   * different values. The sample size can be controlled by setting the value of the parameter
+   * {{spark.sql.execution.rangeExchange.sampleSizePerPartition}}.
    *
    * @group typedrel
    * @since 2.3.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2790,9 +2790,9 @@ class Dataset[T] private[sql](
    * Note, the rows are not sorted in each partition of the resulting Dataset.
    *
    *
-   * [SPARK-26024] Note that due to performance reasons this method uses sampling to
-   * estimate the ranges. Hence, the output may not be consistent, since sampling can return
-   * different values. The sample size can be controlled by setting the value of the parameter
+   * Note that due to performance reasons this method uses sampling to estimate the ranges.
+   * Hence, the output may not be consistent, since sampling can return different values.
+   * The sample size can be controlled by setting the value of the parameter
    * `spark.sql.execution.rangeExchange.sampleSizePerPartition`.
    *
    * @group typedrel

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2792,7 +2792,7 @@ class Dataset[T] private[sql](
    *
    * Note that due to performance reasons this method uses sampling to estimate the ranges.
    * Hence, the output may not be consistent, since sampling can return different values.
-   * The sample size can be controlled by setting the value of the parameter
+   * The sample size can be controlled by the config
    * `spark.sql.execution.rangeExchange.sampleSizePerPartition`.
    *
    * @group typedrel
@@ -2821,7 +2821,7 @@ class Dataset[T] private[sql](
    *
    * Note that due to performance reasons this method uses sampling to estimate the ranges.
    * Hence, the output may not be consistent, since sampling can return different values.
-   * The sample size can be controlled by setting the value of the parameter
+   * The sample size can be controlled by the config
    * `spark.sql.execution.rangeExchange.sampleSizePerPartition`.
    *
    * @group typedrel

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2793,7 +2793,7 @@ class Dataset[T] private[sql](
    * [SPARK-26024] Note that due to performance reasons this method uses sampling to
    * estimate the ranges. Hence, the output may not be consistent, since sampling can return
    * different values. The sample size can be controlled by setting the value of the parameter
-   * {{spark.sql.execution.rangeExchange.sampleSizePerPartition}}.
+   * `spark.sql.execution.rangeExchange.sampleSizePerPartition`.
    *
    * @group typedrel
    * @since 2.3.0
@@ -2819,10 +2819,10 @@ class Dataset[T] private[sql](
    * When no explicit sort order is specified, "ascending nulls first" is assumed.
    * Note, the rows are not sorted in each partition of the resulting Dataset.
    *
-   * [SPARK-26024] Note that due to performance reasons this method uses sampling to
-   * estimate the ranges. Hence, the output may not be consistent, since sampling can return
-   * different values. The sample size can be controlled by setting the value of the parameter
-   * {{spark.sql.execution.rangeExchange.sampleSizePerPartition}}.
+   * Note that due to performance reasons this method uses sampling to estimate the ranges.
+   * Hence, the output may not be consistent, since sampling can return different values.
+   * The sample size can be controlled by setting the value of the parameter
+   * `spark.sql.execution.rangeExchange.sampleSizePerPartition`.
    *
    * @group typedrel
    * @since 2.3.0


### PR DESCRIPTION
Following [SPARK-26024](https://issues.apache.org/jira/browse/SPARK-26024), I noticed the number of elements in each partition after repartitioning using `df.repartitionByRange` can vary for the same setup:

```scala
// Shuffle numbers from 0 to 1000, and make a DataFrame
val df = Random.shuffle(0.to(1000)).toDF("val")

// Repartition it using 3 partitions
// Sum up number of elements in each partition, and collect it.
// And do it several times
for (i <- 0 to 9) {
  var counts = df.repartitionByRange(3, col("val"))
    .mapPartitions{part => Iterator(part.size)}
    .collect()
  println(counts.toList)
}
// -> the number of elements in each partition varies
```

This is expected as for performance reasons this method uses sampling to estimate the ranges (with default size of 100). Hence, the output may not be consistent, since sampling can return different values. But documentation was not mentioning it at all, leading to misunderstanding.

## What changes were proposed in this pull request?

Update the documentation (Spark & PySpark) to mention the impact of `spark.sql.execution.rangeExchange.sampleSizePerPartition` on the resulting partitioned DataFrame.