### PR TITLE
[SPARK-26053][SQL] Enhance LikeSimplification

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -504,6 +504,19 @@ object LikeSimplification extends Rule[LogicalPlan] {
             Like(input, Literal.create(pattern, StringType))
         }
       }
+
+    case Like(Literal(pattern, StringType), input) =>
+      if (pattern == null) {
+        // If pattern is null, return null value directly, since "null like col" == null.
+        Literal(null, BooleanType)
+      } else {
+        pattern.toString match {
+          case equalTo(str) =>
+            EqualTo(Literal(str), input)
+          case _ =>
+            Like(Literal.create(pattern, StringType), input)
+        }
+      }
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LikeSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LikeSimplificationSuite.scala
@@ -88,7 +88,7 @@ class LikeSimplificationSuite extends PlanTest {
     comparePlans(optimized, correctAnswer)
   }
 
-  test("simplify Like into EqualTo") {
+  test("simplify Like into EqualTo (Like(input, literal) case)") {
     val originalQuery =
       testRelation
         .where(('a like "") || ('a like "abc"))
@@ -101,8 +101,27 @@ class LikeSimplificationSuite extends PlanTest {
     comparePlans(optimized, correctAnswer)
   }
 
-  test("null pattern") {
+  test("simplify Like into EqualTo (Like(literal, input) case)") {
+    val originalQuery =
+      testRelation
+        .where(("" like 'a) || ("abc" like 'a))
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val correctAnswer = testRelation
+      .where(("" === 'a) || ("abc" === 'a))
+      .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("null pattern (Like(input, literal) case)") {
     val originalQuery = testRelation.where('a like Literal(null, StringType)).analyze
+    val optimized = Optimize.execute(originalQuery)
+    comparePlans(optimized, testRelation.where(Literal(null, BooleanType)).analyze)
+  }
+
+  test("null pattern (Like(literal, input) case)") {
+    val originalQuery = testRelation.where(Literal(null, StringType) like 'a).analyze
     val optimized = Optimize.execute(originalQuery)
     comparePlans(optimized, testRelation.where(Literal(null, BooleanType)).analyze)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR enhance `LikeSimplification` in 2 cases:

1.  null like col -> null
2. 'str' like col -> col = 'str'

It difficult to handle these cases:
1. 'str%' like col
2. '%str' like col
3. 'str%str' like col
4. '%' like col

for example:
```sql
select '8%' like '8%';  -- true
select '8%' like '%8%';  -- true
select '8%' like '%%8%%';  -- true
select '8%' like '%%5%%8%%'; --false

select '%8' like '%8%';  -- true
select '%8' like '%8%';  -- true
select '%8' like '%%8%';  -- true
select '%8' like '%%5%%8%'; -- false

select '%' like '%';  -- true
select '%' like '%%';  -- true
select '%' like '%%8%';  -- false
```

## How was this patch tested?

unit tests
