### PR TITLE
[MINOR][YARN] Make memLimitExceededLogMessage more clean

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -600,21 +600,16 @@ private[yarn] class YarnAllocator(
             val vmemExceededPattern = raw"$MEM_REGEX of $MEM_REGEX virtual memory used".r
             val diag = vmemExceededPattern.findFirstIn(completedContainer.getDiagnostics)
               .map(_.concat(".")).getOrElse("")
-            val additional = if (conf.getBoolean(YarnConfiguration.NM_VMEM_CHECK_ENABLED,
-              YarnConfiguration.DEFAULT_NM_VMEM_CHECK_ENABLED)) {
-              s"or disabling ${YarnConfiguration.NM_VMEM_CHECK_ENABLED} because of YARN-4714"
-            } else {
-              s"or boosting ${YarnConfiguration.NM_VMEM_PMEM_RATIO}"
-            }
-            val message = "Container killed by YARN for exceeding virtual memory limits." +
-              s" $diag Consider boosting ${EXECUTOR_MEMORY_OVERHEAD.key} $additional."
+            val message = "Container killed by YARN for exceeding virtual memory limits. " +
+              s"$diag Consider boosting ${EXECUTOR_MEMORY_OVERHEAD.key} or disabling " +
+              s"${YarnConfiguration.NM_VMEM_CHECK_ENABLED} because of YARN-4714."
             (true, message)
           case PMEM_EXCEEDED_EXIT_CODE =>
             val pmemExceededPattern = raw"$MEM_REGEX of $MEM_REGEX physical memory used".r
             val diag = pmemExceededPattern.findFirstIn(completedContainer.getDiagnostics)
               .map(_.concat(".")).getOrElse("")
-            val message = "Container killed by YARN for exceeding physical memory limits." +
-              s" $diag Consider boosting ${EXECUTOR_MEMORY_OVERHEAD.key}."
+            val message = "Container killed by YARN for exceeding physical memory limits. " +
+              s"$diag Consider boosting ${EXECUTOR_MEMORY_OVERHEAD.key}."
             (true, message)
           case _ =>
             // all the failures which not covered above, like:

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -601,7 +601,8 @@ private[yarn] class YarnAllocator(
             val diag = vmemExceededPattern.findFirstIn(completedContainer.getDiagnostics)
               .map(_.concat(".")).getOrElse("")
             val message = "Container killed by YARN for exceeding virtual memory limits. " +
-              s"$diag Consider boosting ${EXECUTOR_MEMORY_OVERHEAD.key} or disabling " +
+              s"$diag Consider boosting ${EXECUTOR_MEMORY_OVERHEAD.key} or boosting " +
+              s"${YarnConfiguration.NM_VMEM_PMEM_RATIO} or disabling " +
               s"${YarnConfiguration.NM_VMEM_CHECK_ENABLED} because of YARN-4714."
             (true, message)
           case PMEM_EXCEEDED_EXIT_CODE =>

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -745,8 +745,12 @@ private object YarnAllocator {
   def memLimitExceededLogMessage(diagnostics: String, pattern: Pattern): String = {
     val matcher = pattern.matcher(diagnostics)
     val diag = if (matcher.find()) " " + matcher.group() + "." else ""
+    val additional = if (pattern == VMEM_EXCEEDED_PATTERN) {
+      s" or disabling ${YarnConfiguration.NM_VMEM_CHECK_ENABLED} because of YARN-4714"
+    } else {
+      ""
+    }
     s"Container killed by YARN for exceeding memory limits. $diag " +
-      "Consider boosting spark.yarn.executor.memoryOverhead or " +
-      "disabling yarn.nodemanager.vmem-check-enabled because of YARN-4714."
+      s"Consider boosting ${EXECUTOR_MEMORY_OVERHEAD.key}$additional."
   }
 }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.deploy.yarn
 
-import java.util.regex.Pattern
-
 import scala.collection.JavaConverters._
 
 import org.apache.hadoop.conf.Configuration
@@ -31,7 +29,6 @@ import org.mockito.Mockito._
 import org.scalatest.{BeforeAndAfterEach, Matchers}
 
 import org.apache.spark.{SecurityManager, SparkConf, SparkFunSuite}
-import org.apache.spark.deploy.yarn.YarnAllocator._
 import org.apache.spark.deploy.yarn.YarnSparkHadoopUtil._
 import org.apache.spark.deploy.yarn.config._
 import org.apache.spark.rpc.RpcEndpointRef
@@ -377,19 +374,6 @@ class YarnAllocatorSuite extends SparkFunSuite with Matchers with BeforeAndAfter
 
     handler.requestTotalExecutorsWithPreferredLocalities(3, 0, Map(), Set.empty)
     verify(mockAmClient).updateBlacklist(Seq[String]().asJava, Seq("hostA", "hostB").asJava)
-  }
-
-  test("memory exceeded diagnostic regexes") {
-    def logMessage(pattern: Pattern): String = {
-      val diagnostics =
-        "Container [pid=12465,containerID=container_1412887393566_0003_01_000002] is running " +
-          "beyond physical memory limits. Current usage: 2.1 MB of 2 GB physical memory used; " +
-          "5.8 GB of 4.2 GB virtual memory used. Killing container."
-      val matcher = pattern.matcher(diagnostics)
-      if (matcher.find()) " " + matcher.group() + "." else ""
-    }
-    assert(logMessage(VMEM_EXCEEDED_PATTERN).contains("5.8 GB of 4.2 GB virtual memory used."))
-    assert(logMessage(PMEM_EXCEEDED_PATTERN).contains("2.1 MB of 2 GB physical memory used."))
   }
 
   test("window based failure executor counting") {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Current `memLimitExceededLogMessage`:

<img src="https://user-images.githubusercontent.com/5399861/48467789-ec8e1000-e824-11e8-91fc-280d342e1bf3.png" width="360">

It‘s not very clear, because physical memory exceeds but suggestion contains virtual memory config. This pr makes it more clear and replace  deprecated config: ```spark.yarn.executor.memoryOverhead```.
## How was this patch tested?

manual tests
