### PR TITLE
[WIP][SPARK-26061][SQL][MINOR] Reduce the number of unused UnsafeRowWriters created in whole-stage codegen

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -160,8 +160,6 @@ trait CodegenSupport extends SparkPlan {
         }
       }
 
-    val rowVar = prepareRowVar(ctx, row, outputVars)
-
     // Set up the `currentVars` in the codegen context, as we generate the code of `inputVars`
     // before calling `parent.doConsume`. We can't set up `INPUT_ROW`, because parent needs to
     // generate code of `rowVar` manually.
@@ -185,6 +183,7 @@ trait CodegenSupport extends SparkPlan {
         && CodeGenerator.isValidParamLength(paramLength)) {
       constructDoConsumeFunction(ctx, inputVars, row)
     } else {
+      val rowVar = prepareRowVar(ctx, row, outputVars)
       parent.doConsume(ctx, inputVars, rowVar)
     }
     s"""


### PR DESCRIPTION
## What changes were proposed in this pull request?

Reduce the number of unused `UnsafeRowWriter`s created in whole-stage generated code.
They come from the `CodegenSupport.consume()` calling `prepareRowVar()`, which uses `GenerateUnsafeProjection.createCode()` and registers an `UnsafeRowWriter` mutable state, regardless of whether or not the downstream (parent) operator will use the `rowVar` or not.
Even when the downstream `doConsume` function doesn't use the `rowVar` (i.e. doesn't put `row.code` as a part of this operator's codegen template), the registered `UnsafeRowWriter` stays there, which makes the init function of the generated code a bit bloated.

This PR doesn't heal the root issue, but makes it slightly less painful: when the `doConsume` function is split out, the `prepareRowVar()` function is called twice, so it's double the pain of unused `UnsafeRowWriter`s. This PR simply moves the original call to `prepareRowVar()` down into the `doConsume` split/no-split branch so that we're back to just 1x the pain.

To fix the root issue, something that allows the `CodegenSupport` operators to indicate whether or not they're going to use the `rowVar` would be needed. That's a much more elaborate change so I'd like to just make a minor fix first.

e.g. for this query: `spark.range(10).as[Long].map(x => x + 1).map(x => x * x + 2)`
**Before** (in Spark 2.4.0):
```java
/* 023 */   public void init(int index, scala.collection.Iterator[] inputs) {
/* 024 */     partitionIndex = index;
/* 025 */     this.inputs = inputs;
/* 026 */
/* 027 */     range_taskContext_0 = TaskContext.get();
/* 028 */     range_inputMetrics_0 = range_taskContext_0.taskMetrics().inputMetrics();
/* 029 */     range_mutableStateArray_0[0] = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(1, 0);
/* 030 */     range_mutableStateArray_0[1] = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(1, 0);
/* 031 */     range_mutableStateArray_0[2] = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(1, 0);
/* 032 */     range_mutableStateArray_0[3] = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(1, 0);
/* 033 */     range_mutableStateArray_0[4] = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(1, 0);
/* 034 */     range_mutableStateArray_0[5] = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(1, 0);
/* 035 */     range_mutableStateArray_0[6] = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(1, 0);
/* 036 */     range_mutableStateArray_0[7] = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(1, 0);
/* 037 */     range_mutableStateArray_0[8] = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(1, 0);
/* 038 */
/* 039 */   }
```
9 `UnsafeRowWriter`s created, 1 actually used.

**After**:
```java
/* 023 */   public void init(int index, scala.collection.Iterator[] inputs) {
/* 024 */     partitionIndex = index;
/* 025 */     this.inputs = inputs;
/* 026 */
/* 027 */     range_taskContext_0 = TaskContext.get();
/* 028 */     range_inputMetrics_0 = range_taskContext_0.taskMetrics().inputMetrics();
/* 029 */     deserializetoobject_mutableStateArray_0[0] = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(1, 0);
/* 030 */     deserializetoobject_mutableStateArray_0[1] = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(1, 0);
/* 031 */     deserializetoobject_mutableStateArray_0[2] = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(1, 0);
/* 032 */     deserializetoobject_mutableStateArray_0[3] = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(1, 0);
/* 033 */     deserializetoobject_mutableStateArray_0[4] = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(1, 0);
/* 034 */
/* 035 */   }
```
5 `UnsafeRowWriter`s created, 1 actually used.

## How was this patch tested?

Existing tests.