### PR TITLE
[SPARK-26057][SQL] Transform also analyzed plans when dedup references

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -871,7 +871,7 @@ class Analyzer(
     private def dedupOuterReferencesInSubquery(
         plan: LogicalPlan,
         attrMap: AttributeMap[Attribute]): LogicalPlan = {
-      plan resolveOperatorsDown { case currentFragment =>
+      plan transformDown { case currentFragment =>
         currentFragment transformExpressions {
           case OuterReference(a: Attribute) =>
             OuterReference(dedupAttr(a, attrMap))

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2556,7 +2556,7 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
   }
 
   test("SPARK-26057: attribute deduplication on already analyzed plans") {
-    withTempView("a", "b", "c", "v") {
+    withTempView("a", "b", "v") {
       val df1 = Seq(("1-1", 6)).toDF("id", "n")
       df1.createOrReplaceTempView("a")
       val df3 = Seq("1-1").toDF("id")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2556,31 +2556,27 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
   }
 
   test("SPARK-26057: attribute deduplication on already analyzed plans") {
-    withTempView("cc", "p", "c") {
-      val df1 = Seq(("1-1", "sp", 6)).toDF("id", "layout", "n")
-      df1.createOrReplaceTempView("cc")
-      val df2 = Seq(("sp", 1)).toDF("layout", "ts")
-      df2.createOrReplaceTempView("p")
-      val df3 = Seq(("1-1", "sp", 3)).toDF("id", "layout", "ts")
-      df3.createOrReplaceTempView("c")
+    withTempView("a", "b", "c", "v") {
+      val df1 = Seq(("1-1", 6)).toDF("id", "n")
+      df1.createOrReplaceTempView("a")
+      val df3 = Seq("1-1").toDF("id")
+      df3.createOrReplaceTempView("b")
       spark.sql(
         """
-          |SELECT cc.id, cc.layout, count(*) as m
-          |FROM cc
-          |JOIN p USING(layout)
+          |SELECT a.id, n as m
+          |FROM a
           |WHERE EXISTS(
           |  SELECT 1
-          |  FROM c
-          |  WHERE c.id = cc.id AND c.layout = cc.layout AND c.ts > p.ts)
-          |GROUP BY cc.id, cc.layout
-        """.stripMargin).createOrReplaceTempView("pcc")
+          |  FROM b
+          |  WHERE b.id = a.id)
+        """.stripMargin).createOrReplaceTempView("v")
       val res = spark.sql(
         """
-          |SELECT cc.id, cc.layout, n, m
-          |  FROM cc
-          |  LEFT OUTER JOIN pcc ON pcc.id = cc.id AND pcc.layout = cc.layout
+          |SELECT a.id, n, m
+          |  FROM a
+          |  LEFT OUTER JOIN v ON v.id = a.id
         """.stripMargin)
-      checkAnswer(res, Row("1-1", "sp", 6, 1))
+      checkAnswer(res, Row("1-1", 6, 6))
 
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2577,7 +2577,6 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
           |  LEFT OUTER JOIN v ON v.id = a.id
         """.stripMargin)
       checkAnswer(res, Row("1-1", 6, 6))
-
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In SPARK-24865 `AnalysisBarrier` was removed and in order to improve resolution speed, the `analyzed` flag was (re-)introduced in order to process only plans which are not yet analyzed. This should not be the case when performing attribute deduplication as in that case we need to transform also the plans which were already analyzed, otherwise we can miss to rewrite some attributes leading to invalid plans.

## How was this patch tested?

added UT

Please review http://spark.apache.org/contributing.html before opening a pull request.
