### PR TITLE
[SPARK-26068][Core]ChunkedByteBufferInputStream should handle empty chunks correctly

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/io/ChunkedByteBuffer.scala
+++ b/core/src/main/scala/org/apache/spark/util/io/ChunkedByteBuffer.scala
@@ -222,6 +222,7 @@ private[spark] class ChunkedByteBufferInputStream(
     dispose: Boolean)
   extends InputStream {
 
+  // Filter out empty chunks since `read()` assumes all chunks are non-empty.
   private[this] var chunks = chunkedByteBuffer.getChunks().filter(_.hasRemaining).iterator
   private[this] var currentChunk: ByteBuffer = {
     if (chunks.hasNext) {

--- a/core/src/main/scala/org/apache/spark/util/io/ChunkedByteBuffer.scala
+++ b/core/src/main/scala/org/apache/spark/util/io/ChunkedByteBuffer.scala
@@ -232,7 +232,8 @@ private[spark] class ChunkedByteBufferInputStream(
   }
 
   override def read(): Int = {
-    if (currentChunk != null && !currentChunk.hasRemaining && chunks.hasNext) {
+    // skip empty chunks
+    while (currentChunk != null && !currentChunk.hasRemaining && chunks.hasNext) {
       currentChunk = chunks.next()
     }
     if (currentChunk != null && currentChunk.hasRemaining) {
@@ -244,7 +245,8 @@ private[spark] class ChunkedByteBufferInputStream(
   }
 
   override def read(dest: Array[Byte], offset: Int, length: Int): Int = {
-    if (currentChunk != null && !currentChunk.hasRemaining && chunks.hasNext) {
+    // skip empty chunks
+    while (currentChunk != null && !currentChunk.hasRemaining && chunks.hasNext) {
       currentChunk = chunks.next()
     }
     if (currentChunk != null && currentChunk.hasRemaining) {
@@ -263,7 +265,10 @@ private[spark] class ChunkedByteBufferInputStream(
       currentChunk.position(currentChunk.position() + amountToSkip)
       if (currentChunk.remaining() == 0) {
         if (chunks.hasNext) {
-          currentChunk = chunks.next()
+          // skip empty chunks
+          while (chunks.hasNext && currentChunk.remaining() == 0) {
+            currentChunk = chunks.next()
+          }
         } else {
           close()
         }

--- a/core/src/test/scala/org/apache/spark/io/ChunkedByteBufferSuite.scala
+++ b/core/src/test/scala/org/apache/spark/io/ChunkedByteBufferSuite.scala
@@ -90,7 +90,7 @@ class ChunkedByteBufferSuite extends SparkFunSuite with SharedSparkContext {
     val empty = ByteBuffer.wrap(Array.empty[Byte])
     val bytes1 = ByteBuffer.wrap(Array.tabulate(256)(_.toByte))
     val bytes2 = ByteBuffer.wrap(Array.tabulate(128)(_.toByte))
-    val chunkedByteBuffer = new ChunkedByteBuffer(Array(bytes1, empty, empty, bytes2))
+    val chunkedByteBuffer = new ChunkedByteBuffer(Array(empty, bytes1, empty, bytes2))
     assert(chunkedByteBuffer.size === bytes1.limit() + bytes2.limit())
 
     val inputStream = chunkedByteBuffer.toInputStream(dispose = false)
@@ -98,14 +98,5 @@ class ChunkedByteBufferSuite extends SparkFunSuite with SharedSparkContext {
     ByteStreams.readFully(inputStream, bytesFromStream)
     assert(bytesFromStream === bytes1.array() ++ bytes2.array())
     assert(chunkedByteBuffer.getChunks().head.position() === 0)
-
-    // test skip
-    val skippableInputStream = chunkedByteBuffer.toInputStream(dispose = false)
-    // occurred first empty chunk, skip will return bytes1.limit()
-    assert(skippableInputStream.skip(chunkedByteBuffer.size) === bytes1.limit())
-    // empty chunks will be skipped, next skill will return bytes2.limit()
-    assert(skippableInputStream.skip(chunkedByteBuffer.size) === bytes2.limit())
-    // all data has been skipped. No more data will be skipped.
-    assert(skippableInputStream.skip(chunkedByteBuffer.size) === 0)
   }
 }

--- a/core/src/test/scala/org/apache/spark/io/ChunkedByteBufferSuite.scala
+++ b/core/src/test/scala/org/apache/spark/io/ChunkedByteBufferSuite.scala
@@ -90,7 +90,7 @@ class ChunkedByteBufferSuite extends SparkFunSuite with SharedSparkContext {
     val empty = ByteBuffer.wrap(Array.empty[Byte])
     val bytes1 = ByteBuffer.wrap(Array.tabulate(256)(_.toByte))
     val bytes2 = ByteBuffer.wrap(Array.tabulate(128)(_.toByte))
-    val chunkedByteBuffer = new ChunkedByteBuffer(Array(empty, bytes1, bytes2))
+    val chunkedByteBuffer = new ChunkedByteBuffer(Array(bytes1, empty, empty, bytes2))
     assert(chunkedByteBuffer.size === bytes1.limit() + bytes2.limit())
 
     val inputStream = chunkedByteBuffer.toInputStream(dispose = false)
@@ -98,5 +98,14 @@ class ChunkedByteBufferSuite extends SparkFunSuite with SharedSparkContext {
     ByteStreams.readFully(inputStream, bytesFromStream)
     assert(bytesFromStream === bytes1.array() ++ bytes2.array())
     assert(chunkedByteBuffer.getChunks().head.position() === 0)
+
+    // test skip
+    val skippableInputStream = chunkedByteBuffer.toInputStream(dispose = false)
+    // occurred first empty chunk, skip will return bytes1.limit()
+    assert(skippableInputStream.skip(chunkedByteBuffer.size) === bytes1.limit())
+    // empty chunks will be skipped, next skill will return bytes2.limit()
+    assert(skippableInputStream.skip(chunkedByteBuffer.size) === bytes2.limit())
+    // all data has been skipped. No more data will be skipped.
+    assert(skippableInputStream.skip(chunkedByteBuffer.size) === 0)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Empty chunk in ChunkedByteBuffer will truncate the ChunkedByteBufferInputStream.
The detail reason is described in: https://issues.apache.org/jira/browse/SPARK-26068

## How was this patch tested?
Modified current UT to cover this case.