### PR TITLE
[SPARK-26070][SQL] add rule for implicit type coercion for decimal(x,0)

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -138,6 +138,11 @@ object TypeCoercion {
     case (DateType, TimestampType)
       => if (conf.compareDateTimestampInTimestamp) Some(TimestampType) else Some(StringType)
 
+    // to support a popular use case of tables using Decimal(X, 0) for long IDs instead of strings
+    // see SPARK-26070 for more details
+    case (n: DecimalType, s: StringType) if n.scale == 0 => Some(DecimalType(n.precision, n.scale))
+    case (s: StringType, n: DecimalType) if n.scale == 0 => Some(DecimalType(n.precision, n.scale))
+
     // There is no proper decimal type we can pick,
     // using double type is the best we can do.
     // See SPARK-22469 for details.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -1490,6 +1490,10 @@ class TypeCoercionSuite extends AnalysisTest {
       GreaterThan(Literal("1.5"), Literal(BigDecimal("0.5"))),
       GreaterThan(Cast(Literal("1.5"), DoubleType), Cast(Literal(BigDecimal("0.5")),
         DoubleType)))
+    ruleTest(rule,
+      GreaterThan(Literal("22222222222222222224"), Literal(Decimal("22222222222222222223"))),
+      GreaterThan(Cast(Literal("22222222222222222224"), DecimalType(20, 0)),
+        Literal(Decimal("22222222222222222223"))))
     Seq(true, false).foreach { convertToTS =>
       withSQLConf(
         "spark.sql.legacy.compareDateTimestampInTimestamp" -> convertToTS.toString) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Adding another excpetion rule for a popular case where ID columns are saved as decimal(x,0) and are compared with same ID columns in other tables which are saved as strings:
```
select '22222222222222222224' = 22222222222222222223BD -- returns true
```
this causes a major bug when we join to tables if one is defined as decimal and the other as string. in current situation we get a mix of good and bad results. we would prefer not to get results at all.

## How was this patch tested?

added a unit tests and made some manual tests
