### PR TITLE
transform DenseVector x DenseVector sqdist from imperativ to function…

### DIFF
--- a/mllib-local/src/main/scala/org/apache/spark/ml/linalg/Vectors.scala
+++ b/mllib-local/src/main/scala/org/apache/spark/ml/linalg/Vectors.scala
@@ -370,14 +370,19 @@ object Vectors {
       case (v1: DenseVector, v2: SparseVector) =>
         squaredDistance = sqdist(v2, v1)
 
-      case (DenseVector(vv1), DenseVector(vv2)) =>
-        var kv = 0
+      case (DenseVector(vv1), DenseVector(vv2)) => {
         val sz = vv1.length
-        while (kv < sz) {
-          val score = vv1(kv) - vv2(kv)
-          squaredDistance += score * score
-          kv += 1
+        @annotation.tailrec
+        def go(d: Double, kv: Int): Double = {
+          if (kv < sz) {
+            val score = vv1(kv) - vv2(kv)
+            go(d + score * score, kv + 1)
+          }
+          else d
         }
+        go(0D, 0)
+      }
+
       case _ =>
         throw new IllegalArgumentException("Do not support vector type " + v1.getClass +
           " and " + v2.getClass)


### PR DESCRIPTION
…al tailrec style which improves performance well on low and medium dim vectors

## What changes were proposed in this pull request?

Improving speed efficiency Densevector X Densevector sqdist function

## How was this patch tested?

Both version, imperativ and functional one have been tested separetely showing large improvment in speed for dimension 2, 3, 10, 100 when the performances tend to be the same on very high dim (10000, 100000)


Please review http://spark.apache.org/contributing.html before opening a pull request.
