### PR TITLE
[SPARK-26080][PYTHON] Skips Python resource limit on Windows in Python worker

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -74,13 +74,8 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
   private val reuseWorker = conf.getBoolean("spark.python.worker.reuse", true)
   // each python worker gets an equal part of the allocation. the worker pool will grow to the
   // number of concurrent tasks, which is determined by the number of cores in this executor.
-  private val memoryMb = if (Utils.isWindows) {
-    // Windows currently does not have 'resource' Python module that is required in worker.py
-    None
-  } else {
-    conf.get(PYSPARK_EXECUTOR_MEMORY)
+  private val memoryMb = conf.get(PYSPARK_EXECUTOR_MEMORY)
       .map(_ / conf.getInt("spark.executor.cores", 1))
-  }
 
   // All the Python functions should have the same exec, version and envvars.
   protected val envVars = funcs.head.funcs.head.envVars

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -74,8 +74,13 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
   private val reuseWorker = conf.getBoolean("spark.python.worker.reuse", true)
   // each python worker gets an equal part of the allocation. the worker pool will grow to the
   // number of concurrent tasks, which is determined by the number of cores in this executor.
-  private val memoryMb = conf.get(PYSPARK_EXECUTOR_MEMORY)
+  private val memoryMb = if (Utils.isWindows) {
+    // Windows currently does not have 'resource' Python module that is required in worker.py
+    None
+  } else {
+    conf.get(PYSPARK_EXECUTOR_MEMORY)
       .map(_ / conf.getInt("spark.executor.cores", 1))
+  }
 
   // All the Python functions should have the same exec, version and envvars.
   protected val envVars = funcs.head.funcs.head.envVars

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -191,7 +191,7 @@ of the most common options to set are:
     shared with other non-JVM processes. When PySpark is run in YARN or Kubernetes, this memory
     is added to executor resource requests.
 
-    NOTE: This configuration is not supported on Windows.
+    NOTE: Python memory usage may not be limited on platforms that do not support resource limiting, such as Windows.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -189,7 +189,9 @@ of the most common options to set are:
     limited to this amount. If not set, Spark will not limit Python's memory use
     and it is up to the application to avoid exceeding the overhead memory space
     shared with other non-JVM processes. When PySpark is run in YARN or Kubernetes, this memory
-    is added to executor resource requests. This configuration is not supported on Windows.
+    is added to executor resource requests.
+
+    NOTE: This configuration is not supported on Windows.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -189,7 +189,7 @@ of the most common options to set are:
     limited to this amount. If not set, Spark will not limit Python's memory use
     and it is up to the application to avoid exceeding the overhead memory space
     shared with other non-JVM processes. When PySpark is run in YARN or Kubernetes, this memory
-    is added to executor resource requests.
+    is added to executor resource requests. This configuration is not supported on Windows.
   </td>
 </tr>
 <tr>

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -273,8 +273,6 @@ def main(infile, outfile):
 
         # set up memory limits
         memory_limit_mb = int(os.environ.get('PYSPARK_EXECUTOR_MEMORY_MB', "-1"))
-        # 'PYSPARK_EXECUTOR_MEMORY_MB' should be undefined on Windows because it depends on
-        # resource module which is a Unix specific module.
         if memory_limit_mb > 0 and has_resource_module:
             total_memory = resource.RLIMIT_AS
             try:

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -22,12 +22,12 @@ from __future__ import print_function
 import os
 import sys
 import time
-# 'resource' is a Unix specific package.
-has_resource_package = True
+# 'resource' is a Unix specific module.
+has_resource_module = True
 try:
     import resource
 except ImportError:
-    has_resource_package = False
+    has_resource_module = False
 import socket
 import traceback
 
@@ -274,8 +274,8 @@ def main(infile, outfile):
         # set up memory limits
         memory_limit_mb = int(os.environ.get('PYSPARK_EXECUTOR_MEMORY_MB', "-1"))
         # 'PYSPARK_EXECUTOR_MEMORY_MB' should be undefined on Windows because it depends on
-        # resource package which is a Unix specific package.
-        if memory_limit_mb > 0 and has_resource_package:
+        # resource module which is a Unix specific module.
+        if memory_limit_mb > 0 and has_resource_module:
             total_memory = resource.RLIMIT_AS
             try:
                 (soft_limit, hard_limit) = resource.getrlimit(total_memory)

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -22,7 +22,11 @@ from __future__ import print_function
 import os
 import sys
 import time
-import resource
+# 'resource' is a Unix specific package.
+try:
+    import resource
+except ImportError:
+    pass
 import socket
 import traceback
 
@@ -268,9 +272,11 @@ def main(infile, outfile):
 
         # set up memory limits
         memory_limit_mb = int(os.environ.get('PYSPARK_EXECUTOR_MEMORY_MB', "-1"))
-        total_memory = resource.RLIMIT_AS
-        try:
-            if memory_limit_mb > 0:
+        # 'PYSPARK_EXECUTOR_MEMORY_MB' should be undefined on Windows because it depends on
+        # resource package which is a Unix specific package.
+        if memory_limit_mb > 0:
+            total_memory = resource.RLIMIT_AS
+            try:
                 (soft_limit, hard_limit) = resource.getrlimit(total_memory)
                 msg = "Current mem limits: {0} of max {1}\n".format(soft_limit, hard_limit)
                 print(msg, file=sys.stderr)
@@ -283,9 +289,9 @@ def main(infile, outfile):
                     print(msg, file=sys.stderr)
                     resource.setrlimit(total_memory, (new_limit, new_limit))
 
-        except (resource.error, OSError, ValueError) as e:
-            # not all systems support resource limits, so warn instead of failing
-            print("WARN: Failed to set memory limit: {0}\n".format(e), file=sys.stderr)
+            except (resource.error, OSError, ValueError) as e:
+                # not all systems support resource limits, so warn instead of failing
+                print("WARN: Failed to set memory limit: {0}\n".format(e), file=sys.stderr)
 
         # initialize global state
         taskContext = None

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -23,10 +23,11 @@ import os
 import sys
 import time
 # 'resource' is a Unix specific package.
+has_resource_package = True
 try:
     import resource
 except ImportError:
-    pass
+    has_resource_package = False
 import socket
 import traceback
 
@@ -274,7 +275,7 @@ def main(infile, outfile):
         memory_limit_mb = int(os.environ.get('PYSPARK_EXECUTOR_MEMORY_MB', "-1"))
         # 'PYSPARK_EXECUTOR_MEMORY_MB' should be undefined on Windows because it depends on
         # resource package which is a Unix specific package.
-        if memory_limit_mb > 0:
+        if memory_limit_mb > 0 and has_resource_package:
             total_memory = resource.RLIMIT_AS
             try:
                 (soft_limit, hard_limit) = resource.getrlimit(total_memory)


### PR DESCRIPTION
## What changes were proposed in this pull request?

`resource` package is a Unix specific package. See https://docs.python.org/2/library/resource.html and https://docs.python.org/3/library/resource.html.

Note that we document Windows support:

> Spark runs on both Windows and UNIX-like systems (e.g. Linux, Mac OS). 

This should be backported into branch-2.4 to restore Windows support in Spark 2.4.1.

## How was this patch tested?

Manually mocking the changed logics.