### PR TITLE
[SPARK-8288][SQL] ScalaReflection can use companion object constructor

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -793,9 +793,9 @@ object ScalaReflection extends ScalaReflection {
    * matching constructor is returned if it exists. Otherwise, we check for additional compatible
    * constructors defined in the companion object as `apply` methods. Otherwise, it returns `None`.
    */
-  def findConstructor(cls: Class[_], paramTypes: Seq[Class[_]]): Option[Seq[AnyRef] => Any] = {
+  def findConstructor[T](cls: Class[T], paramTypes: Seq[Class[_]]): Option[Seq[AnyRef] => T] = {
     Option(ConstructorUtils.getMatchingAccessibleConstructor(cls, paramTypes: _*)) match {
-      case Some(c) => Some(x => c.newInstance(x: _*))
+      case Some(c) => Some(x => c.newInstance(x: _*).asInstanceOf[T])
       case None =>
         val companion = mirror.staticClass(cls.getName).companion
         val moduleMirror = mirror.reflectModule(companion.asModule)
@@ -815,7 +815,7 @@ object ScalaReflection extends ScalaReflection {
           (_args: Seq[AnyRef]) => {
             // Drop the "outer" argument if it is provided
             val args = if (_args.size == expectedArgsCount) _args else _args.tail
-            method.apply(args: _*)
+            method.apply(args: _*).asInstanceOf[T]
           }
         }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -795,7 +795,7 @@ object ScalaReflection extends ScalaReflection {
    */
   def findConstructor(cls: Class[_], paramTypes: Seq[Class[_]]): Option[Seq[AnyRef] => Any] = {
     Option(ConstructorUtils.getMatchingAccessibleConstructor(cls, paramTypes: _*)) match {
-      case Some(c) => Some((x: Seq[AnyRef]) => c.newInstance(x: _*))
+      case Some(c) => Some(x => c.newInstance(x: _*))
       case None =>
         val companion = mirror.staticClass(cls.getName).companion
         val moduleMirror = mirror.reflectModule(companion.asModule)
@@ -1002,7 +1002,7 @@ trait ScalaReflection extends Logging {
    * If our type is a Scala trait it may have a companion object that
    * only defines a constructor via `apply` method.
    */
-  def getCompanionConstructor(tpe: Type): Symbol = {
+  private def getCompanionConstructor(tpe: Type): Symbol = {
     tpe.typeSymbol.asClass.companion.asTerm.typeSignature.member(universe.TermName("apply"))
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -788,12 +788,37 @@ object ScalaReflection extends ScalaReflection {
   }
 
   /**
-   * Finds an accessible constructor with compatible parameters. This is a more flexible search
-   * than the exact matching algorithm in `Class.getConstructor`. The first assignment-compatible
-   * matching constructor is returned. Otherwise, it returns `None`.
+   * Finds an accessible constructor with compatible parameters. This is a more flexible search than
+   * the exact matching algorithm in `Class.getConstructor`. The first assignment-compatible
+   * matching constructor is returned if it exists. Otherwise, we check for additional compatible
+   * constructors defined in the companion object as `apply` methods. Otherwise, it returns `None`.
    */
-  def findConstructor(cls: Class[_], paramTypes: Seq[Class[_]]): Option[Constructor[_]] = {
-    Option(ConstructorUtils.getMatchingAccessibleConstructor(cls, paramTypes: _*))
+  def findConstructor(cls: Class[_], paramTypes: Seq[Class[_]]): Option[Seq[AnyRef] => Any] = {
+    Option(ConstructorUtils.getMatchingAccessibleConstructor(cls, paramTypes: _*)) match {
+      case Some(c) => Some((x: Seq[AnyRef]) => c.newInstance(x: _*))
+      case None =>
+        val companion = mirror.staticClass(cls.getName).companion
+        val moduleMirror = mirror.reflectModule(companion.asModule)
+        val applyMethods = companion.asTerm.typeSignature
+          .member(universe.TermName("apply")).asTerm.alternatives
+        applyMethods.filter{ method =>
+          val params = method.typeSignature.paramLists.head
+          // Check that the needed params are the same length and of matching types
+          params.size == paramTypes.tail.size &&
+          params.zip(paramTypes.tail).map{case(ps, pc) =>
+            ps.typeSignature.typeSymbol == mirror.classSymbol(pc)
+          }.reduce(_&&_)
+        }.headOption.map{ applyMethodSymbol =>
+          val expectedArgsCount = applyMethodSymbol.typeSignature.paramLists.head.size
+          val instanceMirror = mirror.reflect(moduleMirror.instance)
+          val method = instanceMirror.reflectMethod(applyMethodSymbol.asMethod)
+          (_args: Seq[AnyRef]) => {
+            // Drop the "outer" argument if it is provided
+            val args = if (_args.size == expectedArgsCount) _args else _args.tail
+            method.apply(args: _*)
+          }
+        }
+    }
   }
 
   /**
@@ -973,8 +998,19 @@ trait ScalaReflection extends Logging {
     }
   }
 
+  /**
+   * If our type is a Scala trait it may have a companion object that
+   * only defines a constructor via `apply` method.
+   */
+  def getCompanionConstructor(tpe: Type): Symbol = {
+    tpe.typeSymbol.asClass.companion.asTerm.typeSignature.member(universe.TermName("apply"))
+  }
+
   protected def constructParams(tpe: Type): Seq[Symbol] = {
-    val constructorSymbol = tpe.dealias.member(termNames.CONSTRUCTOR)
+    val constructorSymbol = tpe.member(termNames.CONSTRUCTOR) match {
+      case NoSymbol => getCompanionConstructor(tpe)
+      case sym => sym
+    }
     val params = if (constructorSymbol.isMethod) {
       constructorSymbol.asMethod.paramLists
     } else {
@@ -989,5 +1025,4 @@ trait ScalaReflection extends Logging {
     }
     params.flatten
   }
-
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -801,14 +801,14 @@ object ScalaReflection extends ScalaReflection {
         val moduleMirror = mirror.reflectModule(companion.asModule)
         val applyMethods = companion.asTerm.typeSignature
           .member(universe.TermName("apply")).asTerm.alternatives
-        applyMethods.filter{ method =>
+        applyMethods.find { method =>
           val params = method.typeSignature.paramLists.head
           // Check that the needed params are the same length and of matching types
           params.size == paramTypes.tail.size &&
-          params.zip(paramTypes.tail).map{case(ps, pc) =>
+          params.zip(paramTypes.tail).forall { case(ps, pc) =>
             ps.typeSignature.typeSymbol == mirror.classSymbol(pc)
-          }.reduce(_&&_)
-        }.headOption.map{ applyMethodSymbol =>
+          }
+        }.map { applyMethodSymbol =>
           val expectedArgsCount = applyMethodSymbol.typeSignature.paramLists.head.size
           val instanceMirror = mirror.reflect(moduleMirror.instance)
           val method = instanceMirror.reflectMethod(applyMethodSymbol.asMethod)
@@ -1025,4 +1025,5 @@ trait ScalaReflection extends Logging {
     }
     params.flatten
   }
+
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -462,12 +462,12 @@ case class NewInstance(
       val d = outerObj.getClass +: paramTypes
       val c = getConstructor(outerObj.getClass +: paramTypes)
       (args: Seq[AnyRef]) => {
-        c(Seq(outerObj +: args: _*))
+        c(outerObj +: args)
       }
     }.getOrElse {
       val c = getConstructor(paramTypes)
       (args: Seq[AnyRef]) => {
-        c(Seq(args: _*))
+        c(args)
       }
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -453,7 +453,7 @@ case class NewInstance(
   @transient private lazy val constructor: (Seq[AnyRef]) => Any = {
     val paramTypes = ScalaReflection.expressionJavaClasses(arguments)
     val getConstructor = (paramClazz: Seq[Class[_]]) => {
-      ScalaReflection.findConstructor(cls, paramClazz).getOrElse{
+      ScalaReflection.findConstructor(cls, paramClazz).getOrElse {
         sys.error(s"Couldn't find a valid constructor on $cls")
       }
     }
@@ -504,7 +504,6 @@ case class NewInstance(
       final $javaType ${ev.value} = ${ev.isNull} ?
         ${CodeGenerator.defaultValue(dataType)} : $constructorCall;
     """
-
     ev.copy(code = code)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -109,6 +109,36 @@ object TestingUDT {
   }
 }
 
+trait ScroogeLikeExample extends Product1[Int] with java.io.Serializable {
+  import ScroogeLikeExample._
+
+  def _1: Int
+
+  def canEqual(other: Any): Boolean = other.isInstanceOf[ScroogeLikeExample]
+
+  private def _equals(x: ScroogeLikeExample, y: ScroogeLikeExample): Boolean =
+      x.productArity == y.productArity &&
+      x.productIterator.sameElements(y.productIterator)
+
+  override def equals(other: Any): Boolean =
+    canEqual(other) &&
+      _equals(this, other.asInstanceOf[ScroogeLikeExample])
+
+  override def hashCode: Int = {
+    var hash = _root_.scala.runtime.ScalaRunTime._hashCode(this)
+    hash
+  }
+  override def toString: String = s"ScroogeLikeExample(${_1})"
+}
+
+
+object ScroogeLikeExample {
+  def apply(x: Int): ScroogeLikeExample = new Immutable(x)
+
+  class Immutable(x: Int) extends ScroogeLikeExample {
+    def _1: Int = x
+  }
+}
 
 class ScalaReflectionSuite extends SparkFunSuite {
   import org.apache.spark.sql.catalyst.ScalaReflection._
@@ -361,5 +391,12 @@ class ScalaReflectionSuite extends SparkFunSuite {
     assert(numberOfCheckedArguments(deserializerFor[(Double, Double)]) == 2)
     assert(numberOfCheckedArguments(deserializerFor[(java.lang.Double, Int)]) == 1)
     assert(numberOfCheckedArguments(deserializerFor[(java.lang.Integer, java.lang.Integer)]) == 0)
+  }
+
+  test("SPARK-8288") {
+    val schema = schemaFor[ScroogeLikeExample]
+    assert(schema === Schema(
+      StructType(Seq(
+        StructField("x", IntegerType, nullable = false))), nullable = true))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -123,20 +123,15 @@ trait ScroogeLikeExample extends Product1[Int] with Serializable {
 
   def x: Int
 
-  override def _1: Int = x
-
-  def copy(x: Int = this.x): ScroogeLikeExample = new Immutable(x)
+  def _1: Int = x
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[ScroogeLikeExample]
 
-  private def _equals(x: ScroogeLikeExample, y: ScroogeLikeExample): Boolean =
-      x.productArity == y.productArity &&
-      x.productIterator.sameElements(y.productIterator)
+  private def _equals(x: ScroogeLikeExample, y: ScroogeLikeExample): Boolean = x.x == y.x
 
   override def equals(other: Any): Boolean =
     canEqual(other) &&
-      _equals(this, other.asInstanceOf[ScroogeLikeExample])
-
+  _equals(this, other.asInstanceOf[ScroogeLikeExample])
 }
 
 class ScalaReflectionSuite extends SparkFunSuite {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -127,11 +127,9 @@ trait ScroogeLikeExample extends Product1[Int] with Serializable {
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[ScroogeLikeExample]
 
-  private def _equals(x: ScroogeLikeExample, y: ScroogeLikeExample): Boolean = x.x == y.x
-
   override def equals(other: Any): Boolean =
     canEqual(other) &&
-  _equals(this, other.asInstanceOf[ScroogeLikeExample])
+      this.x ==  other.asInstanceOf[ScroogeLikeExample].x
 
   override def hashCode: Int = x
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -132,6 +132,8 @@ trait ScroogeLikeExample extends Product1[Int] with Serializable {
   override def equals(other: Any): Boolean =
     canEqual(other) &&
   _equals(this, other.asInstanceOf[ScroogeLikeExample])
+
+  override def hashCode: Int = x
 }
 
 class ScalaReflectionSuite extends SparkFunSuite {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -111,39 +111,21 @@ object TestingUDT {
 
 /** An example derived from Twitter/Scrooge codegen for thrift  */
 object ScroogeLikeExample {
-  def apply(
-    x: Int
-  ): ScroogeLikeExample =
-    new Immutable(
-      x
-    )
+  def apply(x: Int): ScroogeLikeExample = new Immutable(x)
 
-  def unapply(_item: ScroogeLikeExample): _root_.scala.Option[Int] = _root_.scala.Some(_item.x)
+  def unapply(_item: ScroogeLikeExample): Option[Int] = Some(_item.x)
 
   class Immutable(val x: Int) extends ScroogeLikeExample
-
-  trait Proxy extends ScroogeLikeExample {
-    protected def _underlying_ScroogeLikeExample: ScroogeLikeExample
-    override def x: Int = _underlying_ScroogeLikeExample.x
-  }
 }
 
-trait ScroogeLikeExample
-  extends _root_.scala.Product1[Int]
-  with java.io.Serializable
-{
+trait ScroogeLikeExample extends Product1[Int] with Serializable {
   import ScroogeLikeExample._
 
   def x: Int
 
-  def _1: Int = x
+  override def _1: Int = x
 
-  def copy(
-    x: Int = this.x
-  ): ScroogeLikeExample =
-    new Immutable(
-      x
-    )
+  def copy(x: Int = this.x): ScroogeLikeExample = new Immutable(x)
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[ScroogeLikeExample]
 
@@ -155,17 +137,6 @@ trait ScroogeLikeExample
     canEqual(other) &&
       _equals(this, other.asInstanceOf[ScroogeLikeExample])
 
-  override def hashCode: Int = {
-    var hash = _root_.scala.runtime.ScalaRunTime._hashCode(this)
-    hash
-  }
-
-  override def productArity: Int = 1
-
-  override def productElement(n: Int): Any = n match {
-    case 0 => this.x
-    case _ => throw new IndexOutOfBoundsException(n.toString)
-  }
 }
 
 class ScalaReflectionSuite extends SparkFunSuite {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
@@ -411,7 +411,7 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       outerPointer = Some(() => outerObj))
     checkObjectExprEvaluation(newInst2, new outerObj.Inner(1))
 
-    // SPARK-8288 Test
+    // SPARK-8288: A class with only a companion object constructor
     import org.apache.spark.sql.catalyst.ScroogeLikeExample
     val newInst3 = NewInstance(
       cls = classOf[ScroogeLikeExample],

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
@@ -410,6 +410,16 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       dataType = ObjectType(classOf[outerObj.Inner]),
       outerPointer = Some(() => outerObj))
     checkObjectExprEvaluation(newInst2, new outerObj.Inner(1))
+
+    // SPARK-8288 Test
+    import org.apache.spark.sql.catalyst.ScroogeLikeExample
+    val newInst3 = NewInstance(
+      cls = classOf[ScroogeLikeExample],
+      arguments = Literal(1) :: Nil,
+      propagateNull = false,
+      dataType = ObjectType(classOf[ScroogeLikeExample]),
+      outerPointer = Some(() => outerObj))
+    checkObjectExprEvaluation(newInst3, ScroogeLikeExample(1))
   }
 
   test("LambdaVariable should support interpreted execution") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.serializer.{JavaSerializer, KryoSerializer}
 import org.apache.spark.sql.{RandomDataGenerator, Row}
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow, JavaTypeInference, ScalaReflection}
+import org.apache.spark.sql.catalyst.ScroogeLikeExample
 import org.apache.spark.sql.catalyst.analysis.{ResolveTimeZone, SimpleAnalyzer, UnresolvedDeserializer}
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.encoders._
@@ -412,7 +413,6 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkObjectExprEvaluation(newInst2, new outerObj.Inner(1))
 
     // SPARK-8288: A class with only a companion object constructor
-    import org.apache.spark.sql.catalyst.ScroogeLikeExample
     val newInst3 = NewInstance(
       cls = classOf[ScroogeLikeExample],
       arguments = Literal(1) :: Nil,

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -21,6 +21,7 @@ import java.io.{Externalizable, ObjectInput, ObjectOutput}
 import java.sql.{Date, Timestamp}
 
 import org.apache.spark.SparkException
+import org.apache.spark.sql.catalyst.ScroogeLikeExample
 import org.apache.spark.sql.catalyst.encoders.{OuterScopes, RowEncoder}
 import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftSemi}
 import org.apache.spark.sql.catalyst.util.sideBySide
@@ -1569,6 +1570,13 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     val ds = Seq((1, 2), (2, 3), (3, 4)).toDS()
     val agg = ds.groupByKey(x => x).agg(sum("_1").as[Long], sum($"_2" + 1).as[Long])
     checkDatasetUnorderly(agg, ((1, 2), 1L, 3L), ((2, 3), 2L, 4L), ((3, 4), 3L, 5L))
+  }
+
+  test("SPARK-8288: class with only a companion object constructor") {
+    val data = Seq(ScroogeLikeExample(1), ScroogeLikeExample(2))
+    val ds = data.toDS
+    checkDataset(ds, data: _*)
+    checkAnswer(ds.select("x"), Seq(Row(1), Row(2)))
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change fixes a particular scenario where default spark SQL can't encode (thrift) types that are generated by twitter scrooge. These types are a trait that extends `scala.ProductX` with a constructor defined only in a companion object, rather than a actual case class. The actual case class used is child class, but that type is almost never referred to in code. The type has no corresponding constructor symbol and causes an exception. For all other purposes, these classes act just like case classes, so it is unfortunate that spark SQL can't serialize them nicely as it can actual case classes. For an full example of a scrooge codegen class, see https://gist.github.com/anonymous/ba13d4b612396ca72725eaa989900314.

This change catches the case where the type has no constructor but does have an `apply` method on the type's companion object. This allows for thrift types to be serialized/deserialized with implicit encoders the same way as normal case classes. This fix had to be done in three places where the constructor is assumed to be an actual constructor:

1) In serializing, determining the schema for the dataframe relies on inspecting its constructor (`ScalaReflection.constructParams`). Here we fall back to using the companion constructor arguments.
2) In deserializing or evaluating, in the java codegen ( `NewInstance.doGenCode`), the type couldn't be constructed with the new keyword. If there is no constructor, we change the constructor call to try the companion constructor.
3)  In deserializing or evaluating, without codegen, the constructor is directly invoked (`NewInstance.constructor`). This was fixed with scala reflection to get the actual companion apply method.

The return type of `findConstructor` was changed because the companion apply method constructor can't be represented as a `java.lang.reflect.Constructor`.

There might be situations in which this approach would also fail in a new way, but it does at a minimum work for the specific scrooge example and will not impact cases that were already succeeding prior to this change

Note: this fix does not enable using scrooge thrift enums, additional work for this is necessary. With this patch, it seems like you could patch `com.twitter.scrooge.ThriftEnum` to extend `_root_.scala.Product1[Int]` with `def _1 = value` to get spark's implicit encoders to handle enums, but I've yet to use this method myself.

Note: I previously opened a PR for this issue, but only was able to fix case 1) there: https://github.com/apache/spark/pull/18766

## How was this patch tested?

I've fixed all 3 cases and added two tests that use a case class that is similar to scrooge generated one. The test in ScalaReflectionSuite checks 1), and the additional asserting in ObjectExpressionsSuite checks 2) and 3).
