### PR TITLE
[SPARK-26097][Web UI] Add the new partitioning description to the exchange node name

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -54,7 +54,7 @@ case class ShuffleExchangeExec(
     val extraInfo = coordinator match {
       case Some(exchangeCoordinator) =>
         s"(coordinator id: ${System.identityHashCode(exchangeCoordinator)})"
-      case _ => ""
+      case _ => " " + this.newPartitioning.toString
     }
 
     val simpleNodeName = "Exchange"


### PR DESCRIPTION
## What changes were proposed in this pull request?

small change in the node name of the Exchange node to add in the string representation of the partitioning, this is just to have this information propagate to the DAG UI and help with join skew investigation for example.

## How was this patch tested?

tested manually to see the UI impact and regression to see nothing is broken
![image 8](https://user-images.githubusercontent.com/320230/48657327-ee90e280-ea61-11e8-95ec-04bf51d0665e.png)


Please review http://spark.apache.org/contributing.html before opening a pull request.
