### PR TITLE
[SPARK-26102][SQL][TEST] Extracting common CSV/JSON functions tests

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/CsvFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CsvFunctionsSuite.scala
@@ -22,9 +22,7 @@ import java.util.Locale
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.SparkException
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/CsvFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CsvFunctionsSuite.scala
@@ -17,14 +17,8 @@
 
 package org.apache.spark.sql
 
-import java.text.SimpleDateFormat
-import java.util.Locale
-
-import scala.collection.JavaConverters._
-
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSQLContext
-import org.apache.spark.sql.types._
 
 class CsvFunctionsSuite extends QueryTest with SharedSQLContext with FunctionsTests {
   import testImplicits._
@@ -64,45 +58,23 @@ class CsvFunctionsSuite extends QueryTest with SharedSQLContext with FunctionsTe
   }
 
   test("from_csv uses DDL strings for defining a schema - java") {
-    val df = Seq("""1,"haa"""").toDS()
-    checkAnswer(
-      df.select(
-        from_csv($"value", lit("a INT, b STRING"), new java.util.HashMap[String, String]())),
-      Row(Row(1, "haa")) :: Nil)
+    testDDLSchema(from_csv, """1,"haa"""")
   }
 
   test("roundtrip to_csv -> from_csv") {
-    val df = Seq(Tuple1(Tuple1(1)), Tuple1(null)).toDF("struct")
-    val schema = df.schema(0).dataType.asInstanceOf[StructType]
-    val options = Map.empty[String, String]
-    val readback = df.select(to_csv($"struct").as("csv"))
-      .select(from_csv($"csv", schema, options).as("struct"))
-
-    checkAnswer(df, readback)
+    testToFrom(to_csv, from_csv)
   }
 
   test("roundtrip from_csv -> to_csv") {
-    val df = Seq(Some("1"), None).toDF("csv")
-    val schema = new StructType().add("a", IntegerType)
-    val options = Map.empty[String, String]
-    val readback = df.select(from_csv($"csv", schema, options).as("struct"))
-      .select(to_csv($"struct").as("csv"))
-
-    checkAnswer(df, readback)
+    testFromTo(from_csv, to_csv, "1")
   }
 
   test("infers schemas of a CSV string and pass to to from_csv") {
-    val in = Seq("""0.123456789,987654321,"San Francisco"""").toDS()
-    val options = Map.empty[String, String].asJava
-    val out = in.select(from_csv('value, schema_of_csv("0.1,1,a"), options) as "parsed")
-    val expected = StructType(Seq(StructField(
-      "parsed",
-      StructType(Seq(
-        StructField("_c0", DoubleType, true),
-        StructField("_c1", IntegerType, true),
-        StructField("_c2", StringType, true))))))
-
-    assert(out.schema == expected)
+    testFromSchemaOf(
+      from_csv,
+      schema_of_csv,
+      input = """0.123456789,1,"San Francisco"""",
+      example = "0.1,9876543210123456,a")
   }
 
   test("Support to_csv in SQL") {
@@ -111,16 +83,6 @@ class CsvFunctionsSuite extends QueryTest with SharedSQLContext with FunctionsTe
   }
 
   test("parse timestamps with locale") {
-    Seq("en-US", "ko-KR", "zh-CN", "ru-RU").foreach { langTag =>
-      val locale = Locale.forLanguageTag(langTag)
-      val ts = new SimpleDateFormat("dd/MM/yyyy HH:mm").parse("06/11/2018 18:00")
-      val timestampFormat = "dd MMM yyyy HH:mm"
-      val sdf = new SimpleDateFormat(timestampFormat, locale)
-      val input = Seq(s"""${sdf.format(ts)}""").toDS()
-      val options = Map("timestampFormat" -> timestampFormat, "locale" -> langTag)
-      val df = input.select(from_csv($"value", lit("time timestamp"), options.asJava))
-
-      checkAnswer(df, Row(Row(java.sql.Timestamp.valueOf("2018-11-06 18:00:00.0"))))
-    }
+    testLocaleTimestamp(from_csv, identity)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/FunctionsTests.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FunctionsTests.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.sql.types.{StructType, TimestampType}
+
+trait FunctionsTests extends QueryTest with SharedSQLContext {
+  import testImplicits._
+
+  def testEmptyOptions(
+      from: (Column, Column, java.util.Map[String, String]) => Column,
+      input: String): Unit = {
+    val df = Seq(input).toDS()
+    val schema = "a int"
+
+    checkAnswer(
+      df.select(from($"value", lit(schema), Map[String, String]().asJava)),
+      Row(Row(1)) :: Nil)
+  }
+
+  def testOptions(
+      from: (Column, StructType, Map[String, String]) => Column,
+      input: String): Unit = {
+    val df = Seq(input).toDS()
+    val schema = new StructType().add("time", TimestampType)
+    val options = Map("timestampFormat" -> "dd/MM/yyyy HH:mm")
+
+    checkAnswer(
+      df.select(from($"value", schema, options)),
+      Row(Row(java.sql.Timestamp.valueOf("2015-08-26 18:00:00.0"))))
+  }
+
+  def testSchemaInferring(
+      schema_of_col: Column => Column,
+      col: Column,
+      schema_of_str: String => Column,
+      str: String): Unit = {
+    checkAnswer(
+      spark.range(1).select(schema_of_col(col)),
+      Seq(Row("struct<_c0:double,_c1:bigint>")))
+    checkAnswer(
+      spark.range(1).select(schema_of_str(str)),
+      Seq(Row("struct<_c0:double,_c1:bigint>")))
+  }
+
+  def testSchemaInferringOpts(
+      schema_of: (Column, java.util.Map[String, String]) => Column,
+      options: Map[String, String],
+      input: String): Unit = {
+    val df = spark
+      .range(1)
+      .select(schema_of(lit(input), options.asJava))
+
+    checkAnswer(df, Seq(Row("struct<_c0:double,_c1:bigint>")))
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -20,11 +20,7 @@ package org.apache.spark.sql
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-import collection.JavaConverters._
-
-import org.apache.spark.SparkException
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types._
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Extracted common tests from `CsvFunctionsSuite` and `JsonFunctionsSuite` to the `FunctionsTests` trait. 

## How was this patch tested?

by `CsvFunctionsSuite` and `JsonFunctionsSuite`.
