### PR TITLE
[SPARK-19798][SQL] Refresh table does not have effect on other sessions than the issuing one

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/TableRelationCache.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/TableRelationCache.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.catalog
+
+import java.util.concurrent.Callable
+
+import com.google.common.cache.{Cache, CacheBuilder}
+
+import org.apache.spark.sql.catalyst.QualifiedTableName
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.internal.SQLConf
+
+class TableRelationCache {
+  /**
+   * SQL-specific key-value configurations.
+   */
+  lazy val conf: SQLConf = new SQLConf
+
+  /** A cache of qualified table names to table relation plans. */
+  @transient
+  private val tableRelationCache: Cache[QualifiedTableName, LogicalPlan] = {
+    val cacheSize = conf.tableRelationCacheSize
+    CacheBuilder.newBuilder().maximumSize(cacheSize).build[QualifiedTableName, LogicalPlan]()
+  }
+
+  /** This method provides a way to get a cached plan. */
+  def getCachedPlan(t: QualifiedTableName, c: Callable[LogicalPlan]): LogicalPlan = {
+    tableRelationCache.get(t, c)
+  }
+
+  /** This method provides a way to get a cached plan if the key exists. */
+  def getCachedTable(key: QualifiedTableName): LogicalPlan = {
+    tableRelationCache.getIfPresent(key)
+  }
+
+  /** This method provides a way to cache a plan. */
+  def cacheTable(t: QualifiedTableName, l: LogicalPlan): Unit = {
+    tableRelationCache.put(t, l)
+  }
+
+  /** This method provides a way to invalidate a cached plan. */
+  def invalidate(key: QualifiedTableName): Unit = {
+    tableRelationCache.invalidate(key)
+  }
+
+  /** This method provides a way to invalidate all the cached plans. */
+  def invalidateAll(): Unit = {
+    tableRelationCache.invalidateAll()
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -223,8 +223,8 @@ case class DataSourceAnalysis(conf: SQLConf) extends Rule[LogicalPlan] with Cast
 class FindDataSourceTable(sparkSession: SparkSession) extends Rule[LogicalPlan] {
   private def readDataSourceTable(table: CatalogTable): LogicalPlan = {
     val qualifiedTableName = QualifiedTableName(table.database, table.identifier.table)
-    val catalog = sparkSession.sessionState.catalog
-    catalog.getCachedPlan(qualifiedTableName, new Callable[LogicalPlan]() {
+    val tableRelationCache = sparkSession.sessionState.catalog.tableRelationCache
+    tableRelationCache.getCachedPlan(qualifiedTableName, new Callable[LogicalPlan]() {
       override def call(): LogicalPlan = {
         val pathOption = table.storage.locationUri.map("path" -> CatalogUtils.URIToString(_))
         val dataSource =

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -133,6 +133,7 @@ abstract class BaseSessionStateBuilder(
     val catalog = new SessionCatalog(
       () => session.sharedState.externalCatalog,
       () => session.sharedState.globalTempViewManager,
+      () => session.sharedState.tableRelationCache,
       functionRegistry,
       conf,
       SessionState.newHadoopConf(session.sparkContext.hadoopConfiguration, conf),

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -23,7 +23,7 @@ import scala.util.control.NonFatal
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalog.{Catalog, Column, Database, Function, Table}
-import org.apache.spark.sql.catalyst.{DefinedByConstructorParams, FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.{DefinedByConstructorParams, FunctionIdentifier, QualifiedTableName, TableIdentifier}
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
@@ -498,6 +498,12 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
       // Cache it again.
       sparkSession.sharedState.cacheManager.cacheQuery(table, Some(tableIdent.table))
     }
+
+    // invalidate relationtable cache
+    val tableRelationCache = sparkSession.sharedState.tableRelationCache
+    tableRelationCache.invalidate(
+      QualifiedTableName(tableMetadata.identifier.database.getOrElse(""),
+        tableMetadata.identifier.table))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -84,6 +84,11 @@ private[sql] class SharedState(val sparkContext: SparkContext) extends Logging {
   val cacheManager: CacheManager = new CacheManager
 
   /**
+   * Class for caching Logical Plans resolved by session catalogs
+   */
+  val tableRelationCache: TableRelationCache = new TableRelationCache()
+
+  /**
    * A status store to query SQL status/metrics of this Spark application, based on SQL-specific
    * [[org.apache.spark.scheduler.SparkListenerEvent]]s.
    */

--- a/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionTestBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionTestBase.scala
@@ -226,7 +226,7 @@ abstract class StatisticsCollectionTestBase extends QueryTest with SQLTestUtils 
   def getTableFromCatalogCache(tableName: String): LogicalPlan = {
     val catalog = spark.sessionState.catalog
     val qualifiedTableName = QualifiedTableName(catalog.getCurrentDatabase, tableName)
-    catalog.getCachedTable(qualifiedTableName)
+    catalog.tableRelationCache.getCachedTable(qualifiedTableName)
   }
 
   def isTableInCatalogCache(tableName: String): Boolean = {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -30,7 +30,7 @@ import org.apache.hadoop.hive.ql.udf.generic.{AbstractGenericUDAFResolver, Gener
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
-import org.apache.spark.sql.catalyst.catalog.{CatalogFunction, ExternalCatalog, FunctionResourceLoader, GlobalTempViewManager, SessionCatalog}
+import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.expressions.{Cast, Expression}
 import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.hive.HiveShim.HiveFunctionWrapper
@@ -41,6 +41,7 @@ import org.apache.spark.sql.types.{DecimalType, DoubleType}
 private[sql] class HiveSessionCatalog(
     externalCatalogBuilder: () => ExternalCatalog,
     globalTempViewManagerBuilder: () => GlobalTempViewManager,
+    tableRelationCacheBuilder: () => TableRelationCache,
     val metastoreCatalog: HiveMetastoreCatalog,
     functionRegistry: FunctionRegistry,
     conf: SQLConf,
@@ -50,6 +51,7 @@ private[sql] class HiveSessionCatalog(
   extends SessionCatalog(
       externalCatalogBuilder,
       globalTempViewManagerBuilder,
+      tableRelationCacheBuilder,
       functionRegistry,
       conf,
       hadoopConf,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
@@ -53,6 +53,7 @@ class HiveSessionStateBuilder(session: SparkSession, parentState: Option[Session
     val catalog = new HiveSessionCatalog(
       () => externalCatalog,
       () => session.sharedState.globalTempViewManager,
+      () => session.sharedState.tableRelationCache,
       new HiveMetastoreCatalog(session),
       functionRegistry,
       conf,

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSchemaInferenceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSchemaInferenceSuite.scala
@@ -47,7 +47,7 @@ class HiveSchemaInferenceSuite
 
   override def afterEach(): Unit = {
     super.afterEach()
-    spark.sessionState.catalog.invalidateAllCachedTables()
+    spark.sharedState.tableRelationCache.invalidateAll()
     FileStatusCache.resetForTesting()
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Refresh table command does not have effect on other sessions than the issuing one.

Move table relation cache from session catalog to session shared state so that different sessions can synchronize when a table is modified and refreshed.

## How was this patch tested?
New test in HiveMetadataCacheSuite