### PR TITLE
[SPARK-26103][SQL] Added maxDepth to limit the length of text plans

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -483,14 +483,14 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Log
     }
   }
 
-	def treeString(
+  def treeString(
       writer: Writer,
       verbose: Boolean,
       addSuffix: Boolean): Unit = {
   	  treeString(writer, verbose, addSuffix, TreeNode.maxTreeToStringDepth)
-	}
+  }
 
-	def treeString(
+  def treeString(
       writer: Writer,
       verbose: Boolean,
       addSuffix: Boolean,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -75,7 +75,7 @@ object CurrentOrigin {
 }
 
 // scalastyle:off
-abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
+abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Logging {
 // scalastyle:on
   self: BaseType =>
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -484,10 +484,10 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Log
   }
 
 	def treeString(
-		writer: Writer,
-		verbose: Boolean,
-		addSuffix: Boolean): Unit = {
-		treeString(writer, verbose, addSuffix, TreeNode.maxTreeToStringDepth)
+      writer: Writer,
+      verbose: Boolean,
+      addSuffix: Boolean): Unit = {
+  	  treeString(writer, verbose, addSuffix, TreeNode.maxTreeToStringDepth)
 	}
 
 	def treeString(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -484,9 +484,9 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Log
   }
 
 	def treeString(
-		              writer: Writer,
-		              verbose: Boolean,
-		              addSuffix: Boolean): Unit = {
+		writer: Writer,
+		verbose: Boolean,
+		addSuffix: Boolean): Unit = {
 		treeString(writer, verbose, addSuffix, TreeNode.maxTreeToStringDepth)
 	}
 
@@ -498,7 +498,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Log
     generateTreeString(0, Nil, writer, verbose, "", addSuffix, maxDepth)
   }
 
-	/**
+  /**
    * Returns a string representation of the nodes in this tree, where each operator is numbered.
    * The numbers can be used with [[TreeNode.apply]] to easily access specific subtrees.
    *
@@ -599,7 +599,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Log
 	  }
 	  else {
 		  if (TreeNode.treeDepthWarningPrinted.compareAndSet(false, true)) {
-			  logWarn(
+			  logWarning(
 				  "Truncated the string representation of a plan since it was nested too deeply. " +
 					  "This behavior can be adjusted by setting 'spark.debug.maxToStringTreeDepth' in " +
 					  "SparkEnv.conf.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -17,8 +17,12 @@
 
 package org.apache.spark.sql.execution
 
+import java.io.{BufferedWriter, OutputStreamWriter, Writer}
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Timestamp}
+
+import org.apache.commons.io.output.StringBuilderWriter
+import org.apache.hadoop.fs.Path
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
@@ -189,24 +193,38 @@ class QueryExecution(val sparkSession: SparkSession, val logical: LogicalPlan) {
       """.stripMargin.trim
   }
 
-  override def toString: String = withRedaction {
-    def output = Utils.truncatedString(
-      analyzed.output.map(o => s"${o.name}: ${o.dataType.simpleString}"), ", ")
-    val analyzedPlan = Seq(
-      stringOrError(output),
-      stringOrError(analyzed.treeString(verbose = true))
-    ).filter(_.nonEmpty).mkString("\n")
+  private def writeOrError(writer: Writer)(f: Writer => Unit): Unit = {
+    try f(writer)
+    catch {
+      case e: AnalysisException => writer.write(e.toString)
+    }
+  }
 
-    val builder = new StringBuilder
-    builder.append("== Parsed Logical Plan ==\n")
-    builder.append(stringOrError(logical.treeString(verbose = true)))
-    builder.append("== Analyzed Logical Plan ==\n")
-    builder.append(analyzedPlan)
-    builder.append("== Optimized Logical Plan ==\n")
-    builder.append(stringOrError(optimizedPlan.treeString(verbose = true)))
-    builder.append("== Physical Plan ==\n")
-    builder.append(stringOrError(executedPlan.treeString(verbose = true)))
-    builder.toString
+  private def writePlans(writer: Writer): Unit = {
+    val (verbose, addSuffix) = (true, false)
+
+    writer.write("== Parsed Logical Plan ==\n")
+    writeOrError(writer)(logical.treeString(_, verbose, addSuffix))
+    writer.write("\n== Analyzed Logical Plan ==\n")
+    val analyzedOutput = stringOrError(Utils.truncatedString(
+      analyzed.output.map(o => s"${o.name}: ${o.dataType.simpleString}"), ", "))
+    writer.write(analyzedOutput)
+    writer.write("\n")
+    writeOrError(writer)(analyzed.treeString(_, verbose, addSuffix))
+    writer.write("\n== Optimized Logical Plan ==\n")
+    writeOrError(writer)(optimizedPlan.treeString(_, verbose, addSuffix))
+    writer.write("\n== Physical Plan ==\n")
+    writeOrError(writer)(executedPlan.treeString(_, verbose, addSuffix))
+  }
+
+  override def toString: String = withRedaction {
+    val writer = new StringBuilderWriter()
+    try {
+      writePlans(writer)
+      writer.toString
+    } finally {
+      writer.close()
+    }
   }
 
   def stringWithStats: String = withRedaction {
@@ -250,6 +268,23 @@ class QueryExecution(val sparkSession: SparkSession, val logical: LogicalPlan) {
      */
     def codegenToSeq(): Seq[(String, String)] = {
       org.apache.spark.sql.execution.debug.codegenStringSeq(executedPlan)
+    }
+
+    /**
+     * Dumps debug information about query execution into the specified file.
+     */
+    def toFile(path: String): Unit = {
+      val filePath = new Path(path)
+      val fs = filePath.getFileSystem(sparkSession.sessionState.newHadoopConf())
+      val writer = new BufferedWriter(new OutputStreamWriter(fs.create(filePath)))
+
+      try {
+        writePlans(writer)
+        writer.write("\n== Whole Stage Codegen ==\n")
+        org.apache.spark.sql.execution.debug.writeCodegen(writer, executedPlan)
+      } finally {
+        writer.close()
+      }
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -455,8 +455,9 @@ case class InputAdapter(child: SparkPlan) extends UnaryExecNode with CodegenSupp
       writer: Writer,
       verbose: Boolean,
       prefix: String = "",
-      addSuffix: Boolean = false): Unit = {
-    child.generateTreeString(depth, lastChildren, writer, verbose, prefix = "", addSuffix = false)
+      addSuffix: Boolean = false,
+      maxDepth: Int = TreeNode.maxTreeToStringDepth): Unit = {
+    child.generateTreeString(depth, lastChildren, writer, verbose, prefix, addSuffix, maxDepth)
   }
 
   override def needCopyResult: Boolean = false
@@ -731,8 +732,16 @@ case class WholeStageCodegenExec(child: SparkPlan)(val codegenStageId: Int)
       writer: Writer,
       verbose: Boolean,
       prefix: String = "",
-      addSuffix: Boolean = false): Unit = {
-    child.generateTreeString(depth, lastChildren, writer, verbose, s"*($codegenStageId) ", false)
+      addSuffix: Boolean = false,
+      maxDepth: Int = TreeNode.maxTreeToStringDepth): Unit = {
+    child.generateTreeString(
+      depth,
+      lastChildren,
+      writer,
+      verbose,
+      s"*($codegenStageId) ",
+      false,
+      maxDepth)
   }
 
   override def needStopCheck: Boolean = true

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreeNode
 import org.apache.spark.sql.execution.aggregate.HashAggregateExec
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, SortMergeJoinExec}
 import org.apache.spark.sql.execution.metric.SQLMetrics

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
@@ -22,6 +22,8 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, OneRowRelation}
 import org.apache.spark.sql.test.SharedSQLContext
 
+case class Simple(a: String, b: Int)
+
 class QueryExecutionSuite extends SharedSQLContext {
   def checkDumpedPlans(path: String, expected: Int): Unit = {
     assert(Source.fromFile(path).getLines.toList
@@ -107,5 +109,17 @@ class QueryExecutionSuite extends SharedSQLContext {
       })
     val error = intercept[Error](qe.toString)
     assert(error.getMessage.contains("error"))
+  }
+
+  test("toString() tree depth") {
+    import testImplicits._
+
+    val s = Seq(Simple("a", 1), Simple("b", 3), Simple("c", 4))
+    val ds = (1 until 30).foldLeft(s.toDF()) { case (newDs, _) =>
+      newDs.join(s.toDF(), "a")
+    }
+
+    val nLines = ds.queryExecution.optimizedPlan.toString.split("\n").length
+    assert(nLines < 30)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
@@ -42,74 +42,74 @@ class QueryExecutionSuite extends SharedSQLContext {
       s"*(1) Range (0, $expected, step=1, splits=2)",
       ""))
   }
-  test("dumping query execution info to a file") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath + "/plans.txt"
-      val df = spark.range(0, 10)
-      df.queryExecution.debug.toFile(path)
-
-      checkDumpedPlans(path, expected = 10)
-    }
-  }
-
-  test("dumping query execution info to an existing file") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath + "/plans.txt"
-      val df = spark.range(0, 10)
-      df.queryExecution.debug.toFile(path)
-
-      val df2 = spark.range(0, 1)
-      df2.queryExecution.debug.toFile(path)
-      checkDumpedPlans(path, expected = 1)
-    }
-  }
-
-  test("dumping query execution info to non-existing folder") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath + "/newfolder/plans.txt"
-      val df = spark.range(0, 100)
-      df.queryExecution.debug.toFile(path)
-      checkDumpedPlans(path, expected = 100)
-    }
-  }
-
-  test("dumping query execution info by invalid path") {
-    val path = "1234567890://plans.txt"
-    val exception = intercept[IllegalArgumentException] {
-      spark.range(0, 100).queryExecution.debug.toFile(path)
-    }
-
-    assert(exception.getMessage.contains("Illegal character in scheme name"))
-  }
-
-  test("toString() exception/error handling") {
-    spark.experimental.extraStrategies = Seq(
-        new SparkStrategy {
-          override def apply(plan: LogicalPlan): Seq[SparkPlan] = Nil
-        })
-
-    def qe: QueryExecution = new QueryExecution(spark, OneRowRelation())
-
-    // Nothing!
-    assert(qe.toString.contains("OneRowRelation"))
-
-    // Throw an AnalysisException - this should be captured.
-    spark.experimental.extraStrategies = Seq(
-      new SparkStrategy {
-        override def apply(plan: LogicalPlan): Seq[SparkPlan] =
-          throw new AnalysisException("exception")
-      })
-    assert(qe.toString.contains("org.apache.spark.sql.AnalysisException"))
-
-    // Throw an Error - this should not be captured.
-    spark.experimental.extraStrategies = Seq(
-      new SparkStrategy {
-        override def apply(plan: LogicalPlan): Seq[SparkPlan] =
-          throw new Error("error")
-      })
-    val error = intercept[Error](qe.toString)
-    assert(error.getMessage.contains("error"))
-  }
+//  test("dumping query execution info to a file") {
+//    withTempDir { dir =>
+//      val path = dir.getCanonicalPath + "/plans.txt"
+//      val df = spark.range(0, 10)
+//      df.queryExecution.debug.toFile(path)
+//
+//      checkDumpedPlans(path, expected = 10)
+//    }
+//  }
+//
+//  test("dumping query execution info to an existing file") {
+//    withTempDir { dir =>
+//      val path = dir.getCanonicalPath + "/plans.txt"
+//      val df = spark.range(0, 10)
+//      df.queryExecution.debug.toFile(path)
+//
+//      val df2 = spark.range(0, 1)
+//      df2.queryExecution.debug.toFile(path)
+//      checkDumpedPlans(path, expected = 1)
+//    }
+//  }
+//
+//  test("dumping query execution info to non-existing folder") {
+//    withTempDir { dir =>
+//      val path = dir.getCanonicalPath + "/newfolder/plans.txt"
+//      val df = spark.range(0, 100)
+//      df.queryExecution.debug.toFile(path)
+//      checkDumpedPlans(path, expected = 100)
+//    }
+//  }
+//
+//  test("dumping query execution info by invalid path") {
+//    val path = "1234567890://plans.txt"
+//    val exception = intercept[IllegalArgumentException] {
+//      spark.range(0, 100).queryExecution.debug.toFile(path)
+//    }
+//
+//    assert(exception.getMessage.contains("Illegal character in scheme name"))
+//  }
+//
+//  test("toString() exception/error handling") {
+//    spark.experimental.extraStrategies = Seq(
+//        new SparkStrategy {
+//          override def apply(plan: LogicalPlan): Seq[SparkPlan] = Nil
+//        })
+//
+//    def qe: QueryExecution = new QueryExecution(spark, OneRowRelation())
+//
+//    // Nothing!
+//    assert(qe.toString.contains("OneRowRelation"))
+//
+//    // Throw an AnalysisException - this should be captured.
+//    spark.experimental.extraStrategies = Seq(
+//      new SparkStrategy {
+//        override def apply(plan: LogicalPlan): Seq[SparkPlan] =
+//          throw new AnalysisException("exception")
+//      })
+//    assert(qe.toString.contains("org.apache.spark.sql.AnalysisException"))
+//
+//    // Throw an Error - this should not be captured.
+//    spark.experimental.extraStrategies = Seq(
+//      new SparkStrategy {
+//        override def apply(plan: LogicalPlan): Seq[SparkPlan] =
+//          throw new Error("error")
+//      })
+//    val error = intercept[Error](qe.toString)
+//    assert(error.getMessage.contains("error"))
+//  }
 
   test("toString() tree depth") {
     import testImplicits._
@@ -120,6 +120,6 @@ class QueryExecutionSuite extends SharedSQLContext {
     }
 
     val nLines = ds.queryExecution.optimizedPlan.toString.split("\n").length
-    assert(nLines < 30)
+    assert(nLines <= 31)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
@@ -42,74 +42,74 @@ class QueryExecutionSuite extends SharedSQLContext {
       s"*(1) Range (0, $expected, step=1, splits=2)",
       ""))
   }
-//  test("dumping query execution info to a file") {
-//    withTempDir { dir =>
-//      val path = dir.getCanonicalPath + "/plans.txt"
-//      val df = spark.range(0, 10)
-//      df.queryExecution.debug.toFile(path)
-//
-//      checkDumpedPlans(path, expected = 10)
-//    }
-//  }
-//
-//  test("dumping query execution info to an existing file") {
-//    withTempDir { dir =>
-//      val path = dir.getCanonicalPath + "/plans.txt"
-//      val df = spark.range(0, 10)
-//      df.queryExecution.debug.toFile(path)
-//
-//      val df2 = spark.range(0, 1)
-//      df2.queryExecution.debug.toFile(path)
-//      checkDumpedPlans(path, expected = 1)
-//    }
-//  }
-//
-//  test("dumping query execution info to non-existing folder") {
-//    withTempDir { dir =>
-//      val path = dir.getCanonicalPath + "/newfolder/plans.txt"
-//      val df = spark.range(0, 100)
-//      df.queryExecution.debug.toFile(path)
-//      checkDumpedPlans(path, expected = 100)
-//    }
-//  }
-//
-//  test("dumping query execution info by invalid path") {
-//    val path = "1234567890://plans.txt"
-//    val exception = intercept[IllegalArgumentException] {
-//      spark.range(0, 100).queryExecution.debug.toFile(path)
-//    }
-//
-//    assert(exception.getMessage.contains("Illegal character in scheme name"))
-//  }
-//
-//  test("toString() exception/error handling") {
-//    spark.experimental.extraStrategies = Seq(
-//        new SparkStrategy {
-//          override def apply(plan: LogicalPlan): Seq[SparkPlan] = Nil
-//        })
-//
-//    def qe: QueryExecution = new QueryExecution(spark, OneRowRelation())
-//
-//    // Nothing!
-//    assert(qe.toString.contains("OneRowRelation"))
-//
-//    // Throw an AnalysisException - this should be captured.
-//    spark.experimental.extraStrategies = Seq(
-//      new SparkStrategy {
-//        override def apply(plan: LogicalPlan): Seq[SparkPlan] =
-//          throw new AnalysisException("exception")
-//      })
-//    assert(qe.toString.contains("org.apache.spark.sql.AnalysisException"))
-//
-//    // Throw an Error - this should not be captured.
-//    spark.experimental.extraStrategies = Seq(
-//      new SparkStrategy {
-//        override def apply(plan: LogicalPlan): Seq[SparkPlan] =
-//          throw new Error("error")
-//      })
-//    val error = intercept[Error](qe.toString)
-//    assert(error.getMessage.contains("error"))
-//  }
+  test("dumping query execution info to a file") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath + "/plans.txt"
+      val df = spark.range(0, 10)
+      df.queryExecution.debug.toFile(path)
+
+      checkDumpedPlans(path, expected = 10)
+    }
+  }
+
+  test("dumping query execution info to an existing file") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath + "/plans.txt"
+      val df = spark.range(0, 10)
+      df.queryExecution.debug.toFile(path)
+
+      val df2 = spark.range(0, 1)
+      df2.queryExecution.debug.toFile(path)
+      checkDumpedPlans(path, expected = 1)
+    }
+  }
+
+  test("dumping query execution info to non-existing folder") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath + "/newfolder/plans.txt"
+      val df = spark.range(0, 100)
+      df.queryExecution.debug.toFile(path)
+      checkDumpedPlans(path, expected = 100)
+    }
+  }
+
+  test("dumping query execution info by invalid path") {
+    val path = "1234567890://plans.txt"
+    val exception = intercept[IllegalArgumentException] {
+      spark.range(0, 100).queryExecution.debug.toFile(path)
+    }
+
+    assert(exception.getMessage.contains("Illegal character in scheme name"))
+  }
+
+  test("toString() exception/error handling") {
+    spark.experimental.extraStrategies = Seq(
+        new SparkStrategy {
+          override def apply(plan: LogicalPlan): Seq[SparkPlan] = Nil
+        })
+
+    def qe: QueryExecution = new QueryExecution(spark, OneRowRelation())
+
+    // Nothing!
+    assert(qe.toString.contains("OneRowRelation"))
+
+    // Throw an AnalysisException - this should be captured.
+    spark.experimental.extraStrategies = Seq(
+      new SparkStrategy {
+        override def apply(plan: LogicalPlan): Seq[SparkPlan] =
+          throw new AnalysisException("exception")
+      })
+    assert(qe.toString.contains("org.apache.spark.sql.AnalysisException"))
+
+    // Throw an Error - this should not be captured.
+    spark.experimental.extraStrategies = Seq(
+      new SparkStrategy {
+        override def apply(plan: LogicalPlan): Seq[SparkPlan] =
+          throw new Error("error")
+      })
+    val error = intercept[Error](qe.toString)
+    assert(error.getMessage.contains("error"))
+  }
 
   test("toString() tree depth") {
     import testImplicits._


### PR DESCRIPTION
Nested query plans can get extremely large (hundreds of megabytes).

## What changes were proposed in this pull request?

The PR puts in a limit on the nesting depth of trees to be printed when writing a plan string.  
* The default limit is 15, which allows for reasonably nested plans.  
* A new configuration parameter called spark.debug.maxToStringTreeDepth was added to control the depth.
* When plans are truncated, "..." is printed to indicate that tree elements were removed.
* A warning is printed out the first time a truncated plan is displayed.  The warning explains what happened and how to adjust the limit.

## How was this patch tested?

A new unit test in QueryExecutionSuite which creates a highly nested plan and then ensures that the printed plan is not too long.

Please review http://spark.apache.org/contributing.html before opening a pull request.
