### PR TITLE
[SPARK-26106][PYTHON] Prioritizes ML unittests over the doctests in PySpark

### DIFF
--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -250,7 +250,7 @@ def main():
             if python_implementation not in module.blacklisted_python_implementations:
                 for test_goal in module.python_test_goals:
                     heavy_tests = ['pyspark.streaming.tests', 'pyspark.mllib.tests',
-                                   'pyspark.tests', 'pyspark.sql.tests']
+                                   'pyspark.tests', 'pyspark.sql.tests', 'pyspark.ml.tests']
                     if any(map(lambda prefix: test_goal.startswith(prefix), heavy_tests)):
                         priority = 0
                     else:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Arguably, unittests usually takes longer then doctests. We better prioritize unittests over doctests.

Other modules are already being prioritized over doctests. Looks ML module was missed at the very first place.

## How was this patch tested?

Jenkins tests.
