### PR TITLE
[Docs] Added csv, orc, and text output format options to DataFrameWriter doc string

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -85,7 +85,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
   }
 
   /**
-   * Specifies the underlying output data source. Built-in options include "parquet", "json", etc.
+   * Specifies the underlying output data source. Built-in options include "parquet", "json", "csv", "orc", and "text".
    *
    * @since 1.4.0
    */


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added the full set of options for the format used in the DataFrameWriter method.

## How was this patch tested?

It's just a trivial doc change.  I tested the format options worked to prepare files in the specified format for csv, orc and text .

