### PR TITLE
[SPARK-26119][CORE][WEBUI]Task summary table should contain only successful tasks' metrics

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
@@ -268,16 +268,12 @@ private[spark] class AppStatusStore(
           .index(index)
           .first(0L)
           .asScala
-          .filter {_.status == "SUCCESS"} // Filter "SUCCESS" tasks
-          .zipWithIndex
-          .filter { x => indices.contains(x._2) }
+          .filter { _.status == "SUCCESS"} // Filter "SUCCESS" tasks
+          .toIndexedSeq
 
-        if (quantileTasks.size >= indices.length) {
-          quantileTasks.map(task => fn(task._1).toDouble).toIndexedSeq
-        } else {
-          indices.map(index =>
-            fn(quantileTasks.find(_._2 == index).get._1).toDouble).toIndexedSeq
-        }
+        indices.map { index =>
+          fn(quantileTasks(index.toInt)).toDouble
+        }.toIndexedSeq
       }
     }
 

--- a/core/src/test/scala/org/apache/spark/status/AppStatusStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/AppStatusStoreSuite.scala
@@ -89,7 +89,7 @@ class AppStatusStoreSuite extends SparkFunSuite {
 
     for (i <- 0 to 5) {
       if (i % 2 == 1) {
-        store.write(newTaskData(i, "FAILED"))
+        store.write(newTaskData(i, status = "FAILED"))
       } else {
         store.write(newTaskData(i))
       }

--- a/core/src/test/scala/org/apache/spark/status/AppStatusStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/AppStatusStoreSuite.scala
@@ -79,7 +79,7 @@ class AppStatusStoreSuite extends SparkFunSuite {
 
   test("only successfull task have taskSummary") {
     val store = new InMemoryStore()
-    (0 until 5).foreach { i => store.write(newTaskData(i, "FAILED")) }
+    (0 until 5).foreach { i => store.write(newTaskData(i, status = "FAILED")) }
     val appStore = new AppStatusStore(store).taskSummary(stageId, attemptId, uiQuantiles)
     assert(appStore.size === 0)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Task summary table in the stage page currently displays the summary of all the tasks. However, we should display the task summary of only successful tasks, to follow the behavior of previous versions of spark.


## How was this patch tested?
Added UT. attached screenshot
Before patch:
![screenshot from 2018-11-20 00-36-18](https://user-images.githubusercontent.com/23054875/48729339-62e3a580-ec5d-11e8-81f0-0d191a234ffe.png)


![screenshot from 2018-11-20 01-18-37](https://user-images.githubusercontent.com/23054875/48731112-41d18380-ec62-11e8-8c31-1ffbfa04e746.png)

