### PR TITLE
[SPARK-26122][SQL] Support encoding for multiLine in CSV datasource

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
@@ -192,7 +192,8 @@ object MultiLineCSVDataSource extends CSVDataSource {
       UnivocityParser.tokenizeStream(
         CodecStreams.createInputStreamWithCloseResource(lines.getConfiguration, path),
         shouldDropHeader = false,
-        new CsvParser(parsedOptions.asParserSettings))
+        new CsvParser(parsedOptions.asParserSettings),
+        encoding = parsedOptions.charset)
     }.take(1).headOption match {
       case Some(firstRow) =>
         val caseSensitive = sparkSession.sessionState.conf.caseSensitiveAnalysis
@@ -203,7 +204,8 @@ object MultiLineCSVDataSource extends CSVDataSource {
               lines.getConfiguration,
               new Path(lines.getPath())),
             parsedOptions.headerFlag,
-            new CsvParser(parsedOptions.asParserSettings))
+            new CsvParser(parsedOptions.asParserSettings),
+            encoding = parsedOptions.charset)
         }
         val sampled = CSVUtils.sample(tokenRDD, parsedOptions)
         CSVInferSchema.infer(sampled, header, parsedOptions)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -1863,16 +1863,20 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
   test("encoding in multiLine mode") {
     val df = spark.range(3).toDF()
     Seq("UTF-8", "ISO-8859-1", "CP1251", "US-ASCII", "UTF-16BE", "UTF-32LE").foreach { encoding =>
-      withTempPath { path =>
-        df.write
-          .option("encoding", encoding)
-          .csv(path.getCanonicalPath)
-        val readback = spark.read
-          .option("multiLine", true)
-          .option("encoding", encoding)
-          .option("inferSchema", true)
-          .csv(path.getCanonicalPath)
-        checkAnswer(readback, df)
+      Seq(true, false).foreach { header =>
+        withTempPath { path =>
+          df.write
+            .option("encoding", encoding)
+            .option("header", header)
+            .csv(path.getCanonicalPath)
+          val readback = spark.read
+            .option("multiLine", true)
+            .option("encoding", encoding)
+            .option("inferSchema", true)
+            .option("header", header)
+            .csv(path.getCanonicalPath)
+          checkAnswer(readback, df)
+        }
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -1859,4 +1859,18 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
       checkAnswer(df, Row(null, csv))
     }
   }
+
+  test("encoding in multiLine mode") {
+    withTempPath { path =>
+      val df = spark.range(3).toDF()
+      df.write
+        .option("encoding", "UTF-16BE")
+        .csv(path.getCanonicalPath)
+      val readback = spark.read
+        .option("multiLine", true)
+        .option("encoding", "UTF-16BE")
+        .csv(path.getCanonicalPath)
+      checkAnswer(df, readback)
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -1861,16 +1861,19 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
   }
 
   test("encoding in multiLine mode") {
-    withTempPath { path =>
-      val df = spark.range(3).toDF()
-      df.write
-        .option("encoding", "UTF-16BE")
-        .csv(path.getCanonicalPath)
-      val readback = spark.read
-        .option("multiLine", true)
-        .option("encoding", "UTF-16BE")
-        .csv(path.getCanonicalPath)
-      checkAnswer(df, readback)
+    val df = spark.range(3).toDF()
+    Seq("UTF-8", "ISO-8859-1", "CP1251", "US-ASCII", "UTF-16BE", "UTF-32LE").foreach { encoding =>
+      withTempPath { path =>
+        df.write
+          .option("encoding", encoding)
+          .csv(path.getCanonicalPath)
+        val readback = spark.read
+          .option("multiLine", true)
+          .option("encoding", encoding)
+          .option("inferSchema", true)
+          .csv(path.getCanonicalPath)
+        checkAnswer(readback, df)
+      }
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the PR, I propose to pass the CSV option `encoding`/`charset` to `uniVocity` parser to allow parsing CSV files in different encodings when `multiLine` is enabled. The value of the option is passed to the `beginParsing` method of `CSVParser`.

## How was this patch tested?

Added new test to `CSVSuite` for different encodings and enabled/disabled header.
