### PR TITLE
[SPARK-26077][SQL] Reserved SQL words are not escaped by JDBC writer for table names

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -21,6 +21,7 @@ import java.sql.{Connection, DriverManager}
 import java.util.{Locale, Properties}
 
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
+import org.apache.spark.sql.jdbc.JdbcDialects
 import org.apache.spark.sql.types.StructType
 
 /**
@@ -81,7 +82,8 @@ class JDBCOptions(
       if (name.isEmpty) {
         throw new IllegalArgumentException(s"Option '$JDBC_TABLE_NAME' can not be empty.")
       } else {
-        name.trim
+        val dialect = JdbcDialects.get(url)
+        dialect.quoteIdentifier(name.trim)
       }
     case (None, Some(subquery)) =>
       if (subquery.isEmpty) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/AggregatedDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/AggregatedDialect.scala
@@ -42,8 +42,16 @@ private class AggregatedDialect(dialects: List[JdbcDialect]) extends JdbcDialect
     dialects.flatMap(_.getJDBCType(dt)).headOption
   }
 
+  override def getIdentifierQuoteCharacter: String = {
+    dialects.head.getIdentifierQuoteCharacter
+  }
+
   override def quoteIdentifier(colName: String): String = {
     dialects.head.quoteIdentifier(colName)
+  }
+
+  override def quoteSingleIdentifier(colName: String): String = {
+    dialects.head.quoteSingleIdentifier(colName)
   }
 
   override def getTableExistsQuery(table: String): String = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -37,9 +37,7 @@ private case object MySQLDialect extends JdbcDialect {
     } else None
   }
 
-  override def quoteIdentifier(colName: String): String = {
-    s"`$colName`"
-  }
+  override def getIdentifierQuoteCharacter: String = "`"
 
   override def getTableExistsQuery(table: String): String = {
     s"SELECT 1 FROM $table LIMIT 1"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, JDBC Writer doesn't quote tables names. This PR uses dialects to quote the them, too.

## How was this patch tested?

Related unit tests adjusted. In addition added new unit test to cover this bug. All tests are passing.
