### PR TITLE
[SPARK-26148][PYTHON][TESTS] Increases default parallelism in PySpark tests to speed up

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -460,7 +460,7 @@ def parse_opts():
         prog="run-tests"
     )
     parser.add_option(
-        "-p", "--parallelism", type="int", default=4,
+        "-p", "--parallelism", type="int", default=8,
         help="The number of suites to test in parallel (default %default)"
     )
 

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -183,7 +183,7 @@ def parse_opts():
     )
     parser.add_option(
         "-p", "--parallelism", type="int", default=4,
-        help="The number of suites to test in parallel (default %default)"
+        help="The number of suites to test in parallel (default %default)."
     )
     parser.add_option(
         "--verbose", action="store_true",

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -183,7 +183,7 @@ def parse_opts():
     )
     parser.add_option(
         "-p", "--parallelism", type="int", default=4,
-        help="The number of suites to test in parallel (default %default)."
+        help="The number of suites to test in parallel (default %default)"
     )
     parser.add_option(
         "--verbose", action="store_true",

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -182,7 +182,7 @@ def parse_opts():
         help="A comma-separated list of Python modules to test (default: %default)"
     )
     parser.add_option(
-        "-p", "--parallelism", type="int", default=8,
+        "-p", "--parallelism", type="int", default=4,
         help="The number of suites to test in parallel (default %default)"
     )
     parser.add_option(

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -182,7 +182,7 @@ def parse_opts():
         help="A comma-separated list of Python modules to test (default: %default)"
     )
     parser.add_option(
-        "-p", "--parallelism", type="int", default=4,
+        "-p", "--parallelism", type="int", default=8,
         help="The number of suites to test in parallel (default %default)"
     )
     parser.add_option(


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to increase parallelism in PySpark tests to speed up from 4 to 8.

It decreases the elapsed time from

https://amplab.cs.berkeley.edu/jenkins/job/SparkPullRequestBuilder/99163/consoleFull
Tests passed in 1770 seconds

to

https://amplab.cs.berkeley.edu/jenkins/job/SparkPullRequestBuilder/99186/testReport/
Tests passed in 1027 seconds

## How was this patch tested?

Jenkins tests

