### PR TITLE
[SPARK-26019][PYTHON] Fix race condition in accumulators.py: _start_update_server()

### DIFF
--- a/python/pyspark/accumulators.py
+++ b/python/pyspark/accumulators.py
@@ -307,4 +307,4 @@ if __name__ == "__main__":
     import doctest
     (failure_count, test_count) = doctest.testmod()
     if failure_count:
-        exit(-1)
+        sys.exit(-1)

--- a/python/pyspark/accumulators.py
+++ b/python/pyspark/accumulators.py
@@ -230,6 +230,7 @@ class _UpdateRequestHandler(SocketServer.StreamRequestHandler):
     """
 
     def handle(self):
+        from pyspark.accumulators import _accumulatorRegistry
         auth_token = self.server.auth_token
 
         def poll(func):


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixing race condition that happens in accumulators.py: _start_update_server()

1) SocketServer:TCPServer defaults bind_and_activate to True
https://github.com/python/cpython/blob/2.7/Lib/SocketServer.py#L413 

2) Also `handle()` is defined in derived class _UpdateRequestHandler here 
https://github.com/apache/spark/blob/master/python/pyspark/accumulators.py#L232

These both together can causes a race condition that leads to race condition explained in 
https://issues.apache.org/jira/browse/SPARK-26019

> 
> Exception happened during processing of request from ('127.0.0.1', 43418)
>
> Traceback (most recent call last):
>   File "/opt/cloudera/parcels/Anaconda/lib/python2.7/SocketServer.py", line 290, in _handle_request_noblock
>     self.process_request(request, client_address)
>   File "/opt/cloudera/parcels/Anaconda/lib/python2.7/SocketServer.py", line 318, in process_request
>     self.finish_request(request, client_address)
>   File "/opt/cloudera/parcels/Anaconda/lib/python2.7/SocketServer.py", line 331, in finish_request
>     self.RequestHandlerClass(request, client_address, self)
>   File "/opt/cloudera/parcels/Anaconda/lib/python2.7/SocketServer.py", line 652, in __init__
>     self.handle()
>   File "/opt/cloudera/parcels/SPARK2-2.3.0.cloudera4-1.cdh5.13.3.p0.611179/lib/spark2/python/lib/pyspark.zip/pyspark/accumulators.py", line 263, in handle
>     poll(authenticate_and_accum_updates)
>   File "/opt/cloudera/parcels/SPARK2-2.3.0.cloudera4-1.cdh5.13.3.p0.611179/lib/spark2/python/lib/pyspark.zip/pyspark/accumulators.py", line 238, in poll
>     if func():
>   File "/opt/cloudera/parcels/SPARK2-2.3.0.cloudera4-1.cdh5.13.3.p0.611179/lib/spark2/python/lib/pyspark.zip/pyspark/accumulators.py", line 251, in authenticate_and_accum_updates
>     received_token = self.rfile.read(len(auth_token))
> TypeError: object of type 'NoneType' has no len()
>  

## How was this patch tested?

Tested in the same environment where I can always reproduce it. 
This change fixes this issue.
Tested manually.

