### PR TITLE
[SPARK-26172][ML][WIP] Unify String Params' case-insensitivity in ML

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -92,10 +92,10 @@ private[classification] trait LogisticRegressionParams extends ProbabilisticClas
    * @group param
    */
   @Since("2.1.0")
-  final val family: Param[String] = new Param(this, "family",
+  final val family: Param[String] = new StringParam(this, "family",
     "The name of family which is a description of the label distribution to be used in the " +
       s"model. Supported options: ${supportedFamilyNames.mkString(", ")}.",
-    (value: String) => supportedFamilyNames.contains(value.toLowerCase(Locale.ROOT)))
+    ParamValidators.inArray(supportedFamilyNames), StringParamNormalizer.lower)
 
   /** @group getParam */
   @Since("2.1.0")
@@ -537,7 +537,7 @@ class LogisticRegression @Since("1.2.0") (
       case None => histogram.length
     }
 
-    val isMultinomial = getFamily.toLowerCase(Locale.ROOT) match {
+    val isMultinomial = getFamily match {
       case "binomial" =>
         require(numClasses == 1 || numClasses == 2, s"Binomial family only supports 1 or 2 " +
         s"outcome classes but found $numClasses.")

--- a/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
@@ -19,6 +19,7 @@ package org.apache.spark.ml.param
 
 import java.lang.reflect.Modifier
 import java.util.{List => JList}
+import java.util.Locale
 import java.util.NoSuchElementException
 
 import scala.annotation.varargs
@@ -522,6 +523,52 @@ class BooleanParam(parent: String, name: String, doc: String) // No need for isV
     implicit val formats = DefaultFormats
     parse(json).extract[Boolean]
   }
+}
+
+/**
+ * :: DeveloperApi ::
+ * Specialized version of `Param[Boolean]` for Java.
+ */
+@DeveloperApi
+class StringParam(
+    parent: String,
+    name: String,
+    doc: String,
+    isValid: String => Boolean,
+    val normalize: String => String)
+  extends Param[String](parent, name, doc, isValid) {
+
+  def this(parent: Identifiable, name: String, doc: String) =
+    this(parent.uid, name, doc, ParamValidators.alwaysTrue, StringParamNormalizer.identical)
+
+  /** Creates a param pair with the given value (for Java). */
+  override def w(value: String): ParamPair[String] = super.w(value)
+
+  override def jsonEncode(value: String): String = {
+    compact(render(JString(value)))
+  }
+
+  override def jsonDecode(json: String): String = {
+    implicit val formats = DefaultFormats
+    parse(json).extract[String]
+  }
+}
+
+/**
+ * :: DeveloperApi ::
+ * Factory methods for common string normalization functions for `StringParam.normalize`.
+ */
+@DeveloperApi
+object StringParamNormalizer {
+
+  /** (private[param]) Default Normalizer always return the original value */
+  private[param] def identical: String => String = (s: String) => s
+
+  /** (private[param]) Default Normalizer always return the lower case */
+  private[param] def lower: String => String = (s: String) => s.toLowerCase(Locale.ROOT)
+
+  /** (private[param]) Default Normalizer always return the upper case */
+  private[param] def upper: String => String = (s: String) => s.toUpperCase(Locale.ROOT)
 }
 
 /**

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -251,7 +251,7 @@ class LogisticRegressionSuite extends MLTest with DefaultReadWriteTest {
 
   test("check summary types for binary and multiclass") {
     val lr = new LogisticRegression()
-      .setFamily("binomial")
+      .setFamily("Binomial")
       .setMaxIter(1)
 
     val blorModel = lr.fit(smallBinaryDataset)
@@ -259,7 +259,7 @@ class LogisticRegressionSuite extends MLTest with DefaultReadWriteTest {
     assert(blorModel.summary.asBinary.isInstanceOf[BinaryLogisticRegressionSummary])
     assert(blorModel.binarySummary.isInstanceOf[BinaryLogisticRegressionTrainingSummary])
 
-    val mlorModel = lr.setFamily("multinomial").fit(smallMultinomialDataset)
+    val mlorModel = lr.setFamily("MULtinomial").fit(smallMultinomialDataset)
     assert(mlorModel.summary.isInstanceOf[LogisticRegressionTrainingSummary])
     withClue("cannot get binary summary for multiclass model") {
       intercept[RuntimeException] {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.classification
 
+import java.util.Locale
+
 import scala.collection.JavaConverters._
 import scala.language.existentials
 import scala.util.Random
@@ -2748,9 +2750,9 @@ class LogisticRegressionSuite extends MLTest with DefaultReadWriteTest {
     Seq(("AuTo", smallBinaryDataset), ("biNoMial", smallBinaryDataset),
       ("mulTinomIAl", smallMultinomialDataset)).foreach { case (family, data) =>
       lr.setFamily(family)
-      assert(lr.getFamily === family)
+      assert(lr.getFamily === family.toLowerCase(Locale.ROOT))
       val model = lr.fit(data)
-      assert(model.getFamily === family)
+      assert(model.getFamily === family.toLowerCase(Locale.ROOT))
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
1, methods `lowerCaseInArray` and `upperCaseInArray` are created in `ParamValidators` to check case-insensitivity;
2, methods `$$(param: Param[String])` and `%%(param: Param[String])` are created in trait Params to lower/upper the param value conveniently;
3, in `SharedParamsCodeGen`, `handleInvalid` and `distanceMeasure` are updated to use  `lowerCaseInArray`;
4, make string params (except colnames) in ml case-insensitive

## How was this patch tested?
updated suites