### PR TITLE
[SPARK-26173] [MLlib] Prior regularization for Logistic Regression

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -255,9 +255,10 @@ private[classification] trait LogisticRegressionParams extends ProbabilisticClas
    * Default is none.
    *
    * @group expertParam */
-  @Since("2.4.0")
-  val priorMean: DoubleArrayParam = new DoubleArrayParam(this, "priorMean",
-  "The prior mean used for Prior regularization.")
+  @Since("3.0.0")
+  val priorMean: DoubleArrayParam = new DoubleArrayParam(this,
+    "priorMean",
+    "The prior mean used for Prior regularization.")
 
   /** @group expertGetParam */
   def getPriorMean: Array[Double] = $(priorMean)
@@ -272,9 +273,10 @@ private[classification] trait LogisticRegressionParams extends ProbabilisticClas
    * Default is none.
    *
    * @group expertParam */
-  @Since("2.4.0")
-  val priorPrecisions: DoubleArrayParam = new DoubleArrayParam(this, "priorPrecisions",
-  "The prior precisions used for Prior regularization")
+  @Since("3.0.0")
+  val priorPrecisions: DoubleArrayParam = new DoubleArrayParam(this,
+    "priorPrecisions",
+    "The prior precisions used for Prior regularization")
 
   /** @group expertGetParam */
   def getPriorPrecisions: Array[Double] = $(priorPrecisions)

--- a/mllib/src/main/scala/org/apache/spark/ml/optim/loss/DifferentiableRegularization.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/loss/DifferentiableRegularization.scala
@@ -82,7 +82,72 @@ private[ml] class L2Regularization(
         }
         (0.5 * sum * regParam, Vectors.dense(gradient))
       case _: SparseVector =>
-        throw new IllegalArgumentException("Sparse coefficients are not currently supported.")
+        throw new IllegalArgumentException(
+          "Sparse coefficients are not currently supported.")
+    }
+  }
+}
+
+
+/**
+ * Implements regularization for Maximum A Posteriori (MAP) optimization
+ * based on prior means (coefficients) and precisions.
+ *
+ * @param priorMean Prior coefficients (multivariate mean).
+ * @param priorPrecisions Prior precisions.
+ * @param regParam The magnitude of the regularization.
+ * @param shouldApply A function (Int => Boolean) indicating whether a given index should have
+ *                    regularization applied to it. Usually we don't apply regularization to
+ *                    the intercept.
+ * @param applyFeaturesStd Option for a function which maps coefficient index (column major) to the
+ *                         feature standard deviation. Since we always standardize the data during
+ *                         training, if `standardization` is false, we have to reverse
+ *                         standardization by penalizing each component differently by this param.
+ *                         If `standardization` is true, this should be `None`.
+ */
+private[ml] class PriorRegularization(
+    priorMean: Array[Double],
+    priorPrecisions: Array[Double],
+    override val regParam: Double,
+    shouldApply: Int => Boolean,
+    applyFeaturesStd: Option[Int => Double])
+    extends DifferentiableRegularization[Vector] {
+
+  override def calculate(coefficients: Vector): (Double, Vector) = {
+    coefficients match {
+      case dv: DenseVector =>
+        var sum = 0.0
+        val gradient = new Array[Double](dv.size)
+        dv.values.indices.filter(shouldApply).foreach { j =>
+          val coef = coefficients(j)
+          val priorCoef = priorMean(j)
+          val priorPrecision = priorPrecisions(j)
+          applyFeaturesStd match {
+            case Some(getStd) =>
+              // If `standardization` is false, we still standardize the data
+              // to improve the rate of convergence; as a result, we have to
+              // perform this reverse standardization by penalizing each component
+              // differently to get effectively the same objective function when
+              // the training dataset is not standardized.
+              val std = getStd(j)
+              if (std != 0.0) {
+                val temp = (coef - priorCoef) / (std * std)
+                sum += (coef - priorCoef) * temp * priorPrecision
+                gradient(j) = regParam * priorPrecision * temp
+              } else {
+                0.0
+              }
+            case None =>
+              // If `standardization` is true, compute regularization normally.
+              sum += (coef - priorCoef) * (coef - priorCoef) * priorPrecision
+              gradient(j) = (coef - priorCoef) * priorPrecision * regParam
+          }
+        }
+
+        (0.5 * sum * regParam, Vectors.dense(gradient))
+      case _: SparseVector =>
+        throw new IllegalArgumentException(
+          "Sparse coefficients are not currently supported.")
     }
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/optim/loss/DifferentiableRegularization.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/loss/DifferentiableRegularization.scala
@@ -71,8 +71,6 @@ private[ml] class L2Regularization(
                 val temp = coef / (std * std)
                 sum += coef * temp
                 gradient(j) = regParam * temp
-              } else {
-                0.0
               }
             case None =>
               // If `standardization` is true, compute L2 regularization normally.
@@ -134,8 +132,6 @@ private[ml] class PriorRegularization(
                 val temp = (coef - priorCoef) / (std * std)
                 sum += (coef - priorCoef) * temp * priorPrecision
                 gradient(j) = regParam * priorPrecision * temp
-              } else {
-                0.0
               }
             case None =>
               // If `standardization` is true, compute regularization normally.

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -239,7 +239,7 @@ class LogisticRegressionSuite extends MLTest with DefaultReadWriteTest {
       }
     }
 
-    withClue("L2 regularization should be required when using prior regularization") {
+    withClue("`regParam` should be positive when using prior regularization") {
       intercept[IllegalArgumentException] {
         new LogisticRegression()
           .setPriorMean(Array(0.5, 0.5, 0.5, 0.5))

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -1217,8 +1217,44 @@ class LogisticRegressionSuite extends MLTest with DefaultReadWriteTest {
 
     val model = trainer.fit(dataset)
 
-    val expectedCoeffs = Vectors.dense(-0.44989613, 0.36149292, -0.63427473, -0.59001135)
+    val expectedCoeffs = Vectors.dense(-0.44984539, 0.36144524, -0.63427745, -0.58994011)
     assert(model.coefficients ~= expectedCoeffs relTol 1E-2)
+
+    /*
+
+      The expected outputs were produced by using the bayes_logistic package.
+      GitHub: https://github.com/Valassis-Digital-Media/bayes_logistic
+
+      The following code snippet provides the Python implementation:
+
+      from sklearn.preprocessing import StandardScaler
+
+      import bayes_logistic as bl
+      import numpy as np
+
+      csv_path = 'binary_dataset.csv'
+      data = np.genfromtxt(csv_path, delimiter=',')
+
+      y = data[:, 0]
+      X = data[:, 1:5]
+      weights = data[:, 5]
+
+      n = float(X.shape[0])
+      # sqrt(n-1)/sqrt(n) factor for getting the same standardization as spark
+      Xstd = StandardScaler().fit_transform(X) * np.sqrt(n-1) / np.sqrt(n)
+
+      w_prior = np.array([0.1, -0.2, 0.3, -0.4])
+      H_prior = np.array([10.0, 20.0, 30.0, 40.0])
+
+      w_posterior, H_posterior = bl.fit_bayes_logistic(y, Xstd,
+                                                       w_prior, H_prior,
+                                                       weights=weights,
+                                                       solver='L-BFGS-B',
+                                                       maxiter=100)
+
+      print(w_posterior)
+
+     */
   }
 
   test("binary logistic regression with intercept with L2 regularization with bound") {

--- a/mllib/src/test/scala/org/apache/spark/ml/optim/loss/DifferentiableRegularizationSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/optim/loss/DifferentiableRegularizationSuite.scala
@@ -16,11 +16,9 @@
  */
 package org.apache.spark.ml.optim.loss
 
-import org.scalactic.{Equality, TolerantNumerics}
-
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.linalg.{BLAS, Vectors}
-
+import org.apache.spark.ml.util.TestingUtils._
 
 
 class DifferentiableRegularizationSuite extends SparkFunSuite {
@@ -65,7 +63,7 @@ class DifferentiableRegularizationSuite extends SparkFunSuite {
   }
 
   test("Prior regularization") {
-    implicit val doubleEquality: Equality[Double] = TolerantNumerics.tolerantDoubleEquality(1E-12)
+
     val shouldApply = (_: Int) => true
     val regParam = 0.3
     val coefficients = Vectors.dense(Array(1.0, 3.0, -2.0))
@@ -81,12 +79,12 @@ class DifferentiableRegularizationSuite extends SparkFunSuite {
     val expectedSum = (0 until numFeatures).map { i =>
       priorPrecisions(i) * (coefficients(i) - priorCoefficients(i)) *
         (coefficients(i) - priorCoefficients(i))}.toArray.sum
-    assert(actualLoss ===  0.5 * regParam * expectedSum)
+    assert(actualLoss ~==  0.5 * regParam * expectedSum absTol 1E-12)
 
     val expectedGradient = Vectors.dense((0 until numFeatures).map { i =>
       regParam * priorPrecisions(i) * (coefficients(i) - priorCoefficients(i))}.toArray)
     for (i <- 0 until numFeatures)
-      assert(actualGradient(i) === expectedGradient(i))
+      assert(actualGradient(i) ~== expectedGradient(i) absTol 1E-12)
 
     // check with features standard
     val featuresStd = Array(0.1, 1.1, 0.5)
@@ -98,13 +96,13 @@ class DifferentiableRegularizationSuite extends SparkFunSuite {
       priorPrecisions(i) * (coefficients(i) - priorCoefficients(i)) *
         (coefficients(i) - priorCoefficients(i)) / (featuresStd(i) * featuresStd(i))}.toArray.sum
     val expectedLossStd = 0.5 * regParam * expectedSumStd
-    assert(actualLossStd === expectedLossStd)
+    assert(actualLossStd ~== expectedLossStd absTol 1E-12)
 
     val expectedGradientStd = Vectors.dense((0 until numFeatures).map { i =>
       regParam * priorPrecisions(i) * (coefficients(i) - priorCoefficients(i)) /
         (featuresStd(i) * featuresStd(i))}.toArray)
     for (i <- 0 until numFeatures)
-      assert(actualGradientStd(i) === expectedGradientStd(i))
+      assert(actualGradientStd(i) ~== expectedGradientStd(i) absTol 1E-12)
 
     // check should apply
     val shouldApply2 = (i: Int) => i == 1
@@ -114,12 +112,12 @@ class DifferentiableRegularizationSuite extends SparkFunSuite {
 
     val expectedSumApply = priorPrecisions(1) * (coefficients(1) - priorCoefficients(1)) *
         (coefficients(1) - priorCoefficients(1))
-    assert(actualLossApply ===  0.5 * regParam * expectedSumApply)
+    assert(actualLossApply ~==  0.5 * regParam * expectedSumApply absTol 1E-12)
 
     val expectedGradientApply = Vectors.dense(0.0,
       regParam * priorPrecisions(1) * (coefficients(1) - priorCoefficients(1)), 0.0)
     for (i <- 0 until numFeatures)
-      assert(actualGradientApply(i) === expectedGradientApply(i))
+      assert(actualGradientApply(i) ~== expectedGradientApply(i) absTol 1E-12)
 
     // check with zero features standard
     val featuresStdZero = Array(0.1, 0.0, 0.5)

--- a/mllib/src/test/scala/org/apache/spark/ml/optim/loss/DifferentiableRegularizationSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/optim/loss/DifferentiableRegularizationSuite.scala
@@ -16,8 +16,12 @@
  */
 package org.apache.spark.ml.optim.loss
 
+import org.scalactic.{Equality, TolerantNumerics}
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.linalg.{BLAS, Vectors}
+
+
 
 class DifferentiableRegularizationSuite extends SparkFunSuite {
 
@@ -56,6 +60,71 @@ class DifferentiableRegularizationSuite extends SparkFunSuite {
     // check with zero features standard
     val featuresStdZero = Array(0.1, 0.0, 0.5)
     val regFunStdZero = new L2Regularization(regParam, shouldApply, Some(featuresStdZero))
+    val (_, gradStdZero) = regFunStdZero.calculate(coefficients)
+    assert(gradStdZero(1) == 0.0)
+  }
+
+  test("Prior regularization") {
+    implicit val doubleEquality: Equality[Double] = TolerantNumerics.tolerantDoubleEquality(1E-12)
+    val shouldApply = (_: Int) => true
+    val regParam = 0.3
+    val coefficients = Vectors.dense(Array(1.0, 3.0, -2.0))
+    val priorCoefficients = Array(0.1, 0.3, -0.5)
+    val priorPrecisions = Array(10.0, 1.0, 100.0)
+    val numFeatures = coefficients.size
+
+    // check without features standard
+    val regFun = new PriorRegularization(priorCoefficients,
+      priorPrecisions, regParam, shouldApply, None)
+    val (actualLoss, actualGradient) = regFun.calculate(coefficients)
+
+    val expectedSum = (0 until numFeatures).map { i =>
+      priorPrecisions(i) * (coefficients(i) - priorCoefficients(i)) *
+        (coefficients(i) - priorCoefficients(i))}.toArray.sum
+    assert(actualLoss ===  0.5 * regParam * expectedSum)
+
+    val expectedGradient = Vectors.dense((0 until numFeatures).map { i =>
+      regParam * priorPrecisions(i) * (coefficients(i) - priorCoefficients(i))}.toArray)
+    for (i <- 0 until numFeatures)
+      assert(actualGradient(i) === expectedGradient(i))
+
+    // check with features standard
+    val featuresStd = Array(0.1, 1.1, 0.5)
+    val regFunStd = new PriorRegularization(priorCoefficients,
+      priorPrecisions, regParam, shouldApply, Some(featuresStd))
+    val (actualLossStd, actualGradientStd) = regFunStd.calculate(coefficients)
+
+    val expectedSumStd = (0 until numFeatures).map { i =>
+      priorPrecisions(i) * (coefficients(i) - priorCoefficients(i)) *
+        (coefficients(i) - priorCoefficients(i)) / (featuresStd(i) * featuresStd(i))}.toArray.sum
+    val expectedLossStd = 0.5 * regParam * expectedSumStd
+    assert(actualLossStd === expectedLossStd)
+
+    val expectedGradientStd = Vectors.dense((0 until numFeatures).map { i =>
+      regParam * priorPrecisions(i) * (coefficients(i) - priorCoefficients(i)) /
+        (featuresStd(i) * featuresStd(i))}.toArray)
+    for (i <- 0 until numFeatures)
+      assert(actualGradientStd(i) === expectedGradientStd(i))
+
+    // check should apply
+    val shouldApply2 = (i: Int) => i == 1
+    val regFunApply = new PriorRegularization(priorCoefficients,
+      priorPrecisions, regParam, shouldApply2, None)
+    val (actualLossApply, actualGradientApply) = regFunApply.calculate(coefficients)
+
+    val expectedSumApply = priorPrecisions(1) * (coefficients(1) - priorCoefficients(1)) *
+        (coefficients(1) - priorCoefficients(1))
+    assert(actualLossApply ===  0.5 * regParam * expectedSumApply)
+
+    val expectedGradientApply = Vectors.dense(0.0,
+      regParam * priorPrecisions(1) * (coefficients(1) - priorCoefficients(1)), 0.0)
+    for (i <- 0 until numFeatures)
+      assert(actualGradientApply(i) === expectedGradientApply(i))
+
+    // check with zero features standard
+    val featuresStdZero = Array(0.1, 0.0, 0.5)
+    val regFunStdZero = new PriorRegularization(priorCoefficients,
+      priorPrecisions, regParam, shouldApply, Some(featuresStdZero))
     val (_, gradStdZero) = regFunStdZero.calculate(coefficients)
     assert(gradStdZero(1) == 0.0)
   }


### PR DESCRIPTION
Implementation of [SPARK-26173](https://issues.apache.org/jira/browse/SPARK-26173).

This feature enables Maximum A Posteriori (MAP) optimization for Logistic Regression based on a Gaussian prior. In practice, this is just implementing a more general form of L2 regularization parameterized by a (multivariate) mean and precisions vectors. 

_Reference: Bishop, Christopher M. (2006). Pattern Recognition and Machine Learning (section 4.5). Berlin, Heidelberg: Springer-Verlag._

### Existing implementations
* Python: [bayes_logistic](https://pypi.org/project/bayes_logistic/)

## Implementation
* 2 new parameters added to `LogisticRegression`: `priorMean` and `priorPrecisions`.
* 1 new class (`PriorRegularization`) implements the calculations of the value and gradient of the prior regularization term.
* Prior regularization is enabled when both vectors are provided and `regParam` > 0 and `elasticNetParam` < 1.

## Tests
* `DifferentiableRegularizationSuite`
  * `Prior regularization`
* `LogisticRegressionSuite`
  * `prior precisions should be required when prior mean is set`
  * `prior mean should be required when prior precisions is set`
  * `regParam should be positive when using prior regularization`
  * `elasticNetParam should be less than 1.0 when using prior regularization`
  * `prior mean and precisions should have equal length`
  * `priors' length should match number of features`
  * `binary logistic regression with prior regularization equivalent to L2`
  * `binary logistic regression with prior regularization equivalent to L2 (bis)`
  * `binary logistic regression with prior regularization`