### PR TITLE
[SPARK-26205][SQL] Optimize InSet Expression for bytes, shorts, ints, dates

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/javaCode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/javaCode.scala
@@ -224,7 +224,7 @@ object Block {
       } else {
         args.foreach {
           case _: ExprValue | _: Inline | _: Block =>
-          case _: Int | _: Long | _: Float | _: Double | _: String =>
+          case _: Boolean | _: Int | _: Long | _: Float | _: Double | _: String =>
           case other => throw new IllegalArgumentException(
             s"Can not interpolate ${other.getClass.getName} into code block.")
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGe
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.util.TypeUtils
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 
@@ -375,6 +376,25 @@ case class InSet(child: Expression, hset: Set[Any]) extends UnaryExpression with
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    if (canBeComputedUsingSwitch && hset.size <= SQLConf.get.optimizerInSetSwitchThreshold) {
+      genCodeWithSwitch(ctx, ev)
+    } else {
+      genCodeWithSet(ctx, ev)
+    }
+  }
+
+  override def sql: String = {
+    val valueSQL = child.sql
+    val listSQL = hset.toSeq.map(Literal(_).sql).mkString(", ")
+    s"($valueSQL IN ($listSQL))"
+  }
+
+  private def canBeComputedUsingSwitch: Boolean = child.dataType match {
+    case ByteType | ShortType | IntegerType | DateType => true
+    case _ => false
+  }
+
+  private def genCodeWithSet(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     nullSafeCodeGen(ctx, ev, c => {
       val setTerm = ctx.addReferenceObj("set", set)
       val setIsNull = if (hasNull) {
@@ -389,10 +409,30 @@ case class InSet(child: Expression, hset: Set[Any]) extends UnaryExpression with
     })
   }
 
-  override def sql: String = {
-    val valueSQL = child.sql
-    val listSQL = hset.toSeq.map(Literal(_).sql).mkString(", ")
-    s"($valueSQL IN ($listSQL))"
+  private def genCodeWithSwitch(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    val caseValuesGen = hset.filter(_ != null).map(Literal(_).genCode(ctx))
+    val valueGen = child.genCode(ctx)
+
+    val caseBranches = caseValuesGen.map(literal =>
+      code"""
+        case ${literal.value}:
+          ${ev.value} = true;
+          break;
+       """)
+
+    ev.copy(code =
+      code"""
+        ${valueGen.code}
+        ${CodeGenerator.JAVA_BOOLEAN} ${ev.isNull} = ${valueGen.isNull};
+        ${CodeGenerator.JAVA_BOOLEAN} ${ev.value} = false;
+        if (!${valueGen.isNull}) {
+          switch (${valueGen.value}) {
+            ${caseBranches.mkString("")}
+            default:
+              ${ev.isNull} = $hasNull;
+          }
+        }
+       """)
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -177,7 +177,9 @@ object SQLConf {
       .doc("Configures the max set size in InSet for which Spark will generate code with " +
         "switch statements. This is applicable only to bytes, shorts, ints, dates.")
       .intConf
-      .createWithDefault(500)
+      .checkValue(threshold => threshold >= 0 && threshold <= 600, "The max set size " +
+        "for using switch statements in InSet must be positive and less than or equal to 600")
+      .createWithDefault(400)
 
   val OPTIMIZER_PLAN_CHANGE_LOG_LEVEL = buildConf("spark.sql.optimizer.planChangeLog.level")
     .internal()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -178,7 +178,7 @@ object SQLConf {
         "switch statements. This is applicable only to bytes, shorts, ints, dates.")
       .intConf
       .checkValue(threshold => threshold >= 0 && threshold <= 600, "The max set size " +
-        "for using switch statements in InSet must be positive and less than or equal to 600")
+        "for using switch statements in InSet must be non-negative and less than or equal to 600")
       .createWithDefault(400)
 
   val OPTIMIZER_PLAN_CHANGE_LOG_LEVEL = buildConf("spark.sql.optimizer.planChangeLog.level")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -171,6 +171,14 @@ object SQLConf {
       .intConf
       .createWithDefault(10)
 
+  val OPTIMIZER_INSET_SWITCH_THRESHOLD =
+    buildConf("spark.sql.optimizer.inSetSwitchThreshold")
+      .internal()
+      .doc("Configures the max set size in InSet for which Spark will generate code with " +
+        "switch statements. This is applicable only to bytes, shorts, ints, dates.")
+      .intConf
+      .createWithDefault(500)
+
   val OPTIMIZER_PLAN_CHANGE_LOG_LEVEL = buildConf("spark.sql.optimizer.planChangeLog.level")
     .internal()
     .doc("Configures the log level for logging the change from the original plan to the new " +
@@ -1700,6 +1708,8 @@ class SQLConf extends Serializable with Logging {
   def optimizerMaxIterations: Int = getConf(OPTIMIZER_MAX_ITERATIONS)
 
   def optimizerInSetConversionThreshold: Int = getConf(OPTIMIZER_INSET_CONVERSION_THRESHOLD)
+
+  def optimizerInSetSwitchThreshold: Int = getConf(OPTIMIZER_INSET_SWITCH_THRESHOLD)
 
   def optimizerPlanChangeLogLevel: String = getConf(OPTIMIZER_PLAN_CHANGE_LOG_LEVEL)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/PredicateSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/PredicateSuite.scala
@@ -23,11 +23,12 @@ import scala.collection.immutable.HashSet
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.RandomDataGenerator
-import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.encoders.ExamplePointUDT
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
 import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 
@@ -238,6 +239,52 @@ class PredicateSuite extends SparkFunSuite with ExpressionEvalHelper {
       case TypeCheckResult.TypeCheckFailure(msg) =>
         assert(msg.contains("function in does not support ordering on type map"))
       case _ => fail("In should not work on map type")
+    }
+  }
+
+  test("SPARK-26205: Optimize InSet for bytes, shorts, ints, dates using switch statements") {
+    val byteValues = Set[Any](1.toByte, 2.toByte, Byte.MinValue, Byte.MaxValue)
+    val shortValues = Set[Any](-10.toShort, 20.toShort, Short.MinValue, Short.MaxValue)
+    val intValues = Set[Any](20, -100, 30, Int.MinValue, Int.MaxValue)
+    val dateValues = Set[Any](
+      CatalystTypeConverters.convertToCatalyst(Date.valueOf("2017-01-01")),
+      CatalystTypeConverters.convertToCatalyst(Date.valueOf("1950-01-02")))
+
+    def check(presentValue: Expression, absentValue: Expression, values: Set[Any]): Unit = {
+      require(presentValue.dataType == absentValue.dataType)
+
+      val nullLiteral = Literal(null, presentValue.dataType)
+
+      checkEvaluation(InSet(nullLiteral, values), expected = null)
+      checkEvaluation(InSet(nullLiteral, values + null), expected = null)
+      checkEvaluation(InSet(presentValue, values), expected = true)
+      checkEvaluation(InSet(presentValue, values + null), expected = true)
+      checkEvaluation(InSet(absentValue, values), expected = false)
+      checkEvaluation(InSet(absentValue, values + null), expected = null)
+    }
+
+    def checkAllTypes(): Unit = {
+      check(presentValue = Literal(2.toByte), absentValue = Literal(3.toByte), byteValues)
+      check(presentValue = Literal(Byte.MinValue), absentValue = Literal(5.toByte), byteValues)
+      check(presentValue = Literal(20.toShort), absentValue = Literal(-14.toShort), shortValues)
+      check(presentValue = Literal(Short.MaxValue), absentValue = Literal(30.toShort), shortValues)
+      check(presentValue = Literal(20), absentValue = Literal(-14), intValues)
+      check(presentValue = Literal(Int.MinValue), absentValue = Literal(2), intValues)
+      check(
+        presentValue = Literal(Date.valueOf("2017-01-01")),
+        absentValue = Literal(Date.valueOf("2017-01-02")),
+        dateValues)
+      check(
+        presentValue = Literal(Date.valueOf("1950-01-02")),
+        absentValue = Literal(Date.valueOf("2017-10-02")),
+        dateValues)
+    }
+
+    withSQLConf(SQLConf.OPTIMIZER_INSET_SWITCH_THRESHOLD.key -> "0") {
+      checkAllTypes()
+    }
+    withSQLConf(SQLConf.OPTIMIZER_INSET_SWITCH_THRESHOLD.key -> "20") {
+      checkAllTypes()
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/PredicateSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/PredicateSuite.scala
@@ -242,7 +242,7 @@ class PredicateSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
   }
 
-  test("SPARK-26205: Optimize InSet for bytes, shorts, ints, dates using switch statements") {
+  test("switch statements in InSet for bytes, shorts, ints, dates") {
     val byteValues = Set[Any](1.toByte, 2.toByte, Byte.MinValue, Byte.MaxValue)
     val shortValues = Set[Any](-10.toShort, 20.toShort, Short.MinValue, Short.MaxValue)
     val intValues = Set[Any](20, -100, 30, Int.MinValue, Int.MaxValue)

--- a/sql/core/benchmarks/InExpressionBenchmark-results.txt
+++ b/sql/core/benchmarks/InExpressionBenchmark-results.txt
@@ -2,550 +2,739 @@
 In Expression Benchmark
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 bytes:                                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  101 /  138         98.7          10.1       1.0X
-InSet expression                               125 /  136         79.7          12.5       0.8X
+In expression                                   38 /   48        260.1           3.8       1.0X
+InSet expression                                33 /   37        300.5           3.3       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 bytes:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  101 /  111         99.3          10.1       1.0X
-InSet expression                               126 /  133         79.6          12.6       0.8X
+In expression                                   44 /   47        226.6           4.4       1.0X
+InSet expression                                37 /   39        270.8           3.7       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 bytes:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  176 /  183         56.9          17.6       1.0X
-InSet expression                               174 /  184         57.4          17.4       1.0X
+In expression                                   74 /   78        135.6           7.4       1.0X
+InSet expression                                48 /   51        210.4           4.8       1.6X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 bytes:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  299 /  312         33.5          29.9       1.0X
-InSet expression                               243 /  246         41.2          24.3       1.2X
+In expression                                  121 /  127         82.6          12.1       1.0X
+InSet expression                                72 /   75        138.1           7.2       1.7X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 bytes:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  512 /  518         19.5          51.2       1.0X
-InSet expression                               388 /  400         25.8          38.8       1.3X
+In expression                                  210 /  223         47.7          21.0       1.0X
+InSet expression                               123 /  130         81.2          12.3       1.7X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 bytes:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  854 /  866         11.7          85.4       1.0X
-InSet expression                               686 /  694         14.6          68.6       1.2X
+In expression                                  381 /  393         26.2          38.1       1.0X
+InSet expression                               218 /  229         45.8          21.8       1.7X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 shorts:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   59 /   62        169.6           5.9       1.0X
-InSet expression                               163 /  168         61.3          16.3       0.4X
+In expression                                   25 /   27        394.9           2.5       1.0X
+InSet expression                                25 /   27        397.6           2.5       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 shorts:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   76 /   78        132.0           7.6       1.0X
-InSet expression                               182 /  186         54.9          18.2       0.4X
+In expression                                   32 /   34        312.0           3.2       1.0X
+InSet expression                                25 /   27        403.0           2.5       1.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 shorts:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  126 /  128         79.4          12.6       1.0X
-InSet expression                               190 /  193         52.7          19.0       0.7X
+In expression                                   48 /   50        206.3           4.8       1.0X
+InSet expression                                23 /   24        438.9           2.3       2.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 shorts:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  227 /  227         44.1          22.7       1.0X
-InSet expression                               232 /  235         43.1          23.2       1.0X
+In expression                                   79 /   80        126.7           7.9       1.0X
+InSet expression                                26 /   27        389.1           2.6       3.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 shorts:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  408 /  414         24.5          40.8       1.0X
-InSet expression                               203 /  209         49.3          20.3       2.0X
+In expression                                  135 /  138         74.1          13.5       1.0X
+InSet expression                                27 /   28        375.5           2.7       5.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 shorts:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  762 /  765         13.1          76.2       1.0X
-InSet expression                               192 /  196         52.1          19.2       4.0X
+In expression                                  254 /  262         39.4          25.4       1.0X
+InSet expression                                29 /   31        339.5           2.9       8.6X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+450 shorts:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                  721 /  724         13.9          72.1       1.0X
+InSet expression                                36 /   38        275.0           3.6      19.8X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+500 shorts:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                  806 /  812         12.4          80.6       1.0X
+InSet expression                                38 /   40        264.7           3.8      21.3X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+550 shorts:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                  828 /  845         12.1          82.8       1.0X
+InSet expression                               188 /  194         53.3          18.8       4.4X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+5 shorts (non-compact):                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                   24 /   25        415.0           2.4       1.0X
+InSet expression                                24 /   25        419.2           2.4       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+10 shorts (non-compact):                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                   31 /   33        322.8           3.1       1.0X
+InSet expression                                27 /   28        368.6           2.7       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+25 shorts (non-compact):                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                   48 /   50        209.0           4.8       1.0X
+InSet expression                                31 /   32        327.6           3.1       1.6X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+50 shorts (non-compact):                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                   77 /   79        129.4           7.7       1.0X
+InSet expression                                34 /   35        294.5           3.4       2.3X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+100 shorts (non-compact):                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                  135 /  137         74.1          13.5       1.0X
+InSet expression                                37 /   39        266.7           3.7       3.6X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+200 shorts (non-compact):                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                  253 /  257         39.5          25.3       1.0X
+InSet expression                                43 /   45        232.4           4.3       5.9X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+450 shorts (non-compact):                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                  705 /  713         14.2          70.5       1.0X
+InSet expression                                55 /   57        182.9           5.5      12.9X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+500 shorts (non-compact):                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                  756 /  765         13.2          75.6       1.0X
+InSet expression                                57 /   60        176.2           5.7      13.3X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+550 shorts (non-compact):                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                               20240 / 20331          0.5        2024.0       1.0X
+InSet expression                               187 /  193         53.5          18.7     108.3X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 ints:                                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   53 /   57        187.3           5.3       1.0X
-InSet expression                               156 /  160         63.9          15.6       0.3X
+In expression                                   24 /   25        421.8           2.4       1.0X
+InSet expression                                24 /   25        425.2           2.4       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 ints:                                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   70 /   74        142.4           7.0       1.0X
-InSet expression                               170 /  176         58.9          17.0       0.4X
+In expression                                   31 /   32        325.9           3.1       1.0X
+InSet expression                                24 /   24        423.8           2.4       1.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 ints:                                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  125 /  126         80.2          12.5       1.0X
-InSet expression                               174 /  179         57.4          17.4       0.7X
+In expression                                   47 /   48        212.5           4.7       1.0X
+InSet expression                                22 /   23        460.8           2.2       2.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 ints:                                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  220 /  222         45.5          22.0       1.0X
-InSet expression                               215 /  221         46.6          21.5       1.0X
+In expression                                   75 /   78        132.6           7.5       1.0X
+InSet expression                                25 /   25        407.6           2.5       3.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 ints:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  404 /  407         24.8          40.4       1.0X
-InSet expression                               189 /  192         53.0          18.9       2.1X
+In expression                                  133 /  139         75.2          13.3       1.0X
+InSet expression                                25 /   27        392.6           2.5       5.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 ints:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  760 /  764         13.2          76.0       1.0X
-InSet expression                               176 /  179         56.8          17.6       4.3X
+In expression                                  249 /  255         40.1          24.9       1.0X
+InSet expression                                28 /   29        361.0           2.8       9.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+450 ints:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                  719 /  720         13.9          71.9       1.0X
+InSet expression                                34 /   35        296.4           3.4      21.3X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+500 ints:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                  821 /  829         12.2          82.1       1.0X
+InSet expression                                35 /   37        285.1           3.5      23.4X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+550 ints:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                  831 /  866         12.0          83.1       1.0X
+InSet expression                               179 /  184         55.7          17.9       4.6X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+5 ints (non-compact):                    Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                   21 /   22        468.7           2.1       1.0X
+InSet expression                                19 /   20        526.2           1.9       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+10 ints (non-compact):                   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                   31 /   32        321.0           3.1       1.0X
+InSet expression                                19 /   20        522.6           1.9       1.6X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+25 ints (non-compact):                   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                   67 /   68        150.0           6.7       1.0X
+InSet expression                                28 /   30        354.2           2.8       2.4X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+50 ints (non-compact):                   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                  122 /  123         82.0          12.2       1.0X
+InSet expression                                29 /   30        347.0           2.9       4.2X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+100 ints (non-compact):                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                  238 /  240         42.1          23.8       1.0X
+InSet expression                                37 /   40        273.0           3.7       6.5X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+200 ints (non-compact):                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                  475 /  484         21.1          47.5       1.0X
+InSet expression                                44 /   45        228.9           4.4      10.9X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+450 ints (non-compact):                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                  931 /  984         10.7          93.1       1.0X
+InSet expression                                62 /   64        162.5           6.2      15.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+500 ints (non-compact):                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                 1036 / 1078          9.6         103.6       1.0X
+InSet expression                                63 /   66        158.1           6.3      16.4X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+550 ints (non-compact):                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                 1089 / 1124          9.2         108.9       1.0X
+InSet expression                               178 /  186         56.3          17.8       6.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 longs:                                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   50 /   52        200.3           5.0       1.0X
-InSet expression                               147 /  151         68.1          14.7       0.3X
+In expression                                   23 /   25        434.4           2.3       1.0X
+InSet expression                                91 /   96        110.2           9.1       0.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 longs:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   65 /   66        154.8           6.5       1.0X
-InSet expression                               162 /  166         61.6          16.2       0.4X
+In expression                                   21 /   22        476.9           2.1       1.0X
+InSet expression                               106 /  112         94.2          10.6       0.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 longs:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  117 /  119         85.1          11.7       1.0X
-InSet expression                               170 /  175         58.8          17.0       0.7X
+In expression                                   40 /   41        252.7           4.0       1.0X
+InSet expression                               107 /  111         93.4          10.7       0.4X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 longs:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  207 /  208         48.3          20.7       1.0X
-InSet expression                               211 /  214         47.4          21.1       1.0X
+In expression                                   67 /   69        148.6           6.7       1.0X
+InSet expression                               142 /  147         70.5          14.2       0.5X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 longs:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  387 /  389         25.9          38.7       1.0X
-InSet expression                               185 /  187         54.2          18.5       2.1X
+In expression                                  126 /  128         79.6          12.6       1.0X
+InSet expression                               114 /  118         88.0          11.4       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 longs:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  742 /  744         13.5          74.2       1.0X
-InSet expression                               172 /  173         58.3          17.2       4.3X
+In expression                                  243 /  248         41.2          24.3       1.0X
+InSet expression                               108 /  112         92.3          10.8       2.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 floats:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   88 /   91        113.0           8.8       1.0X
-InSet expression                               170 /  171         58.9          17.0       0.5X
+In expression                                   34 /   35        297.3           3.4       1.0X
+InSet expression                               107 /  111         93.3          10.7       0.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 floats:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  129 /  132         77.5          12.9       1.0X
-InSet expression                               188 /  189         53.2          18.8       0.7X
+In expression                                   51 /   52        196.6           5.1       1.0X
+InSet expression                               125 /  129         80.3          12.5       0.4X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 floats:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  243 /  244         41.2          24.3       1.0X
-InSet expression                               192 /  194         52.2          19.2       1.3X
+In expression                                  107 /  110         93.5          10.7       1.0X
+InSet expression                               129 /  135         77.5          12.9       0.8X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 floats:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  421 /  424         23.7          42.1       1.0X
-InSet expression                               237 /  240         42.2          23.7       1.8X
+In expression                                  201 /  205         49.7          20.1       1.0X
+InSet expression                               167 /  171         60.0          16.7       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 floats:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  775 /  777         12.9          77.5       1.0X
-InSet expression                               205 /  209         48.8          20.5       3.8X
+In expression                                  386 /  390         25.9          38.6       1.0X
+InSet expression                               132 /  139         75.8          13.2       2.9X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 floats:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                 3052 / 3151          3.3         305.2       1.0X
-InSet expression                               197 /  199         50.8          19.7      15.5X
+In expression                                 1776 / 1824          5.6         177.6       1.0X
+InSet expression                               126 /  131         79.7          12.6      14.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 doubles:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   82 /   84        121.6           8.2       1.0X
-InSet expression                               167 /  169         60.0          16.7       0.5X
+In expression                                   33 /   34        303.4           3.3       1.0X
+InSet expression                               104 /  109         96.2          10.4       0.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 doubles:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  124 /  131         80.3          12.4       1.0X
-InSet expression                               186 /  187         53.9          18.6       0.7X
+In expression                                   50 /   51        201.7           5.0       1.0X
+InSet expression                               122 /  126         82.2          12.2       0.4X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 doubles:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  237 /  239         42.1          23.7       1.0X
-InSet expression                               193 /  194         51.8          19.3       1.2X
+In expression                                  105 /  109         95.0          10.5       1.0X
+InSet expression                               124 /  130         80.8          12.4       0.9X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 doubles:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  416 /  418         24.0          41.6       1.0X
-InSet expression                               239 /  241         41.8          23.9       1.7X
+In expression                                  200 /  206         50.1          20.0       1.0X
+InSet expression                               164 /  171         60.8          16.4       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 doubles:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  771 /  774         13.0          77.1       1.0X
-InSet expression                               204 /  207         49.1          20.4       3.8X
+In expression                                  384 /  389         26.1          38.4       1.0X
+InSet expression                               126 /  132         79.6          12.6       3.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 doubles:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                 3755 / 3801          2.7         375.5       1.0X
-InSet expression                               194 /  197         51.5          19.4      19.3X
+In expression                                 2066 / 2108          4.8         206.6       1.0X
+InSet expression                               121 /  129         82.5          12.1      17.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 small decimals:                        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   46 /   49         21.6          46.4       1.0X
-InSet expression                               136 /  141          7.4         135.7       0.3X
+In expression                                   20 /   22         49.2          20.3       1.0X
+InSet expression                                72 /   79         13.9          72.1       0.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 small decimals:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   57 /   61         17.5          57.1       1.0X
-InSet expression                               137 /  140          7.3         137.2       0.4X
+In expression                                   24 /   27         40.9          24.5       1.0X
+InSet expression                                76 /   85         13.2          75.6       0.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 small decimals:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   89 /   92         11.2          89.4       1.0X
-InSet expression                               139 /  141          7.2         138.7       0.6X
+In expression                                   38 /   42         26.2          38.2       1.0X
+InSet expression                                79 /   86         12.7          78.8       0.5X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 small decimals:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  170 /  171          5.9         169.5       1.0X
-InSet expression                               146 /  148          6.9         145.8       1.2X
+In expression                                   88 /   94         11.3          88.3       1.0X
+InSet expression                                83 /   88         12.0          83.2       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 small decimals:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  429 /  431          2.3         429.2       1.0X
-InSet expression                               145 /  148          6.9         144.9       3.0X
+In expression                                  236 /  242          4.2         235.6       1.0X
+InSet expression                                82 /   88         12.2          82.0       2.9X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 small decimals:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  995 / 1207          1.0         995.0       1.0X
-InSet expression                               154 /  158          6.5         154.1       6.5X
+In expression                                  532 /  541          1.9         531.8       1.0X
+InSet expression                                87 /   92         11.5          87.1       6.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 large decimals:                        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  268 /  307          3.7         268.3       1.0X
-InSet expression                               171 /  176          5.8         171.1       1.6X
+In expression                                  138 /  143          7.2         138.3       1.0X
+InSet expression                                99 /  106         10.1          99.2       1.4X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 large decimals:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  455 /  458          2.2         455.2       1.0X
-InSet expression                               173 /  176          5.8         173.1       2.6X
+In expression                                  237 /  250          4.2         237.1       1.0X
+InSet expression                               100 /  107         10.0         100.2       2.4X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 large decimals:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                 1095 / 1099          0.9        1095.2       1.0X
-InSet expression                               179 /  183          5.6         178.7       6.1X
+In expression                                  575 /  593          1.7         575.3       1.0X
+InSet expression                               104 /  109          9.7         103.5       5.6X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 large decimals:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                 2099 / 2110          0.5        2098.6       1.0X
-InSet expression                               183 /  187          5.5         183.2      11.5X
+In expression                                 1133 / 1144          0.9        1132.8       1.0X
+InSet expression                               110 /  116          9.1         110.5      10.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 large decimals:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                 3885 / 3911          0.3        3885.4       1.0X
-InSet expression                               207 /  223          4.8         206.6      18.8X
+In expression                                 2234 / 2280          0.4        2234.1       1.0X
+InSet expression                               124 /  131          8.1         124.2      18.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 large decimals:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                 7759 / 7867          0.1        7759.2       1.0X
-InSet expression                               214 /  217          4.7         214.4      36.2X
+In expression                                 4547 / 4576          0.2        4547.2       1.0X
+InSet expression                               128 /  134          7.8         127.8      35.6X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 strings:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  126 /  127          7.9         126.0       1.0X
-InSet expression                               139 /  142          7.2         139.0       0.9X
+In expression                                   71 /   77         14.0          71.3       1.0X
+InSet expression                                86 /   91         11.6          86.2       0.8X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 strings:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  128 /  132          7.8         128.2       1.0X
-InSet expression                               142 /  144          7.0         142.0       0.9X
+In expression                                   78 /   80         12.9          77.7       1.0X
+InSet expression                                88 /   91         11.4          87.5       0.9X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 strings:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  151 /  153          6.6         150.9       1.0X
-InSet expression                               150 /  152          6.7         150.1       1.0X
+In expression                                   87 /   92         11.5          87.2       1.0X
+InSet expression                                93 /   96         10.7          93.2       0.9X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 strings:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  238 /  240          4.2         238.5       1.0X
-InSet expression                               152 /  154          6.6         152.4       1.6X
+In expression                                  113 /  117          8.9         112.6       1.0X
+InSet expression                                94 /   98         10.7          93.7       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 strings:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  431 /  432          2.3         431.2       1.0X
-InSet expression                               149 /  151          6.7         148.8       2.9X
+In expression                                  161 /  166          6.2         161.1       1.0X
+InSet expression                                90 /   95         11.1          90.1       1.8X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 strings:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  822 / 1060          1.2         821.7       1.0X
-InSet expression                               153 /  162          6.5         152.9       5.4X
+In expression                                  453 /  461          2.2         452.9       1.0X
+InSet expression                                94 /   97         10.7          93.8       4.8X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 timestamps:                            Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   42 /   44        240.5           4.2       1.0X
-InSet expression                               158 /  161         63.5          15.8       0.3X
+In expression                                   22 /   24        447.5           2.2       1.0X
+InSet expression                               100 /  103         99.8          10.0       0.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 timestamps:                           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   57 /   59        174.5           5.7       1.0X
-InSet expression                               173 /  176         57.8          17.3       0.3X
+In expression                                   32 /   35        312.0           3.2       1.0X
+InSet expression                               108 /  114         92.3          10.8       0.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 timestamps:                           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  110 /  113         91.1          11.0       1.0X
-InSet expression                               223 /  226         44.9          22.3       0.5X
+In expression                                   67 /   71        148.6           6.7       1.0X
+InSet expression                               151 /  154         66.3          15.1       0.4X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 timestamps:                           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  190 /  193         52.6          19.0       1.0X
-InSet expression                               238 /  240         42.1          23.8       0.8X
+In expression                                  118 /  125         84.7          11.8       1.0X
+InSet expression                               154 /  159         65.0          15.4       0.8X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 timestamps:                          Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  355 /  367         28.2          35.5       1.0X
-InSet expression                               221 /  222         45.2          22.1       1.6X
+In expression                                  237 /  244         42.2          23.7       1.0X
+InSet expression                               122 /  129         82.3          12.2       1.9X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 timestamps:                          Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  692 /  694         14.5          69.2       1.0X
-InSet expression                               220 /  222         45.4          22.0       3.1X
+In expression                                  463 /  476         21.6          46.3       1.0X
+InSet expression                               130 /  138         76.9          13.0       3.6X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 dates:                                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  143 /  145         70.0          14.3       1.0X
-InSet expression                               264 /  269         37.9          26.4       0.5X
+In expression                                  210 /  242         47.7          21.0       1.0X
+InSet expression                               211 /  244         47.3          21.1       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 dates:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  141 /  142         71.1          14.1       1.0X
-InSet expression                               268 /  269         37.3          26.8       0.5X
+In expression                                  244 /  262         41.0          24.4       1.0X
+InSet expression                               225 /  238         44.5          22.5       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 dates:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  196 /  196         51.1          19.6       1.0X
-InSet expression                               277 /  282         36.1          27.7       0.7X
+In expression                                  274 /  282         36.5          27.4       1.0X
+InSet expression                               241 /  268         41.4          24.1       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 dates:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  338 /  351         29.5          33.8       1.0X
-InSet expression                               287 /  290         34.9          28.7       1.2X
+In expression                                  304 /  353         32.9          30.4       1.0X
+InSet expression                               230 /  253         43.4          23.0       1.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 dates:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  541 /  542         18.5          54.1       1.0X
-InSet expression                               299 /  300         33.5          29.9       1.8X
+In expression                                  404 /  472         24.8          40.4       1.0X
+InSet expression                               240 /  266         41.7          24.0       1.7X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 dates:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  883 /  900         11.3          88.3       1.0X
-InSet expression                               296 /  298         33.8          29.6       3.0X
+In expression                                  664 /  681         15.1          66.4       1.0X
+InSet expression                               256 /  266         39.0          25.6       2.6X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+450 dates:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                 1149 / 1205          8.7         114.9       1.0X
+InSet expression                               260 /  273         38.5          26.0       4.4X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+500 dates:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                 1148 / 1216          8.7         114.8       1.0X
+InSet expression                               256 /  262         39.0          25.6       4.5X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+550 dates:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                               22914 / 23111          0.4        2291.4       1.0X
+InSet expression                               349 /  360         28.6          34.9      65.6X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 arrays:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   51 /   53         19.6          51.0       1.0X
-InSet expression                                96 /   97         10.5          95.7       0.5X
+In expression                                   24 /   25         42.5          23.5       1.0X
+InSet expression                                47 /   50         21.4          46.8       0.5X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 arrays:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   77 /   79         13.1          76.6       1.0X
-InSet expression                                96 /   98         10.4          96.0       0.8X
+In expression                                   38 /   40         26.2          38.1       1.0X
+InSet expression                                47 /   49         21.1          47.3       0.8X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 arrays:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  275 /  276          3.6         274.6       1.0X
-InSet expression                               119 /  121          8.4         119.1       2.3X
+In expression                                  138 /  143          7.2         138.3       1.0X
+InSet expression                                60 /   62         16.8          59.6       2.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 arrays:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  592 /  663          1.7         592.1       1.0X
-InSet expression                               164 /  172          6.1         164.3       3.6X
+In expression                                  319 /  325          3.1         318.6       1.0X
+InSet expression                                85 /   88         11.8          85.0       3.7X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 arrays:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                 2555 / 2733          0.4        2554.7       1.0X
-InSet expression                               194 /  198          5.2         193.9      13.2X
+In expression                                  695 /  700          1.4         694.7       1.0X
+InSet expression                               100 /  106         10.0         100.5       6.9X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 arrays:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                 9215 / 9778          0.1        9214.8       1.0X
-InSet expression                               253 /  256          3.9         253.2      36.4X
+In expression                                 1758 / 1953          0.6        1757.6       1.0X
+InSet expression                               134 /  138          7.5         133.7      13.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 structs:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   46 /   47         22.0          45.5       1.0X
-InSet expression                               157 /  162          6.4         156.5       0.3X
+In expression                                   21 /   22         47.0          21.3       1.0X
+InSet expression                                80 /   84         12.5          79.7       0.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 structs:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   61 /   63         16.5          60.7       1.0X
-InSet expression                               158 /  161          6.3         158.2       0.4X
+In expression                                   28 /   29         35.7          28.0       1.0X
+InSet expression                                80 /   84         12.5          80.2       0.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 structs:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  133 /  140          7.5         132.8       1.0X
-InSet expression                               199 /  202          5.0         198.8       0.7X
+In expression                                   69 /   71         14.6          68.5       1.0X
+InSet expression                               102 /  106          9.8         101.9       0.7X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 structs:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  369 /  372          2.7         369.1       1.0X
-InSet expression                               283 /  294          3.5         282.7       1.3X
+In expression                                  202 /  210          4.9         202.2       1.0X
+InSet expression                               149 /  155          6.7         148.6       1.4X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 structs:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                 1570 / 1731          0.6        1569.8       1.0X
-InSet expression                               332 /  334          3.0         332.0       4.7X
+In expression                                  498 /  503          2.0         497.8       1.0X
+InSet expression                               172 /  179          5.8         171.7       2.9X
 
-OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 structs:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                 6332 / 6794          0.2        6331.8       1.0X
-InSet expression                               441 /  444          2.3         440.9      14.4X
+In expression                                 1238 / 1405          0.8        1238.4       1.0X
+InSet expression                               230 /  242          4.3         230.1       5.4X
 
 

--- a/sql/core/benchmarks/InExpressionBenchmark-results.txt
+++ b/sql/core/benchmarks/InExpressionBenchmark-results.txt
@@ -2,739 +2,739 @@
 In Expression Benchmark
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-5 bytes:                                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   37 /   47        267.3           3.7       1.0X
-InSet expression                                33 /   37        300.8           3.3       1.1X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-10 bytes:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   45 /   49        223.4           4.5       1.0X
-InSet expression                                38 /   42        263.4           3.8       1.2X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-25 bytes:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   75 /   79        133.6           7.5       1.0X
-InSet expression                                49 /   53        204.0           4.9       1.5X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-50 bytes:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  123 /  129         81.4          12.3       1.0X
-InSet expression                                72 /   77        138.9           7.2       1.7X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-100 bytes:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  214 /  226         46.7          21.4       1.0X
-InSet expression                               125 /  132         80.2          12.5       1.7X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-200 bytes:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  384 /  392         26.1          38.4       1.0X
-InSet expression                               220 /  233         45.4          22.0       1.7X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-5 shorts:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   26 /   27        387.2           2.6       1.0X
-InSet expression                                25 /   27        393.7           2.5       1.0X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-10 shorts:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   33 /   34        307.3           3.3       1.0X
-InSet expression                                25 /   26        396.8           2.5       1.3X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-25 shorts:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   49 /   51        203.9           4.9       1.0X
-InSet expression                                23 /   24        435.6           2.3       2.1X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-50 shorts:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   79 /   81        127.3           7.9       1.0X
-InSet expression                                26 /   27        389.3           2.6       3.1X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-100 shorts:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  137 /  140         72.8          13.7       1.0X
-InSet expression                                27 /   28        375.6           2.7       5.2X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-200 shorts:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  254 /  257         39.3          25.4       1.0X
-InSet expression                                29 /   31        339.4           2.9       8.6X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-300 shorts:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  370 /  375         27.0          37.0       1.0X
-InSet expression                                32 /   34        309.8           3.2      11.5X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-400 shorts:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  600 /  606         16.7          60.0       1.0X
-InSet expression                                35 /   36        286.8           3.5      17.2X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-500 shorts:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  816 /  823         12.3          81.6       1.0X
-InSet expression                               171 /  177         58.6          17.1       4.8X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-5 shorts (non-compact):                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   24 /   25        414.4           2.4       1.0X
-InSet expression                                24 /   25        414.6           2.4       1.0X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-10 shorts (non-compact):                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   31 /   32        323.6           3.1       1.0X
-InSet expression                                27 /   28        369.7           2.7       1.1X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-25 shorts (non-compact):                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   49 /   51        203.8           4.9       1.0X
-InSet expression                                30 /   31        329.2           3.0       1.6X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-50 shorts (non-compact):                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   78 /   80        128.3           7.8       1.0X
-InSet expression                                34 /   35        292.6           3.4       2.3X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-100 shorts (non-compact):                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  136 /  140         73.4          13.6       1.0X
-InSet expression                                38 /   39        265.9           3.8       3.6X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-200 shorts (non-compact):                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  254 /  257         39.4          25.4       1.0X
-InSet expression                                43 /   44        233.9           4.3       5.9X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-300 shorts (non-compact):                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  386 /  391         25.9          38.6       1.0X
-InSet expression                                48 /   49        210.0           4.8       8.1X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-400 shorts (non-compact):                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  635 /  642         15.8          63.5       1.0X
-InSet expression                                53 /   54        188.3           5.3      12.0X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-500 shorts (non-compact):                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  845 /  850         11.8          84.5       1.0X
-InSet expression                               169 /  178         59.1          16.9       5.0X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-5 ints:                                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   24 /   25        417.9           2.4       1.0X
-InSet expression                                24 /   24        424.1           2.4       1.0X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-10 ints:                                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   30 /   30        338.9           3.0       1.0X
-InSet expression                                24 /   25        423.6           2.4       1.2X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-25 ints:                                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   47 /   48        211.9           4.7       1.0X
-InSet expression                                22 /   23        460.9           2.2       2.2X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-50 ints:                                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   75 /   78        132.8           7.5       1.0X
-InSet expression                                25 /   25        406.0           2.5       3.1X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-100 ints:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  135 /  136         74.1          13.5       1.0X
-InSet expression                                26 /   27        390.6           2.6       5.3X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-200 ints:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  250 /  255         40.0          25.0       1.0X
-InSet expression                                28 /   29        358.9           2.8       9.0X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-300 ints:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  370 /  371         27.0          37.0       1.0X
-InSet expression                                30 /   31        329.5           3.0      12.2X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-400 ints:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  566 /  571         17.7          56.6       1.0X
-InSet expression                                33 /   34        306.4           3.3      17.3X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-500 ints:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  752 /  757         13.3          75.2       1.0X
-InSet expression                               152 /  160         65.9          15.2       5.0X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-5 ints (non-compact):                    Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   21 /   22        468.9           2.1       1.0X
-InSet expression                                19 /   20        530.7           1.9       1.1X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-10 ints (non-compact):                   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   30 /   31        329.3           3.0       1.0X
-InSet expression                                19 /   20        532.3           1.9       1.6X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-25 ints (non-compact):                   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   66 /   68        150.6           6.6       1.0X
-InSet expression                                28 /   29        355.7           2.8       2.4X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-50 ints (non-compact):                   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  122 /  125         82.2          12.2       1.0X
-InSet expression                                29 /   30        347.0           2.9       4.2X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-100 ints (non-compact):                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  236 /  239         42.4          23.6       1.0X
-InSet expression                                37 /   38        273.4           3.7       6.5X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-200 ints (non-compact):                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  469 /  471         21.3          46.9       1.0X
-InSet expression                                43 /   44        230.8           4.3      10.8X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-300 ints (non-compact):                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  697 /  699         14.3          69.7       1.0X
-InSet expression                                50 /   52        200.1           5.0      13.9X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-400 ints (non-compact):                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  837 /  841         11.9          83.7       1.0X
-InSet expression                                50 /   52        198.2           5.0      16.6X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-500 ints (non-compact):                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                 1011 / 1057          9.9         101.1       1.0X
-InSet expression                               152 /  156         65.9          15.2       6.7X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-5 longs:                                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   22 /   23        462.3           2.2       1.0X
-InSet expression                                90 /   95        111.6           9.0       0.2X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-10 longs:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   21 /   22        479.5           2.1       1.0X
-InSet expression                               105 /  111         95.6          10.5       0.2X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-25 longs:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   40 /   40        252.8           4.0       1.0X
-InSet expression                               106 /  113         93.9          10.6       0.4X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-50 longs:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   67 /   68        149.9           6.7       1.0X
-InSet expression                               146 /  153         68.6          14.6       0.5X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-100 longs:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  125 /  129         80.2          12.5       1.0X
-InSet expression                               111 /  117         90.0          11.1       1.1X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-200 longs:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  240 /  242         41.7          24.0       1.0X
-InSet expression                               107 /  112         93.7          10.7       2.2X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-5 floats:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   33 /   35        300.3           3.3       1.0X
-InSet expression                               106 /  111         94.3          10.6       0.3X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-10 floats:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   50 /   52        199.0           5.0       1.0X
-InSet expression                               122 /  128         82.1          12.2       0.4X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-25 floats:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  106 /  109         94.5          10.6       1.0X
-InSet expression                               127 /  133         78.5          12.7       0.8X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-50 floats:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  199 /  204         50.4          19.9       1.0X
-InSet expression                               169 /  175         59.3          16.9       1.2X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-100 floats:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  387 /  391         25.8          38.7       1.0X
-InSet expression                               131 /  136         76.4          13.1       3.0X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-200 floats:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                 1774 / 1835          5.6         177.4       1.0X
-InSet expression                               122 /  129         81.7          12.2      14.5X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-5 doubles:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   33 /   34        303.7           3.3       1.0X
-InSet expression                                95 /  101        104.9           9.5       0.3X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-10 doubles:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   50 /   51        200.5           5.0       1.0X
-InSet expression                               110 /  116         90.9          11.0       0.5X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-25 doubles:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  104 /  107         95.8          10.4       1.0X
-InSet expression                               113 /  119         88.8          11.3       0.9X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-50 doubles:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  193 /  201         51.7          19.3       1.0X
-InSet expression                               143 /  152         69.7          14.3       1.3X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-100 doubles:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  378 /  387         26.4          37.8       1.0X
-InSet expression                               115 /  120         86.6          11.5       3.3X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-200 doubles:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                 2048 / 2133          4.9         204.8       1.0X
-InSet expression                               109 /  115         91.9          10.9      18.8X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-5 small decimals:                        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   20 /   22         49.5          20.2       1.0X
-InSet expression                                70 /   76         14.4          69.6       0.3X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-10 small decimals:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   24 /   25         41.7          24.0       1.0X
-InSet expression                                73 /   79         13.8          72.5       0.3X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-25 small decimals:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   36 /   38         27.4          36.5       1.0X
-InSet expression                                73 /   77         13.8          72.7       0.5X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-50 small decimals:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   86 /   89         11.7          85.7       1.0X
-InSet expression                                77 /   81         13.0          76.8       1.1X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-100 small decimals:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  221 /  227          4.5         221.4       1.0X
-InSet expression                                76 /   80         13.2          75.6       2.9X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-200 small decimals:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  504 /  522          2.0         504.2       1.0X
-InSet expression                                80 /   85         12.5          80.0       6.3X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-5 large decimals:                        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  130 /  139          7.7         130.0       1.0X
-InSet expression                                92 /   98         10.9          91.8       1.4X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-10 large decimals:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  229 /  241          4.4         229.1       1.0X
-InSet expression                                92 /   98         10.9          91.5       2.5X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-25 large decimals:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  550 /  562          1.8         549.5       1.0X
-InSet expression                                95 /  103         10.6          94.6       5.8X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-50 large decimals:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                 1074 / 1095          0.9        1073.8       1.0X
-InSet expression                               101 /  104          9.9         101.0      10.6X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-100 large decimals:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                 2163 / 2208          0.5        2163.5       1.0X
-InSet expression                               110 /  119          9.1         110.0      19.7X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-200 large decimals:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                 4370 / 4421          0.2        4369.9       1.0X
-InSet expression                               114 /  121          8.7         114.4      38.2X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-5 strings:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   71 /   76         14.2          70.6       1.0X
-InSet expression                                78 /   84         12.8          78.1       0.9X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-10 strings:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   75 /   79         13.3          75.4       1.0X
-InSet expression                                81 /   86         12.4          80.7       0.9X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-25 strings:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   82 /   87         12.1          82.4       1.0X
-InSet expression                                86 /   93         11.7          85.7       1.0X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-50 strings:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  104 /  108          9.6         103.6       1.0X
-InSet expression                                87 /   93         11.5          87.2       1.2X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-100 strings:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  161 /  163          6.2         161.0       1.0X
-InSet expression                                85 /   88         11.8          84.7       1.9X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-200 strings:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  426 /  433          2.3         425.9       1.0X
-InSet expression                                85 /   89         11.8          84.7       5.0X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-5 timestamps:                            Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   21 /   22        465.6           2.1       1.0X
-InSet expression                                91 /   95        109.5           9.1       0.2X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-10 timestamps:                           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   31 /   32        320.6           3.1       1.0X
-InSet expression                               102 /  107         98.0          10.2       0.3X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-25 timestamps:                           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   64 /   65        156.4           6.4       1.0X
-InSet expression                               138 /  143         72.3          13.8       0.5X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-50 timestamps:                           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  114 /  116         87.8          11.4       1.0X
-InSet expression                               143 /  147         70.0          14.3       0.8X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-100 timestamps:                          Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  219 /  225         45.8          21.9       1.0X
-InSet expression                               114 /  123         87.7          11.4       1.9X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-200 timestamps:                          Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  431 /  433         23.2          43.1       1.0X
-InSet expression                               122 /  128         81.9          12.2       3.5X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-5 dates:                                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  202 /  210         49.6          20.2       1.0X
-InSet expression                               212 /  224         47.3          21.2       1.0X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-10 dates:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  224 /  231         44.6          22.4       1.0X
-InSet expression                               217 /  229         46.1          21.7       1.0X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-25 dates:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  256 /  275         39.1          25.6       1.0X
-InSet expression                               223 /  229         44.8          22.3       1.1X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-50 dates:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  296 /  323         33.7          29.6       1.0X
-InSet expression                               219 /  231         45.7          21.9       1.4X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-100 dates:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  385 /  437         26.0          38.5       1.0X
-InSet expression                               228 /  238         43.9          22.8       1.7X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-200 dates:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  635 /  647         15.7          63.5       1.0X
-InSet expression                               233 /  252         42.9          23.3       2.7X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-300 dates:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  833 /  840         12.0          83.3       1.0X
-InSet expression                               245 /  252         40.9          24.5       3.4X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-400 dates:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  937 / 1000         10.7          93.7       1.0X
-InSet expression                               250 /  272         40.1          25.0       3.8X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-500 dates:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                 1146 / 1193          8.7         114.6       1.0X
-InSet expression                               345 /  349         29.0          34.5       3.3X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-5 arrays:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   23 /   24         42.6          23.5       1.0X
-InSet expression                                44 /   47         22.5          44.4       0.5X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-10 arrays:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   38 /   39         26.3          38.0       1.0X
-InSet expression                                44 /   48         22.7          44.0       0.9X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-25 arrays:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  148 /  154          6.8         147.8       1.0X
-InSet expression                                56 /   59         17.8          56.1       2.6X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-50 arrays:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  321 /  332          3.1         320.8       1.0X
-InSet expression                                79 /   83         12.7          78.9       4.1X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-100 arrays:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  687 /  701          1.5         686.5       1.0X
-InSet expression                                93 /   97         10.7          93.4       7.4X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-200 arrays:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                 1687 / 1898          0.6        1687.3       1.0X
-InSet expression                               124 /  128          8.1         123.8      13.6X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-5 structs:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   21 /   22         47.1          21.2       1.0X
-InSet expression                                78 /   81         12.9          77.7       0.3X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-10 structs:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   28 /   29         35.7          28.0       1.0X
-InSet expression                                78 /   82         12.8          78.3       0.4X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-25 structs:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                   72 /   75         13.8          72.3       1.0X
-InSet expression                               100 /  105         10.0          99.9       0.7X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-50 structs:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  199 /  205          5.0         199.2       1.0X
-InSet expression                               142 /  147          7.0         142.3       1.4X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-100 structs:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  498 /  507          2.0         497.6       1.0X
-InSet expression                               171 /  176          5.9         170.8       2.9X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-200 structs:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                 1192 / 1367          0.8        1192.0       1.0X
-InSet expression                               231 /  241          4.3         231.4       5.2X
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+5 bytes:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       105            148          42         94.8          10.5       1.0X
+InSet expression                                     79             98          19        126.9           7.9       1.3X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+10 bytes:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       101            115          20         99.3          10.1       1.0X
+InSet expression                                     76             84           8        131.4           7.6       1.3X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+25 bytes:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       172            176           3         58.0          17.2       1.0X
+InSet expression                                    100            107           9         99.6          10.0       1.7X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+50 bytes:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       299            302           4         33.5          29.9       1.0X
+InSet expression                                    145            149           5         69.0          14.5       2.1X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+100 bytes:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       518            524          11         19.3          51.8       1.0X
+InSet expression                                    240            250          12         41.6          24.0       2.2X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+200 bytes:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       831            844          14         12.0          83.1       1.0X
+InSet expression                                    425            432           4         23.5          42.5       2.0X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+5 shorts:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                        58             62           5        171.9           5.8       1.0X
+InSet expression                                     56             58           5        178.0           5.6       1.0X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+10 shorts:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                        76             79           5        131.9           7.6       1.0X
+InSet expression                                     50             55           7        198.2           5.0       1.5X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+25 shorts:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       129            139          23         77.3          12.9       1.0X
+InSet expression                                     48             50           5        210.5           4.8       2.7X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+50 shorts:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       225            226           0         44.4          22.5       1.0X
+InSet expression                                     52             56           7        191.2           5.2       4.3X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+100 shorts:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       400            406          11         25.0          40.0       1.0X
+InSet expression                                     54             58           7        185.0           5.4       7.4X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+200 shorts:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       761            762           1         13.1          76.1       1.0X
+InSet expression                                     60             61           2        167.1           6.0      12.7X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+300 shorts:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      1118           1119           1          8.9         111.8       1.0X
+InSet expression                                     66             67           2        152.2           6.6      17.0X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+400 shorts:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      1478           1487          19          6.8         147.8       1.0X
+InSet expression                                     71             75          11        141.7           7.1      20.9X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+500 shorts:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      1836           1854          27          5.4         183.6       1.0X
+InSet expression                                    248            253           3         40.2          24.8       7.4X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+5 shorts (non-compact):                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                        55             68          19        180.3           5.5       1.0X
+InSet expression                                     60             63           7        167.0           6.0       0.9X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+10 shorts (non-compact):                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                        72             76           5        138.0           7.2       1.0X
+InSet expression                                     63             68          11        157.7           6.3       1.1X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+25 shorts (non-compact):                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       133            136           5         75.0          13.3       1.0X
+InSet expression                                     73             78          10        137.2           7.3       1.8X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+50 shorts (non-compact):                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       223            225           2         44.8          22.3       1.0X
+InSet expression                                     81             84          14        124.1           8.1       2.8X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+100 shorts (non-compact):                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       402            404           1         24.9          40.2       1.0X
+InSet expression                                     90             91           2        111.6           9.0       4.5X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+200 shorts (non-compact):                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       758            759           0         13.2          75.8       1.0X
+InSet expression                                    110            119          20         91.0          11.0       6.9X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+300 shorts (non-compact):                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      1121           1123           3          8.9         112.1       1.0X
+InSet expression                                    121            122           2         82.6          12.1       9.3X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+400 shorts (non-compact):                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      1482           1484           2          6.7         148.2       1.0X
+InSet expression                                    134            135           2         74.6          13.4      11.1X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+500 shorts (non-compact):                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      1838           1882          92          5.4         183.8       1.0X
+InSet expression                                    251            254           3         39.8          25.1       7.3X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+5 ints:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                        51             52           2        197.1           5.1       1.0X
+InSet expression                                     61             63           3        162.8           6.1       0.8X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+10 ints:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                        69             73          10        145.0           6.9       1.0X
+InSet expression                                     43             46           7        231.2           4.3       1.6X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+25 ints:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       123            129          19         81.4          12.3       1.0X
+InSet expression                                     43             46           8        230.0           4.3       2.8X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+50 ints:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       222            223           1         45.1          22.2       1.0X
+InSet expression                                     49             50           2        206.2           4.9       4.6X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+100 ints:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       401            402           0         24.9          40.1       1.0X
+InSet expression                                     51             56          11        196.6           5.1       7.9X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+200 ints:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       755            756           1         13.2          75.5       1.0X
+InSet expression                                     56             57           2        179.5           5.6      13.5X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+300 ints:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      1115           1116           1          9.0         111.5       1.0X
+InSet expression                                     61             62           4        165.2           6.1      18.4X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+400 ints:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      1476           1478           1          6.8         147.6       1.0X
+InSet expression                                     66             67           2        152.2           6.6      22.5X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+500 ints:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      1834           1873          85          5.5         183.4       1.0X
+InSet expression                                    230            233           3         43.5          23.0       8.0X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+5 ints (non-compact):                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                        40             42           2        247.6           4.0       1.0X
+InSet expression                                     37             39           3        271.6           3.7       1.1X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+10 ints (non-compact):                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                        59             60           3        170.0           5.9       1.0X
+InSet expression                                     42             44           3        237.6           4.2       1.4X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+25 ints (non-compact):                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       114            116           6         87.5          11.4       1.0X
+InSet expression                                     53             58          10        188.0           5.3       2.1X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+50 ints (non-compact):                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       207            214          14         48.3          20.7       1.0X
+InSet expression                                     62             63           2        162.1           6.2       3.4X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+100 ints (non-compact):                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       385            391           6         26.0          38.5       1.0X
+InSet expression                                     71             73           2        140.4           7.1       5.4X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+200 ints (non-compact):                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       746            750           2         13.4          74.6       1.0X
+InSet expression                                    101            105           8         98.5          10.1       7.4X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+300 ints (non-compact):                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      1100           1106           4          9.1         110.0       1.0X
+InSet expression                                    109            111           2         91.6          10.9      10.1X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+400 ints (non-compact):                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      1470           1480           7          6.8         147.0       1.0X
+InSet expression                                    115            116           2         87.1          11.5      12.8X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+500 ints (non-compact):                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      1838           1907         152          5.4         183.8       1.0X
+InSet expression                                    231            233           2         43.3          23.1       8.0X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+5 longs:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                        48             52           6        206.5           4.8       1.0X
+InSet expression                                    150            152           4         66.8          15.0       0.3X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+10 longs:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                        62             63           1        161.3           6.2       1.0X
+InSet expression                                    165            168           5         60.7          16.5       0.4X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+25 longs:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       116            116           0         86.1          11.6       1.0X
+InSet expression                                    173            175           3         57.9          17.3       0.7X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+50 longs:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       206            208           6         48.6          20.6       1.0X
+InSet expression                                    212            214           2         47.1          21.2       1.0X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+100 longs:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       384            386           2         26.0          38.4       1.0X
+InSet expression                                    183            185           2         54.6          18.3       2.1X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+200 longs:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       742            748          13         13.5          74.2       1.0X
+InSet expression                                    175            177           2         57.1          17.5       4.2X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+5 floats:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                        88             89           1        114.2           8.8       1.0X
+InSet expression                                    168            170           2         59.5          16.8       0.5X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+10 floats:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       128            129           3         78.0          12.8       1.0X
+InSet expression                                    187            188           2         53.6          18.7       0.7X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+25 floats:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       242            242           0         41.3          24.2       1.0X
+InSet expression                                    192            194           2         52.0          19.2       1.3X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+50 floats:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       419            420           0         23.8          41.9       1.0X
+InSet expression                                    235            236           1         42.5          23.5       1.8X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+100 floats:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       774            775           1         12.9          77.4       1.0X
+InSet expression                                    205            206           3         48.9          20.5       3.8X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+200 floats:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      3036           3123         191          3.3         303.6       1.0X
+InSet expression                                    197            198           1         50.8          19.7      15.4X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+5 doubles:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                        83             84           2        120.9           8.3       1.0X
+InSet expression                                    167            168           2         60.0          16.7       0.5X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+10 doubles:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       125            126           3         80.3          12.5       1.0X
+InSet expression                                    186            188           2         53.7          18.6       0.7X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+25 doubles:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       237            238           1         42.1          23.7       1.0X
+InSet expression                                    192            195           3         52.0          19.2       1.2X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+50 doubles:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       414            415           0         24.1          41.4       1.0X
+InSet expression                                    239            242           3         41.9          23.9       1.7X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+100 doubles:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       769            771           3         13.0          76.9       1.0X
+InSet expression                                    203            213          22         49.3          20.3       3.8X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+200 doubles:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      3757           3796          85          2.7         375.7       1.0X
+InSet expression                                    193            194           2         51.9          19.3      19.5X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+5 small decimals:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                        47             48           3         21.3          47.0       1.0X
+InSet expression                                    155            168          29          6.4         155.3       0.3X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+10 small decimals:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                        58             59           2         17.4          57.6       1.0X
+InSet expression                                    157            160           2          6.4         157.4       0.4X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+25 small decimals:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                        92             92           2         10.9          91.5       1.0X
+InSet expression                                    160            162           2          6.3         159.6       0.6X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+50 small decimals:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       171            171           0          5.9         170.8       1.0X
+InSet expression                                    169            172           3          5.9         169.3       1.0X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+100 small decimals:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       429            429           0          2.3         428.6       1.0X
+InSet expression                                    170            172           2          5.9         170.4       2.5X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+200 small decimals:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       996           1144         328          1.0         996.3       1.0X
+InSet expression                                    177            179           3          5.7         176.8       5.6X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+5 large decimals:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       248            251           2          4.0         248.0       1.0X
+InSet expression                                    175            177           2          5.7         174.9       1.4X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+10 large decimals:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       420            426          11          2.4         420.0       1.0X
+InSet expression                                    177            180           3          5.7         176.9       2.4X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+25 large decimals:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      1005           1008           4          1.0        1004.9       1.0X
+InSet expression                                    184            187           3          5.4         183.7       5.5X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+50 large decimals:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      1922           1933          13          0.5        1922.2       1.0X
+InSet expression                                    189            193           7          5.3         188.9      10.2X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+100 large decimals:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      3861           3871          12          0.3        3860.5       1.0X
+InSet expression                                    213            225          30          4.7         213.5      18.1X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+200 large decimals:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      7731           7774          25          0.1        7731.5       1.0X
+InSet expression                                    222            225           3          4.5         222.4      34.8X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+5 strings:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       127            133           9          7.9         126.8       1.0X
+InSet expression                                    142            143           2          7.0         141.9       0.9X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+10 strings:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       132            133           2          7.6         131.7       1.0X
+InSet expression                                    144            146           2          6.9         144.1       0.9X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+25 strings:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       153            154           2          6.5         152.9       1.0X
+InSet expression                                    151            153           2          6.6         151.2       1.0X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+50 strings:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       186            187           2          5.4         185.8       1.0X
+InSet expression                                    154            156           3          6.5         153.7       1.2X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+100 strings:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       260            263           3          3.8         260.3       1.0X
+InSet expression                                    151            153           2          6.6         151.3       1.7X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+200 strings:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       731            891         352          1.4         731.4       1.0X
+InSet expression                                    155            157           3          6.4         155.4       4.7X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+5 timestamps:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                        42             43           2        240.1           4.2       1.0X
+InSet expression                                    159            160           2         63.0          15.9       0.3X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+10 timestamps:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                        58             59           2        171.4           5.8       1.0X
+InSet expression                                    174            183          21         57.5          17.4       0.3X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+25 timestamps:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       111            113           3         90.0          11.1       1.0X
+InSet expression                                    228            229           2         43.9          22.8       0.5X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+50 timestamps:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       192            193           1         52.1          19.2       1.0X
+InSet expression                                    250            250           1         40.1          25.0       0.8X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+100 timestamps:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       373            384          12         26.8          37.3       1.0X
+InSet expression                                    229            236           7         43.7          22.9       1.6X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+200 timestamps:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       694            707          25         14.4          69.4       1.0X
+InSet expression                                    221            226           7         45.2          22.1       3.1X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+5 dates:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       196            198           2         50.9          19.6       1.0X
+InSet expression                                    169            170           0         59.2          16.9       1.2X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+10 dates:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       212            212           0         47.3          21.2       1.0X
+InSet expression                                    197            197           0         50.8          19.7       1.1X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+25 dates:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       266            266           1         37.7          26.6       1.0X
+InSet expression                                    203            217          23         49.4          20.3       1.3X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+50 dates:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       356            367          12         28.1          35.6       1.0X
+InSet expression                                    212            213           1         47.1          21.2       1.7X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+100 dates:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       559            573          26         17.9          55.9       1.0X
+InSet expression                                    221            223           2         45.2          22.1       2.5X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+200 dates:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       901            916           9         11.1          90.1       1.0X
+InSet expression                                    238            241           9         42.1          23.8       3.8X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+300 dates:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      1264           1282          10          7.9         126.4       1.0X
+InSet expression                                    253            262          15         39.5          25.3       5.0X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+400 dates:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      1628           1646          11          6.1         162.8       1.0X
+InSet expression                                    264            265           1         37.8          26.4       6.2X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+500 dates:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      1993           2015          15          5.0         199.3       1.0X
+InSet expression                                    355            368          10         28.2          35.5       5.6X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+5 arrays:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                        52             63          14         19.3          51.8       1.0X
+InSet expression                                     96             98           2         10.4          95.9       0.5X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+10 arrays:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                        78             80           3         12.8          77.9       1.0X
+InSet expression                                     97            154          48         10.3          97.1       0.8X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+25 arrays:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       269            279          27          3.7         268.7       1.0X
+InSet expression                                    120            124          13          8.3         119.9       2.2X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+50 arrays:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       579            626          96          1.7         579.2       1.0X
+InSet expression                                    165            167           3          6.1         165.1       3.5X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+100 arrays:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      2582           2775         415          0.4        2582.1       1.0X
+InSet expression                                    196            201          10          5.1         196.0      13.2X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+200 arrays:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      9438           9939         763          0.1        9437.9       1.0X
+InSet expression                                    256            258           3          3.9         255.8      36.9X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+5 structs:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                        47             48           2         21.4          46.8       1.0X
+InSet expression                                    158            160           2          6.3         157.6       0.3X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+10 structs:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                        62             63           4         16.2          61.9       1.0X
+InSet expression                                    158            161           4          6.3         158.4       0.4X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+25 structs:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       138            140           3          7.3         137.9       1.0X
+InSet expression                                    202            219          43          5.0         201.7       0.7X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+50 structs:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                       366            367           1          2.7         365.7       1.0X
+InSet expression                                    286            289           4          3.5         285.6       1.3X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+100 structs:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      1055           1212         346          0.9        1054.7       1.0X
+InSet expression                                    348            354           6          2.9         347.9       3.0X
+
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+200 structs:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+In expression                                      6463           6772         650          0.2        6463.3       1.0X
+InSet expression                                    450            455           4          2.2         449.6      14.4X
 
 

--- a/sql/core/benchmarks/InExpressionBenchmark-results.txt
+++ b/sql/core/benchmarks/InExpressionBenchmark-results.txt
@@ -6,735 +6,735 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 bytes:                                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   38 /   48        260.1           3.8       1.0X
-InSet expression                                33 /   37        300.5           3.3       1.2X
+In expression                                   37 /   47        267.3           3.7       1.0X
+InSet expression                                33 /   37        300.8           3.3       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 bytes:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   44 /   47        226.6           4.4       1.0X
-InSet expression                                37 /   39        270.8           3.7       1.2X
+In expression                                   45 /   49        223.4           4.5       1.0X
+InSet expression                                38 /   42        263.4           3.8       1.2X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 bytes:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   74 /   78        135.6           7.4       1.0X
-InSet expression                                48 /   51        210.4           4.8       1.6X
+In expression                                   75 /   79        133.6           7.5       1.0X
+InSet expression                                49 /   53        204.0           4.9       1.5X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 bytes:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  121 /  127         82.6          12.1       1.0X
-InSet expression                                72 /   75        138.1           7.2       1.7X
+In expression                                  123 /  129         81.4          12.3       1.0X
+InSet expression                                72 /   77        138.9           7.2       1.7X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 bytes:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  210 /  223         47.7          21.0       1.0X
-InSet expression                               123 /  130         81.2          12.3       1.7X
+In expression                                  214 /  226         46.7          21.4       1.0X
+InSet expression                               125 /  132         80.2          12.5       1.7X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 bytes:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  381 /  393         26.2          38.1       1.0X
-InSet expression                               218 /  229         45.8          21.8       1.7X
+In expression                                  384 /  392         26.1          38.4       1.0X
+InSet expression                               220 /  233         45.4          22.0       1.7X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 shorts:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   25 /   27        394.9           2.5       1.0X
-InSet expression                                25 /   27        397.6           2.5       1.0X
+In expression                                   26 /   27        387.2           2.6       1.0X
+InSet expression                                25 /   27        393.7           2.5       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 shorts:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   32 /   34        312.0           3.2       1.0X
-InSet expression                                25 /   27        403.0           2.5       1.3X
+In expression                                   33 /   34        307.3           3.3       1.0X
+InSet expression                                25 /   26        396.8           2.5       1.3X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 shorts:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   48 /   50        206.3           4.8       1.0X
-InSet expression                                23 /   24        438.9           2.3       2.1X
+In expression                                   49 /   51        203.9           4.9       1.0X
+InSet expression                                23 /   24        435.6           2.3       2.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 shorts:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   79 /   80        126.7           7.9       1.0X
-InSet expression                                26 /   27        389.1           2.6       3.1X
+In expression                                   79 /   81        127.3           7.9       1.0X
+InSet expression                                26 /   27        389.3           2.6       3.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 shorts:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  135 /  138         74.1          13.5       1.0X
-InSet expression                                27 /   28        375.5           2.7       5.1X
+In expression                                  137 /  140         72.8          13.7       1.0X
+InSet expression                                27 /   28        375.6           2.7       5.2X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 shorts:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  254 /  262         39.4          25.4       1.0X
-InSet expression                                29 /   31        339.5           2.9       8.6X
+In expression                                  254 /  257         39.3          25.4       1.0X
+InSet expression                                29 /   31        339.4           2.9       8.6X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-450 shorts:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+300 shorts:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  721 /  724         13.9          72.1       1.0X
-InSet expression                                36 /   38        275.0           3.6      19.8X
+In expression                                  370 /  375         27.0          37.0       1.0X
+InSet expression                                32 /   34        309.8           3.2      11.5X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+400 shorts:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                  600 /  606         16.7          60.0       1.0X
+InSet expression                                35 /   36        286.8           3.5      17.2X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 500 shorts:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  806 /  812         12.4          80.6       1.0X
-InSet expression                                38 /   40        264.7           3.8      21.3X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-550 shorts:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  828 /  845         12.1          82.8       1.0X
-InSet expression                               188 /  194         53.3          18.8       4.4X
+In expression                                  816 /  823         12.3          81.6       1.0X
+InSet expression                               171 /  177         58.6          17.1       4.8X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 shorts (non-compact):                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   24 /   25        415.0           2.4       1.0X
-InSet expression                                24 /   25        419.2           2.4       1.0X
+In expression                                   24 /   25        414.4           2.4       1.0X
+InSet expression                                24 /   25        414.6           2.4       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 shorts (non-compact):                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   31 /   33        322.8           3.1       1.0X
-InSet expression                                27 /   28        368.6           2.7       1.1X
+In expression                                   31 /   32        323.6           3.1       1.0X
+InSet expression                                27 /   28        369.7           2.7       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 shorts (non-compact):                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   48 /   50        209.0           4.8       1.0X
-InSet expression                                31 /   32        327.6           3.1       1.6X
+In expression                                   49 /   51        203.8           4.9       1.0X
+InSet expression                                30 /   31        329.2           3.0       1.6X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 shorts (non-compact):                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   77 /   79        129.4           7.7       1.0X
-InSet expression                                34 /   35        294.5           3.4       2.3X
+In expression                                   78 /   80        128.3           7.8       1.0X
+InSet expression                                34 /   35        292.6           3.4       2.3X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 shorts (non-compact):                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  135 /  137         74.1          13.5       1.0X
-InSet expression                                37 /   39        266.7           3.7       3.6X
+In expression                                  136 /  140         73.4          13.6       1.0X
+InSet expression                                38 /   39        265.9           3.8       3.6X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 shorts (non-compact):                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  253 /  257         39.5          25.3       1.0X
-InSet expression                                43 /   45        232.4           4.3       5.9X
+In expression                                  254 /  257         39.4          25.4       1.0X
+InSet expression                                43 /   44        233.9           4.3       5.9X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-450 shorts (non-compact):                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+300 shorts (non-compact):                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  705 /  713         14.2          70.5       1.0X
-InSet expression                                55 /   57        182.9           5.5      12.9X
+In expression                                  386 /  391         25.9          38.6       1.0X
+InSet expression                                48 /   49        210.0           4.8       8.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+400 shorts (non-compact):                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                  635 /  642         15.8          63.5       1.0X
+InSet expression                                53 /   54        188.3           5.3      12.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 500 shorts (non-compact):                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  756 /  765         13.2          75.6       1.0X
-InSet expression                                57 /   60        176.2           5.7      13.3X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-550 shorts (non-compact):                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                               20240 / 20331          0.5        2024.0       1.0X
-InSet expression                               187 /  193         53.5          18.7     108.3X
+In expression                                  845 /  850         11.8          84.5       1.0X
+InSet expression                               169 /  178         59.1          16.9       5.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 ints:                                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   24 /   25        421.8           2.4       1.0X
-InSet expression                                24 /   25        425.2           2.4       1.0X
+In expression                                   24 /   25        417.9           2.4       1.0X
+InSet expression                                24 /   24        424.1           2.4       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 ints:                                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   31 /   32        325.9           3.1       1.0X
-InSet expression                                24 /   24        423.8           2.4       1.3X
+In expression                                   30 /   30        338.9           3.0       1.0X
+InSet expression                                24 /   25        423.6           2.4       1.2X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 ints:                                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   47 /   48        212.5           4.7       1.0X
-InSet expression                                22 /   23        460.8           2.2       2.2X
+In expression                                   47 /   48        211.9           4.7       1.0X
+InSet expression                                22 /   23        460.9           2.2       2.2X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 ints:                                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   75 /   78        132.6           7.5       1.0X
-InSet expression                                25 /   25        407.6           2.5       3.1X
+In expression                                   75 /   78        132.8           7.5       1.0X
+InSet expression                                25 /   25        406.0           2.5       3.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 ints:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  133 /  139         75.2          13.3       1.0X
-InSet expression                                25 /   27        392.6           2.5       5.2X
+In expression                                  135 /  136         74.1          13.5       1.0X
+InSet expression                                26 /   27        390.6           2.6       5.3X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 ints:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  249 /  255         40.1          24.9       1.0X
-InSet expression                                28 /   29        361.0           2.8       9.0X
+In expression                                  250 /  255         40.0          25.0       1.0X
+InSet expression                                28 /   29        358.9           2.8       9.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-450 ints:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+300 ints:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  719 /  720         13.9          71.9       1.0X
-InSet expression                                34 /   35        296.4           3.4      21.3X
+In expression                                  370 /  371         27.0          37.0       1.0X
+InSet expression                                30 /   31        329.5           3.0      12.2X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+400 ints:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                  566 /  571         17.7          56.6       1.0X
+InSet expression                                33 /   34        306.4           3.3      17.3X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 500 ints:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  821 /  829         12.2          82.1       1.0X
-InSet expression                                35 /   37        285.1           3.5      23.4X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-550 ints:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                  831 /  866         12.0          83.1       1.0X
-InSet expression                               179 /  184         55.7          17.9       4.6X
+In expression                                  752 /  757         13.3          75.2       1.0X
+InSet expression                               152 /  160         65.9          15.2       5.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 ints (non-compact):                    Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   21 /   22        468.7           2.1       1.0X
-InSet expression                                19 /   20        526.2           1.9       1.1X
+In expression                                   21 /   22        468.9           2.1       1.0X
+InSet expression                                19 /   20        530.7           1.9       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 ints (non-compact):                   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   31 /   32        321.0           3.1       1.0X
-InSet expression                                19 /   20        522.6           1.9       1.6X
+In expression                                   30 /   31        329.3           3.0       1.0X
+InSet expression                                19 /   20        532.3           1.9       1.6X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 ints (non-compact):                   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   67 /   68        150.0           6.7       1.0X
-InSet expression                                28 /   30        354.2           2.8       2.4X
+In expression                                   66 /   68        150.6           6.6       1.0X
+InSet expression                                28 /   29        355.7           2.8       2.4X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 ints (non-compact):                   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  122 /  123         82.0          12.2       1.0X
+In expression                                  122 /  125         82.2          12.2       1.0X
 InSet expression                                29 /   30        347.0           2.9       4.2X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 ints (non-compact):                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  238 /  240         42.1          23.8       1.0X
-InSet expression                                37 /   40        273.0           3.7       6.5X
+In expression                                  236 /  239         42.4          23.6       1.0X
+InSet expression                                37 /   38        273.4           3.7       6.5X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 ints (non-compact):                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  475 /  484         21.1          47.5       1.0X
-InSet expression                                44 /   45        228.9           4.4      10.9X
+In expression                                  469 /  471         21.3          46.9       1.0X
+InSet expression                                43 /   44        230.8           4.3      10.8X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-450 ints (non-compact):                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+300 ints (non-compact):                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  931 /  984         10.7          93.1       1.0X
-InSet expression                                62 /   64        162.5           6.2      15.1X
+In expression                                  697 /  699         14.3          69.7       1.0X
+InSet expression                                50 /   52        200.1           5.0      13.9X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+400 ints (non-compact):                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                  837 /  841         11.9          83.7       1.0X
+InSet expression                                50 /   52        198.2           5.0      16.6X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 500 ints (non-compact):                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                 1036 / 1078          9.6         103.6       1.0X
-InSet expression                                63 /   66        158.1           6.3      16.4X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-550 ints (non-compact):                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                                 1089 / 1124          9.2         108.9       1.0X
-InSet expression                               178 /  186         56.3          17.8       6.1X
+In expression                                 1011 / 1057          9.9         101.1       1.0X
+InSet expression                               152 /  156         65.9          15.2       6.7X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 longs:                                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   23 /   25        434.4           2.3       1.0X
-InSet expression                                91 /   96        110.2           9.1       0.3X
+In expression                                   22 /   23        462.3           2.2       1.0X
+InSet expression                                90 /   95        111.6           9.0       0.2X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 longs:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   21 /   22        476.9           2.1       1.0X
-InSet expression                               106 /  112         94.2          10.6       0.2X
+In expression                                   21 /   22        479.5           2.1       1.0X
+InSet expression                               105 /  111         95.6          10.5       0.2X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 longs:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   40 /   41        252.7           4.0       1.0X
-InSet expression                               107 /  111         93.4          10.7       0.4X
+In expression                                   40 /   40        252.8           4.0       1.0X
+InSet expression                               106 /  113         93.9          10.6       0.4X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 longs:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   67 /   69        148.6           6.7       1.0X
-InSet expression                               142 /  147         70.5          14.2       0.5X
+In expression                                   67 /   68        149.9           6.7       1.0X
+InSet expression                               146 /  153         68.6          14.6       0.5X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 longs:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  126 /  128         79.6          12.6       1.0X
-InSet expression                               114 /  118         88.0          11.4       1.1X
+In expression                                  125 /  129         80.2          12.5       1.0X
+InSet expression                               111 /  117         90.0          11.1       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 longs:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  243 /  248         41.2          24.3       1.0X
-InSet expression                               108 /  112         92.3          10.8       2.2X
+In expression                                  240 /  242         41.7          24.0       1.0X
+InSet expression                               107 /  112         93.7          10.7       2.2X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 floats:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   34 /   35        297.3           3.4       1.0X
-InSet expression                               107 /  111         93.3          10.7       0.3X
+In expression                                   33 /   35        300.3           3.3       1.0X
+InSet expression                               106 /  111         94.3          10.6       0.3X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 floats:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   51 /   52        196.6           5.1       1.0X
-InSet expression                               125 /  129         80.3          12.5       0.4X
+In expression                                   50 /   52        199.0           5.0       1.0X
+InSet expression                               122 /  128         82.1          12.2       0.4X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 floats:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  107 /  110         93.5          10.7       1.0X
-InSet expression                               129 /  135         77.5          12.9       0.8X
+In expression                                  106 /  109         94.5          10.6       1.0X
+InSet expression                               127 /  133         78.5          12.7       0.8X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 floats:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  201 /  205         49.7          20.1       1.0X
-InSet expression                               167 /  171         60.0          16.7       1.2X
+In expression                                  199 /  204         50.4          19.9       1.0X
+InSet expression                               169 /  175         59.3          16.9       1.2X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 floats:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  386 /  390         25.9          38.6       1.0X
-InSet expression                               132 /  139         75.8          13.2       2.9X
+In expression                                  387 /  391         25.8          38.7       1.0X
+InSet expression                               131 /  136         76.4          13.1       3.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 floats:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                 1776 / 1824          5.6         177.6       1.0X
-InSet expression                               126 /  131         79.7          12.6      14.1X
+In expression                                 1774 / 1835          5.6         177.4       1.0X
+InSet expression                               122 /  129         81.7          12.2      14.5X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 doubles:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   33 /   34        303.4           3.3       1.0X
-InSet expression                               104 /  109         96.2          10.4       0.3X
+In expression                                   33 /   34        303.7           3.3       1.0X
+InSet expression                                95 /  101        104.9           9.5       0.3X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 doubles:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   50 /   51        201.7           5.0       1.0X
-InSet expression                               122 /  126         82.2          12.2       0.4X
+In expression                                   50 /   51        200.5           5.0       1.0X
+InSet expression                               110 /  116         90.9          11.0       0.5X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 doubles:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  105 /  109         95.0          10.5       1.0X
-InSet expression                               124 /  130         80.8          12.4       0.9X
+In expression                                  104 /  107         95.8          10.4       1.0X
+InSet expression                               113 /  119         88.8          11.3       0.9X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 doubles:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  200 /  206         50.1          20.0       1.0X
-InSet expression                               164 /  171         60.8          16.4       1.2X
+In expression                                  193 /  201         51.7          19.3       1.0X
+InSet expression                               143 /  152         69.7          14.3       1.3X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 doubles:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  384 /  389         26.1          38.4       1.0X
-InSet expression                               126 /  132         79.6          12.6       3.1X
+In expression                                  378 /  387         26.4          37.8       1.0X
+InSet expression                               115 /  120         86.6          11.5       3.3X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 doubles:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                 2066 / 2108          4.8         206.6       1.0X
-InSet expression                               121 /  129         82.5          12.1      17.0X
+In expression                                 2048 / 2133          4.9         204.8       1.0X
+InSet expression                               109 /  115         91.9          10.9      18.8X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 small decimals:                        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   20 /   22         49.2          20.3       1.0X
-InSet expression                                72 /   79         13.9          72.1       0.3X
+In expression                                   20 /   22         49.5          20.2       1.0X
+InSet expression                                70 /   76         14.4          69.6       0.3X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 small decimals:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   24 /   27         40.9          24.5       1.0X
-InSet expression                                76 /   85         13.2          75.6       0.3X
+In expression                                   24 /   25         41.7          24.0       1.0X
+InSet expression                                73 /   79         13.8          72.5       0.3X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 small decimals:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   38 /   42         26.2          38.2       1.0X
-InSet expression                                79 /   86         12.7          78.8       0.5X
+In expression                                   36 /   38         27.4          36.5       1.0X
+InSet expression                                73 /   77         13.8          72.7       0.5X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 small decimals:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   88 /   94         11.3          88.3       1.0X
-InSet expression                                83 /   88         12.0          83.2       1.1X
+In expression                                   86 /   89         11.7          85.7       1.0X
+InSet expression                                77 /   81         13.0          76.8       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 small decimals:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  236 /  242          4.2         235.6       1.0X
-InSet expression                                82 /   88         12.2          82.0       2.9X
+In expression                                  221 /  227          4.5         221.4       1.0X
+InSet expression                                76 /   80         13.2          75.6       2.9X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 small decimals:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  532 /  541          1.9         531.8       1.0X
-InSet expression                                87 /   92         11.5          87.1       6.1X
+In expression                                  504 /  522          2.0         504.2       1.0X
+InSet expression                                80 /   85         12.5          80.0       6.3X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 large decimals:                        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  138 /  143          7.2         138.3       1.0X
-InSet expression                                99 /  106         10.1          99.2       1.4X
+In expression                                  130 /  139          7.7         130.0       1.0X
+InSet expression                                92 /   98         10.9          91.8       1.4X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 large decimals:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  237 /  250          4.2         237.1       1.0X
-InSet expression                               100 /  107         10.0         100.2       2.4X
+In expression                                  229 /  241          4.4         229.1       1.0X
+InSet expression                                92 /   98         10.9          91.5       2.5X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 large decimals:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  575 /  593          1.7         575.3       1.0X
-InSet expression                               104 /  109          9.7         103.5       5.6X
+In expression                                  550 /  562          1.8         549.5       1.0X
+InSet expression                                95 /  103         10.6          94.6       5.8X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 large decimals:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                 1133 / 1144          0.9        1132.8       1.0X
-InSet expression                               110 /  116          9.1         110.5      10.3X
+In expression                                 1074 / 1095          0.9        1073.8       1.0X
+InSet expression                               101 /  104          9.9         101.0      10.6X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 large decimals:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                 2234 / 2280          0.4        2234.1       1.0X
-InSet expression                               124 /  131          8.1         124.2      18.0X
+In expression                                 2163 / 2208          0.5        2163.5       1.0X
+InSet expression                               110 /  119          9.1         110.0      19.7X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 large decimals:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                 4547 / 4576          0.2        4547.2       1.0X
-InSet expression                               128 /  134          7.8         127.8      35.6X
+In expression                                 4370 / 4421          0.2        4369.9       1.0X
+InSet expression                               114 /  121          8.7         114.4      38.2X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 strings:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   71 /   77         14.0          71.3       1.0X
-InSet expression                                86 /   91         11.6          86.2       0.8X
+In expression                                   71 /   76         14.2          70.6       1.0X
+InSet expression                                78 /   84         12.8          78.1       0.9X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 strings:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   78 /   80         12.9          77.7       1.0X
-InSet expression                                88 /   91         11.4          87.5       0.9X
+In expression                                   75 /   79         13.3          75.4       1.0X
+InSet expression                                81 /   86         12.4          80.7       0.9X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 strings:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   87 /   92         11.5          87.2       1.0X
-InSet expression                                93 /   96         10.7          93.2       0.9X
+In expression                                   82 /   87         12.1          82.4       1.0X
+InSet expression                                86 /   93         11.7          85.7       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 strings:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  113 /  117          8.9         112.6       1.0X
-InSet expression                                94 /   98         10.7          93.7       1.2X
+In expression                                  104 /  108          9.6         103.6       1.0X
+InSet expression                                87 /   93         11.5          87.2       1.2X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 strings:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  161 /  166          6.2         161.1       1.0X
-InSet expression                                90 /   95         11.1          90.1       1.8X
+In expression                                  161 /  163          6.2         161.0       1.0X
+InSet expression                                85 /   88         11.8          84.7       1.9X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 strings:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  453 /  461          2.2         452.9       1.0X
-InSet expression                                94 /   97         10.7          93.8       4.8X
+In expression                                  426 /  433          2.3         425.9       1.0X
+InSet expression                                85 /   89         11.8          84.7       5.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 timestamps:                            Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   22 /   24        447.5           2.2       1.0X
-InSet expression                               100 /  103         99.8          10.0       0.2X
+In expression                                   21 /   22        465.6           2.1       1.0X
+InSet expression                                91 /   95        109.5           9.1       0.2X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 timestamps:                           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   32 /   35        312.0           3.2       1.0X
-InSet expression                               108 /  114         92.3          10.8       0.3X
+In expression                                   31 /   32        320.6           3.1       1.0X
+InSet expression                               102 /  107         98.0          10.2       0.3X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 timestamps:                           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   67 /   71        148.6           6.7       1.0X
-InSet expression                               151 /  154         66.3          15.1       0.4X
+In expression                                   64 /   65        156.4           6.4       1.0X
+InSet expression                               138 /  143         72.3          13.8       0.5X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 timestamps:                           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  118 /  125         84.7          11.8       1.0X
-InSet expression                               154 /  159         65.0          15.4       0.8X
+In expression                                  114 /  116         87.8          11.4       1.0X
+InSet expression                               143 /  147         70.0          14.3       0.8X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 timestamps:                          Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  237 /  244         42.2          23.7       1.0X
-InSet expression                               122 /  129         82.3          12.2       1.9X
+In expression                                  219 /  225         45.8          21.9       1.0X
+InSet expression                               114 /  123         87.7          11.4       1.9X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 timestamps:                          Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  463 /  476         21.6          46.3       1.0X
-InSet expression                               130 /  138         76.9          13.0       3.6X
+In expression                                  431 /  433         23.2          43.1       1.0X
+InSet expression                               122 /  128         81.9          12.2       3.5X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 dates:                                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  210 /  242         47.7          21.0       1.0X
-InSet expression                               211 /  244         47.3          21.1       1.0X
+In expression                                  202 /  210         49.6          20.2       1.0X
+InSet expression                               212 /  224         47.3          21.2       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 dates:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  244 /  262         41.0          24.4       1.0X
-InSet expression                               225 /  238         44.5          22.5       1.1X
+In expression                                  224 /  231         44.6          22.4       1.0X
+InSet expression                               217 /  229         46.1          21.7       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 dates:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  274 /  282         36.5          27.4       1.0X
-InSet expression                               241 /  268         41.4          24.1       1.1X
+In expression                                  256 /  275         39.1          25.6       1.0X
+InSet expression                               223 /  229         44.8          22.3       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 dates:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  304 /  353         32.9          30.4       1.0X
-InSet expression                               230 /  253         43.4          23.0       1.3X
+In expression                                  296 /  323         33.7          29.6       1.0X
+InSet expression                               219 /  231         45.7          21.9       1.4X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 dates:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  404 /  472         24.8          40.4       1.0X
-InSet expression                               240 /  266         41.7          24.0       1.7X
+In expression                                  385 /  437         26.0          38.5       1.0X
+InSet expression                               228 /  238         43.9          22.8       1.7X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 dates:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  664 /  681         15.1          66.4       1.0X
-InSet expression                               256 /  266         39.0          25.6       2.6X
+In expression                                  635 /  647         15.7          63.5       1.0X
+InSet expression                               233 /  252         42.9          23.3       2.7X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-450 dates:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+300 dates:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                 1149 / 1205          8.7         114.9       1.0X
-InSet expression                               260 /  273         38.5          26.0       4.4X
+In expression                                  833 /  840         12.0          83.3       1.0X
+InSet expression                               245 /  252         40.9          24.5       3.4X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
+Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+400 dates:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+In expression                                  937 / 1000         10.7          93.7       1.0X
+InSet expression                               250 /  272         40.1          25.0       3.8X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 500 dates:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                 1148 / 1216          8.7         114.8       1.0X
-InSet expression                               256 /  262         39.0          25.6       4.5X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
-Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
-550 dates:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------
-In expression                               22914 / 23111          0.4        2291.4       1.0X
-InSet expression                               349 /  360         28.6          34.9      65.6X
+In expression                                 1146 / 1193          8.7         114.6       1.0X
+InSet expression                               345 /  349         29.0          34.5       3.3X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 arrays:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   24 /   25         42.5          23.5       1.0X
-InSet expression                                47 /   50         21.4          46.8       0.5X
+In expression                                   23 /   24         42.6          23.5       1.0X
+InSet expression                                44 /   47         22.5          44.4       0.5X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 arrays:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   38 /   40         26.2          38.1       1.0X
-InSet expression                                47 /   49         21.1          47.3       0.8X
+In expression                                   38 /   39         26.3          38.0       1.0X
+InSet expression                                44 /   48         22.7          44.0       0.9X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 arrays:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  138 /  143          7.2         138.3       1.0X
-InSet expression                                60 /   62         16.8          59.6       2.3X
+In expression                                  148 /  154          6.8         147.8       1.0X
+InSet expression                                56 /   59         17.8          56.1       2.6X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 arrays:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  319 /  325          3.1         318.6       1.0X
-InSet expression                                85 /   88         11.8          85.0       3.7X
+In expression                                  321 /  332          3.1         320.8       1.0X
+InSet expression                                79 /   83         12.7          78.9       4.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 arrays:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  695 /  700          1.4         694.7       1.0X
-InSet expression                               100 /  106         10.0         100.5       6.9X
+In expression                                  687 /  701          1.5         686.5       1.0X
+InSet expression                                93 /   97         10.7          93.4       7.4X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 arrays:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                 1758 / 1953          0.6        1757.6       1.0X
-InSet expression                               134 /  138          7.5         133.7      13.1X
+In expression                                 1687 / 1898          0.6        1687.3       1.0X
+InSet expression                               124 /  128          8.1         123.8      13.6X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 5 structs:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   21 /   22         47.0          21.3       1.0X
-InSet expression                                80 /   84         12.5          79.7       0.3X
+In expression                                   21 /   22         47.1          21.2       1.0X
+InSet expression                                78 /   81         12.9          77.7       0.3X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 10 structs:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
 In expression                                   28 /   29         35.7          28.0       1.0X
-InSet expression                                80 /   84         12.5          80.2       0.3X
+InSet expression                                78 /   82         12.8          78.3       0.4X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 25 structs:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                   69 /   71         14.6          68.5       1.0X
-InSet expression                               102 /  106          9.8         101.9       0.7X
+In expression                                   72 /   75         13.8          72.3       1.0X
+InSet expression                               100 /  105         10.0          99.9       0.7X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 50 structs:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  202 /  210          4.9         202.2       1.0X
-InSet expression                               149 /  155          6.7         148.6       1.4X
+In expression                                  199 /  205          5.0         199.2       1.0X
+InSet expression                               142 /  147          7.0         142.3       1.4X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 100 structs:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                  498 /  503          2.0         497.8       1.0X
-InSet expression                               172 /  179          5.8         171.7       2.9X
+In expression                                  498 /  507          2.0         497.6       1.0X
+InSet expression                               171 /  176          5.9         170.8       2.9X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_192-b12 on Mac OS X 10.14.3
 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 200 structs:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-In expression                                 1238 / 1405          0.8        1238.4       1.0X
-InSet expression                               230 /  242          4.3         230.1       5.4X
+In expression                                 1192 / 1367          0.8        1192.0       1.0X
+InSet expression                               231 /  241          4.3         231.4       5.2X
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql
 
+import java.sql.Date
 import java.util.Locale
 
 import scala.collection.JavaConverters._
@@ -28,6 +29,7 @@ import org.scalatest.Matchers._
 import org.apache.spark.sql.catalyst.expressions.NamedExpression
 import org.apache.spark.sql.execution.ProjectExec
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types._
 
@@ -411,6 +413,43 @@ class ColumnExpressionSuite extends QueryTest with SharedSQLContext {
       .foreach { s =>
         assert(e.getMessage.toLowerCase(Locale.ROOT).contains(s.toLowerCase(Locale.ROOT)))
       }
+  }
+
+  test("SPARK-26205: Optimize InSet for bytes, shorts, ints, dates") {
+    def check(): Unit = {
+      val values = Seq(
+        (Byte.MinValue, Some(Short.MinValue), Int.MinValue, Date.valueOf("2017-01-01")),
+        (Byte.MaxValue, None, Int.MaxValue, null))
+      val df = values.toDF("b", "s", "i", "d")
+      checkAnswer(df.select($"b".isin(Byte.MinValue, Byte.MaxValue)), Seq(Row(true), Row(true)))
+      checkAnswer(df.select($"b".isin(-1.toByte, 2.toByte)), Seq(Row(false), Row(false)))
+      checkAnswer(df.select($"s".isin(Short.MinValue, 1.toShort)), Seq(Row(true), Row(null)))
+      checkAnswer(df.select($"s".isin(0.toShort, null)), Seq(Row(null), Row(null)))
+      checkAnswer(df.select($"i".isin(0, Int.MinValue)), Seq(Row(true), Row(false)))
+      checkAnswer(df.select($"i".isin(null, Int.MinValue)), Seq(Row(true), Row(null)))
+      checkAnswer(
+        df.select($"d".isin(Date.valueOf("1950-01-01"), Date.valueOf("2017-01-01"))),
+        Seq(Row(true), Row(null)))
+      checkAnswer(
+        df.select($"d".isin(Date.valueOf("1950-01-01"), null)),
+        Seq(Row(null), Row(null)))
+    }
+
+    withSQLConf(SQLConf.OPTIMIZER_INSET_CONVERSION_THRESHOLD.key -> "10") {
+      check()
+    }
+
+    withSQLConf(
+      SQLConf.OPTIMIZER_INSET_CONVERSION_THRESHOLD.key -> "0",
+      SQLConf.OPTIMIZER_INSET_SWITCH_THRESHOLD.key -> "0") {
+      check()
+    }
+
+    withSQLConf(
+      SQLConf.OPTIMIZER_INSET_CONVERSION_THRESHOLD.key -> "0",
+      SQLConf.OPTIMIZER_INSET_SWITCH_THRESHOLD.key -> "20") {
+      check()
+    }
   }
 
   test("isInCollection: Scala Collection") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -415,7 +415,7 @@ class ColumnExpressionSuite extends QueryTest with SharedSQLContext {
       }
   }
 
-  test("SPARK-26205: Optimize InSet for bytes, shorts, ints, dates") {
+  test("IN/INSET with bytes, shorts, ints, dates") {
     def check(): Unit = {
       val values = Seq(
         (Byte.MinValue, Some(Short.MinValue), Int.MinValue, Date.valueOf("2017-01-01")),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/InExpressionBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/InExpressionBenchmark.scala
@@ -55,9 +55,31 @@ object InExpressionBenchmark extends SqlBasedBenchmark {
     runBenchmark(name, df, values, numRows, minNumIters)
   }
 
+  private def runNonCompactShortBenchmark(numItems: Int, numRows: Long, minNumIters: Int): Unit = {
+    val step = (Short.MaxValue.toInt - Short.MinValue.toInt) / numItems
+    val maxValue = Short.MinValue + numItems * step
+    val rangeSize = maxValue - Short.MinValue
+    require(isLookupSwitch(rangeSize, numItems))
+    val name = s"$numItems shorts (non-compact)"
+    val values = (Short.MinValue until maxValue by step).map(v => s"${v}S")
+    val df = spark.range(0, numRows).select($"id".cast(ShortType))
+    runBenchmark(name, df, values, numRows, minNumIters)
+  }
+
   private def runIntBenchmark(numItems: Int, numRows: Long, minNumIters: Int): Unit = {
     val name = s"$numItems ints"
     val values = 1 to numItems
+    val df = spark.range(0, numRows).select($"id".cast(IntegerType))
+    runBenchmark(name, df, values, numRows, minNumIters)
+  }
+
+  private def runNonCompactIntBenchmark(numItems: Int, numRows: Long, minNumIters: Int): Unit = {
+    val step = (Int.MaxValue.toLong - Int.MinValue.toLong) / numItems
+    val maxValue = Int.MinValue + numItems * step
+    val rangeSize = maxValue - Int.MinValue
+    require(isLookupSwitch(rangeSize, numItems))
+    val name = s"$numItems ints (non-compact)"
+    val values = Int.MinValue until maxValue.toInt by step.toInt
     val df = spark.range(0, numRows).select($"id".cast(IntegerType))
     runBenchmark(name, df, values, numRows, minNumIters)
   }
@@ -163,50 +185,66 @@ object InExpressionBenchmark extends SqlBasedBenchmark {
     benchmark.run()
   }
 
+  // this logic is derived from visitSwitch in com.sun.tools.javac.jvm.Gen
+  private def isLookupSwitch(rangeSize: Long, numLabels: Int): Boolean = {
+    val tableSpaceCost = 4 + rangeSize
+    val tableTimeCost = 3
+    val lookupSpaceCost = 3 + 2 * numLabels
+    val lookupTimeCost = numLabels
+    lookupSpaceCost + 3 * lookupTimeCost < tableSpaceCost + 3 * tableTimeCost
+  }
+
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
-    val numItemsSeq = Seq(5, 10, 25, 50, 100, 200)
+    val smallNumItemsSeq = Seq(5, 10, 25, 50, 100, 200)
+    val largeNumItemsSeq = Seq(450, 500, 550)
     val largeNumRows = 10000000
     val smallNumRows = 1000000
     val minNumIters = 5
 
     runBenchmark("In Expression Benchmark") {
-      numItemsSeq.foreach { numItems =>
+      smallNumItemsSeq.foreach { numItems =>
         runByteBenchmark(numItems, largeNumRows, minNumIters)
       }
-      numItemsSeq.foreach { numItems =>
+      (smallNumItemsSeq ++ largeNumItemsSeq).foreach { numItems =>
         runShortBenchmark(numItems, largeNumRows, minNumIters)
       }
-      numItemsSeq.foreach { numItems =>
+      (smallNumItemsSeq ++ largeNumItemsSeq).foreach { numItems =>
+        runNonCompactShortBenchmark(numItems, largeNumRows, minNumIters)
+      }
+      (smallNumItemsSeq ++ largeNumItemsSeq).foreach { numItems =>
         runIntBenchmark(numItems, largeNumRows, minNumIters)
       }
-      numItemsSeq.foreach { numItems =>
+      (smallNumItemsSeq ++ largeNumItemsSeq).foreach { numItems =>
+        runNonCompactIntBenchmark(numItems, largeNumRows, minNumIters)
+      }
+      smallNumItemsSeq.foreach { numItems =>
         runLongBenchmark(numItems, largeNumRows, minNumIters)
       }
-      numItemsSeq.foreach { numItems =>
+      smallNumItemsSeq.foreach { numItems =>
         runFloatBenchmark(numItems, largeNumRows, minNumIters)
       }
-      numItemsSeq.foreach { numItems =>
+      smallNumItemsSeq.foreach { numItems =>
         runDoubleBenchmark(numItems, largeNumRows, minNumIters)
       }
-      numItemsSeq.foreach { numItems =>
+      smallNumItemsSeq.foreach { numItems =>
         runSmallDecimalBenchmark(numItems, smallNumRows, minNumIters)
       }
-      numItemsSeq.foreach { numItems =>
+      smallNumItemsSeq.foreach { numItems =>
         runLargeDecimalBenchmark(numItems, smallNumRows, minNumIters)
       }
-      numItemsSeq.foreach { numItems =>
+      smallNumItemsSeq.foreach { numItems =>
         runStringBenchmark(numItems, smallNumRows, minNumIters)
       }
-      numItemsSeq.foreach { numItems =>
+      smallNumItemsSeq.foreach { numItems =>
         runTimestampBenchmark(numItems, largeNumRows, minNumIters)
       }
-      numItemsSeq.foreach { numItems =>
+      (smallNumItemsSeq ++ largeNumItemsSeq).foreach { numItems =>
         runDateBenchmark(numItems, largeNumRows, minNumIters)
       }
-      numItemsSeq.foreach { numItems =>
+      smallNumItemsSeq.foreach { numItems =>
         runArrayBenchmark(numItems, smallNumRows, minNumIters)
       }
-      numItemsSeq.foreach { numItems =>
+      smallNumItemsSeq.foreach { numItems =>
         runStructBenchmark(numItems, smallNumRows, minNumIters)
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/InExpressionBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/InExpressionBenchmark.scala
@@ -196,7 +196,7 @@ object InExpressionBenchmark extends SqlBasedBenchmark {
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
     val smallNumItemsSeq = Seq(5, 10, 25, 50, 100, 200)
-    val largeNumItemsSeq = Seq(450, 500, 550)
+    val largeNumItemsSeq = Seq(300, 400, 500)
     val largeNumRows = 10000000
     val smallNumRows = 1000000
     val minNumIters = 5

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -310,4 +310,19 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
     SQLConf.unregister(fallback)
   }
 
+  test("SPARK-26205: spark.sql.optimizer.inSetSwitchThreshold must be handled correctly") {
+    spark.sessionState.conf.clear()
+
+    assert(spark.conf.get(SQLConf.OPTIMIZER_INSET_SWITCH_THRESHOLD) == 400)
+    spark.conf.set(SQLConf.OPTIMIZER_INSET_SWITCH_THRESHOLD.key, 50)
+    assert(spark.conf.get(SQLConf.OPTIMIZER_INSET_SWITCH_THRESHOLD) == 50)
+    intercept[IllegalArgumentException] {
+      spark.conf.set(SQLConf.OPTIMIZER_INSET_SWITCH_THRESHOLD.key, -1)
+    }
+    intercept[IllegalArgumentException] {
+      spark.conf.set(SQLConf.OPTIMIZER_INSET_SWITCH_THRESHOLD.key, 601)
+    }
+
+    spark.sessionState.conf.clear()
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -310,19 +310,4 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
     SQLConf.unregister(fallback)
   }
 
-  test("SPARK-26205: spark.sql.optimizer.inSetSwitchThreshold must be handled correctly") {
-    spark.sessionState.conf.clear()
-
-    assert(spark.conf.get(SQLConf.OPTIMIZER_INSET_SWITCH_THRESHOLD) == 400)
-    spark.conf.set(SQLConf.OPTIMIZER_INSET_SWITCH_THRESHOLD.key, 50)
-    assert(spark.conf.get(SQLConf.OPTIMIZER_INSET_SWITCH_THRESHOLD) == 50)
-    intercept[IllegalArgumentException] {
-      spark.conf.set(SQLConf.OPTIMIZER_INSET_SWITCH_THRESHOLD.key, -1)
-    }
-    intercept[IllegalArgumentException] {
-      spark.conf.set(SQLConf.OPTIMIZER_INSET_SWITCH_THRESHOLD.key, 601)
-    }
-
-    spark.sessionState.conf.clear()
-  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR optimizes `InSet` expressions for byte, short, integer, date types. It is a follow-up on PR #21442 from @dbtsai.  

`In` expressions are compiled into a sequence of if-else statements, which results in O\(n\) time complexity. `InSet` is an optimized version of `In`, which is supposed to improve the performance if all values are literals and the number of elements is big enough. However, `InSet` actually worsens the performance in many cases due to various reasons.

The main idea of this PR is to use Java `switch` statements to significantly improve the performance of `InSet` expressions for bytes, shorts, ints, dates. All `switch` statements are compiled into `tableswitch` and `lookupswitch` bytecode instructions. We will have O\(1\) time complexity if our case values are compact and `tableswitch` can be used. Otherwise, `lookupswitch` will give us O\(log n\).

Locally, I tried Spark `OpenHashSet` and primitive collections from `fastutils` in order to solve the boxing issue in `InSet`. Both options significantly decreased the memory consumption and `fastutils` improved the time compared to `HashSet` from Scala. However, the switch-based approach was still more than two times faster even on 500+ non-compact elements.

I also noticed that applying the switch-based approach on less than 10 elements gives a relatively minor improvement compared to the if-else approach. Therefore, I placed the switch-based logic into `InSet` and added a new config to track when it is applied. Even if we migrate to primitive collections at some point, the switch logic will be still faster unless the number of elements is really big. Another option is to have a separate `InSwitch` expression. However, this would mean we need to modify other places (e.g., `DataSourceStrategy`).

See [here](https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-3.html#jvms-3.10) and [here](https://stackoverflow.com/questions/10287700/difference-between-jvms-lookupswitch-and-tableswitch) for more information.

This PR does not cover long values as Java `switch` statements cannot be used on them. However, we can have a follow-up PR with an approach similar to binary search.

## How was this patch tested?

There are new tests that verify the logic of the proposed optimization.

The performance was evaluated using existing benchmarks. This PR was also tested on an EC2 instance (OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 4.14.77-70.59.amzn1.x86_64, Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz). 

## Notes

- [This link](http://hg.openjdk.java.net/jdk8/jdk8/langtools/file/30db5e0aaf83/src/share/classes/com/sun/tools/javac/jvm/Gen.java#l1153) contains source code that decides between `tableswitch` and `lookupswitch`. The logic was re-used in the benchmarks. See the `isLookupSwitch` method.