### PR TITLE
[SPARK-26211][SQL] Fix InSet for binary, and struct and array with null.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -370,26 +370,8 @@ case class InSet(child: Expression, hset: Set[Any]) extends UnaryExpression with
     case t: AtomicType if !t.isInstanceOf[BinaryType] => hset
     case _: NullType => hset
     case _ =>
-      val ord = TypeUtils.getInterpretedOrdering(child.dataType)
-      val ordering = if (hasNull) {
-        new Ordering[Any] {
-          override def compare(x: Any, y: Any): Int = {
-            if (x == null && y == null) {
-              0
-            } else if (x == null) {
-              -1
-            } else if (y == null) {
-              1
-            } else {
-              ord.compare(x, y)
-            }
-          }
-        }
-      } else {
-        ord
-      }
       // for structs use interpreted ordering to be able to compare UnsafeRows with non-UnsafeRows
-      TreeSet.empty(ordering) ++ hset
+      TreeSet.empty(TypeUtils.getInterpretedOrdering(child.dataType)) ++ (hset - null)
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently `InSet` doesn't work properly for binary type, or struct and array type with null value in the set.
Because, as for binary type, the `HashSet` doesn't work properly for `Array[Byte]`, and as for struct and array type with null value in the set, the `ordering` will throw a `NPE`.

## How was this patch tested?

Added a few tests.
