### PR TITLE
[SPARK-26230][SQL]FileIndex: if case sensitive, validate partitions with original column names

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -351,13 +351,13 @@ object PartitioningUtils {
     if (pathsWithPartitionValues.isEmpty) {
       Seq.empty
     } else {
-      val distinctPartColNames = if (caseSensitive) {
+      val partColNames = if (caseSensitive) {
         pathsWithPartitionValues.map(_._2.columnNames)
       } else {
         pathsWithPartitionValues.map(_._2.columnNames.map(_.toLowerCase()))
       }
       assert(
-        distinctPartColNames.distinct.size == 1,
+        partColNames.distinct.size == 1,
         listConflictingPartitionColumns(pathsWithPartitionValues))
 
       // Resolves possible type conflicts for each column

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -88,9 +88,9 @@ class FileIndexSuite extends SharedSQLContext {
           val fileIndex = new InMemoryFileIndex(spark, Seq(path), Map.empty, None)
           fileIndex.partitionSpec()
         }.getMessage
-        msg.matches("Partition column name list #[0,1]: A")
-        msg.matches("Partition column name list #[0,1]: a")
         assert(msg.contains("Conflicting partition column names detected"))
+        assert("Partition column name list #[0-1]: A".r.findFirstIn(msg).isDefined)
+        assert("Partition column name list #[0-1]: a".r.findFirstIn(msg).isDefined)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -52,7 +52,7 @@ class FileIndexSuite extends SharedSQLContext {
 
   test("SPARK-26188: don't infer data types of partition columns if user specifies schema") {
     withTempDir { dir =>
-      val partitionDirectory = new File(dir, s"a=4d")
+      val partitionDirectory = new File(dir, "a=4d")
       partitionDirectory.mkdir()
       val file = new File(partitionDirectory, "text.txt")
       stringToFile(file, "text")
@@ -67,11 +67,11 @@ class FileIndexSuite extends SharedSQLContext {
 
   test("SPARK-26230: if case sensitive, validate partitions with original column names") {
     withTempDir { dir =>
-      val partitionDirectory = new File(dir, s"a=1")
+      val partitionDirectory = new File(dir, "a=1")
       partitionDirectory.mkdir()
       val file = new File(partitionDirectory, "text.txt")
       stringToFile(file, "text")
-      val partitionDirectory2 = new File(dir, s"A=2")
+      val partitionDirectory2 = new File(dir, "A=2")
       partitionDirectory2.mkdir()
       val file2 = new File(partitionDirectory2, "text.txt")
       stringToFile(file2, "text")
@@ -88,6 +88,8 @@ class FileIndexSuite extends SharedSQLContext {
           val fileIndex = new InMemoryFileIndex(spark, Seq(path), Map.empty, None)
           fileIndex.partitionSpec()
         }.getMessage
+        msg.matches("Partition column name list #[0,1]: A")
+        msg.matches("Partition column name list #[0,1]: a")
         assert(msg.contains("Conflicting partition column names detected"))
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Partition column name is required to be unique under the same directory. The following paths are invalid partitioned directory:
```
hdfs://host:9000/path/a=1
hdfs://host:9000/path/b=2
```

If case sensitive, the following paths should be invalid too:
```
hdfs://host:9000/path/a=1
hdfs://host:9000/path/A=2
```
Since column 'a' and 'A' are different, and it is wrong to use either one as the column name in partition schema.

Also, there is a `TODO` comment in the code. Currently the Spark doesn't validate such case when `CASE_SENSITIVE` enabled.

This PR is to resolve the problem.

## How was this patch tested?

Add unit test