### PR TITLE
[SPARK-26232][Build][test-maven] Remove unused dependency to Netty3

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -249,10 +249,6 @@
       <artifactId>netty-all</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.clearspring.analytics</groupId>
       <artifactId>stream</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -594,11 +594,6 @@
         <version>4.1.30.Final</version>
       </dependency>
       <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty</artifactId>
-        <version>3.9.9.Final</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.derby</groupId>
         <artifactId>derby</artifactId>
         <version>${derby.version}</version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removing dependency to Netty3 as it is unused.
The reason it is not collide with Netty4 is they are using different package names:

Netty3: org.jboss.netty.*
Netty4: io.netty.*

## How was this patch tested?

Maven build.