### PR TITLE
[SPARK-26249][SQL] Add ability to inject a rule in order and to add a batch via the Spark Extension Points API

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.rules
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.errors.TreeNodeException
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.trees.TreeNode
 import org.apache.spark.sql.catalyst.util.sideBySide
 import org.apache.spark.sql.internal.SQLConf
@@ -184,3 +185,22 @@ abstract class RuleExecutor[TreeType <: TreeNode[_]] extends Logging {
     }
   }
 }
+
+object Order extends Enumeration{
+  type Order = Value
+  val after = Value(1)
+  val before = Value(2)
+}
+
+case class RuleInOrder(
+    batchName: String,
+    existingRule: String,
+    ruleOrder: Order.Value,
+    rule: Rule[LogicalPlan])
+
+case class RuleBatch(
+    batchName: String,
+    iterations: Int,
+    existingBatchName: String,
+    order: Order.Value,
+    rules: Seq[Rule[LogicalPlan]])

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
@@ -21,9 +21,10 @@ import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionInfo, Literal}
 import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParserInterface}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.rules.{Order, Rule}
 import org.apache.spark.sql.execution.{SparkPlan, SparkStrategy}
 import org.apache.spark.sql.types.{DataType, IntegerType, StructType}
+import org.apache.spark.sql.types.{DataType, StructType}
 
 /**
  * Test cases for the [[SparkSessionExtensions]].
@@ -45,6 +46,13 @@ class SparkSessionExtensionSuite extends SparkFunSuite {
     }
   }
 
+  private def withSession()(f: SparkSession => Unit): Unit = {
+    val spark = SparkSession.builder().master("local[1]").getOrCreate()
+    try f(spark) finally {
+      stop(spark)
+    }
+  }
+
   test("inject analyzer rule") {
     withSession(_.injectResolutionRule(MyRule)) { session =>
       assert(session.sessionState.analyzer.extendedResolutionRules.contains(MyRule(session)))
@@ -60,6 +68,336 @@ class SparkSessionExtensionSuite extends SparkFunSuite {
   test("inject optimizer rule") {
     withSession(_.injectOptimizerRule(MyRule)) { session =>
       assert(session.sessionState.optimizer.batches.flatMap(_.rules).contains(MyRule(session)))
+    }
+  }
+
+  val RMLITERALGRPEXP = "org.apache.spark.sql.catalyst.optimizer.RemoveLiteralFromGroupExpressions"
+  val RMREPGRPEXP = "org.apache.spark.sql.catalyst.optimizer.RemoveRepetitionFromGroupExpressions"
+
+  test("inject optimizer rule in batch order - after") {
+    withSession(_.injectOptimizerRuleInOrder(
+      MyRule1,
+      "Aggregate",
+      Order.after,
+      RMLITERALGRPEXP)) { session =>
+      val rules = Seq(RMLITERALGRPEXP, "org.apache.spark.sql.MyRule1", RMREPGRPEXP)
+      val batch = session.sessionState.optimizer.batches.find(_.name.equals("Aggregate"))
+      assert(batch.isDefined)
+      assert(rules.equals(batch.get.rules.map(_.ruleName)))
+    }
+  }
+
+  test("inject optimizer rule in batch order - before") {
+    withSession(_.injectOptimizerRuleInOrder(
+      MyRule1,
+      "Aggregate",
+      Order.before,
+      RMLITERALGRPEXP)) { session =>
+      val rules = Seq("org.apache.spark.sql.MyRule1", RMLITERALGRPEXP, RMREPGRPEXP)
+      val batch = session.sessionState.optimizer.batches.find(_.name.equals("Aggregate"))
+      assert(batch.isDefined)
+      assert(rules.equals(batch.get.rules.map(_.ruleName)))
+    }
+  }
+
+  test("two inject optimizer rule in batch order - after") {
+    withSession(e => {
+      e.injectOptimizerRuleInOrder(
+        MyRule1,
+        "Aggregate",
+        Order.after,
+        RMLITERALGRPEXP)
+      e.injectOptimizerRuleInOrder(
+        MyRule,
+        "Aggregate",
+        Order.after,
+        RMLITERALGRPEXP)
+    }) { session =>
+      val rules = Seq(RMLITERALGRPEXP,
+        "org.apache.spark.sql.MyRule1", "org.apache.spark.sql.MyRule", RMREPGRPEXP)
+      val batch = session.sessionState.optimizer.batches.find(_.name.equals("Aggregate"))
+      assert(batch.isDefined)
+      assert(rules.equals(batch.get.rules.map(_.ruleName)))
+    }
+  }
+
+  test("two inject optimizer rule to different batches") {
+    withSession(e => {
+      e.injectOptimizerRuleInOrder(
+        MyRule1,
+        "Union",
+        Order.before,
+        "org.apache.spark.sql.catalyst.optimizer.CombineUnions")
+      e.injectOptimizerRuleInOrder(
+        MyRule,
+        "Aggregate",
+        Order.after,
+        RMLITERALGRPEXP)
+    }) { session =>
+      val aggBatch = Seq(RMLITERALGRPEXP, "org.apache.spark.sql.MyRule", RMREPGRPEXP)
+      val batch = session.sessionState.optimizer.batches.find(_.name.equals("Aggregate"))
+      assert(batch.isDefined)
+      assert(aggBatch.equals(batch.get.rules.map(_.ruleName)))
+      val unionBatchRules = Seq("org.apache.spark.sql.MyRule1",
+        "org.apache.spark.sql.catalyst.optimizer.CombineUnions")
+      val unionBatch = session.sessionState.optimizer.batches.find(_.name.equals("Union"))
+      assert(unionBatch.isDefined)
+      assert(unionBatchRules.equals(unionBatch.get.rules.map(_.ruleName)))
+    }
+  }
+
+  test("two rules after and two rules before to a batch") {
+    withSession(e => {
+      e.injectOptimizerRuleInOrder(
+        MyRule,
+        "Union",
+        Order.before,
+        "org.apache.spark.sql.catalyst.optimizer.CombineUnions")
+      e.injectOptimizerRuleInOrder(
+        MyRule1,
+        "Union",
+        Order.before,
+        "org.apache.spark.sql.catalyst.optimizer.CombineUnions")
+      e.injectOptimizerRuleInOrder(
+        MyRule2,
+        "Union",
+        Order.after,
+        "org.apache.spark.sql.catalyst.optimizer.CombineUnions")
+      e.injectOptimizerRuleInOrder(
+        MyRule3,
+        "Union",
+        Order.after,
+        "org.apache.spark.sql.catalyst.optimizer.CombineUnions")
+    }) { session =>
+      val unionBatchRules = Seq("org.apache.spark.sql.MyRule",
+        "org.apache.spark.sql.MyRule1",
+        "org.apache.spark.sql.catalyst.optimizer.CombineUnions",
+        "org.apache.spark.sql.MyRule2",
+        "org.apache.spark.sql.MyRule3")
+      val unionBatch = session.sessionState.optimizer.batches.find(_.name.equals("Union"))
+      assert(unionBatch.isDefined)
+      assert(unionBatchRules.equals(unionBatch.get.rules.map(_.ruleName)))
+    }
+  }
+
+  test("inject optimizer rule in batch order - nonexistent existing rule") {
+    withSession(_.injectOptimizerRuleInOrder(
+      MyRule1,
+      "Aggregate",
+      Order.after,
+      "org.apache.spark.sql.catalyst.optimizer.XYZ")) { session =>
+      val errMsg = intercept[Exception] {
+        session.sessionState.optimizer.batches.find(_.name.equals("Aggregate"))
+      }.getMessage()
+      assert(errMsg.contains("Unable to add the customized optimization rule(s) to " +
+        "batch Aggregate: [org.apache.spark.sql.MyRule1]." ))
+    }
+  }
+
+  test("inject optimizer rule in batch order - 2 nonexistent rule") {
+    withSession(e => {
+      e.injectOptimizerRuleInOrder(
+        MyRule1,
+        "Aggregate",
+        Order.before,
+        "org.apache.spark.sql.catalyst.optimizer.XYZ")
+      e.injectOptimizerRuleInOrder(
+        MyRule,
+        "Aggregate",
+        Order.after,
+        "org.apache.spark.sql.catalyst.optimizeX.RemoveRepetitionFromGroupExpressions")
+    }) { session =>
+      val errMsg = intercept[Exception] {
+        val batch = session.sessionState.optimizer.batches
+      }.getMessage()
+      val expected = "Unable to add the customized optimization rule(s) to batch Aggregate: " +
+        "[org.apache.spark.sql.MyRule1,org.apache.spark.sql.MyRule]"
+      assert(errMsg.contains(expected))
+    }
+  }
+
+  test("inject optimizer rule in batch order - existent and nonexistent after rule") {
+    withSession(e => {
+      e.injectOptimizerRuleInOrder(
+        MyRule1,
+        "Aggregate",
+        Order.after,
+        "org.apache.spark.sql.catalyst.optimizer.XYZ")
+      e.injectOptimizerRuleInOrder(
+        MyRule,
+        "Aggregate",
+        Order.before,
+        RMREPGRPEXP)
+    }) { session =>
+      val errMsg = intercept[Exception] {
+        val batch = session.sessionState.optimizer.batches.find(_.name.equals("Aggregate"))
+      }.getMessage()
+      assert(errMsg.contains("[org.apache.spark.sql.MyRule1]"))
+      assert(!errMsg.contains("[org.apache.spark.sql.MyRule]"))
+    }
+  }
+
+  test("inject optimizer rule in batch order - nonexistent batch") {
+    withSession(e => {
+      e.injectOptimizerRuleInOrder(
+        MyRule1,
+        "Aggregate1",
+        Order.before,
+        "org.apache.spark.sql.catalyst.optimizer.XYZ")
+      e.injectOptimizerRuleInOrder(
+        MyRule,
+        "Aggregate",
+        Order.before,
+        RMREPGRPEXP)
+    }) { session =>
+      val errMsg = intercept[Exception] {
+        val batch = session.sessionState.optimizer.batches
+      }.getMessage()
+      val expected = "Unable to add the customized optimization rule:" +
+        "[(org.apache.spark.sql.MyRule1 to batch Aggregate1)]"
+      assert(errMsg.contains(expected))
+    }
+  }
+
+  test("inject optimizer batch") {
+    val myrules = Seq(MyRule1, MyRule)
+    withSession(_.injectOptimizerBatch("MyBatch", 10, "Aggregate", Order.after, myrules))
+    { session =>
+      val batches = session.sessionState.optimizer.batches.map(_.name)
+      val idx = batches.indexOf("MyBatch")
+      assert(batches.indexOf("Aggregate") == (idx - 1))
+      val mybatch = session.sessionState.optimizer.batches(idx)
+      assert(mybatch.strategy.maxIterations == 10)
+      assert(mybatch.rules.map(_.ruleName).equals
+        (Seq("org.apache.spark.sql.MyRule1", "org.apache.spark.sql.MyRule")))
+    }
+  }
+
+  test("inject multiple optimizer batch order and disable rule") {
+    val myrules = Seq(MyRule1, MyRule)
+    val e = create { extensions =>
+      extensions.injectOptimizerBatch("MyBatch1", 10, "Aggregate", Order.after, myrules)
+      extensions.injectOptimizerBatch("MyBatch2", 20, "Union", Order.before, Seq(MyRule))
+      extensions.injectOptimizerBatch("MyBatch3", 20, "Union", Order.after, Seq(MyRule1))
+      extensions.injectOptimizerBatch("MyBatch4", 20, "Union", Order.after, Seq(MyRule1))
+    }
+    withSession(e) { session =>
+      val batches = session.sessionState.optimizer.batches
+      val batchNames = batches.map(_.name)
+      assert(batchNames.filter(_.equals("Union")).length == 1)
+      assert(batchNames.indexOf("Aggregate") == (batchNames.indexOf("MyBatch1") - 1))
+      val mybatch = batches(batchNames.indexOf("MyBatch1"))
+      assert(mybatch.strategy.maxIterations == 10)
+      assert(mybatch.rules.map(_.ruleName).equals
+        (Seq("org.apache.spark.sql.MyRule1", "org.apache.spark.sql.MyRule")))
+      assert(batchNames.indexOf("Union") == (batchNames.indexOf("MyBatch2") + 1))
+      val batch2 = batches(batchNames.indexOf("MyBatch2"))
+      assert(batch2.strategy.maxIterations == 20)
+      assert(batch2.rules.map(_.ruleName).equals(Seq("org.apache.spark.sql.MyRule")))
+
+      val batch3 = batches(batchNames.indexOf("MyBatch3"))
+      assert(batchNames.indexOf("MyBatch3") == (batchNames.indexOf("Union") + 1))
+      assert(batch3.strategy.maxIterations == 20)
+      assert(batch3.rules.map(_.ruleName).equals(Seq("org.apache.spark.sql.MyRule1")))
+      assert(batchNames.indexOf("MyBatch4") == (batchNames.indexOf("Union") + 2))
+
+      // Disable a rule in the batch.
+      session.conf.set("spark.sql.optimizer.excludedRules", "org.apache.spark.sql.MyRule")
+      val myBatch2 = session.sessionState.optimizer.batches.find(_.name.equals("MyBatch1"))
+      myBatch2.get.rules.map(_.ruleName).equals(Seq("org.apache.spark.sql.MyRule1"))
+    }
+  }
+
+  test("inject optimizer batch - nonexistent batch") {
+    val myrules = Seq(MyRule1, MyRule)
+    withSession(_.injectOptimizerBatch("MyBatch", 10, "nonexistent", Order.after, myrules))
+    { session =>
+      val errMsg = intercept[Exception] {
+        session.sessionState.optimizer.batches.length
+      }.getMessage
+      assert(errMsg.contains("Unable to add optimizer batch: [MyBatch]"))
+    }
+  }
+
+  test("inject optimizer batch - existent and nonexistent after batch") {
+    val myrules = Seq(MyRule1, MyRule)
+    val e = create { extensions =>
+      extensions.injectOptimizerBatch("MyBatch1", 10, "Aggregate", Order.after, myrules)
+      extensions.injectOptimizerBatch("MyBatch2", 20, "Union2", Order.after, myrules)
+      extensions.injectOptimizerBatch("MyBatch", 10, "nonexistent", Order.after, myrules)
+    }
+    withSession(e) { session =>
+      val errMsg = intercept[Exception] {
+        session.sessionState.optimizer.batches
+      }.getMessage
+      assert(errMsg.contains("Unable to add optimizer batch: [MyBatch2,MyBatch]"))
+    }
+  }
+
+  test("existing rule name is in the excluded list") {
+    val afterRuleName = RMLITERALGRPEXP
+    withSession(_.injectOptimizerRuleInOrder(
+      MyRule1,
+      "Aggregate",
+      Order.after,
+      afterRuleName)) { session =>
+      session.conf.set("spark.sql.optimizer.excludedRules", afterRuleName)
+      val errMsg = intercept[Exception] {
+        val batch = session.sessionState.optimizer.batches.find(_.name.equals("Aggregate"))
+      }.getMessage
+      assert(errMsg.contains("Unable to add the customized optimization rule(s) " +
+        "to batch Aggregate: [org.apache.spark.sql.MyRule1]"))
+    }
+  }
+
+  test("exclude a rule") {
+    val excludeRule = RMLITERALGRPEXP
+    withSession(_.injectOptimizerRuleInOrder(
+      MyRule1,
+      "Aggregate",
+      Order.before,
+      RMREPGRPEXP)) { session =>
+      session.conf.set("spark.sql.optimizer.excludedRules", excludeRule)
+      val rules = Seq("org.apache.spark.sql.MyRule1", RMREPGRPEXP)
+      val batch = session.sessionState.optimizer.batches.find(_.name.equals("Aggregate"))
+      assert(batch.isDefined)
+      assert(rules.equals(batch.get.rules.map(_.ruleName)))
+    }
+  }
+
+  test("excluded after rule - removes the batch itself") {
+    val excludeRules = RMLITERALGRPEXP + "," + RMREPGRPEXP
+    withSession(_.injectOptimizerRuleInOrder(
+      MyRule1,
+      "Aggregate",
+      Order.after,
+      RMREPGRPEXP)) { session =>
+      session.conf.set("spark.sql.optimizer.excludedRules", excludeRules)
+      val errMsg = intercept[Exception] {
+        val batch = session.sessionState.optimizer.batches.find(_.name.equals("Aggregate"))
+      }.getMessage
+      assert(errMsg.contains("Unable to add the customized optimization rule(s) to " +
+        "batch Aggregate: [org.apache.spark.sql.MyRule1]"))
+    }
+  }
+
+  test("disable injected rule using the exclude") {
+    val excludeRules = "org.apache.spark.sql.MyRule1"
+    withSession(_.injectOptimizerRuleInOrder(
+      MyRule1,
+      "Aggregate",
+      Order.before,
+      RMLITERALGRPEXP)) { session =>
+      session.conf.set("spark.sql.optimizer.excludedRules", excludeRules)
+      val rules = Seq(RMLITERALGRPEXP, RMREPGRPEXP)
+      val batch = session.sessionState.optimizer.batches.find(_.name.equals("Aggregate"))
+      assert(batch.isDefined)
+      assert(rules.equals(batch.get.rules.map(_.ruleName)))
+      session.conf.set("spark.sql.optimizer.excludedRules", "")
+      val newBatch = session.sessionState.optimizer.batches.find(_.name.equals("Aggregate"))
+      assert(newBatch.isDefined)
+      val newRules = Seq("org.apache.spark.sql.MyRule1", RMLITERALGRPEXP, RMREPGRPEXP)
+      assert(newRules.equals(newBatch.get.rules.map(_.ruleName)))
     }
   }
 
@@ -110,6 +448,10 @@ class SparkSessionExtensionSuite extends SparkFunSuite {
       assert(session.sessionState.analyzer.extendedResolutionRules.contains(MyRule(session)))
       assert(session.sessionState.functionRegistry
         .lookupFunction(MyExtensions.myFunction._1).isDefined)
+      val batch = session.sessionState.optimizer.batches.find(_.name.equals("Aggregate"))
+      assert(batch.isDefined)
+      assert(batch.get.rules.find(_.ruleName.equals("org.apache.spark.sql.MyRule1")).isDefined)
+      assert(batch.get.rules.find(_.ruleName.equals("org.apache.spark.sql.MyRule")).isDefined)
     } finally {
       stop(session)
     }
@@ -117,6 +459,18 @@ class SparkSessionExtensionSuite extends SparkFunSuite {
 }
 
 case class MyRule(spark: SparkSession) extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan = plan
+}
+
+case class MyRule1(spark: SparkSession) extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan = plan
+}
+
+case class MyRule2(spark: SparkSession) extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan = plan
+}
+
+case class MyRule3(spark: SparkSession) extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = plan
 }
 
@@ -160,5 +514,15 @@ class MyExtensions extends (SparkSessionExtensions => Unit) {
     e.injectPlannerStrategy(MySparkStrategy)
     e.injectResolutionRule(MyRule)
     e.injectFunction(MyExtensions.myFunction)
+    e.injectOptimizerRuleInOrder(
+      MyRule1,
+      "Aggregate",
+      Order.after,
+      "org.apache.spark.sql.catalyst.optimizer.RemoveLiteralFromGroupExpressions")
+    e.injectOptimizerRuleInOrder(
+      MyRule,
+      "Aggregate",
+      Order.after,
+      "org.apache.spark.sql.catalyst.optimizer.RemoveLiteralFromGroupExpressions")
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Motivation
Spark has extension points API to allow third parties to extend Spark with custom optimization rules. The current API does not allow fine grain control on when the optimization rule will be exercised. In the current API,  there is no way to add a batch to the optimization using the SparkSessionExtensions API, similar to the postHocOptimizationBatches in SparkOptimizer.
In our use cases, we have optimization rules that we want to add as extensions to a batch in a specific order.

Changes: 
Add two new methods to SparkSessionExtensions to: 
- Inject optimizer rule in a specific order
- Inject optimizer batch. 

Design details is here: 
https://drive.google.com/file/d/1m7rQZ9OZFl0MH5KS12CiIg3upLJSYfsA/view?usp=sharing

## How was this patch tested?
- New unit tests have been added to the SparkSessionExtensionSuite
- Ran the sql, hive, catalyst unit tests without any issues. 