### PR TITLE
[SPARK-19712][SQL] Move PullupCorrelatedPredicates and RewritePredicateSubquery after OptimizeSubqueries

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
@@ -267,6 +267,17 @@ object ScalarSubquery {
       case _ => false
     }.isDefined
   }
+
+  def hasScalarSubquery(e: Expression): Boolean = {
+    e.find {
+      case s: ScalarSubquery => true
+      case _ => false
+    }.isDefined
+  }
+
+  def hasScalarSubquery(e: Seq[Expression]): Boolean = {
+    e.find(hasScalarSubquery(_)).isDefined
+  }
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -120,7 +120,11 @@ object EliminateOuterJoin extends Rule[LogicalPlan] with PredicateHelper {
    * Returns whether the expression returns null or false when all inputs are nulls.
    */
   private def canFilterOutNull(e: Expression): Boolean = {
-    if (!e.deterministic || SubqueryExpression.hasCorrelatedSubquery(e)) return false
+    if (!e.deterministic ||
+      SubqueryExpression.hasCorrelatedSubquery(e) ||
+      SubExprUtils.containsOuter(e)) {
+      return false
+    }
     val attributes = e.references.toSeq
     val emptyRow = new GenericInternalRow(attributes.length)
     val boundE = BindReferences.bindReference(e, attributes)
@@ -147,10 +151,45 @@ object EliminateOuterJoin extends Rule[LogicalPlan] with PredicateHelper {
     }
   }
 
+  private def buildNewJoinType(
+      upperJoin: Join,
+      lowerJoin: Join,
+      otherTableOutput: AttributeSet): JoinType = {
+    val conditions = upperJoin.constraints
+    // Find the predicates reference only on the other table.
+    val localConditions = conditions.filter(_.references.subsetOf(otherTableOutput))
+    // Find the predicates reference either the left table or the join predicates
+    // between the left table and the other table.
+    val leftConditions = conditions.filter(_.references.
+      subsetOf(lowerJoin.left.outputSet ++ otherTableOutput)).diff(localConditions)
+    // Find the predicates reference either the right table or the join predicates
+    // between the right table and the other table.
+    val rightConditions = conditions.filter(_.references.
+      subsetOf(lowerJoin.right.outputSet ++ otherTableOutput)).diff(localConditions)
+
+    val leftHasNonNullPredicate = leftConditions.exists(canFilterOutNull)
+    val rightHasNonNullPredicate = rightConditions.exists(canFilterOutNull)
+
+    lowerJoin.joinType match {
+      case RightOuter if leftHasNonNullPredicate => Inner
+      case LeftOuter if rightHasNonNullPredicate => Inner
+      case FullOuter if leftHasNonNullPredicate && rightHasNonNullPredicate => Inner
+      case FullOuter if leftHasNonNullPredicate => LeftOuter
+      case FullOuter if rightHasNonNullPredicate => RightOuter
+      case o => o
+    }
+  }
+
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
     case f @ Filter(condition, j @ Join(_, _, RightOuter | LeftOuter | FullOuter, _)) =>
       val newJoinType = buildNewJoinType(f, j)
       if (j.joinType == newJoinType) f else Filter(condition, j.copy(joinType = newJoinType))
+    case j @ Join(child @ Join(_, _, RightOuter | LeftOuter | FullOuter, _),
+      subquery, LeftSemiOrAnti(joinType), joinCond) =>
+      val newJoinType = buildNewJoinType(j, child, subquery.outputSet)
+      if (newJoinType == child.joinType) j else {
+        Join(child.copy(joinType = newJoinType), subquery, joinType, joinCond)
+      }
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/joinTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/joinTypes.scala
@@ -114,3 +114,10 @@ object LeftExistence {
     case _ => None
   }
 }
+
+object LeftSemiOrAnti {
+  def unapply(joinType: JoinType): Option[JoinType] = joinType match {
+    case LeftSemi | LeftAnti => Some(joinType)
+    case _ => None
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -314,7 +314,7 @@ case class Join(
         left.constraints
           .union(right.constraints)
           .union(splitConjunctivePredicates(condition.get).toSet)
-      case LeftSemi if condition.isDefined =>
+      case LeftSemi | LeftAnti if condition.isDefined =>
         left.constraints
           .union(splitConjunctivePredicates(condition.get).toSet)
       case j: ExistenceJoin =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
@@ -17,39 +17,43 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.analysis.EmptyFunctionRegistry
+import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions.ListQuery
 import org.apache.spark.sql.catalyst.plans.{LeftSemi, PlanTest}
-import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
-import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
+import org.apache.spark.sql.internal.SQLConf
+
 
 
 class RewriteSubquerySuite extends PlanTest {
+  object Optimize extends Optimizer(
+    new SessionCatalog(
+      new InMemoryCatalog,
+      EmptyFunctionRegistry,
+      new SQLConf()))
 
-  object Optimize extends RuleExecutor[LogicalPlan] {
-    val batches =
-      Batch("Column Pruning", FixedPoint(100), ColumnPruning) ::
-      Batch("Rewrite Subquery", FixedPoint(1),
-        RewritePredicateSubquery,
-        ColumnPruning,
-        CollapseProject,
-        RemoveRedundantProject) :: Nil
-  }
 
   test("Column pruning after rewriting predicate subquery") {
-    val relation = LocalRelation('a.int, 'b.int)
-    val relInSubquery = LocalRelation('x.int, 'y.int, 'z.int)
+      val schema1 = LocalRelation('a.int, 'b.int)
+      val schema2 = LocalRelation('x.int, 'y.int, 'z.int)
 
-    val query = relation.where('a.in(ListQuery(relInSubquery.select('x)))).select('a)
+      val relation = LocalRelation.fromExternalRows(schema1.output, Seq(Row(1, 1)))
+      val relInSubquery = LocalRelation.fromExternalRows(schema2.output, Seq(Row(1, 1, 1)))
 
-    val optimized = Optimize.execute(query.analyze)
-    val correctAnswer = relation
-      .select('a)
-      .join(relInSubquery.select('x), LeftSemi, Some('a === 'x))
-      .analyze
+      val query = relation.where('a.in(ListQuery(relInSubquery.select('x)))).select('a)
 
-    comparePlans(optimized, correctAnswer)
+      val optimized = Optimize.execute(query.analyze)
+
+      val correctAnswer = relation
+        .select('a)
+        .join(relInSubquery.select('x), LeftSemi, Some('a === 'x))
+        .analyze
+
+      comparePlans(optimized, Optimize.execute(correctAnswer))
   }
 
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/LeftSemiOrAntiPushdownSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/LeftSemiOrAntiPushdownSuite.scala
@@ -1,0 +1,775 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.test.SharedSQLContext
+
+/*
+ * Writing test cases using combinatorial testing technique
+ * Dimension 1: (A) Exists or (B) In
+ * Dimension 2: (A) LeftSemi, (B) LeftAnti, or (C) ExistenceJoin
+ * Dimension 3: (A) Join over Project, (B) Join over Agg, (C) Join over Window,
+ *              (D) Join over Union, or (E) Join over other UnaryNode
+ * Dimension 4: (A) join condition is column or (B) expression
+ * Dimension 5: Subquery is (A) a single table, or (B) more than one table
+ * Dimension 6: Parent side is (A) a single table, or (B) more than one table
+ */
+class LeftSemiOrAntiPushdownSuite extends QueryTest with SharedSQLContext {
+
+  import testImplicits._
+  import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Join}
+  import org.apache.spark.sql.catalyst.plans.LeftSemiOrAnti
+
+  setupTestData()
+
+  val row = identity[(java.lang.Integer, java.lang.Integer, java.lang.Integer)](_)
+
+  lazy val t1 = Seq(
+    row((1, 1, 1)),
+    row((1, 2, 2)),
+    row((2, 1, null)),
+    row((3, 1, 2)),
+    row((null, 0, 3)),
+    row((4, null, 2)),
+    row((0, -1, null))).toDF("t1a", "t1b", "t1c")
+
+  lazy val t2 = Seq(
+    row((1, 1, 1)),
+    row((2, 1, 1)),
+    row((2, 1, null)),
+    row((3, 3, 3)),
+    row((3, 1, 0)),
+    row((null, null, 1)),
+    row((0, 0, -1))).toDF("t2a", "t2b", "t2c")
+
+  lazy val t3 = Seq(
+    row((1, 1, 1)),
+    row((2, 1, 0)),
+    row((2, 1, null)),
+    row((10, 4, -1)),
+    row((3, 2, 0)),
+    row((-2, 1, -1)),
+    row((null, null, null))).toDF("t3a", "t3b", "t3c")
+
+  lazy val t4 = Seq(
+    row((1, 1, 2)),
+    row((1, 2, 1)),
+    row((2, 1, null))).toDF("t4a", "t4b", "t4c")
+
+  lazy val t5 = Seq(
+    row((1, 1, 1)),
+    row((2, null, 0)),
+    row((2, 1, null))).toDF("t5a", "t5b", "t5c")
+
+  protected override def beforeAll(): Unit = {
+    super.beforeAll()
+    t1.createOrReplaceTempView("t1")
+    t2.createOrReplaceTempView("t2")
+    t3.createOrReplaceTempView("t3")
+    t4.createOrReplaceTempView("t4")
+    t5.createOrReplaceTempView("t5")
+  }
+
+  private def checkLeftSemiOrAntiPlan(plan: LogicalPlan): Unit = {
+    plan match {
+      case j@Join(_, _, LeftSemiOrAnti(_), _) =>
+      // This is the expected result.
+      case _ =>
+        fail(
+          s"""
+             |== FAIL: Top operator must be a LeftSemi or LeftAnti ===
+             |${plan.toString}
+           """.stripMargin)
+    }
+  }
+
+  /**
+   * TC 1.1: 1A-2B-3A-4B-5A-6A
+   * Expected result: LeftAnti below Project
+   * Note that the expression T1A+1 is evaluated twice in Join and Project
+   *
+   * TC 1.1.1: Comparing to Inner, we do not push down Inner join under Project
+   *
+   * SELECT TX.*
+   * FROM   (SELECT T1A+1 T1A1, T1B
+   * FROM   T1
+   * WHERE  T1A > 2) TX, T2
+   * WHERE  T2A = T1A1
+   */
+  test("TC 1.1: LeftSemi/LeftAnti over Project") {
+    val plan1 =
+      sql(
+        """
+          | select *
+          | from   (select t1a+1 t1a1, t1b
+          |         from   t1
+          |         where  t1a > 2) tx
+          | where  not exists (select 1
+          |                    from   t2
+          |                    where  t2a = t1a1)
+        """.stripMargin)
+    val plan2 =
+      sql(
+        """
+          | select t1a+1 t1a1, t1b
+          | from   t1
+          | where  t1a > 2
+          | and    not exists (select 1
+          |                    from   t2
+          |                    where  t2a = t1a+1)
+        """.stripMargin)
+    checkAnswer(plan1, plan2)
+    comparePlans(plan1.queryExecution.optimizedPlan, plan2.queryExecution.optimizedPlan)
+  }
+
+  /**
+   * TC 1.2: 1B-2A-3B-4B-5B-6A
+   * Expected result: LeftSemi below Aggregate
+   */
+  test("TC 1.2: LeftSemi/LeftAnti over Aggregate") {
+    val plan1 =
+      sql(
+        """
+          | select *
+          | from   (select   sum(t1a), coalesce(t1c, 0) t1c_expr
+          |         from     t1
+          |         group by coalesce(t1c, 0)) tx
+          | where  t1c_expr in (select t2b
+          |                     from   t2, t3
+          |                     where  t2a = t3a)
+        """.stripMargin)
+    val plan2 =
+      sql(
+        """
+          | select *
+          | from   (select   sum(t1a), coalesce(t1c, 0) t1c_expr
+          |         from     t1
+          |         where    coalesce(t1c, 0) in (select t2b
+          |                                       from   t2, t3
+          |                                       where  t2a = t3a)
+          |         group by coalesce(t1c, 0)) tx
+        """.stripMargin)
+    checkAnswer(plan1, plan2)
+    comparePlans(plan1.queryExecution.optimizedPlan, plan2.queryExecution.optimizedPlan)
+  }
+
+  /**
+   * TC 1.3: 1A-2A-3C-4B-5A-6A
+   * Expected result: LeftSemi below Window
+   *
+   * Variations that yield no push down
+   *
+   * TC 1.3.1: We do not match T1B1 to the expression T1B+1 in the PARTITION BY clause
+   * hence no push down.
+   *
+   * SELECT *
+   * FROM (SELECT T1B+1 as T1B1, SUM(T1B * T1A) OVER (PARTITION BY T1B+1) SUM
+   * FROM   T1) TX
+   * WHERE EXISTS (SELECT 1 FROM T2 WHERE T2B = TX.T1B1)
+   *
+   * TC 1.3.2: With the additional column Exists from the ExistenceJoin that does not exist
+   * in Window, and we do not add a compensation, the result is
+   * we don't push down ExistenceJoin under a Window.
+   *
+   * SELECT *
+   * FROM (SELECT T1B, SUM(T1B * T1A) OVER (PARTITION BY T1B) SUM
+   * FROM   T1) TX
+   * WHERE EXISTS (SELECT 1 FROM T2 WHERE T2B = TX.T1B)
+   * OR T1B1 > 1
+   */
+   test("TC 1.3: LeftSemi/LeftAnti over Window") {
+
+    val plan1 =
+      sql(
+        """
+          | select *
+          | from   (select t1b, sum(t1b * t1a) over (partition by t1b) sum
+          |         from   t1) tx
+          | where  exists (select 1
+          |                from   t2
+          |                where  t2b = tx.t1b)
+        """.stripMargin)
+
+    val plan2 =
+      sql(
+        """
+          | select *
+          | from   (select t1b, sum(t1b * t1a) over (partition by t1b) sum
+          |         from   t1
+          |         where  exists (select 1
+          |                        from   t2
+          |                        where  t2b = t1.t1b)) tx
+        """.stripMargin)
+
+    checkAnswer(plan1, plan2)
+    comparePlans(plan1.queryExecution.optimizedPlan, plan2.queryExecution.optimizedPlan)
+  }
+
+  /**
+   * TC 1.4: 1B-2B-3D-4A-5B-6B
+   * Expected result: LeftAnti below Union
+   */
+  test("TC 1.4: LeftSemi/LeftAnti over Union") {
+    val plan1 =
+      sql(
+        """
+          | select *
+          | from   (select t1a, t1b, t1c
+          |         from   t1, t3
+          |         where  t1a = t3a
+          |         union all
+          |         select t2a, t2b, t2c
+          |         from   t2, t3
+          |         where  t2a = t3a) ua
+          | where  t1c not in (select t4c
+          |                    from   t5, t4
+          |                    where  t5.t5b = t4.t4b)
+        """.stripMargin)
+    val plan2 =
+      sql(
+        """
+          | select *
+          | from   (select t1a, t1b, t1c
+          |         from   t1, t3
+          |         where  t1a = t3a
+          |         and    t1c not in (select t4c
+          |                            from   t5, t4
+          |                            where  t5.t5b = t4.t4b)
+          |         union all
+          |         select t2a, t2b, t2c
+          |         from   t2, t3
+          |         where  t2a = t3a
+          |         and    t2c not in (select t4c
+          |                            from   t5, t4
+          |                            where  t5.t5b = t4.t4b)
+          |        ) ua
+        """.stripMargin)
+    checkAnswer(plan1, plan2)
+    comparePlans(plan1.queryExecution.optimizedPlan, plan2.queryExecution.optimizedPlan)
+  }
+
+  /**
+   * TC 1.5: 1B-2B-3E-4B-5A-6B
+   * Expected result: LeftAnti below Sort
+   */
+  test("TC 1.5: LeftSemi/LeftAnti over other UnaryNode") {
+    val plan1 =
+      sql(
+        """
+          | select *
+          | from   (select   t1a+1 t1a1, t1b, t3c
+          |         from     t1, t3
+          |         where    t1b = t3b
+          |         and      t1a < 3
+          |         order by t1b) tx
+          | where  tx.t1a1 not in (select t2a
+          |                        from   t2
+          |                        where  t2b < 3
+          |                        and    tx.t3c >= 0)
+        """.stripMargin)
+    val plan2 =
+      sql(
+        """
+          | select *
+          | from   (select t1a+1 t1a1, t1b, t3c
+          |         from   t1, t3
+          |         where  t1b = t3b
+          |         and    t1a < 3
+          |         and    t1.t1a+1 not in (select t2a
+          |                                 from   t2
+          |                                 where  t2b < 3
+          |                                 and    t3c >= 0)
+          |         order by t1b) tx
+        """.stripMargin)
+    checkAnswer(plan1, plan2)
+    comparePlans(plan1.queryExecution.optimizedPlan, plan2.queryExecution.optimizedPlan)
+  }
+
+  /**
+   * LeftSemi/LeftAnti over join
+   *
+   * Dimension 1: (A) LeftSemi or (B) LeftAnti
+   * Dimension 2: Join below is (A) Inner (B) LeftOuter (C) RightOuter (D) FullOuter, or,
+   * (E) LeftSemi/LeftAnti
+   * Dimension 3: Subquery correlated to (A) left table (B) right table, (C) both tables,
+   * or, (D) no correlated predicate
+   */
+  /**
+   * TC 2.1: 1A-2A-3A
+   * Expected result: LeftSemi join below Inner join
+   */
+  test("TC 2.1: LeftSemi over inner join") {
+    val plan1 =
+      sql(
+        """
+          | with join as
+          |   (select * from t1 inner join t2 on t1b = t2b and t2a >= 2)
+          | select *
+          | from   join
+          | where  t1a in (select t3a from t3 where t3b >= 1)
+        """.stripMargin)
+    val plan2 =
+      sql(
+        """
+          | select *
+          | from   (select *
+          |         from   t1
+          |         where  t1a in (select t3a from t3 where t3b >= 1)) t1
+          |        inner join t2
+          |        on t1b = t2b and t2a >= 2
+        """.stripMargin)
+    checkAnswer(plan1, plan2)
+    comparePlans(plan1.queryExecution.optimizedPlan, plan2.queryExecution.optimizedPlan)
+  }
+  /**
+   * TC 2.2: 1A-2B-3A
+   * Expected result: LeftSemi join below LeftOuter join
+   */
+  test("TC 2.2: LeftSemi over left outer join with correlated columns on the left table") {
+    val plan1 =
+      sql(
+        """
+          | with join as
+          |   (select * from t1 left join t2 on t1b = t2b and t2c >= 2)
+          | select *
+          | from   join
+          | where  exists (select 1 from t3 where t3a = t1a and t3b >= 1)
+        """.stripMargin)
+    val plan2 =
+      sql(
+        """
+          | select *
+          | from   (select *
+          |         from   t1
+          |         where  exists (select 1 from t3 where t3a = t1a and t3b >= 1)) t1
+          |        left join t2
+          |        on t1b = t2b and t2c >= 2
+        """.stripMargin)
+    checkAnswer(plan1, plan2)
+    comparePlans(plan1.queryExecution.optimizedPlan, plan2.queryExecution.optimizedPlan)
+  }
+  /**
+   * TC 2.3: 1B-2B-3A
+   * Expected result: LeftAnti join below LeftOuter join
+   */
+  test("TC 2.3: LeftAnti over left outer join with correlated columns on the left table") {
+    val plan1 =
+      sql(
+        """
+          | with join as
+          |   (select * from t1 left join t2 on t1b = t2b and t2c >= 2)
+          | select *
+          | from   join
+          | where  not exists (select 1 from t3 where t3a = t1a and t3b >= 1)
+        """.stripMargin)
+    val plan2 =
+      sql(
+        """
+          | select *
+          | from   (select *
+          |         from t1
+          |         where  not exists (select 1 from t3 where t3a = t1a and t3b >= 1)) t1
+          |        left join t2
+          |        on t1b = t2b and t2c >= 2
+        """.stripMargin)
+    checkAnswer(plan1, plan2)
+    comparePlans(plan1.queryExecution.optimizedPlan, plan2.queryExecution.optimizedPlan)
+  }
+  /**
+   * TC 2.4: 1A-2C-3A
+   * Expected result: LeftSemi join below Inner join
+   */
+  test("TC 2.4: LeftSemi over right outer join with correlated columns on the left table") {
+    val plan1 =
+      sql(
+        """
+          | with join as
+          |   (select * from t1 right join t2 on t1b = t2b and t2c is null)
+          | select *
+          | from   join
+          | where  exists (select 1 from t3 where t3a = t1a and t3b >= 1)
+        """.stripMargin)
+    val plan2 =
+      sql(
+        """
+          | select *
+          | from   (select *
+          |         from   t1
+          |         where  exists (select 1 from t3 where t3a = t1a and t3b >= 1)) t1
+          |        inner join t2
+          |        on t1b = t2b and t2c is null
+        """.stripMargin)
+    checkAnswer(plan1, plan2)
+    comparePlans(plan1.queryExecution.optimizedPlan, plan2.queryExecution.optimizedPlan)
+  }
+  /**
+   * TC 2.5: 1B-2C-3B
+   * Expected result: LeftAnti join below RightOuter join
+   * RightOuter does not convert to Inner because NOT IN can return null.
+   */
+  test("TC 2.5: LeftAnti over right outer join with correlated columns on the right table") {
+    val plan1 =
+      sql(
+        """
+          | with join as
+          |   (select * from t1 right join t2 on t1b = t2b and t2c >= 2)
+          | select *
+          | from   join
+          | where  t2a not in (select t3a from t3 where t3b >= 1)
+        """.stripMargin)
+    val plan2 =
+      sql(
+        """
+          | select *
+          | from   t1
+          |        right join
+          |        (select *
+          |         from   t2
+          |         where  t2a not in (select t3a from t3 where t3b >= 1)) t2
+          |        on t1b = t2b and t2c >= 2
+        """.stripMargin)
+    checkAnswer(plan1, plan2)
+    comparePlans(plan1.queryExecution.optimizedPlan, plan2.queryExecution.optimizedPlan)
+  }
+  /**
+   * TC 2.6: 1B-2C-3C
+   * Expected result: No push down
+   */
+  test("TC 2.6: LeftAnti over right outer join with correlated cols on both left and right tbls") {
+    val plan1 =
+      sql(
+        """
+          | with join as
+          |   (select * from t1 right join t2 on t1b = t2b and t2c >= 2)
+          | select *
+          | from   join
+          | where  not exists (select 1 from t3 where t3a = t1a and t3b > t2b)
+        """.stripMargin)
+    val plan2 =
+      sql(
+        """
+          | with join as
+          |   (select * from t1 right join t2 on t1b = t2b and t2c >= 2)
+          | select *
+          | from   join
+          |        left anti join
+          |        (select t3a, t3b
+          |         from   t3
+          |         where  t3a is not null
+          |         and    t3b is not null) t3
+          |        on t3a = t1a and t3b > t2b
+        """.stripMargin)
+    checkAnswer(plan1, plan2)
+    val optPlan = plan1.queryExecution.optimizedPlan
+    checkLeftSemiOrAntiPlan(optPlan)
+  }
+  /**
+   * TC 2.7: 1B-2D-3A
+   * Expected result: LeftAnti join below LeftOuter join
+   */
+  test("TC 2.7: LeftAnti over full outer join with correlated columns on the left table") {
+    val plan1 =
+      sql(
+        """
+          | with join as
+          |   (select * from t1 full join t2 on t1b = t2b and t2c >= 2)
+          | select *
+          | from   join
+          | where  not exists (select 1 from t3 where t3a = t1a and t3b >= 1)
+        """.stripMargin)
+    val plan2 =
+      sql(
+        """
+          | select *
+          | from   (select *
+          |         from   t1
+          |         where  not exists (select 1 from t3 where t3a = t1a and t3b >= 1)) t1
+          |        left join t2
+          |        on t1b = t2b and t2c >= 2
+        """.stripMargin)
+    checkAnswer(plan1, plan2)
+    comparePlans(plan1.queryExecution.optimizedPlan, plan2.queryExecution.optimizedPlan)
+  }
+  /**
+   * TC 2.8: 1A-2D-3B
+   * Expected result: LeftSemi join below RightOuter join
+   */
+  test("TC 2.8: LeftSemi over full outer join with correlated columns on the right table") {
+    val plan1 =
+      sql(
+        """
+          | with join as
+          |   (select * from t1 full join t2 on t1b = t2b and t2c >= 2)
+          | select *
+          | from   join
+          | where  exists (select 1 from t3 where t3a = t2a and t3b >= 1)
+        """.stripMargin)
+    val plan2 =
+      sql(
+        """
+          | select *
+          | from   t1
+          |        right join
+          |        (select *
+          |         from   t2
+          |         where  exists (select 1 from t3 where t3a = t2a and t3b >= 1)) t2
+          |        on t1b = t2b and t2c >= 2
+        """.stripMargin)
+    checkAnswer(plan1, plan2)
+    comparePlans(plan1.queryExecution.optimizedPlan, plan2.queryExecution.optimizedPlan)
+  }
+  /**
+   * TC 2.9: 1A-2E-3A
+   * Expected result: No push down
+   */
+  test("TC 2.9: LeftSemi over left semi join with correlated columns on the left table") {
+    import org.apache.spark.sql.catalyst.plans.logical.Union
+    val plan1 =
+      sql(
+        """
+          | with join as
+          |   (select * from t1 left semi join t2 on t1b = t2b and t2c >= 0)
+          | select *
+          | from   join
+          | where  exists (select 1
+          |                from   (select * from t3
+          |                        union all
+          |                        select * from t4) t3
+          |                where  t3a = t1a and t3c is not null)
+        """.stripMargin)
+    val plan2 =
+      sql(
+        """
+          | with join as
+          |   (select *
+          |    from   t1
+          |           left semi join t2
+          |           on t1b = t2b and t2c >= 0)
+          | select *
+          | from   join
+          |        left semi join
+          |        (select * from t3
+          |         union all
+          |         select * from t4) t3
+          |        on t3a = t1a and t3c is not null
+        """.stripMargin)
+    checkAnswer(plan1, plan2)
+    val optPlan = plan1.queryExecution.optimizedPlan.collectFirst {
+      case j @ Join(_, _, LeftSemiOrAnti(_), _) => j
+    }
+    optPlan match {
+      case Some(j@Join(_, _: Union, LeftSemiOrAnti(_), _)) =>
+      // This is the expected result.
+      case _ =>
+        fail(
+          s"""
+             |== FAIL: The right operand of the top operator must be a Union ===
+             |${optPlan.toString}
+           """.stripMargin)
+    }
+  }
+  /**
+   * TC 2.10: 1A-2A-3C
+   * Expected result: No push down
+   */
+  test("TC 2.10: LeftSemi over inner join with correlated columns on both left and right tables") {
+    val plan1 =
+      sql(
+        """
+          | with join as
+          |   (select * from t1 inner join t2 on t1b = t2b and t2c is null)
+          | select *
+          | from   join
+          | where  exists (select 1 from t3 where t3a = t1a and t3a = t2a)
+        """.stripMargin)
+    val plan2 =
+      sql(
+        """
+          | with join as
+          |   (select *
+          |    from   t1
+          |           inner join t2
+          |           on t1b = t2b and t2c is null)
+          | select *
+          | from   join
+          |        left semi join t3
+          |        on t3a = t1a and t3a = t2a
+        """.stripMargin)
+    checkAnswer(plan1, plan2)
+    val optPlan = plan1.queryExecution.optimizedPlan
+    checkLeftSemiOrAntiPlan(optPlan)
+  }
+  /**
+   * TC 2.11: 1B-2C-3D
+   * Expected result: LeftSemi join below RightOuter join
+   */
+  test("TC 2.11: LeftAnti over right outer join with no correlated columns") {
+    val plan1 =
+      sql(
+        """
+          | with join as
+          |   (select * from t1 right join t2 on t1b = t2b and t2c >= 2)
+          | select *
+          | from   join
+          | where  not exists (select 1 from t3 where t3b < -1)
+        """.stripMargin)
+    val plan2 =
+      sql(
+        """
+          | select *
+          | from   t1
+          |        right outer join
+          |        (select *
+          |         from   t2
+          |         where  not exists (select 1 from t3 where t3b < -1)) t2
+          |        on t1b = t2b and t2c >= 2
+        """.stripMargin)
+    checkAnswer(plan1, plan2)
+    comparePlans(plan1.queryExecution.optimizedPlan, plan2.queryExecution.optimizedPlan)
+  }
+  /**
+   * TC 2.12: 1B-2D-3D
+   * Expected result: LeftSemi join below RightOuter join
+   */
+  test("TC 2.12: LeftAnti over full outer join with no correlated columns") {
+    val plan1 =
+      sql(
+        """
+          | with join as
+          |   (select * from t1 full join t2 on t1b = t2b and t2c >= 0)
+          | select *
+          | from   join
+          | where  not exists (select 1 from t3 where t3b < -1)
+          | and    (t1c = 1 or t1c is null)
+        """.stripMargin)
+    val plan2 =
+      sql(
+        """
+          | with join as
+          |   (select * from t1 full join t2 on t1b = t2b and t2c >= 0)
+          | select *
+          | from   join
+          |        left anti join t3
+          |        on t3b < -1
+          | where  (t1c = 1 or t1c is null)
+        """.stripMargin)
+    checkAnswer(plan1, plan2)
+    comparePlans(plan1.queryExecution.optimizedPlan, plan2.queryExecution.optimizedPlan)
+  }
+  /**
+   * TC 3.1: Negative case - LeftSemi over Aggregate
+   * Expected result: No push down
+   */
+  test("TC 3.1: Negative case - LeftSemi over Aggregate") {
+    val plan1 =
+      sql(
+        """
+          | select   t1b, min(t1a) as min
+          | from     t1 b
+          | group by t1b
+          | having   t1b in (select t1b+1
+          |                  from   t1 a
+          |                  where  a.t1a = min(b.t1a) )
+        """.stripMargin)
+    val plan2 =
+      sql(
+        """
+          | select   b.*
+          | from     (select   t1b, min(t1a) as min
+          |           from     t1
+          |           group by t1b) b
+          |          left semi join t1
+          |          on  b.t1b = t1.t1b+1
+          |          and b.min = t1.t1a
+          |          and t1.t1a is not null
+        """.stripMargin)
+    checkAnswer(plan1, plan2)
+    val optPlan = plan1.queryExecution.optimizedPlan
+    checkLeftSemiOrAntiPlan(optPlan)
+  }
+  /**
+   * TC 3.2: Negative case - LeftAnti over Window
+   * Expected result: No push down
+   */
+  test("TC 3.2: Negative case - LeftAnti over Window") {
+
+    val plan1 =
+      sql(
+        """
+          | select   b.t1b, b.min
+          | from     (select t1b, min(t1a) over (partition by t1b) min
+          |           from   t1) b
+          | where    not exists (select 1
+          |                      from   t1 a
+          |                      where  a.t1a = b.min
+          |                      and    a.t1b = b.t1b)
+        """.stripMargin)
+
+    val plan2 =
+      sql(
+        """
+          | select   b.t1b, b.min
+          | from     (select t1b, min(t1a) over (partition by t1b) min
+          |           from   t1) b
+          |          left anti join t1 a
+          |          on  a.t1a = b.min
+          |          and a.t1b = b.t1b
+        """.stripMargin)
+
+    checkAnswer(plan1, plan2)
+    val optPlan = plan1.queryExecution.optimizedPlan
+    checkLeftSemiOrAntiPlan(optPlan)
+  }
+  /**
+   * TC 3.3: Negative case - LeftSemi over Union
+   * Expected result: No push down
+   */
+  test("TC 3.3: Negative case - LeftSemi over Union") {
+    val plan1 =
+      sql(
+        """
+          | select   un.t2b, un.t2a
+          | from     (select t2b, t2a
+          |           from   t2
+          |           union all
+          |           select t3b, t3a
+          |           from   t3) un
+          | where    exists (select 1
+          |                  from   t1 a
+          |                  where  a.t1b = un.t2b
+          |                  and    a.t1a = un.t2a + case when rand() < 0 then 1 else 0 end)
+        """.stripMargin)
+    val plan2 =
+      sql(
+        """
+          | select   un.t2b, un.t2a
+          | from     (select t2b, t2a
+          |           from   t2
+          |           union all
+          |           select t3b, t3a
+          |           from   t3) un
+          |          left semi join t1 a
+          |          on  a.t1b = un.t2b
+          |          and a.t1a = un.t2a
+        """.stripMargin)
+    checkAnswer(plan1, plan2)
+    val optPlan = plan1.queryExecution.optimizedPlan
+    checkLeftSemiOrAntiPlan(optPlan)
+  }
+}
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -169,7 +169,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSQLContext {
 
       val plan = df.queryExecution.executedPlan
       assert(!plan.find(p =>
-        p.isInstanceOf[WholeStageCodegenExec] &&
+        p.isInstanceOf[WholeStageCodegenExec] && p.isInstanceOf[SortMergeJoinExec] &&
           p.asInstanceOf[WholeStageCodegenExec].child.children(0)
             .isInstanceOf[SortMergeJoinExec]).isDefined)
       assert(df.collect() === Array(Row(1), Row(2)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -396,10 +396,10 @@ class SQLMetricsSuite extends SparkFunSuite with SQLMetricsTestUtils with Shared
     val df1 = Seq((1, "1"), (2, "2")).toDF("key", "value")
     val df2 = Seq((1, "1"), (2, "2"), (3, "3"), (4, "4")).toDF("key2", "value")
     // Assume the execution plan is
-    // ... -> BroadcastHashJoin(nodeId = 0)
+    // ... -> BroadcastHashJoin(nodeId = 1)
     val df = df1.join(broadcast(df2), $"key" === $"key2", "leftsemi")
     testSparkPlanMetrics(df, 2, Map(
-      0L -> (("BroadcastHashJoin", Map(
+      1L -> (("BroadcastHashJoin", Map(
         "number of output rows" -> 2L))))
     )
   }


### PR DESCRIPTION
Currently predicate subqueries (IN/EXISTS) are converted to Joins at the end of optimizer in RewritePredicateSubquery. This change moves the rewrite close to beginning of optimizer. The original idea was to keep the subquery expressions in Filter form so that we can push them down as deep as possible. One disadvantage is that, after the subqueries are rewritten in join form, they are not subjected to further optimizations. In this change, we convert the subqueries to join form early in the rewrite phase and then add logic to push the left-semi and left-anti joins down like we do for normal filter ops. I can think of the following advantages : 

1. We will produce consistent optimized plans for subqueries written using SQL dialect and data frame apis or queries using left semi/anti joins directly.
2. Will hopefully make it easier to do the next phase of de-correlations when we open up more cases of de-correlation. In this case, it would be beneficial to expose the rewritten queries to all the other optimization rules, i think.
3. We can now hopefully get-rid of PullupCorrelatedPredicates rule and combine this with RewritePredicateSubquery. I haven't tried it. Will take it on a followup.

(P.S Thanks to Natt for his original work in [here](https://github.com/apache/spark/pull/17520). I have based this pr on his work)

## How was this patch tested?
A new suite LeftSemiOrAntiPushDownSuite is added. Existing subquery suite should verify the results and any potential regressions.
