### PR TITLE
[SPARK-26155] Optimizing the performance of LongToUnsafeRowMap

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -724,8 +724,8 @@ private[execution] final class LongToUnsafeRowMap(val mm: TaskMemoryManager, cap
     writeLong(maxKey)
     writeLong(numKeys)
     writeLong(numValues)
-    writeLong(numKeyLookups)
-    writeLong(numProbes)
+    writeLong(numKeyLookups.longValue())
+    writeLong(numProbes.longValue())
 
     writeLong(array.length)
     writeLongArray(writeBuffer, array, array.length)


### PR DESCRIPTION
## What changes were proposed in this pull request?

To slove @JkSelf report problem at [SPARK-26155](https://issues.apache.org/jira/browse/SPARK-26155), use LongAdder instead of Long of `numKeyLookups` and `numProbes` to reduce add operation times. @JkSelf  test this patch in Intel performance testing environment and run TPCDS sqls after this patch with Spark-2.3 and master no longer slower than  Spark-2.1.

## How was this patch tested?
N/A