### PR TITLE
[SPARK-26264][CORE]It is better to add @transient to field 'locs' for class `ResultTask`.

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala
@@ -56,7 +56,7 @@ private[spark] class ResultTask[T, U](
     stageAttemptId: Int,
     taskBinary: Broadcast[Array[Byte]],
     partition: Partition,
-    locs: Seq[TaskLocation],
+    @transient private var locs: Seq[TaskLocation],
     val outputId: Int,
     localProperties: Properties,
     serializedTaskMetrics: Array[Byte],


### PR DESCRIPTION
## What changes were proposed in this pull request?
The field 'locs' is only used in driver side  for class `ResultTask`, so it is not needed to serialize  when sending the `ResultTask`  to executor.
Although it's not very big, it's very frequent, so we can add` transient` for it  like `ShuffleMapTask`.


## How was this patch tested?
Existed unit tests
