### PR TITLE
[SPARK-25829][SQL][FOLLOWUP] Refactor MapConcat in order to check properly the limit size

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapBuilder.scala
@@ -48,14 +48,14 @@ class ArrayBasedMapBuilder(keyType: DataType, valueType: DataType) extends Seria
   private lazy val keyGetter = InternalRow.getAccessor(keyType)
   private lazy val valueGetter = InternalRow.getAccessor(valueType)
 
-  def put(key: Any, value: Any, withSizeCheck: Boolean = false): Unit = {
+  def put(key: Any, value: Any): Unit = {
     if (key == null) {
       throw new RuntimeException("Cannot use null as map key.")
     }
 
     val index = keyToIndex.getOrDefault(key, -1)
     if (index == -1) {
-      if (withSizeCheck && size >= ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH) {
+      if (size >= ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH) {
         throw new RuntimeException(s"Unsuccessful attempt to build maps with $size elements " +
           s"due to exceeding the map size limit ${ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH}.")
       }
@@ -81,11 +81,10 @@ class ArrayBasedMapBuilder(keyType: DataType, valueType: DataType) extends Seria
       throw new RuntimeException(
         "The key array and value array of MapData must have the same length.")
     }
-    val sizeCheckRequired =
-      size + keyArray.numElements() > ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH
+
     var i = 0
     while (i < keyArray.numElements()) {
-      put(keyGetter(keyArray, i), valueGetter(valueArray, i), withSizeCheck = sizeCheckRequired)
+      put(keyGetter(keyArray, i), valueGetter(valueArray, i))
       i += 1
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapBuilder.scala
@@ -56,7 +56,7 @@ class ArrayBasedMapBuilder(keyType: DataType, valueType: DataType) extends Seria
     val index = keyToIndex.getOrDefault(key, -1)
     if (index == -1) {
       if (withSizeCheck && size >= ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH) {
-        throw new RuntimeException(s"Unsuccessful attempt to concat maps with $size elements " +
+        throw new RuntimeException(s"Unsuccessful attempt to build maps with $size elements " +
           s"due to exceeding the map size limit ${ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH}.")
       }
       keyToIndex.put(key, values.length)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The PR starts from the [comment](https://github.com/apache/spark/pull/23124#discussion_r236112390) in the main one and it aims at:
 - simplifying the code for `MapConcat`;
 - be more precise in checking the limit size.

## How was this patch tested?

existing tests
