### PR TITLE
[SPARK-26269][YARN]Yarnallocator should have same blacklist behaviour with yarn to maxmize use of cluster resource

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -618,14 +618,14 @@ private[yarn] class YarnAllocator(
             // oop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/ap
             // ache/hadoop/yarn/util/Apps.java#L273 for details)
             if (NOT_APP_AND_SYSTEM_FAULT_EXIT_STATUS.contains(other_exit_status)) {
-              (true, s"Container marked as failed: $containerId$onHostStr" +
-                s". Exit status:  ${completedContainer.getExitStatus}" +
+              (false, s"Container marked as failed: $containerId$onHostStr" +
+                s". Exit status: ${completedContainer.getExitStatus}" +
                 s". Diagnostics: ${completedContainer.getDiagnostics}.")
             } else {
               // completed container from a bad node
               allocatorBlacklistTracker.handleResourceAllocationFailure(hostOpt)
               (true, s"Container from a bad node: $containerId$onHostStr" +
-                s". Exit status:  ${completedContainer.getExitStatus}" +
+                s". Exit status: ${completedContainer.getExitStatus}" +
                 s". Diagnostics: ${completedContainer.getDiagnostics}.")
             }
 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -612,16 +612,23 @@ private[yarn] class YarnAllocator(
             val message = "Container killed by YARN for exceeding physical memory limits. " +
               s"$diag Consider boosting ${EXECUTOR_MEMORY_OVERHEAD.key}."
             (true, message)
-          case exit_status if NOT_APP_AND_SYSTEM_FAULT_EXIT_STATUS.contains(exit_status) =>
-            (true, "Container marked as failed: " + containerId + onHostStr +
-              ". Exit status: " + completedContainer.getExitStatus +
-              ". Diagnostics: " + completedContainer.getDiagnostics)
-          case _ =>
-            // completed container from a bad node
-            allocatorBlacklistTracker.handleResourceAllocationFailure(hostOpt)
-            (true, "Container from a bad node: " + containerId + onHostStr +
-              ". Exit status: " + completedContainer.getExitStatus +
-              ". Diagnostics: " + completedContainer.getDiagnostics)
+          case other_exit_status =>
+            // SPARK-26269: follow YARN's blacklisting behaviour(see https://github
+            // .com/apache/hadoop/blob/228156cfd1b474988bc4fedfbf7edddc87db41e3/had
+            // oop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/ap
+            // ache/hadoop/yarn/util/Apps.java#L273 for details)
+            if (NOT_APP_AND_SYSTEM_FAULT_EXIT_STATUS.contains(other_exit_status)) {
+              (true, s"Container marked as failed: $containerId$onHostStr" +
+                s". Exit status:  ${completedContainer.getExitStatus}" +
+                s". Diagnostics: ${completedContainer.getDiagnostics}.")
+            } else {
+              // completed container from a bad node
+              allocatorBlacklistTracker.handleResourceAllocationFailure(hostOpt)
+              (true, s"Container from a bad node: $containerId$onHostStr" +
+                s". Exit status:  ${completedContainer.getExitStatus}" +
+                s". Diagnostics: ${completedContainer.getDiagnostics}.")
+            }
+
 
         }
         if (exitCausedByApp) {
@@ -749,11 +756,6 @@ private object YarnAllocator {
   val PMEM_EXCEEDED_EXIT_CODE = -104
 
   val NOT_APP_AND_SYSTEM_FAULT_EXIT_STATUS = Set(
-    ContainerExitStatus.SUCCESS,
-    ContainerExitStatus.PREEMPTED,
-    ContainerExitStatus.KILLED_EXCEEDED_VMEM,
-    ContainerExitStatus.KILLED_EXCEEDED_PMEM,
-
     ContainerExitStatus.KILLED_BY_RESOURCEMANAGER,
     ContainerExitStatus.KILLED_BY_APPMASTER,
     ContainerExitStatus.KILLED_AFTER_APP_COMPLETION,

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -612,7 +612,7 @@ private[yarn] class YarnAllocator(
             val message = "Container killed by YARN for exceeding physical memory limits. " +
               s"$diag Consider boosting ${EXECUTOR_MEMORY_OVERHEAD.key}."
             (true, message)
-          case exit_code if NOT_APP_AND_SYSTEM_FAULT_EXIT_STATUS.contains(exit_code) =>
+          case exit_status if NOT_APP_AND_SYSTEM_FAULT_EXIT_STATUS.contains(exit_status) =>
             (true, "Container marked as failed: " + containerId + onHostStr +
               ". Exit status: " + completedContainer.getExitStatus +
               ". Diagnostics: " + completedContainer.getDiagnostics)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocatorBlacklistTracker.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocatorBlacklistTracker.scala
@@ -120,7 +120,9 @@ private[spark] class YarnAllocatorBlacklistTracker(
     if (removals.nonEmpty) {
       logInfo(s"removing nodes from YARN application master's blacklist: $removals")
     }
-    amClient.updateBlacklist(additions.asJava, removals.asJava)
+    if (additions.nonEmpty || removals.nonEmpty) {
+      amClient.updateBlacklist(additions.asJava, removals.asJava)
+    }
     currentBlacklistedYarnNodes = nodesToBlacklist
   }
 

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorBlacklistTrackerSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorBlacklistTrackerSuite.scala
@@ -87,7 +87,7 @@ class YarnAllocatorBlacklistTrackerSuite extends SparkFunSuite with Matchers
     // expired blacklisted nodes (simulating a resource request)
     yarnBlacklistTracker.setSchedulerBlacklistedNodes(Set("host1", "host2"))
     // no change is communicated to YARN regarding the blacklisting
-    verify(amClientMock).updateBlacklist(Collections.emptyList(), Collections.emptyList())
+    verify(amClientMock, times(0)).updateBlacklist(Collections.emptyList(), Collections.emptyList())
   }
 
   test("combining scheduler and allocation blacklist") {

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
@@ -17,8 +17,9 @@
 
 package org.apache.spark.deploy.yarn
 
-import scala.collection.JavaConverters._
+import java.util.{Arrays, Collections}
 
+import scala.collection.JavaConverters._
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.yarn.api.records._
 import org.apache.hadoop.yarn.client.api.AMRMClient
@@ -27,10 +28,10 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito._
 import org.scalatest.{BeforeAndAfterEach, Matchers}
-
 import org.apache.spark.{SecurityManager, SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.yarn.YarnSparkHadoopUtil._
 import org.apache.spark.deploy.yarn.config._
+import org.apache.spark.internal.config.{BLACKLIST_TIMEOUT_CONF, MAX_FAILED_EXEC_PER_NODE}
 import org.apache.spark.rpc.RpcEndpointRef
 import org.apache.spark.scheduler.SplitInfo
 import org.apache.spark.util.ManualClock
@@ -416,5 +417,49 @@ class YarnAllocatorSuite extends SparkFunSuite with Matchers with BeforeAndAfter
 
     clock.advance(50 * 1000L)
     handler.getNumExecutorsFailed should be (0)
+  }
+
+  test("YarnAllocator should have same blacklist behaviour with YARN") {
+    val amrmClientMock = mock(classOf[AMRMClient[ContainerRequest]])
+
+    val handler = createAllocator(
+      2,
+      amrmClientMock,
+      Map(
+        "spark.yarn.blacklist.executor.launch.blacklisting.enabled" -> "true",
+        "spark.blacklist.application.maxFailedExecutorsPerNode" -> "0"))
+    val container1 = createContainer("host1")
+    handler.updateResourceRequests()
+    handler.handleAllocatedContainers(Array(container1))
+
+    val cs1 = ContainerStatus.newInstance(container1.getId, ContainerState.COMPLETE,
+      "success", ContainerExitStatus.SUCCESS)
+    val cs2 = ContainerStatus.newInstance(container1.getId, ContainerState.COMPLETE,
+      "preempted", ContainerExitStatus.PREEMPTED)
+    val cs3 = ContainerStatus.newInstance(container1.getId, ContainerState.COMPLETE,
+      "killed_exceeded_vmem", ContainerExitStatus.KILLED_EXCEEDED_VMEM)
+    val cs4 = ContainerStatus.newInstance(container1.getId, ContainerState.COMPLETE,
+      "killed_exceeded_pmem", ContainerExitStatus.KILLED_EXCEEDED_PMEM)
+    val cs5 = ContainerStatus.newInstance(container1.getId, ContainerState.COMPLETE,
+      "killed_by_resourcemanager", ContainerExitStatus.KILLED_BY_RESOURCEMANAGER)
+    val cs6 = ContainerStatus.newInstance(container1.getId, ContainerState.COMPLETE,
+      "killed_by_appmaster", ContainerExitStatus.KILLED_BY_APPMASTER)
+    val cs7 = ContainerStatus.newInstance(container1.getId, ContainerState.COMPLETE,
+      "killed_after_app_completion", ContainerExitStatus.KILLED_AFTER_APP_COMPLETION)
+    val cs8 = ContainerStatus.newInstance(container1.getId, ContainerState.COMPLETE,
+      "aborted", ContainerExitStatus.ABORTED)
+    val cs9 = ContainerStatus.newInstance(container1.getId, ContainerState.COMPLETE,
+      "disk_failed", ContainerExitStatus.DISKS_FAILED)
+    handler.processCompletedContainers(Seq(cs1, cs2, cs3, cs4, cs5, cs6, cs7, cs8, cs9))
+
+    verify(amrmClientMock, never())
+      .updateBlacklist(Arrays.asList("host1"), Collections.emptyList())
+
+    val cs10 = ContainerStatus.newInstance(container1.getId, ContainerState.COMPLETE,
+      "invalid", ContainerExitStatus.INVALID)
+    handler.processCompletedContainers(Seq(cs10))
+    verify(amrmClientMock)
+      .updateBlacklist(Arrays.asList("host1"), Collections.emptyList())
+
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

As I mentioned in jira [SPARK-26269](https://issues.apache.org/jira/browse/SPARK-26269), in order to maxmize the use of cluster resource,  this pr try to make `YarnAllocator` have the same blacklist behaviour with YARN.

## How was this patch tested?

Added.