### PR TITLE
[SPARK-26279][CORE] Remove unused method in Logging

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/Logging.scala
+++ b/core/src/main/scala/org/apache/spark/internal/Logging.scala
@@ -95,10 +95,6 @@ trait Logging {
     if (log.isErrorEnabled) log.error(msg, throwable)
   }
 
-  protected def isTraceEnabled(): Boolean = {
-    log.isTraceEnabled
-  }
-
   protected def initializeLogIfNecessary(isInterpreter: Boolean): Unit = {
     initializeLogIfNecessary(isInterpreter, silent = false)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
The method `Logging.isTraceEnabled` is not used anywhere. We should remove it to avoid confusion.

## How was this patch tested?
Test locally with existing tests.