### PR TITLE
[SPARK-26281][WebUI] Duration column of task table should be executor run time instead of real duration

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -667,8 +667,9 @@ $(document).ready(function () {
                         {data : "launchTime", name: "Launch Time", render: formatDate},
                         {
                             data : function (row, type) {
-                                if (row.duration) {
-                                    return type === 'display' ? formatDuration(row.duration) : row.duration;
+                                // SPARK-26281: Duration column of task table should be executorRunTime instead of real duration
+                                if (row.taskMetrics && row.taskMetrics.executorRunTime) {
+                                    return type === 'display' ? formatDuration(row.taskMetrics.executorRunTime) : row.taskMetrics.executorRunTime;
                                 } else {
                                     return "";
                                 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In PR https://github.com/apache/spark/pull/23081/ , the duration column is changed to executor run time. The behavior is consistent with the summary metrics table and previous Spark version.

However, after PR https://github.com/apache/spark/pull/21688, the issue can be reproduced again.

## How was this patch tested?

Before the change, we can see:

1. The minimum duration in aggregation table doesn't match with the task table below.
2. The sorting order is wrong.
![image](https://user-images.githubusercontent.com/1097932/49533048-f7eecb80-f8f8-11e8-9256-2eb524e81be0.png)

After the change, the issues are fixed:
![image](https://user-images.githubusercontent.com/1097932/49533069-06d57e00-f8f9-11e8-872b-402e3014f557.png)

