### PR TITLE
[SPARK-26283][CORE] Enable reading from open frames of zstd, when reading zstd compressed eventLog

### DIFF
--- a/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
+++ b/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
@@ -43,10 +43,6 @@ trait CompressionCodec {
   def compressedOutputStream(s: OutputStream): OutputStream
 
   def compressedInputStream(s: InputStream): InputStream
-
-  private[spark] def compressedInputStreamForPartialFrame(s: InputStream): InputStream = {
-    compressedInputStream(s)
-  }
 }
 
 private[spark] object CompressionCodec {
@@ -199,14 +195,10 @@ class ZStdCompressionCodec(conf: SparkConf) extends CompressionCodec {
   override def compressedInputStream(s: InputStream): InputStream = {
     // Wrap the zstd input stream in a buffered input stream so that we can
     // avoid overhead excessive of JNI call while trying to uncompress small amount of data.
-    new BufferedInputStream(new ZstdInputStream(s), bufferSize)
-  }
-
-  override def compressedInputStreamForPartialFrame(s: InputStream): InputStream = {
     // SPARK-26283: Enable reading from open frames of zstd (for eg: zstd compressed eventLog
     // Reading). By default `isContinuous` is false, and when we try to read from open frames,
-    // `compressedInputStream` method above throws truncated error exception. This method set
-    // `isContinuous` true to allow reading from open frames.
+    // throws truncated error exception. This method set `isContinuous` true to allow reading
+    // from open frames.
     new BufferedInputStream(new ZstdInputStream(s).setContinuous(true), bufferSize)
   }
 }

--- a/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
+++ b/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
@@ -204,9 +204,9 @@ class ZStdCompressionCodec(conf: SparkConf) extends CompressionCodec {
 
   override def compressedInputStreamForPartialFrame(s: InputStream): InputStream = {
     // SPARK-26283: Enable reading from open frames of zstd (for eg: zstd compressed eventLog
-    // Reading). By default `isContinous` is false, and when we try to read from open frames,
+    // Reading). By default `isContinuous` is false, and when we try to read from open frames,
     // `compressedInputStream` method above throws truncated error exception. This method set
-    // `isContinous` true to allow reading from open frames.
+    // `isContinuous` true to allow reading from open frames.
     new BufferedInputStream(new ZstdInputStream(s).setContinuous(true), bufferSize)
   }
 }

--- a/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
+++ b/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
@@ -43,6 +43,10 @@ trait CompressionCodec {
   def compressedOutputStream(s: OutputStream): OutputStream
 
   def compressedInputStream(s: InputStream): InputStream
+
+  private[spark] def zstdEventLogCompressedInputStream(s: InputStream): InputStream = {
+    compressedInputStream(s)
+  }
 }
 
 private[spark] object CompressionCodec {
@@ -196,5 +200,9 @@ class ZStdCompressionCodec(conf: SparkConf) extends CompressionCodec {
     // Wrap the zstd input stream in a buffered input stream so that we can
     // avoid overhead excessive of JNI call while trying to uncompress small amount of data.
     new BufferedInputStream(new ZstdInputStream(s), bufferSize)
+  }
+
+  override def zstdEventLogCompressedInputStream(s: InputStream): InputStream = {
+    new BufferedInputStream(new ZstdInputStream(s).setContinuous(true), bufferSize)
   }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -402,7 +402,7 @@ private[spark] object EventLoggingListener extends Logging {
       val codec = codecName(log).map { c =>
         codecMap.getOrElseUpdate(c, CompressionCodec.createCodec(new SparkConf, c))
       }
-      codec.map(_.compressedInputStreamForPartialFrame(in)).getOrElse(in)
+      codec.map(_.compressedInputStream(in)).getOrElse(in)
     } catch {
       case e: Throwable =>
         in.close()

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -35,7 +35,7 @@ import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.executor.ExecutorMetrics
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
-import org.apache.spark.io.{CompressionCodec, ZStdCompressionCodec}
+import org.apache.spark.io.CompressionCodec
 import org.apache.spark.util.{JsonProtocol, Utils}
 
 /**
@@ -402,11 +402,7 @@ private[spark] object EventLoggingListener extends Logging {
       val codec = codecName(log).map { c =>
         codecMap.getOrElseUpdate(c, CompressionCodec.createCodec(new SparkConf, c))
       }
-      if(codec.isDefined && codec.get.isInstanceOf[ZStdCompressionCodec]) {
-        codec.map(_.zstdEventLogCompressedInputStream(in)).get
-      } else {
-        codec.map(_.compressedInputStream(in)).getOrElse(in)
-      }
+      codec.map(_.compressedInputStreamForPartialFrame(in)).getOrElse(in)
     } catch {
       case e: Throwable =>
         in.close()

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -402,7 +402,7 @@ private[spark] object EventLoggingListener extends Logging {
       val codec = codecName(log).map { c =>
         codecMap.getOrElseUpdate(c, CompressionCodec.createCodec(new SparkConf, c))
       }
-      codec.map(_.compressedInputStream(in)).getOrElse(in)
+      codec.map(_.compressedContinuousInputStream(in)).getOrElse(in)
     } catch {
       case e: Throwable =>
         in.close()

--- a/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
@@ -118,8 +118,6 @@ private[spark] class ReplayListenerBus extends SparkListenerBus with Logging {
       case e: HaltReplayException =>
         // Just stop replay.
       case _: EOFException if maybeTruncated =>
-      case _: IOException if maybeTruncated =>
-        logWarning(s"Failed to read Spark event log: $sourceName")
       case ioe: IOException =>
         throw ioe
       case e: Exception =>

--- a/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
@@ -118,7 +118,7 @@ private[spark] class ReplayListenerBus extends SparkListenerBus with Logging {
       case e: HaltReplayException =>
         // Just stop replay.
       case _: EOFException if maybeTruncated =>
-      case ioe: IOException if maybeTruncated =>
+      case ioe: IOException =>
         if (maybeTruncated) {
           logWarning(s"Failed to read Spark event log: $sourceName")
         } else {

--- a/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
@@ -118,8 +118,12 @@ private[spark] class ReplayListenerBus extends SparkListenerBus with Logging {
       case e: HaltReplayException =>
         // Just stop replay.
       case _: EOFException if maybeTruncated =>
-      case ioe: IOException =>
-        throw ioe
+      case ioe: IOException if maybeTruncated =>
+        if (maybeTruncated) {
+          logWarning(s"Failed to read Spark event log: $sourceName")
+        } else {
+          throw ioe
+        }
       case e: Exception =>
         logError(s"Exception parsing Spark event log: $sourceName", e)
         logError(s"Malformed line #$lineNumber: $currentLine\n")

--- a/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
@@ -119,11 +119,7 @@ private[spark] class ReplayListenerBus extends SparkListenerBus with Logging {
         // Just stop replay.
       case _: EOFException if maybeTruncated =>
       case ioe: IOException =>
-        if (maybeTruncated) {
-          logWarning(s"Failed to read Spark event log: $sourceName")
-        } else {
-          throw ioe
-        }
+        throw ioe
       case e: Exception =>
         logError(s"Exception parsing Spark event log: $sourceName", e)
         logError(s"Malformed line #$lineNumber: $currentLine\n")


### PR DESCRIPTION
## What changes were proposed in this pull request?
Root cause: Prior to Spark2.4, When we enable zst for eventLog compression, for inprogress application, It always throws exception in the Application UI, when we open from the history server. But after 2.4 it will display the UI information based on the completed frames in the zstd compressed eventLog. But doesn't read incomplete frames for inprogress application.
In this PR, we have added 'setContinous(true)' for reading input stream from eventLog, so that it can read from open frames also. (By default 'isContinous=false' for zstd inputStream and when we try to read an open frame, it throws truncated error)

## How was this patch tested?
Test steps:
1) Add the configurations in the spark-defaults.conf
   (i) spark.eventLog.compress true
   (ii) spark.io.compression.codec zstd 
2) Restart history server
3) bin/spark-shell
4) sc.parallelize(1 to 1000, 1000).count
5) Open app UI from the history server UI

**Before fix**
![screenshot from 2018-12-06 00-01-38](https://user-images.githubusercontent.com/23054875/49537340-bfe28b00-f8ee-11e8-9fca-6d42fdc89e1a.png)

**After fix:**
![screenshot from 2018-12-06 00-34-39](https://user-images.githubusercontent.com/23054875/49537353-ca9d2000-f8ee-11e8-803d-645897b9153b.png)


