### PR TITLE
[SPARK-26285][CORE] accumulator metrics sources for LongAccumulator and Doub…

### DIFF
--- a/core/src/main/scala/org/apache/spark/metrics/source/AccumulatorSource.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/source/AccumulatorSource.scala
@@ -20,6 +20,7 @@ package org.apache.spark.metrics.source
 import com.codahale.metrics.{Gauge, MetricRegistry}
 
 import org.apache.spark.SparkContext
+import org.apache.spark.annotation.Experimental
 import org.apache.spark.util.{AccumulatorV2, DoubleAccumulator, LongAccumulator}
 
 /**
@@ -31,7 +32,7 @@ import org.apache.spark.util.{AccumulatorV2, DoubleAccumulator, LongAccumulator}
  * the CollectionAccumulator, as that is a List of values (hard to report,
  * to a metrics system)
  */
-class AccumulatorSource extends Source {
+private[spark] class AccumulatorSource extends Source {
   private val registry = new MetricRegistry
   protected def register[T](accumulators: Map[String, AccumulatorV2[_, T]]): Unit = {
     accumulators.foreach {
@@ -47,9 +48,19 @@ class AccumulatorSource extends Source {
   override def metricRegistry: MetricRegistry = registry
 }
 
+@Experimental
 class LongAccumulatorSource extends AccumulatorSource
+
+@Experimental
 class DoubleAccumulatorSource extends AccumulatorSource
 
+/**
+ * :: Experimental ::
+ * Metrics source specifically for LongAccumulators.
+ * Register LongAccumulators using:
+ *    LongAccumulatorSource.register(sc, {"name" -> longAccumulator})
+ */
+@Experimental
 object LongAccumulatorSource {
   def register(sc: SparkContext, accumulators: Map[String, LongAccumulator]): Unit = {
     val source = new LongAccumulatorSource
@@ -58,6 +69,13 @@ object LongAccumulatorSource {
   }
 }
 
+/**
+ * :: Experimental ::
+ * Metrics source specifically for DoubleAccumulators.
+ * Register DoubleAccumulators using:
+ *    DoubleAccumulatorSource.register(sc, {"name" -> doubleAccumulator})
+ */
+@Experimental
 object DoubleAccumulatorSource {
   def register(sc: SparkContext, accumulators: Map[String, DoubleAccumulator]): Unit = {
     val source = new DoubleAccumulatorSource

--- a/core/src/main/scala/org/apache/spark/metrics/source/AccumulatorSource.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/source/AccumulatorSource.scala
@@ -56,7 +56,9 @@ class DoubleAccumulatorSource extends AccumulatorSource
 
 /**
  * :: Experimental ::
- * Metrics source specifically for LongAccumulators.
+ * Metrics source specifically for LongAccumulators. Accumulators
+ * are only valid on the driver side, so these metrics are reported
+ * only by the driver.
  * Register LongAccumulators using:
  *    LongAccumulatorSource.register(sc, {"name" -> longAccumulator})
  */
@@ -71,7 +73,9 @@ object LongAccumulatorSource {
 
 /**
  * :: Experimental ::
- * Metrics source specifically for DoubleAccumulators.
+ * Metrics source specifically for DoubleAccumulators. Accumulators
+ * are only valid on the driver side, so these metrics are reported
+ * only by the driver.
  * Register DoubleAccumulators using:
  *    DoubleAccumulatorSource.register(sc, {"name" -> doubleAccumulator})
  */

--- a/core/src/main/scala/org/apache/spark/metrics/source/AccumulatorSource.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/source/AccumulatorSource.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.metrics.source
+
+import com.codahale.metrics.{Gauge, MetricRegistry}
+
+import org.apache.spark.SparkContext
+import org.apache.spark.util.{AccumulatorV2, DoubleAccumulator, LongAccumulator}
+
+/**
+ * AccumulatorSource is a Spark metric Source that reports the current value
+ * of the accumulator as a gauge.
+ *
+ * It is restricted to the LongAccumulator and the DoubleAccumulator, as those
+ * are the current built-in numerical accumulators with Spark, and excludes
+ * the CollectionAccumulator, as that is a List of values (hard to report,
+ * to a metrics system)
+ */
+class AccumulatorSource extends Source {
+  private val registry = new MetricRegistry
+  protected def register[T](accumulators: Map[String, AccumulatorV2[_, T]]): Unit = {
+    accumulators.foreach {
+      case (name, accumulator) =>
+        val gauge = new Gauge[T] {
+          override def getValue: T = accumulator.value
+        }
+        registry.register(MetricRegistry.name(name), gauge)
+    }
+  }
+
+  override def sourceName: String = "AccumulatorSource"
+  override def metricRegistry: MetricRegistry = registry
+}
+
+class LongAccumulatorSource extends AccumulatorSource
+class DoubleAccumulatorSource extends AccumulatorSource
+
+object LongAccumulatorSource {
+  def register(sc: SparkContext, accumulators: Map[String, LongAccumulator]): Unit = {
+    val source = new LongAccumulatorSource
+    source.register(accumulators)
+    sc.env.metricsSystem.registerSource(source)
+  }
+}
+
+object DoubleAccumulatorSource {
+  def register(sc: SparkContext, accumulators: Map[String, DoubleAccumulator]): Unit = {
+    val source = new DoubleAccumulatorSource
+    source.register(accumulators)
+    sc.env.metricsSystem.registerSource(source)
+  }
+}

--- a/core/src/test/scala/org/apache/spark/metrics/source/AccumulatorSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/source/AccumulatorSourceSuite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.metrics.source
 
 import com.codahale.metrics.MetricRegistry
-
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.{mock, never, spy, times, verify, when}
 
@@ -47,7 +46,7 @@ class AccumulatorSourceSuite extends SparkFunSuite {
     assert (gauges.lastKey == "my-accumulator-2")
   }
 
-  test("the accumulators value property is checked when the gauge's value is requested"){
+  test("the accumulators value property is checked when the gauge's value is requested") {
     val acc1 = new LongAccumulator()
     acc1.add(123)
     val acc2 = new LongAccumulator()
@@ -68,7 +67,7 @@ class AccumulatorSourceSuite extends SparkFunSuite {
     assert(gauges.get("my-accumulator-2").getValue() == 456)
   }
 
-  test("the double accumulators value propety is checked when the gauge's value is requested"){
+  test("the double accumulators value propety is checked when the gauge's value is requested") {
     val acc1 = new DoubleAccumulator()
     acc1.add(123.123)
     val acc2 = new DoubleAccumulator()

--- a/core/src/test/scala/org/apache/spark/metrics/source/AccumulatorSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/source/AccumulatorSourceSuite.scala
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.metrics.source
+
+import com.codahale.metrics.MetricRegistry
+
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.{mock, never, spy, times, verify, when}
+
+import org.apache.spark.{SparkContext, SparkEnv, SparkFunSuite}
+import org.apache.spark.metrics.MetricsSystem
+import org.apache.spark.util.{DoubleAccumulator, LongAccumulator}
+
+class AccumulatorSourceSuite extends SparkFunSuite {
+  test("that that accumulators register against the metric system's register") {
+    val acc1 = new LongAccumulator()
+    val acc2 = new LongAccumulator()
+    val mockContext = mock(classOf[SparkContext])
+    val mockEnvironment = mock(classOf[SparkEnv])
+    val mockMetricSystem = mock(classOf[MetricsSystem])
+    when(mockEnvironment.metricsSystem) thenReturn (mockMetricSystem)
+    when(mockContext.env) thenReturn (mockEnvironment)
+    val accs = Map("my-accumulator-1" -> acc1,
+                   "my-accumulator-2" -> acc2)
+    LongAccumulatorSource.register(mockContext, accs)
+    val captor = new ArgumentCaptor[AccumulatorSource]()
+    verify(mockMetricSystem, times(1)).registerSource(captor.capture())
+    val source = captor.getValue()
+    val gauges = source.metricRegistry.getGauges()
+    assert (gauges.size == 2)
+    assert (gauges.firstKey == "my-accumulator-1")
+    assert (gauges.lastKey == "my-accumulator-2")
+  }
+
+  test("the accumulators value property is checked when the gauge's value is requested"){
+    val acc1 = new LongAccumulator()
+    acc1.add(123)
+    val acc2 = new LongAccumulator()
+    acc2.add(456)
+    val mockContext = mock(classOf[SparkContext])
+    val mockEnvironment = mock(classOf[SparkEnv])
+    val mockMetricSystem = mock(classOf[MetricsSystem])
+    when(mockEnvironment.metricsSystem) thenReturn (mockMetricSystem)
+    when(mockContext.env) thenReturn (mockEnvironment)
+    val accs = Map("my-accumulator-1" -> acc1,
+                   "my-accumulator-2" -> acc2)
+    LongAccumulatorSource.register(mockContext, accs)
+    val captor = new ArgumentCaptor[AccumulatorSource]()
+    verify(mockMetricSystem, times(1)).registerSource(captor.capture())
+    val source = captor.getValue()
+    val gauges = source.metricRegistry.getGauges()
+    assert(gauges.get("my-accumulator-1").getValue() == 123)
+    assert(gauges.get("my-accumulator-2").getValue() == 456)
+  }
+
+  test("the double accumulators value propety is checked when the gauge's value is requested"){
+    val acc1 = new DoubleAccumulator()
+    acc1.add(123.123)
+    val acc2 = new DoubleAccumulator()
+    acc2.add(456.456)
+    val mockContext = mock(classOf[SparkContext])
+    val mockEnvironment = mock(classOf[SparkEnv])
+    val mockMetricSystem = mock(classOf[MetricsSystem])
+    when(mockEnvironment.metricsSystem) thenReturn (mockMetricSystem)
+    when(mockContext.env) thenReturn (mockEnvironment)
+    val accs = Map(
+      "my-accumulator-1" -> acc1,
+      "my-accumulator-2" -> acc2)
+    DoubleAccumulatorSource.register(mockContext, accs)
+    val captor = new ArgumentCaptor[AccumulatorSource]()
+    verify(mockMetricSystem, times(1)).registerSource(captor.capture())
+    val source = captor.getValue()
+    val gauges = source.metricRegistry.getGauges()
+    assert(gauges.get("my-accumulator-1").getValue() == 123.123)
+    assert(gauges.get("my-accumulator-2").getValue() == 456.456)
+  }
+}

--- a/examples/src/main/scala/org/apache/spark/examples/AccumulatorMetricsTest.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/AccumulatorMetricsTest.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// scalastyle:off println
+package org.apache.spark.examples
+
+import org.apache.spark.metrics.source.{DoubleAccumulatorSource, LongAccumulatorSource}
+import org.apache.spark.sql.SparkSession
+
+/**
+ * Usage: AccumulatorMetricsTest [partitions] [numElem] [blockSize]
+ */
+object AccumulatorMetricsTest {
+  def main(args: Array[String]) {
+
+    val blockSize = if (args.length > 2) args(2) else "4096"
+
+    val spark = SparkSession
+      .builder()
+      .config("spark.broadcast.blockSize", blockSize)
+      .getOrCreate()
+
+    val sc = spark.sparkContext
+
+    val acc = sc.longAccumulator("my-long-metric")
+    LongAccumulatorSource.register(sc, List(("my-long-metric" -> acc)).toMap)
+
+    val acc2 = sc.doubleAccumulator("my-double-metric")
+    DoubleAccumulatorSource.register(sc, List(("my-double-metric" -> acc2)).toMap)
+
+    val slices = if (args.length > 0) args(0).toInt else 2
+    val num = if (args.length > 1) args(1).toInt else 1000000
+
+    val arr1 = (0 until num).toArray
+
+    for (i <- 0 until 3) {
+      println(s"Iteration $i")
+      println("===========")
+      val startTime = System.nanoTime
+      val barr1 = sc.broadcast(arr1)
+      val observedSizes = sc.parallelize(1 to 10, slices).map(_ => {
+        acc.add(1)
+        acc2.add(1.1)
+        barr1.value.length
+      })
+      // Collect the small RDD so we can print the observed sizes locally.
+      observedSizes.repartition(100).collect().foreach(i => println(i))
+      println("Iteration %d took %.0f milliseconds".format(i, (System.nanoTime - startTime) / 1E6))
+    }
+
+    spark.stop()
+  }
+}
+// scalastyle:on println

--- a/examples/src/main/scala/org/apache/spark/examples/AccumulatorMetricsTest.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/AccumulatorMetricsTest.scala
@@ -22,15 +22,15 @@ import org.apache.spark.metrics.source.{DoubleAccumulatorSource, LongAccumulator
 import org.apache.spark.sql.SparkSession
 
 /**
- * Usage: AccumulatorMetricsTest [numElem] 
+ * Usage: AccumulatorMetricsTest [numElem]
  *
  * This example shows how to register accumulators against the accumulator source.
  * A simple RDD is created, and during the map, the accumulators are incremented.
- * 
- * The only argument, numElem, sets the number elements in the collection to parallize. 
- * 
+ *
+ * The only argument, numElem, sets the number elements in the collection to parallize.
+ *
  * The result is output to stdout in the driver with the values of the accumulators.
- * For the long accumulator, it should equal numElem the double accumulator should be 
+ * For the long accumulator, it should equal numElem the double accumulator should be
  * roughly 1.1 x numElem (within double precision.)
  */
 object AccumulatorMetricsTest {
@@ -38,7 +38,7 @@ object AccumulatorMetricsTest {
 
     val spark = SparkSession
       .builder()
-      .config("spark.metrics.conf.*.sink.console.class", 
+      .config("spark.metrics.conf.*.sink.console.class",
               "org.apache.spark.metrics.sink.ConsoleSink")
       .getOrCreate()
 

--- a/examples/src/main/scala/org/apache/spark/examples/AccumulatorMetricsTest.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/AccumulatorMetricsTest.scala
@@ -31,7 +31,9 @@ import org.apache.spark.sql.SparkSession
  *
  * The result is output to stdout in the driver with the values of the accumulators.
  * For the long accumulator, it should equal numElem the double accumulator should be
- * roughly 1.1 x numElem (within double precision.)
+ * roughly 1.1 x numElem (within double precision.) This example also sets up a
+ * ConsoleSink (metrics) instance, and so registered codahale metrics (like the
+ * accumulator source) are reported to stdout as well.
  */
 object AccumulatorMetricsTest {
   def main(args: Array[String]) {
@@ -45,9 +47,13 @@ object AccumulatorMetricsTest {
     val sc = spark.sparkContext
 
     val acc = sc.longAccumulator("my-long-metric")
+    // register the accumulator, the metric system will report as
+    // [spark.metrics.namespace].[execId|driver].AccumulatorSource.my-long-metric
     LongAccumulatorSource.register(sc, List(("my-long-metric" -> acc)).toMap)
 
     val acc2 = sc.doubleAccumulator("my-double-metric")
+    // register the accumulator, the metric system will report as
+    // [spark.metrics.namespace].[execId|driver].AccumulatorSource.my-double-metric
     DoubleAccumulatorSource.register(sc, List(("my-double-metric" -> acc2)).toMap)
 
     val num = if (args.length > 0) args(0).toInt else 1000000


### PR DESCRIPTION
…leAccumulator

## What changes were proposed in this pull request?

This PR implements metric sources for LongAccumulator and DoubleAccumulator, such that a user can register these accumulators easily and have their values be reported by the driver's metric namespace.

## How was this patch tested?

Unit tests, and manual tests.

Please review http://spark.apache.org/contributing.html before opening a pull request.
