### PR TITLE
[SPARK-26292][CORE]Assert statement of currentPage may be not in right place

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/sort/ShuffleExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/ShuffleExternalSorter.java
@@ -378,6 +378,7 @@ final class ShuffleExternalSorter extends MemoryConsumer {
       pageCursor + required > currentPage.getBaseOffset() + currentPage.size() ) {
       // TODO: try to find space in previous pages
       currentPage = allocatePage(required);
+      assert(currentPage != null);
       pageCursor = currentPage.getBaseOffset();
       allocatedPages.add(currentPage);
     }
@@ -403,7 +404,6 @@ final class ShuffleExternalSorter extends MemoryConsumer {
     final int required = length + uaoSize;
     acquireNewPageIfNecessary(required);
 
-    assert(currentPage != null);
     final Object base = currentPage.getBaseObject();
     final long recordAddress = taskMemoryManager.encodePageNumberAndOffset(currentPage, pageCursor);
     UnsafeAlignedOffset.putSize(base, pageCursor, length);


### PR DESCRIPTION
## What changes were proposed in this pull request?
The assert  statement of currentPage is not in right place，it should be add to the back of 
allocatePage in a function acquireNewPageIfNecessary.

## How was this patch tested?
Existing tests

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
