### PR TITLE
[SPARK-26297][SQL] improve the doc of Distribution/Partitioning

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -24,10 +24,9 @@ import org.apache.spark.sql.types.{DataType, IntegerType}
  * Specifies how tuples that share common expressions will be distributed when a query is executed
  * in parallel on many machines.
  *
- * Distribution here refers to inter-node partitioning of data:
- *   - The distribution describes how tuples are partitioned across physical machines in a cluster.
- *     Knowing this property allows some operators (e.g., Aggregate) to perform partition local
- *     operations instead of global ones.
+ * Distribution here refers to inter-node partitioning of data. That is, it describes how tuples
+ * are partitioned across physical machines in a cluster. Knowing this property allows some
+ * operators (e.g., Aggregate) to perform partition local operations instead of global ones.
  */
 sealed trait Distribution {
   /**
@@ -241,8 +240,8 @@ case class HashPartitioning(expressions: Seq[Expression], numPartitions: Int)
 /**
  * Represents a partitioning where rows are split across partitions based on some total ordering of
  * the expressions specified in `ordering`.  When data is partitioned in this manner, it guarantees:
- *   - Given any 2 adjacent partitions, all the rows of the second partition must be larger than
- *     any row in the first partition, according to the `ordering` expressions.
+ * Given any 2 adjacent partitions, all the rows of the second partition must be larger than any row
+ * in the first partition, according to the `ordering` expressions.
  *
  * This is a strictly stronger guarantee than what `OrderedDistribution(ordering)` requires, as
  * there is no overlap between partitions.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -264,12 +264,12 @@ case class RangePartitioning(ordering: Seq[SortOrder], numPartitions: Int)
           // If `ordering` is a prefix of `requiredOrdering`:
           //   - Let's say `ordering` is [a, b] and `requiredOrdering` is [a, b, c]. If a row is
           //     larger than another row w.r.t. [a, b], it's also larger w.r.t. [a, b, c]. So
-          //     `RangePartitioning(a, b)` satisfy `OrderedDistribution(a, b, c)`.
+          //     `RangePartitioning(a, b)` satisfies `OrderedDistribution(a, b, c)`.
           //
           // If `requiredOrdering` is a prefix of `ordering`:
           //   - Let's say `ordering` is [a, b, c] and `requiredOrdering` is [a, b]. If a row is
           //     larger than another row w.r.t. [a, b, c], this row will not be smaller w.r.t.
-          //     [a. b].  So `RangePartitioning(a, b, c)` satisfy `OrderedDistribution(a, b)`.
+          //     [a. b].  So `RangePartitioning(a, b, c)` satisfies `OrderedDistribution(a, b)`.
           val minSize = Seq(requiredOrdering.size, ordering.size).min
           requiredOrdering.take(minSize) == ordering.take(minSize)
         case ClusteredDistribution(requiredClustering, _) =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some documents of `Distribution/Partitioning` are stale and misleading, this PR fixes them:
1. `Distribution` never have intra-partition requirement
2. `OrderedDistribution` does not require tuples that share the same value being colocated in the same partition.
3. `RangePartitioning` can provide a weaker guarantee for a prefix of its `ordering` expressions.

## How was this patch tested?

comment-only PR.