### PR TITLE
[SPARK-23375][SQL][FOLLOWUP][TEST] Test Sort metrics while Sort is missing

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -202,14 +202,12 @@ class SQLMetricsSuite extends SparkFunSuite with SQLMetricsTestUtils with Shared
     // Because of SPARK-25267, ConvertToLocalRelation is disabled in the test cases of sql/core,
     // so Project here is not collapsed into LocalTableScan.
     val df = Seq(1, 3, 2).toDF("id").sort('id)
-    testSparkPlanMetricsWithPredicates(df, 2, Map(
+    testSparkPlanMetrics(df, 2, Map(
       0L -> (("Sort", Map(
-        // In SortExec, sort time is collected as nanoseconds, but it is converted and stored as
-        // milliseconds. So sort time may be 0 if sort is executed very fast.
-        "sort time total (min, med, max)" -> timingMetricAllStatsShould(_ >= 0),
-        "peak memory total (min, med, max)" -> sizeMetricAllStatsShould(_ > 0),
-        "spill size total (min, med, max)" -> sizeMetricAllStatsShould(_ >= 0))))
-    ))
+        "sort time total (min, med, max)" -> timingMetricPattern,
+        "peak memory total (min, med, max)" -> sizeMetricPattern,
+        "spill size total (min, med, max)" -> sizeMetricPattern)))),
+      ExpectedMetricsType.PATTERN)
   }
 
   test("SortMergeJoin metrics") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -203,17 +203,18 @@ class SQLMetricsSuite extends SparkFunSuite with SQLMetricsTestUtils with Shared
     // so Project here is not collapsed into LocalTableScan.
     val df = Seq(1, 3, 2).toDF("id").sort('id)
     val metrics = getSparkPlanMetrics(df, 2, Set(0))
+    assert(metrics.isDefined)
     val sortMetrics = metrics.get.get(0).get
     // Check node 0 is Sort node
     val operatorName = sortMetrics._1
     assert(operatorName == "Sort")
     // Check metrics values
     val sortTimeStr = sortMetrics._2.get("sort time total (min, med, max)").get.toString
-    timingMetricStats(sortTimeStr).foreach { case (sortTime, _) => assert(sortTime >= 0) }
+    assert(timingMetricStats(sortTimeStr).forall { case (sortTime, _) => sortTime >= 0 })
     val peakMemoryStr = sortMetrics._2.get("peak memory total (min, med, max)").get.toString
-    sizeMetricStats(peakMemoryStr).foreach { case (peakMemory, _) => assert(peakMemory > 0) }
+    assert(sizeMetricStats(peakMemoryStr).forall { case (peakMemory, _) => peakMemory > 0 })
     val spillSizeStr = sortMetrics._2.get("spill size total (min, med, max)").get.toString
-    sizeMetricStats(spillSizeStr).foreach { case (spillSize, _) => assert(spillSize >= 0) }
+    assert(sizeMetricStats(spillSizeStr).forall { case (spillSize, _) => spillSize >= 0 })
   }
 
   test("SortMergeJoin metrics") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{Final, Partial}
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
-import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.{FilterExec, RangeExec, SortExec, SparkPlan, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.aggregate.HashAggregateExec
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
@@ -197,10 +197,10 @@ class SQLMetricsSuite extends SparkFunSuite with SQLMetricsTestUtils with Shared
     // Assume the execution plan with node id is
     // Sort(nodeId = 0)
     //   Exchange(nodeId = 1)
-    //     Range(nodeId = 2)
-    val df = spark.range(9, -1, -1).sort('id).toDF()
+    //     LocalTableScan(nodeId = 2)
+    val df = Seq(1, 3, 2).toDF("id").sort('id)
     testSparkPlanMetrics(df, 2, Map.empty)
-    df.queryExecution.executedPlan.find(_.isInstanceOf[SortExec]).getOrElse(assert(false))
+    assert(df.queryExecution.executedPlan.find(_.isInstanceOf[SortExec]).isDefined)
   }
 
   test("SortMergeJoin metrics") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -204,9 +204,9 @@ class SQLMetricsSuite extends SparkFunSuite with SQLMetricsTestUtils with Shared
     val df = Seq(1, 3, 2).toDF("id").sort('id)
     testSparkPlanMetricsWithPredicates(df, 2, Map(
       0L -> (("Sort", Map(
-        "sort time total (min, med, max)" -> checkPattern(timingMetricPattern),
-        "peak memory total (min, med, max)" -> checkPattern(sizeMetricPattern),
-        "spill size total (min, med, max)" -> checkPattern(sizeMetricPattern))))
+        "sort time total (min, med, max)" -> {_.toString.matches(timingMetricPattern)},
+        "peak memory total (min, med, max)" -> {_.toString.matches(sizeMetricPattern)},
+        "spill size total (min, med, max)" -> {_.toString.matches(sizeMetricPattern)})))
     ))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{Final, Partial}
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
-import org.apache.spark.sql.execution.{FilterExec, RangeExec, SortExec, SparkPlan, WholeStageCodegenExec}
+import org.apache.spark.sql.execution.{FilterExec, RangeExec, SparkPlan, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.aggregate.HashAggregateExec
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -202,12 +202,12 @@ class SQLMetricsSuite extends SparkFunSuite with SQLMetricsTestUtils with Shared
     // Because of SPARK-25267, ConvertToLocalRelation is disabled in the test cases of sql/core,
     // so Project here is not collapsed into LocalTableScan.
     val df = Seq(1, 3, 2).toDF("id").sort('id)
-    testSparkPlanMetrics(df, 2, Map(
+    testSparkPlanMetricsWithPredicates(df, 2, Map(
       0L -> (("Sort", Map(
-        "sort time total (min, med, max)" -> timingMetricPattern,
-        "peak memory total (min, med, max)" -> sizeMetricPattern,
-        "spill size total (min, med, max)" -> sizeMetricPattern)))),
-      ExpectedMetricsType.PATTERN)
+        "sort time total (min, med, max)" -> checkPattern(timingMetricPattern),
+        "peak memory total (min, med, max)" -> checkPattern(sizeMetricPattern),
+        "spill size total (min, med, max)" -> checkPattern(sizeMetricPattern))))
+    ))
   }
 
   test("SortMergeJoin metrics") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsTestUtils.scala
@@ -223,8 +223,8 @@ trait SQLMetricsTestUtils extends SQLTestUtils {
           <- expectedMetricsPredicates) {
         val (actualNodeName, actualMetricsMap) = actualMetrics(nodeId)
         assert(expectedNodeName === actualNodeName)
-        for (metricName <- expectedMetricsPredicatesMap.keySet) {
-          assert(expectedMetricsPredicatesMap(metricName)(actualMetricsMap(metricName)))
+        for ((metricName, metricPredicate) <- expectedMetricsPredicatesMap) {
+          assert(metricPredicate(actualMetricsMap(metricName)))
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsTestUtils.scala
@@ -208,7 +208,8 @@ trait SQLMetricsTestUtils extends SQLTestUtils {
   }
 
   private def stringToBytes(str: String): (Float, String) = {
-    val matcher = Pattern.compile("([0-9]+(\\.[0-9]+)?) (EB|PB|TB|GB|MB|KB|B)").matcher(str)
+    val matcher =
+      Pattern.compile("([0-9]+(\\.[0-9]+)?) (EiB|PiB|TiB|GiB|MiB|KiB|B)").matcher(str)
     if (matcher.matches()) {
       (matcher.group(1).toFloat, matcher.group(3))
     } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsTestUtils.scala
@@ -41,6 +41,10 @@ trait SQLMetricsTestUtils extends SQLTestUtils {
 
   protected def statusStore: SQLAppStatusStore = spark.sharedState.statusStore
 
+  protected val bytesPattern = Pattern.compile("([0-9]+(\\.[0-9]+)?) (EiB|PiB|TiB|GiB|MiB|KiB|B)")
+
+  protected val durationPattern = Pattern.compile("([0-9]+(\\.[0-9]+)?) (ms|s|m|h)")
+
   /**
    * Get execution metrics for the SQL execution and verify metrics values.
    *
@@ -208,8 +212,7 @@ trait SQLMetricsTestUtils extends SQLTestUtils {
   }
 
   private def stringToBytes(str: String): (Float, String) = {
-    val matcher =
-      Pattern.compile("([0-9]+(\\.[0-9]+)?) (EiB|PiB|TiB|GiB|MiB|KiB|B)").matcher(str)
+    val matcher = bytesPattern.matcher(str)
     if (matcher.matches()) {
       (matcher.group(1).toFloat, matcher.group(3))
     } else {
@@ -218,7 +221,7 @@ trait SQLMetricsTestUtils extends SQLTestUtils {
   }
 
   private def stringToDuration(str: String): (Float, String) = {
-    val matcher = Pattern.compile("([0-9]+(\\.[0-9]+)?) (ms|s|m|h)").matcher(str)
+    val matcher = durationPattern.matcher(str)
     if (matcher.matches()) {
       (matcher.group(1).toFloat, matcher.group(3))
     } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsTestUtils.scala
@@ -199,10 +199,11 @@ trait SQLMetricsTestUtils extends SQLTestUtils {
 
   /**
    * Call `df.collect()` and verify if the collected metrics satisfy the specified predicates.
+   *
    * @param df `DataFrame` to run
    * @param expectedNumOfJobs number of jobs that will run
    * @param expectedMetricsPredicates the expected metrics predicates. The format is
-   *                        `nodeId -> (operatorName, metric name -> metric value predicate)`.
+   * `nodeId -> (operatorName, metric name -> metric value predicate)`.
    */
   protected def testSparkPlanMetricsWithPredicates(
       df: DataFrame,


### PR DESCRIPTION
## What changes were proposed in this pull request?
#20560/[SPARK-23375](https://issues.apache.org/jira/browse/SPARK-23375) introduced an optimizer rule to eliminate redundant Sort. For a test case named "Sort metrics" in `SQLMetricsSuite`, because range is already sorted, sort is removed by the `RemoveRedundantSorts`, which makes this test case meaningless.

This PR modifies the query for testing Sort metrics and checks Sort exists in the plan.

## How was this patch tested?
Modify the existing test case.