### PR TITLE
[SPARK-26312][SQL]Replace RDDConversions.rowToRowRdd with RowEncoder to improve its conversion performance

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExistingRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExistingRDD.scala
@@ -33,8 +33,8 @@ import org.apache.spark.sql.types.StructType
 
 object RDDConversions {
   def productToRowRdd[A <: Product : TypeTag](data: RDD[A],
-                                              attrs: Seq[Attribute]): RDD[InternalRow] = {
-    val converters = ExpressionEncoder[A].resolveAndBind(attrs)
+                                              outputSchema: StructType): RDD[InternalRow] = {
+    val converters = ExpressionEncoder[A].resolveAndBind(outputSchema.toAttributes)
     data.mapPartitions { iterator =>
       iterator.map { r =>
         converters.toRow(r)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExistingRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExistingRDD.scala
@@ -32,8 +32,9 @@ import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.sql.types.StructType
 
 object RDDConversions {
-  def productToRowRdd[A <: Product : TypeTag](data: RDD[A],
-                                              outputSchema: StructType): RDD[InternalRow] = {
+  def productToRowRdd[A <: Product : TypeTag](
+      data: RDD[A],
+      outputSchema: StructType): RDD[InternalRow] = {
     val converters = ExpressionEncoder[A].resolveAndBind(outputSchema.toAttributes)
     data.mapPartitions { iterator =>
       iterator.map { r =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExistingRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExistingRDD.scala
@@ -17,44 +17,15 @@
 
 package org.apache.spark.sql.execution
 
-import scala.reflect.runtime.universe.TypeTag
-
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{Encoder, Row, SparkSession}
+import org.apache.spark.sql.{Encoder, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.MultiInstanceRelation
-import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, UnknownPartitioning}
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.execution.metric.SQLMetrics
-import org.apache.spark.sql.types.StructType
-
-object RDDConversions {
-  def productToRowRdd[A <: Product : TypeTag](
-      data: RDD[A],
-      outputSchema: StructType): RDD[InternalRow] = {
-    val converters = ExpressionEncoder[A].resolveAndBind(outputSchema.toAttributes)
-    data.mapPartitions { iterator =>
-      iterator.map { r =>
-        converters.toRow(r)
-      }
-    }
-  }
-
-  /**
-   * Convert the objects inside Row into the types Catalyst expected.
-   */
-  def rowToRowRdd(data: RDD[Row], outputSchema: StructType): RDD[InternalRow] = {
-    val converters = RowEncoder(outputSchema)
-    data.mapPartitions { iterator =>
-      iterator.map { r =>
-        converters.toRow(r)
-      }
-    }
-  }
-}
 
 object ExternalRDD {
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExistingRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExistingRDD.scala
@@ -33,7 +33,7 @@ object RDDConversions {
     data.mapPartitions { iterator =>
       val numColumns = outputTypes.length
       val mutableRow = new GenericInternalRow(numColumns)
-      val converters = outputTypes.map(CatalystTypeConverters.createToCatalystConverter)
+      val converters = outputTypes.map(CatalystTypeConverters.createToCatalystConverter).toArray
       iterator.map { r =>
         var i = 0
         while (i < numColumns) {
@@ -53,7 +53,7 @@ object RDDConversions {
     data.mapPartitions { iterator =>
       val numColumns = outputTypes.length
       val mutableRow = new GenericInternalRow(numColumns)
-      val converters = outputTypes.map(CatalystTypeConverters.createToCatalystConverter)
+      val converters = outputTypes.map(CatalystTypeConverters.createToCatalystConverter).toArray
       iterator.map { r =>
         var i = 0
         while (i < numColumns) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -416,7 +416,7 @@ case class DataSourceStrategy(conf: SQLConf) extends Strategy with Logging with 
       output: Seq[Attribute],
       rdd: RDD[Row]): RDD[InternalRow] = {
     if (relation.relation.needConversion) {
-      execution.RDDConversions.rowToRowRdd(rdd, output.map(_.dataType))
+      execution.RDDConversions.rowToRowRdd(rdd, StructType.fromAttributes(output))
     } else {
       rdd.asInstanceOf[RDD[InternalRow]]
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -418,9 +418,7 @@ case class DataSourceStrategy(conf: SQLConf) extends Strategy with Logging with 
     if (relation.relation.needConversion) {
       val converters = RowEncoder(StructType.fromAttributes(output))
       rdd.mapPartitions { iterator =>
-        iterator.map { r =>
-          converters.toRow(r)
-        }
+        iterator.map(converters.toRow)
       }
     } else {
       rdd.asInstanceOf[RDD[InternalRow]]


### PR DESCRIPTION
## What changes were proposed in this pull request?

`RDDConversions` would get disproportionately slower as the number of columns in the query increased,
for the type of `converters` before is `scala.collection.immutable.::` which is a subtype of list.
This PR removing `RDDConversions` and using `RowEncoder` to convert the Row to InternalRow.

The test of `PrunedScanSuite` for 2000 columns and 20k rows takes 409 seconds before this PR, and 361 seconds after.

## How was this patch tested?

Test case of `PrunedScanSuite` 

