### PR TITLE
[SPARK-26321][SQL] Improve the behavior of sql text splitting for the spark-sql command line 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -134,14 +134,14 @@ object StringUtils {
                           && current == '/'
                           && remaining.startsWith(BRACKETED_COMMENT_START) =>
           quoteFlag = current
-          currentSQL.append("/*")
+          currentSQL.append(BRACKETED_COMMENT_START)
           cursor += 2
         // if it stands on the ending of a bracketed comment, consume 2 characters
         case remaining if quoteFlag == FORWARD_SLASH
                           && current == '*'
                           && remaining.startsWith(BRACKETED_COMMENT_END) =>
           quoteFlag = DOT
-          currentSQL.append("*/")
+          currentSQL.append(BRACKETED_COMMENT_END)
           cursor += 2
 
         // if it stands on the opening of inline comment, move cursor at the end of this line

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -21,6 +21,8 @@ import java.util.regex.{Pattern, PatternSyntaxException}
 
 import scala.collection.mutable
 
+import org.apache.commons.lang.StringUtils.isNotBlank
+
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -92,15 +94,15 @@ object StringUtils {
   }
 
   def split(sql: String): Array[String] = {
-    val dQuote: Char = '"'
-    val sQuote: Char = '\''
-    val semicolon: Char = ';'
-    val escape: Char = '\\'
-    val dot = '.'
-    val inlineComment = "--"
+    val D_QUOTE: Char = '"'
+    val S_QUOTE: Char = '\''
+    val SEMICOLON: Char = ';'
+    val ESCAPE: Char = '\\'
+    val DOT = '.'
+    val INLINE_COMMENT = "--"
 
     var cursor: Int = 0
-    var inStr: Char = dot // dot means that the cursor is not in a quoted string
+    var inStr: Char = DOT // dot means that the cursor is not in a quoted string
     val ret: mutable.ArrayBuffer[String] = mutable.ArrayBuffer()
     var currentSQL: mutable.StringBuilder = mutable.StringBuilder.newBuilder
 
@@ -108,24 +110,24 @@ object StringUtils {
       val current: Char = sql(cursor)
       sql.substring(cursor) match {
         // if it is comment, move cursor at the end of this line
-        case remaining if inStr == dot && remaining.startsWith(inlineComment) =>
+        case remaining if inStr == DOT && remaining.startsWith(INLINE_COMMENT) =>
           cursor += remaining.takeWhile(x => x != '\n').length
         // end of the sql
-        case remaining if inStr == dot && current == semicolon =>
+        case remaining if inStr == DOT && current == SEMICOLON =>
           ret += currentSQL.toString.trim
           currentSQL.clear()
           cursor += 1
         // start of single/double quote
-        case remaining if inStr == dot && (List(dQuote, sQuote) contains current) =>
+        case remaining if inStr == DOT && (List(D_QUOTE, S_QUOTE) contains current) =>
           inStr = current
           currentSQL += current
           cursor += 1
-        case remaining if remaining.length >= 2 && inStr != dot && current == escape =>
+        case remaining if remaining.length >= 2 && inStr != DOT && current == ESCAPE =>
           currentSQL.append(remaining.take(2))
           cursor += 2
         // end of single/double quote
-        case remaining if (inStr == dQuote || inStr == sQuote) && current == inStr =>
-          inStr = '.'
+        case remaining if (inStr == D_QUOTE || inStr == S_QUOTE) && current == inStr =>
+          inStr = DOT
           currentSQL += current
           cursor += 1
         case remaining =>
@@ -134,7 +136,7 @@ object StringUtils {
       }
     }
     ret += currentSQL.toString.trim
-    ret.filter(org.apache.commons.lang.StringUtils.isNotBlank).toArray
+    ret.filter(isNotBlank).toArray
   }
 
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
@@ -57,6 +57,18 @@ class StringUtilsSuite extends SparkFunSuite {
         |select "^;^"
       """.stripMargin.trim
     assert(StringUtils.split(semicolonInStr) === Array(semicolonInStr))
+
+    val inlineComments =
+      """
+        |select 1; --;;;;;;;;
+        |select "---";
+      """.stripMargin
+    val select1 = "select 1"
+    val selectComments =
+      """
+        |select "---"
+      """.stripMargin.trim
+    assert(StringUtils.split(inlineComments) === Array(select1, selectComments))
   }
 
   test("string concatenation") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
@@ -48,15 +48,32 @@ class StringUtilsSuite extends SparkFunSuite {
     val statement = "select * from tmp.dada;"
     assert(StringUtils.split(statement) === Array("select * from tmp.dada"))
 
-    val statements = "select * from tmp.dada;;select * from tmp.ada;"
+    // blanks will be omitted
+    val statements = " select * from tmp.dada;;select * from tmp.ada;"
     assert(StringUtils.split(statements) ===
       Array("select * from tmp.dada", "select * from tmp.ada"))
 
-    val semicolonInStr =
+    val escapedSingleQuote =
+      raw"""
+           |select "\';"
+         """.stripMargin.trim
+    val escapedDoubleQuote =
+      raw"""
+           |select "\";"
+         """.stripMargin.trim
+    assert(StringUtils.split(escapedSingleQuote) === Array(escapedSingleQuote))
+    assert(StringUtils.split(escapedDoubleQuote) === Array(escapedDoubleQuote))
+
+    val semicolonInDoubleQuotes =
       """
         |select "^;^"
       """.stripMargin.trim
-    assert(StringUtils.split(semicolonInStr) === Array(semicolonInStr))
+    val semicolonInSingleQuotes =
+      """
+        |select '^;^'
+      """.stripMargin.trim
+    assert(StringUtils.split(semicolonInDoubleQuotes) === Array(semicolonInDoubleQuotes))
+    assert(StringUtils.split(semicolonInSingleQuotes) === Array(semicolonInSingleQuotes))
 
     val inlineComments =
       """

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
@@ -44,7 +44,7 @@ class StringUtilsSuite extends SparkFunSuite {
     assert(filterPattern(names, " d* ") === Nil)
   }
 
-  test("split a SQL") {
+  test("split the SQL text") {
     val statement = "select * from tmp.dada;"
     assert(StringUtils.split(statement) === Array("select * from tmp.dada"))
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
@@ -44,6 +44,21 @@ class StringUtilsSuite extends SparkFunSuite {
     assert(filterPattern(names, " d* ") === Nil)
   }
 
+  test("split a SQL") {
+    val statement = "select * from tmp.dada;"
+    assert(StringUtils.split(statement) === Array("select * from tmp.dada"))
+
+    val statements = "select * from tmp.dada;;select * from tmp.ada;"
+    assert(StringUtils.split(statements) ===
+      Array("select * from tmp.dada", "select * from tmp.ada"))
+
+    val semicolonInStr =
+      """
+        |select "^;^"
+      """.stripMargin.trim
+    assert(StringUtils.split(semicolonInStr) === Array(semicolonInStr))
+  }
+
   test("string concatenation") {
     def concat(seq: String*): String = {
       seq.foldLeft(new StringConcat())((acc, s) => {acc.append(s); acc}).toString

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
@@ -49,9 +49,9 @@ class StringUtilsSuite extends SparkFunSuite {
     assert(StringUtils.split(statement) === Array("select * from tmp.dada"))
 
     // blanks will be omitted
-    val statements = " select * from tmp.dada;;select * from tmp.ada;"
+    val statements = " select * from tmp.data;;select * from tmp.ata;"
     assert(StringUtils.split(statements) ===
-      Array("select * from tmp.dada", "select * from tmp.ada"))
+      Array("select * from tmp.data", "select * from tmp.ata"))
 
     val escapedSingleQuote =
       raw"""
@@ -86,6 +86,19 @@ class StringUtilsSuite extends SparkFunSuite {
         |select "---"
       """.stripMargin.trim
     assert(StringUtils.split(inlineComments) === Array(select1, selectComments))
+
+    val bracketedComment1 = "select 1 /*;*/" // Good
+    assert(StringUtils.split(bracketedComment1) === Array())
+    val bracketedComment2 = "select 1 /* /* ; */" // Good
+    val bracketedComment3 = "select 1 /* */ ; */" // Bad
+    val bracketedComment4 = "select 1 /**/ ; */" // Good
+    val bracketedComment5 = "select 1 /**/ ; /**/" // Good
+    val bracketedComment6 = "select 1 /**/  ; /* */" // Good
+    val bracketedComment7 = "select 1 /* */ ; /* */" // Bad
+
+    val qQuote1 = "select 1 as `;`" // Good
+    val qQuote2 = "select 1 as ```;`" // Good
+    val qQuote3 = "select 1 as ``;`" // Bad
   }
 
   test("string concatenation") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
@@ -88,17 +88,26 @@ class StringUtilsSuite extends SparkFunSuite {
     assert(StringUtils.split(inlineComments) === Array(select1, selectComments))
 
     val bracketedComment1 = "select 1 /*;*/" // Good
-    assert(StringUtils.split(bracketedComment1) === Array())
+    assert(StringUtils.split(bracketedComment1) === Array(bracketedComment1))
     val bracketedComment2 = "select 1 /* /* ; */" // Good
+    assert(StringUtils.split(bracketedComment2) === Array(bracketedComment2))
     val bracketedComment3 = "select 1 /* */ ; */" // Bad
-    val bracketedComment4 = "select 1 /**/ ; */" // Good
+    assert(StringUtils.split(bracketedComment3).head === "select 1 /* */")
+    val bracketedComment4 = "select 1 /**/  ; /* */" // Good
+    assert(StringUtils.split(bracketedComment4).head === "select 1 /**/")
     val bracketedComment5 = "select 1 /**/ ; /**/" // Good
-    val bracketedComment6 = "select 1 /**/  ; /* */" // Good
-    val bracketedComment7 = "select 1 /* */ ; /* */" // Bad
+    assert(StringUtils.split(bracketedComment5).head === "select 1 /**/")
 
     val qQuote1 = "select 1 as `;`" // Good
-    val qQuote2 = "select 1 as ```;`" // Good
-    val qQuote3 = "select 1 as ``;`" // Bad
+    assert(StringUtils.split(qQuote1) === Array(qQuote1))
+    val qQuote2 = "select 1 as ``;`" // Bad
+    assert(StringUtils.split(qQuote2) === Array("select 1 as ``", "`"))
+
+    // The splitter rule of the following two cases does not match the actual antlr4 rule
+    // We should not make the splitter two complicated
+    // val bracketedComment6 = "select 1 /**/ ; */" // Good
+    // val bracketedComment7 = "select 1 /* */ ; /* */" // Bad
+    // val qQuote3 = "select 1 as ```;`" // Good
   }
 
   test("string concatenation") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
@@ -97,6 +97,8 @@ class StringUtilsSuite extends SparkFunSuite {
     assert(StringUtils.split(bracketedComment4).head === "select 1 /**/")
     val bracketedComment5 = "select 1 /**/ ; /**/" // Good
     assert(StringUtils.split(bracketedComment5).head === "select 1 /**/")
+    val bracketedComment6 = "select /* bla bla */ 1" // Hints are reserved
+    assert(StringUtils.split(bracketedComment6).head === bracketedComment6)
 
     val qQuote1 = "select 1 as `;`" // Good
     assert(StringUtils.split(qQuote1) === Array(qQuote1))

--- a/sql/hive-thriftserver/pom.xml
+++ b/sql/hive-thriftserver/pom.xml
@@ -85,6 +85,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_${scala.binary.version}</artifactId>
       <type>test-jar</type>

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -337,6 +337,7 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
     console.printInfo(s"Spark master: $master, Application Id: $appId")
   }
 
+  // method body imported from Hive and translated from Java to Scala
   override def processLine(line: String, allowInterrupting: Boolean): Int = {
     var oldSignal: SignalHandler = null
     var interruptSignal: Signal = null

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -312,7 +312,11 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
     if (sessionState != null) sessionState.getConf else new Configuration()
 
   if (!isRemoteMode) {
-    if (!Utils.isTesting) {
+    // Utils.isTesing consists of env[SPARK_TESTING] or props[spark.testing]
+    // env is multi-process-level, props is single-process-level
+    // CliSuite with env[SPARK_TESTING] requires SparkSQLEnv
+    // props[spark.testing] acts as a switcher for SparkSQLCLIDriverSuite
+    if (!sys.props.contains("spark.testing")) {
       SparkSQLEnv.init()
       if (sessionState.getIsSilent) {
         SparkSQLEnv.sparkContext.setLogLevel(Level.WARN.toString)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.hive.thriftserver
 
 import java.io._
-import java.util.{ArrayList, Locale}
+import java.util.{ArrayList => JArrayList, Locale}
 
 import scala.collection.JavaConverters._
 
@@ -448,7 +448,7 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
             return ret
           }
 
-          val res = new ArrayList[String]()
+          val res = new JArrayList[String]()
 
           if (HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVE_CLI_PRINT_HEADER)) {
             // Print the column names.

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriverSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriverSuite.scala
@@ -20,16 +20,16 @@ import org.apache.hadoop.hive.cli.CliSessionState
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.ql.session.SessionState
 import org.mockito.ArgumentMatcher
-import org.mockito.Matchers.argThat
+import org.mockito.ArgumentMatchers.argThat
 import org.mockito.Mockito._
 
 import org.apache.spark.SparkFunSuite
 
 class SparkSQLCLIDriverSuite extends SparkFunSuite {
 
-  def matchSQL(sql: String, candidates: String*): Unit = {
+  def matchSQL(sqlText: String, candidates: String*): Unit = {
     class SQLMatcher extends ArgumentMatcher[String] {
-      override def matches(command: Any): Boolean =
+      override def matches(command: String): Boolean =
         candidates.contains(command.asInstanceOf[String])
     }
 
@@ -39,10 +39,10 @@ class SparkSQLCLIDriverSuite extends SparkFunSuite {
     val cli = mock(classOf[SparkSQLCLIDriver])
 
     when(cli.processCmd(argThat(new SQLMatcher))).thenReturn(0)
-    assert(cli.processLine(sql) == 0)
+    assert(cli.processLine(sqlText) == 0)
   }
 
-  test("SPARK-26312: Split a SQL in a correct way") {
+  test("SPARK-26312: sql text splitting for the processCmd method") {
     // semicolon in a string
     val sql =
       """

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriverSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriverSuite.scala
@@ -53,11 +53,11 @@ class SparkSQLCLIDriverSuite extends SparkFunSuite {
     // normal statements
     val statements =
       """
-        |select d from dada;
-        |select a from dada
+        |select d from data;
+        |select a from data
       """.stripMargin
-    val dStatement = "select d from dada"
-    val aStatement = "select a from dada"
+    val dStatement = "select d from data"
+    val aStatement = "select a from data"
     matchSQL(statements, dStatement, aStatement)
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriverSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriverSuite.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.hive.thriftserver
+
+import org.apache.hadoop.hive.cli.CliSessionState
+import org.apache.hadoop.hive.conf.HiveConf
+import org.apache.hadoop.hive.ql.session.SessionState
+import org.mockito.ArgumentMatcher
+import org.mockito.Matchers.argThat
+import org.mockito.Mockito._
+
+import org.apache.spark.SparkFunSuite
+
+class SparkSQLCLIDriverSuite extends SparkFunSuite {
+
+  def matchSQL(sql: String, candidates: String*): Unit = {
+    class SQLMatcher extends ArgumentMatcher[String] {
+      override def matches(command: Any): Boolean =
+        candidates.contains(command.asInstanceOf[String])
+    }
+
+    val conf = new HiveConf(classOf[SessionState])
+    val sessionState = new CliSessionState(conf)
+    SessionState.start(sessionState)
+    val cli = mock(classOf[SparkSQLCLIDriver])
+
+    when(cli.processCmd(argThat(new SQLMatcher))).thenReturn(0)
+    assert(cli.processLine(sql) == 0)
+  }
+
+  test("SPARK-26312: Split a SQL in a correct way") {
+    // semicolon in a string
+    val sql =
+      """
+        |select "^;^"
+      """.stripMargin.trim
+    matchSQL(sql, sql)
+
+    // normal statements
+    val statements =
+      """
+        |select d from dada;
+        |select a from dada
+      """.stripMargin
+    val dStatement = "select d from dada"
+    val aStatement = "select a from dada"
+    matchSQL(statements, dStatement, aStatement)
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Improve the behavior of sql text splitting for the spark-sql command line.

Currently, the spark-sql command line does not split the sql text correctly, for example, the `;` in double quotes.


## How was this patch tested?
Manually tested:
```
$ ./build/mvn -Phive-thriftserver -DskipTests package
$ bin/spark-sql
> select "^;^";
```

The expected result is `^;^` . However, Spark master will split the SQL by `;`. As as result, `select "^` is not a valid SQL.

```
spark-sql> select "\";";
";
spark-sql> select "\';";
';
```

Unit Tests:
```
$ build/sbt -Phive-thriftserver
> project hive-thriftserver
> testOnly *SparkSQLCLIDriverSuite
> project catalyst
> testOnly *StringUtilsSuite
```

## TODO
Polish the code on SignalHandler. However, it should be another PR.

+ [x] Fix the failed tests.
+ [x] Polish StringUtils.split and add more unit tests
+ [x] Add scaladoc
+ [x] Handling comments