### PR TITLE
[SPARK-24920][Core] Allow sharing Netty's memory pool allocators

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
@@ -105,7 +105,7 @@ public class TransportClientFactory implements Closeable {
         conf.getModuleName() + "-client");
     if (conf.sharedByteBufAllocators()) {
       this.pooledAllocator = NettyUtils.getSharedPooledByteBufAllocator(
-          conf.preferDirectBufs(), false /* allowCache */);
+          conf.preferDirectBufsForSharedByteBufAllocators(), false /* allowCache */);
     } else {
       this.pooledAllocator = NettyUtils.createPooledByteBufAllocator(
           conf.preferDirectBufs(), false /* allowCache */, conf.clientThreads());

--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
@@ -84,7 +84,7 @@ public class TransportClientFactory implements Closeable {
 
   private final Class<? extends Channel> socketChannelClass;
   private EventLoopGroup workerGroup;
-  private PooledByteBufAllocator pooledAllocator;
+  private final PooledByteBufAllocator pooledAllocator;
   private final NettyMemoryMetrics metrics;
 
   public TransportClientFactory(
@@ -103,8 +103,13 @@ public class TransportClientFactory implements Closeable {
         ioMode,
         conf.clientThreads(),
         conf.getModuleName() + "-client");
-    this.pooledAllocator = NettyUtils.createPooledByteBufAllocator(
-      conf.preferDirectBufs(), false /* allowCache */, conf.clientThreads());
+    if (conf.sharedByteBufAllocators()) {
+      this.pooledAllocator = NettyUtils.getSharedPooledByteBufAllocator(
+          conf.preferDirectBufs(), false /* allowCache */);
+    } else {
+      this.pooledAllocator = NettyUtils.createPooledByteBufAllocator(
+          conf.preferDirectBufs(), false /* allowCache */, conf.clientThreads());
+    }
     this.metrics = new NettyMemoryMetrics(
       this.pooledAllocator, conf.getModuleName() + "-client", conf);
   }

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
@@ -53,6 +53,7 @@ public class TransportServer implements Closeable {
   private ServerBootstrap bootstrap;
   private ChannelFuture channelFuture;
   private int port = -1;
+  private final PooledByteBufAllocator pooledAllocator;
   private NettyMemoryMetrics metrics;
 
   /**
@@ -68,6 +69,13 @@ public class TransportServer implements Closeable {
     this.context = context;
     this.conf = context.getConf();
     this.appRpcHandler = appRpcHandler;
+    if (conf.sharedByteBufAllocators()) {
+      this.pooledAllocator = NettyUtils.getSharedPooledByteBufAllocator(
+          conf.preferDirectBufs(), true /* allowCache */);
+    } else {
+      this.pooledAllocator = NettyUtils.createPooledByteBufAllocator(
+          conf.preferDirectBufs(), true /* allowCache */, conf.serverThreads());
+    }
     this.bootstraps = Lists.newArrayList(Preconditions.checkNotNull(bootstraps));
 
     boolean shouldClose = true;
@@ -95,18 +103,15 @@ public class TransportServer implements Closeable {
       NettyUtils.createEventLoop(ioMode, conf.serverThreads(), conf.getModuleName() + "-server");
     EventLoopGroup workerGroup = bossGroup;
 
-    PooledByteBufAllocator allocator = NettyUtils.createPooledByteBufAllocator(
-      conf.preferDirectBufs(), true /* allowCache */, conf.serverThreads());
-
     bootstrap = new ServerBootstrap()
       .group(bossGroup, workerGroup)
       .channel(NettyUtils.getServerChannelClass(ioMode))
-      .option(ChannelOption.ALLOCATOR, allocator)
+      .option(ChannelOption.ALLOCATOR, pooledAllocator)
       .option(ChannelOption.SO_REUSEADDR, !SystemUtils.IS_OS_WINDOWS)
-      .childOption(ChannelOption.ALLOCATOR, allocator);
+      .childOption(ChannelOption.ALLOCATOR, pooledAllocator);
 
     this.metrics = new NettyMemoryMetrics(
-      allocator, conf.getModuleName() + "-server", conf);
+      pooledAllocator, conf.getModuleName() + "-server", conf);
 
     if (conf.backLog() > 0) {
       bootstrap.option(ChannelOption.SO_BACKLOG, conf.backLog());

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
@@ -71,7 +71,7 @@ public class TransportServer implements Closeable {
     this.appRpcHandler = appRpcHandler;
     if (conf.sharedByteBufAllocators()) {
       this.pooledAllocator = NettyUtils.getSharedPooledByteBufAllocator(
-          conf.preferDirectBufs(), true /* allowCache */);
+          conf.preferDirectBufsForSharedByteBufAllocators(), true /* allowCache */);
     } else {
       this.pooledAllocator = NettyUtils.createPooledByteBufAllocator(
           conf.preferDirectBufs(), true /* allowCache */, conf.serverThreads());

--- a/common/network-common/src/main/java/org/apache/spark/network/util/NettyUtils.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/NettyUtils.java
@@ -49,7 +49,7 @@ public class NettyUtils {
    */
   private static int MAX_DEFAULT_NETTY_THREADS = 8;
 
-  private static PooledByteBufAllocator[] _sharedPooledByteBufAllocator =
+  private static final PooledByteBufAllocator[] _sharedPooledByteBufAllocator =
       new PooledByteBufAllocator[2];
 
   /** Creates a new ThreadFactory which prefixes each thread with the given name. */

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -272,7 +272,7 @@ public class TransportConf {
    * When disabled a new allocator is created for each transport servers and clients.
    */
   public Boolean sharedByteBufAllocators() {
-    return conf.getBoolean("spark.network.sharedByteBufAllocators", true);
+    return conf.getBoolean("spark.network.sharedByteBufAllocators.enabled", true);
   }
 
   /**

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -271,7 +271,7 @@ public class TransportConf {
    * is allowed (for transport servers) and one where not (for transport clients).
    * When disabled a new allocator is created for each transport servers and clients.
    */
-  public Boolean sharedByteBufAllocators() {
+  public boolean sharedByteBufAllocators() {
     return conf.getBoolean("spark.network.sharedByteBufAllocators.enabled", true);
   }
 

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -266,6 +266,16 @@ public class TransportConf {
   }
 
   /**
+   * Flag indicating whether to share the pooled ByteBuf allocators between the different Netty
+   * channels. If enabled then only two pooled ByteBuf allocators are created: one where caching
+   * is allowed (for transport servers) and one where not (for transport clients).
+   * When disabled a new allocator is created for each transport servers and clients.
+   */
+  public Boolean sharedByteBufAllocators() {
+    return conf.getBoolean("spark.network.sharedByteBufAllocators", true);
+  }
+
+  /**
    * The commons-crypto configuration for the module.
    */
   public Properties cryptoConf() {
@@ -313,4 +323,5 @@ public class TransportConf {
      (this.serverThreads() > 0 ? this.serverThreads() : 2 * NettyRuntime.availableProcessors()) *
      chunkFetchHandlerThreadsPercent/(double)100);
   }
+
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -279,7 +279,7 @@ public class TransportConf {
   * If enabled then off-heap byte buffers will be prefered for the shared ByteBuf allocators.
   */
   public boolean preferDirectBufsForSharedByteBufAllocators() {
-    return conf.getBoolean("spark.network.sharedByteBufAllocators.io.preferDirectBufs", true);
+    return conf.getBoolean("spark.network.io.preferDirectBufs", true);
   }
 
   /**

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -276,6 +276,13 @@ public class TransportConf {
   }
 
   /**
+  * If enabled then off-heap byte buffers will be prefered for the shared ByteBuf allocators.
+  */
+  public boolean preferDirectBufsForSharedByteBufAllocators() {
+    return conf.getBoolean("spark.network.sharedByteBufAllocators.io.preferDirectBufs", true);
+  }
+
+  /**
    * The commons-crypto configuration for the module.
    */
   public Properties cryptoConf() {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1292,16 +1292,6 @@ Apart from these, the following properties are also available, and may be useful
     Controls whether to clean checkpoint files if the reference is out of scope.
   </td>
 </tr>
-<tr>
-  <td><code>spark.network.io.preferDirectBufs</code></td>
-  <td>true</td>
-  <td>
-    If enable then off-heap buffer allocations are prefered by the shared ByteBuf allocators.
-    Off-heap buffers are used to reduce garbage collection during shuffle and cache
-    block transfer. For environments where off-heap memory is tightly limited, users may wish to
-    turn this off to force all allocations from Netty to be on-heap.
-    </td>
-</tr>
 </table>
 
 ### Execution Behavior
@@ -1514,6 +1504,16 @@ Apart from these, the following properties are also available, and may be useful
     <code>spark.shuffle.io.connectionTimeout</code>, <code>spark.rpc.askTimeout</code> or
     <code>spark.rpc.lookupTimeout</code> if they are not configured.
   </td>
+</tr>
+<tr>
+  <td><code>spark.network.io.preferDirectBufs</code></td>
+  <td>true</td>
+  <td>
+    If enable then off-heap buffer allocations are prefered by the shared ByteBuf allocators.
+    Off-heap buffers are used to reduce garbage collection during shuffle and cache
+    block transfer. For environments where off-heap memory is tightly limited, users may wish to
+    turn this off to force all allocations from Netty to be on-heap.
+    </td>
 </tr>
 <tr>
   <td><code>spark.port.maxRetries</code></td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1293,15 +1293,7 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
-  <td><code>spark.network.sharedByteBufAllocators.enabled</code></td>
-  <td>true</td>
-  <td>
-   Controls whether to share the pooled ByteBuf allocators between the different Netty channels.
-   When disabled a separate allocator is created for each transport servers and clients.
-  </td>
-</tr>
-<tr>
-  <td><code>spark.network.sharedByteBufAllocators.io.preferDirectBufs</code></td>
+  <td><code>spark.network.io.preferDirectBufs</code></td>
   <td>true</td>
   <td>
     If enable then off-heap buffer allocations are prefered by the shared ByteBuf allocators.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1292,6 +1292,24 @@ Apart from these, the following properties are also available, and may be useful
     Controls whether to clean checkpoint files if the reference is out of scope.
   </td>
 </tr>
+<tr>
+  <td><code>spark.network.sharedByteBufAllocators.enabled</code></td>
+  <td>true</td>
+  <td>
+   Controls whether to share the pooled ByteBuf allocators between the different Netty channels.
+   When disabled a separate allocator is created for each transport servers and clients.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.network.sharedByteBufAllocators.io.preferDirectBufs</code></td>
+  <td>true</td>
+  <td>
+    If enable then off-heap buffer allocations are prefered by the shared ByteBuf allocators.
+    Off-heap buffers are used to reduce garbage collection during shuffle and cache
+    block transfer. For environments where off-heap memory is tightly limited, users may wish to
+    turn this off to force all allocations from Netty to be on-heap.
+    </td>
+</tr>
 </table>
 
 ### Execution Behavior

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1509,10 +1509,10 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.network.io.preferDirectBufs</code></td>
   <td>true</td>
   <td>
-    If enable then off-heap buffer allocations are prefered by the shared ByteBuf allocators.
+    If enabled then off-heap buffer allocations are preferred by the shared allocators.
     Off-heap buffers are used to reduce garbage collection during shuffle and cache
     block transfer. For environments where off-heap memory is tightly limited, users may wish to
-    turn this off to force all allocations from Netty to be on-heap.
+    turn this off to force all allocations to be on-heap.
     </td>
 </tr>
 <tr>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introducing shared polled ByteBuf allocators. 
This feature can be enabled via the "spark.network.sharedByteBufAllocators.enabled" configuration. 

When it is on then only two pooled ByteBuf allocators are created: 
- one for transport servers where caching is allowed and
- one for transport clients where caching is disabled

This way the cache allowance remains as before. 
Both shareable pools are created with numCores parameter set to 0 (which defaults to the available processors) as conf.serverThreads() and conf.clientThreads() are module dependant and the lazy creation of this allocators would lead to unpredicted behaviour.

When "spark.network.sharedByteBufAllocators.enabled" is false then a new allocator is created for every transport client and server separately as was before this PR.

## How was this patch tested?

Existing unit tests.
