### PR TITLE
[MINOR][SQL]Change  `ThreadLocal.withInitial`  to Scala lambda syntax

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.execution
 
 import java.io.Writer
 import java.util.Locale
-import java.util.function.Supplier
 
 import scala.collection.mutable
 import scala.util.control.NonFatal
@@ -557,9 +556,7 @@ object WholeStageCodegenId {
   // is created, e.g. for special fallback handling when an existing WholeStageCodegenExec
   // failed to generate/compile code.
 
-  private val codegenStageCounter = ThreadLocal.withInitial(new Supplier[Integer] {
-    override def get() = 1  // TODO: change to Scala lambda syntax when upgraded to Scala 2.12+
-  })
+  private val codegenStageCounter = ThreadLocal.withInitial[Int](() => 1)
 
   def resetPerQuery(): Unit = codegenStageCounter.set(1)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, Scala  has updated to Scala 2.12.8 ,  so  we can change this to Scala lambda syntax


## How was this patch tested?
Existing tests.
And Manual tested:
```
== Physical Plan ==
*(3) HashAggregate(keys=[attribute#237L], functions=[sum(cnt#227L)])
+- Exchange hashpartitioning(attribute#237L, 5)
   +- *(2) HashAggregate(keys=[attribute#237L], functions=[partial_sum(cnt#227L)])
      +- *(2) HashAggregate(keys=[nested#223.attribute#243L], functions=[count(1)])
         +- Exchange hashpartitioning(nested#223.attribute#243L, 5)
            +- *(1) HashAggregate(keys=[nested#223.attribute AS nested#223.attribute#243L], functions=[partial_count(1)])
               +- *(1) Project [nested#223]
                  +- *(1) Scan ExistingRDD[nested#223,value#224L]
```
