### PR TITLE
[SPARK-26222][SQL] Track file listing time

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
@@ -82,6 +82,10 @@ object QueryPlanningTracker {
   /** Returns the current tracker in scope, based on the thread local variable. */
   def get: QueryPlanningTracker = Option(localTracker.get()).getOrElse(NoopTracker)
 
+  /** Returns the current tracker in scope or create a new one. */
+  def getOrCreate: QueryPlanningTracker =
+    Option(localTracker.get()).getOrElse(new QueryPlanningTracker)
+
   /** Sets the current tracker for the execution of function f. We assume f is single-threaded. */
   def withTracker[T](tracker: QueryPlanningTracker)(f: => T): T = {
     val originalTracker = localTracker.get()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
@@ -40,7 +40,10 @@ object QueryPlanningTracker {
   val ANALYSIS = "analysis"
   val OPTIMIZATION = "optimization"
   val PLANNING = "planning"
+
+  // Define a list about file listing phases.
   val FILE_LISTING = "fileListing"
+  val PARTITION_PRUNING = "partitionPruning"
 
   /**
    * Summary for a rule.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
@@ -41,7 +41,7 @@ object QueryPlanningTracker {
   val OPTIMIZATION = "optimization"
   val PLANNING = "planning"
 
-  // Define a list about file listing phases.
+  // File listing relative phases.
   val FILE_LISTING = "fileListing"
   val PARTITION_PRUNING = "partitionPruning"
 
@@ -170,6 +170,7 @@ class QueryPlanningTracker {
 
 }
 
+/** A no-op tracker used for current tracker in scope not set. */
 object NoopTracker extends QueryPlanningTracker {
   override def measurePhase[T](phase: String)(f: => T): T = f
   override def recordRuleInvocation(rule: String, timeNs: Long, effective: Boolean): Unit = {}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
@@ -86,7 +86,7 @@ abstract class RuleExecutor[TreeType <: TreeNode[_]] extends Logging {
     var curPlan = plan
     val queryExecutionMetrics = RuleExecutor.queryExecutionMeter
     val planChangeLogger = new PlanChangeLogger()
-    val tracker: Option[QueryPlanningTracker] = QueryPlanningTracker.get
+    val tracker: QueryPlanningTracker = QueryPlanningTracker.get
 
     batches.foreach { batch =>
       val batchStartPlan = curPlan
@@ -112,7 +112,7 @@ abstract class RuleExecutor[TreeType <: TreeNode[_]] extends Logging {
             queryExecutionMetrics.incNumExecution(rule.ruleName)
 
             // Record timing information using QueryPlanningTracker
-            tracker.foreach(_.recordRuleInvocation(rule.ruleName, runTime, effective))
+            tracker.recordRuleInvocation(rule.ruleName, runTime, effective)
 
             // Run the structural integrity checker against the plan after each rule.
             if (!isPlanIntegral(result)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -194,6 +194,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
         "read files of Hive data source directly.")
     }
 
+    // Pass the new tracker into the created DataFrame.
     val tracker = new QueryPlanningTracker
     val cls = DataSource.lookupDataSource(source, sparkSession.sessionState.conf)
     if (classOf[TableProvider].isAssignableFrom(cls)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -22,7 +22,7 @@ import java.util.{Locale, Properties, UUID}
 import scala.collection.JavaConverters._
 
 import org.apache.spark.annotation.Stable
-import org.apache.spark.sql.catalyst.{QueryPlanningTracker, TableIdentifier}
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, UnresolvedRelation}
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, InsertIntoTable, LogicalPlan}
@@ -674,11 +674,8 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
    */
   private def runCommand(session: SparkSession, name: String)(command: LogicalPlan): Unit = {
     val qe = session.sessionState.executePlan(command)
-    // Use tracker in original DataSet to keep tracking write process.
-    QueryPlanningTracker.withTracker(ds.queryExecution.tracker) {
-      // call `QueryExecution.toRDD` to trigger the execution of commands.
-      SQLExecution.withNewExecutionId(session, qe, Some(name))(qe.toRdd)
-    }
+    // call `QueryExecution.toRDD` to trigger the execution of commands.
+    SQLExecution.withNewExecutionId(session, qe, Some(name))(qe.toRdd)
   }
 
   ///////////////////////////////////////////////////////////////////////////////////////

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -438,7 +438,7 @@ class SparkSession private(
    * @since 2.0.0
    */
   def baseRelationToDataFrame(baseRelation: BaseRelation): DataFrame = {
-    Dataset.ofRows(self, LogicalRelation(baseRelation))
+    Dataset.ofRows(self, LogicalRelation(baseRelation), QueryPlanningTracker.getOrCreate)
   }
 
   /* ------------------------------- *

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -433,7 +433,8 @@ class SparkSession private(
   }
 
   /**
-   * Convert a `BaseRelation` created for external data sources into a `DataFrame`.
+   * Convert a `BaseRelation` created for external data sources into a `DataFrame`. Use the local
+   * tracker in scope if it exists.
    *
    * @since 2.0.0
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.execution.ui.{SparkListenerSQLExecutionEnd, SparkListenerSQLExecutionStart}
 
 object SQLExecution {
@@ -84,7 +85,10 @@ object SQLExecution {
             // will be caught and reported in the `SparkListenerSQLExecutionEnd`
             sparkPlanInfo = SparkPlanInfo.fromSparkPlan(queryExecution.executedPlan),
             time = System.currentTimeMillis()))
-          body
+          // Sets the tracker in the `queryExecution` for execution.
+          QueryPlanningTracker.withTracker(queryExecution.tracker) {
+            body
+          }
         } catch {
           case e: Exception =>
             ex = Some(e)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -85,7 +85,7 @@ object SQLExecution {
             // will be caught and reported in the `SparkListenerSQLExecutionEnd`
             sparkPlanInfo = SparkPlanInfo.fromSparkPlan(queryExecution.executedPlan),
             time = System.currentTimeMillis()))
-          // Sets the tracker in the `queryExecution` for execution.
+          // Set the tracker in the query execution as the `localTracker` during execute.
           QueryPlanningTracker.withTracker(queryExecution.tracker) {
             body
           }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/CatalogFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/CatalogFileIndex.scala
@@ -69,7 +69,6 @@ class CatalogFileIndex(
    */
   def filterPartitions(filters: Seq[Expression]): InMemoryFileIndex = {
     if (table.partitionColumnNames.nonEmpty) {
-      val startTime = System.nanoTime()
       val selectedPartitions = sparkSession.sessionState.catalog.listPartitionsByFilter(
         table.identifier, filters)
       val partitions = selectedPartitions.map { p =>
@@ -80,9 +79,8 @@ class CatalogFileIndex(
           path.makeQualified(fs.getUri, fs.getWorkingDirectory))
       }
       val partitionSpec = PartitionSpec(partitionSchema, partitions)
-      val timeNs = System.nanoTime() - startTime
       new PrunedInMemoryFileIndex(
-        sparkSession, new Path(baseLocation.get), fileStatusCache, partitionSpec, Option(timeNs))
+        sparkSession, new Path(baseLocation.get), fileStatusCache, partitionSpec)
     } else {
       new InMemoryFileIndex(
         sparkSession, rootPaths, table.storage.properties, userSpecifiedSchema = None)
@@ -113,8 +111,7 @@ private class PrunedInMemoryFileIndex(
     sparkSession: SparkSession,
     tableBasePath: Path,
     fileStatusCache: FileStatusCache,
-    override val partitionSpec: PartitionSpec,
-    override val metadataOpsTimeNs: Option[Long])
+    override val partitionSpec: PartitionSpec)
   extends InMemoryFileIndex(
     sparkSession,
     partitionSpec.partitions.map(_.path),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileIndex.scala
@@ -72,14 +72,4 @@ trait FileIndex {
 
   /** Schema of the partitioning columns, or the empty schema if the table is not partitioned. */
   def partitionSchema: StructType
-
-  /**
-   * Returns an optional metadata operation time, in nanoseconds, for listing files.
-   *
-   * We do file listing in query optimization (in order to get the proper statistics) and we want
-   * to account for file listing time in physical execution (as metrics). To do that, we save the
-   * file listing time in some implementations and physical execution calls it in this method
-   * to update the metrics.
-   */
-  def metadataOpsTimeNs: Option[Long] = None
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/QueryPlanningMetricsSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/QueryPlanningMetricsSupport.scala
@@ -52,7 +52,7 @@ object QueryPlanningMetricsSupport {
   def getUpdatedFileListingMetrics(metrics: Map[String, SQLMetric]): Seq[SQLMetric] = {
     val updatedMetrics = new ArrayBuffer[SQLMetric]()
 
-    // Update all metric relative with file listing phase.
+    // Update all metrics relative with file listing phase.
     def phaseMetricsUpdate(phase: String): Unit = {
       val phaseSummary = QueryPlanningTracker.get.phases.get(phase)
       if (phaseSummary.isDefined) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/QueryPlanningMetricsSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/QueryPlanningMetricsSupport.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.metric
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.catalyst.QueryPlanningTracker
+
+/**
+ * It is a helper object for the metrics which is traced by [[QueryPlanningTracker]].
+ */
+object QueryPlanningMetricsSupport {
+  import QueryPlanningTracker._
+
+  val FILE_LISTING_TIME = FILE_LISTING + "Time"
+  private def startTimestampMetric(prefix: String) = prefix + "Start"
+  private def endTimestampMetric(prefix: String) = prefix + "End"
+
+  /**
+   * Create all file listing relative metrics and return the Map.
+   */
+  def createFileListingMetrics(sc: SparkContext): Map[String, SQLMetric] = Map(
+    FILE_LISTING_TIME -> SQLMetrics.createMetric(sc, "total file listing time (ms)"),
+    startTimestampMetric(FILE_LISTING) ->
+      SQLMetrics.createTimestampMetric(sc, "file listing start"),
+    startTimestampMetric(PARTITION_PRUNING) ->
+      SQLMetrics.createTimestampMetric(sc, "partition pruning start"),
+    endTimestampMetric(PARTITION_PRUNING) ->
+      SQLMetrics.createTimestampMetric(sc, "partition pruning end"),
+    endTimestampMetric(FILE_LISTING) ->
+      SQLMetrics.createTimestampMetric(sc, "file listing end"))
+
+  /**
+   * Get updated file listing relative metrics from QueryPlanningTracker phases.
+   */
+  def getUpdatedFileListingMetrics(metrics: Map[String, SQLMetric]): Seq[SQLMetric] = {
+    val updatedMetrics = new ArrayBuffer[SQLMetric]()
+
+    // Update all metric relative with file listing phase.
+    def phaseMetricsUpdate(phase: String): Unit = {
+      val phaseSummary = QueryPlanningTracker.get.phases.get(phase)
+      if (phaseSummary.isDefined) {
+        metrics(FILE_LISTING_TIME).add(phaseSummary.get.durationMs)
+        metrics(startTimestampMetric(phase)).set(phaseSummary.get.startTimeMs)
+        metrics(endTimestampMetric(phase)).set(phaseSummary.get.endTimeMs)
+
+        updatedMetrics.append(
+          metrics(FILE_LISTING_TIME),
+          metrics(startTimestampMetric(phase)),
+          metrics(endTimestampMetric(phase)))
+      }
+    }
+    phaseMetricsUpdate(FILE_LISTING)
+    phaseMetricsUpdate(PARTITION_PRUNING)
+
+    updatedMetrics.toSeq
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
@@ -166,7 +166,7 @@ object SQLMetrics {
       numberFormat.format(values.sum)
     } else if (metricsType == TIMESTAMP_METRIC) {
       val validValue = values.filter(_ > 0)
-      assert(validValue.size == 1, "Timestamp metrics should has only 1 valid value.")
+      assert(validValue.size == 1, "Timestamp metrics should have only one valid value.")
       val ts = new Timestamp(validValue.head)
       ts.toLocalDateTime.toString
     } else if (metricsType == AVERAGE_METRIC) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryPlanningTrackerEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryPlanningTrackerEndToEndSuite.scala
@@ -82,15 +82,6 @@ class QueryPlanningTrackerEndToEndSuite extends SharedSQLContext {
     }
   }
 
-  test("file listing time - DataFrameWriter") {
-    withTable("tbl") {
-      val df = spark.range(10).selectExpr("id")
-      // File listing will be triggered by DataSource.resolveRelation
-      df.write.saveAsTable("tbl")
-      checkTrackerWithPhaseKeySet(df, Set("analysis", "fileListing"))
-    }
-  }
-
   test("file listing time - DataFrameReader") {
     withTempPath { path =>
       val pathStr = path.getAbsolutePath

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryPlanningTrackerEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryPlanningTrackerEndToEndSuite.scala
@@ -82,4 +82,12 @@ class QueryPlanningTrackerEndToEndSuite extends SharedSQLContext {
     }
   }
 
+  test("file listing time - dataframe writer") {
+    withTable("tbl") {
+      val df = spark.range(10).selectExpr("id")
+      df.write.saveAsTable("tbl")
+      checkTrackerWithPhaseKeySet(df, Set("analysis", "fileListing"))
+    }
+  }
+
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -564,7 +564,7 @@ class SQLMetricsSuite extends SparkFunSuite with SQLMetricsTestUtils with Shared
       // Insert ten rows into the table.
       spark.range(10).selectExpr("id", "id + 1").write.insertInto("parquetTable")
 
-      // For second time read, file listing time will not update cause read from cache.
+      // For the second time read, file listing time will not update cause read from cache.
       val df1 = spark.read.table("parquetTable")
       df1.collect()
       val metrics1 = df1.queryExecution.executedPlan.collectLeaves().head.metrics


### PR DESCRIPTION
## What changes were proposed in this pull request?

Tracking file listing time and add them into scan node's metrics, also add the start and end timestamp metrics for both file listing phase and partition pruning phase.

## How was this patch tested?

Add test in QueryPlanningTrackerEndToEndSuite and SQLMetricsSuite.
Manually test as below:

|             Scenario            | UI |
|:-------------------------------:|----|
| With file listing               |  ![image](https://user-images.githubusercontent.com/4833765/50044398-d4c4d880-00bd-11e9-8e2f-73310ab67c3f.png) |
| Without file listing(cache hit) |  ![image](https://user-images.githubusercontent.com/4833765/50044400-e1493100-00bd-11e9-9124-7dbb444361aa.png) |
| With partition pruning          | ![image](https://user-images.githubusercontent.com/4833765/50044428-3ab16000-00be-11e9-8535-b4d5e74c48aa.png) |