### PR TITLE
[SPARK-26335][SQL] Add a property for Dataset#show not to care about wide characters when padding them

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2822,6 +2822,19 @@ private[spark] object Utils extends Logging {
     if (str == null) 0 else str.length + fullWidthRegex.findAllIn(str).size
   }
 
+  /**
+   * Return a width of a given string.
+   *
+   * @param str a string
+   * @param halfWidth If it is set to true, the number of half widths of a given string will be
+   *                  returned.
+   *                  Otherwise, the number of characters of a given string will be returned.
+   * @return a width of a given string
+   */
+  def stringWidth(str: String, halfWidth: Boolean): Int = {
+    if (str == null) 0 else if (halfWidth) stringHalfWidth(str) else str.length
+  }
+
   def sanitizeDirName(str: String): String = {
     str.replaceAll("[ :/]", "-").replaceAll("[.${}'\"]", "_").toLowerCase(Locale.ROOT)
   }

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -1193,6 +1193,44 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     // scalastyle:on nonascii
   }
 
+   test("stringWidth") {
+    // scalastyle:off nonascii
+    assert(Utils.stringWidth(null, false) == 0)
+    assert(Utils.stringWidth(null, true) == 0)
+    assert(Utils.stringWidth("", false) == 0)
+    assert(Utils.stringWidth("", true) == 0)
+    assert(Utils.stringWidth("ab c", false) == 4)
+    assert(Utils.stringWidth("ab c", true) == 4)
+    assert(Utils.stringWidth("1098", false) == 4)
+    assert(Utils.stringWidth("1098", true) == 4)
+    assert(Utils.stringWidth("mø", false) == 2)
+    assert(Utils.stringWidth("mø", true) == 2)
+    assert(Utils.stringWidth("γύρ", false) == 3)
+    assert(Utils.stringWidth("γύρ", true) == 3)
+    assert(Utils.stringWidth("pê", false) == 2)
+    assert(Utils.stringWidth("pê", true) == 2)
+    assert(Utils.stringWidth("ー", false) == 1)
+    assert(Utils.stringWidth("ー", true) == 2)
+    assert(Utils.stringWidth("测", false) == 1)
+    assert(Utils.stringWidth("测", true) == 2)
+    assert(Utils.stringWidth("か", false) == 1)
+    assert(Utils.stringWidth("か", true) == 2)
+    assert(Utils.stringWidth("걸", false) == 1)
+    assert(Utils.stringWidth("걸", true) == 2)
+    assert(Utils.stringWidth("à", false) == 1)
+    assert(Utils.stringWidth("à", true) == 1)
+    assert(Utils.stringWidth("焼", false) == 1)
+    assert(Utils.stringWidth("焼", true) == 2)
+    assert(Utils.stringWidth("羍む", false) == 2)
+    assert(Utils.stringWidth("羍む", true) == 4)
+    assert(Utils.stringWidth("뺭ᾘ", false) == 2)
+    assert(Utils.stringWidth("뺭ᾘ", true) == 3)
+    assert(Utils.stringWidth("\u0967\u0968\u0969", false) == 3)
+    assert(Utils.stringWidth("\u0967\u0968\u0969", true) == 3)
+    // scalastyle:on nonascii
+  }
+
+
   test("trimExceptCRLF standalone") {
     val crlfSet = Set("\r", "\n")
     val nonPrintableButCRLF = (0 to 32).map(_.toChar.toString).toSet -- crlfSet

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1635,6 +1635,18 @@ object SQLConf {
       "java.time.* packages are used for the same purpose.")
     .booleanConf
     .createWithDefault(false)
+
+  val DATASET_SHOW_HANDLE_FULL_WIDTH_CHARACTERS =
+    buildConf("spark.sql.dataset.show.handleFullWidthCharacters")
+      .doc("If it is set to true, a width of a full width character will be calculated as two " +
+        "half widths. That makes it easy for humans to view a result of " +
+        "`org.apache.spark.sql.Dataset#show`. On the other hand, that makes it impossible for " +
+        "programs to parse a result of `org.apache.spark.sql.Dataset#show` because each cell of " +
+        "a column has a different width depending on how many full width characters it has. " +
+        "So, it should be set to false if programs need to parse a result of " +
+        "`org.apache.spark.sql.Dataset#show`.")
+      .booleanConf
+      .createWithDefault(true)
 }
 
 /**
@@ -2061,6 +2073,9 @@ class SQLConf extends Serializable with Logging {
     getConf(SQLConf.SET_COMMAND_REJECTS_SPARK_CORE_CONFS)
 
   def legacyTimeParserEnabled: Boolean = getConf(SQLConf.LEGACY_TIME_PARSER_ENABLED)
+
+  def datasetShowHandleFullWidthCharacters: Boolean =
+    getConf(SQLConf.DATASET_SHOW_HANDLE_FULL_WIDTH_CHARACTERS)
 
   /** ********************** SQLConf functionality methods ************ */
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

### Issue
[SPARK-25108](https://issues.apache.org/jira/browse/SPARK-25108) made `Dataset#show` care about wide characters when padding them. That is useful for humans to read a result of `Dataset#show`. On the other hand, that makes it impossible for programs to parse a result of `Dataset#show` because each cell's length can be different from its header's length. My company develops and manages a Jupyter/Apache Zeppelin-like visualization tool named [OASIS](https://databricks.com/session/oasis-collaborative-data-analysis-platform-using-apache-spark). On this application, a result of `Dataset#show` on a Scala or Python process is parsed to visualize it as an HTML table format as follows: 

<img width="1092" alt="screen shot 2018-12-13 at 16 38 58" src="https://user-images.githubusercontent.com/31149688/49923017-9e3c6180-fef5-11e8-970b-077bed46cdee.png">

### Solution
Add the `spark.sql.dataset.show.handleFullWidthCharacters` property for `Dataset#show` to control whether wide characters are cared/handled or not.

## How was this patch tested?
This patch was tested via unit tests.

## Jira Issue
https://issues.apache.org/jira/browse/SPARK-26335