### PR TITLE
[SPARK-26367] [SQL] Remove ReplaceExceptWithFilter from nonExcludableRules

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -199,7 +199,6 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
       RewriteDistinctAggregates.ruleName ::
       ReplaceDeduplicateWithAggregate.ruleName ::
       ReplaceIntersectWithSemiJoin.ruleName ::
-      ReplaceExceptWithFilter.ruleName ::
       ReplaceExceptWithAntiJoin.ruleName ::
       RewriteExceptAll.ruleName ::
       RewriteIntersectAll.ruleName ::


### PR DESCRIPTION
## What changes were proposed in this pull request?
ReplaceExceptWithFilter is optional and thus remove it from nonExcludableRules

## How was this patch tested?
N/A