### PR TITLE
[SPARK-26222][SQL] Track file listing time

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
@@ -28,7 +28,7 @@ import org.apache.spark.util.BoundedPriorityQueue
  * There are two separate concepts we track:
  *
  * 1. Phases: These are broad scope phases in query planning, as listed below, i.e. analysis,
- * optimizationm and physical planning (just planning).
+ * optimization and physical planning (just planning).
  *
  * 2. Rules: These are the individual Catalyst rules that we track. In addition to time, we also
  * track the number of invocations and effective invocations.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
@@ -87,6 +87,15 @@ object QueryPlanningTracker {
     localTracker.set(tracker)
     try f finally { localTracker.set(originalTracker) }
   }
+
+  /** Record the phase by the passing in record function. */
+  def recordPhase[T](record: PhaseSummary => Unit)(f: => T): T = {
+    val startTime = System.currentTimeMillis()
+    val ret = f
+    val endTime = System.currentTimeMillis
+    record(new PhaseSummary(startTime, endTime))
+    ret
+  }
 }
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -183,7 +183,7 @@ case class FileSourceScanExec(
 
   /** Phase summary for file listing in FileIndex. Visible for testing. */
   @transient private[sql] lazy val fileListingPhaseSummary: Option[PhaseSummary] =
-    relation.location.fileListingPhaseSummary
+    relation.location.getAndCleanFileListingPhaseSummary
 
   @transient private lazy val selectedPartitions: Seq[PartitionDirectory] = {
     val optimizerMetadataTimeNs = relation.location.metadataOpsTimeNs.getOrElse(0L)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -178,7 +178,7 @@ case class FileSourceScanExec(
     val fileListingPhase = relation.location.fileListingPhase
     if (fileListingPhase.isDefined) {
       val phase = fileListingPhase.get
-      driverMetrics("fileListingTime") = phase.durationMs
+      driverMetrics("metadataTime") = phase.durationMs
       driverMetrics("fileListingStart") = phase.startTimeMs
       driverMetrics("fileListingEnd") = phase.endTimeMs
     }
@@ -328,7 +328,7 @@ case class FileSourceScanExec(
     Map("numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
       "numFiles" -> SQLMetrics.createMetric(sparkContext, "number of files"),
       "scanTime" -> SQLMetrics.createTimingMetric(sparkContext, "scan time"),
-      "fileListingTime" -> SQLMetrics.createMetric(sparkContext, "file listing time (ms)"),
+      "metadataTime" -> SQLMetrics.createMetric(sparkContext, "metadata time (ms)"),
       "fileListingStart" -> SQLMetrics.createTimestampMetric(sparkContext, "file listing start"),
       "fileListingEnd" -> SQLMetrics.createTimestampMetric(sparkContext, "file listing end"))
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/CatalogFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/CatalogFileIndex.scala
@@ -69,7 +69,11 @@ class CatalogFileIndex(
 
   override def refresh(): Unit = fileStatusCache.invalidateAll()
 
-  override def fileListingPhaseSummary: Option[PhaseSummary] = _fileListingPhaseSummary
+  override def getAndCleanFileListingPhaseSummary: Option[PhaseSummary] = {
+    val ret = _fileListingPhaseSummary
+    _fileListingPhaseSummary = None
+    ret
+  }
 
   /**
    * Returns a [[InMemoryFileIndex]] for this table restricted to the subset of partitions

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileIndex.scala
@@ -19,7 +19,8 @@ package org.apache.spark.sql.execution.datasources
 
 import org.apache.hadoop.fs._
 
-import org.apache.spark.sql.catalyst.{InternalRow, QueryPlanningTracker}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.QueryPlanningTracker.PhaseSummary
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types.StructType
 
@@ -74,11 +75,15 @@ trait FileIndex {
   def partitionSchema: StructType
 
   /**
-   * Returns an optional file listing phase summary.
+   * Returns an optional metadata operation time, in nanoseconds, for listing files.
    *
-   * We call this in physical execution while we want to account for the file listing time as
-   * metrics. If partition pruning happened in query planning, the phase also contains this
-   * part of the cost, otherwise, it only contains file listing time of FileIndex initialize.
+   * We do file listing in query optimization (in order to get the proper statistics) and we want
+   * to account for file listing time in physical execution (as metrics). To do that, we save the
+   * file listing time in some implementations and physical execution calls it in this method
+   * to update the metrics.
    */
-  def fileListingPhase: Option[QueryPlanningTracker.PhaseSummary] = None
+  def metadataOpsTimeNs: Option[Long] = None
+
+  /** Returns an optional phase summary to record the start and end timestamp for listing file. */
+  def fileListingPhaseSummary: Option[PhaseSummary] = None
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileIndex.scala
@@ -84,6 +84,15 @@ trait FileIndex {
    */
   def metadataOpsTimeNs: Option[Long] = None
 
-  /** Returns an optional phase summary to record the start and end timestamp for listing file. */
-  def fileListingPhaseSummary: Option[PhaseSummary] = None
+  /**
+   * Returns the latest phase summary of file listing in the current FileIndex, we should also
+   * clean the phase summary cause in the scenario of the cached plan, we shouldn't report the
+   * old phase summary.
+   * This interface is only overridden in [[InMemoryFileIndex]] and [[CatalogFileIndex]], we do
+   * not override this in [[PartitioningAwareFileIndex]] cause all its subclass using in scan
+   * node already track file listing time.
+   *
+   * @return An optional phase summary to record the start and end timestamp for listing file.
+   */
+  def getAndCleanFileListingPhaseSummary: Option[PhaseSummary] = None
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileIndex.scala
@@ -34,9 +34,6 @@ case class PartitionDirectory(values: InternalRow, files: Seq[FileStatus])
  * partitions of a relation subject to some pruning expressions.
  */
 trait FileIndex {
-  import QueryPlanningTracker._
-
-  private var _fileListingPhase: Option[PhaseSummary] = None
 
   /**
    * Returns the list of root input paths from which the catalog will get files. There may be a
@@ -76,15 +73,6 @@ trait FileIndex {
   /** Schema of the partitioning columns, or the empty schema if the table is not partitioned. */
   def partitionSchema: StructType
 
-  /** Measure the start and end time of file listing phase and memorize result. */
-  protected def measureFileListingPhase[T](f: => T): T = {
-    val startTime = System.currentTimeMillis()
-    val ret = f
-    val endTime = System.currentTimeMillis
-    _fileListingPhase = Some(new PhaseSummary(startTime, endTime))
-    ret
-  }
-
   /**
    * Returns an optional file listing phase summary.
    *
@@ -92,5 +80,5 @@ trait FileIndex {
    * metrics. If partition pruning happened in query planning, the phase also contains this
    * part of the cost, otherwise, it only contains file listing time of FileIndex initialize.
    */
-  final def fileListingPhase: Option[PhaseSummary] = _fileListingPhase
+  def fileListingPhase: Option[QueryPlanningTracker.PhaseSummary] = None
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -87,7 +87,7 @@ class InMemoryFileIndex(
     refresh0()
   }
 
-  private def refresh0(): Unit = {
+  private def refresh0(): Unit = measureFileListingPhase {
     val files = listLeafFiles(rootPaths)
     cachedLeafFiles =
       new mutable.LinkedHashMap[Path, FileStatus]() ++= files.map(f => f.getPath -> f)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.metric
 
+import java.sql.Timestamp
 import java.text.NumberFormat
 import java.util.Locale
 
@@ -82,6 +83,7 @@ object SQLMetrics {
   private val TIMING_METRIC = "timing"
   private val NS_TIMING_METRIC = "nsTiming"
   private val AVERAGE_METRIC = "average"
+  private val TIMESTAMP_METRIC = "timestamp"
 
   private val baseForAvgMetric: Int = 10
 
@@ -131,6 +133,14 @@ object SQLMetrics {
     acc
   }
 
+  def createTimestampMetric(sc: SparkContext, name: String): SQLMetric = {
+    // The final result of this metric in physical operator UI may looks like:
+    // start: 2018-12-15T16:49:12.634
+    val acc = new SQLMetric(TIMESTAMP_METRIC)
+    acc.register(sc, name = Some(name), countFailedValues = false)
+    acc
+  }
+
   /**
    * Create a metric to report the average information (including min, med, max) like
    * avg hash probe. As average metrics are double values, this kind of metrics should be
@@ -154,6 +164,11 @@ object SQLMetrics {
     if (metricsType == SUM_METRIC) {
       val numberFormat = NumberFormat.getIntegerInstance(Locale.US)
       numberFormat.format(values.sum)
+    } else if (metricsType == TIMESTAMP_METRIC) {
+      val validValue = values.filter(_ > 0)
+      assert(validValue.size == 1, "Timestamp metrics should have only one valid value.")
+      val ts = new Timestamp(validValue.head)
+      ts.toLocalDateTime.toString
     } else if (metricsType == AVERAGE_METRIC) {
       val numberFormat = NumberFormat.getNumberInstance(Locale.US)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.execution.metric
 
-import java.sql.Timestamp
 import java.text.NumberFormat
 import java.util.Locale
 
@@ -83,7 +82,6 @@ object SQLMetrics {
   private val TIMING_METRIC = "timing"
   private val NS_TIMING_METRIC = "nsTiming"
   private val AVERAGE_METRIC = "average"
-  private val TIMESTAMP_METRIC = "timestamp"
 
   private val baseForAvgMetric: Int = 10
 
@@ -133,14 +131,6 @@ object SQLMetrics {
     acc
   }
 
-  def createTimestampMetric(sc: SparkContext, name: String): SQLMetric = {
-    // The final result of this metric in physical operator UI may looks like:
-    // start: 2018-12-15T16:49:12.634
-    val acc = new SQLMetric(TIMESTAMP_METRIC)
-    acc.register(sc, name = Some(name), countFailedValues = false)
-    acc
-  }
-
   /**
    * Create a metric to report the average information (including min, med, max) like
    * avg hash probe. As average metrics are double values, this kind of metrics should be
@@ -164,11 +154,6 @@ object SQLMetrics {
     if (metricsType == SUM_METRIC) {
       val numberFormat = NumberFormat.getIntegerInstance(Locale.US)
       numberFormat.format(values.sum)
-    } else if (metricsType == TIMESTAMP_METRIC) {
-      val validValue = values.filter(_ > 0)
-      assert(validValue.size == 1, "Timestamp metrics should have only one valid value.")
-      val ts = new Timestamp(validValue.head)
-      ts.toLocalDateTime.toString
     } else if (metricsType == AVERAGE_METRIC) {
       val numberFormat = NumberFormat.getNumberInstance(Locale.US)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -552,10 +552,9 @@ class SQLMetricsSuite extends SparkFunSuite with SQLMetricsTestUtils with Shared
       val df0 = spark.read.table("parquetTable")
       df0.collect()
       val metrics0 = df0.queryExecution.executedPlan.collectLeaves().head.metrics
-      // Check file listing duration and timestamp change.
+      // Check file listing timestamp change.
       assert(metrics0("fileListingStart").value > 0)
       assert(metrics0("fileListingEnd").value > 0)
-      assert(metrics0("fileListingTime").value > 0)
       // Insert 10 rows into the table, this will trigger file index refresh.
       spark.range(10).selectExpr("id", "id + 1").write.insertInto("parquetTable")
       // For the second time read, file listing metrics will change.
@@ -565,10 +564,9 @@ class SQLMetricsSuite extends SparkFunSuite with SQLMetricsTestUtils with Shared
       // Check deterministic metrics.
       assert(metrics1("numFiles").value == 2)
       assert(metrics1("numOutputRows").value == 10)
-      // Check file listing duration and timestamp.
+      // Check file listing timestamp change.
       assert(metrics1("fileListingStart").value > metrics0("fileListingStart").value)
       assert(metrics1("fileListingEnd").value > metrics0("fileListingEnd").value)
-      assert(metrics1("fileListingTime").value > 0)
 
       val df2 = spark.read.table("parquetTable")
       df2.collect()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -595,7 +595,6 @@ class SQLMetricsSuite extends SparkFunSuite with SQLMetricsTestUtils with Shared
       // Check file listing duration and timestamp changed.
       assert(metrics("fileListingStart").value > 0)
       assert(metrics("fileListingEnd").value > 0)
-      assert(metrics("fileListingTime").value > 0)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -574,7 +574,7 @@ class SQLMetricsSuite extends SparkFunSuite with SQLMetricsTestUtils with Shared
       // Check file listing duration and timestamp not change.
       assert(metrics2("fileListingStart").value == metrics1("fileListingStart").value)
       assert(metrics2("fileListingEnd").value == metrics1("fileListingEnd").value)
-      assert(metrics2("fileListingTime").value == metrics1("fileListingTime").value)
+      assert(metrics2("metadataTime").value == metrics1("metadataTime").value)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Tracking file listing time and add them into scan node's metrics, also add the start and end timestamp into the metadata message of the plan.
![image](https://user-images.githubusercontent.com/4833765/50227532-e6b9ba80-03e0-11e9-9f65-921275da0493.png)


## How was this patch tested?

Add new tests in SQLMetricsSuite.
