### PR TITLE
[SPARK-26019][PYSPARK] Allow insecure py4j gateways

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonGatewayServer.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonGatewayServer.scala
@@ -51,7 +51,7 @@ private[spark] object PythonGatewayServer extends Logging {
       builder.authToken(secret)
     } else {
       assert(sys.env.getOrElse("SPARK_TESTING", "0") == "1",
-        "Creating insecure java gateways only allowed for testing")
+        "Creating insecure Java gateways only allowed for testing")
     }
     val gatewayServer: GatewayServer = builder.build()
 

--- a/core/src/main/scala/org/apache/spark/api/python/PythonGatewayServer.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonGatewayServer.scala
@@ -47,7 +47,7 @@ private[spark] object PythonGatewayServer extends Logging {
       .javaPort(0)
       .javaAddress(localhost)
       .callbackClient(GatewayServer.DEFAULT_PYTHON_PORT, localhost, secret)
-    if (sys.env.getOrElse("_PYSPARK_INSECURE_GATEWAY", "0") != "1") {
+    if (sys.env.getOrElse("_PYSPARK_CREATE_INSECURE_GATEWAY", "0") != "1") {
       builder.authToken(secret)
     } else {
       assert(sys.env.getOrElse("SPARK_TESTING", "0") == "1",

--- a/core/src/main/scala/org/apache/spark/api/python/PythonGatewayServer.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonGatewayServer.scala
@@ -43,12 +43,17 @@ private[spark] object PythonGatewayServer extends Logging {
     // with the same secret, in case the app needs callbacks from the JVM to the underlying
     // python processes.
     val localhost = InetAddress.getLoopbackAddress()
-    val gatewayServer: GatewayServer = new GatewayServer.GatewayServerBuilder()
-      .authToken(secret)
+    val builder = new GatewayServer.GatewayServerBuilder()
       .javaPort(0)
       .javaAddress(localhost)
       .callbackClient(GatewayServer.DEFAULT_PYTHON_PORT, localhost, secret)
-      .build()
+    if (sys.env.getOrElse("_PYSPARK_INSECURE_GATEWAY", "0") != "1") {
+      builder.authToken(secret)
+    } else {
+      assert(sys.env.getOrElse("SPARK_TESTING", "0") == "1",
+        "Creating insecure java gateways only allowed for testing")
+    }
+    val gatewayServer: GatewayServer = builder.build()
 
     gatewayServer.start()
     val boundPort: Int = gatewayServer.getListeningPort

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -616,8 +616,10 @@ private[spark] class PythonAccumulatorV2(
     if (socket == null || socket.isClosed) {
       socket = new Socket(serverHost, serverPort)
       logInfo(s"Connected to AccumulatorServer at host: $serverHost port: $serverPort")
-      // send the secret just for the initial authentication when opening a new connection
-      socket.getOutputStream.write(secretToken.getBytes(StandardCharsets.UTF_8))
+      if (secretToken != null) {
+        // send the secret just for the initial authentication when opening a new connection
+        socket.getOutputStream.write(secretToken.getBytes(StandardCharsets.UTF_8))
+      }
     }
     socket
   }

--- a/python/pyspark/accumulators.py
+++ b/python/pyspark/accumulators.py
@@ -262,7 +262,7 @@ class _UpdateRequestHandler(SocketServer.StreamRequestHandler):
                 raise Exception(
                     "The value of the provided token to the AccumulatorServer is not correct.")
 
-        if auth_token:
+        if auth_token is not None:
             # first we keep polling till we've received the authentication token
             poll(authenticate_and_accum_updates)
         # now we've authenticated if needed, don't need to check for the token anymore

--- a/python/pyspark/accumulators.py
+++ b/python/pyspark/accumulators.py
@@ -262,9 +262,10 @@ class _UpdateRequestHandler(SocketServer.StreamRequestHandler):
                 raise Exception(
                     "The value of the provided token to the AccumulatorServer is not correct.")
 
-        # first we keep polling till we've received the authentication token
-        poll(authenticate_and_accum_updates)
-        # now we've authenticated, don't need to check for the token anymore
+        if auth_token:
+            # first we keep polling till we've received the authentication token
+            poll(authenticate_and_accum_updates)
+        # now we've authenticated if needed, don't need to check for the token anymore
         poll(accum_updates)
 
 

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -112,6 +112,17 @@ class SparkContext(object):
         ValueError:...
         """
         self._callsite = first_spark_call() or CallSite(None, None, None)
+        if gateway != None and gateway.gateway_parameters.auth_token == None:
+            if conf and conf.get("spark.python.allowInsecurePy4j", "false") == "true":
+                print("****BAM****")
+                warnings.warn("You are passing in an insecure py4j gateway.  This "
+                  "presents a security risk, and will be completely forbidden in Spark 3.0")
+            else:
+                raise Exception("You are trying to pass an insecure py4j gateway to spark. This"
+                    " presents a security risk.  If you are sure you understand and accept this"
+                    " risk, you can add the conf 'spark.python.allowInsecurePy4j=true', but"
+                    " note this option will be removed in Spark 3.0")
+
         SparkContext._ensure_initialized(self, gateway=gateway, conf=conf)
         try:
             self._do_init(master, appName, sparkHome, pyFiles, environment, batchSize, serializer,

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -115,11 +115,11 @@ class SparkContext(object):
         if gateway is not None and gateway.gateway_parameters.auth_token is None:
             if conf and conf.get("spark.python.allowInsecurePy4j", "false") == "true":
                 warnings.warn(
-                    "You are passing in an insecure py4j gateway.  This "
+                    "You are passing in an insecure Py4j gateway.  This "
                     "presents a security risk, and will be completely forbidden in Spark 3.0")
             else:
                 raise Exception(
-                    "You are trying to pass an insecure py4j gateway to spark. This"
+                    "You are trying to pass an insecure Py4j gateway to Spark. This"
                     " presents a security risk.  If you are sure you understand and accept this"
                     " risk, you can add the conf 'spark.python.allowInsecurePy4j=true', but"
                     " note this option will be removed in Spark 3.0")

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -112,13 +112,14 @@ class SparkContext(object):
         ValueError:...
         """
         self._callsite = first_spark_call() or CallSite(None, None, None)
-        if gateway != None and gateway.gateway_parameters.auth_token == None:
+        if gateway is not None and gateway.gateway_parameters.auth_token is None:
             if conf and conf.get("spark.python.allowInsecurePy4j", "false") == "true":
-                print("****BAM****")
-                warnings.warn("You are passing in an insecure py4j gateway.  This "
-                  "presents a security risk, and will be completely forbidden in Spark 3.0")
+                warnings.warn(
+                    "You are passing in an insecure py4j gateway.  This "
+                    "presents a security risk, and will be completely forbidden in Spark 3.0")
             else:
-                raise Exception("You are trying to pass an insecure py4j gateway to spark. This"
+                raise Exception(
+                    "You are trying to pass an insecure py4j gateway to spark. This"
                     " presents a security risk.  If you are sure you understand and accept this"
                     " risk, you can add the conf 'spark.python.allowInsecurePy4j=true', but"
                     " note this option will be removed in Spark 3.0")

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -113,7 +113,8 @@ class SparkContext(object):
         """
         self._callsite = first_spark_call() or CallSite(None, None, None)
         if gateway is not None and gateway.gateway_parameters.auth_token is None:
-            if conf and conf.get("spark.python.allowInsecurePy4j", "false") == "true":
+            allow_insecure_env = os.environ.get("PYSPARK_ALLOW_INSECURE_GATEWAY", "0")
+            if allow_insecure_env == "1" or allow_insecure_env.lower() == "true":
                 warnings.warn(
                     "You are passing in an insecure Py4j gateway.  This "
                     "presents a security risk, and will be completely forbidden in Spark 3.0")
@@ -121,7 +122,8 @@ class SparkContext(object):
                 raise Exception(
                     "You are trying to pass an insecure Py4j gateway to Spark. This"
                     " presents a security risk.  If you are sure you understand and accept this"
-                    " risk, you can add the conf 'spark.python.allowInsecurePy4j=true', but"
+                    " risk, you can set the environment variable"
+                    " 'PYSPARK_ALLOW_INSECURE_GATEWAY=1', but"
                     " note this option will be removed in Spark 3.0")
 
         SparkContext._ensure_initialized(self, gateway=gateway, conf=conf)

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -119,7 +119,7 @@ class SparkContext(object):
                     "You are passing in an insecure Py4j gateway.  This "
                     "presents a security risk, and will be completely forbidden in Spark 3.0")
             else:
-                raise Exception(
+                raise ValueError(
                     "You are trying to pass an insecure Py4j gateway to Spark. This"
                     " presents a security risk.  If you are sure you understand and accept this"
                     " risk, you can set the environment variable"

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -50,6 +50,7 @@ def _launch_gateway(conf=None, insecure=False):
     """
     launch jvm gateway
     :param conf: spark configuration passed to spark-submit
+    :param insecure: True to create an insecure gateway; only for testing
     :return: a JVM gateway
     """
     if insecure and not os.environ.get("SPARK_TESTING", "0") == "1":
@@ -86,7 +87,7 @@ def _launch_gateway(conf=None, insecure=False):
             env = dict(os.environ)
             env["_PYSPARK_DRIVER_CONN_INFO_PATH"] = conn_info_file
             if insecure:
-                env["_PYSPARK_INSECURE_GATEWAY"] = "1"
+                env["_PYSPARK_CREATE_INSECURE_GATEWAY"] = "1"
 
             # Launch the Java gateway.
             # We open a pipe to stdin so that the Java gateway can die when the pipe is broken

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -41,7 +41,7 @@ def launch_gateway(conf=None):
     """
     launch jvm gateway
     :param conf: spark configuration passed to spark-submit
-    :return:
+    :return: a JVM gateway
     """
     return _launch_gateway(conf)
 
@@ -50,7 +50,7 @@ def _launch_gateway(conf=None, insecure=False):
     """
     launch jvm gateway
     :param conf: spark configuration passed to spark-submit
-    :return:
+    :return: a JVM gateway
     """
     if insecure and not os.environ.get("SPARK_TESTING", "0") == "1":
         raise Exception("creating insecure gateways is only for testing")

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -43,6 +43,16 @@ def launch_gateway(conf=None):
     :param conf: spark configuration passed to spark-submit
     :return:
     """
+    return _launch_gateway(conf)
+
+def _launch_gateway(conf=None, insecure=False):
+    """
+    launch jvm gateway
+    :param conf: spark configuration passed to spark-submit
+    :return:
+    """
+    if insecure and not os.environ.get("SPARK_TESTING", "0") == "1":
+        raise Exception("creating insecure gateways is only for testing")
     if "PYSPARK_GATEWAY_PORT" in os.environ:
         gateway_port = int(os.environ["PYSPARK_GATEWAY_PORT"])
         gateway_secret = os.environ["PYSPARK_GATEWAY_SECRET"]
@@ -74,6 +84,8 @@ def launch_gateway(conf=None):
 
             env = dict(os.environ)
             env["_PYSPARK_DRIVER_CONN_INFO_PATH"] = conn_info_file
+            if insecure:
+                env["_PYSPARK_INSECURE_GATEWAY"] = "1"
 
             # Launch the Java gateway.
             # We open a pipe to stdin so that the Java gateway can die when the pipe is broken
@@ -116,9 +128,10 @@ def launch_gateway(conf=None):
             atexit.register(killChild)
 
     # Connect to the gateway
-    gateway = JavaGateway(
-        gateway_parameters=GatewayParameters(port=gateway_port, auth_token=gateway_secret,
-                                             auto_convert=True))
+    gateway_params = GatewayParameters(port=gateway_port, auto_convert=True)
+    if not insecure:
+        gateway_params.auth_token=gateway_secret
+    gateway = JavaGateway(gateway_parameters=gateway_params)
 
     # Import the classes used by PySpark
     java_import(gateway.jvm, "org.apache.spark.SparkConf")

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -45,6 +45,7 @@ def launch_gateway(conf=None):
     """
     return _launch_gateway(conf)
 
+
 def _launch_gateway(conf=None, insecure=False):
     """
     launch jvm gateway
@@ -130,7 +131,7 @@ def _launch_gateway(conf=None, insecure=False):
     # Connect to the gateway
     gateway_params = GatewayParameters(port=gateway_port, auto_convert=True)
     if not insecure:
-        gateway_params.auth_token=gateway_secret
+        gateway_params.auth_token = gateway_secret
     gateway = JavaGateway(gateway_parameters=gateway_params)
 
     # Import the classes used by PySpark

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -53,8 +53,8 @@ def _launch_gateway(conf=None, insecure=False):
     :param insecure: True to create an insecure gateway; only for testing
     :return: a JVM gateway
     """
-    if insecure and not os.environ.get("SPARK_TESTING", "0") == "1":
-        raise Exception("creating insecure gateways is only for testing")
+    if insecure and os.environ.get("SPARK_TESTING", "0") != "1":
+        raise ValueError("creating insecure gateways is only for testing")
     if "PYSPARK_GATEWAY_PORT" in os.environ:
         gateway_port = int(os.environ["PYSPARK_GATEWAY_PORT"])
         gateway_secret = os.environ["PYSPARK_GATEWAY_SECRET"]

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -2403,9 +2403,11 @@ class ContextTests(unittest.TestCase):
         with SparkContext(conf=conf, gateway=gateway) as sc:
             print("sc created, about to create accum")
             a = sc.accumulator(1)
-            rdd = sc.parallelize([1,2,3])
+            rdd = sc.parallelize([1, 2, 3])
+
             def f(x):
                 a.add(x)
+
             rdd.foreach(f)
             self.assertEqual(7, a.value)
         print("exiting allow insecure test")

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -2388,9 +2388,9 @@ class ContextTests(unittest.TestCase):
         gateway = _launch_gateway(insecure=True)
         with self.assertRaises(Exception) as context:
             SparkContext(gateway=gateway)
-        self.assertIn("insecure py4j gateway", context.exception.message)
-        self.assertIn("spark.python.allowInsecurePy4j", context.exception.message)
-        self.assertIn("removed in Spark 3.0", context.exception.message)
+        self.assertIn("insecure Py4j gateway", str(context.exception))
+        self.assertIn("spark.python.allowInsecurePy4j", str(context.exception))
+        self.assertIn("removed in Spark 3.0", str(context.exception))
 
     def test_allow_insecure_gateway_with_conf(self):
         with SparkContext._lock:
@@ -2399,18 +2399,12 @@ class ContextTests(unittest.TestCase):
         gateway = _launch_gateway(insecure=True)
         conf = SparkConf()
         conf.set("spark.python.allowInsecurePy4j", "true")
-        print("entering allow insecure test")
         with SparkContext(conf=conf, gateway=gateway) as sc:
             print("sc created, about to create accum")
             a = sc.accumulator(1)
             rdd = sc.parallelize([1, 2, 3])
-
-            def f(x):
-                a.add(x)
-
-            rdd.foreach(f)
+            rdd.foreach(lambda x: a.add(x))
             self.assertEqual(7, a.value)
-        print("exiting allow insecure test")
 
 
 class ConfTests(unittest.TestCase):


### PR DESCRIPTION
Spark always creates secure py4j connections between java and python,
but it also allows users to pass in their own connection.  This restores
the ability for users to pass in an _insecure_ connection, though it
forces them to set the env variable 'PYSPARK_ALLOW_INSECURE_GATEWAY=1', and still
issues a warning.

Added test cases verifying the failure without the extra configuration,
and verifying things still work with an insecure configuration (in
particular, accumulators, as those were broken with an insecure py4j
gateway before).

For the tests, I added ways to create insecure gateways, but I tried to put in protections to make sure that wouldn't get used incorrectly.