### PR TITLE
[SPARK-26415][SQL] Mark StreamSinkProvider and StreamSourceProvider as stable

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -111,13 +111,11 @@ trait SchemaRelationProvider {
 }
 
 /**
- * ::Experimental::
  * Implemented by objects that can produce a streaming `Source` for a specific format or system.
  *
  * @since 2.0.0
  */
-@Experimental
-@Unstable
+@Stable
 trait StreamSourceProvider {
 
   /**
@@ -142,13 +140,11 @@ trait StreamSourceProvider {
 }
 
 /**
- * ::Experimental::
  * Implemented by objects that can produce a streaming `Sink` for a specific format or system.
  *
  * @since 2.0.0
  */
-@Experimental
-@Unstable
+@Stable
 trait StreamSinkProvider {
   def createSink(
       sqlContext: SQLContext,


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change marks the StreamSinkProvider and StreamSourceProvider
interfaces as stable so that it can be relied on for compatibility for all of
Spark 2.x.

These interfaces have been available since Spark 2.0.0 and unchanged 
since Spark 2.1.0. Additionally the Kafka integration has been using it 
since Spark 2.1.0.

Because structured streaming general availability was announced in 
Spark 2.2.0, I suspect there are other third-party integrations using it
already as well.