### PR TITLE
[SPARK-26418][SHUFFLE] Only OpenBlocks without any ChunkFetch for one stream will cause memory leak in ExternalShuffleService

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportClient.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportClient.java
@@ -124,6 +124,9 @@ public class TransportClient implements Closeable {
    * to be returned in the same order that they were requested, assuming only a single
    * TransportClient is used to fetch the chunks.
    *
+   * OpenBlocks and following FetchChunk requests for a stream should be sent by the same
+   * TransportClient to avoid potential memory leak on server side.
+   *
    * @param streamId Identifier that refers to a stream in the remote StreamManager. This should
    *                 be agreed upon by client and server beforehand.
    * @param chunkIndex 0-based index of the chunk to fetch

--- a/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
@@ -90,7 +90,6 @@ public class ChunkFetchRequestHandler extends SimpleChannelInboundHandler<ChunkF
     ManagedBuffer buf;
     try {
       streamManager.checkAuthorization(client, msg.streamChunkId.streamId);
-      streamManager.registerChannel(channel, msg.streamChunkId.streamId);
       buf = streamManager.getChunk(msg.streamChunkId.streamId, msg.streamChunkId.chunkIndex);
     } catch (Exception e) {
       logger.error(String.format("Error opening block %s for request from %s",

--- a/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
@@ -204,7 +204,7 @@ public class OneForOneStreamManager extends StreamManager {
   }
 
   @VisibleForTesting
-  public long getStreamsSize() {
+  public long getStreamCount() {
     return streams.size();
   }
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
@@ -23,6 +23,7 @@ import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.netty.channel.Channel;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -202,4 +203,8 @@ public class OneForOneStreamManager extends StreamManager {
     return myStreamId;
   }
 
+  @VisibleForTesting
+  public long getStreamsSize() {
+    return streams.size();
+  }
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockHandler.java
@@ -92,6 +92,7 @@ public class ExternalShuffleBlockHandler extends RpcHandler {
         checkAuth(client, msg.appId);
         long streamId = streamManager.registerStream(client.getClientId(),
           new ManagedBufferIterator(msg.appId, msg.execId, msg.blockIds));
+        streamManager.registerChannel(client.getChannel(), streamId);
         if (logger.isTraceEnabled()) {
           logger.trace("Registered streamId {} with {} buffers for client {} from host {}",
                        streamId,

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/StreamStatesCleanupSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/StreamStatesCleanupSuite.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle;
+
+import io.netty.channel.Channel;
+import org.apache.spark.network.buffer.ManagedBuffer;
+import org.apache.spark.network.buffer.NioManagedBuffer;
+import org.apache.spark.network.client.RpcResponseCallback;
+import org.apache.spark.network.client.TransportClient;
+import org.apache.spark.network.client.TransportResponseHandler;
+import org.apache.spark.network.server.OneForOneStreamManager;
+import org.apache.spark.network.server.RpcHandler;
+import org.apache.spark.network.shuffle.protocol.OpenBlocks;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class StreamStatesCleanupSuite {
+
+  @Test
+  public void testStreamsAreRemovedCorrectly() {
+    OneForOneStreamManager streamManager = new OneForOneStreamManager();
+    ExternalShuffleBlockResolver blockResolver = mock(ExternalShuffleBlockResolver.class);
+    TransportClient reverseClient
+      = new TransportClient(mock(Channel.class), mock(TransportResponseHandler.class));
+    RpcHandler handler = new ExternalShuffleBlockHandler(streamManager, blockResolver);
+
+    ManagedBuffer block0Marker = new NioManagedBuffer(ByteBuffer.wrap(new byte[3]));
+    ManagedBuffer block1Marker = new NioManagedBuffer(ByteBuffer.wrap(new byte[7]));
+    when(blockResolver.getBlockData("app0", "exec1", 0, 0, 0))
+      .thenReturn(block0Marker);
+    when(blockResolver.getBlockData("app0", "exec1", 0, 0, 1))
+      .thenReturn(block1Marker);
+    ByteBuffer openBlocks = new OpenBlocks("app0", "exec1",
+      new String[]{"shuffle_0_0_0", "shuffle_0_0_1"})
+      .toByteBuffer();
+
+    RpcResponseCallback callback = mock(RpcResponseCallback.class);
+
+    // Open blocks
+    handler.receive(reverseClient, openBlocks, callback);
+    // Connection closed before any FetchChunk request received
+    streamManager.connectionTerminated(reverseClient.getChannel());
+
+    assert streamManager.getStreamsSize() == 0;
+  }
+
+}

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/StreamStatesCleanupSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/StreamStatesCleanupSuite.java
@@ -17,7 +17,15 @@
 
 package org.apache.spark.network.shuffle;
 
+import java.nio.ByteBuffer;
+
 import io.netty.channel.Channel;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.apache.spark.network.buffer.ManagedBuffer;
 import org.apache.spark.network.buffer.NioManagedBuffer;
 import org.apache.spark.network.client.RpcResponseCallback;
@@ -26,12 +34,6 @@ import org.apache.spark.network.client.TransportResponseHandler;
 import org.apache.spark.network.server.OneForOneStreamManager;
 import org.apache.spark.network.server.RpcHandler;
 import org.apache.spark.network.shuffle.protocol.OpenBlocks;
-import org.junit.Test;
-
-import java.nio.ByteBuffer;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class StreamStatesCleanupSuite {
 
@@ -60,7 +62,7 @@ public class StreamStatesCleanupSuite {
     // Connection closed before any FetchChunk request received
     streamManager.connectionTerminated(reverseClient.getChannel());
 
-    assert streamManager.getStreamsSize() == 0;
+    assertEquals(0, streamManager.getStreamCount());
   }
 
 }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/StreamStatesCleanupSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/StreamStatesCleanupSuite.java
@@ -59,9 +59,10 @@ public class StreamStatesCleanupSuite {
 
     // Open blocks
     handler.receive(reverseClient, openBlocks, callback);
+    assertEquals(1, streamManager.getStreamCount());
+
     // Connection closed before any FetchChunk request received
     streamManager.connectionTerminated(reverseClient.getChannel());
-
     assertEquals(0, streamManager.getStreamCount());
   }
 

--- a/core/src/main/scala/org/apache/spark/network/netty/NettyBlockRpcServer.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/NettyBlockRpcServer.scala
@@ -61,6 +61,7 @@ class NettyBlockRpcServer(
           yield blockManager.getBlockData(BlockId.apply(openBlocks.blockIds(i)))
         val streamId = streamManager.registerStream(appId, blocks.iterator.asJava)
         logTrace(s"Registered streamId $streamId with $blocksNum buffers")
+        streamManager.registerChannel(client.getChannel, streamId)
         responseContext.onSuccess(new StreamHandle(streamId, blocksNum).toByteBuffer)
 
       case uploadBlock: UploadBlock =>

--- a/core/src/test/scala/org/apache/spark/network/netty/StreamsStateCleanupSuite.scala
+++ b/core/src/test/scala/org/apache/spark/network/netty/StreamsStateCleanupSuite.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.netty
+
+import io.netty.channel.Channel
+import org.scalatest.mockito.MockitoSugar
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.network.BlockDataManager
+import org.apache.spark.network.client.{RpcResponseCallback, TransportClient, TransportResponseHandler}
+import org.apache.spark.network.server.OneForOneStreamManager
+import org.apache.spark.network.shuffle.protocol.OpenBlocks
+import org.apache.spark.serializer.Serializer
+
+class StreamsStateCleanupSuite extends SparkFunSuite with MockitoSugar {
+
+  test("test streams are removed correctly") {
+    val streamManager = new OneForOneStreamManager()
+    val reverseClient = new TransportClient(mock[Channel], mock[TransportResponseHandler])
+    val rpcHandler
+      = new NettyBlockRpcServer("app0", mock[Serializer], mock[BlockDataManager])
+
+    val openBlocks = new OpenBlocks("app0", "exec1",
+      Array[String]("shuffle_0_0_0", "shuffle_0_0_1"))
+      .toByteBuffer
+    val callback = mock[RpcResponseCallback]
+
+    // Open blocks
+    rpcHandler.receive(reverseClient, openBlocks, callback)
+    assert(streamManager.getStreamCount === 1)
+
+    // Connection closed before any FetchChunk request received
+    streamManager.connectionTerminated(reverseClient.getChannel)
+    assert(streamManager.getStreamCount === 0)
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

In current code path,  `OneForOneStreamManager` holds `StreamState` in a Map named `streams`. 

A `StreamState` is initialized and put into `streams` when `OpenBlocks` request received.
One specific `StreamState` is removed from streams in two scenarios below:
1. The last chunk of a stream is fetched
2. The connection of `ChunkFetchRequest` is closed

`StreamState` will never be clean up, if `OpenBlocks` request is received without any following  `ChunkFetchRequest`. This will cause memory leak in server side, which is harmful for long running service such as `ExternalShuffleService`.

This PR associates `StreamState` with channel when handle `OpenBlocks` request, because `OpenBlocks` request and following `ChunkFetchRequest`s for a specific stream are sent from the same `TransportClient` in `OneForOneBlockFetcher`.

## How was this patch tested?
New test added.
