### PR TITLE
[SPARK-26269][YARN][BRANCH-2.4] Yarnallocator should have same blacklist behaviour with yarn to maxmize use of cluster resource

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -590,14 +590,14 @@ private[yarn] class YarnAllocator(
             // oop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/ap
             // ache/hadoop/yarn/util/Apps.java#L273 for details)
             if (NOT_APP_AND_SYSTEM_FAULT_EXIT_STATUS.contains(other_exit_status)) {
-              (true, s"Container marked as failed: $containerId$onHostStr" +
-                s". Exit status:  ${completedContainer.getExitStatus}" +
+              (false, s"Container marked as failed: $containerId$onHostStr" +
+                s". Exit status: ${completedContainer.getExitStatus}" +
                 s". Diagnostics: ${completedContainer.getDiagnostics}.")
             } else {
               // completed container from a bad node
               allocatorBlacklistTracker.handleResourceAllocationFailure(hostOpt)
               (true, s"Container from a bad node: $containerId$onHostStr" +
-                s". Exit status:  ${completedContainer.getExitStatus}" +
+                s". Exit status: ${completedContainer.getExitStatus}" +
                 s". Diagnostics: ${completedContainer.getDiagnostics}.")
             }
 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -584,7 +584,7 @@ private[yarn] class YarnAllocator(
             val message = "Container killed by YARN for exceeding physical memory limits. " +
               s"$diag Consider boosting ${EXECUTOR_MEMORY_OVERHEAD.key}."
             (true, message)
-          case exit_code if NOT_APP_AND_SYSTEM_FAULT_EXIT_STATUS.contains(exit_code) =>
+          case exit_status if NOT_APP_AND_SYSTEM_FAULT_EXIT_STATUS.contains(exit_status) =>
             (true, "Container marked as failed: " + containerId + onHostStr +
               ". Exit status: " + completedContainer.getExitStatus +
               ". Diagnostics: " + completedContainer.getDiagnostics)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -578,12 +578,6 @@ private[yarn] class YarnAllocator(
             (true, memLimitExceededLogMessage(
               completedContainer.getDiagnostics,
               PMEM_EXCEEDED_PATTERN))
-            val pmemExceededPattern = raw"$MEM_REGEX of $MEM_REGEX physical memory used".r
-            val diag = pmemExceededPattern.findFirstIn(completedContainer.getDiagnostics)
-              .map(_.concat(".")).getOrElse("")
-            val message = "Container killed by YARN for exceeding physical memory limits. " +
-              s"$diag Consider boosting ${EXECUTOR_MEMORY_OVERHEAD.key}."
-            (true, message)
           case other_exit_status =>
             // SPARK-26269: follow YARN's blacklisting behaviour(see https://github
             // .com/apache/hadoop/blob/228156cfd1b474988bc4fedfbf7edddc87db41e3/had

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocatorBlacklistTracker.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocatorBlacklistTracker.scala
@@ -120,7 +120,9 @@ private[spark] class YarnAllocatorBlacklistTracker(
     if (removals.nonEmpty) {
       logInfo(s"removing nodes from YARN application master's blacklist: $removals")
     }
-    amClient.updateBlacklist(additions.asJava, removals.asJava)
+    if (additions.nonEmpty || removals.nonEmpty) {
+      amClient.updateBlacklist(additions.asJava, removals.asJava)
+    }
     currentBlacklistedYarnNodes = nodesToBlacklist
   }
 

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorBlacklistTrackerSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorBlacklistTrackerSuite.scala
@@ -87,7 +87,7 @@ class YarnAllocatorBlacklistTrackerSuite extends SparkFunSuite with Matchers
     // expired blacklisted nodes (simulating a resource request)
     yarnBlacklistTracker.setSchedulerBlacklistedNodes(Set("host1", "host2"))
     // no change is communicated to YARN regarding the blacklisting
-    verify(amClientMock).updateBlacklist(Collections.emptyList(), Collections.emptyList())
+    verify(amClientMock, times(0)).updateBlacklist(Collections.emptyList(), Collections.emptyList())
   }
 
   test("combining scheduler and allocation blacklist") {

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
@@ -17,9 +17,10 @@
 
 package org.apache.spark.deploy.yarn
 
-import java.util.{Arrays, Collections}
+import java.util.Collections
 
 import scala.collection.JavaConverters._
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.yarn.api.records._
 import org.apache.hadoop.yarn.client.api.AMRMClient
@@ -27,11 +28,11 @@ import org.apache.hadoop.yarn.client.api.AMRMClient.ContainerRequest
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.mockito.Mockito._
 import org.scalatest.{BeforeAndAfterEach, Matchers}
+
 import org.apache.spark.{SecurityManager, SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.yarn.YarnAllocator._
 import org.apache.spark.deploy.yarn.YarnSparkHadoopUtil._
 import org.apache.spark.deploy.yarn.config._
-import org.apache.spark.internal.config.{BLACKLIST_TIMEOUT_CONF, MAX_FAILED_EXEC_PER_NODE}
 import org.apache.spark.rpc.RpcEndpointRef
 import org.apache.spark.scheduler.SplitInfo
 import org.apache.spark.util.ManualClock
@@ -109,13 +110,19 @@ class YarnAllocatorSuite extends SparkFunSuite with Matchers with BeforeAndAfter
       clock)
   }
 
-  def createContainer(host: String): Container = {
-    // When YARN 2.6+ is required, avoid deprecation by using version with long second arg
-    val containerId = ContainerId.newInstance(appAttemptId, containerNum)
+  def createContainer(
+      host: String,
+      containerId: ContainerId = ContainerId.newContainerId(appAttemptId, containerNum),
+      resource: Resource = containerResource): Container = {
     containerNum += 1
     val nodeId = NodeId.newInstance(host, 1000)
     Container.newInstance(containerId, nodeId, "", containerResource, RM_REQUEST_PRIORITY, null)
   }
+
+  def createContainers(hosts: Seq[String], containerIds: Seq[ContainerId]): Seq[Container] = {
+    hosts.zip(containerIds).map{case (host, id) => createContainer(host, id)}
+  }
+
 
   test("single container allocated") {
     // request a single container and receive it
@@ -133,6 +140,29 @@ class YarnAllocatorSuite extends SparkFunSuite with Matchers with BeforeAndAfter
 
     val size = rmClient.getMatchingRequests(container.getPriority, "host1", containerResource).size
     size should be (0)
+  }
+
+  test("custom resource requested from yarn") {
+    assume(ResourceRequestHelper.isYarnResourceTypesAvailable())
+    ResourceRequestTestHelper.initializeResourceTypes(List("gpu"))
+
+    val mockAmClient = mock(classOf[AMRMClient[ContainerRequest]])
+    val handler = createAllocator(1, mockAmClient,
+      Map(YARN_EXECUTOR_RESOURCE_TYPES_PREFIX + "gpu" -> "2G"))
+
+    handler.updateResourceRequests()
+    val container = createContainer("host1", resource = handler.resource)
+    handler.handleAllocatedContainers(Array(container))
+
+    // get amount of memory and vcores from resource, so effectively skipping their validation
+    val expectedResources = Resource.newInstance(handler.resource.getMemory(),
+      handler.resource.getVirtualCores)
+    ResourceRequestHelper.setResourceRequests(Map("gpu" -> "2G"), expectedResources)
+    val captor = ArgumentCaptor.forClass(classOf[ContainerRequest])
+
+    verify(mockAmClient).addContainerRequest(captor.capture())
+    val containerRequest: ContainerRequest = captor.getValue
+    assert(containerRequest.getCapability === expectedResources)
   }
 
   test("container should not be created if requested number if met") {
@@ -402,47 +432,58 @@ class YarnAllocatorSuite extends SparkFunSuite with Matchers with BeforeAndAfter
     handler.getNumExecutorsFailed should be (0)
   }
 
-  test("YarnAllocator should have same blacklist behaviour with YARN") {
-    val amrmClientMock = mock(classOf[AMRMClient[ContainerRequest]])
+  test("SPARK-26296: YarnAllocator should have same blacklist behaviour with YARN") {
+    val rmClientSpy = spy(rmClient)
+    val maxExecutors = 11
 
     val handler = createAllocator(
-      2,
-      amrmClientMock,
+      maxExecutors,
+      rmClientSpy,
       Map(
         "spark.yarn.blacklist.executor.launch.blacklisting.enabled" -> "true",
         "spark.blacklist.application.maxFailedExecutorsPerNode" -> "0"))
-    val container1 = createContainer("host1")
     handler.updateResourceRequests()
-    handler.handleAllocatedContainers(Array(container1))
 
-    val cs1 = ContainerStatus.newInstance(container1.getId, ContainerState.COMPLETE,
+    val hosts = (0 until maxExecutors).map(i => s"host$i")
+    val ids = (0 to maxExecutors).map(i => ContainerId.newContainerId(appAttemptId, i))
+    val containers = createContainers(hosts, ids)
+    handler.handleAllocatedContainers(containers.slice(0, 9))
+    val cs0 = ContainerStatus.newInstance(containers(0).getId, ContainerState.COMPLETE,
       "success", ContainerExitStatus.SUCCESS)
-    val cs2 = ContainerStatus.newInstance(container1.getId, ContainerState.COMPLETE,
+    val cs1 = ContainerStatus.newInstance(containers(1).getId, ContainerState.COMPLETE,
       "preempted", ContainerExitStatus.PREEMPTED)
-    val cs3 = ContainerStatus.newInstance(container1.getId, ContainerState.COMPLETE,
+    val cs2 = ContainerStatus.newInstance(containers(2).getId, ContainerState.COMPLETE,
       "killed_exceeded_vmem", ContainerExitStatus.KILLED_EXCEEDED_VMEM)
-    val cs4 = ContainerStatus.newInstance(container1.getId, ContainerState.COMPLETE,
+    val cs3 = ContainerStatus.newInstance(containers(3).getId, ContainerState.COMPLETE,
       "killed_exceeded_pmem", ContainerExitStatus.KILLED_EXCEEDED_PMEM)
-    val cs5 = ContainerStatus.newInstance(container1.getId, ContainerState.COMPLETE,
+    val cs4 = ContainerStatus.newInstance(containers(4).getId, ContainerState.COMPLETE,
       "killed_by_resourcemanager", ContainerExitStatus.KILLED_BY_RESOURCEMANAGER)
-    val cs6 = ContainerStatus.newInstance(container1.getId, ContainerState.COMPLETE,
+    val cs5 = ContainerStatus.newInstance(containers(5).getId, ContainerState.COMPLETE,
       "killed_by_appmaster", ContainerExitStatus.KILLED_BY_APPMASTER)
-    val cs7 = ContainerStatus.newInstance(container1.getId, ContainerState.COMPLETE,
+    val cs6 = ContainerStatus.newInstance(containers(6).getId, ContainerState.COMPLETE,
       "killed_after_app_completion", ContainerExitStatus.KILLED_AFTER_APP_COMPLETION)
-    val cs8 = ContainerStatus.newInstance(container1.getId, ContainerState.COMPLETE,
+    val cs7 = ContainerStatus.newInstance(containers(7).getId, ContainerState.COMPLETE,
       "aborted", ContainerExitStatus.ABORTED)
-    val cs9 = ContainerStatus.newInstance(container1.getId, ContainerState.COMPLETE,
+    val cs8 = ContainerStatus.newInstance(containers(8).getId, ContainerState.COMPLETE,
       "disk_failed", ContainerExitStatus.DISKS_FAILED)
-    handler.processCompletedContainers(Seq(cs1, cs2, cs3, cs4, cs5, cs6, cs7, cs8, cs9))
+    handler.processCompletedContainers(Seq(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7, cs8))
 
-    verify(amrmClientMock, never())
-      .updateBlacklist(Arrays.asList("host1"), Collections.emptyList())
+    verify(rmClientSpy, never())
+      .updateBlacklist(hosts.slice(0, 9).asJava, Collections.emptyList())
 
-    val cs10 = ContainerStatus.newInstance(container1.getId, ContainerState.COMPLETE,
+    handler.handleAllocatedContainers(Array(containers(9)))
+    val cs9 = ContainerStatus.newInstance(containers(9).getId, ContainerState.COMPLETE,
       "invalid", ContainerExitStatus.INVALID)
-    handler.processCompletedContainers(Seq(cs10))
-    verify(amrmClientMock)
-      .updateBlacklist(Arrays.asList("host1"), Collections.emptyList())
+    handler.processCompletedContainers(Seq(cs9))
+    verify(rmClientSpy)
+      .updateBlacklist(Seq(hosts(9)).asJava, Collections.emptyList())
 
+    handler.handleAllocatedContainers(Array(containers(10)))
+    val UNKNOWN_EXIT_CODE = 1
+    val cs10 = ContainerStatus.newInstance(containers(10).getId, ContainerState.COMPLETE,
+      "unknown_exit_code", UNKNOWN_EXIT_CODE)
+    handler.processCompletedContainers(Seq(cs10))
+    verify(rmClientSpy)
+      .updateBlacklist(Seq(hosts(10)).asJava, Collections.emptyList())
   }
 }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
@@ -157,7 +157,7 @@ class YarnAllocatorSuite extends SparkFunSuite with Matchers with BeforeAndAfter
     val size = rmClient.getMatchingRequests(container.getPriority, "host1", containerResource).size
     size should be (0)
   }
-  
+
   test("container should not be created if requested number if met") {
     // request a single container and receive it
     val handler = createAllocator(1)

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
@@ -26,6 +26,7 @@ import org.apache.hadoop.yarn.api.records._
 import org.apache.hadoop.yarn.client.api.AMRMClient
 import org.apache.hadoop.yarn.client.api.AMRMClient.ContainerRequest
 import org.apache.hadoop.yarn.conf.YarnConfiguration
+import org.mockito.ArgumentCaptor
 import org.mockito.Mockito._
 import org.scalatest.{BeforeAndAfterEach, Matchers}
 
@@ -88,7 +89,8 @@ class YarnAllocatorSuite extends SparkFunSuite with Matchers with BeforeAndAfter
 
   def createAllocator(
       maxExecutors: Int = 5,
-      rmClient: AMRMClient[ContainerRequest] = rmClient): YarnAllocator = {
+      rmClient: AMRMClient[ContainerRequest] = rmClient,
+      additionalConfigs: Map[String, String] = Map()): YarnAllocator = {
     val args = Array(
       "--jar", "somejar.jar",
       "--class", "SomeClass")
@@ -97,6 +99,11 @@ class YarnAllocatorSuite extends SparkFunSuite with Matchers with BeforeAndAfter
       .set("spark.executor.instances", maxExecutors.toString)
       .set("spark.executor.cores", "5")
       .set("spark.executor.memory", "2048")
+
+    for ((name, value) <- additionalConfigs) {
+      sparkConfClone.set(name, value)
+    }
+
     new YarnAllocator(
       "not used",
       mock(classOf[RpcEndpointRef]),
@@ -150,30 +157,7 @@ class YarnAllocatorSuite extends SparkFunSuite with Matchers with BeforeAndAfter
     val size = rmClient.getMatchingRequests(container.getPriority, "host1", containerResource).size
     size should be (0)
   }
-
-  test("custom resource requested from yarn") {
-    assume(ResourceRequestHelper.isYarnResourceTypesAvailable())
-    ResourceRequestTestHelper.initializeResourceTypes(List("gpu"))
-
-    val mockAmClient = mock(classOf[AMRMClient[ContainerRequest]])
-    val handler = createAllocator(1, mockAmClient,
-      Map(YARN_EXECUTOR_RESOURCE_TYPES_PREFIX + "gpu" -> "2G"))
-
-    handler.updateResourceRequests()
-    val container = createContainer("host1", resource = handler.resource)
-    handler.handleAllocatedContainers(Array(container))
-
-    // get amount of memory and vcores from resource, so effectively skipping their validation
-    val expectedResources = Resource.newInstance(handler.resource.getMemory(),
-      handler.resource.getVirtualCores)
-    ResourceRequestHelper.setResourceRequests(Map("gpu" -> "2G"), expectedResources)
-    val captor = ArgumentCaptor.forClass(classOf[ContainerRequest])
-
-    verify(mockAmClient).addContainerRequest(captor.capture())
-    val containerRequest: ContainerRequest = captor.getValue
-    assert(containerRequest.getCapability === expectedResources)
-  }
-
+  
   test("container should not be created if requested number if met") {
     // request a single container and receive it
     val handler = createAllocator(1)

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
@@ -112,15 +112,24 @@ class YarnAllocatorSuite extends SparkFunSuite with Matchers with BeforeAndAfter
 
   def createContainer(
       host: String,
-      containerId: ContainerId = ContainerId.newContainerId(appAttemptId, containerNum),
+      containerNumber: Int = containerNum,
       resource: Resource = containerResource): Container = {
+    val  containerId: ContainerId = ContainerId.newContainerId(appAttemptId, containerNum)
     containerNum += 1
     val nodeId = NodeId.newInstance(host, 1000)
     Container.newInstance(containerId, nodeId, "", containerResource, RM_REQUEST_PRIORITY, null)
   }
 
-  def createContainers(hosts: Seq[String], containerIds: Seq[ContainerId]): Seq[Container] = {
+  def createContainers(hosts: Seq[String], containerIds: Seq[Int]): Seq[Container] = {
     hosts.zip(containerIds).map{case (host, id) => createContainer(host, id)}
+  }
+
+  def createContainerStatus(
+      containerId: ContainerId,
+      exitStatus: Int,
+      containerState: ContainerState = ContainerState.COMPLETE,
+      diagnostics: String = "diagnostics"): ContainerStatus = {
+    ContainerStatus.newInstance(containerId, containerState, diagnostics, exitStatus)
   }
 
 
@@ -432,7 +441,7 @@ class YarnAllocatorSuite extends SparkFunSuite with Matchers with BeforeAndAfter
     handler.getNumExecutorsFailed should be (0)
   }
 
-  test("SPARK-26296: YarnAllocator should have same blacklist behaviour with YARN") {
+  test("SPARK-26269: YarnAllocator should have same blacklist behaviour with YARN") {
     val rmClientSpy = spy(rmClient)
     val maxExecutors = 11
 
@@ -445,45 +454,41 @@ class YarnAllocatorSuite extends SparkFunSuite with Matchers with BeforeAndAfter
     handler.updateResourceRequests()
 
     val hosts = (0 until maxExecutors).map(i => s"host$i")
-    val ids = (0 to maxExecutors).map(i => ContainerId.newContainerId(appAttemptId, i))
+    val ids = 0 to maxExecutors
     val containers = createContainers(hosts, ids)
-    handler.handleAllocatedContainers(containers.slice(0, 9))
-    val cs0 = ContainerStatus.newInstance(containers(0).getId, ContainerState.COMPLETE,
-      "success", ContainerExitStatus.SUCCESS)
-    val cs1 = ContainerStatus.newInstance(containers(1).getId, ContainerState.COMPLETE,
-      "preempted", ContainerExitStatus.PREEMPTED)
-    val cs2 = ContainerStatus.newInstance(containers(2).getId, ContainerState.COMPLETE,
-      "killed_exceeded_vmem", ContainerExitStatus.KILLED_EXCEEDED_VMEM)
-    val cs3 = ContainerStatus.newInstance(containers(3).getId, ContainerState.COMPLETE,
-      "killed_exceeded_pmem", ContainerExitStatus.KILLED_EXCEEDED_PMEM)
-    val cs4 = ContainerStatus.newInstance(containers(4).getId, ContainerState.COMPLETE,
-      "killed_by_resourcemanager", ContainerExitStatus.KILLED_BY_RESOURCEMANAGER)
-    val cs5 = ContainerStatus.newInstance(containers(5).getId, ContainerState.COMPLETE,
-      "killed_by_appmaster", ContainerExitStatus.KILLED_BY_APPMASTER)
-    val cs6 = ContainerStatus.newInstance(containers(6).getId, ContainerState.COMPLETE,
-      "killed_after_app_completion", ContainerExitStatus.KILLED_AFTER_APP_COMPLETION)
-    val cs7 = ContainerStatus.newInstance(containers(7).getId, ContainerState.COMPLETE,
-      "aborted", ContainerExitStatus.ABORTED)
-    val cs8 = ContainerStatus.newInstance(containers(8).getId, ContainerState.COMPLETE,
-      "disk_failed", ContainerExitStatus.DISKS_FAILED)
-    handler.processCompletedContainers(Seq(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7, cs8))
 
+    val nonBlacklistedStatuses = Seq(
+      ContainerExitStatus.SUCCESS,
+      ContainerExitStatus.PREEMPTED,
+      ContainerExitStatus.KILLED_EXCEEDED_VMEM,
+      ContainerExitStatus.KILLED_EXCEEDED_PMEM,
+      ContainerExitStatus.KILLED_BY_RESOURCEMANAGER,
+      ContainerExitStatus.KILLED_BY_APPMASTER,
+      ContainerExitStatus.KILLED_AFTER_APP_COMPLETION,
+      ContainerExitStatus.ABORTED,
+      ContainerExitStatus.DISKS_FAILED)
+
+    val nonBlacklistedContainerStatuses = nonBlacklistedStatuses.zipWithIndex.map {
+      case (exitStatus, idx) => createContainerStatus(containers(idx).getId, exitStatus)
+    }
+
+    val BLACKLISTED_EXIT_CODE = 1
+    val blacklistedStatuses = Seq(ContainerExitStatus.INVALID, BLACKLISTED_EXIT_CODE)
+
+    val blacklistedContainerStatuses = blacklistedStatuses.zip(9 until maxExecutors).map {
+      case (exitStatus, idx) => createContainerStatus(containers(idx).getId, exitStatus)
+    }
+
+    handler.handleAllocatedContainers(containers.slice(0, 9))
+    handler.processCompletedContainers(nonBlacklistedContainerStatuses)
     verify(rmClientSpy, never())
       .updateBlacklist(hosts.slice(0, 9).asJava, Collections.emptyList())
 
-    handler.handleAllocatedContainers(Array(containers(9)))
-    val cs9 = ContainerStatus.newInstance(containers(9).getId, ContainerState.COMPLETE,
-      "invalid", ContainerExitStatus.INVALID)
-    handler.processCompletedContainers(Seq(cs9))
+    handler.handleAllocatedContainers(containers.slice(9, 11))
+    handler.processCompletedContainers(blacklistedContainerStatuses)
     verify(rmClientSpy)
-      .updateBlacklist(Seq(hosts(9)).asJava, Collections.emptyList())
-
-    handler.handleAllocatedContainers(Array(containers(10)))
-    val UNKNOWN_EXIT_CODE = 1
-    val cs10 = ContainerStatus.newInstance(containers(10).getId, ContainerState.COMPLETE,
-      "unknown_exit_code", UNKNOWN_EXIT_CODE)
-    handler.processCompletedContainers(Seq(cs10))
+      .updateBlacklist(hosts.slice(9, 10).asJava, Collections.emptyList())
     verify(rmClientSpy)
-      .updateBlacklist(Seq(hosts(10)).asJava, Collections.emptyList())
+      .updateBlacklist(hosts.slice(10, 11).asJava, Collections.emptyList())
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

As I mentioned in jira [SPARK-26269](https://issues.apache.org/jira/browse/SPARK-26269), in order to maxmize the use of cluster resource,  this pr try to make `YarnAllocator` have the same blacklist behaviour with YARN.

## How was this patch tested?

Added.