### PR TITLE
[SPARK-26440][WEBUI] Show total CPU time across all tasks on stage pages

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -153,8 +153,12 @@ private[ui] class StagePage(parent: StagesTab, store: AppStatusStore) extends We
       <div>
         <ul class="unstyled">
           <li>
-            <strong>Total Time Across All Tasks: </strong>
+            <strong>Total Run Time Across All Tasks: </strong>
             {UIUtils.formatDuration(stageData.executorRunTime)}
+          </li>
+          <li>
+            <strong>Total CPU Time Across All Tasks: </strong>
+            {UIUtils.formatDuration(stageData.executorCpuTime / 1000000)}
           </li>
           <li>
             <strong>Locality Level Summary: </strong>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Task CPU time was added since [SPARK-12221](https://issues.apache.org/jira/browse/SPARK-12221). However, total CPU time across all tasks is not displayed on stage pages. This could be used to check whether a stage is CPU intensive or not.

This PR lets total CPU time across all tasks showed on stage pages.

## How was this patch tested?
Manually tested locally.
<img width="361" alt="screen shot 2018-12-26 at 12 29 22 am" src="https://user-images.githubusercontent.com/12194089/50424797-52020180-08a5-11e9-8f9f-f8b601b821d7.png">

