### PR TITLE
[SPARK-26441][KUBERNETES] Add kind configuration of driver pod 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,7 @@
     <module>external/kafka-0-10-assembly</module>
     <module>external/kafka-0-10-sql</module>
     <module>external/avro</module>
+    <module>resource-managers/kubernetes/core</module>
     <!-- See additional modules enabled by profiles below -->
   </modules>
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -289,6 +289,19 @@ private[spark] object Config extends Logging {
       .booleanConf
       .createWithDefault(true)
 
+  val KUBERNETES_DRIVER_POD_KIND =
+    ConfigBuilder("spark.kubernetes.driver.pod.kind")
+      .doc("Specify the kind of driver's pod on Kubernetes.")
+      .stringConf
+      .checkValues(Set("Pod", "Job", "Deployment"))
+      .createWithDefault("Pod")
+
+  val KUBERNETES_JOB_BACKOFFLIMIT =
+    ConfigBuilder("spark.kubernetes.job.backofflimit")
+      .doc("Specify backoffLimit of job.")
+      .intConf
+      .createWithDefault(3)
+
   val KUBERNETES_DRIVER_LABEL_PREFIX = "spark.kubernetes.driver.label."
   val KUBERNETES_DRIVER_ANNOTATION_PREFIX = "spark.kubernetes.driver.annotation."
   val KUBERNETES_DRIVER_SECRETS_PREFIX = "spark.kubernetes.driver.secrets."


### PR DESCRIPTION
## What changes were proposed in this pull request?
Spark running on kubernetes now starts driver pod in Pod kind by default , which has a problem that entire job fails when  host machine crashs. In other words , driver pod can not failover in kind of Pod in this situation.  So , we add kind configuration of driver pod which supports Pod、Deployment、Job. For example , in streaming jobs , starting driver pod in Deployment kind will ensure  the driver service high available even there is host-machine-crash. In batch jobs , there is configurable backoffLimits for retry.   

## How was this patch tested?
We test in production env. Starting driver in Deployment or Job kind can make driver high available when host machine crashs.
