### PR TITLE
[SPARK-26447][SQL]Allow OrcColumnarBatchReader to return less partition columns

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReader.java
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.datasources.orc;
 import java.io.IOException;
 import java.util.stream.IntStream;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -64,7 +65,8 @@ public class OrcColumnarBatchReader extends RecordReader<Void, ColumnarBatch> {
    * but Spark will discard the values from the file, and use the partition value got from
    * directory name. The column order will be reserved though.
    */
-  private int[] requestedDataColIds;
+  @VisibleForTesting
+  public int[] requestedDataColIds;
 
   // Record reader from ORC row batch.
   private org.apache.orc.RecordReader recordReader;
@@ -72,7 +74,8 @@ public class OrcColumnarBatchReader extends RecordReader<Void, ColumnarBatch> {
   private StructField[] requiredFields;
 
   // The result columnar batch for vectorized execution by whole-stage codegen.
-  private ColumnarBatch columnarBatch;
+  @VisibleForTesting
+  public ColumnarBatch columnarBatch;
 
   // Writable column vectors of the result columnar batch.
   private WritableColumnVector[] columnVectors;

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -539,6 +539,25 @@ object PartitioningUtils {
     }).asNullable
   }
 
+  def requestedPartitionColumnIds(
+      requiredSchema: StructType,
+      partitionSchema: StructType,
+      caseSensitive: Boolean): Array[Int] = {
+    val columnNameMap =
+      partitionSchema.fields.map(getColName(_, caseSensitive)).zipWithIndex.toMap
+    requiredSchema.fields.map { field =>
+      columnNameMap.getOrElse(getColName(field, caseSensitive), -1)
+    }
+  }
+
+  private def getColName(f: StructField, caseSensitive: Boolean): String = {
+    if (caseSensitive) {
+      f.name
+    } else {
+      f.name.toLowerCase(Locale.ROOT)
+    }
+  }
+
   private def columnNameEquality(caseSensitive: Boolean): (String, String) => Boolean = {
     if (caseSensitive) {
       org.apache.spark.sql.catalyst.analysis.caseSensitiveResolution

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -539,25 +539,6 @@ object PartitioningUtils {
     }).asNullable
   }
 
-  def requestedPartitionColumnIds(
-      requiredSchema: StructType,
-      partitionSchema: StructType,
-      caseSensitive: Boolean): Array[Int] = {
-    val columnNameMap =
-      partitionSchema.fields.map(getColName(_, caseSensitive)).zipWithIndex.toMap
-    requiredSchema.fields.map { field =>
-      columnNameMap.getOrElse(getColName(field, caseSensitive), -1)
-    }
-  }
-
-  private def getColName(f: StructField, caseSensitive: Boolean): String = {
-    if (caseSensitive) {
-      f.name
-    } else {
-      f.name.toLowerCase(Locale.ROOT)
-    }
-  }
-
   private def columnNameEquality(caseSensitive: Boolean): (String, String) => Boolean = {
     if (caseSensitive) {
       org.apache.spark.sql.catalyst.analysis.caseSensitiveResolution

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -207,8 +207,8 @@ class OrcFileFormat
           val iter = new RecordReaderIterator(batchReader)
           Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => iter.close()))
           val requestedDataColIds = requestedColIds ++ Array.fill(partitionSchema.length)(-1)
-          val requestedPartitionColIds =
-            Array.fill(requiredSchema.length)(-1) ++ Range(0, partitionSchema.length)
+          val requestedPartitionColIds = PartitioningUtils.requestedPartitionColumnIds(
+            resultSchema, partitionSchema, isCaseSensitive)
           batchReader.initialize(fileSplit, taskAttemptContext)
           batchReader.initBatch(
             reader.getSchema,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -186,9 +186,8 @@ class OrcFileFormat
       if (requestedColIdsOrEmptyFile.isEmpty) {
         Iterator.empty
       } else {
-        val requestedColIds =
-          requestedColIdsOrEmptyFile.get ++ Array.fill(partitionSchema.length)(-1)
-        assert(requestedColIds.length == resultSchema.length,
+        val requestedColIds = requestedColIdsOrEmptyFile.get
+        assert(requestedColIds.length == requiredSchema.length,
           "[BUG] requested column IDs do not match required schema")
         val taskConf = new Configuration(conf)
         taskConf.set(OrcConf.INCLUDE_COLUMNS.getAttribute,
@@ -207,13 +206,14 @@ class OrcFileFormat
           // after opening a file.
           val iter = new RecordReaderIterator(batchReader)
           Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => iter.close()))
+          val requestedDataColIds = requestedColIds ++ Array.fill(partitionSchema.length)(-1)
           val requestedPartitionColIds =
             Array.fill(requiredSchema.length)(-1) ++ Range(0, partitionSchema.length)
           batchReader.initialize(fileSplit, taskAttemptContext)
           batchReader.initBatch(
             reader.getSchema,
             resultSchema.fields,
-            requestedColIds,
+            requestedDataColIds,
             requestedPartitionColIds,
             file.partitionValues)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -207,8 +207,8 @@ class OrcFileFormat
           val iter = new RecordReaderIterator(batchReader)
           Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => iter.close()))
           val requestedDataColIds = requestedColIds ++ Array.fill(partitionSchema.length)(-1)
-          val requestedPartitionColIds = PartitioningUtils.requestedPartitionColumnIds(
-            resultSchema, partitionSchema, isCaseSensitive)
+          val requestedPartitionColIds =
+            Array.fill(requiredSchema.length)(-1) ++ Range(0, partitionSchema.length)
           batchReader.initialize(fileSplit, taskAttemptContext)
           batchReader.initBatch(
             reader.getSchema,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReaderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReaderSuite.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.orc
+
+import org.apache.orc.TypeDescription
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.vectorized.{OnHeapColumnVector, WritableColumnVector}
+import org.apache.spark.sql.test.{SharedSQLContext, SQLTestUtils}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.unsafe.types.UTF8String.fromString
+
+class OrcColumnarBatchReaderSuite extends QueryTest with SQLTestUtils with SharedSQLContext {
+
+  private val orcFileSchema = TypeDescription.fromString(s"struct<col1:int,col2:int>")
+  private val requiredSchema = StructType.fromDDL("col1 int, col3 int")
+  private val partitionSchema = StructType.fromDDL("partCol1 string, partCol2 string")
+  private val partitionValues = InternalRow(fromString("partValue1"), fromString("partValue2"))
+  private val resultSchema = StructType(requiredSchema.fields ++ partitionSchema.fields)
+
+  private val isConstant = classOf[WritableColumnVector].getDeclaredField("isConstant")
+  isConstant.setAccessible(true)
+
+  private def getReader(requestedDataColIds: Array[Int], requestedPartitionColIds: Array[Int]) = {
+    val reader = new OrcColumnarBatchReader(false, false, 4096)
+    reader.initBatch(
+      orcFileSchema,
+      resultSchema.fields,
+      requestedDataColIds,
+      requestedPartitionColIds,
+      partitionValues)
+    reader
+  }
+
+  test("requestedPartitionColIds resets requestedDataColIds - all partitions are requested") {
+    val requestedDataColIds = Array(0, 1, 0, 0)
+    val requestedPartitionColIds = Array(-1, -1, 0, 1)
+    val reader = getReader(requestedDataColIds, requestedPartitionColIds)
+    assert(reader.requestedDataColIds === Array(0, 1, -1, -1))
+  }
+
+  test("requestedPartitionColIds resets requestedDataColIds - one partition is requested") {
+    Seq((Array(-1, -1, 0, -1), Array(0, 1, -1, 0)),
+      (Array(-1, -1, -1, 0), Array(0, 1, 0, -1))).foreach {
+      case (requestedPartitionColIds, answer) =>
+        val requestedDataColIds = Array(0, 1, 0, 0)
+        val reader = getReader(requestedDataColIds, requestedPartitionColIds)
+        assert(reader.requestedDataColIds === answer)
+    }
+  }
+
+  test("initBatch should initialize requested partition columns only") {
+    val requestedDataColIds = Array(0, -1, -1, -1) // only `col1` is requested, `col3` doesn't exist
+    val requestedPartitionColIds = Array(-1, -1, 0, -1) // only `partCol1` is requested
+    val reader = getReader(requestedDataColIds, requestedPartitionColIds)
+    val batch = reader.columnarBatch
+    assert(batch.numCols() === 4)
+
+    assert(batch.column(0).isInstanceOf[OrcColumnVector])
+    assert(batch.column(1).isInstanceOf[OnHeapColumnVector])
+    assert(batch.column(2).isInstanceOf[OnHeapColumnVector])
+    assert(batch.column(3).isInstanceOf[OnHeapColumnVector])
+
+    val col3 = batch.column(1).asInstanceOf[OnHeapColumnVector]
+    val partCol1 = batch.column(2).asInstanceOf[OnHeapColumnVector]
+    val partCol2 = batch.column(3).asInstanceOf[OnHeapColumnVector]
+
+    assert(isConstant.get(col3).asInstanceOf[Boolean]) // `col3` is NULL.
+    assert(isConstant.get(partCol1).asInstanceOf[Boolean]) // Partition column is constant.
+    assert(isConstant.get(partCol2).asInstanceOf[Boolean]) // Null column is constant.
+
+    assert(partCol1.getUTF8String(0) === partitionValues.getUTF8String(0))
+    assert(partCol2.isNullAt(0)) // This is NULL because it's not requested.
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently OrcColumnarBatchReader returns all the partition column values in the batch read.
In data source V2, we can improve it by returning the required partition column values only.

This PR is part of https://github.com/apache/spark/pull/23383 . As @cloud-fan suggested, create a new PR to make review easier.

Also, this PR doesn't improve `OrcFileFormat`, since in the method `buildReaderWithPartitionValues`, the `requiredSchema` filter out all the partition columns, so we can't know which partition column is required.

## How was this patch tested?

Unit test