### PR TITLE
[SPARK-26397][SQL] Driver side only metrics support

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -167,15 +167,6 @@ case class FileSourceScanExec(
       partitionSchema = relation.partitionSchema,
       relation.sparkSession.sessionState.conf)
 
-  /**
-   * Send the driver-side metrics. Before calling this function, selectedPartitions has
-   * been initialized. See SPARK-26327 for more details.
-   */
-  private def sendDriverMetrics(): Unit = {
-    val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
-    SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, driverMetrics.values.toSeq)
-  }
-
   @transient private lazy val selectedPartitions: Seq[PartitionDirectory] = {
     val optimizerMetadataTimeNs = relation.location.metadataOpsTimeNs.getOrElse(0L)
     val startTime = System.nanoTime()
@@ -322,7 +313,7 @@ case class FileSourceScanExec(
     Map("numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
       "scanTime" -> SQLMetrics.createTimingMetric(sparkContext, "scan time"))
 
-  @transient override lazy val driverMetrics =
+  driverMetrics ++=
     Map("numFiles" -> SQLMetrics.createMetric(sparkContext, "number of files"),
       "metadataTime" -> SQLMetrics.createMetric(sparkContext, "metadata time (ms)"))
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -167,11 +167,10 @@ case class FileSourceScanExec(
       partitionSchema = relation.partitionSchema,
       relation.sparkSession.sessionState.conf)
 
-  driverMetrics ++=
-    Map("numFiles" -> SQLMetrics.createMetric(sparkContext, "number of files"),
-      "metadataTime" -> SQLMetrics.createMetric(sparkContext, "metadata time (ms)"))
-
   @transient private lazy val selectedPartitions: Seq[PartitionDirectory] = {
+    driverMetrics ++= Map(
+      "numFiles" -> SQLMetrics.createMetric(sparkContext, "number of files"),
+      "metadataTime" -> SQLMetrics.createMetric(sparkContext, "metadata time (ms)"))
     val optimizerMetadataTimeNs = relation.location.metadataOpsTimeNs.getOrElse(0L)
     val startTime = System.nanoTime()
     val ret = relation.location.listFiles(partitionFilters, dataFilters)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -167,6 +167,10 @@ case class FileSourceScanExec(
       partitionSchema = relation.partitionSchema,
       relation.sparkSession.sessionState.conf)
 
+  driverMetrics ++=
+    Map("numFiles" -> SQLMetrics.createMetric(sparkContext, "number of files"),
+      "metadataTime" -> SQLMetrics.createMetric(sparkContext, "metadata time (ms)"))
+
   @transient private lazy val selectedPartitions: Seq[PartitionDirectory] = {
     val optimizerMetadataTimeNs = relation.location.metadataOpsTimeNs.getOrElse(0L)
     val startTime = System.nanoTime()
@@ -312,10 +316,6 @@ case class FileSourceScanExec(
   override lazy val metrics =
     Map("numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
       "scanTime" -> SQLMetrics.createTimingMetric(sparkContext, "scan time"))
-
-  driverMetrics ++=
-    Map("numFiles" -> SQLMetrics.createMetric(sparkContext, "number of files"),
-      "metadataTime" -> SQLMetrics.createMetric(sparkContext, "metadata time (ms)"))
 
   protected override def doExecute(): RDD[InternalRow] = {
     if (supportsBatch) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -167,26 +167,22 @@ case class FileSourceScanExec(
       partitionSchema = relation.partitionSchema,
       relation.sparkSession.sessionState.conf)
 
-  val driverMetrics: HashMap[String, Long] = HashMap.empty
-
   /**
    * Send the driver-side metrics. Before calling this function, selectedPartitions has
    * been initialized. See SPARK-26327 for more details.
    */
   private def sendDriverMetrics(): Unit = {
-    driverMetrics.foreach(e => metrics(e._1).add(e._2))
     val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
-    SQLMetrics.postDriverMetricUpdates(sparkContext, executionId,
-      metrics.filter(e => driverMetrics.contains(e._1)).values.toSeq)
+    SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, driverMetrics.values.toSeq)
   }
 
   @transient private lazy val selectedPartitions: Seq[PartitionDirectory] = {
     val optimizerMetadataTimeNs = relation.location.metadataOpsTimeNs.getOrElse(0L)
     val startTime = System.nanoTime()
     val ret = relation.location.listFiles(partitionFilters, dataFilters)
-    driverMetrics("numFiles") = ret.map(_.files.size.toLong).sum
+    driverMetrics("numFiles").add(ret.map(_.files.size.toLong).sum)
     val timeTakenMs = ((System.nanoTime() - startTime) + optimizerMetadataTimeNs) / 1000 / 1000
-    driverMetrics("metadataTime") = timeTakenMs
+    driverMetrics("metadataTime").add(timeTakenMs)
     ret
   }
 
@@ -324,9 +320,11 @@ case class FileSourceScanExec(
 
   override lazy val metrics =
     Map("numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
-      "numFiles" -> SQLMetrics.createMetric(sparkContext, "number of files"),
-      "metadataTime" -> SQLMetrics.createMetric(sparkContext, "metadata time"),
       "scanTime" -> SQLMetrics.createTimingMetric(sparkContext, "scan time"))
+
+  @transient override lazy val driverMetrics =
+    Map("numFiles" -> SQLMetrics.createMetric(sparkContext, "number of files"),
+      "metadataTime" -> SQLMetrics.createMetric(sparkContext, "metadata time (ms)"))
 
   protected override def doExecute(): RDD[InternalRow] = {
     if (supportsBatch) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -180,9 +180,9 @@ case class FileSourceScanExec(
     val optimizerMetadataTimeNs = relation.location.metadataOpsTimeNs.getOrElse(0L)
     val startTime = System.nanoTime()
     val ret = relation.location.listFiles(partitionFilters, dataFilters)
-    driverMetrics("numFiles").add(ret.map(_.files.size.toLong).sum)
+    driverMetrics("numFiles").set(ret.map(_.files.size.toLong).sum)
     val timeTakenMs = ((System.nanoTime() - startTime) + optimizerMetadataTimeNs) / 1000 / 1000
-    driverMetrics("metadataTime").add(timeTakenMs)
+    driverMetrics("metadataTime").set(timeTakenMs)
     ret
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -74,9 +74,19 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
   }
 
   /**
-   * @return All metrics containing metrics of this SparkPlan.
+   * @return Executor side metrics of this SparkPlan.
    */
   def metrics: Map[String, SQLMetric] = Map.empty
+
+  /**
+   * @return Driver side metrics of this SparkPlan.
+   */
+  @transient def driverMetrics: Map[String, SQLMetric] = Map.empty
+
+  /**
+   * @return All metrics of this SparkPlan.
+   */
+  def allMetrics: Map[String, SQLMetric] = metrics ++ driverMetrics
 
   /**
    * Resets all the metrics.
@@ -88,7 +98,7 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
   /**
    * @return [[SQLMetric]] for the `name`.
    */
-  def longMetric(name: String): SQLMetric = metrics(name)
+  def longMetric(name: String): SQLMetric = allMetrics(name)
 
   // TODO: Move to `DistributedPlan`
   /** Specifies how data is partitioned across different nodes in the cluster. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -89,8 +89,7 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
   /**
    * Send the driver-side metrics.
    */
-  def sendDriverMetrics(): Unit = {
-    val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+  def sendDriverMetrics(executionId: String): Unit = {
     SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, driverMetrics.values.toSeq)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -74,19 +74,21 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
   }
 
   /**
-   * @return Executor side metrics of this SparkPlan.
+   * @return Executor side metrics of this SparkPlan, which needs to be serialized and sent
+   *         to executors.
    */
   def metrics: Map[String, SQLMetric] = Map.empty
 
   /**
-   * @return Driver side metrics of this SparkPlan which no need to send them to executor.
+   * @return Driver side metrics of this SparkPlan, which only create, update and display
+   *         on driver side, no need to be serialized and sent to executors.
    */
   def driverMetrics: Map[String, SQLMetric] = Map.empty
 
   /**
    * @return All metrics of this SparkPlan.
    */
-  def allMetrics: Map[String, SQLMetric] = metrics ++ driverMetrics
+  @inline def allMetrics: Map[String, SQLMetric] = metrics ++ driverMetrics
 
   /**
    * Resets all the metrics.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -81,14 +81,10 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
 
   /**
    * @return Driver side metrics of this SparkPlan, which only create, update and display
-   *         on driver side, no need to be serialized and sent to executors.
+   *         on driver side, no need to be serialized and sent to executors. So when override
+   *         this method, we should decorate it with `@transient override lazy val`.
    */
   def driverMetrics: Map[String, SQLMetric] = Map.empty
-
-  /**
-   * @return All metrics of this SparkPlan.
-   */
-  @inline def allMetrics: Map[String, SQLMetric] = metrics ++ driverMetrics
 
   /**
    * Resets all the metrics.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -79,9 +79,9 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
   def metrics: Map[String, SQLMetric] = Map.empty
 
   /**
-   * @return Driver side metrics of this SparkPlan.
+   * @return Driver side metrics of this SparkPlan which no need to send them to executor.
    */
-  @transient def driverMetrics: Map[String, SQLMetric] = Map.empty
+  def driverMetrics: Map[String, SQLMetric] = Map.empty
 
   /**
    * @return All metrics of this SparkPlan.
@@ -98,7 +98,7 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
   /**
    * @return [[SQLMetric]] for the `name`.
    */
-  def longMetric(name: String): SQLMetric = allMetrics(name)
+  def longMetric(name: String): SQLMetric = metrics(name)
 
   // TODO: Move to `DistributedPlan`
   /** Specifies how data is partitioned across different nodes in the cluster. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanInfo.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanInfo.scala
@@ -53,7 +53,7 @@ private[execution] object SparkPlanInfo {
       case ReusedExchangeExec(_, child) => child :: Nil
       case _ => plan.children ++ plan.subqueries
     }
-    val metrics = plan.metrics.toSeq.map { case (key, metric) =>
+    val metrics = plan.allMetrics.toSeq.map { case (key, metric) =>
       new SQLMetricInfo(metric.name.getOrElse(key), metric.id, metric.metricType)
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanInfo.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanInfo.scala
@@ -53,7 +53,7 @@ private[execution] object SparkPlanInfo {
       case ReusedExchangeExec(_, child) => child :: Nil
       case _ => plan.children ++ plan.subqueries
     }
-    val metrics = plan.allMetrics.toSeq.map { case (key, metric) =>
+    val metrics = (plan.metrics ++ plan.driverMetrics).toSeq.map { case (key, metric) =>
       new SQLMetricInfo(metric.name.getOrElse(key), metric.id, metric.metricType)
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -681,9 +681,9 @@ case class SubqueryExec(name: String, child: SparkPlan) extends UnaryExecNode {
         // Note that we use .executeCollect() because we don't want to convert data to Scala types
         val rows: Array[InternalRow] = child.executeCollect()
         val beforeBuild = System.nanoTime()
-        longMetric("collectTime") += (beforeBuild - beforeCollect) / 1000000
+        driverMetrics("collectTime") += (beforeBuild - beforeCollect) / 1000000
         val dataSize = rows.map(_.asInstanceOf[UnsafeRow].getSizeInBytes.toLong).sum
-        longMetric("dataSize") += dataSize
+        driverMetrics("dataSize") += dataSize
 
         SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, driverMetrics.values.toSeq)
         rows

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -659,7 +659,7 @@ object CoalesceExec {
  */
 case class SubqueryExec(name: String, child: SparkPlan) extends UnaryExecNode {
 
-  @transient override lazy val driverMetrics = Map(
+  driverMetrics ++= Map(
     "dataSize" -> SQLMetrics.createMetric(sparkContext, "data size (bytes)"),
     "collectTime" -> SQLMetrics.createMetric(sparkContext, "time to collect (ms)"))
 
@@ -685,7 +685,7 @@ case class SubqueryExec(name: String, child: SparkPlan) extends UnaryExecNode {
         val dataSize = rows.map(_.asInstanceOf[UnsafeRow].getSizeInBytes.toLong).sum
         driverMetrics("dataSize") += dataSize
 
-        SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, driverMetrics.values.toSeq)
+        sendDriverMetrics()
         rows
       }
     }(SubqueryExec.executionContext)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -659,7 +659,7 @@ object CoalesceExec {
  */
 case class SubqueryExec(name: String, child: SparkPlan) extends UnaryExecNode {
 
-  override lazy val metrics = Map(
+  @transient override lazy val driverMetrics = Map(
     "dataSize" -> SQLMetrics.createMetric(sparkContext, "data size (bytes)"),
     "collectTime" -> SQLMetrics.createMetric(sparkContext, "time to collect (ms)"))
 
@@ -685,7 +685,7 @@ case class SubqueryExec(name: String, child: SparkPlan) extends UnaryExecNode {
         val dataSize = rows.map(_.asInstanceOf[UnsafeRow].getSizeInBytes.toLong).sum
         longMetric("dataSize") += dataSize
 
-        SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, metrics.values.toSeq)
+        SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, driverMetrics.values.toSeq)
         rows
       }
     }(SubqueryExec.executionContext)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -668,9 +668,8 @@ case class SubqueryExec(name: String, child: SparkPlan) extends UnaryExecNode {
   @transient
   private lazy val relationFuture: Future[Array[InternalRow]] = {
     // create relative sql metrics and add them into driverMetrics
-    driverMetrics ++= Map(
-      "dataSize" -> SQLMetrics.createMetric(sparkContext, "data size (bytes)"),
-      "collectTime" -> SQLMetrics.createMetric(sparkContext, "time to collect (ms)"))
+    driverMetrics("dataSize") = SQLMetrics.createMetric(sparkContext, "data size (bytes)")
+    driverMetrics("collectTime") = SQLMetrics.createMetric(sparkContext, "time to collect (ms)")
     // relationFuture is used in "doExecute". Therefore we can get the execution id correctly here.
     val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
     Future {
@@ -685,7 +684,7 @@ case class SubqueryExec(name: String, child: SparkPlan) extends UnaryExecNode {
         val dataSize = rows.map(_.asInstanceOf[UnsafeRow].getSizeInBytes.toLong).sum
         driverMetrics("dataSize") += dataSize
 
-        sendDriverMetrics()
+        sendDriverMetrics(executionId)
         rows
       }
     }(SubqueryExec.executionContext)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -659,10 +659,6 @@ object CoalesceExec {
  */
 case class SubqueryExec(name: String, child: SparkPlan) extends UnaryExecNode {
 
-  driverMetrics ++= Map(
-    "dataSize" -> SQLMetrics.createMetric(sparkContext, "data size (bytes)"),
-    "collectTime" -> SQLMetrics.createMetric(sparkContext, "time to collect (ms)"))
-
   override def output: Seq[Attribute] = child.output
 
   override def outputPartitioning: Partitioning = child.outputPartitioning
@@ -671,6 +667,10 @@ case class SubqueryExec(name: String, child: SparkPlan) extends UnaryExecNode {
 
   @transient
   private lazy val relationFuture: Future[Array[InternalRow]] = {
+    // create relative sql metrics and add them into driverMetrics
+    driverMetrics ++= Map(
+      "dataSize" -> SQLMetrics.createMetric(sparkContext, "data size (bytes)"),
+      "collectTime" -> SQLMetrics.createMetric(sparkContext, "time to collect (ms)"))
     // relationFuture is used in "doExecute". Therefore we can get the execution id correctly here.
     val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
     Future {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -83,7 +83,7 @@ case class BroadcastExchangeExec(
           }
 
           val beforeBuild = System.nanoTime()
-          longMetric("collectTime") += (beforeBuild - beforeCollect) / 1000000
+          driverMetrics("collectTime") += (beforeBuild - beforeCollect) / 1000000
 
           // Construct the relation.
           val relation = mode.transform(input, Some(numRows))
@@ -98,18 +98,18 @@ case class BroadcastExchangeExec(
                   relation.getClass.getName)
           }
 
-          longMetric("dataSize") += dataSize
+          driverMetrics("dataSize") += dataSize
           if (dataSize >= (8L << 30)) {
             throw new SparkException(
               s"Cannot broadcast the table that is larger than 8GB: ${dataSize >> 30} GB")
           }
 
           val beforeBroadcast = System.nanoTime()
-          longMetric("buildTime") += (beforeBroadcast - beforeBuild) / 1000000
+          driverMetrics("buildTime") += (beforeBroadcast - beforeBuild) / 1000000
 
           // Broadcast the relation
           val broadcasted = sparkContext.broadcast(relation)
-          longMetric("broadcastTime") += (System.nanoTime() - beforeBroadcast) / 1000000
+          driverMetrics("broadcastTime") += (System.nanoTime() - beforeBroadcast) / 1000000
 
           SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, driverMetrics.values.toSeq)
           broadcasted

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -43,7 +43,7 @@ case class BroadcastExchangeExec(
     mode: BroadcastMode,
     child: SparkPlan) extends Exchange {
 
-  @transient override lazy val driverMetrics = Map(
+  driverMetrics ++= Map(
     "dataSize" -> SQLMetrics.createMetric(sparkContext, "data size (bytes)"),
     "collectTime" -> SQLMetrics.createMetric(sparkContext, "time to collect (ms)"),
     "buildTime" -> SQLMetrics.createMetric(sparkContext, "time to build (ms)"),
@@ -111,7 +111,7 @@ case class BroadcastExchangeExec(
           val broadcasted = sparkContext.broadcast(relation)
           driverMetrics("broadcastTime") += (System.nanoTime() - beforeBroadcast) / 1000000
 
-          SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, driverMetrics.values.toSeq)
+          sendDriverMetrics()
           broadcasted
         } catch {
           // SPARK-24294: To bypass scala bug: https://github.com/scala/bug/issues/9554, we throw

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -43,12 +43,6 @@ case class BroadcastExchangeExec(
     mode: BroadcastMode,
     child: SparkPlan) extends Exchange {
 
-  driverMetrics ++= Map(
-    "dataSize" -> SQLMetrics.createMetric(sparkContext, "data size (bytes)"),
-    "collectTime" -> SQLMetrics.createMetric(sparkContext, "time to collect (ms)"),
-    "buildTime" -> SQLMetrics.createMetric(sparkContext, "time to build (ms)"),
-    "broadcastTime" -> SQLMetrics.createMetric(sparkContext, "time to broadcast (ms)"))
-
   override def outputPartitioning: Partitioning = BroadcastPartitioning(mode)
 
   override def doCanonicalize(): SparkPlan = {
@@ -67,6 +61,12 @@ case class BroadcastExchangeExec(
 
   @transient
   private lazy val relationFuture: Future[broadcast.Broadcast[Any]] = {
+    // create relative sql metrics and add them into driverMetrics
+    driverMetrics ++= Map(
+      "dataSize" -> SQLMetrics.createMetric(sparkContext, "data size (bytes)"),
+      "collectTime" -> SQLMetrics.createMetric(sparkContext, "time to collect (ms)"),
+      "buildTime" -> SQLMetrics.createMetric(sparkContext, "time to build (ms)"),
+      "broadcastTime" -> SQLMetrics.createMetric(sparkContext, "time to broadcast (ms)"))
     // broadcastFuture is used in "doExecute". Therefore we can get the execution id correctly here.
     val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
     Future {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -62,11 +62,11 @@ case class BroadcastExchangeExec(
   @transient
   private lazy val relationFuture: Future[broadcast.Broadcast[Any]] = {
     // create relative sql metrics and add them into driverMetrics
-    driverMetrics ++= Map(
-      "dataSize" -> SQLMetrics.createMetric(sparkContext, "data size (bytes)"),
-      "collectTime" -> SQLMetrics.createMetric(sparkContext, "time to collect (ms)"),
-      "buildTime" -> SQLMetrics.createMetric(sparkContext, "time to build (ms)"),
-      "broadcastTime" -> SQLMetrics.createMetric(sparkContext, "time to broadcast (ms)"))
+    driverMetrics("dataSize") = SQLMetrics.createMetric(sparkContext, "data size (bytes)")
+    driverMetrics("collectTime") = SQLMetrics.createMetric(sparkContext, "time to collect (ms)")
+    driverMetrics("buildTime") = SQLMetrics.createMetric(sparkContext, "time to build (ms)")
+    driverMetrics("broadcastTime") =
+      SQLMetrics.createMetric(sparkContext, "time to broadcast (ms)")
     // broadcastFuture is used in "doExecute". Therefore we can get the execution id correctly here.
     val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
     Future {
@@ -111,7 +111,7 @@ case class BroadcastExchangeExec(
           val broadcasted = sparkContext.broadcast(relation)
           driverMetrics("broadcastTime") += (System.nanoTime() - beforeBroadcast) / 1000000
 
-          sendDriverMetrics()
+          sendDriverMetrics(executionId)
           broadcasted
         } catch {
           // SPARK-24294: To bypass scala bug: https://github.com/scala/bug/issues/9554, we throw

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -43,7 +43,7 @@ case class BroadcastExchangeExec(
     mode: BroadcastMode,
     child: SparkPlan) extends Exchange {
 
-  override lazy val metrics = Map(
+  @transient override lazy val driverMetrics = Map(
     "dataSize" -> SQLMetrics.createMetric(sparkContext, "data size (bytes)"),
     "collectTime" -> SQLMetrics.createMetric(sparkContext, "time to collect (ms)"),
     "buildTime" -> SQLMetrics.createMetric(sparkContext, "time to build (ms)"),
@@ -111,7 +111,7 @@ case class BroadcastExchangeExec(
           val broadcasted = sparkContext.broadcast(relation)
           longMetric("broadcastTime") += (System.nanoTime() - beforeBroadcast) / 1000000
 
-          SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, metrics.values.toSeq)
+          SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, driverMetrics.values.toSeq)
           broadcasted
         } catch {
           // SPARK-24294: To bypass scala bug: https://github.com/scala/bug/issues/9554, we throw

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -552,13 +552,11 @@ class SQLMetricsSuite extends SparkFunSuite with SQLMetricsTestUtils with Shared
       // The execution plan only has 1 FileScan node.
       val df = spark.sql(
         "SELECT * FROM testDataForScan WHERE p = 1")
-      df.collect()
-      val plan = df.queryExecution.executedPlan.collectLeaves().head
-      val metrics = plan.metrics
-      val driverMetrics = plan.driverMetrics
-      // Check deterministic metrics.
-      assert(driverMetrics("numFiles").value == 2)
-      assert(metrics("numOutputRows").value == 3)
+      testSparkPlanMetrics(df, 1, Map(
+        0L -> (("Scan parquet default.testdataforscan", Map(
+          "number of output rows" -> 3L,
+          "number of files" -> 2L))))
+      )
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -552,11 +552,13 @@ class SQLMetricsSuite extends SparkFunSuite with SQLMetricsTestUtils with Shared
       // The execution plan only has 1 FileScan node.
       val df = spark.sql(
         "SELECT * FROM testDataForScan WHERE p = 1")
-      testSparkPlanMetrics(df, 1, Map(
-        0L -> (("Scan parquet default.testdataforscan", Map(
-          "number of output rows" -> 3L,
-          "number of files" -> 2L))))
-      )
+      df.collect()
+      val plan = df.queryExecution.executedPlan.collectLeaves().head
+      val metrics = plan.metrics
+      val driverMetrics = plan.driverMetrics
+      // Check deterministic metrics.
+      assert(driverMetrics("numFiles").value == 2)
+      assert(metrics("numOutputRows").value == 3)
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Here we add the support for driver-side only metrics, which are only created and updated on driver-side and no need to send them to the executor.

## How was this patch tested?

New UT in SQLMetricsSuite.
