### PR TITLE
[SPARK-26501][CORE][TEST] Fix unexpected overriden of exitFn in SparkSubmitSuite

### DIFF
--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -72,13 +72,9 @@ trait TestPrematureExit {
     mainObject.printStream = printStream
 
     @volatile var exitedCleanly = false
-    def withFakeExit(body: => Unit): Unit = {
-      val original = mainObject.exitFn
-      mainObject.exitFn = (_) => exitedCleanly = true
-      body
-      mainObject.exitFn = original
-    }
-    withFakeExit {
+    val original = mainObject.exitFn
+    mainObject.exitFn = (_) => exitedCleanly = true
+    try {
       @volatile var exception: Exception = null
       val thread = new Thread {
         override def run() = try {
@@ -99,6 +95,8 @@ trait TestPrematureExit {
           throw exception
         }
       }
+    } finally {
+      mainObject.exitFn = original
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The overriden of SparkSubmit's exitFn at some previous tests in SparkSubmitSuite may cause the following tests pass even they failed when they were run separately. This PR is to fix this problem. 

## How was this patch tested?

unittest