### PR TITLE
[SPARK-26504][SQL] Rope-wise dumping of Spark plans

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.plans
 
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, TreeNode}
 import org.apache.spark.sql.internal.SQLConf
@@ -299,6 +300,22 @@ object QueryPlan extends PredicateHelper {
       splitConjunctivePredicates(normalized)
     } else {
       Nil
+    }
+  }
+
+  /**
+   * Converts the query plan to string and appends it via provided function.
+   */
+  def append[T <: QueryPlan[T]](
+      plan: => QueryPlan[T],
+      append: String => Unit,
+      verbose: Boolean,
+      addSuffix: Boolean,
+      maxFields: Int = SQLConf.get.maxToStringFields): Unit = {
+    try {
+      plan.treeString(append, verbose, addSuffix, maxFields)
+    } catch {
+      case e: AnalysisException => append(e.toString)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.catalyst.errors._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, Partitioning}
-import org.apache.spark.sql.catalyst.util.StringUtils.StringRope
+import org.apache.spark.sql.catalyst.util.StringUtils.StringConcat
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -480,10 +480,10 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
       verbose: Boolean,
       addSuffix: Boolean = false,
       maxFields: Int = SQLConf.get.maxToStringFields): String = {
-    val rope = new StringRope()
+    val concat = new StringConcat()
 
-    treeString(rope.append, verbose, addSuffix, maxFields)
-    rope.toString
+    treeString(concat.append, verbose, addSuffix, maxFields)
+    concat.toString
   }
 
   def treeString(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -17,13 +17,11 @@
 
 package org.apache.spark.sql.catalyst.trees
 
-import java.io.Writer
 import java.util.UUID
 
 import scala.collection.Map
 import scala.reflect.ClassTag
 
-import org.apache.commons.io.output.StringBuilderWriter
 import org.apache.commons.lang3.ClassUtils
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
@@ -37,6 +35,7 @@ import org.apache.spark.sql.catalyst.errors._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, Partitioning}
+import org.apache.spark.sql.catalyst.util.StringUtils.StringRope
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -481,13 +480,10 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
       verbose: Boolean,
       addSuffix: Boolean = false,
       maxFields: Int = SQLConf.get.maxToStringFields): String = {
-    val writer = new StringBuilderWriter()
-    try {
-      treeString(writer.write, verbose, addSuffix, maxFields)
-      writer.toString
-    } finally {
-      writer.close()
-    }
+    val rope = new StringRope()
+
+    treeString(rope.append, verbose, addSuffix, maxFields)
+    rope.toString
   }
 
   def treeString(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -94,8 +94,8 @@ object StringUtils {
    * Concatenation of sequence of strings to final string with cheap append method
    * and one memory allocation for the final string.
    */
-  class StringRope {
-    private val rope = new ArrayBuffer[String]
+  class StringConcat {
+    private val strings = new ArrayBuffer[String]
     private var length: Int = 0
 
     /**
@@ -104,7 +104,7 @@ object StringUtils {
      */
     def append(s: String): Unit = {
       if (s != null) {
-        rope.append(s)
+        strings.append(s)
         length += s.length
       }
     }
@@ -114,10 +114,9 @@ object StringUtils {
      * returns concatenated string.
      */
     override def toString: String = {
-      val buffer = new StringBuffer(length)
-
-      rope.foreach(buffer.append)
-      buffer.toString
+      val result = new StringBuffer(length)
+      strings.foreach(result.append)
+      result.toString
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -87,4 +87,26 @@ object StringUtils {
     }
     funcNames.toSeq
   }
+
+  class StringRope {
+    private var list = List.empty[String]
+    private var length: Int = 0
+
+    def append(s: String): Unit = {
+      list = s :: list
+      length += s.length
+    }
+
+    override def toString: String = {
+      val buffer = new StringBuffer(length)
+      var reversed = list.reverse
+
+      while (!reversed.isEmpty) {
+        buffer.append(reversed.head)
+        reversed = reversed.tail
+      }
+
+      buffer.toString
+    }
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.catalyst.util
 
 import java.util.regex.{Pattern, PatternSyntaxException}
 
+import scala.collection.mutable.ArrayBuffer
+
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -93,7 +95,7 @@ object StringUtils {
    * and one memory allocation for the final string.
    */
   class StringRope {
-    private var list = List.empty[String]
+    private val rope = new ArrayBuffer[String]
     private var length: Int = 0
 
     /**
@@ -102,7 +104,7 @@ object StringUtils {
      */
     def append(s: String): Unit = {
       if (s != null) {
-        list = s :: list
+        rope.append(s)
         length += s.length
       }
     }
@@ -113,13 +115,8 @@ object StringUtils {
      */
     override def toString: String = {
       val buffer = new StringBuffer(length)
-      var reversed = list.reverse
 
-      while (!reversed.isEmpty) {
-        buffer.append(reversed.head)
-        reversed = reversed.tail
-      }
-
+      rope.foreach(buffer.append)
       buffer.toString
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -114,7 +114,7 @@ object StringUtils {
      * returns concatenated string.
      */
     override def toString: String = {
-      val result = new StringBuffer(length)
+      val result = new java.lang.StringBuilder(length)
       strings.foreach(result.append)
       result.toString
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -88,10 +88,18 @@ object StringUtils {
     funcNames.toSeq
   }
 
+  /**
+   * Concatenation of sequence of strings to final string with cheap append method
+   * and one memory allocation for the final string.
+   */
   class StringRope {
     private var list = List.empty[String]
     private var length: Int = 0
 
+    /**
+     * Appends a string and accumulates its length to allocate a string buffer for all
+     * appended strings once in the toString method.
+     */
     def append(s: String): Unit = {
       if (s != null) {
         list = s :: list
@@ -99,6 +107,10 @@ object StringUtils {
       }
     }
 
+    /**
+     * The method allocates memory for all appended strings, writes them to the memory and
+     * returns concatenated string.
+     */
     override def toString: String = {
       val buffer = new StringBuffer(length)
       var reversed = list.reverse

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -93,8 +93,10 @@ object StringUtils {
     private var length: Int = 0
 
     def append(s: String): Unit = {
-      list = s :: list
-      length += s.length
+      if (s != null) {
+        list = s :: list
+        length += s.length
+      }
     }
 
     override def toString: String = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
@@ -46,10 +46,10 @@ class StringUtilsSuite extends SparkFunSuite {
 
   test("string rope") {
     def toRope(seq: String*): String = {
-      seq.foldLeft(new StringRope())((rope, s) => {rope.append(s); rope}).toString
+      seq.foldLeft(new StringConcat())((rope, s) => {rope.append(s); rope}).toString
     }
 
-    assert(new StringRope().toString == "")
+    assert(new StringConcat().toString == "")
     assert(toRope("") == "")
     assert(toRope(null) == "")
     assert(toRope("a") == "a")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
@@ -43,4 +43,17 @@ class StringUtilsSuite extends SparkFunSuite {
     assert(filterPattern(names, " a. ") === Seq("a1", "a2"))
     assert(filterPattern(names, " d* ") === Nil)
   }
+
+  test("string rope") {
+    def toRope(seq: String*): String = {
+      seq.foldLeft(new StringRope())((rope, s) => {rope.append(s); rope}).toString
+    }
+
+    assert(new StringRope().toString == "")
+    assert(toRope("") == "")
+    assert(toRope(null) == "")
+    assert(toRope("a") == "a")
+    assert(toRope("1", "2") == "12")
+    assert(toRope("abc", "\n", "123") == "abc\n123")
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
@@ -44,16 +44,16 @@ class StringUtilsSuite extends SparkFunSuite {
     assert(filterPattern(names, " d* ") === Nil)
   }
 
-  test("string rope") {
-    def toRope(seq: String*): String = {
-      seq.foldLeft(new StringConcat())((rope, s) => {rope.append(s); rope}).toString
+  test("string concatenation") {
+    def concat(seq: String*): String = {
+      seq.foldLeft(new StringConcat())((acc, s) => {acc.append(s); acc}).toString
     }
 
     assert(new StringConcat().toString == "")
-    assert(toRope("") == "")
-    assert(toRope(null) == "")
-    assert(toRope("a") == "a")
-    assert(toRope("1", "2") == "12")
-    assert(toRope("abc", "\n", "123") == "abc\n123")
+    assert(concat("") == "")
+    assert(concat(null) == "")
+    assert(concat("a") == "a")
+    assert(concat("1", "2") == "12")
+    assert(concat("abc", "\n", "123") == "abc\n123")
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -211,16 +211,17 @@ class QueryExecution(
   }
 
   private def writePlans(append: String => Unit, maxFields: Int): Unit = {
-    def stringOrError[A](f: => A): String = {
-      try f.toString catch { case e: AnalysisException => e.toString }
-    }
     val (verbose, addSuffix) = (true, false)
 
     append("== Parsed Logical Plan ==\n")
     appendOrError(append)(logical.treeString(_, verbose, addSuffix, maxFields))
     append("\n== Analyzed Logical Plan ==\n")
-    val analyzedOutput = stringOrError(truncatedString(
-      analyzed.output.map(o => s"${o.name}: ${o.dataType.simpleString}"), ", ", maxFields))
+    val analyzedOutput = try {
+      truncatedString(
+        analyzed.output.map(o => s"${o.name}: ${o.dataType.simpleString}"), ", ", maxFields)
+    } catch {
+      case e: AnalysisException => e.toString
+    }
     append(analyzedOutput)
     append("\n")
     appendOrError(append)(analyzed.treeString(_, verbose, addSuffix, maxFields))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, ReturnAnswer}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
-import org.apache.spark.sql.catalyst.util.StringUtils.StringRope
+import org.apache.spark.sql.catalyst.util.StringUtils.StringConcat
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.execution.command.{DescribeTableCommand, ExecutedCommandExec, ShowTablesCommand}
 import org.apache.spark.sql.execution.exchange.{EnsureRequirements, ReuseExchange}
@@ -194,11 +194,11 @@ class QueryExecution(
   }
 
   def simpleString: String = withRedaction {
-    val rope = new StringRope()
-    rope.append("== Physical Plan ==\n")
-    QueryPlan.append(executedPlan, rope.append, verbose = false, addSuffix = false)
-    rope.append("\n")
-    rope.toString
+    val concat = new StringConcat()
+    concat.append("== Physical Plan ==\n")
+    QueryPlan.append(executedPlan, concat.append, verbose = false, addSuffix = false)
+    concat.append("\n")
+    concat.toString
   }
 
   private def writePlans(append: String => Unit, maxFields: Int): Unit = {
@@ -222,25 +222,25 @@ class QueryExecution(
   }
 
   override def toString: String = withRedaction {
-    val rope = new StringRope()
-    writePlans(rope.append, SQLConf.get.maxToStringFields)
-    rope.toString
+    val concat = new StringConcat()
+    writePlans(concat.append, SQLConf.get.maxToStringFields)
+    concat.toString
   }
 
   def stringWithStats: String = withRedaction {
-    val rope = new StringRope()
+    val concat = new StringConcat()
     val maxFields = SQLConf.get.maxToStringFields
 
     // trigger to compute stats for logical plans
     optimizedPlan.stats
 
     // only show optimized logical plan and physical plan
-    rope.append("== Optimized Logical Plan ==\n")
-    QueryPlan.append(optimizedPlan, rope.append, verbose = true, addSuffix = true, maxFields)
-    rope.append("\n== Physical Plan ==\n")
-    QueryPlan.append(executedPlan, rope.append, verbose = true, addSuffix = false, maxFields)
-    rope.append("\n")
-    rope.toString
+    concat.append("== Optimized Logical Plan ==\n")
+    QueryPlan.append(optimizedPlan, concat.append, verbose = true, addSuffix = true, maxFields)
+    concat.append("\n== Physical Plan ==\n")
+    QueryPlan.append(executedPlan, concat.append, verbose = true, addSuffix = false, maxFields)
+    concat.append("\n")
+    concat.toString
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -282,7 +282,7 @@ class QueryExecution(
     /**
      * Dumps debug information about query execution into the specified file.
      *
-     * @param maxFields maximim number of fields converted to string representation.
+     * @param maxFields maximum number of fields converted to string representation.
      */
     def toFile(path: String, maxFields: Int = Int.MaxValue): Unit = {
       val filePath = new Path(path)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -493,7 +493,7 @@ case class InputAdapter(child: SparkPlan) extends UnaryExecNode with InputRDDCod
   override def generateTreeString(
       depth: Int,
       lastChildren: Seq[Boolean],
-      writer: Writer,
+      append: String => Unit,
       verbose: Boolean,
       prefix: String = "",
       addSuffix: Boolean = false,
@@ -501,7 +501,7 @@ case class InputAdapter(child: SparkPlan) extends UnaryExecNode with InputRDDCod
     child.generateTreeString(
       depth,
       lastChildren,
-      writer,
+      append,
       verbose,
       prefix = "",
       addSuffix = false,
@@ -777,7 +777,7 @@ case class WholeStageCodegenExec(child: SparkPlan)(val codegenStageId: Int)
   override def generateTreeString(
       depth: Int,
       lastChildren: Seq[Boolean],
-      writer: Writer,
+      append: String => Unit,
       verbose: Boolean,
       prefix: String = "",
       addSuffix: Boolean = false,
@@ -785,7 +785,7 @@ case class WholeStageCodegenExec(child: SparkPlan)(val codegenStageId: Int)
     child.generateTreeString(
       depth,
       lastChildren,
-      writer,
+      append,
       verbose,
       s"*($codegenStageId) ",
       false,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodeFormatter, CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.trees.TreeNodeRef
-import org.apache.spark.sql.catalyst.util.StringUtils.StringRope
+import org.apache.spark.sql.catalyst.util.StringUtils.StringConcat
 import org.apache.spark.sql.execution.streaming.{StreamExecution, StreamingQueryWrapper}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.StreamingQuery
@@ -71,10 +71,9 @@ package object debug {
    * @return single String containing all WholeStageCodegen subtrees and corresponding codegen
    */
   def codegenString(plan: SparkPlan): String = {
-    val rope = new StringRope()
-
-    writeCodegen(rope.append, plan)
-    rope.toString
+    val concat = new StringConcat()
+    writeCodegen(concat.append, plan)
+    concat.toString
   }
 
   def writeCodegen(append: String => Unit, plan: SparkPlan): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
@@ -17,12 +17,9 @@
 
 package org.apache.spark.sql.execution
 
-import java.io.Writer
 import java.util.Collections
 
 import scala.collection.JavaConverters._
-
-import org.apache.commons.io.output.StringBuilderWriter
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
@@ -32,6 +29,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodeFormatter, CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.trees.TreeNodeRef
+import org.apache.spark.sql.catalyst.util.StringUtils.StringRope
 import org.apache.spark.sql.execution.streaming.{StreamExecution, StreamingQueryWrapper}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.StreamingQuery
@@ -73,24 +71,20 @@ package object debug {
    * @return single String containing all WholeStageCodegen subtrees and corresponding codegen
    */
   def codegenString(plan: SparkPlan): String = {
-    val writer = new StringBuilderWriter()
+    val rope = new StringRope()
 
-    try {
-      writeCodegen(writer, plan)
-      writer.toString
-    } finally {
-      writer.close()
-    }
+    writeCodegen(rope.append, plan)
+    rope.toString
   }
 
-  def writeCodegen(writer: Writer, plan: SparkPlan): Unit = {
+  def writeCodegen(append: String => Unit, plan: SparkPlan): Unit = {
     val codegenSeq = codegenStringSeq(plan)
-    writer.write(s"Found ${codegenSeq.size} WholeStageCodegen subtrees.\n")
+    append(s"Found ${codegenSeq.size} WholeStageCodegen subtrees.\n")
     for (((subtree, code), i) <- codegenSeq.zipWithIndex) {
-      writer.write(s"== Subtree ${i + 1} / ${codegenSeq.size} ==\n")
-      writer.write(subtree)
-      writer.write("\nGenerated code:\n")
-      writer.write(s"${code}\n")
+      append(s"== Subtree ${i + 1} / ${codegenSeq.size} ==\n")
+      append(subtree)
+      append("\nGenerated code:\n")
+      append(s"${code}\n")
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Proposed new class `StringConcat` for converting a sequence of strings to string with one memory allocation in the `toString` method.  `StringConcat` replaces `StringBuilderWriter` in methods of dumping of Spark plans and codegen to strings.

All `Writer` arguments are replaced by `String => Unit` in methods related to Spark plans stringification.  

## How was this patch tested?

It was tested by existing suites `QueryExecutionSuite`, `DebuggingSuite` as well as new tests for `StringConcat` in `StringUtilsSuite`.
