### PR TITLE
[SPARK-26449][PYTHON] add a transform method to the Dataframe class

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2078,7 +2078,7 @@ class DataFrame(object):
         +----+---+--------+---------+
         <BLANKLINE>
         """
-        return func(self, *args, **kwargs)
+        return func(self)
 
     @since(1.3)
     def toPandas(self):

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2051,9 +2051,7 @@ class DataFrame(object):
         """Returns a new class:`DataFrame` according to a custom transform function.
         This allows chaining transformations rather than using nested or temporary variables.
 
-        :param func: a user-defined custom transform function
-        This is equivalent to a nested call:
-            actual_df = with_something(with_greeting(source_df), "crazy"))
+        :param func: a custom transform function which returns a DataFrame
 
         >>> from pyspark.sql.functions import lit
         >>> def with_greeting(df):

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2047,13 +2047,11 @@ class DataFrame(object):
         return DataFrame(jdf, self.sql_ctx)
 
     @since(3.0)
-    def transform(self, func, *args, **kwargs):
+    def transform(self, func):
         """Returns a new class:`DataFrame` according to a user-defined custom transform method.
         This allows chaining transformations rather than using nested or temporary variables.
 
         :param func: a user-defined custom transform function
-        :param *args: optional positional arguments to pass to `func`
-        :param **kwargs: optional keywarded arguments to pass to `func`
         This is equiavalent to a nested call:
             actual_df = with_something(with_greeting(source_df), "crazy"))
 
@@ -2069,7 +2067,7 @@ class DataFrame(object):
         ...     return df.withColumn("something", lit(something))
         >>> data = [("jose", 1), ("li", 2), ("liz", 3)]
         >>> source_df = spark.createDataFrame(data, ["name", "age"])
-        >>> actual_df = source_df.transform(with_greeting).transform(with_something, "crazy")
+        >>> actual_df = source_df.transform(with_greeting).transform(lambda x: with_something(x, "crazy"))
         >>> actual_df.show()
         +----+---+--------+---------+
         |name|age|greeting|something|

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2046,7 +2046,7 @@ class DataFrame(object):
         jdf = self._jdf.toDF(self._jseq(cols))
         return DataFrame(jdf, self.sql_ctx)
     
-    @since(2.5)
+    @since(3.0)
     def transform(self, func, *args, **kwargs):
         """Returns a new class:`DataFrame` according to a user-defined custom transform method.
         This allows chaining transformations rather than using nested or temporary variables.

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2045,7 +2045,7 @@ class DataFrame(object):
         """
         jdf = self._jdf.toDF(self._jseq(cols))
         return DataFrame(jdf, self.sql_ctx)
-    
+
     @since(3.0)
     def transform(self, func, *args, **kwargs):
         """Returns a new class:`DataFrame` according to a user-defined custom transform method.

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2050,18 +2050,18 @@ class DataFrame(object):
     def transform(self, func, *args, **kwargs):
         """Returns a new class:`DataFrame` according to a user-defined custom transform method.
         This allows chaining transformations rather than using nested or temporary variables.
-        
+
         :param func: a user-defined custom transform function
         :param *args: optional positional arguments to pass to `func`
         :param **kwargs: optional keywarded arguments to pass to `func`
-        
+
         A more concrete example::
 
-            def with_greeting(df):
+        def with_greeting(df):
                return df.withColumn("greeting", lit("hi"))
             def with_something(df, something):
                 return df.withColumn("something", lit(something))
-
+            
             data = [("jose", 1), ("li", 2), ("liz", 3)]
             source_df = spark.createDataFrame(data, ["name", "age"])
 
@@ -2076,15 +2076,14 @@ class DataFrame(object):
             |  li|  2|      hi|    crazy|
             | liz|  3|      hi|    crazy|
             +----+---+--------+---------+
-        
+
         This is equiavalent to a nested:
             actual_df = with_something(with_greeting(source_df), "crazy"))
 
-            
         credit to: https://medium.com/@mrpowers/chaining-custom-pyspark-transformations-4f38a8c7ae55
         """
         return func(self, *args, **kwargs)
-    
+
     @since(1.3)
     def toPandas(self):
         """

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2048,18 +2048,13 @@ class DataFrame(object):
 
     @since(3.0)
     def transform(self, func):
-        """Returns a new class:`DataFrame` according to a user-defined custom transform method.
+        """Returns a new class:`DataFrame` according to a custom transform function.
         This allows chaining transformations rather than using nested or temporary variables.
 
         :param func: a user-defined custom transform function
-        This is equiavalent to a nested call:
+        This is equivalent to a nested call:
             actual_df = with_something(with_greeting(source_df), "crazy"))
 
-        credit to: https://medium.com/@mrpowers/chaining-custom-pyspark-transformations-4f38a8c7ae55
-
-        A more concrete example::
-        >>> sc = pyspark.SparkContext(master='local')
-        >>> spark = pyspark.sql.SparkSession(sparkContext=sc)
         >>> from pyspark.sql.functions import lit
         >>> def with_greeting(df):
         ...     return df.withColumn("greeting", lit("hi"))
@@ -2076,9 +2071,10 @@ class DataFrame(object):
         |  li|  2|      hi|    crazy|
         | liz|  3|      hi|    crazy|
         +----+---+--------+---------+
-        <BLANKLINE>
         """
-        return func(self)
+        res = func(self)
+        assert isinstance(res, DataFrame)
+        return res
 
     @since(1.3)
     def toPandas(self):

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2054,33 +2054,31 @@ class DataFrame(object):
         :param func: a user-defined custom transform function
         :param *args: optional positional arguments to pass to `func`
         :param **kwargs: optional keywarded arguments to pass to `func`
-
-        A more concrete example::
-
-        def with_greeting(df):
-               return df.withColumn("greeting", lit("hi"))
-            def with_something(df, something):
-                return df.withColumn("something", lit(something))
-            
-            data = [("jose", 1), ("li", 2), ("liz", 3)]
-            source_df = spark.createDataFrame(data, ["name", "age"])
-
-            actual_df = (source_df
-                .transform(with_greeting)
-                .transform(with_something, "crazy"))
-            print(actual_df.show())
-            +----+---+--------+---------+
-            |name|age|greeting|something|
-            +----+---+--------+---------+
-            |jose|  1|      hi|    crazy|
-            |  li|  2|      hi|    crazy|
-            | liz|  3|      hi|    crazy|
-            +----+---+--------+---------+
-
-        This is equiavalent to a nested:
+        This is equiavalent to a nested call:
             actual_df = with_something(with_greeting(source_df), "crazy"))
 
         credit to: https://medium.com/@mrpowers/chaining-custom-pyspark-transformations-4f38a8c7ae55
+
+        A more concrete example::
+        >>> sc = pyspark.SparkContext(master='local')
+        >>> spark = pyspark.sql.SparkSession(sparkContext=sc)
+        >>> from pyspark.sql.functions import lit
+        >>> def with_greeting(df):
+        ...     return df.withColumn("greeting", lit("hi"))
+        >>> def with_something(df, something):
+        ...     return df.withColumn("something", lit(something))
+        >>> data = [("jose", 1), ("li", 2), ("liz", 3)]
+        >>> source_df = spark.createDataFrame(data, ["name", "age"])
+        >>> actual_df = source_df.transform(with_greeting).transform(with_something, "crazy")
+        >>> actual_df.show()
+        +----+---+--------+---------+
+        |name|age|greeting|something|
+        +----+---+--------+---------+
+        |jose|  1|      hi|    crazy|
+        |  li|  2|      hi|    crazy|
+        | liz|  3|      hi|    crazy|
+        +----+---+--------+---------+
+        <BLANKLINE>
         """
         return func(self, *args, **kwargs)
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2060,14 +2060,16 @@ class DataFrame(object):
         ...     return df.withColumn("something", lit(something))
         >>> data = [("jose", 1), ("li", 2), ("liz", 3)]
         >>> source_df = spark.createDataFrame(data, ["name", "age"])
-        >>> actual_df = source_df.transform(with_greeting).transform(lambda x: with_something(x, "crazy"))
+        >>> actual_df = (source_df
+        ...             .transform(with_greeting)
+        ...             .transform(lambda x: with_something(x, "nice")))
         >>> actual_df.show()
         +----+---+--------+---------+
         |name|age|greeting|something|
         +----+---+--------+---------+
-        |jose|  1|      hi|    crazy|
-        |  li|  2|      hi|    crazy|
-        | liz|  3|      hi|    crazy|
+        |jose|  1|      hi|     nice|
+        |  li|  2|      hi|     nice|
+        | liz|  3|      hi|     nice|
         +----+---+--------+---------+
         """
         res = func(self)


### PR DESCRIPTION
## What changes were proposed in this pull request?

added a transform method to the Dataframe class, see https://issues.apache.org/jira/browse/SPARK-26449

## How was this patch tested?

Tested manually by injecting the proposed method to the current spark version dataframe class.
I've tried to compile spark from scratch and test using ./build/mvn test. However, unrelated tests fails before my change.

Please review http://spark.apache.org/contributing.html before opening a pull request.
