### PR TITLE
[SPARK-24421][CORE][FOLLOWUP] Use normal direct ByteBuffer allocation if Cleaner can't be set

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -218,8 +218,10 @@ public final class Platform {
         try {
           return ByteBuffer.allocateDirect(size);
         } catch (OutOfMemoryError oome) {
+          // checkstyle.off: RegexpSinglelineJava
           throw new OutOfMemoryError("Failed to allocate direct buffer (" + oome.getMessage() +
               "); try increasing -XX:MaxDirectMemorySize=... to, for example, your heap size");
+          // checkstyle.on: RegexpSinglelineJava
         }
       }
       // Otherwise, use internal JDK APIs to allocate a DirectByteBuffer while ignoring the JVM's

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -215,7 +215,12 @@ public final class Platform {
     try {
       if (CLEANER_CREATE_METHOD == null) {
         // Can't set a Cleaner (see comments on field), so need to allocate via normal Java APIs
-        return ByteBuffer.allocateDirect(size);
+        try {
+          return ByteBuffer.allocateDirect(size);
+        } catch (OutOfMemoryError oome) {
+          throw new OutOfMemoryError("Failed to allocate direct buffer (" + oome.getMessage() +
+              "); try increasing -XX:MaxDirectMemorySize=... to, for example, your heap size");
+        }
       }
       // Otherwise, use internal JDK APIs to allocate a DirectByteBuffer while ignoring the JVM's
       // MaxDirectMemorySize limit (the default limit is too low and we do not want to


### PR DESCRIPTION
## What changes were proposed in this pull request?

In Java 9+ we can't use sun.misc.Cleaner by default anymore, and this was largely handled in https://github.com/apache/spark/pull/22993 However I think the change there left a significant problem.

If a DirectByteBuffer is allocated using the reflective hack in Platform, now, we by default can't set a Cleaner. But I believe this means the memory isn't freed promptly or possibly at all. If a Cleaner can't be set, I think we need to use normal APIs to allocate the direct ByteBuffer.

According to comments in the code, the downside is simply that the normal APIs will check and impose limits on how much off-heap memory can be allocated. Per the original review on https://github.com/apache/spark/pull/22993 this much seems fine, as either way in this case the user would have to add a JVM setting (increase max, or allow the reflective access).

## How was this patch tested?

Existing tests. This resolved an OutOfMemoryError in Java 11 from TimSort tests without increasing test heap size. (See https://github.com/apache/spark/pull/23419#issuecomment-450772125 ) This suggests there is a problem and that this resolves it.