### PR TITLE
[SPARK-25921][Follow Up][PySpark] Fix barrier task run without BarrierTaskContext while python worker reuse

### DIFF
--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -48,10 +48,6 @@ class TaskContext(object):
         cls._taskContext = taskContext = object.__new__(cls)
         return taskContext
 
-    def __init__(self):
-        """Construct a TaskContext, use get instead"""
-        pass
-
     @classmethod
     def _getOrCreate(cls):
         """Internal function to get or create global TaskContext."""
@@ -140,13 +136,13 @@ class BarrierTaskContext(TaskContext):
     _port = None
     _secret = None
 
-    def __init__(self):
-        """Construct a BarrierTaskContext, use get instead"""
-        pass
-
     @classmethod
     def _getOrCreate(cls):
-        """Internal function to get or create global BarrierTaskContext."""
+        """
+        Internal function to get or create global BarrierTaskContext. We need to make sure
+        BarrierTaskContext returns here because it needs in python worker reuse scenario,
+        see SPARK-25921 for more details.
+        """
         if not isinstance(cls._taskContext, BarrierTaskContext):
             cls._taskContext = object.__new__(cls)
         return cls._taskContext

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -140,8 +140,8 @@ class BarrierTaskContext(TaskContext):
     def _getOrCreate(cls):
         """
         Internal function to get or create global BarrierTaskContext. We need to make sure
-        BarrierTaskContext returns here because it needs in python worker reuse scenario,
-        see SPARK-25921 for more details.
+        BarrierTaskContext is returned from here because it is needed in python worker reuse
+        scenario, see SPARK-25921 for more details.
         """
         if not isinstance(cls._taskContext, BarrierTaskContext):
             cls._taskContext = object.__new__(cls)

--- a/python/pyspark/tests/test_taskcontext.py
+++ b/python/pyspark/tests/test_taskcontext.py
@@ -148,7 +148,6 @@ class TaskContextTestsWithWorkerReuse(PySparkTestCase):
         reused python worker.
         """
         import os
-        self.sc._conf.set("spark.python.work.reuse", "true")
         # start a normal job first to start all workers and get all worker pids
         worker_pids = self.sc.parallelize(range(2), 2).map(lambda x: os.getpid()).collect()
         # the worker will reuse in this barrier job
@@ -164,8 +163,8 @@ class TaskContextTestsWithWorkerReuse(PySparkTestCase):
             return (time.time(), os.getpid())
 
         result = rdd.barrier().mapPartitions(f).map(context_barrier).collect()
-        times = map(lambda x: x[0], result)
-        pids = map(lambda x: x[1], result)
+        times = list(map(lambda x: x[0], result))
+        pids = list(map(lambda x: x[1], result))
         # check both barrier and worker reuse effect
         self.assertTrue(max(times) - min(times) < 1)
         for pid in pids:


### PR DESCRIPTION
## What changes were proposed in this pull request?

It's the follow-up PR for #22962, contains the following works:
- Remove `__init__` in TaskContext and BarrierTaskContext.
- Add more comments to explain the fix.
- Rewrite UT in a new class.

## How was this patch tested?

New UT in test_taskcontext.py
