### PR TITLE
[SPARK-26524] If the application directory fails to be created on the SPARK_WORKER_…

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
@@ -63,7 +63,8 @@ private[deploy] object DeployMessages {
       execId: Int,
       state: ExecutorState,
       message: Option[String],
-      exitStatus: Option[Int])
+      exitStatus: Option[Int],
+      workerId: String = "")
     extends DeployMessage
 
   case class DriverStateChanged(

--- a/core/src/main/scala/org/apache/spark/deploy/master/MasterMessages.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/MasterMessages.scala
@@ -32,6 +32,8 @@ private[master] object MasterMessages {
 
   case object CheckForWorkerTimeOut
 
+  case object CheckForWorkerBlackTimeOut
+
   case class BeginRecovery(storedApps: Seq[ApplicationInfo], storedWorkers: Seq[WorkerInfo])
 
   case object CompleteRecovery

--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -551,11 +551,11 @@ private[deploy] class Worker(
               executors -= appId + "/" + execId
             }
             sendToMaster(ExecutorStateChanged(appId, execId, ExecutorState.FAILED,
-              Some(e.toString), None))
+              Some(e.toString), None, workerId))
         }
       }
 
-    case executorStateChanged @ ExecutorStateChanged(appId, execId, state, message, exitStatus) =>
+    case executorStateChanged @ ExecutorStateChanged(_, _, _, _, _, _) =>
       handleExecutorStateChanged(executorStateChanged)
 
     case KillExecutor(masterUrl, appId, execId) =>


### PR DESCRIPTION
…DIR on some woker nodes (for example, bad disk or disk has no capacity), the application executor will be allocated indefinitely.

## What changes were proposed in this pull request?

When the spark worker is started, the workerdir is created successfully. When the application is submitted, the disks mounted by the workerdir and worker122 workerdir are damaged.

When a worker allocates an executor, it creates a working directory and a temporary directory. If the creation fails, the executor allocation fails. The application directory fails to be created on the SPARK_WORKER_DIR on woker121 and worker122，the application executor will be allocated indefinitely.

I added two configuration items, spark.deploy.executorFailedPerWorkerThreshold and spark.worker.black.timeout. Record the number of times the woker fails to allocate an executor to the same application. The maximum value is controlled by spark.deploy.executorFailedPerWorkerThreshold. It is determined whether the worker can be set to black.  And the worker black will be removed by configuring the timeout period.

Master will judge whether the worker is available according to the resources of the worker and whether the worker is black. 

    // Filter out workers that don't have enough resources to launch an executor
    val usableWorkers = workers.toArray.filter(_.state == WorkerState.ALIVE)
    .filter(worker => worker.memoryFree >= app.desc.memoryPerExecutorMB &&
    worker.coresFree >= coresPerExecutor && !worker.isBlack)
    .sortBy(_.coresFree).reverse

This is a solution I can think of, I don’t know if it’s suitable.

## How was this patch tested?

 manual tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
