### PR TITLE
[SPARK-26454][CORE][Minor] Lowering the log level when the same jars are duplicatedly added

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1780,7 +1780,7 @@ class SparkContext(config: SparkConf) extends Logging {
         env.rpcEnv.fileServer.addJar(file)
       } catch {
         case NonFatal(e) =>
-          logError(s"Failed to add $path to Spark environment", e)
+          logWarning(s"Failed to add $path to Spark environment", e)
           null
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

While creating new UDF with JAR,though function is created successfully,  it throws IllegegalArgument Exception,  so instead of giving error log, log level is changed to warning as error log sounds operation failure so giving warning and moving ahead sounds better. 
