### PR TITLE
[SPARK-26529]Add debug logs for confArchive when preparing local resource

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -728,6 +728,7 @@ private[spark] class Client(
       new File(Utils.getLocalDir(sparkConf)))
     val confStream = new ZipOutputStream(new FileOutputStream(confArchive))
 
+    logDebug(s"Creating an archive with the config files for distribution at $confArchive.")
     try {
       confStream.setLevel(0)
 
@@ -780,19 +781,10 @@ private[spark] class Client(
       props.store(writer, "Spark configuration.")
       writer.flush()
       confStream.closeEntry()
-      confArchive
-    } catch {
-      case e: IOException =>
-        logError(s"IOException occurred while writing to confArchive $confArchive", e)
-        throw e
     } finally {
-      try {
-        confStream.close()
-      } catch {
-        case e: IOException =>
-          logError(s"IOException occurred while close confArchive $confArchive", e)
-      }
+      confStream.close()
     }
+    confArchive
   }
 
   /**

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -780,10 +780,19 @@ private[spark] class Client(
       props.store(writer, "Spark configuration.")
       writer.flush()
       confStream.closeEntry()
+      confArchive
+    } catch {
+      case e: IOException =>
+        logError(s"IOException occurred while writing to confArchive $confArchive", e)
+        throw e
     } finally {
-      confStream.close()
+      try {
+        confStream.close()
+      } catch {
+        case e: IOException =>
+          logError(s"IOException occurred while close confArchive $confArchive", e)
+      }
     }
-    confArchive
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, `Client#createConfArchive` do not handle IOException, and some detail info is not provided in logs. Sometimes, this may delay the time of locating the root cause of io error.
This PR will add debug logs for confArchive when preparing local resource.

## How was this patch tested?

unittest