### PR TITLE
[SPARK-26530][core] Validate heartheat arguments in HeartbeatReceiver

### DIFF
--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -79,6 +79,17 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
 
   private val checkTimeoutIntervalMs = sc.conf.get(Network.NETWORK_TIMEOUT_INTERVAL)
 
+  private val executorHeartbeatIntervalMs = sc.conf.get(config.EXECUTOR_HEARTBEAT_INTERVAL)
+
+  require(checkTimeoutIntervalMs >= executorTimeoutMs,
+    s"checkTimeoutIntervalMs should be less than executorTimeoutMs, " +
+      s"please set ${Network.NETWORK_TIMEOUT_INTERVAL.key} and " +
+      s"${config.STORAGE_BLOCKMANAGER_SLAVE_TIMEOUT.key} properly.")
+  require(executorHeartbeatIntervalMs >= executorTimeoutMs,
+    "executorHeartbeatIntervalMs should be less than executorTimeoutMs, " +
+      s"please set ${config.EXECUTOR_HEARTBEAT_INTERVAL.key} and " +
+      s"${config.STORAGE_BLOCKMANAGER_SLAVE_TIMEOUT.key} properly.")
+
   private var timeoutCheckingTask: ScheduledFuture[_] = null
 
   // "eventLoopThread" is used to run some pretty fast actions. The actions running in it should not

--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -81,14 +81,12 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
 
   private val executorHeartbeatIntervalMs = sc.conf.get(config.EXECUTOR_HEARTBEAT_INTERVAL)
 
-  require(checkTimeoutIntervalMs < executorTimeoutMs,
-    s"checkTimeoutIntervalMs should be less than executorTimeoutMs, " +
-      s"please set ${Network.NETWORK_TIMEOUT_INTERVAL.key} and " +
-      s"${config.STORAGE_BLOCKMANAGER_SLAVE_TIMEOUT.key} properly.")
+  require(checkTimeoutIntervalMs <= executorTimeoutMs,
+    s"${Network.NETWORK_TIMEOUT_INTERVAL.key} should be less than or " +
+      s"equal to ${config.STORAGE_BLOCKMANAGER_SLAVE_TIMEOUT.key}.")
   require(executorHeartbeatIntervalMs < executorTimeoutMs,
-    "executorHeartbeatIntervalMs should be less than executorTimeoutMs, " +
-      s"please set ${config.EXECUTOR_HEARTBEAT_INTERVAL.key} and " +
-      s"${config.STORAGE_BLOCKMANAGER_SLAVE_TIMEOUT.key} properly.")
+    s"${config.EXECUTOR_HEARTBEAT_INTERVAL.key} should be less than " +
+      s"${config.STORAGE_BLOCKMANAGER_SLAVE_TIMEOUT.key}")
 
   private var timeoutCheckingTask: ScheduledFuture[_] = null
 

--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -81,11 +81,11 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
 
   private val executorHeartbeatIntervalMs = sc.conf.get(config.EXECUTOR_HEARTBEAT_INTERVAL)
 
-  require(checkTimeoutIntervalMs >= executorTimeoutMs,
+  require(checkTimeoutIntervalMs < executorTimeoutMs,
     s"checkTimeoutIntervalMs should be less than executorTimeoutMs, " +
       s"please set ${Network.NETWORK_TIMEOUT_INTERVAL.key} and " +
       s"${config.STORAGE_BLOCKMANAGER_SLAVE_TIMEOUT.key} properly.")
-  require(executorHeartbeatIntervalMs >= executorTimeoutMs,
+  require(executorHeartbeatIntervalMs < executorTimeoutMs,
     "executorHeartbeatIntervalMs should be less than executorTimeoutMs, " +
       s"please set ${config.EXECUTOR_HEARTBEAT_INTERVAL.key} and " +
       s"${config.STORAGE_BLOCKMANAGER_SLAVE_TIMEOUT.key} properly.")

--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -84,9 +84,9 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
   require(checkTimeoutIntervalMs <= executorTimeoutMs,
     s"${Network.NETWORK_TIMEOUT_INTERVAL.key} should be less than or " +
       s"equal to ${config.STORAGE_BLOCKMANAGER_SLAVE_TIMEOUT.key}.")
-  require(executorHeartbeatIntervalMs < executorTimeoutMs,
-    s"${config.EXECUTOR_HEARTBEAT_INTERVAL.key} should be less than " +
-      s"${config.STORAGE_BLOCKMANAGER_SLAVE_TIMEOUT.key}")
+  require(executorHeartbeatIntervalMs <= executorTimeoutMs,
+    s"${config.EXECUTOR_HEARTBEAT_INTERVAL.key} should be less than or " +
+      s"equal to ${config.STORAGE_BLOCKMANAGER_SLAVE_TIMEOUT.key}")
 
   private var timeoutCheckingTask: ScheduledFuture[_] = null
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -304,25 +304,25 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     }
 
     // Ensure heartbeat arguments is valid.
+    val networkTimeout = Utils.timeStringAsSeconds(
+      sparkProperties.getOrElse("spark.network.timeout", "120s"))
     val executorTimeoutMs =
       Utils.timeStringAsMs(sparkProperties.getOrElse(
-        "spark.storage.blockManagerSlaveTimeoutMs",
-        s"${Utils.timeStringAsSeconds(
-          sparkProperties.getOrElse("spark.network.timeout", "120s"))}s"))
+        "spark.storage.blockManagerSlaveTimeoutMs", s"${networkTimeout}s"))
     val executorHeartbeatIntervalMs = Utils.timeStringAsMs(
       sparkProperties.getOrElse("spark.executor.heartbeatInterval", "10s"))
-    val checkTimeoutIntervalMs =
+    val blockManagerTimeoutInterval = Utils.timeStringAsMs(
+      sparkProperties.getOrElse("spark.storage.blockManagerTimeoutIntervalMs", "60s"))
+    val checkNetworkTimeoutIntervalMs =
       Utils.timeStringAsSeconds(sparkProperties.getOrElse(
-        "spark.network.timeoutInterval",
-        s"${Utils.timeStringAsMs(sparkProperties.getOrElse(
-          "spark.storage.blockManagerTimeoutIntervalMs", "60s"))}ms")) * 1000
-    if (checkTimeoutIntervalMs >= executorTimeoutMs) {
-      error(s"Incorrect heartbeat arguments, checkTimeoutIntervalMs should " +
+        "spark.network.timeoutInterval", s"${blockManagerTimeoutInterval}ms")) * 1000
+    if (checkNetworkTimeoutIntervalMs >= executorTimeoutMs) {
+      error(s"Incorrect heartbeat arguments, checkNetworkTimeoutIntervalMs should " +
         s"less than executorTimeoutMs.")
     }
-    if (executorHeartbeatIntervalMs >= checkTimeoutIntervalMs) {
+    if (executorHeartbeatIntervalMs >= checkNetworkTimeoutIntervalMs) {
       error(s"Incorrect heartbeat arguments, executorHeartbeatIntervalMs should " +
-        s"less than checkTimeoutIntervalMs")
+        s"less than checkNetworkTimeoutIntervalMs")
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -302,28 +302,6 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     if (proxyUser != null && principal != null) {
       error("Only one of --proxy-user or --principal can be provided.")
     }
-
-    // Ensure heartbeat arguments is valid.
-    val networkTimeout = Utils.timeStringAsSeconds(
-      sparkProperties.getOrElse("spark.network.timeout", "120s"))
-    val executorTimeoutMs =
-      Utils.timeStringAsMs(sparkProperties.getOrElse(
-        "spark.storage.blockManagerSlaveTimeoutMs", s"${networkTimeout}s"))
-    val executorHeartbeatIntervalMs = Utils.timeStringAsMs(
-      sparkProperties.getOrElse("spark.executor.heartbeatInterval", "10s"))
-    val blockManagerTimeoutInterval = Utils.timeStringAsMs(
-      sparkProperties.getOrElse("spark.storage.blockManagerTimeoutIntervalMs", "60s"))
-    val checkNetworkTimeoutIntervalMs =
-      Utils.timeStringAsSeconds(sparkProperties.getOrElse(
-        "spark.network.timeoutInterval", s"${blockManagerTimeoutInterval}ms")) * 1000
-    if (checkNetworkTimeoutIntervalMs >= executorTimeoutMs) {
-      error(s"Incorrect heartbeat arguments, checkNetworkTimeoutIntervalMs should " +
-        s"less than executorTimeoutMs.")
-    }
-    if (executorHeartbeatIntervalMs >= checkNetworkTimeoutIntervalMs) {
-      error(s"Incorrect heartbeat arguments, executorHeartbeatIntervalMs should " +
-        s"less than checkNetworkTimeoutIntervalMs")
-    }
   }
 
   private def validateKillArguments(): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, heartbeat related arguments is not validated in spark, so if these args are inproperly specified, the Application may run for a while and not failed until the max executor failures reached(especially with spark.dynamicAllocation.enabled=true), thus may incurs resources waste.

This PR is to precheck these arguments in HeartbeatReceiver to fix this problem.

## How was this patch tested?

NA-just validation changes
