### PR TITLE
[SPARK-26339][SQL]Throws better exception when reading files that start with underscore

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -554,7 +554,8 @@ case class DataSource(
 
       // Sufficient to check head of the globPath seq for non-glob scenario
       // Don't need to check once again if files exist in streaming mode
-      if (checkFilesExist && !fs.exists(globPath.head)) {
+      if (checkFilesExist &&
+          (!fs.exists(globPath.head) || InMemoryFileIndex.shouldFilterOut(globPath.head.getName))) {
         throw new AnalysisException(s"Path does not exist: ${globPath.head}")
       }
       globPath

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -554,8 +554,7 @@ case class DataSource(
 
       // Sufficient to check head of the globPath seq for non-glob scenario
       // Don't need to check once again if files exist in streaming mode
-      if (checkFilesExist &&
-          (!fs.exists(globPath.head) || InMemoryFileIndex.shouldFilterOut(globPath.head.getName))) {
+      if (checkFilesExist && !fs.exists(globPath.head)) {
         throw new AnalysisException(s"Path does not exist: ${globPath.head}")
       }
       globPath

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -560,20 +560,18 @@ case class DataSource(
       globPath
     }.toSeq
 
-    if (checkFilesExist) {
-      val (filtered, filteredOut) = allGlobPath.partition { path =>
-        !InMemoryFileIndex.shouldFilterOut(path.getName)
-      }
-      if (filteredOut.nonEmpty) {
-        if (filtered.isEmpty) {
-          throw new AnalysisException(
-            "All path were ignored. The following path were ignored:\n" +
-              s"${filteredOut.mkString("\n  ")}")
-        } else {
-          logDebug(
-            "The following path were ignored:\n" +
-              s"${filteredOut.mkString("\n  ")}")
-        }
+    val (filtered, filteredOut) = allGlobPath.partition { path =>
+      !InMemoryFileIndex.shouldFilterOut(path.getName)
+    }
+    if (filteredOut.nonEmpty) {
+      if (filtered.isEmpty) {
+        throw new AnalysisException(
+          "All path were ignored. The following path were ignored:\n" +
+            s"${filteredOut.mkString("\n  ")}")
+      } else {
+        logDebug(
+          "The following path were ignored:\n" +
+            s"${filteredOut.mkString("\n  ")}")
       }
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -554,13 +554,9 @@ case class DataSource(
 
       // Sufficient to check head of the globPath seq for non-glob scenario
       // Don't need to check once again if files exist in streaming mode
-      if (checkFilesExist) {
-        val firstPath = globPath.head
-        if (!fs.exists(firstPath)) {
-          throw new AnalysisException(s"Path does not exist: ${firstPath}")
-        } else if (InMemoryFileIndex.shouldFilterOut(firstPath.getName)) {
-          throw new AnalysisException(s"Path exists but is ignored: ${firstPath}")
-        }
+      if (checkFilesExist &&
+          (!fs.exists(globPath.head) || InMemoryFileIndex.shouldFilterOut(globPath.head.getName))) {
+        throw new AnalysisException(s"Path does not exist: ${globPath.head}")
       }
       globPath
     }.toSeq

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -554,9 +554,13 @@ case class DataSource(
 
       // Sufficient to check head of the globPath seq for non-glob scenario
       // Don't need to check once again if files exist in streaming mode
-      if (checkFilesExist &&
-          (!fs.exists(globPath.head) || InMemoryFileIndex.shouldFilterOut(globPath.head.getName))) {
-        throw new AnalysisException(s"Path does not exist: ${globPath.head}")
+      if (checkFilesExist) {
+        val firstPath = globPath.head
+        if (!fs.exists(firstPath)) {
+          throw new AnalysisException(s"Path does not exist: ${firstPath}")
+        } else if (InMemoryFileIndex.shouldFilterOut(firstPath.getName)) {
+          throw new AnalysisException(s"Path exists but is ignored: ${firstPath}")
+        }
       }
       globPath
     }.toSeq

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -560,18 +560,16 @@ case class DataSource(
       globPath
     }.toSeq
 
-    val (filtered, filteredOut) = allGlobPath.partition { path =>
-      !InMemoryFileIndex.shouldFilterOut(path.getName)
+    val (filteredOut, filteredIn) = allGlobPath.partition { path =>
+      InMemoryFileIndex.shouldFilterOut(path.getName)
     }
     if (filteredOut.nonEmpty) {
-      if (filtered.isEmpty) {
+      if (filteredIn.isEmpty) {
         throw new AnalysisException(
-          "All path were ignored. The following path were ignored:\n" +
-            s"${filteredOut.mkString("\n  ")}")
+          s"All paths were ignored:\n${filteredOut.mkString("\n  ")}")
       } else {
         logDebug(
-          "The following path were ignored:\n" +
-            s"${filteredOut.mkString("\n  ")}")
+          s"Some paths were ignored:\n${filteredOut.mkString("\n  ")}")
       }
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -560,16 +560,18 @@ case class DataSource(
       globPath
     }.toSeq
 
-    val (filteredOut, filteredIn) = allGlobPath.partition { path =>
-      InMemoryFileIndex.shouldFilterOut(path.getName)
-    }
-    if (filteredOut.nonEmpty) {
-      if (filteredIn.isEmpty) {
-        throw new AnalysisException(
-          s"All paths were ignored:\n${filteredOut.mkString("\n  ")}")
-      } else {
-        logDebug(
-          s"Some paths were ignored:\n${filteredOut.mkString("\n  ")}")
+    if (checkFilesExist) {
+      val (filteredOut, filteredIn) = allGlobPath.partition { path =>
+        InMemoryFileIndex.shouldFilterOut(path.getName)
+      }
+      if (filteredOut.nonEmpty) {
+        if (filteredIn.isEmpty) {
+          throw new AnalysisException(
+            s"All paths were ignored:\n${filteredOut.mkString("\n  ")}")
+        } else {
+          logDebug(
+            s"Some paths were ignored:\n${filteredOut.mkString("\n  ")}")
+        }
       }
     }
 

--- a/sql/core/src/test/resources/test-data/_cars.csv
+++ b/sql/core/src/test/resources/test-data/_cars.csv
@@ -1,0 +1,7 @@
+
+year,make,model,comment,blank
+"2012","Tesla","S","No comment",
+
+1997,Ford,E350,"Go get one now they are going fast",
+2015,Chevy,Volt
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -346,7 +346,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
     assert(result.schema.fieldNames.size === 1)
   }
 
-  test("SPARK-26339 Debug statement if some of the files are filtered out") {
+  test("SPARK-26339 Debug statement if some of specified paths are filtered out") {
     class TestAppender extends AppenderSkeleton {
       var events = new java.util.ArrayList[LoggingEvent]
       override def close(): Unit = {}
@@ -373,10 +373,10 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
     }
     assert(testAppender1.events.asScala
       .exists(msg => msg.getRenderedMessage.contains(
-        "The following files were ignored during file scan:")))
+        "The following path were ignored:")))
   }
 
-  test("SPARK-26339 Throw an exception only if all of the files are filtered out") {
+  test("SPARK-26339 Throw an exception only if all of the specified paths are filtered out") {
     val e = intercept[AnalysisException] {
       val cars = spark
         .read
@@ -384,8 +384,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
         .option("header", "false")
         .load(testFile(carsFilteredOutFile))
     }.getMessage
-    assert(e.contains("All files were ignored. " +
-      "The following files were ignored during file scan:"))
+    assert(e.contains("All path were ignored. The following path were ignored:"))
   }
 
   test("DDL test with empty file") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -362,9 +362,8 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
     try {
       val cars = spark
         .read
-        .format("csv")
         .option("header", "false")
-        .load(testFile(carsFile), testFile(carsFilteredOutFile))
+        .csv(testFile(carsFile), testFile(carsFilteredOutFile))
 
       verifyCars(cars, withHeader = false, checkTypes = false)
     } finally {
@@ -373,18 +372,17 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
     }
     assert(testAppender1.events.asScala
       .exists(msg => msg.getRenderedMessage.contains(
-        "The following path were ignored:")))
+        "Some paths were ignored:")))
   }
 
   test("SPARK-26339 Throw an exception only if all of the specified paths are filtered out") {
     val e = intercept[AnalysisException] {
       val cars = spark
         .read
-        .format("csv")
         .option("header", "false")
-        .load(testFile(carsFilteredOutFile))
+        .csv(testFile(carsFilteredOutFile))
     }.getMessage
-    assert(e.contains("All path were ignored. The following path were ignored:"))
+    assert(e.contains("All paths were ignored:"))
   }
 
   test("DDL test with empty file") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -346,7 +346,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
     assert(result.schema.fieldNames.size === 1)
   }
 
-  test("SPARK-26339 Not throw an exception if some of specified paths are filtered out") {
+  test("SPARK-26339 Not throw an exception if some of specified paths are filtered in") {
     val cars = spark
       .read
       .option("header", "false")


### PR DESCRIPTION
## What changes were proposed in this pull request?
My pull request #23288 was resolved and merged to master, but it turned out  later that my change breaks another regression test. Because we cannot reopen pull request, I create a new pull request here.
Commit 92934b4 is only change after pull request #23288.
`CheckFileExist` was avoided at 239cfa4 after discussing #23288 (comment).
But, that change turned out to be wrong because we should not check if argument checkFileExist is false.

Test https://github.com/apache/spark/blob/27e42c1de502da80fa3e22bb69de47fb00158174/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala#L2555
failed when we avoided checkFileExist, but now successed after commit 92934b4 .

## How was this patch tested?
Both of below tests were passed.
```
testOnly org.apache.spark.sql.execution.datasources.csv.CSVSuite
testOnly org.apache.spark.sql.SQLQuerySuite
```