### PR TITLE
[SPARK-26126]Put scala-library deps into root pom

### DIFF
--- a/common/tags/pom.xml
+++ b/common/tags/pom.xml
@@ -34,14 +34,6 @@
     <sbt.project.name>tags</sbt.project.name>
   </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.scala-lang</groupId>
-      <artifactId>scala-library</artifactId>
-      <version>${scala.version}</version>
-    </dependency>
-  </dependencies>
-
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,11 @@
       <artifactId>unused</artifactId>
       <version>1.0.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
     <!--
          This is needed by the scalatest plugin, and so is declared here to be available in
          all child modules, just as scalatest is run in all children


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, scala-library deps is put into the pom of spark-tags module, however, some modules could no need for spark-tags intentionally. So we shall put it into root pom for better understanding.
This PR to about to fix it.

## How was this patch tested?

manual build

Please review http://spark.apache.org/contributing.html before opening a pull request.
