### PR TITLE
[SPARK-26089][CORE] Handle corruption in large shuffle blocks

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -928,6 +928,15 @@ package object config {
       .booleanConf
       .createWithDefault(true)
 
+  private[spark] val SHUFFLE_DETECT_CORRUPT_MEMORY =
+    ConfigBuilder("spark.shuffle.detectCorrupt.useExtraMemory")
+      .doc("If enabled, part of a compressed/encrypted stream will be de-compressed/de-crypted " +
+        "by using extra memory to detect early corruption. Any IOException thrown will cause " +
+        "the task to be retried once and if it fails again with same exception, then " +
+        "FetchFailedException will be thrown to retry previous stage")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val SHUFFLE_SYNC =
     ConfigBuilder("spark.shuffle.sync")
       .doc("Whether to force outstanding writes to disk.")
@@ -954,22 +963,6 @@ package object config {
       .intConf
       .checkValue(v => v > 0, "The value should be a positive integer.")
       .createWithDefault(2000)
-
-  private[spark] val SHUFFLE_DETECT_CORRUPT =
-    ConfigBuilder("spark.shuffle.detectCorrupt")
-      .doc("If enabled, IOException thrown while reading a compressed/encrypted stream will be " +
-        "converted to a FetchFailedException, to ensure that previous stage is retried")
-      .booleanConf
-      .createWithDefault(true)
-
-  private[spark] val SHUFFLE_DETECT_CORRUPT_MEMORY =
-    ConfigBuilder("spark.shuffle.detectCorrupt.useExtraMemory")
-      .doc("If enabled, part of a compressed/encrypted stream will be de-compressed/de-crypted " +
-        "by using extra memory to detect early corruption. Any IOException thrown will cause " +
-        "the task to be retried once and if it fails again with same exception, then " +
-        "FetchFailedException will be thrown to retry previous stage")
-      .booleanConf
-      .createWithDefault(false)
 
   private[spark] val MEMORY_MAP_LIMIT_FOR_TESTS =
     ConfigBuilder("spark.storage.memoryMapLimitForTests")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -955,6 +955,22 @@ package object config {
       .checkValue(v => v > 0, "The value should be a positive integer.")
       .createWithDefault(2000)
 
+  private[spark] val SHUFFLE_DETECT_CORRUPT =
+    ConfigBuilder("spark.shuffle.detectCorrupt")
+      .doc("If enabled, IOException thrown while reading a compressed/encrypted stream will be " +
+        "converted to a FetchFailedException, to ensure that previous stage is retried")
+      .booleanConf
+      .createWithDefault(true)
+
+  private[spark] val SHUFFLE_DETECT_CORRUPT_MEMORY =
+    ConfigBuilder("spark.shuffle.detectCorrupt.useExtraMemory")
+      .doc("If enabled, part of a compressed/encrypted stream will be de-compressed/de-crypted " +
+        "by using extra memory to detect early corruption. Any IOException thrown will cause " +
+        "the task to be retried once and if it fails again with same exception, then " +
+        "FetchFailedException will be thrown to retry previous stage")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val MEMORY_MAP_LIMIT_FOR_TESTS =
     ConfigBuilder("spark.storage.memoryMapLimitForTests")
       .internal()

--- a/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
@@ -55,6 +55,7 @@ private[spark] class BlockStoreShuffleReader[K, C](
       SparkEnv.get.conf.get(config.REDUCER_MAX_BLOCKS_IN_FLIGHT_PER_ADDRESS),
       SparkEnv.get.conf.get(config.MAX_REMOTE_BLOCK_SIZE_FETCH_TO_MEM),
       SparkEnv.get.conf.get(config.SHUFFLE_DETECT_CORRUPT),
+      SparkEnv.get.conf.get(config.SHUFFLE_DETECT_CORRUPT_MEMORY),
       readMetrics).toCompletionIterator
 
     val serializerInstance = dep.serializer.newInstance()

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -584,7 +584,9 @@ final class ShuffleBlockFetcherIterator(
   }
 
   private[storage] def throwFetchFailedException(
-      blockId: BlockId, address: BlockManagerId, e: Throwable) = {
+      blockId: BlockId,
+      address: BlockManagerId,
+      e: Throwable) = {
     blockId match {
       case ShuffleBlockId(shufId, mapId, reduceId) =>
         throw new FetchFailedException(address, shufId.toInt, mapId.toInt, reduceId, e)
@@ -605,7 +607,7 @@ private class BufferReleasingInputStream(
     private val iterator: ShuffleBlockFetcherIterator,
     private val blockId: BlockId,
     private val address: BlockManagerId,
-    private val streamCompressedOrEncrypted: Boolean)
+    private val detectCorruption: Boolean)
   extends InputStream {
   private[this] var closed = false
 
@@ -613,7 +615,7 @@ private class BufferReleasingInputStream(
     try {
       delegate.read()
     } catch {
-      case e: IOException if streamCompressedOrEncrypted =>
+      case e: IOException if detectCorruption =>
         IOUtils.closeQuietly(this)
         iterator.throwFetchFailedException(blockId, address, e)
     }
@@ -635,7 +637,7 @@ private class BufferReleasingInputStream(
     try {
       delegate.skip(n)
     } catch {
-      case e: IOException if streamCompressedOrEncrypted =>
+      case e: IOException if detectCorruption =>
         IOUtils.closeQuietly(this)
         iterator.throwFetchFailedException(blockId, address, e)
     }
@@ -647,7 +649,7 @@ private class BufferReleasingInputStream(
     try {
       delegate.read(b)
     } catch {
-      case e: IOException if streamCompressedOrEncrypted =>
+      case e: IOException if detectCorruption =>
         IOUtils.closeQuietly(this)
         iterator.throwFetchFailedException(blockId, address, e)
     }
@@ -657,7 +659,7 @@ private class BufferReleasingInputStream(
     try {
       delegate.read(b, off, len)
     } catch {
-      case e: IOException if streamCompressedOrEncrypted =>
+      case e: IOException if detectCorruption =>
         IOUtils.closeQuietly(this)
         iterator.throwFetchFailedException(blockId, address, e)
     }

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -25,6 +25,8 @@ import javax.annotation.concurrent.GuardedBy
 import scala.collection.mutable
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet, Queue}
 
+import org.apache.commons.io.IOUtils
+
 import org.apache.spark.{SparkException, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.network.buffer.{FileSegmentManagedBuffer, ManagedBuffer}
@@ -32,7 +34,6 @@ import org.apache.spark.network.shuffle._
 import org.apache.spark.network.util.TransportConf
 import org.apache.spark.shuffle.{FetchFailedException, ShuffleReadMetricsReporter}
 import org.apache.spark.util.{CompletionIterator, TaskCompletionListener, Utils}
-import org.apache.spark.util.io.ChunkedByteBufferOutputStream
 
 /**
  * An iterator that fetches multiple blocks. For local blocks, it fetches from the local block
@@ -613,6 +614,7 @@ private class BufferReleasingInputStream(
       delegate.read()
     } catch {
       case e: IOException if streamCompressedOrEncrypted =>
+        IOUtils.closeQuietly(this)
         iterator.throwFetchFailedException(blockId, address, e)
     }
   }
@@ -634,6 +636,7 @@ private class BufferReleasingInputStream(
       delegate.skip(n)
     } catch {
       case e: IOException if streamCompressedOrEncrypted =>
+        IOUtils.closeQuietly(this)
         iterator.throwFetchFailedException(blockId, address, e)
     }
   }
@@ -645,6 +648,7 @@ private class BufferReleasingInputStream(
       delegate.read(b)
     } catch {
       case e: IOException if streamCompressedOrEncrypted =>
+        IOUtils.closeQuietly(this)
         iterator.throwFetchFailedException(blockId, address, e)
     }
   }
@@ -654,6 +658,7 @@ private class BufferReleasingInputStream(
       delegate.read(b, off, len)
     } catch {
       case e: IOException if streamCompressedOrEncrypted =>
+        IOUtils.closeQuietly(this)
         iterator.throwFetchFailedException(blockId, address, e)
     }
   }

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -474,14 +474,13 @@ final class ShuffleBlockFetcherIterator(
             streamCompressedOrEncrypted = !input.eq(in)
             if (streamCompressedOrEncrypted && detectCorruptUseExtraMemory) {
               isStreamCopied = true
-              val out = new ChunkedByteBufferOutputStream(64 * 1024, ByteBuffer.allocate)
               // Decompress the block upto maxBytesInFlight/3 at once to detect any corruption which
               // could increase the memory usage and potentially increase the chance of OOM.
               // TODO: manage the memory used here, and spill it into disk in case of OOM.
-              val (completeStreamCopied: Boolean, newStream: InputStream) = Utils.copyStreamUpTo(
-                input, out, maxBytesInFlight / 3, closeStreams = true)
-              isStreamCopied = completeStreamCopied
-              input = newStream
+              val (fullyCopied: Boolean, mergedStream: InputStream) = Utils.copyStreamUpTo(
+                input, maxBytesInFlight / 3, closeStreams = true)
+              isStreamCopied = fullyCopied
+              input = mergedStream
             }
           } catch {
             case e: IOException =>

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -347,7 +347,7 @@ private[spark] object Utils extends Logging {
   def copyStreamUpTo(in: InputStream, maxSize: Long): (Boolean, InputStream) = {
     var count = 0L
     val out = new ChunkedByteBufferOutputStream(64 * 1024, ByteBuffer.allocate)
-    val streamCopied = tryWithSafeFinally {
+    val fullyCopied = tryWithSafeFinally {
       val bufSize = Math.min(8192L, maxSize)
       val buf = new Array[Byte](bufSize.toInt)
       var n = 0
@@ -368,10 +368,10 @@ private[spark] object Utils extends Logging {
         out.close()
       }
     }
-    if (streamCopied) {
-      (streamCopied, out.toChunkedByteBuffer.toInputStream(dispose = true))
+    if (fullyCopied) {
+      (fullyCopied, out.toChunkedByteBuffer.toInputStream(dispose = true))
     } else {
-      (streamCopied, new SequenceInputStream(
+      (fullyCopied, new SequenceInputStream(
         out.toChunkedByteBuffer.toInputStream(dispose = true), in))
     }
   }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -338,9 +338,9 @@ private[spark] object Utils extends Logging {
   }
 
   /**
-    * Copy all data from an InputStream to an OutputStream upto maxSize and
-    * closes the input stream if closeStreams is true and all data is read.
-    */
+   * Copy all data from an InputStream to an OutputStream upto maxSize and
+   * closes the input stream if closeStreams is true and all data is read.
+   */
   def copyStreamUpto(
       in: InputStream,
       out: OutputStream,

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -340,12 +340,10 @@ private[spark] object Utils extends Logging {
 
   /**
    * Copy all data from an InputStream to an OutputStream upto maxSize and
-   * closes the input stream if closeStreams is true and all data is read.
+   * close the input stream if all data is read.
+    * @return A combined stream of read data and any remaining data
    */
-  def copyStreamUpTo(
-      in: InputStream,
-      maxSize: Long,
-      closeStreams: Boolean = false): (Boolean, InputStream) = {
+  def copyStreamUpTo(in: InputStream, maxSize: Long): (Boolean, InputStream) = {
     var count = 0L
     val out = new ChunkedByteBufferOutputStream(64 * 1024, ByteBuffer.allocate)
     val streamCopied = tryWithSafeFinally {
@@ -361,14 +359,12 @@ private[spark] object Utils extends Logging {
       }
       count < maxSize
     } {
-      if (closeStreams) {
-        try {
-          if (count < maxSize) {
-            in.close()
-          }
-        } finally {
-          out.close()
+      try {
+        if (count < maxSize) {
+          in.close()
         }
+      } finally {
+        out.close()
       }
     }
     if (streamCopied) {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -341,7 +341,8 @@ private[spark] object Utils extends Logging {
   /**
    * Copy all data from an InputStream to an OutputStream upto maxSize and
    * close the input stream if all data is read.
-    * @return A combined stream of read data and any remaining data
+   * @return A tuple of boolean, which is whether the stream was fully copied, and an InputStream,
+   *         which is a combined stream of read data and any remaining data
    */
   def copyStreamUpTo(in: InputStream, maxSize: Long): (Boolean, InputStream) = {
     var count = 0L

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -341,7 +341,7 @@ private[spark] object Utils extends Logging {
    * Copy all data from an InputStream to an OutputStream upto maxSize and
    * closes the input stream if closeStreams is true and all data is read.
    */
-  def copyStreamUpto(
+  def copyStreamUpTo(
       in: InputStream,
       out: OutputStream,
       maxSize: Long,

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -344,10 +344,10 @@ private[spark] object Utils extends Logging {
    */
   def copyStreamUpTo(
       in: InputStream,
-      out: ChunkedByteBufferOutputStream,
       maxSize: Long,
       closeStreams: Boolean = false): (Boolean, InputStream) = {
     var count = 0L
+    val out = new ChunkedByteBufferOutputStream(64 * 1024, ByteBuffer.allocate)
     val streamCopied = tryWithSafeFinally {
       val bufSize = Math.min(8192L, maxSize)
       val buf = new Array[Byte](bufSize.toInt)

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -345,7 +345,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     } else {
       when(corruptStream.read(any(), any(), any(classOf[Int]))).thenAnswer(new Answer[Int] {
         override def answer(invocationOnMock: InvocationOnMock): Int = {
-          val bufSize = invocationOnMock.getArgumentAt(2, classOf[Int])
+          val bufSize = invocationOnMock.getArguments()(2).asInstanceOf[Int]
           // This condition is needed as we don't throw exception until we read the stream
           // less than maxBytesInFlight/3
           if (bufSize < 8 * 1024) {

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -495,8 +495,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       true,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
 
-    // Only one block should be returned which has corruption after maxBytesInFlight/3 because the
-    // other block will detect corruption on first fetch, and then get added to the queue again for
+    // We'll get back the block which has corruption after maxBytesInFlight/3 because the other
+    // block will detect corruption on first fetch, and then get added to the queue again for
     // a retry
     val (id, st) = iterator.next()
     assert(id === shuffleBlockId2)
@@ -507,7 +507,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     }
 
     // Following will succeed as it reads part of the stream which is not corrupt. This will read
-    // maxBytesInFlight/3 bytes from first stream and remaining from the second stream
+    // maxBytesInFlight/3 bytes from the portion copied into memory, and remaining from the
+    // underlying stream
     new DataInputStream(st).readFully(
       new Array[Byte](streamNotCorruptTill), 0, streamNotCorruptTill)
 

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -119,6 +119,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       Int.MaxValue,
       true,
+      false,
       metrics)
 
     // 3 local blocks fetched in initialization
@@ -198,6 +199,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       Int.MaxValue,
       true,
+      false,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
 
     verify(blocks(ShuffleBlockId(0, 0, 0)), times(0)).release()
@@ -326,6 +328,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       Int.MaxValue,
       true,
+      false,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
 
     // Continue only after the mock calls onBlockFetchFailure
@@ -414,6 +417,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       Int.MaxValue,
       true,
+      true,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
 
     // Continue only after the mock calls onBlockFetchFailure
@@ -480,6 +484,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       Int.MaxValue,
       true,
+      true,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
     // Only one block should be returned which has corruption after maxBytesInFlight/3
     val (id, st) = iterator.next()
@@ -529,16 +534,17 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       Int.MaxValue,
       true,
+      true,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
     val (id, st) = iterator.next()
-    // The returned stream is a concatenated stream
+    // Check that the test setup is correct -- make sure we have a concatenated stream.
     assert (st.asInstanceOf[BufferReleasingInputStream].delegate.isInstanceOf[SequenceInputStream])
 
     val dst = new DataInputStream(st)
     for (i <- 1 to 2500) {
       assert(i === dst.readInt())
     }
-    assert(dst.available() === 0)
+    assert(dst.read() === -1)
     dst.close()
   }
 
@@ -590,6 +596,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       Int.MaxValue,
       Int.MaxValue,
+      true,
       false,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
 
@@ -653,6 +660,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
         maxBlocksInFlightPerAddress = Int.MaxValue,
         maxReqSizeShuffleToMem = 200,
         detectCorrupt = true,
+        false,
         taskContext.taskMetrics.createTempShuffleReadMetrics())
     }
 
@@ -700,6 +708,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       Int.MaxValue,
       true,
+      false,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
 
     // All blocks fetched return zero length and should trigger a receive-side error:

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -490,7 +490,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     // Only one block should be returned which has corruption after maxBytesInFlight/3
     val (id, st) = iterator.next()
     assert(id === ShuffleBlockId(0, 1, 0))
-    intercept[FetchFailedException] { iterator.next(); iterator.next() }
+    intercept[FetchFailedException] { iterator.next() }
     // Following will succeed as it reads the first part of the stream which is not corrupt
     st.read(new Array[Byte](8 * 1024), 0, 8 * 1024)
     // Following will fail as it reads the remaining part of the stream which is corrupt

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -268,6 +268,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       Int.MaxValue,
       true,
+      false,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
 
 

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -222,7 +222,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     // testing for inputLength less than, equal to and greater than limit
     List(998, 999, 1000, 1001, 1002).foreach { inputLength =>
       val in = new ByteArrayInputStream(bytes.take(inputLength))
-      val (fullyCopied: Boolean, mergedStream: InputStream) = Utils.copyStreamUpTo(in, limit, true)
+      val (fullyCopied: Boolean, mergedStream: InputStream) = Utils.copyStreamUpTo(in, limit)
       try {
         // Get a handle on the buffered data, to make sure memory gets freed once we read past the
         // end of it. Need to use reflection to get handle on inner structures for this check

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -220,7 +220,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
 
     val limit = 1000
     // testing for inputLength less than, equal to and greater than limit
-    List(998, 999, 1000, 1001, 1002).foreach { inputLength =>
+    (limit - 2 to limit + 2).foreach { inputLength =>
       val in = new ByteArrayInputStream(bytes.take(inputLength))
       val (fullyCopied: Boolean, mergedStream: InputStream) = Utils.copyStreamUpTo(in, limit)
       try {

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.util
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataOutput, DataOutputStream, File,
-  FileOutputStream, InputStream, PrintStream}
+  FileOutputStream, InputStream, PrintStream, SequenceInputStream}
 import java.lang.{Double => JDouble, Float => JFloat}
 import java.net.{BindException, ServerSocket, URI}
 import java.nio.{ByteBuffer, ByteOrder}
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit
 import java.util.zip.GZIPOutputStream
 
 import scala.collection.mutable.ListBuffer
+import scala.reflect.runtime.universe
 import scala.util.Random
 
 import com.google.common.io.Files
@@ -43,7 +44,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.scheduler.SparkListener
-import org.apache.spark.util.io.ChunkedByteBufferOutputStream
+import org.apache.spark.util.io.ChunkedByteBufferInputStream
 
 class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
 
@@ -217,44 +218,42 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     val bytes = Array.ofDim[Byte](1200)
     Random.nextBytes(bytes)
 
-    var os: ChunkedByteBufferOutputStream = null
-    var in: InputStream = null
-    var copiedStream: InputStream = null
-    try {
-      os = new ChunkedByteBufferOutputStream(64 * 1024, ByteBuffer.allocate)
-      in = new ByteArrayInputStream(bytes.take(900))
-      val (cp1: Boolean, input1: InputStream) = Utils.copyStreamUpTo(in, os, 1000, true)
-      copiedStream = input1
-      assert(cp1)
-      assert(in.read() === -1)
-      IOUtils.closeQuietly(copiedStream)
-      IOUtils.closeQuietly(in)
-      IOUtils.closeQuietly(os)
-
-      os = new ChunkedByteBufferOutputStream(64 * 1024, ByteBuffer.allocate)
-      in = new ByteArrayInputStream(bytes.take(1000))
-      val (cp2: Boolean, input2: InputStream) = Utils.copyStreamUpTo(in, os, 1000, true)
-      copiedStream = input2
-      assert(!cp2)
-      assert(in.read() === -1)
-      IOUtils.closeQuietly(copiedStream)
-      IOUtils.closeQuietly(in)
-      IOUtils.closeQuietly(os)
-
-      os = new ChunkedByteBufferOutputStream(64 * 1024, ByteBuffer.allocate)
-      in = new ByteArrayInputStream(bytes.take(1100))
-      val (cp3: Boolean, input3: InputStream) = Utils.copyStreamUpTo(in, os, 1000, true)
-      copiedStream = input3
-      assert(!cp3)
-      assert(in.read() != -1)
-      IOUtils.closeQuietly(copiedStream)
-      IOUtils.closeQuietly(in)
-      IOUtils.closeQuietly(os)
-    } finally {
-      IOUtils.closeQuietly(copiedStream)
-      IOUtils.closeQuietly(in)
-      IOUtils.closeQuietly(os)
+    val limit = 1000
+    // testing for inputLength less than, equal to and greater than limit
+    List(900, 1000, 1100).foreach { inputLength =>
+      val in = new ByteArrayInputStream(bytes.take(inputLength))
+      val (fullyCopied: Boolean, mergedStream: InputStream) = Utils.copyStreamUpTo(in, limit, true)
+      try {
+        val byteBufferInputStream = if (mergedStream.isInstanceOf[ChunkedByteBufferInputStream]) {
+          mergedStream.asInstanceOf[ChunkedByteBufferInputStream]
+        } else {
+          val sequenceStream = mergedStream.asInstanceOf[SequenceInputStream]
+          val fieldValue = getFieldValue(sequenceStream, "in")
+          assert(fieldValue.isInstanceOf[ChunkedByteBufferInputStream])
+          fieldValue.asInstanceOf[ChunkedByteBufferInputStream]
+        }
+        assert(fullyCopied === (inputLength < limit))
+        (0 until inputLength).foreach { idx =>
+          assert(bytes(idx) === mergedStream.read().asInstanceOf[Byte])
+          if (idx == limit) {
+            assert(byteBufferInputStream.chunkedByteBuffer === null)
+          }
+        }
+        assert(mergedStream.read() === -1)
+        assert(byteBufferInputStream.chunkedByteBuffer === null)
+      } finally {
+        IOUtils.closeQuietly(mergedStream)
+        IOUtils.closeQuietly(in)
+      }
     }
+  }
+
+  private def getFieldValue(obj: AnyRef, fieldName: String): Any = {
+    val mirror = universe.runtimeMirror(obj.getClass().getClassLoader())
+    val field = mirror.classSymbol(obj.getClass()).info.decl(universe.TermName(fieldName)).asTerm
+    val instanceMirror = mirror.reflect(obj)
+    val fieldMirror = instanceMirror.reflectField(field)
+    fieldMirror.get
   }
 
   test("memoryStringToMb") {


### PR DESCRIPTION

## What changes were proposed in this pull request?

SPARK-4105 added corruption detection in shuffle blocks but that was limited to blocks which are
smaller than maxBytesInFlight/3. This commit adds upon that by adding corruption check for large
blocks. There are two changes/improvements that are made in this commit:

1. Large blocks are checked upto maxBytesInFlight/3 size in a similar way as smaller blocks, so if a
large block is corrupt in the starting, that block will be re-fetched and if that also fails,
FetchFailureException will be thrown.
2. If large blocks are corrupt after size maxBytesInFlight/3, then any IOException thrown while
reading the stream will be converted to FetchFailureException.  This is slightly more aggressive
than was originally intended but since the consumer of the stream may have already read some records and processed them, we can't just re-fetch the block, we need to fail the whole task. Additionally, we also thought about maybe adding a new type of TaskEndReason, which would re-try the task couple of times before failing the previous stage, but given the complexity involved in that solution we decided to not proceed in that direction.

Thanks to @squito for direction and support.

## How was this patch tested?

Changed the junit test for big blocks to check for corruption.
