### PR TITLE
[SPARK-26544][SQL] Escape string to keep alignment with hive

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/HiveResult.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/HiveResult.scala
@@ -125,7 +125,8 @@ object HiveResult {
     case (other, tpe) if primitiveTypes.contains(tpe) => other.toString
   }
 
-  /** Escape a String in JSON format. */
+  // Escape a String in JSON format.
+  // This code was taken from org.apache.hadoop.hive.serde2.SerDeUtils
   private def escapeString(str: String): String = {
     val length = str.length
     val escape = new StringBuilder(length + 16)
@@ -150,7 +151,7 @@ object HiveResult {
         escape.append('\\')
         escape.append('t')
       case c =>
-        // Control characeters! According to JSON RFC u0020
+        // Control characters! According to JSON RFC u0020
         if (c < ' ') {
           val hex = Integer.toHexString(c)
           escape.append('\\')

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/HiveResultSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/HiveResultSuite.scala
@@ -21,6 +21,7 @@ import java.sql.{Date, Timestamp}
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.test.{ExamplePoint, ExamplePointUDT, SharedSQLContext}
+import org.apache.spark.sql.types.MapType
 
 class HiveResultSuite extends SparkFunSuite with SharedSQLContext {
   import testImplicits._
@@ -44,4 +45,11 @@ class HiveResultSuite extends SparkFunSuite with SharedSQLContext {
     val tpe = new ExamplePointUDT()
     assert(HiveResult.toHiveString((point, tpe)) === "(50.0, 50.0)")
   }
+
+  test("SPARK-26544: toHiveString correctly escape map type") {
+    val m = Map("log_pb" -> """{"impr_id":"20181231"}""", "request_id" -> "001")
+    assert(HiveResult.toHiveString((m, new MapType)) ===
+      """{"log_pb":"{\"impr_id\":\"20181231\"}", "request_id":"001"}""")
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, in spark thrift server mode, the string serialized from map/array type is not escaped, so it is not a valid JSON, while hive does.

For example, select a field whose type is map<string, string>,  the spark thrift server returns 
BEFORE
`{"author_id":"123","log_pb":"{"impr_id":"20181231"}","request_id":"001"}`
 
AFTER
`{"author_id":"123", "log_pb":"{\"impr_id\":\"20181231\"}","request_id":"001"}`

see https://issues.apache.org/jira/browse/SPARK-26544

## How was this patch tested?
Run the HiveUtilsSuite.