### PR TITLE
[SPARK-26546][SQL] Caching of java.time.format.DateTimeFormatter

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
@@ -36,7 +36,7 @@ class Iso8601DateFormatter(
     locale: Locale) extends DateFormatter with DateTimeFormatterHelper {
 
   @transient
-  private lazy val formatter = DateTimeFormatterHelper.getFormatter(pattern, locale)
+  private lazy val formatter = getOrCreateFormatter(pattern, locale)
   private val UTC = ZoneId.of("UTC")
 
   private def toInstant(s: String): Instant = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
@@ -36,7 +36,7 @@ class Iso8601DateFormatter(
     locale: Locale) extends DateFormatter with DateTimeFormatterHelper {
 
   @transient
-  private lazy val formatter = buildFormatter(pattern, locale)
+  private lazy val formatter = DateTimeFormatterHelper.getFormatter(pattern, locale)
   private val UTC = ZoneId.of("UTC")
 
   private def toInstant(s: String): Instant = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
@@ -65,11 +65,13 @@ object DateTimeFormatterHelper {
 
   def getFormatter(pattern: String, locale: Locale): DateTimeFormatter = {
     try {
-      cache.get(
-        (pattern, locale),
-        new Callable[DateTimeFormatter]() {
-          override def call = buildFormatter(pattern, locale)
-        })
+      val key = (pattern, locale)
+      var formatter = cache.getIfPresent(key)
+      if (formatter == null) {
+        formatter = buildFormatter(pattern, locale)
+        cache.put(key, formatter)
+      }
+      formatter
     } catch {
       // Cache.get() may wrap the original exception.
       case e @ (_: UncheckedExecutionException | _: ExecutionError) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
@@ -42,19 +42,13 @@ trait DateTimeFormatterHelper {
   }
 
   def getOrCreateFormatter(pattern: String, locale: Locale): DateTimeFormatter = {
-    try {
-      val key = (pattern, locale)
-      var formatter = cache.getIfPresent(key)
-      if (formatter == null) {
-        formatter = buildFormatter(pattern, locale)
-        cache.put(key, formatter)
-      }
-      formatter
-    } catch {
-      // Cache.get() may wrap the original exception.
-      case e @ (_: UncheckedExecutionException | _: ExecutionError) =>
-        throw e.getCause
+    val key = (pattern, locale)
+    var formatter = cache.getIfPresent(key)
+    if (formatter == null) {
+      formatter = buildFormatter(pattern, locale)
+      cache.put(key, formatter)
     }
+    formatter
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
@@ -24,7 +24,6 @@ import java.time.temporal.{ChronoField, TemporalAccessor, TemporalQueries}
 import java.util.Locale
 
 import com.google.common.cache.CacheBuilder
-import com.google.common.util.concurrent.{ExecutionError, UncheckedExecutionException}
 
 import org.apache.spark.sql.catalyst.util.DateTimeFormatterHelper._
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
@@ -40,7 +40,7 @@ trait DateTimeFormatterHelper {
     Instant.from(zonedDateTime)
   }
 
-  def getOrCreateFormatter(pattern: String, locale: Locale): DateTimeFormatter = {
+  protected def getOrCreateFormatter(pattern: String, locale: Locale): DateTimeFormatter = {
     val key = (pattern, locale)
     var formatter = cache.getIfPresent(key)
     if (formatter == null) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
@@ -40,6 +40,12 @@ trait DateTimeFormatterHelper {
     Instant.from(zonedDateTime)
   }
 
+  // Gets a formatter from the cache or creates new one. The buildFormatter method can be called
+  // a few times with the same parameters in parallel if the cache does not contain values
+  // associated to those parameters. Since the formatter is immutable, it does not matter.
+  // In this way, synchronised is intentionally omitted in this method to make parallel calls
+  // less synchronised.
+  // The Cache.get method is not used here to avoid creation of additional instances of Callable.
   protected def getOrCreateFormatter(pattern: String, locale: Locale): DateTimeFormatter = {
     val key = (pattern, locale)
     var formatter = cache.getIfPresent(key)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
@@ -42,17 +42,7 @@ object DateTimeFormatterHelper {
   private val cache = new ConcurrentHashMap[(String, Locale), DateTimeFormatter]()
 
   def getFormatter(pattern: String, locale: Locale): DateTimeFormatter = {
-    val key = (pattern, locale)
-    var formatter = cache.get(key)
-    if (formatter == null) {
-      formatter = buildFormatter(pattern, locale)
-      val previousFormatter = cache.putIfAbsent(key, formatter)
-      if (previousFormatter != null) {
-        // Another thread already updated the cache, we should return the instance from the cache
-        formatter = previousFormatter
-      }
-    }
-    formatter
+    cache.computeIfAbsent((pattern, locale), _ => buildFormatter(pattern, locale))
   }
 
   private def buildFormatter(pattern: String, locale: Locale): DateTimeFormatter = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
@@ -43,9 +43,7 @@ trait DateTimeFormatterHelper {
 
 object DateTimeFormatterHelper {
   private val cache = CacheBuilder.newBuilder()
-    .initialCapacity(8)
     .maximumSize(128)
-    .expireAfterAccess(1, TimeUnit.HOURS)
     .build[(String, Locale), DateTimeFormatter]()
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
@@ -51,7 +51,7 @@ class Iso8601TimestampFormatter(
     timeZone: TimeZone,
     locale: Locale) extends TimestampFormatter with DateTimeFormatterHelper {
   @transient
-  private lazy val formatter = DateTimeFormatterHelper.getFormatter(pattern, locale)
+  private lazy val formatter = getOrCreateFormatter(pattern, locale)
 
   private def toInstant(s: String): Instant = {
     val temporalAccessor = formatter.parse(s)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
@@ -51,7 +51,7 @@ class Iso8601TimestampFormatter(
     timeZone: TimeZone,
     locale: Locale) extends TimestampFormatter with DateTimeFormatterHelper {
   @transient
-  private lazy val formatter = buildFormatter(pattern, locale)
+  private lazy val formatter = DateTimeFormatterHelper.getFormatter(pattern, locale)
 
   private def toInstant(s: String): Instant = {
     val temporalAccessor = formatter.parse(s)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a cache for  java.time.format.DateTimeFormatter instances with keys consist of pattern and locale. This should allow to avoid parsing of timestamp/date patterns each time when new instance of `TimestampFormatter`/`DateFormatter` is created.

## How was this patch tested?

By existing test suites `TimestampFormatterSuite`/`DateFormatterSuite` and `JsonFunctionsSuite`/`JsonSuite`.
