### PR TITLE
[SPARK-26383][Core] - NPE when use DataFrameReader.jdbc with wrong URL

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -55,10 +55,6 @@ object JDBCRDD extends Logging {
     val dialect = JdbcDialects.get(url)
     val conn: Connection = JdbcUtils.createConnectionFactory(options)()
 
-    if (null == conn) {
-      throw new IllegalArgumentException("Wrong url in JDBC options.")
-    }
-
     try {
       val statement = conn.prepareStatement(dialect.getSchemaQuery(table))
       try {
@@ -73,9 +69,7 @@ object JDBCRDD extends Logging {
         statement.close()
       }
     } finally {
-      if (null != conn) {
-        conn.close()
-      }
+      conn.close()
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -68,7 +68,9 @@ object JDBCRDD extends Logging {
         statement.close()
       }
     } finally {
-      conn.close()
+      if (null != conn) {
+        conn.close()
+      }
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -54,7 +54,6 @@ object JDBCRDD extends Logging {
     val table = options.tableOrQuery
     val dialect = JdbcDialects.get(url)
     val conn: Connection = JdbcUtils.createConnectionFactory(options)()
-
     try {
       val statement = conn.prepareStatement(dialect.getSchemaQuery(table))
       try {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -55,7 +55,7 @@ object JDBCRDD extends Logging {
     val dialect = JdbcDialects.get(url)
     val conn: Connection = JdbcUtils.createConnectionFactory(options)()
 
-    if (null != conn) {
+    if (null == conn) {
       throw new IllegalArgumentException("Wrong url in JDBC options.")
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -54,6 +54,11 @@ object JDBCRDD extends Logging {
     val table = options.tableOrQuery
     val dialect = JdbcDialects.get(url)
     val conn: Connection = JdbcUtils.createConnectionFactory(options)()
+
+    if (null != conn) {
+      throw new IllegalArgumentException("Wrong url in JDBC options.")
+    }
+
     try {
       val statement = conn.prepareStatement(dialect.getSchemaQuery(table))
       try {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -48,6 +48,7 @@ object JdbcUtils extends Logging {
    * Returns a factory for creating connections to the given JDBC URL.
    *
    * @param options - JDBC options that contains url, table and other information.
+   * @throws IllegalArgumentException If JDBC options has wrong url
    */
   def createConnectionFactory(options: JDBCOptions): () => Connection = {
     val driverClass: String = options.driverClass
@@ -60,7 +61,13 @@ object JdbcUtils extends Logging {
         throw new IllegalStateException(
           s"Did not find registered driver with class $driverClass")
       }
-      driver.connect(options.url, options.asConnectionProperties)
+      val connection: Connection = driver.connect(options.url, options.asConnectionProperties)
+
+      if (connection == null) {
+        throw new IllegalArgumentException("Wrong url in JDBC options.")
+      }
+
+      connection
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -48,7 +48,7 @@ object JdbcUtils extends Logging {
    * Returns a factory for creating connections to the given JDBC URL.
    *
    * @param options - JDBC options that contains url, table and other information.
-   * @throws IllegalArgumentException If JDBC options has wrong url
+   * @throws IllegalArgumentException if the driver could not open a JDBC connection.
    */
   def createConnectionFactory(options: JDBCOptions): () => Connection = {
     val driverClass: String = options.driverClass

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -62,10 +62,8 @@ object JdbcUtils extends Logging {
           s"Did not find registered driver with class $driverClass")
       }
       val connection: Connection = driver.connect(options.url, options.asConnectionProperties)
-
-      if (connection == null) {
-        throw new IllegalArgumentException("Wrong url in JDBC options.")
-      }
+      require(connection != null,
+        s"The driver could not open a JDBC connection. Check the URL: ${options.url}")
 
       connection
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -45,7 +45,6 @@ class JDBCSuite extends QueryTest
 
   val url = "jdbc:h2:mem:testdb0"
   val urlWithUserAndPass = "jdbc:h2:mem:testdb0;user=testUser;password=testPass"
-  val wrongUrl = "jdbc:h2:mem:testdbx"
   var conn: java.sql.Connection = null
 
   val testBytes = Array[Byte](99.toByte, 134.toByte, 135.toByte, 200.toByte, 205.toByte)

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -1509,7 +1509,7 @@ class JDBCSuite extends QueryTest
       Row("fred", 1) :: Nil)
   }
 
-  test("SPARK-26383 throw IllegalArgumentException if url is wrong") {
+  test("SPARK-26383 throw IllegalArgumentException if wrong kind of driver to the given url") {
     val e = intercept[IllegalArgumentException] {
       val opts = Map(
         "url" -> "jdbc:mysql://localhost/db",
@@ -1518,6 +1518,7 @@ class JDBCSuite extends QueryTest
       )
       spark.read.format("jdbc").options(opts).load
     }.getMessage
-    assert(e.contains("Wrong url in JDBC options."))
+    assert(e.contains("The driver could not open a JDBC connection. " +
+      "Check the URL: jdbc:mysql://localhost/db"))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
When passing wrong url to jdbc then It would throw IllegalArgumentException instead of NPE.
### How was this patch tested?
Adding test case to Existing tests in JDBCSuite