### PR TITLE
[SPARK-26549][PySpark] Fix for python worker reuse take no effect for parallelize lazy iterable range

### DIFF
--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -493,9 +493,13 @@ class SparkContext(object):
                 return start0 + int((split * size / numSlices)) * step
 
             def f(split, iterator):
-                # it's an empty iterator here but we need this line for triggering the logic of
-                # checking END_OF_DATA_SECTION during load iterator in runtime, thus make sure
-                # worker reuse takes effect. See more details in SPARK-26549.
+                # it's an empty iterator here but we need this line for triggering the
+                # logic of signal handling in FramedSerializer.load_stream, for instance,
+                # SpecialLengths.END_OF_DATA_SECTION in _read_with_length. Since
+                # FramedSerializer.load_stream produces a generator, the control should
+                # at least be in that function once. Here we do it by explicitly converting
+                # the empty iterator to a list, thus make sure worker reuse takes effect.
+                # See more details in SPARK-26549.
                 assert len(list(iterator)) == 0
                 return xrange(getStart(split), getStart(split + 1), step)
 

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -493,6 +493,10 @@ class SparkContext(object):
                 return start0 + int((split * size / numSlices)) * step
 
             def f(split, iterator):
+                # it's an empty iterator here but we need this line for triggering the logic of
+                # checking END_OF_DATA_SECTION during load iterator in runtime, thus make sure
+                # worker reuse takes effect. See more details in SPARK-26549.
+                assert len(list(iterator)) == 0
                 return xrange(getStart(split), getStart(split + 1), step)
 
             return self.parallelize([], numSlices).mapPartitionsWithIndex(f)

--- a/python/pyspark/tests/test_worker.py
+++ b/python/pyspark/tests/test_worker.py
@@ -22,7 +22,7 @@ import time
 
 from py4j.protocol import Py4JJavaError
 
-from pyspark.testing.utils import ReusedPySparkTestCase, QuietTest
+from pyspark.testing.utils import ReusedPySparkTestCase, PySparkTestCase, QuietTest
 
 if sys.version_info[0] >= 3:
     xrange = range
@@ -144,14 +144,15 @@ class WorkerTests(ReusedPySparkTestCase):
         finally:
             self.sc.pythonVer = version
 
+
+class WorkerReuseTest(PySparkTestCase):
+
     def test_reuse_worker_of_parallelize_xrange(self):
-        def get_worker_pid(input_rdd):
-            return input_rdd.map(lambda x: os.getpid()).collect()
-        rdd = self.sc.parallelize(xrange(20), 20)
-        worker_pids = get_worker_pid(rdd)
-        pids = get_worker_pid(rdd)
-        for pid in pids:
-            self.assertTrue(pid in worker_pids)
+        rdd = self.sc.parallelize(xrange(20), 8)
+        previous_pids = rdd.map(lambda x: os.getpid()).collect()
+        current_pids = rdd.map(lambda x: os.getpid()).collect()
+        for pid in current_pids:
+            self.assertTrue(pid in previous_pids)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/tests/test_worker.py
+++ b/python/pyspark/tests/test_worker.py
@@ -144,6 +144,15 @@ class WorkerTests(ReusedPySparkTestCase):
         finally:
             self.sc.pythonVer = version
 
+    def test_reuse_worker(self):
+        def get_worker_pid(input_rdd):
+            return input_rdd.map(lambda x: os.getpid()).collect()
+        rdd = self.sc.parallelize(range(20), 20)
+        worker_pids = get_worker_pid(rdd)
+        pids = get_worker_pid(rdd)
+        for pid in pids:
+            self.assertTrue(pid in worker_pids)
+
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/tests/test_worker.py
+++ b/python/pyspark/tests/test_worker.py
@@ -144,10 +144,10 @@ class WorkerTests(ReusedPySparkTestCase):
         finally:
             self.sc.pythonVer = version
 
-    def test_reuse_worker(self):
+    def test_reuse_worker_of_parallelize_xrange(self):
         def get_worker_pid(input_rdd):
             return input_rdd.map(lambda x: os.getpid()).collect()
-        rdd = self.sc.parallelize(range(20), 20)
+        rdd = self.sc.parallelize(xrange(20), 20)
         worker_pids = get_worker_pid(rdd)
         pids = get_worker_pid(rdd)
         for pid in pids:

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -446,7 +446,12 @@ def main(infile, outfile):
         pickleSer._write_with_length((aid, accum._value), outfile)
 
     # check end of stream
-    if read_int(infile) == SpecialLengths.END_OF_STREAM:
+    res = read_int(infile)
+    if sys.version >= '3' and res == SpecialLengths.END_OF_DATA_SECTION:
+        # skip the END_OF_DATA_SECTION for Python3, otherwise the worker reuse will take
+        # no effect, see SPARK-26549 for more details.
+        res = read_int(infile)
+    if res == SpecialLengths.END_OF_STREAM:
         write_int(SpecialLengths.END_OF_STREAM, outfile)
     else:
         # write a different value to tell JVM to not reuse this worker

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -446,12 +446,7 @@ def main(infile, outfile):
         pickleSer._write_with_length((aid, accum._value), outfile)
 
     # check end of stream
-    res = read_int(infile)
-    if sys.version >= '3' and res == SpecialLengths.END_OF_DATA_SECTION:
-        # skip the END_OF_DATA_SECTION for Python3, otherwise the worker reuse will take
-        # no effect, see SPARK-26549 for more details.
-        res = read_int(infile)
-    if res == SpecialLengths.END_OF_STREAM:
+    if read_int(infile) == SpecialLengths.END_OF_STREAM:
         write_int(SpecialLengths.END_OF_STREAM, outfile)
     else:
         # write a different value to tell JVM to not reuse this worker


### PR DESCRIPTION
## What changes were proposed in this pull request?

During the follow-up work(#23435) for PySpark worker reuse scenario, we found that the worker reuse takes no effect for `sc.parallelize(xrange(...))`. It happened because of the specialize rdd.parallelize logic for xrange(introduced in #3264) generated data by lazy iterable range, which don't need to use the passed-in iterator. But this will break the end of stream checking in python worker and finally cause worker reuse takes no effect. See more details in [SPARK-26549](https://issues.apache.org/jira/browse/SPARK-26549) description.

We fix this by force using the passed-in iterator.

## How was this patch tested?
New UT in test_worker.py.