### PR TITLE
[SPARK-26537][BUILD][BRANCH-2.3] change git-wip-us to gitbox

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -101,7 +101,7 @@ SCALA_2_11_PROFILES="-Pkafka-0-8"
 SCALA_2_12_PROFILES="-Pscala-2.12"
 
 rm -rf spark
-git clone https://git-wip-us.apache.org/repos/asf/spark.git
+git clone https://gitbox.apache.org/repos/asf/spark.git
 cd spark
 git checkout $GIT_REF
 git_hash=`git rev-parse --short HEAD`

--- a/dev/create-release/release-tag.sh
+++ b/dev/create-release/release-tag.sh
@@ -54,7 +54,7 @@ for env in ASF_USERNAME ASF_PASSWORD RELEASE_VERSION RELEASE_TAG NEXT_VERSION GI
   fi
 done
 
-ASF_SPARK_REPO="git-wip-us.apache.org/repos/asf/spark.git"
+ASF_SPARK_REPO="gitbox.apache.org/repos/asf/spark.git"
 MVN="build/mvn --force"
 
 rm -rf spark

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
   </licenses>
   <scm>
     <connection>scm:git:git@github.com:apache/spark.git</connection>
-    <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/spark.git</developerConnection>
+    <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/spark.git</developerConnection>
     <url>scm:git:git@github.com:apache/spark.git</url>
     <tag>HEAD</tag>
   </scm>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a backport of https://github.com/apache/spark/pull/23454

due to apache recently moving from git-wip-us.apache.org to gitbox.apache.org, we need to update the packaging scripts to point to the new repo location.

this will also need to be backported to 2.4, 2.3, 2.1, 2.0 and 1.6.

## How was this patch tested?

the build system will test this.