### PR TITLE
[SPARK-26552][SQL] Add a new function - regexp_to_map

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -337,6 +337,7 @@ object FunctionRegistry {
     expression[FormatString]("printf"),
     expression[RegExpExtract]("regexp_extract"),
     expression[RegExpReplace]("regexp_replace"),
+    expression[RegExpToMap]("regexp_to_map"),
     expression[StringRepeat]("repeat"),
     expression[StringReplace]("replace"),
     expression[RLike]("rlike"),

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2386,6 +2386,17 @@ object functions {
   }
 
   /**
+   * Extract a map matched by a Java regex, from the specified string column.
+   * The keys of map are group names, and the values are related group values.
+   * If a group are not set a name, we will give it a default name based on its index,
+   * like column1, column2, ... etc.
+   * @group string_funcs
+   */
+  def regexp_to_map(e: Column, exp: String): Column = withExpr {
+    RegExpToMap(e.expr, lit(exp).expr)
+  }
+
+  /**
    * Decodes a BASE64 encoded string column and returns it as a binary column.
    * This is the reverse of base64.
    *

--- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
@@ -104,19 +104,19 @@ class StringFunctionsSuite extends QueryTest with SharedSQLContext {
     // every group has a name
     checkAnswer(df.select(
       regexp_to_map($"a", "(?<first>\\d+)-(?<second>\\d+)-(?<third>\\d+)") as "temp"
-    ).selectExpr("temp.second, temp.first"),
+    ).selectExpr("temp.second", "temp.first"),
       Row("200", "100") :: Row("300", "200") :: Row("100", "500") :: Nil)
 
     // every group does not has a name
     checkAnswer(df.select(
       regexp_to_map($"a", "(\\d+)-(\\d+)-(\\d+)") as "temp"
-    ).selectExpr("temp.column2, temp.column1"),
+    ).selectExpr("temp.column2", "temp.column1"),
       Row("200", "100") :: Row("300", "200") :: Row("100", "500") :: Nil)
 
     // some groups do not has a name, while others have
     checkAnswer(df.select(
       regexp_to_map($"a", "(?<first>\\d+)-(\\d+)-(?<third>\\d+)") as "temp"
-    ).selectExpr("temp.column2, temp.first"),
+    ).selectExpr("temp.column2", "temp.first"),
       Row("200", "100") :: Row("300", "200") :: Row("100", "500") :: Nil)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

New function takes a string and a regex, returns a map extracted from the string identified by the regex, with group names as keys and group values as values. If there are groups without name, we will give them default names based on its group index, like column1, column2 , ... etc.

## How was this patch tested?

Add a test in StringFunctionsSuite 

