### PR TITLE
 [SPARK-26556][SQL]Add custom provider for thrid party connector

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -621,7 +621,7 @@ object DataSource extends Logging {
         "org.apache.spark.sql.hive.orc.OrcFileFormat"
       case "com.databricks.spark.avro" if conf.replaceDatabricksSparkAvroEnabled =>
         "org.apache.spark.sql.avro.AvroFileFormat"
-      case name => name
+      case name => conf.getConfString(s"spark.sql.source.provider.$name", name)
     }
     val provider2 = s"$provider1.DefaultSource"
     val loader = Utils.getContextOrSparkClassLoader

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/CustomProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/CustomProviderSuite.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.sources
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.execution.datasources.DataSource
+import org.apache.spark.sql.test.SharedSQLContext
+
+class CustomProviderSuite extends SparkFunSuite with SharedSQLContext {
+
+  override protected def sparkConf = {
+    val conf = super.sparkConf
+    conf.set("spark.sql.source.provider.fake1", "org.apache.spark.sql.sources.FakeSourceOne")
+  }
+
+  private def getProvidingClass(name: String): Class[_] =
+    DataSource(
+      sparkSession = spark,
+      className = name
+    ).providingClass
+
+  test("fake source with custom provider") {
+    assert(
+      getProvidingClass("fake1") ===
+      classOf[org.apache.spark.sql.sources.FakeSourceOne])
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
In current code path, object `DataSource` have method `lookupDataSource` used for look up data source.
`DataSource` has built-in support for some data sources, such as orc, avro and other backward compatibility data sources.
Create table using simplified provider when you use backward compatibility or built-in data sources, such as csv, jdbc and so on.
But, create table using lengthy provider when you use thrid party data sources, such as elasticsearch , mongo and so on.
The different here is spark use `java.util.ServiceLoader` and `META-INF/services/org.apache.spark.sql.sources.DataSourceRegister` file to load backward compatibility or built-in data sources. But there no chance write into `META-INF/services/org.apache.spark.sql.sources.DataSourceRegister` for thrid party data sources.
I add a item `spark.sql.source.provider.$name` to config your qualified provider, and variable `name` is a simplified name.
## How was this patch tested?
This pr have a test case in `org.apache.spark.sql.sources.CustomProviderSuite`.