### PR TITLE
[Spark-26557][build] The configuration of maven-checkstyle-plugin is error for mvn install

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2522,7 +2522,7 @@
         <configuration>
           <failOnViolation>false</failOnViolation>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
-          <sourceDirectories>${basedir}/src/main/java,${basedir}/src/main/scala</sourceDirectories>
+          <sourceDirectory>${basedir}/src/main/java,${basedir}/src/main/scala</sourceDirectory>
           <testSourceDirectory>${basedir}/src/test/java</testSourceDirectory>
           <configLocation>dev/checkstyle.xml</configLocation>
           <outputFile>${basedir}/target/checkstyle-output.xml</outputFile>


### PR DESCRIPTION
## What changes were proposed in this pull request?

When I  build the Spark with the maven script:

`mvn install -Psparkr -Pyarn -Phadoop-2.7 -Dhadoop.version=2.7.3  -Phive-thriftserver -Pnetlib-lgpl -Pspark-ganglia-lgpl -DskipTests -Denforcer.skip=true  `

There is a error:

> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:2.17:check (default) on project spark-parent_2.11: Unable to parse configuration of mojo org.apache.maven.plugins:maven-checkstyle-plugin:2.17:check for parameter sourceDirectories: Cannot assign configuration entry 'sourceDirectories' with value 
> ' /../../main/java, /../../main/scala' of type java.lang.String to property of type java.util.List -> [Help 1]

For Major Version Upgrade to version 3.0.0,we could change the config "sourceDirectory" to "sourceDirectories",but the version we set is 2.17.

After fix
mvn install success.
## How was this patch tested?

manual

