### PR TITLE
[SPARK-26559][ML][PySpark] ML image can't work with numpy versions prior to 1.9

### DIFF
--- a/python/pyspark/ml/image.py
+++ b/python/pyspark/ml/image.py
@@ -190,7 +190,13 @@ class _ImageSchema(object):
         # Running `bytearray(numpy.array([1]))` fails in specific Python versions
         # with a specific Numpy version, for example in Python 3.6.0 and NumPy 1.13.3.
         # Here, it avoids it by converting it to bytes.
-        data = bytearray(array.astype(dtype=np.uint8).ravel().tobytes())
+        numpy_version = np.__version__.split('.')
+        numpy_version_major = int(numpy_version[0])
+        numpy_version_minor = int(numpy_version[1])
+        if numpy_version_major > 1 or (numpy_version_major == 1 and numpy_version_minor >= 9):
+            data = bytearray(array.astype(dtype=np.uint8).ravel().tobytes())
+        else:
+            data = bytearray(array.astype(dtype=np.uint8).ravel().tostring())
 
         # Creating new Row with _create_row(), because Row(name = value, ... )
         # orders fields by name, which conflicts with expected schema order

--- a/python/pyspark/ml/image.py
+++ b/python/pyspark/ml/image.py
@@ -194,7 +194,8 @@ class _ImageSchema(object):
         if LooseVersion(np.__version__) >= LooseVersion('1.9'):
             data = bytearray(array.astype(dtype=np.uint8).ravel().tobytes())
         else:
-            data = bytearray(array.astype(dtype=np.uint8).ravel().tostring())
+            # Numpy prior to 1.9 don't have `tobytes` method.
+            data = bytearray(array.astype(dtype=np.uint8).ravel())
 
         # Creating new Row with _create_row(), because Row(name = value, ... )
         # orders fields by name, which conflicts with expected schema order

--- a/python/pyspark/ml/image.py
+++ b/python/pyspark/ml/image.py
@@ -28,6 +28,7 @@ import sys
 import warnings
 
 import numpy as np
+from distutils.version import LooseVersion
 
 from pyspark import SparkContext
 from pyspark.sql.types import Row, _create_row, _parse_datatype_json_string
@@ -190,10 +191,7 @@ class _ImageSchema(object):
         # Running `bytearray(numpy.array([1]))` fails in specific Python versions
         # with a specific Numpy version, for example in Python 3.6.0 and NumPy 1.13.3.
         # Here, it avoids it by converting it to bytes.
-        numpy_version = np.__version__.split('.')
-        numpy_version_major = int(numpy_version[0])
-        numpy_version_minor = int(numpy_version[1])
-        if numpy_version_major > 1 or (numpy_version_major == 1 and numpy_version_minor >= 9):
+        if LooseVersion(np.__version__) >= LooseVersion('1.9'):
             data = bytearray(array.astype(dtype=np.uint8).ravel().tobytes())
         else:
             data = bytearray(array.astype(dtype=np.uint8).ravel().tostring())


### PR DESCRIPTION
## What changes were proposed in this pull request?

Due to [API change](https://github.com/numpy/numpy/pull/4257/files#diff-c39521d89f7e61d6c0c445d93b62f7dc) at 1.9, PySpark image doesn't work with numpy version prior to 1.9.

When running image test with numpy version prior to 1.9, we can see error:
```
test_read_images (pyspark.ml.tests.test_image.ImageReaderTest) ... ERROR                                                                              
test_read_images_multiple_times (pyspark.ml.tests.test_image.ImageReaderTest2) ... ok                                                                 
                                                                                                                                                      
======================================================================                                                                                
ERROR: test_read_images (pyspark.ml.tests.test_image.ImageReaderTest)                                                                                 
----------------------------------------------------------------------                                                                                
Traceback (most recent call last):
  File "/Users/viirya/docker_tmp/repos/spark-1/python/pyspark/ml/tests/test_image.py", line 36, in test_read_images                                   
    self.assertEqual(ImageSchema.toImage(array, origin=first_row[0]), first_row)                                                                      
  File "/Users/viirya/docker_tmp/repos/spark-1/python/pyspark/ml/image.py", line 193, in toImage                                                      
    data = bytearray(array.astype(dtype=np.uint8).ravel().tobytes())                                                                                  
AttributeError: 'numpy.ndarray' object has no attribute 'tobytes'                                                                                     
                                                                                                                                                      
----------------------------------------------------------------------
Ran 2 tests in 29.040s                                                                                                                                
                                                                                                                                                      
FAILED (errors=1)
```


## How was this patch tested?

Manually test with numpy version prior and after 1.9.