### PR TITLE
[SPARK-26334][SQL] NullPointerException in CallMethodViaReflection when we apply reflect function for empty field

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CallMethodViaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CallMethodViaReflection.scala
@@ -92,8 +92,12 @@ case class CallMethodViaReflection(children: Seq[Expression])
       }
       i += 1
     }
-    val ret = method.invoke(null, buffer : _*)
-    UTF8String.fromString(String.valueOf(ret))
+    var ret: Any = null
+    try{
+      ret = method.invoke(null, buffer : _*)
+    } catch {
+      case _ =>
+    }    UTF8String.fromString(String.valueOf(ret))
   }
 
   @transient private lazy val argExprs: Array[Expression] = children.drop(2).toArray

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CallMethodViaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CallMethodViaReflection.scala
@@ -97,7 +97,8 @@ case class CallMethodViaReflection(children: Seq[Expression])
       ret = method.invoke(null, buffer : _*)
     } catch {
       case _ =>
-    }    UTF8String.fromString(String.valueOf(ret))
+    }
+    UTF8String.fromString(String.valueOf(ret))
   }
 
   @transient private lazy val argExprs: Array[Expression] = children.drop(2).toArray


### PR DESCRIPTION
## What changes were proposed in this pull request?
As the description in [SPARK-26334](https://issues.apache.org/jira/browse/SPARK-26334),When we apply reflect function  to empty field,  it will  always  lead to  NullPointerException. We can catch the NPE  when invocation is triggered by reflect function.


## How was this patch tested?
manual tests!
In the table shown below,  for field `url`, some values  are initialized to NULL .

![image](https://user-images.githubusercontent.com/20614350/49791627-dd3eab80-fd6b-11e8-90f0-e181163f6627.png)

When we apply reflect function  to `url` ,
before fix:
![image](https://user-images.githubusercontent.com/20614350/49791773-19720c00-fd6c-11e8-8342-e010b48e38c0.png)

after fix:
![image](https://user-images.githubusercontent.com/20614350/49791850-48887d80-fd6c-11e8-87c1-25b25750fbb5.png)


Please review http://spark.apache.org/contributing.html before opening a pull request.
