### PR TITLE
[SPARK-26563]Fix java `SimpleApp` documentation

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -307,7 +307,7 @@ import org.apache.spark.sql.Dataset;
 public class SimpleApp {
   public static void main(String[] args) {
     String logFile = "YOUR_SPARK_HOME/README.md"; // Should be some file on your system
-    SparkSession spark = SparkSession.builder().appName("Simple Application").getOrCreate();
+    SparkSession spark = SparkSession.builder().appName("Simple Application").config("spark.master", "local").getOrCreate();
     Dataset<String> logData = spark.read().textFile(logFile).cache();
 
     long numAs = logData.filter(s -> s.contains("a")).count();


### PR DESCRIPTION
As is, the example provided by the documentation will crash with `org.apache.spark.SparkException: A master URL must be set in your configuration`. This error happens due to no `Spark Master` being configured.

When creating a spark master locally, the simple application works correctly, as [This StackOverflow Answer](https://stackoverflow.com/a/40555616/4257162) will state.

---

This change is very important as the original example will not work without this.

