### PR TITLE
[SPARK-26543][SQL] Support the coordinator to determine post-shuffle partitions more reasonably

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala
@@ -178,11 +178,17 @@ class ExchangeCoordinator(
       // If including the nextShuffleInputSize would exceed the target partition size, then start a
       // new partition.
       if (i > 0 && postShuffleInputSize + nextShuffleInputSize > targetPostShuffleInputSize) {
-        partitionStartIndices += i
+        if (postShuffleInputSize != 0) {
+          partitionStartIndices += i
+        }
         // reset postShuffleInputSize.
         postShuffleInputSize = nextShuffleInputSize
       } else postShuffleInputSize += nextShuffleInputSize
 
+      // filter the last indice which will split the postShuffleInputSize=0
+      if (postShuffleInputSize == 0 && i == numPreShufflePartitions - 1) {
+        partitionStartIndices.remove(partitionStartIndices.size - 1)
+      }
       i += 1
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala
@@ -178,6 +178,7 @@ class ExchangeCoordinator(
       // If including the nextShuffleInputSize would exceed the target partition size, then start a
       // new partition.
       if (i > 0 && postShuffleInputSize + nextShuffleInputSize > targetPostShuffleInputSize) {
+        // Ignore the case of  postShuffleInputSize=0 and continue iterating
         if (postShuffleInputSize != 0) {
           partitionStartIndices += i
         }
@@ -185,11 +186,12 @@ class ExchangeCoordinator(
         postShuffleInputSize = nextShuffleInputSize
       } else postShuffleInputSize += nextShuffleInputSize
 
-      // filter the last indice which will split the postShuffleInputSize=0
-      if (postShuffleInputSize == 0 && i == numPreShufflePartitions - 1) {
-        partitionStartIndices.remove(partitionStartIndices.size - 1)
-      }
       i += 1
+    }
+
+    // Filter the last indice which will split the postShuffleInputSize=0
+    if (postShuffleInputSize == 0) {
+      partitionStartIndices.remove(partitionStartIndices.size - 1)
     }
 
     partitionStartIndices.toArray

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeCoordinatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeCoordinatorSuite.scala
@@ -63,7 +63,7 @@ class ExchangeCoordinatorSuite extends SparkFunSuite with BeforeAndAfterAll {
     {
       // All bytes per partition are 0.
       val bytesByPartitionId = Array[Long](0, 0, 0, 0, 0)
-      val expectedPartitionStartIndices = Array[Int](0)
+      val expectedPartitionStartIndices = Array[Int]()
       checkEstimation(coordinator, Array(bytesByPartitionId), expectedPartitionStartIndices)
     }
 
@@ -85,7 +85,14 @@ class ExchangeCoordinatorSuite extends SparkFunSuite with BeforeAndAfterAll {
     {
       // There are a few large pre-shuffle partitions.
       val bytesByPartitionId = Array[Long](110, 10, 100, 110, 0)
-      val expectedPartitionStartIndices = Array[Int](0, 1, 2, 3, 4)
+      val expectedPartitionStartIndices = Array[Int](0, 1, 2, 3)
+      checkEstimation(coordinator, Array(bytesByPartitionId), expectedPartitionStartIndices)
+    }
+
+    {
+      // There are a few large pre-shuffle partitions and some bytes per partition are 0.
+      val bytesByPartitionId = Array[Long](110, 120, 0, 130, 0, 0, 100, 110, 0)
+      val expectedPartitionStartIndices = Array[Int](0, 1, 2, 4, 7)
       checkEstimation(coordinator, Array(bytesByPartitionId), expectedPartitionStartIndices)
     }
 
@@ -123,7 +130,7 @@ class ExchangeCoordinatorSuite extends SparkFunSuite with BeforeAndAfterAll {
       // All bytes per partition are 0.
       val bytesByPartitionId1 = Array[Long](0, 0, 0, 0, 0)
       val bytesByPartitionId2 = Array[Long](0, 0, 0, 0, 0)
-      val expectedPartitionStartIndices = Array[Int](0)
+      val expectedPartitionStartIndices = Array[Int]()
       checkEstimation(
         coordinator,
         Array(bytesByPartitionId1, bytesByPartitionId2),
@@ -206,7 +213,7 @@ class ExchangeCoordinatorSuite extends SparkFunSuite with BeforeAndAfterAll {
       // the size of data is 0.
       val bytesByPartitionId1 = Array[Long](0, 0, 0, 0, 0)
       val bytesByPartitionId2 = Array[Long](0, 0, 0, 0, 0)
-      val expectedPartitionStartIndices = Array[Int](0)
+      val expectedPartitionStartIndices = Array[Int]()
       checkEstimation(
         coordinator,
         Array(bytesByPartitionId1, bytesByPartitionId2),


### PR DESCRIPTION
## What changes were proposed in this pull request?

For SparkSQL ,when we open AE by 'set spark.sql.adapative.enable=true'，the ExchangeCoordinator will introduced to determine the number of post-shuffle partitions. But in some certain conditions,the coordinator performed not very well, there are always some tasks retained and they worked with Shuffle Read Size / Records 0.0B/0 ,We could increase the spark.sql.adaptive.shuffle.targetPostShuffleInputSize to solve this,but this action is unreasonable as targetPostShuffleInputSize Should not be set too large. As follow:
![image](https://user-images.githubusercontent.com/20614350/50747129-5519cc00-126d-11e9-8511-8cdb324366c9.png)

We could   reproduce this problem easily with the SQL:

`set spark.sql.adaptive.enabled=true；`
`  spark.sql.shuffle.partitions 100；`
`  spark.sql.adaptive.shuffle.targetPostShuffleInputSize  33554432 ；`
`  SELECT a,COUNT(1) FROM TABLE  GROUP BY  a DISTRIBUTE BY cast(rand()* 10 as bigint)` 

before fix：
![image](https://user-images.githubusercontent.com/20614350/50747540-577d2580-126f-11e9-80b0-1b36fc2fd692.png)
after fix：
![image](https://user-images.githubusercontent.com/20614350/50747608-c65a7e80-126f-11e9-9b10-32494232f0f9.png)


## How was this patch tested?
manual and  unit tests 
