### PR TITLE
[SPARK-26565][BUILD] skip gpg signing/svn publish for jenkins package builds

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -181,10 +181,13 @@ if [[ "$1" == "package" ]]; then
   rm spark-$SPARK_VERSION/NOTICE-binary
   rm -r spark-$SPARK_VERSION/licenses-binary
   tar cvzf spark-$SPARK_VERSION.tgz spark-$SPARK_VERSION
-  echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --armour --output spark-$SPARK_VERSION.tgz.asc \
-    --detach-sig spark-$SPARK_VERSION.tgz
-  echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --print-md \
-    SHA512 spark-$SPARK_VERSION.tgz > spark-$SPARK_VERSION.tgz.sha512
+
+  if [ -z "$AMPLAB_JENKINS" ]; then
+    echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --armour --output spark-$SPARK_VERSION.tgz.asc \
+                                --detach-sig spark-$SPARK_VERSION.tgz
+    echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --print-md \
+                                SHA512 spark-$SPARK_VERSION.tgz > spark-$SPARK_VERSION.tgz.sha512
+  fi
   rm -rf spark-$SPARK_VERSION
 
   ZINC_PORT=3035
@@ -235,40 +238,46 @@ if [[ "$1" == "package" ]]; then
       -DzincPort=$ZINC_PORT 2>&1 >  ../binary-release-$NAME.log
     cd ..
 
-    if [[ -n $R_FLAG ]]; then
-      echo "Copying and signing R source package"
-      R_DIST_NAME=SparkR_$SPARK_VERSION.tar.gz
-      cp spark-$SPARK_VERSION-bin-$NAME/R/$R_DIST_NAME .
+    if [ -z "$AMPLAB_JENKINS" ]; then
+      if [[ -n $R_FLAG ]]; then
+        echo "Copying and signing R source package"
+        R_DIST_NAME=SparkR_$SPARK_VERSION.tar.gz
+        cp spark-$SPARK_VERSION-bin-$NAME/R/$R_DIST_NAME .
 
-      echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --armour \
-        --output $R_DIST_NAME.asc \
-        --detach-sig $R_DIST_NAME
-      echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --print-md \
-        SHA512 $R_DIST_NAME > \
-        $R_DIST_NAME.sha512
+        echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --armour \
+                                    --output $R_DIST_NAME.asc \
+                                    --detach-sig $R_DIST_NAME
+        echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --print-md \
+                                    SHA512 $R_DIST_NAME > \
+                                    $R_DIST_NAME.sha512
+      fi
     fi
 
-    if [[ -n $PIP_FLAG ]]; then
-      echo "Copying and signing python distribution"
-      PYTHON_DIST_NAME=pyspark-$PYSPARK_VERSION.tar.gz
-      cp spark-$SPARK_VERSION-bin-$NAME/python/dist/$PYTHON_DIST_NAME .
+    if [ -z "$AMPLAB_JENKINS" ]; then
+      if [[ -n $PIP_FLAG ]]; then
+        echo "Copying and signing python distribution"
+        PYTHON_DIST_NAME=pyspark-$PYSPARK_VERSION.tar.gz
+        cp spark-$SPARK_VERSION-bin-$NAME/python/dist/$PYTHON_DIST_NAME .
 
-      echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --armour \
-        --output $PYTHON_DIST_NAME.asc \
-        --detach-sig $PYTHON_DIST_NAME
-      echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --print-md \
-        SHA512 $PYTHON_DIST_NAME > \
-        $PYTHON_DIST_NAME.sha512
+        echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --armour \
+                                    --output $PYTHON_DIST_NAME.asc \
+                                    --detach-sig $PYTHON_DIST_NAME
+        echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --print-md \
+                                    SHA512 $PYTHON_DIST_NAME > \
+                                    $PYTHON_DIST_NAME.sha512
+      fi
     fi
 
-    echo "Copying and signing regular binary distribution"
-    cp spark-$SPARK_VERSION-bin-$NAME/spark-$SPARK_VERSION-bin-$NAME.tgz .
-    echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --armour \
-      --output spark-$SPARK_VERSION-bin-$NAME.tgz.asc \
-      --detach-sig spark-$SPARK_VERSION-bin-$NAME.tgz
-    echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --print-md \
-      SHA512 spark-$SPARK_VERSION-bin-$NAME.tgz > \
-      spark-$SPARK_VERSION-bin-$NAME.tgz.sha512
+    if [ -z "$AMPLAB_JENKINS" ]; then
+      echo "Copying and signing regular binary distribution"
+      cp spark-$SPARK_VERSION-bin-$NAME/spark-$SPARK_VERSION-bin-$NAME.tgz .
+      echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --armour \
+                                  --output spark-$SPARK_VERSION-bin-$NAME.tgz.asc \
+                                  --detach-sig spark-$SPARK_VERSION-bin-$NAME.tgz
+      echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --print-md \
+                                  SHA512 spark-$SPARK_VERSION-bin-$NAME.tgz > \
+                                  spark-$SPARK_VERSION-bin-$NAME.tgz.sha512
+    fi
   }
 
   # List of binary packages built. Populates two associative arrays, where the key is the "name" of
@@ -314,21 +323,23 @@ if [[ "$1" == "package" ]]; then
 
   rm -rf spark-$SPARK_VERSION-bin-*/
 
-  if ! is_dry_run; then
-    svn co --depth=empty $RELEASE_STAGING_LOCATION svn-spark
-    rm -rf "svn-spark/${DEST_DIR_NAME}-bin"
-    mkdir -p "svn-spark/${DEST_DIR_NAME}-bin"
+  if [ -z "$AMPLAB_JENKINS" ]; then
+    if ! is_dry_run; then
+      svn co --depth=empty $RELEASE_STAGING_LOCATION svn-spark
+      rm -rf "svn-spark/${DEST_DIR_NAME}-bin"
+      mkdir -p "svn-spark/${DEST_DIR_NAME}-bin"
 
-    echo "Copying release tarballs"
-    cp spark-* "svn-spark/${DEST_DIR_NAME}-bin/"
-    cp pyspark-* "svn-spark/${DEST_DIR_NAME}-bin/"
-    cp SparkR_* "svn-spark/${DEST_DIR_NAME}-bin/"
-    svn add "svn-spark/${DEST_DIR_NAME}-bin"
+      echo "Copying release tarballs"
+      cp spark-* "svn-spark/${DEST_DIR_NAME}-bin/"
+      cp pyspark-* "svn-spark/${DEST_DIR_NAME}-bin/"
+      cp SparkR_* "svn-spark/${DEST_DIR_NAME}-bin/"
+      svn add "svn-spark/${DEST_DIR_NAME}-bin"
 
-    cd svn-spark
-    svn ci --username $ASF_USERNAME --password "$ASF_PASSWORD" -m"Apache Spark $SPARK_PACKAGE_VERSION" --no-auth-cache
-    cd ..
-    rm -rf svn-spark
+      cd svn-spark
+      svn ci --username $ASF_USERNAME --password "$ASF_PASSWORD" -m"Apache Spark $SPARK_PACKAGE_VERSION" --no-auth-cache
+      cd ..
+      rm -rf svn-spark
+    fi
   fi
 
   exit 0

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
-
-set -x  # testing only
-
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -242,14 +242,14 @@ if [[ "$1" == "package" ]]; then
       -DzincPort=$ZINC_PORT 2>&1 >  ../binary-release-$NAME.log
     cd ..
 
+    R_DIST_NAME=SparkR_$SPARK_VERSION.tar.gz
+    cp spark-$SPARK_VERSION-bin-$NAME/R/$R_DIST_NAME .
+
     if [ -n "$AMPLAB_JENKINS" ]; then
       echo "Skipping signing of R source package"
     else
       if [[ -n $R_FLAG ]]; then
-        echo "Copying and signing R source package"
-        R_DIST_NAME=SparkR_$SPARK_VERSION.tar.gz
-        cp spark-$SPARK_VERSION-bin-$NAME/R/$R_DIST_NAME .
-
+        echo "Signing R source package"
         echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --armour \
                                     --output $R_DIST_NAME.asc \
                                     --detach-sig $R_DIST_NAME
@@ -259,14 +259,14 @@ if [[ "$1" == "package" ]]; then
       fi
     fi
 
+    PYTHON_DIST_NAME=pyspark-$PYSPARK_VERSION.tar.gz
+    cp spark-$SPARK_VERSION-bin-$NAME/python/dist/$PYTHON_DIST_NAME .
+
     if [ -n "$AMPLAB_JENKINS" ]; then
       echo "Skipping signing of python distribution"
     else
       if [[ -n $PIP_FLAG ]]; then
-        echo "Copying and signing python distribution"
-        PYTHON_DIST_NAME=pyspark-$PYSPARK_VERSION.tar.gz
-        cp spark-$SPARK_VERSION-bin-$NAME/python/dist/$PYTHON_DIST_NAME .
-
+        echo "Signing python distribution"
         echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --armour \
                                     --output $PYTHON_DIST_NAME.asc \
                                     --detach-sig $PYTHON_DIST_NAME
@@ -276,11 +276,12 @@ if [[ "$1" == "package" ]]; then
       fi
     fi
 
+    cp spark-$SPARK_VERSION-bin-$NAME/spark-$SPARK_VERSION-bin-$NAME.tgz .
+
     if [ -n "$AMPLAB_JENKINS" ]; then
       echo "Skipping signing of regular binary distribution"
     else
-      echo "Copying and signing regular binary distribution"
-      cp spark-$SPARK_VERSION-bin-$NAME/spark-$SPARK_VERSION-bin-$NAME.tgz .
+      echo "Signing regular binary distribution"
       echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --armour \
                                   --output spark-$SPARK_VERSION-bin-$NAME.tgz.asc \
                                   --detach-sig spark-$SPARK_VERSION-bin-$NAME.tgz

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -184,7 +184,9 @@ if [[ "$1" == "package" ]]; then
   rm -r spark-$SPARK_VERSION/licenses-binary
   tar cvzf spark-$SPARK_VERSION.tgz spark-$SPARK_VERSION
 
-  if [ -z "$AMPLAB_JENKINS" ]; then
+  if [ -n "$AMPLAB_JENKINS" ]; then
+    echo "Skipping signing of Spark source"
+  else
     echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --armour --output spark-$SPARK_VERSION.tgz.asc \
                                 --detach-sig spark-$SPARK_VERSION.tgz
     echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --print-md \
@@ -240,7 +242,9 @@ if [[ "$1" == "package" ]]; then
       -DzincPort=$ZINC_PORT 2>&1 >  ../binary-release-$NAME.log
     cd ..
 
-    if [ -z "$AMPLAB_JENKINS" ]; then
+    if [ -n "$AMPLAB_JENKINS" ]; then
+      echo "Skipping signing of R source package"
+    else
       if [[ -n $R_FLAG ]]; then
         echo "Copying and signing R source package"
         R_DIST_NAME=SparkR_$SPARK_VERSION.tar.gz
@@ -255,7 +259,9 @@ if [[ "$1" == "package" ]]; then
       fi
     fi
 
-    if [ -z "$AMPLAB_JENKINS" ]; then
+    if [ -n "$AMPLAB_JENKINS" ]; then
+      echo "Skipping signing of python distribution"
+    else
       if [[ -n $PIP_FLAG ]]; then
         echo "Copying and signing python distribution"
         PYTHON_DIST_NAME=pyspark-$PYSPARK_VERSION.tar.gz
@@ -270,7 +276,9 @@ if [[ "$1" == "package" ]]; then
       fi
     fi
 
-    if [ -z "$AMPLAB_JENKINS" ]; then
+    if [ -n "$AMPLAB_JENKINS" ]; then
+      echo "Skipping signing of regular binary distribution"
+    else
       echo "Copying and signing regular binary distribution"
       cp spark-$SPARK_VERSION-bin-$NAME/spark-$SPARK_VERSION-bin-$NAME.tgz .
       echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --armour \
@@ -325,7 +333,9 @@ if [[ "$1" == "package" ]]; then
 
   rm -rf spark-$SPARK_VERSION-bin-*/
 
-  if [ -z "$AMPLAB_JENKINS" ]; then
+  if [ -n "$AMPLAB_JENKINS" ]; then
+    echo "Skipping SVN push of release tarballs"
+  else
     if ! is_dry_run; then
       svn co --depth=empty $RELEASE_STAGING_LOCATION svn-spark
       rm -rf "svn-spark/${DEST_DIR_NAME}-bin"

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -x  # testing only
+
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
## What changes were proposed in this pull request?

to get our package builds green again, we will skip gpg signing and publishing for jenkins only

## How was this patch tested?

i will create a test build for this

this will need to be backported to:  2.2.3, 2.3.3, 2.4.1, 3.0.0