### PR TITLE
[MINOR] Follow up for SPARK-23936, fixed description of "map_concat" function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -516,7 +516,7 @@ case class MapEntries(child: Expression) extends UnaryExpression with ExpectsInp
   examples = """
     Examples:
       > SELECT _FUNC_(map(1, 'a', 2, 'b'), map(2, 'c', 3, 'd'));
-       {1:"a",2:"c",3:"d"}
+       {1:"a",2:"b",2:"c",3:"d"}
   """, since = "2.4.0")
 case class MapConcat(children: Seq[Expression]) extends ComplexTypeMergingExpression {
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The description of "map_concat" function does not correspond to the actual behavior. Unit tests, an example in shell, and the PR description (https://jira.apache.org/jira/browse/SPARK-23936, https://github.com/apache/spark/pull/21073) say that duplicated keys will be duplicated, but the function description says the opposite.
```
scala> spark.sql("SELECT map_concat(map(1, 'a', 2, 'b'), map(2, 'c', 3, 'd'))").show(20, false)
+--------------------------------------------+
|map_concat(map(1, a, 2, b), map(2, c, 3, d))|
+--------------------------------------------+
|[1 -> a, 2 -> b, 2 -> c, 3 -> d]            |
+--------------------------------------------+
```

Looks like it was implemented correctly in the original PR, but then incorrectly changed in this PR: https://github.com/apache/spark/pull/22437