### PR TITLE
[SPARK-26577][SQL] Add input optimizer when reading Hive table by SparkSQL

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -561,23 +561,6 @@ object SQLConf {
     .checkValues(HiveCaseSensitiveInferenceMode.values.map(_.toString))
     .createWithDefault(HiveCaseSensitiveInferenceMode.INFER_AND_SAVE.toString)
 
-  val HIVE_FILE_INPUT_FORMAT_ENABLED = buildConf("spark.sql.hive.fileInputFormat.enabled")
-    .doc("When true, enable optimizing the `fileInputFormat` in Spark SQL.")
-    .booleanConf
-    .createWithDefault(false)
-
-  val HIVE_FILE_INPUT_FORMAT_SPLIT_MAXSIZE =
-    buildConf("spark.sql.hive.fileInputFormat.split.maxsize")
-      .doc("The maxsize of per split while reading Hive tables.")
-      .longConf
-      .createWithDefault(128 * 1024 * 1024)
-
-  val HIVE_FILE_INPUT_FORMAT_SPLIT_MINSIZE =
-    buildConf("spark.sql.hive.fileInputFormat.split.minsize")
-      .doc("The minsize of per split while reading Hive tables.")
-      .longConf
-      .createWithDefault(32 * 1024 * 1024)
-
   val OPTIMIZER_METADATA_ONLY = buildConf("spark.sql.optimizer.metadataOnly")
     .doc("When true, enable the metadata-only query optimization that use the table's metadata " +
       "to produce the partition columns instead of table scans. It applies when all the columns " +
@@ -1697,12 +1680,6 @@ class SQLConf extends Serializable with Logging {
 
   def caseSensitiveInferenceMode: HiveCaseSensitiveInferenceMode.Value =
     HiveCaseSensitiveInferenceMode.withName(getConf(HIVE_CASE_SENSITIVE_INFERENCE))
-
-  def fileInputFormatEnabled: Boolean = getConf(HIVE_FILE_INPUT_FORMAT_ENABLED)
-
-  def fileInputFormatSplitMaxsize: Long = getConf(HIVE_FILE_INPUT_FORMAT_SPLIT_MAXSIZE)
-
-  def fileInputFormatSplitMinsize: Long = getConf(HIVE_FILE_INPUT_FORMAT_SPLIT_MINSIZE)
 
   def compareDateTimestampInTimestamp : Boolean = getConf(COMPARE_DATE_TIMESTAMP_IN_TIMESTAMP)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -561,6 +561,23 @@ object SQLConf {
     .checkValues(HiveCaseSensitiveInferenceMode.values.map(_.toString))
     .createWithDefault(HiveCaseSensitiveInferenceMode.INFER_AND_SAVE.toString)
 
+  val HIVE_FILE_INPUT_FORMAT_ENABLED = buildConf("spark.sql.hive.fileInputFormat.enabled")
+    .doc("When true, enable optimizing the `fileInputFormat` in Spark SQL.")
+    .booleanConf
+    .createWithDefault(false)
+
+  val HIVE_FILE_INPUT_FORMAT_SPLIT_MAXSIZE =
+    buildConf("spark.sql.hive.fileInputFormat.split.maxsize")
+      .doc("The maxsize of per split while reading Hive tables.")
+      .longConf
+      .createWithDefault(128 * 1024 * 1024)
+
+  val HIVE_FILE_INPUT_FORMAT_SPLIT_MINSIZE =
+    buildConf("spark.sql.hive.fileInputFormat.split.minsize")
+      .doc("The minsize of per split while reading Hive tables.")
+      .longConf
+      .createWithDefault(32 * 1024 * 1024)
+
   val OPTIMIZER_METADATA_ONLY = buildConf("spark.sql.optimizer.metadataOnly")
     .doc("When true, enable the metadata-only query optimization that use the table's metadata " +
       "to produce the partition columns instead of table scans. It applies when all the columns " +
@@ -1680,6 +1697,12 @@ class SQLConf extends Serializable with Logging {
 
   def caseSensitiveInferenceMode: HiveCaseSensitiveInferenceMode.Value =
     HiveCaseSensitiveInferenceMode.withName(getConf(HIVE_CASE_SENSITIVE_INFERENCE))
+
+  def fileInputFormatEnabled: Boolean = getConf(HIVE_FILE_INPUT_FORMAT_ENABLED)
+
+  def fileInputFormatSplitMaxsize: Long = getConf(HIVE_FILE_INPUT_FORMAT_SPLIT_MAXSIZE)
+
+  def fileInputFormatSplitMinsize: Long = getConf(HIVE_FILE_INPUT_FORMAT_SPLIT_MINSIZE)
 
   def compareDateTimestampInTimestamp : Boolean = getConf(COMPARE_DATE_TIMESTAMP_IN_TIMESTAMP)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -120,6 +120,23 @@ private[spark] object HiveUtils extends Logging {
     .toSequence
     .createWithDefault(jdbcPrefixes)
 
+  val HIVE_FILE_INPUT_FORMAT_ENABLED = buildConf("spark.sql.hive.fileInputFormat.enabled")
+    .doc("When true, enable optimizing the `fileInputFormat` in Spark SQL.")
+    .booleanConf
+    .createWithDefault(false)
+
+  val HIVE_FILE_INPUT_FORMAT_SPLIT_MAXSIZE =
+    buildConf("spark.sql.hive.fileInputFormat.split.maxsize")
+      .doc("The maxsize of per split while reading Hive tables.")
+      .longConf
+      .createWithDefault(128 * 1024 * 1024)
+
+  val HIVE_FILE_INPUT_FORMAT_SPLIT_MINSIZE =
+    buildConf("spark.sql.hive.fileInputFormat.split.minsize")
+      .doc("The minsize of per split while reading Hive tables.")
+      .longConf
+      .createWithDefault(32 * 1024 * 1024)
+
   private def jdbcPrefixes = Seq(
     "com.mysql.jdbc", "org.postgresql", "com.microsoft.sqlserver", "oracle.jdbc")
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -311,11 +311,12 @@ class HadoopTableReader(
   }
 
   /**
-    * If `spark.sql.hive.fileInputFormat.enabled` is true, this function will optimize the input
-    * method(including format and the size of splits) while reading Hive tables.
-    */
+   * If `spark.sql.hive.fileInputFormat.enabled` is true, this function will optimize the input
+   * method(including format and the size of splits) while reading Hive tables.
+   */
   private def getAndOptimizeInput(
-                               inputClassName: String): Class[InputFormat[Writable, Writable]] = {
+    inputClassName: String): Class[InputFormat[Writable, Writable]] = {
+
     var ifc = Utils.classForName(inputClassName)
       .asInstanceOf[java.lang.Class[InputFormat[Writable, Writable]]]
     if (conf.getConf(HiveUtils.HIVE_FILE_INPUT_FORMAT_ENABLED)) {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -178,7 +178,7 @@ class HadoopTableReader(
     def verifyPartitionPath(
         partitionToDeserializer: Map[HivePartition, Class[_ <: Deserializer]]):
         Map[HivePartition, Class[_ <: Deserializer]] = {
-      if (!sparkSession.sessionState.conf.verifyPartitionPath) {
+      if (!conf.verifyPartitionPath) {
         partitionToDeserializer
       } else {
         val existPathSet = collection.mutable.Set[String]()

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveTableScanSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveTableScanSuite.scala
@@ -228,18 +228,11 @@ class HiveTableScanSuite extends HiveComparisonTest with SQLTestUtils with TestH
            |INPUTFORMAT 'org.apache.hadoop.mapreduce.lib.input.TextInputFormat'
            |OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
        """.stripMargin)
-      intercept[Exception] {
-        sql("SELECT count(1) FROM table_old")
-      }
-      intercept[Exception] {
-        sql("SELECT count(1) FROM table_pt_old")
-      }
-      intercept[Exception] {
-        sql("SELECT count(1) FROM table_new")
-      }
-      intercept[Exception] {
-        sql("SELECT count(1) FROM table_pt_new")
-      }
+
+      sql("SELECT count(1) FROM table_old")
+      sql("SELECT count(1) FROM table_pt_old")
+      sql("SELECT count(1) FROM table_new")
+      sql("SELECT count(1) FROM table_pt_new")
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveTableScanSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveTableScanSuite.scala
@@ -193,7 +193,7 @@ class HiveTableScanSuite extends HiveComparisonTest with SQLTestUtils with TestH
     }.get
   }
 
-  test("HiveTableScanExec canonicalization for different orders of partition filters") {
+  test("Test the InputFormat optimizer") {
     withTable("table_old", "table_pt_old", "table_new", "table_pt_new") {
       sql("set spark.sql.hive.fileInputFormat.enabled=true")
       sql("set spark.sql.hive.fileInputFormat.split.maxsize=134217728")


### PR DESCRIPTION
## What changes were proposed in this pull request?

When using SparkSQL, for example the ThriftServer, if we set

`spark.sql.hive.fileInputFormat.enabled=true`

we can optimize the InputFormat to CombineTextInputFormat automatically if it's TextInputFormat before. And we can also change the max/min size of input splits by setting, for example 

`spark.sql.hive.fileInputFormat.split.maxsize=268435456`
`spark.sql.hive.fileInputFormat.split.minsize=134217728`

Otherwise, we have to modify Hive Configs and structure of tables.

And we made a test by using a Hive table with a lot of small files in HDFS and haven't combined :

Before improved:
![image](https://user-images.githubusercontent.com/25916266/50877374-85e43780-140c-11e9-9724-31d367739552.png)


After improved:
![image](https://user-images.githubusercontent.com/25916266/50877387-9694ad80-140c-11e9-99e2-f55a3c7285e0.png)



## How was this patch tested?

Added a test.
