### PR TITLE
[SPARK-26585][K8S] Add additional integration tests for K8s Scheduler Backend

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesTestComponents.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesTestComponents.scala
@@ -90,6 +90,8 @@ private[spark] class SparkAppConf {
   override def toString: String = map.toString
 
   def toStringArray: Iterable[String] = map.toList.flatMap(t => List("--conf", s"${t._1}=${t._2}"))
+
+  def remove(key: String): Unit = map.remove(key)
 }
 
 private[spark] case class SparkAppArguments(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added following integration tests to cover additional tests for K8s scheduler backend functionality
- Run SparkPi with driver and executor image specified independently
- Run SparkPi with custom cpu requirements
- Run SparkPi with custom memory and memory overhead factor requirements
- Run SparkPi with custom memory and memory overhead requirements

## How was this patch tested?

Ran K8s integration tests locally on minikube and all tests succeeded including new ones.

