### PR TITLE
[SPARK-26590][CORE] make fetch-block-to-disk backward compatible

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportClient.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportClient.java
@@ -115,7 +115,9 @@ public class TransportClient implements Closeable {
   }
 
   /**
-   * Requests a single chunk from the remote side, from the pre-negotiated streamId.
+   * Requests a chunk from the remote side, from the pre-negotiated streamId. The chunk will be
+   * fetched with a single response, or a stream if `streamCallback` is not null and the server
+   * supports fetching chunk as stream.
    *
    * Chunk indices go from 0 onwards. It is valid to request the same chunk multiple times, though
    * some streams may not support this.

--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportResponseHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportResponseHandler.java
@@ -123,7 +123,7 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
       try {
         entry.getValue().onFailure(entry.getKey().toString(), cause);
       } catch (Exception e) {
-        logger.warn("ChunkReceivedCallback.onFailure throws exception", e);
+        logger.warn("ChunkFetchRequest's StreamCallback.onFailure throws exception", e);
       }
     }
     for (Map.Entry<Long, RpcResponseCallback> entry : outstandingRpcs.entrySet()) {

--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportResponseHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportResponseHandler.java
@@ -78,9 +78,9 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
   }
 
   public void addFetchAsStreamRequest(
-    StreamChunkId streamChunkId,
-    StreamCallback callback) {
-    updateTimeOfLastRequest();
+      StreamChunkId streamChunkId,
+      StreamCallback callback) {
+      updateTimeOfLastRequest();
     outstandingFetchAsStreams.put(streamChunkId, callback);
   }
 

--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportResponseHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportResponseHandler.java
@@ -80,7 +80,7 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
   public void addFetchAsStreamRequest(
       StreamChunkId streamChunkId,
       StreamCallback callback) {
-      updateTimeOfLastRequest();
+    updateTimeOfLastRequest();
     outstandingFetchAsStreams.put(streamChunkId, callback);
   }
 

--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportResponseHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportResponseHandler.java
@@ -195,10 +195,11 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
       ChunkFetchStreamResponse resp = (ChunkFetchStreamResponse) message;
       StreamCallback callback = outstandingFetchAsStreams.get(resp.streamChunkId);
       if (callback == null) {
-        logger.warn("Ignoring response for block {} from {} since it is not outstanding",
+        logger.warn("Ignoring stream response for block {} from {} since it is not outstanding",
           resp.streamChunkId, getRemoteAddress(channel));
         resp.body().release();
       } else {
+        outstandingFetchAsStreams.remove(resp.streamChunkId);
         readStream(resp.streamChunkId.toString(), resp.byteCount, callback);
       }
     } else if (message instanceof ChunkFetchFailure) {

--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/ChunkFetchRequest.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/ChunkFetchRequest.java
@@ -89,6 +89,7 @@ public final class ChunkFetchRequest extends AbstractMessage implements RequestM
   public String toString() {
     return Objects.toStringHelper(this)
       .add("streamChunkId", streamChunkId)
+      .add("fetchAsStream", fetchAsStream)
       .toString();
   }
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/ChunkFetchStreamResponse.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/ChunkFetchStreamResponse.java
@@ -23,7 +23,8 @@ import io.netty.buffer.ByteBuf;
 import org.apache.spark.network.buffer.ManagedBuffer;
 
 /**
- * Response to {@link StreamRequest} when the stream has been successfully opened.
+ * Response to {@link ChunkFetchRequest} when its `fetchAsStream` flag is true and the stream has
+ * been successfully opened.
  * <p>
  * Note the message itself does not contain the stream data. That is written separately by the
  * sender. The receiver is expected to set a temporary channel handler that will consume the

--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/ChunkFetchStreamResponse.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/ChunkFetchStreamResponse.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.protocol;
+
+import com.google.common.base.Objects;
+import io.netty.buffer.ByteBuf;
+
+import org.apache.spark.network.buffer.ManagedBuffer;
+
+/**
+ * Response to {@link StreamRequest} when the stream has been successfully opened.
+ * <p>
+ * Note the message itself does not contain the stream data. That is written separately by the
+ * sender. The receiver is expected to set a temporary channel handler that will consume the
+ * number of bytes this message says the stream has.
+ */
+public final class ChunkFetchStreamResponse extends AbstractResponseMessage {
+  public final StreamChunkId streamChunkId;
+  public final long byteCount;
+
+  public ChunkFetchStreamResponse(
+      StreamChunkId streamChunkId,
+      long byteCount,
+      ManagedBuffer buffer) {
+    super(buffer, false);
+    this.streamChunkId = streamChunkId;
+    this.byteCount = byteCount;
+  }
+
+  @Override
+  public Message.Type type() { return Type.ChunkFetchStreamResponse; }
+
+  @Override
+  public int encodedLength() {
+    return streamChunkId.encodedLength() + 8;
+  }
+
+  /** Encoding does NOT include 'buffer' itself. See {@link MessageEncoder}. */
+  @Override
+  public void encode(ByteBuf buf) {
+    streamChunkId.encode(buf);
+    buf.writeLong(byteCount);
+  }
+
+  @Override
+  public ResponseMessage createFailureResponse(String error) {
+    return new ChunkFetchFailure(streamChunkId, error);
+  }
+
+  public static ChunkFetchStreamResponse decode(ByteBuf buf) {
+    StreamChunkId streamChunkId = StreamChunkId.decode(buf);
+    long byteCount = buf.readLong();
+    return new ChunkFetchStreamResponse(streamChunkId, byteCount, null);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(streamChunkId, byteCount);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other instanceof ChunkFetchStreamResponse) {
+      ChunkFetchStreamResponse o = (ChunkFetchStreamResponse) other;
+      return streamChunkId.equals(o.streamChunkId) && byteCount == o.byteCount;
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("streamChunkId", streamChunkId)
+      .add("byteCount", byteCount)
+      .add("body", body())
+      .toString();
+  }
+}

--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/Message.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/Message.java
@@ -37,7 +37,7 @@ public interface Message extends Encodable {
     ChunkFetchRequest(0), ChunkFetchSuccess(1), ChunkFetchFailure(2),
     RpcRequest(3), RpcResponse(4), RpcFailure(5),
     StreamRequest(6), StreamResponse(7), StreamFailure(8),
-    OneWayMessage(9), UploadStream(10), User(-1);
+    OneWayMessage(9), UploadStream(10), ChunkFetchStreamResponse(11), User(-1);
 
     private final byte id;
 
@@ -66,6 +66,7 @@ public interface Message extends Encodable {
         case 8: return StreamFailure;
         case 9: return OneWayMessage;
         case 10: return UploadStream;
+        case 11: return ChunkFetchStreamResponse;
         case -1: throw new IllegalArgumentException("User type messages cannot be decoded.");
         default: throw new IllegalArgumentException("Unknown message type: " + id);
       }

--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/MessageDecoder.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/MessageDecoder.java
@@ -83,6 +83,9 @@ public final class MessageDecoder extends MessageToMessageDecoder<ByteBuf> {
       case UploadStream:
         return UploadStream.decode(in);
 
+      case ChunkFetchStreamResponse:
+        return ChunkFetchStreamResponse.decode(in);
+
       default:
         throw new IllegalArgumentException("Unexpected message type: " + msgType);
     }

--- a/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
@@ -30,10 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.spark.network.buffer.ManagedBuffer;
 import org.apache.spark.network.client.TransportClient;
-import org.apache.spark.network.protocol.ChunkFetchFailure;
-import org.apache.spark.network.protocol.ChunkFetchRequest;
-import org.apache.spark.network.protocol.ChunkFetchSuccess;
-import org.apache.spark.network.protocol.Encodable;
+import org.apache.spark.network.protocol.*;
 
 import static org.apache.spark.network.util.NettyUtils.*;
 
@@ -101,7 +98,13 @@ public class ChunkFetchRequestHandler extends SimpleChannelInboundHandler<ChunkF
     }
 
     streamManager.chunkBeingSent(msg.streamChunkId.streamId);
-    respond(channel, new ChunkFetchSuccess(msg.streamChunkId, buf)).addListener(
+    AbstractResponseMessage response;
+    if (msg.fetchAsStream) {
+      response = new ChunkFetchStreamResponse(msg.streamChunkId, buf.size(), buf);
+    } else {
+      response = new ChunkFetchSuccess(msg.streamChunkId, buf);
+    }
+    respond(channel, response).addListener(
       (ChannelFutureListener) future -> streamManager.chunkSent(msg.streamChunkId.streamId));
   }
 

--- a/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
@@ -99,14 +99,12 @@ public class OneForOneStreamManager extends StreamManager {
     return nextChunk;
   }
 
+  // This is needed for clients of Spark 2.2, 2.3, 2.4, which will send stream request to fetch
+  // block chunks.
   @Override
   public ManagedBuffer openStream(String streamChunkId) {
     Pair<Long, Integer> streamChunkIdPair = parseStreamChunkId(streamChunkId);
     return getChunk(streamChunkIdPair.getLeft(), streamChunkIdPair.getRight());
-  }
-
-  public static String genStreamChunkId(long streamId, int chunkId) {
-    return String.format("%d_%d", streamId, chunkId);
   }
 
   // Parse streamChunkId to be stream id and chunk id. This is used when fetch remote chunk as a

--- a/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
@@ -100,7 +100,7 @@ public class OneForOneStreamManager extends StreamManager {
   }
 
   // This is needed for clients of Spark 2.2, 2.3, 2.4, which will send stream request to fetch
-  // block chunks.
+  // chunks.
   @Override
   public ManagedBuffer openStream(String streamChunkId) {
     Pair<Long, Integer> streamChunkIdPair = parseStreamChunkId(streamChunkId);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
@@ -57,12 +57,12 @@ public class OneForOneBlockFetcher {
   private StreamHandle streamHandle = null;
 
   public OneForOneBlockFetcher(
-    TransportClient client,
-    String appId,
-    String execId,
-    String[] blockIds,
-    BlockFetchingListener listener,
-    TransportConf transportConf) {
+      TransportClient client,
+      String appId,
+      String execId,
+      String[] blockIds,
+      BlockFetchingListener listener,
+      TransportConf transportConf) {
     this(client, appId, execId, blockIds, listener, transportConf, null);
   }
 

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
@@ -95,7 +95,7 @@ public class OneForOneBlockFetcher {
     public void onFailure(int chunkIndex, Throwable e) {
       // On receipt of a failure, fail every block from chunkIndex onwards.
       String[] remainingBlockIds = Arrays.copyOfRange(blockIds, chunkIndex, blockIds.length);
-      failRemainingBlocks(remainingBlockIds, e);
+      failBlocks(remainingBlockIds, e);
     }
   }
 
@@ -129,20 +129,20 @@ public class OneForOneBlockFetcher {
           }
         } catch (Exception e) {
           logger.error("Failed while starting block fetches after success", e);
-          failRemainingBlocks(blockIds, e);
+          failBlocks(blockIds, e);
         }
       }
 
       @Override
       public void onFailure(Throwable e) {
         logger.error("Failed while starting block fetches", e);
-        failRemainingBlocks(blockIds, e);
+        failBlocks(blockIds, e);
       }
     });
   }
 
   /** Invokes the "onBlockFetchFailure" callback for every listed block id. */
-  private void failRemainingBlocks(String[] failedBlockIds, Throwable e) {
+  private void failBlocks(String[] failedBlockIds, Throwable e) {
     for (String blockId : failedBlockIds) {
       try {
         listener.onBlockFetchFailure(blockId, e);
@@ -184,7 +184,7 @@ public class OneForOneBlockFetcher {
       channel.close();
       // On receipt of a failure, fail every block from chunkIndex onwards.
       String[] remainingBlockIds = Arrays.copyOfRange(blockIds, chunkIndex, blockIds.length);
-      failRemainingBlocks(remainingBlockIds, cause);
+      failBlocks(remainingBlockIds, cause);
       targetFile.delete();
     }
   }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockFetcherSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockFetcherSuite.java
@@ -165,7 +165,7 @@ public class OneForOneBlockFetcherSuite {
         fail("Unexpected failure");
       }
       return null;
-    }).when(client).fetchChunk(anyLong(), anyInt(), any());
+    }).when(client).fetchChunk(anyLong(), anyInt(), any(), any());
 
     fetcher.start();
     return listener;

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -551,9 +551,7 @@ package object config {
       .doc("Remote block will be fetched to disk when size of the block is above this threshold " +
         "in bytes. This is to avoid a giant request takes too much memory. We can enable this " +
         "config by setting a specific value(e.g. 200m). Note this configuration will affect " +
-        "both shuffle fetch and block manager remote block fetch. For users who enabled " +
-        "external shuffle service, this feature can only be worked when external shuffle" +
-        "service is newer than Spark 2.2.")
+        "both shuffle fetch and block manager remote block fetch.")
       .bytesConf(ByteUnit.BYTE)
       // fetch-to-mem is guaranteed to fail if the message is bigger than 2 GB, so we might
       // as well use fetch-to-disk in that case.  The message includes some metadata in addition


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a followup of https://github.com/apache/spark/pull/16989

The fetch-block-to-disk feature is disabled by default, because it's not compatible with external shuffle service prior to Spark 2.2. The client sends stream request to fetch block chunks, and old shuffle service can't support it.

This PR proposes a new approach:
1. extend `ChunkFetchRequest` to add an optional `fetchAsStream` boolean flag. It will only be encoded to the message when it's true. `ChunkFetchRequest` from old clients do not have this flag, which means this flag is false for them.
2. server side takes care of the new flag in `ChunkFetchRequest`. If the flag is true, return a new chunk stream response, otherwise return a normal chunk fetch response.
3. when client side sends `ChunkFetchRequest` with `fetchAsStream=true`, it will set up two callbacks for the new chunk stream response and the normal chunk fetch response. This is necessary because the server side may be an old version which ignores the `fetchAsStream` flag.

This is fully compatible:
1. new client <-> new server: Definitely fine
2. old client <-> new server: The `ChunkFetchRequest` message doesn't have the `fetchAsStream` flag, the server treats it as a normal fetch request, and returns normal fetch request response.
3. new client <-> old server: The `ChunkFetchRequest` message contains the `fetchAsStream` flag, but the old server doesn't know about it and stops reading the message right before the `fetchAsStream` part. Then the old server returns normal chunk fetch response, and new client accept it.

Note that, the previous server side changes made in #16989 are still there, so clients of Spark 2.2, 2.3, 2.4 with fetch-block-to-disk enabled still work.

TODO: setup different versions of shuffle service and test it.

## How was this patch tested?

existing tests.
