### PR TITLE
[SPARK-26599][SQL]BroardCast hint can not work with PruneFileSourcePartitions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -20,11 +20,12 @@ package org.apache.spark.sql.execution.datasources
 import org.apache.spark.sql.catalyst.catalog.CatalogStatistics
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
-import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project, ResolvedHint}
 import org.apache.spark.sql.catalyst.rules.Rule
 
 private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = plan transformDown {
+    case h: ResolvedHint => h
     case op @ PhysicalOperation(projects, filters,
         logicalRelation @
           LogicalRelation(fsRelation @


### PR DESCRIPTION
## What changes were proposed in this pull request?
BroardCast hint can not work with `PruneFileSourcePartitions`, for example, when the filter condition p is a partition field, table b in SQL below cannot be broadcast.

`   sql("select /*+ broadcastjoin(b) */ * from (select a from empty_test where p=1) a " +
      "join (select a,b from par_1 where p=1) b on a.a=b.a").explain`

The reason is that `PruneFileSourcePartitions ` deleted `ResolvedHint ` when matching `PhysicalOperations`, the plan after `PruneFileSourcePartitions ` before this PR is:

![image](https://user-images.githubusercontent.com/26834091/51019165-eada9180-15b4-11e9-93da-3f435cac6049.png)
  
The original reason for this problem is that when `PhysicalOperation ` matches ResolvedHint, it returns directly to its child nodes and skips over itself.
`case h: ResolvedHint =>
        collectProjectsAndFilters(h.child)`

This PR adds processing to `ResolvedHint `,  when matched to it in `PruneFileSourcePartitions`, skip it directly and parse its child nodes.


## How was this patch tested?


Unit test of `PruneFileSourcePartitionsSuite`