### PR TITLE
[SPARK-26610][PYTHON] Fix inconsistency between toJSON Method in Python and Scala.

### DIFF
--- a/docs/sql-migration-guide-upgrade.md
+++ b/docs/sql-migration-guide-upgrade.md
@@ -45,6 +45,8 @@ displayTitle: Spark SQL Upgrading Guide
 
   - In Spark version 2.4 and earlier, if `org.apache.spark.sql.functions.udf(Any, DataType)` gets a Scala closure with primitive-type argument, the returned UDF will return null if the input values is null. Since Spark 3.0, the UDF will return the default value of the Java type if the input value is null. For example, `val f = udf((x: Int) => x, IntegerType)`, `f($"x")` will return null in Spark 2.4 and earlier if column `x` is null, and return 0 in Spark 3.0. This behavior change is introduced because Spark 3.0 is built with Scala 2.12 by default.
 
+  - Since Spark 3.0, `DataFrame.toJSON()` in PySpark returns `DataFrame` of JSON string instead of `RDD`. The method in Scala/Java was changed to return `DataFrame` before, but the one in PySpark was not changed at that time. If you still want to return `RDD`, you can restore the previous behavior by setting `spark.sql.legacy.pyspark.dataframe.toJsonShouldReturnDataFrame` to `false`.
+
 ## Upgrading From Spark SQL 2.3 to 2.4
 
   - In Spark version 2.3 and earlier, the second parameter to array_contains function is implicitly promoted to the element type of first array type parameter. This type promotion can be lossy and may cause `array_contains` function to return wrong result. This problem has been addressed in 2.4 by employing a safer type promotion mechanism. This can cause some change in behavior and are illustrated in the table below.

--- a/docs/sql-migration-guide-upgrade.md
+++ b/docs/sql-migration-guide-upgrade.md
@@ -45,7 +45,7 @@ displayTitle: Spark SQL Upgrading Guide
 
   - In Spark version 2.4 and earlier, if `org.apache.spark.sql.functions.udf(Any, DataType)` gets a Scala closure with primitive-type argument, the returned UDF will return null if the input values is null. Since Spark 3.0, the UDF will return the default value of the Java type if the input value is null. For example, `val f = udf((x: Int) => x, IntegerType)`, `f($"x")` will return null in Spark 2.4 and earlier if column `x` is null, and return 0 in Spark 3.0. This behavior change is introduced because Spark 3.0 is built with Scala 2.12 by default.
 
-  - Since Spark 3.0, `DataFrame.toJSON()` in PySpark returns `DataFrame` of JSON string instead of `RDD`. The method in Scala/Java was changed to return `DataFrame` before, but the one in PySpark was not changed at that time. If you still want to return `RDD`, you can restore the previous behavior by setting `spark.sql.legacy.pyspark.dataframe.toJsonShouldReturnDataFrame` to `false`.
+  - Since Spark 3.0, `DataFrame.toJSON()` in PySpark returns `DataFrame` of JSON string instead of `RDD`. The method in Scala/Java was changed to return `DataFrame` before, but the one in PySpark was not changed at that time. If you still want to return `RDD`, you can restore the previous behavior by setting `spark.sql.legacy.pyspark.toJsonShouldReturnDataFrame` to `false`.
 
 ## Upgrading From Spark SQL 2.3 to 2.4
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -109,15 +109,18 @@ class DataFrame(object):
     @ignore_unicode_prefix
     @since(1.3)
     def toJSON(self, use_unicode=True):
-        """Converts a :class:`DataFrame` into a :class:`RDD` of string.
+        """Converts a :class:`DataFrame` into a :class:`DataFrame` of JSON string.
 
-        Each row is turned into a JSON document as one element in the returned RDD.
+        Each row is turned into a JSON document as one element in the returned DataFrame.
 
         >>> df.toJSON().first()
-        u'{"age":2,"name":"Alice"}'
+        Row(value=u'{"age":2,"name":"Alice"}')
         """
-        rdd = self._jdf.toJSON()
-        return RDD(rdd.toJavaRDD(), self._sc, UTF8Deserializer(use_unicode))
+        jdf = self._jdf.toJSON()
+        if self.sql_ctx._conf.pysparkDataFrameToJSONShouldReturnDataFrame():
+            return DataFrame(jdf, self.sql_ctx)
+        else:
+            return RDD(jdf.toJavaRDD(), self._sc, UTF8Deserializer(use_unicode))
 
     @since(2.0)
     def createTempView(self, name):

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -117,7 +117,7 @@ class DataFrame(object):
         Row(value=u'{"age":2,"name":"Alice"}')
         """
         jdf = self._jdf.toJSON()
-        if self.sql_ctx._conf.pysparkDataFrameToJSONShouldReturnDataFrame():
+        if self.sql_ctx._conf.pysparkToJSONShouldReturnDataFrame():
             return DataFrame(jdf, self.sql_ctx)
         else:
             return RDD(jdf.toJavaRDD(), self._sc, UTF8Deserializer(use_unicode))

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -676,6 +676,16 @@ class DataFrameTests(ReusedSQLTestCase):
                     self.assertEquals(None, df._repr_html_())
                     self.assertEquals(expected, df.__repr__())
 
+    def test_toJSON(self):
+        df = self.spark.createDataFrame([("Alice", 5), ("Bob", 8)], ["name", "age"])
+        self.assertEqual(df.toJSON().collect(), [
+            Row(u'{"name":"Alice","age":5}'), Row(u'{"name":"Bob","age":8}')])
+
+        with self.sql_conf({
+                "spark.sql.legacy.pyspark.dataframe.toJsonShouldReturnDataFrame": False}):
+            self.assertEqual(df.toJSON().collect(), [
+                u'{"name":"Alice","age":5}', u'{"name":"Bob","age":8}'])
+
 
 class QueryExecutionListenerTests(unittest.TestCase, SQLTestUtils):
     # These tests are separate because it uses 'spark.sql.queryExecutionListeners' which is

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -682,7 +682,7 @@ class DataFrameTests(ReusedSQLTestCase):
             Row(u'{"name":"Alice","age":5}'), Row(u'{"name":"Bob","age":8}')])
 
         with self.sql_conf({
-                "spark.sql.legacy.pyspark.dataframe.toJsonShouldReturnDataFrame": False}):
+                "spark.sql.legacy.pyspark.toJsonShouldReturnDataFrame": False}):
             self.assertEqual(df.toJSON().collect(), [
                 u'{"name":"Alice","age":5}', u'{"name":"Bob","age":8}'])
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1626,8 +1626,8 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
-  val PYSPARK_DATAFRAME_TOJSON_SHOULD_RETURN_DATAFRAME =
-    buildConf("spark.sql.legacy.pyspark.dataframe.toJsonShouldReturnDataFrame")
+  val PYSPARK_TOJSON_SHOULD_RETURN_DATAFRAME =
+    buildConf("spark.sql.legacy.pyspark.toJsonShouldReturnDataFrame")
       .internal()
       .doc("If it is set to true, DataFrame.toJSON in PySpark returns DataFrame of JSON string " +
         "instead of RDD.")
@@ -2058,8 +2058,8 @@ class SQLConf extends Serializable with Logging {
   def setCommandRejectsSparkCoreConfs: Boolean =
     getConf(SQLConf.SET_COMMAND_REJECTS_SPARK_CORE_CONFS)
 
-  def pysparkDataFrameToJSONShouldReturnDataFrame: Boolean =
-    getConf(SQLConf.PYSPARK_DATAFRAME_TOJSON_SHOULD_RETURN_DATAFRAME)
+  def pysparkToJSONShouldReturnDataFrame: Boolean =
+    getConf(SQLConf.PYSPARK_TOJSON_SHOULD_RETURN_DATAFRAME)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1625,6 +1625,14 @@ object SQLConf {
         "a SparkConf entry.")
       .booleanConf
       .createWithDefault(true)
+
+  val PYSPARK_DATAFRAME_TOJSON_SHOULD_RETURN_DATAFRAME =
+    buildConf("spark.sql.legacy.pyspark.dataframe.toJsonShouldReturnDataFrame")
+    .internal()
+    .doc("If it is set to true, DataFrame.toJSON in PySpark returns DataFrame of JSON string " +
+      "instead of RDD.")
+    .booleanConf
+    .createWithDefault(true)
 }
 
 /**
@@ -2049,6 +2057,9 @@ class SQLConf extends Serializable with Logging {
 
   def setCommandRejectsSparkCoreConfs: Boolean =
     getConf(SQLConf.SET_COMMAND_REJECTS_SPARK_CORE_CONFS)
+
+  def pysparkDataFrameToJSONShouldReturnDataFrame: Boolean =
+    getConf(SQLConf.PYSPARK_DATAFRAME_TOJSON_SHOULD_RETURN_DATAFRAME)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1628,11 +1628,11 @@ object SQLConf {
 
   val PYSPARK_DATAFRAME_TOJSON_SHOULD_RETURN_DATAFRAME =
     buildConf("spark.sql.legacy.pyspark.dataframe.toJsonShouldReturnDataFrame")
-    .internal()
-    .doc("If it is set to true, DataFrame.toJSON in PySpark returns DataFrame of JSON string " +
-      "instead of RDD.")
-    .booleanConf
-    .createWithDefault(true)
+      .internal()
+      .doc("If it is set to true, DataFrame.toJSON in PySpark returns DataFrame of JSON string " +
+        "instead of RDD.")
+      .booleanConf
+      .createWithDefault(true)
 }
 
 /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

`DataFrame.toJSON()` in PySpark should return `DataFrame` of JSON string instead of `RDD`. The method in Scala/Java was changed to return `DataFrame` before, but the one in PySpark was not changed at that time.

Also introduced a config `spark.sql.legacy.pyspark.dataframe.toJsonShouldReturnDataFrame` to restore the previous behavior.

## How was this patch tested?

Added a test and existing tests.
