### PR TITLE
[SPARK-26613][SQL] Add another rename table grammar for spark sql

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -105,6 +105,7 @@ statement
         ADD COLUMNS '(' columns=colTypeList ')'                        #addTableColumns
     | ALTER (TABLE | VIEW) from=tableIdentifier
         RENAME TO to=tableIdentifier                                   #renameTable
+    | RENAME (TABLE | VIEW) from=tableIdentifier TO to=tableIdentifier #renameTable
     | ALTER (TABLE | VIEW) tableIdentifier
         SET TBLPROPERTIES tablePropertyList                            #setTableProperties
     | ALTER (TABLE | VIEW) tableIdentifier

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
@@ -636,8 +636,12 @@ class DDLParserSuite extends PlanTest with SharedSQLContext {
   test("alter table/view: rename table/view") {
     val sql_table = "ALTER TABLE table_name RENAME TO new_table_name"
     val sql_view = sql_table.replace("TABLE", "VIEW")
+    val sql_table2 = "RENAME TABLE table_name TO new_table_name"
+    val sql_view2 = sql_table2.replace("TABLE", "VIEW")
     val parsed_table = parser.parsePlan(sql_table)
     val parsed_view = parser.parsePlan(sql_view)
+    val parsed_table2 = parser.parsePlan(sql_table2)
+    val parsed_view2 = parser.parsePlan(sql_view2)
     val expected_table = AlterTableRenameCommand(
       TableIdentifier("table_name"),
       TableIdentifier("new_table_name"),
@@ -646,15 +650,29 @@ class DDLParserSuite extends PlanTest with SharedSQLContext {
       TableIdentifier("table_name"),
       TableIdentifier("new_table_name"),
       isView = true)
+    val expected_table2 = AlterTableRenameCommand(
+      TableIdentifier("table_name"),
+      TableIdentifier("new_table_name"),
+      isView = false)
+    val expected_view2 = AlterTableRenameCommand(
+      TableIdentifier("table_name"),
+      TableIdentifier("new_table_name"),
+      isView = true)
     comparePlans(parsed_table, expected_table)
     comparePlans(parsed_view, expected_view)
+    comparePlans(parsed_table2, expected_table2)
+    comparePlans(parsed_view2, expected_view2)
   }
 
   test("alter table: rename table with database") {
     val query = "ALTER TABLE db1.tbl RENAME TO db1.tbl2"
+    val query2 = "RENAME TABLE db1.tbl TO db1.tbl2"
     val plan = parseAs[AlterTableRenameCommand](query)
+    val plan2 = parseAs[AlterTableRenameCommand](query2)
     assert(plan.oldName == TableIdentifier("tbl", Some("db1")))
     assert(plan.newName == TableIdentifier("tbl2", Some("db1")))
+    assert(plan2.oldName == TableIdentifier("tbl", Some("db1")))
+    assert(plan2.newName == TableIdentifier("tbl2", Some("db1")))
   }
 
   // ALTER TABLE table_name SET TBLPROPERTIES ('comment' = new_comment);

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/PathOptionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/PathOptionSuite.scala
@@ -131,6 +131,12 @@ class PathOptionSuite extends DataSourceTest with SharedSQLContext {
       sql("ALTER TABLE src RENAME TO src2")
       assert(getPathOption("src2").map(makeQualifiedPath) == Some(defaultTablePath("src2")))
     }
+
+    withTable("src", "src2") {
+      sql(s"CREATE TABLE src(i int) USING ${classOf[TestOptionsSource].getCanonicalName}")
+      sql("RENAME TABLE src TO src2")
+      assert(getPathOption("src2").map(makeQualifiedPath) == Some(defaultTablePath("src2")))
+    }
   }
 
   private def getPathOption(tableName: String): Option[String] = {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -718,10 +718,13 @@ class HiveDDLSuite
         assert(!catalog.tableExists(TableIdentifier(newViewName)))
 
         assertErrorForAlterViewOnTable(s"ALTER VIEW $tabName RENAME TO $newViewName")
+        assertErrorForAlterViewOnTable(s"RENAME VIEW $tabName TO $newViewName")
 
         assertErrorForAlterTableOnView(s"ALTER TABLE $oldViewName RENAME TO $newViewName")
+        assertErrorForAlterTableOnView(s"RENAME TABLE $oldViewName TO $newViewName")
 
         assertErrorForAlterViewOnTable(s"ALTER VIEW $tabName SET TBLPROPERTIES ('p' = 'an')")
+
 
         assertErrorForAlterTableOnView(s"ALTER TABLE $oldViewName SET TBLPROPERTIES ('p' = 'an')")
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current version of spark sql contains a rename grammar,like:

`alter table nameA rename to nameB` or `alter view nameA rename to nameB`.

Many database(e.g. mysql,oracle.) provide another grammar,like:

`rename table nameA to nameB`.

I thought maybe spark sql could consider the compatibility.

## How was this patch tested?

This pr have a test case as follows:
`sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala`
`sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala`
`sql/core/src/test/scala/org/apache/spark/sql/sources/PathOptionSuite.scala`
`sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala`
