### PR TITLE
[SPARK-26618][SQL] Make typed Timestamp/Date literals consistent to casting

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1559,7 +1559,7 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
             DateType,
             Some(SQLConf.get.sessionLocalTimeZone)).eval()
           if (castedValue == null) {
-            throw new ParseException(s"Cannot parse the date value: ${value}", ctx)
+            throw new ParseException(s"Cannot parse the date value: $value", ctx)
           } else {
             Literal(castedValue, DateType)
           }
@@ -1569,7 +1569,7 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
             TimestampType,
             Some(SQLConf.get.sessionLocalTimeZone)).eval()
           if (castedValue == null) {
-            throw new ParseException(s"Cannot parse the timestamp value: ${value}", ctx)
+            throw new ParseException(s"Cannot parse the timestamp value: $value", ctx)
           } else {
             Literal(castedValue, TimestampType)
           }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -17,6 +17,8 @@
 package org.apache.spark.sql.catalyst.parser
 
 import java.sql.{Date, Timestamp}
+import java.time.LocalDate
+import java.util.concurrent.TimeUnit
 
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, _}
@@ -679,5 +681,23 @@ class ExpressionParserSuite extends PlanTest {
     assertEqual("first(a)", First('a, Literal(false)).toAggregateExpression())
     assertEqual("last(a ignore nulls)", Last('a, Literal(true)).toAggregateExpression())
     assertEqual("last(a)", Last('a, Literal(false)).toAggregateExpression())
+  }
+
+  test("timestamp literals") {
+    assertEqual("TIMESTAMP '2019-01-14 20:54:00.000'", Literal(new Timestamp(1547495640000L)))
+    assertEqual("TIMESTAMP '1400-01-01 20:54:00.000'", Literal(new Timestamp(-17986680360000L)))
+    assertEqual("timestamp '2000-01-01T00:00:00.123'", Literal(new Timestamp(946681200123L)))
+    assertEqual(
+      sqlCommand = "TIMESTAMP '2019-01-16 20:50:00.567000+01:00'",
+      Literal(new Timestamp(1547668200567L)))
+  }
+
+  test("date literals") {
+    def dateLiteral(year: Int, month: Int, day: Int): Literal = {
+      Literal(new Date(TimeUnit.DAYS.toMillis(LocalDate.of(year, month, day).toEpochDay)))
+    }
+    assertEqual(sqlCommand = "DATE '2019-01-14'", dateLiteral(2019, 1, 14))
+    assertEqual(sqlCommand = "date '2019-01'", dateLiteral(2019, 1, 1))
+    assertEqual(sqlCommand = "Date '2019'", dateLiteral(2019, 1, 1))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -17,12 +17,15 @@
 package org.apache.spark.sql.catalyst.parser
 
 import java.sql.{Date, Timestamp}
+import java.time.LocalDateTime
+import java.util.concurrent.TimeUnit
 
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, _}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{First, Last}
 import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.util.DateTimeTestUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.CalendarInterval
@@ -689,19 +692,34 @@ class ExpressionParserSuite extends PlanTest {
   }
 
   test("timestamp literals") {
-    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
-      assertEval("TIMESTAMP '2019-01-14 20:54:00.000'", 1547499240000000L)
-      assertEval("TIMESTAMP '1400-01-01 20:54:00.000'", -17986676760000000L)
-      assertEval("timestamp '2000-01-01T00:00:00.123'", 946684800123000L)
-      assertEval(
-        sqlCommand = "TIMESTAMP '2019-01-16 20:50:00.567000+01:00'",
-        1547668200567000L)
+    DateTimeTestUtils.outstandingTimezones.foreach { timeZone =>
+      withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> timeZone.getID) {
+        def toMicros(time: LocalDateTime): Long = {
+          val seconds = time.atZone(timeZone.toZoneId).toInstant.getEpochSecond
+          TimeUnit.SECONDS.toMicros(seconds)
+        }
+        assertEval(
+          sqlCommand = "TIMESTAMP '2019-01-14 20:54:00.000'",
+          expect = toMicros(LocalDateTime.of(2019, 1, 14, 20, 54)))
+        assertEval(
+          sqlCommand = "Timestamp '2000-01-01T00:55:00'",
+          expect = toMicros(LocalDateTime.of(2000, 1, 1, 0, 55)))
+        // Parsing of the string does not depend on the SQL config because the string contains
+        // time zone offset already.
+        assertEval(
+          sqlCommand = "TIMESTAMP '2019-01-16 20:50:00.567000+01:00'",
+          expect = 1547668200567000L)
+      }
     }
   }
 
   test("date literals") {
-    assertEval("DATE '2019-01-14'", 17910)
-    assertEval("DATE '2019-01'", 17897)
-    assertEval("DATE '2019'", 17897)
+    DateTimeTestUtils.outstandingTimezonesIds.foreach { timeZone =>
+      withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> timeZone) {
+        assertEval("DATE '2019-01-14'", 17910)
+        assertEval("DATE '2019-01'", 17897)
+        assertEval("DATE '2019'", 17897)
+      }
+    }
   }
 }

--- a/sql/core/src/test/resources/sql-tests/results/literals.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/literals.sql.out
@@ -254,12 +254,10 @@ pattern%	no-pattern\%	pattern\%	pattern\\%
 select '\'', '"', '\n', '\r', '\t', 'Z'
 -- !query 27 schema
 struct<':string,":string,
-:string,
-:string,	:string,Z:string>
+:string,:string,	:string,Z:string>
 -- !query 27 output
 '	"	
-	
-			Z
+				Z
 
 
 -- !query 28

--- a/sql/core/src/test/resources/sql-tests/results/literals.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/literals.sql.out
@@ -254,10 +254,12 @@ pattern%	no-pattern\%	pattern\%	pattern\\%
 select '\'', '"', '\n', '\r', '\t', 'Z'
 -- !query 27 schema
 struct<':string,":string,
-:string,:string,	:string,Z:string>
+:string,
+:string,	:string,Z:string>
 -- !query 27 output
 '	"	
-				Z
+	
+			Z
 
 
 -- !query 28
@@ -291,7 +293,7 @@ struct<>
 -- !query 31 output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-Cannot parse the date value: mar 11 2016(line 1, pos 7)
+Cannot parse the DATE value: mar 11 2016(line 1, pos 7)
 
 == SQL ==
 select date 'mar 11 2016'
@@ -313,7 +315,7 @@ struct<>
 -- !query 33 output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-Cannot parse the timestamp value: 2016-33-11 20:54:00.000(line 1, pos 7)
+Cannot parse the TIMESTAMP value: 2016-33-11 20:54:00.000(line 1, pos 7)
 
 == SQL ==
 select timestamp '2016-33-11 20:54:00.000'

--- a/sql/core/src/test/resources/sql-tests/results/literals.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/literals.sql.out
@@ -291,7 +291,7 @@ struct<>
 -- !query 31 output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-Exception parsing DATE(line 1, pos 7)
+Cannot parse the date value: mar 11 2016(line 1, pos 7)
 
 == SQL ==
 select date 'mar 11 2016'
@@ -313,7 +313,7 @@ struct<>
 -- !query 33 output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-Timestamp format must be yyyy-mm-dd hh:mm:ss[.fffffffff](line 1, pos 7)
+Cannot parse the timestamp value: 2016-33-11 20:54:00.000(line 1, pos 7)
 
 == SQL ==
 select timestamp '2016-33-11 20:54:00.000'


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the PR, I propose to make creation of typed Literals `TIMESTAMP` and `DATE` consistent to the `Cast` expression. More precisely, reusing the `Cast` expression in the type constructors. In this way, it allows:
- To use the same calendar in parsing methods
- To support the same set of timestamp/date patterns

For example, creating timestamp literal:
```sql
SELECT TIMESTAMP '2019-01-14 20:54:00.000'
```
behaves similarly as casting the string literal:
```sql
SELECT CAST('2019-01-14 20:54:00.000' AS TIMESTAMP)
```

## How was this patch tested?

This was tested by `SQLQueryTestSuite` as well as `ExpressionParserSuite`.
