### PR TITLE
[SPARK-26634]Do not allow task of FetchFailureStage commit in OutputCommitCoordinator

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1101,10 +1101,12 @@ private[spark] class DAGScheduler(
     // event.
     stage match {
       case s: ShuffleMapStage =>
-        outputCommitCoordinator.stageStart(stage = s.id, maxPartitionId = s.numPartitions - 1)
+        outputCommitCoordinator.stageStart(
+          stage = s.id, stage.latestInfo.attemptNumber(), maxPartitionId = s.numPartitions - 1)
       case s: ResultStage =>
         outputCommitCoordinator.stageStart(
-          stage = s.id, maxPartitionId = s.rdd.partitions.length - 1)
+          stage = s.id, stage.latestInfo.attemptNumber(),
+          maxPartitionId = s.rdd.partitions.length - 1)
     }
     val taskIdToLocations: Map[Int, Seq[TaskLocation]] = try {
       stage match {

--- a/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
@@ -181,9 +181,9 @@ private[spark] class OutputCommitCoordinator(conf: SparkConf, isDriver: Boolean)
       partition: Int,
       attemptNumber: Int): Boolean = synchronized {
     stageStates.get(stage) match {
-      case Some(state) if attemptInvalidOrFailed(state, stageAttempt, partition, attemptNumber) =>
+      case Some(state) if attemptOutdatedOrFailed(state, stageAttempt, partition, attemptNumber) =>
         logInfo(s"Commit denied for stage=$stage.$stageAttempt, partition=$partition: " +
-          s"task attempt $attemptNumber already marked as failed.")
+          s"task attempt $attemptNumber already outdated or marked as failed.")
         false
       case Some(state) =>
         val existing = state.authorizedCommitters(partition)
@@ -204,7 +204,7 @@ private[spark] class OutputCommitCoordinator(conf: SparkConf, isDriver: Boolean)
     }
   }
 
-  private def attemptInvalidOrFailed(
+  private def attemptOutdatedOrFailed(
       stageState: StageState,
       stageAttempt: Int,
       partition: Int,

--- a/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
@@ -288,7 +288,7 @@ class OutputCommitCoordinatorSuite extends SparkFunSuite with BeforeAndAfter {
     outputCommitCoordinator.taskCompleted(stage, stageAttempt - 1, partition,
       attemptNumber = taskAttempt,
       reason = Success)
-    // attempts of current stage is authorized for committing
+    // attempts of latest retry stage is authorized for committing
     assert(outputCommitCoordinator.canCommit(stage, stageAttempt, partition, taskAttempt))
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

### What's the problem?
canCommit of OutputCommitCoordinator would allow the task of FetchFailure stage commit, which result in TaskCommitDenied for the task(with the same partition as the commit task of the fetchfailure stage) of retry stage. Because of TaskCommitDenied is not counting towards failure,  So the scheduler will constantly scheduling task and got TaskCommitDenied, thus causing the application hangs forever.

### How does it happen?
A detailed explaination for this:
Let's say we have:
stage 0.0 . (stage id 0, attempt 0)
  - task 1.0 (task 1, attempt 0)

Stage 0.1 (stage id 0, attempt 1) started due to fetch failure for instance
  - task 1.0 (task 1, attempt 0) . Equivalent with task 1.0 in stage 0.0

1. Task 1.0 in stage 0.0 is successfuly compeleted after the the launch of Stage 0.1, it will hold the commit lock for partition 1. (Sure, because AuthorizedCommiters for partition 1 is not exist and the attempt is not failed.)
https://github.com/apache/spark/blob/4915cb3adff6f1ec9638b24bfb74f83940ec3d95/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala#L180
https://github.com/apache/spark/blob/4915cb3adff6f1ec9638b24bfb74f83940ec3d95/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala#L183
https://github.com/apache/spark/blob/4915cb3adff6f1ec9638b24bfb74f83940ec3d95/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala#L184
https://github.com/apache/spark/blob/4915cb3adff6f1ec9638b24bfb74f83940ec3d95/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala#L185
https://github.com/apache/spark/blob/4915cb3adff6f1ec9638b24bfb74f83940ec3d95/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala#L186
https://github.com/apache/spark/blob/4915cb3adff6f1ec9638b24bfb74f83940ec3d95/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala#L189
https://github.com/apache/spark/blob/4915cb3adff6f1ec9638b24bfb74f83940ec3d95/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala#L190
2. Task 1.0 in stage 0.1 compeleted, it can not get the commit lock. (Sure, already hold by task 1.0 in stage 0.0)
https://github.com/apache/spark/blob/4915cb3adff6f1ec9638b24bfb74f83940ec3d95/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala#L185
https://github.com/apache/spark/blob/4915cb3adff6f1ec9638b24bfb74f83940ec3d95/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala#L186
https://github.com/apache/spark/blob/4915cb3adff6f1ec9638b24bfb74f83940ec3d95/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala#L191
https://github.com/apache/spark/blob/4915cb3adff6f1ec9638b24bfb74f83940ec3d95/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala#L192
https://github.com/apache/spark/blob/4915cb3adff6f1ec9638b24bfb74f83940ec3d95/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala#L194
3. Because of TaskCommitDenied not counting towards failure, TaskSetManager.handleFailedTask would not abort despite the consecutive failure of task1.x for parition 1 in stage0.1.
https://github.com/apache/spark/blob/4915cb3adff6f1ec9638b24bfb74f83940ec3d95/core/src/main/scala/org/apache/spark/TaskEndReason.scala#L242
https://github.com/apache/spark/blob/4915cb3adff6f1ec9638b24bfb74f83940ec3d95/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala#L907

4. task 1 will be readded to pendingTasks and scheduler will schedule Task1.1 later.
https://github.com/apache/spark/blob/4915cb3adff6f1ec9638b24bfb74f83940ec3d95/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala#L927

5. Task 1.1 in stage 0.1 completed and also can not get the commit lock. and so back and forth

Logs:
```
2019-01-09,08:39:53,676 INFO org.apache.spark.scheduler.TaskSetManager: Starting task 138.0 in stage 5.1 (TID 31437, zjy-hadoop-prc-st159.bj, executor 456, partition 138, PROCESS_LOCAL, 5829 bytes)
2019-01-09,08:43:37,514 INFO org.apache.spark.scheduler.TaskSetManager: Finished task 138.0 in stage 5.0 (TID 30634) in 466958 ms on zjy-hadoop-prc-st1212.bj (executor 1632) (674/5000)
 2019-01-09,08:45:56,284 INFO org.apache.spark.scheduler.OutputCommitCoordinator: Denying attemptNumber=1 to commit for stage=5, partition=138; existingCommitter = 0
2019-01-09,08:45:57,372 WARN org.apache.spark.scheduler.TaskSetManager: Lost task 138.0 in stage 5.1 (TID 31437, zjy-hadoop-prc-st159.bj, executor 456): TaskCommitDenied (Driver denied task commit) for job: 5, partition: 138, attemptNumber: 1
166483 2019-01-09,08:45:57,373 INFO org.apache.spark.scheduler.OutputCommitCoordinator: Task was denied committing, stage: 5, partition: 138, attempt number: 0, attempt number(counting failed stage): 1
```
### How does this PR fix?

This PR will forbidden task of failed stage commit in the term of the new stage and thus solve the problem.

## How was this patch tested?

unittest

Please review http://spark.apache.org/contributing.html before opening a pull request.
