### PR TITLE
[SPARK-26637][SQL] Makes GetArrayItem nullability more precise

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
@@ -238,9 +238,9 @@ case class GetArrayItem(child: Expression, ordinal: Expression)
     child match {
       case CreateArray(ar) if intOrdinal < ar.length =>
         ar(intOrdinal).nullable
-      case GetArrayStructFields(CreateArray(ar), _, _, _, containsNull)
-          if intOrdinal < ar.length =>
-        containsNull
+      case GetArrayStructFields(CreateArray(elements), field, _, _, _)
+          if intOrdinal < elements.length =>
+        elements(intOrdinal).nullable || field.nullable
       case _ =>
         true
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ComplexTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ComplexTypeSuite.scala
@@ -74,18 +74,20 @@ class ComplexTypeSuite extends SparkFunSuite with ExpressionEvalHelper {
     val f2 = StructField("b", IntegerType, nullable = true)
     val structType = StructType(f1 :: f2 :: Nil)
     val c = AttributeReference("c", structType, nullable = false)()
-    val stArray1 = GetArrayStructFields(CreateArray(c :: Nil), f1, 0, 2, containsNull = f1.nullable)
+    val inputArray1 = CreateArray(c :: Nil)
+    val inputArray1ContainsNull = c.nullable
+    val stArray1 = GetArrayStructFields(inputArray1, f1, 0, 2, inputArray1ContainsNull)
     assert(!GetArrayItem(stArray1, Literal(0)).nullable)
-    val stArray2 = GetArrayStructFields(CreateArray(c :: Nil), f2, 1, 2, containsNull = f2.nullable)
+    val stArray2 = GetArrayStructFields(inputArray1, f2, 1, 2, inputArray1ContainsNull)
     assert(GetArrayItem(stArray2, Literal(0)).nullable)
 
     val d = AttributeReference("d", structType, nullable = true)()
-    val stArray3 = GetArrayStructFields(CreateArray(c :: d :: Nil), f1, 0, 2,
-      containsNull = f1.nullable)
+    val inputArray2 = CreateArray(c :: d :: Nil)
+    val inputArray2ContainsNull = c.nullable || d.nullable
+    val stArray3 = GetArrayStructFields(inputArray2, f1, 0, 2, inputArray2ContainsNull)
     assert(!GetArrayItem(stArray3, Literal(0)).nullable)
     assert(GetArrayItem(stArray3, Literal(1)).nullable)
-    val stArray4 = GetArrayStructFields(CreateArray(c :: d :: Nil), f2, 1, 2,
-      containsNull = f2.nullable)
+    val stArray4 = GetArrayStructFields(inputArray2, f2, 1, 2, inputArray2ContainsNull)
     assert(GetArrayItem(stArray4, Literal(0)).nullable)
     assert(GetArrayItem(stArray4, Literal(1)).nullable)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ComplexTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ComplexTypeSuite.scala
@@ -74,16 +74,18 @@ class ComplexTypeSuite extends SparkFunSuite with ExpressionEvalHelper {
     val f2 = StructField("b", IntegerType, nullable = true)
     val structType = StructType(f1 :: f2 :: Nil)
     val c = AttributeReference("c", structType, nullable = false)()
-    val stArray1 = GetArrayStructFields(CreateArray(c :: Nil), f1, 0, 2, containsNull = false)
+    val stArray1 = GetArrayStructFields(CreateArray(c :: Nil), f1, 0, 2, containsNull = f1.nullable)
     assert(!GetArrayItem(stArray1, Literal(0)).nullable)
-    val stArray2 = GetArrayStructFields(CreateArray(c :: Nil), f1, 1, 2, containsNull = true)
+    val stArray2 = GetArrayStructFields(CreateArray(c :: Nil), f2, 1, 2, containsNull = f2.nullable)
     assert(GetArrayItem(stArray2, Literal(0)).nullable)
 
     val d = AttributeReference("d", structType, nullable = true)()
-    val stArray3 = GetArrayStructFields(CreateArray(c :: d :: Nil), f1, 0, 2, containsNull = false)
+    val stArray3 = GetArrayStructFields(CreateArray(c :: d :: Nil), f1, 0, 2,
+      containsNull = f1.nullable)
     assert(!GetArrayItem(stArray3, Literal(0)).nullable)
-    assert(!GetArrayItem(stArray3, Literal(1)).nullable)
-    val stArray4 = GetArrayStructFields(CreateArray(c :: d :: Nil), f1, 1, 2, containsNull = true)
+    assert(GetArrayItem(stArray3, Literal(1)).nullable)
+    val stArray4 = GetArrayStructFields(CreateArray(c :: d :: Nil), f2, 1, 2,
+      containsNull = f2.nullable)
     assert(GetArrayItem(stArray4, Literal(0)).nullable)
     assert(GetArrayItem(stArray4, Literal(1)).nullable)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
In the master, GetArrayItem nullable is always true;
https://github.com/apache/spark/blob/cf133e611020ed178f90358464a1b88cdd9b7889/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala#L236

But, If input array size is constant and ordinal is foldable, we could make GetArrayItem nullability more precise. This pr added code to make `GetArrayItem` nullability more precise.

## How was this patch tested?
Added tests in `ComplexTypeSuite`.