### PR TITLE
[SPARK-26641][Spark Core] Seperate capacity configurations of different event queue

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
@@ -46,8 +46,9 @@ private class AsyncEventQueue(
 
   // Cap the capacity of the queue so we get an explicit error (rather than an OOM exception) if
   // it's perpetually being added to more quickly than it's being drained.
+  val defaultQueueCapacity = conf.get(LISTENER_BUS_EVENT_QUEUE_CAPACITY)
   private val eventQueue = new LinkedBlockingQueue[SparkListenerEvent](
-    conf.get(LISTENER_BUS_EVENT_QUEUE_CAPACITY))
+    conf.getInt("spark.scheduler.listenerbus.eventqueue.$name.capacity", defaultQueueCapacity))
 
   // Keep the event count separately, so that waitUntilEmpty() can be implemented properly;
   // this allows that method to return only when the events in the queue have been fully

--- a/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
@@ -48,7 +48,7 @@ private class AsyncEventQueue(
   // it's perpetually being added to more quickly than it's being drained.
   val defaultQueueCapacity = conf.get(LISTENER_BUS_EVENT_QUEUE_CAPACITY)
   private val eventQueue = new LinkedBlockingQueue[SparkListenerEvent](
-    conf.getInt("spark.scheduler.listenerbus.eventqueue.$name.capacity", defaultQueueCapacity))
+    conf.getInt(s"spark.scheduler.listenerbus.eventqueue.$name.capacity", defaultQueueCapacity))
 
   // Keep the event count separately, so that waitUntilEmpty() can be implemented properly;
   // this allows that method to return only when the events in the queue have been fully


### PR DESCRIPTION
## What changes were proposed in this pull request?

I always maintance a spark on yarn cluster on line.I always found the error:

`Dropping event from queue eventLog. This likely means one of the listeners is too slow and cannot keep up with the rate at which tasks are being started by the scheduler.`

Spark event log write to a hdfs cluster on line, and this hdfs cluster support write a few TB every day.The performance issuse of write frequently, lead to the `EventLoggingListener` exists the bottleneck.

But other event queue appear the problem rarely,so I think seperate the configurations of different event queue.

For spark user, this pr will provide four dynamic config:
`spark.scheduler.listenerbus.eventqueue.shared.capacity`
`spark.scheduler.listenerbus.eventqueue.appStatus.capacity`
`spark.scheduler.listenerbus.eventqueue.executorManagement.capacity`
`spark.scheduler.listenerbus.eventqueue.eventLog.capacity`

## How was this patch tested?



Please review http://spark.apache.org/contributing.html before opening a pull request.
