### PR TITLE
[SPARK-26655] [SS] Support multiple aggregates in append mode

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -96,7 +96,7 @@ object UnsupportedOperationChecker {
     // Disallow some output mode
     outputMode match {
       case InternalOutputModes.Append if aggregates.nonEmpty =>
-        aggregates.foreach(aggregate => {
+        aggregates.foreach { aggregate =>
           // Find any attributes that are associated with an eventTime watermark.
           val watermarkAttributes = aggregate.groupingExpressions.collect {
             case a: Attribute if a.metadata.contains(EventTimeWatermark.delayKey) => a
@@ -109,7 +109,7 @@ object UnsupportedOperationChecker {
               s"$outputMode output mode not supported when there are streaming aggregations on " +
                 s"streaming DataFrames/DataSets without watermark")(plan)
           }
-        })
+        }
 
       case InternalOutputModes.Complete if aggregates.isEmpty =>
         throwError(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -101,9 +101,15 @@ class UnsupportedOperationsSuite extends SparkFunSuite {
     Update)
 
   assertNotSupportedInStreamingPlan(
-    "aggregate - multiple streaming aggregations",
+    "aggregate - multiple streaming aggregations in update mode",
     Aggregate(Nil, aggExprs("c"), Aggregate(Nil, aggExprs("d"), streamRelation)),
     outputMode = Update,
+    expectedMsgs = Seq("multiple streaming aggregations"))
+
+  assertNotSupportedInStreamingPlan(
+    "aggregate - multiple streaming aggregations in complete mode",
+    Aggregate(Nil, aggExprs("c"), Aggregate(Nil, aggExprs("d"), streamRelation)),
+    outputMode = Complete,
     expectedMsgs = Seq("multiple streaming aggregations"))
 
   assertSupportedInStreamingPlan(
@@ -124,6 +130,32 @@ class UnsupportedOperationsSuite extends SparkFunSuite {
   assertNotSupportedInStreamingPlan(
     "aggregate - streaming aggregations without watermark in append mode",
     Aggregate(Nil, aggExprs("d"), streamRelation),
+    outputMode = Append,
+    expectedMsgs = Seq("streaming aggregations", "without watermark"))
+
+  assertSupportedInStreamingPlan(
+    "aggregate - multiple streaming aggregations in append mode with watermark",
+    Aggregate(Seq(attributeWithWatermark), aggExprs("c"),
+      Aggregate(Seq(attributeWithWatermark), aggExprs("d"), streamRelation)),
+    outputMode = Append)
+
+  assertNotSupportedInStreamingPlan(
+    "aggregate - multiple streaming aggregations without watermark in append mode",
+    Aggregate(Nil, aggExprs("c"), Aggregate(Nil, aggExprs("d"), streamRelation)),
+    outputMode = Append,
+    expectedMsgs = Seq("streaming aggregations", "without watermark"))
+
+  assertNotSupportedInStreamingPlan(
+    "aggregate - multiple streaming aggregations, watermark for second aggregate in append mode",
+    Aggregate(Nil, aggExprs("c"),
+      Aggregate(Seq(attributeWithWatermark), aggExprs("d"), streamRelation)),
+    outputMode = Append,
+    expectedMsgs = Seq("streaming aggregations", "without watermark"))
+
+  assertNotSupportedInStreamingPlan(
+    "aggregate - multiple streaming aggregations, watermark for first aggregate in append mode",
+    Aggregate(Seq(attributeWithWatermark), aggExprs("c"),
+      Aggregate(Nil, aggExprs("d"), streamRelation)),
     outputMode = Append,
     expectedMsgs = Seq("streaming aggregations", "without watermark"))
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/CommitLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/CommitLog.scala
@@ -77,7 +77,8 @@ object CommitLog {
 }
 
 
-case class CommitMetadata(nextBatchWatermarkMs: Long = 0) {
+case class CommitMetadata(nextBatchWatermarkMs: Long = 0,
+                          operatorWatermarks: Map[Long, Long] = Map.empty) {
   def json: String = Serialization.write(this)(CommitMetadata.format)
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
@@ -85,7 +85,7 @@ case class FlatMapGroupsWithStateExec(
         true  // Always run batches to process timeouts
       case EventTimeTimeout =>
         // Process another non-data batch only if the watermark has changed in this executed plan
-        eventTimeWatermark.isDefined && newMetadata.batchWatermarkMs > eventTimeWatermark.get
+        eventTimeWatermark.isDefined && getWatermark(newMetadata) > eventTimeWatermark.get
       case _ =>
         false
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/OffsetSeq.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/OffsetSeq.scala
@@ -77,11 +77,13 @@ object OffsetSeq {
  * @param batchTimestampMs: The current batch processing timestamp.
  * Time unit: milliseconds
  * @param conf: Additional conf_s to be persisted across batches, e.g. number of shuffle partitions.
+ * @param operatorWatermarks: the watermarks at the individual stateful operators.
  */
 case class OffsetSeqMetadata(
     batchWatermarkMs: Long = 0,
     batchTimestampMs: Long = 0,
-    conf: Map[String, String] = Map.empty) {
+    conf: Map[String, String] = Map.empty,
+    operatorWatermarks: Map[Long, Long] = Map.empty) {
   def json: String = Serialization.write(this)(OffsetSeqMetadata.format)
 }
 
@@ -114,9 +116,10 @@ object OffsetSeqMetadata extends Logging {
   def apply(
       batchWatermarkMs: Long,
       batchTimestampMs: Long,
-      sessionConf: RuntimeConfig): OffsetSeqMetadata = {
+      sessionConf: RuntimeConfig,
+      operatorWatermarks: Map[Long, Long]): OffsetSeqMetadata = {
     val confs = relevantSQLConfs.map { conf => conf.key -> sessionConf.get(conf.key) }.toMap
-    OffsetSeqMetadata(batchWatermarkMs, batchTimestampMs, confs)
+    OffsetSeqMetadata(batchWatermarkMs, batchTimestampMs, confs, operatorWatermarks)
   }
 
   /** Set the SparkSession configuration with the values in the metadata */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -134,7 +134,8 @@ abstract class StreamExecution(
 
   /** Metadata associated with the offset seq of a batch in the query. */
   protected var offsetSeqMetadata = OffsetSeqMetadata(
-    batchWatermarkMs = 0, batchTimestampMs = 0, sparkSession.conf)
+    batchWatermarkMs = 0, batchTimestampMs = 0, sessionConf = sparkSession.conf,
+    operatorWatermarks = Map.empty)
 
   /**
    * A map of current watermarks, keyed by the position of the watermark operator in the
@@ -277,7 +278,8 @@ abstract class StreamExecution(
       // Disable cost-based join optimization as we do not want stateful operations to be rearranged
       sparkSessionForStream.conf.set(SQLConf.CBO_ENABLED.key, "false")
       offsetSeqMetadata = OffsetSeqMetadata(
-        batchWatermarkMs = 0, batchTimestampMs = 0, sparkSessionForStream.conf)
+        batchWatermarkMs = 0, batchTimestampMs = 0, sessionConf = sparkSessionForStream.conf,
+        operatorWatermarks = Map.empty)
 
       if (state.compareAndSet(INITIALIZING, ACTIVE)) {
         // Unblock `awaitInitialization`

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
@@ -193,7 +193,7 @@ case class StreamingSymmetricHashJoinExec(
 
     // Latest watermark value is more than that used in this previous executed plan
     val watermarkHasChanged =
-      eventTimeWatermark.isDefined && newMetadata.batchWatermarkMs > eventTimeWatermark.get
+      eventTimeWatermark.isDefined &&  getWatermark(newMetadata) > eventTimeWatermark.get
 
     watermarkUsedForStateCleanup && watermarkHasChanged
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
@@ -193,7 +193,7 @@ case class StreamingSymmetricHashJoinExec(
 
     // Latest watermark value is more than that used in this previous executed plan
     val watermarkHasChanged =
-      eventTimeWatermark.isDefined &&  getWatermark(newMetadata) > eventTimeWatermark.get
+      eventTimeWatermark.isDefined && getWatermark(newMetadata) > eventTimeWatermark.get
 
     watermarkUsedForStateCleanup && watermarkHasChanged
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/WatermarkTracker.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/WatermarkTracker.scala
@@ -125,7 +125,7 @@ case class WatermarkTracker(policy: MultipleWatermarkPolicy) extends Logging {
       case s: StatefulOperator => s
     }
 
-    statefulOperators.foreach(statefulOperator => {
+    statefulOperators.foreach { statefulOperator =>
       // find the first event time child node(s)
       val eventTimeExecs = statefulOperator match {
         case op: UnaryExecNode =>
@@ -143,7 +143,7 @@ case class WatermarkTracker(policy: MultipleWatermarkPolicy) extends Logging {
       }
 
       // compute watermark for the stateful operator node
-      statefulOperator.stateInfo.foreach(state => {
+      statefulOperator.stateInfo.foreach { state =>
         if (eventTimeExecs.nonEmpty) {
           updateWaterMarkMap(eventTimeExecs,
             statefulOperatorToEventTimeMap.getOrElseUpdate(state.operatorId,
@@ -154,8 +154,8 @@ case class WatermarkTracker(policy: MultipleWatermarkPolicy) extends Logging {
             statefulOperatorToWatermark.put(state.operatorId, newWatermarkMs)
           }
         }
-      })
-    })
+      }
+    }
 
 
     // Update the global watermark to the minimum of all watermark nodes.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/OffsetSeqLogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/OffsetSeqLogSuite.scala
@@ -55,9 +55,15 @@ class OffsetSeqLogSuite extends SparkFunSuite with SharedSQLContext {
     assert(OffsetSeqMetadata(0, 2, getConfWith(shufflePartitions = 3)) ===
       OffsetSeqMetadata(s"""{"batchTimestampMs":2,"conf": {"$key":3}}"""))
 
-    // All set
+    // Three set
     assert(OffsetSeqMetadata(1, 2, getConfWith(shufflePartitions = 3)) ===
       OffsetSeqMetadata(s"""{"batchWatermarkMs":1,"batchTimestampMs":2,"conf": {"$key":3}}"""))
+
+    // All set
+    assert(OffsetSeqMetadata(1, 2, getConfWith(shufflePartitions = 3), Map(0L -> 1000L)) ===
+      OffsetSeqMetadata(
+        s"""{"batchWatermarkMs":1,"batchTimestampMs":2,"conf": {"$key":3},
+           |"operatorWatermarks": {"0": 1000}}""".stripMargin))
 
     // Drop unknown fields
     assert(OffsetSeqMetadata(1, 2, getConfWith(shufflePartitions = 3)) ===

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
@@ -364,8 +364,8 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Matche
                                 // window2 [15 - 20] -> (1,1), (2,2) is retained in state2
                                 // since watermark of group2 is at 10
         CheckNewAnswer(),
-        assertNumTotalStateRows(3), // {[25-30],25} -> 1 in state1 and
-                                    // {[30-35],1} -> 1, {[30-35],1} -> 1 {[30-35],2} -> 2 in state2
+        assertNumTotalStateRows(3), // [25 - 30] -> (25,1) in state1 and
+                                    // [15 - 20] -> (1,1), (2,2) in state2
         AddData(inputData, 26, 26, 27),
         CheckNewAnswer(),
         AddData(inputData, 40), // watermark -> group1 = 30 , group2 = 25
@@ -422,7 +422,7 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Matche
                                 // window1 [40 - 45] -> (40,1) is emitted down
                                 // window1 [55 - 60] -> (55, 1) is retained in state1
                                 // window2 [30 - 35] -> (1,2), (2,1) is emitted out
-                                // window2 [40 - 45] -> (40, 1) is retained in state2
+                                // window2 [40 - 45] -> (1, 1) is retained in state2
         CheckAnswer((30, 1, 2), (30, 2, 1))
       )
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch proposes to add support for multiple aggregates in append mode. In
append mode, the aggregates are emitted only after the watermark passes
the threshold (e.g. the window boundary) and the emitted value is not
affected by further late data. This allows to chain multiple aggregates
in 'Append' output mode without worrying about retractions etc.

However the current event time watermarks in structured streaming are
tracked at a global level and this does not work when aggregates are
chained. The downstream watermarks usually lags the ones before and the
global (min or max) watermarks will not let the stages make progress
independently.

The patch tracks the watermarks at each (stateful)
operator so that the aggregate outputs are generated when the watermark
passes the thresholds at the corresponding stateful operator. The values
are also saved into the commit/offset logs (similar to global watermark)

Each aggregate should have a corresponding watermark defined while
creating the query (E.g. via withWatermark) and this is used to
track the progress of event time corresponding to the stateful operator.


## How was this patch tested?

New and existing unit tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
