### PR TITLE
[SPARK-26660]Add warning logs when broadcasting large task binary

### DIFF
--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
@@ -236,7 +236,9 @@ private[spark] class TorrentBroadcast[T: ClassTag](obj: T, id: Long)
               throw new SparkException(s"Failed to get locally stored broadcast data: $broadcastId")
             }
           case None =>
-            logInfo("Started reading broadcast variable " + id)
+            val estimatedTotalSize = Utils.bytesToString(numBlocks * blockSize)
+            logInfo(s"Started reading broadcast variable $id with $numBlocks pieces " +
+              s"(estimated total size $estimatedTotalSize)")
             val startTimeMs = System.currentTimeMillis()
             val blocks = readBlocks()
             logInfo("Reading broadcast variable " + id + " took" + Utils.getUsedTimeMs(startTimeMs))

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1082,4 +1082,11 @@ package object config {
     .stringConf
     .toSequence
     .createWithDefault(Nil)
+
+  private[spark] val SUBMIT_TASK_BINARY_WANRING_THRESHOLD =
+    ConfigBuilder("spark.submit.taskBinaryWarningThreshold")
+    .doc("Warning size Threshold for taskBinary to broadcast when submitting task, " +
+      "large task binary size may indicate unexpected data in RDD closure or potential risk.")
+      .bytesConf(ByteUnit.MiB)
+      .createWithDefaultString("100m")
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1082,11 +1082,4 @@ package object config {
     .stringConf
     .toSequence
     .createWithDefault(Nil)
-
-  private[spark] val SUBMIT_TASK_BINARY_WANRING_THRESHOLD =
-    ConfigBuilder("spark.submit.taskBinaryWarningThreshold")
-    .doc("Warning size Threshold for taskBinary to broadcast when submitting task, " +
-      "large task binary size may indicate unexpected data in RDD closure or potential risk.")
-      .bytesConf(ByteUnit.MiB)
-      .createWithDefaultString("100m")
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1162,11 +1162,9 @@ private[spark] class DAGScheduler(
         partitions = stage.rdd.partitions
       }
 
-      val taskBinarySizeKb = Utils.byteStringAsKb(s"${taskBinaryBytes.length}b")
-
-      if (taskBinarySizeKb > TaskSetManager.TASK_SIZE_TO_WARN_KB) {
+      if (taskBinaryBytes.length * 1000 > TaskSetManager.TASK_SIZE_TO_WARN_KB) {
         logWarning(s"Broadcasting large task binary with size " +
-          s"${Utils.bytesToString(taskBinarySizeKb * 1000)}")
+          s"${Utils.bytesToString(taskBinaryBytes.length)}")
       }
       taskBinary = sc.broadcast(taskBinaryBytes)
     } catch {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, some ML library may generate large ml model, which may be referenced in the task closure, so driver will broadcasting large task binary, and executor may not able to deserialize it and result in OOM failures(for instance, executor's memory is not enough). This problem not only affects apps using ml library, some user specified closure or function which refers large data may also have this problem.

In order to facilitate the debuging of memory problem caused by large taskBinary broadcast, we can add same warning logs for it.

This PR will add some warning logs on the driver side when broadcasting a large task binary, and it also included some minor log changes in the reading of broadcast.

## How was this patch tested?
NA-Just log changes.

Please review http://spark.apache.org/contributing.html before opening a pull request.
