### PR TITLE
[SPARK-26661][SQL] Show actual class name of the writing command in CTAS explain

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateHiveTableAsSelectCommand.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateHiveTableAsSelectCommand.scala
@@ -84,14 +84,14 @@ trait CreateHiveTableAsSelectBase extends DataWritingCommand {
     tableDesc: CatalogTable,
     tableExists: Boolean): DataWritingCommand
 
-  // A subclass should override this with the Class of the concrete type expected to be
+  // A subclass should override this with the Class name of the concrete type expected to be
   // returned from `getWritingCommand`.
-  def writingCommandClass: Class[_]
+  def writingCommandClassName: String
 
   override def argString(maxFields: Int): String = {
     s"[Database: ${tableDesc.database}, " +
     s"TableName: ${tableDesc.identifier.table}, " +
-    s"${Utils.getSimpleName(writingCommandClass)}]"
+    s"${writingCommandClassName}]"
   }
 }
 
@@ -124,7 +124,8 @@ case class CreateHiveTableAsSelectCommand(
       outputColumnNames = outputColumnNames)
   }
 
-  override def writingCommandClass: Class[_] = classOf[InsertIntoHiveTable]
+  override def writingCommandClassName: String =
+    Utils.getSimpleName(classOf[InsertIntoHiveTable])
 }
 
 /**
@@ -170,5 +171,6 @@ case class OptimizedCreateHiveTableAsSelectCommand(
       query.output.map(_.name))
   }
 
-  override def writingCommandClass: Class[_] = classOf[InsertIntoHadoopFsRelationCommand]
+  override def writingCommandClassName: String =
+    Utils.getSimpleName(classOf[InsertIntoHadoopFsRelationCommand])
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateHiveTableAsSelectCommand.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateHiveTableAsSelectCommand.scala
@@ -87,7 +87,7 @@ trait CreateHiveTableAsSelectBase extends DataWritingCommand {
   def writingCommandClass: Class[_]
 
   override def argString(maxFields: Int): String = {
-    s"[Database:${tableDesc.database}, " +
+    s"[Database: ${tableDesc.database}, " +
     s"TableName: ${tableDesc.identifier.table}, " +
     s"${Utils.getSimpleName(writingCommandClass)}]"
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateHiveTableAsSelectCommand.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateHiveTableAsSelectCommand.scala
@@ -84,6 +84,8 @@ trait CreateHiveTableAsSelectBase extends DataWritingCommand {
     tableDesc: CatalogTable,
     tableExists: Boolean): DataWritingCommand
 
+  // A subclass should override this with the Class of the concrete type expected to be
+  // returned from `getWritingCommand`.
   def writingCommandClass: Class[_]
 
   override def argString(maxFields: Int): String = {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveExplainSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveExplainSuite.scala
@@ -20,10 +20,13 @@ package org.apache.spark.sql.hive.execution
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.parser.ParseException
+import org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelationCommand
 import org.apache.spark.sql.hive.HiveUtils
+import org.apache.spark.sql.hive.execution._
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestUtils
+import org.apache.spark.util.Utils
 
 /**
  * A set of tests that validates support for Hive Explain command.
@@ -186,23 +189,21 @@ class HiveExplainSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
 
   test("SPARK-26661: Show actual class name of the writing command in CTAS explain") {
     Seq(true, false).foreach { convertCTAS =>
-
       withSQLConf(
           HiveUtils.CONVERT_METASTORE_CTAS.key -> convertCTAS.toString,
           HiveUtils.CONVERT_METASTORE_PARQUET.key -> convertCTAS.toString) {
 
-        val tableName = "tab1"
-        checkKeywordsExist(
-          df = sql(s"EXPLAIN CREATE TABLE $tableName STORED AS PARQUET AS SELECT * FROM range(2)"),
-          (if (convertCTAS) {
-            Seq(
-              "Execute OptimizedCreateHiveTableAsSelectCommand",
-              "InsertIntoHadoopFsRelationCommand")
-          } else {
-            Seq(
-              "Execute CreateHiveTableAsSelectCommand",
-              "InsertIntoHiveTable")
-          }): _*)
+        val df = sql(s"EXPLAIN CREATE TABLE tab1 STORED AS PARQUET AS SELECT * FROM range(2)")
+        val keywords = if (convertCTAS) {
+          Seq(
+            s"Execute ${Utils.getSimpleName(classOf[OptimizedCreateHiveTableAsSelectCommand])}",
+            Utils.getSimpleName(classOf[InsertIntoHadoopFsRelationCommand]))
+        } else {
+          Seq(
+            s"Execute ${Utils.getSimpleName(classOf[CreateHiveTableAsSelectCommand])}",
+            Utils.getSimpleName(classOf[InsertIntoHiveTable]))
+        }
+        checkKeywordsExist(df, keywords: _*)
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The explain output of the Hive CTAS command, regardless of whether it's actually writing via Hive's SerDe or converted into using Spark's data source, would always show that it's using `InsertIntoHiveTable` because it's hardcoded.

e.g.
```
Execute OptimizedCreateHiveTableAsSelectCommand [Database:default, TableName: foo, InsertIntoHiveTable]
```
This CTAS is converted into using Spark's data source, but it still says `InsertIntoHiveTable` in the explain output.

It's better to show the actual class name of the writing command used. For the example above, it'd be:
```
Execute OptimizedCreateHiveTableAsSelectCommand [Database:default, TableName: foo, InsertIntoHadoopFsRelationCommand]
```

## How was this patch tested?

Added test case in `HiveExplainSuite`