### PR TITLE
[SPARK-21213][SQL][FOLLOWUP] Improve partition statistics in AnalyzePartitionCommand

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzePartitionCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzePartitionCommand.scala
@@ -110,7 +110,7 @@ case class AnalyzePartitionCommand(
       val newTotalSize = CommandUtils.calculateLocationSize(
         sessionState, tableMeta.identifier, p.storage.locationUri)
       val newRowCount = rowCounts.get(p.spec)
-      val newStats = CommandUtils.compareAndGetNewStats(tableMeta.stats, newTotalSize, newRowCount)
+      val newStats = CommandUtils.compareAndGetNewStats(p.stats, newTotalSize, newRowCount)
       newStats.map(_ => p.copy(stats = newStats))
     }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -1040,6 +1040,11 @@ private[hive] object HiveClientImpl {
   /**
    * Reads statistics from Hive.
    * Note that this statistics could be overridden by Spark's statistics if that's available.
+   *
+   * Table level statistics would be overridden by Spark's in
+   * [[org.apache.spark.sql.hive.HiveExternalCatalog.restoreTableMetadata]]
+   * Partition level statistics would be overridden by Spark's in
+   * [[org.apache.spark.sql.hive.HiveExternalCatalog.restorePartitionMetadata]]
    */
   private def readHiveStats(properties: Map[String, String]): Option[CatalogStatistics] = {
     val totalSize = properties.get(StatsSetupConst.TOTAL_SIZE).map(BigInt(_))


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr proposes to improve partition statistics in `AnalyzePartitionCommand`:

1.  Restore Spark partition statistics in `HiveExternalCatalog.listPartitions` and `HiveExternalCatalog.listPartitionsByFilter`. 
2.  Compare with old partition stats instead of old table stats in `AnalyzePartitionCommand`.

Thus partitions listed in `AnalyzePartitionCommand` would contain Spark stats and would not update HiveMetaStore if stats not changed.
https://github.com/apache/spark/blob/6d9c54b62cee6fdf396f507caf7eb7f2e3f35b0a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzePartitionCommand.scala#L87
## How was this patch tested?
Modified existing tests.