### PR TITLE
[SPARK-26662][CORE] Dispose off-heap memory when MemoryStore is cleared

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
@@ -405,6 +405,14 @@ private[spark] class MemoryStore(
 
   def clear(): Unit = memoryManager.synchronized {
     entries.synchronized {
+      val iterator = entries.values().iterator()
+      while (iterator.hasNext) {
+        val entry = iterator.next()
+        entry match {
+          case SerializedMemoryEntry(buffer, _, _) => buffer.dispose()
+          case _ =>
+        }
+      }
       entries.clear()
     }
     onHeapUnrollMemoryMap.clear()


### PR DESCRIPTION
## What changes were proposed in this pull request?

If buffer in `MemoryStore`'s `SerializedMemoryEntry` is allocated off-heap, current `clear()` action doesn't dispose them. These off-heap memory, though, will be freed when process ends, but for application that need to stop and restart `SparkContext` serveral times, this may cause some kind of off-heap memory leak. 
This PR try to dispose off-heap memory by itself when clearing `MemoryStore`.

## How was this patch tested?

Tested manually by running code written myself, while observing system resources monitor to verify off-heap memory allocation and free behavior.
I have tried to add a unit test, but it's hard to find a way counting off-heap memory allocated by Unsafe API. 
