### PR TITLE
[SPARK-26667][DOC] Add `Scanning Input Table` to Performance Tuning Guide

### DIFF
--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -42,13 +42,13 @@ Configuration of in-memory caching can be done using the `setConf` method on `Sp
 
 ## Scanning Input Table
 
-Spark SQL can increase the speed while scanning tables via tuning Hadoop configurations.
+Spark SQL can increase the speed while scanning Hive tables via tuning Hadoop configurations.
 For example, setting the max/min size of input splits.
 
 When we use `TextInputFormat`, we can set the input format to `CombineTextInputFormat`. So it will
-combine small files automatically when we read a table.
+combine small files automatically when we read a Hive table.
 
-It can be quite useful especially when scanning a table with a lot of small files.
+It can be quite useful especially when scanning a Hive table with a lot of small files.
 
 <table class="table">
 <tr><th>Property Name</th><th>Default</th><th>Meaning</th></tr>

--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -42,19 +42,19 @@ Configuration of in-memory caching can be done using the `setConf` method on `Sp
 
 ## Scanning Input Table
 
-Spark SQL can increase the speed while scanning tables via tuning hadoop configurations.
-For example, setting the Max/Min size of input splits.
+Spark SQL can increase the speed while scanning tables via tuning Hadoop configurations.
+For example, setting the max/min size of input splits.
 
-When we use `TextInputFormat`, we can change the input format to `CombineTextInputFormat` so as to
-combine small files automatically while reading a table.
+When we use `TextInputFormat`, we can set the input format to `CombineTextInputFormat`. So it will
+combine small files automatically when we read a table.
 
-It can be quite useful especially when we scanning a table with a lot of small files.
+It can be quite useful especially when scanning a table with a lot of small files.
 
 <table class="table">
 <tr><th>Property Name</th><th>Default</th><th>Meaning</th></tr>
 <tr>
   <td><code>mapreduce.input.fileinputformat.split.maxsize</code></td>
-  <td>as you set in your hadoop conf</td>
+  <td>as you set in your Hadoop conf</td>
   <td>
     The maximum size chunk that map input should be split into when using CombineFileInputFormat.
     By decreasing this value below the size of blocks in HDFS, you can increase the number of input tasks in your job.
@@ -64,7 +64,7 @@ It can be quite useful especially when we scanning a table with a lot of small f
 </tr>
 <tr>
   <td><code>mapreduce.input.fileinputformat.split.minsize</code></td>
-  <td>as you set in your hadoop conf</td>
+  <td>as you set in your Hadoop conf</td>
   <td>
     The minimum size chunk that map input should be split into.
     By increasing this value beyond the size of blocks in HDFS, you can decrease the number of input tasks in your job.

--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -40,6 +40,41 @@ Configuration of in-memory caching can be done using the `setConf` method on `Sp
 
 </table>
 
+## Scanning Input Table
+
+Spark SQL can increase the speed while scanning tables via tuning hadoop configurations.
+For example, setting the Max/Min size of input splits.
+
+When we use `TextInputFormat`, we can change the input format to `CombineTextInputFormat` so as to
+combine small files automatically while reading a table.
+
+It can be quite useful especially when we scanning a table with a lot of small files.
+
+<table class="table">
+<tr><th>Property Name</th><th>Default</th><th>Meaning</th></tr>
+<tr>
+  <td><code>mapreduce.input.fileinputformat.split.maxsize</code></td>
+  <td>as you set in your hadoop conf</td>
+  <td>
+    The maximum size chunk that map input should be split into when using CombineFileInputFormat.
+    By decreasing this value below the size of blocks in HDFS, you can increase the number of input tasks in your job.
+    For example, if we set the value to 1/3 of the size of a block, every split will receive 1/3 records of this block.
+    Thus to set the value to 128MB, you will specify 134217728 as the value for this property.
+  </td>
+</tr>
+<tr>
+  <td><code>mapreduce.input.fileinputformat.split.minsize</code></td>
+  <td>as you set in your hadoop conf</td>
+  <td>
+    The minimum size chunk that map input should be split into.
+    By increasing this value beyond the size of blocks in HDFS, you can decrease the number of input tasks in your job.
+    For example, if we set the value to 3x of the size of a block, every split will receive 3x records from several blocks.
+    Thus to set the value to 128MB, you will specify 134217728 as the value for this property. Note that if you do not set a max split size when using CombineFileInputFormat, your job will only use 1 task (which is probably not what you want)!
+  </td>
+</tr>
+</table>
+
+
 ## Other Configuration Options
 
 The following options can also be used to tune the performance of query execution. It is possible

--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -42,34 +42,27 @@ Configuration of in-memory caching can be done using the `setConf` method on `Sp
 
 ## Scanning Input Table
 
-Spark SQL can increase the speed while scanning Hive tables via tuning Hadoop configurations.
-For example, setting the max/min size of input splits.
-
-When we use `TextInputFormat`, we can set the input format to `CombineTextInputFormat`. So it will
-combine small files automatically when we read a Hive table.
-
-It can be quite useful especially when scanning a Hive table with a lot of small files.
+If a table of `TextInputFormat` contains small files, you can use `CombineTextInputFormat` which 
+will combine small files automatically. Spark will receive fewer tasks and become more efficient 
+while scanning tables.
 
 <table class="table">
 <tr><th>Property Name</th><th>Default</th><th>Meaning</th></tr>
 <tr>
   <td><code>mapreduce.input.fileinputformat.split.maxsize</code></td>
-  <td>as you set in your Hadoop conf</td>
+  <td>Long.MAX_VALUE</td>
   <td>
     The maximum size chunk that map input should be split into when using CombineFileInputFormat.
+    If this is not configured, a single split will be generated per node.
     By decreasing this value below the size of blocks in HDFS, you can increase the number of input tasks in your job.
-    For example, if we set the value to 1/3 of the size of a block, every split will receive 1/3 records of this block.
-    Thus to set the value to 128MB, you will specify 134217728 as the value for this property.
   </td>
 </tr>
 <tr>
   <td><code>mapreduce.input.fileinputformat.split.minsize</code></td>
-  <td>as you set in your Hadoop conf</td>
+  <td>1</td>
   <td>
     The minimum size chunk that map input should be split into.
     By increasing this value beyond the size of blocks in HDFS, you can decrease the number of input tasks in your job.
-    For example, if we set the value to 3x of the size of a block, every split will receive 3x records from several blocks.
-    Thus to set the value to 128MB, you will specify 134217728 as the value for this property. Note that if you do not set a max split size when using CombineFileInputFormat, your job will only use 1 task (which is probably not what you want)!
   </td>
 </tr>
 </table>


### PR DESCRIPTION
## What changes were proposed in this pull request?

We can use `CombineTextInputFormat` instead of `TextInputFormat` and set configurations to increase the speed when reading tables. 

There's no need to add spark configurations, so add it to the Performance Tuning.

This part of the document will be like : 
![image](https://user-images.githubusercontent.com/25916266/61504392-c0f3a300-aa0d-11e9-8cfa-76d29c3359fc.png)



Linked to #23506 

## How was this patch tested?

Manually tested
