### PR TITLE
[SPARK-26652][SQL] Use Proleptic Gregorian Calendar in Literal.fromString

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
@@ -243,7 +243,7 @@ class LiteralExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(Literal.fromString("Databricks", StringType), "Databricks")
     val dateString = "1970-01-01"
     checkEvaluation(Literal.fromString(dateString, DateType), java.sql.Date.valueOf(dateString))
-    val timestampString = "0000-01-01 00:00:00"
+    val timestampString = "2000-01-01 00:00:00.123"
     checkEvaluation(Literal.fromString(timestampString, TimestampType),
       java.sql.Timestamp.valueOf(timestampString))
     val calInterval = new CalendarInterval(1, 1)


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Avoid using `Timestamp.valueOf` and `Date.valueOf` in parsing `TimestampType` and `DateType` literal values in `Literal.fromString` since the method uses the hybrid calendar (Julian+Gregorian) internally.
- Replace the methods above by `stringToDate` and `stringToTimestamp` because they have been already ported on Proleptic Gregorian calendar which is required by SQL standard.
- Reuse `Literal.fromString` from `AstBuilder` in parsing `Timestamp` and `Date` literal values.

## How was this patch tested?

The changes were tested by `ExpressionParserSuite` and `LiteralExpressionSuite`.
