### PR TITLE
[SPARK-26671][CORE][Minor] Enviroment page in the webui need to display hadoop properties in only in history the ui

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -440,11 +440,7 @@ object SparkEnv extends Logging {
 
     // Add Hadoop properties, it will not ignore configs including in Spark. Some spark
     // conf starting with "spark.hadoop" may overwrite it.
-    val hadoopProperties = if (!conf.get("spark.master").contains("local")) {
-      hadoopConf.asScala.map(entry => (entry.getKey, entry.getValue)).toSeq
-    } else {
-      Nil
-    }
+    val hadoopProperties = hadoopConf.asScala.map(entry => (entry.getKey, entry.getValue)).toSeq
     Map[String, Seq[(String, String)]](
       "JVM Information" -> jvmInformation,
       "Spark Properties" -> sparkProperties,

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -440,7 +440,11 @@ object SparkEnv extends Logging {
 
     // Add Hadoop properties, it will not ignore configs including in Spark. Some spark
     // conf starting with "spark.hadoop" may overwrite it.
-    val hadoopProperties = hadoopConf.asScala.map(entry => (entry.getKey, entry.getValue)).toSeq
+    val hadoopProperties = if (!conf.get("spark.master").contains("local")) {
+      hadoopConf.asScala.map(entry => (entry.getKey, entry.getValue)).toSeq
+    } else {
+      Nil
+    }
     Map[String, Seq[(String, String)]](
       "JVM Information" -> jvmInformation,
       "Spark Properties" -> sparkProperties,

--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -147,7 +147,7 @@ private[spark] class AppStatusListener(
     val envInfo = new v1.ApplicationEnvironmentInfo(
       runtime,
       details.getOrElse("Spark Properties", Nil),
-      details.getOrElse("Hadoop Properties", Nil),
+      if (!live) details.getOrElse("Hadoop Properties", Nil) else Nil,
       details.getOrElse("System Properties", Nil),
       details.getOrElse("Classpath Entries", Nil))
 

--- a/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
@@ -72,6 +72,7 @@ private[ui] class EnvironmentPage(
         <div class="aggregated-sparkProperties collapsible-table">
           {sparkPropertiesTable}
         </div>
+        {if (appEnv.hadoopProperties.nonEmpty) {
         <span class="collapse-aggregated-hadoopProperties collapse-table"
               onClick="collapseTable('collapse-aggregated-hadoopProperties',
             'aggregated-hadoopProperties')">
@@ -80,9 +81,10 @@ private[ui] class EnvironmentPage(
             <a>Hadoop Properties</a>
           </h4>
         </span>
-        <div class="aggregated-hadoopProperties collapsible-table collapsed">
-          {hadoopPropertiesTable}
-        </div>
+          <div class="aggregated-hadoopProperties collapsible-table collapsed">
+            {hadoopPropertiesTable}
+          </div>
+        }}
         <span class="collapse-aggregated-systemProperties collapse-table"
             onClick="collapseTable('collapse-aggregated-systemProperties',
             'aggregated-systemProperties')">


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR has 3 minor fixes related to the environment page in the webui
1) In local mode, don't show default hadoop properties
2) If the "hadoop properties" is empty, don't display empty table in the env page
3) Show "hadoop properties" only in the history application page

## How was this patch tested?

Existing tests
