### PR TITLE
[SPARK-26379][SS] Fix issue on adding current_timestamp/current_date to streaming query

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
@@ -513,8 +513,7 @@ class MicroBatchExecution(
     // of attributes, so we don't need to concern about the value of literals.
 
     val newAttrPlanPreResolvedForSchema = newAttributePlan transformAllExpressions {
-      case ct: CurrentBatchTimestamp => ct.toLiteral
-      case cd: CurrentBatchTimestamp => cd.toLiteral
+      case cbt: CurrentBatchTimestamp => cbt.toLiteral
     }
 
     val triggerLogicalPlan = sink match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
@@ -508,12 +508,21 @@ class MicroBatchExecution(
           cd.dataType, cd.timeZoneId)
     }
 
+    // Pre-resolve new attributes to ensure all attributes are resolved before
+    // accessing schema of logical plan. Note that it only leverages the information
+    // of attributes, so we don't need to concern about the value of literals.
+
+    val newAttrPlanPreResolvedForSchema = newAttributePlan transformAllExpressions {
+      case ct: CurrentBatchTimestamp => ct.toLiteral
+      case cd: CurrentBatchTimestamp => cd.toLiteral
+    }
+
     val triggerLogicalPlan = sink match {
       case _: Sink => newAttributePlan
       case s: StreamingWriteSupportProvider =>
         val writer = s.createStreamingWriteSupport(
           s"$runId",
-          newAttributePlan.schema,
+          newAttrPlanPreResolvedForSchema.schema,
           outputMode,
           new DataSourceOptions(extraOptions.asJava))
         WriteToDataSourceV2(new MicroBatchWrite(currentBatchId, writer), newAttributePlan)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -1118,7 +1118,7 @@ class StreamSuite extends StreamTest {
       CheckLastBatch { rows: Seq[Row] =>
         lastTimestamp = assertBatchOutputAndUpdateLastTimestamp(rows, lastTimestamp, currentDate, 1)
       },
-      Execute { _ => Thread.sleep(3 * 1000) },
+      Execute { _ => Thread.sleep(1000) },
       AddData(input, 2),
       CheckLastBatch { rows: Seq[Row] =>
         lastTimestamp = assertBatchOutputAndUpdateLastTimestamp(rows, lastTimestamp, currentDate, 2)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -34,6 +34,7 @@ import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.plans.logical.Range
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.command.ExplainCommand
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.execution.streaming.sources.ContinuousMemoryStream
@@ -1080,40 +1081,49 @@ class StreamSuite extends StreamTest {
     }
   }
 
-  Seq(true, false).foreach { useV2Sink =>
-    import org.apache.spark.sql.functions._
+  test("SPARK-26379 Structured Streaming - Exception on adding current_timestamp / current_date" +
+    " to Dataset - use v2 sink") {
+    testCurrentTimestampOnStreamingQuery(useV2Sink = true)
+  }
 
-    val newTestName = "SPARK-26379 Structured Streaming - Exception on adding column to Dataset" +
-      s" - use v2 sink - $useV2Sink"
+  test("SPARK-26379 Structured Streaming - Exception on adding current_timestamp / current_date" +
+    " to Dataset - use v1 sink") {
+    testCurrentTimestampOnStreamingQuery(useV2Sink = false)
+  }
 
-    test(newTestName) {
-      val input = MemoryStream[Int]
-      val df = input.toDS().withColumn("cur_timestamp", lit(current_timestamp()))
+  private def testCurrentTimestampOnStreamingQuery(useV2Sink: Boolean): Unit = {
+    val input = MemoryStream[Int]
+    val df = input.toDS()
+      .withColumn("cur_timestamp", lit(current_timestamp()))
+      .withColumn("cur_date", lit(current_date()))
 
-      def assertBatchOutputAndUpdateLastTimestamp(
-          rows: Seq[Row],
-          curTimestamp: Long,
-          expectedValue: Int): Long = {
-        assert(rows.size === 1)
-        val row = rows.head
-        assert(row.getInt(0) === expectedValue)
-        assert(row.getTimestamp(1).getTime > curTimestamp)
-        row.getTimestamp(1).getTime
-      }
-
-      var lastTimestamp = -1L
-      testStream(df, useV2Sink = useV2Sink) (
-        AddData(input, 1),
-        CheckLastBatch { rows: Seq[Row] =>
-          lastTimestamp = assertBatchOutputAndUpdateLastTimestamp(rows, lastTimestamp, 1)
-        },
-        Execute { _ => Thread.sleep(3 * 1000) },
-        AddData(input, 2),
-        CheckLastBatch { rows: Seq[Row] =>
-          lastTimestamp = assertBatchOutputAndUpdateLastTimestamp(rows, lastTimestamp, 2)
-        }
-      )
+    def assertBatchOutputAndUpdateLastTimestamp(
+        rows: Seq[Row],
+        curTimestamp: Long,
+        curDate: Int,
+        expectedValue: Int): Long = {
+      assert(rows.size === 1)
+      val row = rows.head
+      assert(row.getInt(0) === expectedValue)
+      assert(row.getTimestamp(1).getTime >= curTimestamp)
+      val days = DateTimeUtils.millisToDays(row.getDate(2).getTime)
+      assert(days == curDate || days == curDate + 1)
+      row.getTimestamp(1).getTime
     }
+
+    var lastTimestamp = System.currentTimeMillis()
+    val currentDate = DateTimeUtils.millisToDays(lastTimestamp)
+    testStream(df, useV2Sink = useV2Sink) (
+      AddData(input, 1),
+      CheckLastBatch { rows: Seq[Row] =>
+        lastTimestamp = assertBatchOutputAndUpdateLastTimestamp(rows, lastTimestamp, currentDate, 1)
+      },
+      Execute { _ => Thread.sleep(3 * 1000) },
+      AddData(input, 2),
+      CheckLastBatch { rows: Seq[Row] =>
+        lastTimestamp = assertBatchOutputAndUpdateLastTimestamp(rows, lastTimestamp, currentDate, 2)
+      }
+    )
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch proposes to fix issue on adding `current_timestamp` / `current_date` with streaming query. 

The root reason is that Spark transforms `CurrentTimestamp`/`CurrentDate` to `CurrentBatchTimestamp` in MicroBatchExecution which makes transformed attributes not-yet-resolved. They will be resolved by IncrementalExecution.
(In ContinuousExecution, Spark doesn't allow using `current_timestamp` and `current_date` so it has been OK.)

It's OK for DataSource V1 sink because it simply leverages transformed logical plan and don't evaluate until they're resolved, but for DataSource V2 sink, Spark tries to extract the schema of transformed logical plan in prior to IncrementalExecution, and unresolved attributes will raise errors.

This patch fixes the issue via having separate pre-resolved logical plan to pass the schema to StreamingWriteSupport safely.

## How was this patch tested?

Added UT.