### PR TITLE
[SPARK-26684]Add logs when allocating large memory for PooledByteBufAllocator

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/buffer/SparkPooledByteBufAllocator.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/buffer/SparkPooledByteBufAllocator.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.buffer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SparkPooledByteBufAllocator extends PooledByteBufAllocator {
+  private final Logger LOG = LoggerFactory.getLogger(SparkPooledByteBufAllocator.class);
+
+  public SparkPooledByteBufAllocator(boolean preferDirect, int nHeapArena, int nDirectArena,
+      int pageSize, int maxOrder, int tinyCacheSize, int smallCacheSize, int normalCacheSize,
+      boolean useCacheForAllThreads) {
+    super(preferDirect, nHeapArena, nDirectArena, pageSize, maxOrder, tinyCacheSize,
+        smallCacheSize, normalCacheSize, useCacheForAllThreads);
+  }
+
+  @Override
+  protected ByteBuf newDirectBuffer(int initialCapacity, int maxCapacity) {
+    if (initialCapacity > 1024 * 1024) {
+      LOG.info("Try to allocate direct buffer with initialCapacity: " +
+          initialCapacity + " maxCapacity: " + maxCapacity + ", current usedDirectMemory: " +
+          metric().usedDirectMemory());
+    }
+    return super.newDirectBuffer(initialCapacity, maxCapacity);
+  }
+
+  @Override
+  protected ByteBuf newHeapBuffer(int initialCapacity, int maxCapacity) {
+    if (initialCapacity > 1024 * 1024) {
+      LOG.info("Try to allocate heap buffer with initialCapacity: " +
+          initialCapacity + " maxCapacity: " + maxCapacity + ", current usedHeapMemory: " +
+          metric().usedHeapMemory());
+    }
+    return super.newHeapBuffer(initialCapacity, maxCapacity);
+  }
+}

--- a/common/network-common/src/main/java/org/apache/spark/network/util/NettyUtils.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/NettyUtils.java
@@ -31,6 +31,7 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.internal.PlatformDependent;
+import org.apache.spark.network.buffer.SparkPooledByteBufAllocator;
 
 /**
  * Utilities for creating various Netty constructs based on whether we're using EPOLL or NIO.
@@ -156,7 +157,7 @@ public class NettyUtils {
     if (numCores == 0) {
       numCores = Runtime.getRuntime().availableProcessors();
     }
-    return new PooledByteBufAllocator(
+    return new SparkPooledByteBufAllocator(
       allowDirectBufs && PlatformDependent.directBufferPreferred(),
       Math.min(PooledByteBufAllocator.defaultNumHeapArena(), numCores),
       Math.min(PooledByteBufAllocator.defaultNumDirectArena(), allowDirectBufs ? numCores : 0),


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, Spark use `PooledByteBufAllocator` to allocate memory for channel reading. However, the allocated heap/offheap memory size is not tracked. Sometimes, this make it difficult to  find out the cause of OOM failures(for instance, direct memory oom) due to data skew. we have to use more advanced tools like MAT or pmap to locate the cause.

Actually, we can add some logs for `PooledByteBufAllocator` when allocating large memory, which can facilitate the debugging.

## How was this patch tested?

NA

Please review http://spark.apache.org/contributing.html before opening a pull request.
