### PR TITLE
[SPARK-26689][CORE]Support blacklisting bad disk directory and retry in DiskBlockManager

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -286,11 +286,13 @@ package object config {
 
   private[spark] val DISK_STORE_BLACKLIST_TIMEOUT =
     ConfigBuilder("spark.diskStore.blacklist.timeoutMs")
+      .doc("The timeout in milliseconds to wait before moving blacklisted local directory " +
+        "out from the blacklist.")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("1d")
 
-  private[spark] val DISK_STORE_MAX_RETIRES =
-    ConfigBuilder("spark.diskStore.maxRetries")
+  private[spark] val DISK_STORE_MAX_ATTEMPTS =
+    ConfigBuilder("spark.diskStore.maxAttempts")
       .intConf
       .createWithDefault(3)
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -284,6 +284,16 @@ package object config {
       .intConf
       .createWithDefault(64)
 
+  private[spark] val DISK_STORE_BLACKLIST_TIMEOUT =
+    ConfigBuilder("spark.diskStore.blacklist.timeout")
+      .timeConf(TimeUnit.SECONDS)
+      .createWithDefaultString("1d")
+
+  private[spark] val DISK_STORE_MAX_RETIRES =
+    ConfigBuilder("spark.diskStore.maxRetries")
+      .intConf
+      .createWithDefault(3)
+
   private[spark] val BLOCK_FAILURES_BEFORE_LOCATION_REFRESH =
     ConfigBuilder("spark.block.failures.beforeLocationRefresh")
       .doc("Max number of failures before this block manager refreshes " +

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -285,8 +285,8 @@ package object config {
       .createWithDefault(64)
 
   private[spark] val DISK_STORE_BLACKLIST_TIMEOUT =
-    ConfigBuilder("spark.diskStore.blacklist.timeout")
-      .timeConf(TimeUnit.SECONDS)
+    ConfigBuilder("spark.diskStore.blacklist.timeoutMs")
+      .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("1d")
 
   private[spark] val DISK_STORE_MAX_RETIRES =

--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
@@ -19,12 +19,10 @@ package org.apache.spark.storage
 
 import java.io.{File, IOException}
 import java.util.UUID
-import javax.annotation.concurrent.ThreadSafe
 
 import scala.collection.mutable.{ArrayBuffer, HashMap}
 
 import org.apache.spark.SparkConf
-
 import org.apache.spark.executor.ExecutorExitCode
 import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.util.{ShutdownHookManager, Utils}

--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
@@ -41,7 +41,7 @@ private[spark] class DiskBlockManager(conf: SparkConf,
   deleteFilesOnStop: Boolean, clock: Clock = new SystemClock()) extends Logging {
 
   private[spark] val subDirsPerLocalDir = conf.get(config.DISKSTORE_SUB_DIRECTORIES)
-  private[spark] val maxRetries = conf.get(config.DISK_STORE_MAX_RETIRES)
+  private[spark] val maxAttempts = conf.get(config.DISK_STORE_MAX_ATTEMPTS)
   private[spark] val blacklistTimeout = conf.get(config.DISK_STORE_BLACKLIST_TIMEOUT)
 
   /* Create one local directory for each path mentioned in spark.local.dir; then, inside this
@@ -91,7 +91,7 @@ private[spark] class DiskBlockManager(conf: SparkConf,
       } else {
         assert(!migratedDirIdIndex.contains(filename))
         var newDir: File = null
-        for (attempt <- 0 until maxRetries if newDir == null) {
+        for (attempt <- 0 until maxAttempts if newDir == null) {
           val goodDirId = badDirs.synchronized {
             val isBlacklisted = badDirs.contains(localDirs(dirId))
             if (isBlacklisted) {

--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
@@ -116,9 +116,8 @@ private[spark] class DiskBlockManager(conf: SparkConf,
               dirToBlacklistExpiryTime.put(localDirs(dirId), now + blacklistTimeout)
               mostRecentFailure = e
           }
-          Option(newDir).getOrElse(throw mostRecentFailure)
         }
-        newDir
+        Option(newDir).getOrElse(throw mostRecentFailure)
       }
     }
     new File(subDir, filename)

--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.storage
 
 import java.io.{File, IOException}
+import java.nio.file.Files
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
@@ -101,9 +102,7 @@ private[spark] class DiskBlockManager(conf: SparkConf,
               throw new IOException("No good disk directories available")
             }
             newDir = new File(localDirs(goodDirId), "%02x".format(subDirId))
-            if (!newDir.exists() && !newDir.mkdir()) {
-              throw new IOException(s"Failed to create local dir in $newDir.")
-            }
+            Files.createDirectories(newDir.toPath)
             subDirs(goodDirId)(subDirId) = newDir
             if (goodDirId != dirId) {
               migratedDirIdIndex.put(hash, goodDirId)
@@ -111,7 +110,7 @@ private[spark] class DiskBlockManager(conf: SparkConf,
             succeed = true
           } catch {
             case e: IOException =>
-              logError(s"Failed to looking up file $filename in attempt $attempt", e)
+              logError(s"Failed to look up file $filename in attempt $attempt", e)
               badDirs += localDirs(dirId)
               dirToBlacklistExpiryTime.put(localDirs(dirId), now + blacklistTimeout)
               mostRecentFailure = e

--- a/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
@@ -18,11 +18,10 @@
 package org.apache.spark.storage
 
 import java.io.{File, FileWriter}
-import java.util.UUID
 
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
-import org.apache.spark.{SparkConf, SparkFunSuite}
 
+import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.internal.config
 import org.apache.spark.util.{ManualClock, Utils}
 

--- a/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
@@ -138,9 +138,9 @@ class DiskBlockManagerSuite extends SparkFunSuite with BeforeAndAfterEach with B
         val file2 = diskBlockManager.getFile(blockId2)
         val rootDirOfFile2 = file2.getParentFile.getParentFile.getParentFile
         assert(file2 != null && file2.getParentFile.exists() && rootDirOfFile2 === goodDiskDir)
-        if (diskBlockManager.badDirs.nonEmpty) {
-          assert(diskBlockManager.badDirs.size === 1)
-          assert(diskBlockManager.badDirs.exists(_.getParentFile === badDiskDir))
+        if (diskBlockManager.blacklistedDirs.nonEmpty) {
+          assert(diskBlockManager.blacklistedDirs.size === 1)
+          assert(diskBlockManager.blacklistedDirs.exists(_.getParentFile === badDiskDir))
           assert(diskBlockManager.dirToBlacklistExpiryTime.size === 1)
           assert(diskBlockManager.dirToBlacklistExpiryTime.exists { case (f, expireTime) =>
             f.getParentFile === badDiskDir && expireTime === 20000
@@ -169,7 +169,7 @@ class DiskBlockManagerSuite extends SparkFunSuite with BeforeAndAfterEach with B
       // Update blacklist when getting file for new block
       // Bad disk directory is fixed here, so blacklist should be empty
       assert(diskBlockManager.getFile(blockId3) != null)
-      assert(diskBlockManager.badDirs.isEmpty)
+      assert(diskBlockManager.blacklistedDirs.isEmpty)
       assert(diskBlockManager.dirToBlacklistExpiryTime.isEmpty)
       diskBlockManager.stop()
     }

--- a/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
@@ -94,8 +94,8 @@ class DiskBlockManagerSuite extends SparkFunSuite with BeforeAndAfterEach with B
 
   test("test blacklisting bad disk directory") {
     val blockId = new TestBlockId("1")
-    val hash = Utils.nonNegativeHash(blockId)
-    val (badDiskDir, goodDiskDir) = if (hash % rootDirs.length == 0) {
+    val hash = Utils.nonNegativeHash(blockId.name)
+    val (badDiskDir, goodDiskDir) = if (hash % 2 == 0) {
       (rootDir0, rootDir1)
     } else {
       (rootDir1, rootDir0)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1249,6 +1249,20 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 </table>
 
+### Disk Management
+
+<table class="table">
+<tr><th>Property Name</th><th>Default</th><th>Meaning</th></tr>
+<tr>
+  <td><code>spark.diskStore.blacklist.timeoutMs</code></td>
+  <td>1d</td>
+  <td>
+    How long that a bad local directory is blacklisted for the diskStore before is is unconditionally removed
+    from the blacklist to attempt storing new file.
+  </td>
+</tr>
+</table>
+
 ### Execution Behavior
 
 <table class="table">


### PR DESCRIPTION
## What changes were proposed in this pull request?

We encoutered an application failure in our production cluster which caused by a single broken disk. It will cause application failure.

```
Job aborted due to stage failure: Task serialization failed: java.io.IOException: Failed to create local dir in /home/work/hdd5/yarn/c3prc-hadoop/nodemanager/usercache/h_user_profile/appcache/application_1463372393999_144979/blockmgr-1f96b724-3e16-4c09-8601-1a2e3b758185/3b.
org.apache.spark.storage.DiskBlockManager.getFile(DiskBlockManager.scala:73)
org.apache.spark.storage.DiskStore.contains(DiskStore.scala:173)
org.apache.spark.storage.BlockManager.org$apache$spark$storage$BlockManager$$getCurrentBlockStatus(BlockManager.scala:391)
org.apache.spark.storage.BlockManager.doPut(BlockManager.scala:801)
org.apache.spark.storage.BlockManager.putIterator(BlockManager.scala:629)
org.apache.spark.storage.BlockManager.putSingle(BlockManager.scala:987)
org.apache.spark.broadcast.TorrentBroadcast.writeBlocks(TorrentBroadcast.scala:99)
org.apache.spark.broadcast.TorrentBroadcast.<init>(TorrentBroadcast.scala:85)
org.apache.spark.broadcast.TorrentBroadcastFactory.newBroadcast(TorrentBroadcastFactory.scala:34)
org.apache.spark.broadcast.BroadcastManager.newBroadcast(BroadcastManager.scala:63)
org.apache.spark.SparkContext.broadcast(SparkContext.scala:1332)
org.apache.spark.scheduler.DAGScheduler.org$apache$spark$scheduler$DAGScheduler$$submitMissingTasks(DAGScheduler.scala:863)
org.apache.spark.scheduler.DAGScheduler$$anonfun$handleTaskCompletion$14$$anonfun$apply$1.apply$mcVI$sp(DAGScheduler.scala:1090)
org.apache.spark.scheduler.DAGScheduler$$anonfun$handleTaskCompletion$14$$anonfun$apply$1.apply(DAGScheduler.scala:1086)
org.apache.spark.scheduler.DAGScheduler$$anonfun$handleTaskCompletion$14$$anonfun$apply$1.apply(DAGScheduler.scala:1086)
scala.Option.foreach(Option.scala:236)
org.apache.spark.scheduler.DAGScheduler$$anonfun$handleTaskCompletion$14.apply(DAGScheduler.scala:1086)
org.apache.spark.scheduler.DAGScheduler$$anonfun$handleTaskCompletion$14.apply(DAGScheduler.scala:1085)
scala.collection.mutable.ResizableArray$class.foreach(ResizableArray.scala:59)
scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:47)
org.apache.spark.scheduler.DAGScheduler.handleTaskCompletion(DAGScheduler.scala:1085)
org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive(DAGScheduler.scala:1528)
org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:1493)
org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:1482)
org.apache.spark.util.EventLoop$$anon$1.run(EventLoop.scala:48)
```
We have configured `yarn.nodemanager.local-dirs` with multiple directories which are mounted on multiple disk, however, it still failed due to single disk broken. I think it's because spark does not handle disk broken in `DiskBlockManager` currently, even though there are always multi disk directories configured in a production environment.

Though, we can probably bypass this error by enlarge settings  like `spark.yarn.maxAppAttemps`, but other apps may also suffer the same problem repeatedly which is annoying and unstable.... Also, for some large task, the retry will bring some downside, one major downside is that it will cause the delay of application completion(the extra recomputing time when retry for `ShuffleMapTask` and some extra schedule delay).

Actually, we can handle this case by simply adding a few of codes, for localDirs already mounted on  multiple disk for a production environment in most cases.

This PR will support blacklisting bad disk directory and switch to a good directory for writing. thus can improve the robustness.

## How was this patch tested?

UT

Please review http://spark.apache.org/contributing.html before opening a pull request.
