### PR TITLE
[SPARK-26677][SQL] Disable dictionary filtering by default at Parquet

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -314,7 +314,7 @@ class ParquetFileFormat
       SQLConf.CASE_SENSITIVE.key,
       sparkSession.sessionState.conf.caseSensitiveAnalysis)
 
-    // There are three things to note here.
+    // There are two things to note here.
     //
     // 1. Dictionary filtering has an issue about the predication on null. For this reason,
     //   This filtering is disabled. See SPARK-26677.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -314,6 +314,17 @@ class ParquetFileFormat
       SQLConf.CASE_SENSITIVE.key,
       sparkSession.sessionState.conf.caseSensitiveAnalysis)
 
+    // There are three things to note here.
+    //
+    // 1. Dictionary filtering has an issue about the predication on null. For this reason,
+    //   This filtering is disabled. See SPARK-26677.
+    //
+    // 2. We should disable 'parquet.filter.dictionary.enabled' but
+    //   the 'parquet.filter.stats.enabled' and 'parquet.filter.dictionary.enabled' were
+    //   swapped mistakenly in Parquet side. It should use 'parquet.filter.dictionary.enabled'
+    //   when Spark upgrades Parquet. See PARQUET-1309.
+    hadoopConf.setIfUnset(ParquetInputFormat.STATS_FILTERING_ENABLED, "false")
+
     ParquetWriteSupport.setSchema(requiredSchema, hadoopConf)
 
     // Sets flags for `ParquetToSparkSchemaConverter`


### PR DESCRIPTION
## What changes were proposed in this pull request?


### Problem

This is a correctness issue and should be backported as well. If we use dictionary encoding as below, it hits a correctness issue as below:

```scala
// Repeat the values for dictionary encoding. PLAIN_DICTIONARY.
Seq(Some("A"), Some("A"), None).toDF.repartition(1).write.mode("overwrite").parquet("/tmp/foo")
spark.read.parquet("/tmp/foo").where("NOT (value <=> 'A')").show()
```
```
+-----+
|value|
+-----+
+-----+
```

Note that, if we don't use dictionary encoding it's fine. So it was difficult to find the issue.

```scala
// It becomes PLAIN encoding.
Seq(Some("A"), None).toDF.repartition(1).write.mode("overwrite").parquet("/tmp/bar")
spark.read.parquet("/tmp/bar").where("NOT (value <=> 'A')").show()
```
```
+-----+
|value|
+-----+
| null|
+-----+
```

### How did it happen?

This is because Parquet side dictionary filter fails to handle `null`. The former case hits here:

```java
      Set<T> dictSet = expandDictionary(meta);
      if (dictSet != null && dictSet.size() == 1 && dictSet.contains(value)) {
        return BLOCK_CANNOT_MATCH;
      }
```

See [here](https://github.com/apache/parquet-mr/blob/apache-parquet-1.10.0/parquet-hadoop/src/main/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilter.java#L182) for codes.

Given dictionary set does not contain `null` but only `'A'`. `value` (given to the predicate) is `'A'` here. So, it filters the row group out.

The latter case above works fine because it hits here:

```java
    // if the chunk has non-dictionary pages, don't bother decoding the
    // dictionary because the row group can't be eliminated.
    if (hasNonDictionaryPages(meta)) {
      return BLOCK_MIGHT_MATCH;
    }
```

See [here](https://github.com/apache/parquet-mr/blob/apache-parquet-1.10.0/parquet-hadoop/src/main/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilter.java#L176) for codes.

So, it does not filter the row group out.

Parquet equality predicate handles `null` too (see also [here](https://github.com/apache/parquet-mr/blob/apache-parquet-1.10.0/parquet-column/src/main/java/org/apache/parquet/filter2/predicate/Operators.java#L188)). Up to my knowledge, Parquet predicate is null-safe quality comparison.


### How does this PR fix?

This PR explicitly disables dictionary filtering if not set by default. However there's another problem:

We should disable `parquet.filter.dictionary.enabled` but Parquet 1.10.x has a mistake - the `parquet.filter.stats.enabled` and `parquet.filter.dictionary.enabled` were swapped mistakenly in Parquet side:

```java
      useDictionaryFilter(conf.getBoolean(STATS_FILTERING_ENABLED, true));
      useStatsFilter(conf.getBoolean(DICTIONARY_FILTERING_ENABLED, true));
```

See [here](https://github.com/apache/parquet-mr/blob/apache-parquet-1.10.0/parquet-hadoop/src/main/java/org/apache/parquet/HadoopReadOptions.java#L83-L84) for codes.

This is fixed after 1.11. See [PARQUET-1309](https://issues.apache.org/jira/browse/PARQUET-1309).

Therefore, this PR explicitly disables `parquet.filter.stats.enabled` to disable dictionary filtering if that's not set by default.


### User side workaround

They can explicitly disable `parquet.filter.stats.enabled` to disable dictionary filtering.


### ETC

- This is quite a conservative fix. This should be backported to Spark 2.4.
- I only tested null-safe equality comparison but looks regular equality comparison having related issues as well.

## How was this patch tested?

Unit tests were added.
