### PR TITLE
[SPARK-26672][SQL] SinglePartition may not satisfies HashClusteredDistribu…

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -202,6 +202,9 @@ case object SinglePartition extends Partitioning {
 
   override def satisfies0(required: Distribution): Boolean = required match {
     case _: BroadcastDistribution => false
+    case HashClusteredDistribution(_, num) if num.nonEmpty && num.get != 1 => false
+    case OrderedDistribution(orders) if orders.nonEmpty => false
+    case _: OrderedDistribution => false
     case _ => true
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
@@ -140,7 +140,23 @@ class DistributionSuite extends SparkFunSuite {
 
     checkSatisfied(
       SinglePartition,
+      ClusteredDistribution(Seq('a, 'b, 'c), Some(1)),
+      true)
+
+    checkSatisfied(
+      SinglePartition,
+      ClusteredDistribution(Seq('a, 'b, 'c), Some(200)),
+      false)
+
+    checkSatisfied(
+      SinglePartition,
       OrderedDistribution(Seq('a.asc, 'b.asc, 'c.asc)),
+      false)
+
+    
+    checkSatisfied(
+      SinglePartition,
+      OrderedDistribution(Nil),
       true)
 
     checkSatisfied(


### PR DESCRIPTION
…tion/OrderedDistribution

[SPARK-26672] SinglePartition may not satisfies HashClusteredDistribution/OrderedDistribution

## What changes were proposed in this pull request?
Fix a bug which may result lack of shuffle. 
Say,
If we are loading data to a bucketed table TEST_TABLE of which bucket number is not 1,  from another table SRC_TABLE(bucketed or not) with sql:

insert overwrite table TEST_TABLE select * from SRC_TABLE limit 1000.

Data inserted into TEST_TABLE will not be bucketed since after LimitExec the output partitioning will be SinglePartition, and in current logic, it satisfies the HashClusteredDistribution, so no shuffle will be added.

## How was this patch tested?
unit tests,
