### PR TITLE
[SPARK-26702][SQL][TEST] Create a test trait for Parquet and Orc test

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceTest.scala
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import java.io.File
+
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe.TypeTag
+
+import org.apache.spark.sql.{DataFrame, SaveMode}
+import org.apache.spark.sql.test.SQLTestUtils
+
+private[sql] trait DataSourceTest extends SQLTestUtils {
+
+  protected val dataSourceName: String
+  protected val vectorizedReaderEnabledKey: String
+
+  /**
+   * Reads data source file from given `path` as `DataFrame` and pass it to given function.
+   *
+   * @param path           The path to file
+   * @param testVectorized Whether to read the file with vectorized reader. If the data source
+   *                       doesn't support vectorized reader, this is no op.
+   * @param f              The given function that takes a `DataFrame` as input.
+   */
+  protected def readFile(path: String, testVectorized: Boolean = true)
+      (f: DataFrame => Unit): Unit = {
+    (true :: false :: Nil).foreach { vectorized =>
+      if (!vectorized || testVectorized) {
+        withSQLConf(vectorizedReaderEnabledKey -> vectorized.toString) {
+          f(spark.read.format(dataSourceName).load(path.toString))
+        }
+      }
+    }
+  }
+
+  /**
+   * Writes `data` to a data source file, which is then passed to `f` and will be deleted after `f`
+   * returns.
+   */
+  protected def withDataSourceFile[T <: Product : ClassTag : TypeTag]
+      (data: Seq[T])
+      (f: String => Unit): Unit = {
+    withTempPath { file =>
+      spark.createDataFrame(data).write.format(dataSourceName).save(file.getCanonicalPath)
+      f(file.getCanonicalPath)
+    }
+  }
+
+  /**
+   * Writes `data` to a data source file and reads it back as a [[DataFrame]],
+   * which is then passed to `f`. The file will be deleted after `f` returns.
+   */
+  protected def withDataSourceDataFrame[T <: Product : ClassTag : TypeTag]
+      (data: Seq[T], testVectorized: Boolean = true)
+      (f: DataFrame => Unit): Unit = {
+    withDataSourceFile(data)(path => readFile(path.toString, testVectorized)(f))
+  }
+
+  /**
+   * Writes `data` to a data source file, reads it back as a [[DataFrame]] and registers it as a
+   * temporary table named `tableName`, then call `f`. The temporary table together with the
+   * data file will be dropped/deleted after `f` returns.
+   */
+  protected def withDataSourceTable[T <: Product : ClassTag : TypeTag]
+      (data: Seq[T], tableName: String, testVectorized: Boolean = true)
+      (f: => Unit): Unit = {
+    withDataSourceDataFrame(data, testVectorized) { df =>
+      df.createOrReplaceTempView(tableName)
+      withTempView(tableName)(f)
+    }
+  }
+
+  protected def makeDataSourceFile[T <: Product : ClassTag : TypeTag](
+      data: Seq[T], path: File): Unit = {
+    spark.createDataFrame(data).write.mode(SaveMode.Overwrite).format(dataSourceName)
+      .save(path.getCanonicalPath)
+  }
+
+  protected def makeDataSourceFile[T <: Product : ClassTag : TypeTag](
+      df: DataFrame, path: File): Unit = {
+    df.write.mode(SaveMode.Overwrite).format(dataSourceName).save(path.getCanonicalPath)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileBasedDataSourceTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileBasedDataSourceTest.scala
@@ -25,6 +25,11 @@ import scala.reflect.runtime.universe.TypeTag
 import org.apache.spark.sql.{DataFrame, SaveMode}
 import org.apache.spark.sql.test.SQLTestUtils
 
+/**
+ * A helper trait that provides convenient facilities for file-based data source testing.
+ * Specifically, it is used for Parquet and Orc testing. It can be used to write tests
+ * that are shared between Parquet and Orc.
+ */
 private[sql] trait FileBasedDataSourceTest extends SQLTestUtils {
 
   // Defines the data source name to run the test.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileBasedDataSourceTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileBasedDataSourceTest.scala
@@ -40,11 +40,12 @@ private[sql] trait FileBasedDataSourceTest extends SQLTestUtils {
    */
   protected def readFile(path: String, testVectorized: Boolean = true)
       (f: DataFrame => Unit): Unit = {
-    (true :: false :: Nil).foreach { vectorized =>
-      if (!vectorized || testVectorized) {
-        withSQLConf(vectorizedReaderEnabledKey -> vectorized.toString) {
-          f(spark.read.format(dataSourceName).load(path.toString))
-        }
+    withSQLConf(vectorizedReaderEnabledKey -> "false") {
+      f(spark.read.format(dataSourceName).load(path.toString))
+    }
+    if (testVectorized) {
+      withSQLConf(vectorizedReaderEnabledKey -> "true") {
+        f(spark.read.format(dataSourceName).load(path.toString))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileBasedDataSourceTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileBasedDataSourceTest.scala
@@ -25,13 +25,13 @@ import scala.reflect.runtime.universe.TypeTag
 import org.apache.spark.sql.{DataFrame, SaveMode}
 import org.apache.spark.sql.test.SQLTestUtils
 
-private[sql] trait DataSourceTest extends SQLTestUtils {
+private[sql] trait FileBasedDataSourceTest extends SQLTestUtils {
 
   protected val dataSourceName: String
   protected val vectorizedReaderEnabledKey: String
 
   /**
-   * Reads data source file from given `path` as `DataFrame` and pass it to given function.
+   * Reads data source file from given `path` as `DataFrame` and passes it to given function.
    *
    * @param path           The path to file
    * @param testVectorized Whether to read the file with vectorized reader. If the data source

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileBasedDataSourceTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileBasedDataSourceTest.scala
@@ -27,15 +27,16 @@ import org.apache.spark.sql.test.SQLTestUtils
 
 private[sql] trait FileBasedDataSourceTest extends SQLTestUtils {
 
+  // Defines the data source name to run the test.
   protected val dataSourceName: String
+  // The SQL config key for enabling vectorized reader.
   protected val vectorizedReaderEnabledKey: String
 
   /**
    * Reads data source file from given `path` as `DataFrame` and passes it to given function.
    *
    * @param path           The path to file
-   * @param testVectorized Whether to read the file with vectorized reader. If the data source
-   *                       doesn't support vectorized reader, this is no op.
+   * @param testVectorized Whether to read the file with vectorized reader.
    * @param f              The given function that takes a `DataFrame` as input.
    */
   protected def readFile(path: String, testVectorized: Boolean = true)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala
@@ -270,7 +270,10 @@ abstract class OrcQueryTest extends OrcTest {
   test("appending") {
     val data = (0 until 10).map(i => (i, i.toString))
     spark.createDataFrame(data).toDF("c1", "c2").createOrReplaceTempView("tmp")
-    withOrcTable(data, "t") {
+    // The test closure has side effect that changes table 't'. Running it without resetting
+    // the table data twice with vectorized=true and false will fail at the second time.
+    // Since it cares about inserting, we only do testing for vectorized=false.
+    withOrcTable(data, "t", testVectorized = false) {
       sql("INSERT INTO TABLE t SELECT * FROM tmp")
       checkAnswer(spark.table("t"), (data ++ data).map(Row.fromTuple))
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
@@ -25,8 +25,9 @@ import scala.reflect.runtime.universe.TypeTag
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.spark.sql._
+import org.apache.spark.sql.execution.datasources.DataSourceTest
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.ORC_IMPLEMENTATION
-import org.apache.spark.sql.test.SQLTestUtils
 
 /**
  * OrcTest
@@ -42,12 +43,16 @@ import org.apache.spark.sql.test.SQLTestUtils
  *   -> OrcFilterSuite
  *   -> HiveOrcFilterSuite
  */
-abstract class OrcTest extends QueryTest with SQLTestUtils with BeforeAndAfterAll {
+abstract class OrcTest extends QueryTest with DataSourceTest with BeforeAndAfterAll {
   import testImplicits._
 
   val orcImp: String = "native"
 
   private var originalConfORCImplementation = "native"
+
+  override protected val dataSourceName: String = "orc"
+  override protected val vectorizedReaderEnabledKey: String =
+    SQLConf.ORC_VECTORIZED_READER_ENABLED.key
 
   protected override def beforeAll(): Unit = {
     super.beforeAll()
@@ -66,22 +71,15 @@ abstract class OrcTest extends QueryTest with SQLTestUtils with BeforeAndAfterAl
    */
   protected def withOrcFile[T <: Product: ClassTag: TypeTag]
       (data: Seq[T])
-      (f: String => Unit): Unit = {
-    withTempPath { file =>
-      sparkContext.parallelize(data).toDF().write.orc(file.getCanonicalPath)
-      f(file.getCanonicalPath)
-    }
-  }
+      (f: String => Unit): Unit = withDataSourceFile(data)(f)
 
   /**
    * Writes `data` to a Orc file and reads it back as a `DataFrame`,
    * which is then passed to `f`. The Orc file will be deleted after `f` returns.
    */
   protected def withOrcDataFrame[T <: Product: ClassTag: TypeTag]
-      (data: Seq[T])
-      (f: DataFrame => Unit): Unit = {
-    withOrcFile(data)(path => f(spark.read.orc(path)))
-  }
+      (data: Seq[T], testVectorized: Boolean = true)
+      (f: DataFrame => Unit): Unit = withDataSourceDataFrame(data, testVectorized)(f)
 
   /**
    * Writes `data` to a Orc file, reads it back as a `DataFrame` and registers it as a
@@ -89,23 +87,14 @@ abstract class OrcTest extends QueryTest with SQLTestUtils with BeforeAndAfterAl
    * Orc file will be dropped/deleted after `f` returns.
    */
   protected def withOrcTable[T <: Product: ClassTag: TypeTag]
-      (data: Seq[T], tableName: String)
-      (f: => Unit): Unit = {
-    withOrcDataFrame(data) { df =>
-      df.createOrReplaceTempView(tableName)
-      withTempView(tableName)(f)
-    }
-  }
+      (data: Seq[T], tableName: String, testVectorized: Boolean = true)
+      (f: => Unit): Unit = withDataSourceTable(data, tableName, testVectorized)(f)
 
   protected def makeOrcFile[T <: Product: ClassTag: TypeTag](
-      data: Seq[T], path: File): Unit = {
-    data.toDF().write.mode(SaveMode.Overwrite).orc(path.getCanonicalPath)
-  }
+      data: Seq[T], path: File): Unit = makeDataSourceFile(data, path)
 
   protected def makeOrcFile[T <: Product: ClassTag: TypeTag](
-      df: DataFrame, path: File): Unit = {
-    df.write.mode(SaveMode.Overwrite).orc(path.getCanonicalPath)
-  }
+      df: DataFrame, path: File): Unit = makeDataSourceFile(df, path)
 
   protected def checkPredicatePushDown(df: DataFrame, numRows: Int, predicate: String): Unit = {
     withTempPath { file =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
@@ -44,7 +44,6 @@ import org.apache.spark.sql.internal.SQLConf.ORC_IMPLEMENTATION
  *   -> HiveOrcFilterSuite
  */
 abstract class OrcTest extends QueryTest with FileBasedDataSourceTest with BeforeAndAfterAll {
-  import testImplicits._
 
   val orcImp: String = "native"
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
@@ -25,7 +25,7 @@ import scala.reflect.runtime.universe.TypeTag
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.spark.sql._
-import org.apache.spark.sql.execution.datasources.DataSourceTest
+import org.apache.spark.sql.execution.datasources.FileBasedDataSourceTest
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.ORC_IMPLEMENTATION
 
@@ -43,7 +43,7 @@ import org.apache.spark.sql.internal.SQLConf.ORC_IMPLEMENTATION
  *   -> OrcFilterSuite
  *   -> HiveOrcFilterSuite
  */
-abstract class OrcTest extends QueryTest with DataSourceTest with BeforeAndAfterAll {
+abstract class OrcTest extends QueryTest with FileBasedDataSourceTest with BeforeAndAfterAll {
   import testImplicits._
 
   val orcImp: String = "native"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTest.scala
@@ -31,8 +31,8 @@ import org.apache.parquet.hadoop.metadata.{BlockMetaData, FileMetaData, ParquetM
 import org.apache.parquet.schema.MessageType
 
 import org.apache.spark.sql.{DataFrame, SaveMode}
+import org.apache.spark.sql.execution.datasources.DataSourceTest
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SQLTestUtils
 import org.apache.spark.sql.types.StructType
 
 /**
@@ -42,21 +42,17 @@ import org.apache.spark.sql.types.StructType
  * convenient to use tuples rather than special case classes when writing test cases/suites.
  * Especially, `Tuple1.apply` can be used to easily wrap a single type/value.
  */
-private[sql] trait ParquetTest extends SQLTestUtils {
+private[sql] trait ParquetTest extends DataSourceTest {
+
+  override protected val dataSourceName: String = "parquet"
+  override protected val vectorizedReaderEnabledKey: String =
+    SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key
 
   /**
    * Reads the parquet file at `path`
    */
   protected def readParquetFile(path: String, testVectorized: Boolean = true)
-      (f: DataFrame => Unit) = {
-    (true :: false :: Nil).foreach { vectorized =>
-      if (!vectorized || testVectorized) {
-        withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> vectorized.toString) {
-          f(spark.read.parquet(path.toString))
-        }
-      }
-    }
-  }
+      (f: DataFrame => Unit) = readFile(path, testVectorized)(f)
 
   /**
    * Writes `data` to a Parquet file, which is then passed to `f` and will be deleted after `f`
@@ -64,12 +60,7 @@ private[sql] trait ParquetTest extends SQLTestUtils {
    */
   protected def withParquetFile[T <: Product: ClassTag: TypeTag]
       (data: Seq[T])
-      (f: String => Unit): Unit = {
-    withTempPath { file =>
-      spark.createDataFrame(data).write.parquet(file.getCanonicalPath)
-      f(file.getCanonicalPath)
-    }
-  }
+      (f: String => Unit): Unit = withDataSourceFile(data)(f)
 
   /**
    * Writes `data` to a Parquet file and reads it back as a [[DataFrame]],
@@ -77,9 +68,7 @@ private[sql] trait ParquetTest extends SQLTestUtils {
    */
   protected def withParquetDataFrame[T <: Product: ClassTag: TypeTag]
       (data: Seq[T], testVectorized: Boolean = true)
-      (f: DataFrame => Unit): Unit = {
-    withParquetFile(data)(path => readParquetFile(path.toString, testVectorized)(f))
-  }
+      (f: DataFrame => Unit): Unit = withDataSourceDataFrame(data, testVectorized)(f)
 
   /**
    * Writes `data` to a Parquet file, reads it back as a [[DataFrame]] and registers it as a
@@ -88,22 +77,13 @@ private[sql] trait ParquetTest extends SQLTestUtils {
    */
   protected def withParquetTable[T <: Product: ClassTag: TypeTag]
       (data: Seq[T], tableName: String, testVectorized: Boolean = true)
-      (f: => Unit): Unit = {
-    withParquetDataFrame(data, testVectorized) { df =>
-      df.createOrReplaceTempView(tableName)
-      withTempView(tableName)(f)
-    }
-  }
+      (f: => Unit): Unit = withDataSourceTable(data, tableName, testVectorized)(f)
 
   protected def makeParquetFile[T <: Product: ClassTag: TypeTag](
-      data: Seq[T], path: File): Unit = {
-    spark.createDataFrame(data).write.mode(SaveMode.Overwrite).parquet(path.getCanonicalPath)
-  }
+      data: Seq[T], path: File): Unit = makeDataSourceFile(data, path)
 
   protected def makeParquetFile[T <: Product: ClassTag: TypeTag](
-      df: DataFrame, path: File): Unit = {
-    df.write.mode(SaveMode.Overwrite).parquet(path.getCanonicalPath)
-  }
+      df: DataFrame, path: File): Unit = makeDataSourceFile(df, path)
 
   protected def makePartitionDir(
       basePath: File,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTest.scala
@@ -31,7 +31,7 @@ import org.apache.parquet.hadoop.metadata.{BlockMetaData, FileMetaData, ParquetM
 import org.apache.parquet.schema.MessageType
 
 import org.apache.spark.sql.{DataFrame, SaveMode}
-import org.apache.spark.sql.execution.datasources.DataSourceTest
+import org.apache.spark.sql.execution.datasources.FileBasedDataSourceTest
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 
@@ -42,7 +42,7 @@ import org.apache.spark.sql.types.StructType
  * convenient to use tuples rather than special case classes when writing test cases/suites.
  * Especially, `Tuple1.apply` can be used to easily wrap a single type/value.
  */
-private[sql] trait ParquetTest extends DataSourceTest {
+private[sql] trait ParquetTest extends FileBasedDataSourceTest {
 
   override protected val dataSourceName: String = "parquet"
   override protected val vectorizedReaderEnabledKey: String =

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTest.scala
@@ -30,7 +30,7 @@ import org.apache.parquet.hadoop.{Footer, ParquetFileReader, ParquetFileWriter}
 import org.apache.parquet.hadoop.metadata.{BlockMetaData, FileMetaData, ParquetMetadata}
 import org.apache.parquet.schema.MessageType
 
-import org.apache.spark.sql.{DataFrame, SaveMode}
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.execution.datasources.FileBasedDataSourceTest
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType


### PR DESCRIPTION
## What changes were proposed in this pull request?

For making test suite supporting both Parquet and Orc by reusing test cases, this patch extracts the methods for testing. For example, if we need to test a common feature shared by Parquet and Orc, we should be able to write test cases once and reuse them to test both formats.

This patch extracts the methods for testing and uses a variable `dataSourceName` to set up data format to test against with.

## How was this patch tested?

Existing tests.