### PR TITLE
[MINOR] Add Jenkins and AppVeyor badges at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
-# Apache Spark
+[![Jenkins Build](https://amplab.cs.berkeley.edu/jenkins/job/spark-master-test-sbt-hadoop-2.7/badge/icon)](https://amplab.cs.berkeley.edu/jenkins/job/spark-master-test-sbt-hadoop-2.7)
+[![AppVeyor Build](https://img.shields.io/appveyor/ci/ApacheSoftwareFoundation/spark/master.svg?style=plastic&logo=appveyor)](https://ci.appveyor.com/project/ApacheSoftwareFoundation/spark)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/pyspark.svg?label=pypi%20downloads&style=plastic)](https://pypi.org/project/pyspark)
+[![Commit Activity](https://img.shields.io/github/commit-activity/4w/apache/spark.svg?style=plastic)](https://github.com/apache/spark/commits/master)
+
+<p align="center">
+  <a href="http://spark.apache.org">
+    <img src="https://spark.apache.org/images/spark-logo-trademark.png" alt="Apache Spark Logo">
+  </a>
+</p>
 
 Spark is a fast and general cluster computing system for Big Data. It provides
 high-level APIs in Scala, Java, Python, and R, and an optimized engine that
@@ -6,9 +15,6 @@ supports general computation graphs for data analysis. It also supports a
 rich set of higher-level tools including Spark SQL for SQL and DataFrames,
 MLlib for machine learning, GraphX for graph processing,
 and Spark Streaming for stream processing.
-
-<http://spark.apache.org/>
-
 
 ## Online Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 [![Jenkins Build](https://amplab.cs.berkeley.edu/jenkins/job/spark-master-test-sbt-hadoop-2.7/badge/icon)](https://amplab.cs.berkeley.edu/jenkins/job/spark-master-test-sbt-hadoop-2.7)
 [![AppVeyor Build](https://img.shields.io/appveyor/ci/ApacheSoftwareFoundation/spark/master.svg?style=plastic&logo=appveyor)](https://ci.appveyor.com/project/ApacheSoftwareFoundation/spark)
-[![PyPI Downloads](https://img.shields.io/pypi/dm/pyspark.svg?label=pypi%20downloads&style=plastic)](https://pypi.org/project/pyspark)
-[![Commit Activity](https://img.shields.io/github/commit-activity/4w/apache/spark.svg?style=plastic)](https://github.com/apache/spark/commits/master)
 
 <p align="center">
   <a href="http://spark.apache.org">

--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
+# Apache Spark
+
 [![Jenkins Build](https://amplab.cs.berkeley.edu/jenkins/job/spark-master-test-sbt-hadoop-2.7/badge/icon)](https://amplab.cs.berkeley.edu/jenkins/job/spark-master-test-sbt-hadoop-2.7)
 [![AppVeyor Build](https://img.shields.io/appveyor/ci/ApacheSoftwareFoundation/spark/master.svg?style=plastic&logo=appveyor)](https://ci.appveyor.com/project/ApacheSoftwareFoundation/spark)
-
-<p align="center">
-  <a href="http://spark.apache.org">
-    <img src="https://spark.apache.org/images/spark-logo-trademark.png" alt="Apache Spark Logo">
-  </a>
-</p>
 
 Spark is a fast and general cluster computing system for Big Data. It provides
 high-level APIs in Scala, Java, Python, and R, and an optimized engine that
@@ -13,6 +9,9 @@ supports general computation graphs for data analysis. It also supports a
 rich set of higher-level tools including Spark SQL for SQL and DataFrames,
 MLlib for machine learning, GraphX for graph processing,
 and Spark Streaming for stream processing.
+
+<http://spark.apache.org/>
+
 
 ## Online Documentation
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds Jenkins build and AppVeyor build badges

Take a look at https://github.com/apache/spark/blob/cc24b9e0b35e947e97b47ca9d1b350bb37148b41/README.md

## How was this patch tested?

Manually tested by `grip`.
