### PR TITLE
[SPARK-26712]Support multi directories for executor shuffle info recovery in yarn shuffle serivce

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockHandler.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import com.codahale.metrics.Gauge;
@@ -64,6 +65,12 @@ public class ExternalShuffleBlockHandler extends RpcHandler {
     throws IOException {
     this(new OneForOneStreamManager(),
       new ExternalShuffleBlockResolver(conf, registeredExecutorFile));
+  }
+
+  public ExternalShuffleBlockHandler(
+      TransportConf conf, List<String> localDirs, String recoveryFileName, long diskCheckInterval) throws IOException {
+    this(new OneForOneStreamManager(),
+        new ExternalShuffleBlockResolver(conf, localDirs, recoveryFileName, diskCheckInterval));
   }
 
   /** Enables mocking out the StreamManager and BlockManager. */

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockHandler.java
@@ -61,16 +61,17 @@ public class ExternalShuffleBlockHandler extends RpcHandler {
   private final OneForOneStreamManager streamManager;
   private final ShuffleMetrics metrics;
 
-  public ExternalShuffleBlockHandler(TransportConf conf, File registeredExecutorFile)
+  public ExternalShuffleBlockHandler(
+      TransportConf conf, File registeredExecutorFile)
     throws IOException {
-    this(new OneForOneStreamManager(),
-      new ExternalShuffleBlockResolver(conf, registeredExecutorFile));
+    this(conf, registeredExecutorFile, null, -1L);
   }
 
   public ExternalShuffleBlockHandler(
-      TransportConf conf, List<String> localDirs, String recoveryFileName, long diskCheckInterval) throws IOException {
+      TransportConf conf, File registeredExecutorFile, String[] recoveryDirs, long checkInterval)
+    throws IOException {
     this(new OneForOneStreamManager(),
-        new ExternalShuffleBlockResolver(conf, localDirs, recoveryFileName, diskCheckInterval));
+      new ExternalShuffleBlockResolver(conf, registeredExecutorFile, recoveryDirs, checkInterval));
   }
 
   /** Enables mocking out the StreamManager and BlockManager. */

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
@@ -24,6 +24,9 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -36,6 +39,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.cache.Weigher;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.iq80.leveldb.DB;
 import org.iq80.leveldb.DBIterator;
@@ -86,10 +90,16 @@ public class ExternalShuffleBlockResolver {
 
   private final TransportConf conf;
 
+  private final List<String> recoveryPaths;
+
+  private final String recoveryFileName;
+
+  private AtomicBoolean registerExecutorFailed = new AtomicBoolean(false);
+
   @VisibleForTesting
-  final File registeredExecutorFile;
+  File registeredExecutorFile;
   @VisibleForTesting
-  final DB db;
+  DB db;
 
   private final List<String> knownManagers = Arrays.asList(
     "org.apache.spark.shuffle.sort.SortShuffleManager",
@@ -97,19 +107,56 @@ public class ExternalShuffleBlockResolver {
 
   public ExternalShuffleBlockResolver(TransportConf conf, File registeredExecutorFile)
       throws IOException {
-    this(conf, registeredExecutorFile, Executors.newSingleThreadExecutor(
+    this(conf, registeredExecutorFile, null, null, -1,
+        Executors.newSingleThreadExecutor(
         // Add `spark` prefix because it will run in NM in Yarn mode.
         NettyUtils.createThreadFactory("spark-shuffle-directory-cleaner")));
   }
+
+  public ExternalShuffleBlockResolver(
+      TransportConf conf,
+      File registeredExecutorFile,
+      Executor directoryCleaner) throws IOException {
+    this(conf, registeredExecutorFile, null, null, -1, directoryCleaner);
+  }
+
+  ExternalShuffleBlockResolver(
+      TransportConf conf,
+      List<String> recoveryPaths,
+      String registeredExecutorFileName,
+      long checkInterval) throws IOException {
+    this(conf, null, recoveryPaths, registeredExecutorFileName, checkInterval,
+        Executors.newSingleThreadExecutor(
+            NettyUtils.createThreadFactory("spark-shuffle-directory-cleaner")));
+  }
+
 
   // Allows tests to have more control over when directories are cleaned up.
   @VisibleForTesting
   ExternalShuffleBlockResolver(
       TransportConf conf,
       File registeredExecutorFile,
+      List<String> recoveryPaths,
+      String recoveryFileName,
+      long checkInterval,
       Executor directoryCleaner) throws IOException {
     this.conf = conf;
-    this.registeredExecutorFile = registeredExecutorFile;
+    if (registeredExecutorFile != null) {
+      this.registeredExecutorFile = registeredExecutorFile;
+      this.recoveryPaths = null;
+      this.recoveryFileName = null;
+    } else {
+      this.recoveryPaths = recoveryPaths;
+      this.recoveryFileName = recoveryFileName;
+      this.registeredExecutorFile = findRegisteredExecutorFile();
+    }
+    if (checkInterval > 0) {
+      ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(
+          NettyUtils.createThreadFactory("spark-shuffle-disk-checker"));
+      executor.scheduleAtFixedRate(() -> {
+        checkRegisteredExecutorFileAndRecover();
+      }, checkInterval, checkInterval, TimeUnit.MILLISECONDS);
+    }
     String indexCacheSize = conf.get("spark.shuffle.service.index.cache.size", "100m");
     CacheLoader<File, ShuffleIndexInformation> indexCacheLoader =
         new CacheLoader<File, ShuffleIndexInformation>() {
@@ -138,6 +185,69 @@ public class ExternalShuffleBlockResolver {
     return executors.size();
   }
 
+  public File findRegisteredExecutorFile() {
+    File newFile = null;
+    if (recoveryPaths != null) {
+      File latestFile = null;
+      for (String path : recoveryPaths) {
+        File registeredExecutorFile = new File(path, recoveryFileName);
+        if (registeredExecutorFile.exists()) {
+          if (registeredExecutorFile.canRead()
+              && registeredExecutorFile.canWrite()) {
+            if (latestFile == null || registeredExecutorFile.lastModified() > latestFile.lastModified()) {
+              latestFile = registeredExecutorFile;
+            }
+          }
+        } else {
+          try {
+            JavaUtils.deleteRecursively(registeredExecutorFile);
+            newFile = registeredExecutorFile;
+          } catch (IOException e) {
+            logger.warn("Failed to delete old registered executor file " + registeredExecutorFile, e);
+          }
+        }
+      }
+      if (latestFile == null) {
+        return newFile;
+      }
+      return latestFile;
+    }
+    return null;
+  }
+
+  public File saveNewRegisteredExecutorFile() {
+    if (recoveryPaths != null) {
+      for (String path : recoveryPaths) {
+        File newRegisteredExecutorFile = new File(path, recoveryFileName);
+        if (!newRegisteredExecutorFile.exists()) {
+          try {
+            DB newDb = LevelDBProvider.initLevelDB(newRegisteredExecutorFile, CURRENT_VERSION, mapper);
+            for (Map.Entry<AppExecId, ExecutorShuffleInfo> entry : executors.entrySet()) {
+              byte[] key = dbAppExecKey(entry.getKey());
+              byte[] value = mapper.writeValueAsString(entry.getValue()).getBytes(StandardCharsets.UTF_8);
+              db.put(key, value);
+            }
+            if (this.db != null) {
+              try {
+                this.db.close();
+                JavaUtils.deleteRecursively(registeredExecutorFile);
+              } catch (IOException e) {
+                logger.warn("Failed to clean up old registered executors file at " + registeredExecutorFile, e);
+              }
+            }
+            this.db = newDb;
+            this.registeredExecutorFile = newRegisteredExecutorFile;
+            return newRegisteredExecutorFile;
+          } catch (Exception e) {
+            logger.error("Exception occurred while saving registered executors info to new file " + newRegisteredExecutorFile, e);
+            // continue
+          }
+        }
+      }
+    }
+    return null;
+  }
+
   /** Registers a new Executor with all the configuration we need to find its shuffle files. */
   public void registerExecutor(
       String appId,
@@ -157,6 +267,7 @@ public class ExternalShuffleBlockResolver {
       }
     } catch (Exception e) {
       logger.error("Error saving registered executors", e);
+      registerExecutorFailed.getAndSet(true);
     }
     executors.put(fullId, executorInfo);
   }
@@ -271,6 +382,22 @@ public class ExternalShuffleBlockResolver {
       } catch (Exception e) {
         logger.error("Failed to delete non-shuffle files in directory: " + localDir, e);
       }
+    }
+  }
+
+  /**
+   * Check if the registeredExecutorFile is unhealthy, and try to recover. In the recovery,
+   * It will create a new registeredExecutorFile and save the latest executors info.
+   */
+  private void checkRegisteredExecutorFileAndRecover() {
+    if (this.registeredExecutorFile == null) {
+      return;
+    } else if (db != null && (!registeredExecutorFile.exists() ||
+        !registeredExecutorFile.canRead() ||
+        !registeredExecutorFile.canWrite())) {
+        saveNewRegisteredExecutorFile();
+    } else if (registerExecutorFailed.getAndSet(false)) {
+      saveNewRegisteredExecutorFile();
     }
   }
 

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/shuffle/ShuffleTestAccessor.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/shuffle/ShuffleTestAccessor.scala
@@ -44,6 +44,11 @@ object ShuffleTestAccessor {
     Option(resolver.executors.get(id))
   }
 
+  def getAllExecutorInfos(resolver: ExternalShuffleBlockResolver):
+  ConcurrentMap[ExternalShuffleBlockResolver.AppExecId, ExecutorShuffleInfo] = {
+    resolver.executors
+  }
+
   def registeredExecutorFile(resolver: ExternalShuffleBlockResolver): File = {
     resolver.registeredExecutorFile
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, `ExecutorShuffleInfo` can be recovered from file if NM recovery enabled, however, the recovery file is under a single directory, which may be unavailable if disk broken. So if a NM restart happen(may be caused by kill or some reason), the shuffle service can not start and the `ExecutorShuffleInfo` would lost even if there are existing executors on the node.

This may finally cause job failures(if node or executors on it not blacklisted), or at least, it will cause resource waste.(shuffle from this node always failed.), for long running spark applications, this problem may be more serious.

This PR introduced a mechanism to support multi directories for executor shuffle info recovery, this can improve the robustness of the `YarnShuffleService`.

## How was this patch tested?

UT

Please review http://spark.apache.org/contributing.html before opening a pull request.
