### PR TITLE
[SPARK-26726] Synchronize the amount of memory used by the broadcast variable to the UI display

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -991,15 +991,15 @@ private[spark] class AppStatusListener(
   private def updateBroadcastBlock(
       event: SparkListenerBlockUpdated,
       broadcast: BroadcastBlockId): Unit = {
-    val now = System.nanoTime()
     val executorId = event.blockUpdatedInfo.blockManagerId.executorId
-    val storageLevel = event.blockUpdatedInfo.storageLevel
-
-    // Whether values are being added to or removed from the existing accounting.
-    val diskDelta = event.blockUpdatedInfo.diskSize * (if (storageLevel.useDisk) 1 else -1)
-    val memoryDelta = event.blockUpdatedInfo.memSize * (if (storageLevel.useMemory) 1 else -1)
-
     liveExecutors.get(executorId).foreach { exec =>
+      val now = System.nanoTime()
+      val storageLevel = event.blockUpdatedInfo.storageLevel
+
+      // Whether values are being added to or removed from the existing accounting.
+      val diskDelta = event.blockUpdatedInfo.diskSize * (if (storageLevel.useDisk) 1 else -1)
+      val memoryDelta = event.blockUpdatedInfo.memSize * (if (storageLevel.useMemory) 1 else -1)
+
       updateExecutorMemoryDiskInfo(exec, storageLevel, memoryDelta, diskDelta)
       maybeUpdate(exec, now)
     }

--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -772,7 +772,6 @@ private[spark] class AppStatusListener(
           maybeUpdate(exec, now)
         }
       }
-
     }
 
     kvstore.delete(classOf[RDDStorageInfoWrapper], event.rddId)

--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -760,7 +760,7 @@ private[spark] class AppStatusListener(
       // Use RDD distribution to update executor memory and disk usage info.
       liveRDD.getDistributions().foreach { case (executorId, rddDist) =>
         val maybeExec = liveExecutors.get(executorId)
-        updateExecutorMemoryDiskUsed(maybeExec, storageLevel, -rddDist.memoryUsed,
+        updateExecutorMemoryDiskInfo(maybeExec, storageLevel, -rddDist.memoryUsed,
           -rddDist.diskUsed, Option(-rddDist.offHeapUsed), Option(-rddDist.onHeapUsed))
         maybeExec.foreach(exec => maybeUpdate(exec, now))
       }
@@ -877,7 +877,7 @@ private[spark] class AppStatusListener(
 
     // Update the executor stats first, since they are used to calculate the free memory
     // on tracked RDD distributions.
-    updateExecutorMemoryDiskUsed(maybeExec, storageLevel, memoryDelta, diskDelta, None, None)
+    updateExecutorMemoryDiskInfo(maybeExec, storageLevel, memoryDelta, diskDelta, None, None)
 
     // Update the block entry in the RDD info, keeping track of the deltas above so that we
     // can update the executor information too.
@@ -990,12 +990,13 @@ private[spark] class AppStatusListener(
     val memoryDelta = event.blockUpdatedInfo.memSize * (if (storageLevel.useMemory) 1 else -1)
 
     val maybeExec = liveExecutors.get(executorId)
-    updateExecutorMemoryDiskUsed(maybeExec, storageLevel, memoryDelta, diskDelta, None, None)
+    updateExecutorMemoryDiskInfo(maybeExec, storageLevel, memoryDelta, diskDelta, None, None)
     maybeExec.foreach(exec => maybeUpdate(exec, now))
 
   }
+    
   // update executor memory and disk usage info
-  private def updateExecutorMemoryDiskUsed(
+  private def updateExecutorMemoryDiskInfo(
       maybeExec: Option[LiveExecutor],
       storageLevel: StorageLevel,
       memoryDelta: Long,


### PR DESCRIPTION
…not synchronized to the UI display

## What changes were proposed in this pull request?
The amount of memory used by the broadcast variable is not synchronized to the UI display.
I added the case for BroadcastBlockId and updated the memory usage.

## How was this patch tested?

We can test this patch with unit tests.