### PR TITLE
[SPARK-26718][SS][BRANCH-2.4] Fixed integer overflow in SS kafka rateLimit calculation

### DIFF
--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchReader.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchReader.scala
@@ -243,7 +243,11 @@ private[kafka010] class KafkaMicroBatchReader(
             // need to be careful of integer overflow
             // therefore added canary checks where to see if off variable could be overflowed
             // refer to [https://issues.apache.org/jira/browse/SPARK-26718]
-            val off = if (prorateLong > Long.MaxValue - begin) Long.MaxValue else begin + prorateLong
+            val off = if (prorateLong > Long.MaxValue - begin) {
+              Long.MaxValue
+            } else {
+              begin + prorateLong
+            }
             // Paranoia, make sure not to return an offset that's past end
             Math.min(end, off)
           }.getOrElse(end)

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchReader.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchReader.scala
@@ -239,7 +239,11 @@ private[kafka010] class KafkaMicroBatchReader(
             val begin = from.get(tp).getOrElse(fromNew(tp))
             val prorate = limit * (size / total)
             // Don't completely starve small topicpartitions
-            val off = begin + (if (prorate < 1) Math.ceil(prorate) else Math.floor(prorate)).toLong
+            val prorateLong = (if (prorate < 1) Math.ceil(prorate) else Math.floor(prorate)).toLong
+            // need to be careful of integer overflow
+            // therefore added canary checks where to see if off variable could be overflowed
+            // refer to [https://issues.apache.org/jira/browse/SPARK-26718]
+            val off = if (prorateLong > Long.MaxValue - begin) Long.MaxValue else begin + prorateLong
             // Paranoia, make sure not to return an offset that's past end
             Math.min(end, off)
           }.getOrElse(end)

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
@@ -188,9 +188,11 @@ private[kafka010] class KafkaSource(
           tp -> sizes.get(tp).map { size =>
             val begin = from.get(tp).getOrElse(fromNew(tp))
             val prorate = limit * (size / total)
-            logDebug(s"rateLimit $tp prorated amount is $prorate")
-            // Don't completely starve small topicpartitions
-            val off = begin + (if (prorate < 1) Math.ceil(prorate) else Math.floor(prorate)).toLong
+            val prorateLong = (if (prorate < 1) Math.ceil(prorate) else Math.floor(prorate)).toLong
+            // need to be careful of integer overflow
+            // therefore added canary checks where to see if off variable could be overflowed
+            // refer to [https://issues.apache.org/jira/browse/SPARK-26718]
+            val off = if (prorateLong > Long.MaxValue - begin) Long.MaxValue else begin + prorateLong
             logDebug(s"rateLimit $tp new offset is $off")
             // Paranoia, make sure not to return an offset that's past end
             Math.min(end, off)

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
@@ -192,7 +192,11 @@ private[kafka010] class KafkaSource(
             // need to be careful of integer overflow
             // therefore added canary checks where to see if off variable could be overflowed
             // refer to [https://issues.apache.org/jira/browse/SPARK-26718]
-            val off = if (prorateLong > Long.MaxValue - begin) Long.MaxValue else begin + prorateLong
+            val off = if (prorateLong > Long.MaxValue - begin) {
+              Long.MaxValue
+            } else {
+              begin + prorateLong
+            }
             logDebug(s"rateLimit $tp new offset is $off")
             // Paranoia, make sure not to return an offset that's past end
             Math.min(end, off)

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
@@ -188,6 +188,8 @@ private[kafka010] class KafkaSource(
           tp -> sizes.get(tp).map { size =>
             val begin = from.get(tp).getOrElse(fromNew(tp))
             val prorate = limit * (size / total)
+            logDebug(s"rateLimit $tp prorated amount is $prorate")
+            // Don't completely starve small topicpartitions
             val prorateLong = (if (prorate < 1) Math.ceil(prorate) else Math.floor(prorate)).toLong
             // need to be careful of integer overflow
             // therefore added canary checks where to see if off variable could be overflowed

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -199,7 +199,6 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
       StopStream)
   }
 
-
   test("SPARK-26718 Rate limit set to Long.Max should not overflow integer " +
     "during end offset calculation") {
     val topic = newTopic()

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -1093,7 +1093,6 @@ class KafkaMicroBatchV2SourceSuite extends KafkaMicroBatchSourceSuiteBase {
     intercept[IllegalArgumentException] { test(minPartitions = "-1", 1, true) }
   }
 
-
 }
 
 abstract class KafkaSourceSuiteBase extends KafkaSourceTest {

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -200,25 +200,26 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
   }
 
 
-  test("Rate limit set to Long.Max should not overflow integer during end offset calculation[SPARK-26718]") {
+  test("SPARK-26718 Rate limit set to Long.Max should not overflow integer " +
+    "during end offset calculation") {
     val topic = newTopic()
     testUtils.createTopic(topic, partitions = 1)
-    testUtils.sendMessages(topic, (0 until 5000).map(_.toString).toArray, Some(0))   // fill in 5000 messages to trigger potential integer overflow
-
+    // fill in 5 messages to trigger potential integer overflow
+    testUtils.sendMessages(topic, (0 until 5).map(_.toString).toArray, Some(0))
 
     val partitionOffsets = Map(
-      new TopicPartition(topic, 0) -> 5000L
+      new TopicPartition(topic, 0) -> 5L
     )
     val startingOffsets = JsonUtils.partitionOffsets(partitionOffsets)
 
-    val sparkSession = spark
-    import sparkSession.implicits._
     val kafka = spark
       .readStream
       .format("kafka")
       .option("kafka.bootstrap.servers", testUtils.brokerAddress)
-      .option("startingOffsets", startingOffsets)                 // use latest to force begin to be 5000
-      .option("maxOffsetsPerTrigger", Long.MaxValue.toString)     // use Long.Max to try to trigger overflow
+      // use latest to force begin to be 5
+      .option("startingOffsets", startingOffsets)
+      // use Long.Max to try to trigger overflow
+      .option("maxOffsetsPerTrigger", Long.MaxValue)
       .option("subscribe", topic)
       .option("kafka.metadata.max.age.ms", "1")
       .load()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the integer overflow issue in rateLimit.

## How was this patch tested?

Pass the Jenkins with newly added UT for the possible case where integer could be overflowed.
