### PR TITLE
[SPARK-26732][CORE][TEST] Wait for listener bus to process events in SparkContextInfoSuite.

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkContextInfoSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextInfoSuite.scala
@@ -60,6 +60,7 @@ class SparkContextInfoSuite extends SparkFunSuite with LocalSparkContext {
     val rdd = sc.makeRDD(Array(1, 2, 3, 4), 2).cache()
     assert(sc.getRDDStorageInfo.size === 0)
     rdd.collect()
+    sc.listenerBus.waitUntilEmpty(10000)
     assert(sc.getRDDStorageInfo.size === 1)
     assert(sc.getRDDStorageInfo.head.isCached)
     assert(sc.getRDDStorageInfo.head.memSize > 0)


### PR DESCRIPTION
Otherwise the RDD data may be out of date by the time the test tries to check it.

Tested with an artificial delay inserted in AppStatusListener.
