### PR TITLE
[SPARK-26737][YARN] Executor/Task STDERR & STDOUT log urls are not correct in Yarn deployment mode

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
@@ -243,7 +243,7 @@ private[yarn] class ExecutorRunnable(
 
     // Add log urls
     container.foreach { c =>
-      sys.env.filterKeys(_.endsWith("USER")).foreach { user =>
+      sys.env.get("SPARK_USER").orElse(sys.env.get("USER")).foreach { user =>
         val containerId = ConverterUtils.toString(c.getId)
         val address = c.getNodeHttpAddress
         val baseUrl = s"$httpScheme$address/node/containerlogs/$containerId/$user"


### PR DESCRIPTION
## What changes were proposed in this pull request?

As part of the SPARK-22404 PR, base log url formation has been changed for unmanaged am which causes to include key is also part of the base url. This PR corrects the addition of key into base url.

## How was this patch tested?

Verified the url manually and see that this has been corrected with the PR change.

Before this PR the base log url is like,

- Unmanaged AM enabled: 
  `http://ip:8042/node/containerlogs/container_1544212645385_0252_01_000002/(USER, devaraj)`

- Unmanaged AM disabled:
  `http://ip:8042/node/containerlogs/container_1544212645385_0254_01_000002/(SPARK_USER, devaraj)`

With the PR change, base log url is like this:
- Unmanaged AM enabled/disabled:
  `http://ip:8042/node/containerlogs/container_1544212645385_0253_01_000002/devaraj`

