### PR TITLE
[SPARK-26656][SQL] Benchmarks for date and timestamp functions

### DIFF
--- a/sql/core/benchmarks/DateTimeBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-results.txt
@@ -6,92 +6,92 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 cast to timestamp:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off               297 /  309         33.7          29.7       1.0X
-cast to timestamp wholestage on                271 /  288         36.9          27.1       1.1X
+cast to timestamp wholestage off               276 /  290         36.2          27.6       1.0X
+cast to timestamp wholestage on                254 /  267         39.4          25.4       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 year of timestamp:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-year of timestamp wholestage off               713 /  753         14.0          71.3       1.0X
-year of timestamp wholestage on                797 /  808         12.6          79.7       0.9X
+year of timestamp wholestage off               699 /  700         14.3          69.9       1.0X
+year of timestamp wholestage on                680 /  689         14.7          68.0       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 quarter of timestamp:                    Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off            942 /  942         10.6          94.2       1.0X
-quarter of timestamp wholestage on             812 /  839         12.3          81.2       1.2X
+quarter of timestamp wholestage off            848 /  864         11.8          84.8       1.0X
+quarter of timestamp wholestage on             784 /  797         12.8          78.4       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 month of timestamp:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-month of timestamp wholestage off              698 /  699         14.3          69.8       1.0X
-month of timestamp wholestage on               683 /  702         14.6          68.3       1.0X
+month of timestamp wholestage off              652 /  653         15.3          65.2       1.0X
+month of timestamp wholestage on               671 /  677         14.9          67.1       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 weekofyear of timestamp:                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off        1279 / 1285          7.8         127.9       1.0X
-weekofyear of timestamp wholestage on         1212 / 1260          8.3         121.2       1.1X
+weekofyear of timestamp wholestage off        1233 / 1233          8.1         123.3       1.0X
+weekofyear of timestamp wholestage on         1236 / 1240          8.1         123.6       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 day of timestamp:                        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                699 /  706         14.3          69.9       1.0X
-day of timestamp wholestage on                 679 /  683         14.7          67.9       1.0X
+day of timestamp wholestage off                649 /  655         15.4          64.9       1.0X
+day of timestamp wholestage on                 670 /  678         14.9          67.0       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 dayofyear of timestamp:                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off          732 /  733         13.7          73.2       1.0X
-dayofyear of timestamp wholestage on           709 /  715         14.1          70.9       1.0X
+dayofyear of timestamp wholestage off          692 /  704         14.5          69.2       1.0X
+dayofyear of timestamp wholestage on           695 /  698         14.4          69.5       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 dayofmonth of timestamp:                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off         713 /  729         14.0          71.3       1.0X
-dayofmonth of timestamp wholestage on          684 /  685         14.6          68.4       1.0X
+dayofmonth of timestamp wholestage off         660 /  660         15.1          66.0       1.0X
+dayofmonth of timestamp wholestage on          667 /  671         15.0          66.7       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 dayofweek of timestamp:                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off          858 /  861         11.6          85.8       1.0X
-dayofweek of timestamp wholestage on           819 /  824         12.2          81.9       1.0X
+dayofweek of timestamp wholestage off          798 /  802         12.5          79.8       1.0X
+dayofweek of timestamp wholestage on           804 /  820         12.4          80.4       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 weekday of timestamp:                    Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off            797 /  802         12.5          79.7       1.0X
-weekday of timestamp wholestage on             776 /  801         12.9          77.6       1.0X
+weekday of timestamp wholestage off            759 /  760         13.2          75.9       1.0X
+weekday of timestamp wholestage on             774 /  813         12.9          77.4       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 hour of timestamp:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off               468 /  474         21.4          46.8       1.0X
-hour of timestamp wholestage on                442 /  445         22.6          44.2       1.1X
+hour of timestamp wholestage off               465 /  468         21.5          46.5       1.0X
+hour of timestamp wholestage on                443 /  451         22.6          44.3       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 minute of timestamp:                     Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off             484 /  493         20.7          48.4       1.0X
-minute of timestamp wholestage on              449 /  452         22.3          44.9       1.1X
+minute of timestamp wholestage off             439 /  440         22.8          43.9       1.0X
+minute of timestamp wholestage on              448 /  452         22.3          44.8       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 second of timestamp:                     Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-second of timestamp wholestage off             454 /  461         22.0          45.4       1.0X
-second of timestamp wholestage on              475 /  488         21.1          47.5       1.0X
+second of timestamp wholestage off             438 /  448         22.8          43.8       1.0X
+second of timestamp wholestage on              430 /  445         23.3          43.0       1.0X
 
 
 ================================================================================================
@@ -102,15 +102,15 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 current_date:                            Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-current_date wholestage off                    220 /  222         45.5          22.0       1.0X
-current_date wholestage on                     224 /  258         44.6          22.4       1.0X
+current_date wholestage off                    212 /  213         47.2          21.2       1.0X
+current_date wholestage on                     225 /  230         44.4          22.5       0.9X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 current_timestamp:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-current_timestamp wholestage off               225 /  239         44.4          22.5       1.0X
-current_timestamp wholestage on                200 /  208         50.0          20.0       1.1X
+current_timestamp wholestage off               216 /  217         46.3          21.6       1.0X
+current_timestamp wholestage on                210 /  216         47.7          21.0       1.0X
 
 
 ================================================================================================
@@ -121,43 +121,43 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 cast to date:                            Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-cast to date wholestage off                    491 /  491         20.4          49.1       1.0X
-cast to date wholestage on                     497 /  504         20.1          49.7       1.0X
+cast to date wholestage off                    463 /  464         21.6          46.3       1.0X
+cast to date wholestage on                     502 /  508         19.9          50.2       0.9X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 last_day:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-last_day wholestage off                        722 /  728         13.8          72.2       1.0X
-last_day wholestage on                         709 /  723         14.1          70.9       1.0X
+last_day wholestage off                        693 /  701         14.4          69.3       1.0X
+last_day wholestage on                         697 /  706         14.3          69.7       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 next_day:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-next_day wholestage off                        584 /  594         17.1          58.4       1.0X
-next_day wholestage on                         603 /  611         16.6          60.3       1.0X
+next_day wholestage off                        553 /  570         18.1          55.3       1.0X
+next_day wholestage on                         595 /  597         16.8          59.5       0.9X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 date_add:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-date_add wholestage off                        496 /  496         20.1          49.6       1.0X
-date_add wholestage on                         470 /  472         21.3          47.0       1.1X
+date_add wholestage off                        459 /  463         21.8          45.9       1.0X
+date_add wholestage on                         473 /  477         21.1          47.3       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 date_sub:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-date_sub wholestage off                        475 /  476         21.1          47.5       1.0X
-date_sub wholestage on                         469 /  473         21.3          46.9       1.0X
+date_sub wholestage off                        473 /  475         21.1          47.3       1.0X
+date_sub wholestage on                         479 /  497         20.9          47.9       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 add_months:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-add_months wholestage off                      925 /  926         10.8          92.5       1.0X
-add_months wholestage on                       911 /  923         11.0          91.1       1.0X
+add_months wholestage off                      898 /  908         11.1          89.8       1.0X
+add_months wholestage on                       898 /  906         11.1          89.8       1.0X
 
 
 ================================================================================================
@@ -168,8 +168,8 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 format date:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-format date wholestage off                    7727 / 7921          1.3         772.7       1.0X
-format date wholestage on                     7449 / 7537          1.3         744.9       1.0X
+format date wholestage off                    7181 / 7228          1.4         718.1       1.0X
+format date wholestage on                     7303 / 7356          1.4         730.3       1.0X
 
 
 ================================================================================================
@@ -180,8 +180,8 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 from_unixtime:                           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                  7633 / 7797          1.3         763.3       1.0X
-from_unixtime wholestage on                   7543 / 7575          1.3         754.3       1.0X
+from_unixtime wholestage off                  7472 / 7476          1.3         747.2       1.0X
+from_unixtime wholestage on                   7453 / 7460          1.3         745.3       1.0X
 
 
 ================================================================================================
@@ -192,14 +192,225 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 from_utc_timestamp:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off              928 /  931         10.8          92.8       1.0X
-from_utc_timestamp wholestage on               865 /  873         11.6          86.5       1.1X
+from_utc_timestamp wholestage off              894 /  895         11.2          89.4       1.0X
+from_utc_timestamp wholestage on               881 /  883         11.4          88.1       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 to_utc_timestamp:                        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                915 /  921         10.9          91.5       1.0X
-to_utc_timestamp wholestage on                 877 /  881         11.4          87.7       1.0X
+to_utc_timestamp wholestage off                909 /  910         11.0          90.9       1.0X
+to_utc_timestamp wholestage on                 903 /  906         11.1          90.3       1.0X
+
+
+================================================================================================
+Intervals
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+cast interval:                           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+cast interval wholestage off                   245 /  256         40.7          24.5       1.0X
+cast interval wholestage on                    227 /  230         44.0          22.7       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+datediff:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+datediff wholestage off                        735 /  738         13.6          73.5       1.0X
+datediff wholestage on                         687 /  689         14.6          68.7       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+months_between:                          Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+months_between wholestage off                 1653 / 1654          6.1         165.3       1.0X
+months_between wholestage on                  1630 / 1636          6.1         163.0       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+window:                                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+window wholestage off                         1636 / 1661          0.6        1635.9       1.0X
+window wholestage on                        19997 / 20240          0.1       19997.4       0.1X
+
+
+================================================================================================
+Truncation
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+date_trunc YEAR:                         Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+date_trunc YEAR wholestage off                 889 /  892         11.2          88.9       1.0X
+date_trunc YEAR wholestage on                  831 /  837         12.0          83.1       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+date_trunc YYYY:                         Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+date_trunc YYYY wholestage off                 910 /  917         11.0          91.0       1.0X
+date_trunc YYYY wholestage on                  834 /  849         12.0          83.4       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+date_trunc YY:                           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+date_trunc YY wholestage off                   897 /  901         11.2          89.7       1.0X
+date_trunc YY wholestage on                    836 /  841         12.0          83.6       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+date_trunc MON:                          Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+date_trunc MON wholestage off                  942 /  944         10.6          94.2       1.0X
+date_trunc MON wholestage on                   881 /  887         11.3          88.1       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+date_trunc MONTH:                        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+date_trunc MONTH wholestage off                935 /  937         10.7          93.5       1.0X
+date_trunc MONTH wholestage on                 881 /  886         11.4          88.1       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+date_trunc MM:                           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+date_trunc MM wholestage off                   934 /  935         10.7          93.4       1.0X
+date_trunc MM wholestage on                    878 /  880         11.4          87.8       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+date_trunc DAY:                          Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+date_trunc DAY wholestage off                  472 /  478         21.2          47.2       1.0X
+date_trunc DAY wholestage on                   415 /  418         24.1          41.5       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+date_trunc DD:                           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+date_trunc DD wholestage off                   472 /  485         21.2          47.2       1.0X
+date_trunc DD wholestage on                    414 /  417         24.1          41.4       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+date_trunc HOUR:                         Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+date_trunc HOUR wholestage off                 451 /  462         22.2          45.1       1.0X
+date_trunc HOUR wholestage on                  422 /  429         23.7          42.2       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+date_trunc MINUTE:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+date_trunc MINUTE wholestage off               291 /  291         34.4          29.1       1.0X
+date_trunc MINUTE wholestage on                268 /  272         37.3          26.8       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+date_trunc SECOND:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+date_trunc SECOND wholestage off               290 /  290         34.5          29.0       1.0X
+date_trunc SECOND wholestage on                266 /  270         37.6          26.6       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+date_trunc WEEK:                         Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+date_trunc WEEK wholestage off                 794 /  797         12.6          79.4       1.0X
+date_trunc WEEK wholestage on                  754 /  761         13.3          75.4       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+date_trunc QUARTER:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+date_trunc QUARTER wholestage off             5261 / 5271          1.9         526.1       1.0X
+date_trunc QUARTER wholestage on              5145 / 5151          1.9         514.5       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+trunc year:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+trunc year wholestage off                      233 /  233         43.0          23.3       1.0X
+trunc year wholestage on                       213 /  216         46.9          21.3       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+trunc yyyy:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+trunc yyyy wholestage off                      232 /  233         43.1          23.2       1.0X
+trunc yyyy wholestage on                       214 /  223         46.7          21.4       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+trunc yy:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+trunc yy wholestage off                        228 /  228         43.9          22.8       1.0X
+trunc yy wholestage on                         215 /  219         46.6          21.5       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+trunc mon:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+trunc mon wholestage off                       232 /  232         43.0          23.2       1.0X
+trunc mon wholestage on                        216 /  217         46.4          21.6       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+trunc month:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+trunc month wholestage off                     233 /  233         43.0          23.3       1.0X
+trunc month wholestage on                      215 /  217         46.4          21.5       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+trunc mm:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+trunc mm wholestage off                        226 /  233         44.2          22.6       1.0X
+trunc mm wholestage on                         214 /  220         46.7          21.4       1.1X
+
+
+================================================================================================
+Parsing
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+to timestamp str:                        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+to timestamp str wholestage off                166 /  170          6.0         165.8       1.0X
+to timestamp str wholestage on                 165 /  167          6.1         164.9       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+to_timestamp:                            Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+to_timestamp wholestage off                   1439 / 1445          0.7        1439.4       1.0X
+to_timestamp wholestage on                    1366 / 1368          0.7        1365.7       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+to_unix_timestamp:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+to_unix_timestamp wholestage off              1386 / 1389          0.7        1385.6       1.0X
+to_unix_timestamp wholestage on               1388 / 1392          0.7        1387.8       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+to date str:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+to date str wholestage off                     163 /  166          6.1         163.3       1.0X
+to date str wholestage on                      160 /  163          6.2         160.3       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+to_date:                                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+to_date wholestage off                        1474 / 1474          0.7        1473.9       1.0X
+to_date wholestage on                         1460 / 1465          0.7        1459.6       1.0X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-results.txt
@@ -6,92 +6,92 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 cast to timestamp:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off               283 /  303         35.4          28.3       1.0X
-cast to timestamp wholestage on                267 /  290         37.4          26.7       1.1X
+cast to timestamp wholestage off               297 /  309         33.7          29.7       1.0X
+cast to timestamp wholestage on                271 /  288         36.9          27.1       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
-year to timestamp:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+year of timestamp:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-year to timestamp wholestage off               725 /  774         13.8          72.5       1.0X
-year to timestamp wholestage on                685 /  699         14.6          68.5       1.1X
+year of timestamp wholestage off               713 /  753         14.0          71.3       1.0X
+year of timestamp wholestage on                797 /  808         12.6          79.7       0.9X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
-quarter to timestamp:                    Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+quarter of timestamp:                    Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-quarter to timestamp wholestage off            836 /  836         12.0          83.6       1.0X
-quarter to timestamp wholestage on             837 /  847         11.9          83.7       1.0X
+quarter of timestamp wholestage off            942 /  942         10.6          94.2       1.0X
+quarter of timestamp wholestage on             812 /  839         12.3          81.2       1.2X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
-month to timestamp:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+month of timestamp:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-month to timestamp wholestage off              687 /  688         14.6          68.7       1.0X
-month to timestamp wholestage on               712 /  722         14.1          71.2       1.0X
+month of timestamp wholestage off              698 /  699         14.3          69.8       1.0X
+month of timestamp wholestage on               683 /  702         14.6          68.3       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
-weekofyear to timestamp:                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+weekofyear of timestamp:                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-weekofyear to timestamp wholestage off        1217 / 1220          8.2         121.7       1.0X
-weekofyear to timestamp wholestage on         1208 / 1224          8.3         120.8       1.0X
+weekofyear of timestamp wholestage off        1279 / 1285          7.8         127.9       1.0X
+weekofyear of timestamp wholestage on         1212 / 1260          8.3         121.2       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
-day to timestamp:                        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+day of timestamp:                        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-day to timestamp wholestage off                708 /  712         14.1          70.8       1.0X
-day to timestamp wholestage on                 707 /  715         14.1          70.7       1.0X
+day of timestamp wholestage off                699 /  706         14.3          69.9       1.0X
+day of timestamp wholestage on                 679 /  683         14.7          67.9       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
-dayofyear to timestamp:                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+dayofyear of timestamp:                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-dayofyear to timestamp wholestage off          714 /  715         14.0          71.4       1.0X
-dayofyear to timestamp wholestage on           737 /  753         13.6          73.7       1.0X
+dayofyear of timestamp wholestage off          732 /  733         13.7          73.2       1.0X
+dayofyear of timestamp wholestage on           709 /  715         14.1          70.9       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
-dayofmonth to timestamp:                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+dayofmonth of timestamp:                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-dayofmonth to timestamp wholestage off         700 /  703         14.3          70.0       1.0X
-dayofmonth to timestamp wholestage on          710 /  722         14.1          71.0       1.0X
+dayofmonth of timestamp wholestage off         713 /  729         14.0          71.3       1.0X
+dayofmonth of timestamp wholestage on          684 /  685         14.6          68.4       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
-dayofweek to timestamp:                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+dayofweek of timestamp:                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-dayofweek to timestamp wholestage off          862 /  866         11.6          86.2       1.0X
-dayofweek to timestamp wholestage on           849 /  868         11.8          84.9       1.0X
+dayofweek of timestamp wholestage off          858 /  861         11.6          85.8       1.0X
+dayofweek of timestamp wholestage on           819 /  824         12.2          81.9       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
-weekday to timestamp:                    Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+weekday of timestamp:                    Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-weekday to timestamp wholestage off            770 /  771         13.0          77.0       1.0X
-weekday to timestamp wholestage on             795 /  808         12.6          79.5       1.0X
+weekday of timestamp wholestage off            797 /  802         12.5          79.7       1.0X
+weekday of timestamp wholestage on             776 /  801         12.9          77.6       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
-hour to timestamp:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+hour of timestamp:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-hour to timestamp wholestage off               470 /  471         21.3          47.0       1.0X
-hour to timestamp wholestage on                475 /  479         21.1          47.5       1.0X
+hour of timestamp wholestage off               468 /  474         21.4          46.8       1.0X
+hour of timestamp wholestage on                442 /  445         22.6          44.2       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
-minute to timestamp:                     Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+minute of timestamp:                     Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-minute to timestamp wholestage off             470 /  480         21.3          47.0       1.0X
-minute to timestamp wholestage on              478 /  488         20.9          47.8       1.0X
+minute of timestamp wholestage off             484 /  493         20.7          48.4       1.0X
+minute of timestamp wholestage on              449 /  452         22.3          44.9       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
-second to timestamp:                     Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+second of timestamp:                     Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-second to timestamp wholestage off             451 /  453         22.2          45.1       1.0X
-second to timestamp wholestage on              458 /  461         21.8          45.8       1.0X
+second of timestamp wholestage off             454 /  461         22.0          45.4       1.0X
+second of timestamp wholestage on              475 /  488         21.1          47.5       1.0X
 
 
 ================================================================================================
@@ -102,15 +102,15 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 current_date:                            Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-current_date wholestage off                    218 /  219         45.8          21.8       1.0X
-current_date wholestage on                     246 /  251         40.7          24.6       0.9X
+current_date wholestage off                    220 /  222         45.5          22.0       1.0X
+current_date wholestage on                     224 /  258         44.6          22.4       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 current_timestamp:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-current_timestamp wholestage off               226 /  246         44.2          22.6       1.0X
-current_timestamp wholestage on                225 /  239         44.4          22.5       1.0X
+current_timestamp wholestage off               225 /  239         44.4          22.5       1.0X
+current_timestamp wholestage on                200 /  208         50.0          20.0       1.1X
 
 
 ================================================================================================
@@ -121,43 +121,43 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 cast to date:                            Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-cast to date wholestage off                    483 /  484         20.7          48.3       1.0X
-cast to date wholestage on                     534 /  538         18.7          53.4       0.9X
+cast to date wholestage off                    491 /  491         20.4          49.1       1.0X
+cast to date wholestage on                     497 /  504         20.1          49.7       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 last_day:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-last_day wholestage off                        723 /  730         13.8          72.3       1.0X
-last_day wholestage on                         741 /  759         13.5          74.1       1.0X
+last_day wholestage off                        722 /  728         13.8          72.2       1.0X
+last_day wholestage on                         709 /  723         14.1          70.9       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 next_day:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-next_day wholestage off                        576 /  577         17.4          57.6       1.0X
-next_day wholestage on                         624 /  639         16.0          62.4       0.9X
+next_day wholestage off                        584 /  594         17.1          58.4       1.0X
+next_day wholestage on                         603 /  611         16.6          60.3       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 date_add:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-date_add wholestage off                        485 /  486         20.6          48.5       1.0X
-date_add wholestage on                         496 /  510         20.2          49.6       1.0X
+date_add wholestage off                        496 /  496         20.1          49.6       1.0X
+date_add wholestage on                         470 /  472         21.3          47.0       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 date_sub:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-date_sub wholestage off                        480 /  500         20.8          48.0       1.0X
-date_sub wholestage on                         499 /  501         20.0          49.9       1.0X
+date_sub wholestage off                        475 /  476         21.1          47.5       1.0X
+date_sub wholestage on                         469 /  473         21.3          46.9       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 add_months:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-add_months wholestage off                      979 /  989         10.2          97.9       1.0X
-add_months wholestage on                       979 /  989         10.2          97.9       1.0X
+add_months wholestage off                      925 /  926         10.8          92.5       1.0X
+add_months wholestage on                       911 /  923         11.0          91.1       1.0X
 
 
 ================================================================================================
@@ -168,8 +168,8 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 format date:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-format date wholestage off                    7796 / 7808          1.3         779.6       1.0X
-format date wholestage on                     7737 / 7798          1.3         773.7       1.0X
+format date wholestage off                    7727 / 7921          1.3         772.7       1.0X
+format date wholestage on                     7449 / 7537          1.3         744.9       1.0X
 
 
 ================================================================================================
@@ -180,8 +180,8 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 from_unixtime:                           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                  7826 / 7833          1.3         782.6       1.0X
-from_unixtime wholestage on                   7844 / 7868          1.3         784.4       1.0X
+from_unixtime wholestage off                  7633 / 7797          1.3         763.3       1.0X
+from_unixtime wholestage on                   7543 / 7575          1.3         754.3       1.0X
 
 
 ================================================================================================
@@ -192,14 +192,14 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 from_utc_timestamp:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off              979 /  988         10.2          97.9       1.0X
-from_utc_timestamp wholestage on               915 /  929         10.9          91.5       1.1X
+from_utc_timestamp wholestage off              928 /  931         10.8          92.8       1.0X
+from_utc_timestamp wholestage on               865 /  873         11.6          86.5       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 to_utc_timestamp:                        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                957 /  959         10.5          95.7       1.0X
-to_utc_timestamp wholestage on                 943 /  968         10.6          94.3       1.0X
+to_utc_timestamp wholestage off                915 /  921         10.9          91.5       1.0X
+to_utc_timestamp wholestage on                 877 /  881         11.4          87.7       1.0X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-results.txt
@@ -1,0 +1,205 @@
+================================================================================================
+Extract components
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+cast to timestamp:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+cast to timestamp wholestage off               283 /  303         35.4          28.3       1.0X
+cast to timestamp wholestage on                267 /  290         37.4          26.7       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+year to timestamp:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+year to timestamp wholestage off               725 /  774         13.8          72.5       1.0X
+year to timestamp wholestage on                685 /  699         14.6          68.5       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+quarter to timestamp:                    Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+quarter to timestamp wholestage off            836 /  836         12.0          83.6       1.0X
+quarter to timestamp wholestage on             837 /  847         11.9          83.7       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+month to timestamp:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+month to timestamp wholestage off              687 /  688         14.6          68.7       1.0X
+month to timestamp wholestage on               712 /  722         14.1          71.2       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+weekofyear to timestamp:                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+weekofyear to timestamp wholestage off        1217 / 1220          8.2         121.7       1.0X
+weekofyear to timestamp wholestage on         1208 / 1224          8.3         120.8       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+day to timestamp:                        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+day to timestamp wholestage off                708 /  712         14.1          70.8       1.0X
+day to timestamp wholestage on                 707 /  715         14.1          70.7       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+dayofyear to timestamp:                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+dayofyear to timestamp wholestage off          714 /  715         14.0          71.4       1.0X
+dayofyear to timestamp wholestage on           737 /  753         13.6          73.7       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+dayofmonth to timestamp:                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+dayofmonth to timestamp wholestage off         700 /  703         14.3          70.0       1.0X
+dayofmonth to timestamp wholestage on          710 /  722         14.1          71.0       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+dayofweek to timestamp:                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+dayofweek to timestamp wholestage off          862 /  866         11.6          86.2       1.0X
+dayofweek to timestamp wholestage on           849 /  868         11.8          84.9       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+weekday to timestamp:                    Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+weekday to timestamp wholestage off            770 /  771         13.0          77.0       1.0X
+weekday to timestamp wholestage on             795 /  808         12.6          79.5       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+hour to timestamp:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+hour to timestamp wholestage off               470 /  471         21.3          47.0       1.0X
+hour to timestamp wholestage on                475 /  479         21.1          47.5       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+minute to timestamp:                     Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+minute to timestamp wholestage off             470 /  480         21.3          47.0       1.0X
+minute to timestamp wholestage on              478 /  488         20.9          47.8       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+second to timestamp:                     Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+second to timestamp wholestage off             451 /  453         22.2          45.1       1.0X
+second to timestamp wholestage on              458 /  461         21.8          45.8       1.0X
+
+
+================================================================================================
+Current date and time
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+current_date:                            Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+current_date wholestage off                    218 /  219         45.8          21.8       1.0X
+current_date wholestage on                     246 /  251         40.7          24.6       0.9X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+current_timestamp:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+current_timestamp wholestage off               226 /  246         44.2          22.6       1.0X
+current_timestamp wholestage on                225 /  239         44.4          22.5       1.0X
+
+
+================================================================================================
+Date arithmetic
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+cast to date:                            Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+cast to date wholestage off                    483 /  484         20.7          48.3       1.0X
+cast to date wholestage on                     534 /  538         18.7          53.4       0.9X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+last_day:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+last_day wholestage off                        723 /  730         13.8          72.3       1.0X
+last_day wholestage on                         741 /  759         13.5          74.1       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+next_day:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+next_day wholestage off                        576 /  577         17.4          57.6       1.0X
+next_day wholestage on                         624 /  639         16.0          62.4       0.9X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+date_add:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+date_add wholestage off                        485 /  486         20.6          48.5       1.0X
+date_add wholestage on                         496 /  510         20.2          49.6       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+date_sub:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+date_sub wholestage off                        480 /  500         20.8          48.0       1.0X
+date_sub wholestage on                         499 /  501         20.0          49.9       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+add_months:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+add_months wholestage off                      979 /  989         10.2          97.9       1.0X
+add_months wholestage on                       979 /  989         10.2          97.9       1.0X
+
+
+================================================================================================
+Formatting dates
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+format date:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+format date wholestage off                    7796 / 7808          1.3         779.6       1.0X
+format date wholestage on                     7737 / 7798          1.3         773.7       1.0X
+
+
+================================================================================================
+Formatting timestamps
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+from_unixtime:                           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+from_unixtime wholestage off                  7826 / 7833          1.3         782.6       1.0X
+from_unixtime wholestage on                   7844 / 7868          1.3         784.4       1.0X
+
+
+================================================================================================
+Convert timestamps
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+from_utc_timestamp:                      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+from_utc_timestamp wholestage off              979 /  988         10.2          97.9       1.0X
+from_utc_timestamp wholestage on               915 /  929         10.9          91.5       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-ea-b03 on Mac OS X 10.14.2
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+to_utc_timestamp:                        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+to_utc_timestamp wholestage off                957 /  959         10.5          95.7       1.0X
+to_utc_timestamp wholestage on                 943 /  968         10.6          94.3       1.0X
+
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
@@ -33,9 +33,7 @@ import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
  */
 object DateTimeBenchmark extends SqlBasedBenchmark {
   private def doBenchmark(cardinality: Int, expr: String): Unit = {
-    spark.range(cardinality)
-      .selectExpr(expr)
-      .write.format("noop").save()
+    spark.range(cardinality).selectExpr(expr).write.format("noop").save()
   }
 
   private def run(cardinality: Int, name: String, expr: String): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
+import org.apache.spark.sql.functions._
+
+/**
+ * Synthetic benchmark for date and timestamp functions.
+ * To run this benchmark:
+ * {{{
+ *   1. without sbt:
+ *      bin/spark-submit --class <this class> --jars <spark core test jar> <spark catalyst test jar>
+ *   2. build/sbt "catalyst/test:runMain <this class>"
+ *   3. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "catalyst/test:runMain <this class>"
+ *      Results will be written to "benchmarks/DateTimeBenchmark-results.txt".
+ * }}}
+ */
+object DateTimeBenchmark extends SqlBasedBenchmark {
+  import spark.implicits._
+
+  def getYear(cardinality: Int): Unit = {
+    def yearBenchmark(expr: String): Unit = {
+      spark.range(cardinality)
+        .selectExpr(expr)
+        .select(year('input))
+        .write.format("noop").save()
+    }
+    codegenBenchmark("year from date", cardinality) {
+      yearBenchmark("DATE '2019-01-26' AS input")
+    }
+    codegenBenchmark("year from timestamp", cardinality) {
+      yearBenchmark("DATE '2019-01-26 10:46:00' AS input")
+    }
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    val cardinality = 100000000
+    runBenchmark("Extract components") {
+      getYear(cardinality)
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
@@ -24,10 +24,10 @@ import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
  * To run this benchmark:
  * {{{
  *   1. without sbt:
- *      bin/spark-submit --class <this class> --jars <spark core test jar> <spark catalyst test jar>
- *   2. build/sbt "catalyst/test:runMain <this class>"
+ *      bin/spark-submit --class <this class> --jars <spark core test jar> <sql core test jar>
+ *   2. build/sbt "sql/test:runMain <this class>"
  *   3. generate result:
- *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "catalyst/test:runMain <this class>"
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain <this class>"
  *      Results will be written to "benchmarks/DateTimeBenchmark-results.txt".
  * }}}
  */

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
@@ -18,9 +18,6 @@
 package org.apache.spark.sql
 
 import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
-import org.apache.spark.sql.execution.datasources.json.JSONBenchmark.spark
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.TimestampType
 
 /**
  * Synthetic benchmark for date and timestamp functions.
@@ -69,6 +66,10 @@ object DateTimeBenchmark extends SqlBasedBenchmark {
       run(N, "hour")
       run(N, "minute")
       run(N, "second")
+    }
+    runBenchmark("Current date and time") {
+      run(N, "current_date", "current_date")
+      run(N, "current_timestamp", "current_timestamp")
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
@@ -103,11 +103,21 @@ object DateTimeBenchmark extends SqlBasedBenchmark {
           "SECOND", "WEEK", "QUARTER").foreach { level =>
         run(N, s"date_trunc $level", s"date_trunc('$level', $timestampExpr)")
       }
-
       val dateExpr = "cast(cast(id as timestamp) as date)"
       Seq("year", "yyyy", "yy", "mon", "month", "mm").foreach { level =>
         run(N, s"trunc $level", s"trunc('$level', $dateExpr)")
       }
+    }
+    runBenchmark("Parsing") {
+      val n = 1000000
+      val timestampStrExpr = "concat('2019-01-27 11:02:01.', cast(mod(id, 1000) as string))"
+      val pattern = "'yyyy-MM-dd HH:mm:ss.SSS'"
+      run(n, "to timestamp str", timestampStrExpr)
+      run(n, "to_timestamp", s"to_timestamp($timestampStrExpr, $pattern)")
+      run(n, "to_unix_timestamp", s"to_unix_timestamp($timestampStrExpr, $pattern)")
+      val dateStrExpr = "concat('2019-01-', cast(mod(id, 25) as string))"
+      run(n, "to date str", dateStrExpr)
+      run(n, "to_date", s"to_date($dateStrExpr, 'yyyy-MM-dd')")
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
@@ -84,5 +84,13 @@ object DateTimeBenchmark extends SqlBasedBenchmark {
       val dateExpr = "cast(cast(id as timestamp) as date)"
       run(N, "format date", s"date_format($dateExpr, 'MMM yyyy')")
     }
+    runBenchmark("Formatting timestamps") {
+      run(N, "from_unixtime", "from_unixtime(id, 'yyyy-MM-dd HH:mm:ss.SSSSSS')")
+    }
+    runBenchmark("Convert timestamps") {
+      val timestampExpr = "cast(id as timestamp)"
+      run(N, "from_utc_timestamp", s"from_utc_timestamp($timestampExpr, 'CET')")
+      run(N, "to_utc_timestamp", s"to_utc_timestamp($timestampExpr, 'CET')")
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
@@ -32,19 +32,19 @@ import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
  * }}}
  */
 object DateTimeBenchmark extends SqlBasedBenchmark {
-  def doBenchmark(cardinality: Int, expr: String): Unit = {
+  private def doBenchmark(cardinality: Int, expr: String): Unit = {
     spark.range(cardinality)
       .selectExpr(expr)
       .write.format("noop").save()
   }
 
-  def run(cardinality: Int, name: String, expr: String): Unit = {
+  private def run(cardinality: Int, name: String, expr: String): Unit = {
     codegenBenchmark(name, cardinality) {
       doBenchmark(cardinality, expr)
     }
   }
 
-  def run(cardinality: Int, func: String): Unit = {
+  private def run(cardinality: Int, func: String): Unit = {
     codegenBenchmark(s"$func to timestamp", cardinality) {
       doBenchmark(cardinality, s"$func(cast(id as timestamp))")
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
@@ -71,5 +71,14 @@ object DateTimeBenchmark extends SqlBasedBenchmark {
       run(N, "current_date", "current_date")
       run(N, "current_timestamp", "current_timestamp")
     }
+    runBenchmark("Date arithmetic") {
+      val dateExpr = "cast(cast(id as timestamp) as date)"
+      run(N, "cast to date", dateExpr)
+      run(N, "last_day", s"last_day($dateExpr)")
+      run(N, "next_day", s"next_day($dateExpr, 'TU')")
+      run(N, "date_add", s"date_add($dateExpr, 10)")
+      run(N, "date_sub", s"date_sub($dateExpr, 10)")
+      run(N, "add_months", s"add_months($dateExpr, 10)")
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
@@ -43,7 +43,7 @@ object DateTimeBenchmark extends SqlBasedBenchmark {
   }
 
   private def run(cardinality: Int, func: String): Unit = {
-    codegenBenchmark(s"$func to timestamp", cardinality) {
+    codegenBenchmark(s"$func of timestamp", cardinality) {
       doBenchmark(cardinality, s"$func(cast(id as timestamp))")
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
@@ -35,31 +35,40 @@ import org.apache.spark.sql.types.TimestampType
  * }}}
  */
 object DateTimeBenchmark extends SqlBasedBenchmark {
-  import spark.implicits._
-
   def doBenchmark(cardinality: Int, expr: String): Unit = {
     spark.range(cardinality)
       .selectExpr(expr)
       .write.format("noop").save()
   }
 
-  def castToTimestamp(cardinality: Int): Unit = {
-    codegenBenchmark("cast to timestamp", cardinality) {
-      doBenchmark(cardinality, "cast(id as timestamp)")
+  def run(cardinality: Int, name: String, expr: String): Unit = {
+    codegenBenchmark(name, cardinality) {
+      doBenchmark(cardinality, expr)
     }
   }
 
-  def getYear(cardinality: Int): Unit = {
-    codegenBenchmark("year from timestamp", cardinality) {
-      doBenchmark(cardinality, "year(cast(id as timestamp))")
+  def run(cardinality: Int, func: String): Unit = {
+    codegenBenchmark(s"$func to timestamp", cardinality) {
+      doBenchmark(cardinality, s"$func(cast(id as timestamp))")
     }
   }
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
-    val cardinality = 100000000
+    val N = 10000000
     runBenchmark("Extract components") {
-      castToTimestamp(cardinality)
-      getYear(cardinality)
+      run(N, "cast to timestamp", "cast(id as timestamp)")
+      run(N, "year")
+      run(N, "quarter")
+      run(N, "month")
+      run(N, "weekofyear")
+      run(N, "day")
+      run(N, "dayofyear")
+      run(N, "dayofmonth")
+      run(N, "dayofweek")
+      run(N, "weekday")
+      run(N, "hour")
+      run(N, "minute")
+      run(N, "second")
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
@@ -80,5 +80,9 @@ object DateTimeBenchmark extends SqlBasedBenchmark {
       run(N, "date_sub", s"date_sub($dateExpr, 10)")
       run(N, "add_months", s"add_months($dateExpr, 10)")
     }
+    runBenchmark("Formatting dates") {
+      val dateExpr = "cast(cast(id as timestamp) as date)"
+      run(N, "format date", s"date_format($dateExpr, 'MMM yyyy')")
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added the following benchmarks:
- Extract components from timestamp like year, month, day and etc.
- Current date and time
- Date arithmetic like date_add, date_sub
- Format dates and timestamps
- Convert timestamps from/to UTC