### PR TITLE
[MINOR][DOCS] Add a note that 'spark.executor.pyspark.memory' is dependent on 'resource'

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -192,6 +192,7 @@ of the most common options to set are:
     is added to executor resource requests.
 
     NOTE: Python memory usage may not be limited on platforms that do not support resource limiting, such as Windows.
+    NOTE: Python memory usage is dependent on Python's 'resource' module; therefore, the behaviors and limitations are inherited.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -190,9 +190,10 @@ of the most common options to set are:
     and it is up to the application to avoid exceeding the overhead memory space
     shared with other non-JVM processes. When PySpark is run in YARN or Kubernetes, this memory
     is added to executor resource requests.
-
-    NOTE: Python memory usage may not be limited on platforms that do not support resource limiting, such as Windows.
-    NOTE: Python memory usage is dependent on Python's 'resource' module; therefore, the behaviors and limitations are inherited.
+    <br/>
+    <em>Note:</em> Python memory usage may not be limited on platforms that do not support resource limiting, such as Windows.
+    <br/>
+    <em>Note:</em> Python memory usage is dependent on Python's 'resource' module; therefore, the behaviors and limitations are inherited.
   </td>
 </tr>
 <tr>
@@ -224,7 +225,8 @@ of the most common options to set are:
     stored on disk. This should be on a fast, local disk in your system. It can also be a
     comma-separated list of multiple directories on different disks.
 
-    NOTE: In Spark 1.0 and later this will be overridden by SPARK_LOCAL_DIRS (Standalone), MESOS_SANDBOX (Mesos) or
+    <br/>
+    <em>Note:</em> In Spark 1.0 and later this will be overridden by SPARK_LOCAL_DIRS (Standalone), MESOS_SANDBOX (Mesos) or
     LOCAL_DIRS (YARN) environment variables set by the cluster manager.
   </td>
 </tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -191,7 +191,9 @@ of the most common options to set are:
     shared with other non-JVM processes. When PySpark is run in YARN or Kubernetes, this memory
     is added to executor resource requests.
     <br/>
-    <em>Note:</em> This feature is dependent on Python's `resource` module; therefore, the behaviors and limitations are inherited.
+    <em>Note:</em> This feature is dependent on Python's `resource` module; therefore, the behaviors and 
+    limitations are inherited. For instance, Windows does not support resource limiting and actual 
+    resource is not limited on MacOS.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -191,9 +191,7 @@ of the most common options to set are:
     shared with other non-JVM processes. When PySpark is run in YARN or Kubernetes, this memory
     is added to executor resource requests.
     <br/>
-    <em>Note:</em> Python memory usage may not be limited on platforms that do not support resource limiting, such as Windows.
-    <br/>
-    <em>Note:</em> Python memory usage is dependent on Python's 'resource' module; therefore, the behaviors and limitations are inherited.
+    <em>Note:</em> This feature is dependent on Python's `resource` module; therefore, the behaviors and limitations are inherited.
   </td>
 </tr>
 <tr>
@@ -226,7 +224,7 @@ of the most common options to set are:
     comma-separated list of multiple directories on different disks.
 
     <br/>
-    <em>Note:</em> In Spark 1.0 and later this will be overridden by SPARK_LOCAL_DIRS (Standalone), MESOS_SANDBOX (Mesos) or
+    <em>Note:</em> This will be overridden by SPARK_LOCAL_DIRS (Standalone), MESOS_SANDBOX (Mesos) or
     LOCAL_DIRS (YARN) environment variables set by the cluster manager.
   </td>
 </tr>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds a note that explicitly `spark.executor.pyspark.memory` is dependent on resource module's behaviours at Python memory usage.

For instance, I at least see some difference at https://github.com/apache/spark/pull/21977#discussion_r251220966

## How was this patch tested?

Manually built the doc.
