### PR TITLE
[SPARK-26718][SS] Fixed integer overflow in SS kafka rateLimit calculation 

### DIFF
--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
@@ -231,7 +231,11 @@ private[kafka010] class KafkaMicroBatchStream(
             val begin = from.get(tp).getOrElse(fromNew(tp))
             val prorate = limit * (size / total)
             // Don't completely starve small topicpartitions
-            val off = begin + (if (prorate < 1) Math.ceil(prorate) else Math.floor(prorate)).toLong
+            val prorateLong = (if (prorate < 1) Math.ceil(prorate) else Math.floor(prorate)).toLong
+            // need to be careful of integer overflow
+            // therefore added canary checks where to see if off variable could be overflowed
+            // refer to [https://issues.apache.org/jira/browse/SPARK-26718]
+            val off = if (prorateLong > Long.MaxValue - begin) Long.MaxValue else begin + prorateLong
             // Paranoia, make sure not to return an offset that's past end
             Math.min(end, off)
           }.getOrElse(end)

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
@@ -235,7 +235,11 @@ private[kafka010] class KafkaMicroBatchStream(
             // need to be careful of integer overflow
             // therefore added canary checks where to see if off variable could be overflowed
             // refer to [https://issues.apache.org/jira/browse/SPARK-26718]
-            val off = if (prorateLong > Long.MaxValue - begin) Long.MaxValue else begin + prorateLong
+            val off = if (prorateLong > Long.MaxValue - begin) {
+              Long.MaxValue
+            } else {
+              begin + prorateLong
+            }
             // Paranoia, make sure not to return an offset that's past end
             Math.min(end, off)
           }.getOrElse(end)

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
@@ -191,7 +191,11 @@ private[kafka010] class KafkaSource(
             val prorate = limit * (size / total)
             logDebug(s"rateLimit $tp prorated amount is $prorate")
             // Don't completely starve small topicpartitions
-            val off = begin + (if (prorate < 1) Math.ceil(prorate) else Math.floor(prorate)).toLong
+            val prorateLong = (if (prorate < 1) Math.ceil(prorate) else Math.floor(prorate)).toLong
+            // need to be careful of integer overflow
+            // therefore added canary checks where to see if off variable could be overflowed
+            // refer to [https://issues.apache.org/jira/browse/SPARK-26718]
+            val off = if (prorateLong > Long.MaxValue - begin) Long.MaxValue else begin + prorateLong
             logDebug(s"rateLimit $tp new offset is $off")
             // Paranoia, make sure not to return an offset that's past end
             Math.min(end, off)

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
@@ -195,7 +195,11 @@ private[kafka010] class KafkaSource(
             // need to be careful of integer overflow
             // therefore added canary checks where to see if off variable could be overflowed
             // refer to [https://issues.apache.org/jira/browse/SPARK-26718]
-            val off = if (prorateLong > Long.MaxValue - begin) Long.MaxValue else begin + prorateLong
+            val off = if (prorateLong > Long.MaxValue - begin) {
+              Long.MaxValue
+            } else {
+              begin + prorateLong
+            }
             logDebug(s"rateLimit $tp new offset is $off")
             // Paranoia, make sure not to return an offset that's past end
             Math.min(end, off)

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -216,8 +216,6 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
     )
     val startingOffsets = JsonUtils.partitionOffsets(partitionOffsets)
 
-    val sparkSession = spark
-    import sparkSession.implicits._
     val kafka = spark
       .readStream
       .format("kafka")

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -208,7 +208,7 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
     "during end offset calculation") {
     val topic = newTopic()
     testUtils.createTopic(topic, partitions = 1)
-    // fill in 5000 messages to trigger potential integer overflow
+    // fill in 5 messages to trigger potential integer overflow
     testUtils.sendMessages(topic, (0 until 5).map(_.toString).toArray, Some(0))
 
     val partitionOffsets = Map(
@@ -220,7 +220,7 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
       .readStream
       .format("kafka")
       .option("kafka.bootstrap.servers", testUtils.brokerAddress)
-      // use latest to force begin to be 5000
+      // use latest to force begin to be 5
       .option("startingOffsets", startingOffsets)
       // use Long.Max to try to trigger overflow
       .option("maxOffsetsPerTrigger", Long.MaxValue)

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -204,6 +204,40 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
       StopStream)
   }
 
+  test("Rate limit set to Long.Max should not overflow integer during end offset calculation[SPARK-26718]") {
+    val topic = newTopic()
+    testUtils.createTopic(topic, partitions = 1)
+    testUtils.sendMessages(topic, (0 until 5000).map(_.toString).toArray, Some(0))   // fill in 5000 messages to trigger potential integer overflow
+
+
+    val partitionOffsets = Map(
+      new TopicPartition(topic, 0) -> 5000L
+    )
+    val startingOffsets = JsonUtils.partitionOffsets(partitionOffsets)
+
+    val sparkSession = spark
+    import sparkSession.implicits._
+    val kafka = spark
+      .readStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+      .option("startingOffsets", startingOffsets)                 // use latest to force begin to be 5000
+      .option("maxOffsetsPerTrigger", Long.MaxValue.toString)     // use Long.Max to try to trigger overflow
+      .option("subscribe", topic)
+      .option("kafka.metadata.max.age.ms", "1")
+      .load()
+      .selectExpr("CAST(key AS STRING)", "CAST(value AS STRING)")
+      .as[(String, String)]
+    val mapped: org.apache.spark.sql.Dataset[_] = kafka.map(kv => kv._2.toInt)
+
+    testStream(mapped)(
+      makeSureGetOffsetCalled,
+      AddKafkaData(Set(topic), 30, 31, 32, 33, 34),
+      CheckAnswer(30, 31, 32, 33, 34),
+      StopStream
+    )
+  }
+
   test("maxOffsetsPerTrigger") {
     val topic = newTopic()
     testUtils.createTopic(topic, partitions = 3)

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -209,10 +209,10 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
     val topic = newTopic()
     testUtils.createTopic(topic, partitions = 1)
     // fill in 5000 messages to trigger potential integer overflow
-    testUtils.sendMessages(topic, (0 until 5000).map(_.toString).toArray, Some(0))
+    testUtils.sendMessages(topic, (0 until 5).map(_.toString).toArray, Some(0))
 
     val partitionOffsets = Map(
-      new TopicPartition(topic, 0) -> 5000L
+      new TopicPartition(topic, 0) -> 5L
     )
     val startingOffsets = JsonUtils.partitionOffsets(partitionOffsets)
 

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -204,8 +204,8 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
       StopStream)
   }
 
-  test("Rate limit set to Long.Max should not overflow integer " +
-    "during end offset calculation[SPARK-26718]") {
+  test("SPARK-26718 Rate limit set to Long.Max should not overflow integer " +
+    "during end offset calculation") {
     val topic = newTopic()
     testUtils.createTopic(topic, partitions = 1)
     // fill in 5000 messages to trigger potential integer overflow

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -204,11 +204,12 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
       StopStream)
   }
 
-  test("Rate limit set to Long.Max should not overflow integer during end offset calculation[SPARK-26718]") {
+  test("Rate limit set to Long.Max should not overflow integer " +
+    "during end offset calculation[SPARK-26718]") {
     val topic = newTopic()
     testUtils.createTopic(topic, partitions = 1)
-    testUtils.sendMessages(topic, (0 until 5000).map(_.toString).toArray, Some(0))   // fill in 5000 messages to trigger potential integer overflow
-
+    // fill in 5000 messages to trigger potential integer overflow
+    testUtils.sendMessages(topic, (0 until 5000).map(_.toString).toArray, Some(0))
 
     val partitionOffsets = Map(
       new TopicPartition(topic, 0) -> 5000L
@@ -221,8 +222,10 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
       .readStream
       .format("kafka")
       .option("kafka.bootstrap.servers", testUtils.brokerAddress)
-      .option("startingOffsets", startingOffsets)                 // use latest to force begin to be 5000
-      .option("maxOffsetsPerTrigger", Long.MaxValue.toString)     // use Long.Max to try to trigger overflow
+      // use latest to force begin to be 5000
+      .option("startingOffsets", startingOffsets)
+      // use Long.Max to try to trigger overflow
+      .option("maxOffsetsPerTrigger", Long.MaxValue.toString)
       .option("subscribe", topic)
       .option("kafka.metadata.max.age.ms", "1")
       .load()

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -225,7 +225,7 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
       // use latest to force begin to be 5000
       .option("startingOffsets", startingOffsets)
       // use Long.Max to try to trigger overflow
-      .option("maxOffsetsPerTrigger", Long.MaxValue.toString)
+      .option("maxOffsetsPerTrigger", Long.MaxValue)
       .option("subscribe", topic)
       .option("kafka.metadata.max.age.ms", "1")
       .load()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the integer overflow issue in rateLimit.

## How was this patch tested?

Pass the Jenkins with newly added UT for the possible case where integer could be overflowed.
