### PR TITLE
[SPARK-26750]Estimate memory overhead with multi-cores

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -40,6 +40,7 @@ object YarnSparkHadoopUtil {
 
   val MEMORY_OVERHEAD_FACTOR = 0.10
   val MEMORY_OVERHEAD_MIN = 384L
+  val SHARED_MEMORY_OVERHEAD_MIN = 128L
 
   val ANY_HOST = "*"
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, spark esitmate the memory overhead without taking multi-cores into account, sometimes, it might cause direct memory oom, or container killed by yarn for exceeding requested physical memory. 

Since the memory overhead(mainly the direct memory used by spark execution/storage and some related jvm native memory, for instance, the thread stacks, GC data etc.) is related to the executor's core number. so maybe we can improve this estimation by taking the core number into account.

## How was this patch tested?

NA

Please review http://spark.apache.org/contributing.html before opening a pull request.
