### PR TITLE
[SPARK-26753][CORE] Fixed custom log levels for spark-shell by using Filter instead of Threshold

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -53,6 +53,8 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, FileUtil, Path}
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.hadoop.yarn.conf.YarnConfiguration
+import org.apache.log4j.{Level, LogManager}
+import org.apache.log4j.spi.{Filter, LoggingEvent}
 import org.eclipse.jetty.util.MultiException
 import org.slf4j.Logger
 
@@ -2285,7 +2287,15 @@ private[spark] object Utils extends Logging {
     val rootLogger = org.apache.log4j.Logger.getRootLogger()
     rootLogger.setLevel(l)
     rootLogger.getAllAppenders().asScala.foreach {
-      case ca: org.apache.log4j.ConsoleAppender => ca.setThreshold(l)
+      case ca: org.apache.log4j.ConsoleAppender =>
+        var f = ca.getFirstFilter()
+        while (f != null) {
+          f match {
+            case ssf: SparkShellLoggingFilter =>
+              ssf.setThresholdLevel(l)
+          }
+          f = f.getNext()
+        }
       case _ => // no-op
     }
   }
@@ -2989,5 +2999,34 @@ private[spark] class CircularBuffer(sizeInBytes: Int = 10240) extends java.io.Ou
     System.arraycopy(buffer, pos, nonCircularBuffer, 0, buffer.length - pos)
     System.arraycopy(buffer, 0, nonCircularBuffer, buffer.length - pos, pos)
     new String(nonCircularBuffer, StandardCharsets.UTF_8)
+  }
+}
+
+private[spark] class SparkShellLoggingFilter(var thresholdLevel: Level) extends Filter {
+
+  /**
+   * If log level of event is lower than thresholdLevel, then the decision is made based on
+   * whether the log came from root or some custom configuration
+   * @param loggingEvent
+   * @return decision for accept/deny log event
+   */
+  def decide(loggingEvent: LoggingEvent): Int = {
+    val rootLevel = LogManager.getRootLogger().getLevel()
+    if (loggingEvent.getLevel().isGreaterOrEqual(thresholdLevel) ||
+          !loggingEvent.getLevel().eq(rootLevel)) {
+      return Filter.NEUTRAL
+    }
+    var logger = loggingEvent.getLogger()
+    while(logger.getParent() != null) {
+      if (logger.getLevel() != null) {
+        return Filter.NEUTRAL
+      }
+      logger = logger.getParent()
+    }
+    return Filter.DENY
+  }
+
+  private[spark] def setThresholdLevel(level: Level): Unit = {
+    thresholdLevel = level
   }
 }

--- a/core/src/test/scala/org/apache/spark/internal/LoggingSuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/LoggingSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.internal
+
+import org.apache.log4j.{Level, Logger}
+import org.apache.log4j.spi.{Filter, LoggingEvent}
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.util.Utils
+
+class LoggingSuite extends SparkFunSuite {
+
+  test("spark-shell logging filter") {
+    val ssf = new SparkShellLoggingFilter()
+    val rootLogger = Logger.getRootLogger()
+    val originalLevel = rootLogger.getLevel()
+    rootLogger.setLevel(Level.INFO)
+    Logging.sparkShellThresholdLevel = Level.WARN
+    try {
+      val logger = Logger.getLogger("a.b.c.D")
+      val logEvent = new LoggingEvent(logger.getName(), logger, Level.INFO, "Test", null)
+      assert(ssf.decide(logEvent) === Filter.DENY)
+
+      // log level is less than threshold level but different from root level
+      val logEvent1 = new LoggingEvent(logger.getName(), logger, Level.DEBUG, "Test", null)
+      assert(ssf.decide(logEvent1) != Filter.DENY)
+
+      // custom log level configured
+      val parentLogger = Logger.getLogger("a.b.c")
+      parentLogger.setLevel(Level.INFO)
+      assert(ssf.decide(logEvent) != Filter.DENY)
+
+      // log level is greater than or equal to threshold level
+      val logger2 = Logger.getLogger("a.b.E")
+      val logEvent2 = new LoggingEvent(logger2.getName(), logger2, Level.INFO, "Test", null)
+      Utils.setLogLevel(Level.INFO)
+      assert(ssf.decide(logEvent2) != Filter.DENY)
+    } finally {
+      rootLogger.setLevel(originalLevel)
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/spark/internal/LoggingSuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/LoggingSuite.scala
@@ -30,6 +30,7 @@ class LoggingSuite extends SparkFunSuite {
     val rootLogger = Logger.getRootLogger()
     val originalLevel = rootLogger.getLevel()
     rootLogger.setLevel(Level.INFO)
+    val originalThreshold = Logging.sparkShellThresholdLevel
     Logging.sparkShellThresholdLevel = Level.WARN
     try {
       val logger = Logger.getLogger("a.b.c.D")
@@ -52,6 +53,7 @@ class LoggingSuite extends SparkFunSuite {
       assert(ssf.decide(logEvent2) != Filter.DENY)
     } finally {
       rootLogger.setLevel(originalLevel)
+      Logging.sparkShellThresholdLevel = originalThreshold
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This fix replaces the Threshold with a Filter for ConsoleAppender which checks
to ensure that either the logLevel is greater than thresholdLevel (shell log
level) or the log originated from a custom defined logger. In these cases, it
lets a log event go through, otherwise it doesn't.

## How was this patch tested?

1. Ensured that custom log level works when set by default (via log4j.properties)
2. Ensured that logs are not printed twice when log level is changed by setLogLevel
3. Ensured that custom logs are printed when log level is changed back by setLogLevel