### PR TITLE
[SPARK-25035][Core] Avoiding memory mapping at disk-stored blocks replication

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -604,7 +604,6 @@ private[spark] class BlockManager(
 
       override def onComplete(streamId: String): Unit = {
         logTrace(s"Done receiving block $blockId, now putting into local blockManager")
-        // Read the contents of the downloaded file as a buffer to put into the blockManager.
         // Note this is all happening inside the netty thread as soon as it reads the end of the
         // stream.
         channel.close()

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -33,6 +33,7 @@ import scala.util.Random
 import scala.util.control.NonFatal
 
 import com.codahale.metrics.{MetricRegistry, MetricSet}
+import org.apache.commons.io.IOUtils
 
 import org.apache.spark._
 import org.apache.spark.executor.DataReadMethod
@@ -253,6 +254,7 @@ private[spark] class BlockManager(
           iter.close()
           false
       }
+      IOUtils.closeQuietly(inputStream)
     }
 
     private def saveSerializedValuesToMemoryStore(bytes: ChunkedByteBuffer): Boolean = {

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -221,6 +221,9 @@ private[spark] class BlockManager(
     new BlockManager.RemoteBlockDownloadFileManager(this)
   private val maxRemoteBlockToMem = conf.get(config.MAX_REMOTE_BLOCK_SIZE_FETCH_TO_MEM)
 
+  /**
+   * @param blockSize the decrypted size of the block
+   */
   private abstract class BlockStoreUpdater[T](
       blockSize: Long,
       blockId: BlockId,

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -244,17 +244,21 @@ private[spark] class BlockManager(
     protected def saveToDiskStore(): Unit
 
     private def saveDeserializedValuesToMemoryStore(inputStream: InputStream): Boolean = {
-      val values = serializerManager.dataDeserializeStream(blockId, inputStream)(classTag)
-      val res = memoryStore.putIteratorAsValues(blockId, values, classTag) match {
-        case Right(_) => true
-        case Left(iter) =>
-          // If putting deserialized values in memory failed, we will put the bytes directly
-          // to disk, so we don't need this iterator and can close it to free resources
-          // earlier.
-          iter.close()
-          false
+      var res = false
+      try {
+        val values = serializerManager.dataDeserializeStream(blockId, inputStream)(classTag)
+        res = memoryStore.putIteratorAsValues(blockId, values, classTag) match {
+          case Right(_) => true
+          case Left(iter) =>
+            // If putting deserialized values in memory failed, we will put the bytes directly
+            // to disk, so we don't need this iterator and can close it to free resources
+            // earlier.
+            iter.close()
+            false
+        }
+      } finally {
+        IOUtils.closeQuietly(inputStream)
       }
-      IOUtils.closeQuietly(inputStream)
       res
     }
 

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -245,7 +245,7 @@ private[spark] class BlockManager(
 
     private def saveDeserializedValuesToMemoryStore(inputStream: InputStream): Boolean = {
       val values = serializerManager.dataDeserializeStream(blockId, inputStream)(classTag)
-      memoryStore.putIteratorAsValues(blockId, values, classTag) match {
+      val res = memoryStore.putIteratorAsValues(blockId, values, classTag) match {
         case Right(_) => true
         case Left(iter) =>
           // If putting deserialized values in memory failed, we will put the bytes directly
@@ -255,6 +255,7 @@ private[spark] class BlockManager(
           false
       }
       IOUtils.closeQuietly(inputStream)
+      res
     }
 
     private def saveSerializedValuesToMemoryStore(bytes: ChunkedByteBuffer): Boolean = {

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -233,7 +233,6 @@ private[spark] class BlockManager(
      *
      * If the block already exists, this method will not overwrite it.
      *
-     *
      * @param keepReadLock if true, this method will hold the read lock when it returns (even if the
      *                     block already exists). If false, this method will hold no locks when it
      *                     returns.

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -252,8 +252,7 @@ private[spark] class BlockManager(
       } else {
         val memoryMode = level.memoryMode
         memoryStore.putBytes(blockId, blockSize, memoryMode, () => {
-          if (memoryMode == MemoryMode.OFF_HEAP &&
-            byteBuffer.chunks.exists(buffer => !buffer.isDirect)) {
+          if (memoryMode == MemoryMode.OFF_HEAP && byteBuffer.chunks.exists(!_.isDirect)) {
             byteBuffer.copy(Platform.allocateDirectBuffer)
           } else {
             byteBuffer

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -221,6 +221,145 @@ private[spark] class BlockManager(
     new BlockManager.RemoteBlockDownloadFileManager(this)
   private val maxRemoteBlockToMem = conf.get(config.MAX_REMOTE_BLOCK_SIZE_FETCH_TO_MEM)
 
+  private abstract class BlockStoreUpdater[T](tellMaster: Boolean, keepReadLock: Boolean) {
+
+    protected def toBlockData: BlockData
+
+    protected def saveContent(): Unit
+
+    /**
+     * Put the given data according to the given level in one of the block stores, replicating
+     * the values if necessary.
+     *
+     * If the block already exists, this method will not overwrite it.
+     *
+     *
+     * @param keepReadLock if true, this method will hold the read lock when it returns (even if the
+     *                     block already exists). If false, this method will hold no locks when it
+     *                     returns.
+     * @return true if the block was already present or if the put succeeded, false otherwise.
+     */
+    protected def doSave(
+        blockSize: Long,
+        blockId: BlockId,
+        level: StorageLevel,
+        classTag: ClassTag[T]): Boolean = {
+      doPut(blockId, level, classTag, tellMaster, keepReadLock) { info =>
+        val startTimeNs = System.nanoTime()
+        // Since we're storing bytes, initiate the replication before storing them locally.
+        // This is faster as data is already serialized and ready to send.
+        val replicationFuture = if (level.replication > 1) {
+          Future {
+            // This is a blocking action and should run in futureExecutionContext which is a cached
+            // thread pool. The ByteBufferBlockData wrapper is not disposed of to avoid releasing
+            // buffers that are owned by the caller.
+            replicate(blockId, toBlockData, level, classTag)
+          }(futureExecutionContext)
+        } else {
+          null
+        }
+        saveContent()
+        val putBlockStatus = getCurrentBlockStatus(blockId, info)
+        val blockWasSuccessfullyStored = putBlockStatus.storageLevel.isValid
+        if (blockWasSuccessfullyStored) {
+          // Now that the block is in either the memory or disk store,
+          // tell the master about it.
+          info.size = blockSize
+          if (tellMaster && info.tellMaster) {
+            reportBlockStatus(blockId, putBlockStatus)
+          }
+          addUpdatedBlockStatusToTaskMetrics(blockId, putBlockStatus)
+        }
+        logDebug(s"Put block ${blockId} locally took ${Utils.getUsedTimeNs(startTimeNs)}")
+        if (level.replication > 1) {
+          // Wait for asynchronous replication to finish
+          try {
+            ThreadUtils.awaitReady(replicationFuture, Duration.Inf)
+          } catch {
+            case NonFatal(t) =>
+              throw new Exception("Error occurred while waiting for replication to finish", t)
+          }
+        }
+        if (blockWasSuccessfullyStored) {
+          None
+        } else {
+          Some(blockSize)
+        }
+      }.isEmpty
+    }
+  }
+
+  /**
+   * '''Important!''' Callers must not mutate or release the data buffer underlying `bytes`. Doing
+   * so may corrupt or change the data stored by the `BlockManager`.
+   */
+  private case class ByteBufferBlockStoreUpdater[T](
+      blockId: BlockId,
+      level: StorageLevel,
+      classTag: ClassTag[T],
+      bytes: ChunkedByteBuffer,
+      tellMaster: Boolean = true,
+      keepReadLock: Boolean = false) extends BlockStoreUpdater[T](tellMaster, keepReadLock) {
+
+    override def toBlockData: BlockData = new ByteBufferBlockData(bytes, false)
+
+    override def saveContent(): Unit = {
+      if (level.useMemory) {
+        // Put it in memory first, even if it also has useDisk set to true;
+        // We will drop it to disk later if the memory store can't hold it.
+        val putSucceeded = if (level.deserialized) {
+          val values =
+            serializerManager.dataDeserializeStream(blockId, bytes.toInputStream())(classTag)
+          memoryStore.putIteratorAsValues(blockId, values, classTag) match {
+            case Right(_) => true
+            case Left(iter) =>
+              // If putting deserialized values in memory failed, we will put the bytes directly to
+              // disk, so we don't need this iterator and can close it to free resources earlier.
+              iter.close()
+              false
+          }
+        } else {
+          val memoryMode = level.memoryMode
+          memoryStore.putBytes(blockId, bytes.size, memoryMode, () => {
+            if (memoryMode == MemoryMode.OFF_HEAP &&
+              bytes.chunks.exists(buffer => !buffer.isDirect)) {
+              bytes.copy(Platform.allocateDirectBuffer)
+            } else {
+              bytes
+            }
+          })
+        }
+        if (!putSucceeded && level.useDisk) {
+          logWarning(s"Persisting block $blockId to disk instead.")
+          diskStore.putBytes(blockId, bytes)
+        }
+      } else if (level.useDisk) {
+        diskStore.putBytes(blockId, bytes)
+      }
+    }
+
+    def save(blockSize: Long): Boolean = doSave(blockSize, blockId, level, classTag)
+
+  }
+
+  private case class TempFileBlockStoreUpdater[T](
+      blockId: BlockId,
+      level: StorageLevel,
+      classTag: ClassTag[T],
+      tmpFile: File,
+      tmpBlockId: BlockId,
+      blockSize: Long,
+      tellMaster: Boolean = true,
+      keepReadLock: Boolean = false) extends BlockStoreUpdater[T](tellMaster, keepReadLock) {
+
+    override def toBlockData: BlockData = diskStore.getBytes(tmpBlockId)
+
+    override def saveContent(): Unit = diskStore.moveFileToBlock(tmpFile, blockSize, blockId)
+
+    def save(): Boolean = doSave(blockSize, blockId, level, classTag)
+
+  }
+
   /**
    * Initializes the BlockManager with the given appId. This is not performed in the constructor as
    * the appId may not be known at BlockManager instantiation time (in particular for the driver,
@@ -412,10 +551,7 @@ private[spark] class BlockManager(
       blockId: BlockId,
       level: StorageLevel,
       classTag: ClassTag[_]): StreamCallbackWithID = {
-    // TODO if we're going to only put the data in the disk store, we should just write it directly
-    // to the final location, but that would require a deeper refactor of this code.  So instead
-    // we just write to a temp file, and call putBytes on the data in that file.
-    val tmpFile = diskBlockManager.createTempLocalBlock()._2
+    val (tmpBlockId, tmpFile) = diskBlockManager.createTempLocalBlock()
     val channel = new CountingWritableChannel(
       Channels.newChannel(serializerManager.wrapForEncryption(new FileOutputStream(tmpFile))))
     logTrace(s"Streaming block $blockId to tmp file $tmpFile")
@@ -435,24 +571,27 @@ private[spark] class BlockManager(
         // Note this is all happening inside the netty thread as soon as it reads the end of the
         // stream.
         channel.close()
-        // TODO SPARK-25035 Even if we're only going to write the data to disk after this, we end up
-        // using a lot of memory here. We'll read the whole file into a regular
-        // byte buffer and OOM.  We could at least read the tmp file as a stream.
-        val buffer = securityManager.getIOEncryptionKey() match {
-          case Some(key) =>
-            // we need to pass in the size of the unencrypted block
-            val blockSize = channel.getCount
-            val allocator = level.memoryMode match {
-              case MemoryMode.ON_HEAP => ByteBuffer.allocate _
-              case MemoryMode.OFF_HEAP => Platform.allocateDirectBuffer _
-            }
-            new EncryptedBlockData(tmpFile, blockSize, conf, key).toChunkedByteBuffer(allocator)
+        val blockSize = channel.getCount
+        if (level == StorageLevel.DISK_ONLY) {
+          val blockStoreUpdater =
+            TempFileBlockStoreUpdater(blockId, level, classTag, tmpFile, tmpBlockId, blockSize)
+          blockStoreUpdater.save()
+        } else {
+          val buffer = securityManager.getIOEncryptionKey() match {
+            case Some(key) =>
+              // we need to pass in the size of the unencrypted block
+              val allocator = level.memoryMode match {
+                case MemoryMode.ON_HEAP => ByteBuffer.allocate _
+                case MemoryMode.OFF_HEAP => Platform.allocateDirectBuffer _
+              }
+              new EncryptedBlockData(tmpFile, blockSize, conf, key).toChunkedByteBuffer(allocator)
 
-          case None =>
-            ChunkedByteBuffer.fromFile(tmpFile)
+            case None =>
+              ChunkedByteBuffer.fromFile(tmpFile)
+          }
+          putBytes(blockId, buffer, level)(classTag)
+          tmpFile.delete()
         }
-        putBytes(blockId, buffer, level)(classTag)
-        tmpFile.delete()
       }
 
       override def onFailure(streamId: String, cause: Throwable): Unit = {
@@ -953,111 +1092,14 @@ private[spark] class BlockManager(
       level: StorageLevel,
       tellMaster: Boolean = true): Boolean = {
     require(bytes != null, "Bytes is null")
-    doPutBytes(blockId, bytes, level, implicitly[ClassTag[T]], tellMaster)
+    val blockStoreUpdater =
+      ByteBufferBlockStoreUpdater(blockId, level, implicitly[ClassTag[T]], bytes, tellMaster)
+    blockStoreUpdater.save(bytes.size)
   }
 
   /**
-   * Put the given bytes according to the given level in one of the block stores, replicating
-   * the values if necessary.
-   *
-   * If the block already exists, this method will not overwrite it.
-   *
-   * '''Important!''' Callers must not mutate or release the data buffer underlying `bytes`. Doing
-   * so may corrupt or change the data stored by the `BlockManager`.
-   *
-   * @param keepReadLock if true, this method will hold the read lock when it returns (even if the
-   *                     block already exists). If false, this method will hold no locks when it
-   *                     returns.
-   * @return true if the block was already present or if the put succeeded, false otherwise.
-   */
-  private def doPutBytes[T](
-      blockId: BlockId,
-      bytes: ChunkedByteBuffer,
-      level: StorageLevel,
-      classTag: ClassTag[T],
-      tellMaster: Boolean = true,
-      keepReadLock: Boolean = false): Boolean = {
-    doPut(blockId, level, classTag, tellMaster = tellMaster, keepReadLock = keepReadLock) { info =>
-      val startTimeNs = System.nanoTime()
-      // Since we're storing bytes, initiate the replication before storing them locally.
-      // This is faster as data is already serialized and ready to send.
-      val replicationFuture = if (level.replication > 1) {
-        Future {
-          // This is a blocking action and should run in futureExecutionContext which is a cached
-          // thread pool. The ByteBufferBlockData wrapper is not disposed of to avoid releasing
-          // buffers that are owned by the caller.
-          replicate(blockId, new ByteBufferBlockData(bytes, false), level, classTag)
-        }(futureExecutionContext)
-      } else {
-        null
-      }
-
-      val size = bytes.size
-
-      if (level.useMemory) {
-        // Put it in memory first, even if it also has useDisk set to true;
-        // We will drop it to disk later if the memory store can't hold it.
-        val putSucceeded = if (level.deserialized) {
-          val values =
-            serializerManager.dataDeserializeStream(blockId, bytes.toInputStream())(classTag)
-          memoryStore.putIteratorAsValues(blockId, values, classTag) match {
-            case Right(_) => true
-            case Left(iter) =>
-              // If putting deserialized values in memory failed, we will put the bytes directly to
-              // disk, so we don't need this iterator and can close it to free resources earlier.
-              iter.close()
-              false
-          }
-        } else {
-          val memoryMode = level.memoryMode
-          memoryStore.putBytes(blockId, size, memoryMode, () => {
-            if (memoryMode == MemoryMode.OFF_HEAP &&
-                bytes.chunks.exists(buffer => !buffer.isDirect)) {
-              bytes.copy(Platform.allocateDirectBuffer)
-            } else {
-              bytes
-            }
-          })
-        }
-        if (!putSucceeded && level.useDisk) {
-          logWarning(s"Persisting block $blockId to disk instead.")
-          diskStore.putBytes(blockId, bytes)
-        }
-      } else if (level.useDisk) {
-        diskStore.putBytes(blockId, bytes)
-      }
-
-      val putBlockStatus = getCurrentBlockStatus(blockId, info)
-      val blockWasSuccessfullyStored = putBlockStatus.storageLevel.isValid
-      if (blockWasSuccessfullyStored) {
-        // Now that the block is in either the memory or disk store,
-        // tell the master about it.
-        info.size = size
-        if (tellMaster && info.tellMaster) {
-          reportBlockStatus(blockId, putBlockStatus)
-        }
-        addUpdatedBlockStatusToTaskMetrics(blockId, putBlockStatus)
-      }
-      logDebug(s"Put block ${blockId} locally took ${Utils.getUsedTimeNs(startTimeNs)}")
-      if (level.replication > 1) {
-        // Wait for asynchronous replication to finish
-        try {
-          ThreadUtils.awaitReady(replicationFuture, Duration.Inf)
-        } catch {
-          case NonFatal(t) =>
-            throw new Exception("Error occurred while waiting for replication to finish", t)
-        }
-      }
-      if (blockWasSuccessfullyStored) {
-        None
-      } else {
-        Some(bytes)
-      }
-    }.isEmpty
-  }
-
-  /**
-   * Helper method used to abstract common code from [[doPutBytes()]] and [[doPutIterator()]].
+   * Helper method used to abstract common code from [[BlockStoreUpdater.doSave()]]
+   * and [[doPutIterator()]].
    *
    * @param putBody a function which attempts the actual put() and returns None on success
    *                or Some on failure.

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -244,10 +244,9 @@ private[spark] class BlockManager(
     protected def saveToDiskStore(): Unit
 
     private def saveDeserializedValuesToMemoryStore(inputStream: InputStream): Boolean = {
-      var res = false
       try {
         val values = serializerManager.dataDeserializeStream(blockId, inputStream)(classTag)
-        res = memoryStore.putIteratorAsValues(blockId, values, classTag) match {
+        memoryStore.putIteratorAsValues(blockId, values, classTag) match {
           case Right(_) => true
           case Left(iter) =>
             // If putting deserialized values in memory failed, we will put the bytes directly
@@ -259,7 +258,6 @@ private[spark] class BlockManager(
       } finally {
         IOUtils.closeQuietly(inputStream)
       }
-      res
     }
 
     private def saveSerializedValuesToMemoryStore(bytes: ChunkedByteBuffer): Boolean = {

--- a/core/src/main/scala/org/apache/spark/storage/DiskStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskStore.scala
@@ -124,6 +124,10 @@ private[spark] class DiskStore(
     }
   }
 
+  /**
+   * @param blockSize if encryption is configured, the file is assumed to already be encrypted and
+   *                  blockSize should be the decrypted size
+   */
   def moveFileToBlock(sourceFile: File, blockSize: Long, targetBlockId: BlockId): Unit = {
     blockSizes.put(targetBlockId, blockSize)
     val targetFile = diskManager.getFile(targetBlockId.name)

--- a/core/src/main/scala/org/apache/spark/storage/DiskStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskStore.scala
@@ -27,6 +27,7 @@ import scala.collection.mutable.ListBuffer
 
 import com.google.common.io.Closeables
 import io.netty.channel.DefaultFileRegion
+import org.apache.commons.io.FileUtils
 
 import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.internal.{config, Logging}
@@ -126,7 +127,7 @@ private[spark] class DiskStore(
   def moveFileToBlock(sourceFile: File, blockSize: Long, targetBlockId: BlockId): Unit = {
     blockSizes.put(targetBlockId, blockSize)
     val targetFile = diskManager.getFile(targetBlockId.name)
-    sourceFile.renameTo(targetFile)
+    FileUtils.moveFile(sourceFile, targetFile)
   }
 
   def contains(blockId: BlockId): Boolean = {

--- a/core/src/main/scala/org/apache/spark/storage/DiskStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskStore.scala
@@ -123,6 +123,12 @@ private[spark] class DiskStore(
     }
   }
 
+  def moveFileToBlock(sourceFile: File, blockSize: Long, targetBlockId: BlockId): Unit = {
+    blockSizes.put(targetBlockId, blockSize)
+    val targetFile = diskManager.getFile(targetBlockId.name)
+    sourceFile.renameTo(targetFile)
+  }
+
   def contains(blockId: BlockId): Boolean = {
     val file = diskManager.getFile(blockId.name)
     file.exists()

--- a/core/src/test/scala/org/apache/spark/security/EncryptionFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/security/EncryptionFunSuite.scala
@@ -33,9 +33,13 @@ trait EncryptionFunSuite {
     }
   }
 
-  final protected def encryptionTestHelper(name: String)(fn: (String, SparkConf) => Unit): Unit = {
+  final protected def encryptionTestHelper(name: String)(fn: (String, SparkConf) => Unit): Unit =
+    encryptionTestHelper(name, new SparkConf())(fn)
+
+  final protected def encryptionTestHelper(name: String, sparkConf: SparkConf)
+      (fn: (String, SparkConf) => Unit): Unit = {
     Seq(false, true).foreach { encrypt =>
-      val conf = new SparkConf().set(IO_ENCRYPTION_ENABLED, encrypt)
+      val conf = sparkConf.set(IO_ENCRYPTION_ENABLED, encrypt)
       fn(s"$name (encryption = ${ if (encrypt) "on" else "off" })", conf)
     }
   }

--- a/core/src/test/scala/org/apache/spark/security/EncryptionFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/security/EncryptionFunSuite.scala
@@ -33,13 +33,9 @@ trait EncryptionFunSuite {
     }
   }
 
-  final protected def encryptionTestHelper(name: String)(fn: (String, SparkConf) => Unit): Unit =
-    encryptionTestHelper(name, new SparkConf())(fn)
-
-  final protected def encryptionTestHelper(name: String, sparkConf: SparkConf)
-      (fn: (String, SparkConf) => Unit): Unit = {
+  final protected def encryptionTestHelper(name: String)(fn: (String, SparkConf) => Unit): Unit = {
     Seq(false, true).foreach { encrypt =>
-      val conf = sparkConf.set(IO_ENCRYPTION_ENABLED, encrypt)
+      val conf = new SparkConf().set(IO_ENCRYPTION_ENABLED, encrypt)
       fn(s"$name (encryption = ${ if (encrypt) "on" else "off" })", conf)
     }
   }

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -928,6 +928,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
 
   Seq(
     "caching" -> StorageLevel.MEMORY_ONLY,
+    "caching, serialized" -> StorageLevel.MEMORY_ONLY_SER,
     "caching on disk" -> StorageLevel.DISK_ONLY
   ).foreach { case (name, storageLevel) =>
     encryptionTest(s"test putBlockDataAsStream with $name") { conf =>

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -121,9 +121,8 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
     super.beforeEach()
     // Set the arch to 64-bit and compressedOops to true to get a deterministic test-case
     System.setProperty("os.arch", "amd64")
-    if (conf == null) {
-      conf = createSparkConf()
-    }
+    conf = createSparkConf()
+
     rpcEnv = RpcEnv.create("test", "localhost", 0, conf, securityMgr)
     conf.set(DRIVER_PORT, rpcEnv.address.port)
 

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -910,13 +910,10 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
     }
   }
 
-  def testPutBlockDataAsStream(
-      name: String,
-      blockManager: BlockManager,
-      storageLevel: StorageLevel): Unit = {
+  def testPutBlockDataAsStream(blockManager: BlockManager, storageLevel: StorageLevel): Unit = {
     val message = "message"
     val ser = serializer.newInstance().serialize(message).array()
-    val blockId = new ShuffleDataBlockId(0, 0, 0)
+    val blockId = new RDDBlockId(0, 0)
     val streamCallbackWithId =
       blockManager.putBlockDataAsStream(blockId, storageLevel, ClassTag(message.getClass))
     streamCallbackWithId.onData("0", ByteBuffer.wrap(ser))
@@ -931,12 +928,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
 
   Seq(
     "caching" -> StorageLevel.MEMORY_ONLY,
-    "caching on disk" -> StorageLevel.DISK_ONLY,
-    "caching in memory, replicated" -> StorageLevel.MEMORY_ONLY_2,
-    "caching in memory, serialized, replicated" -> StorageLevel.MEMORY_ONLY_SER_2,
-    "caching on disk, replicated" -> StorageLevel.DISK_ONLY_2,
-    "caching in memory and disk, replicated" -> StorageLevel.MEMORY_AND_DISK_2,
-    "caching in memory and disk, serialized, replicated" -> StorageLevel.MEMORY_AND_DISK_SER_2
+    "caching on disk" -> StorageLevel.DISK_ONLY
   ).foreach { case (name, storageLevel) =>
     encryptionTest(s"test putBlockDataAsStream with $name") { conf =>
       init(conf)
@@ -952,7 +944,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
         shuffleManager, transfer, securityMgr, 0)
       try {
         blockManager.initialize("app-id")
-        testPutBlockDataAsStream(name, blockManager, storageLevel)
+        testPutBlockDataAsStream(blockManager, storageLevel)
       } finally {
         blockManager.stop()
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Before this PR the method `BlockManager#putBlockDataAsStream()` (which is used during block replication where the block data is received as a stream) was reading the whole block content into the memory even at DISK_ONLY storage level. 

With this change the received block data (which was temporary stored in a file) is just simply moved into the right location backing the target block. This way a possible OOM error is avoided.

In this implementation to save code duplications the method `doPutBytes` is refactored into a template method called `BlockStoreUpdater` which has a separate implementation to handle byte buffer based and temporary file based block store updates.

## How was this patch tested?

With existing unit tests of `DistributedSuite` (the ones dealing with replications):
- caching on disk, replicated (encryption = off) (with replication as stream)
- caching on disk, replicated (encryption = on) (with replication as stream)
- caching in memory, serialized, replicated (encryption = on) (with replication as stream)
- caching in memory, serialized, replicated (encryption = off) (with replication as stream)
- etc.

And with new unit tests testing `putBlockDataAsStream` method directly:
- test putBlockDataAsStream with caching (encryption = off) 
- test putBlockDataAsStream with caching (encryption = on) 
- test putBlockDataAsStream with caching on disk (encryption = off) 
- test putBlockDataAsStream with caching on disk (encryption = on) 
