### PR TITLE
[SPARK-26780][CORE]Improve shuffle read using ReadAheadInputStream 

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -946,6 +946,14 @@ package object config {
       .booleanConf
       .createWithDefault(false)
 
+  private[spark] val SHUFFLE_READ_AHEAD_BUFFER_SIZE =
+    ConfigBuilder("spark.shuffle.read.ahead.buffer.size")
+      .doc("The buffer size for shuffle read ahead, if it is set to 0, shuffle read ahead won't" +
+        "be enabled, and if `spark.shuffle.detectCorrupt.useExtraMemory` is enabled, shuffle" +
+        "read ahead won't be enabled too")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("1M")
+
   private[spark] val SHUFFLE_SYNC =
     ConfigBuilder("spark.shuffle.sync")
       .doc("Whether to force outstanding writes to disk.")

--- a/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
@@ -56,6 +56,7 @@ private[spark] class BlockStoreShuffleReader[K, C](
       SparkEnv.get.conf.get(config.MAX_REMOTE_BLOCK_SIZE_FETCH_TO_MEM),
       SparkEnv.get.conf.get(config.SHUFFLE_DETECT_CORRUPT),
       SparkEnv.get.conf.get(config.SHUFFLE_DETECT_CORRUPT_MEMORY),
+      SparkEnv.get.conf.get(config.SHUFFLE_READ_AHEAD_BUFFER_SIZE).toInt,
       readMetrics).toCompletionIterator
 
     val serializerInstance = dep.serializer.newInstance()

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -117,6 +117,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       false,
+      0,
       metrics)
 
     // 3 local blocks fetched in initialization
@@ -195,6 +196,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       false,
+      0,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
 
     verify(blocks(ShuffleBlockId(0, 0, 0)), times(0)).release()
@@ -262,6 +264,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       false,
+      0,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
 
 
@@ -321,6 +324,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       false,
+      0,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
 
     // Continue only after the mock calls onBlockFetchFailure
@@ -410,6 +414,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       true,
+      0,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
 
     // Continue only after the mock calls onBlockFetchFailure
@@ -480,6 +485,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       true,
+      0,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
 
     // We'll get back the block which has corruption after maxBytesInFlight/3 because the other
@@ -544,6 +550,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       true,
+      0,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
     val (id, st) = iterator.next()
     // Check that the test setup is correct -- make sure we have a concatenated stream.
@@ -605,6 +612,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       false,
+      0,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
 
     // Continue only after the mock calls onBlockFetchFailure
@@ -666,6 +674,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
         maxReqSizeShuffleToMem = 200,
         detectCorrupt = true,
         false,
+        0,
         taskContext.taskMetrics.createTempShuffleReadMetrics())
     }
 
@@ -714,6 +723,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       false,
+      0,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
 
     // All blocks fetched return zero length and should trigger a receive-side error:


### PR DESCRIPTION
## What changes were proposed in this pull request?
Using `ReadAheadInputStream`  to improve  shuffle read  performance.
 `ReadAheadInputStream` can save cpu utilization and almost no performance regression


## How was this patch tested?
1. Using unit tests for correctness testing.
1. TPCDS test: 
./spark-shell --executor-memory 4G --total-executor-cores 18 --conf "spark.sql.shuffle.partitions=6" --conf "spark.shuffle.detectCorrupt=false" --conf "spark.shuffle.read.ahead.enabled=true" --jars /home/spark-sql-perf-assembly-0.5.0-SNAPSHOT.jar

Test cases ran three times.

**Before this PR：**
**One(Total time :1759.577170773999969s)**：
Running execution q4-v2.50 iteration: 1, StandardRun=true
Execution time: 402.58029997799997s
Running execution q14a-v2.50 iteration: 1, StandardRun=true
Execution time: 652.151175984s
Running execution q14b-v2.50 iteration: 1, StandardRun=true
Execution time: 547.148668606s
Running execution q25-v2.50 iteration: 1, StandardRun=true
Execution time: 150.53358054s
Running execution ss_max-v2.50 iteration: 1, StandardRun=true
Execution time: 7.163445665999999s

**Two(Total time :1734.5941864229999s)**：
Running execution q4-v2.50 iteration: 1, StandardRun=true
Execution time: 391.070943194s
Running execution q14a-v2.50 iteration: 1, StandardRun=true
Execution time: 654.8007626389999s
Running execution q14b-v2.50 iteration: 1, StandardRun=true
Execution time: 537.754249246s
Running execution q25-v2.50 iteration: 1, StandardRun=true
Execution time: 143.928162026s
Running execution ss_max-v2.50 iteration: 1, StandardRun=true
Execution time: 7.040069318s

**Three(Total time :1749.7357909459999995s)**：
Running execution q4-v2.50 iteration: 1, StandardRun=true
Execution time: 395.008734361s
Running execution q14a-v2.50 iteration: 1, StandardRun=true
Execution time: 651.273268132s
Running execution q14b-v2.50 iteration: 1, StandardRun=true
Execution time: 544.524801175s
Running execution q25-v2.50 iteration: 1, StandardRun=true
Execution time: 151.95291255s
Running execution ss_max-v2.50 iteration: 1, StandardRun=true
Execution time: 6.9760747279999995s

Average time of three times：(1759.577170773999969 +1734.5941864229999 +1749.7357909459999995 ) / 3 = **1747.969s**

**After this PR：**
**One(Total time :1751.97129727800003s)**：
Running execution q4-v2.50 iteration: 1, StandardRun=true
Execution time: 395.34360907900003s
Running execution q14a-v2.50 iteration: 1, StandardRun=true
Execution time: 658.750893903s
Running execution q14b-v2.50 iteration: 1, StandardRun=true
Execution time: 539.719277862s
Running execution q25-v2.50 iteration: 1, StandardRun=true
Execution time: 150.859470327s
Running execution ss_max-v2.50 iteration: 1, StandardRun=true
Execution time: 7.298046107s

**Two(Total time :1706.564606477s)**：
Running execution q4-v2.50 iteration: 1, StandardRun=true
Execution time: 382.847373545s
Running execution q14a-v2.50 iteration: 1, StandardRun=true
Execution time: 649.87997278s
Running execution q14b-v2.50 iteration: 1, StandardRun=true
Execution time: 522.374645028s
Running execution q25-v2.50 iteration: 1, StandardRun=true
Execution time: 143.963793466s
Running execution ss_max-v2.50 iteration: 1, StandardRun=true
Execution time: 7.498821658s

**Three(Total time :1732.8683500150001s)**：
Running execution q4-v2.50 iteration: 1, StandardRun=true
Execution time: 393.625937426s
Running execution q14a-v2.50 iteration: 1, StandardRun=true
Execution time: 644.5871864950001s
Running execution q14b-v2.50 iteration: 1, StandardRun=true
Execution time: 542.764517975s
Running execution q25-v2.50 iteration: 1, StandardRun=true
Execution time: 144.518587871s
Running execution ss_max-v2.50 iteration: 1, StandardRun=true
Execution time: 7.372120248s

Average time of three times：(1751.97129727800003 +1706.564606477 +1732.8683500150001 ) / 3 = **1730.468s**