### PR TITLE
[SPARK-26781][SQL]Avoid additional shuffle when the data is already partitioned on the same key in previous stage 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -231,6 +231,10 @@ abstract class Expression extends TreeNode[Expression] {
   def semanticEquals(other: Expression): Boolean =
     deterministic && other.deterministic && canonicalized == other.canonicalized
 
+  def resolveEquals(other: Expression): Boolean = {
+    semanticEquals(other)
+  }
+
   /**
    * Returns a `hashCode` for the calculation performed by this expression. Unlike the standard
    * `hashCode`, an attempt has been made to eliminate cosmetic differences.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -262,7 +262,7 @@ case class AttributeReference(
 
   override def semanticEquals(other: Expression): Boolean = other match {
     case ar: AttributeReference if ar.metadata.contains("exprId") =>
-      exprId.toString == ar.metadata.getString("exprId")
+      sameRef(ar) || exprId.toString == ar.metadata.getString("exprId")
     case ar: AttributeReference => sameRef(ar)
     case _ => false
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -261,10 +261,22 @@ case class AttributeReference(
   }
 
   override def semanticEquals(other: Expression): Boolean = other match {
-    case ar: AttributeReference if ar.metadata.contains("exprId") =>
-      sameRef(ar) || exprId.toString == ar.metadata.getString("exprId")
     case ar: AttributeReference => sameRef(ar)
     case _ => false
+  }
+
+  override def resolveEquals(other: Expression): Boolean = {
+    def isSame = {
+      var same: Boolean = false
+      if (other.isInstanceOf[AttributeReference]) {
+        val ar = other.asInstanceOf[AttributeReference]
+        if (ar.metadata.contains("exprId")) {
+          same = (exprId.toString == ar.metadata.getString("exprId"))
+        }
+      }
+      same
+    }
+    semanticEquals(other) || isSame
   }
 
   override def semanticHash(): Int = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -221,7 +221,7 @@ case class HashPartitioning(expressions: Seq[Expression], numPartitions: Int)
       required match {
         case h: HashClusteredDistribution =>
           expressions.length == h.expressions.length && expressions.zip(h.expressions).forall {
-            case (l, r) => l.semanticEquals(r)
+            case (l, r) => l.resolveEquals(r)
           }
         case ClusteredDistribution(requiredClustering, _) =>
           expressions.forall(x => requiredClustering.exists(_.semanticEquals(x)))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -150,14 +150,6 @@ object SQLConf {
     }
   }
 
-  val ATTR_COMPARE_NEW =
-    buildConf("spark.sql.attribute.compare.new")
-      .doc("When true, semanticEquals of Attribute reference" +
-        " also checks the associated metadata object's exprId" +
-        " before failing the comparison")
-      .booleanConf
-      .createWithDefault(false)
-
   val OPTIMIZER_EXCLUDED_RULES = buildConf("spark.sql.optimizer.excludedRules")
     .doc("Configures a list of rules to be disabled in the optimizer, in which the rules are " +
       "specified by their rule names and separated by comma. It is not guaranteed that all the " +
@@ -2027,8 +2019,6 @@ class SQLConf extends Serializable with Logging {
   def literalPickMinimumPrecision: Boolean = getConf(LITERAL_PICK_MINIMUM_PRECISION)
 
   def continuousStreamingExecutorQueueSize: Int = getConf(CONTINUOUS_STREAMING_EXECUTOR_QUEUE_SIZE)
-
-  def useAttrCompareNew: Boolean = getConf(ATTR_COMPARE_NEW)
 
   def continuousStreamingExecutorPollIntervalMs: Long =
     getConf(CONTINUOUS_STREAMING_EXECUTOR_POLL_INTERVAL_MS)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -150,6 +150,14 @@ object SQLConf {
     }
   }
 
+  val ATTR_COMPARE_NEW =
+    buildConf("spark.sql.attribute.compare.new")
+      .doc("When true, semanticEquals of Attribute reference" +
+        " also checks the associated metadata object's exprId" +
+        " before failing the comparison")
+      .booleanConf
+      .createWithDefault(false)
+
   val OPTIMIZER_EXCLUDED_RULES = buildConf("spark.sql.optimizer.excludedRules")
     .doc("Configures a list of rules to be disabled in the optimizer, in which the rules are " +
       "specified by their rule names and separated by comma. It is not guaranteed that all the " +
@@ -2019,6 +2027,8 @@ class SQLConf extends Serializable with Logging {
   def literalPickMinimumPrecision: Boolean = getConf(LITERAL_PICK_MINIMUM_PRECISION)
 
   def continuousStreamingExecutorQueueSize: Int = getConf(CONTINUOUS_STREAMING_EXECUTOR_QUEUE_SIZE)
+
+  def useAttrCompareNew: Boolean = getConf(ATTR_COMPARE_NEW)
 
   def continuousStreamingExecutorPollIntervalMs: Long =
     getConf(CONTINUOUS_STREAMING_EXECUTOR_POLL_INTERVAL_MS)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AttributeReferenceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AttributeReferenceSuite.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.execution
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.execution.exchange.Exchange
+import org.apache.spark.sql.hive.test.TestHiveSingleton
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SQLTestUtils
+
+class AttributeReferenceSuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
+
+  val confName: String = SQLConf.ATTR_COMPARE_NEW.key
+
+  val query: String = "select * from (select a.id as newid, a.name from a join b" +
+    " where a.id = b.id) temp  join c  on temp.newid = c.id"
+
+  val tableNames = Seq("a", "b", "c")
+
+  // Create 3 tables with schema id INT, name STRING
+  protected override def beforeAll(): Unit = {
+    super.beforeAll()
+    tableNames.foreach {
+      name =>
+        sql(
+          s"""
+             |CREATE TABLE $name (id INT, name STRING)
+             |STORED AS PARQUET
+          """.stripMargin)
+    }
+  }
+
+
+  test(s"Tests to check for presence of exchange when falg is enable/disabled") {
+    val confs = Array("true" -> 3, "false" -> 4)
+
+    confs.foreach { conf =>
+      withSQLConf(confName -> conf._1) {
+        val df = spark.sql(query)
+        val executedPlan = df.queryExecution.executedPlan
+        val exchanges = executedPlan.collect {
+          case e: Exchange => e
+        }
+        assert(exchanges.size == conf._2)
+      }
+    }
+  }
+
+  protected override def afterAll(): Unit = {
+    super.afterAll()
+    tableNames.foreach {
+      name =>
+        spark.sql(s"drop table if exists $name")
+    }
+  }
+}

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AttributeReferenceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AttributeReferenceSuite.scala
@@ -17,15 +17,11 @@
 
 package org.apache.spark.sql.hive.execution
 
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.execution.exchange.Exchange
 import org.apache.spark.sql.hive.test.TestHiveSingleton
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestUtils
 
-class AttributeReferenceSuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
-
-  val confName: String = SQLConf.ATTR_COMPARE_NEW.key
+class AttributeReferenceSuite extends SQLTestUtils with TestHiveSingleton {
 
   val query: String = "select * from (select a.id as newid, a.name from a join b" +
     " where a.id = b.id) temp  join c  on temp.newid = c.id"
@@ -46,19 +42,13 @@ class AttributeReferenceSuite extends QueryTest with SQLTestUtils with TestHiveS
   }
 
 
-  test(s"Tests to check for presence of exchange when falg is enable/disabled") {
-    val confs = Array("true" -> 3, "false" -> 4)
-
-    confs.foreach { conf =>
-      withSQLConf(confName -> conf._1) {
-        val df = spark.sql(query)
-        val executedPlan = df.queryExecution.executedPlan
-        val exchanges = executedPlan.collect {
-          case e: Exchange => e
-        }
-        assert(exchanges.size == conf._2)
-      }
+  test(s"Tests to check for presence of exchange when flag is enable/disabled") {
+    val df = spark.sql(query)
+    val executedPlan = df.queryExecution.executedPlan
+    val exchanges = executedPlan.collect {
+      case e: Exchange => e
     }
+    assert(exchanges.size == 3)
   }
 
   protected override def afterAll(): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid additonal exchanges 
Consider three tables: a(id int), b(id int), c(id, int)

query:  
`select * from (select a.id as newid from a join b where a.id = b.id) temp join c on temp.newid = c.id`

Plan(physical plan: org.apache.spark.sql.execution.QueryExecution#executedPlan):
Before fix:
```
*(9) SortMergeJoin [newid#1L], [id#6L], Inner
:- *(6) Sort [newid#1L ASC NULLS FIRST], false, 0
:  +- Exchange hashpartitioning(newid#1L, 200)
:     +- *(5) Project [id#2L AS newid#1L, name#3]
:        +- *(5) SortMergeJoin [id#2L], [id#4L], Inner
:           :- *(2) Sort [id#2L ASC NULLS FIRST], false, 0
:           :  +- Exchange hashpartitioning(id#2L, 200)
:           :     +- *(1) Project [id#2L, name#3]
:           :        +- *(1) Filter isnotnull(id#2L)
:           :           +- *(1) FileScan parquet a[id#2L,name#3] Batched: true, DataFilters: [isnotnull(id#2L)], Format: Parquet, Location: InMemoryFileIndex[file:/tmp/spark/a], PartitionFilters: [], PushedFilters: [IsNotNull(id)], ReadSchema: struct<id:bigint,name:string>
:           +- *(4) Sort [id#4L ASC NULLS FIRST], false, 0
:              +- Exchange hashpartitioning(id#4L, 200)
:                 +- *(3) Project [id#4L]
:                    +- *(3) Filter isnotnull(id#4L)
:                       +- *(3) FileScan parquet b[id#4L] Batched: true, DataFilters: [isnotnull(id#4L)], Format: Parquet, Location: InMemoryFileIndex[file:/tmp/spark/b], PartitionFilters: [], PushedFilters: [IsNotNull(id)], ReadSchema: struct<id:bigint>
+- *(8) Sort [id#6L ASC NULLS FIRST], false, 0
   +- Exchange hashpartitioning(id#6L, 200)
      +- *(7) Project [id#6L, name#7]
         +- *(7) Filter isnotnull(id#6L)
            +- *(7) FileScan parquet \c[id#6L,name#7] Batched: true, DataFilters: [isnotnull(id#6L)], Format: Parquet, Location: InMemoryFileIndex[file:/tmp/spark/c], PartitionFilters: [], PushedFilters: [IsNotNull(id)], ReadSchema: struct<id:bigint,name:string>
```
 The exchange operator below stage 6 is not required since the data from project is already partitioned based on id.

An exchange gets added since the outputPartitioning of Project(5) is HashPartitioning on id#2L whereas the requiredPartitioning of Sort(Stage 6) is HashPartitioning on newid#1L which is nothing but alias of id#2L.

The exchange operator is not required in this case if we are able to compare the attribute id#2L referenced by alias newid#1L 0

## How the additional exchange can be avoided
1. `org.apache.spark.sql.catalyst.plans.physical.HashPartitioning#satisfies0` gets executed as part of EnsureRequiremenst planner rule(check below stacktrace), which has the following code
has the following code
```
expressions.length == h.expressions.length && expressions.zip(h.expressions).forall {
            case (l, r) => l.semanticEquals(r)
```
`l.semanticEquals(r)` check fails due to comparsion between id#2L and newid#1L(which is the alias for id#2L) ()
```
semanticEquals:265, AttributeReference (org.apache.spark.sql.catalyst.expressions)
satisfies0:223, HashPartitioning (org.apache.spark.sql.catalyst.plans.physical)
satisfies:171, Partitioning (org.apache.spark.sql.catalyst.plans.physical)
satisfies:212, HashPartitioning (org.apache.spark.sql.catalyst.plans.physical)
satisfies0:324, PartitioningCollection (org.apache.spark.sql.catalyst.plans.physical)
satisfies:171, Partitioning (org.apache.spark.sql.catalyst.plans.physical)
satisfies:302, PartitioningCollection (org.apache.spark.sql.catalyst.plans.physical)
org$apache$spark$sql$execution$exchange$EnsureRequirements$$ensureDistributionAndOrdering:149, EnsureRequirements (org.apache.spark.sql.execution.exchange)
```
2. why is change made in `org.apache.spark.sql.catalyst.expressions.Alias#toAttribute`
`org.apache.spark.sql.catalyst.plans.logical.Project#output`
converts Alias to Attributes which is the child node of Join(this hapen when child resolution takes place)
```
  override def output: Seq[Attribute] = projectList.map(_.toAttribute)
```

After fix:
```
*(8) Project [newid#1L, name#3, id#6L, name#7]
+- *(8) SortMergeJoin [newid#1L], [id#6L], Inner
   :- *(5) Sort [newid#1L ASC NULLS FIRST], false, 0
   :  +- *(5) Project [id#2L AS newid#1L, name#3]
   :     +- *(5) SortMergeJoin [id#2L], [id#4L], Inner
   :        :- *(2) Sort [id#2L ASC NULLS FIRST], false, 0
   :        :  +- Exchange hashpartitioning(id#2L, 200)
   :        :     +- *(1) Project [id#2L, name#3]
   :        :        +- *(1) Filter isnotnull(id#2L)
   :        :           +- *(1) FileScan parquet a[id#2L,name#3] Batched: true, DataFilters: [isnotnull(id#2L)], Format: Parquet, Location: InMemoryFileIndex[file:/tmp/spark/a], PartitionFilters: [], PushedFilters: [IsNotNull(id)], ReadSchema: struct<id:bigint,name:string>
   :        +- *(4) Sort [id#4L ASC NULLS FIRST], false, 0
   :           +- Exchange hashpartitioning(id#4L, 200)
   :              +- *(3) Project [id#4L]
   :                 +- *(3) Filter isnotnull(id#4L)
   :                    +- *(3) FileScan parquet b[id#4L] Batched: true, DataFilters: [isnotnull(id#4L)], Format: Parquet, Location: InMemoryFileIndex[file:/tmp/spark/b], PartitionFilters: [], PushedFilters: [IsNotNull(id)], ReadSchema: struct<id:bigint>
   +- *(7) Sort [id#6L ASC NULLS FIRST], false, 0
      +- Exchange hashpartitioning(id#6L, 200)
         +- *(6) Project [id#6L, name#7]
            +- *(6) Filter isnotnull(id#6L)
               +- *(6) FileScan parquet c[id#6L,name#7] Batched: true, DataFilters: [isnotnull(id#6L)], Format: Parquet, Location: InMemoryFileIndex[file:/tmp/spark/c], PartitionFilters: [], PushedFilters: [IsNotNull(id)], ReadSchema: struct<id:bigint,name:string>

```


## How was this patch tested?

Unit tests, manual test(checked against TPC-DS query2 where this issue occurs)
