### PR TITLE
[SPARK-26794][SQL]SparkSession enableHiveSupport does not point to hive but in-memory while the SparkContext exists

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -127,7 +127,7 @@ class SparkSession private(
   @Unstable
   @transient
   lazy val sharedState: SharedState = {
-    existingSharedState.getOrElse(new SharedState(sparkContext, initialSessionOptions.toMap))
+    existingSharedState.getOrElse(new SharedState(sparkContext, initialSessionOptions))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -127,7 +127,7 @@ class SparkSession private(
   @Unstable
   @transient
   lazy val sharedState: SharedState = {
-    existingSharedState.getOrElse(new SharedState(sparkContext))
+    existingSharedState.getOrElse(new SharedState(sparkContext, initialSessionOptions.toMap))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -83,7 +83,7 @@ private[sql] class SharedState(
   }
   logInfo(s"Warehouse path is '$warehousePath'.")
 
-  // This variable should be initiated after `warehousePath`, because in the first place we need
+  // These 2 variables should be initiated after `warehousePath`, because in the first place we need
   // to load hive-site.xml into hadoopConf and determine the warehouse path which will be set into
   // both spark conf and hadoop conf avoiding be affected by any SparkSession level options
   private val (conf, hadoopConf) = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -42,7 +42,7 @@ import org.apache.spark.util.{MutableURLClassLoader, Utils}
  */
 private[sql] class SharedState(
     val sparkContext: SparkContext,
-    initConfig: scala.collection.Map[String, String])
+    initialConfigs: scala.collection.Map[String, String])
   extends Logging {
   private val conf = sparkContext.conf.clone()
   private val hadoopConf = new Configuration(sparkContext.hadoopConfiguration)
@@ -50,7 +50,7 @@ private[sql] class SharedState(
   // If `SparkSession` is instantiated using an existing `SparkContext` instance and no existing
   // `SharedState`, all `SparkSession` level configurations have higher priority to generate a
   // `SharedState` instance. This will be done only once then shared across `SparkSession`s
-  initConfig.foreach { case (k, v) =>
+  initialConfigs.foreach { case (k, v) =>
     logDebug(s"Applying initial SparkSession options to SparkConf/HadoopConf: $k -> $v")
     conf.set(k, v)
     hadoopConf.set(k, v)

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.internal
 import java.net.URL
 import java.util.Locale
 
-import scala.collection.Map
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
@@ -41,7 +40,9 @@ import org.apache.spark.util.{MutableURLClassLoader, Utils}
 /**
  * A class that holds all state shared across sessions in a given [[SQLContext]].
  */
-private[sql] class SharedState(val sparkContext: SparkContext, initConfig: Map[String, String])
+private[sql] class SharedState(
+    val sparkContext: SparkContext,
+    initConfig: scala.collection.Map[String, String])
   extends Logging {
   private val conf = sparkContext.conf.clone()
   private val hadoopConf = new Configuration(sparkContext.hadoopConfiguration)
@@ -121,7 +122,7 @@ private[sql] class SharedState(val sparkContext: SparkContext, initConfig: Map[S
       SessionCatalog.DEFAULT_DATABASE,
       "default database",
       CatalogUtils.stringToURI(warehousePath),
-      Map.empty[String, String])
+      Map())
     // Create default database if it doesn't exist
     if (!externalCatalog.databaseExists(SessionCatalog.DEFAULT_DATABASE)) {
       // There may be another Spark application creating default database at the same time, here we

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -90,7 +90,7 @@ private[hive] class TestHiveExternalCatalog(
 private[hive] class TestHiveSharedState(
     sc: SparkContext,
     hiveClient: Option[HiveClient] = None)
-  extends SharedState(sc, initialConfigs = Map.empty) {
+  extends SharedState(sc, initialConfigs = Map.empty[String, String]) {
 
   override lazy val externalCatalog: ExternalCatalogWithListener = {
     new ExternalCatalogWithListener(new TestHiveExternalCatalog(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -90,7 +90,7 @@ private[hive] class TestHiveExternalCatalog(
 private[hive] class TestHiveSharedState(
     sc: SparkContext,
     hiveClient: Option[HiveClient] = None)
-  extends SharedState(sc, Map.empty) {
+  extends SharedState(sc, initialConfigs = Map.empty) {
 
   override lazy val externalCatalog: ExternalCatalogWithListener = {
     new ExternalCatalogWithListener(new TestHiveExternalCatalog(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -90,7 +90,7 @@ private[hive] class TestHiveExternalCatalog(
 private[hive] class TestHiveSharedState(
     sc: SparkContext,
     hiveClient: Option[HiveClient] = None)
-  extends SharedState(sc) {
+  extends SharedState(sc, Map.empty) {
 
   override lazy val externalCatalog: ExternalCatalogWithListener = {
     new ExternalCatalogWithListener(new TestHiveExternalCatalog(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSharedStateSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSharedStateSuite.scala
@@ -62,7 +62,6 @@ class HiveSharedStateSuite extends SparkFunSuite {
 
     assert(!state.sparkContext.conf.contains("spark.foo"),
       "static spark conf should not be affected by session")
-    assert(state.sparkContext.conf.get(CATALOG_IMPLEMENTATION) === "in-memory")
     assert(state.globalTempViewManager.database === tmpDb)
     assert(state.externalCatalog.unwrapped.isInstanceOf[HiveExternalCatalog],
       "Initial SparkSession options can determine the catalog")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSharedStateSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSharedStateSuite.scala
@@ -20,24 +20,11 @@ package org.apache.spark.sql.hive
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars
 
 import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.internal.SharedState
 import org.apache.spark.sql.internal.StaticSQLConf._
 import org.apache.spark.util.Utils
 
 class HiveSharedStateSuite extends SparkFunSuite {
-
-  test("enableHiveSupport has right to determine the catalog while using an existing sc") {
-    val conf = new SparkConf().setMaster("local").setAppName("SharedState Test")
-    val sc = SparkContext.getOrCreate(conf)
-    val ss = SparkSession.builder().enableHiveSupport().getOrCreate()
-    assert(ss.sharedState.externalCatalog.unwrapped.isInstanceOf[HiveExternalCatalog],
-      "The catalog should be hive ")
-
-    val ss2 = SparkSession.builder().getOrCreate()
-    assert(ss2.sharedState.externalCatalog.unwrapped.isInstanceOf[HiveExternalCatalog],
-      "The catalog should be shared across sessions")
-  }
 
   test("initial configs should be passed to SharedState but not SparkContext") {
     val conf = new SparkConf().setMaster("local").setAppName("SharedState Test")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSharedStateSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSharedStateSuite.scala
@@ -29,13 +29,12 @@ class HiveSharedStateSuite extends SparkFunSuite {
       val conf = new SparkConf().setMaster("local").setAppName("SharedState Test")
       sc = new SparkContext(conf)
       val ss = SparkSession.builder().enableHiveSupport().getOrCreate()
-      assert(ss.sharedState.externalCatalog.unwrapped.getClass.getName ===
-        "org.apache.spark.sql.hive.HiveExternalCatalog", "The catalog should be hive ")
+      assert(ss.sharedState.externalCatalog.unwrapped.getClass.getName
+        .contains("HiveExternalCatalog"), "The catalog should be hive ")
 
       val ss2 = SparkSession.builder().getOrCreate()
-      assert(ss2.sharedState.externalCatalog.unwrapped.getClass.getName ===
-        "org.apache.spark.sql.hive.HiveExternalCatalog",
-        "The catalog should be shared across sessions")
+      assert(ss2.sharedState.externalCatalog.unwrapped.getClass.getName
+        .contains("HiveExternalCatalog"), "The catalog should be shared across sessions")
     } finally {
       if (sc != null && !sc.isStopped) {
         sc.stop()

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSharedStateSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSharedStateSuite.scala
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.internal
+package org.apache.spark.sql.hive
 
 import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
 import org.apache.spark.sql.SparkSession
 
-class SharedStateSuite extends SparkFunSuite {
+class HiveSharedStateSuite extends SparkFunSuite {
 
   test("the catalog should be determined at the very first") {
     val conf = new SparkConf().setMaster("local").setAppName("SharedState Test")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/internal/SharedStateSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/internal/SharedStateSuite.scala
@@ -24,7 +24,7 @@ class SharedStateSuite extends SparkFunSuite {
 
   test("the catalog should be determined at the very first") {
     val conf = new SparkConf().setMaster("local").setAppName("SharedState Test")
-    val sc = new SparkContext(conf)
+    val sc = SparkContext.getOrCreate(conf)
     val ss = SparkSession.builder().enableHiveSupport().getOrCreate()
     assert(ss.sharedState.externalCatalog.unwrapped.getClass.getName ===
       "org.apache.spark.sql.hive.HiveExternalCatalog", "The catalog should be hive ")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/internal/SharedStateSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/internal/SharedStateSuite.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.internal
+
+import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
+import org.apache.spark.sql.SparkSession
+
+class SharedStateSuite extends SparkFunSuite {
+
+  test("the catalog should be determined at the very first") {
+    val conf = new SparkConf().setMaster("local").setAppName("SharedState Test")
+    val sc = new SparkContext(conf)
+    val ss = SparkSession.builder().enableHiveSupport().getOrCreate()
+    assert(ss.sharedState.externalCatalog.unwrapped.getClass.getName ===
+      "org.apache.spark.sql.hive.HiveExternalCatalog", "The catalog should be hive ")
+    val ss2 = SparkSession.builder().getOrCreate()
+
+    assert(ss2.sharedState.externalCatalog.unwrapped.getClass.getName ===
+      "org.apache.spark.sql.hive.HiveExternalCatalog", "The catalog should shared across sessions")
+  }
+
+}

--- a/sql/hive/src/test/scala/org/apache/spark/sql/internal/SharedStateSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/internal/SharedStateSuite.scala
@@ -28,10 +28,10 @@ class SharedStateSuite extends SparkFunSuite {
     val ss = SparkSession.builder().enableHiveSupport().getOrCreate()
     assert(ss.sharedState.externalCatalog.unwrapped.getClass.getName ===
       "org.apache.spark.sql.hive.HiveExternalCatalog", "The catalog should be hive ")
+
     val ss2 = SparkSession.builder().getOrCreate()
-
     assert(ss2.sharedState.externalCatalog.unwrapped.getClass.getName ===
-      "org.apache.spark.sql.hive.HiveExternalCatalog", "The catalog should shared across sessions")
+      "org.apache.spark.sql.hive.HiveExternalCatalog",
+      "The catalog should be shared across sessions")
   }
-
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

```java
public class SqlDemo {
    public static void main(final String[] args) throws Exception {
        SparkConf conf = new SparkConf().setAppName("spark-sql-demo");
        JavaSparkContext sc = new JavaSparkContext(conf);
        SparkSession ss = SparkSession.builder().enableHiveSupport().getOrCreate();
        ss.sql("show databases").show();
    }
}
```
Before https://issues.apache.org/jira/browse/SPARK-20946, the demo above point to the right hive metastore if the hive-site.xml is present. But now it can only point to the default in-memory one.

Catalog is now as a variable shared across SparkSessions, it is instantiated with SparkContext's conf. After https://issues.apache.org/jira/browse/SPARK-20946, Session level configs are not pass to SparkContext's conf anymore, so the enableHiveSupport API takes no affect on the catalog instance.

You can set spark.sql.catalogImplementation=hive application wide to solve the problem, or never create a sc before you call SparkSession.builder().enableHiveSupport().getOrCreate()

Here we respect the SparkSession level configuration at the first time to generate catalog within SharedState


## How was this patch tested?

1. add ut
2. manually
```scala
test("enableHiveSupport has right to determine the catalog while using an existing sc") {
    val conf = new SparkConf().setMaster("local").setAppName("SharedState Test")
    val sc = SparkContext.getOrCreate(conf)
    val ss = SparkSession.builder().enableHiveSupport().getOrCreate()
    assert(ss.sharedState.externalCatalog.unwrapped.isInstanceOf[HiveExternalCatalog],
      "The catalog should be hive ")

    val ss2 = SparkSession.builder().getOrCreate()
    assert(ss2.sharedState.externalCatalog.unwrapped.isInstanceOf[HiveExternalCatalog],
      "The catalog should be shared across sessions")
  }
```

Without this fix, the above test will fail.
You can apply it to `org.apache.spark.sql.hive.HiveSharedStateSuite`,
and run,
```sbt
./build/sbt  -Phadoop-2.7 -Phive  "hive/testOnly org.apache.spark.sql.hive.HiveSharedStateSuite"
```
to verify.

