### PR TITLE
[SPARK-26795][SHUFFLE]Retry remote fileSegmentManagedBuffer when creating inputStream failed during shuffle read phase#SPARK-26795

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -471,7 +471,7 @@ final class ShuffleBlockFetcherIterator(
                   if (address == blockManager.blockManagerId) {
                     logError("Failed to create input stream from local block", e)
                   } else {
-                    logError("Failed to create input stream from remote block twice", e)
+                    logError("Failed to create input stream from remote downloaded block twice", e)
                   }
                   throwFetchFailedException(blockId, address, e)
                 }

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -442,8 +442,8 @@ final class ShuffleBlockFetcherIterator(
               //
               // - BypassMergeSortShuffleWriterSuite: "write with some empty partitions"
               // - UnsafeShuffleWriterSuite: "writeEmptyIterator"
-              // - DiskBlockObjectWriterSuite: "commit() and close() without ever opening or writing"
-              //
+              // - DiskBlockObjectWriterSuite: "commit() and close() without ever opening or
+              // writing"
               // There is not an explicit test for SortShuffleWriter but the underlying APIs that
               // uses are shared by the UnsafeShuffleWriter (both writers use DiskBlockObjectWriter
               // which returns a zero-size from commitAndGet() in case no records were written

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -456,17 +456,23 @@ final class ShuffleBlockFetcherIterator(
             val in = try {
               buf.createInputStream()
             } catch {
-              // The exception could only be throwed by local shuffle block
+              // The exception could be throwed by local shuffle block or remote downloaded block
               case e: IOException =>
                 assert(buf.isInstanceOf[FileSegmentManagedBuffer])
-                logError("Failed to create input stream from local block", e)
                 buf.release()
                 if (address != blockManager.blockManagerId && !corruptedBlocks.contains(blockId)) {
+                  logError("Failed to create input stream from remote downloaded block " +
+                    "and try again", e)
                   corruptedBlocks += blockId
                   fetchRequests += FetchRequest(address, Array((blockId, size)))
                   result = null
                   break()
                 } else {
+                  if (address == blockManager.blockManagerId) {
+                    logError("Failed to create input stream from local block", e)
+                  } else {
+                    logError("Failed to create input stream from remote block twice", e)
+                  }
                   throwFetchFailedException(blockId, address, e)
                 }
             }

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -412,17 +412,15 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
         Future {
           // Return the first block, and then fail.
           listener.onBlockFetchSuccess(
-            ShuffleBlockId(0, 1, 0).toString, mockCorruptBuffer())
+            ShuffleBlockId(0, 1, 0).toString, blocks(ShuffleBlockId(0, 1, 0)))
           sem.release()
         }
       }
     })
 
-    // The next block is corrupt local block (the second one is corrupt and retried)
-    intercept[FetchFailedException] { iterator.next() }
-
-    sem.acquire()
-    intercept[FetchFailedException] { iterator.next() }
+    // The next block is a correct ShuffleBlockId (the second and third are corrupt and retried)
+    val (id2, _) = iterator.next()
+    assert(id2 == ShuffleBlockId(0, 1, 0))
   }
 
   test("big blocks are not checked for corruption") {

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -418,7 +418,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       }
     })
 
-    // The next block is a correct ShuffleBlockId (the second and third are corrupt and retried)
+    // The next block is a correct ShuffleBlock (the second and third are corrupt and retried)
     val (id2, _) = iterator.next()
     assert(id2 == ShuffleBlockId(0, 1, 0))
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

There is a parameter spark.maxRemoteBlockSizeFetchToMem, which means the remote block will be fetched to disk when size of the block is above this threshold in bytes.

So during shuffle read phase, the managedBuffer which throw IOException may be a remote downloaded FileSegment and should be retried instead of throwFetchFailed directly.
## How was this patch tested?

Unit Test
