### PR TITLE
[SPARK-26808][SQL] Pruned schema should not change nullability

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruning.scala
@@ -177,9 +177,9 @@ private[sql] object ParquetSchemaPruning extends Rule[LogicalPlan] {
    * Filters the schema from the given file by the requested fields.
    * Schema field ordering from the file is preserved.
    */
-  private[sql] def pruneDataSchema(
+  def pruneDataSchema(
       fileDataSchema: StructType,
-      requestedRootFields: Seq[RootField]) = {
+      requestedRootFields: Seq[RootField]): StructType = {
     // Merge the requested root fields into a single schema. Note the ordering of the fields
     // in the resulting schema may differ from their ordering in the logical relation's
     // original schema
@@ -292,6 +292,6 @@ private[sql] object ParquetSchemaPruning extends Rule[LogicalPlan] {
    * was derived from an attribute or had a proper child. `prunedIfAnyChildAccessed` means
    * whether this root field can be pruned if any of child field is used in the query.
    */
-  private[sql] case class RootField(field: StructField, derivedFromAtt: Boolean,
+  case class RootField(field: StructField, derivedFromAtt: Boolean,
     prunedIfAnyChildAccessed: Boolean = false)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruning.scala
@@ -177,7 +177,7 @@ private[sql] object ParquetSchemaPruning extends Rule[LogicalPlan] {
    * Filters the schema from the given file by the requested fields.
    * Schema field ordering from the file is preserved.
    */
-  private def pruneDataSchema(
+  private[sql] def pruneDataSchema(
       fileDataSchema: StructType,
       requestedRootFields: Seq[RootField]) = {
     // Merge the requested root fields into a single schema. Note the ordering of the fields
@@ -280,7 +280,7 @@ private[sql] object ParquetSchemaPruning extends Rule[LogicalPlan] {
           val leftFieldType = leftStruct(fieldName).dataType
           val rightFieldType = rightStruct(fieldName).dataType
           val sortedLeftFieldType = sortLeftFieldsByRight(leftFieldType, rightFieldType)
-          StructField(fieldName, sortedLeftFieldType)
+          StructField(fieldName, sortedLeftFieldType, nullable = leftStruct(fieldName).nullable)
         }
         StructType(sortedLeftFields)
       case _ => left
@@ -292,6 +292,6 @@ private[sql] object ParquetSchemaPruning extends Rule[LogicalPlan] {
    * was derived from an attribute or had a proper child. `prunedIfAnyChildAccessed` means
    * whether this root field can be pruned if any of child field is used in the query.
    */
-  private case class RootField(field: StructField, derivedFromAtt: Boolean,
+  private[sql] case class RootField(field: StructField, derivedFromAtt: Boolean,
     prunedIfAnyChildAccessed: Boolean = false)
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We prune unnecessary nested fields from requested schema when reading Parquet. Now seems we don't keep original nullability in pruned schema. We should keep original nullability.

## How was this patch tested?

Added unit test.