### PR TITLE
[WIP]: create attributes from live log urls to form a permalink past YARN log aggregation

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/History.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/History.scala
@@ -143,4 +143,16 @@ private[spark] object History {
         "not running spark applications.")
       .booleanConf
       .createWithDefault(true)
+
+  val LIVE_EXECUTOR_LOG_URL_REGEX =
+    ConfigBuilder("spark.history.executor.log.url.regex")
+      .doc("Regex to extract node and container information from log urls")
+      .stringConf
+      .createOptional
+
+  val LIVE_EXECUTOR_LOR_URL_CAPTURING_GROUPS =
+    ConfigBuilder("spark.history.executor.log.url.regex.groups")
+      .doc("CSV of group names that can later be used to build post runtime URL")
+      .stringConf
+      .createOptional
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Provide ability to recover attributes for log url rewrite in #23260 from event logs produced by older spark versions using the log urls of live containers

The current solution in #23260 currently works only with the apps run on the to-be-released version of Spark. However, deployments with a wealth of historic event logs are left out. More importantly SHS is less critical and can be upgraded much faster than production apps. 

Another improvement in this PR is going beyond a fixed set of supported variables for wider set of deployments. This PR proposes to use configurable named capturing groups for a regex to extract building blocks for a permalink. Below is an example for YARN.

## How was this patch tested?

Just locally so far. With configuration like 
```
spark.history.executor.log.url.regex            //(.+):\\d+/.*/(container_\\d+_\\d+_\\d+_[0-9]\\d+)/
spark.history.executor.log.url.regex.groups     YARN_NM_HOST,YARN_CID
spark.history.custom.executor.log.url           http://jhs.host.xyz:19888/jobhistory/logs/{{YARN_NM_HOST}}:8041/{{YARN_CID}}/{{YARN_CID}}/hadoop
```
 I was able to use this PR with old event logs from EMR stored on S3
