### PR TITLE
[SPARK-26814][SQL] Avoid unnecessary block concatenation while empty block exists

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/javaCode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/javaCode.scala
@@ -192,8 +192,9 @@ trait Block extends TreeNode[Block] with JavaCode {
   }
 
   // Concatenates this block with other block.
-  def + (other: Block): Block = other match {
-    case EmptyBlock => this
+  def + (other: Block): Block = (this, other) match {
+    case (EmptyBlock, o) => o
+    case (o, EmptyBlock) => o
     case _ => code"$this\n$other"
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

We should always avoid unnecessary block concatenation while empty block exists among the two Blocks, which avoid redundant code interpolation for blocks. 

For example(see code snapshot below), when we do not need to register comment, method "+"  should return immediately instead of doing redundant code interpolation for `eval.code`.

``` 
If (eval.code.toString.nonEmpty) {
  // Add `this` in the comment.
  eval.copy(code = ctx.registerComment(this.toString) + eval.code)
} else {
  eval
} 
```

## How was this patch tested?

Exists.