### PR TITLE
[SPARK-7721][INFRA][FOLLOW-UP] Remove cloned coverage repo after posting HTMLs

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -625,6 +625,7 @@ def main():
         # We only run PySpark tests with coverage report in one specific job with
         # Spark master with SBT in Jenkins.
         is_sbt_master_job = "SPARK_MASTER_SBT_HADOOP_2_7" in os.environ
+        is_sbt_master_job = True  # Remove this before merging it
         run_python_tests(
             modules_with_python_tests, opts.parallelism, with_coverage=is_sbt_master_job)
         run_python_packaging_tests()

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -461,6 +461,8 @@ def post_python_tests_results():
         run_cmd(["git", "push", "-f", "origin", "gh-pages"])
     finally:
         os.chdir("..")
+        # 10. Remove the cloned repository.
+        shutil.rmtree("pyspark-coverage-site")
 
 
 def run_python_packaging_tests():

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -625,7 +625,6 @@ def main():
         # We only run PySpark tests with coverage report in one specific job with
         # Spark master with SBT in Jenkins.
         is_sbt_master_job = "SPARK_MASTER_SBT_HADOOP_2_7" in os.environ
-        is_sbt_master_job = True  # Remove this before merging it
         run_python_tests(
             modules_with_python_tests, opts.parallelism, with_coverage=is_sbt_master_job)
         run_python_packaging_tests()


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to remove cloned `pyspark-coverage-site` repo.

it doesn't looks a problem in PR builder but somehow it's problematic in `spark-master-test-sbt-hadoop-2.7`.

## How was this patch tested?

Jenkins.