### PR TITLE
[SPARK-26822]Upgrade the deprecated module 'optparse'

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -488,7 +488,7 @@ def parse_opts():
         prog="run-tests"
     )
     parser.add_argument(
-        "-p", "--parallelism", type="int", default=8,
+        "-p", "--parallelism", type=int, default=8,
         help="The number of suites to test in parallel (default %(default)d)"
     )
 

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -19,7 +19,7 @@
 
 from __future__ import print_function
 import itertools
-from optparse import OptionParser
+from argparse import ArgumentParser
 import os
 import random
 import re
@@ -484,20 +484,20 @@ def run_sparkr_tests():
 
 
 def parse_opts():
-    parser = OptionParser(
+    parser = ArgumentParser(
         prog="run-tests"
     )
-    parser.add_option(
+    parser.add_argument(
         "-p", "--parallelism", type="int", default=8,
-        help="The number of suites to test in parallel (default %default)"
+        help="The number of suites to test in parallel (default %(default)d)"
     )
 
-    (opts, args) = parser.parse_args()
-    if args:
-        parser.error("Unsupported arguments: %s" % ' '.join(args))
-    if opts.parallelism < 1:
+    args, unknown = parser.parse_known_args()
+    if unknown:
+        parser.error("Unsupported arguments: %s" % ' '.join(unknown))
+    if args.parallelism < 1:
         parser.error("Parallelism cannot be less than 1")
-    return opts
+    return args
 
 
 def main():
@@ -635,6 +635,7 @@ def _test():
     failure_count = doctest.testmod()[0]
     if failure_count:
         sys.exit(-1)
+
 
 if __name__ == "__main__":
     _test()

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -19,7 +19,7 @@
 
 from __future__ import print_function
 import logging
-from optparse import OptionParser, OptionGroup
+from argparse import ArgumentParser
 import os
 import re
 import shutil
@@ -168,29 +168,29 @@ def get_default_python_executables():
 
 
 def parse_opts():
-    parser = OptionParser(
+    parser = ArgumentParser(
         prog="run-tests"
     )
-    parser.add_option(
+    parser.add_argument(
         "--python-executables", type="string", default=','.join(get_default_python_executables()),
         help="A comma-separated list of Python executables to test against (default: %default)"
     )
-    parser.add_option(
+    parser.add_argument(
         "--modules", type="string",
         default=",".join(sorted(python_modules.keys())),
         help="A comma-separated list of Python modules to test (default: %default)"
     )
-    parser.add_option(
+    parser.add_argument(
         "-p", "--parallelism", type="int", default=4,
         help="The number of suites to test in parallel (default %default)"
     )
-    parser.add_option(
+    parser.add_argument(
         "--verbose", action="store_true",
         help="Enable additional debug logging"
     )
 
-    group = OptionGroup(parser, "Developer Options")
-    group.add_option(
+    group = parser.add_argument_group("Developer Options")
+    group.add_argument(
         "--testnames", type="string",
         default=None,
         help=(
@@ -201,14 +201,13 @@ def parse_opts():
             "'pyspark.sql.tests FooTests.test_foo' to run the specific unittest in the class. "
             "'--modules' option is ignored if they are given.")
     )
-    parser.add_option_group(group)
 
-    (opts, args) = parser.parse_args()
+    args = parser.parse_args()
     if args:
         parser.error("Unsupported arguments: %s" % ' '.join(args))
-    if opts.parallelism < 1:
+    if args.parallelism < 1:
         parser.error("Parallelism cannot be less than 1")
-    return opts
+    return args
 
 
 def _check_coverage(python_exec):

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -172,17 +172,17 @@ def parse_opts():
         prog="run-tests"
     )
     parser.add_argument(
-        "--python-executables", type="string", default=','.join(get_default_python_executables()),
-        help="A comma-separated list of Python executables to test against (default: %default)"
+        "--python-executables", type=str, default=','.join(get_default_python_executables()),
+        help="A comma-separated list of Python executables to test against (default: %(default)s)"
     )
     parser.add_argument(
-        "--modules", type="string",
+        "--modules", type=str,
         default=",".join(sorted(python_modules.keys())),
-        help="A comma-separated list of Python modules to test (default: %default)"
+        help="A comma-separated list of Python modules to test (default: %(default)s)"
     )
     parser.add_argument(
-        "-p", "--parallelism", type="int", default=4,
-        help="The number of suites to test in parallel (default %default)"
+        "-p", "--parallelism", type=int, default=4,
+        help="The number of suites to test in parallel (default %(default)d)"
     )
     parser.add_argument(
         "--verbose", action="store_true",
@@ -191,7 +191,7 @@ def parse_opts():
 
     group = parser.add_argument_group("Developer Options")
     group.add_argument(
-        "--testnames", type="string",
+        "--testnames", type=str,
         default=None,
         help=(
             "A comma-separated list of specific modules, classes and functions of doctest "
@@ -202,9 +202,9 @@ def parse_opts():
             "'--modules' option is ignored if they are given.")
     )
 
-    args = parser.parse_args()
-    if args:
-        parser.error("Unsupported arguments: %s" % ' '.join(args))
+    args, unknown = parser.parse_known_args()
+    if unknown:
+        parser.error("Unsupported arguments: %s" % ' '.join(unknown))
     if args.parallelism < 1:
         parser.error("Parallelism cannot be less than 1")
     return args


### PR DESCRIPTION
Follow the [official document](https://docs.python.org/2/library/argparse.html#upgrading-optparse-code)  to upgrade the deprecated module 'optparse' to  'argparse'.

## What changes were proposed in this pull request?

This PR proposes to replace 'optparse' module with 'argparse' module.

## How was this patch tested?

Follow the [previous testing](https://github.com/apache/spark/commit/7e3eb3cd209d83394ca2b2cec79b26b1bbe9d7ea), manually tested and negative tests were also done. My [test results](https://gist.github.com/cchung100m/1661e7df6e8b66940a6e52a20861f61d)
