### PR TITLE
[SPARK-26572][SQL] fix aggregate codegen result evaluation

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -291,6 +291,18 @@ trait CodegenSupport extends SparkPlan {
   }
 
   /**
+   * Returns source code to evaluate the variables for non-deterministic expressions, and clear the
+   * code of evaluated variables, to prevent them to be evaluated twice.
+   */
+  protected def evaluateNondeterministicVariables(
+      attributes: Seq[Attribute],
+      variables: Seq[ExprCode],
+      expressions: Seq[NamedExpression]): String = {
+    val nondeterministicAttrs = expressions.filterNot(_.deterministic).map(_.toAttribute)
+    evaluateRequiredVariables(attributes, variables, AttributeSet(nondeterministicAttrs))
+  }
+
+  /**
    * The subset of inputSet those should be evaluated before this plan.
    *
    * We will use this to insert some code to access those columns that are actually used by current

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -466,12 +466,13 @@ case class HashAggregateExec(
       val resultVars = bindReferences[Expression](
         resultExpressions,
         inputAttrs).map(_.genCode(ctx))
-      val evaluateResultVars = evaluateVariables(resultVars)
+      val evaluateNondeterministicAggResults =
+        evaluateNondeterministicVariables(output, resultVars, resultExpressions)
       s"""
        $evaluateKeyVars
        $evaluateBufferVars
        $evaluateAggResults
-       $evaluateResultVars
+       $evaluateNondeterministicAggResults
        ${consume(ctx, resultVars)}
        """
     } else if (modes.contains(Partial) || modes.contains(PartialMerge)) {
@@ -499,11 +500,9 @@ case class HashAggregateExec(
       val resultVars = bindReferences[Expression](
         resultExpressions,
         inputAttrs).map(_.genCode(ctx))
-      val evaluateResultVars = evaluateVariables(resultVars)
       s"""
        $evaluateKeyVars
        $evaluateResultBufferVars
-       $evaluateResultVars
        ${consume(ctx, resultVars)}
        """
     } else {
@@ -513,9 +512,10 @@ case class HashAggregateExec(
       val resultVars = bindReferences[Expression](
         resultExpressions,
         groupingAttributes).map(_.genCode(ctx))
-      val evaluateResultVars = evaluateVariables(resultVars)
+      val evaluateNondeterministicAggResults =
+        evaluateNondeterministicVariables(output, resultVars, resultExpressions)
       s"""
-       $evaluateResultVars
+       $evaluateNondeterministicAggResults
        ${consume(ctx, resultVars)}
        """
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -466,13 +466,13 @@ case class HashAggregateExec(
       val resultVars = bindReferences[Expression](
         resultExpressions,
         inputAttrs).map(_.genCode(ctx))
-      val evaluateNondeterministicAggResults =
+      val evaluateNondeterministicResults =
         evaluateNondeterministicVariables(output, resultVars, resultExpressions)
       s"""
        $evaluateKeyVars
        $evaluateBufferVars
        $evaluateAggResults
-       $evaluateNondeterministicAggResults
+       $evaluateNondeterministicResults
        ${consume(ctx, resultVars)}
        """
     } else if (modes.contains(Partial) || modes.contains(PartialMerge)) {
@@ -512,10 +512,10 @@ case class HashAggregateExec(
       val resultVars = bindReferences[Expression](
         resultExpressions,
         groupingAttributes).map(_.genCode(ctx))
-      val evaluateNondeterministicAggResults =
+      val evaluateNondeterministicResults =
         evaluateNondeterministicVariables(output, resultVars, resultExpressions)
       s"""
-       $evaluateNondeterministicAggResults
+       $evaluateNondeterministicResults
        ${consume(ctx, resultVars)}
        """
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2110,4 +2110,14 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
       checkAnswer(res, Row("1-1", 6, 6))
     }
   }
+
+  test("SPARK-26572: fix aggregate codegen result evaluation") {
+    val baseTable = Seq((1), (1)).toDF("idx")
+    val distinctWithId =
+        baseTable.distinct.withColumn("id", functions.monotonically_increasing_id())
+    val res = baseTable.join(distinctWithId, "idx")
+      .groupBy("id").count().as("count")
+      .select("count")
+    checkAnswer(res, Row(2))
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2114,7 +2114,7 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
   test("SPARK-26572: fix aggregate codegen result evaluation") {
     val baseTable = Seq((1), (1)).toDF("idx")
     val distinctWithId =
-        baseTable.distinct.withColumn("id", functions.monotonically_increasing_id())
+      baseTable.distinct.withColumn("id", functions.monotonically_increasing_id())
     val res = baseTable.join(distinctWithId, "idx")
       .groupBy("id").count().as("count")
       .select("count")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is a correctness fix in `HashAggregateExec` code generation. It forces evaluation of result expressions before calling `consume()` to avoid multiple executions.

This PR fixes a use case where an aggregate is nested into a broadcast join and appears on the "stream" side. The issue is that Broadcast join generates it's own loop. And without forcing evaluation of `resultExpressions` of `HashAggregateExec` before the join's loop these expressions can be executed multiple times giving incorrect results.

## How was this patch tested?

New UT was added.
