### PR TITLE
[SPARK-26826][SQL] Array indexing functions

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1975,6 +1975,23 @@ def array_position(col, value):
     return Column(sc._jvm.functions.array_position(_to_java_column(col), value))
 
 
+@since(3.0)
+def array_allpositions(col, value):
+    """
+    Collection function: Locates the positions of all the occurrences of the value in the given
+    array as an array of longs. Returns null if either of the arguments are null.
+
+    .. note:: The position is not zero based, but 1 based index. Returns an empty array if value
+        could not be found in the array.
+
+    >>> df = spark.createDataFrame([(["a", "b", "a"],), ([],)], ['data'])
+    >>> df.select(array_allpositions(df.data, "a")).collect()
+    [Row(array_allpositions(data, a)=[1, 3]), Row(array_allpositions(data, a)=[])]
+    """
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.functions.array_allpositions(_to_java_column(col), value))
+
+
 @ignore_unicode_prefix
 @since(2.4)
 def element_at(col, extraction):
@@ -2013,6 +2030,28 @@ def array_remove(col, element):
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.array_remove(_to_java_column(col), element))
+
+
+@ignore_unicode_prefix
+@since(3.0)
+def array_select(col, indexes, ignore_out_of_bounds=True):
+    """
+    Collection function: Selects elements from an array column corresponding to indexes
+    from `indexes` array. If `ignore_out_of_bounds` is set to `True`, null values are
+    returned for out of bounds indexes are out of bounds. An exception is thrown otherwise.
+
+    :param col: name of column containing an array
+    :param indexes: array column containing indexes to check for in array
+
+    .. note:: Indexes are 1 based.
+
+    >>> df = spark.createDataFrame([(["a", "b", "c"],), ([],)], ['data'])
+    >>> df.select(array_select(df.data, [1, 3])).collect()
+    [Row(array_select(data, [1, 3])=["a", "c"]), Row(array_select(data, [1, 3])=[])]
+    """
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.functions.array_select(_to_java_column(col),
+        _to_java_column(indexes), ignore_out_of_bounds))
 
 
 @since(2.4)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -416,6 +416,8 @@ object FunctionRegistry {
     expression[ArrayIntersect]("array_intersect"),
     expression[ArrayJoin]("array_join"),
     expression[ArrayPosition]("array_position"),
+    expression[ArrayAllPositions]("array_allpositions"),
+    expression[ArraySelect]("array_select"),
     expression[ArraySort]("array_sort"),
     expression[ArrayExcept]("array_except"),
     expression[ArrayUnion]("array_union"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -1789,17 +1789,17 @@ case class ArrayAllPositions(array: Expression, element: Expression)
     val getValue = CodeGenerator.getValue(arval, arrayElementType, i)
 
     val c = code"""
-                  |${arCode.code}
-                  |${elCode.code}
-                  |${arrayListName}.clear();
-                  |if(!${arCode.isNull}) {
-                  |  for(int $i = 0; $i < $arval.numElements(); $i ++) {
-                  |    if (!$arval.isNullAt($i) && ${ctx.genEqual(arrayElementType, elval, getValue)}) {
-                  |      $arrayListName.add($i+1);
-                  |    }
-                  |  }
-                  |}
-                  |final ArrayData $arrayName = new $genericArrayClass($arrayListName);
+        |${arCode.code}
+        |${elCode.code}
+        |${arrayListName}.clear();
+        |if(!${arCode.isNull}) {
+        |  for(int $i = 0; $i < $arval.numElements(); $i ++) {
+        |    if (!$arval.isNullAt($i) && ${ctx.genEqual(arrayElementType, elval, getValue)}) {
+        |      $arrayListName.add($i+1);
+        |    }
+        |  }
+        |}
+        |final ArrayData $arrayName = new $genericArrayClass($arrayListName);
       """
 
     ev.copy(

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3235,6 +3235,34 @@ object functions {
   }
 
   /**
+   * Locates the positions of all the occurrences of the value in the given array as an array
+   * of longs. Returns null if either of the arguments are null.
+   *
+   * @note The position is not zero based, but 1 based index. Returns an empty array if value
+   * could not be found in the array.
+   *
+   * @group collection_funcs
+   * @since 3.0.0
+   */
+  def array_allpositions(column: Column, value: Any): Column = withExpr {
+    ArrayAllPositions(column.expr, lit(value).expr)
+  }
+
+  /**
+   * Selects elements from `array` corresponding to indexes from `idsArray`.
+   *
+   * If `ignoreOutOfIndex` is set to `true`, null values are returned for the elements whose indexes
+   * are out of bounds. An exception is thrown otherwise.
+   *
+   * @note The indexes are 1 based.
+   *
+   * @group collection_funcs
+   * @since 3.0.0
+   */
+  def array_select(array: Column, idsArray: Column, ignoreOutOfIndex: Boolean = true): Column =
+    withExpr { ArraySelect(array.expr, idsArray.expr, ignoreOutOfIndex) }
+
+  /**
    * Returns element of array at given index in value if column is array. Returns value for
    * the given key in value if column is map.
    *

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -22,7 +22,6 @@ import java.sql.{Date, Timestamp}
 import java.util.TimeZone
 
 import scala.util.Random
-
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
@@ -1341,13 +1340,13 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
         Seq(Row(null), Row(null), Row(null), Row(null))
       )
     }
-    intercept[RuntimeException] {
+    intercept[Exception] {
       checkAnswer(
         df.select(array_select(df("a"), lit(Array(5)))),
         Seq(Row(null), Row(null), Row(null), Row(null))
       )
     }.getMessage.contains("Array selection failed:")
-    intercept[RuntimeException] {
+    intercept[Exception] {
       checkAnswer(
         df.selectExpr("array_select(a, array(4))"),
         Seq(Row(null), Row(null), Row(null), Row(null))


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes two extra array functions: `array_allpositions` (named after `array_position`) and `array_select`. These functions should make it easier to:
- get an array of indices of all occurences of a value in an array (`array_allpositions`)
- select all elements of an array based on an array of indices (`array_select`)

Although higher-order functions, such as `aggregate` and `transform`, have been recently added, performing tasks above is still not simple, hence this addition.


## How was this patch tested?
Unit tests
