### PR TITLE
[MINOR][SQL][PYTHON] Make projection creation separate of the output in FlatMapGroupsInPandasExec

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInPandasExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInPandasExec.scala
@@ -145,7 +145,8 @@ case class FlatMapGroupsInPandasExec(
         sessionLocalTimeZone,
         pythonRunnerConf).compute(grouped, context.partitionId(), context)
 
-      columnarBatchIter.flatMap(_.rowIterator.asScala).map(UnsafeProjection.create(output, output))
+      val outputProj = UnsafeProjection.create(output, output)
+      columnarBatchIter.flatMap(_.rowIterator.asScala).map(outputProj)
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The projection creation at output looks confusing. It looks like creating each projection for each record (but actually it doesn't). We should better pull it out.

## How was this patch tested?

Existing tests should cover.