### PR TITLE
[SPARK-26707][SQL] Insertion of a single struct into a table

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2740,6 +2740,7 @@ object TimeWindowing extends Rule[LogicalPlan] {
  */
 object ResolveCreateNamedStruct extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveExpressions {
+    case UnresolvedRow(children) => CreateStruct(children)
     case e: CreateNamedStruct if !e.resolved =>
       val children = e.children.grouped(2).flatMap {
         case Seq(NamePlaceholder, e: NamedExpression) if e.resolved =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -69,6 +69,17 @@ case class UnresolvedInlineTable(
 }
 
 /**
+ * Represents a row of an unresolved inline table.
+ * @param children cells of a given row
+ */
+case class UnresolvedRow(children: Seq[Expression]) extends Unevaluable {
+  override def dataType: DataType = throw new UnresolvedException(this, "dataType")
+  override def foldable: Boolean = throw new UnresolvedException(this, "foldable")
+  override def nullable: Boolean = throw new UnresolvedException(this, "nullable")
+  override lazy val resolved = false
+}
+
+/**
  * A table-valued function, e.g.
  * {{{
  *   select id from range(10);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -846,8 +846,8 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
         // inline table comes in two styles:
         // style 1: values (1), (2), (3)  -- multiple columns are supported
         // style 2: values 1, 2, 3  -- only a single column is supported here
-        case struct: CreateNamedStruct => struct.valExprs // style 1
-        case child => Seq(child)                          // style 2
+        case UnresolvedRow(children) => children // style 1
+        case child => Seq(child)                 // style 2
       }
     }
 
@@ -1121,7 +1121,7 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
     }
 
     def getValueExpressions(e: Expression): Seq[Expression] = e match {
-      case c: CreateNamedStruct => c.valExprs
+      case UnresolvedRow(children) => children
       case other => Seq(other)
     }
 
@@ -1405,10 +1405,10 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
   }
 
   /**
-   * Create a [[CreateStruct]] expression.
+   * Create an [[UnresolvedRow]] expression.
    */
   override def visitRowConstructor(ctx: RowConstructorContext): Expression = withOrigin(ctx) {
-    CreateStruct(ctx.namedExpression().asScala.map(expression))
+    UnresolvedRow(ctx.namedExpression().asScala.map(expression))
   }
 
   /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -366,9 +366,9 @@ class ExpressionParserSuite extends PlanTest {
 
   test("row constructor") {
     // Note that '(a)' will be interpreted as a nested expression.
-    assertEqual("(a, b)", CreateStruct(Seq('a, 'b)))
-    assertEqual("(a, b, c)", CreateStruct(Seq('a, 'b, 'c)))
-    assertEqual("(a as b, b as c)", CreateStruct(Seq('a as 'b, 'b as 'c)))
+    assertEqual("(a, b)", UnresolvedRow(Seq('a, 'b)))
+    assertEqual("(a, b, c)", UnresolvedRow(Seq('a, 'b, 'c)))
+    assertEqual("(a as b, b as c)", UnresolvedRow(Seq('a as 'b, 'b as 'c)))
   }
 
   test("scalar sub-query") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.parser
 
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
-import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, UnresolvedAttribute, UnresolvedFunction, UnresolvedGenerator, UnresolvedInlineTable, UnresolvedRelation, UnresolvedSubqueryColumnAliases, UnresolvedTableValuedFunction}
+import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, UnresolvedAttribute, UnresolvedFunction, UnresolvedGenerator, UnresolvedInlineTable, UnresolvedRelation, UnresolvedRow, UnresolvedSubqueryColumnAliases, UnresolvedTableValuedFunction}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -643,8 +643,8 @@ class PlanParserSuite extends AnalysisTest {
       parsePlan("SELECT /*+ HINT1('a', (b, c), (1, 2)) */ * from t"),
       UnresolvedHint("HINT1",
         Seq(Literal("a"),
-          CreateStruct($"b" :: $"c" :: Nil),
-          CreateStruct(Literal(1) :: Literal(2) :: Nil)),
+          UnresolvedRow($"b" :: $"c" :: Nil),
+          UnresolvedRow(Literal(1) :: Literal(2) :: Nil)),
         table("t").select(star())
       )
     )

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2967,6 +2967,14 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
     }
   }
 
+  test("SPARK-26707: insertion of a single struct into a table should be allowed") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(col struct<i: Int>) USING PARQUET")
+      sql("INSERT INTO tbl values (struct(123))")
+      checkAnswer(sql("SELECT col FROM tbl"), Row(Row(123)))
+    }
+  }
+
   test("SPARK-26709: OptimizeMetadataOnlyQuery does not handle empty records correctly") {
     Seq(true, false).foreach { enableOptimizeMetadataOnlyQuery =>
       withSQLConf(SQLConf.OPTIMIZER_METADATA_ONLY.key -> enableOptimizeMetadataOnlyQuery.toString) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2970,7 +2970,7 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
   test("SPARK-26707: insertion of a single struct into a table should be allowed") {
     withTable("tbl") {
       sql("CREATE TABLE tbl(col struct<i: Int>) USING PARQUET")
-      sql("INSERT INTO tbl values (struct(123))")
+      sql("INSERT INTO tbl VALUES (struct(123))")
       checkAnswer(sql("SELECT col FROM tbl"), Row(Row(123)))
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
A commend like ```INSERT INTO tbl VALUES (struct(123))``` currently leads to an ```AnalysisException```.  The PR tries to fix the problem by introducing a new unresolved expression that plays a role of a collection for multiple named expressions.

## How was this patch tested?
- Added UT describing  the problem
- Run all existing SQL test 