### PR TITLE
[SPARK-26761][SQL][R] Vectorized R gapply() implementation

### DIFF
--- a/R/pkg/R/deserialize.R
+++ b/R/pkg/R/deserialize.R
@@ -240,7 +240,8 @@ readDeserializeInArrow <- function(inputCon) {
     as_tibble <- get("as_tibble", envir = asNamespace("arrow"))
 
     # Currently, there looks no way to read batch by batch by socket connection in R side,
-    # See ARROW-4512. Therefore, it reads the whole Arrow streaming-formatted binary at once for now.
+    # See ARROW-4512. Therefore, it reads the whole Arrow streaming-formatted binary at once
+    # for now.
     dataLen <- readInt(inputCon)
     arrowData <- readBin(inputCon, raw(), as.integer(dataLen), endian = "big")
     batches <- RecordBatchStreamReader(arrowData)$batches()

--- a/R/pkg/R/deserialize.R
+++ b/R/pkg/R/deserialize.R
@@ -234,24 +234,27 @@ readMultipleObjectsWithKeys <- function(inputCon) {
 readDeserializeInArrow <- function(inputCon) {
   # This is a hack to avoid CRAN check. Arrow is not uploaded into CRAN now. See ARROW-3204.
   requireNamespace1 <- requireNamespace
-  requireNamespace1("arrow", quietly = TRUE)
-  RecordBatchStreamReader <- get(
-    "RecordBatchStreamReader", envir = asNamespace("arrow"), inherits = FALSE)
-  as_tibble <- get("as_tibble", envir = asNamespace("arrow"))
+  if (requireNamespace1("arrow", quietly = TRUE)) {
+    RecordBatchStreamReader <- get(
+      "RecordBatchStreamReader", envir = asNamespace("arrow"), inherits = FALSE)
+    as_tibble <- get("as_tibble", envir = asNamespace("arrow"))
 
-  # Currently, there looks no way to read batch by batch by socket connection in R side,
-  # See ARROW-4512. Therefore, it reads the whole Arrow streaming-formatted binary at once for now.
-  dataLen <- readInt(inputCon)
-  arrowData <- readBin(inputCon, raw(), as.integer(dataLen), endian = "big")
-  batches <- RecordBatchStreamReader(arrowData)$batches()
+    # Currently, there looks no way to read batch by batch by socket connection in R side,
+    # See ARROW-4512. Therefore, it reads the whole Arrow streaming-formatted binary at once for now.
+    dataLen <- readInt(inputCon)
+    arrowData <- readBin(inputCon, raw(), as.integer(dataLen), endian = "big")
+    batches <- RecordBatchStreamReader(arrowData)$batches()
 
-  # Read all groupped batches. Tibble -> data.frame is cheap.
-  data <- lapply(batches, function(batch) as.data.frame(as_tibble(batch)))
+    # Read all groupped batches. Tibble -> data.frame is cheap.
+    data <- lapply(batches, function(batch) as.data.frame(as_tibble(batch)))
 
-  # Read keys to map with each groupped batch.
-  keys <- readMultipleObjects(inputCon)
+    # Read keys to map with each groupped batch.
+    keys <- readMultipleObjects(inputCon)
 
-  list(keys = keys, data = data)
+    list(keys = keys, data = data)
+  } else {
+    stop("'arrow' package should be installed.")
+  }
 }
 
 readRowList <- function(obj) {

--- a/R/pkg/R/group.R
+++ b/R/pkg/R/group.R
@@ -231,14 +231,18 @@ gapplyInternal <- function(x, func, schema) {
   }
   arrowEnabled <- sparkR.conf("spark.sql.execution.arrow.enabled")[[1]] == "true"
   if (arrowEnabled) {
+    if (is.null(schema)) {
+      stop(paste0("Arrow optimization does not support gapplyCollect yet. Please use ",
+                  "'collect' and 'gapply' APIs instead."))
+    }
     # Currenty Arrow optimization does not support raw for now.
     # Also, it does not support explicit float type set by users.
     if (inherits(schema, "structType")) {
       if (any(sapply(schema$fields(), function(x) x$dataType.toString() == "FloatType"))) {
-        stop("Arrow optimization with gapply and gapplyCollect do not support FloatType yet.")
+        stop("Arrow optimization with gapply do not support FloatType yet.")
       }
       if (any(sapply(schema$fields(), function(x) x$dataType.toString() == "BinaryType"))) {
-        stop("Arrow optimization with gapply and gapplyCollect do not support BinaryType yet.")
+        stop("Arrow optimization with gapply do not support BinaryType yet.")
       }
     }
   }

--- a/R/pkg/R/group.R
+++ b/R/pkg/R/group.R
@@ -231,15 +231,18 @@ gapplyInternal <- function(x, func, schema) {
   }
   arrowEnabled <- sparkR.conf("spark.sql.execution.arrow.enabled")[[1]] == "true"
   if (arrowEnabled) {
+    # Currenty Arrow optimization does not support raw for now.
+    # Also, it does not support explicit float type set by users.
     if (inherits(schema, "structType")) {
       if (any(sapply(schema$fields(), function(x) x$dataType.toString() == "FloatType"))) {
-        stop("Arrow optimization with gapply[Collect] does not support FloatType type yet.")
+        stop("Arrow optimization with gapply[Collect] does not support FloatType yet.")
       }
       if (any(sapply(schema$fields(), function(x) x$dataType.toString() == "BinaryType"))) {
-        stop("Arrow optimization with gapply[Collect] does not support Binary type yet.")
+        stop("Arrow optimization with gapply[Collect] does not support BinaryType yet.")
       }
     }
   }
+
   packageNamesArr <- serialize(.sparkREnv[[".packages"]],
                        connection = NULL)
   broadcastArr <- lapply(ls(.broadcastNames),

--- a/R/pkg/R/group.R
+++ b/R/pkg/R/group.R
@@ -229,6 +229,17 @@ gapplyInternal <- function(x, func, schema) {
   if (is.character(schema)) {
     schema <- structType(schema)
   }
+  arrowEnabled <- sparkR.conf("spark.sql.execution.arrow.enabled")[[1]] == "true"
+  if (arrowEnabled) {
+    if (inherits(schema, "structType")) {
+      if (any(sapply(schema$fields(), function(x) x$dataType.toString() == "FloatType"))) {
+        stop("Arrow optimization with gapply[Collect] does not support FloatType type yet.")
+      }
+      if (any(sapply(schema$fields(), function(x) x$dataType.toString() == "BinaryType"))) {
+        stop("Arrow optimization with gapply[Collect] does not support Binary type yet.")
+      }
+    }
+  }
   packageNamesArr <- serialize(.sparkREnv[[".packages"]],
                        connection = NULL)
   broadcastArr <- lapply(ls(.broadcastNames),

--- a/R/pkg/R/group.R
+++ b/R/pkg/R/group.R
@@ -231,9 +231,9 @@ gapplyInternal <- function(x, func, schema) {
   }
   arrowEnabled <- sparkR.conf("spark.sql.execution.arrow.enabled")[[1]] == "true"
   if (arrowEnabled) {
-    if (is.null(schema)) {
-      stop(paste0("Arrow optimization does not support gapplyCollect yet. Please use ",
-                  "'collect' and 'gapply' APIs instead."))
+    requireNamespace1 <- requireNamespace
+    if (!requireNamespace1("arrow", quietly = TRUE)) {
+      stop("'arrow' package should be installed.")
     }
     # Currenty Arrow optimization does not support raw for now.
     # Also, it does not support explicit float type set by users.
@@ -244,6 +244,11 @@ gapplyInternal <- function(x, func, schema) {
       if (any(sapply(schema$fields(), function(x) x$dataType.toString() == "BinaryType"))) {
         stop("Arrow optimization with gapply do not support BinaryType yet.")
       }
+    } else if (is.null(schema)) {
+      stop(paste0("Arrow optimization does not support gapplyCollect yet. Please use ",
+                  "'collect' and 'gapply' APIs instead."))
+    } else {
+      stop("'schema' should be DDL-formatted string or structType.")
     }
   }
 

--- a/R/pkg/R/group.R
+++ b/R/pkg/R/group.R
@@ -235,10 +235,10 @@ gapplyInternal <- function(x, func, schema) {
     # Also, it does not support explicit float type set by users.
     if (inherits(schema, "structType")) {
       if (any(sapply(schema$fields(), function(x) x$dataType.toString() == "FloatType"))) {
-        stop("Arrow optimization with gapply[Collect] does not support FloatType yet.")
+        stop("Arrow optimization with gapply and gapplyCollect do not support FloatType yet.")
       }
       if (any(sapply(schema$fields(), function(x) x$dataType.toString() == "BinaryType"))) {
-        stop("Arrow optimization with gapply[Collect] does not support BinaryType yet.")
+        stop("Arrow optimization with gapply and gapplyCollect do not support BinaryType yet.")
       }
     }
   }

--- a/R/pkg/inst/worker/worker.R
+++ b/R/pkg/inst/worker/worker.R
@@ -193,7 +193,6 @@ if (isEmpty != 0) {
                       colNames, computeFunc, data[[i]])
           computeElap <- elapsedSecs()
           if (deserializer == "arrow") {
-            requireNamespace("arrow", quietly = TRUE)
             outputs[[length(outputs) + 1L]] <- output
           } else {
             outputResult(serializer, output, outputCon)
@@ -204,7 +203,10 @@ if (isEmpty != 0) {
         }
 
         if (deserializer == "arrow") {
-          requireNamespace("arrow", quietly = TRUE)
+          # This is a hack to avoid CRAN check. Arrow is not uploaded into CRAN now. See ARROW-3204.
+          requireNamespace1 <- requireNamespace
+          requireNamespace1("arrow", quietly = TRUE)
+          write_arrow <- get("write_arrow", envir = asNamespace("arrow"), inherits = FALSE)
           # See https://stat.ethz.ch/pipermail/r-help/2010-September/252046.html
           # rbind.fill might be an anternative to make it faster if plyr is installed.
           combined <- do.call("rbind", outputs)
@@ -212,7 +214,7 @@ if (isEmpty != 0) {
           # Likewise, there looks no way to send each batch in streaming format via socket
           # connection. See ARROW-4512.
           # So, it writes the whole Arrow streaming-formatted binary at once for now.
-          SparkR:::writeRaw(outputCon, arrow::write_arrow(combined, raw()))
+          SparkR:::writeRaw(outputCon, write_arrow(combined, raw()))
         }
       }
     } else {

--- a/R/pkg/inst/worker/worker.R
+++ b/R/pkg/inst/worker/worker.R
@@ -205,16 +205,19 @@ if (isEmpty != 0) {
         if (deserializer == "arrow") {
           # This is a hack to avoid CRAN check. Arrow is not uploaded into CRAN now. See ARROW-3204.
           requireNamespace1 <- requireNamespace
-          requireNamespace1("arrow", quietly = TRUE)
-          write_arrow <- get("write_arrow", envir = asNamespace("arrow"), inherits = FALSE)
-          # See https://stat.ethz.ch/pipermail/r-help/2010-September/252046.html
-          # rbind.fill might be an anternative to make it faster if plyr is installed.
-          combined <- do.call("rbind", outputs)
+          if (requireNamespace1("arrow", quietly = TRUE)) {
+            write_arrow <- get("write_arrow", envir = asNamespace("arrow"), inherits = FALSE)
+            # See https://stat.ethz.ch/pipermail/r-help/2010-September/252046.html
+            # rbind.fill might be an anternative to make it faster if plyr is installed.
+            combined <- do.call("rbind", outputs)
 
-          # Likewise, there looks no way to send each batch in streaming format via socket
-          # connection. See ARROW-4512.
-          # So, it writes the whole Arrow streaming-formatted binary at once for now.
-          SparkR:::writeRaw(outputCon, write_arrow(combined, raw()))
+            # Likewise, there looks no way to send each batch in streaming format via socket
+            # connection. See ARROW-4512.
+            # So, it writes the whole Arrow streaming-formatted binary at once for now.
+            SparkR:::writeRaw(outputCon, write_arrow(combined, raw()))
+          } else {
+            stop("'arrow' package should be installed.")
+          }
         }
       }
     } else {

--- a/R/pkg/inst/worker/worker.R
+++ b/R/pkg/inst/worker/worker.R
@@ -206,9 +206,8 @@ if (isEmpty != 0) {
         if (deserializer == "arrow") {
           requireNamespace("arrow", quietly = TRUE)
           # See https://stat.ethz.ch/pipermail/r-help/2010-September/252046.html
-          # Using matrix with rbind is almost the fastest and minimzed way to
-          # concatenate data frames.
-          combined_output <- as.data.frame(do.call("rbind", lapply(outputs, as.matrix)))
+          # rbind.fill might be an anternative to make it faster if plyr is installed.
+          combined_output <- do.call("rbind", outputs)
 
           # Likewise, there looks no way to send each batch in streaming format via socket
           # connection. See ARROW-4512.

--- a/R/pkg/inst/worker/worker.R
+++ b/R/pkg/inst/worker/worker.R
@@ -49,7 +49,7 @@ compute <- function(mode, partition, serializer, deserializer, key,
       names(inputData) <- colNames
     } else {
       # Check to see if inputData is a valid data.frame
-      stopifnot(deserializer == "byte")
+      stopifnot(deserializer == "byte" || deserializer == "arrow")
       stopifnot(class(inputData) == "data.frame")
     }
 
@@ -63,7 +63,7 @@ compute <- function(mode, partition, serializer, deserializer, key,
       output <- split(output, seq(nrow(output)))
     } else {
       # Serialize the output to a byte array
-      stopifnot(serializer == "byte")
+      stopifnot(serializer == "byte" || serializer == "arrow")
     }
   } else {
     output <- computeFunc(partition, inputData)
@@ -171,6 +171,10 @@ if (isEmpty != 0) {
       data <- dataWithKeys$data
     } else if (deserializer == "row") {
       data <- SparkR:::readMultipleObjects(inputCon)
+    } else if (deserializer == "arrow" && mode == 2) {
+      dataWithKeys <- SparkR:::readDeserializeInArrow(inputCon)
+      keys <- dataWithKeys$keys
+      data <- dataWithKeys$data
     }
 
     # Timing reading input data for execution
@@ -181,16 +185,35 @@ if (isEmpty != 0) {
                     colNames, computeFunc, data)
        } else {
         # gapply mode
+        outputs <- list()
         for (i in 1:length(data)) {
           # Timing reading input data for execution
           inputElap <- elapsedSecs()
           output <- compute(mode, partition, serializer, deserializer, keys[[i]],
                       colNames, computeFunc, data[[i]])
           computeElap <- elapsedSecs()
-          outputResult(serializer, output, outputCon)
+          if (deserializer == "arrow") {
+            requireNamespace("arrow", quietly = TRUE)
+            outputs[[length(outputs) + 1L]] <- output
+          } else {
+            outputResult(serializer, output, outputCon)
+          }
           outputElap <- elapsedSecs()
           computeInputElapsDiff <-  computeInputElapsDiff + (computeElap - inputElap)
           outputComputeElapsDiff <- outputComputeElapsDiff + (outputElap - computeElap)
+        }
+
+        if (deserializer == "arrow") {
+          requireNamespace("arrow", quietly = TRUE)
+          # See https://stat.ethz.ch/pipermail/r-help/2010-September/252046.html
+          # Using matrix with rbind is almost the fastest and minimzed way to
+          # concatenate data frames.
+          combined_output <- as.data.frame(do.call("rbind", lapply(outputs, as.matrix)))
+
+          # Likewise, there looks no way to send each batch in streaming format via socket
+          # connection. See ARROW-4512.
+          # So, it writes the whole Arrow streaming-formatted binary at once for now.
+          SparkR:::writeRaw(outputCon, arrow::write_arrow(combined_output, raw()))
         }
       }
     } else {

--- a/R/pkg/inst/worker/worker.R
+++ b/R/pkg/inst/worker/worker.R
@@ -207,12 +207,12 @@ if (isEmpty != 0) {
           requireNamespace("arrow", quietly = TRUE)
           # See https://stat.ethz.ch/pipermail/r-help/2010-September/252046.html
           # rbind.fill might be an anternative to make it faster if plyr is installed.
-          combined_output <- do.call("rbind", outputs)
+          combined <- do.call("rbind", outputs)
 
           # Likewise, there looks no way to send each batch in streaming format via socket
           # connection. See ARROW-4512.
           # So, it writes the whole Arrow streaming-formatted binary at once for now.
-          SparkR:::writeRaw(outputCon, arrow::write_arrow(combined_output, raw()))
+          SparkR:::writeRaw(outputCon, arrow::write_arrow(combined, raw()))
         }
       }
     } else {

--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -3546,14 +3546,14 @@ test_that("gapply() Arrow optimization", {
                    }
                    stopifnot(class(grouped) == "data.frame")
                    grouped
-                 }, schema(df))
+                 },
+                 schema(df))
     expected <- collect(ret)
   },
   finally = {
     # Resetting the conf back to default value
     callJMethod(conf, "set", "spark.sql.execution.arrow.enabled", arrowEnabled)
   })
-
 
   callJMethod(conf, "set", "spark.sql.execution.arrow.enabled", "true")
   tryCatch({
@@ -3565,9 +3565,73 @@ test_that("gapply() Arrow optimization", {
                    }
                    stopifnot(class(grouped) == "data.frame")
                    grouped
-                 }, schema(df))
+                 },
+                 schema(df))
     actual <- collect(ret)
     expect_equal(actual, expected)
+  },
+  finally = {
+    # Resetting the conf back to default value
+    callJMethod(conf, "set", "spark.sql.execution.arrow.enabled", arrowEnabled)
+  })
+})
+
+test_that("gapply() Arrow optimization - type specification", {
+  skip_if_not_installed("arrow")
+  # Note that regular gapply() seems not supporting date and timestamps
+  # whereas Arrow-optimized gapply() does.
+  rdf <- data.frame(list(list(a = 1,
+                              b = "a",
+                              c = TRUE,
+                              d = 1.1,
+                              e = 1L)))
+  df <- createDataFrame(rdf)
+
+  conf <- callJMethod(sparkSession, "conf")
+  arrowEnabled <- sparkR.conf("spark.sql.execution.arrow.enabled")[[1]]
+
+  callJMethod(conf, "set", "spark.sql.execution.arrow.enabled", "false")
+  tryCatch({
+    ret <- gapply(df,
+                 "a",
+                 function(key, grouped) { grouped }, schema(df))
+    expected <- collect(ret)
+  },
+  finally = {
+    # Resetting the conf back to default value
+    callJMethod(conf, "set", "spark.sql.execution.arrow.enabled", arrowEnabled)
+  })
+
+
+  callJMethod(conf, "set", "spark.sql.execution.arrow.enabled", "true")
+  tryCatch({
+    ret <- gapply(df,
+                 "a",
+                 function(key, grouped) { grouped }, schema(df))
+    actual <- collect(ret)
+    expect_equal(actual, expected)
+  },
+  finally = {
+    # Resetting the conf back to default value
+    callJMethod(conf, "set", "spark.sql.execution.arrow.enabled", arrowEnabled)
+  })
+})
+
+test_that("gapply() Arrow optimization - type specification (date and timestamp)", {
+  skip_if_not_installed("arrow")
+  rdf <- data.frame(list(list(a = as.Date("1990-02-24"),
+                              b = as.POSIXct("1990-02-24 12:34:56"))))
+  df <- createDataFrame(rdf)
+
+  conf <- callJMethod(sparkSession, "conf")
+  arrowEnabled <- sparkR.conf("spark.sql.execution.arrow.enabled")[[1]]
+
+  callJMethod(conf, "set", "spark.sql.execution.arrow.enabled", "true")
+  tryCatch({
+    ret <- gapply(df,
+                  "a",
+                  function(key, grouped) { grouped }, schema(df))
+    expect_equal(collect(ret), rdf)
   },
   finally = {
     # Resetting the conf back to default value

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1288,7 +1288,7 @@ object SQLConf {
       .doc("When true, make use of Apache Arrow for columnar data transfers. Currently available " +
         "for use with pyspark.sql.DataFrame.toPandas, " +
         "pyspark.sql.SparkSession.createDataFrame when its input is a Pandas DataFrame, " +
-        "and createDataFrame when its input is an R DataFrame. " +
+        "createDataFrame when its input is an R DataFrame, and gapply[Collect] in R." +
         "The following data types are unsupported: " +
         "BinaryType, MapType, ArrayType of TimestampType, and nested StructType.")
       .booleanConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1288,7 +1288,7 @@ object SQLConf {
       .doc("When true, make use of Apache Arrow for columnar data transfers. Currently available " +
         "for use with pyspark.sql.DataFrame.toPandas, " +
         "pyspark.sql.SparkSession.createDataFrame when its input is a Pandas DataFrame, " +
-        "createDataFrame when its input is an R DataFrame, and gapply[Collect] in R." +
+        "and createDataFrame when its input is an R DataFrame. " +
         "The following data types are unsupported: " +
         "BinaryType, MapType, ArrayType of TimestampType, and nested StructType.")
       .booleanConf

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -596,6 +596,9 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
       case logical.FlatMapGroupsInR(f, p, b, is, os, key, value, grouping, data, objAttr, child) =>
         execution.FlatMapGroupsInRExec(f, p, b, is, os, key, value, grouping,
           data, objAttr, planLater(child)) :: Nil
+      case logical.FlatMapGroupsInRWithArrow(f, p, b, is, ot, key, grouping, child) =>
+        execution.FlatMapGroupsInRWithArrowExec(
+          f, p, b, is, ot, key, grouping, planLater(child)) :: Nil
       case logical.FlatMapGroupsInPandas(grouping, func, output, child) =>
         execution.python.FlatMapGroupsInPandasExec(grouping, func, output, planLater(child)) :: Nil
       case logical.MapElements(f, _, _, objAttr, child) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
@@ -493,8 +493,7 @@ case class FlatMapGroupsInRWithArrowExec(
       // 4.                                 Computes vectorized operations by each R data frame
       // 5.                                 Converts all R data frames to Arrow record batches
       // 6. Columnar batches      <-------- Arrow record batches
-      // 7. Read each row from
-      //    batch's row view.
+      // 7. Each row from batch
       //
       // Note that, unlike Python vectorization implementation, R side sends Arrow formatted
       // binary in a batch due to the limitation of R API. See also ARROW-4512.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
@@ -491,7 +491,7 @@ case class FlatMapGroupsInRWithArrowExec(
       // 4.                                    Converts each Arrow record batch to each R data frame
       // 5.                                    Deserializes keys
       // 6.                                    Maps each key to each R Data frame
-      // 7.                                    Computes vectorized operations by each R data frame
+      // 7.                                    Computes R native function on each key/R data frame
       // 8.                                    Converts all R data frames to Arrow record batches
       // 9. Columnar batches         <-------- Arrow record batches
       // 10. Each row from each batch

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
@@ -483,7 +483,7 @@ case class FlatMapGroupsInRWithArrowExec(
 
       // The communication mechanism is as follows:
       //
-      //    JVM side                        R side
+      //    JVM side                           R side
       //
       // 1. Group internal rows
       // 2. Grouped internal rows    --------> Arrow record natches

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
@@ -485,15 +485,16 @@ case class FlatMapGroupsInRWithArrowExec(
       //
       //    JVM side                        R side
       //
-      // 1. Grouped internal rows --------> Arrow record natches
-      // 2. Grouped keys          --------> Regular serialized keys
-      // 3.                                 Converts each Arrow record batch to each R data frame
-      // 4.                                 Deserializes keys
-      // 5.                                 Maps each key and each R Data frame
-      // 4.                                 Computes vectorized operations by each R data frame
-      // 5.                                 Converts all R data frames to Arrow record batches
-      // 6. Columnar batches      <-------- Arrow record batches
-      // 7. Each row from batch
+      // 1. Group internal rows
+      // 2. Grouped internal rows    --------> Arrow record natches
+      // 3. Grouped keys             --------> Regular serialized keys
+      // 4.                                    Converts each Arrow record batch to each R data frame
+      // 5.                                    Deserializes keys
+      // 6.                                    Maps each key to each R Data frame
+      // 7.                                    Computes vectorized operations by each R data frame
+      // 8.                                    Converts all R data frames to Arrow record batches
+      // 9. Columnar batches         <-------- Arrow record batches
+      // 10. Each row from each batch
       //
       // Note that, unlike Python vectorization implementation, R side sends Arrow formatted
       // binary in a batch due to the limitation of R API. See also ARROW-4512.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
@@ -486,7 +486,7 @@ case class FlatMapGroupsInRWithArrowExec(
       //    JVM side                           R side
       //
       // 1. Group internal rows
-      // 2. Grouped internal rows    --------> Arrow record natches
+      // 2. Grouped internal rows    --------> Arrow record batches
       // 3. Grouped keys             --------> Regular serialized keys
       // 4.                                    Converts each Arrow record batch to each R data frame
       // 5.                                    Deserializes keys

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/r/ArrowRRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/r/ArrowRRunner.scala
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.r
+
+import java.io._
+import java.nio.channels.Channels
+
+import scala.collection.JavaConverters._
+
+import org.apache.arrow.vector.VectorSchemaRoot
+import org.apache.arrow.vector.ipc.{ArrowStreamReader, ArrowStreamWriter}
+import org.apache.arrow.vector.util.ByteArrayReadableSeekableByteChannel
+
+import org.apache.spark.{SparkException, TaskContext}
+import org.apache.spark.api.r._
+import org.apache.spark.api.r.SpecialLengths
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.arrow.{ArrowUtils, ArrowWriter}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch, ColumnVector}
+import org.apache.spark.util.Utils
+
+
+/**
+ * Similar to `ArrowPythonRunner`, but exchange data with R worker via Arrow stream.
+ */
+class ArrowRRunner(
+    func: Array[Byte],
+    packageNames: Array[Byte],
+    broadcastVars: Array[Broadcast[Object]],
+    schema: StructType,
+    timeZoneId: String)
+  extends RRunner[ColumnarBatch](
+    func,
+    "arrow",
+    "arrow",
+    packageNames,
+    broadcastVars,
+    numPartitions = -1,
+    isDataFrame = true,
+    schema.fieldNames,
+    RRunnerModes.DATAFRAME_GAPPLY) {
+
+  protected override def writeData(
+      dataOut: DataOutputStream,
+      printOut: PrintStream,
+      iter: Iterator[_]): Unit = if (iter.hasNext) {
+    val inputIterator = iter.asInstanceOf[Iterator[(Array[Byte], Iterator[InternalRow])]]
+    val arrowSchema = ArrowUtils.toArrowSchema(schema, timeZoneId)
+    val allocator = ArrowUtils.rootAllocator.newChildAllocator(
+      "stdout writer for R", 0, Long.MaxValue)
+    val root = VectorSchemaRoot.create(arrowSchema, allocator)
+    val out = new ByteArrayOutputStream()
+    val keys = collection.mutable.ArrayBuffer.empty[Array[Byte]]
+
+    Utils.tryWithSafeFinally {
+      val arrowWriter = ArrowWriter.create(root)
+      val writer = new ArrowStreamWriter(root, null, Channels.newChannel(out))
+      writer.start()
+
+      while (inputIterator.hasNext) {
+        val (key, nextBatch) = inputIterator.next()
+        keys.append(key)
+
+        while (nextBatch.hasNext) {
+          arrowWriter.write(nextBatch.next())
+        }
+
+        arrowWriter.finish()
+        writer.writeBatch()
+        arrowWriter.reset()
+      }
+      writer.end()
+    } {
+      // Don't close root and allocator in TaskCompletionListener to prevent
+      // a race condition. See `ArrowPythonRunner`.
+      root.close()
+      allocator.close()
+    }
+
+    // Currently, there looks no way to read batch by batch by socket connection in R side,
+    // See ARROW-4512. Therefore, it writes the whole Arrow streaming-formatted binary at
+    // once for now.
+    val data = out.toByteArray
+    dataOut.writeInt(data.length)
+    dataOut.write(data)
+
+    keys.foreach(dataOut.write)
+  }
+
+  protected override def newReaderIterator(
+      dataStream: DataInputStream, errThread: BufferedStreamThread): Iterator[ColumnarBatch] = {
+    new Iterator[ColumnarBatch] {
+      private val allocator = ArrowUtils.rootAllocator.newChildAllocator(
+        "stdin reader for R", 0, Long.MaxValue)
+
+      private var reader: ArrowStreamReader = _
+      private var root: VectorSchemaRoot = _
+      private var vectors: Array[ColumnVector] = _
+
+      TaskContext.get().addTaskCompletionListener[Unit] { _ =>
+        if (reader != null) {
+          reader.close(false)
+        }
+        allocator.close()
+      }
+
+      private var batchLoaded = true
+      private var nextObj: ColumnarBatch = _
+      private var eos = false
+
+      override def hasNext: Boolean = nextObj != null || {
+        if (!eos) {
+          nextObj = read()
+          hasNext
+        } else {
+          false
+        }
+      }
+
+      override def next(): ColumnarBatch = {
+        if (hasNext) {
+          val obj = nextObj
+          nextObj = null.asInstanceOf[ColumnarBatch]
+          obj
+        } else {
+          Iterator.empty.next()
+        }
+      }
+
+      private def read(): ColumnarBatch = try {
+        if (reader != null && batchLoaded) {
+          batchLoaded = reader.loadNextBatch()
+          if (batchLoaded) {
+            val batch = new ColumnarBatch(vectors)
+            batch.setNumRows(root.getRowCount)
+            batch
+          } else {
+            reader.close(false)
+            allocator.close()
+            eos = true
+            null
+          }
+        } else {
+          dataStream.readInt() match {
+            case SpecialLengths.TIMING_DATA =>
+              // Timing data from R worker
+              val boot = dataStream.readDouble - bootTime
+              val init = dataStream.readDouble
+              val broadcast = dataStream.readDouble
+              val input = dataStream.readDouble
+              val compute = dataStream.readDouble
+              val output = dataStream.readDouble
+              logInfo(
+                ("Times: boot = %.3f s, init = %.3f s, broadcast = %.3f s, " +
+                  "read-input = %.3f s, compute = %.3f s, write-output = %.3f s, " +
+                  "total = %.3f s").format(
+                  boot,
+                  init,
+                  broadcast,
+                  input,
+                  compute,
+                  output,
+                  boot + init + broadcast + input + compute + output))
+              read()
+            case length if length > 0 =>
+              // Likewise, there looks no way to send each batch in streaming format via socket
+              // connection. See ARROW-4512.
+              // So, it reads the whole Arrow streaming-formatted binary at once for now.
+              val in = new ByteArrayReadableSeekableByteChannel(readByteArrayData(length))
+              reader = new ArrowStreamReader(in, allocator)
+              root = reader.getVectorSchemaRoot
+              vectors = root.getFieldVectors.asScala.map { vector =>
+                new ArrowColumnVector(vector)
+              }.toArray[ColumnVector]
+              read()
+            case length if length == 0 =>
+              eos = true
+              null
+          }
+        }
+      } catch {
+        case eof: EOFException =>
+          throw new SparkException(
+            "R worker exited unexpectedly (crashed)\n " + errThread.getLines(), eof)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR targets to add vectorized `gapply()` in R, Arrow optimization.

This can be tested as below:

```bash
$ ./bin/sparkR --conf spark.sql.execution.arrow.enabled=true
```

```r
df <- createDataFrame(mtcars)
collect(gapply(df,
               "gear",
               function(key, group) {
                 data.frame(gear = key[[1]], disp = mean(group$disp) > group$disp)
               },
               structType("gear double, disp boolean")))
```

### Requirements
  - R 3.5.x 
  - Arrow package 0.12+
    ```bash
    Rscript -e 'remotes::install_github("apache/arrow@apache-arrow-0.12.0", subdir = "r")'
    ```

**Note:** currently, Arrow R package is not in CRAN. Please take a look at ARROW-3204.
**Note:** currently, Arrow R package seems not supporting Windows. Please take a look at ARROW-3204.


### Benchmarks

**Shall**

```bash
sync && sudo purge
./bin/sparkR --conf spark.sql.execution.arrow.enabled=false --driver-memory 4g
```

```bash
sync && sudo purge
./bin/sparkR --conf spark.sql.execution.arrow.enabled=true --driver-memory 4g
```

**R code**

```r
rdf <- read.csv("500000.csv")
df <- cache(createDataFrame(rdf))
count(df)


test <- function() {
  options(digits.secs = 6) # milliseconds
  start.time <- Sys.time()
  count(cache(gapply(df,
                     "Month_of_Joining",
                     function(key, group) { group },
                     schema(df))))
  end.time <- Sys.time()
  time.taken <- end.time - start.time
  print(time.taken)
}


test()
```

**Data (350 MB):**

```r
object.size(read.csv("500000.csv"))
350379504 bytes
```

"500000 Records"  http://eforexcel.com/wp/downloads-16-sample-csv-files-data-sets-for-testing/

**Results**

```
Time difference of 5.195142 mins
```

```
Time difference of 12.64185 secs
```

The performance improvement was around **2465%**.

### Limitations

- For now, Arrow optimization with R does not support when the data is `raw`, and when user explicitly gives float type in the schema. They produce corrupt values.

- Due to ARROW-4512, it cannot send and receive batch by batch. It has to send all batches in Arrow stream format at once. It needs improvement later.

## How was this patch tested?

Unit tests were added

**TODOs:**
- [x] Draft codes
- [x] make the tests passed
- [x] make the CRAN check pass
- [x] Performance measurement
- [x] Supportability investigation (for instance types)
