### PR TITLE
[SPARK-26852][PYTHON] Add absolute transform to CrossValidator

### DIFF
--- a/python/pyspark/ml/evaluation.py
+++ b/python/pyspark/ml/evaluation.py
@@ -85,9 +85,10 @@ class Evaluator(Params):
         """
         Indicates whether the metric returned by :py:meth:`evaluate` should be transformed
         to non-negative values (True) prior to testing for minimization or maximization,
-        or left unchanged (False, default). 
+        or left unchanged (False, default).
         """
         return False
+
 
 @inherit_doc
 class JavaEvaluator(JavaParams, Evaluator):

--- a/python/pyspark/ml/evaluation.py
+++ b/python/pyspark/ml/evaluation.py
@@ -81,6 +81,13 @@ class Evaluator(Params):
         """
         return True
 
+    def applyAbsoluteTransform(self):
+        """
+        Indicates whether the metric returned by :py:meth:`evaluate` should be transformed
+        to non-negative values (True) prior to testing for minimization or maximization,
+        or left unchanged (False, default). 
+        """
+        return False
 
 @inherit_doc
 class JavaEvaluator(JavaParams, Evaluator):

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -308,9 +308,9 @@ class CrossValidator(Estimator, ValidatorParams, HasParallelism, HasCollectSubMo
 
             validation.unpersist()
             train.unpersist()
-           
+
         if eva.applyAbsoluteTransform():
-            metrics = np.absolute(metrics) 
+            metrics = np.absolute(metrics)
 
         if eva.isLargerBetter():
             bestIndex = np.argmax(metrics)

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -308,6 +308,9 @@ class CrossValidator(Estimator, ValidatorParams, HasParallelism, HasCollectSubMo
 
             validation.unpersist()
             train.unpersist()
+           
+        if eva.applyAbsoluteTransform():
+            metrics = np.absolute(metrics) 
 
         if eva.isLargerBetter():
             bestIndex = np.argmax(metrics)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Updates to the `Evaluator` and `CrossValidation` classes to support an absolute transform on metrics.

## How was this patch tested?

I cloned from the following branch:

```bash
git clone --single-branch --branch bgweber-abs-evaluator https://github.com/bgweber/spark.git
```

And ran `./dev/run-tests`

```
========================================================================
Running Python style checks
========================================================================
starting python compilation test...
python compilation succeeded.

downloading pycodestyle from https://raw.githubusercontent.com/PyCQA/pycodestyle/2.4.0/pycodestyle.py...
starting pycodestyle test...
pycodestyle checks passed.

starting flake8 test...
flake8 checks passed.

The pydocstyle command was not found. Skipping pydocstyle checks for now.

The sphinx-build command was not found. Skipping pydoc checks for now.


all lint-python tests passed!
```
