### PR TITLE
[SPARK-26816][CORE][TEST] Add XORShiftRandom Benchmark

### DIFF
--- a/core/benchmarks/XORShiftRandomBenchmark-results.txt
+++ b/core/benchmarks/XORShiftRandomBenchmark-results.txt
@@ -1,0 +1,44 @@
+================================================================================================
+Pseudo random
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_172-b11 on Mac OS X 10.13.6
+Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
+nextInt:                                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+java.util.Random                              1050 / 1053         95.2          10.5       1.0X
+XORShiftRandom                                 182 /  183        549.0           1.8       5.8X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_172-b11 on Mac OS X 10.13.6
+Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
+nextLong:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+java.util.Random                              2084 / 2095         48.0          20.8       1.0X
+XORShiftRandom                                 445 /  448        224.7           4.4       4.7X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_172-b11 on Mac OS X 10.13.6
+Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
+nextDouble:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+java.util.Random                              2087 / 2111         47.9          20.9       1.0X
+XORShiftRandom                                 462 /  470        216.6           4.6       4.5X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_172-b11 on Mac OS X 10.13.6
+Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
+nextGaussian:                            Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+java.util.Random                              7837 / 7946         12.8          78.4       1.0X
+XORShiftRandom                                4743 / 4878         21.1          47.4       1.7X
+
+
+================================================================================================
+hash seed
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_172-b11 on Mac OS X 10.13.6
+Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
+Hashing seed:                            Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+XORShiftRandom.hashSeed                        820 /  829         12.2          82.0       1.0X
+
+

--- a/core/benchmarks/XORShiftRandomBenchmark-results.txt
+++ b/core/benchmarks/XORShiftRandomBenchmark-results.txt
@@ -2,43 +2,43 @@
 Pseudo random
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_172-b11 on Mac OS X 10.13.6
-Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 nextInt:                                 Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-java.util.Random                              1050 / 1053         95.2          10.5       1.0X
-XORShiftRandom                                 182 /  183        549.0           1.8       5.8X
+java.util.Random                              1362 / 1362         73.4          13.6       1.0X
+XORShiftRandom                                 227 /  227        440.6           2.3       6.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_172-b11 on Mac OS X 10.13.6
-Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 nextLong:                                Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-java.util.Random                              2084 / 2095         48.0          20.8       1.0X
-XORShiftRandom                                 445 /  448        224.7           4.4       4.7X
+java.util.Random                              2732 / 2732         36.6          27.3       1.0X
+XORShiftRandom                                 629 /  629        159.0           6.3       4.3X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_172-b11 on Mac OS X 10.13.6
-Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 nextDouble:                              Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-java.util.Random                              2087 / 2111         47.9          20.9       1.0X
-XORShiftRandom                                 462 /  470        216.6           4.6       4.5X
+java.util.Random                              2730 / 2730         36.6          27.3       1.0X
+XORShiftRandom                                 629 /  629        159.0           6.3       4.3X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_172-b11 on Mac OS X 10.13.6
-Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 nextGaussian:                            Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-java.util.Random                              7837 / 7946         12.8          78.4       1.0X
-XORShiftRandom                                4743 / 4878         21.1          47.4       1.7X
+java.util.Random                            10288 / 10288          9.7         102.9       1.0X
+XORShiftRandom                                6351 / 6351         15.7          63.5       1.6X
 
 
 ================================================================================================
 hash seed
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_172-b11 on Mac OS X 10.13.6
-Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
-Hashing seed:                            Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+OpenJDK 64-Bit Server VM 1.8.0_191-b12 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Hash seed:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-XORShiftRandom.hashSeed                        820 /  829         12.2          82.0       1.0X
+XORShiftRandom.hashSeed                       1193 / 1195          8.4         119.3       1.0X
 
 

--- a/core/src/main/scala/org/apache/spark/util/random/XORShiftRandom.scala
+++ b/core/src/main/scala/org/apache/spark/util/random/XORShiftRandom.scala
@@ -22,8 +22,6 @@ import java.util.{Random => JavaRandom}
 
 import scala.util.hashing.MurmurHash3
 
-import org.apache.spark.util.Utils.timeIt
-
 /**
  * This class implements a XORShift random number generator algorithm
  * Source:
@@ -65,44 +63,5 @@ private[spark] object XORShiftRandom {
     val lowBits = MurmurHash3.bytesHash(bytes)
     val highBits = MurmurHash3.bytesHash(bytes, lowBits)
     (highBits.toLong << 32) | (lowBits.toLong & 0xFFFFFFFFL)
-  }
-
-  /**
-   * Main method for running benchmark
-   * @param args takes one argument - the number of random numbers to generate
-   */
-  def main(args: Array[String]): Unit = {
-    // scalastyle:off println
-    if (args.length != 1) {
-      println("Benchmark of XORShiftRandom vis-a-vis java.util.Random")
-      println("Usage: XORShiftRandom number_of_random_numbers_to_generate")
-      System.exit(1)
-    }
-    println(benchmark(args(0).toInt))
-    // scalastyle:on println
-  }
-
-  /**
-   * @param numIters Number of random numbers to generate while running the benchmark
-   * @return Map of execution times for {@link java.util.Random java.util.Random}
-   * and XORShift
-   */
-  def benchmark(numIters: Int): Map[String, Long] = {
-
-    val seed = 1L
-    val million = 1e6.toInt
-    val javaRand = new JavaRandom(seed)
-    val xorRand = new XORShiftRandom(seed)
-
-    // this is just to warm up the JIT - we're not timing anything
-    timeIt(million) {
-      javaRand.nextInt()
-      xorRand.nextInt()
-    }
-
-    /* Return results as a map instead of just printing to screen
-    in case the user wants to do something with them */
-    Map("javaTime" -> timeIt(numIters) { javaRand.nextInt() },
-        "xorTime" -> timeIt(numIters) { xorRand.nextInt() })
   }
 }

--- a/core/src/test/scala/org/apache/spark/util/random/XORShiftRandomBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/util/random/XORShiftRandomBenchmark.scala
@@ -67,12 +67,27 @@ object XORShiftRandomBenchmark extends BenchmarkBase {
     benchmark.run()
   }
 
+  def nextGaussian(numIters: Int, valuesPerIteration: Int): Unit = {
+    val benchmark = new Benchmark("nextGaussian", valuesPerIteration, output = output)
+
+    benchmark.addCase("java.util.Random", numIters) { _ =>
+      times(valuesPerIteration) { javaRand.nextGaussian() }
+    }
+
+    benchmark.addCase("XORShiftRandom", numIters) { _ =>
+      times(valuesPerIteration) { xorRand.nextGaussian() }
+    }
+
+    benchmark.run()
+  }
+
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
     val numIters = 3
     val valuesPerIteration = 100000000
     runBenchmark("Pseudo random") {
       nextInt(numIters, valuesPerIteration)
       nextDouble(numIters, valuesPerIteration)
+      nextGaussian(numIters, valuesPerIteration)
     }
   }
 }

--- a/core/src/test/scala/org/apache/spark/util/random/XORShiftRandomBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/util/random/XORShiftRandomBenchmark.scala
@@ -53,11 +53,26 @@ object XORShiftRandomBenchmark extends BenchmarkBase {
     benchmark.run()
   }
 
+  def nextDouble(numIters: Int, valuesPerIteration: Int): Unit = {
+    val benchmark = new Benchmark("nextDouble", valuesPerIteration, output = output)
+
+    benchmark.addCase("java.util.Random", numIters) { _ =>
+      times(valuesPerIteration) { javaRand.nextDouble() }
+    }
+
+    benchmark.addCase("XORShiftRandom", numIters) { _ =>
+      times(valuesPerIteration) { xorRand.nextDouble() }
+    }
+
+    benchmark.run()
+  }
+
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
     val numIters = 3
     val valuesPerIteration = 100000000
     runBenchmark("Pseudo random") {
       nextInt(numIters, valuesPerIteration)
+      nextDouble(numIters, valuesPerIteration)
     }
   }
 }

--- a/core/src/test/scala/org/apache/spark/util/random/XORShiftRandomBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/util/random/XORShiftRandomBenchmark.scala
@@ -39,7 +39,7 @@ object XORShiftRandomBenchmark extends BenchmarkBase {
   val javaRand = new JavaRandom(seed)
   val xorRand = new XORShiftRandom(seed)
 
-  def nextInt(numIters: Int, valuesPerIteration: Int): Unit = {
+  private def nextInt(numIters: Int, valuesPerIteration: Int): Unit = {
     val benchmark = new Benchmark("nextInt", valuesPerIteration, output = output)
 
     benchmark.addCase("java.util.Random", numIters) { _ =>
@@ -53,7 +53,7 @@ object XORShiftRandomBenchmark extends BenchmarkBase {
     benchmark.run()
   }
 
-  def nextLong(numIters: Int, valuesPerIteration: Int): Unit = {
+  private def nextLong(numIters: Int, valuesPerIteration: Int): Unit = {
     val benchmark = new Benchmark("nextLong", valuesPerIteration, output = output)
 
     benchmark.addCase("java.util.Random", numIters) { _ =>
@@ -67,7 +67,7 @@ object XORShiftRandomBenchmark extends BenchmarkBase {
     benchmark.run()
   }
 
-  def nextDouble(numIters: Int, valuesPerIteration: Int): Unit = {
+  private def nextDouble(numIters: Int, valuesPerIteration: Int): Unit = {
     val benchmark = new Benchmark("nextDouble", valuesPerIteration, output = output)
 
     benchmark.addCase("java.util.Random", numIters) { _ =>
@@ -81,7 +81,7 @@ object XORShiftRandomBenchmark extends BenchmarkBase {
     benchmark.run()
   }
 
-  def nextGaussian(numIters: Int, valuesPerIteration: Int): Unit = {
+  private def nextGaussian(numIters: Int, valuesPerIteration: Int): Unit = {
     val benchmark = new Benchmark("nextGaussian", valuesPerIteration, output = output)
 
     benchmark.addCase("java.util.Random", numIters) { _ =>
@@ -95,8 +95,8 @@ object XORShiftRandomBenchmark extends BenchmarkBase {
     benchmark.run()
   }
 
-  def hashSeed(numIters: Int, valuesPerIteration: Int): Unit = {
-    val benchmark = new Benchmark("Hashing seed", valuesPerIteration, output = output)
+  private def hashSeed(numIters: Int, valuesPerIteration: Int): Unit = {
+    val benchmark = new Benchmark("Hash seed", valuesPerIteration, output = output)
 
     benchmark.addCase("XORShiftRandom.hashSeed", numIters) { _ =>
       var i = 0

--- a/core/src/test/scala/org/apache/spark/util/random/XORShiftRandomBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/util/random/XORShiftRandomBenchmark.scala
@@ -95,14 +95,34 @@ object XORShiftRandomBenchmark extends BenchmarkBase {
     benchmark.run()
   }
 
+  def hashSeed(numIters: Int, valuesPerIteration: Int): Unit = {
+    val benchmark = new Benchmark("Hashing seed", valuesPerIteration, output = output)
+
+    benchmark.addCase("XORShiftRandom.hashSeed", numIters) { _ =>
+      var i = 0
+      while (i < valuesPerIteration) {
+        XORShiftRandom.hashSeed(seed + 9876543210L + i)
+        i += 1
+      }
+    }
+
+    benchmark.run()
+  }
+
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
     val numIters = 3
-    val valuesPerIteration = 100000000
     runBenchmark("Pseudo random") {
+      val valuesPerIteration = 100000000
+
       nextInt(numIters, valuesPerIteration)
       nextLong(numIters, valuesPerIteration)
       nextDouble(numIters, valuesPerIteration)
       nextGaussian(numIters, valuesPerIteration)
+    }
+    runBenchmark("hash seed") {
+      val valuesPerIteration = 10000000
+
+      hashSeed(numIters, valuesPerIteration)
     }
   }
 }

--- a/core/src/test/scala/org/apache/spark/util/random/XORShiftRandomBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/util/random/XORShiftRandomBenchmark.scala
@@ -53,6 +53,20 @@ object XORShiftRandomBenchmark extends BenchmarkBase {
     benchmark.run()
   }
 
+  def nextLong(numIters: Int, valuesPerIteration: Int): Unit = {
+    val benchmark = new Benchmark("nextLong", valuesPerIteration, output = output)
+
+    benchmark.addCase("java.util.Random", numIters) { _ =>
+      times(valuesPerIteration) { javaRand.nextLong() }
+    }
+
+    benchmark.addCase("XORShiftRandom", numIters) { _ =>
+      times(valuesPerIteration) { xorRand.nextLong() }
+    }
+
+    benchmark.run()
+  }
+
   def nextDouble(numIters: Int, valuesPerIteration: Int): Unit = {
     val benchmark = new Benchmark("nextDouble", valuesPerIteration, output = output)
 
@@ -86,6 +100,7 @@ object XORShiftRandomBenchmark extends BenchmarkBase {
     val valuesPerIteration = 100000000
     runBenchmark("Pseudo random") {
       nextInt(numIters, valuesPerIteration)
+      nextLong(numIters, valuesPerIteration)
       nextDouble(numIters, valuesPerIteration)
       nextGaussian(numIters, valuesPerIteration)
     }

--- a/core/src/test/scala/org/apache/spark/util/random/XORShiftRandomBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/util/random/XORShiftRandomBenchmark.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util.random
+
+import java.util.{Random => JavaRandom}
+
+import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
+import org.apache.spark.util.Utils.times
+
+/**
+ * Benchmarks for pseudo random generators
+ * To run this benchmark:
+ * {{{
+ *   1. without sbt:
+ *      bin/spark-submit --class <this class> --jars <spark core test jar>
+ *   2. build/sbt "core/test:runMain <this class>"
+ *   3. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "core/test:runMain <this class>"
+ *      Results will be written to "benchmarks/XORShiftRandomBenchmark-results.txt".
+ * }}}
+ */
+object XORShiftRandomBenchmark extends BenchmarkBase {
+  val seed = 123456789101112L
+  val javaRand = new JavaRandom(seed)
+  val xorRand = new XORShiftRandom(seed)
+
+  def nextInt(numIters: Int, valuesPerIteration: Int): Unit = {
+    val benchmark = new Benchmark("nextInt", valuesPerIteration, output = output)
+
+    benchmark.addCase("java.util.Random", numIters) { _ =>
+      times(valuesPerIteration) { javaRand.nextInt() }
+    }
+
+    benchmark.addCase("XORShiftRandom", numIters) { _ =>
+      times(valuesPerIteration) { xorRand.nextInt() }
+    }
+
+    benchmark.run()
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    val numIters = 3
+    val valuesPerIteration = 100000000
+    runBenchmark("Pseudo random") {
+      nextInt(numIters, valuesPerIteration)
+    }
+  }
+}
+


### PR DESCRIPTION
## What changes were proposed in this pull request?

- The benchmark of `XORShiftRandom.nextInt` vis-a-vis `java.util.Random.nextInt` is moved from the `XORShiftRandom` object to `XORShiftRandomBenchmark`.
- Added benchmarks for `nextLong`, `nextDouble` and `nextGaussian` that are used in Spark as well.
- Added a separate benchmark for `XORShiftRandom.hashSeed`.