### PR TITLE
[SPARK-26853][SQL] Add example and version for commonly used aggregate function descriptions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
@@ -64,7 +64,8 @@ import org.apache.spark.sql.types._
        [10.0,10.0,10.0]
       > SELECT _FUNC_(10.0, 0.5, 100);
        10.0
-  """)
+  """,
+  since = "2.1.0")
 case class ApproximatePercentile(
     child: Expression,
     percentageExpression: Expression,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Average.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Average.scala
@@ -24,7 +24,15 @@ import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.types._
 
 @ExpressionDescription(
-  usage = "_FUNC_(expr) - Returns the mean calculated from values of a group.")
+  usage = "_FUNC_(expr) - Returns the mean calculated from values of a group.",
+  examples = """
+    Examples:
+      > SELECT _FUNC(col) FROM VALUES (1), (2), (3) AS tab(col);
+       2.0
+      > SELECT _FUNC(col) FROM VALUES (1), (2), (NULL) AS tab(col);
+       1.5
+  """,
+  since = "1.3.0")
 case class Average(child: Expression) extends DeclarativeAggregate with ImplicitCastInputTypes {
 
   override def prettyName: String = "avg"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Average.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Average.scala
@@ -27,9 +27,9 @@ import org.apache.spark.sql.types._
   usage = "_FUNC_(expr) - Returns the mean calculated from values of a group.",
   examples = """
     Examples:
-      > SELECT _FUNC(col) FROM VALUES (1), (2), (3) AS tab(col);
+      > SELECT _FUNC_(col) FROM VALUES (1), (2), (3) AS tab(col);
        2.0
-      > SELECT _FUNC(col) FROM VALUES (1), (2), (NULL) AS tab(col);
+      > SELECT _FUNC_(col) FROM VALUES (1), (2), (NULL) AS tab(col);
        1.5
   """,
   since = "1.3.0")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Average.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Average.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.types._
       > SELECT _FUNC_(col) FROM VALUES (1), (2), (NULL) AS tab(col);
        1.5
   """,
-  since = "1.3.0")
+  since = "1.0.0")
 case class Average(child: Expression) extends DeclarativeAggregate with ImplicitCastInputTypes {
 
   override def prettyName: String = "avg"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CentralMomentAgg.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CentralMomentAgg.scala
@@ -135,7 +135,13 @@ abstract class CentralMomentAgg(child: Expression)
 // Compute the population standard deviation of a column
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(expr) - Returns the population standard deviation calculated from values of a group.")
+  usage = "_FUNC_(expr) - Returns the population standard deviation calculated from values of a group.",
+  examples = """
+    Examples:
+      > SELECT _FUNC_(col) FROM VALUES (1), (2), (3) AS tab(col);
+       0.816496580927726
+  """,
+  since = "1.6.0")
 // scalastyle:on line.size.limit
 case class StddevPop(child: Expression) extends CentralMomentAgg(child) {
 
@@ -151,7 +157,13 @@ case class StddevPop(child: Expression) extends CentralMomentAgg(child) {
 // Compute the sample standard deviation of a column
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(expr) - Returns the sample standard deviation calculated from values of a group.")
+  usage = "_FUNC_(expr) - Returns the sample standard deviation calculated from values of a group.",
+  examples = """
+    Examples:
+      > SELECT _FUNC_(col) FROM VALUES (1), (2), (3) AS tab(col);
+       1.0
+  """,
+  since = "1.6.0")
 // scalastyle:on line.size.limit
 case class StddevSamp(child: Expression) extends CentralMomentAgg(child) {
 
@@ -167,7 +179,13 @@ case class StddevSamp(child: Expression) extends CentralMomentAgg(child) {
 
 // Compute the population variance of a column
 @ExpressionDescription(
-  usage = "_FUNC_(expr) - Returns the population variance calculated from values of a group.")
+  usage = "_FUNC_(expr) - Returns the population variance calculated from values of a group.",
+  examples = """
+    Examples:
+      > SELECT _FUNC_(col) FROM VALUES (1), (2), (3) AS tab(col);
+       0.6666666666666666
+  """,
+  since = "1.6.0")
 case class VariancePop(child: Expression) extends CentralMomentAgg(child) {
 
   override protected def momentOrder = 2
@@ -181,7 +199,13 @@ case class VariancePop(child: Expression) extends CentralMomentAgg(child) {
 
 // Compute the sample variance of a column
 @ExpressionDescription(
-  usage = "_FUNC_(expr) - Returns the sample variance calculated from values of a group.")
+  usage = "_FUNC_(expr) - Returns the sample variance calculated from values of a group.",
+  examples = """
+    Examples:
+      > SELECT _FUNC_(col) FROM VALUES (1), (2), (3) AS tab(col);
+       1.0
+  """,
+  since = "1.6.0")
 case class VarianceSamp(child: Expression) extends CentralMomentAgg(child) {
 
   override protected def momentOrder = 2
@@ -195,7 +219,15 @@ case class VarianceSamp(child: Expression) extends CentralMomentAgg(child) {
 }
 
 @ExpressionDescription(
-  usage = "_FUNC_(expr) - Returns the skewness value calculated from values of a group.")
+  usage = "_FUNC_(expr) - Returns the skewness value calculated from values of a group.",
+  examples = """
+    Examples:
+      > SELECT _FUNC_(col) FROM VALUES (-10), (-20), (100), (1000) AS tab(col);
+       1.1135657469022013
+      > SELECT _FUNC_(col) FROM VALUES (-1000), (-100), (10), (20) AS tab(col);
+       -1.1135657469022011
+  """,
+  since = "1.6.0")
 case class Skewness(child: Expression) extends CentralMomentAgg(child) {
 
   override def prettyName: String = "skewness"
@@ -209,7 +241,15 @@ case class Skewness(child: Expression) extends CentralMomentAgg(child) {
 }
 
 @ExpressionDescription(
-  usage = "_FUNC_(expr) - Returns the kurtosis value calculated from values of a group.")
+  usage = "_FUNC_(expr) - Returns the kurtosis value calculated from values of a group.",
+  examples = """
+    Examples:
+      > SELECT _FUNC_(col) FROM VALUES (-10), (-20), (100), (1000) AS tab(col);
+       -0.7014368047529618
+      > SELECT _FUNC_(col) FROM VALUES (1), (10), (100), (10), (1) as tab(col);
+       0.19432323191698986
+  """,
+  since = "1.6.0")
 case class Kurtosis(child: Expression) extends CentralMomentAgg(child) {
 
   override protected def momentOrder = 4

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Corr.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Corr.scala
@@ -93,7 +93,13 @@ abstract class PearsonCorrelation(x: Expression, y: Expression)
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(expr1, expr2) - Returns Pearson coefficient of correlation between a set of number pairs.")
+  usage = "_FUNC_(expr1, expr2) - Returns Pearson coefficient of correlation between a set of number pairs.",
+  examples = """
+    Examples:
+      > SELECT _FUNC_(c1, c2) FROM VALUES (3, 2), (3, 3), (6, 4) as tab(c1, c2);
+       0.8660254037844387
+  """,
+  since = "1.6.0")
 // scalastyle:on line.size.limit
 case class Corr(x: Expression, y: Expression)
   extends PearsonCorrelation(x, y) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Count.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Count.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.types._
       > SELECT _FUNC_(DISTINCT col) FROM VALUES (NULL), (5), (5), (10) AS tab(col);
        2
   """,
-  since = "1.3.0")
+  since = "1.0.0")
 // scalastyle:on line.size.limit
 case class Count(children: Seq[Expression]) extends DeclarativeAggregate {
   override def nullable: Boolean = false

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Count.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Count.scala
@@ -29,7 +29,17 @@ import org.apache.spark.sql.types._
     _FUNC_(expr[, expr...]) - Returns the number of rows for which the supplied expression(s) are all non-null.
 
     _FUNC_(DISTINCT expr[, expr...]) - Returns the number of rows for which the supplied expression(s) are unique and non-null.
-  """)
+  """,
+  examples = """
+    Examples:
+      > SELECT _FUNC(*) FROM VALUES (NULL), (5), (5), (20) AS tab(col)
+       4
+      > SELECT _FUNC(col) FROM VALUES (NULL), (5), (5), (20) AS tab(col)
+       3
+      > SELECT _FUNC(DISTINCT col) FROM VALUES (NULL), (5), (5), (10) AS tab(col)
+       2
+  """,
+  since = "1.3.0")
 // scalastyle:on line.size.limit
 case class Count(children: Seq[Expression]) extends DeclarativeAggregate {
   override def nullable: Boolean = false

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Count.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Count.scala
@@ -32,11 +32,11 @@ import org.apache.spark.sql.types._
   """,
   examples = """
     Examples:
-      > SELECT _FUNC(*) FROM VALUES (NULL), (5), (5), (20) AS tab(col)
+      > SELECT _FUNC_(*) FROM VALUES (NULL), (5), (5), (20) AS tab(col);
        4
-      > SELECT _FUNC(col) FROM VALUES (NULL), (5), (5), (20) AS tab(col)
+      > SELECT _FUNC_(col) FROM VALUES (NULL), (5), (5), (20) AS tab(col);
        3
-      > SELECT _FUNC(DISTINCT col) FROM VALUES (NULL), (5), (5), (10) AS tab(col)
+      > SELECT _FUNC_(DISTINCT col) FROM VALUES (NULL), (5), (5), (10) AS tab(col);
        2
   """,
   since = "1.3.0")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CountMinSketchAgg.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CountMinSketchAgg.scala
@@ -43,7 +43,8 @@ import org.apache.spark.util.sketch.CountMinSketch
       confidence and seed. The result is an array of bytes, which can be deserialized to a
       `CountMinSketch` before usage. Count-min sketch is a probabilistic data structure used for
       cardinality estimation using sub-linear space.
-  """)
+  """,
+  since = "2.2.0")
 case class CountMinSketchAgg(
     child: Expression,
     epsExpression: Expression,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Covariance.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Covariance.scala
@@ -80,7 +80,13 @@ abstract class Covariance(x: Expression, y: Expression)
 }
 
 @ExpressionDescription(
-  usage = "_FUNC_(expr1, expr2) - Returns the population covariance of a set of number pairs.")
+  usage = "_FUNC_(expr1, expr2) - Returns the population covariance of a set of number pairs.",
+  examples = """
+    Examples:
+      > SELECT _FUNC_(c1, c2) FROM VALUES (1,1), (2,2), (3,3) AS tab(c1, c2);
+       0.6666666666666666
+  """,
+  since = "2.0.0")
 case class CovPopulation(left: Expression, right: Expression) extends Covariance(left, right) {
   override val evaluateExpression: Expression = {
     If(n === 0.0, Literal.create(null, DoubleType), ck / n)
@@ -90,7 +96,13 @@ case class CovPopulation(left: Expression, right: Expression) extends Covariance
 
 
 @ExpressionDescription(
-  usage = "_FUNC_(expr1, expr2) - Returns the sample covariance of a set of number pairs.")
+  usage = "_FUNC_(expr1, expr2) - Returns the sample covariance of a set of number pairs.",
+  examples = """
+    Examples:
+      > SELECT _FUNC_(c1, c2) FROM VALUES (1,1), (2,2), (3,3) AS tab(c1, c2);
+       1.0
+  """,
+  since = "2.0.0")
 case class CovSample(left: Expression, right: Expression) extends Covariance(left, right) {
   override val evaluateExpression: Expression = {
     If(n === 0.0, Literal.create(null, DoubleType),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/First.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/First.scala
@@ -36,11 +36,11 @@ import org.apache.spark.sql.types._
       If `isIgnoreNull` is true, returns only non-null values.""",
   examples = """
     Examples:
-      > SELECT _FUNC(col) FROM VALUES (10), (5), (20) AS tab(col);
+      > SELECT _FUNC_(col) FROM VALUES (10), (5), (20) AS tab(col);
        10
-      > SELECT _FUNC(col) FROM VALUES (NULL), (5), (20) AS tab(col);
+      > SELECT _FUNC_(col) FROM VALUES (NULL), (5), (20) AS tab(col);
        NULL
-      > SELECT _FUNC(col, true) FROM VALUES (NULL), (5), (20) AS tab(col);
+      > SELECT _FUNC_(col, true) FROM VALUES (NULL), (5), (20) AS tab(col);
        5
   """,
   since = "2.0.0")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/First.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/First.scala
@@ -33,8 +33,17 @@ import org.apache.spark.sql.types._
 @ExpressionDescription(
   usage = """
     _FUNC_(expr[, isIgnoreNull]) - Returns the first value of `expr` for a group of rows.
-      If `isIgnoreNull` is true, returns only non-null values.
-  """)
+      If `isIgnoreNull` is true, returns only non-null values.""",
+  examples = """
+    Examples:
+      > SELECT _FUNC(col) FROM VALUES (10), (5), (20) AS tab(col);
+       10
+      > SELECT _FUNC(col) FROM VALUES (NULL), (5), (20) AS tab(col);
+       NULL
+      > SELECT _FUNC(col, true) FROM VALUES (NULL), (5), (20) AS tab(col);
+       5
+  """,
+  since = "2.0.0")
 case class First(child: Expression, ignoreNullsExpr: Expression)
   extends DeclarativeAggregate with ExpectsInputTypes {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlus.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlus.scala
@@ -47,8 +47,13 @@ import org.apache.spark.sql.types._
 @ExpressionDescription(
   usage = """
     _FUNC_(expr[, relativeSD]) - Returns the estimated cardinality by HyperLogLog++.
-      `relativeSD` defines the maximum estimation error allowed.
-  """)
+      `relativeSD` defines the maximum estimation error allowed.""",
+  examples = """
+    Examples:
+      > SELECT _FUNC_(col1) FROM VALUES (1), (1), (2), (2), (3) tab(col1);
+       3
+  """,
+  since = "1.6.0")
 case class HyperLogLogPlusPlus(
     child: Expression,
     relativeSD: Double = 0.05,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Last.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Last.scala
@@ -36,11 +36,11 @@ import org.apache.spark.sql.types._
       If `isIgnoreNull` is true, returns only non-null values""",
   examples = """
     Examples:
-      > SELECT _FUNC(col) FROM VALUES (10), (5), (20) AS tab(col);
+      > SELECT _FUNC_(col) FROM VALUES (10), (5), (20) AS tab(col);
        20
-      > SELECT _FUNC(col) FROM VALUES (10), (5), (NULL) AS tab(col);
+      > SELECT _FUNC_(col) FROM VALUES (10), (5), (NULL) AS tab(col);
        NULL
-      > SELECT _FUNC(col, true) FROM VALUES (10), (5), (NULL) AS tab(col);
+      > SELECT _FUNC_(col, true) FROM VALUES (10), (5), (NULL) AS tab(col);
        5
   """,
   since = "2.0.0")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Last.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Last.scala
@@ -33,8 +33,17 @@ import org.apache.spark.sql.types._
 @ExpressionDescription(
   usage = """
     _FUNC_(expr[, isIgnoreNull]) - Returns the last value of `expr` for a group of rows.
-      If `isIgnoreNull` is true, returns only non-null values.
-  """)
+      If `isIgnoreNull` is true, returns only non-null values""",
+  examples = """
+    Examples:
+      > SELECT _FUNC(col) FROM VALUES (10), (5), (20) AS tab(col);
+       20
+      > SELECT _FUNC(col) FROM VALUES (10), (5), (NULL) AS tab(col);
+       NULL
+      > SELECT _FUNC(col, true) FROM VALUES (10), (5), (NULL) AS tab(col);
+       5
+  """,
+  since = "2.0.0")
 case class Last(child: Expression, ignoreNullsExpr: Expression)
   extends DeclarativeAggregate with ExpectsInputTypes {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Max.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Max.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.types._
   usage = "_FUNC_(expr) - Returns the maximum value of `expr`.",
   examples = """
     Examples:
-      > SELECT _FUNC(col) FROM VALUES (10), (50), (20) AS tab(col);
+      > SELECT _FUNC_(col) FROM VALUES (10), (50), (20) AS tab(col);
        50
   """,
   since = "1.3.0")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Max.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Max.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.types._
       > SELECT _FUNC_(col) FROM VALUES (10), (50), (20) AS tab(col);
        50
   """,
-  since = "1.3.0")
+  since = "1.0.0")
 case class Max(child: Expression) extends DeclarativeAggregate {
 
   override def children: Seq[Expression] = child :: Nil

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Max.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Max.scala
@@ -24,7 +24,13 @@ import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.types._
 
 @ExpressionDescription(
-  usage = "_FUNC_(expr) - Returns the maximum value of `expr`.")
+  usage = "_FUNC_(expr) - Returns the maximum value of `expr`.",
+  examples = """
+    Examples:
+      > SELECT _FUNC(col) FROM VALUES (10), (50), (20) AS tab(col);
+       50
+  """,
+  since = "1.3.0")
 case class Max(child: Expression) extends DeclarativeAggregate {
 
   override def children: Seq[Expression] = child :: Nil

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Min.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Min.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.types._
   usage = "_FUNC_(expr) - Returns the minimum value of `expr`.",
   examples = """
     Examples:
-      > SELECT _FUNC(col) FROM VALUES (10), (-1), (20) AS tab(col);
+      > SELECT _FUNC_(col) FROM VALUES (10), (-1), (20) AS tab(col);
        -1
   """,
   since = "1.3.0")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Min.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Min.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.types._
       > SELECT _FUNC_(col) FROM VALUES (10), (-1), (20) AS tab(col);
        -1
   """,
-  since = "1.3.0")
+  since = "1.0.0")
 case class Min(child: Expression) extends DeclarativeAggregate {
 
   override def children: Seq[Expression] = child :: Nil

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Min.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Min.scala
@@ -24,7 +24,13 @@ import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.types._
 
 @ExpressionDescription(
-  usage = "_FUNC_(expr) - Returns the minimum value of `expr`.")
+  usage = "_FUNC_(expr) - Returns the minimum value of `expr`.",
+  examples = """
+    Examples:
+      > SELECT _FUNC(col) FROM VALUES (10), (-1), (20) AS tab(col);
+       -1
+  """,
+  since = "1.3.0")
 case class Min(child: Expression) extends DeclarativeAggregate {
 
   override def children: Seq[Expression] = child :: Nil

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Percentile.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Percentile.scala
@@ -54,7 +54,15 @@ import org.apache.spark.util.collection.OpenHashMap
       of the percentage array must be between 0.0 and 1.0. The value of frequency should be
       positive integral
 
-      """)
+      """,
+  examples = """
+    Examples:
+      > SELECT _FUNC_(col, 0.3) FROM VALUES (0), (10) AS tab(col);
+       3.0
+      > SELECT _FUNC_(col, array(0.25, 0.75)) FROM VALUES (0), (10) AS tab(col);
+       [2.5,7.5]
+  """,
+  since = "2.1.0")
 case class Percentile(
     child: Expression,
     percentageExpression: Expression,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.types._
       > SELECT _FUNC_(col) FROM VALUES (NULL), (NULL) AS tab(col);
        NULL
   """,
-  since = "1.3.0")
+  since = "1.0.0")
 case class Sum(child: Expression) extends DeclarativeAggregate with ImplicitCastInputTypes {
 
   override def children: Seq[Expression] = child :: Nil

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
@@ -24,7 +24,17 @@ import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.types._
 
 @ExpressionDescription(
-  usage = "_FUNC_(expr) - Returns the sum calculated from values of a group.")
+  usage = "_FUNC_(expr) - Returns the sum calculated from values of a group.",
+  examples = """
+    Examples:
+      > SELECT _FUNC(col) FROM VALUES (5), (10), (15) AS tab(col);
+       30
+      > SELECT _FUNC(col) FROM VALUES (NULL), (10), (15) AS tab(col);
+       25
+      > SELECT _FUNC(col) FROM VALUES (NULL), (NULL) AS tab(col);
+       NULL
+  """,
+  since = "1.3.0")
 case class Sum(child: Expression) extends DeclarativeAggregate with ImplicitCastInputTypes {
 
   override def children: Seq[Expression] = child :: Nil

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
@@ -27,11 +27,11 @@ import org.apache.spark.sql.types._
   usage = "_FUNC_(expr) - Returns the sum calculated from values of a group.",
   examples = """
     Examples:
-      > SELECT _FUNC(col) FROM VALUES (5), (10), (15) AS tab(col);
+      > SELECT _FUNC_(col) FROM VALUES (5), (10), (15) AS tab(col);
        30
-      > SELECT _FUNC(col) FROM VALUES (NULL), (10), (15) AS tab(col);
+      > SELECT _FUNC_(col) FROM VALUES (NULL), (10), (15) AS tab(col);
        25
-      > SELECT _FUNC(col) FROM VALUES (NULL), (NULL) AS tab(col);
+      > SELECT _FUNC_(col) FROM VALUES (NULL), (NULL) AS tab(col);
        NULL
   """,
   since = "1.3.0")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/UnevaluableAggs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/UnevaluableAggs.scala
@@ -44,11 +44,11 @@ abstract class UnevaluableBooleanAggBase(arg: Expression)
   usage = "_FUNC_(expr) - Returns true if all values of `expr` are true.",
   examples = """
     Examples:
-      > SELECT _FUNC(col) FROM VALUES (true), (true), (true) AS tab(col)
+      > SELECT _FUNC_(col) FROM VALUES (true), (true), (true) AS tab(col);
        true
-      > SELECT _FUNC(col) FROM VALUES (NULL), (true), (true) AS tab(col)
+      > SELECT _FUNC_(col) FROM VALUES (NULL), (true), (true) AS tab(col);
        true
-      > SELECT _FUNC(col) FROM VALUES (true), (false), (true) AS tab(col)
+      > SELECT _FUNC_(col) FROM VALUES (true), (false), (true) AS tab(col);
        false
   """,
   since = "3.0.0")
@@ -60,11 +60,11 @@ case class EveryAgg(arg: Expression) extends UnevaluableBooleanAggBase(arg) {
   usage = "_FUNC_(expr) - Returns true if at least one value of `expr` is true.",
   examples = """
     Examples:
-      > SELECT _FUNC(col) FROM VALUES (true), (false), (false) AS tab(col)
+      > SELECT _FUNC_(col) FROM VALUES (true), (false), (false) AS tab(col);
        true
-      > SELECT _FUNC(col) FROM VALUES (NULL), (true), (false) AS tab(col)
+      > SELECT _FUNC_(col) FROM VALUES (NULL), (true), (false) AS tab(col);
        true
-      > SELECT _FUNC(col) FROM VALUES (false), (false), (NULL) AS tab(col)
+      > SELECT _FUNC_(col) FROM VALUES (false), (false), (NULL) AS tab(col);
        false
   """,
   since = "3.0.0")
@@ -76,11 +76,11 @@ case class AnyAgg(arg: Expression) extends UnevaluableBooleanAggBase(arg) {
   usage = "_FUNC_(expr) - Returns true if at least one value of `expr` is true.",
   examples = """
     Examples:
-      > SELECT _FUNC(col) FROM VALUES (true), (false), (false) AS tab(col)
+      > SELECT _FUNC_(col) FROM VALUES (true), (false), (false) AS tab(col);
        true
-      > SELECT _FUNC(col) FROM VALUES (NULL), (true), (false) AS tab(col)
+      > SELECT _FUNC_(col) FROM VALUES (NULL), (true), (false) AS tab(col);
        true
-      > SELECT _FUNC(col) FROM VALUES (false), (false), (NULL) AS tab(col)
+      > SELECT _FUNC_(col) FROM VALUES (false), (false), (NULL) AS tab(col);
        false
   """,
   since = "3.0.0")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/UnevaluableAggs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/UnevaluableAggs.scala
@@ -42,6 +42,15 @@ abstract class UnevaluableBooleanAggBase(arg: Expression)
 
 @ExpressionDescription(
   usage = "_FUNC_(expr) - Returns true if all values of `expr` are true.",
+  examples = """
+    Examples:
+      > SELECT _FUNC(col) FROM VALUES (true), (true), (true) AS tab(col)
+       true
+      > SELECT _FUNC(col) FROM VALUES (NULL), (true), (true) AS tab(col)
+       true
+      > SELECT _FUNC(col) FROM VALUES (true), (false), (true) AS tab(col)
+       false
+  """,
   since = "3.0.0")
 case class EveryAgg(arg: Expression) extends UnevaluableBooleanAggBase(arg) {
   override def nodeName: String = "Every"
@@ -49,6 +58,15 @@ case class EveryAgg(arg: Expression) extends UnevaluableBooleanAggBase(arg) {
 
 @ExpressionDescription(
   usage = "_FUNC_(expr) - Returns true if at least one value of `expr` is true.",
+  examples = """
+    Examples:
+      > SELECT _FUNC(col) FROM VALUES (true), (false), (false) AS tab(col)
+       true
+      > SELECT _FUNC(col) FROM VALUES (NULL), (true), (false) AS tab(col)
+       true
+      > SELECT _FUNC(col) FROM VALUES (false), (false), (NULL) AS tab(col)
+       false
+  """,
   since = "3.0.0")
 case class AnyAgg(arg: Expression) extends UnevaluableBooleanAggBase(arg) {
   override def nodeName: String = "Any"
@@ -56,6 +74,15 @@ case class AnyAgg(arg: Expression) extends UnevaluableBooleanAggBase(arg) {
 
 @ExpressionDescription(
   usage = "_FUNC_(expr) - Returns true if at least one value of `expr` is true.",
+  examples = """
+    Examples:
+      > SELECT _FUNC(col) FROM VALUES (true), (false), (false) AS tab(col)
+       true
+      > SELECT _FUNC(col) FROM VALUES (NULL), (true), (false) AS tab(col)
+       true
+      > SELECT _FUNC(col) FROM VALUES (false), (false), (NULL) AS tab(col)
+       false
+  """,
   since = "3.0.0")
 case class SomeAgg(arg: Expression) extends UnevaluableBooleanAggBase(arg) {
   override def nodeName: String = "Some"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/collect.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/collect.scala
@@ -86,7 +86,13 @@ abstract class Collect[T <: Growable[Any] with Iterable[Any]] extends TypedImper
  * Collect a list of elements.
  */
 @ExpressionDescription(
-  usage = "_FUNC_(expr) - Collects and returns a list of non-unique elements.")
+  usage = "_FUNC_(expr) - Collects and returns a list of non-unique elements.",
+  examples = """
+    Examples:
+      > SELECT _FUNC_(col) FROM VALUES (1), (2), (1) AS tab(col);
+       [1,2,1]
+  """,
+  since = "2.0.0")
 case class CollectList(
     child: Expression,
     mutableAggBufferOffset: Int = 0,
@@ -109,7 +115,13 @@ case class CollectList(
  * Collect a set of unique elements.
  */
 @ExpressionDescription(
-  usage = "_FUNC_(expr) - Collects and returns a set of unique elements.")
+  usage = "_FUNC_(expr) - Collects and returns a set of unique elements.",
+  examples = """
+    Examples:
+      > SELECT _FUNC_(col) FROM VALUES (1), (2), (1) AS tab(col);
+       [1,2]
+  """,
+  since = "2.0.0")
 case class CollectSet(
     child: Expression,
     mutableAggBufferOffset: Int = 0,


### PR DESCRIPTION

## What changes were proposed in this pull request?
This improves the expression description for commonly used aggregate functions such as Max, Min, Count, etc.

## How was this patch tested?
Verified the function description manually from the shell.