### PR TITLE
[SPARK-17454][MESOS] Use Mesos disk resources for executors.

### DIFF
--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -702,7 +702,16 @@ See the [configuration page](configuration.html) for information on Spark config
     Set the maximum number GPU resources to acquire for this job. Note that executors will still launch when no GPU resources are found
     since this configuration is just an upper limit and not a guaranteed amount.
   </td>
-  </tr>
+</tr>
+<tr>
+  <td><code>spark.mesos.disk</code></td>
+  <td><code>(none)</code></td>
+  <td>
+    Set the amount of disk to acquire for this job. You might need to set this value depending on the type of disk isolation set up in Mesos.
+    For instance, setting an amount of disk is required when XFS isolator is enabled with hard limit enforced otherwise the isolator will kill
+    the Mesos executor when downloading the Spark executor archive.
+  </td>
+</tr>
 <tr>
   <td><code>spark.mesos.network.name</code></td>
   <td><code>(none)</code></td>

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
@@ -321,6 +321,16 @@ package object config {
       .intConf
       .createWithDefault(0)
 
+  private[spark] val EXECUTOR_DISK =
+    ConfigBuilder("spark.mesos.disk")
+      .doc("Set the amount of disk to acquire for this job. You might need to set this value " +
+        "depending on the type of disk isolation set up in Mesos. For instance, setting an " +
+        "amount of disk is required when XFS isolator is enabled with hard limit enforced " +
+        "otherwise the isolator will kill the Mesos executor when downloading the Spark executor " +
+        "archive.")
+      .intConf
+      .createOptional
+
   private[spark] val TASK_LABELS =
     ConfigBuilder("spark.mesos.task.labels")
       .doc("Set the Mesos labels to add to each task. Labels are free-form key-value pairs. " +

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
@@ -180,6 +180,10 @@ trait MesosSchedulerUtils extends Logging {
     res.asScala.filter(_.getName == name).map(_.getScalar.getValue).sum
   }
 
+  def resourceExists(res: JList[Resource], name: String): Boolean = {
+    res.asScala.exists(_.getName == name)
+  }
+
   /**
    * Transforms a range resource to a list of ranges
    *

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -314,8 +314,8 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
       Utils.createTextAttribute("c2", "b"))
     val offers = List(
       Utils.createOffer("o1", "s1", mem, cpu, None, 0),
-      Utils.createOffer("o2", "s2", mem, cpu, None, 0, s2Attributes),
-      Utils.createOffer("o3", "s3", mem, cpu, None, 0, s3Attributes))
+      Utils.createOffer("o2", "s2", mem, cpu, None, 0, None, s2Attributes),
+      Utils.createOffer("o3", "s3", mem, cpu, None, 0, None, s3Attributes))
 
     def submitDriver(driverConstraints: String): Unit = {
       val response = scheduler.submitDriver(

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/Utils.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/Utils.scala
@@ -50,6 +50,7 @@ object Utils {
                    cpus: Int,
                    ports: Option[(Long, Long)] = None,
                    gpus: Int = 0,
+                   disk: Option[Int] = None,
                    attributes: List[Attribute] = List.empty): Offer = {
     val builder = Offer.newBuilder()
     builder.addResourcesBuilder()
@@ -72,6 +73,12 @@ object Utils {
         .setName("gpus")
         .setType(Value.Type.SCALAR)
         .setScalar(Scalar.newBuilder().setValue(gpus))
+    }
+    if (disk.isDefined) {
+      builder.addResourcesBuilder()
+        .setName("disk")
+        .setType(Value.Type.SCALAR)
+        .setScalar(Scalar.newBuilder().setValue(disk.get))
     }
     builder.setId(createOfferId(offerId))
       .setFrameworkId(FrameworkID.newBuilder()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Before this change, there was no way to allocate a given amount of
disk when using Mesos scheduler. It's good enough when using default isolation
options but not when enabling the XFS isolator with hard limit in order to
properly isolate all containers. In that case, the executor is killed by Mesos
during the download of the Spark executor archive.

Therefore, this change introduces a configuration flag, specific to Mesos, to
declare the amount of disk required by the executors and therefore prevent
Mesos from killing the container because the XFS hard limit has been exceeded.

## How was this patch tested?

I added 3 unit tests and tested my built version of Spark against a real Mesos cluster.
