### PR TITLE
[SPARK-21492][SQL][WIP] Memory leak in SortMergeJoin

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowIterator.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowIterator.java
@@ -18,9 +18,57 @@
 package org.apache.spark.sql.execution;
 
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.Platform;
+import org.apache.spark.util.collection.unsafe.sort.UnsafeSorterIterator;
 import scala.collection.AbstractIterator;
 
-public abstract class UnsafeExternalRowIterator extends AbstractIterator<UnsafeRow> {
+import java.io.Closeable;
+import java.io.IOException;
 
+public abstract class UnsafeExternalRowIterator extends AbstractIterator<UnsafeRow> implements Closeable {
+
+    private final UnsafeSorterIterator sortedIterator;
+    private UnsafeRow row;
+
+    UnsafeExternalRowIterator(StructType schema, UnsafeSorterIterator iterator) {
+        row = new UnsafeRow(schema.length());
+        sortedIterator = iterator;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return sortedIterator.hasNext();
+    }
+
+    @Override
+    public UnsafeRow next() {
+        try {
+            sortedIterator.loadNext();
+            row.pointTo(
+                    sortedIterator.getBaseObject(),
+                    sortedIterator.getBaseOffset(),
+                    sortedIterator.getRecordLength());
+            if (!hasNext()) {
+                UnsafeRow copy = row.copy(); // so that we don't have dangling pointers to freed page
+                row = null; // so that we don't keep references to the base object
+                close();
+                return copy;
+            } else {
+                return row;
+            }
+        } catch (IOException e) {
+            close();
+            // Scala iterators don't declare any checked exceptions, so we need to use this hack
+            // to re-throw the exception:
+            Platform.throwException(e);
+        }
+        throw new RuntimeException("Exception should have been re-thrown in next()");
+    }
+
+    /**
+     * Implementation should clean up resources used by this iterator, to prevent memory leaks
+     */
+    @Override
     public abstract void close();
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowIterator.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowIterator.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution;
+
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
+import scala.collection.AbstractIterator;
+
+public abstract class UnsafeExternalRowIterator extends AbstractIterator<UnsafeRow> {
+
+    public abstract void close();
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowSorter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowSorter.java
@@ -168,43 +168,12 @@ public final class UnsafeExternalRowSorter {
         // here in order to prevent memory leaks.
         cleanupResources();
       }
-      return new UnsafeExternalRowIterator() {
-
-        private final int numFields = schema.length();
-        private UnsafeRow row = new UnsafeRow(numFields);
-
-        @Override
-        public boolean hasNext() {
-          return sortedIterator.hasNext();
-        }
-
-        @Override
-        public UnsafeRow next() {
-          try {
-            sortedIterator.loadNext();
-            row.pointTo(
-              sortedIterator.getBaseObject(),
-              sortedIterator.getBaseOffset(),
-              sortedIterator.getRecordLength());
-            if (!hasNext()) {
-              UnsafeRow copy = row.copy(); // so that we don't have dangling pointers to freed page
-              row = null; // so that we don't keep references to the base object
-              cleanupResources();
-              return copy;
-            } else {
-              return row;
-            }
-          } catch (IOException e) {
-            cleanupResources();
-            // Scala iterators don't declare any checked exceptions, so we need to use this hack
-            // to re-throw the exception:
-            Platform.throwException(e);
-          }
-          throw new RuntimeException("Exception should have been re-thrown in next()");
-        }
+      return new UnsafeExternalRowIterator(schema, sortedIterator) {
 
         @Override
         public void close() {
+          // Caller should clean up resources if the iterator is not consumed in it's entirety,
+          // for example, in a SortMergeJoin.
           cleanupResources();
         }
       };

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowSorter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowSorter.java
@@ -20,7 +20,6 @@ package org.apache.spark.sql.execution;
 import java.io.IOException;
 import java.util.function.Supplier;
 
-import scala.collection.AbstractIterator;
 import scala.collection.Iterator;
 import scala.math.Ordering;
 
@@ -169,7 +168,7 @@ public final class UnsafeExternalRowSorter {
         // here in order to prevent memory leaks.
         cleanupResources();
       }
-      return new AbstractIterator<UnsafeRow>() {
+      return new UnsafeExternalRowIterator() {
 
         private final int numFields = schema.length();
         private UnsafeRow row = new UnsafeRow(numFields);
@@ -202,6 +201,11 @@ public final class UnsafeExternalRowSorter {
             Platform.throwException(e);
           }
           throw new RuntimeException("Exception should have been re-thrown in next()");
+        }
+
+        @Override
+        public void close() {
+          cleanupResources();
         }
       };
     } catch (IOException e) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -1180,13 +1180,15 @@ private class FullOuterIterator(
 
 trait CloseableScanner {
   def closeIterator(iter: RowIterator): Unit = {
-    if (iter.isInstanceOf[RowIteratorFromScala]) {
-      val rowIter = iter.asInstanceOf[RowIteratorFromScala]
-      val underlyingIter = rowIter.toScala
-      if (underlyingIter.isInstanceOf[UnsafeExternalRowIterator]) {
-        val toClose = underlyingIter.asInstanceOf[UnsafeExternalRowIterator]
-        toClose.close()
-      }
+    iter match {
+      case rowIter: RowIteratorFromScala =>
+        val underlyingIter = rowIter.toScala
+        underlyingIter match {
+          case toClose: UnsafeExternalRowIterator =>
+            toClose.close()
+          case _ =>
+        }
+      case _ =>
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

If SortMergeJoinScanner doesn't consume the iterator from
UnsafeExternalRowSorter entirely, the memory that
UnsafeExternalSorter acquired from TaskMemoryManager will not
be released. This leads to a memory leak, spills, and OOME. A
page will be held per partition of the unused iterator.
This patch will allow the SortMergeJoinScanner to explicitly close the iterators (for non-generated code)

## How was this patch tested?

Manual testing and profiling with scripts in SPARK-21492 comments.

