### PR TITLE
[SPARK-26859][SQL] Fix field writer index bug in non-vectorized ORC deserializer

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
@@ -47,8 +47,6 @@ class OrcDeserializer(
       }.toArray
   }
 
-  private val validColIds = requestedColIds.filterNot(_ == -1)
-
   def deserialize(orcStruct: OrcStruct): InternalRow = {
     var fieldWriterIndex = 0
     var targetColumnIndex = 0

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
@@ -50,15 +50,19 @@ class OrcDeserializer(
   private val validColIds = requestedColIds.filterNot(_ == -1)
 
   def deserialize(orcStruct: OrcStruct): InternalRow = {
-    var i = 0
-    while (i < validColIds.length) {
-      val value = orcStruct.getFieldValue(validColIds(i))
-      if (value == null) {
-        resultRow.setNullAt(i)
-      } else {
-        fieldWriters(i)(value)
+    var fieldWriterIndex = 0
+    var targetColumnIndex = 0
+    while (targetColumnIndex < requestedColIds.length) {
+      if (requestedColIds(targetColumnIndex) != -1) {
+        val value = orcStruct.getFieldValue(requestedColIds(targetColumnIndex))
+        if (value == null) {
+          resultRow.setNullAt(targetColumnIndex)
+        } else {
+          fieldWriters(fieldWriterIndex)(value)
+        }
+        fieldWriterIndex += 1
       }
-      i += 1
+      targetColumnIndex += 1
     }
     resultRow
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
@@ -55,7 +55,7 @@ class OrcDeserializer(
 
   def deserialize(orcStruct: OrcStruct): InternalRow = {
     var targetColumnIndex = 0
-    while (targetColumnIndex < requestedColIds.length) {
+    while (targetColumnIndex < fieldWriters.length) {
       if (fieldWriters(targetColumnIndex) != null) {
         var value = orcStruct.getFieldValue(requestedColIds(targetColumnIndex))
         if (value == null) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
@@ -57,7 +57,7 @@ class OrcDeserializer(
     var targetColumnIndex = 0
     while (targetColumnIndex < fieldWriters.length) {
       if (fieldWriters(targetColumnIndex) != null) {
-        var value = orcStruct.getFieldValue(requestedColIds(targetColumnIndex))
+        val value = orcStruct.getFieldValue(requestedColIds(targetColumnIndex))
         if (value == null) {
           resultRow.setNullAt(targetColumnIndex)
         } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ReadSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ReadSchemaSuite.scala
@@ -72,6 +72,7 @@ class HeaderCSVReadSchemaSuite
 
 class JsonReadSchemaSuite
   extends ReadSchemaSuite
+  with AddColumnIntoTheMiddleTest
   with HideColumnInTheMiddleTest
   with ChangePositionTest
   with IntegralTypeTest
@@ -84,6 +85,7 @@ class JsonReadSchemaSuite
 
 class OrcReadSchemaSuite
   extends ReadSchemaSuite
+  with AddColumnIntoTheMiddleTest
   with HideColumnInTheMiddleTest
   with ChangePositionTest {
 
@@ -103,6 +105,7 @@ class OrcReadSchemaSuite
 
 class VectorizedOrcReadSchemaSuite
   extends ReadSchemaSuite
+  with AddColumnIntoTheMiddleTest
   with HideColumnInTheMiddleTest
   with ChangePositionTest
   with BooleanTypeTest
@@ -125,6 +128,7 @@ class VectorizedOrcReadSchemaSuite
 
 class ParquetReadSchemaSuite
   extends ReadSchemaSuite
+  with AddColumnIntoTheMiddleTest
   with HideColumnInTheMiddleTest
   with ChangePositionTest {
 
@@ -144,6 +148,7 @@ class ParquetReadSchemaSuite
 
 class VectorizedParquetReadSchemaSuite
   extends ReadSchemaSuite
+  with AddColumnIntoTheMiddleTest
   with HideColumnInTheMiddleTest
   with ChangePositionTest {
 
@@ -163,6 +168,7 @@ class VectorizedParquetReadSchemaSuite
 
 class MergedParquetReadSchemaSuite
   extends ReadSchemaSuite
+  with AddColumnIntoTheMiddleTest
   with HideColumnInTheMiddleTest
   with ChangePositionTest {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ReadSchemaTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ReadSchemaTest.scala
@@ -69,7 +69,7 @@ trait ReadSchemaTest extends QueryTest with SQLTestUtils with SharedSQLContext {
 }
 
 /**
- * Add column (Case 1).
+ * Add column (Case 1-1).
  * This test suite assumes that the missing column should be `null`.
  */
 trait AddColumnTest extends ReadSchemaTest {
@@ -108,6 +108,9 @@ trait AddColumnTest extends ReadSchemaTest {
   }
 }
 
+/**
+ * Add column into the middle (Case 1-2).
+ */
 trait AddColumnIntoTheMiddleTest extends ReadSchemaTest {
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
@@ -335,12 +335,11 @@ abstract class OrcSuite extends OrcTest with BeforeAndAfterAll {
     }
   }
 
-  test("[SPARK-26859] Reading ORC files with explicit schema can result in wrong data") {
+  test("SPARK-26859 Reading ORC files with explicit schema can result in wrong data") {
     withSQLConf(SQLConf.ORC_VECTORIZED_READER_ENABLED.key -> "false") {
       withTempPath { path =>
-        val rdd = sparkContext.parallelize(Seq((1, 2, "abc"), (4, 5, "def"), (8, 9, null)))
-        val df = rdd.toDF("col1", "col2", "col3")
-        df.write.format("orc").save(path.getCanonicalPath)
+        val df = Seq((1, 2, "abc"), (4, 5, "def"), (8, 9, null)).toDF("col1", "col2", "col3")
+        df.write.orc(path.getCanonicalPath)
         checkAnswer(
           spark.read.schema("col1 int, col4 int, col2 int, col3 string").orc(path.getCanonicalPath),
           Seq(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
@@ -334,23 +334,6 @@ abstract class OrcSuite extends OrcTest with BeforeAndAfterAll {
       assert(version === SPARK_VERSION_SHORT)
     }
   }
-
-  test("SPARK-26859 Reading ORC files with explicit schema can result in wrong data") {
-    withSQLConf(SQLConf.ORC_VECTORIZED_READER_ENABLED.key -> "false") {
-      withTempPath { path =>
-        val df = Seq((1, 2, "abc"), (4, 5, "def"), (8, 9, null)).toDF("col1", "col2", "col3")
-        df.write.orc(path.getCanonicalPath)
-        checkAnswer(
-          spark.read.schema("col1 int, col4 int, col2 int, col3 string").orc(path.getCanonicalPath),
-          Seq(
-            Row(1, null, 2, "abc"),
-            Row(4, null, 5, "def"),
-            Row(8, null, 9, null)
-          )
-        )
-      }
-    }
-  }
 }
 
 class OrcSourceSuite extends OrcSuite with SharedSQLContext {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
@@ -35,8 +35,6 @@ import org.apache.spark.SPARK_VERSION_SHORT
 import org.apache.spark.sql.{Row, SPARK_VERSION_METADATA_KEY}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
-import org.apache.spark.sql.types.{LongType, StringType, StructType}
-import org.apache.spark.sql.types.DataTypes._
 import org.apache.spark.util.Utils
 
 case class OrcData(intField: Int, stringField: String)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This happens in a schema evolution use case only when a user specifies the schema manually and use non-vectorized ORC deserializer code path.

There is a bug in `OrcDeserializer.scala` that results in `null`s being set at the wrong column position, and for state from previous records to remain uncleared in next records. There are more details for when exactly the bug gets triggered and what the outcome is in the [JIRA issue](https://jira.apache.org/jira/browse/SPARK-26859).

The high-level summary is that this bug results in severe data correctness issues, but fortunately the set of conditions to expose the bug are complicated and make the surface area somewhat small.

This change fixes the problem and adds a respective test.

## How was this patch tested?

Pass the Jenkins with the newly added test cases.