### PR TITLE
[SPARK-26865] ORC filter pushdown should be case insensitive by default

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScanBuilder.scala
@@ -52,8 +52,8 @@ case class OrcScanBuilder(
         // changed `hadoopConf` in executors.
         OrcInputFormat.setSearchArgument(hadoopConf, f, schema.fieldNames)
       }
-      val dataTypeMap = schema.map(f => f.name -> f.dataType).toMap
-      _pushedFilters = OrcFilters.convertibleFilters(schema, dataTypeMap, filters).toArray
+      val dataTypeMap = OrcFilters.getNameToTypeMap(schema)
+      _pushedFilters = OrcFilters.convertibleFilters(dataTypeMap, filters).toArray
     }
     filters
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala
@@ -603,6 +603,15 @@ abstract class OrcQueryTest extends OrcTest {
       assert(m4.contains("Malformed ORC file"))
     }
   }
+
+  test("SPARK-26865: case insensitive filter pushdown") {
+    withTempPath { path =>
+      withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
+        spark.range(2).write.orc(path.getCanonicalPath)
+        checkAnswer(spark.read.orc(path.getCanonicalPath).filter('ID > 0), Row(1))
+      }
+    }
+  }
 }
 
 class OrcQuerySuite extends OrcQueryTest with SharedSQLContext {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Like parquet, orc should also respect the case sensitivity config during filter pushdow

## How was this patch tested?

a new test