### PR TITLE
[SPARK-26860][PySpark] Fix for RangeBetween docs appear to be wrong

### DIFF
--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -89,6 +89,9 @@ class Window(object):
         Creates a :class:`WindowSpec` with the frame boundaries defined,
         from `start` (inclusive) to `end` (inclusive).
 
+        Rows Between cares only about the order of rows, and takes fixed number of
+        preceding and following rows when computing frame.
+
         Both `start` and `end` are relative positions from the current row.
         For example, "0" means "current row", while "-1" means the row before
         the current row, and "5" means the fifth row after the current row.
@@ -117,7 +120,8 @@ class Window(object):
     def rangeBetween(start, end):
         """
         Creates a :class:`WindowSpec` with the frame boundaries defined,
-        from `start` (inclusive) to `end` (inclusive).
+        from `start` (inclusive) to `end` (inclusive).Range Between considers values
+        when computing frame.
 
         Both `start` and `end` are relative from the current row. For example,
         "0" means "current row", while "-1" means one off before the current row,


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added the same
ROWS BETWEEN  cares only about the order of rows, and takes fixed number of preceding and following rows when computing frame.
RANGE BETWEEN considers values when computing frame

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
