### PR TITLE
[SPARK-26884][CORE] Let task acquire memory accurately when using spilled memory

### DIFF
--- a/core/src/main/java/org/apache/spark/memory/TaskMemoryManager.java
+++ b/core/src/main/java/org/apache/spark/memory/TaskMemoryManager.java
@@ -178,7 +178,8 @@ public class TaskMemoryManager {
             if (released > 0) {
               logger.debug("Task {} released {} from {} for {}", taskAttemptId,
                 Utils.bytesToString(released), c, consumer);
-              got += memoryManager.acquireExecutionMemory(required - got, taskAttemptId, mode);
+              long memToAcquire = released < required - got ? released : required - got;
+              got += memoryManager.acquireExecutionMemory(memToAcquire, taskAttemptId, mode);
               if (got >= required) {
                 break;
               }
@@ -209,7 +210,8 @@ public class TaskMemoryManager {
           if (released > 0) {
             logger.debug("Task {} released {} from itself ({})", taskAttemptId,
               Utils.bytesToString(released), consumer);
-            got += memoryManager.acquireExecutionMemory(required - got, taskAttemptId, mode);
+            long memToAcquire = released < required - got ? released : required - got;
+            got += memoryManager.acquireExecutionMemory(memToAcquire, taskAttemptId, mode);
           }
         } catch (ClosedByInterruptException e) {
           // This called by user to kill a task (e.g: speculative task).

--- a/core/src/main/java/org/apache/spark/memory/TaskMemoryManager.java
+++ b/core/src/main/java/org/apache/spark/memory/TaskMemoryManager.java
@@ -178,7 +178,7 @@ public class TaskMemoryManager {
             if (released > 0) {
               logger.debug("Task {} released {} from {} for {}", taskAttemptId,
                 Utils.bytesToString(released), c, consumer);
-              long memToAcquire = released < required - got ? released : required - got;
+              long memToAcquire = Math.min(released, required - got);
               got += memoryManager.acquireExecutionMemory(memToAcquire, taskAttemptId, mode);
               if (got >= required) {
                 break;
@@ -210,7 +210,7 @@ public class TaskMemoryManager {
           if (released > 0) {
             logger.debug("Task {} released {} from itself ({})", taskAttemptId,
               Utils.bytesToString(released), consumer);
-            long memToAcquire = released < required - got ? released : required - got;
+            long memToAcquire = Math.min(released, required - got);
             got += memoryManager.acquireExecutionMemory(memToAcquire, taskAttemptId, mode);
           }
         } catch (ClosedByInterruptException e) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When task can't get required execution memory, it will call `spill()` of consumers to release more memory. After spilling, it tries again to acquire memory needed which is `(required - got)`. That's not accurate as actually `released `memory by spilling may not equal to size it try to spill. 
So it may be better to acquire memory in more accurate size :
- when released >= needed, acquire needed size. (`required - got`)
- when released < needed, acquire `released `size.

## How was this patch tested?
Existed unit tests.
