### PR TITLE
[WIP][SPARK-26896] JDK 11 module adjustments for running tests

### DIFF
--- a/mllib/pom.xml
+++ b/mllib/pom.xml
@@ -150,6 +150,21 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <id>JDK11</id>
+      <dependencies>
+        <!-- see https://www.jesperdj.com/2018/09/30/jaxb-on-java-9-10-11-and-beyond/ -->
+        <dependency>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.glassfish.jaxb</groupId>
+          <artifactId>jaxb-runtime</artifactId>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,8 @@
     <spark.test.home>${session.executionRootDirectory}</spark.test.home>
 
     <CodeCacheSize>512m</CodeCacheSize>
+    <!-- with the JDK11 profile, this will be replaces to open modules to reflective access -->
+    <jdk11.module.args></jdk11.module.args>
   </properties>
   <repositories>
     <repository>
@@ -2117,7 +2119,7 @@
               <include>**/*Suite.java</include>
             </includes>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-            <argLine>-ea -Xmx4g -Xss4m -XX:ReservedCodeCacheSize=${CodeCacheSize}</argLine>
+            <argLine>-ea -Xmx3g -Xss4m -XX:ReservedCodeCacheSize=${CodeCacheSize} ${jdk11.module.args}</argLine>
             <environmentVariables>
               <!--
                 Setting SPARK_DIST_CLASSPATH is a simple way to make sure any child processes
@@ -2167,7 +2169,7 @@
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
             <junitxml>.</junitxml>
             <filereports>SparkTestSuite.txt</filereports>
-            <argLine>-ea -Xmx4g -Xss4m -XX:ReservedCodeCacheSize=${CodeCacheSize}</argLine>
+            <argLine>-ea -Xmx3g -Xss4m -XX:ReservedCodeCacheSize=${CodeCacheSize} ${jdk11.module.args}</argLine>
             <stderr/>
             <environmentVariables>
               <!--
@@ -2654,6 +2656,29 @@
           <scope>compile</scope>
         </dependency>
       </dependencies>
+    </profile>
+
+    <profile>
+      <id>JDK11</id>
+      <dependencyManagement>
+        <dependencies>
+          <!-- see https://www.jesperdj.com/2018/09/30/jaxb-on-java-9-10-11-and-beyond/ -->
+          <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+          </dependency>
+          <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.1</version>
+            <scope>runtime</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+      <properties>
+        <jdk11.module.args>--add-opens java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED --illegal-access=warn</jdk11.module.args>
+      </properties>
     </profile>
 
     <!-- Ganglia integration is not included by default due to LGPL-licensed code -->


### PR DESCRIPTION
This adds a JDK11 profile, just intended for running tests.  It adds
extra runtime arguments to the test runners to get around new module
limitations.  This includes:

1) removal of jaxb from java itself (used in pmml export in mllib)

2) Some reflective access which results in failures, eg.

Unable to make field jdk.internal.ref.PhantomCleanable
jdk.internal.ref.PhantomCleanable.prev accessible: module java.base does
not "opens jdk.internal.ref" to unnamed module

3) Some reflective access which results in warnings.