### PR TITLE
[MINOR][DOC] Add note regarding proper usage of QueryExecution.toRdd

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -85,7 +85,14 @@ class QueryExecution(
     prepareForExecution(sparkPlan)
   }
 
-  /** Internal version of the RDD. Avoids copies and has no schema */
+  /**
+   * Internal version of the RDD. Avoids copies and has no schema.
+   * Note for callers: Spark may apply various optimization including reusing object: this means
+   * the row is valid only for the iteration it is retrieved. You should avoid storing row and
+   * accessing after iteration. (Calling `collect()` is one of known bad usage.)
+   * If you want to store these rows into collection, please apply some converter or copy row
+   * which produces new object per iteration.
+   */
   lazy val toRdd: RDD[InternalRow] = executedPlan.execute()
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -92,6 +92,8 @@ class QueryExecution(
    * accessing after iteration. (Calling `collect()` is one of known bad usage.)
    * If you want to store these rows into collection, please apply some converter or copy row
    * which produces new object per iteration.
+   * Given QueryExecution is not a public class, end users are discouraged to use this: please
+   * user `Dataset.rdd` instead which conversion will be applied.
    */
   lazy val toRdd: RDD[InternalRow] = executedPlan.execute()
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -93,7 +93,7 @@ class QueryExecution(
    * If you want to store these rows into collection, please apply some converter or copy row
    * which produces new object per iteration.
    * Given QueryExecution is not a public class, end users are discouraged to use this: please
-   * user `Dataset.rdd` instead which conversion will be applied.
+   * use `Dataset.rdd` instead where conversion will be applied.
    */
   lazy val toRdd: RDD[InternalRow] = executedPlan.execute()
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This proposes adding a note on `QueryExecution.toRdd` regarding Spark's internal optimization callers would need to indicate.

## How was this patch tested?

This patch is a documentation change.