### PR TITLE
[SPARK-26912][CORE][HISTORY] Allow setting permission for event_log

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -83,6 +83,12 @@ package object config {
       .booleanConf
       .createWithDefault(false)
 
+  private[spark] val EVENT_LOG_PERMISSION =
+    ConfigBuilder("spark.eventLog.permission")
+      .doc("Hdfs permission for spark event_log file, especially used in common history server.")
+      .stringConf
+      .createWithDefault("770")
+
   private[spark] val EVENT_LOG_BLOCK_UPDATES =
     ConfigBuilder("spark.eventLog.logBlockUpdates.enabled")
       .booleanConf

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -82,6 +82,10 @@ private[spark] class EventLoggingListener(
     CompressionCodec.getShortName(c.getClass.getName)
   }
 
+  private val eventLogPermission = sparkConf.get(EVENT_LOG_PERMISSION)
+  private val LOG_FILE_PERMISSIONS =
+    new FsPermission(Integer.parseInt(eventLogPermission, 8).toShort)
+
   // Only defined if the file system scheme is not local
   private var hadoopDataStream: Option[FSDataOutputStream] = None
 
@@ -333,8 +337,6 @@ private[spark] object EventLoggingListener extends Logging {
   // Suffix applied to the names of files still being written by applications.
   val IN_PROGRESS = ".inprogress"
   val DEFAULT_LOG_DIR = "/tmp/spark-events"
-
-  private val LOG_FILE_PERMISSIONS = new FsPermission(Integer.parseInt("770", 8).toShort)
 
   // A cache for compression codecs to avoid creating the same codec many times
   private val codecMap = Map.empty[String, CompressionCodec]


### PR DESCRIPTION
## What changes were proposed in this pull request?
Spark_event_log is set to 770 permissions by default. This will be a problem in the following scenarios.
1, the user has some ugis that can not be added to the same group
2, the user, who created applications, does not allow others to see or modifie it, event they are in same group
3, the user allows other ugi to subscribe to information

Thus, we add a new configuration for event_log permission.

## How was this patch tested?
change permission test and unit tests
