### PR TITLE
[SPARK-26935][SQL]Skip DataFrameReader's CSV first line scan when not used

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -508,7 +508,9 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
       sparkSession.sessionState.conf.sessionLocalTimeZone)
     val filteredLines: Dataset[String] =
       CSVUtils.filterCommentAndEmpty(csvDataset, parsedOptions)
-    val maybeFirstLine: Option[String] = filteredLines.take(1).headOption
+    val maybeFirstLine: Option[String] =
+      if (userSpecifiedSchema.isEmpty)
+	filteredLines.take(1).headOption else None
 
     val schema = userSpecifiedSchema.getOrElse {
       TextInputCSVDataSource.inferFromDataset(

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -508,9 +508,14 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
       sparkSession.sessionState.conf.sessionLocalTimeZone)
     val filteredLines: Dataset[String] =
       CSVUtils.filterCommentAndEmpty(csvDataset, parsedOptions)
+    val needsFirstLine: Boolean =
+      userSpecifiedSchema.isEmpty || parsedOptions.headerFlag
     val maybeFirstLine: Option[String] =
-      if (userSpecifiedSchema.isEmpty)
-	filteredLines.take(1).headOption else None
+      if (needsFirstLine) {
+	filteredLines.take(1).headOption 
+      } else {
+	None
+      }
 
     val schema = userSpecifiedSchema.getOrElse {
       TextInputCSVDataSource.inferFromDataset(

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -513,6 +513,8 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
     //   - TextInputCSVDataSource - Only uses firstLine to infer an unspecified schema
     //   - CSVHeaderChecker       - Only uses firstLine to check header, when headerFlag is true
     //   - CSVUtils               - Only uses firstLine to filter headers, when headerFlag is true
+    // (If the downstream logic grows more complicated, consider refactoring to an approach that
+    //  delegates this decision to the constituent consumers themselves.)
     val maybeFirstLine: Option[String] =
       if (userSpecifiedSchema.isEmpty || parsedOptions.headerFlag) {
         filteredLines.take(1).headOption

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -508,13 +508,11 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
       sparkSession.sessionState.conf.sessionLocalTimeZone)
     val filteredLines: Dataset[String] =
       CSVUtils.filterCommentAndEmpty(csvDataset, parsedOptions)
-    val needsFirstLine: Boolean =
-      userSpecifiedSchema.isEmpty || parsedOptions.headerFlag
     val maybeFirstLine: Option[String] =
-      if (needsFirstLine) {
-	filteredLines.take(1).headOption 
+      if (userSpecifiedSchema.isEmpty || parsedOptions.headerFlag) {
+        filteredLines.take(1).headOption
       } else {
-	None
+        None
       }
 
     val schema = userSpecifiedSchema.getOrElse {


### PR DESCRIPTION
Prior to this patch, all DataFrameReader.csv() calls would collect the first
line from the CSV input iterator. This is done to allow schema inference from the
header row.

However when schema is already specified this is a wasteful operation. It results
in an unncessary compute step on the first partition. This can be expensive if
the CSV itself is expensive to generate (e.g. it's the product of a long-running
external pipe()).

This patch short-circuits the first-line collection in DataFrameReader.csv() when
schema is specified. Thereby improving CSV read performance in certain cases.

## What changes were proposed in this pull request?

Short-circuiting DataFrameReader.csv() first-line read when schema is user-specified.

## How was this patch tested?

Compiled and tested against several CSV datasets.