### PR TITLE
[SPARK-26919][Build] change maven default compile java home

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
     -->
     <arrow.version>0.12.0</arrow.version>
 
-    <test.java.home>${java.home}</test.java.home>
+    <test.java.home>${env.JAVA_HOME}</test.java.home>
     <test.exclude.tags></test.exclude.tags>
     <test.include.tags></test.include.tags>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

change maven default compile java home

## How was this patch tested?

${java.home}". I tried the environment of mac os and winodws and found that the default java.home is */jre but the jre environment does not have the javac complie command. So I think it can be replaced with the system environment variable and the test is successfully compiled.

