### PR TITLE
[SPARK-26927][core] Ensure executor is active when processing events in dynamic allocation manager.

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -147,7 +147,8 @@ private[spark] class ExecutorAllocationManager(
   private val executorIds = new mutable.HashSet[String]
 
   // Max number of removed executors to track
-  // Assumes the late events will be correctly handled before the queue capacity reached.
+  // Assumes the late events for the executor will be correctly handled before the removal
+  // of executorId from this queue when it's full.
   private val MAXIMUM_NUM_REMOVED_EXECUTORS = 10000
   // Tracking all known executors that have been removed
   private val removedExecutorIds = new LinkedBlockingQueue[String](MAXIMUM_NUM_REMOVED_EXECUTORS)

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark
 
+import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 
 import scala.collection.mutable
@@ -144,6 +145,12 @@ private[spark] class ExecutorAllocationManager(
 
   // All known executors
   private val executorIds = new mutable.HashSet[String]
+
+  // Max number of removed executors to track
+  // Assumes the late events will be correctly handled before the queue capacity reached.
+  private val MAXIMUM_NUM_REMOVED_EXECUTORS = 10000
+  // Tracking all known executors that have been removed
+  private val removedExecutorIds = new LinkedBlockingQueue[String](MAXIMUM_NUM_REMOVED_EXECUTORS)
 
   // A timestamp of when an addition should be triggered, or NOT_SET if it is not set
   // This is set when pending tasks are added but not scheduled yet
@@ -566,6 +573,13 @@ private[spark] class ExecutorAllocationManager(
     if (executorIds.contains(executorId)) {
       executorIds.remove(executorId)
       removeTimes.remove(executorId)
+      if (!removedExecutorIds.offer(executorId)) {
+        logWarning(s"The queue is full for tracking removed executors, will trim old " +
+          s"executor ids and offer again")
+        val trimSize = math.max(1, removedExecutorIds.size() / 10)
+        (0 to trimSize).foreach(removedExecutorIds.poll())
+        removedExecutorIds.offer(executorId)
+      }
       logInfo(s"Existing executor $executorId has been removed (new total is ${executorIds.size})")
       if (executorsPendingToRemove.contains(executorId)) {
         executorsPendingToRemove.remove(executorId)
@@ -725,10 +739,15 @@ private[spark] class ExecutorAllocationManager(
         if (stageIdToNumRunningTask.contains(stageId)) {
           stageIdToNumRunningTask(stageId) += 1
         }
-        // This guards against the race condition in which the `SparkListenerTaskStart`
-        // event is posted before the `SparkListenerBlockManagerAdded` event, which is
-        // possible because these events are posted in different threads. (see SPARK-4951)
-        if (!allocationManager.executorIds.contains(executorId)) {
+        // This guards against the following race condition:
+        // 1. The `SparkListenerTaskStart` event is posted before the
+        // `SparkListenerExecutorAdded` event
+        // 2. The `SparkListenerExecutorRemoved` event is posted before the
+        // `SparkListenerTaskStart` event
+        // Above cases are possible because these events are posted in different threads.
+        // (see SPARK-4951 SPARK-26927)
+        if (!allocationManager.executorIds.contains(executorId) &&
+          !allocationManager.removedExecutorIds.contains(executorId)) {
           allocationManager.onExecutorAdded(executorId)
         }
 

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -733,7 +733,7 @@ private[spark] class ExecutorAllocationManager(
         // Above cases are possible because these events are posted in different threads.
         // (see SPARK-4951 SPARK-26927)
         if (!allocationManager.executorIds.contains(executorId) &&
-          client.getExecutorIds().contains(executorId)) {
+            client.getExecutorIds().contains(executorId)) {
           allocationManager.onExecutorAdded(executorId)
         }
 

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -421,6 +421,7 @@ class ExecutorAllocationManagerSuite
     // Remove when numExecutorsTarget is the same as the current number of executors
     assert(addExecutors(manager) === 1)
     assert(addExecutors(manager) === 2)
+    (1 to 8).foreach(execId => onExecutorAdded(manager, execId.toString))
     (1 to 8).map { i => createTaskInfo(i, i, s"$i") }.foreach {
       info => post(sc.listenerBus, SparkListenerTaskStart(0, 0, info)) }
     assert(executorIds(manager).size === 8)


### PR DESCRIPTION
## What changes were proposed in this pull request?

There is a race condition in the `ExecutorAllocationManager` that the `SparkListenerExecutorRemoved` event is posted before the `SparkListenerTaskStart` event, which will cause the incorrect result of `executorIds`. Then, when some executor idles, the real executors will be removed even actual executor number is equal to `minNumExecutors` due to the incorrect computation of `newExecutorTotal`(may greater than the `minNumExecutors`), thus may finally causing zero available executors but a wrong positive number of executorIds was kept in memory.

What's more, even the `SparkListenerTaskEnd` event can not make the fake `executorIds` released, because later idle event for the fake executors can not cause the real removal of these executors, as they are already removed and they are not exist in the `executorDataMap`  of `CoaseGrainedSchedulerBackend`, so that the `onExecutorRemoved` method will never be called again.

For details see https://issues.apache.org/jira/browse/SPARK-26927

This PR is to fix this problem.

## How was this patch tested?

existUT and added UT
