### PR TITLE
[SPARK-26938][CORE]fill taskMetrics to SparkListenerTaskEnd Event even though task is failed

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
@@ -346,6 +346,12 @@ private[spark] class AppStatusStore(
 
   private def quantileToString(q: Double): String = math.round(q * 100).toString
 
+  def task(stageId: Int, stageAttemptId: Int, taskId: Long): v1.TaskData = {
+    val stageKey = Array(stageId, stageAttemptId)
+    val indexed = store.view(classOf[TaskDataWrapper]).index("stage").first(stageKey).last(stageKey)
+    indexed.skip(taskId).max(1).asScala.head.toApi
+  }
+
   def taskList(stageId: Int, stageAttemptId: Int, maxTasks: Int): Seq[v1.TaskData] = {
     val stageKey = Array(stageId, stageAttemptId)
     store.view(classOf[TaskDataWrapper]).index("stage").first(stageKey).last(stageKey).reverse()


### PR DESCRIPTION
## What changes were proposed in this pull request?
this commit modify TaskSetManager handleFailedTask: 
  try to retrieve task's taskMetrics from AppStatusStore saved in executor's least heartbeat

## How was this patch tested?
manual tests
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
![image](https://user-images.githubusercontent.com/16742851/53073031-df6a7680-3521-11e9-8b51-03d33f904c04.png)

Please review http://spark.apache.org/contributing.html before opening a pull request.
