### PR TITLE
[SPARK-26949][SS] Prevent 'purge' to remove needed batch files in CompactibleFileStreamLog

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/CompactibleFileStreamLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/CompactibleFileStreamLog.scala
@@ -171,7 +171,7 @@ abstract class CompactibleFileStreamLog[T <: AnyRef : ClassTag](
    * of given parameter, and let CompactibleFileStreamLog handles purging by itself.
    */
   override def purge(thresholdBatchId: Long): Unit = throw new UnsupportedOperationException(
-    s"'purge' might break internal state of CompactibleFileStreamLog hence not supported")
+    s"Cannot purge as it might break internal state.")
 
   /**
    * Compacts all logs before `batchId` plus the provided `logs`, and writes them into the

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/CompactibleFileStreamLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/CompactibleFileStreamLog.scala
@@ -164,6 +164,16 @@ abstract class CompactibleFileStreamLog[T <: AnyRef : ClassTag](
   }
 
   /**
+   * CompactibleFileStreamLog maintains logs by itself, and manual purging might break internal
+   * state, specifically which latest compaction batch is purged.
+   *
+   * To simplify the situation, this method just throws UnsupportedOperationException regardless
+   * of given parameter, and let CompactibleFileStreamLog handles purging by itself.
+   */
+  override def purge(thresholdBatchId: Long): Unit = throw new UnsupportedOperationException(
+    s"'purge' might break internal state of CompactibleFileStreamLog hence not supported")
+
+  /**
    * Compacts all logs before `batchId` plus the provided `logs`, and writes them into the
    * corresponding `batchId` file. It will delete expired files as well if enabled.
    */

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/CompactibleFileStreamLogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/CompactibleFileStreamLogSuite.scala
@@ -246,7 +246,7 @@ class CompactibleFileStreamLogSuite extends SparkFunSuite with SharedSQLContext 
         val exc = intercept[UnsupportedOperationException] {
           compactibleLog.purge(2)
         }
-        assert(exc.getMessage.contains("break internal state of CompactibleFileStreamLog"))
+        assert(exc.getMessage.contains("Cannot purge as it might break internal state"))
 
         // Below line would fail with IllegalStateException if we don't prevent purge:
         // - purge(2) would delete batch 0 and 1 which batch 1 is compaction batch

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/CompactibleFileStreamLogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/CompactibleFileStreamLogSuite.scala
@@ -232,6 +232,29 @@ class CompactibleFileStreamLogSuite extends SparkFunSuite with SharedSQLContext 
       })
   }
 
+  test("prevent removing metadata files via method purge") {
+    withFakeCompactibleFileStreamLog(
+      fileCleanupDelayMs = 10000,
+      defaultCompactInterval = 2,
+      defaultMinBatchesToRetain = 3,
+      compactibleLog => {
+        // compaction batches: 1
+        compactibleLog.add(0, Array("some_path_0"))
+        compactibleLog.add(1, Array("some_path_1"))
+        compactibleLog.add(2, Array("some_path_2"))
+
+        val exc = intercept[UnsupportedOperationException] {
+          compactibleLog.purge(2)
+        }
+        assert(exc.getMessage.contains("breaks internal state of CompactibleFileStreamLog"))
+
+        // Below line would fail with IllegalStateException if we don't prevent purge:
+        // - purge(2) would delete batch 0 and 1 which batch 1 is compaction batch
+        // - allFiles() would read batch 1 (latest compaction) and 2 which batch 1 is deleted
+        compactibleLog.allFiles()
+      })
+  }
+
   private def withFakeCompactibleFileStreamLog(
     fileCleanupDelayMs: Long,
     defaultCompactInterval: Int,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/CompactibleFileStreamLogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/CompactibleFileStreamLogSuite.scala
@@ -246,7 +246,7 @@ class CompactibleFileStreamLogSuite extends SparkFunSuite with SharedSQLContext 
         val exc = intercept[UnsupportedOperationException] {
           compactibleLog.purge(2)
         }
-        assert(exc.getMessage.contains("breaks internal state of CompactibleFileStreamLog"))
+        assert(exc.getMessage.contains("break internal state of CompactibleFileStreamLog"))
 
         // Below line would fail with IllegalStateException if we don't prevent purge:
         // - purge(2) would delete batch 0 and 1 which batch 1 is compaction batch


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch proposes making `purge` in `CompactibleFileStreamLog` to throw `UnsupportedOperationException` to prevent purging necessary batch files, as well as adding javadoc to document its behavior. Actually it would only break when latest compaction batch is requested to be purged, but caller wouldn't be aware of this so safer to just prevent it. 

## How was this patch tested?

Added UT.