### PR TITLE
[SPARK-26979][PYTHON] Add missing string column name support for some SQL functions

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -38,7 +38,7 @@ from pyspark.sql.udf import UserDefinedFunction, _create_udf
 
 
 def _create_name_function(name, doc=""):
-    """ Create a column-name-based function by name"""
+    """ Create a function that takes a column name argument, by name"""
     def _(col):
         sc = SparkContext._active_spark_context
         jc = getattr(sc._jvm.functions, name)(col._jc if isinstance(col, Column) else col)
@@ -49,7 +49,7 @@ def _create_name_function(name, doc=""):
 
 
 def _create_function(name, doc=""):
-    """ Create a column-based function by name"""
+    """ Create a function that takes a Column object, by name"""
     def _(col):
         sc = SparkContext._active_spark_context
         jc = getattr(sc._jvm.functions, name)(_to_java_column(col))
@@ -90,7 +90,6 @@ def _create_window_function(name, doc=''):
     _.__doc__ = 'Window function: ' + doc
     return _
 
-
 _lit_doc = """
     Creates a :class:`Column` of literal value.
 
@@ -98,6 +97,7 @@ _lit_doc = """
     [Row(height=5, spark_user=True)]
     """
 _name_functions = {
+    # name functions take a column name as their argument
     'lit': _lit_doc,
     'col': 'Returns a :class:`Column` based on the given column name.',
     'column': 'Returns a :class:`Column` based on the given column name.',

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -92,10 +92,7 @@ _functions = {
     'asc': 'Returns a sort expression based on the ascending order of the given column name.',
     'desc': 'Returns a sort expression based on the descending order of the given column name.',
 
-    'upper': 'Converts a string expression to upper case.',
-    'lower': 'Converts a string expression to upper case.',
     'sqrt': 'Computes the square root of the specified float value.',
-    'abs': 'Computes the absolute value.',
 
     'max': 'Aggregate function: returns the maximum value of the expression in a group.',
     'min': 'Aggregate function: returns the minimum value of the expression in a group.',
@@ -138,7 +135,6 @@ _functions_1_4 = {
                      as if computed by `java.lang.Math.tanh()`""",
     'toDegrees': '.. note:: Deprecated in 2.1, use :func:`degrees` instead.',
     'toRadians': '.. note:: Deprecated in 2.1, use :func:`radians` instead.',
-    'bitwiseNOT': 'Computes bitwise not.',
 }
 
 _functions_2_4 = {
@@ -576,6 +572,15 @@ def randn(seed=None):
     else:
         jc = sc._jvm.functions.randn()
     return Column(jc)
+
+
+@since(1.3)
+def abs(col):
+    """
+    Computes the absolute value.
+    """
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.functions.abs(_to_java_column(col)))
 
 
 @since(1.5)
@@ -1439,8 +1444,6 @@ _string_functions = {
     'unbase64': 'Decodes a BASE64 encoded string column and returns it as a binary column.',
     'initcap': 'Returns a new string column by converting the first letter of each word to ' +
                'uppercase. Words are delimited by whitespace.',
-    'lower': 'Converts a string column to lower case.',
-    'upper': 'Converts a string column to upper case.',
     'ltrim': 'Trim the spaces from left end for the specified string value.',
     'rtrim': 'Trim the spaces from right end for the specified string value.',
     'trim': 'Trim the spaces from both ends for the specified string column.',
@@ -1450,6 +1453,24 @@ _string_functions = {
 for _name, _doc in _string_functions.items():
     globals()[_name] = since(1.5)(_create_function(_name, _doc))
 del _name, _doc
+
+
+@since(1.3)
+def lower(col):
+    """
+    Converts a string column to lower case.
+    """
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.functions.lower(_to_java_column(col)))
+
+
+@since(1.3)
+def upper(col):
+    """
+    Converts a string column to upper case.
+    """
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.functions.upper(_to_java_column(col)))
 
 
 @since(1.5)
@@ -1753,6 +1774,15 @@ def bin(col):
     sc = SparkContext._active_spark_context
     jc = sc._jvm.functions.bin(_to_java_column(col))
     return Column(jc)
+
+
+@since(1.4)
+def bitwiseNOT(col):
+    """
+    Computes bitwise not.
+    """
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.functions.bitwiseNOT(_to_java_column(col)))
 
 
 @ignore_unicode_prefix

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1438,22 +1438,6 @@ def hash(*cols):
 
 # ---------------------- String/Binary functions ------------------------------
 
-_string_functions = {
-    'ascii': 'Computes the numeric value of the first character of the string column.',
-    'base64': 'Computes the BASE64 encoding of a binary column and returns it as a string column.',
-    'unbase64': 'Decodes a BASE64 encoded string column and returns it as a binary column.',
-    'initcap': 'Returns a new string column by converting the first letter of each word to ' +
-               'uppercase. Words are delimited by whitespace.',
-    'ltrim': 'Trim the spaces from left end for the specified string value.',
-    'rtrim': 'Trim the spaces from right end for the specified string value.',
-    'trim': 'Trim the spaces from both ends for the specified string column.',
-}
-
-
-for _name, _doc in _string_functions.items():
-    globals()[_name] = since(1.5)(_create_function(_name, _doc))
-del _name, _doc
-
 
 @since(1.3)
 def lower(col):
@@ -1471,6 +1455,60 @@ def upper(col):
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.upper(_to_java_column(col)))
+
+
+@since(1.5)
+def ltrim(col):
+    """
+    Trim the spaces from left end for the specified string value.
+    """
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.functions.ltrim(_to_java_column(col)))
+
+
+@since(1.5)
+def rtrim(col):
+    """
+    Trim the spaces from right end for the specified string value.
+    """
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.functions.rtrim(_to_java_column(col)))
+
+
+@since(1.5)
+def trim(col):
+    """
+    Trim the spaces from both ends for the specified string column.
+    """
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.functions.trim(_to_java_column(col)))
+
+
+@since(1.5)
+def ascii(col):
+    """
+    Computes the numeric value of the first character of the string column.
+    """
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.functions.ascii(_to_java_column(col)))
+
+
+@since(1.5)
+def base64(col):
+    """
+    Computes the BASE64 encoding of a binary column and returns it as a string column.
+    """
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.functions.base64(_to_java_column(col)))
+
+
+@since(1.5)
+def unbase64(col):
+    """
+    Decodes a BASE64 encoded string column and returns it as a binary column.
+    """
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.functions.unbase64(_to_java_column(col)))
 
 
 @since(1.5)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Most SQL functions defined in `spark.sql.functions` have two calling patterns, one with a Column object as input, and another with a string representing a column name, which is then converted into a Column object internally.

There are, however, a few notable exceptions:

- lower()
- upper()
- abs()
- bitwiseNOT()
- ltrim()
- rtrim()
- trim()
- ascii()
- base64()
- unbase64()

While this doesn't break anything, as you can easily create a Column object yourself prior to passing it to one of these functions, it has two undesirable consequences:

1. It is surprising - it breaks coder's expectations when they are first starting with Spark. Every API should be as consistent as possible, so as to make the learning curve smoother and to reduce causes for human error;

2. It gets in the way of stylistic conventions. Most of the time it makes Python code more readable to use literal names, and the API provides ample support for that, but these few exceptions prevent this pattern from being universally applicable.

This patch is meant to fix the aforementioned problem.

### Effect

This patch **enables** support for passing column names as input to those functions mentioned above.

### Side effects

This PR also **fixes** an issue with some functions being defined multiple times by using `_create_function()`.

### How it works

`_create_function()` was redefined to always convert the argument to a Column object. The old implementation has been kept under `_create_name_function()`, and is still being used to generate the following special functions:

- lit()
- col()
- column()
- asc()
- desc()
- asc_nulls_first()
- asc_nulls_last()
- desc_nulls_first()
- desc_nulls_last()

This is because these functions can only take a column name as their argument. This is not a problem, as their semantics require so.

## How was this patch tested?

Ran ./dev/run-tests and tested it manually.