### PR TITLE
[SPARK-26987][SQL] Add a new method to RowFactory: Row with schema

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/RowFactory.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/RowFactory.java
@@ -19,6 +19,8 @@ package org.apache.spark.sql;
 
 import org.apache.spark.annotation.Stable;
 import org.apache.spark.sql.catalyst.expressions.GenericRow;
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
+import org.apache.spark.sql.types.StructType;
 
 /**
  * A factory class used to construct {@link Row} objects.
@@ -36,5 +38,18 @@ public class RowFactory {
    */
   public static Row create(Object ... values) {
     return new GenericRow(values);
+  }
+
+  /**
+   * Create a {@link Row} from the given arguments. Provided schema is incorporated into
+   * created {@link Row} object, and allows getAs(fieldName) to access the value of column.
+   *
+   * Note that every Rows will contain the duplicated schema, hence in high volume it is still
+   * recommended to use `create` with accessing column by position.
+   *
+   * @since 3.0.0
+   */
+  public static Row createWithSchema(StructType schema, Object ... values) {
+    return new GenericRowWithSchema(values, schema);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch proposes to expose an official approach for Java API to create a Row with schema.

## How was this patch tested?

This only exposes the way to leverage existing class in official API, hence no UT added.
Manually tested against below query:

```
SparkSession sparkSession = SparkSession.builder().master("local").getOrCreate();
StructType inSchema = DataTypes.createStructType(
        new StructField[] {
                DataTypes.createStructField("id", DataTypes.StringType      , false),
                DataTypes.createStructField("ts", DataTypes.TimestampType   , false),
                DataTypes.createStructField("f1", DataTypes.LongType        , true)
        }
);
Dataset<Row> rawSet = sparkSession.sqlContext().readStream()
        .format("rate")
        .option("rowsPerSecond", 1)
        .load()
        .map(   (MapFunction<Row, Row>) raw -> {
                    Object[] fields = new Object[3];
                    fields[0] = "id1";
                    fields[1] = raw.getAs("timestamp");
                    fields[2] = raw.getAs("value");
                    return RowFactory.createWithSchema(inSchema, fields);
                },
                RowEncoder.apply(inSchema)
        )
        .filter((FilterFunction<Row>) row -> !row.getAs("f1").equals(0L))
        .withWatermark("ts", "10 seconds");

StreamingQuery streamingQuery = rawSet
        .select("*")
        .writeStream()
        .format("console")
        .outputMode("append")
        .start();

try {
    streamingQuery.awaitTermination(30_000);
} catch (StreamingQueryException e) {
    System.out.println("Caught exception at 'awaitTermination':");
    e.printStackTrace();
}
```

If we change the map function to `return RowFactory.create(fields);`, filter function fails.