### PR TITLE
[MINOR] Exclude core dump file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ target/
 unit-tests.log
 work/
 docs/.jekyll-metadata
+hs_err_pid*.log
 
 # For Hive
 TempStatsStore/


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch proposes excluding core dump files to `.gitignore`, which files could be generated mostly dealing with SQL module. When SQL module developers want to just add whole directory to the git stage, these files bother them.

## How was this patch tested?

Placed `sql/core/hs_err_pid15014.log` and verified after the change the file is excluded to untracked files.