### PR TITLE
[SPARK-26969][SQL] Using ODBC client not able to see the query data when column datatype is decimal

### DIFF
--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkThriftServerProtocolVersionsSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkThriftServerProtocolVersionsSuite.scala
@@ -186,8 +186,7 @@ class SparkThriftServerProtocolVersionsSuite extends HiveThriftJdbcTest {
       }
     }
 
-    // TODO: enable this test case after SPARK-28463 and SPARK-26969
-    ignore(s"$version get decimal type") {
+    test(s"$version get decimal type") {
       testExecuteStatementWithProtocolVersion(version,
         "SELECT cast(1 as decimal(18, 2)) as c") { rs =>
         assert(rs.next())

--- a/sql/hive-thriftserver/v1.2.1/src/main/java/org/apache/hive/service/cli/ColumnValue.java
+++ b/sql/hive-thriftserver/v1.2.1/src/main/java/org/apache/hive/service/cli/ColumnValue.java
@@ -23,7 +23,6 @@ import java.sql.Date;
 import java.sql.Timestamp;
 
 import org.apache.hadoop.hive.common.type.HiveChar;
-import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.common.type.HiveIntervalDayTime;
 import org.apache.hadoop.hive.common.type.HiveIntervalYearMonth;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
@@ -138,14 +137,6 @@ public class ColumnValue {
       tStringValue.setValue(value.toString());
     }
     return TColumnValue.stringVal(tStringValue);
-  }
-
-  private static TColumnValue stringValue(HiveDecimal value) {
-    TStringValue tStrValue = new TStringValue();
-    if (value != null) {
-      tStrValue.setValue(value.toString());
-    }
-    return TColumnValue.stringVal(tStrValue);
   }
 
   private static TColumnValue stringValue(HiveIntervalYearMonth value) {

--- a/sql/hive-thriftserver/v1.2.1/src/main/java/org/apache/hive/service/cli/ColumnValue.java
+++ b/sql/hive-thriftserver/v1.2.1/src/main/java/org/apache/hive/service/cli/ColumnValue.java
@@ -195,7 +195,7 @@ public class ColumnValue {
     case INTERVAL_DAY_TIME_TYPE:
       return stringValue((HiveIntervalDayTime) value);
     case DECIMAL_TYPE:
-      return getDecimalType(value);
+      return stringValue(((BigDecimal)value).toPlainString());
     case BINARY_TYPE:
       String strVal = value == null ? null : UTF8String.fromBytes((byte[])value).toString();
       return stringValue(strVal);
@@ -210,14 +210,6 @@ public class ColumnValue {
     default:
       return null;
     }
-  }
-
-  private static TColumnValue getDecimalType(Object value) {
-    Object decV = value;
-    if (value instanceof BigDecimal) {
-      decV = HiveDecimal.create((BigDecimal) decV);
-    }
-    return stringValue(((HiveDecimal) decV));
   }
 
   private static Boolean getBooleanValue(TBoolValue tBoolValue) {

--- a/sql/hive-thriftserver/v1.2.1/src/main/java/org/apache/hive/service/cli/ColumnValue.java
+++ b/sql/hive-thriftserver/v1.2.1/src/main/java/org/apache/hive/service/cli/ColumnValue.java
@@ -195,7 +195,7 @@ public class ColumnValue {
     case INTERVAL_DAY_TIME_TYPE:
       return stringValue((HiveIntervalDayTime) value);
     case DECIMAL_TYPE:
-      return stringValue(((HiveDecimal)value));
+      return getDecimalType(value);
     case BINARY_TYPE:
       String strVal = value == null ? null : UTF8String.fromBytes((byte[])value).toString();
       return stringValue(strVal);
@@ -210,6 +210,14 @@ public class ColumnValue {
     default:
       return null;
     }
+  }
+
+  private static TColumnValue getDecimalType(Object value) {
+    Object decV = value;
+    if (value instanceof BigDecimal) {
+      decV = HiveDecimal.create((BigDecimal) decV);
+    }
+    return stringValue(((HiveDecimal) decV));
   }
 
   private static Boolean getBooleanValue(TBoolValue tBoolValue) {

--- a/sql/hive-thriftserver/v2.3.5/src/main/java/org/apache/hive/service/cli/ColumnValue.java
+++ b/sql/hive-thriftserver/v2.3.5/src/main/java/org/apache/hive/service/cli/ColumnValue.java
@@ -199,7 +199,7 @@ public class ColumnValue {
     case INTERVAL_DAY_TIME_TYPE:
       return stringValue((HiveIntervalDayTime) value);
     case DECIMAL_TYPE:
-      return stringValue((HiveDecimal)value, typeDescriptor);
+      stringValue(((BigDecimal)value).toPlainString());
     case BINARY_TYPE:
       String strVal = value == null ? null : UTF8String.fromBytes((byte[])value).toString();
       return stringValue(strVal);

--- a/sql/hive-thriftserver/v2.3.5/src/main/java/org/apache/hive/service/cli/ColumnValue.java
+++ b/sql/hive-thriftserver/v2.3.5/src/main/java/org/apache/hive/service/cli/ColumnValue.java
@@ -23,7 +23,6 @@ import java.sql.Date;
 import java.sql.Timestamp;
 
 import org.apache.hadoop.hive.common.type.HiveChar;
-import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.common.type.HiveIntervalDayTime;
 import org.apache.hadoop.hive.common.type.HiveIntervalYearMonth;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
@@ -141,15 +140,6 @@ public class ColumnValue {
     return TColumnValue.stringVal(tStringValue);
   }
 
-  private static TColumnValue stringValue(HiveDecimal value, TypeDescriptor typeDescriptor) {
-    TStringValue tStrValue = new TStringValue();
-    if (value != null) {
-      int scale = typeDescriptor.getDecimalDigits();
-      tStrValue.setValue(value.toFormatString(scale));
-    }
-    return TColumnValue.stringVal(tStrValue);
-  }
-
   private static TColumnValue stringValue(HiveIntervalYearMonth value) {
     TStringValue tStrValue = new TStringValue();
     if (value != null) {
@@ -199,7 +189,7 @@ public class ColumnValue {
     case INTERVAL_DAY_TIME_TYPE:
       return stringValue((HiveIntervalDayTime) value);
     case DECIMAL_TYPE:
-      stringValue(((BigDecimal)value).toPlainString());
+      return stringValue(((BigDecimal)value).toPlainString());
     case BINARY_TYPE:
       String strVal = value == null ? null : UTF8String.fromBytes((byte[])value).toString();
       return stringValue(strVal);


### PR DESCRIPTION
## What changes were proposed in this pull request?
While processing the Rowdata in the server side ColumnValue BigDecimal type value processed by server has to converted to the HiveDecmal data type for successful processing of query using Hive ODBC client.As per current logic  corresponding to the Decimal column datatype, the Spark server uses BigDecimal, and the ODBC client uses HiveDecimal. If the data type does not match, the client fail to parse

Since this handing was missing the query executed in Hive ODBC client wont return or provides result to the user even though the decimal type column value data present.

## How was this patch tested?

Manual test report and impact assessment is done using existing test-cases

Before fix 
![decimal_odbc](https://user-images.githubusercontent.com/12999161/53440179-e74a7f00-3a29-11e9-93db-83f2ae37ef16.PNG)

After Fix
![hive_odbc](https://user-images.githubusercontent.com/12999161/53679519-70e0a200-3cf3-11e9-9437-9c27d2e5056d.PNG)

