### PR TITLE
[SPARK-27003] [MINOR][DOC]Default value of spark.executor.instances is applicable…

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -270,7 +270,7 @@ To use a custom metrics.properties for the application master and executors, upd
  <td><code>spark.executor.instances</code></td>
   <td><code>2</code></td>
   <td>
-    The number of executors for static allocation. With <code>spark.dynamicAllocation.enabled</code>, the initial set of executors will be at least this large.
+    The number of executors for static allocation. With <code>spark.dynamicAllocation.enabled</code>, the initial set of executors will be at least this large. Default value for static allocation is 2, whereas in dynamic allocation, is 0.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
… for static allocation case. 

## What changes were proposed in this pull request?
Default value of spark.executor.instances is applicable for static allocation case. In dynamic allocation, default value is taken as 0, if not set. Need to update the document clearly to avoid ambiguous warning for the end users.

(Please fill in changes proposed in this fix)
Updated doc

