### PR TITLE
[SPARK-21029][SS] StreamingQuery should be stopped when the SparkSession is stopped

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -89,7 +89,7 @@ class SparkContext(config: SparkConf) extends Logging {
     new AtomicReference[State](SparkContext.State.INITIAL)
 
   private[spark] def assertNotStopped(): Unit = {
-    if (state.get() == SparkContext.State.STOPPED) {
+    if (isStopped) {
       val activeContext = SparkContext.activeContext.get()
       val activeCreationSite =
         if (activeContext == null) {
@@ -245,8 +245,7 @@ class SparkContext(config: SparkConf) extends Logging {
    * @return true if context is stopped or in the midst of stopping.
    */
   def isStopped: Boolean = {
-    val curState = state.get()
-    curState == SparkContext.State.STOPPING || curState == SparkContext.State.STOPPED
+    state.get() == SparkContext.State.STOPPED
   }
 
   private[spark] def statusStore: AppStatusStore = _statusStore

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -811,7 +811,7 @@ private[spark] class TaskSchedulerImpl(
     }
     while (!backend.isReady) {
       // Might take a while for backend to be ready if it is waiting on resources.
-      if (sc.stopped.get) {
+      if (sc.isStopped) {
         // For example: the master removes the application for some reason
         throw new IllegalStateException("Spark context stopped while waiting for backend")
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -723,6 +723,7 @@ class SparkSession private(
    * @since 2.0.0
    */
   def stop(): Unit = {
+    stopStreamingQueries()
     sparkContext.stop()
   }
 
@@ -740,6 +741,20 @@ class SparkSession private(
    */
   protected[sql] def parseDataType(dataTypeString: String): DataType = {
     DataType.fromJson(dataTypeString)
+  }
+
+  /**
+   * Stops all active streaming queries
+   */
+  private def stopStreamingQueries(): Unit = {
+    streams.active.foreach { query =>
+      try {
+        query.stop()
+      } catch {
+        case NonFatal(e) =>
+          logError(s"Exception while stopping query ${query.id}", e)
+      }
+    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -725,12 +725,12 @@ class SparkSession private(
    * @since 2.0.0
    */
   def stop(): Unit = {
-    if (!stopped.compareAndSet(false, true)) {
+    if (stopped.compareAndSet(false, true)) {
+      stopStreamingQueries()
+      sparkContext.stop()
+    } else {
       logInfo("SparkSession already stopped.")
-      return
     }
-    stopStreamingQueries()
-    sparkContext.stop()
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryStopSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryStopSuite.scala
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.streaming
+
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.sql.{Dataset, Encoder, SparkSession}
+import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.apache.spark.sql.test.{SQLTestUtilsBase, TestSparkSession}
+
+class StreamingQueryStopSuite extends SparkFunSuite with SQLTestUtilsBase with BeforeAndAfterEach {
+
+  import testImplicits._
+
+  private var session: SparkSession = _
+
+  override protected def spark: SparkSession = session
+
+  test("Stopping spark session should stop underlying query") {
+    val input = MemoryStream[Int](implicitly[Encoder[Int]], spark.sqlContext)
+    val q = startQuery(input.toDS(), "q1")
+    assert(q.isActive)
+    assert(q.exception.isEmpty)
+    input.addData(1, 2, 3)
+    q.processAllAvailable()
+    spark.stop()
+    assert(!q.isActive)
+    assert(q.exception.isEmpty)
+  }
+
+  test("Stopping spark session should stop all the streaming queries") {
+    val input1 = MemoryStream[Int](implicitly[Encoder[Int]], spark.sqlContext)
+    val input2 = MemoryStream[Int](implicitly[Encoder[Int]], spark.sqlContext)
+    val q1 = startQuery(input1.toDS(), "q1")
+    val q2 = startQuery(input2.toDS(), "q2")
+    assert(q1.isActive)
+    assert(q1.exception.isEmpty)
+    assert(q2.isActive)
+    assert(q2.exception.isEmpty)
+    input1.addData(1, 2, 3)
+    input2.addData(1, 3, 5)
+    q1.processAllAvailable()
+    q2.processAllAvailable()
+    spark.stop()
+    assert(!q1.isActive)
+    assert(!q2.isActive)
+    assert(q1.exception.isEmpty)
+    assert(q2.exception.isEmpty)
+  }
+
+  test("Stopping spark context should stop all the streaming queries") {
+    val input1 = MemoryStream[Int](implicitly[Encoder[Int]], spark.sqlContext)
+    val input2 = MemoryStream[Int](implicitly[Encoder[Int]], spark.sqlContext)
+    val q1 = startQuery(input1.toDS(), "q1")
+    val q2 = startQuery(input2.toDS(), "q2")
+    input1.addData(1, 2, 3)
+    input2.addData(1, 3, 5)
+    q1.processAllAvailable()
+    q2.processAllAvailable()
+    sparkContext.stop()
+    assert(!q1.isActive)
+    assert(!q2.isActive)
+    assert(q1.exception.isEmpty)
+    assert(q2.exception.isEmpty)
+  }
+
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    session = new TestSparkSession(new SparkConf())
+  }
+
+  override protected def afterEach(): Unit = {
+    super.afterEach()
+    session.stop()
+    SparkSession.clearActiveSession()
+    SparkSession.clearDefaultSession()
+  }
+
+  private def startQuery(ds: Dataset[Int], name: String): StreamingQuery = {
+    ds.writeStream
+      .queryName(name)
+      .format("memory")
+      .start()
+  }
+}

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -109,7 +109,7 @@ object HiveThriftServer2 extends Logging {
       }
       // If application was killed before HiveThriftServer2 start successfully then SparkSubmit
       // process can not exit, so check whether if SparkContext was stopped.
-      if (SparkSQLEnv.sparkContext.stopped.get()) {
+      if (SparkSQLEnv.sparkContext.isStopped) {
         logError("SparkContext has stopped even if HiveServer2 has started, so exit")
         System.exit(-1)
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch proposes to stop the underlying streaming queries when a spark session is stopped.

Without this, the streaming query continues to run and fails with exception during the next trigger.

For E.g.
```
val lines = spark.readStream.format("socket").option("host", "localhost").option("port", "9999").load()
lines.writeStream.format("console").start
...
> send some input
...
spark.stop
...
> send more input
...
```
The job fails with exception

## How was this patch tested?

Tested manually. Would add unit tests once I receive feedback on the approach.

Please review http://spark.apache.org/contributing.html before opening a pull request.
