### PR TITLE
[SPARK-26872][STREAMING] Use a configurable value for final termination in the JobScheduler.stop() method

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1266,4 +1266,10 @@ package object config {
     .doc("Staging directory used while submitting applications.")
     .stringConf
     .createOptional
+
+  private[spark] val STREAMING_JOB_TIMEOUT =
+    ConfigBuilder("spark.streaming.jobTimeout")
+      .doc("Waiting time for the queued streaming jobs to complete.")
+      .timeConf(TimeUnit.HOURS)
+      .createWithDefaultString("1h")
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR provides user to set the spark.streaming.jobTimeout, After that it will terminate forcefully.

## How was this patch tested?
Tested manually

