### PR TITLE
[SPARK-27023][K8S] Make k8s client timeouts configurable

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -990,6 +990,52 @@ See the [configuration page](configuration.html) for information on Spark config
   Specify whether executor pods should be deleted in case of failure or normal termination.
   </td>
 </tr>
+<tr>
+  <td><code>spark.kubernetes.kubernetesClient.submission.connectionTimeout</code></td>
+  <td>10000</td>
+  <td>
+    Connection timeout in milliseconds for the kubernetes client to use for starting the driver. In client mode, use
+    <code>spark.kubernetes.kubernetesClient.connectionTimeout</code> instead.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.kubernetes.kubernetesClient.submission.requestTimeout</code></td>
+  <td>10000</td>
+  <td>
+    Request timeout in milliseconds for the kubernetes client to use for starting the driver. In client mode, use
+    <code>spark.kubernetes.kubernetesClient.submission.requestTimeout</code> instead.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.kubernetes.kubernetesClient.driver.connectionTimeout</code></td>
+  <td>10000</td>
+  <td>
+    Connection timeout in milliseconds for the kubernetes client in driver to use when requesting executors.
+    In client mode, use <code>spark.kubernetes.kubernetesClient.connectionTimeout</code> instead.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.kubernetes.kubernetesClient.driver.requestTimeout</code></td>
+  <td>10000</td>
+  <td>
+    Request timeout in milliseconds for the kubernetes client in driver to use when requesting executors.
+    In client mode, use <code>spark.kubernetes.kubernetesClient.connectionTimeout</code> instead.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.kubernetes.kubernetesClient.connectionTimeout</code></td>
+  <td>10000</td>
+  <td>
+    In client mode, connection timeout in milliseconds for the kubernetes client in driver to use when requesting executors.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.kubernetes.kubernetesClient.requestTimeout</code></td>
+  <td>10000</td>
+  <td>
+    In client mode, request timeout in milliseconds for the kubernetes client in driver to use when requesting executors.
+  </td>
+</tr>
 </table>
 
 #### Pod template properties

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -991,49 +991,31 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
 </tr>
 <tr>
-  <td><code>spark.kubernetes.kubernetesClient.submission.connectionTimeout</code></td>
+  <td><code>spark.kubernetes.submission.connectionTimeout</code></td>
   <td>10000</td>
   <td>
-    Connection timeout in milliseconds for the kubernetes client to use for starting the driver. In client mode, use
-    <code>spark.kubernetes.kubernetesClient.connectionTimeout</code> instead.
+    Connection timeout in milliseconds for the kubernetes client to use for starting the driver.
   </td>
 </tr>
 <tr>
-  <td><code>spark.kubernetes.kubernetesClient.submission.requestTimeout</code></td>
+  <td><code>spark.kubernetes.submission.requestTimeout</code></td>
   <td>10000</td>
   <td>
-    Request timeout in milliseconds for the kubernetes client to use for starting the driver. In client mode, use
-    <code>spark.kubernetes.kubernetesClient.submission.requestTimeout</code> instead.
+    Request timeout in milliseconds for the kubernetes client to use for starting the driver.
   </td>
 </tr>
 <tr>
-  <td><code>spark.kubernetes.kubernetesClient.driver.connectionTimeout</code></td>
+  <td><code>spark.kubernetes.driver.connectionTimeout</code></td>
   <td>10000</td>
   <td>
     Connection timeout in milliseconds for the kubernetes client in driver to use when requesting executors.
-    In client mode, use <code>spark.kubernetes.kubernetesClient.connectionTimeout</code> instead.
   </td>
 </tr>
 <tr>
-  <td><code>spark.kubernetes.kubernetesClient.driver.requestTimeout</code></td>
+  <td><code>spark.kubernetes.driver.requestTimeout</code></td>
   <td>10000</td>
   <td>
     Request timeout in milliseconds for the kubernetes client in driver to use when requesting executors.
-    In client mode, use <code>spark.kubernetes.kubernetesClient.connectionTimeout</code> instead.
-  </td>
-</tr>
-<tr>
-  <td><code>spark.kubernetes.kubernetesClient.connectionTimeout</code></td>
-  <td>10000</td>
-  <td>
-    In client mode, connection timeout in milliseconds for the kubernetes client in driver to use when requesting executors.
-  </td>
-</tr>
-<tr>
-  <td><code>spark.kubernetes.kubernetesClient.requestTimeout</code></td>
-  <td>10000</td>
-  <td>
-    In client mode, request timeout in milliseconds for the kubernetes client in driver to use when requesting executors.
   </td>
 </tr>
 </table>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -75,12 +75,6 @@ private[spark] object Config extends Logging {
       .toSequence
       .createWithDefault(Nil)
 
-  val SUBMISSION_CLIENT_PREFIX =
-      "spark.kubernetes.kubernetesClient.submission"
-  val DRIVER_CLIENT_PREFIX =
-      "spark.kubernetes.kubernetesClient.driver"
-  val CLIENT_MODE_CLIENT_PREFIX =
-      "spark.kubernetes.kubernetesClient"
   val KUBERNETES_AUTH_DRIVER_CONF_PREFIX =
       "spark.kubernetes.authenticate.driver"
   val KUBERNETES_AUTH_DRIVER_MOUNTED_CONF_PREFIX =
@@ -91,41 +85,39 @@ private[spark] object Config extends Logging {
   val CLIENT_KEY_FILE_CONF_SUFFIX = "clientKeyFile"
   val CLIENT_CERT_FILE_CONF_SUFFIX = "clientCertFile"
   val CA_CERT_FILE_CONF_SUFFIX = "caCertFile"
-  val REQUEST_TIMEOUT_SUFFIX = "requestTimeout"
-  val CONNECTION_TIMEOUT_SUFFIX = "connectionTimeout"
 
   val SUBMISSION_CLIENT_REQUEST_TIMEOUT =
-    ConfigBuilder(s"$SUBMISSION_CLIENT_PREFIX.$REQUEST_TIMEOUT_SUFFIX")
+    ConfigBuilder(s"spark.kubernetes.kubernetesClient.submission.requestTimeout")
       .doc("request timeout to be used in milliseconds for starting the driver")
       .intConf
       .createWithDefault(10000)
 
   val SUBMISSION_CLIENT_CONNECTION_TIMEOUT =
-    ConfigBuilder(s"$SUBMISSION_CLIENT_PREFIX.$CONNECTION_TIMEOUT_SUFFIX")
+    ConfigBuilder(s"spark.kubernetes.kubernetesClient.submission.connectionTimeout")
       .doc("connection timeout to be used in milliseconds for starting the driver")
       .intConf
       .createWithDefault(10000)
 
   val DRIVER_CLIENT_REQUEST_TIMEOUT =
-    ConfigBuilder(s"$DRIVER_CLIENT_PREFIX.$REQUEST_TIMEOUT_SUFFIX")
+    ConfigBuilder(s"spark.kubernetes.kubernetesClient.driver.requestTimeout")
       .doc("request timeout to be used in milliseconds for requesting executors")
       .intConf
       .createWithDefault(10000)
 
   val DRIVER_CLIENT_CONNECTION_TIMEOUT =
-    ConfigBuilder(s"$DRIVER_CLIENT_PREFIX.$CONNECTION_TIMEOUT_SUFFIX")
+    ConfigBuilder(s"spark.kubernetes.kubernetesClient.driver.connectionTimeout")
       .doc("connection timeout to be used in milliseconds for requesting executors")
       .intConf
       .createWithDefault(10000)
 
   val CLIENT_MODE_CLIENT_REQUEST_TIMEOUT =
-    ConfigBuilder(s"$CLIENT_MODE_CLIENT_PREFIX.$REQUEST_TIMEOUT_SUFFIX")
+    ConfigBuilder(s"spark.kubernetes.kubernetesClient.requestTimeout")
       .doc("request timeout to be used in milliseconds for requesting executors in client mode")
       .intConf
       .createWithDefault(10000)
 
   val CLIENT_MODE_CLIENT_CONNECTION_TIMEOUT =
-    ConfigBuilder(s"$CLIENT_MODE_CLIENT_PREFIX.$CONNECTION_TIMEOUT_SUFFIX")
+    ConfigBuilder(s"spark.kubernetes.kubernetesClient.connectionTimeout")
       .doc("connection timeout to be used in milliseconds for requesting executors in client mode")
       .intConf
       .createWithDefault(10000)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -75,6 +75,12 @@ private[spark] object Config extends Logging {
       .toSequence
       .createWithDefault(Nil)
 
+  val SUBMISSION_CLIENT_PREFIX =
+      "spark.kubernetes.kubernetesClient.submission"
+  val DRIVER_CLIENT_PREFIX =
+      "spark.kubernetes.kubernetesClient.driver"
+  val CLIENT_MODE_CLIENT_PREFIX =
+      "spark.kubernetes.kubernetesClient"
   val KUBERNETES_AUTH_DRIVER_CONF_PREFIX =
       "spark.kubernetes.authenticate.driver"
   val KUBERNETES_AUTH_DRIVER_MOUNTED_CONF_PREFIX =
@@ -85,6 +91,9 @@ private[spark] object Config extends Logging {
   val CLIENT_KEY_FILE_CONF_SUFFIX = "clientKeyFile"
   val CLIENT_CERT_FILE_CONF_SUFFIX = "clientCertFile"
   val CA_CERT_FILE_CONF_SUFFIX = "caCertFile"
+  val REQUEST_TIMEOUT_SUFFIX = "requestTimeout"
+  val CONNECTION_TIMEOUT_SUFFIX = "connectionTimeout"
+
 
   val KUBERNETES_SERVICE_ACCOUNT_NAME =
     ConfigBuilder(s"$KUBERNETES_AUTH_DRIVER_CONF_PREFIX.serviceAccountName")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -94,6 +94,41 @@ private[spark] object Config extends Logging {
   val REQUEST_TIMEOUT_SUFFIX = "requestTimeout"
   val CONNECTION_TIMEOUT_SUFFIX = "connectionTimeout"
 
+  val SUBMISSION_CLIENT_REQUEST_TIMEOUT =
+    ConfigBuilder(s"$SUBMISSION_CLIENT_PREFIX.$REQUEST_TIMEOUT_SUFFIX")
+      .doc("request timeout to be used in milliseconds for starting the driver")
+      .intConf
+      .createWithDefault(10000)
+
+  val SUBMISSION_CLIENT_CONNECTION_TIMEOUT =
+    ConfigBuilder(s"$SUBMISSION_CLIENT_PREFIX.$CONNECTION_TIMEOUT_SUFFIX")
+      .doc("connection timeout to be used in milliseconds for starting the driver")
+      .intConf
+      .createWithDefault(10000)
+
+  val DRIVER_CLIENT_REQUEST_TIMEOUT =
+    ConfigBuilder(s"$DRIVER_CLIENT_PREFIX.$REQUEST_TIMEOUT_SUFFIX")
+      .doc("request timeout to be used in milliseconds for requesting executors")
+      .intConf
+      .createWithDefault(10000)
+
+  val DRIVER_CLIENT_CONNECTION_TIMEOUT =
+    ConfigBuilder(s"$DRIVER_CLIENT_PREFIX.$CONNECTION_TIMEOUT_SUFFIX")
+      .doc("connection timeout to be used in milliseconds for requesting executors")
+      .intConf
+      .createWithDefault(10000)
+
+  val CLIENT_MODE_CLIENT_REQUEST_TIMEOUT =
+    ConfigBuilder(s"$CLIENT_MODE_CLIENT_PREFIX.$REQUEST_TIMEOUT_SUFFIX")
+      .doc("request timeout to be used in milliseconds for requesting executors in client mode")
+      .intConf
+      .createWithDefault(10000)
+
+  val CLIENT_MODE_CLIENT_CONNECTION_TIMEOUT =
+    ConfigBuilder(s"$CLIENT_MODE_CLIENT_PREFIX.$CONNECTION_TIMEOUT_SUFFIX")
+      .doc("connection timeout to be used in milliseconds for requesting executors in client mode")
+      .intConf
+      .createWithDefault(10000)
 
   val KUBERNETES_SERVICE_ACCOUNT_NAME =
     ConfigBuilder(s"$KUBERNETES_AUTH_DRIVER_CONF_PREFIX.serviceAccountName")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -100,13 +100,13 @@ private[spark] object Config extends Logging {
 
   val DRIVER_CLIENT_REQUEST_TIMEOUT =
     ConfigBuilder("spark.kubernetes.driver.requestTimeout")
-      .doc("request timeout to be used in milliseconds for requesting executors")
+      .doc("request timeout to be used in milliseconds for driver to request executors")
       .intConf
       .createWithDefault(10000)
 
   val DRIVER_CLIENT_CONNECTION_TIMEOUT =
     ConfigBuilder("spark.kubernetes.driver.connectionTimeout")
-      .doc("connection timeout to be used in milliseconds for requesting executors")
+      .doc("connection timeout to be used in milliseconds for driver to request executors")
       .intConf
       .createWithDefault(10000)
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -87,37 +87,37 @@ private[spark] object Config extends Logging {
   val CA_CERT_FILE_CONF_SUFFIX = "caCertFile"
 
   val SUBMISSION_CLIENT_REQUEST_TIMEOUT =
-    ConfigBuilder(s"spark.kubernetes.kubernetesClient.submission.requestTimeout")
+    ConfigBuilder("spark.kubernetes.kubernetesClient.submission.requestTimeout")
       .doc("request timeout to be used in milliseconds for starting the driver")
       .intConf
       .createWithDefault(10000)
 
   val SUBMISSION_CLIENT_CONNECTION_TIMEOUT =
-    ConfigBuilder(s"spark.kubernetes.kubernetesClient.submission.connectionTimeout")
+    ConfigBuilder("spark.kubernetes.kubernetesClient.submission.connectionTimeout")
       .doc("connection timeout to be used in milliseconds for starting the driver")
       .intConf
       .createWithDefault(10000)
 
   val DRIVER_CLIENT_REQUEST_TIMEOUT =
-    ConfigBuilder(s"spark.kubernetes.kubernetesClient.driver.requestTimeout")
+    ConfigBuilder("spark.kubernetes.kubernetesClient.driver.requestTimeout")
       .doc("request timeout to be used in milliseconds for requesting executors")
       .intConf
       .createWithDefault(10000)
 
   val DRIVER_CLIENT_CONNECTION_TIMEOUT =
-    ConfigBuilder(s"spark.kubernetes.kubernetesClient.driver.connectionTimeout")
+    ConfigBuilder("spark.kubernetes.kubernetesClient.driver.connectionTimeout")
       .doc("connection timeout to be used in milliseconds for requesting executors")
       .intConf
       .createWithDefault(10000)
 
   val CLIENT_MODE_CLIENT_REQUEST_TIMEOUT =
-    ConfigBuilder(s"spark.kubernetes.kubernetesClient.requestTimeout")
+    ConfigBuilder("spark.kubernetes.kubernetesClient.requestTimeout")
       .doc("request timeout to be used in milliseconds for requesting executors in client mode")
       .intConf
       .createWithDefault(10000)
 
   val CLIENT_MODE_CLIENT_CONNECTION_TIMEOUT =
-    ConfigBuilder(s"spark.kubernetes.kubernetesClient.connectionTimeout")
+    ConfigBuilder("spark.kubernetes.kubernetesClient.connectionTimeout")
       .doc("connection timeout to be used in milliseconds for requesting executors in client mode")
       .intConf
       .createWithDefault(10000)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -87,38 +87,26 @@ private[spark] object Config extends Logging {
   val CA_CERT_FILE_CONF_SUFFIX = "caCertFile"
 
   val SUBMISSION_CLIENT_REQUEST_TIMEOUT =
-    ConfigBuilder("spark.kubernetes.kubernetesClient.submission.requestTimeout")
+    ConfigBuilder("spark.kubernetes.submission.requestTimeout")
       .doc("request timeout to be used in milliseconds for starting the driver")
       .intConf
       .createWithDefault(10000)
 
   val SUBMISSION_CLIENT_CONNECTION_TIMEOUT =
-    ConfigBuilder("spark.kubernetes.kubernetesClient.submission.connectionTimeout")
+    ConfigBuilder("spark.kubernetes.submission.connectionTimeout")
       .doc("connection timeout to be used in milliseconds for starting the driver")
       .intConf
       .createWithDefault(10000)
 
   val DRIVER_CLIENT_REQUEST_TIMEOUT =
-    ConfigBuilder("spark.kubernetes.kubernetesClient.driver.requestTimeout")
+    ConfigBuilder("spark.kubernetes.driver.requestTimeout")
       .doc("request timeout to be used in milliseconds for requesting executors")
       .intConf
       .createWithDefault(10000)
 
   val DRIVER_CLIENT_CONNECTION_TIMEOUT =
-    ConfigBuilder("spark.kubernetes.kubernetesClient.driver.connectionTimeout")
+    ConfigBuilder("spark.kubernetes.driver.connectionTimeout")
       .doc("connection timeout to be used in milliseconds for requesting executors")
-      .intConf
-      .createWithDefault(10000)
-
-  val CLIENT_MODE_CLIENT_REQUEST_TIMEOUT =
-    ConfigBuilder("spark.kubernetes.kubernetesClient.requestTimeout")
-      .doc("request timeout to be used in milliseconds for requesting executors in client mode")
-      .intConf
-      .createWithDefault(10000)
-
-  val CLIENT_MODE_CLIENT_CONNECTION_TIMEOUT =
-    ConfigBuilder("spark.kubernetes.kubernetesClient.connectionTimeout")
-      .doc("connection timeout to be used in milliseconds for requesting executors in client mode")
       .intConf
       .createWithDefault(10000)
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
@@ -124,7 +124,6 @@ private[spark] object SparkKubernetesClientFactory extends Logging {
     import Config._
     val Driver = Val(DRIVER_CLIENT_REQUEST_TIMEOUT, DRIVER_CLIENT_CONNECTION_TIMEOUT)
     val Submission = Val(SUBMISSION_CLIENT_REQUEST_TIMEOUT, SUBMISSION_CLIENT_CONNECTION_TIMEOUT)
-    val ClientMode = Val(CLIENT_MODE_CLIENT_REQUEST_TIMEOUT, CLIENT_MODE_CLIENT_CONNECTION_TIMEOUT)
 
     protected case class Val(
         requestTimeoutEntry: ConfigEntry[Int],

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
@@ -67,8 +67,6 @@ private[spark] object SparkKubernetesClientFactory extends Logging {
       .getOption(s"$kubernetesAuthConfPrefix.$CLIENT_KEY_FILE_CONF_SUFFIX")
     val clientCertFile = sparkConf
       .getOption(s"$kubernetesAuthConfPrefix.$CLIENT_CERT_FILE_CONF_SUFFIX")
-    val requestTimeout = clientType.requestTimeout(sparkConf)
-    val connectionTimeout = clientType.connectionTimeout(sparkConf)
     val dispatcher = new Dispatcher(
       ThreadUtils.newDaemonCachedThreadPool("kubernetes-dispatcher"))
 
@@ -85,8 +83,8 @@ private[spark] object SparkKubernetesClientFactory extends Logging {
       .withApiVersion("v1")
       .withMasterUrl(master)
       .withWebsocketPingInterval(0)
-      .withRequestTimeout(requestTimeout)
-      .withConnectionTimeout(connectionTimeout)
+      .withRequestTimeout(clientType.requestTimeout(sparkConf))
+      .withConnectionTimeout(clientType.connectionTimeout(sparkConf))
       .withOption(oauthTokenValue) {
         (token, configBuilder) => configBuilder.withOauthToken(token)
       }.withOption(oauthTokenFile) {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
@@ -118,7 +118,6 @@ private[spark] object SparkKubernetesClientFactory extends Logging {
 
   object ClientType extends Enumeration {
     import scala.language.implicitConversions
-    import Config._
     val Driver = Val(DRIVER_CLIENT_REQUEST_TIMEOUT, DRIVER_CLIENT_CONNECTION_TIMEOUT)
     val Submission = Val(SUBMISSION_CLIENT_REQUEST_TIMEOUT, SUBMISSION_CLIENT_CONNECTION_TIMEOUT)
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
@@ -18,8 +18,6 @@ package org.apache.spark.deploy.k8s
 
 import java.io.File
 
-import scala.language.implicitConversions
-
 import com.google.common.base.Charsets
 import com.google.common.io.Files
 import io.fabric8.kubernetes.client.{ConfigBuilder, DefaultKubernetesClient, KubernetesClient}
@@ -119,6 +117,7 @@ private[spark] object SparkKubernetesClientFactory extends Logging {
   }
 
   object ClientType extends Enumeration {
+    import scala.language.implicitConversions
     import Config._
     val Driver = Val(DRIVER_CLIENT_REQUEST_TIMEOUT, DRIVER_CLIENT_CONNECTION_TIMEOUT)
     val Submission = Val(SUBMISSION_CLIENT_REQUEST_TIMEOUT, SUBMISSION_CLIENT_CONNECTION_TIMEOUT)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
@@ -220,6 +220,7 @@ private[spark] class KubernetesClientApplication extends SparkApplication {
       master,
       Some(kubernetesConf.namespace),
       KUBERNETES_AUTH_SUBMISSION_CONF_PREFIX,
+      SUBMISSION_CLIENT_PREFIX,
       sparkConf,
       None,
       None)) { kubernetesClient =>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
@@ -220,7 +220,7 @@ private[spark] class KubernetesClientApplication extends SparkApplication {
       master,
       Some(kubernetesConf.namespace),
       KUBERNETES_AUTH_SUBMISSION_CONF_PREFIX,
-      SUBMISSION_CLIENT_PREFIX,
+      SparkKubernetesClientFactory.ClientType.Submission,
       sparkConf,
       None,
       None)) { kubernetesClient =>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
@@ -44,7 +44,7 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
       scheduler: TaskScheduler): SchedulerBackend = {
     val wasSparkSubmittedInClusterMode = sc.conf.get(KUBERNETES_DRIVER_SUBMIT_CHECK)
     val (authConfPrefix,
-      clientConfPrefix,
+      clientType,
       apiServerUri,
       defaultServiceAccountToken,
       defaultServiceAccountCaCrt) = if (wasSparkSubmittedInClusterMode) {
@@ -52,13 +52,13 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
         "If the application is deployed using spark-submit in cluster mode, the driver pod name " +
           "must be provided.")
       (KUBERNETES_AUTH_DRIVER_MOUNTED_CONF_PREFIX,
-        DRIVER_CLIENT_PREFIX,
+        SparkKubernetesClientFactory.ClientType.Driver,
         KUBERNETES_MASTER_INTERNAL_URL,
         Some(new File(Config.KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH)),
         Some(new File(Config.KUBERNETES_SERVICE_ACCOUNT_CA_CRT_PATH)))
     } else {
       (KUBERNETES_AUTH_CLIENT_MODE_PREFIX,
-        CLIENT_MODE_CLIENT_PREFIX,
+        SparkKubernetesClientFactory.ClientType.ClientMode,
         KubernetesUtils.parseMasterUrl(masterURL),
         None,
         None)
@@ -68,7 +68,7 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
       apiServerUri,
       Some(sc.conf.get(KUBERNETES_NAMESPACE)),
       authConfPrefix,
-      clientConfPrefix,
+      clientType,
       sc.conf,
       defaultServiceAccountToken,
       defaultServiceAccountCaCrt)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
@@ -44,7 +44,6 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
       scheduler: TaskScheduler): SchedulerBackend = {
     val wasSparkSubmittedInClusterMode = sc.conf.get(KUBERNETES_DRIVER_SUBMIT_CHECK)
     val (authConfPrefix,
-      clientType,
       apiServerUri,
       defaultServiceAccountToken,
       defaultServiceAccountCaCrt) = if (wasSparkSubmittedInClusterMode) {
@@ -52,13 +51,11 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
         "If the application is deployed using spark-submit in cluster mode, the driver pod name " +
           "must be provided.")
       (KUBERNETES_AUTH_DRIVER_MOUNTED_CONF_PREFIX,
-        SparkKubernetesClientFactory.ClientType.Driver,
         KUBERNETES_MASTER_INTERNAL_URL,
         Some(new File(Config.KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH)),
         Some(new File(Config.KUBERNETES_SERVICE_ACCOUNT_CA_CRT_PATH)))
     } else {
       (KUBERNETES_AUTH_CLIENT_MODE_PREFIX,
-        SparkKubernetesClientFactory.ClientType.Driver,
         KubernetesUtils.parseMasterUrl(masterURL),
         None,
         None)
@@ -68,7 +65,7 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
       apiServerUri,
       Some(sc.conf.get(KUBERNETES_NAMESPACE)),
       authConfPrefix,
-      clientType,
+      SparkKubernetesClientFactory.ClientType.Driver,
       sc.conf,
       defaultServiceAccountToken,
       defaultServiceAccountCaCrt)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
@@ -58,7 +58,7 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
         Some(new File(Config.KUBERNETES_SERVICE_ACCOUNT_CA_CRT_PATH)))
     } else {
       (KUBERNETES_AUTH_CLIENT_MODE_PREFIX,
-        SparkKubernetesClientFactory.ClientType.ClientMode,
+        SparkKubernetesClientFactory.ClientType.Driver,
         KubernetesUtils.parseMasterUrl(masterURL),
         None,
         None)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
@@ -44,6 +44,7 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
       scheduler: TaskScheduler): SchedulerBackend = {
     val wasSparkSubmittedInClusterMode = sc.conf.get(KUBERNETES_DRIVER_SUBMIT_CHECK)
     val (authConfPrefix,
+      clientConfPrefix,
       apiServerUri,
       defaultServiceAccountToken,
       defaultServiceAccountCaCrt) = if (wasSparkSubmittedInClusterMode) {
@@ -51,11 +52,13 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
         "If the application is deployed using spark-submit in cluster mode, the driver pod name " +
           "must be provided.")
       (KUBERNETES_AUTH_DRIVER_MOUNTED_CONF_PREFIX,
+        DRIVER_CLIENT_PREFIX,
         KUBERNETES_MASTER_INTERNAL_URL,
         Some(new File(Config.KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH)),
         Some(new File(Config.KUBERNETES_SERVICE_ACCOUNT_CA_CRT_PATH)))
     } else {
       (KUBERNETES_AUTH_CLIENT_MODE_PREFIX,
+        CLIENT_MODE_CLIENT_PREFIX,
         KubernetesUtils.parseMasterUrl(masterURL),
         None,
         None)
@@ -65,6 +68,7 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
       apiServerUri,
       Some(sc.conf.get(KUBERNETES_NAMESPACE)),
       authConfPrefix,
+      clientConfPrefix,
       sc.conf,
       defaultServiceAccountToken,
       defaultServiceAccountCaCrt)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make k8s client timeouts configurable. No test suite exists for the client factory class, happy to add one if needed
