### PR TITLE
[MINOR][DOC] Updated PySpark Binarizer docstring to match Scala's.

### DIFF
--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -86,9 +86,9 @@ class Binarizer(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, Java
     """
 
     threshold = Param(Params._dummy(), "threshold",
-                      "Param for threshold used to binarize continuous features. " + 
-"The features greater than the threshold will be binarized to 1.0. " +  
-"The features equal to or less than the threshold will be binarized to 0.0",
+                      "Param for threshold used to binarize continuous features. " +
+		      "The features greater than the threshold will be binarized to 1.0. " +
+		      "The features equal to or less than the threshold will be binarized to 0.0",
                       typeConverter=TypeConverters.toFloat)
 
     @keyword_only

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -86,9 +86,9 @@ class Binarizer(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, Java
     """
 
     threshold = Param(Params._dummy(), "threshold",
-                      "Param for threshold used to binarize continuous features.
-The features greater than the threshold will be binarized to 1.0. 
-The features equal to or less than the threshold will be binarized to 0.0",
+                      "Param for threshold used to binarize continuous features. " + 
+"The features greater than the threshold will be binarized to 1.0. " +  
+"The features equal to or less than the threshold will be binarized to 0.0",
                       typeConverter=TypeConverters.toFloat)
 
     @keyword_only

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -87,8 +87,8 @@ class Binarizer(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, Java
 
     threshold = Param(Params._dummy(), "threshold",
                       "Param for threshold used to binarize continuous features. " +
-		      "The features greater than the threshold will be binarized to 1.0. " +
-		      "The features equal to or less than the threshold will be binarized to 0.0",
+                      "The features greater than the threshold will be binarized to 1.0. " +
+                      "The features equal to or less than the threshold will be binarized to 0.0",
                       typeConverter=TypeConverters.toFloat)
 
     @keyword_only

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -86,7 +86,7 @@ class Binarizer(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, Java
     """
 
     threshold = Param(Params._dummy(), "threshold",
-                      "threshold in binary classification prediction, in range [0, 1]",
+                      "Param for threshold used to binarize continuous features. The features greater than the threshold will be binarized to 1.0. The features equal to or less than the threshold will be binarized to 0.0",
                       typeConverter=TypeConverters.toFloat)
 
     @keyword_only

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -86,7 +86,9 @@ class Binarizer(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, Java
     """
 
     threshold = Param(Params._dummy(), "threshold",
-                      "Param for threshold used to binarize continuous features. The features greater than the threshold will be binarized to 1.0. The features equal to or less than the threshold will be binarized to 0.0",
+                      "Param for threshold used to binarize continuous features.
+The features greater than the threshold will be binarized to 1.0. 
+The features equal to or less than the threshold will be binarized to 0.0",
                       typeConverter=TypeConverters.toFloat)
 
     @keyword_only


### PR DESCRIPTION
## What changes were proposed in this pull request?

PySpark's Binarizer docstring had two issues:
1) The values did not need to be in the range [0, 1].
2) It can be used for binary classification prediction.

This change corrects both of these issues by making it consistent with Scala's docstring for Binarizer. 

## How was this patch tested?

Not applicable because I only changed the docstring. But if I need to do any testing, let me know and I'll do it.

Please review http://spark.apache.org/contributing.html before opening a pull request.
