### PR TITLE
[SPARK-27031][SQL] Avoid double formatting in timestampToString

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -233,7 +233,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
   @inline private[this] def buildCast[T](a: Any, func: T => Any): Any = func(a.asInstanceOf[T])
 
   private lazy val dateFormatter = DateFormatter()
-  private lazy val timestampFormatter = TimestampFormatter(timeZone)
+  private lazy val timestampFormatter = TimestampFormatter.getFractionFormatter(timeZone)
 
   // UDFToString
   private[this] def castToString(from: DataType): Any => Any = from match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
@@ -62,10 +62,24 @@ private object DateTimeFormatterHelper {
     .maximumSize(128)
     .build[(String, Locale), DateTimeFormatter]()
 
+  private def appendPattern(pattern: String): DateTimeFormatterBuilder = {
+    val builder = new DateTimeFormatterBuilder().parseCaseInsensitive()
+
+    if (pattern == TimestampFormatter.fractionPattern) {
+      builder
+        .append(DateTimeFormatter.ISO_LOCAL_DATE)
+        .appendLiteral(' ')
+        .appendValue(ChronoField.HOUR_OF_DAY, 2).appendLiteral(':')
+        .appendValue(ChronoField.MINUTE_OF_HOUR, 2).appendLiteral(':')
+        .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+        .appendFraction(ChronoField.NANO_OF_SECOND, 1, 6, true)
+    } else {
+      builder.appendPattern(pattern)
+    }
+  }
+
   def buildFormatter(pattern: String, locale: Locale): DateTimeFormatter = {
-    new DateTimeFormatterBuilder()
-      .parseCaseInsensitive()
-      .appendPattern(pattern)
+    appendPattern(pattern)
       .parseDefaulting(ChronoField.ERA, 1)
       .parseDefaulting(ChronoField.MONTH_OF_YEAR, 1)
       .parseDefaulting(ChronoField.DAY_OF_MONTH, 1)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
@@ -61,26 +61,13 @@ private object DateTimeFormatterHelper {
   val cache = CacheBuilder.newBuilder()
     .maximumSize(128)
     .build[(String, Locale), DateTimeFormatter]()
-  val fractionPattern = "fraction-pattern"
 
-  private def appendPattern(pattern: String): DateTimeFormatterBuilder = {
-    val builder = new DateTimeFormatterBuilder().parseCaseInsensitive()
-
-    if (pattern == fractionPattern) {
-      builder
-        .append(DateTimeFormatter.ISO_LOCAL_DATE)
-        .appendLiteral(' ')
-        .appendValue(ChronoField.HOUR_OF_DAY, 2).appendLiteral(':')
-        .appendValue(ChronoField.MINUTE_OF_HOUR, 2).appendLiteral(':')
-        .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
-        .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
-    } else {
-      builder.appendPattern(pattern)
-    }
+  def createBuilder(): DateTimeFormatterBuilder = {
+    new DateTimeFormatterBuilder().parseCaseInsensitive()
   }
 
-  def buildFormatter(pattern: String, locale: Locale): DateTimeFormatter = {
-    appendPattern(pattern)
+  def toFormatter(builder: DateTimeFormatterBuilder, locale: Locale): DateTimeFormatter = {
+    builder
       .parseDefaulting(ChronoField.ERA, 1)
       .parseDefaulting(ChronoField.MONTH_OF_YEAR, 1)
       .parseDefaulting(ChronoField.DAY_OF_MONTH, 1)
@@ -89,5 +76,21 @@ private object DateTimeFormatterHelper {
       .toFormatter(locale)
       .withChronology(IsoChronology.INSTANCE)
       .withResolverStyle(ResolverStyle.STRICT)
+  }
+
+  def buildFormatter(pattern: String, locale: Locale): DateTimeFormatter = {
+    val builder = createBuilder().appendPattern(pattern)
+    toFormatter(builder, locale)
+  }
+
+  lazy val fractionFormatter: DateTimeFormatter = {
+    val builder = createBuilder()
+      .append(DateTimeFormatter.ISO_LOCAL_DATE)
+      .appendLiteral(' ')
+      .appendValue(ChronoField.HOUR_OF_DAY, 2).appendLiteral(':')
+      .appendValue(ChronoField.MINUTE_OF_HOUR, 2).appendLiteral(':')
+      .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+      .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+    toFormatter(builder, TimestampFormatter.defaultLocale)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
@@ -61,11 +61,12 @@ private object DateTimeFormatterHelper {
   val cache = CacheBuilder.newBuilder()
     .maximumSize(128)
     .build[(String, Locale), DateTimeFormatter]()
+  val fractionPattern = "fraction-pattern"
 
   private def appendPattern(pattern: String): DateTimeFormatterBuilder = {
     val builder = new DateTimeFormatterBuilder().parseCaseInsensitive()
 
-    if (pattern == TimestampFormatter.fractionPattern) {
+    if (pattern == fractionPattern) {
       builder
         .append(DateTimeFormatter.ISO_LOCAL_DATE)
         .appendLiteral(' ')

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
@@ -72,7 +72,7 @@ private object DateTimeFormatterHelper {
         .appendValue(ChronoField.HOUR_OF_DAY, 2).appendLiteral(':')
         .appendValue(ChronoField.MINUTE_OF_HOUR, 2).appendLiteral(':')
         .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
-        .appendFraction(ChronoField.NANO_OF_SECOND, 1, 6, true)
+        .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
     } else {
       builder.appendPattern(pattern)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -99,15 +99,7 @@ object DateTimeUtils {
 
   // Converts Timestamp to string according to Hive TimestampWritable convention.
   def timestampToString(tf: TimestampFormatter, us: SQLTimestamp): String = {
-    val ts = toJavaTimestamp(us)
-    val timestampString = ts.toString
-    val formatted = tf.format(us)
-
-    if (timestampString.length > 19 && timestampString.substring(19) != ".0") {
-      formatted + timestampString.substring(19)
-    } else {
-      formatted
-    }
+    tf.format(us)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
@@ -82,8 +82,7 @@ object TimestampFormatter {
     apply(defaultPattern, timeZone, defaultLocale)
   }
 
-  val fractionPattern = "fraction-pattern"
   def getFractionFormatter(timeZone: TimeZone): TimestampFormatter = {
-    apply(fractionPattern, timeZone, defaultLocale)
+    apply(DateTimeFormatterHelper.fractionPattern, timeZone, defaultLocale)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
@@ -81,4 +81,9 @@ object TimestampFormatter {
   def apply(timeZone: TimeZone): TimestampFormatter = {
     apply(defaultPattern, timeZone, defaultLocale)
   }
+
+  val fractionPattern = "fraction-pattern"
+  def getFractionFormatter(timeZone: TimeZone): TimestampFormatter = {
+    apply(fractionPattern, timeZone, defaultLocale)
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
@@ -66,6 +66,14 @@ class Iso8601TimestampFormatter(
   }
 }
 
+/**
+ * The formatter parses/formats timestamps according to the pattern `yyyy-MM-dd HH:mm:ss.[..fff..]`
+ * where `[..fff..]` is a fraction of second up to microsecond resolution. The formatter does not
+ * output trailing zeros in the fraction. For example, the timestamp `2019-03-05 15:00:01.123400` is
+ * formatted as the string `2019-03-05 15:00:01.1234`.
+ *
+ * @param timeZone the time zone in which the formatter parses or format timestamps
+ */
 class FractionTimestampFormatter(timeZone: TimeZone)
   extends Iso8601TimestampFormatter("", timeZone, TimestampFormatter.defaultLocale) {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
@@ -47,7 +47,7 @@ class Iso8601TimestampFormatter(
     timeZone: TimeZone,
     locale: Locale) extends TimestampFormatter with DateTimeFormatterHelper {
   @transient
-  private lazy val formatter = getOrCreateFormatter(pattern, locale)
+  protected lazy val formatter = getOrCreateFormatter(pattern, locale)
 
   private def toInstant(s: String): Instant = {
     val temporalAccessor = formatter.parse(s)
@@ -64,6 +64,13 @@ class Iso8601TimestampFormatter(
     val instant = DateTimeUtils.microsToInstant(us)
     formatter.withZone(timeZone.toZoneId).format(instant)
   }
+}
+
+class FractionTimestampFormatter(timeZone: TimeZone)
+  extends Iso8601TimestampFormatter("", timeZone, TimestampFormatter.defaultLocale) {
+
+  @transient
+  override protected lazy val formatter = DateTimeFormatterHelper.fractionFormatter
 }
 
 object TimestampFormatter {
@@ -83,6 +90,6 @@ object TimestampFormatter {
   }
 
   def getFractionFormatter(timeZone: TimeZone): TimestampFormatter = {
-    apply(DateTimeFormatterHelper.fractionPattern, timeZone, defaultLocale)
+    new FractionTimestampFormatter(timeZone)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -33,7 +33,7 @@ class DateTimeUtilsSuite extends SparkFunSuite {
   private def defaultTz = DateTimeUtils.defaultTimeZone()
 
   test("nanoseconds truncation") {
-    val tf = TimestampFormatter(DateTimeUtils.defaultTimeZone())
+    val tf = TimestampFormatter.getFractionFormatter(DateTimeUtils.defaultTimeZone())
     def checkStringToTimestamp(originalTime: String, expectedParsedTime: String) {
       val parsedTimestampOp = DateTimeUtils.stringToTimestamp(
         UTF8String.fromString(originalTime), defaultTz)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/TimestampFormatterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/TimestampFormatterSuite.scala
@@ -120,10 +120,10 @@ class TimestampFormatterSuite extends SparkFunSuite with SQLHelper {
 
   test("format fraction of second") {
     val formatter = TimestampFormatter.getFractionFormatter(TimeZone.getTimeZone("UTC"))
-    assert(formatter.format(0) === "1970-01-01 00:00:00.0")
+    assert(formatter.format(0) === "1970-01-01 00:00:00")
     assert(formatter.format(1) === "1970-01-01 00:00:00.000001")
     assert(formatter.format(1000) === "1970-01-01 00:00:00.001")
     assert(formatter.format(900000) === "1970-01-01 00:00:00.9")
-    assert(formatter.format(1000000) === "1970-01-01 00:00:01.0")
+    assert(formatter.format(1000000) === "1970-01-01 00:00:01")
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/TimestampFormatterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/TimestampFormatterSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.util
 
 import java.time.{LocalDateTime, ZoneOffset}
-import java.util.{Locale, TimeZone}
+import java.util.TimeZone
 import java.util.concurrent.TimeUnit
 
 import org.apache.spark.SparkFunSuite
@@ -116,5 +116,14 @@ class TimestampFormatterSuite extends SparkFunSuite with SQLHelper {
     val micros = formatter.parse("2009 Mar 20 11:30:01 am")
     assert(micros === TimeUnit.SECONDS.toMicros(
       LocalDateTime.of(2009, 3, 20, 11, 30, 1).toEpochSecond(ZoneOffset.UTC)))
+  }
+
+  test("format fraction of second") {
+    val formatter = TimestampFormatter.getFractionFormatter(TimeZone.getTimeZone("UTC"))
+    assert(formatter.format(0) === "1970-01-01 00:00:00.0")
+    assert(formatter.format(1) === "1970-01-01 00:00:00.000001")
+    assert(formatter.format(1000) === "1970-01-01 00:00:00.001")
+    assert(formatter.format(900000) === "1970-01-01 00:00:00.9")
+    assert(formatter.format(1000000) === "1970-01-01 00:00:01.0")
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/HiveResult.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/HiveResult.scala
@@ -78,7 +78,7 @@ object HiveResult {
     BinaryType)
 
   private lazy val dateFormatter = DateFormatter()
-  private lazy val timestampFormatter = TimestampFormatter(
+  private lazy val timestampFormatter = TimestampFormatter.getFractionFormatter(
     DateTimeUtils.getTimeZone(SQLConf.get.sessionLocalTimeZone))
 
   /** Hive outputs fields of structs slightly differently than top level attributes. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
@@ -199,7 +199,8 @@ private[sql] object JDBCRelation extends Logging {
       val dateTimeStr = columnType match {
         case DateType => DateFormatter().format(value.toInt)
         case TimestampType =>
-          val timestampFormatter = TimestampFormatter(DateTimeUtils.getTimeZone(timeZoneId))
+          val timestampFormatter = TimestampFormatter.getFractionFormatter(
+            DateTimeUtils.getTimeZone(timeZoneId))
           DateTimeUtils.timestampToString(timestampFormatter, value)
       }
       s"'$dateTimeStr'"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removed unnecessary conversion of microseconds in `DateTimeUtils.timestampToString` to `java.sql.Timestamp` which aims to output fraction of seconds by casting it to string. This was replaced by special `TimestampFormatter` which appends the fraction formatter to `DateTimeFormatterBuilder`: `appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)`. The former one means trailing zeros in second's fraction should be truncated while formatting. 

## How was this patch tested?

By existing test suites like `CastSuite`, `DateTimeUtilsSuite`, `JDBCSuite`, and by new test in `TimestampFormatterSuite`.