### PR TITLE
[WIP][SQL] Turn on spark.sql.datetime.java8API.enabled

### DIFF
--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroLogicalTypeSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroLogicalTypeSuite.scala
@@ -34,6 +34,11 @@ import org.apache.spark.sql.types.{StructField, StructType, TimestampType}
 class AvroLogicalTypeSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
   import testImplicits._
 
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.conf.set("spark.sql.datetime.java8API.enabled", false)
+  }
+
   val dateSchema = s"""
       {
         "namespace": "logical",

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -51,6 +51,7 @@ class AvroSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
   override protected def beforeAll(): Unit = {
     super.beforeAll()
     spark.conf.set("spark.sql.files.maxPartitionBytes", 1024)
+    spark.conf.set("spark.sql.datetime.java8API.enabled", false)
   }
 
   def checkReloadMatchesSaved(originalFile: String, newFile: String): Unit = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1696,7 +1696,7 @@ object SQLConf {
       "Catalyst's TimestampType and DateType. If it is set to false, java.sql.Timestamp " +
       "and java.sql.Date are used for the same purpose.")
     .booleanConf
-    .createWithDefault(false)
+    .createWithDefault(true)
 }
 
 /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

I want to see which tests depend on `java.sql.Timestamp`/`java.sql.Date` as external types for `TimestampType`/`DateType`. Purpose of the check is find out the tests that should be fixed when Java 8 time API classes `java.time.Instant`/`java.time.LocalDate` will be used as external types by default.