### PR TITLE
[SPARK-26860][PySpark] [SparkR] Fix for RangeBetween and RowsBetween docs to be in sync with spark documentation

### DIFF
--- a/R/pkg/R/WindowSpec.R
+++ b/R/pkg/R/WindowSpec.R
@@ -155,7 +155,7 @@ setMethod("orderBy",
 #'   df <- createDataFrame(df)
 #'   w1 <- orderBy(windowPartitionBy('desc'), df$id)
 #'   w2 <- rowsBetween(w1, 0, 3)
-#'   df1 <- withColumn(df, “sum”, over(sum(df$id), w2))
+#'   df1 <- withColumn(df, "sum", over(sum(df$id), w2))
 #'   head(df1)
 #' }
 #' @note rowsBetween since 2.0.0

--- a/R/pkg/R/WindowSpec.R
+++ b/R/pkg/R/WindowSpec.R
@@ -127,6 +127,19 @@ setMethod("orderBy",
 #' "0" means "current row", while "-1" means the row before the current row, and "5" means the
 #' fifth row after the current row.
 #'
+#' We recommend users use \code{Window.unboundedPreceding}, \code{Window.unboundedFollowing},
+#' and \code{Window.currentRow} to specify special boundary values, rather than using long values
+#' directly.
+#'
+#' A range-based boundary is based on the actual value of the ORDER BY
+#' expression(s). An offset is used to alter the value of the ORDER BY expression, for
+#' instance if the current order by expression has a value of 10 and the lower bound offset
+#' is -3, the resulting lower bound for the current row will be 10 - 3 = 7. This however puts a
+#' number of constraints on the ORDER BY expressions: there can be only one expression and this
+#' expression must have a numerical data type. An exception can be made when the offset is
+#' unbounded, because no value modification is needed, in this case multiple and non-numeric
+#' ORDER BY expression are allowed.
+#'
 #' @param x a WindowSpec
 #' @param start boundary start, inclusive.
 #'              The frame is unbounded if this is the minimum long value.
@@ -139,7 +152,14 @@ setMethod("orderBy",
 #' @family windowspec_method
 #' @examples
 #' \dontrun{
-#'   rowsBetween(ws, 0, 3)
+#'   id <- c(rep(1, 3), rep(2, 3), 3)
+#'   desc <- c('New','New','Good','New','Good','Good','New')
+#'   df <- data.frame(id, desc)
+#'   df <- createDataFrame(df)
+#'   w1 <- orderBy(windowPartitionBy('desc'), df$id)
+#'   w2 <- rowsBetween(w1,0,3)
+#'   df1 <- withColumn(df, “sum”, over(sum(df$id), w2))
+#'   head(df1)
 #' }
 #' @note rowsBetween since 2.0.0
 setMethod("rowsBetween",
@@ -158,6 +178,19 @@ setMethod("rowsBetween",
 #' "current row", while "-1" means one off before the current row, and "5" means the five off
 #' after the current row.
 #'
+#' We recommend users use \code{Window.unboundedPreceding}, \code{Window.unboundedFollowing},
+#' and \code{Window.currentRow} to specify special boundary values, rather than using long values
+#' directly.
+#'
+#' A range-based boundary is based on the actual value of the ORDER BY
+#' expression(s). An offset is used to alter the value of the ORDER BY expression, for
+#' instance if the current order by expression has a value of 10 and the lower bound offset
+#' is -3, the resulting lower bound for the current row will be 10 - 3 = 7. This however puts a
+#' number of constraints on the ORDER BY expressions: there can be only one expression and this
+#' expression must have a numerical data type. An exception can be made when the offset is
+#' unbounded, because no value modification is needed, in this case multiple and non-numeric
+#' ORDER BY expression are allowed.
+#'
 #' @param x a WindowSpec
 #' @param start boundary start, inclusive.
 #'              The frame is unbounded if this is the minimum long value.
@@ -170,7 +203,14 @@ setMethod("rowsBetween",
 #' @family windowspec_method
 #' @examples
 #' \dontrun{
-#'   rangeBetween(ws, 0, 3)
+#'   id <- c(rep(1, 3), rep(2, 3), 3)
+#'   desc <- c('New','New','Good','New','Good','Good','New')
+#'   df <- data.frame(id, desc)
+#'   df <- createDataFrame(df)
+#'   w1 <- orderBy(windowPartitionBy('desc'), df$id)
+#'   w2 <- rangeBetween(w1,0,3)
+#'   df1 <- withColumn(df, “sum”, over(sum(df$id), w2))
+#'   head(df1)
 #' }
 #' @note rangeBetween since 2.0.0
 setMethod("rangeBetween",

--- a/R/pkg/R/WindowSpec.R
+++ b/R/pkg/R/WindowSpec.R
@@ -153,7 +153,7 @@ setMethod("orderBy",
 #' @examples
 #' \dontrun{
 #'   id <- c(rep(1, 3), rep(2, 3), 3)
-#'   desc <- c('New','New','Good','New','Good','Good','New')
+#'   desc <- c('New', 'New', 'Good', 'New', 'Good', 'Good', 'New')
 #'   df <- data.frame(id, desc)
 #'   df <- createDataFrame(df)
 #'   w1 <- orderBy(windowPartitionBy('desc'), df$id)
@@ -204,7 +204,7 @@ setMethod("rowsBetween",
 #' @examples
 #' \dontrun{
 #'   id <- c(rep(1, 3), rep(2, 3), 3)
-#'   desc <- c('New','New','Good','New','Good','Good','New')
+#'   desc <- c('New', 'New', 'Good', 'New', 'Good', 'Good', 'New')
 #'   df <- data.frame(id, desc)
 #'   df <- createDataFrame(df)
 #'   w1 <- orderBy(windowPartitionBy('desc'), df$id)

--- a/R/pkg/R/WindowSpec.R
+++ b/R/pkg/R/WindowSpec.R
@@ -131,14 +131,11 @@ setMethod("orderBy",
 #' and \code{Window.currentRow} to specify special boundary values, rather than using long values
 #' directly.
 #'
-#' A range-based boundary is based on the actual value of the ORDER BY
-#' expression(s). An offset is used to alter the value of the ORDER BY expression, for
-#' instance if the current order by expression has a value of 10 and the lower bound offset
-#' is -3, the resulting lower bound for the current row will be 10 - 3 = 7. This however puts a
-#' number of constraints on the ORDER BY expressions: there can be only one expression and this
-#' expression must have a numerical data type. An exception can be made when the offset is
-#' unbounded, because no value modification is needed, in this case multiple and non-numeric
-#' ORDER BY expression are allowed.
+#' A row based boundary is based on the position of the row within the partition.
+#' An offset indicates the number of rows above or below the current row, the frame for the
+#' current row starts or ends. For instance, given a row based sliding frame with a lower bound
+#' offset of -1 and a upper bound offset of +2. The frame for row with index 5 would range from
+#' index 4 to index 6.
 #'
 #' @param x a WindowSpec
 #' @param start boundary start, inclusive.
@@ -157,7 +154,7 @@ setMethod("orderBy",
 #'   df <- data.frame(id, desc)
 #'   df <- createDataFrame(df)
 #'   w1 <- orderBy(windowPartitionBy('desc'), df$id)
-#'   w2 <- rowsBetween(w1,0,3)
+#'   w2 <- rowsBetween(w1, 0, 3)
 #'   df1 <- withColumn(df, “sum”, over(sum(df$id), w2))
 #'   head(df1)
 #' }
@@ -183,8 +180,8 @@ setMethod("rowsBetween",
 #' directly.
 #'
 #' A range-based boundary is based on the actual value of the ORDER BY
-#' expression(s). An offset is used to alter the value of the ORDER BY expression, for
-#' instance if the current order by expression has a value of 10 and the lower bound offset
+#' expression(s). An offset is used to alter the value of the ORDER BY expression,
+#' for instance if the current ORDER BY expression has a value of 10 and the lower bound offset
 #' is -3, the resulting lower bound for the current row will be 10 - 3 = 7. This however puts a
 #' number of constraints on the ORDER BY expressions: there can be only one expression and this
 #' expression must have a numerical data type. An exception can be made when the offset is
@@ -208,8 +205,8 @@ setMethod("rowsBetween",
 #'   df <- data.frame(id, desc)
 #'   df <- createDataFrame(df)
 #'   w1 <- orderBy(windowPartitionBy('desc'), df$id)
-#'   w2 <- rangeBetween(w1,0,3)
-#'   df1 <- withColumn(df, “sum”, over(sum(df$id), w2))
+#'   w2 <- rangeBetween(w1, 0, 3)
+#'   df1 <- withColumn(df, "sum", over(sum(df$id), w2))
 #'   head(df1)
 #' }
 #' @note rangeBetween since 2.0.0

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -89,6 +89,9 @@ class Window(object):
         Creates a :class:`WindowSpec` with the frame boundaries defined,
         from `start` (inclusive) to `end` (inclusive).
 
+        Rows Between cares only about the order of rows, and takes fixed number of
+        preceding and following rows when computing frame.
+
         Both `start` and `end` are relative positions from the current row.
         For example, "0" means "current row", while "-1" means the row before
         the current row, and "5" means the fifth row after the current row.
@@ -117,7 +120,8 @@ class Window(object):
     def rangeBetween(start, end):
         """
         Creates a :class:`WindowSpec` with the frame boundaries defined,
-        from `start` (inclusive) to `end` (inclusive).
+        from `start` (inclusive) to `end` (inclusive).Range Between considers values
+        when computing frame.
 
         Both `start` and `end` are relative from the current row. For example,
         "0" means "current row", while "-1" means one off before the current row,

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -112,14 +112,14 @@ class Window(object):
         window = Window.partitionBy("category").orderBy("id").rowsBetween(Window.currentRow, 1)
         df.withColumn("sum",func.sum("id").over(window)).show()
 
-        id category sum
+        # id category sum
 
-        1       b    3
-        2       b    5
-        3       b    3
-        1       a    2
-        1       a    3
-        2       a    2
+        # 1       b    3
+        # 2       b    5
+        # 3       b    3
+        # 1       a    2
+        # 1       a    3
+        # 2       a    2
 
         """
 
@@ -173,14 +173,14 @@ class Window(object):
         window = Window.partitionBy("category").orderBy("id").rangeBetween(Window.currentRow, 1)
         df.withColumn("sum",func.sum("id").over(window)).show()
 
-        id category sum
+        # id category sum
 
-        1       b    3
-        2       b    5
-        3       b    3
-        1       a    4
-        1       a    4
-        2       a    2
+        # 1       b    3
+        # 2       b    5
+        # 3       b    3
+        # 1       a    4
+        # 1       a    4
+        # 2       a    2
 
         """
 

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -103,25 +103,25 @@ class Window(object):
         offset of -1 and a upper bound offset of +2. The frame for row with index 5 would range from
         index 4 to index 6.
         """
-           from pyspark.conf import SparkConf
-           SparkSession.builder.config(conf=SparkConf())
-           from pyspark.sql import Window
-           from pyspark.sql import functions as func
-           tup = [(1, "a"), (1, "a"), (1, "b"), (2, "b"), (3, "b")]
-           df = spark.createDataFrame(tup, ["id", "category"])
-           window = Window.partitionBy("category").orderBy("id").rowsBetween(Window.currentRow, 1)
-           df.withColumn("sum",func.sum("id").over(window)).show()
+        from pyspark.conf import SparkConf
+        SparkSession.builder.config(conf=SparkConf())
+        from pyspark.sql import Window
+        from pyspark.sql import functions as func
+        tup = [(1, "a"), (1, "a"), (1, "b"), (2, "b"), (3, "b")]
+        df = spark.createDataFrame(tup, ["id", "category"])
+        window = Window.partitionBy("category").orderBy("id").rowsBetween(Window.currentRow, 1)
+        df.withColumn("sum",func.sum("id").over(window)).show()
 
-               +---+--------+---+
-               | id|category|sum|
-               +---+--------+---+
-               |  1|       b|  3|
-               |  2|       b|  5|
-               |  3|       b|  3|
-               |  1|       a|  2|
-               |  1|       a|  3|
-               |  2|       a|  2|
-               +---+--------+---+
+        +---+--------+---+
+        | id|category|sum|
+        +---+--------+---+
+        |  1|       b|  3|
+        |  2|       b|  5|
+        |  3|       b|  3|
+        |  1|       a|  2|
+        |  1|       a|  3|
+        |  2|       a|  2|
+        +---+--------+---+
         """
 
         :param start: boundary start, inclusive.
@@ -165,25 +165,25 @@ class Window(object):
         ORDER BY expression are allowed.
 
         """
-            from pyspark.conf import SparkConf
-            SparkSession.builder.config(conf=SparkConf())
-            from pyspark.sql import Window
-            from pyspark.sql import functions as func
-            tup = [(1, "a"), (1, "a"),(2, "a"), (1, "b"), (2, "b"), (3, "b")]
-            df = spark.createDataFrame(tup, ["id", "category"])
-            window = Window.partitionBy("category").orderBy("id").rangeBetween(Window.currentRow, 1)
-            df.withColumn("sum",func.sum("id").over(window)).show()
+        from pyspark.conf import SparkConf
+        SparkSession.builder.config(conf=SparkConf())
+        from pyspark.sql import Window
+        from pyspark.sql import functions as func
+        tup = [(1, "a"), (1, "a"),(2, "a"), (1, "b"), (2, "b"), (3, "b")]
+        df = spark.createDataFrame(tup, ["id", "category"])
+        window = Window.partitionBy("category").orderBy("id").rangeBetween(Window.currentRow, 1)
+        df.withColumn("sum",func.sum("id").over(window)).show()
 
-              +---+--------+---+
-              | id|category|sum|
-              +---+--------+---+
-              |  1|       b|  3|
-              |  2|       b|  5|
-              |  3|       b|  3|
-              |  1|       a|  4|
-              |  1|       a|  4|
-              |  2|       a|  2|
-              +---+--------+---+
+        +---+--------+---+
+        | id|category|sum|
+        +---+--------+---+
+        |  1|       b|  3|
+        |  2|       b|  5|
+        |  3|       b|  3|
+        |  1|       a|  4|
+        |  1|       a|  4|
+        |  2|       a|  2|
+        +---+--------+---+
         """
 
         :param start: boundary start, inclusive.

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -89,9 +89,6 @@ class Window(object):
         Creates a :class:`WindowSpec` with the frame boundaries defined,
         from `start` (inclusive) to `end` (inclusive).
 
-        Rows Between cares only about the order of rows, and takes fixed number of
-        preceding and following rows when computing frame.
-
         Both `start` and `end` are relative positions from the current row.
         For example, "0" means "current row", while "-1" means the row before
         the current row, and "5" means the fifth row after the current row.
@@ -99,6 +96,34 @@ class Window(object):
         We recommend users use ``Window.unboundedPreceding``, ``Window.unboundedFollowing``,
         and ``Window.currentRow`` to specify special boundary values, rather than using integral
         values directly.
+
+        A row based boundary is based on the position of the row within the partition.
+        An offset indicates the number of rows above or below the current row, the frame for the
+        current row starts or ends. For instance, given a row based sliding frame with a lower bound
+        offset of -1 and a upper bound offset of +2. The frame for row with index 5 would range from
+        index 4 to index 6.
+
+        {{{
+           from pyspark.conf import SparkConf
+           SparkSession.builder.config(conf=SparkConf())
+           from pyspark.sql import Window
+           from pyspark.sql import functions as func
+           tup =[(1, "a"), (1, "a"), (1, "b"), (2, "b"), (3, "b")]
+           df =spark.createDataFrame(tup, ["id", "category"])
+           window = Window.partitionBy("category").orderBy("id").rowsBetween(Window.currentRow, 1)
+           df.withColumn("sum",func.sum("id").over(window)).show()
+
+               +---+--------+---+
+               | id|category|sum|
+               +---+--------+---+
+               |  1|       b|  3|
+               |  2|       b|  5|
+               |  3|       b|  3|
+               |  1|       a|  2|
+               |  1|       a|  3|
+               |  2|       a|  2|
+               +---+--------+---+
+        }}}
 
         :param start: boundary start, inclusive.
                       The frame is unbounded if this is ``Window.unboundedPreceding``, or
@@ -130,6 +155,37 @@ class Window(object):
         We recommend users use ``Window.unboundedPreceding``, ``Window.unboundedFollowing``,
         and ``Window.currentRow`` to specify special boundary values, rather than using integral
         values directly.
+
+        A range-based boundary is based on the actual value of the ORDER BY
+        expression(s). An offset is used to alter the value of the ORDER BY expression, for
+        instance if the current order by expression has a value of 10 and the lower bound offset
+        is -3, the resulting lower bound for the current row will be 10 - 3 = 7. This however puts a
+        number of constraints on the ORDER BY expressions: there can be only one expression and this
+        expression must have a numerical data type. An exception can be made when the offset is
+        unbounded, because no value modification is needed, in this case multiple and non-numeric
+        ORDER BY expression are allowed.
+
+         {{{
+            from pyspark.conf import SparkConf
+            SparkSession.builder.config(conf=SparkConf())
+            from pyspark.sql import Window
+            from pyspark.sql import functions as func
+            tup =[(1, "a"), (1, "a"),(2, "a"), (1, "b"), (2, "b"), (3, "b")]
+            df =spark.createDataFrame(tup, ["id", "category"])
+            window = Window.partitionBy("category").orderBy("id").rangeBetween(Window.currentRow, 1)
+            df.withColumn("sum",func.sum("id").over(window)).show()
+
+              +---+--------+---+
+              | id|category|sum|
+              +---+--------+---+
+              |  1|       b|  3|
+              |  2|       b|  5|
+              |  3|       b|  3|
+              |  1|       a|  4|
+              |  1|       a|  4|
+              |  2|       a|  2|
+              +---+--------+---+
+         }}}
 
         :param start: boundary start, inclusive.
                       The frame is unbounded if this is ``Window.unboundedPreceding``, or

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -102,16 +102,16 @@ class Window(object):
         current row starts or ends. For instance, given a row based sliding frame with a lower bound
         offset of -1 and a upper bound offset of +2. The frame for row with index 5 would range from
         index 4 to index 6.
-        """
-        # from pyspark.sql import Window
-        # from pyspark.sql import functions as func
-        # from pyspark.sql import SQLContext
-        # sc = SparkContext.getOrCreate()
-        # sqlContext = SQLContext(sc)
-        # tup = [(1, "a"), (1, "a"), (2, "a"), (1, "b"), (2, "b"), (3, "b")]
-        # df = sqlContext.createDataFrame(tup, ["id", "category"])
-        # window = Window.partitionBy("category").orderBy("id").rowsBetween(Window.currentRow, 1)
-        # df.withColumn("sum", func.sum("id").over(window)).show()
+
+        >>> from pyspark.sql import Window
+        >>> from pyspark.sql import functions as func
+        >>> from pyspark.sql import SQLContext
+        >>> sc = SparkContext.getOrCreate()
+        >>> sqlContext = SQLContext(sc)
+        >>> tup = [(1, "a"), (1, "a"), (2, "a"), (1, "b"), (2, "b"), (3, "b")]
+        >>> df = sqlContext.createDataFrame(tup, ["id", "category"])
+        >>> window = Window.partitionBy("category").orderBy("id").rowsBetween(Window.currentRow, 1)
+        >>> df.withColumn("sum", func.sum("id").over(window)).show()
 
         # id category sum
 
@@ -122,7 +122,6 @@ class Window(object):
         # 1       a    3
         # 2       a    2
 
-        """
 
         :param start: boundary start, inclusive.
                       The frame is unbounded if this is ``Window.unboundedPreceding``, or
@@ -163,16 +162,15 @@ class Window(object):
         unbounded, because no value modification is needed, in this case multiple and non-numeric
         ORDER BY expression are allowed.
 
-        """
-        # from pyspark.sql import Window
-        # from pyspark.sql import functions as func
-        # from pyspark.sql import SQLContext
-        # sc = SparkContext.getOrCreate()
-        # sqlContext = SQLContext(sc)
-        # tup = [(1, "a"), (1, "a"), (2, "a"), (1, "b"), (2, "b"), (3, "b")]
-        # df = sqlContext.createDataFrame(tup, ["id", "category"])
-        # window = Window.partitionBy("category").orderBy("id").rangeBetween(Window.currentRow, 1)
-        # df.withColumn("sum", func.sum("id").over(window)).show()
+        >>> from pyspark.sql import Window
+        >>> from pyspark.sql import functions as func
+        >>> from pyspark.sql import SQLContext
+        >>> sc = SparkContext.getOrCreate()
+        >>> sqlContext = SQLContext(sc)
+        >>> tup = [(1, "a"), (1, "a"), (2, "a"), (1, "b"), (2, "b"), (3, "b")]
+        >>> df = sqlContext.createDataFrame(tup, ["id", "category"])
+        >>> window = Window.partitionBy("category").orderBy("id").rangeBetween(Window.currentRow, 1)
+        >>> df.withColumn("sum", func.sum("id").over(window)).show()
 
         # id category sum
 
@@ -183,7 +181,6 @@ class Window(object):
         # 1       a    4
         # 2       a    2
 
-        """
 
         :param start: boundary start, inclusive.
                       The frame is unbounded if this is ``Window.unboundedPreceding``, or

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -112,14 +112,14 @@ class Window(object):
         window = Window.partitionBy("category").orderBy("id").rowsBetween(Window.currentRow, 1)
         df.withColumn("sum",func.sum("id").over(window)).show()
 
-         id category sum
+        id category sum
 
-          1       b   3
-          2       b   5
-          3       b   3
-          1       a   2
-          1       a   3
-          2       a   2
+        1       b    3
+        2       b    5
+        3       b    3
+        1       a    2
+        1       a    3
+        2       a    2
 
         """
 
@@ -173,14 +173,14 @@ class Window(object):
         window = Window.partitionBy("category").orderBy("id").rangeBetween(Window.currentRow, 1)
         df.withColumn("sum",func.sum("id").over(window)).show()
 
-         id category sum
+        id category sum
 
-          1       b   3
-          2       b   5
-          3       b   3
-          1       a   4
-          1       a   4
-          2       a   2
+        1       b    3
+        2       b    5
+        3       b    3
+        1       a    4
+        1       a    4
+        2       a    2
 
         """
 

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -122,7 +122,6 @@ class Window(object):
         |  1|       a|  3|
         |  2|       a|  2|
         +---+--------+---+
-        <BLANKLINE>
 
         :param start: boundary start, inclusive.
                       The frame is unbounded if this is ``Window.unboundedPreceding``, or
@@ -182,7 +181,6 @@ class Window(object):
         |  1|       a|  4|
         |  2|       a|  2|
         +---+--------+---+
-        <BLANKLINE>
 
         :param start: boundary start, inclusive.
                       The frame is unbounded if this is ``Window.unboundedPreceding``, or
@@ -288,8 +286,12 @@ class WindowSpec(object):
 
 def _test():
     import doctest
+    import pyspark.sql.window
     SparkContext('local[4]', 'PythonTest')
-    (failure_count, test_count) = doctest.testmod()
+    globs = pyspark.sql.window.__dict__.copy()
+    (failure_count, test_count) = doctest.testmod(
+        pyspark.sql.window, globs=globs,
+        optionflags=doctest.NORMALIZE_WHITESPACE)
     if failure_count:
         sys.exit(-1)
 

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -103,14 +103,14 @@ class Window(object):
         offset of -1 and a upper bound offset of +2. The frame for row with index 5 would range from
         index 4 to index 6.
         """
-        from pyspark.conf import SparkConf
-        SparkSession.builder.config(conf=SparkConf())
         from pyspark.sql import Window
         from pyspark.sql import functions as func
-        tup = [(1, "a"), (1, "a"), (1, "b"), (2, "b"), (3, "b")]
-        df = spark.createDataFrame(tup, ["id", "category"])
+        from pyspark.sql import SQLContext
+        sqlContext = SQLContext(sc)
+        tup =[(1, "a"), (1, "a"), (2, "a"), (1, "b"), (2, "b"), (3, "b")]
+        df = sqlContext.createDataFrame(tup, ["id", "category"])
         window = Window.partitionBy("category").orderBy("id").rowsBetween(Window.currentRow, 1)
-        df.withColumn("sum", func.sum("id").over(window)).show()
+        df.withColumn("sum",func.sum("id").over(window)).show()
 
         # id category sum
 
@@ -164,14 +164,14 @@ class Window(object):
         ORDER BY expression are allowed.
 
         """
-        from pyspark.conf import SparkConf
-        SparkSession.builder.config(conf=SparkConf())
         from pyspark.sql import Window
         from pyspark.sql import functions as func
-        tup = [(1, "a"), (1, "a"), (2, "a"), (1, "b"), (2, "b"), (3, "b")]
-        df = spark.createDataFrame(tup, ["id", "category"])
+        from pyspark.sql import SQLContext
+        sqlContext = SQLContext(sc)
+        tup =[(1, "a"), (1, "a"), (2, "a"), (1, "b"), (2, "b"), (3, "b")]
+        df = sqlContext.createDataFrame(tup, ["id", "category"])
         window = Window.partitionBy("category").orderBy("id").rangeBetween(Window.currentRow, 1)
-        df.withColumn("sum", func.sum("id").over(window)).show()
+        df.withColumn("sum",func.sum("id").over(window)).show()
 
         # id category sum
 

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -112,16 +112,17 @@ class Window(object):
         >>> df = sqlContext.createDataFrame(tup, ["id", "category"])
         >>> window = Window.partitionBy("category").orderBy("id").rowsBetween(Window.currentRow, 1)
         >>> df.withColumn("sum", func.sum("id").over(window)).show()
-
-        # id category sum
-
-        # 1       b    3
-        # 2       b    5
-        # 3       b    3
-        # 1       a    2
-        # 1       a    3
-        # 2       a    2
-
+        +---+--------+---+
+        | id|category|sum|
+        +---+--------+---+
+        |  1|       b|  3|
+        |  2|       b|  5|
+        |  3|       b|  3|
+        |  1|       a|  2|
+        |  1|       a|  3|
+        |  2|       a|  2|
+        +---+--------+---+
+        <BLANKLINE>
 
         :param start: boundary start, inclusive.
                       The frame is unbounded if this is ``Window.unboundedPreceding``, or
@@ -171,16 +172,17 @@ class Window(object):
         >>> df = sqlContext.createDataFrame(tup, ["id", "category"])
         >>> window = Window.partitionBy("category").orderBy("id").rangeBetween(Window.currentRow, 1)
         >>> df.withColumn("sum", func.sum("id").over(window)).show()
-
-        # id category sum
-
-        # 1       b    3
-        # 2       b    5
-        # 3       b    3
-        # 1       a    4
-        # 1       a    4
-        # 2       a    2
-
+        +---+--------+---+
+        | id|category|sum|
+        +---+--------+---+
+        |  1|       b|  3|
+        |  2|       b|  5|
+        |  3|       b|  3|
+        |  1|       a|  4|
+        |  1|       a|  4|
+        |  2|       a|  2|
+        +---+--------+---+
+        <BLANKLINE>
 
         :param start: boundary start, inclusive.
                       The frame is unbounded if this is ``Window.unboundedPreceding``, or

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -107,10 +107,10 @@ class Window(object):
         from pyspark.sql import functions as func
         from pyspark.sql import SQLContext
         sqlContext = SQLContext(sc)
-        tup =[(1, "a"), (1, "a"), (2, "a"), (1, "b"), (2, "b"), (3, "b")]
+        tup = [(1, "a"), (1, "a"), (2, "a"), (1, "b"), (2, "b"), (3, "b")]
         df = sqlContext.createDataFrame(tup, ["id", "category"])
         window = Window.partitionBy("category").orderBy("id").rowsBetween(Window.currentRow, 1)
-        df.withColumn("sum",func.sum("id").over(window)).show()
+        df.withColumn("sum", func.sum("id").over(window)).show()
 
         # id category sum
 
@@ -168,10 +168,10 @@ class Window(object):
         from pyspark.sql import functions as func
         from pyspark.sql import SQLContext
         sqlContext = SQLContext(sc)
-        tup =[(1, "a"), (1, "a"), (2, "a"), (1, "b"), (2, "b"), (3, "b")]
+        tup = [(1, "a"), (1, "a"), (2, "a"), (1, "b"), (2, "b"), (3, "b")]
         df = sqlContext.createDataFrame(tup, ["id", "category"])
         window = Window.partitionBy("category").orderBy("id").rangeBetween(Window.currentRow, 1)
-        df.withColumn("sum",func.sum("id").over(window)).show()
+        df.withColumn("sum", func.sum("id").over(window)).show()
 
         # id category sum
 

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -112,16 +112,15 @@ class Window(object):
         window = Window.partitionBy("category").orderBy("id").rowsBetween(Window.currentRow, 1)
         df.withColumn("sum",func.sum("id").over(window)).show()
 
-        +---+--------+---+
-        | id|category|sum|
-        +---+--------+---+
-        |  1|       b|  3|
-        |  2|       b|  5|
-        |  3|       b|  3|
-        |  1|       a|  2|
-        |  1|       a|  3|
-        |  2|       a|  2|
-        +---+--------+---+
+         id category sum
+
+          1       b   3
+          2       b   5
+          3       b   3
+          1       a   2
+          1       a   3
+          2       a   2
+
         """
 
         :param start: boundary start, inclusive.
@@ -174,16 +173,15 @@ class Window(object):
         window = Window.partitionBy("category").orderBy("id").rangeBetween(Window.currentRow, 1)
         df.withColumn("sum",func.sum("id").over(window)).show()
 
-        +---+--------+---+
-        | id|category|sum|
-        +---+--------+---+
-        |  1|       b|  3|
-        |  2|       b|  5|
-        |  3|       b|  3|
-        |  1|       a|  4|
-        |  1|       a|  4|
-        |  2|       a|  2|
-        +---+--------+---+
+         id category sum
+
+          1       b   3
+          2       b   5
+          3       b   3
+          1       a   4
+          1       a   4
+          2       a   2
+
         """
 
         :param start: boundary start, inclusive.

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -103,15 +103,15 @@ class Window(object):
         offset of -1 and a upper bound offset of +2. The frame for row with index 5 would range from
         index 4 to index 6.
         """
-        from pyspark.sql import Window
-        from pyspark.sql import functions as func
-        from pyspark.sql import SQLContext
-        sc = SparkContext.getOrCreate()
-        sqlContext = SQLContext(sc)
-        tup = [(1, "a"), (1, "a"), (2, "a"), (1, "b"), (2, "b"), (3, "b")]
-        df = sqlContext.createDataFrame(tup, ["id", "category"])
-        window = Window.partitionBy("category").orderBy("id").rowsBetween(Window.currentRow, 1)
-        df.withColumn("sum", func.sum("id").over(window)).show()
+        # from pyspark.sql import Window
+        # from pyspark.sql import functions as func
+        # from pyspark.sql import SQLContext
+        # sc = SparkContext.getOrCreate()
+        # sqlContext = SQLContext(sc)
+        # tup = [(1, "a"), (1, "a"), (2, "a"), (1, "b"), (2, "b"), (3, "b")]
+        # df = sqlContext.createDataFrame(tup, ["id", "category"])
+        # window = Window.partitionBy("category").orderBy("id").rowsBetween(Window.currentRow, 1)
+        # df.withColumn("sum", func.sum("id").over(window)).show()
 
         # id category sum
 
@@ -144,8 +144,7 @@ class Window(object):
     def rangeBetween(start, end):
         """
         Creates a :class:`WindowSpec` with the frame boundaries defined,
-        from `start` (inclusive) to `end` (inclusive).Range Between considers values
-        when computing frame.
+        from `start` (inclusive) to `end` (inclusive).
 
         Both `start` and `end` are relative from the current row. For example,
         "0" means "current row", while "-1" means one off before the current row,
@@ -157,7 +156,7 @@ class Window(object):
 
         A range-based boundary is based on the actual value of the ORDER BY
         expression(s). An offset is used to alter the value of the ORDER BY expression, for
-        instance if the current order by expression has a value of 10 and the lower bound offset
+        instance if the current ORDER BY expression has a value of 10 and the lower bound offset
         is -3, the resulting lower bound for the current row will be 10 - 3 = 7. This however puts a
         number of constraints on the ORDER BY expressions: there can be only one expression and this
         expression must have a numerical data type. An exception can be made when the offset is
@@ -165,15 +164,15 @@ class Window(object):
         ORDER BY expression are allowed.
 
         """
-        from pyspark.sql import Window
-        from pyspark.sql import functions as func
-        from pyspark.sql import SQLContext
-        sc = SparkContext.getOrCreate()
-        sqlContext = SQLContext(sc)
-        tup = [(1, "a"), (1, "a"), (2, "a"), (1, "b"), (2, "b"), (3, "b")]
-        df = sqlContext.createDataFrame(tup, ["id", "category"])
-        window = Window.partitionBy("category").orderBy("id").rangeBetween(Window.currentRow, 1)
-        df.withColumn("sum", func.sum("id").over(window)).show()
+        # from pyspark.sql import Window
+        # from pyspark.sql import functions as func
+        # from pyspark.sql import SQLContext
+        # sc = SparkContext.getOrCreate()
+        # sqlContext = SQLContext(sc)
+        # tup = [(1, "a"), (1, "a"), (2, "a"), (1, "b"), (2, "b"), (3, "b")]
+        # df = sqlContext.createDataFrame(tup, ["id", "category"])
+        # window = Window.partitionBy("category").orderBy("id").rangeBetween(Window.currentRow, 1)
+        # df.withColumn("sum", func.sum("id").over(window)).show()
 
         # id category sum
 

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -106,6 +106,7 @@ class Window(object):
         from pyspark.sql import Window
         from pyspark.sql import functions as func
         from pyspark.sql import SQLContext
+        sc = SparkContext.getOrCreate()
         sqlContext = SQLContext(sc)
         tup = [(1, "a"), (1, "a"), (2, "a"), (1, "b"), (2, "b"), (3, "b")]
         df = sqlContext.createDataFrame(tup, ["id", "category"])
@@ -167,6 +168,7 @@ class Window(object):
         from pyspark.sql import Window
         from pyspark.sql import functions as func
         from pyspark.sql import SQLContext
+        sc = SparkContext.getOrCreate()
         sqlContext = SQLContext(sc)
         tup = [(1, "a"), (1, "a"), (2, "a"), (1, "b"), (2, "b"), (3, "b")]
         df = sqlContext.createDataFrame(tup, ["id", "category"])

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -102,14 +102,13 @@ class Window(object):
         current row starts or ends. For instance, given a row based sliding frame with a lower bound
         offset of -1 and a upper bound offset of +2. The frame for row with index 5 would range from
         index 4 to index 6.
-
-        {{{
+        """
            from pyspark.conf import SparkConf
            SparkSession.builder.config(conf=SparkConf())
            from pyspark.sql import Window
            from pyspark.sql import functions as func
-           tup =[(1, "a"), (1, "a"), (1, "b"), (2, "b"), (3, "b")]
-           df =spark.createDataFrame(tup, ["id", "category"])
+           tup = [(1, "a"), (1, "a"), (1, "b"), (2, "b"), (3, "b")]
+           df = spark.createDataFrame(tup, ["id", "category"])
            window = Window.partitionBy("category").orderBy("id").rowsBetween(Window.currentRow, 1)
            df.withColumn("sum",func.sum("id").over(window)).show()
 
@@ -123,7 +122,7 @@ class Window(object):
                |  1|       a|  3|
                |  2|       a|  2|
                +---+--------+---+
-        }}}
+        """
 
         :param start: boundary start, inclusive.
                       The frame is unbounded if this is ``Window.unboundedPreceding``, or
@@ -165,13 +164,13 @@ class Window(object):
         unbounded, because no value modification is needed, in this case multiple and non-numeric
         ORDER BY expression are allowed.
 
-         {{{
+        """
             from pyspark.conf import SparkConf
             SparkSession.builder.config(conf=SparkConf())
             from pyspark.sql import Window
             from pyspark.sql import functions as func
-            tup =[(1, "a"), (1, "a"),(2, "a"), (1, "b"), (2, "b"), (3, "b")]
-            df =spark.createDataFrame(tup, ["id", "category"])
+            tup = [(1, "a"), (1, "a"),(2, "a"), (1, "b"), (2, "b"), (3, "b")]
+            df = spark.createDataFrame(tup, ["id", "category"])
             window = Window.partitionBy("category").orderBy("id").rangeBetween(Window.currentRow, 1)
             df.withColumn("sum",func.sum("id").over(window)).show()
 
@@ -185,7 +184,7 @@ class Window(object):
               |  1|       a|  4|
               |  2|       a|  2|
               +---+--------+---+
-         }}}
+        """
 
         :param start: boundary start, inclusive.
                       The frame is unbounded if this is ``Window.unboundedPreceding``, or

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -110,7 +110,7 @@ class Window(object):
         tup = [(1, "a"), (1, "a"), (1, "b"), (2, "b"), (3, "b")]
         df = spark.createDataFrame(tup, ["id", "category"])
         window = Window.partitionBy("category").orderBy("id").rowsBetween(Window.currentRow, 1)
-        df.withColumn("sum",func.sum("id").over(window)).show()
+        df.withColumn("sum", func.sum("id").over(window)).show()
 
         # id category sum
 
@@ -168,10 +168,10 @@ class Window(object):
         SparkSession.builder.config(conf=SparkConf())
         from pyspark.sql import Window
         from pyspark.sql import functions as func
-        tup = [(1, "a"), (1, "a"),(2, "a"), (1, "b"), (2, "b"), (3, "b")]
+        tup = [(1, "a"), (1, "a"), (2, "a"), (1, "b"), (2, "b"), (3, "b")]
         df = spark.createDataFrame(tup, ["id", "category"])
         window = Window.partitionBy("category").orderBy("id").rangeBetween(Window.currentRow, 1)
-        df.withColumn("sum",func.sum("id").over(window)).show()
+        df.withColumn("sum", func.sum("id").over(window)).show()
 
         # id category sum
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/expressions/Window.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/expressions/Window.scala
@@ -175,8 +175,8 @@ object Window {
    * directly.
    *
    * A range-based boundary is based on the actual value of the ORDER BY
-   * expression(s). An offset is used to alter the value of the ORDER BY expression, for
-   * instance if the current order by expression has a value of 10 and the lower bound offset
+   * expression(s). An offset is used to alter the value of the ORDER BY expression,
+   * for instance if the current ORDER BY expression has a value of 10 and the lower bound offset
    * is -3, the resulting lower bound for the current row will be 10 - 3 = 7. This however puts a
    * number of constraints on the ORDER BY expressions: there can be only one expression and this
    * expression must have a numerical data type. An exception can be made when the offset is


### PR DESCRIPTION
The docs describing RangeBetween & RowsBetween for pySpark & SparkR are not in sync with Spark description. 

a. Edited PySpark and SparkR docs  and made description same for both RangeBetween and RowsBetween
b. created executable examples in both pySpark and SparkR documentation
c. Locally tested the patch for scala Style checks and UT for checking no testcase failures