### PR TITLE
[SPARK-27140][SQL]The feature is 'insert overwrite local directory' has an inconsistent behavior in different environment.

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
@@ -731,6 +731,8 @@ class InsertSuite extends QueryTest with TestHiveSingleton with BeforeAndAfter
   }
 
   test("insert overwrite to not exists dir will lead to expected dir is a file indeed.") {
+    val testMaster = System.getProperty("spark.sql.test.master")
+    logWarning(s"Unit test master is $testMaster")
     withTempDir { dir =>
       val path = dir.toURI.getPath
       val notExistsPath = s"$path/noexistdir"

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
@@ -730,6 +730,23 @@ class InsertSuite extends QueryTest with TestHiveSingleton with BeforeAndAfter
     }
   }
 
+  test("insert overwrite to not exists dir will lead to expected dir is a file indeed.") {
+    withTempDir { dir =>
+      val path = dir.toURI.getPath
+      val notExistsPath = s"$path/noexistdir"
+      val target = new File(notExistsPath)
+      if (target.exists()) {
+        target.delete()
+      }
+      assert(!target.exists())
+
+      sql(s"INSERT OVERWRITE LOCAL DIRECTORY '$notExistsPath' SELECT * FROM src where key < 10")
+
+      assert(target.isFile())
+      assert(!target.isDirectory())
+    }
+  }
+
   test("SPARK-21165: FileFormatWriter should only rely on attributes from analyzed plan") {
     withSQLConf(("hive.exec.dynamic.partition.mode", "nonstrict")) {
       withTable("tab1", "tab2") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Maropu and I have some conversation about insert overwrite noexist local path.
In local[*] mode, maropu give a test case as follows:
```
$ls /tmp/noexistdir
ls: /tmp/noexistdir: No such file or directory

scala> sql("""create table t(c0 int, c1 int)""")
scala> spark.table("t").explain
== Physical Plan ==
Scan hive default.t [c0#5, c1#6], HiveTableRelation `default`.`t`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, [c0#5, c1#6]

scala> sql("""insert into t values(1, 1)""")
scala> sql("""select * from t""").show
+---+---+
| c0| c1|
+---+---+
|  1|  1|
+---+---+

scala> sql("""insert overwrite local directory '/tmp/noexistdir/t' select * from t""")

$ls /tmp/noexistdir/t/
_SUCCESS  part-00000-bbea4213-071a-49b4-aac8-8510e7263d45-c000
```
This test case prove spark will create the not exists path and move middle result from local temporary path to created path.This test based on newest master.
I follow the test case provided by maropu,but find another behavior.
I run these SQL maropu provided on local[*] deploy mode based on 2.3.0.
Inconsistent behavior appears as follows:
```
ls /tmp/noexistdir
ls: cannot access /tmp/noexistdir: No such file or directory

scala> sql("""create table t(c0 int, c1 int)""")
res0: org.apache.spark.sql.DataFrame = []
scala> spark.table("t").explain
== Physical Plan ==
HiveTableScan [c0#5, c1#6], HiveTableRelation `default`.`t`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, [c0#5, c1#6]

scala> sql("""insert into t values(1, 1)""")
scala> sql("""select * from t""").show
+---+---+                                                                       
| c0| c1|
+---+---+
|  1|  1|
+---+---+

scala> sql("""insert overwrite local directory '/tmp/noexistdir/t' select * from t""")
res1: org.apache.spark.sql.DataFrame = [] 

ls /tmp/noexistdir/t/
/tmp/noexistdir/t

vi /tmp/noexistdir/t
  1 
```
Then I pull the master branch and compile it and deploy it on my hadoop cluster.I get the inconsistent behavior again.
The spark version to test is 3.0.0.
```
ls /tmp/noexistdir
ls: cannot access /tmp/noexistdir: No such file or directory
Java HotSpot(TM) 64-Bit Server VM warning: Using the ParNew young collector with the Serial old collector is deprecated and will likely be removed in a future release
Spark context Web UI available at http://10.198.66.204:55326
Spark context available as 'sc' (master = local[*], app id = local-1551259036573).
Spark session available as 'spark'.
Welcome to spark version 3.0.0-SNAPSHOT
Using Scala version 2.12.8 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_131)
Type in expressions to have them evaluated.
Type :help for more information.

scala> sql("""select * from t""").show
+---+---+                                                                       
| c0| c1|
+---+---+
|  1|  1|
+---+---+


scala> sql("""insert overwrite local directory '/tmp/noexistdir/t' select * from t""")
res1: org.apache.spark.sql.DataFrame = []                                       

scala> 
ll /tmp/noexistdir/t
-rw-r--r-- 1 xitong xitong 0 Feb 27 17:19 /tmp/noexistdir/t
vi /tmp/noexistdir/t
  1
```
The /tmp/noexistdir/t is a file too.

I want add a UT to master and need jenkins run it so that prove it or tell me some information.
UT results are the same as those of maropu's test, but different from mine.
The `insert overwrite local directory` will use `LocalFileSystem`. I have check the source of Hadoop `LocalFileSystem `.`LocalFileSystem` don't implement the method `rename`. `LocalFileSystem` extends `ChecksumFileSystem` and the latter implement the method `rename`.
The method `rename` of `ChecksumFileSystem` as follows:
```
  public boolean rename(Path src, Path dst) throws IOException {
    if (fs.isDirectory(src)) {
      return fs.rename(src, dst);
    } else {
      if (fs.isDirectory(dst)) {
        dst = new Path(dst, src.getName());
      }

      boolean value = fs.rename(src, dst);
      if (!value)
        return false;

      Path srcCheckFile = getChecksumFile(src);
      Path dstCheckFile = getChecksumFile(dst);
      if (fs.exists(srcCheckFile)) { //try to rename checksum
        value = fs.rename(srcCheckFile, dstCheckFile);
      } else if (fs.exists(dstCheckFile)) {
        // no src checksum, so remove dst checksum
        value = fs.delete(dstCheckFile, true); 
      }

      return value;
    }
  }
```
If target path is a directory, `ChecksumFileSystem` will move source file into target path.
If target path is not a directory, `ChecksumFileSystem` will rename source file to target file.
There exists a variable named `fs` that is a `RawLocalFileSystem`. `RawLocalFileSystem` will call the method `rename` of UNIXFileSystem or `WinNTFileSystem`.
I have tried to find out why UT and my spark behave differently when executing insert overwrite local directory in local mode. But I'm failed! According to the source code of InsertIntoHiveDirCommand, there no chance to create the target path that doesn't exist yet.Could you help me, find out the reason. Thanks!
## How was this patch tested?

UT
