### PR TITLE
[SPARK-27040][SQL] Avoid using unnecessary JoinRow in FileFormat

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
@@ -132,8 +132,6 @@ trait FileFormat {
     new (PartitionedFile => Iterator[InternalRow]) with Serializable {
       private val fullSchema = requiredSchema.toAttributes ++ partitionSchema.toAttributes
 
-      private lazy val joinedRow = new JoinedRow()
-
       // Using lazy val to avoid serialization
       private lazy val appendPartitionColumns =
         GenerateUnsafeProjection.generate(fullSchema, fullSchema)
@@ -150,6 +148,7 @@ trait FileFormat {
             converter(dataRow)
           }
         } else {
+          val joinedRow = new JoinedRow()
           dataReader(file).map { dataRow =>
             converter(joinedRow(dataRow, file.partitionValues))
           }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When reading files with empty partition columns, we can avoid using JoinRow.

## How was this patch tested?

Existing unit tests.
