### PR TITLE
[SPARK-27049][SQL] Support handling partition values in the abstraction of file source V2

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PartitionRecordReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PartitionRecordReader.scala
@@ -29,13 +29,3 @@ class PartitionRecordReader[T](
 
   override def close(): Unit = rowReader.close()
 }
-
-class PartitionRecordReaderWithProject[X, T](
-    private[this] var rowReader: RecordReader[_, X],
-    project: X => T) extends PartitionReader[T] {
-  override def next(): Boolean = rowReader.nextKeyValue()
-
-  override def get(): T = project(rowReader.getCurrentValue)
-
-  override def close(): Unit = rowReader.close()
-}


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `FileFormat`, the method `buildReaderWithPartitionValues` appends the partition values to the end of the result returned by `buildReader`, so that for data sources like CSV/JSON/AVRO only need to implement `buildReader` to read a single file without taking care of partition values.

This PR proposes to support handling partition values in file source v2 abstraction by:
1. Have two methods `buildReader` and `buildReaderWithPartitionValues` in `FilePartitionReaderFactory`, which have exactly the same meaning as they are in `FileFormat`
2. Rename `buildColumnarReader` as `buildColumnarReaderWithPartitionValues` to make the naming consistent.

## How was this patch tested?

Existing unit tests.

