### PR TITLE
[SPARK-26975][SQL] Support nested-column pruning over limit/sample/repartition

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
@@ -84,7 +84,7 @@ object NestedColumnAliasing {
   }
 
   /**
-   * Return root references and `GetStructField`s.
+   * Return root references that are individually accessed as a whole, and `GetStructField`s.
    */
   private def collectRootReferenceAndGetStructField(plan: LogicalPlan): Seq[Expression] = {
     def helper(e: Expression): Seq[Expression] = e match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.types._
+
+/**
+ * This aims to handle a nested column aliasing pattern inside the `ColumnPruning` optimizer rule.
+ * If a project or its child references to nested fields, and not all the fields
+ * in a nested attribute are used, we can substitute them by alias attributes; then a project
+ * of the nested fields as aliases on the children of the child will be created.
+ */
+object NestedColumnAliasing {
+
+  def unapply(plan: LogicalPlan)
+    : Option[(Map[GetStructField, Alias], Map[ExprId, Seq[Alias]])] = plan match {
+    case Project(_, child) if canProjectPushThrough(child) =>
+      getAliasSubMap(plan, child)
+    case _ => None
+  }
+
+  /**
+   * Replace nested columns to prune unused nested columns later.
+   */
+  def replaceToAliases(
+      plan: LogicalPlan,
+      nestedFieldToAlias: Map[GetStructField, Alias],
+      attrToAliases: Map[ExprId, Seq[Alias]]): LogicalPlan = plan match {
+    case Project(projectList, child) =>
+      Project(
+        getNewProjectList(projectList, nestedFieldToAlias),
+        replaceChildrenWithAliases(child, attrToAliases))
+  }
+
+  /**
+   * Return a replaced project list.
+   */
+  private def getNewProjectList(
+      projectList: Seq[NamedExpression],
+      nestedFieldToAlias: Map[GetStructField, Alias]): Seq[NamedExpression] = {
+    projectList.map(_.transform {
+      case f: GetStructField if nestedFieldToAlias.contains(f) =>
+        nestedFieldToAlias(f).toAttribute
+    }.asInstanceOf[NamedExpression])
+  }
+
+  /**
+   * Return a plan with new childen replaced with aliases.
+   */
+  private def replaceChildrenWithAliases(
+      plan: LogicalPlan,
+      attrToAliases: Map[ExprId, Seq[Alias]]): LogicalPlan = {
+    plan.withNewChildren(plan.children.map { plan =>
+      Project(plan.output.flatMap(a => attrToAliases.getOrElse(a.exprId, Seq(a))), plan)
+    })
+  }
+
+  /**
+   * Returns true for those operators that project can be pushed through.
+   */
+  private def canProjectPushThrough(plan: LogicalPlan) = plan match {
+    case _: GlobalLimit => true
+    case _: LocalLimit => true
+    case _: Repartition => true
+    case _: Sample => true
+    case _ => false
+  }
+
+  /**
+   * Return root references and `GetStructField`s.
+   */
+  private def collectRootReferenceAndGetStructField(plan: LogicalPlan): Seq[Expression] = {
+    def helper(e: Expression): Seq[Expression] = e match {
+      case _: AttributeReference | _: GetStructField => Seq(e)
+      case es if es.children.nonEmpty => es.children.flatMap(helper)
+      case _ => Seq.empty
+    }
+    plan.expressions.flatMap(helper)
+  }
+
+  /**
+   * Return two maps in order to replace nested fields to aliases.
+   *
+   * 1. GetStructField -> Alias: A new alias is created for each nested field.
+   * 2. ExprId -> Seq[Alias]: A reference attribute has multiple aliases pointing it.
+   */
+  private def getAliasSubMap(plans: LogicalPlan*)
+    : Option[(Map[GetStructField, Alias], Map[ExprId, Seq[Alias]])] = {
+    val (nestedFieldReferences, otherRootReferences) = plans
+      .map(collectRootReferenceAndGetStructField).reduce(_ ++ _).partition {
+        case _: GetStructField => true
+        case _ => false
+      }
+
+    val aliasSub = nestedFieldReferences.asInstanceOf[Seq[GetStructField]]
+      .filter(!_.references.subsetOf(AttributeSet(otherRootReferences)))
+      .groupBy(_.references.head)
+      .flatMap { case (attr: Attribute, nestedFields: Seq[GetStructField]) =>
+        // Each expression can contain multiple nested fields.
+        // Note that we keep the original names to deliver to parquet in a case-sensitive way.
+        val nestedFieldToAlias = nestedFields.distinct.map { f =>
+          val exprId = NamedExpression.newExprId
+          (f, Alias(f, s"_gen_alias_${exprId.id}")(exprId, Seq.empty, None))
+        }
+
+        if (nestedFieldToAlias.nonEmpty &&
+            nestedFieldToAlias.length < totalFieldNum(attr.dataType)) {
+          Some(attr.exprId -> nestedFieldToAlias)
+        } else {
+          None
+        }
+      }
+
+    if (aliasSub.isEmpty) {
+      None
+    } else {
+      Some((aliasSub.values.flatten.toMap, aliasSub.map(x => (x._1, x._2.map(_._2)))))
+    }
+  }
+
+  /**
+   * Return total number of fields of this type. This is used as a threshold to use nested column
+   * pruning. It's okay to underestimate. If the number of reference is bigger than this, the parent
+   * reference is used instead of nested field references.
+   */
+  private def totalFieldNum(dataType: DataType): Int = dataType match {
+    case _: AtomicType => 1
+    case StructType(fields) => fields.map(f => totalFieldNum(f.dataType)).sum
+    case ArrayType(elementType, _) => totalFieldNum(elementType)
+    case MapType(keyType, valueType, _) => totalFieldNum(keyType) + totalFieldNum(valueType)
+    case _ => 1 // UDT and others
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
@@ -64,7 +64,7 @@ object NestedColumnAliasing {
   }
 
   /**
-   * Return a plan with new childen replaced with aliases.
+   * Return a plan with new children replaced with aliases.
    */
   private def replaceChildrenWithAliases(
       plan: LogicalPlan,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -17,8 +17,7 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
-import scala.collection.mutable
-
+import scala.collection.{immutable, mutable}
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
@@ -647,6 +646,30 @@ object ColumnPruning extends Rule[LogicalPlan] {
     // Can't prune the columns on LeafNode
     case p @ Project(_, _: LeafNode) => p
 
+    // If current project or child references to nested fields, we substitute them
+    // by alias attributes; then a project of the nested fields as aliases
+    // on the children of the child will be created.
+    // Note that if the child is a [[Project]], it will be handled by the previous rule;
+    // if the child is a [[Filter]], TODO: doc
+    case p @ Project(_, child) if !child.isInstanceOf[Project] && !child.isInstanceOf[Filter] &&
+      !child.isInstanceOf[SerializeFromObject] &&
+        getAliasSubMap(p, child).nonEmpty =>
+      val aliasSub: Map[AttributeSet, Seq[(Expression, Alias)]] = getAliasSubMap(p, child)
+      val nestedFieldToAlias = aliasSub.values.flatten.toMap
+      val attrToAliases: Map[AttributeSet, Seq[Alias]] = aliasSub.map(x => (x._1, x._2.map(_._2)))
+
+      val newChild = child.withNewChildren(child.children.map { plan =>
+        // Creating a project of nested fields using aliases.
+        Project(plan.output.flatMap(a => attrToAliases.getOrElse(AttributeSet(a), Seq(a))), plan)
+      })
+      val newProjectList = p.projectList.map(_.transform {
+        // Replacing the `GetStructField` by alias attribute.
+        case f: GetStructField if nestedFieldToAlias.contains(f.canonicalized) =>
+          nestedFieldToAlias(f.canonicalized).toAttribute
+        // TODO: Support GetArrayStructFields, GetMapValue, GetArrayItem
+      }.asInstanceOf[NamedExpression])
+      Project(newProjectList, newChild)
+
     // for all other logical plans that inherits the output from it's children
     // Project over project is handled by the first case, skip it here.
     case p @ Project(_, child) if !child.isInstanceOf[Project] =>
@@ -658,6 +681,81 @@ object ColumnPruning extends Rule[LogicalPlan] {
         p
       }
   })
+
+  /**
+   * Similar to [[QueryPlan.references]], but this only returns all attributes
+   * that are explicitly referenced on the root levels in a [[LogicalPlan]].
+   */
+  private def getRootReferences(plan: LogicalPlan): AttributeSet = {
+    def helper(e: Expression): AttributeSet = e match {
+      case attr: AttributeReference => AttributeSet(attr)
+      case _: GetStructField => AttributeSet.empty
+      case es if es.children.nonEmpty => AttributeSet(es.children.flatMap(helper))
+      case _ => AttributeSet.empty
+    }
+
+    AttributeSet.fromAttributeSets(plan.expressions.map(helper))
+  }
+
+  /**
+   * Returns all the nested fields that are explicitly referenced as [[Expression]]
+   * in a [[LogicalPlan]].
+   */
+  private def getNestedFieldReferences(plan: LogicalPlan): Seq[Expression] = {
+    // TODO: Currently, we only support to have [[GetStructField]] in the chain
+    // of the expressions. If the chain contains GetArrayStructFields, GetMapValue, or
+    // GetArrayItem, the nested field alias substitution will not be performed.
+    def isGetStructFieldOrAttr(e: Expression): Boolean = e match {
+      case _: AttributeReference => true
+      case GetStructField(child, _, _) => isGetStructFieldOrAttr(child)
+      case _ => false
+    }
+
+    def helper(e: Expression): Seq[Expression] = e match {
+      case f @ GetStructField(child, _, _) if isGetStructFieldOrAttr(child) => Seq(f)
+      case es if es.children.nonEmpty => es.children.flatMap(e => helper(e))
+      case _ => Seq.empty[Expression]
+    }
+
+    plan.expressions.flatMap(helper)
+  }
+
+  /**
+   * The first map is used to replace `GetStructField` in current project to alias attributes.
+   * The second map is used in the children projects to convert attributes of entire nested
+   * columns into each referred nested columns as aliases. The key in the first map,
+   * `GetStructField` is canonicalized to remove the cosmetic differences.
+   *
+   * Note that when all of the nested fields in a root column are referred, this substitution
+   * will not be performed. For example, let's say `name` has three nested fields, `first`,
+   * `middle`, and `last`, and if all of them are referred, it's not necessary to replace each of
+   * them by alias variables.
+   */
+  private def getAliasSubMap(plans: LogicalPlan*): Map[AttributeSet, Seq[(Expression, Alias)]] = {
+    val rootReferences: AttributeSet = plans.map(getRootReferences).reduce(_ ++ _)
+    val nestedFieldReferences = plans.map(getNestedFieldReferences).reduce(_ ++ _)
+
+    nestedFieldReferences
+      // If a referenced nested field is part of the rootReferences, we can filter it out
+      // because we have to read the entire root column which already contains the nested field.
+      .filter(!_.references.subsetOf(rootReferences))
+      .groupBy(_.references)
+      .flatMap { case (attrSet: AttributeSet, nestedFields: Seq[Expression]) =>
+        // Note that each attrSet contains only one attribute. Each attribute can
+        // contain multiple nested fields.
+        val nestedFieldToAlias: Seq[(Expression, Alias)] =
+          nestedFields.map(_.canonicalized).distinct.flatMap {
+            case f: GetStructField => Some((f, Alias(f, f.sql)()))
+            // TODO: Top level extractor such as GetArrayStructFields is not supported yet.
+            case _ => None
+          }
+        if (nestedFieldToAlias.nonEmpty) {
+          Some(attrSet -> nestedFieldToAlias)
+        } else {
+          None
+        }
+      }
+  }
 
   /** Applies a projection only when the child is producing unnecessary attributes */
   private def prunedChild(c: LogicalPlan, allReferences: AttributeSet) =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -647,8 +647,7 @@ object ColumnPruning extends Rule[LogicalPlan] {
     // Can't prune the columns on LeafNode
     case p @ Project(_, _: LeafNode) => p
 
-    case p @ NestedColumnAliasing(nestedFieldToAlias, attrToAliases)
-        if SQLConf.get.nestedSchemaPruningEnabled =>
+    case p @ NestedColumnAliasing(nestedFieldToAlias, attrToAliases) =>
       NestedColumnAliasing.replaceToAliases(p, nestedFieldToAlias, attrToAliases)
 
     // for all other logical plans that inherits the output from it's children

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -17,7 +17,8 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
-import scala.collection.{immutable, mutable}
+import scala.collection.mutable
+
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
@@ -646,29 +647,9 @@ object ColumnPruning extends Rule[LogicalPlan] {
     // Can't prune the columns on LeafNode
     case p @ Project(_, _: LeafNode) => p
 
-    // If current project or child references to nested fields, we substitute them
-    // by alias attributes; then a project of the nested fields as aliases
-    // on the children of the child will be created.
-    // Note that if the child is a [[Project]], it will be handled by the previous rule;
-    // if the child is a [[Filter]], TODO: doc
-    case p @ Project(_, child) if !child.isInstanceOf[Project] && !child.isInstanceOf[Filter] &&
-      !child.isInstanceOf[SerializeFromObject] &&
-        getAliasSubMap(p, child).nonEmpty =>
-      val aliasSub: Map[AttributeSet, Seq[(Expression, Alias)]] = getAliasSubMap(p, child)
-      val nestedFieldToAlias = aliasSub.values.flatten.toMap
-      val attrToAliases: Map[AttributeSet, Seq[Alias]] = aliasSub.map(x => (x._1, x._2.map(_._2)))
-
-      val newChild = child.withNewChildren(child.children.map { plan =>
-        // Creating a project of nested fields using aliases.
-        Project(plan.output.flatMap(a => attrToAliases.getOrElse(AttributeSet(a), Seq(a))), plan)
-      })
-      val newProjectList = p.projectList.map(_.transform {
-        // Replacing the `GetStructField` by alias attribute.
-        case f: GetStructField if nestedFieldToAlias.contains(f.canonicalized) =>
-          nestedFieldToAlias(f.canonicalized).toAttribute
-        // TODO: Support GetArrayStructFields, GetMapValue, GetArrayItem
-      }.asInstanceOf[NamedExpression])
-      Project(newProjectList, newChild)
+    case p @ NestedColumnAliasing(nestedFieldToAlias, attrToAliases)
+        if SQLConf.get.nestedSchemaPruningEnabled =>
+      NestedColumnAliasing.replaceToAliases(p, nestedFieldToAlias, attrToAliases)
 
     // for all other logical plans that inherits the output from it's children
     // Project over project is handled by the first case, skip it here.
@@ -681,81 +662,6 @@ object ColumnPruning extends Rule[LogicalPlan] {
         p
       }
   })
-
-  /**
-   * Similar to [[QueryPlan.references]], but this only returns all attributes
-   * that are explicitly referenced on the root levels in a [[LogicalPlan]].
-   */
-  private def getRootReferences(plan: LogicalPlan): AttributeSet = {
-    def helper(e: Expression): AttributeSet = e match {
-      case attr: AttributeReference => AttributeSet(attr)
-      case _: GetStructField => AttributeSet.empty
-      case es if es.children.nonEmpty => AttributeSet(es.children.flatMap(helper))
-      case _ => AttributeSet.empty
-    }
-
-    AttributeSet.fromAttributeSets(plan.expressions.map(helper))
-  }
-
-  /**
-   * Returns all the nested fields that are explicitly referenced as [[Expression]]
-   * in a [[LogicalPlan]].
-   */
-  private def getNestedFieldReferences(plan: LogicalPlan): Seq[Expression] = {
-    // TODO: Currently, we only support to have [[GetStructField]] in the chain
-    // of the expressions. If the chain contains GetArrayStructFields, GetMapValue, or
-    // GetArrayItem, the nested field alias substitution will not be performed.
-    def isGetStructFieldOrAttr(e: Expression): Boolean = e match {
-      case _: AttributeReference => true
-      case GetStructField(child, _, _) => isGetStructFieldOrAttr(child)
-      case _ => false
-    }
-
-    def helper(e: Expression): Seq[Expression] = e match {
-      case f @ GetStructField(child, _, _) if isGetStructFieldOrAttr(child) => Seq(f)
-      case es if es.children.nonEmpty => es.children.flatMap(e => helper(e))
-      case _ => Seq.empty[Expression]
-    }
-
-    plan.expressions.flatMap(helper)
-  }
-
-  /**
-   * The first map is used to replace `GetStructField` in current project to alias attributes.
-   * The second map is used in the children projects to convert attributes of entire nested
-   * columns into each referred nested columns as aliases. The key in the first map,
-   * `GetStructField` is canonicalized to remove the cosmetic differences.
-   *
-   * Note that when all of the nested fields in a root column are referred, this substitution
-   * will not be performed. For example, let's say `name` has three nested fields, `first`,
-   * `middle`, and `last`, and if all of them are referred, it's not necessary to replace each of
-   * them by alias variables.
-   */
-  private def getAliasSubMap(plans: LogicalPlan*): Map[AttributeSet, Seq[(Expression, Alias)]] = {
-    val rootReferences: AttributeSet = plans.map(getRootReferences).reduce(_ ++ _)
-    val nestedFieldReferences = plans.map(getNestedFieldReferences).reduce(_ ++ _)
-
-    nestedFieldReferences
-      // If a referenced nested field is part of the rootReferences, we can filter it out
-      // because we have to read the entire root column which already contains the nested field.
-      .filter(!_.references.subsetOf(rootReferences))
-      .groupBy(_.references)
-      .flatMap { case (attrSet: AttributeSet, nestedFields: Seq[Expression]) =>
-        // Note that each attrSet contains only one attribute. Each attribute can
-        // contain multiple nested fields.
-        val nestedFieldToAlias: Seq[(Expression, Alias)] =
-          nestedFields.map(_.canonicalized).distinct.flatMap {
-            case f: GetStructField => Some((f, Alias(f, f.sql)()))
-            // TODO: Top level extractor such as GetArrayStructFields is not supported yet.
-            case _ => None
-          }
-        if (nestedFieldToAlias.nonEmpty) {
-          Some(attrSet -> nestedFieldToAlias)
-        } else {
-          None
-        }
-      }
-  }
 
   /** Applies a projection only when the child is producing unnecessary attributes */
   private def prunedChild(c: LogicalPlan, allReferences: AttributeSet) =

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasingSuite.scala
@@ -191,6 +191,24 @@ class NestedColumnAliasingSuite extends SchemaPruningTest {
     comparePlans(optimized, expected)
   }
 
+  test("Some nested column means the whole structure") {
+    val nestedRelation = LocalRelation('a.struct('b.struct('c.int, 'd.int, 'e.int)))
+
+    val query = nestedRelation
+      .limit(5)
+      .select(GetStructField('a, 0, Some("b")))
+      .analyze
+
+    val optimized = Optimize.execute(query)
+
+    val expected = nestedRelation
+      .select(GetStructField('a, 0, Some("b")))
+      .limit(5)
+      .analyze
+
+    comparePlans(optimized, expected)
+  }
+
   private def testSingleFieldPushDown(op: LogicalPlan => LogicalPlan): Unit = {
     val middle = GetStructField('name, 1, Some("middle"))
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasingSuite.scala
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.sql.catalyst.SchemaPruningTest
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, _}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.types.{StringType, StructType}
+
+class NestedColumnAliasingSuite extends SchemaPruningTest {
+
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches = Batch("Nested column pruning", FixedPoint(100),
+      ColumnPruning,
+      CollapseProject,
+      RemoveNoopOperators) :: Nil
+  }
+
+  private val name = StructType.fromDDL("first string, middle string, last string")
+  private val employer = StructType.fromDDL("id int, company struct<name:string, address:string>")
+  private val contact = LocalRelation(
+    'id.int,
+    'name.struct(name),
+    'address.string,
+    'friends.array(name),
+    'relatives.map(StringType, name),
+    'employer.struct(employer))
+
+  test("Pushing a single nested field projection") {
+    testSingleFieldPushDown("limit", (input: LogicalPlan) => input.limit(5))
+    testSingleFieldPushDown("repartition", (input: LogicalPlan) => input.repartition(1))
+    testSingleFieldPushDown("sample", (input: LogicalPlan) => Sample(0.0, 0.6, false, 11L, input))
+  }
+
+  test("Pushing multiple nested field projection") {
+    val first = GetStructField('name, 0, Some("first"))
+    val last = GetStructField('name, 2, Some("last"))
+
+    val query = contact
+      .limit(5)
+      .select('id, first, last)
+      .analyze
+
+    val optimized = Optimize.execute(query)
+
+    val expected = contact
+      .select('id, first, last)
+      .limit(5)
+      .analyze
+
+    comparePlans(optimized, expected)
+  }
+
+  test("function with nested field inputs") {
+    val first = GetStructField('name, 0, Some("first"))
+    val last = GetStructField('name, 2, Some("last"))
+
+    val query = contact
+      .limit(5)
+      .select('id, ConcatWs(Seq(first, last)))
+      .analyze
+
+    val optimized = Optimize.execute(query)
+
+    val expected = contact
+      .select('id, ConcatWs(Seq(first, last)))
+      .limit(5)
+      .analyze
+    comparePlans(optimized, expected)
+  }
+
+  test("multi-level nested field") {
+    val field1 = GetStructField(GetStructField('employer, 1, Some("company")), 0, Some("name"))
+    val field2 = GetStructField('employer, 0, Some("id"))
+
+    val query = contact
+      .limit(5)
+      .select(field1, field2)
+      .analyze
+
+    val optimized = Optimize.execute(query)
+
+    val expected = contact
+      .select(field1, field2)
+      .limit(5)
+      .analyze
+    comparePlans(optimized, expected)
+  }
+
+  test("Push original case-sensitive names") {
+    val first1 = GetStructField('name, 0, Some("first"))
+    val first2 = GetStructField('name, 1, Some("FIRST"))
+
+    val query = contact
+      .limit(5)
+      .select('id, first1, first2)
+      .analyze
+
+    val optimized = Optimize.execute(query)
+
+    val expected = contact
+      .select('id, first1, first2)
+      .limit(5)
+      .analyze
+
+    comparePlans(optimized, expected)
+  }
+
+  test("Pushing a single nested field projection - negative") {
+    val ops = Array(
+      (input: LogicalPlan) => input.distribute('name)(1),
+      (input: LogicalPlan) => input.distribute($"name.middle")(1),
+      (input: LogicalPlan) => input.orderBy('name.asc),
+      (input: LogicalPlan) => input.orderBy($"name.middle".asc),
+      (input: LogicalPlan) => input.sortBy('name.asc),
+      (input: LogicalPlan) => input.sortBy($"name.middle".asc),
+      (input: LogicalPlan) => input.union(input)
+    )
+
+    val queries = ops.map { op =>
+      op(contact.select('name))
+        .select(GetStructField('name, 1, Some("middle")))
+        .analyze
+    }
+
+    val optimizedQueries = queries.map(Optimize.execute)
+    val expectedQueries = queries
+    optimizedQueries.zip(expectedQueries).foreach { case (optimized, expected) =>
+      comparePlans(optimized, expected)
+    }
+  }
+
+  test("Pushing a single nested field projection through filters - negative") {
+    val ops = Array(
+      (input: LogicalPlan) => input.where('name.isNotNull),
+      (input: LogicalPlan) => input.where($"name.middle".isNotNull)
+    )
+
+    val queries = ops.map { op =>
+      op(contact)
+        .select(GetStructField('name, 1, Some("middle")))
+        .analyze
+    }
+
+    val optimizedQueries = queries.map(Optimize.execute)
+    val expectedQueries = queries
+
+    optimizedQueries.zip(expectedQueries).foreach { case (optimized, expected) =>
+      comparePlans(optimized, expected)
+    }
+  }
+
+  test("Do not optimize when parent field is used") {
+    val query = contact
+      .limit(5)
+      .select('id, GetStructField('name, 0, Some("first")), 'name)
+      .analyze
+
+    val optimized = Optimize.execute(query)
+
+    val expected = contact
+      .select('id, GetStructField('name, 0, Some("first")), 'name)
+      .limit(5)
+      .analyze
+    comparePlans(optimized, expected)
+  }
+
+  test("Do not optimize when all fields are used") {
+    val first = GetStructField('name, 0, Some("first"))
+    val middle = GetStructField('name, 1, Some("middle"))
+    val last = GetStructField('name, 2, Some("last"))
+
+    val query = contact
+      .limit(5)
+      .select('id, first, middle, last)
+      .analyze
+
+    val optimized = Optimize.execute(query)
+
+    val expected = contact
+      .select('id, first, middle, last)
+      .limit(5)
+      .analyze
+
+    comparePlans(optimized, expected)
+  }
+
+  private def testSingleFieldPushDown(name: String, op: LogicalPlan => LogicalPlan): Unit = {
+    val middle = GetStructField('name, 1, Some("middle"))
+
+    val query = op(contact).select(middle).analyze
+
+    val optimized = Optimize.execute(query)
+
+    val expected = op(contact.select(middle)).analyze
+
+    comparePlans(optimized, expected)
+  }
+
+  private def collectGeneratedAliases(query: LogicalPlan): ArrayBuffer[String] = {
+    val aliases = ArrayBuffer[String]()
+    query.transformAllExpressions {
+      case a @ Alias(_, name) if name.startsWith("_gen_alias_") =>
+        aliases += name
+        a
+    }
+    aliases
+  }
+}

--- a/sql/core/benchmarks/OrcNestedSchemaPruningBenchmark-results.txt
+++ b/sql/core/benchmarks/OrcNestedSchemaPruningBenchmark-results.txt
@@ -6,35 +6,42 @@ OpenJDK 64-Bit Server VM 1.8.0_201-b09 on Linux 3.10.0-862.3.2.el7.x86_64
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Selection:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Top-level column                                    117            154          23          8.5         117.5       1.0X
-Nested column                                      1271           1295          26          0.8        1270.5       0.1X
+Top-level column                                    131            150          25          7.7         130.6       1.0X
+Nested column                                       922            954          21          1.1         922.2       0.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_201-b09 on Linux 3.10.0-862.3.2.el7.x86_64
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Limiting:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Top-level column                                    431            488          73          2.3         431.2       1.0X
-Nested column                                      1738           1777          24          0.6        1738.3       0.2X
+Top-level column                                    446            477          50          2.2         445.5       1.0X
+Nested column                                      1328           1366          44          0.8        1328.4       0.3X
 
 OpenJDK 64-Bit Server VM 1.8.0_201-b09 on Linux 3.10.0-862.3.2.el7.x86_64
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Repartitioning:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Top-level column                                    349            381          87          2.9         348.7       1.0X
-Nested column                                      4374           4456         125          0.2        4373.6       0.1X
+Top-level column                                    357            386          33          2.8         356.8       1.0X
+Nested column                                      1266           1274           7          0.8        1266.3       0.3X
 
 OpenJDK 64-Bit Server VM 1.8.0_201-b09 on Linux 3.10.0-862.3.2.el7.x86_64
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Repartitioning by exprs:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Top-level column                                    358            410          85          2.8         358.5       1.0X
-Nested column                                      4447           4517         125          0.2        4447.3       0.1X
+Top-level column                                    368            394          54          2.7         367.6       1.0X
+Nested column                                      3890           3954          80          0.3        3890.3       0.1X
+
+OpenJDK 64-Bit Server VM 1.8.0_201-b09 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Sample:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Top-level column                                    129            140          10          7.7         129.1       1.0X
+Nested column                                       966            999          26          1.0         966.2       0.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_201-b09 on Linux 3.10.0-862.3.2.el7.x86_64
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Sorting:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Top-level column                                    553            566          13          1.8         552.8       1.0X
-Nested column                                      5115           5248          84          0.2        5115.1       0.1X
+Top-level column                                    573            601          61          1.7         573.2       1.0X
+Nested column                                      4417           4598         149          0.2        4417.1       0.1X
 
 

--- a/sql/core/benchmarks/OrcV2NestedSchemaPruningBenchmark-results.txt
+++ b/sql/core/benchmarks/OrcV2NestedSchemaPruningBenchmark-results.txt
@@ -6,35 +6,42 @@ OpenJDK 64-Bit Server VM 1.8.0_201-b09 on Linux 3.10.0-862.3.2.el7.x86_64
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Selection:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Top-level column                                    120            148          24          8.3         120.0       1.0X
-Nested column                                      2367           2415          43          0.4        2367.0       0.1X
+Top-level column                                    135            169          19          7.4         134.7       1.0X
+Nested column                                      2131           2216          95          0.5        2131.4       0.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_201-b09 on Linux 3.10.0-862.3.2.el7.x86_64
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Limiting:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Top-level column                                    129            153          16          7.8         128.5       1.0X
-Nested column                                      2368           2400          32          0.4        2367.7       0.1X
+Top-level column                                    147            158          10          6.8         146.9       1.0X
+Nested column                                      2149           2204          50          0.5        2148.9       0.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_201-b09 on Linux 3.10.0-862.3.2.el7.x86_64
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Repartitioning:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Top-level column                                    359            396          59          2.8         358.9       1.0X
-Nested column                                      4100           4147          59          0.2        4099.9       0.1X
+Top-level column                                    386            399          16          2.6         385.8       1.0X
+Nested column                                      2612           2666          57          0.4        2612.2       0.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_201-b09 on Linux 3.10.0-862.3.2.el7.x86_64
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Repartitioning by exprs:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Top-level column                                    367            394          56          2.7         366.8       1.0X
-Nested column                                      4182           4236          64          0.2        4181.5       0.1X
+Top-level column                                    392            454         119          2.5         392.2       1.0X
+Nested column                                      4106           4168          79          0.2        4106.1       0.1X
+
+OpenJDK 64-Bit Server VM 1.8.0_201-b09 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Sample:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Top-level column                                    146            157          13          6.9         145.9       1.0X
+Nested column                                      2294           2338          44          0.4        2293.6       0.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_201-b09 on Linux 3.10.0-862.3.2.el7.x86_64
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Sorting:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Top-level column                                    262            269           6          3.8         262.5       1.0X
-Nested column                                      2950           3021          65          0.3        2949.8       0.1X
+Top-level column                                    290            294           4          3.5         289.7       1.0X
+Nested column                                      2914           2997          87          0.3        2913.6       0.1X
 
 

--- a/sql/core/benchmarks/ParquetNestedSchemaPruningBenchmark-results.txt
+++ b/sql/core/benchmarks/ParquetNestedSchemaPruningBenchmark-results.txt
@@ -6,35 +6,42 @@ OpenJDK 64-Bit Server VM 1.8.0_201-b09 on Linux 3.10.0-862.3.2.el7.x86_64
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Selection:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Top-level column                                    145            174          23          6.9         145.1       1.0X
-Nested column                                       325            346          19          3.1         324.8       0.4X
+Top-level column                                    128            166          24          7.8         128.0       1.0X
+Nested column                                       308            325          10          3.2         308.3       0.4X
 
 OpenJDK 64-Bit Server VM 1.8.0_201-b09 on Linux 3.10.0-862.3.2.el7.x86_64
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Limiting:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Top-level column                                    434            508         108          2.3         434.3       1.0X
-Nested column                                       625            647          23          1.6         624.8       0.7X
+Top-level column                                    447            496          91          2.2         447.0       1.0X
+Nested column                                       631            666          40          1.6         631.2       0.7X
 
 OpenJDK 64-Bit Server VM 1.8.0_201-b09 on Linux 3.10.0-862.3.2.el7.x86_64
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Repartitioning:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Top-level column                                    357            368           9          2.8         356.9       1.0X
-Nested column                                      2897           2976          88          0.3        2897.4       0.1X
+Top-level column                                    360            394          84          2.8         360.0       1.0X
+Nested column                                       553            586          65          1.8         553.5       0.7X
 
 OpenJDK 64-Bit Server VM 1.8.0_201-b09 on Linux 3.10.0-862.3.2.el7.x86_64
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Repartitioning by exprs:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Top-level column                                    365            413          77          2.7         364.9       1.0X
-Nested column                                      2902           2969          99          0.3        2902.4       0.1X
+Top-level column                                    368            393          50          2.7         368.3       1.0X
+Nested column                                      2942           3017          82          0.3        2942.0       0.1X
+
+OpenJDK 64-Bit Server VM 1.8.0_201-b09 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Sample:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Top-level column                                    124            143          10          8.1         124.1       1.0X
+Nested column                                       345            366          34          2.9         344.8       0.4X
 
 OpenJDK 64-Bit Server VM 1.8.0_201-b09 on Linux 3.10.0-862.3.2.el7.x86_64
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Sorting:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Top-level column                                    555            600          80          1.8         555.4       1.0X
-Nested column                                      3448           3490          45          0.3        3447.9       0.2X
+Top-level column                                    577            618          55          1.7         576.8       1.0X
+Nested column                                      3473           3524          49          0.3        3473.0       0.2X
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

As [SPARK-26958](https://github.com/apache/spark/pull/23862/files) benchmark shows, nested-column pruning has limitations. This PR aims to remove the limitations on `limit/repartition/sample`. Here, repartition means `Repartition`, not `RepartitionByExpression`.

**PREPARATION**
```scala
scala> spark.range(100).map(x => (x, (x, s"$x" * 100))).toDF("col1", "col2").write.mode("overwrite").save("/tmp/p")
scala> sql("set spark.sql.optimizer.nestedSchemaPruning.enabled=true")
scala> spark.read.parquet("/tmp/p").createOrReplaceTempView("t")
```

**BEFORE**
```scala
scala> sql("SELECT col2._1 FROM (SELECT col2 FROM t LIMIT 1000000)").explain
== Physical Plan ==
CollectLimit 1000000
+- *(1) Project [col2#22._1 AS _1#28L]
   +- *(1) FileScan parquet [col2#22] Batched: false, DataFilters: [], Format: Parquet, Location: InMemoryFileIndex[file:/tmp/p], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<col2:struct<_1:bigint>>

scala> sql("SELECT col2._1 FROM (SELECT /*+ REPARTITION(1) */ col2 FROM t)").explain
== Physical Plan ==
*(2) Project [col2#22._1 AS _1#33L]
+- Exchange RoundRobinPartitioning(1)
   +- *(1) Project [col2#22]
      +- *(1) FileScan parquet [col2#22] Batched: false, DataFilters: [], Format: Parquet, Location: InMemoryFileIndex[file:/tmp/p], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<col2:struct<_1:bigint,_2:string>>
```

**AFTER**
```scala
scala> sql("SELECT col2._1 FROM (SELECT /*+ REPARTITION(1) */ col2 FROM t)").explain
== Physical Plan ==
Exchange RoundRobinPartitioning(1)
+- *(1) Project [col2#5._1 AS _1#11L]
   +- *(1) FileScan parquet [col2#5] Batched: false, DataFilters: [], Format: Parquet, Location: InMemoryFileIndex[file:/tmp/p], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<col2:struct<_1:bigint>>
```

This supercedes https://github.com/apache/spark/pull/23542 and https://github.com/apache/spark/pull/23873 .

## How was this patch tested?

Pass the Jenkins with a newly added test suite.