### PR TITLE
[SPARK-27001][SQL][FOLLOW-UP] Drop Serializable in WalkedTypePath

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/WalkedTypePath.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/WalkedTypePath.scala
@@ -22,7 +22,7 @@ package org.apache.spark.sql.catalyst
  * Note that this class adds new path in prior to recorded paths so it maintains
  * the paths as reverse order.
  */
-case class WalkedTypePath(private val walkedPaths: Seq[String] = Nil) extends Serializable {
+case class WalkedTypePath(private val walkedPaths: Seq[String] = Nil) {
   def recordRoot(className: String): WalkedTypePath =
     newInstance(s"""- root class: "$className"""")
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr tried to drop `Serializable` in `WalkedTypePath`.

## How was this patch tested?
Pass Jenkins.