### PR TITLE
[SPARK-26592][SS][DOC] Add Kafka proxy user caveat to documentation

### DIFF
--- a/docs/structured-streaming-kafka-integration.md
+++ b/docs/structured-streaming-kafka-integration.md
@@ -693,6 +693,10 @@ must match with Kafka broker configuration.
 
 When delegation token is available on an executor it can be overridden with JAAS login configuration.
 
+#### Caveats
+
+- Obtaining delegation token for proxy user is not yet supported ([KAFKA-6945](https://issues.apache.org/jira/browse/KAFKA-6945)).
+
 ### JAAS login configuration
 
 JAAS login configuration must placed on all nodes where Spark tries to access Kafka cluster.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since this caveat added to the DStreams documentation it would be good to add to Structured Streaming as well.

## How was this patch tested?

cd docs/
SKIP_API=1 jekyll build
Manual webpage check.
