### PR TITLE
[SPARK-27062] CatalogImpl.refreshTable should recreate cache with received tableName.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -492,7 +492,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
       // Uncache the logicalPlan.
       sparkSession.sharedState.cacheManager.uncacheQuery(table, blocking = true)
       // Cache it again.
-      sparkSession.sharedState.cacheManager.cacheQuery(table, Some(tableIdent.table))
+      sparkSession.sharedState.cacheManager.cacheQuery(table, Some(tableName))
     }
   }
 


### PR DESCRIPTION
If CatalogImpl.refreshTable() method is invoked against a cached table, this method would first uncache corresponding query in the shared state cache manager, and then cache it back to refresh the cache copy. 

However, the table was recached with only 'table name'. The database name will be missed. Therefore, if cached table is not on the default database, the recreated cache may refer to a different table. For example, we may see the cached table name in driver's storage page will be changed after table refreshing. 

Actually, CatalogImpl registers cache with received table name. Therefore, I would like to propose aligning the behavior. RefreshTable method should reuse the received table name instead. 

## What changes were proposed in this pull request?

Align the behavior of CatalogImpl.cacheTable and CatalogImpl.refreshTable, such that they both register query with received tableName. 

## How was this patch tested?

It was tested with existing unit tests. 

Please review http://spark.apache.org/contributing.html before opening a pull request.
