### PR TITLE
[SPARK-27063][K8S] Up timeouts for slower clusters

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SecretsTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SecretsTestsSuite.scala
@@ -105,7 +105,7 @@ private[spark] trait SecretsTestsSuite { k8sSuite: KubernetesSuite =>
       .withTTY()
       .exec(cmd.toArray: _*)
     // wait to get some result back
-    Thread.sleep(1000)
+    Thread.sleep(5000)
     watch.close()
     out.flush()
     out.toString()


### PR DESCRIPTION
## What changes were proposed in this pull request?

As noted and discussed in PR #23846 there are a couple of K8S integration tests whose timeouts are too low to reliably succeed on lower powered clusters e.g. developers laptops, small CI clusters.

This PR increases those timeouts accordingly.

## How was this patch tested?

Verified that the intermittently failing test now reliably passes on my low powered cluster
