### PR TITLE
[SPARK-26439][CORE][WIP] Introduce WorkerOffer reservation mechanism for Barrier TaskSet

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1007,6 +1007,24 @@ package object config {
       .checkValue(v => v > 0, "The max failures should be a positive value.")
       .createWithDefault(40)
 
+  private[spark] val BARRIER_NO_SUFFICIENT_RESOURCE_TIMEOUT =
+    ConfigBuilder("spark.scheduler.barrier.noSufficientResource.timeout")
+      .doc("Time in minutes to wait before a barrier TaskSet get sufficient resource " +
+        "to launch tasks. Abort the barrier TaskSet once it expires to avoid job " +
+        "hanging indefinitely.")
+      .timeConf(TimeUnit.MINUTES)
+      .checkValue(v => v > 0, "Time value should be a positive value.")
+      .createWithDefault(5)
+
+  private[spark] val BARRIER_MAX_CONSECUTIVE_NO_BARRIER_TASKSET_LAUNCH_TIMES =
+    ConfigBuilder("spark.scheduler.barrier.maxConsecutiveNoBarrierTaskSetLaunchTimes")
+      .doc("Number of max consecutive times of no any barrier taskSet launched in each " +
+        "resourceOffers round. TaskScheduler will ask barrier taskSets to release reserved" +
+        "WorkOffers if it reach this point.")
+      .intConf
+      .checkValue(v => v > 0, "The maxConsecutiveNoTaskSetLaunchTimes should be a positive value.")
+      .createWithDefault(5)
+
   private[spark] val UNSAFE_EXCEPTION_ON_MEMORY_LEAK =
     ConfigBuilder("spark.unsafe.exceptionOnMemoryLeak")
       .internal()

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -358,10 +358,6 @@ private[spark] class TaskSchedulerImpl(
     rootPool.getSortedTaskSetQueue.filter(_.isBarrier)
   }
 
-  private def excludeReservedCpus(offers: Seq[WorkerOffer]): Array[Int] = {
-    excludeReservedCpus(offers.toIndexedSeq, getSortedBarrierTaskSets)
-  }
-
   private def excludeReservedCpus(
     offers: IndexedSeq[WorkerOffer],
     barrierTaskSets: ArrayBuffer[TaskSetManager])
@@ -422,29 +418,27 @@ private[spark] class TaskSchedulerImpl(
       tasks: IndexedSeq[ArrayBuffer[TaskDescription]]) : Boolean = {
     var launchedTask = false
     val reviveOffers = new ArrayBuffer[WorkerOffer] ++ shuffledOffers
-    var dynamicAvailableCpus = availableCpus
+    val addedReviveOffersPerRound = new ArrayBuffer[WorkerOffer]()
     // nodes and executors that are blacklisted for the entire application have already been
     // filtered out by this point
     while (reviveOffers.nonEmpty) {
-      val addedReviveOffersPerRound = new ArrayBuffer[WorkerOffer]()
-      var replaced = false
       for (i <- 0 until shuffledOffers.size if reviveOffers.contains(shuffledOffers(i))) {
         val execId = shuffledOffers(i).executorId
         val host = shuffledOffers(i).host
-        if (dynamicAvailableCpus(i) >= CPUS_PER_TASK) {
+        if (availableCpus(i) >= CPUS_PER_TASK) {
           try {
             for (task <- taskSet.resourceOffer(execId, host, maxLocality)) {
-              dynamicAvailableCpus(i) -= CPUS_PER_TASK
+              availableCpus(i) -= CPUS_PER_TASK
               launchedTask = true
               // Only update hosts for a barrier task.
               if (taskSet.isBarrier) {
                 if (task.executorId != execId) {
-                  replaced = true
                   val replacedExecId = task.executorId
                   val offerIndex = execIdToOfferIndex(replacedExecId)
+                  availableCpus(offerIndex) += CPUS_PER_TASK
                   if (offerIndex < i) {
-                    // given the WorkerOffer a second chance to offer the resource for the taskSet,
-                    // which reclaims the resource just now
+                    // given the WorkerOffer, which reclaims the resource just now,
+                    // a second chance to offer the resource for the taskSet
                     addedReviveOffersPerRound += shuffledOffers(offerIndex)
                   }
                 }
@@ -467,11 +461,6 @@ private[spark] class TaskSchedulerImpl(
               return launchedTask
           }
         }
-      }
-      if (replaced) {
-        // update WorkerOffers'free cores since some reserved WorkerOffers are
-        // released during resourceOffer()
-        dynamicAvailableCpus = excludeReservedCpus(shuffledOffers)
       }
       reviveOffers.clear()
       reviveOffers ++= addedReviveOffersPerRound

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -367,9 +367,9 @@ private[spark] class TaskSchedulerImpl(
     barrierTaskSets: ArrayBuffer[TaskSetManager])
     : Array[Int] = {
     val execIdToReadyTaskNum = barrierTaskSets.map { ts =>
-      val execIdToTaskNum = ts.getReadyTaskToReservedWorkOffer.map {
-        case (_, (_, reservedWorkOffer)) =>
-          (reservedWorkOffer.execId, 1)
+      val execIdToTaskNum = ts.getReadyTaskToReservedWorkerOffer.map {
+        case (_, (_, reservedWorkerOffer)) =>
+          (reservedWorkerOffer.execId, 1)
       }.groupBy { case (execId, _) =>
         execId
       }.map { case (execId, taskList) =>
@@ -389,23 +389,23 @@ private[spark] class TaskSchedulerImpl(
     }.toArray
   }
 
-  private def releaseReservedWorkOfferIfNecessary(alreadyReleased: Int): Unit = {
+  private def releaseReservedWorkerOfferIfNecessary(alreadyReleased: Int): Unit = {
     val barrierTaskSets = getSortedBarrierTaskSets
     val needed =
-      barrierTaskSets.map(ts => ts.numTasks - ts.getReadyTaskToReservedWorkOffer.size).sum
+      barrierTaskSets.map(ts => ts.numTasks - ts.getReadyTaskToReservedWorkerOffer.size).sum
     // take a half by taking waiting time into account roughly
     val canBeReleased = runningTasksByExecutors.values.sum / 2
     var extraNeeded = math.max(needed - alreadyReleased - canBeReleased, 0)
-    // start to force release reserved WorkOffer from the last barrier in the sorted queue
+    // start to force release reserved WorkerOffer from the last barrier in the sorted queue
     var index = barrierTaskSets.size
     while (extraNeeded > 0 && index > 0) {
       index -= 1
       val bts = barrierTaskSets(index)
-      val readyTaskNum = bts.getReadyTaskToReservedWorkOffer.size
+      val readyTaskNum = bts.getReadyTaskToReservedWorkerOffer.size
       if (readyTaskNum <= extraNeeded) {
-        bts.releaseReservedWorkOffer()
+        bts.releaseReservedWorkerOffer()
       } else {
-        bts.releaseReservedWorkOfferByLocality(extraNeeded)
+        bts.releaseReservedWorkerOfferByLocality(extraNeeded)
       }
       extraNeeded -= readyTaskNum
     }
@@ -441,7 +441,7 @@ private[spark] class TaskSchedulerImpl(
                   val replacedExecId = task.executorId
                   val offerIndex = execIdToOfferIndex(replacedExecId)
                   if (offerIndex < i) {
-                    // given the WorkOffer a second chance to offer the resource for the taskSet,
+                    // given the WorkerOffer a second chance to offer the resource for the taskSet,
                     // which reclaims the resource just now
                     addedReviveOffersPerRound += shuffledOffers(offerIndex)
                   }
@@ -449,7 +449,7 @@ private[spark] class TaskSchedulerImpl(
                 // don't do another resourceOffer round if we've already archived the goal, even if
                 // we have new added reviveOffers in this round, which may provide better locality
                 // preference, but that's not guaranteed.
-                if (taskSet.getReadyTaskToReservedWorkOffer.size == taskSet.numTasks) {
+                if (taskSet.getReadyTaskToReservedWorkerOffer.size == taskSet.numTasks) {
                   return launchedTask
                 }
               } else {
@@ -467,7 +467,7 @@ private[spark] class TaskSchedulerImpl(
         }
       }
       if (replaced) {
-        // update WorkOffers' free cores since some reserved WorkOffers are
+        // update WorkerOffers'free cores since some reserved WorkerOffers are
         // released during resourceOffer()
         dynamicAvailableCpus = excludeReservedCpus(shuffledOffers)
       }
@@ -592,8 +592,8 @@ private[spark] class TaskSchedulerImpl(
       }
 
       if (taskSet.isBarrier &&
-        taskSet.getReadyTaskToReservedWorkOffer.size == taskSet.numTasks) {
-          val readyTasks = taskSet.getReadyTaskToReservedWorkOffer
+        taskSet.getReadyTaskToReservedWorkerOffer.size == taskSet.numTasks) {
+          val readyTasks = taskSet.getReadyTaskToReservedWorkerOffer
           val curTime = clock.getTimeMillis()
           // Record all the executor IDs assigned barrier tasks on.
           val addressesWithDescs = readyTasks.map { case (index, (speculative, reservedOffer)) =>
@@ -618,9 +618,9 @@ private[spark] class TaskSchedulerImpl(
             .map(_._1)
             .mkString(",")
           addressesWithDescs.foreach(_._2.properties.setProperty("addresses", addressesStr))
-          // clear reserved WorkOffer, so that we do not exclude its reserved Cpus
+          // clear reserved WorkerOffer, so that we do not exclude its reserved Cpus
           // in next resourceOffer round.
-          taskSet.releaseReservedWorkOffer()
+          taskSet.releaseReservedWorkerOffer()
           launchedAnyBarrierTaskSet = true
           logInfo(s"Successfully scheduled all the ${addressesWithDescs.size} tasks for barrier " +
             s"stage ${taskSet.stageId}.")
@@ -634,7 +634,7 @@ private[spark] class TaskSchedulerImpl(
         val timeoutTaskSets = barrierTaskSetByTimeout.filter(_._2._2 < curTime)
         // given a second chance for barrier TaskSets who timeout for the first time,
         // since we've successfully launched some barrier TaskSets in this resourceOffer
-        // round and hopefully to get released WorkOffer in latter round.
+        // round and hopefully to get released WorkerOffer in latter round.
         val (firsts, seconds) = timeoutTaskSets.partition(_._2._1 == 0)
         firsts.keySet.foreach { ts =>
           barrierTaskSetByTimeout(ts) = (1, curTime + barrierTaskSetNoSufficientResourceTimeoutMs)
@@ -648,8 +648,8 @@ private[spark] class TaskSchedulerImpl(
 
     val released = {
       abortBarrierTaskSets.map { case (ts, times) =>
-        val reserved = ts.getReadyTaskToReservedWorkOffer.size
-        ts.releaseReservedWorkOffer()
+        val reserved = ts.getReadyTaskToReservedWorkerOffer.size
+        ts.releaseReservedWorkerOffer()
         val waitTime = 1.0 * (times + 1) * barrierTaskSetNoSufficientResourceTimeoutMs / 60 / 1000
         ts.abort(
           s"Barrier TaskSet ${ts.taskSet.id} abort due to " +
@@ -661,9 +661,9 @@ private[spark] class TaskSchedulerImpl(
     if (abortBarrierTaskSets.nonEmpty ||
       (getSortedBarrierTaskSets.nonEmpty && !launchedAnyBarrierTaskSet &&
       noBarrierTaskSetLaunchCounter >= MAX_CONSECUTIVE_NO_BARRIER_TASKSET_LAUNCH_TIMES)) {
-      // to force release reserved WorkOffer in case of some barrier TaskSets holds the resource
+      // to force release reserved WorkerOffer in case of some barrier TaskSets holds the resource
       // for a long time and cause deadlock problem on the resource in the end.
-      releaseReservedWorkOfferIfNecessary(released)
+      releaseReservedWorkerOfferIfNecessary(released)
     }
 
     // TODO SPARK-24823 Cancel a job that contains barrier stage(s) if the barrier tasks don't get

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -97,6 +97,15 @@ private[spark] class TaskSchedulerImpl(
   // on this class.  Protected by `this`
   private val taskSetsByStageIdAndAttempt = new HashMap[Int, HashMap[Int, TaskSetManager]]
 
+  private val MAX_CONSECUTIVE_NO_BARRIER_TASKSET_LAUNCH_TIMES =
+    conf.get(config.BARRIER_MAX_CONSECUTIVE_NO_BARRIER_TASKSET_LAUNCH_TIMES)
+
+  private val barrierTaskSetNoSufficientResourceTimeoutMs =
+    conf.get(config.BARRIER_NO_SUFFICIENT_RESOURCE_TIMEOUT) * 60 * 1000
+
+  private var noBarrierTaskSetLaunchCounter = 0
+  private val barrierTaskSetByTimeout = new HashMap[TaskSetManager, (Int, Long)]
+
   // Protected by `this`
   private[scheduler] val taskIdToTaskSetManager = new ConcurrentHashMap[Long, TaskSetManager]
   // Protected by `this`
@@ -229,6 +238,10 @@ private[spark] class TaskSchedulerImpl(
         ts.isZombie = true
       }
       stageTaskSets(taskSet.stageAttemptId) = manager
+      if (manager.isBarrier) {
+        barrierTaskSetByTimeout(manager) =
+          (0, clock.getTimeMillis() + barrierTaskSetNoSufficientResourceTimeoutMs)
+      }
       schedulableBuilder.addTaskSetManager(manager, manager.taskSet.properties)
 
       if (!isLocal && !hasReceivedTask) {
@@ -335,45 +348,134 @@ private[spark] class TaskSchedulerImpl(
       s" ${manager.parent.name}")
   }
 
+  private def addRunningTask(tid: Long, taskSet: TaskSetManager, execId: String): Unit = {
+    taskIdToTaskSetManager.put(tid, taskSet)
+    taskIdToExecutorId(tid) = execId
+    executorIdToRunningTaskIds(execId).add(tid)
+  }
+
+  private def getSortedBarrierTaskSets: ArrayBuffer[TaskSetManager] = {
+    rootPool.getSortedTaskSetQueue.filter(_.isBarrier)
+  }
+
+  private def excludeReservedCpus(offers: Seq[WorkerOffer]): Array[Int] = {
+    excludeReservedCpus(offers.toIndexedSeq, getSortedBarrierTaskSets)
+  }
+
+  private def excludeReservedCpus(
+    offers: IndexedSeq[WorkerOffer],
+    barrierTaskSets: ArrayBuffer[TaskSetManager])
+    : Array[Int] = {
+    val execIdToReadyTaskNum = barrierTaskSets.map { ts =>
+      val execIdToTaskNum = ts.getReadyTaskToReservedWorkOffer.map {
+        case (_, (_, reservedWorkOffer)) =>
+          (reservedWorkOffer.execId, 1)
+      }.groupBy { case (execId, _) =>
+        execId
+      }.map { case (execId, taskList) =>
+        val sum = taskList.map {case (_, num) => num }.sum
+        (execId, sum)
+      }
+      execIdToTaskNum
+    }.foldLeft(HashMap[String, Int]()) { case (resMap, execIdToTaskNum) =>
+      execIdToTaskNum.foreach { case (execId, num) =>
+        resMap += (execId -> (num + resMap.getOrElse(execId, 0)))
+      }
+      resMap
+    }
+    offers.map { o =>
+      val reservedCpus = execIdToReadyTaskNum.getOrElse(o.executorId, 0) * CPUS_PER_TASK
+      o.cores - reservedCpus
+    }.toArray
+  }
+
+  private def releaseReservedWorkOfferIfNecessary(alreadyReleased: Int): Unit = {
+    val barrierTaskSets = getSortedBarrierTaskSets
+    val needed =
+      barrierTaskSets.map(ts => ts.numTasks - ts.getReadyTaskToReservedWorkOffer.size).sum
+    // take a half by taking waiting time into account roughly
+    val canBeReleased = runningTasksByExecutors.values.sum / 2
+    var extraNeeded = math.max(needed - alreadyReleased - canBeReleased, 0)
+    // start to force release reserved WorkOffer from the last barrier in the sorted queue
+    var index = barrierTaskSets.size
+    while (extraNeeded > 0 && index > 0) {
+      index -= 1
+      val bts = barrierTaskSets(index)
+      val readyTaskNum = bts.getReadyTaskToReservedWorkOffer.size
+      if (readyTaskNum <= extraNeeded) {
+        bts.releaseReservedWorkOffer()
+      } else {
+        bts.releaseReservedWorkOfferByLocality(extraNeeded)
+      }
+      extraNeeded -= readyTaskNum
+    }
+  }
+
   private def resourceOfferSingleTaskSet(
       taskSet: TaskSetManager,
       maxLocality: TaskLocality,
       shuffledOffers: Seq[WorkerOffer],
       availableCpus: Array[Int],
-      tasks: IndexedSeq[ArrayBuffer[TaskDescription]],
-      addressesWithDescs: ArrayBuffer[(String, TaskDescription)]) : Boolean = {
+      execIdToOfferIndex: Map[String, Int],
+      tasks: IndexedSeq[ArrayBuffer[TaskDescription]]) : Boolean = {
     var launchedTask = false
+    val reviveOffers = new ArrayBuffer[WorkerOffer] ++ shuffledOffers
+    var dynamicAvailableCpus = availableCpus
     // nodes and executors that are blacklisted for the entire application have already been
     // filtered out by this point
-    for (i <- 0 until shuffledOffers.size) {
-      val execId = shuffledOffers(i).executorId
-      val host = shuffledOffers(i).host
-      if (availableCpus(i) >= CPUS_PER_TASK) {
-        try {
-          for (task <- taskSet.resourceOffer(execId, host, maxLocality)) {
-            tasks(i) += task
-            val tid = task.taskId
-            taskIdToTaskSetManager.put(tid, taskSet)
-            taskIdToExecutorId(tid) = execId
-            executorIdToRunningTaskIds(execId).add(tid)
-            availableCpus(i) -= CPUS_PER_TASK
-            assert(availableCpus(i) >= 0)
-            // Only update hosts for a barrier task.
-            if (taskSet.isBarrier) {
-              // The executor address is expected to be non empty.
-              addressesWithDescs += (shuffledOffers(i).address.get -> task)
+    while (reviveOffers.nonEmpty) {
+      val addedReviveOffersPerRound = new ArrayBuffer[WorkerOffer]()
+      var replaced = false
+      for (i <- 0 until shuffledOffers.size if reviveOffers.contains(shuffledOffers(i))) {
+        val execId = shuffledOffers(i).executorId
+        val host = shuffledOffers(i).host
+        if (dynamicAvailableCpus(i) >= CPUS_PER_TASK) {
+          try {
+            for (task <- taskSet.resourceOffer(execId, host, maxLocality)) {
+              dynamicAvailableCpus(i) -= CPUS_PER_TASK
+              launchedTask = true
+              // Only update hosts for a barrier task.
+              if (taskSet.isBarrier) {
+                if (task.executorId != execId) {
+                  replaced = true
+                  val replacedExecId = task.executorId
+                  val offerIndex = execIdToOfferIndex(replacedExecId)
+                  if (offerIndex < i) {
+                    // given the WorkOffer a second chance to offer the resource for the taskSet,
+                    // which reclaims the resource just now
+                    addedReviveOffersPerRound += shuffledOffers(offerIndex)
+                  }
+                }
+                // don't do another resourceOffer round if we've already archived the goal, even if
+                // we have new added reviveOffers in this round, which may provide better locality
+                // preference, but that's not guaranteed.
+                if (taskSet.getReadyTaskToReservedWorkOffer.size == taskSet.numTasks) {
+                  return launchedTask
+                }
+              } else {
+                tasks(i) += task
+                addRunningTask(task.taskId, taskSet, execId)
+              }
             }
-            launchedTask = true
+          } catch {
+            case e: TaskNotSerializableException =>
+              logError(s"Resource offer failed, task set ${taskSet.name} was not serializable")
+              // Do not offer resources for this task, but don't throw an error to allow other
+              // task sets to be submitted.
+              return launchedTask
           }
-        } catch {
-          case e: TaskNotSerializableException =>
-            logError(s"Resource offer failed, task set ${taskSet.name} was not serializable")
-            // Do not offer resources for this task, but don't throw an error to allow other
-            // task sets to be submitted.
-            return launchedTask
         }
       }
+      if (replaced) {
+        // update WorkOffers' free cores since some reserved WorkOffers are
+        // released during resourceOffer()
+        dynamicAvailableCpus = excludeReservedCpus(shuffledOffers)
+      }
+      reviveOffers.clear()
+      reviveOffers ++= addedReviveOffersPerRound
+      addedReviveOffersPerRound.clear()
     }
+
     return launchedTask
   }
 
@@ -414,12 +516,13 @@ private[spark] class TaskSchedulerImpl(
       }
     }.getOrElse(offers)
 
+    val sortedTaskSets = rootPool.getSortedTaskSetQueue
     val shuffledOffers = shuffleOffers(filteredOffers)
+    val availableCpus = excludeReservedCpus(shuffledOffers, sortedTaskSets)
+    val execIdToOfferIndex =
+      shuffledOffers.zipWithIndex.map { case (o, i) => (o.executorId, i)}.toMap
     // Build a list of tasks to assign to each worker.
     val tasks = shuffledOffers.map(o => new ArrayBuffer[TaskDescription](o.cores / CPUS_PER_TASK))
-    val availableCpus = shuffledOffers.map(o => o.cores).toArray
-    val availableSlots = shuffledOffers.map(o => o.cores / CPUS_PER_TASK).sum
-    val sortedTaskSets = rootPool.getSortedTaskSetQueue
     for (taskSet <- sortedTaskSets) {
       logDebug("parentName: %s, name: %s, runningTasks: %s".format(
         taskSet.parent.name, taskSet.name, taskSet.runningTasks))
@@ -427,87 +530,83 @@ private[spark] class TaskSchedulerImpl(
         taskSet.executorAdded()
       }
     }
-
+    var launchedAnyBarrierTaskSet = false
     // Take each TaskSet in our scheduling order, and then offer it each node in increasing order
     // of locality levels so that it gets a chance to launch local tasks on all of them.
     // NOTE: the preferredLocality order: PROCESS_LOCAL, NODE_LOCAL, NO_PREF, RACK_LOCAL, ANY
     for (taskSet <- sortedTaskSets) {
-      // Skip the barrier taskSet if the available slots are less than the number of pending tasks.
-      if (taskSet.isBarrier && availableSlots < taskSet.numTasks) {
-        // Skip the launch process.
-        // TODO SPARK-24819 If the job requires more slots than available (both busy and free
-        // slots), fail the job on submit.
-        logInfo(s"Skip current round of resource offers for barrier stage ${taskSet.stageId} " +
-          s"because the barrier taskSet requires ${taskSet.numTasks} slots, while the total " +
-          s"number of available slots is $availableSlots.")
+      var launchedAnyTask = false
+      for (currentMaxLocality <- taskSet.myLocalityLevels) {
+        var launchedTaskAtCurrentMaxLocality = false
+        do {
+          launchedTaskAtCurrentMaxLocality = resourceOfferSingleTaskSet(taskSet,
+            currentMaxLocality, shuffledOffers, availableCpus, execIdToOfferIndex, tasks)
+          launchedAnyTask |= launchedTaskAtCurrentMaxLocality
+        } while (launchedTaskAtCurrentMaxLocality)
+      }
+
+      if (!launchedAnyTask) {
+        taskSet.getCompletelyBlacklistedTaskIfAny(hostToExecutors).foreach { taskIndex =>
+            // If the taskSet is unschedulable we try to find an existing idle blacklisted
+            // executor. If we cannot find one, we abort immediately. Else we kill the idle
+            // executor and kick off an abortTimer which if it doesn't schedule a task within the
+            // the timeout will abort the taskSet if we were unable to schedule any task from the
+            // taskSet.
+            // Note 1: We keep track of schedulability on a per taskSet basis rather than on a per
+            // task basis.
+            // Note 2: The taskSet can still be aborted when there are more than one idle
+            // blacklisted executors and dynamic allocation is on. This can happen when a killed
+            // idle executor isn't replaced in time by ExecutorAllocationManager as it relies on
+            // pending tasks and doesn't kill executors on idle timeouts, resulting in the abort
+            // timer to expire and abort the taskSet.
+            executorIdToRunningTaskIds.find(x => !isExecutorBusy(x._1)) match {
+              case Some ((executorId, _)) =>
+                if (!unschedulableTaskSetToExpiryTime.contains(taskSet)) {
+                  blacklistTrackerOpt.foreach(blt => blt.killBlacklistedIdleExecutor(executorId))
+
+                  val timeout = conf.get(config.UNSCHEDULABLE_TASKSET_TIMEOUT) * 1000
+                  unschedulableTaskSetToExpiryTime(taskSet) = clock.getTimeMillis() + timeout
+                  logInfo(s"Waiting for $timeout ms for completely "
+                    + s"blacklisted task to be schedulable again before aborting $taskSet.")
+                  abortTimer.schedule(
+                    createUnschedulableTaskSetAbortTimer(taskSet, taskIndex), timeout)
+                }
+              case None => // Abort Immediately
+                logInfo("Cannot schedule any task because of complete blacklisting. No idle" +
+                  s" executors can be found to kill. Aborting $taskSet." )
+                taskSet.abortSinceCompletelyBlacklisted(taskIndex)
+            }
+        }
       } else {
-        var launchedAnyTask = false
-        // Record all the executor IDs assigned barrier tasks on.
-        val addressesWithDescs = ArrayBuffer[(String, TaskDescription)]()
-        for (currentMaxLocality <- taskSet.myLocalityLevels) {
-          var launchedTaskAtCurrentMaxLocality = false
-          do {
-            launchedTaskAtCurrentMaxLocality = resourceOfferSingleTaskSet(taskSet,
-              currentMaxLocality, shuffledOffers, availableCpus, tasks, addressesWithDescs)
-            launchedAnyTask |= launchedTaskAtCurrentMaxLocality
-          } while (launchedTaskAtCurrentMaxLocality)
+        // We want to defer killing any taskSets as long as we have a non blacklisted executor
+        // which can be used to schedule a task from any active taskSets. This ensures that the
+        // job can make progress.
+        // Note: It is theoretically possible that a taskSet never gets scheduled on a
+        // non-blacklisted executor and the abort timer doesn't kick in because of a constant
+        // submission of new TaskSets. See the PR for more details.
+        if (unschedulableTaskSetToExpiryTime.nonEmpty) {
+          logInfo("Clearing the expiry times for all unschedulable taskSets as a task was " +
+            "recently scheduled.")
+          unschedulableTaskSetToExpiryTime.clear()
         }
+      }
 
-        if (!launchedAnyTask) {
-          taskSet.getCompletelyBlacklistedTaskIfAny(hostToExecutors).foreach { taskIndex =>
-              // If the taskSet is unschedulable we try to find an existing idle blacklisted
-              // executor. If we cannot find one, we abort immediately. Else we kill the idle
-              // executor and kick off an abortTimer which if it doesn't schedule a task within the
-              // the timeout will abort the taskSet if we were unable to schedule any task from the
-              // taskSet.
-              // Note 1: We keep track of schedulability on a per taskSet basis rather than on a per
-              // task basis.
-              // Note 2: The taskSet can still be aborted when there are more than one idle
-              // blacklisted executors and dynamic allocation is on. This can happen when a killed
-              // idle executor isn't replaced in time by ExecutorAllocationManager as it relies on
-              // pending tasks and doesn't kill executors on idle timeouts, resulting in the abort
-              // timer to expire and abort the taskSet.
-              executorIdToRunningTaskIds.find(x => !isExecutorBusy(x._1)) match {
-                case Some ((executorId, _)) =>
-                  if (!unschedulableTaskSetToExpiryTime.contains(taskSet)) {
-                    blacklistTrackerOpt.foreach(blt => blt.killBlacklistedIdleExecutor(executorId))
-
-                    val timeout = conf.get(config.UNSCHEDULABLE_TASKSET_TIMEOUT) * 1000
-                    unschedulableTaskSetToExpiryTime(taskSet) = clock.getTimeMillis() + timeout
-                    logInfo(s"Waiting for $timeout ms for completely "
-                      + s"blacklisted task to be schedulable again before aborting $taskSet.")
-                    abortTimer.schedule(
-                      createUnschedulableTaskSetAbortTimer(taskSet, taskIndex), timeout)
-                  }
-                case None => // Abort Immediately
-                  logInfo("Cannot schedule any task because of complete blacklisting. No idle" +
-                    s" executors can be found to kill. Aborting $taskSet." )
-                  taskSet.abortSinceCompletelyBlacklisted(taskIndex)
-              }
-          }
-        } else {
-          // We want to defer killing any taskSets as long as we have a non blacklisted executor
-          // which can be used to schedule a task from any active taskSets. This ensures that the
-          // job can make progress.
-          // Note: It is theoretically possible that a taskSet never gets scheduled on a
-          // non-blacklisted executor and the abort timer doesn't kick in because of a constant
-          // submission of new TaskSets. See the PR for more details.
-          if (unschedulableTaskSetToExpiryTime.nonEmpty) {
-            logInfo("Clearing the expiry times for all unschedulable taskSets as a task was " +
-              "recently scheduled.")
-            unschedulableTaskSetToExpiryTime.clear()
-          }
-        }
-
-        if (launchedAnyTask && taskSet.isBarrier) {
-          // Check whether the barrier tasks are partially launched.
-          // TODO SPARK-24818 handle the assert failure case (that can happen when some locality
-          // requirements are not fulfilled, and we should revert the launched tasks).
-          require(addressesWithDescs.size == taskSet.numTasks,
-            s"Skip current round of resource offers for barrier stage ${taskSet.stageId} " +
-              s"because only ${addressesWithDescs.size} out of a total number of " +
-              s"${taskSet.numTasks} tasks got resource offers. The resource offers may have " +
-              "been blacklisted or cannot fulfill task locality requirements.")
+      if (taskSet.isBarrier &&
+        taskSet.getReadyTaskToReservedWorkOffer.size == taskSet.numTasks) {
+          val readyTasks = taskSet.getReadyTaskToReservedWorkOffer
+          val curTime = clock.getTimeMillis()
+          // Record all the executor IDs assigned barrier tasks on.
+          val addressesWithDescs = readyTasks.map { case (index, (speculative, reservedOffer)) =>
+            val execId = reservedOffer.execId
+            val host = reservedOffer.host
+            val locality = reservedOffer.locality
+            val taskDesc = taskSet.setupTask(index, execId, host, locality, curTime, speculative)
+            val offerIndex = execIdToOfferIndex(execId)
+            tasks(offerIndex) += taskDesc
+            addRunningTask(taskDesc.taskId, taskSet, execId)
+            // The executor address is expected to be non empty.
+            (shuffledOffers(offerIndex).address, taskDesc)
+          }.toArray
 
           // materialize the barrier coordinator.
           maybeInitBarrierCoordinator()
@@ -519,11 +618,52 @@ private[spark] class TaskSchedulerImpl(
             .map(_._1)
             .mkString(",")
           addressesWithDescs.foreach(_._2.properties.setProperty("addresses", addressesStr))
-
+          // clear reserved WorkOffer, so that we do not exclude its reserved Cpus
+          // in next resourceOffer round.
+          taskSet.releaseReservedWorkOffer()
+          launchedAnyBarrierTaskSet = true
           logInfo(s"Successfully scheduled all the ${addressesWithDescs.size} tasks for barrier " +
             s"stage ${taskSet.stageId}.")
-        }
       }
+    }
+
+    val curTime = clock.getTimeMillis()
+    val abortBarrierTaskSets = {
+      if (launchedAnyBarrierTaskSet) {
+        noBarrierTaskSetLaunchCounter = 0
+        val timeoutTaskSets = barrierTaskSetByTimeout.filter(_._2._2 < curTime)
+        // given a second chance for barrier TaskSets who timeout for the first time,
+        // since we've successfully launched some barrier TaskSets in this resourceOffer
+        // round and hopefully to get released WorkOffer in latter round.
+        val (firsts, seconds) = timeoutTaskSets.partition(_._2._1 == 0)
+        firsts.keySet.foreach { ts =>
+          barrierTaskSetByTimeout(ts) = (1, curTime + barrierTaskSetNoSufficientResourceTimeoutMs)
+        }
+        seconds.map { case (k, v) => (k, v._1.toInt) }
+      } else {
+        noBarrierTaskSetLaunchCounter += 1
+        barrierTaskSetByTimeout.filter(_._2._2 < curTime).map { case (k, v) => (k, v._1.toInt) }
+      }
+    }
+
+    val released = {
+      abortBarrierTaskSets.map { case (ts, times) =>
+        val reserved = ts.getReadyTaskToReservedWorkOffer.size
+        ts.releaseReservedWorkOffer()
+        val waitTime = 1.0 * (times + 1) * barrierTaskSetNoSufficientResourceTimeoutMs / 60 / 1000
+        ts.abort(
+          s"Barrier TaskSet ${ts.taskSet.id} abort due to " +
+          s"insufficient resource after waiting $waitTime min.")
+        reserved
+      }.sum
+    }
+
+    if (abortBarrierTaskSets.nonEmpty ||
+      (getSortedBarrierTaskSets.nonEmpty && !launchedAnyBarrierTaskSet &&
+      noBarrierTaskSetLaunchCounter >= MAX_CONSECUTIVE_NO_BARRIER_TASKSET_LAUNCH_TIMES)) {
+      // to force release reserved WorkOffer in case of some barrier TaskSets holds the resource
+      // for a long time and cause deadlock problem on the resource in the end.
+      releaseReservedWorkOfferIfNecessary(released)
     }
 
     // TODO SPARK-24823 Cancel a job that contains barrier stage(s) if the barrier tasks don't get

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -355,7 +355,9 @@ private[spark] class TaskSchedulerImpl(
   }
 
   private def getSortedBarrierTaskSets: ArrayBuffer[TaskSetManager] = {
-    rootPool.getSortedTaskSetQueue.filter(_.isBarrier)
+    rootPool.getSortedTaskSetQueue.filter { ts =>
+      ts.isBarrier && ts.runningTasks == 0
+    }
   }
 
   private def excludeReservedCpus(

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -104,7 +104,7 @@ private[spark] class TaskSchedulerImpl(
     conf.get(config.BARRIER_NO_SUFFICIENT_RESOURCE_TIMEOUT) * 60 * 1000
 
   private var noBarrierTaskSetLaunchCounter = 0
-  private val barrierTaskSetByTimeout = new HashMap[TaskSetManager, (Int, Long)]
+  private[scheduler] val barrierTaskSetByTimeout = new HashMap[TaskSetManager, (Int, Long)]
 
   // Protected by `this`
   private[scheduler] val taskIdToTaskSetManager = new ConcurrentHashMap[Long, TaskSetManager]
@@ -396,9 +396,11 @@ private[spark] class TaskSchedulerImpl(
     // take a half by taking waiting time into account roughly
     val canBeReleased = runningTasksByExecutors.values.sum / 2
     var extraNeeded = math.max(needed - alreadyReleased - canBeReleased, 0)
-    // start to force release reserved WorkerOffer from the last barrier in the sorted queue
+    // start to force release reserved WorkerOffer from the last barrier taskSet
+    // in the sorted queue
     var index = barrierTaskSets.size
-    while (extraNeeded > 0 && index > 0) {
+    // no need to release reserved WorkerOffer for the first barrier taskSet
+    while (extraNeeded > 0 && index > 1) {
       index -= 1
       val bts = barrierTaskSets(index)
       val readyTaskNum = bts.getReadyTaskToReservedWorkerOffer.size
@@ -621,6 +623,7 @@ private[spark] class TaskSchedulerImpl(
           // clear reserved WorkerOffer, so that we do not exclude its reserved Cpus
           // in next resourceOffer round.
           taskSet.releaseReservedWorkerOffer()
+          barrierTaskSetByTimeout.remove(taskSet)
           launchedAnyBarrierTaskSet = true
           logInfo(s"Successfully scheduled all the ${addressesWithDescs.size} tasks for barrier " +
             s"stage ${taskSet.stageId}.")
@@ -659,7 +662,7 @@ private[spark] class TaskSchedulerImpl(
     }
 
     if (abortBarrierTaskSets.nonEmpty ||
-      (getSortedBarrierTaskSets.nonEmpty && !launchedAnyBarrierTaskSet &&
+      (getSortedBarrierTaskSets.length > 1 && !launchedAnyBarrierTaskSet &&
       noBarrierTaskSetLaunchCounter >= MAX_CONSECUTIVE_NO_BARRIER_TASKSET_LAUNCH_TIMES)) {
       // to force release reserved WorkerOffer in case of some barrier TaskSets holds the resource
       // for a long time and cause deadlock problem on the resource in the end.

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -589,17 +589,18 @@ private[spark] class TaskSchedulerImpl(
           val readyTasks = taskSet.getReadyTaskToReservedWorkerOffer
           val curTime = clock.getTimeMillis()
           // Record all the executor IDs assigned barrier tasks on.
-          val addressesWithDescs = readyTasks.map { case (index, (speculative, reservedOffer)) =>
-            val execId = reservedOffer.execId
-            val host = reservedOffer.host
-            val locality = reservedOffer.locality
-            val taskDesc = taskSet.setupTask(index, execId, host, locality, curTime, speculative)
-            val offerIndex = execIdToOfferIndex(execId)
-            tasks(offerIndex) += taskDesc
-            addRunningTask(taskDesc.taskId, taskSet, execId)
-            // The executor address is expected to be non empty.
-            (shuffledOffers(offerIndex).address, taskDesc)
-          }.toArray
+          val addressesWithDescs =
+            readyTasks.toIterator.map { case (index, (speculative, reservedOffer)) =>
+              val execId = reservedOffer.execId
+              val host = reservedOffer.host
+              val locality = reservedOffer.locality
+              val taskDesc = taskSet.setupTask(index, execId, host, locality, curTime, speculative)
+              val offerIndex = execIdToOfferIndex(execId)
+              tasks(offerIndex) += taskDesc
+              addRunningTask(taskDesc.taskId, taskSet, execId)
+              // The executor address is expected to be non empty.
+              (shuffledOffers(offerIndex).address, taskDesc)
+            }.toArray
 
           // materialize the barrier coordinator.
           maybeInitBarrierCoordinator()

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -511,7 +511,7 @@ private[spark] class TaskSchedulerImpl(
 
     val sortedTaskSets = rootPool.getSortedTaskSetQueue
     val shuffledOffers = shuffleOffers(filteredOffers)
-    val availableCpus = excludeReservedCpus(shuffledOffers, sortedTaskSets)
+    val availableCpus = excludeReservedCpus(shuffledOffers, getSortedBarrierTaskSets)
     val execIdToOfferIndex =
       shuffledOffers.zipWithIndex.map { case (o, i) => (o.executorId, i)}.toMap
     // Build a list of tasks to assign to each worker.

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -33,7 +33,7 @@ import org.apache.spark.scheduler.SchedulingMode._
 import org.apache.spark.util.{AccumulatorV2, Clock, LongAccumulator, SystemClock, Utils}
 import org.apache.spark.util.collection.MedianHeap
 
-case class ReservedWorkOffer(execId: String, host: String, locality: TaskLocality.Value)
+case class ReservedWorkerOffer(execId: String, host: String, locality: TaskLocality.Value)
 
 /**
  * Schedules the tasks within a single TaskSet in the TaskSchedulerImpl. This class keeps track of
@@ -179,7 +179,7 @@ private[spark] class TaskSetManager(
   // was printed. This should ideally be an LRU map that can drop old exceptions automatically.
   private val recentExceptions = HashMap[String, (Int, Long)]()
 
-  private val readyTaskToReservedWorkOffer = HashMap[Int, (Boolean, ReservedWorkOffer)]()
+  private val readyTaskToReservedWorkerOffer = HashMap[Int, (Boolean, ReservedWorkerOffer)]()
 
   private val execIdToReadyTasks = HashMap[String, HashSet[Int]]()
 
@@ -276,8 +276,8 @@ private[spark] class TaskSetManager(
     pendingTasksForRack.getOrElse(rack, ArrayBuffer())
   }
 
-  def getReadyTaskToReservedWorkOffer: HashMap[Int, (Boolean, ReservedWorkOffer)] = {
-    readyTaskToReservedWorkOffer
+  def getReadyTaskToReservedWorkerOffer: HashMap[Int, (Boolean, ReservedWorkerOffer)] = {
+    readyTaskToReservedWorkerOffer
   }
 
   /**
@@ -501,27 +501,27 @@ private[spark] class TaskSetManager(
       serializedTask)
   }
 
-  def releaseReservedWorkOfferByLocality(num: Int): Unit = {
-    val sortedReservedWorkOffer = readyTaskToReservedWorkOffer.toArray.sortBy {
+  def releaseReservedWorkerOfferByLocality(num: Int): Unit = {
+    val sortedReservedWorkerOffer = readyTaskToReservedWorkerOffer.toArray.sortBy {
       case (_, (_, reservedOffer)) =>
         reservedOffer.locality
     }
 
-    val toRelease = sortedReservedWorkOffer.takeRight(num)
+    val toRelease = sortedReservedWorkerOffer.takeRight(num)
     toRelease.foreach {
       case (index, (_, _)) =>
-        releaseReservedWorkOffer(index)
+        releaseReservedWorkerOffer(index)
     }
   }
 
-  def releaseReservedWorkOffer(): Unit = {
+  def releaseReservedWorkerOffer(): Unit = {
     execIdToReadyTasks.foreach { case (_, tasks) =>
-      tasks.foreach(releaseReservedWorkOffer)
+      tasks.foreach(releaseReservedWorkerOffer)
     }
   }
 
-  private def releaseReservedWorkOffer(index: Int): Unit = {
-    readyTaskToReservedWorkOffer.remove(index) match {
+  private def releaseReservedWorkerOffer(index: Int): Unit = {
+    readyTaskToReservedWorkerOffer.remove(index) match {
       case Some((_, reservedOffer)) =>
         val execId = reservedOffer.execId
         execIdToReadyTasks(execId) -= index
@@ -531,9 +531,9 @@ private[spark] class TaskSetManager(
         // TODO hui bu hui chongfu ?
         addPendingTask(index)
         logInfo(s"ready task $index in barrier TaskSet ${taskSet.id} release " +
-          s"reserved WorkOffer(executor ${reservedOffer.execId}, host ${reservedOffer.host}).")
+          s"reserved WorkerOffer(executor ${reservedOffer.execId}, host ${reservedOffer.host}).")
       case None =>
-        logWarning(s"Trying to release reserved WorkOffer for an unknown ready task.")
+        logWarning(s"Trying to release reserved WorkerOffer for an unknown ready task.")
     }
   }
 
@@ -583,19 +583,19 @@ private[spark] class TaskSetManager(
         }
         if (isBarrier) {
           var replacedExecId = execId
-          if (readyTaskToReservedWorkOffer.contains(index)) {
-            val currentReservedResourceOffer = readyTaskToReservedWorkOffer(index)._2
-            if (taskLocality < currentReservedResourceOffer.locality) {
-              replacedExecId = currentReservedResourceOffer.execId
-              readyTaskToReservedWorkOffer(index) =
-                (speculative, ReservedWorkOffer(execId, host, taskLocality))
+          if (readyTaskToReservedWorkerOffer.contains(index)) {
+            val currentReservedWorkerOffer = readyTaskToReservedWorkerOffer(index)._2
+            if (taskLocality < currentReservedWorkerOffer.locality) {
+              replacedExecId = currentReservedWorkerOffer.execId
+              readyTaskToReservedWorkerOffer(index) =
+                (speculative, ReservedWorkerOffer(execId, host, taskLocality))
               val readyTasks = execIdToReadyTasks.getOrElse(execId, HashSet[Int]())
               readyTasks.add(index)
               execIdToReadyTasks(execId) = readyTasks
             }
           } else {
-            readyTaskToReservedWorkOffer(index) =
-              (speculative, ReservedWorkOffer(execId, host, taskLocality))
+            readyTaskToReservedWorkerOffer(index) =
+              (speculative, ReservedWorkerOffer(execId, host, taskLocality))
             val readyTasks = execIdToReadyTasks.getOrElse(execId, HashSet[Int]())
             readyTasks.add(index)
             execIdToReadyTasks(execId) = readyTasks
@@ -644,7 +644,7 @@ private[spark] class TaskSetManager(
         val index = pendingTaskIds(indexOffset)
         if (copiesRunning(index) == 0 && !successful(index)) {
           return true
-        } else if (isBarrier && !getReadyTaskToReservedWorkOffer.contains(index)) {
+        } else if (isBarrier && !getReadyTaskToReservedWorkerOffer.contains(index)) {
           return true
         } else {
           pendingTaskIds.remove(indexOffset)
@@ -1107,7 +1107,7 @@ private[spark] class TaskSetManager(
     execIdToReadyTasks.get(execId) match {
       case Some(taskIndexes) =>
         taskIndexes.foreach { index =>
-          releaseReservedWorkOffer(index)
+          releaseReservedWorkerOffer(index)
         }
       case _ => // not a barrier TaskSet or no ready tasks reserve it
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -33,6 +33,8 @@ import org.apache.spark.scheduler.SchedulingMode._
 import org.apache.spark.util.{AccumulatorV2, Clock, LongAccumulator, SystemClock, Utils}
 import org.apache.spark.util.collection.MedianHeap
 
+case class ReservedWorkOffer(execId: String, host: String, locality: TaskLocality.Value)
+
 /**
  * Schedules the tasks within a single TaskSet in the TaskSchedulerImpl. This class keeps track of
  * each task, retries tasks if they fail (up to a limited number of times), and
@@ -177,6 +179,10 @@ private[spark] class TaskSetManager(
   // was printed. This should ideally be an LRU map that can drop old exceptions automatically.
   private val recentExceptions = HashMap[String, (Int, Long)]()
 
+  private val readyTaskToReservedWorkOffer = HashMap[Int, (Boolean, ReservedWorkOffer)]()
+
+  private val execIdToReadyTasks = HashMap[String, HashSet[Int]]()
+
   // Figure out the current map output tracker epoch and set it on all tasks
   val epoch = sched.mapOutputTracker.getEpoch
   logDebug("Epoch for " + taskSet + ": " + epoch)
@@ -268,6 +274,10 @@ private[spark] class TaskSetManager(
    */
   private def getPendingTasksForRack(rack: String): ArrayBuffer[Int] = {
     pendingTasksForRack.getOrElse(rack, ArrayBuffer())
+  }
+
+  def getReadyTaskToReservedWorkOffer: HashMap[Int, (Boolean, ReservedWorkOffer)] = {
+    readyTaskToReservedWorkOffer
   }
 
   /**
@@ -431,6 +441,102 @@ private[spark] class TaskSetManager(
       case (taskIndex, allowedLocality) => (taskIndex, allowedLocality, true)}
   }
 
+  def setupTask(
+      index: Int,
+      execId: String,
+      host: String,
+      taskLocality: TaskLocality.Value,
+      launchTime: Long,
+      speculative: Boolean): TaskDescription = {
+    val task = tasks(index)
+    val taskId = sched.newTaskId()
+    // Do various bookkeeping
+    copiesRunning(index) += 1
+    val attemptNum = taskAttempts(index).size
+    val info = new TaskInfo(taskId, index, attemptNum, launchTime,
+      execId, host, taskLocality, speculative)
+    taskInfos(taskId) = info
+    taskAttempts(index) = info :: taskAttempts(index)
+    // Serialize and return the task
+    val serializedTask: ByteBuffer = try {
+      ser.serialize(task)
+    } catch {
+      // If the task cannot be serialized, then there's no point to re-attempt the task,
+      // as it will always fail. So just abort the whole task-set.
+      case NonFatal(e) =>
+        val msg = s"Failed to serialize task $taskId, not attempting to retry it."
+        logError(msg, e)
+        abort(s"$msg Exception during serialization: $e")
+        throw new TaskNotSerializableException(e)
+    }
+    if (serializedTask.limit() > TaskSetManager.TASK_SIZE_TO_WARN_KIB * 1024 &&
+      !emittedTaskSizeWarning) {
+      emittedTaskSizeWarning = true
+      logWarning(s"Stage ${task.stageId} contains a task of very large size " +
+        s"(${serializedTask.limit() / 1024} KiB). The maximum recommended task size is " +
+        s"${TaskSetManager.TASK_SIZE_TO_WARN_KIB} KiB.")
+    }
+
+    addRunningTask(taskId)
+
+    // We used to log the time it takes to serialize the task, but task size is already
+    // a good proxy to task serialization time.
+    // val timeTaken = clock.getTime() - startTime
+    val taskName = s"task ${info.id} in stage ${taskSet.id}"
+    logInfo(s"Starting $taskName (TID $taskId, $host, executor ${info.executorId}, " +
+      s"partition ${task.partitionId}, $taskLocality, ${serializedTask.limit()} bytes)")
+
+    sched.dagScheduler.taskStarted(task, info)
+
+    new TaskDescription(
+      taskId,
+      attemptNum,
+      execId,
+      taskName,
+      index,
+      task.partitionId,
+      addedFiles,
+      addedJars,
+      task.localProperties,
+      serializedTask)
+  }
+
+  def releaseReservedWorkOfferByLocality(num: Int): Unit = {
+    val sortedReservedWorkOffer = readyTaskToReservedWorkOffer.toArray.sortBy {
+      case (_, (_, reservedOffer)) =>
+        reservedOffer.locality
+    }
+
+    val toRelease = sortedReservedWorkOffer.takeRight(num)
+    toRelease.foreach {
+      case (index, (_, _)) =>
+        releaseReservedWorkOffer(index)
+    }
+  }
+
+  def releaseReservedWorkOffer(): Unit = {
+    execIdToReadyTasks.foreach { case (_, tasks) =>
+      tasks.foreach(releaseReservedWorkOffer)
+    }
+  }
+
+  private def releaseReservedWorkOffer(index: Int): Unit = {
+    readyTaskToReservedWorkOffer.remove(index) match {
+      case Some((_, reservedOffer)) =>
+        val execId = reservedOffer.execId
+        execIdToReadyTasks(execId) -= index
+        if (execIdToReadyTasks(execId).isEmpty) {
+          execIdToReadyTasks.remove(execId)
+        }
+        // TODO hui bu hui chongfu ?
+        addPendingTask(index)
+        logInfo(s"ready task $index in barrier TaskSet ${taskSet.id} release " +
+          s"reserved WorkOffer(executor ${reservedOffer.execId}, host ${reservedOffer.host}).")
+      case None =>
+        logWarning(s"Trying to release reserved WorkOffer for an unknown ready task.")
+    }
+  }
+
   /**
    * Respond to an offer of a single executor from the scheduler by finding a task
    *
@@ -469,60 +575,45 @@ private[spark] class TaskSetManager(
       dequeueTask(execId, host, allowedLocality).map { case ((index, taskLocality, speculative)) =>
         // Found a task; do some bookkeeping and return a task description
         val task = tasks(index)
-        val taskId = sched.newTaskId()
-        // Do various bookkeeping
-        copiesRunning(index) += 1
-        val attemptNum = taskAttempts(index).size
-        val info = new TaskInfo(taskId, index, attemptNum, curTime,
-          execId, host, taskLocality, speculative)
-        taskInfos(taskId) = info
-        taskAttempts(index) = info :: taskAttempts(index)
         // Update our locality level for delay scheduling
         // NO_PREF will not affect the variables related to delay scheduling
         if (maxLocality != TaskLocality.NO_PREF) {
           currentLocalityIndex = getLocalityIndex(taskLocality)
           lastLaunchTime = curTime
         }
-        // Serialize and return the task
-        val serializedTask: ByteBuffer = try {
-          ser.serialize(task)
-        } catch {
-          // If the task cannot be serialized, then there's no point to re-attempt the task,
-          // as it will always fail. So just abort the whole task-set.
-          case NonFatal(e) =>
-            val msg = s"Failed to serialize task $taskId, not attempting to retry it."
-            logError(msg, e)
-            abort(s"$msg Exception during serialization: $e")
-            throw new TaskNotSerializableException(e)
+        if (isBarrier) {
+          var replacedExecId = execId
+          if (readyTaskToReservedWorkOffer.contains(index)) {
+            val currentReservedResourceOffer = readyTaskToReservedWorkOffer(index)._2
+            if (taskLocality < currentReservedResourceOffer.locality) {
+              replacedExecId = currentReservedResourceOffer.execId
+              readyTaskToReservedWorkOffer(index) =
+                (speculative, ReservedWorkOffer(execId, host, taskLocality))
+              val readyTasks = execIdToReadyTasks.getOrElse(execId, HashSet[Int]())
+              readyTasks.add(index)
+              execIdToReadyTasks(execId) = readyTasks
+            }
+          } else {
+            readyTaskToReservedWorkOffer(index) =
+              (speculative, ReservedWorkOffer(execId, host, taskLocality))
+            val readyTasks = execIdToReadyTasks.getOrElse(execId, HashSet[Int]())
+            readyTasks.add(index)
+            execIdToReadyTasks(execId) = readyTasks
+          }
+          new TaskDescription(
+            0,
+            0,
+            replacedExecId, // just take a ride
+            "",
+            index,
+            task.partitionId,
+            addedFiles,
+            addedJars,
+            task.localProperties,
+            ByteBuffer.allocate(0))
+        } else {
+          setupTask(index, execId, host, taskLocality, curTime, speculative)
         }
-        if (serializedTask.limit() > TaskSetManager.TASK_SIZE_TO_WARN_KIB * 1024 &&
-          !emittedTaskSizeWarning) {
-          emittedTaskSizeWarning = true
-          logWarning(s"Stage ${task.stageId} contains a task of very large size " +
-            s"(${serializedTask.limit() / 1024} KiB). The maximum recommended task size is " +
-            s"${TaskSetManager.TASK_SIZE_TO_WARN_KIB} KiB.")
-        }
-        addRunningTask(taskId)
-
-        // We used to log the time it takes to serialize the task, but task size is already
-        // a good proxy to task serialization time.
-        // val timeTaken = clock.getTime() - startTime
-        val taskName = s"task ${info.id} in stage ${taskSet.id}"
-        logInfo(s"Starting $taskName (TID $taskId, $host, executor ${info.executorId}, " +
-          s"partition ${task.partitionId}, $taskLocality, ${serializedTask.limit()} bytes)")
-
-        sched.dagScheduler.taskStarted(task, info)
-        new TaskDescription(
-          taskId,
-          attemptNum,
-          execId,
-          taskName,
-          index,
-          task.partitionId,
-          addedFiles,
-          addedJars,
-          task.localProperties,
-          serializedTask)
       }
     } else {
       None
@@ -552,6 +643,8 @@ private[spark] class TaskSetManager(
         indexOffset -= 1
         val index = pendingTaskIds(indexOffset)
         if (copiesRunning(index) == 0 && !successful(index)) {
+          return true
+        } else if (isBarrier && !getReadyTaskToReservedWorkOffer.contains(index)) {
           return true
         } else {
           pendingTaskIds.remove(indexOffset)
@@ -1010,6 +1103,15 @@ private[spark] class TaskSetManager(
       handleFailedTask(tid, TaskState.FAILED, ExecutorLostFailure(info.executorId, exitCausedByApp,
         Some(reason.toString)))
     }
+
+    execIdToReadyTasks.get(execId) match {
+      case Some(taskIndexes) =>
+        taskIndexes.foreach { index =>
+          releaseReservedWorkOffer(index)
+        }
+      case _ => // not a barrier TaskSet or no ready tasks reserve it
+    }
+
     // recalculate valid locality levels and waits when executor is lost
     recomputeLocality()
   }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -528,7 +528,7 @@ private[spark] class TaskSetManager(
         if (execIdToReadyTasks(execId).isEmpty) {
           execIdToReadyTasks.remove(execId)
         }
-        // TODO hui bu hui chongfu ?
+        // NOTE: this may add duplicate task into a single pending queue
         addPendingTask(index)
         logInfo(s"ready task $index in barrier TaskSet ${taskSet.id} release " +
           s"reserved WorkerOffer(executor ${reservedOffer.execId}, host ${reservedOffer.host}).")
@@ -589,9 +589,8 @@ private[spark] class TaskSetManager(
               replacedExecId = currentReservedWorkerOffer.execId
               readyTaskToReservedWorkerOffer(index) =
                 (speculative, ReservedWorkerOffer(execId, host, taskLocality))
-              val readyTasks = execIdToReadyTasks.getOrElse(execId, HashSet[Int]())
-              readyTasks.add(index)
-              execIdToReadyTasks(execId) = readyTasks
+            } else {
+              return None
             }
           } else {
             readyTaskToReservedWorkerOffer(index) =

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -1310,6 +1310,69 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     assert(3 === taskDescription3.length)
   }
 
+  test("barrier taskSet should force to release reserved WorkerOffer if there's a long" +
+    "time without any launched barrier taskSet to avoid deadlock problem on resource") {
+    val taskCpus = 2
+    val taskScheduler = setupScheduler(
+      "spark.task.cpus" -> taskCpus.toString,
+      config.BARRIER_MAX_CONSECUTIVE_NO_BARRIER_TASKSET_LAUNCH_TIMES.key -> "3")
+
+    val numFreeCores = 3
+    val workerOffers = IndexedSeq(
+      new WorkerOffer("executor0", "host0", numFreeCores, Some("192.168.0.101:49625")),
+      new WorkerOffer("executor1", "host1", numFreeCores, Some("192.168.0.101:49627")))
+
+    val ts1 = FakeTask.createBarrierTaskSet(2, 0, 0,
+      Seq(TaskLocation("host0", "executor0")),
+      Seq(TaskLocation("host1", "executor0")))
+    val ts2 = FakeTask.createBarrierTaskSet(2, 1, 0,
+      Seq(TaskLocation("host1", "executor1")),
+      Seq(TaskLocation("host0", "executor1")))
+    taskScheduler.submitTasks(ts1)
+    taskScheduler.submitTasks(ts2)
+    assert(taskScheduler.barrierTaskSetByTimeout.size === 2)
+    // 1st resourceOffers round
+    var taskDescriptions = taskScheduler.resourceOffers(workerOffers).flatten
+    assert(0 === taskDescriptions.length)
+
+    // after 1st resourceOffers round, ts1 reserved WorkerOffer(executor0, host0), and do not
+    // reserve WorkerOffer(executor1, host1) due to task locality delay scheduling
+    val manager1 = taskScheduler.taskSetManagerForAttempt(0, 0).get
+    val reserveOffer1 = manager1.getReadyTaskToReservedWorkerOffer.values
+    assert(reserveOffer1.size === 1)
+    assert(reserveOffer1.head._2.execId === "executor0")
+
+    // after ts1 resourceOffer finish, ts2 only has WorkerOffer(executor1, host1) to be reserved.
+    val manager2 = taskScheduler.taskSetManagerForAttempt(1, 0).get
+    val reserveOffer2 = manager2.getReadyTaskToReservedWorkerOffer.values
+    assert(reserveOffer2.size === 1)
+    assert(reserveOffer2.head._2.execId === "executor1")
+
+    // Now, ts1 and ts2 fall into a deadlock situation if no more WorkerOffer will get in and
+    // could not launch any barrier taskSets in the latter resourceOffers round before we reach
+    // the BARRIER_MAX_CONSECUTIVE_NO_BARRIER_TASKSET_LAUNCH_TIMES.
+
+    // 2nd resourceOffers round
+    taskDescriptions = taskScheduler.resourceOffers(workerOffers).flatten
+    assert(0 === taskDescriptions.length)
+    // 3rd resourceOffers round, reach the BARRIER_MAX_CONSECUTIVE_NO_BARRIER_TASKSET_LAUNCH_TIMES,
+    // trigger a fore reserved WorkerOffer release for barrier taskSet.
+    taskDescriptions = taskScheduler.resourceOffers(workerOffers).flatten
+    assert(0 === taskDescriptions.length)
+
+    // wait for localityWaits timeout, so that we could move to NODE_LOCAL level
+    Thread.sleep(3100)
+
+    // since ts2 has released its reserved WorkerOffer, ts1 gets a chance to accumulate sufficient
+    // resource to launch tasks finally.
+    taskDescriptions = taskScheduler.resourceOffers(workerOffers).flatten
+    assert(2 === taskDescriptions.length)
+    assert(taskScheduler.barrierTaskSetByTimeout.size === 1)
+    val unLaunchedBarrierTaskSet = taskScheduler.barrierTaskSetByTimeout.head._1
+    assert(unLaunchedBarrierTaskSet.taskSet.stageId === 1)
+    assert(unLaunchedBarrierTaskSet.getReadyTaskToReservedWorkerOffer.size === 0)
+  }
+
   test("cancelTasks shall kill all the running tasks and fail the stage") {
     val taskScheduler = setupScheduler()
 

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -1273,6 +1273,43 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     assert(3 === taskDescriptions.length)
   }
 
+  test("barrier taskSet can launch all tasks after multiple resourceOffers round" +
+    "until it accumulate sufficient resource") {
+    val taskCpus = 2
+    val taskScheduler = setupScheduler("spark.task.cpus" -> taskCpus.toString)
+
+    val numFreeCores = 3
+    val workerOffers1 = IndexedSeq(
+      new WorkerOffer("executor0", "host0", numFreeCores, Some("192.168.0.101:49625")),
+      new WorkerOffer("executor1", "host1", numFreeCores, Some("192.168.0.101:49627")))
+
+    val workerOffers2 = IndexedSeq(
+      new WorkerOffer("executor0", "host0", numFreeCores, Some("192.168.0.101:49625")),
+      new WorkerOffer("executor1", "host1", numFreeCores, Some("192.168.0.101:49627")),
+      new WorkerOffer("executor2", "host2", numFreeCores, Some("192.168.0.101:49629")))
+
+
+    // submit barrier taskSet 1, offer some resources, since the available Cpus are not
+    // sufficient, so scheduler won't launch any tasks.
+    val ts1 = FakeTask.createBarrierTaskSet(3)
+    taskScheduler.submitTasks(ts1)
+    val taskDescriptions1 = taskScheduler.resourceOffers(workerOffers1).flatten
+    assert(0 === taskDescriptions1.length)
+
+    // submit non-barrier taskSet 2, offer the same resources, since ts1 has
+    // already reserved resources, so there're no more available Cpus for ts2
+    // to launch any tasks.
+    val ts2 = FakeTask.createTaskSet(3)
+    taskScheduler.submitTasks(ts2)
+    val taskDescriptions2 = taskScheduler.resourceOffers(workerOffers1).flatten
+    assert(0 === taskDescriptions2.length)
+
+    // offer a new resource, thus, ts1 could accumulate sufficient resource to
+    // launch its tasks at the same time. But for ts2, still no resources for it.
+    val taskDescription3 = taskScheduler.resourceOffers(workerOffers2).flatten
+    assert(3 === taskDescription3.length)
+  }
+
   test("cancelTasks shall kill all the running tasks and fail the stage") {
     val taskScheduler = setupScheduler()
 

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -1273,7 +1273,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     assert(3 === taskDescriptions.length)
   }
 
-  test("barrier taskSet can launch all tasks after multiple resourceOffers round" +
+  test("barrier taskSet can launch all tasks after multiple resourceOffers round " +
     "until it accumulate sufficient resource") {
     val taskCpus = 2
     val taskScheduler = setupScheduler("spark.task.cpus" -> taskCpus.toString)
@@ -1291,7 +1291,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
 
     // submit barrier taskSet 1, offer some resources, since the available Cpus are not
     // sufficient, so scheduler won't launch any tasks.
-    val ts1 = FakeTask.createBarrierTaskSet(3)
+    val ts1 = FakeTask.createBarrierTaskSet(3, 0, 0)
     taskScheduler.submitTasks(ts1)
     val taskDescriptions1 = taskScheduler.resourceOffers(workerOffers1).flatten
     assert(0 === taskDescriptions1.length)
@@ -1299,7 +1299,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     // submit non-barrier taskSet 2, offer the same resources, since ts1 has
     // already reserved resources, so there're no more available Cpus for ts2
     // to launch any tasks.
-    val ts2 = FakeTask.createTaskSet(3)
+    val ts2 = FakeTask.createTaskSet(3, 1, 0)
     taskScheduler.submitTasks(ts2)
     val taskDescriptions2 = taskScheduler.resourceOffers(workerOffers1).flatten
     assert(0 === taskDescriptions2.length)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, Barrier TaskSet has a hard requirement that tasks can only be launched
in a single resourceOffers round with enough slots(or sufficient resources), but
can not be guaranteed even if with enough slots due to task locality delay scheduling.
So, it is very likely that Barrier TaskSet gets a chunk of sufficient resources after
all the trouble, but let it go easily just because one of pending tasks can not be
scheduled. Futhermore, it causes severe resource competition between TaskSets and jobs
and introduce unclear semantic for DynamicAllocation.

This pr trys to introduce WorkerOffer reservation mechanism for Barrier TaskSet, which
allows Barrier TaskSet to reserve WorkerOffer in each resourceOffers round, and launch
tasks at the same time once it accumulate the sufficient resource. In this way, we
relax the requirement of resources for the Barrier TaskSet.

Besides, we have two features along with WorkerOffer reservation mechanism:

To avoid the deadlock which may be introuduced by serveral Barrier TaskSets holding the reserved WorkerOffers for a long time, we'll ask Barrier TaskSets to force releasing part of reserved WorkerOffers
on demand. So, it is highly possible that each Barrier TaskSet would be launched in the end.

Barrier TaskSet could replace old high level locality reserved WorkerOffer with new low level locality WorkerOffer during the time it wating for sufficient resources, to perform better locality at the end.

To integrate with DynamicAllocation:

The possible effective way I can imagine is that adding new event, e.g.
ExecutorReservedEvent, ExecutorReleasedEvent, which behaved like busy executor with
running tasks or idle executor without running tasks. Thus, ExecutorAllocationManager
would not let the executor go if it reminds of there're some reserved resource on that
executor.

## How was this patch tested?

existed and added some, needs to add more.
