### PR TITLE
[MINOR][SQL]Fix the typo in the spark.sql.extensions conf doc

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -100,7 +100,7 @@ object StaticSQLConf {
 
   val SPARK_SESSION_EXTENSIONS = buildStaticConf("spark.sql.extensions")
     .doc("A comma-separated list of classes that implement " +
-      "Function1[SparkSessionExtension, Unit] used to configure Spark Session extensions. The " +
+      "Function1[SparkSessionExtensions, Unit] used to configure Spark Session extensions. The " +
       "classes must have a no-args constructor. If multiple extensions are specified, they are " +
       "applied in the specified order. For the case of rules and planner strategies, they are " +
       "applied in the specified order. For the case of parsers, the last parser is used and each " +


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix the  typo (missing the s)  in the class name (SparkSessionExtensions)  in the doc for Spark conf spark.sql.extensions. 

## How was this patch tested?
Verified by checking that the configuration doc shows up correctly in spark-shell using the SET -v 