### PR TITLE
[SPARK-27101][PYTHON] Drop the created database after the test in test_session

### DIFF
--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -114,6 +114,7 @@ class SparkSessionTests3(unittest.TestCase):
             self.assertEqual(spark.table("table1").columns, ['name', 'age'])
             self.assertEqual(spark.range(3).count(), 3)
         finally:
+            spark.sql("DROP DATABASE test_db CASCADE")
             spark.stop()
 
     def test_global_default_session(self):


### PR DESCRIPTION
## What changes were proposed in this pull request?

Cleaning the testcase, drop the database after use

## How was this patch tested?

existing UT
