### PR TITLE
[SPARK-27109][SQL] Refactoring of TimestampFormatter and DateFormatter

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.util
 
-import java.time.{Instant, ZonedDateTime, ZoneId}
+import java.time.{Instant, ZonedDateTime, ZoneOffset}
 import java.time.temporal.TemporalAccessor
 import java.util.Locale
 import java.util.concurrent.TimeUnit.SECONDS
@@ -33,7 +33,7 @@ class Iso8601DateFormatter(
 
   @transient
   private lazy val formatter = getOrCreateFormatter(pattern, locale)
-  private val UTC = ZoneId.of("UTC")
+  private val UTC = ZoneOffset.UTC
 
   private def zonedDateTimeToDays(zonedDateTime: ZonedDateTime): Int = {
     val seconds = zonedDateTime.toEpochSecond

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
@@ -17,8 +17,7 @@
 
 package org.apache.spark.sql.catalyst.util
 
-import java.time.{Instant, ZonedDateTime, ZoneOffset}
-import java.time.temporal.TemporalAccessor
+import java.time.{Instant, ZoneOffset}
 import java.util.Locale
 import java.util.concurrent.TimeUnit.SECONDS
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
@@ -17,7 +17,8 @@
 
 package org.apache.spark.sql.catalyst.util
 
-import java.time.{Instant, ZoneId}
+import java.time.{Instant, ZonedDateTime, ZoneId}
+import java.time.temporal.TemporalAccessor
 import java.util.Locale
 import java.util.concurrent.TimeUnit.SECONDS
 
@@ -34,10 +35,19 @@ class Iso8601DateFormatter(
   private lazy val formatter = getOrCreateFormatter(pattern, locale)
   private val UTC = ZoneId.of("UTC")
 
-  override def parse(s: String): Int = {
-    val zonedDateTime = toZonedDateTime(formatter.parse(s), UTC)
+  private def zonedDateTimeToDays(zonedDateTime: ZonedDateTime): Int = {
     val seconds = zonedDateTime.toEpochSecond
     SECONDS.toDays(seconds).toInt
+  }
+
+  private def parsedToDays(parsed: TemporalAccessor): Int = {
+    val zonedDateTime = toZonedDateTime(parsed, UTC)
+    zonedDateTimeToDays(zonedDateTime)
+  }
+
+  override def parse(s: String): Int = {
+    val parsed = formatter.parse(s)
+    parsedToDays(parsed)
   }
 
   override def format(days: Int): String = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
@@ -32,18 +32,17 @@ class Iso8601DateFormatter(
 
   @transient
   private lazy val formatter = getOrCreateFormatter(pattern, locale)
-  private val UTC = ZoneOffset.UTC
 
   override def parse(s: String): Int = {
     val parsed = formatter.parse(s)
-    val zonedDateTime = toZonedDateTime(parsed, UTC)
+    val zonedDateTime = toZonedDateTime(parsed, ZoneOffset.UTC)
     val seconds = zonedDateTime.toEpochSecond
     SECONDS.toDays(seconds).toInt
   }
 
   override def format(days: Int): String = {
     val instant = Instant.ofEpochSecond(days * DateTimeUtils.SECONDS_PER_DAY)
-    formatter.withZone(UTC).format(instant)
+    formatter.withZone(ZoneOffset.UTC).format(instant)
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.util
 
 import java.time.{Instant, ZoneId}
 import java.util.Locale
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit.SECONDS
 
 sealed trait DateFormatter extends Serializable {
   def parse(s: String): Int // returns days since epoch
@@ -37,7 +37,7 @@ class Iso8601DateFormatter(
   override def parse(s: String): Int = {
     val zonedDateTime = toZonedDateTime(formatter.parse(s), UTC)
     val seconds = zonedDateTime.toEpochSecond
-    TimeUnit.SECONDS.toDays(seconds).toInt
+    SECONDS.toDays(seconds).toInt
   }
 
   override def format(days: Int): String = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
@@ -35,19 +35,11 @@ class Iso8601DateFormatter(
   private lazy val formatter = getOrCreateFormatter(pattern, locale)
   private val UTC = ZoneOffset.UTC
 
-  private def zonedDateTimeToDays(zonedDateTime: ZonedDateTime): Int = {
-    val seconds = zonedDateTime.toEpochSecond
-    SECONDS.toDays(seconds).toInt
-  }
-
-  private def parsedToDays(parsed: TemporalAccessor): Int = {
-    val zonedDateTime = toZonedDateTime(parsed, UTC)
-    zonedDateTimeToDays(zonedDateTime)
-  }
-
   override def parse(s: String): Int = {
     val parsed = formatter.parse(s)
-    parsedToDays(parsed)
+    val zonedDateTime = toZonedDateTime(parsed, UTC)
+    val seconds = zonedDateTime.toEpochSecond
+    SECONDS.toDays(seconds).toInt
   }
 
   override def format(days: Int): String = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
@@ -35,7 +35,7 @@ trait DateTimeFormatterHelper {
       zoneId: ZoneId): ZonedDateTime = {
     // Parsed input might not have time related part. In that case, time component is set to zeros.
     val parsedLocalTime = temporalAccessor.query(TemporalQueries.localTime)
-    val localTime = if (parsedLocalTime == null) zeroLocalTime else parsedLocalTime
+    val localTime = if (parsedLocalTime == null) LocalTime.MIDNIGHT else parsedLocalTime
     // Parsed input must have date component. At least, year must present in temporalAccessor.
     val localDate = temporalAccessor.query(TemporalQueries.localDate)
 
@@ -63,8 +63,6 @@ private object DateTimeFormatterHelper {
   val cache = CacheBuilder.newBuilder()
     .maximumSize(128)
     .build[(String, Locale), DateTimeFormatter]()
-  // Sets hours, minutes, seconds and nanos of second to zeros
-  val zeroLocalTime = LocalTime.ofNanoOfDay(0)
 
   def createBuilder(): DateTimeFormatterBuilder = {
     new DateTimeFormatterBuilder().parseCaseInsensitive()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
@@ -28,17 +28,17 @@ import com.google.common.cache.CacheBuilder
 import org.apache.spark.sql.catalyst.util.DateTimeFormatterHelper._
 
 trait DateTimeFormatterHelper {
+  // Sets hours, minutes, seconds and nanos of second to zeros
+  lazy val zeroLocalTime = LocalTime.ofNanoOfDay(0)
+
+  // Converts the parsed temporal object to ZonedDateTime. It sets time components to zeros
+  // if they does not exist in the parsed object.
   protected def toZonedDateTime(
       temporalAccessor: TemporalAccessor,
       zoneId: ZoneId): ZonedDateTime = {
     // Parsed input might not have time related part. In that case, time component is set to zeros.
     val parsedLocalTime = temporalAccessor.query(TemporalQueries.localTime)
-    val localTime = if (parsedLocalTime == null) {
-      // Sets hours, minutes, seconds and nanos of second to zeros
-      LocalTime.ofNanoOfDay(0)
-    } else {
-      parsedLocalTime
-    }
+    val localTime = if (parsedLocalTime == null) zeroLocalTime else parsedLocalTime
     // Parsed input must have date component. At least, year must present in temporalAccessor.
     val localDate = temporalAccessor.query(TemporalQueries.localDate)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
@@ -28,9 +28,6 @@ import com.google.common.cache.CacheBuilder
 import org.apache.spark.sql.catalyst.util.DateTimeFormatterHelper._
 
 trait DateTimeFormatterHelper {
-  // Sets hours, minutes, seconds and nanos of second to zeros
-  lazy val zeroLocalTime = LocalTime.ofNanoOfDay(0)
-
   // Converts the parsed temporal object to ZonedDateTime. It sets time components to zeros
   // if they does not exist in the parsed object.
   protected def toZonedDateTime(
@@ -66,6 +63,8 @@ private object DateTimeFormatterHelper {
   val cache = CacheBuilder.newBuilder()
     .maximumSize(128)
     .build[(String, Locale), DateTimeFormatter]()
+  // Sets hours, minutes, seconds and nanos of second to zeros
+  val zeroLocalTime = LocalTime.ofNanoOfDay(0)
 
   def createBuilder(): DateTimeFormatterBuilder = {
     new DateTimeFormatterBuilder().parseCaseInsensitive()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
@@ -28,7 +28,9 @@ import com.google.common.cache.CacheBuilder
 import org.apache.spark.sql.catalyst.util.DateTimeFormatterHelper._
 
 trait DateTimeFormatterHelper {
-  protected def toInstantWithZoneId(temporalAccessor: TemporalAccessor, zoneId: ZoneId): Instant = {
+  protected def toZonedDateTime(
+      temporalAccessor: TemporalAccessor,
+      zoneId: ZoneId): ZonedDateTime = {
     // Parsed input might not have time related part. In that case, time component is set to zeros.
     val parsedLocalTime = temporalAccessor.query(TemporalQueries.localTime)
     val localTime = if (parsedLocalTime == null) {
@@ -39,9 +41,8 @@ trait DateTimeFormatterHelper {
     }
     // Parsed input must have date component. At least, year must present in temporalAccessor.
     val localDate = temporalAccessor.query(TemporalQueries.localDate)
-    val localDateTime = LocalDateTime.of(localDate, localTime)
-    val zonedDateTime = ZonedDateTime.of(localDateTime, zoneId)
-    Instant.from(zonedDateTime)
+
+    ZonedDateTime.of(localDate, localTime, zoneId)
   }
 
   // Gets a formatter from the cache or creates new one. The buildFormatter method can be called

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
@@ -49,24 +49,15 @@ class Iso8601TimestampFormatter(
   @transient
   protected lazy val formatter = getOrCreateFormatter(pattern, locale)
 
-  private def zonedDateTimeToMicros(zonedDateTime: ZonedDateTime): Long = {
+  override def parse(s: String): Long = {
+    val parsed = formatter.parse(s)
+    val parsedZoneId = parsed.query(TemporalQueries.zone())
+    val zoneId = if (parsedZoneId == null) timeZone.toZoneId else parsedZoneId
+    val zonedDateTime = toZonedDateTime(parsed, zoneId)
     val epochSeconds = zonedDateTime.toEpochSecond
     val microsOfSecond = zonedDateTime.get(MICRO_OF_SECOND)
 
     Math.addExact(SECONDS.toMicros(epochSeconds), microsOfSecond)
-  }
-
-  private def parsedToMicros(parsed: TemporalAccessor): Long = {
-    val parsedZoneId = parsed.query(TemporalQueries.zone())
-    val zoneId = if (parsedZoneId == null) timeZone.toZoneId else parsedZoneId
-    val zonedDateTime = toZonedDateTime(parsed, zoneId)
-
-    zonedDateTimeToMicros(zonedDateTime)
-  }
-
-  override def parse(s: String): Long = {
-    val parsed = formatter.parse(s)
-    parsedToMicros(parsed)
   }
 
   override def format(us: Long): String = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
@@ -20,8 +20,8 @@ package org.apache.spark.sql.catalyst.util
 import java.text.ParseException
 import java.time._
 import java.time.format.DateTimeParseException
-import java.time.temporal.{TemporalAccessor, TemporalQueries}
 import java.time.temporal.ChronoField.MICRO_OF_SECOND
+import java.time.temporal.TemporalQueries
 import java.util.{Locale, TimeZone}
 import java.util.concurrent.TimeUnit.SECONDS
 
@@ -48,11 +48,12 @@ class Iso8601TimestampFormatter(
     locale: Locale) extends TimestampFormatter with DateTimeFormatterHelper {
   @transient
   protected lazy val formatter = getOrCreateFormatter(pattern, locale)
+  private val timeZoneId = timeZone.toZoneId
 
   override def parse(s: String): Long = {
     val parsed = formatter.parse(s)
     val parsedZoneId = parsed.query(TemporalQueries.zone())
-    val zoneId = if (parsedZoneId == null) timeZone.toZoneId else parsedZoneId
+    val zoneId = if (parsedZoneId == null) timeZoneId else parsedZoneId
     val zonedDateTime = toZonedDateTime(parsed, zoneId)
     val epochSeconds = zonedDateTime.toEpochSecond
     val microsOfSecond = zonedDateTime.get(MICRO_OF_SECOND)
@@ -62,7 +63,7 @@ class Iso8601TimestampFormatter(
 
   override def format(us: Long): String = {
     val instant = DateTimeUtils.microsToInstant(us)
-    formatter.withZone(timeZone.toZoneId).format(instant)
+    formatter.withZone(timeZoneId).format(instant)
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
@@ -20,10 +20,10 @@ package org.apache.spark.sql.catalyst.util
 import java.text.ParseException
 import java.time._
 import java.time.format.DateTimeParseException
-import java.time.temporal.ChronoField.{INSTANT_SECONDS, MICRO_OF_SECOND}
+import java.time.temporal.ChronoField.MICRO_OF_SECOND
 import java.time.temporal.TemporalQueries
 import java.util.{Locale, TimeZone}
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit.SECONDS
 
 sealed trait TimestampFormatter extends Serializable {
   /**
@@ -54,10 +54,10 @@ class Iso8601TimestampFormatter(
     val parsedZoneId = parsed.query(TemporalQueries.zone())
     val zoneId = if (parsedZoneId == null) timeZone.toZoneId else parsedZoneId
     val zonedDateTime = toZonedDateTime(parsed, zoneId)
-    val epochSeconds = zonedDateTime.getLong(INSTANT_SECONDS)
+    val epochSeconds = zonedDateTime.toEpochSecond
     val microsOfSecond = zonedDateTime.get(MICRO_OF_SECOND)
 
-    Math.addExact(TimeUnit.SECONDS.toMicros(epochSeconds), microsOfSecond)
+    Math.addExact(SECONDS.toMicros(epochSeconds), microsOfSecond)
   }
 
   override def format(us: Long): String = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/DateFormatterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/DateFormatterSuite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.util
 
 import java.time.LocalDate
-import java.util.Locale
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.plans.SQLHelper


### PR DESCRIPTION
## What changes were proposed in this pull request?

In PR, I propose to refactor the `parse()` method of `Iso8601DateFormatter`/`Iso8601DateFormatter` and `toInstantWithZoneId` of `toInstantWithZoneId` to achieve the following:
- Avoid unnecessary conversion of parsed input to `java.time.Instant` before converting it to micros and days. Necessary information exists in `ZonedDateTime` already, and micros/days can be extracted from the former one.
- Avoid additional extraction of LocalTime from parsed object, more precisely, double query of `TemporalQueries.localTime` from `temporalAccessor`.
- Avoid additional extraction of zone id from parsed object, in particular, double query of `TemporalQueries.offset()`.
- Using `ZoneOffset.UTC` instead of `ZoneId.of` in `DateFormatter`. This allows to avoid looking for zone offset by zone id.

## How was this patch tested?

By existing test suite `DateTimeUtilsSuite`, `TimestampFormatterSuite` and `DateFormatterSuite`.
