### PR TITLE
[SPARK-27112] : Spark Scheduler encounters two independent Deadlocks …

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
@@ -59,15 +59,18 @@ private[spark] trait ExecutorAllocationClient {
    * @param adjustTargetNumExecutors whether the target number of executors will be adjusted down
    *                                 after these executors have been killed
    * @param countFailures if there are tasks running on the executors when they are killed, whether
-    *                     to count those failures toward task failure limits
+   *                      to count those failures toward task failure limits
    * @param force whether to force kill busy executors, default false
+   * @param blacklistingOnTaskCompletion whether the executors are being killed due to
+   *                                     blacklisting triggered by the task completion event
    * @return the ids of the executors acknowledged by the cluster manager to be removed.
    */
   def killExecutors(
     executorIds: Seq[String],
     adjustTargetNumExecutors: Boolean,
     countFailures: Boolean,
-    force: Boolean = false): Seq[String]
+    force: Boolean = false,
+    blacklistingOnTaskCompletion: Boolean = false): Seq[String]
 
   /**
    * Request that the cluster manager kill every executor on the specified host.

--- a/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
@@ -146,12 +146,15 @@ private[scheduler] class BlacklistTracker (
     nextExpiryTime = math.min(execMinExpiry, nodeMinExpiry)
   }
 
-  private def killExecutor(exec: String, msg: String): Unit = {
+  private def killExecutor(
+      exec: String,
+      msg: String,
+      blacklistingOnTaskCompletion: Boolean = false): Unit = {
     allocationClient match {
       case Some(a) =>
         logInfo(msg)
         a.killExecutors(Seq(exec), adjustTargetNumExecutors = false, countFailures = false,
-          force = true)
+          force = true, blacklistingOnTaskCompletion = blacklistingOnTaskCompletion)
       case None =>
         logInfo(s"Not attempting to kill blacklisted executor id $exec " +
           s"since allocation client is not defined.")
@@ -161,7 +164,8 @@ private[scheduler] class BlacklistTracker (
   private def killBlacklistedExecutor(exec: String): Unit = {
     if (conf.get(config.BLACKLIST_KILL_ENABLED)) {
       killExecutor(exec,
-        s"Killing blacklisted executor id $exec since ${config.BLACKLIST_KILL_ENABLED.key} is set.")
+        s"Killing blacklisted executor id $exec since ${config.BLACKLIST_KILL_ENABLED.key}" +
+          s" is set.", blacklistingOnTaskCompletion = true)
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -1128,19 +1128,19 @@ class ExecutorAllocationManagerSuite
     clock.advance(1000)
     manager invokePrivate _updateAndSyncNumExecutorsTarget(clock.getTimeMillis())
     assert(numExecutorsTarget(manager) === 1)
-    verify(mockAllocationClient, never).killExecutors(any(), any(), any(), any())
+    verify(mockAllocationClient, never).killExecutors(any(), any(), any(), any(), any())
 
     // now we cross the idle timeout for executor-1, so we kill it.  the really important
     // thing here is that we do *not* ask the executor allocation client to adjust the target
     // number of executors down
-    when(mockAllocationClient.killExecutors(Seq("executor-1"), false, false, false))
+    when(mockAllocationClient.killExecutors(Seq("executor-1"), false, false, false, false))
       .thenReturn(Seq("executor-1"))
     clock.advance(3000)
     schedule(manager)
     assert(maxNumExecutorsNeeded(manager) === 1)
     assert(numExecutorsTarget(manager) === 1)
     // here's the important verify -- we did kill the executors, but did not adjust the target count
-    verify(mockAllocationClient).killExecutors(Seq("executor-1"), false, false, false)
+    verify(mockAllocationClient).killExecutors(Seq("executor-1"), false, false, false, false)
   }
 
   test("SPARK-26758 check executor target number after idle time out ") {

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -1382,7 +1382,8 @@ private class DummyLocalSchedulerBackend (sc: SparkContext, sb: SchedulerBackend
       executorIds: Seq[String],
       adjustTargetNumExecutors: Boolean,
       countFailures: Boolean,
-      force: Boolean): Seq[String] = executorIds
+      force: Boolean,
+      blacklistingOnTaskCompletion: Boolean): Seq[String] = executorIds
 
   override def start(): Unit = sb.start()
 

--- a/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
@@ -479,7 +479,7 @@ class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with M
 
   test("blacklisting kills executors, configured by BLACKLIST_KILL_ENABLED") {
     val allocationClientMock = mock[ExecutorAllocationClient]
-    when(allocationClientMock.killExecutors(any(), any(), any(), any())).thenReturn(Seq("called"))
+    when(allocationClientMock.killExecutors(any(), any(), any(), any(), any())).thenReturn(Seq("called"))
     when(allocationClientMock.killExecutorsOnHost("hostA")).thenAnswer(new Answer[Boolean] {
       // To avoid a race between blacklisting and killing, it is important that the nodeBlacklist
       // is updated before we ask the executor allocation client to kill all the executors
@@ -517,7 +517,7 @@ class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with M
     }
     blacklist.updateBlacklistForSuccessfulTaskSet(0, 0, taskSetBlacklist1.execToFailures)
 
-    verify(allocationClientMock, never).killExecutors(any(), any(), any(), any())
+    verify(allocationClientMock, never).killExecutors(any(), any(), any(), any(), any())
     verify(allocationClientMock, never).killExecutorsOnHost(any())
 
     // Enable auto-kill. Blacklist an executor and make sure killExecutors is called.
@@ -533,7 +533,7 @@ class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with M
     }
     blacklist.updateBlacklistForSuccessfulTaskSet(0, 0, taskSetBlacklist2.execToFailures)
 
-    verify(allocationClientMock).killExecutors(Seq("1"), false, false, true)
+    verify(allocationClientMock).killExecutors(Seq("1"), false, false, true, true)
 
     val taskSetBlacklist3 = createTaskSetBlacklist(stageId = 1)
     // Fail 4 tasks in one task set on executor 2, so that executor gets blacklisted for the whole
@@ -545,13 +545,13 @@ class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with M
     }
     blacklist.updateBlacklistForSuccessfulTaskSet(0, 0, taskSetBlacklist3.execToFailures)
 
-    verify(allocationClientMock).killExecutors(Seq("2"), false, false, true)
+    verify(allocationClientMock).killExecutors(Seq("2"), false, false, true, true)
     verify(allocationClientMock).killExecutorsOnHost("hostA")
   }
 
   test("fetch failure blacklisting kills executors, configured by BLACKLIST_KILL_ENABLED") {
     val allocationClientMock = mock[ExecutorAllocationClient]
-    when(allocationClientMock.killExecutors(any(), any(), any(), any())).thenReturn(Seq("called"))
+    when(allocationClientMock.killExecutors(any(), any(), any(), any(), any())).thenReturn(Seq("called"))
     when(allocationClientMock.killExecutorsOnHost("hostA")).thenAnswer(new Answer[Boolean] {
       // To avoid a race between blacklisting and killing, it is important that the nodeBlacklist
       // is updated before we ask the executor allocation client to kill all the executors
@@ -571,7 +571,7 @@ class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with M
     conf.set(config.BLACKLIST_KILL_ENABLED, false)
     blacklist.updateBlacklistForFetchFailure("hostA", exec = "1")
 
-    verify(allocationClientMock, never).killExecutors(any(), any(), any(), any())
+    verify(allocationClientMock, never).killExecutors(any(), any(), any(), any(), any())
     verify(allocationClientMock, never).killExecutorsOnHost(any())
 
     assert(blacklist.nodeToBlacklistedExecs.contains("hostA"))
@@ -583,7 +583,7 @@ class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with M
     clock.advance(1000)
     blacklist.updateBlacklistForFetchFailure("hostA", exec = "1")
 
-    verify(allocationClientMock).killExecutors(Seq("1"), false, false, true)
+    verify(allocationClientMock).killExecutors(Seq("1"), false, false, true, true)
     verify(allocationClientMock, never).killExecutorsOnHost(any())
 
     assert(blacklist.executorIdToBlacklistStatus.contains("1"))

--- a/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
@@ -479,7 +479,8 @@ class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with M
 
   test("blacklisting kills executors, configured by BLACKLIST_KILL_ENABLED") {
     val allocationClientMock = mock[ExecutorAllocationClient]
-    when(allocationClientMock.killExecutors(any(), any(), any(), any(), any())).thenReturn(Seq("called"))
+    when(allocationClientMock.killExecutors(
+      any(), any(), any(), any(), any())).thenReturn(Seq("called"))
     when(allocationClientMock.killExecutorsOnHost("hostA")).thenAnswer(new Answer[Boolean] {
       // To avoid a race between blacklisting and killing, it is important that the nodeBlacklist
       // is updated before we ask the executor allocation client to kill all the executors
@@ -551,7 +552,8 @@ class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with M
 
   test("fetch failure blacklisting kills executors, configured by BLACKLIST_KILL_ENABLED") {
     val allocationClientMock = mock[ExecutorAllocationClient]
-    when(allocationClientMock.killExecutors(any(), any(), any(), any(), any())).thenReturn(Seq("called"))
+    when(allocationClientMock.killExecutors(
+      any(), any(), any(), any(), any())).thenReturn(Seq("called"))
     when(allocationClientMock.killExecutorsOnHost("hostA")).thenAnswer(new Answer[Boolean] {
       // To avoid a race between blacklisting and killing, it is important that the nodeBlacklist
       // is updated before we ask the executor allocation client to kill all the executors


### PR DESCRIPTION
…when trying to kill executors either due to dynamic allocation or blacklisting

Recently, a few spark users in the organization have reported that their jobs were getting stuck. On further analysis, it was found out that there exist two independent deadlocks and either of them occur under different circumstances. The screenshots for these two deadlocks are attached here. 

We were able to reproduce the deadlocks with the following piece of code:

```
import org.apache.hadoop.conf.Configuration
import org.apache.hadoop.fs.{FileSystem, Path}

import org.apache.spark._
import org.apache.spark.TaskContext

// Simple example of Word Count in Scala
object ScalaWordCount {
def main(args: Array[String]) {

if (args.length < 2) {
System.err.println("Usage: ScalaWordCount <inputFilesURI> <outputFilesUri>")
System.exit(1)
}

val conf = new SparkConf().setAppName("Scala Word Count")
val sc = new SparkContext(conf)

// get the input file uri
val inputFilesUri = args(0)

// get the output file uri
val outputFilesUri = args(1)

while (true) {
val textFile = sc.textFile(inputFilesUri)
val counts = textFile.flatMap(line => line.split(" "))
.map(word => {if (TaskContext.get.partitionId == 5 && TaskContext.get.attemptNumber == 0) throw new Exception("Fail for blacklisting") else (word, 1)})
.reduceByKey(_ + _)
counts.saveAsTextFile(outputFilesUri)
val conf: Configuration = new Configuration()
val path: Path = new Path(outputFilesUri)
val hdfs: FileSystem = FileSystem.get(conf)
hdfs.delete(path, true)
}

sc.stop()
}
}
```

Additionally, to ensure that the deadlock surfaces up soon enough, I also added a small delay in the Spark code here:

https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala#L256

```
executorIdToFailureList.remove(exec)
updateNextExpiryTime()
Thread.sleep(2000)
killBlacklistedExecutor(exec)
```
Also make sure that the following configs are set when launching the above spark job:
**spark.blacklist.enabled=true
spark.blacklist.killBlacklistedExecutors=true
spark.blacklist.application.maxFailedTasksPerExecutor=1**

Screenshots for deadlock between task-result-getter-thread and spark-dynamic-executor-allocation thread:
<img width="1417" alt="Screen Shot 2019-02-26 at 4 10 26 PM" src="https://user-images.githubusercontent.com/22228190/54062129-de943e80-41c9-11e9-8c62-cc810b7be74d.png">

<img width="1416" alt="Screen Shot 2019-02-26 at 4 10 48 PM" src="https://user-images.githubusercontent.com/22228190/54062135-e653e300-41c9-11e9-99a2-7569045487bd.png">

Screenshots for deadlock between task-result-getter-thread and dispatcher-event-loop thread:

<img width="1417" alt="Screen Shot 2019-02-26 at 4 11 11 PM" src="https://user-images.githubusercontent.com/22228190/54062148-fc61a380-41c9-11e9-9014-9199b46863d8.png">

<img width="1417" alt="Screen Shot 2019-02-26 at 4 11 26 PM" src="https://user-images.githubusercontent.com/22228190/54062150-01beee00-41ca-11e9-8d0b-a7a1836a4e11.png">



## What changes were proposed in this pull request?

There are two deadlocks as a result of the interplay between three different threads:

**task-result-getter thread**

**spark-dynamic-executor-allocation thread**

**dispatcher-event-loop thread(makeOffers())**

The fix for the deadlock between dynamic allocation thread and result getter thread involves moving the method isExecutorBusy outside of the lock CoarseGrainedSchedulerBackend.this.

The fix for the deadlock between event loop thread and result getter thread involves removing synchronized on CoarseGrainedSchedulerBackend.this. The same synchronization has been replaced by a dummy lock to ensure synchronization between dynamic allocation thread and event loop thread in order to fix https://issues.apache.org/jira/browse/SPARK-19757 but avoid the deadlock scenario which was introduced by the code changes for the above JIRA.


## How was this patch tested?

The code used to reproduce the deadlock issue is documented above.
