### PR TITLE
[SPARK-27123][SQL] Improve CollapseProject to handle projects cross limit/repartition/sample

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -713,15 +713,10 @@ object CollapseProject extends Rule[LogicalPlan] {
         val newProjectList = buildCleanedProjectList(p1.projectList, p2.projectList)
         l.copy(child = p2.copy(projectList = newProjectList))
       }
-    case p1 @ Project(_, s @ Sample(_, _, _, _, p2: Project)) =>
-      if (haveCommonNonDeterministicOutput(p1.projectList, p2.projectList)) {
-        p1
-      } else {
-        val newProjectList = buildCleanedProjectList(p1.projectList, p2.projectList)
-        s.copy(child = p2.copy(projectList = newProjectList))
-      }
     case Project(list, r @ Repartition(_, _, p: Project)) if list.forall(_.deterministic) =>
       r.copy(child = p.copy(projectList = buildCleanedProjectList(list, p.projectList)))
+    case Project(list, s @ Sample(_, _, _, _, p2: Project)) if list.forall(_.deterministic) =>
+      s.copy(child = p2.copy(projectList = buildCleanedProjectList(list, p2.projectList)))
   }
 
   private def collectAliases(projectList: Seq[NamedExpression]): AttributeMap[Alias] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -713,10 +713,10 @@ object CollapseProject extends Rule[LogicalPlan] {
         val newProjectList = buildCleanedProjectList(p1.projectList, p2.projectList)
         l.copy(child = p2.copy(projectList = newProjectList))
       }
-    case Project(list, r @ Repartition(_, _, p: Project)) if list.forall(_.deterministic) =>
-      r.copy(child = p.copy(projectList = buildCleanedProjectList(list, p.projectList)))
-    case Project(list, s @ Sample(_, _, _, _, p2: Project)) if list.forall(_.deterministic) =>
-      s.copy(child = p2.copy(projectList = buildCleanedProjectList(list, p2.projectList)))
+    case Project(l1, r @ Repartition(_, _, p @ Project(l2, _))) if isRenaming(l1, l2) =>
+      r.copy(child = p.copy(projectList = buildCleanedProjectList(l1, p.projectList)))
+    case Project(l1, s @ Sample(_, _, _, _, p2 @ Project(l2, _))) if isRenaming(l1, l2) =>
+      s.copy(child = p2.copy(projectList = buildCleanedProjectList(l1, p2.projectList)))
   }
 
   private def collectAliases(projectList: Seq[NamedExpression]): AttributeMap[Alias] = {
@@ -755,6 +755,14 @@ object CollapseProject extends Rule[LogicalPlan] {
     // collapse upper and lower Projects may introduce unnecessary Aliases, trim them here.
     rewrittenUpper.map { p =>
       CleanupAliases.trimNonTopLevelAliases(p).asInstanceOf[NamedExpression]
+    }
+  }
+
+  private def isRenaming(list1: Seq[NamedExpression], list2: Seq[NamedExpression]): Boolean = {
+    list1.length == list2.length && list1.zip(list2).forall {
+      case (e1, e2) if e1.semanticEquals(e2) => true
+      case (Alias(a: Attribute, _), b) if a.metadata == Metadata.empty && a.name == b.name => true
+      case _ => false
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -713,13 +713,6 @@ object CollapseProject extends Rule[LogicalPlan] {
         val newProjectList = buildCleanedProjectList(p1.projectList, p2.projectList)
         l.copy(child = p2.copy(projectList = newProjectList))
       }
-    case p1 @ Project(_, r @ Repartition(_, _, p2: Project)) =>
-      if (haveCommonNonDeterministicOutput(p1.projectList, p2.projectList)) {
-        p1
-      } else {
-        val newProjectList = buildCleanedProjectList(p1.projectList, p2.projectList)
-        r.copy(child = p2.copy(projectList = newProjectList))
-      }
     case p1 @ Project(_, s @ Sample(_, _, _, _, p2: Project)) =>
       if (haveCommonNonDeterministicOutput(p1.projectList, p2.projectList)) {
         p1
@@ -727,6 +720,8 @@ object CollapseProject extends Rule[LogicalPlan] {
         val newProjectList = buildCleanedProjectList(p1.projectList, p2.projectList)
         s.copy(child = p2.copy(projectList = newProjectList))
       }
+    case Project(list, r @ Repartition(_, _, p: Project)) if list.forall(_.deterministic) =>
+      r.copy(child = p.copy(projectList = buildCleanedProjectList(list, p.projectList)))
   }
 
   private def collectAliases(projectList: Seq[NamedExpression]): AttributeMap[Alias] = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ColumnPruningSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ColumnPruningSuite.scala
@@ -388,7 +388,7 @@ class ColumnPruningSuite extends PlanTest {
 
     val query2 = Sample(0.0, 0.6, false, 11L, x).select('a as 'aa)
     val optimized2 = Optimize.execute(query2.analyze)
-    val expected2 = Sample(0.0, 0.6, false, 11L, x.select('a)).select('a as 'aa)
+    val expected2 = Sample(0.0, 0.6, false, 11L, x.select('a as 'aa))
     comparePlans(optimized2, expected2.analyze)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`CollapseProject` optimizer rule simplifies some plans by merging the adjacent projects and performing alias substitutions.
```scala
scala> sql("SELECT b c FROM (SELECT a b FROM t)").explain
== Physical Plan ==
*(1) Project [a#5 AS c#1]
+- Scan hive default.t [a#5], HiveTableRelation `default`.`t`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, [a#5]
```

We can do that more complex cases like the following. This PR aims to handle adjacent projects across limit/repartition/sample. Here, repartition means `Repartition`, not `RepartitionByExpression`.

**BEFORE**
```scala
scala> sql("SELECT b c FROM (SELECT /*+ REPARTITION(1) */ a b FROM t)").explain
== Physical Plan ==
*(2) Project [b#0 AS c#1]
+- Exchange RoundRobinPartitioning(1)
   +- *(1) Project [a#5 AS b#0]
      +- Scan hive default.t [a#5], HiveTableRelation `default`.`t`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, [a#5]
```

**AFTER**
```scala
scala> sql("SELECT b c FROM (SELECT /*+ REPARTITION(1) */ a b FROM t)").explain
== Physical Plan ==
Exchange RoundRobinPartitioning(1)
+- *(1) Project [a#11 AS c#7]
   +- Scan hive default.t [a#11], HiveTableRelation `default`.`t`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, [a#11]
```

## How was this patch tested?

Pass the Jenkins with the newly added and updated test cases.