### PR TITLE
[DO-NOT-MERGE][SPARK-27127][SQL] Deduplicate codes reading from/writing to unsafe object

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/UnsafeHelper.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/UnsafeHelper.java
@@ -22,14 +22,6 @@ import java.nio.ByteBuffer;
 public final class UnsafeHelper {
   private UnsafeHelper() {}
 
-  public static byte[] getBinary(long offsetAndSize, Object baseObject, long baseOffset) {
-    final int offset = getOffsetFromOffsetAndSize(offsetAndSize);
-    final int size = getSizeFromOffsetAndSize(offsetAndSize);
-    final byte[] bytes = new byte[size];
-    Platform.copyMemory(baseObject, baseOffset + offset, bytes, Platform.BYTE_ARRAY_OFFSET, size);
-    return bytes;
-  }
-
   public static void writeTo(
       ByteBuffer buffer,
       Object baseObject,
@@ -58,13 +50,5 @@ public final class UnsafeHelper {
     Platform.copyMemory(baseObject, baseOffset, arrayDataCopy, Platform.BYTE_ARRAY_OFFSET,
         sizeInBytes);
     return arrayDataCopy;
-  }
-
-  public static int getOffsetFromOffsetAndSize(long offsetAndSize) {
-    return (int) (offsetAndSize >> 32);
-  }
-
-  public static int getSizeFromOffsetAndSize(long offsetAndSize) {
-    return (int) offsetAndSize;
   }
 }

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/UnsafeHelper.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/UnsafeHelper.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.unsafe;
+
+import org.apache.spark.unsafe.types.CalendarInterval;
+import org.apache.spark.unsafe.types.UTF8String;
+
+import java.nio.ByteBuffer;
+
+public final class UnsafeHelper {
+  private UnsafeHelper() {}
+
+  public static byte[] getBinary(long offsetAndSize, Object baseObject, long baseOffset) {
+    final int offset = getOffsetFromOffsetAndSize(offsetAndSize);
+    final int size = getSizeFromOffsetAndSize(offsetAndSize);
+    final byte[] bytes = new byte[size];
+    Platform.copyMemory(baseObject, baseOffset + offset, bytes, Platform.BYTE_ARRAY_OFFSET, size);
+    return bytes;
+  }
+
+  public static UTF8String getUTF8String(long offsetAndSize, Object baseObject, long baseOffset) {
+    final int offset = getOffsetFromOffsetAndSize(offsetAndSize);
+    final int size = getSizeFromOffsetAndSize(offsetAndSize);
+    return UTF8String.fromAddress(baseObject, baseOffset + offset, size);
+  }
+
+  public static CalendarInterval getInterval(
+      long offsetAndSize,
+      Object baseObject,
+      long baseOffset) {
+    final int offset = getOffsetFromOffsetAndSize(offsetAndSize);
+    final int months = (int) Platform.getLong(baseObject, baseOffset + offset);
+    final long microseconds = Platform.getLong(baseObject, baseOffset + offset + 8);
+    return new CalendarInterval(months, microseconds);
+  }
+
+  public static void writeTo(
+      ByteBuffer buffer,
+      Object baseObject,
+      long baseOffset,
+      int sizeInBytes) {
+    assert(buffer.hasArray());
+    byte[] target = buffer.array();
+    int offset = buffer.arrayOffset();
+    int pos = buffer.position();
+    writeToMemory(baseObject, baseOffset, target,
+        Platform.BYTE_ARRAY_OFFSET + offset + pos, sizeInBytes);
+    buffer.position(pos + sizeInBytes);
+  }
+
+  public static void writeToMemory(
+      Object baseObject,
+      long baseOffset,
+      Object target,
+      long targetOffset,
+      int sizeInBytes) {
+    Platform.copyMemory(baseObject, baseOffset, target, targetOffset, sizeInBytes);
+  }
+
+  public static byte[] copyToMemory(Object baseObject, long baseOffset, int sizeInBytes) {
+    final byte[] arrayDataCopy = new byte[sizeInBytes];
+    Platform.copyMemory(baseObject, baseOffset, arrayDataCopy, Platform.BYTE_ARRAY_OFFSET,
+        sizeInBytes);
+    return arrayDataCopy;
+  }
+
+  public static int getOffsetFromOffsetAndSize(long offsetAndSize) {
+    return (int) (offsetAndSize >> 32);
+  }
+
+  public static int getSizeFromOffsetAndSize(long offsetAndSize) {
+    return (int) offsetAndSize;
+  }
+}

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/UnsafeHelper.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/UnsafeHelper.java
@@ -17,9 +17,6 @@
 
 package org.apache.spark.unsafe;
 
-import org.apache.spark.unsafe.types.CalendarInterval;
-import org.apache.spark.unsafe.types.UTF8String;
-
 import java.nio.ByteBuffer;
 
 public final class UnsafeHelper {
@@ -31,22 +28,6 @@ public final class UnsafeHelper {
     final byte[] bytes = new byte[size];
     Platform.copyMemory(baseObject, baseOffset + offset, bytes, Platform.BYTE_ARRAY_OFFSET, size);
     return bytes;
-  }
-
-  public static UTF8String getUTF8String(long offsetAndSize, Object baseObject, long baseOffset) {
-    final int offset = getOffsetFromOffsetAndSize(offsetAndSize);
-    final int size = getSizeFromOffsetAndSize(offsetAndSize);
-    return UTF8String.fromAddress(baseObject, baseOffset + offset, size);
-  }
-
-  public static CalendarInterval getInterval(
-      long offsetAndSize,
-      Object baseObject,
-      long baseOffset) {
-    final int offset = getOffsetFromOffsetAndSize(offsetAndSize);
-    final int months = (int) Platform.getLong(baseObject, baseOffset + offset);
-    final long microseconds = Platform.getLong(baseObject, baseOffset + offset + 8);
-    return new CalendarInterval(months, microseconds);
   }
 
   public static void writeTo(

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -32,6 +32,7 @@ import com.esotericsoftware.kryo.io.Output;
 import com.google.common.primitives.Ints;
 
 import org.apache.spark.unsafe.Platform;
+import org.apache.spark.unsafe.UnsafeHelper;
 import org.apache.spark.unsafe.array.ByteArrayMethods;
 import org.apache.spark.unsafe.hash.Murmur3_x86_32;
 
@@ -168,16 +169,11 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
    * bytes in this string.
    */
   public void writeToMemory(Object target, long targetOffset) {
-    Platform.copyMemory(base, offset, target, targetOffset, numBytes);
+    UnsafeHelper.writeToMemory(base, offset, target, targetOffset, numBytes);
   }
 
   public void writeTo(ByteBuffer buffer) {
-    assert(buffer.hasArray());
-    byte[] target = buffer.array();
-    int offset = buffer.arrayOffset();
-    int pos = buffer.position();
-    writeToMemory(target, Platform.BYTE_ARRAY_OFFSET + offset + pos);
-    buffer.position(pos + numBytes);
+    UnsafeHelper.writeTo(buffer, base, offset, numBytes);
   }
 
   /**

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/SqlTypesUnsafeHelper.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/SqlTypesUnsafeHelper.java
@@ -18,13 +18,32 @@
 package org.apache.spark.sql.catalyst.expressions;
 
 import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.unsafe.Platform;
 import org.apache.spark.unsafe.UnsafeHelper;
+import org.apache.spark.unsafe.types.CalendarInterval;
+import org.apache.spark.unsafe.types.UTF8String;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
 public final class SqlTypesUnsafeHelper {
   private SqlTypesUnsafeHelper() {}
+
+  public static UTF8String getUTF8String(long offsetAndSize, Object baseObject, long baseOffset) {
+    final int offset = UnsafeHelper.getOffsetFromOffsetAndSize(offsetAndSize);
+    final int size = UnsafeHelper.getSizeFromOffsetAndSize(offsetAndSize);
+    return UTF8String.fromAddress(baseObject, baseOffset + offset, size);
+  }
+
+  public static CalendarInterval getInterval(
+      long offsetAndSize,
+      Object baseObject,
+      long baseOffset) {
+    final int offset = UnsafeHelper.getOffsetFromOffsetAndSize(offsetAndSize);
+    final int months = (int) Platform.getLong(baseObject, baseOffset + offset);
+    final long microseconds = Platform.getLong(baseObject, baseOffset + offset + 8);
+    return new CalendarInterval(months, microseconds);
+  }
 
   public static Decimal getDecimalExceedingLong(
       byte[] bytes,

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/SqlTypesUnsafeHelper.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/SqlTypesUnsafeHelper.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions;
+
+import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.unsafe.UnsafeHelper;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+public final class SqlTypesUnsafeHelper {
+  private SqlTypesUnsafeHelper() {}
+
+  public static Decimal getDecimalExceedingLong(
+      byte[] bytes,
+      int precision,
+      int scale,
+      boolean wrapWithScalaBigDecimal) {
+    final BigInteger bigInteger = new BigInteger(bytes);
+    BigDecimal decimal = new BigDecimal(bigInteger, scale);
+    if (wrapWithScalaBigDecimal) {
+      return Decimal.apply(new scala.math.BigDecimal(decimal), precision, scale);
+    } else {
+      return Decimal.apply(decimal, precision, scale);
+    }
+  }
+
+  public static UnsafeRow getStruct(
+      long offsetAndSize,
+      Object baseObject,
+      long baseOffset,
+      int numFields) {
+    final int offset = UnsafeHelper.getOffsetFromOffsetAndSize(offsetAndSize);
+    final int size = UnsafeHelper.getSizeFromOffsetAndSize(offsetAndSize);
+    final UnsafeRow row = new UnsafeRow(numFields);
+    row.pointTo(baseObject, baseOffset + offset, size);
+    return row;
+  }
+
+  public static UnsafeArrayData getArray(long offsetAndSize, Object baseObject, long baseOffset) {
+    final int offset = UnsafeHelper.getOffsetFromOffsetAndSize(offsetAndSize);
+    final int size = UnsafeHelper.getSizeFromOffsetAndSize(offsetAndSize);
+    final UnsafeArrayData array = new UnsafeArrayData();
+    array.pointTo(baseObject, baseOffset + offset, size);
+    return array;
+  }
+
+  public static UnsafeMapData getMap(long offsetAndSize, Object baseObject, long baseOffset) {
+    final int offset = UnsafeHelper.getOffsetFromOffsetAndSize(offsetAndSize);
+    final int size = UnsafeHelper.getSizeFromOffsetAndSize(offsetAndSize);
+    final UnsafeMapData map = new UnsafeMapData();
+    map.pointTo(baseObject, baseOffset + offset, size);
+    return map;
+  }
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeArrayData.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeArrayData.java
@@ -240,7 +240,7 @@ public final class UnsafeArrayData extends ArrayData {
   @Override
   public byte[] getBinary(int ordinal) {
     if (isNullAt(ordinal)) return null;
-    return UnsafeHelper.getBinary(getLong(ordinal), baseObject, baseOffset);
+    return SqlTypesUnsafeHelper.getBinary(getLong(ordinal), baseObject, baseOffset);
   }
 
   @Override

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeArrayData.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeArrayData.java
@@ -234,7 +234,7 @@ public final class UnsafeArrayData extends ArrayData {
   @Override
   public UTF8String getUTF8String(int ordinal) {
     if (isNullAt(ordinal)) return null;
-    return UnsafeHelper.getUTF8String(getLong(ordinal), baseObject, baseOffset);
+    return SqlTypesUnsafeHelper.getUTF8String(getLong(ordinal), baseObject, baseOffset);
   }
 
   @Override
@@ -246,7 +246,7 @@ public final class UnsafeArrayData extends ArrayData {
   @Override
   public CalendarInterval getInterval(int ordinal) {
     if (isNullAt(ordinal)) return null;
-    return UnsafeHelper.getInterval(getLong(ordinal), baseObject, baseOffset);
+    return SqlTypesUnsafeHelper.getInterval(getLong(ordinal), baseObject, baseOffset);
   }
 
   @Override

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
@@ -405,7 +405,7 @@ public final class UnsafeRow extends InternalRow implements Externalizable, Kryo
   @Override
   public UTF8String getUTF8String(int ordinal) {
     if (isNullAt(ordinal)) return null;
-    return UnsafeHelper.getUTF8String(getLong(ordinal), baseObject, baseOffset);
+    return SqlTypesUnsafeHelper.getUTF8String(getLong(ordinal), baseObject, baseOffset);
   }
 
   @Override
@@ -422,7 +422,7 @@ public final class UnsafeRow extends InternalRow implements Externalizable, Kryo
     if (isNullAt(ordinal)) {
       return null;
     } else {
-      return UnsafeHelper.getInterval(getLong(ordinal), baseObject, baseOffset);
+      return SqlTypesUnsafeHelper.getInterval(getLong(ordinal), baseObject, baseOffset);
     }
   }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
@@ -413,7 +413,7 @@ public final class UnsafeRow extends InternalRow implements Externalizable, Kryo
     if (isNullAt(ordinal)) {
       return null;
     } else {
-      return UnsafeHelper.getBinary(getLong(ordinal), baseObject, baseOffset);
+      return SqlTypesUnsafeHelper.getBinary(getLong(ordinal), baseObject, baseOffset);
     }
   }
 
@@ -590,8 +590,8 @@ public final class UnsafeRow extends InternalRow implements Externalizable, Kryo
    */
   public void writeFieldTo(int ordinal, ByteBuffer buffer) {
     final long offsetAndSize = getLong(ordinal);
-    final int offset = UnsafeHelper.getOffsetFromOffsetAndSize(offsetAndSize);
-    final int size = UnsafeHelper.getSizeFromOffsetAndSize(offsetAndSize);
+    final int offset = SqlTypesUnsafeHelper.getOffsetFromOffsetAndSize(offsetAndSize);
+    final int size = SqlTypesUnsafeHelper.getSizeFromOffsetAndSize(offsetAndSize);
 
     buffer.putInt(size);
     int pos = buffer.position();


### PR DESCRIPTION
## What changes were proposed in this pull request?

IntelliJ found lots of code duplication among some Unsafe classes, and code duplications occur from reading from/writing to unsafe object. This patch deduplicates code block around reading from/writing to unsafe object among various classes. 

This would help not only reducing codes, but also let the way of dealing with unsafe object consistently.

## How was this patch tested?

Existing tests.