### PR TITLE
[MINOR][DOC] Fix spark.kubernetes.executor.label.[LabelName] parameter meaning

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -702,7 +702,7 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>
     Add the label specified by <code>LabelName</code> to the executor pods.
     For example, <code>spark.kubernetes.executor.label.something=true</code>.
-    Note that Spark also adds its own labels to the driver pod
+    Note that Spark also adds its own labels to the executor pod
     for bookkeeping purposes.
   </td>
 </tr>


### PR DESCRIPTION
## What changes were proposed in this pull request?


It would be better to change the explanation to this spark.kubernetes.executor.label.[LabelName].
Before:
    Note that Spark also adds its own labels to the **driver pod** for bookkeeping purposes.


After modification:
   Note that Spark also adds its own labels to the **executor pod** for bookkeeping purposes.		    