### PR TITLE
[SPARK-26152] Handle RejectedExecutionException due to Worker Cleanup on Worker Shutdown

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -473,8 +473,8 @@ private[deploy] class Worker(
           logError("App dir cleanup failed: " + e.getMessage, e)
         )(cleanupThreadExecutor)
       } catch {
-        case _ : RejectedExecutionException if cleanupThreadExecutor.isShutdown =>
-          logDebug("Failed to cleanup work dir as executor pool was shutdown")
+        case _: RejectedExecutionException if cleanupThreadExecutor.isShutdown =>
+          logWarning("Failed to cleanup work dir as executor pool was shutdown")
       }
 
     case MasterChanged(masterRef, masterWebUiUrl) =>
@@ -651,8 +651,8 @@ private[deploy] class Worker(
           )(cleanupThreadExecutor)
         }
       } catch {
-        case _ : RejectedExecutionException if cleanupThreadExecutor.isShutdown =>
-          logDebug("Failed to cleanup application as executor pool was shutdown")
+        case _: RejectedExecutionException if cleanupThreadExecutor.isShutdown =>
+          logWarning("Failed to cleanup application as executor pool was shutdown")
       }
       shuffleService.applicationRemoved(id)
     }

--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -69,8 +69,8 @@ private[deploy] class Worker(
 
   // A separated thread to clean up the workDir and the directories of finished applications.
   // Used to provide the implicit parameter of `Future` methods.
-  private val cleanupThreadExecutor = ExecutionContext.fromExecutorService(new ShutdownSafeExecutor(
-    ThreadUtils.newDaemonSingleThreadExecutor("worker-cleanup-thread")))
+  private val cleanupThreadExecutor = ExecutionContext.fromExecutorService(
+    ThreadUtils.newDaemonSingleThreadExecutor("worker-cleanup-thread"))
 
   // For worker and executor IDs
   private def createDateFormat = new SimpleDateFormat("yyyyMMddHHmmss", Locale.US)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The race between org.apache.spark.deploy.DeployMessages.WorkDirCleanup event and  org.apache.spark.deploy.worker.Worker#onStop. Here its possible that while the WorkDirCleanup event is being processed, org.apache.spark.deploy.worker.Worker#cleanupThreadExecutor was shutdown. hence any submission after ThreadPoolExecutor will result in java.util.concurrent.RejectedExecutionException

This must be gracefully handled(logged) instead of exiting thread abruptly

## How was this patch tested?

Manually