### PR TITLE
[SPARK-27130][BUILD] Automatically select profile when executing sbt-checkstyle

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -180,9 +180,9 @@ def run_scala_style_checks():
     run_cmd([os.path.join(SPARK_HOME, "dev", "lint-scala")])
 
 
-def run_java_style_checks():
+def run_java_style_checks(build_profiles):
     set_title_and_block("Running Java style checks", "BLOCK_JAVA_STYLE")
-    run_cmd([os.path.join(SPARK_HOME, "dev", "sbt-checkstyle")])
+    run_cmd([os.path.join(SPARK_HOME, "dev", "sbt-checkstyle"), build_profiles])
 
 
 def run_python_style_checks():
@@ -333,7 +333,7 @@ def build_spark_assembly_sbt(hadoop_version, checkstyle=False):
     exec_sbt(profiles_and_goals)
 
     if checkstyle:
-        run_java_style_checks()
+        run_java_style_checks(" ".join(build_profiles))
 
     build_spark_unidoc_sbt(hadoop_version)
 

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -182,7 +182,11 @@ def run_scala_style_checks():
 
 def run_java_style_checks(build_profiles):
     set_title_and_block("Running Java style checks", "BLOCK_JAVA_STYLE")
-    run_cmd([os.path.join(SPARK_HOME, "dev", "sbt-checkstyle"), build_profiles])
+    # The same profiles used for building are used to run Checkstyle by SBT as well because
+    # the previous build looks reused for Checkstyle and affecting Checkstyle. See SPARK-27130.
+    profiles = " ".join(build_profiles)
+    print("[info] Checking Java style using SBT with these profiles: ", profiles)
+    run_cmd([os.path.join(SPARK_HOME, "dev", "sbt-checkstyle"), profiles])
 
 
 def run_python_style_checks():
@@ -333,7 +337,7 @@ def build_spark_assembly_sbt(hadoop_version, checkstyle=False):
     exec_sbt(profiles_and_goals)
 
     if checkstyle:
-        run_java_style_checks(" ".join(build_profiles))
+        run_java_style_checks(build_profiles)
 
     build_spark_unidoc_sbt(hadoop_version)
 

--- a/dev/sbt-checkstyle
+++ b/dev/sbt-checkstyle
@@ -17,17 +17,13 @@
 # limitations under the License.
 #
 
+build_profiles=$1
+echo "Checking Spark style using SBT with these arguments: ${build_profiles}"
+
 # NOTE: echo "q" is needed because SBT prompts the user for input on encountering a build file
 # with failure (either resolution or compilation); the "q" makes SBT quit.
 ERRORS=$(echo -e "q\n" \
-    | build/sbt \
-        -Pkinesis-asl \
-        -Pmesos \
-        -Pkubernetes \
-        -Pyarn \
-        -Phive \
-        -Phive-thriftserver \
-        checkstyle test:checkstyle \
+    | build/sbt ${build_profiles} checkstyle test:checkstyle \
     | awk '{if($1~/error/)print}' \
 )
 

--- a/dev/sbt-checkstyle
+++ b/dev/sbt-checkstyle
@@ -17,13 +17,12 @@
 # limitations under the License.
 #
 
-build_profiles=$1
-echo "Checking Spark style using SBT with these arguments: ${build_profiles}"
+profiles=${1:-"-Pkinesis-asl -Pmesos -Pkubernetes -Pyarn -Phive -Phive-thriftserver"}
 
 # NOTE: echo "q" is needed because SBT prompts the user for input on encountering a build file
 # with failure (either resolution or compilation); the "q" makes SBT quit.
 ERRORS=$(echo -e "q\n" \
-    | build/sbt ${build_profiles} checkstyle test:checkstyle \
+    | build/sbt ${profiles} checkstyle test:checkstyle \
     | awk '{if($1~/error/)print}' \
 )
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR makes it automatically select profile when executing `sbt-checkstyle`. The reason for this is that `hadoop-2.7` and `hadoop-3.1` may have different `hive-thriftserver` module in the future.

## How was this patch tested?

manual tests:
```
Update AbstractService.java file.
export HADOOP_PROFILE=hadoop2.7
./dev/run-tests
```
The result:
![image](https://user-images.githubusercontent.com/5399861/54197992-5337e780-4500-11e9-930c-722982cdcd45.png)

