### PR TITLE
[SPARK-27135][WebUI]Add ToolTip support for overflow text

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/initialize-tooltips.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/initialize-tooltips.js
@@ -19,3 +19,13 @@ $(document).ready(function(){
    $("[data-toggle=tooltip]").tooltip({container: 'body'});
 });
 
+$(document).on('mouseenter', ".description-input", function () {
+   var $this = $(this);
+   if (this.offsetWidth < this.scrollWidth && !$this.attr('title')) {
+        $this.tooltip({
+            title: $this.text(),
+            placement: "right"
+        });
+        $this.tooltip('show');
+   }
+});


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hover is supported on the description column,so when the description column overflows user can view the complete details

## How was this patch tested?

Manually

## Before Fix
![UIIssue](https://user-images.githubusercontent.com/35216143/54195580-0f83b480-44e5-11e9-8732-39f13e01e0d6.PNG)
## After Fix 
 e.g. 1
![toolTip2](https://user-images.githubusercontent.com/35216143/54276637-ce0e0a80-45b3-11e9-9742-bc4b0028c03b.png)
e.g. 2
![ToolTipWithLargeQuery](https://user-images.githubusercontent.com/35216143/54276655-da926300-45b3-11e9-83ba-808011222671.png)
