### PR TITLE
[SPARK-27122][core] Jetty classes must not be return via getters in org.apache.spark.ui.WebUI

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/WebUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/WebUI.scala
@@ -102,13 +102,12 @@ private[spark] abstract class WebUI(
   }
 
   /** Attaches a handler to this UI. */
-  def attachHandler(contextPath: String, httpServlet: HttpServlet, pathSpec: String): Unit =
-    synchronized {
-      val ctx = new ServletContextHandler
-      ctx.setContextPath(contextPath)
-      ctx.addServlet(new ServletHolder(httpServlet), pathSpec)
-      attachHandler(ctx)
-    }
+  def attachHandler(contextPath: String, httpServlet: HttpServlet, pathSpec: String): Unit = {
+    val ctx = new ServletContextHandler()
+    ctx.setContextPath(contextPath)
+    ctx.addServlet(new ServletHolder(httpServlet), pathSpec)
+    attachHandler(ctx)
+  }
 
   /** Detaches a handler from this UI. */
   def detachHandler(handler: ServletContextHandler): Unit = synchronized {
@@ -215,7 +214,7 @@ private[spark] class DelegatingServletContextHandler(handler: ServletContextHand
       filterName: String,
       spec: String,
       types: EnumSet[DispatcherType]): Unit = {
-    val mapping = new FilterMapping
+    val mapping = new FilterMapping()
     mapping.setFilterName(filterName)
     mapping.setPathSpec(spec)
     mapping.setDispatcherTypes(types)
@@ -226,7 +225,7 @@ private[spark] class DelegatingServletContextHandler(handler: ServletContextHand
       filterName: String,
       className: String,
       filterParams: Map[String, String]): Unit = {
-    val filterHolder = new FilterHolder
+    val filterHolder = new FilterHolder()
     filterHolder.setName(filterName)
     filterHolder.setClassName(className)
     filterParams.foreach { case (k, v) => filterHolder.setInitParameter(k, v) }

--- a/core/src/main/scala/org/apache/spark/ui/WebUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/WebUI.scala
@@ -102,14 +102,13 @@ private[spark] abstract class WebUI(
   }
 
   /** Attaches a handler to this UI. */
-  def attachHandler(contextPath: String,
-    httpServlet: HttpServlet,
-    pathSpec: String): Unit = synchronized {
-    val ctx = new ServletContextHandler
-    ctx.setContextPath(contextPath)
-    ctx.addServlet(new ServletHolder(httpServlet), pathSpec)
-    attachHandler(ctx)
-  }
+  def attachHandler(contextPath: String, httpServlet: HttpServlet, pathSpec: String): Unit =
+    synchronized {
+      val ctx = new ServletContextHandler
+      ctx.setContextPath(contextPath)
+      ctx.addServlet(new ServletHolder(httpServlet), pathSpec)
+      attachHandler(ctx)
+    }
 
   /** Detaches a handler from this UI. */
   def detachHandler(handler: ServletContextHandler): Unit = synchronized {
@@ -212,9 +211,10 @@ private[spark] abstract class WebUIPage(var prefix: String) {
 
 private[spark] class DelegatingServletContextHandler(handler: ServletContextHandler) {
 
-  def prependFilterMapping(filterName: String,
-    spec: String,
-    types: EnumSet[DispatcherType]): Unit = {
+  def prependFilterMapping(
+      filterName: String,
+      spec: String,
+      types: EnumSet[DispatcherType]): Unit = {
     val mapping = new FilterMapping
     mapping.setFilterName(filterName)
     mapping.setPathSpec(spec)
@@ -222,9 +222,10 @@ private[spark] class DelegatingServletContextHandler(handler: ServletContextHand
     handler.getServletHandler.prependFilterMapping(mapping)
   }
 
-  def addFilter(filterName: String,
-    className: String,
-    filterParams: Map[String, String]): Unit = {
+  def addFilter(
+      filterName: String,
+      className: String,
+      filterParams: Map[String, String]): Unit = {
     val filterHolder = new FilterHolder
     filterHolder.setName(filterName)
     filterHolder.setClassName(className)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -180,19 +180,9 @@ private[spark] abstract class YarnSchedulerBackend(
           }
           conf.set(UI_FILTERS, allFilters)
 
-          ui.getHandlers.map(_.getServletHandler()).foreach { h =>
-            val holder = new FilterHolder()
-            holder.setName(filterName)
-            holder.setClassName(filterName)
-            filterParams.foreach { case (k, v) => holder.setInitParameter(k, v) }
-            h.addFilter(holder)
-
-            val mapping = new FilterMapping()
-            mapping.setFilterName(filterName)
-            mapping.setPathSpec("/*")
-            mapping.setDispatcherTypes(EnumSet.allOf(classOf[DispatcherType]))
-
-            h.prependFilterMapping(mapping)
+          ui.getDelegatingHandlers.foreach { h =>
+            h.addFilter(filterName, filterName, filterParams)
+            h.prependFilterMapping(filterName, "/*", EnumSet.allOf(classOf[DispatcherType]))
           }
         }
       }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackendSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackendSuite.scala
@@ -103,7 +103,7 @@ class YarnSchedulerBackendSuite extends SparkFunSuite with MockitoSugar with Loc
 
     sc.ui.get.getDelegatingHandlers.foreach { h =>
       // Two filters above + security filter.
-      assert(h.filterSize() === 3)
+      assert(h.filterCount() === 3)
     }
 
     // The filter should have been added first in the chain, so we should get SC_NOT_ACCEPTABLE
@@ -117,7 +117,7 @@ class YarnSchedulerBackendSuite extends SparkFunSuite with MockitoSugar with Loc
       }
     }
 
-    sc.ui.get.attachNewHandler("/new-handler", servlet, "/")
+    sc.ui.get.attachHandler("/new-handler", servlet, "/")
 
     val newUrl = new URL(sc.uiWebUrl.get + "/new-handler/")
     assert(TestUtils.httpResponseCode(newUrl) === HttpServletResponse.SC_NOT_ACCEPTABLE)

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackendSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackendSuite.scala
@@ -101,9 +101,9 @@ class YarnSchedulerBackendSuite extends SparkFunSuite with MockitoSugar with Loc
     yarnSchedulerBackend.addWebUIFilter(classOf[TestFilter2].getName(),
       Map("responseCode" -> HttpServletResponse.SC_NOT_ACCEPTABLE.toString), "")
 
-    sc.ui.get.getHandlers.foreach { h =>
+    sc.ui.get.getDelegatingHandlers.foreach { h =>
       // Two filters above + security filter.
-      assert(h.getServletHandler().getFilters().length === 3)
+      assert(h.filterSize() === 3)
     }
 
     // The filter should have been added first in the chain, so we should get SC_NOT_ACCEPTABLE
@@ -117,11 +117,7 @@ class YarnSchedulerBackendSuite extends SparkFunSuite with MockitoSugar with Loc
       }
     }
 
-    val ctx = new ServletContextHandler()
-    ctx.setContextPath("/new-handler")
-    ctx.addServlet(new ServletHolder(servlet), "/")
-
-    sc.ui.get.attachHandler(ctx)
+    sc.ui.get.attachNewHandler("/new-handler", servlet, "/")
 
     val newUrl = new URL(sc.uiWebUrl.get + "/new-handler/")
     assert(TestUtils.httpResponseCode(newUrl) === HttpServletResponse.SC_NOT_ACCEPTABLE)


### PR DESCRIPTION
## What changes were proposed in this pull request?

When we run YarnSchedulerBackendSuite, the class path seems to be made from the classes folder(resource-managers/yarn/target/scala-2.12/classes) instead of jar (resource-managers/yarn/target/spark-yarn_2.12-3.0.0-SNAPSHOT.jar) . ui.getHandlers is in spark-core and its loaded from spark-core.jar which is shaded and hence refers to org.spark_project.jetty.servlet.ServletContextHandler

Here in  org.apache.spark.scheduler.cluster.YarnSchedulerBackend, as its not shaded, it expects org.eclipse.jetty.servlet.ServletContextHandler
Refer discussion @ https://issues.apache.org/jira/browse/SPARK-27122?focusedCommentId=16792318&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16792318

Hence as a fix, org.apache.spark.ui.WebUI must only return a wrapper class instance or references so that Jetty classes can be avoided in getters which are accessed outside spark-core

## How was this patch tested?

Existing UT can pass