### PR TITLE
[SPARK-27162][SQL] Add new method asCaseSensitiveMap in CaseInsensitiveStringMap

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalog/v2/Catalogs.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalog/v2/Catalogs.java
@@ -23,6 +23,7 @@ import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.apache.spark.util.Utils;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -96,7 +97,7 @@ public class Catalogs {
     Map<String, String> allConfs = mapAsJavaMapConverter(conf.getAllConfs()).asJava();
     Pattern prefix = Pattern.compile("^spark\\.sql\\.catalog\\." + name + "\\.(.+)");
 
-    CaseInsensitiveStringMap options = CaseInsensitiveStringMap.empty();
+    HashMap<String, String> options = new HashMap<>();
     for (Map.Entry<String, String> entry : allConfs.entrySet()) {
       Matcher matcher = prefix.matcher(entry.getKey());
       if (matcher.matches() && matcher.groupCount() > 0) {
@@ -104,6 +105,6 @@ public class Catalogs {
       }
     }
 
-    return options;
+    return new CaseInsensitiveStringMap(options);
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/util/CaseInsensitiveStringMap.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/util/CaseInsensitiveStringMap.java
@@ -18,6 +18,8 @@
 package org.apache.spark.sql.util;
 
 import org.apache.spark.annotation.Experimental;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -35,6 +37,9 @@ import java.util.Set;
  */
 @Experimental
 public class CaseInsensitiveStringMap implements Map<String, String> {
+  private final Logger logger = LoggerFactory.getLogger(CaseInsensitiveStringMap.class);
+
+  private String unsupportedOperationMsg = "CaseInsensitiveStringMap is read-only.";
 
   public static CaseInsensitiveStringMap empty() {
     return new CaseInsensitiveStringMap(new HashMap<>(0));
@@ -47,8 +52,13 @@ public class CaseInsensitiveStringMap implements Map<String, String> {
   public CaseInsensitiveStringMap(Map<String, String> originalMap) {
     original = new HashMap<>(originalMap);
     delegate = new HashMap<>(originalMap.size());
-    for (Map.Entry<? extends String, ? extends String> entry : originalMap.entrySet()) {
-      delegate.put(toLowerCase(entry.getKey()), entry.getValue());
+    for (Map.Entry<String, String> entry : originalMap.entrySet()) {
+      String key = toLowerCase(entry.getKey());
+      if (delegate.containsKey(key)) {
+        logger.warn("Converting duplicated key " + entry.getKey() +
+                " into CaseInsensitiveStringMap.");
+      }
+      delegate.put(key, entry.getValue());
     }
   }
 
@@ -83,22 +93,22 @@ public class CaseInsensitiveStringMap implements Map<String, String> {
 
   @Override
   public String put(String key, String value) {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(unsupportedOperationMsg);
   }
 
   @Override
   public String remove(Object key) {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(unsupportedOperationMsg);
   }
 
   @Override
   public void putAll(Map<? extends String, ? extends String> m) {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(unsupportedOperationMsg);
   }
 
   @Override
   public void clear() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(unsupportedOperationMsg);
   }
 
   @Override

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/util/CaseInsensitiveStringMap.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/util/CaseInsensitiveStringMap.java
@@ -45,9 +45,11 @@ public class CaseInsensitiveStringMap implements Map<String, String> {
   private final Map<String, String> delegate;
 
   public CaseInsensitiveStringMap(Map<String, String> originalMap) {
-    this.original = new HashMap<>(originalMap.size());
-    this.delegate = new HashMap<>(originalMap.size());
-    putAll(originalMap);
+    original = new HashMap<>(originalMap);
+    delegate = new HashMap<>(originalMap.size());
+    for (Map.Entry<? extends String, ? extends String> entry : originalMap.entrySet()) {
+      delegate.put(toLowerCase(entry.getKey()), entry.getValue());
+    }
   }
 
   @Override
@@ -81,27 +83,22 @@ public class CaseInsensitiveStringMap implements Map<String, String> {
 
   @Override
   public String put(String key, String value) {
-    original.put(key, value);
-    return delegate.put(toLowerCase(key), value);
+    throw new UnsupportedOperationException();
   }
 
   @Override
   public String remove(Object key) {
-    original.remove(key);
-    return delegate.remove(toLowerCase(key));
+    throw new UnsupportedOperationException();
   }
 
   @Override
   public void putAll(Map<? extends String, ? extends String> m) {
-    for (Map.Entry<? extends String, ? extends String> entry : m.entrySet()) {
-      put(entry.getKey(), entry.getValue());
-    }
+    throw new UnsupportedOperationException();
   }
 
   @Override
   public void clear() {
-    original.clear();
-    delegate.clear();
+    throw new UnsupportedOperationException();
   }
 
   @Override
@@ -167,7 +164,7 @@ public class CaseInsensitiveStringMap implements Map<String, String> {
   /**
    * Returns the original case-sensitive map.
    */
-  public Map<String, String> getOriginalMap() {
+  public Map<String, String> asCaseSensitiveMap() {
     return original;
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/util/CaseInsensitiveStringMap.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/util/CaseInsensitiveStringMap.java
@@ -45,7 +45,7 @@ public class CaseInsensitiveStringMap implements Map<String, String> {
   private final Map<String, String> delegate;
 
   public CaseInsensitiveStringMap(Map<String, String> originalMap) {
-    this.original = new HashMap<>(originalMap);
+    this.original = new HashMap<>(originalMap.size());
     this.delegate = new HashMap<>(originalMap.size());
     putAll(originalMap);
   }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/util/CaseInsensitiveStringMap.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/util/CaseInsensitiveStringMap.java
@@ -21,11 +21,7 @@ import org.apache.spark.annotation.Experimental;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Case-insensitive map of string keys to string values.
@@ -175,6 +171,6 @@ public class CaseInsensitiveStringMap implements Map<String, String> {
    * Returns the original case-sensitive map.
    */
   public Map<String, String> asCaseSensitiveMap() {
-    return original;
+    return Collections.unmodifiableMap(original);
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/util/CaseInsensitiveStringMap.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/util/CaseInsensitiveStringMap.java
@@ -21,7 +21,12 @@ import org.apache.spark.annotation.Experimental;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Case-insensitive map of string keys to string values.

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/util/CaseInsensitiveStringMap.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/util/CaseInsensitiveStringMap.java
@@ -40,12 +40,12 @@ public class CaseInsensitiveStringMap implements Map<String, String> {
     return new CaseInsensitiveStringMap(new HashMap<>(0));
   }
 
-  private final Map<String, String> originalMap;
+  private final Map<String, String> original;
 
   private final Map<String, String> delegate;
 
   public CaseInsensitiveStringMap(Map<String, String> originalMap) {
-    this.originalMap = new HashMap<>(originalMap);
+    this.original = new HashMap<>(originalMap);
     this.delegate = new HashMap<>(originalMap.size());
     putAll(originalMap);
   }
@@ -81,13 +81,13 @@ public class CaseInsensitiveStringMap implements Map<String, String> {
 
   @Override
   public String put(String key, String value) {
-    originalMap.put(key, value);
+    original.put(key, value);
     return delegate.put(toLowerCase(key), value);
   }
 
   @Override
   public String remove(Object key) {
-    originalMap.remove(key);
+    original.remove(key);
     return delegate.remove(toLowerCase(key));
   }
 
@@ -100,7 +100,7 @@ public class CaseInsensitiveStringMap implements Map<String, String> {
 
   @Override
   public void clear() {
-    originalMap.clear();
+    original.clear();
     delegate.clear();
   }
 
@@ -168,6 +168,6 @@ public class CaseInsensitiveStringMap implements Map<String, String> {
    * Returns the original case-sensitive map.
    */
   public Map<String, String> getOriginalMap() {
-    return originalMap;
+    return original;
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/util/CaseInsensitiveStringMap.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/util/CaseInsensitiveStringMap.java
@@ -40,9 +40,12 @@ public class CaseInsensitiveStringMap implements Map<String, String> {
     return new CaseInsensitiveStringMap(new HashMap<>(0));
   }
 
+  private final Map<String, String> originalMap;
+
   private final Map<String, String> delegate;
 
   public CaseInsensitiveStringMap(Map<String, String> originalMap) {
+    this.originalMap = new HashMap<>(originalMap);
     this.delegate = new HashMap<>(originalMap.size());
     putAll(originalMap);
   }
@@ -78,11 +81,13 @@ public class CaseInsensitiveStringMap implements Map<String, String> {
 
   @Override
   public String put(String key, String value) {
+    originalMap.put(key, value);
     return delegate.put(toLowerCase(key), value);
   }
 
   @Override
   public String remove(Object key) {
+    originalMap.remove(key);
     return delegate.remove(toLowerCase(key));
   }
 
@@ -95,6 +100,7 @@ public class CaseInsensitiveStringMap implements Map<String, String> {
 
   @Override
   public void clear() {
+    originalMap.clear();
     delegate.clear();
   }
 
@@ -156,5 +162,12 @@ public class CaseInsensitiveStringMap implements Map<String, String> {
   public double getDouble(String key, double defaultValue) {
     String value = get(key);
     return value == null ? defaultValue : Double.parseDouble(value);
+  }
+
+  /**
+   * Returns the original case-sensitive map.
+   */
+  public Map<String, String> getOriginalMap() {
+    return originalMap;
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/CaseInsensitiveStringMapSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/CaseInsensitiveStringMapSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.util
 
+import java.util
+
 import scala.collection.JavaConverters._
 
 import org.apache.spark.SparkFunSuite
@@ -79,5 +81,31 @@ class CaseInsensitiveStringMapSuite extends SparkFunSuite {
     intercept[NumberFormatException]{
       options.getDouble("foo", 0.1d)
     }
+  }
+
+  test("getOriginalMap") {
+    val originalMap = new util.HashMap[String, String] {
+      put("Foo", "Bar")
+      put("OFO", "ABR")
+      put("OoF", "bar")
+    }
+
+    val options = new CaseInsensitiveStringMap(originalMap)
+    assert(options.getOriginalMap.equals(originalMap))
+
+    val key = "Key"
+    val value = "value"
+    originalMap.put(key, value)
+    options.put(key, value)
+    originalMap.put(key, value)
+    assert(options.getOriginalMap.equals(originalMap))
+
+    val removedKey = "OFO"
+    originalMap.remove(removedKey)
+    options.remove(removedKey)
+    assert(options.getOriginalMap.equals(originalMap))
+
+    options.clear()
+    assert(options.getOriginalMap.isEmpty)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/CaseInsensitiveStringMapSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/CaseInsensitiveStringMapSuite.scala
@@ -98,6 +98,11 @@ class CaseInsensitiveStringMapSuite extends SparkFunSuite {
     }
 
     val options = new CaseInsensitiveStringMap(originalMap)
-    assert(options.asCaseSensitiveMap.equals(originalMap))
+    val caseSensitiveMap = options.asCaseSensitiveMap
+    assert(caseSensitiveMap.equals(originalMap))
+    // The result of `asCaseSensitiveMap` is read-only.
+    intercept[UnsupportedOperationException] {
+      caseSensitiveMap.put("kEy", "valUE")
+    }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/CaseInsensitiveStringMapSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/CaseInsensitiveStringMapSuite.scala
@@ -27,9 +27,16 @@ class CaseInsensitiveStringMapSuite extends SparkFunSuite {
 
   test("put and get") {
     val options = CaseInsensitiveStringMap.empty()
-    options.put("kEy", "valUE")
-    assert(options.get("key") == "valUE")
-    assert(options.get("KEY") == "valUE")
+    intercept[UnsupportedOperationException] {
+      options.put("kEy", "valUE")
+    }
+  }
+
+  test("clear") {
+    val options = new CaseInsensitiveStringMap(Map("kEy" -> "valUE").asJava)
+    intercept[UnsupportedOperationException] {
+      options.clear()
+    }
   }
 
   test("key and value set") {
@@ -83,7 +90,7 @@ class CaseInsensitiveStringMapSuite extends SparkFunSuite {
     }
   }
 
-  test("getOriginalMap") {
+  test("asCaseSensitiveMap") {
     val originalMap = new util.HashMap[String, String] {
       put("Foo", "Bar")
       put("OFO", "ABR")
@@ -91,21 +98,6 @@ class CaseInsensitiveStringMapSuite extends SparkFunSuite {
     }
 
     val options = new CaseInsensitiveStringMap(originalMap)
-    assert(options.getOriginalMap.equals(originalMap))
-
-    val key = "Key"
-    val value = "value"
-    originalMap.put(key, value)
-    options.put(key, value)
-    originalMap.put(key, value)
-    assert(options.getOriginalMap.equals(originalMap))
-
-    val removedKey = "OFO"
-    originalMap.remove(removedKey)
-    options.remove(removedKey)
-    assert(options.getOriginalMap.equals(originalMap))
-
-    options.clear()
-    assert(options.getOriginalMap.isEmpty)
+    assert(options.asCaseSensitiveMap.equals(originalMap))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileTable.scala
@@ -35,13 +35,14 @@ abstract class FileTable(
   extends Table with SupportsBatchRead with SupportsBatchWrite {
 
   lazy val fileIndex: PartitioningAwareFileIndex = {
-    val hadoopConf = sparkSession.sessionState.newHadoopConfWithCaseInsensitiveOptions(options)
+    val caseSensitiveMap = options.asCaseSensitiveMap.asScala.toMap
+    // Hadoop Configurations are case sensitive.
+    val hadoopConf = sparkSession.sessionState.newHadoopConfWithOptions(caseSensitiveMap)
     val rootPathsSpecified = DataSource.checkAndGlobPathIfNecessary(paths, hadoopConf,
       checkEmptyGlobPath = true, checkFilesExist = true)
     val fileStatusCache = FileStatusCache.getOrCreate(sparkSession)
-    val scalaMap = options.getOriginalMap.asScala.toMap
     new InMemoryFileIndex(
-      sparkSession, rootPathsSpecified, scalaMap, userSpecifiedSchema, fileStatusCache)
+      sparkSession, rootPathsSpecified, caseSensitiveMap, userSpecifiedSchema, fileStatusCache)
   }
 
   lazy val dataSchema: StructType = userSpecifiedSchema.orElse {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileTable.scala
@@ -35,11 +35,11 @@ abstract class FileTable(
   extends Table with SupportsBatchRead with SupportsBatchWrite {
 
   lazy val fileIndex: PartitioningAwareFileIndex = {
-    val scalaMap = options.asScala.toMap
-    val hadoopConf = sparkSession.sessionState.newHadoopConfWithOptions(scalaMap)
+    val hadoopConf = sparkSession.sessionState.newHadoopConfWithCaseInsensitiveOptions(options)
     val rootPathsSpecified = DataSource.checkAndGlobPathIfNecessary(paths, hadoopConf,
       checkEmptyGlobPath = true, checkFilesExist = true)
     val fileStatusCache = FileStatusCache.getOrCreate(sparkSession)
+    val scalaMap = options.getOriginalMap.asScala.toMap
     new InMemoryFileIndex(
       sparkSession, rootPathsSpecified, scalaMap, userSpecifiedSchema, fileStatusCache)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileWriteBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileWriteBuilder.scala
@@ -64,16 +64,14 @@ abstract class FileWriteBuilder(options: CaseInsensitiveStringMap, paths: Seq[St
     val sparkSession = SparkSession.active
     validateInputs(sparkSession.sessionState.conf.caseSensitiveAnalysis)
     val path = new Path(paths.head)
-    val optionsAsScala = options.asScala.toMap
-
-    val hadoopConf = sparkSession.sessionState.newHadoopConfWithOptions(optionsAsScala)
+    val hadoopConf = sparkSession.sessionState.newHadoopConfWithCaseInsensitiveOptions(options)
     val job = getJobInstance(hadoopConf, path)
     val committer = FileCommitProtocol.instantiate(
       sparkSession.sessionState.conf.fileCommitProtocolClass,
       jobId = java.util.UUID.randomUUID().toString,
       outputPath = paths.head)
     lazy val description =
-      createWriteJobDescription(sparkSession, hadoopConf, job, paths.head, optionsAsScala)
+      createWriteJobDescription(sparkSession, hadoopConf, job, paths.head, options.asScala.toMap)
 
     val fs = path.getFileSystem(hadoopConf)
     mode match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileWriteBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileWriteBuilder.scala
@@ -64,7 +64,9 @@ abstract class FileWriteBuilder(options: CaseInsensitiveStringMap, paths: Seq[St
     val sparkSession = SparkSession.active
     validateInputs(sparkSession.sessionState.conf.caseSensitiveAnalysis)
     val path = new Path(paths.head)
-    val hadoopConf = sparkSession.sessionState.newHadoopConfWithCaseInsensitiveOptions(options)
+    val caseSensitiveMap = options.asCaseSensitiveMap.asScala.toMap
+    // Hadoop Configurations are case sensitive.
+    val hadoopConf = sparkSession.sessionState.newHadoopConfWithOptions(caseSensitiveMap)
     val job = getJobInstance(hadoopConf, path)
     val committer = FileCommitProtocol.instantiate(
       sparkSession.sessionState.conf.fileCommitProtocolClass,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScanBuilder.scala
@@ -37,7 +37,11 @@ case class OrcScanBuilder(
     dataSchema: StructType,
     options: CaseInsensitiveStringMap)
   extends FileScanBuilder(schema) with SupportsPushDownFilters {
-  lazy val hadoopConf = sparkSession.sessionState.newHadoopConfWithCaseInsensitiveOptions(options)
+  lazy val hadoopConf = {
+    val caseSensitiveMap = options.asCaseSensitiveMap.asScala.toMap
+    // Hadoop Configurations are case sensitive.
+    sparkSession.sessionState.newHadoopConfWithOptions(caseSensitiveMap)
+  }
 
   override def build(): Scan = {
     OrcScan(sparkSession, hadoopConf, fileIndex, dataSchema, readSchema, options)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScanBuilder.scala
@@ -37,7 +37,7 @@ case class OrcScanBuilder(
     dataSchema: StructType,
     options: CaseInsensitiveStringMap)
   extends FileScanBuilder(schema) with SupportsPushDownFilters {
-  lazy val hadoopConf = sparkSession.sessionState.newHadoopConfWithOptions(options.asScala.toMap)
+  lazy val hadoopConf = sparkSession.sessionState.newHadoopConfWithCaseInsensitiveOptions(options)
 
   override def build(): Scan = {
     OrcScan(sparkSession, hadoopConf, fileIndex, dataSchema, readSchema, options)

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
@@ -19,8 +19,6 @@ package org.apache.spark.sql.internal
 
 import java.io.File
 
-import scala.collection.JavaConverters._
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
@@ -98,11 +98,6 @@ private[sql] class SessionState(
     hadoopConf
   }
 
-  def newHadoopConfWithCaseInsensitiveOptions(options: CaseInsensitiveStringMap): Configuration = {
-    // Hadoop configurations are case sensitive.
-    newHadoopConfWithOptions(options.getOriginalMap.asScala.toMap)
-  }
-
   /**
    * Get an identical copy of the `SessionState` and associate it with the given `SparkSession`
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.internal
 
 import java.io.File
 
+import scala.collection.JavaConverters._
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
@@ -32,7 +34,7 @@ import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.streaming.StreamingQueryManager
-import org.apache.spark.sql.util.{ExecutionListenerManager, QueryExecutionListener}
+import org.apache.spark.sql.util.{CaseInsensitiveStringMap, ExecutionListenerManager, QueryExecutionListener}
 
 /**
  * A class that holds all session-specific state in a given [[SparkSession]].
@@ -94,6 +96,11 @@ private[sql] class SessionState(
       }
     }
     hadoopConf
+  }
+
+  def newHadoopConfWithCaseInsensitiveOptions(options: CaseInsensitiveStringMap): Configuration = {
+    // Hadoop configurations are case sensitive.
+    newHadoopConfWithOptions(options.getOriginalMap.asScala.toMap)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.streaming.StreamingQueryManager
-import org.apache.spark.sql.util.{CaseInsensitiveStringMap, ExecutionListenerManager, QueryExecutionListener}
+import org.apache.spark.sql.util.{ExecutionListenerManager, QueryExecutionListener}
 
 /**
  * A class that holds all session-specific state in a given [[SparkSession]].


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, DataFrameReader/DataFrameReader supports setting Hadoop configurations via method `.option()`. 
E.g, the following test case should be passed in both ORC V1 and V2
```
  class TestFileFilter extends PathFilter {
    override def accept(path: Path): Boolean = path.getParent.getName != "p=2"
  }

  withTempPath { dir =>
      val path = dir.getCanonicalPath

      val df = spark.range(2)
      df.write.orc(path + "/p=1")
      df.write.orc(path + "/p=2")
      val extraOptions = Map(
        "mapred.input.pathFilter.class" -> classOf[TestFileFilter].getName,
        "mapreduce.input.pathFilter.class" -> classOf[TestFileFilter].getName
      )
      assert(spark.read.options(extraOptions).orc(path).count() === 2)
    }
  }
```
While Hadoop Configurations are case sensitive, the current data source V2 APIs are using `CaseInsensitiveStringMap` in the top level entry `TableProvider`. 
To create Hadoop configurations correctly, I suggest 
1. adding a new method `asCaseSensitiveMap` in `CaseInsensitiveStringMap`.
2. Make `CaseInsensitiveStringMap` read-only to ambiguous conversion in `asCaseSensitiveMap`


## How was this patch tested?

Unit test
