### PR TITLE
[SPARK-27165][SPARK-27107][BUILD][SQL] Upgrade Apache ORC to 1.5.5

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -156,9 +156,9 @@ objenesis-2.5.1.jar
 okhttp-3.8.1.jar
 okio-1.13.0.jar
 opencsv-2.3.jar
-orc-core-1.5.4-nohive.jar
-orc-mapreduce-1.5.4-nohive.jar
-orc-shims-1.5.4.jar
+orc-core-1.5.5-nohive.jar
+orc-mapreduce-1.5.5-nohive.jar
+orc-shims-1.5.5.jar
 oro-2.0.8.jar
 osgi-resource-locator-1.0.1.jar
 paranamer-2.8.jar

--- a/dev/deps/spark-deps-hadoop-3.1
+++ b/dev/deps/spark-deps-hadoop-3.1
@@ -173,9 +173,9 @@ okhttp-2.7.5.jar
 okhttp-3.8.1.jar
 okio-1.13.0.jar
 opencsv-2.3.jar
-orc-core-1.5.4-nohive.jar
-orc-mapreduce-1.5.4-nohive.jar
-orc-shims-1.5.4.jar
+orc-core-1.5.5-nohive.jar
+orc-mapreduce-1.5.5-nohive.jar
+orc-shims-1.5.5.jar
 oro-2.0.8.jar
 osgi-resource-locator-1.0.1.jar
 paranamer-2.8.jar

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
     <kafka.version>2.1.1</kafka.version>
     <derby.version>10.12.1.1</derby.version>
     <parquet.version>1.10.1</parquet.version>
-    <orc.version>1.5.4</orc.version>
+    <orc.version>1.5.5</orc.version>
     <orc.classifier>nohive</orc.classifier>
     <hive.parquet.group>com.twitter</hive.parquet.group>
     <hive.parquet.version>1.6.0</hive.parquet.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to update Apache ORC dependency to fix [SPARK-27107](https://issues.apache.org/jira/browse/SPARK-27107) .
```
[ORC-452] Support converting MAP column from JSON to ORC Improvement
[ORC-447] Change the docker scripts to keep a persistent m2 cache
[ORC-463] Add `version` command
[ORC-475] ORC reader should lazily get filesystem
[ORC-476] Make SearchAgument kryo buffer size configurable
```

## How was this patch tested?

Pass the Jenkins with the existing tests.