### PR TITLE
[SPARK-27171][SQL] Support Full-Partitons scan in limit for the first time

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -257,6 +257,14 @@ object SQLConf {
     .longConf
     .createWithDefault(10L * 1024 * 1024)
 
+  val LIMIT_START_UP_FACTOR = buildConf("spark.sql.limit.startupFactor")
+    .internal()
+    .doc("The factor of total partition in the first execution. Higher values lead to more" +
+      " partitions read. Lower values might lead to longer execution times as more jobs will " +
+      "be run. By setting this value to 1.0, it will read all partition in the first time.")
+    .doubleConf
+    .createWithDefault(0.1)
+
   val LIMIT_SCALE_UP_FACTOR = buildConf("spark.sql.limit.scaleUpFactor")
     .internal()
     .doc("Minimal increase rate in number of partitions between attempts when executing a take " +
@@ -1924,6 +1932,8 @@ class SQLConf extends Serializable with Logging {
     getConf(SUBEXPRESSION_ELIMINATION_ENABLED)
 
   def autoBroadcastJoinThreshold: Long = getConf(AUTO_BROADCASTJOIN_THRESHOLD)
+
+  def limitStartUpFactor: Double = getConf(LIMIT_START_UP_FACTOR)
 
   def limitScaleUpFactor: Int = getConf(LIMIT_SCALE_UP_FACTOR)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -344,7 +344,7 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
     while (buf.size < n && partsScanned < totalParts) {
       // The number of partitions to try in this iteration. It is ok for this number to be
       // greater than totalParts because we actually cap it at totalParts in runJob.
-      var numPartsToTry = Math.max(Math.ceil(sqlContext.conf.limitStartUpFactor * totalParts).toInt, 1)
+      var numPartsToTry = Math.max(Math.ceil(sqlContext.conf.limitStartUpFactor * totalParts).toLong, 1L)
       if (partsScanned > 0) {
         // If we didn't find any rows after the previous iteration, quadruple and retry.
         // Otherwise, interpolate the number of partitions we need to try, but overestimate

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -344,7 +344,7 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
     while (buf.size < n && partsScanned < totalParts) {
       // The number of partitions to try in this iteration. It is ok for this number to be
       // greater than totalParts because we actually cap it at totalParts in runJob.
-      var numPartsToTry = 1L
+      var numPartsToTry = Math.max(Math.ceil(sqlContext.conf.limitStartUpFactor * totalParts).toInt, 1)
       if (partsScanned > 0) {
         // If we didn't find any rows after the previous iteration, quadruple and retry.
         // Otherwise, interpolate the number of partitions we need to try, but overestimate


### PR DESCRIPTION
## What changes were proposed in this pull request?

SparkPlan#executeTake will pick element starting with one partition. Sometimes it will be slow for some queries. Although, Spark is better at batch query. It's not bad to add a switch to allow user control the ratio of partitons for the first time in limit.

## How was this patch tested?

Exist tests.
