### PR TITLE
[MINOR][SQL]Fix incorrect comment of SessionCatalog.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -47,9 +47,9 @@ object SessionCatalog {
 }
 
 /**
- * An internal catalog that is used by a Spark Session. This internal catalog serves as a
- * proxy to the underlying metastore (e.g. Hive Metastore) and it also manages temporary
- * views and functions of the Spark Session that it belongs to.
+ * An internal catalog that is used by a Spark Session, Rule, LogicalPlan and so on.
+ * This internal catalog serves as a proxy to the underlying metastore (e.g. Hive Metastore)
+ * and it also manages temporary views and functions of the Spark Session that it belongs to.
  *
  * This class must be thread-safe.
  */


### PR DESCRIPTION
## What changes were proposed in this pull request?

I accidentally found the comment of `SessionCatalog` is incorrect.
The original comment of `SessionCatalog` contains the description `An internal catalog that is used by a Spark Session`. But `SessionCatalog` also used by `Rule`, `LogicalPlan` and so on.
## How was this patch tested?

Not need UT.
