### PR TITLE
[MINOR][CORE] Add comment about reasoning to use deprecated Scala ForkJoinPool

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/UnionRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/UnionRDD.scala
@@ -21,13 +21,12 @@ import java.io.{IOException, ObjectOutputStream}
 
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.parallel.ForkJoinTaskSupport
-import scala.concurrent.forkjoin.ForkJoinPool
 import scala.reflect.ClassTag
 
 import org.apache.spark.{Dependency, Partition, RangeDependency, SparkContext, TaskContext}
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.internal.config.RDD_PARALLEL_LISTING_THRESHOLD
-import org.apache.spark.util.Utils
+import org.apache.spark.util.{ThreadUtils, Utils}
 
 /**
  * Partition for UnionRDD.
@@ -61,7 +60,7 @@ private[spark] class UnionPartition[T: ClassTag](
 
 object UnionRDD {
   private[spark] lazy val partitionEvalTaskSupport =
-    new ForkJoinTaskSupport(new ForkJoinPool(8))
+    new ForkJoinTaskSupport(ThreadUtils.newForkJoinPool("partition-eval-task-support", 8))
 }
 
 @DeveloperApi

--- a/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
@@ -183,6 +183,8 @@ private[spark] object ThreadUtils {
   /**
    * Construct a new Scala ForkJoinPool with a specified max parallelism and name prefix.
    */
+  // We keep using deprecated Scala ForkJoinPool to support both versions of Scala 2.11 and 2.12.
+  // Please refer the PR https://github.com/apache/spark/pull/24113 for more details.
   def newForkJoinPool(prefix: String, maxThreadNumber: Int): SForkJoinPool = {
     // Custom factory to set thread names
     val factory = new SForkJoinPool.ForkJoinWorkerThreadFactory {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a derived patch from #24113.

This patch proposes to add comment about reasoning why we keep using deprecated Scala ForkJoinPool even Spark 3.0.0 supports Scala 2.12. The origin intention was disabling deprecation warning, but Scala doesn't seem to have equivalent one for `@Suppresswarnings` for Java, so ended up just adding comment to make the intention clear.

## How was this patch tested?

This is a minor change which would be expected to work same as it was, so Jenkins test would be enough.