### PR TITLE
[SPARK-27185][SQL] mapPartition to replace map to speedUp Dataset's toLocalIterator process

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -318,7 +318,6 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
     getByteArrayRdd().mapPartitionsInternal(iter => {
       iter.flatMap(row => decodeUnsafeRows(row._2))
     }).toLocalIterator
-//    getByteArrayRdd().map(_._2).toLocalIterator.flatMap(decodeUnsafeRows)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -315,7 +315,10 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
    * @note Triggers multiple jobs (one for each partition).
    */
   def executeToIterator(): Iterator[InternalRow] = {
-    getByteArrayRdd().map(_._2).toLocalIterator.flatMap(decodeUnsafeRows)
+    getByteArrayRdd().mapPartitionsInternal(iter => {
+      iter.flatMap(row => decodeUnsafeRows(row._2))
+    }).toLocalIterator
+//    getByteArrayRdd().map(_._2).toLocalIterator.flatMap(decodeUnsafeRows)
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

For this change, it use mapPartitionsInternal method replace map method to speed up decode process to parallel execution
https://issues.apache.org/jira/browse/SPARK-27185
## How was this patch tested?

Build project and run in our enviroment

Please review http://spark.apache.org/contributing.html before opening a pull request.
