### PR TITLE
[SPARK-27189][CORE] Add Executor metrics and memory usage instrumentation to the metrics system

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -629,11 +629,7 @@ class SparkContext(config: SparkConf) extends Logging {
     _env.metricsSystem.registerSource(_dagScheduler.metricsSource)
     _env.metricsSystem.registerSource(new BlockManagerSource(_env.blockManager))
     _env.metricsSystem.registerSource(new JVMCPUSource())
-    _executorMetricsSource match {
-      case Some(executorMetricsSource: ExecutorMetricsSource) =>
-        executorMetricsSource.register(_env.metricsSystem)
-      case None => None
-    }
+    _executorMetricsSource.foreach(_.register(_env.metricsSystem))
     _executorAllocationManager.foreach { e =>
       _env.metricsSystem.registerSource(e.executorAllocationManagerSource)
     }
@@ -2487,12 +2483,7 @@ class SparkContext(config: SparkConf) extends Logging {
   /** Reports heartbeat metrics for the driver. */
   private def reportHeartBeat(executorMetricsSource: Option[ExecutorMetricsSource]): Unit = {
     val currentMetrics = ExecutorMetrics.getCurrentMetrics(env.memoryManager)
-
-    executorMetricsSource match {
-      case Some(executorMetricsSource: ExecutorMetricsSource) =>
-        executorMetricsSource.updateMetricsSnapshot(currentMetrics)
-      case None => None
-    }
+    executorMetricsSource.foreach(_.updateMetricsSnapshot(currentMetrics))
 
     val driverUpdates = new HashMap[(Int, Int), ExecutorMetrics]
     // In the driver, we do not track per-stage metrics, so use a dummy stage for the key

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -632,6 +632,7 @@ class SparkContext(config: SparkConf) extends Logging {
     _executorMetricsSource match {
       case Some(executorMetricsSource: ExecutorMetricsSource) =>
         executorMetricsSource.register(_env.metricsSystem)
+      case None => None
     }
     _executorAllocationManager.foreach { e =>
       _env.metricsSystem.registerSource(e.executorAllocationManagerSource)
@@ -2490,6 +2491,7 @@ class SparkContext(config: SparkConf) extends Logging {
     executorMetricsSource match {
       case Some(executorMetricsSource: ExecutorMetricsSource) =>
         executorMetricsSource.updateMetricsSnapshot(currentMetrics)
+      case None => None
     }
 
     val driverUpdates = new HashMap[(Int, Int), ExecutorMetrics]

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -115,18 +115,18 @@ private[spark] class Executor(
 
   val executorMetricsSource =
     if (conf.get(METRICS_EXECUTORMETRICS_SOURCE_ENABLED)) {
-      new ExecutorMetricsSource
+      Some(new ExecutorMetricsSource)
     } else {
-      null
+      None
     }
 
   if (!isLocal) {
     env.blockManager.initialize(conf.getAppId)
     env.metricsSystem.registerSource(executorSource)
     env.metricsSystem.registerSource(new JVMCPUSource())
-    if (conf.get(METRICS_EXECUTORMETRICS_SOURCE_ENABLED)) {
-      executorMetricsSource.register
-      env.metricsSystem.registerSource(executorMetricsSource)
+    executorMetricsSource match {
+      case Some(executorMetricsSource: ExecutorMetricsSource) =>
+        executorMetricsSource.register(env.metricsSystem)
     }
     env.metricsSystem.registerSource(env.blockManager.shuffleMetricsSource)
   }

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -113,14 +113,21 @@ private[spark] class Executor(
   // create. The map key is a task id.
   private val taskReaperForTask: HashMap[Long, TaskReaper] = HashMap[Long, TaskReaper]()
 
-  val executorMetricsSource = new ExecutorMetricsSource
+  val executorMetricsSource =
+    if (conf.get(METRICS_EXECUTORMETRICS_SOURCE_ENABLED)) {
+      new ExecutorMetricsSource
+    } else {
+      null
+    }
 
   if (!isLocal) {
     env.blockManager.initialize(conf.getAppId)
     env.metricsSystem.registerSource(executorSource)
     env.metricsSystem.registerSource(new JVMCPUSource())
-    executorMetricsSource.register
-    env.metricsSystem.registerSource(executorMetricsSource)
+    if (conf.get(METRICS_EXECUTORMETRICS_SOURCE_ENABLED)) {
+      executorMetricsSource.register
+      env.metricsSystem.registerSource(executorMetricsSource)
+    }
     env.metricsSystem.registerSource(env.blockManager.shuffleMetricsSource)
   }
 

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -127,6 +127,7 @@ private[spark] class Executor(
     executorMetricsSource match {
       case Some(executorMetricsSource: ExecutorMetricsSource) =>
         executorMetricsSource.register(env.metricsSystem)
+      case None => None
     }
     env.metricsSystem.registerSource(env.blockManager.shuffleMetricsSource)
   }

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -124,11 +124,7 @@ private[spark] class Executor(
     env.blockManager.initialize(conf.getAppId)
     env.metricsSystem.registerSource(executorSource)
     env.metricsSystem.registerSource(new JVMCPUSource())
-    executorMetricsSource match {
-      case Some(executorMetricsSource: ExecutorMetricsSource) =>
-        executorMetricsSource.register(env.metricsSystem)
-      case None => None
-    }
+    executorMetricsSource.foreach(_.register(env.metricsSystem))
     env.metricsSystem.registerSource(env.blockManager.shuffleMetricsSource)
   }
 

--- a/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsPoller.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsPoller.scala
@@ -49,7 +49,7 @@ import org.apache.spark.util.{ThreadUtils, Utils}
 private[spark] class ExecutorMetricsPoller(
     memoryManager: MemoryManager,
     pollingInterval: Long,
-    executorMetricsSource: ExecutorMetricsSource) extends Logging {
+    executorMetricsSource: Option[ExecutorMetricsSource]) extends Logging {
 
   type StageKey = (Int, Int)
   // Task Count and Metric Peaks
@@ -81,8 +81,9 @@ private[spark] class ExecutorMetricsPoller(
     // get the latest values for the metrics
     val latestMetrics = ExecutorMetrics.getCurrentMetrics(memoryManager)
 
-    if (executorMetricsSource != null) {
-      executorMetricsSource.updateMetricsSnapshot(latestMetrics)
+    executorMetricsSource match {
+      case Some(executorMetricsSource: ExecutorMetricsSource) =>
+        executorMetricsSource.updateMetricsSnapshot(latestMetrics)
     }
 
     def updatePeaks(metrics: AtomicLongArray): Unit = {

--- a/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsPoller.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsPoller.scala
@@ -81,7 +81,9 @@ private[spark] class ExecutorMetricsPoller(
     // get the latest values for the metrics
     val latestMetrics = ExecutorMetrics.getCurrentMetrics(memoryManager)
 
-    executorMetricsSource.updateMetricsSnapshot(latestMetrics)
+    if (executorMetricsSource != null) {
+      executorMetricsSource.updateMetricsSnapshot(latestMetrics)
+    }
 
     def updatePeaks(metrics: AtomicLongArray): Unit = {
       (0 until metrics.length).foreach { i =>

--- a/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsPoller.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsPoller.scala
@@ -48,7 +48,8 @@ import org.apache.spark.util.{ThreadUtils, Utils}
  */
 private[spark] class ExecutorMetricsPoller(
     memoryManager: MemoryManager,
-    pollingInterval: Long) extends Logging {
+    pollingInterval: Long,
+    executorMetricsSource: ExecutorMetricsSource) extends Logging {
 
   type StageKey = (Int, Int)
   // Task Count and Metric Peaks
@@ -79,6 +80,8 @@ private[spark] class ExecutorMetricsPoller(
 
     // get the latest values for the metrics
     val latestMetrics = ExecutorMetrics.getCurrentMetrics(memoryManager)
+
+    executorMetricsSource.updateMetricsSnapshot(latestMetrics)
 
     def updatePeaks(metrics: AtomicLongArray): Unit = {
       (0 until metrics.length).foreach { i =>

--- a/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsPoller.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsPoller.scala
@@ -80,12 +80,7 @@ private[spark] class ExecutorMetricsPoller(
 
     // get the latest values for the metrics
     val latestMetrics = ExecutorMetrics.getCurrentMetrics(memoryManager)
-
-    executorMetricsSource match {
-      case Some(executorMetricsSource: ExecutorMetricsSource) =>
-        executorMetricsSource.updateMetricsSnapshot(latestMetrics)
-      case None => None
-    }
+    executorMetricsSource.foreach(_.updateMetricsSnapshot(latestMetrics))
 
     def updatePeaks(metrics: AtomicLongArray): Unit = {
       (0 until metrics.length).foreach { i =>

--- a/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsPoller.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsPoller.scala
@@ -84,6 +84,7 @@ private[spark] class ExecutorMetricsPoller(
     executorMetricsSource match {
       case Some(executorMetricsSource: ExecutorMetricsSource) =>
         executorMetricsSource.updateMetricsSnapshot(latestMetrics)
+      case None => None
     }
 
     def updatePeaks(metrics: AtomicLongArray): Unit = {

--- a/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsSource.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsSource.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.executor
+
+import com.codahale.metrics.{Gauge, MetricRegistry}
+
+import org.apache.spark.metrics.ExecutorMetricType
+import org.apache.spark.metrics.source.Source
+
+private[spark] class ExecutorMetricsSource extends Source {
+
+  override val metricRegistry = new MetricRegistry()
+  override val sourceName = "ExecutorMetrics"
+  @volatile var metricsSnapshot: Array[Long] = Array.fill(ExecutorMetricType.numMetrics)(0L)
+
+  // called by ExecutorMetricsPoller
+  def updateMetricsSnapshot(metricsUpdates: Array[Long]): Unit = {
+    metricsSnapshot = metricsUpdates
+  }
+
+  class ExecutorMetricGauge(idx: Int) extends Gauge[Long] {
+    def getValue: Long = metricsSnapshot(idx)
+  }
+
+  def register: Unit = {
+    // This looks like a bunch of independent gauges as far the metric system
+    // is concerned, but actually they're all using one shared snapshot.
+    val gauges: IndexedSeq[ExecutorMetricGauge] = (0 until ExecutorMetricType.numMetrics).map {
+      idx => new ExecutorMetricGauge(idx)
+    }.toIndexedSeq
+
+    ExecutorMetricType.metricToOffset.foreach {
+      case (name, idx) =>
+        metricRegistry.register(MetricRegistry.name(name), gauges(idx))
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsSource.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsSource.scala
@@ -19,9 +19,18 @@ package org.apache.spark.executor
 
 import com.codahale.metrics.{Gauge, MetricRegistry}
 
-import org.apache.spark.metrics.ExecutorMetricType
+import org.apache.spark.metrics.{ExecutorMetricType, MetricsSystem}
 import org.apache.spark.metrics.source.Source
 
+// Expose executor metrics from [[ExecutorMetricsType]] using the Dropwizard metrics system
+// Metrics related the memory system can be expensive to gather, we implement some optimizations:
+// (1) Metrics values are cached, updated at each heartbeat (default period is 10 seconds)
+// An alternative faster polling mechanism is used only if activated, by setting
+// spark.executor.metrics.pollingInterval=<interval in ms>
+// (2) procfs metrics are gathered all in one-go and only conditionally:
+// if the /proc filesystem exists
+// and spark.eventLog.logStageExecutorProcessTreeMetrics.enabled=true
+// and spark.eventLog.logStageExecutorMetrics.enabled=true
 private[spark] class ExecutorMetricsSource extends Source {
 
   override val metricRegistry = new MetricRegistry()
@@ -37,9 +46,7 @@ private[spark] class ExecutorMetricsSource extends Source {
     def getValue: Long = metricsSnapshot(idx)
   }
 
-  def register: Unit = {
-    // This looks like a bunch of independent gauges as far the metric system
-    // is concerned, but actually they're all using one shared snapshot.
+  def register(metricsSystem: MetricsSystem): Unit = {
     val gauges: IndexedSeq[ExecutorMetricGauge] = (0 until ExecutorMetricType.numMetrics).map {
       idx => new ExecutorMetricGauge(idx)
     }.toIndexedSeq
@@ -48,5 +55,7 @@ private[spark] class ExecutorMetricsSource extends Source {
       case (name, idx) =>
         metricRegistry.register(MetricRegistry.name(name), gauges(idx))
     }
+
+    metricsSystem.registerSource(this)
   }
 }

--- a/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsSource.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsSource.scala
@@ -22,15 +22,19 @@ import com.codahale.metrics.{Gauge, MetricRegistry}
 import org.apache.spark.metrics.{ExecutorMetricType, MetricsSystem}
 import org.apache.spark.metrics.source.Source
 
-// Expose executor metrics from [[ExecutorMetricsType]] using the Dropwizard metrics system
-// Metrics related the memory system can be expensive to gather, we implement some optimizations:
-// (1) Metrics values are cached, updated at each heartbeat (default period is 10 seconds)
-// An alternative faster polling mechanism is used only if activated, by setting
-// spark.executor.metrics.pollingInterval=<interval in ms>
-// (2) procfs metrics are gathered all in one-go and only conditionally:
-// if the /proc filesystem exists
-// and spark.eventLog.logStageExecutorProcessTreeMetrics.enabled=true
-// and spark.eventLog.logStageExecutorMetrics.enabled=true
+/**
+ * Expose executor metrics from [[ExecutorMetricsType]] using the Dropwizard metrics system.
+ *
+ * Metrics related to the memory system can be expensive to gather, therefore
+ * we implement some optimizations:
+ * (1) Metrics values are cached, updated at each heartbeat (default period is 10 seconds).
+ * An alternative faster polling mechanism is used, only if activated, by setting
+ * spark.executor.metrics.pollingInterval=<interval in ms>.
+ * (2) Procfs metrics are gathered all in one-go and only conditionally:
+ * if the /proc filesystem exists
+ * and spark.eventLog.logStageExecutorProcessTreeMetrics.enabled=true
+ * and spark.eventLog.logStageExecutorMetrics.enabled=true.
+ */
 private[spark] class ExecutorMetricsSource extends Source {
 
   override val metricRegistry = new MetricRegistry()

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -616,7 +616,7 @@ package object config {
     .createOptional
 
   private[spark] val METRICS_EXECUTORMETRICS_SOURCE_ENABLED =
-    ConfigBuilder("spark.metrics.executormetrics.source.enabled")
+    ConfigBuilder("spark.metrics.executorMetricsSource.enabled")
       .doc("Whether to register the ExecutorMetrics source with the metrics system.")
       .booleanConf
       .createWithDefault(true)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -615,6 +615,12 @@ package object config {
     .stringConf
     .createOptional
 
+  private[spark] val METRICS_EXECUTORMETRICS_SOURCE_ENABLED =
+    ConfigBuilder("spark.metrics.executormetrics.source.enabled")
+      .doc("Whether to register the ExecutorMetrics source with the metrics system.")
+      .booleanConf
+      .createWithDefault(true)
+
   private[spark] val METRICS_STATIC_SOURCES_ENABLED =
     ConfigBuilder("spark.metrics.static.sources.enabled")
       .doc("Whether to register static sources with the metrics system.")

--- a/core/src/test/scala/org/apache/spark/metrics/source/SourceConfigSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/source/SourceConfigSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.metrics.source
 
 import org.apache.spark.{LocalSparkContext, SparkConf, SparkContext, SparkFunSuite}
-import org.apache.spark.internal.config.METRICS_STATIC_SOURCES_ENABLED
+import org.apache.spark.internal.config.{METRICS_EXECUTORMETRICS_SOURCE_ENABLED, METRICS_STATIC_SOURCES_ENABLED}
 
 class SourceConfigSuite extends SparkFunSuite with LocalSparkContext {
 
@@ -47,6 +47,34 @@ class SourceConfigSuite extends SparkFunSuite with LocalSparkContext {
       // Static sources should not be registered
       assert (metricsSystem.getSourcesByName("CodeGenerator").isEmpty)
       assert (metricsSystem.getSourcesByName("HiveExternalCatalog").isEmpty)
+    } finally {
+      sc.stop()
+    }
+  }
+
+  test("Test configuration for adding ExecutorMetrics source registration") {
+    val conf = new SparkConf()
+    conf.set(METRICS_EXECUTORMETRICS_SOURCE_ENABLED, true)
+    val sc = new SparkContext("local", "test", conf)
+    try {
+      val metricsSystem = sc.env.metricsSystem
+
+      // ExecutorMetrics source should be registered
+      assert (metricsSystem.getSourcesByName("ExecutorMetrics").nonEmpty)
+    } finally {
+      sc.stop()
+    }
+  }
+
+  test("Test configuration for skipping ExecutorMetrics source registration") {
+    val conf = new SparkConf()
+    conf.set(METRICS_EXECUTORMETRICS_SOURCE_ENABLED, false)
+    val sc = new SparkContext("local", "test", conf)
+    try {
+      val metricsSystem = sc.env.metricsSystem
+
+      // ExecutorMetrics source should not be registered
+      assert (metricsSystem.getSourcesByName("ExecutorMetrics").isEmpty)
     } finally {
       sc.stop()
     }

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1055,9 +1055,9 @@ when running in local mode.
 - namespace=ExecutorMetrics
   - **notes:** 
     - These metrics are conditional to a configuration parameter:
-    `spark.metrics.executormetrics.source.enabled` (default is true) 
+    `spark.metrics.executormetrics.source.enabled` (default value is true) 
     - ExecutorMetrics are updated as part of heartbeat processes scheduled
-   for the executors and for the driver at regular intervals: `spark.executor.heartbeatInterval`, default 10 seconds
+   for the executors and for the driver at regular intervals: `spark.executor.heartbeatInterval` (default value is 10 seconds)
     - An optional faster polling mechanism is available for executor memory metrics, 
    it can be activated by setting a polling interval (in milliseconds) using the configuration parameter `spark.executor.metrics.pollingInterval`
   - JVMHeapMemory

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -995,6 +995,10 @@ This is the component with the largest amount of instrumented metrics
 - namespace=JVMCPU
   - jvmCpuTime
 
+- namespace=ExecutorMetrics
+   - This contains memory-related metrics. A full list of available metrics in this namespace can be
+    found in the corresponding entry for the Executor component instance.
+
 - namespace=plugin.\<Plugin Class Name>
   - Optional namespace(s). Metrics in this namespace are defined by user-supplied code, and
   configured using the Spark plugin API. See "Advanced Instrumentation" below for how to load
@@ -1045,6 +1049,38 @@ when running in local mode.
   - threadpool.currentPool_size
   - threadpool.maxPool_size
   - threadpool.startedTasks
+
+- namespace=ExecutorMetrics
+  - **note:** ExecutorMetrics are updated as part of heartbeat processes scheduled
+   for the executors and for the driver at regular intervals: `spark.executor.heartbeatInterval`, default 10 seconds
+   An optional faster polling mechanism is available for executor memory metrics, 
+   it can be activated by setting a polling interval (in milliseconds) using the configuration parameter `spark.executor.metrics.pollingInterval`
+  - JVMHeapMemory
+  - JVMOffHeapMemory
+  - OnHeapExecutionMemory
+  - OnHeapStorageMemory
+  - OnHeapUnifiedMemory
+  - OffHeapExecutionMemory
+  - OffHeapStorageMemory
+  - OffHeapUnifiedMemory
+  - DirectPoolMemory
+  - MappedPoolMemory
+  - MinorGCCount
+  - MinorGCTime
+  - MajorGCCount
+  - MajorGCTime
+  - "ProcessTree*" metric counters:
+    - ProcessTreeJVMVMemory
+    - ProcessTreeJVMRSSMemory
+    - ProcessTreePythonVMemory
+    - ProcessTreePythonRSSMemory
+    - ProcessTreeOtherVMemory
+    - ProcessTreeOtherRSSMemory
+    - **note:** "ProcessTree*" metrics are collected only under certain conditions.
+      The conditions are the logical AND of the following: `/proc` filesystem exists,
+      `spark.eventLog.logStageExecutorProcessTreeMetrics.enabled=true`,
+      `spark.eventLog.logStageExecutorMetrics.enabled=true`.
+      "ProcessTree*" metrics report 0 when those conditions are not met.
 
 - namespace=JVMCPU
   - jvmCpuTime

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -996,9 +996,11 @@ This is the component with the largest amount of instrumented metrics
   - jvmCpuTime
 
 - namespace=ExecutorMetrics
-   - This contains memory-related metrics. A full list of available metrics in this namespace can be
-    found in the corresponding entry for the Executor component instance.
-
+  - **note:** these metrics are conditional to a configuration parameter:
+    `spark.metrics.executormetrics.source.enabled` (default is true) 
+  - This source contains memory-related metrics. A full list of available metrics in this 
+    namespace can be found in the corresponding entry for the Executor component instance.
+ 
 - namespace=plugin.\<Plugin Class Name>
   - Optional namespace(s). Metrics in this namespace are defined by user-supplied code, and
   configured using the Spark plugin API. See "Advanced Instrumentation" below for how to load
@@ -1051,9 +1053,12 @@ when running in local mode.
   - threadpool.startedTasks
 
 - namespace=ExecutorMetrics
-  - **note:** ExecutorMetrics are updated as part of heartbeat processes scheduled
+  - **notes:** 
+    - These metrics are conditional to a configuration parameter:
+    `spark.metrics.executormetrics.source.enabled` (default is true) 
+    - ExecutorMetrics are updated as part of heartbeat processes scheduled
    for the executors and for the driver at regular intervals: `spark.executor.heartbeatInterval`, default 10 seconds
-   An optional faster polling mechanism is available for executor memory metrics, 
+    - An optional faster polling mechanism is available for executor memory metrics, 
    it can be activated by setting a polling interval (in milliseconds) using the configuration parameter `spark.executor.metrics.pollingInterval`
   - JVMHeapMemory
   - JVMOffHeapMemory

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -997,7 +997,7 @@ This is the component with the largest amount of instrumented metrics
 
 - namespace=ExecutorMetrics
   - **note:** these metrics are conditional to a configuration parameter:
-    `spark.metrics.executormetrics.source.enabled` (default is true) 
+    `spark.metrics.executorMetricsSource.enabled` (default is true) 
   - This source contains memory-related metrics. A full list of available metrics in this 
     namespace can be found in the corresponding entry for the Executor component instance.
  
@@ -1055,7 +1055,7 @@ when running in local mode.
 - namespace=ExecutorMetrics
   - **notes:** 
     - These metrics are conditional to a configuration parameter:
-    `spark.metrics.executormetrics.source.enabled` (default value is true) 
+    `spark.metrics.executorMetricsSource.enabled` (default value is true) 
     - ExecutorMetrics are updated as part of heartbeat processes scheduled
    for the executors and for the driver at regular intervals: `spark.executor.heartbeatInterval` (default value is 10 seconds)
     - An optional faster polling mechanism is available for executor memory metrics, 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to add instrumentation of memory usage via the Spark Dropwizard/Codahale metrics system. Memory usage metrics are available via the Executor metrics, recently implemented as detailed in https://issues.apache.org/jira/browse/SPARK-23206.
Additional notes: This takes advantage of the metrics poller introduced in #23767. 

## Why are the changes needed?
Executor metrics bring have many useful insights on memory usage, in particular on the usage of storage memory and executor memory. This is useful for troubleshooting. Having the information in the metrics systems allows to add those metrics to Spark performance dashboards and study memory usage as a function of time, as in the example graph https://issues.apache.org/jira/secure/attachment/12962810/Example_dashboard_Spark_Memory_Metrics.PNG

## Does this PR introduce any user-facing change?
Adds `ExecutorMetrics` source to publish executor metrics via the Dropwizard metrics system. Details of the available metrics in docs/monitoring.md
Adds configuration parameter `spark.metrics.executormetrics.source.enabled`

## How was this patch tested?

Tested on YARN cluster and with an existing setup for a Spark dashboard based on InfluxDB and Grafana. 
