### PR TITLE
[SPARK-27197][SQL][TEST] Add ReadNestedSchemaTest for file-based data sources

### DIFF
--- a/external/avro/src/test/scala/org/apache/spark/sql/execution/datasources/AvroReadSchemaSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/execution/datasources/AvroReadSchemaSuite.scala
@@ -21,6 +21,8 @@ class AvroReadSchemaSuite
   extends ReadSchemaSuite
   with AddColumnIntoTheMiddleTest
   with HideColumnInTheMiddleTest
+  with AddNestedColumnTest
+  with HideNestedColumnTest
   with ChangePositionTest {
 
   override val format: String = "avro"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ReadNestedSchemaTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ReadNestedSchemaTest.scala
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import java.io.File
+
+import org.apache.spark.sql.Row
+
+
+/**
+ * Add a nested column.
+ */
+trait AddNestedColumnTest extends ReadSchemaTest {
+
+  test("add a nested column at the end of the leaf struct column") {
+    withTempPath { dir =>
+      val path = dir.getCanonicalPath
+
+      val df1 = sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2")
+      val df2 =
+        sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4, 'c7', 5)) c2")
+
+      val dir1 = s"$path${File.separator}part=one"
+      val dir2 = s"$path${File.separator}part=two"
+
+      df1.write.format(format).options(options).save(dir1)
+      df2.write.format(format).options(options).save(dir2)
+
+      val df = spark.read
+        .schema(df2.schema)
+        .format(format)
+        .options(options)
+        .load(path)
+
+      checkAnswer(df, Seq(
+        Row(1, Row(2, Row(3, 4, null)), "one"),
+        Row(1, Row(2, Row(3, 4, 5)), "two")))
+    }
+  }
+
+  test("add a nested column in the middle of the leaf struct column") {
+    withTempPath { dir =>
+      val path = dir.getCanonicalPath
+
+      val df1 = sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2")
+      val df2 =
+        sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c7', 5, 'c6', 4)) c2")
+
+      val dir1 = s"$path${File.separator}part=one"
+      val dir2 = s"$path${File.separator}part=two"
+
+      df1.write.format(format).options(options).save(dir1)
+      df2.write.format(format).options(options).save(dir2)
+
+      val df = spark.read
+        .schema(df2.schema)
+        .format(format)
+        .options(options)
+        .load(path)
+
+      checkAnswer(df, Seq(
+        Row(1, Row(2, Row(3, null, 4)), "one"),
+        Row(1, Row(2, Row(3, 5, 4)), "two")))
+    }
+  }
+
+  test("add a nested column at the end of the middle struct column") {
+    withTempPath { dir =>
+      val path = dir.getCanonicalPath
+
+      val df1 = sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2")
+      val df2 =
+        sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4), 'c7', 5) c2")
+
+      val dir1 = s"$path${File.separator}part=one"
+      val dir2 = s"$path${File.separator}part=two"
+
+      df1.write.format(format).options(options).save(dir1)
+      df2.write.format(format).options(options).save(dir2)
+
+      val df = spark.read
+        .schema(df2.schema)
+        .format(format)
+        .options(options)
+        .load(path)
+
+      checkAnswer(df, Seq(
+        Row(1, Row(2, Row(3, 4), null), "one"),
+        Row(1, Row(2, Row(3, 4), 5), "two")))
+    }
+  }
+
+  test("add a nested column in the middle of the middle struct column") {
+    withTempPath { dir =>
+      val path = dir.getCanonicalPath
+
+      val df1 = sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2")
+      val df2 =
+        sql("SELECT 1 c1, named_struct('c3', 2, 'c7', 5, 'c4', named_struct('c5', 3, 'c6', 4)) c2")
+
+      val dir1 = s"$path${File.separator}part=one"
+      val dir2 = s"$path${File.separator}part=two"
+
+      df1.write.format(format).options(options).save(dir1)
+      df2.write.format(format).options(options).save(dir2)
+
+      val df = spark.read
+        .schema(df2.schema)
+        .format(format)
+        .options(options)
+        .load(path)
+
+      checkAnswer(df, Seq(
+        Row(1, Row(2, null, Row(3, 4)), "one"),
+        Row(1, Row(2, 5, Row(3, 4)), "two")))
+    }
+  }
+}
+
+/**
+ * Hide a nested column.
+ */
+trait HideNestedColumnTest extends ReadSchemaTest {
+
+  test("hide a nested column at the end of the leaf struct column") {
+    withTempPath { dir =>
+      val path = dir.getCanonicalPath
+
+      val df1 = sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2")
+      val df2 =
+        sql("SELECT 5 c1, named_struct('c3', 6, 'c4', named_struct('c5', 7, 'c6', 8, 'c7', 9)) c2")
+
+      val dir1 = s"$path${File.separator}part=one"
+      val dir2 = s"$path${File.separator}part=two"
+
+      df1.write.format(format).options(options).save(dir1)
+      df2.write.format(format).options(options).save(dir2)
+
+      val df = spark.read
+        .schema(df1.schema)
+        .format(format)
+        .options(options)
+        .load(path)
+
+      checkAnswer(df, Seq(
+        Row(1, Row(2, Row(3, 4)), "one"),
+        Row(5, Row(6, Row(7, 8)), "two")))
+    }
+  }
+
+  test("hide a nested column in the middle of the leaf struct column") {
+    withTempPath { dir =>
+      val path = dir.getCanonicalPath
+
+      val df1 = sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2")
+      val df2 =
+        sql("SELECT 5 c1, named_struct('c3', 6, 'c4', named_struct('c5', 7, 'c7', 8, 'c6', 9)) c2")
+
+      val dir1 = s"$path${File.separator}part=one"
+      val dir2 = s"$path${File.separator}part=two"
+
+      df1.write.format(format).options(options).save(dir1)
+      df2.write.format(format).options(options).save(dir2)
+
+      val df = spark.read
+        .schema(df1.schema)
+        .format(format)
+        .options(options)
+        .load(path)
+
+      checkAnswer(df, Seq(
+        Row(1, Row(2, Row(3, 4)), "one"),
+        Row(5, Row(6, Row(7, 9)), "two")))
+    }
+  }
+
+  test("hide a nested column at the end of the middle struct column") {
+    withTempPath { dir =>
+      val path = dir.getCanonicalPath
+
+      val df1 = sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2")
+      val df2 =
+        sql("SELECT 5 c1, named_struct('c3', 6, 'c4', named_struct('c5', 7, 'c6', 8), 'c7', 9) c2")
+
+      val dir1 = s"$path${File.separator}part=one"
+      val dir2 = s"$path${File.separator}part=two"
+
+      df1.write.format(format).options(options).save(dir1)
+      df2.write.format(format).options(options).save(dir2)
+
+      val df = spark.read
+        .schema(df1.schema)
+        .format(format)
+        .options(options)
+        .load(path)
+
+      checkAnswer(df, Seq(
+        Row(1, Row(2, Row(3, 4)), "one"),
+        Row(5, Row(6, Row(7, 8)), "two")))
+    }
+  }
+
+  test("hide a nested column in the middle of the middle struct column") {
+    withTempPath { dir =>
+      val path = dir.getCanonicalPath
+
+      val df1 = sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2")
+      val df2 =
+        sql("SELECT 5 c1, named_struct('c3', 6, 'c7', 7, 'c4', named_struct('c5', 8, 'c6', 9)) c2")
+
+      val dir1 = s"$path${File.separator}part=one"
+      val dir2 = s"$path${File.separator}part=two"
+
+      df1.write.format(format).options(options).save(dir1)
+      df2.write.format(format).options(options).save(dir2)
+
+      val df = spark.read
+        .schema(df1.schema)
+        .format(format)
+        .options(options)
+        .load(path)
+
+      checkAnswer(df, Seq(
+        Row(1, Row(2, Row(3, 4)), "one"),
+        Row(5, Row(6, Row(8, 9)), "two")))
+    }
+  }
+}
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ReadNestedSchemaTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ReadNestedSchemaTest.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources
 
 import java.io.File
 
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{DataFrame, Row}
 
 
 /**
@@ -27,13 +27,9 @@ import org.apache.spark.sql.Row
  */
 trait AddNestedColumnTest extends ReadSchemaTest {
 
-  test("add a nested column at the end of the leaf struct column") {
+  private def testAdd(df1: DataFrame, df2: DataFrame, expectedRows: Seq[Row]): Unit = {
     withTempPath { dir =>
       val path = dir.getCanonicalPath
-
-      val df1 = sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2")
-      val df2 =
-        sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4, 'c7', 5)) c2")
 
       val dir1 = s"$path${File.separator}part=one"
       val dir2 = s"$path${File.separator}part=two"
@@ -47,88 +43,44 @@ trait AddNestedColumnTest extends ReadSchemaTest {
         .options(options)
         .load(path)
 
-      checkAnswer(df, Seq(
+      checkAnswer(df, expectedRows)
+    }
+  }
+
+  test("add a nested column at the end of the leaf struct column") {
+    testAdd(
+      sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2"),
+      sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4, 'c7', 5)) c2"),
+      Seq(
         Row(1, Row(2, Row(3, 4, null)), "one"),
         Row(1, Row(2, Row(3, 4, 5)), "two")))
-    }
   }
 
   test("add a nested column in the middle of the leaf struct column") {
-    withTempPath { dir =>
-      val path = dir.getCanonicalPath
-
-      val df1 = sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2")
-      val df2 =
-        sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c7', 5, 'c6', 4)) c2")
-
-      val dir1 = s"$path${File.separator}part=one"
-      val dir2 = s"$path${File.separator}part=two"
-
-      df1.write.format(format).options(options).save(dir1)
-      df2.write.format(format).options(options).save(dir2)
-
-      val df = spark.read
-        .schema(df2.schema)
-        .format(format)
-        .options(options)
-        .load(path)
-
-      checkAnswer(df, Seq(
+    testAdd(
+      sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2"),
+      sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c7', 5, 'c6', 4)) c2"),
+      Seq(
         Row(1, Row(2, Row(3, null, 4)), "one"),
         Row(1, Row(2, Row(3, 5, 4)), "two")))
-    }
   }
 
   test("add a nested column at the end of the middle struct column") {
-    withTempPath { dir =>
-      val path = dir.getCanonicalPath
-
-      val df1 = sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2")
-      val df2 =
-        sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4), 'c7', 5) c2")
-
-      val dir1 = s"$path${File.separator}part=one"
-      val dir2 = s"$path${File.separator}part=two"
-
-      df1.write.format(format).options(options).save(dir1)
-      df2.write.format(format).options(options).save(dir2)
-
-      val df = spark.read
-        .schema(df2.schema)
-        .format(format)
-        .options(options)
-        .load(path)
-
-      checkAnswer(df, Seq(
+    testAdd(
+      sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2"),
+      sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4), 'c7', 5) c2"),
+      Seq(
         Row(1, Row(2, Row(3, 4), null), "one"),
         Row(1, Row(2, Row(3, 4), 5), "two")))
-    }
   }
 
   test("add a nested column in the middle of the middle struct column") {
-    withTempPath { dir =>
-      val path = dir.getCanonicalPath
-
-      val df1 = sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2")
-      val df2 =
-        sql("SELECT 1 c1, named_struct('c3', 2, 'c7', 5, 'c4', named_struct('c5', 3, 'c6', 4)) c2")
-
-      val dir1 = s"$path${File.separator}part=one"
-      val dir2 = s"$path${File.separator}part=two"
-
-      df1.write.format(format).options(options).save(dir1)
-      df2.write.format(format).options(options).save(dir2)
-
-      val df = spark.read
-        .schema(df2.schema)
-        .format(format)
-        .options(options)
-        .load(path)
-
-      checkAnswer(df, Seq(
+    testAdd(
+      sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2"),
+      sql("SELECT 1 c1, named_struct('c3', 2, 'c7', 5, 'c4', named_struct('c5', 3, 'c6', 4)) c2"),
+      Seq(
         Row(1, Row(2, null, Row(3, 4)), "one"),
         Row(1, Row(2, 5, Row(3, 4)), "two")))
-    }
   }
 }
 
@@ -137,19 +89,17 @@ trait AddNestedColumnTest extends ReadSchemaTest {
  */
 trait HideNestedColumnTest extends ReadSchemaTest {
 
-  test("hide a nested column at the end of the leaf struct column") {
+  private def testHide(df1: DataFrame, df2: DataFrame, df3: DataFrame, expectedRows: Seq[Row]) = {
     withTempPath { dir =>
       val path = dir.getCanonicalPath
 
-      val df1 = sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2")
-      val df2 =
-        sql("SELECT 5 c1, named_struct('c3', 6, 'c4', named_struct('c5', 7, 'c6', 8, 'c7', 9)) c2")
-
       val dir1 = s"$path${File.separator}part=one"
       val dir2 = s"$path${File.separator}part=two"
+      val dir3 = s"$path${File.separator}part=three"
 
       df1.write.format(format).options(options).save(dir1)
       df2.write.format(format).options(options).save(dir2)
+      df3.write.format(format).options(options).save(dir3)
 
       val df = spark.read
         .schema(df1.schema)
@@ -157,88 +107,52 @@ trait HideNestedColumnTest extends ReadSchemaTest {
         .options(options)
         .load(path)
 
-      checkAnswer(df, Seq(
-        Row(1, Row(2, Row(3, 4)), "one"),
-        Row(5, Row(6, Row(7, 8)), "two")))
+      checkAnswer(df, expectedRows)
     }
+  }
+
+  test("hide a nested column at the end of the leaf struct column") {
+    testHide(
+      sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2"),
+      sql("SELECT 5 c1, named_struct('c3', 6, 'c4', named_struct('c5', 7, 'c6', 8, 'c7', 9)) c2"),
+      sql("SELECT 0 c1, named_struct('c3', 1, 'c4', named_struct('c5', 2, 'c6', 3, 'c8', 4)) c2"),
+      Seq(
+        Row(1, Row(2, Row(3, 4)), "one"),
+        Row(5, Row(6, Row(7, 8)), "two"),
+        Row(0, Row(1, Row(2, 3)), "three")))
   }
 
   test("hide a nested column in the middle of the leaf struct column") {
-    withTempPath { dir =>
-      val path = dir.getCanonicalPath
-
-      val df1 = sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2")
-      val df2 =
-        sql("SELECT 5 c1, named_struct('c3', 6, 'c4', named_struct('c5', 7, 'c7', 8, 'c6', 9)) c2")
-
-      val dir1 = s"$path${File.separator}part=one"
-      val dir2 = s"$path${File.separator}part=two"
-
-      df1.write.format(format).options(options).save(dir1)
-      df2.write.format(format).options(options).save(dir2)
-
-      val df = spark.read
-        .schema(df1.schema)
-        .format(format)
-        .options(options)
-        .load(path)
-
-      checkAnswer(df, Seq(
+    testHide(
+      sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2"),
+      sql("SELECT 5 c1, named_struct('c3', 6, 'c4', named_struct('c5', 7, 'c7', 8, 'c6', 9)) c2"),
+      sql("SELECT 0 c1, named_struct('c3', 1, 'c4', named_struct('c7', 2, 'c5', 3, 'c6', 4)) c2"),
+      Seq(
         Row(1, Row(2, Row(3, 4)), "one"),
-        Row(5, Row(6, Row(7, 9)), "two")))
-    }
+        Row(5, Row(6, Row(7, 9)), "two"),
+        Row(0, Row(1, Row(3, 4)), "three")))
   }
 
   test("hide a nested column at the end of the middle struct column") {
-    withTempPath { dir =>
-      val path = dir.getCanonicalPath
-
-      val df1 = sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2")
-      val df2 =
-        sql("SELECT 5 c1, named_struct('c3', 6, 'c4', named_struct('c5', 7, 'c6', 8), 'c7', 9) c2")
-
-      val dir1 = s"$path${File.separator}part=one"
-      val dir2 = s"$path${File.separator}part=two"
-
-      df1.write.format(format).options(options).save(dir1)
-      df2.write.format(format).options(options).save(dir2)
-
-      val df = spark.read
-        .schema(df1.schema)
-        .format(format)
-        .options(options)
-        .load(path)
-
-      checkAnswer(df, Seq(
+    testHide(
+      sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2"),
+      sql("SELECT 5 c1, named_struct('c3', 6, 'c4', named_struct('c5', 7, 'c6', 8), 'c7', 9) c2"),
+      sql("SELECT 0 c1, named_struct('c3', 1, 'c4', named_struct('c5', 2, 'c6', 3), 'c8', 4) c2"),
+      Seq(
         Row(1, Row(2, Row(3, 4)), "one"),
-        Row(5, Row(6, Row(7, 8)), "two")))
-    }
+        Row(5, Row(6, Row(7, 8)), "two"),
+        Row(0, Row(1, Row(2, 3)), "three")))
   }
 
   test("hide a nested column in the middle of the middle struct column") {
-    withTempPath { dir =>
-      val path = dir.getCanonicalPath
-
-      val df1 = sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2")
-      val df2 =
-        sql("SELECT 5 c1, named_struct('c3', 6, 'c7', 7, 'c4', named_struct('c5', 8, 'c6', 9)) c2")
-
-      val dir1 = s"$path${File.separator}part=one"
-      val dir2 = s"$path${File.separator}part=two"
-
-      df1.write.format(format).options(options).save(dir1)
-      df2.write.format(format).options(options).save(dir2)
-
-      val df = spark.read
-        .schema(df1.schema)
-        .format(format)
-        .options(options)
-        .load(path)
-
-      checkAnswer(df, Seq(
+    testHide(
+      sql("SELECT 1 c1, named_struct('c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2"),
+      sql("SELECT 5 c1, named_struct('c3', 6, 'c7', 7, 'c4', named_struct('c5', 8, 'c6', 9)) c2"),
+      sql("SELECT 0 c1, named_struct('c7', 1, 'c3', 2, 'c4', named_struct('c5', 3, 'c6', 4)) c2"),
+      Seq(
         Row(1, Row(2, Row(3, 4)), "one"),
-        Row(5, Row(6, Row(8, 9)), "two")))
-    }
+        Row(5, Row(6, Row(8, 9)), "two"),
+        Row(0, Row(2, Row(3, 4)), "three")))
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ReadSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ReadSchemaSuite.scala
@@ -76,6 +76,8 @@ class JsonReadSchemaSuite
   extends ReadSchemaSuite
   with AddColumnIntoTheMiddleTest
   with HideColumnInTheMiddleTest
+  with AddNestedColumnTest
+  with HideNestedColumnTest
   with ChangePositionTest
   with IntegralTypeTest
   with ToDoubleTypeTest
@@ -89,6 +91,8 @@ class OrcReadSchemaSuite
   extends ReadSchemaSuite
   with AddColumnIntoTheMiddleTest
   with HideColumnInTheMiddleTest
+  with AddNestedColumnTest
+  with HideNestedColumnTest
   with ChangePositionTest {
 
   override val format: String = "orc"
@@ -109,6 +113,8 @@ class VectorizedOrcReadSchemaSuite
   extends ReadSchemaSuite
   with AddColumnIntoTheMiddleTest
   with HideColumnInTheMiddleTest
+  with AddNestedColumnTest
+  with HideNestedColumnTest
   with ChangePositionTest
   with BooleanTypeTest
   with IntegralTypeTest
@@ -132,6 +138,8 @@ class ParquetReadSchemaSuite
   extends ReadSchemaSuite
   with AddColumnIntoTheMiddleTest
   with HideColumnInTheMiddleTest
+  with AddNestedColumnTest
+  with HideNestedColumnTest
   with ChangePositionTest {
 
   override val format: String = "parquet"
@@ -152,6 +160,8 @@ class VectorizedParquetReadSchemaSuite
   extends ReadSchemaSuite
   with AddColumnIntoTheMiddleTest
   with HideColumnInTheMiddleTest
+  with AddNestedColumnTest
+  with HideNestedColumnTest
   with ChangePositionTest {
 
   override val format: String = "parquet"
@@ -172,6 +182,8 @@ class MergedParquetReadSchemaSuite
   extends ReadSchemaSuite
   with AddColumnIntoTheMiddleTest
   with HideColumnInTheMiddleTest
+  with AddNestedColumnTest
+  with HideNestedColumnTest
   with ChangePositionTest {
 
   override val format: String = "parquet"


### PR DESCRIPTION
## What changes were proposed in this pull request?

The reader schema is said to be evolved (or projected) when it changed after the data is written by writers. Apache Spark file-based data sources have a test coverage for that; e.g. [ReadSchemaSuite.scala](https://github.com/apache/spark/blob/master/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ReadSchemaSuite.scala). This PR aims to add a test coverage for nested columns by adding and hiding nested columns.

## How was this patch tested?

Pass the Jenkins with newly added tests.