### PR TITLE
[SPARK-27194][core] Job failures when task attempts do not clean up spark-staging parquet files

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
@@ -140,8 +140,9 @@ class HadoopMapReduceCommitProtocol(
     // The file name looks like part-00000-2dd664f9-d2c4-4ffe-878f-c6c70c1fb0cb_00003-c000.parquet
     // Note that %05d does not truncate the split number, so if we have more than 100000 tasks,
     // the file name is fine and won't overflow.
-    val split = taskContext.getTaskAttemptID.getTaskID.getId
-    f"part-$split%05d-$jobId$ext"
+    val tid = taskContext.getTaskAttemptID.getTaskID.getId
+    val attemptId = taskContext.getTaskAttemptID.getId
+    f"part-$tid%05d-$attemptId%05d-$jobId$ext"
   }
 
   override def setupJob(jobContext: JobContext): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid task output file overlap when task are reattempted. As currently file name considers only taskId which will be same across reattempts, it will cause collision. Instead file name can instead contain taskId along with attempt id

## How was this patch tested?

Will update UT if approach is ok
