### PR TITLE
[SPARK-27201][WebUI] Toggle full job description on click

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/additional-metrics.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/additional-metrics.js
@@ -83,7 +83,7 @@ $(function() {
         $(this).parent().find('input[type="checkbox"]').trigger('click');
     });
 
-    // Trigger a double click on the span to show full job description.
+    // Show/hide full job description on click event.
     $(".description-input").click(function() {
         $(this).toggleClass("description-input-full");
     });

--- a/core/src/main/resources/org/apache/spark/ui/static/additional-metrics.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/additional-metrics.js
@@ -84,7 +84,7 @@ $(function() {
     });
 
     // Trigger a double click on the span to show full job description.
-    $(".description-input").dblclick(function() {
-        $(this).removeClass("description-input").addClass("description-input-full");
+    $(".description-input").click(function() {
+        $(this).toggleClass("description-input-full");
     });
 });


### PR DESCRIPTION
## What changes were proposed in this pull request?

Previously, in https://github.com/apache/spark/pull/6646 there was an improvement to show full job description after double clicks.
I think this is a bit hard to be noticed by some users. I suggest changing the event to one click.
Also, after the full description is shown, another click should be able to hide the overflow text again.

Before click:
![short](https://user-images.githubusercontent.com/1097932/54608784-79bfca80-4a8c-11e9-912b-30799be0d6cb.png)

After click:
![full](https://user-images.githubusercontent.com/1097932/54608790-7b898e00-4a8c-11e9-9251-86061158db68.png)

Click again:
![short](https://user-images.githubusercontent.com/1097932/54608784-79bfca80-4a8c-11e9-912b-30799be0d6cb.png)

## How was this patch tested?

Manually check.
