### PR TITLE
[SPARK-27205][CORE] Remove complicated logic for just leaving warning log when main class is scala.App

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -833,7 +833,8 @@ private[spark] class SparkSubmit extends Logging {
       // Users will pass in childMainClass which will delegate all invocations to childMainClass$
       // but it's childMainClass$ that subclasses scala.App and we should check for.
       Try {
-        if (classOf[scala.App].isAssignableFrom(Utils.classForName(s"$childMainClass$$"))) {
+        if (classOf[scala.App].isAssignableFrom(
+          Utils.classForName(s"$childMainClass$$", initialize = false))) {
           logWarning("Subclasses of scala.App may not work correctly. " +
             "Use a main() method instead.")
         }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -826,19 +826,6 @@ private[spark] class SparkSubmit extends Logging {
     val app: SparkApplication = if (classOf[SparkApplication].isAssignableFrom(mainClass)) {
       mainClass.getConstructor().newInstance().asInstanceOf[SparkApplication]
     } else {
-      // Scala object subclassing scala.App has its whole class body executed in the
-      // main method it inherits. Fields of the object will not have been initialized
-      // before the main method has been executed, which will cause problems like SPARK-4170
-      // Note two Java classes are generated, the childMainClass and childMainClass$.
-      // Users will pass in childMainClass which will delegate all invocations to childMainClass$
-      // but it's childMainClass$ that subclasses scala.App and we should check for.
-      Try {
-        if (classOf[scala.App].isAssignableFrom(
-          Utils.classForName(s"$childMainClass$$", initialize = false))) {
-          logWarning("Subclasses of scala.App may not work correctly. " +
-            "Use a main() method instead.")
-        }
-      }
       new JavaMainApplication(mainClass)
     }
 

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -201,6 +201,13 @@ private[spark] object Utils extends Logging {
     // scalastyle:on classforname
   }
 
+  // scalastyle:off classforname
+  /** Preferred alternative to Class.forName(className, initialize, classloader) */
+  def classForName(className: String, initialize: Boolean): Class[_] = {
+    Class.forName(className, initialize, getContextOrSparkClassLoader)
+    // scalastyle:on classforname
+  }
+
   /**
    * Run a segment of code using a different context class loader in the current thread
    */

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -201,13 +201,6 @@ private[spark] object Utils extends Logging {
     // scalastyle:on classforname
   }
 
-  // scalastyle:off classforname
-  /** Preferred alternative to Class.forName(className, initialize, classloader) */
-  def classForName(className: String, initialize: Boolean): Class[_] = {
-    Class.forName(className, initialize, getContextOrSparkClassLoader)
-    // scalastyle:on classforname
-  }
-
   /**
    * Run a segment of code using a different context class loader in the current thread
    */


### PR DESCRIPTION
## What changes were proposed in this pull request?

[SPARK-26977](https://issues.apache.org/jira/browse/SPARK-26977) introduced very strange bug which spark-shell is no longer able to load classes which are provided via `--packages`. TBH I don't know about the details why it is broken, but looks like initializing `object class` brings the weirdness (maybe due to static initialization done twice?).

This patch removes the logic to leave warning log when main class is scala.App, to not deal with such complexity for just leaving warning message.

## How was this patch tested?

Manual test: suppose we run spark-shell with `--packages` option like below:

```
./bin/spark-shell --verbose   --master "local[*]" --packages org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.0
```

Before this patch, importing class in transitive dependency fails:

```
Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
Spark context Web UI available at http://localhost:4040
Spark context available as 'sc' (master = local[*], app id = local-1553005771597).
Spark session available as 'spark'.
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 3.0.0-SNAPSHOT
      /_/

Using Scala version 2.12.8 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_191)
Type in expressions to have them evaluated.
Type :help for more information.

scala> import org.apache.kafka
<console>:23: error: object kafka is not a member of package org.apache
       import org.apache.kafka
```

After this patch, importing class in transitive dependency succeeds:

```
Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
Spark context Web UI available at http://localhost:4040
Spark context available as 'sc' (master = local[*], app id = local-1553004095542).
Spark session available as 'spark'.
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 3.0.0-SNAPSHOT
      /_/

Using Scala version 2.12.8 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_191)
Type in expressions to have them evaluated.
Type :help for more information.

scala> import org.apache.kafka
import org.apache.kafka
```