### PR TITLE
[SPARK-26739][SQL] Standardized Join Types for DataFrames

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
@@ -44,6 +44,7 @@ import org.apache.spark.mllib.linalg.CholeskyDecomposition
 import org.apache.spark.mllib.optimization.NNLS
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Dataset}
+import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
@@ -308,9 +309,9 @@ class ALSModel private[ml] (
     // create a new column named map(predictionCol) by running the predict UDF.
     val predictions = dataset
       .join(userFactors,
-        checkedCast(dataset($(userCol))) === userFactors("id"), "left")
+        checkedCast(dataset($(userCol))) === userFactors("id"), LeftOuter)
       .join(itemFactors,
-        checkedCast(dataset($(itemCol))) === itemFactors("id"), "left")
+        checkedCast(dataset($(itemCol))) === itemFactors("id"), LeftOuter)
       .select(dataset("*"),
         predict(userFactors("features"), itemFactors("features")).as($(predictionCol)))
     getColdStartStrategy match {
@@ -404,7 +405,7 @@ class ALSModel private[ml] (
       factors: DataFrame,
       column: String): DataFrame = {
     factors
-      .join(dataset.select(column), factors("id") === dataset(column), joinType = "left_semi")
+      .join(dataset.select(column), factors("id") === dataset(column), joinType = LeftSemi)
       .select(factors("id"), factors("features"))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
@@ -25,6 +25,7 @@ import scala.collection.mutable
 
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogColumnStat
+import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util.{DateTimeTestUtils, DateTimeUtils}
 import org.apache.spark.sql.internal.SQLConf
@@ -46,7 +47,7 @@ class StatisticsCollectionSuite extends StatisticsCollectionTestBase with Shared
         .createOrReplaceTempView("test")
       val df1 = spark.table("test")
       val df2 = spark.table("test").limit(0)
-      val df = df1.join(df2, Seq("k"), "left")
+      val df = df1.join(df2, Seq("k"), LeftOuter)
 
       val sizes = df.queryExecution.analyzed.collect { case g: Join =>
         g.stats.sizeInBytes

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution
 import org.apache.spark.metrics.source.CodegenMetrics
 import org.apache.spark.sql.{QueryTest, Row, SaveMode}
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodeAndComment, CodeGenerator}
+import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.execution.aggregate.HashAggregateExec
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.joins.BroadcastHashJoinExec
@@ -325,8 +326,8 @@ class WholeStageCodegenSuite extends QueryTest with SharedSQLContext {
     val b = Seq((1, "a")).toDF("key", "value")
     val c = Seq(1).toDF("key")
 
-    val ab = a.join(b, Stream("key"), "left")
-    val abc = ab.join(c, Seq("key"), "left")
+    val ab = a.join(b, Stream("key"), LeftOuter)
+    val abc = ab.join(c, Seq("key"), LeftOuter)
 
     checkAnswer(abc, Row(1, "a"))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/JoinBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/JoinBenchmark.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.benchmark
 
+import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
@@ -107,7 +108,7 @@ object JoinBenchmark extends SqlBasedBenchmark {
     val M = 1 << 16
     val dim = broadcast(spark.range(M).selectExpr("id as k", "cast(id as string) as v"))
     codegenBenchmark("outer join w long", N) {
-      val df = spark.range(N).join(dim, (col("id") % M) === col("k"), "left")
+      val df = spark.range(N).join(dim, (col("id") % M) === col("k"), LeftOuter)
       assert(df.queryExecution.sparkPlan.find(_.isInstanceOf[BroadcastHashJoinExec]).isDefined)
       df.count()
     }
@@ -118,7 +119,7 @@ object JoinBenchmark extends SqlBasedBenchmark {
     val M = 1 << 16
     val dim = broadcast(spark.range(M).selectExpr("id as k", "cast(id as string) as v"))
     codegenBenchmark("semi join w long", N) {
-      val df = spark.range(N).join(dim, (col("id") % M) === col("k"), "leftsemi")
+      val df = spark.range(N).join(dim, (col("id") % M) === col("k"), LeftSemi)
       assert(df.queryExecution.sparkPlan.find(_.isInstanceOf[BroadcastHashJoinExec]).isDefined)
       df.count()
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -32,6 +32,7 @@ import org.apache.spark.{SparkException, TestUtils}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{functions => F, _}
 import org.apache.spark.sql.catalyst.json._
+import org.apache.spark.sql.catalyst.plans.FullOuter
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.ExternalRDD
 import org.apache.spark.sql.execution.datasources.DataSource
@@ -1810,7 +1811,7 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
         .join(
           additionalCorruptRecords.toDF("value"),
           F.regexp_replace($"_corrupt_record", "(^\\s+|\\s+$)", "") === F.trim($"value"),
-          "outer")
+          FullOuter)
         .agg(
           F.count($"dummy").as("valid"),
           F.count($"_corrupt_record").as("corrupt"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -25,6 +25,7 @@ import scala.util.Random
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{Final, Partial}
+import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.execution.{FilterExec, RangeExec, SparkPlan, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.aggregate.HashAggregateExec
@@ -310,13 +311,13 @@ class SQLMetricsSuite extends SparkFunSuite with SQLMetricsTestUtils with Shared
     val df2 = Seq((1, "a"), (1, "b"), (2, "c"), (3, "d")).toDF("key2", "value")
     // Assume the execution plan is
     // ... -> BroadcastHashJoin(nodeId = 0)
-    val df = df1.join(broadcast(df2), $"key" === $"key2", "left_outer")
+    val df = df1.join(broadcast(df2), $"key" === $"key2", LeftOuter)
     testSparkPlanMetrics(df, 2, Map(
       0L -> (("BroadcastHashJoin", Map(
         "number of output rows" -> 5L))))
     )
 
-    val df3 = df1.join(broadcast(df2), $"key" === $"key2", "right_outer")
+    val df3 = df1.join(broadcast(df2), $"key" === $"key2", RightOuter)
     testSparkPlanMetrics(df3, 2, Map(
       0L -> (("BroadcastHashJoin", Map(
         "number of output rows" -> 6L))))
@@ -346,7 +347,7 @@ class SQLMetricsSuite extends SparkFunSuite with SQLMetricsTestUtils with Shared
     val df2 = Seq((1, "1"), (2, "2"), (3, "3"), (4, "4")).toDF("key2", "value")
     // Assume the execution plan is
     // ... -> BroadcastHashJoin(nodeId = 1)
-    val df = df1.join(broadcast(df2), $"key" === $"key2", "leftsemi")
+    val df = df1.join(broadcast(df2), $"key" === $"key2", LeftSemi)
     testSparkPlanMetrics(df, 2, Map(
       1L -> (("BroadcastHashJoin", Map(
         "number of output rows" -> 2L))))

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
 import org.apache.spark.sql.execution.{DataSourceScanExec, SortExec}
 import org.apache.spark.sql.execution.datasources.BucketingUtils
@@ -328,7 +329,7 @@ abstract class BucketedReadSuite extends QueryTest with SQLTestUtils {
   private def testBucketing(
       bucketedTableTestSpecLeft: BucketedTableTestSpec,
       bucketedTableTestSpecRight: BucketedTableTestSpec,
-      joinType: String = "inner",
+      joinType: JoinType = Inner,
       joinCondition: (DataFrame, DataFrame) => Column): Unit = {
     val BucketedTableTestSpec(bucketSpecLeft, numPartitionsLeft, shuffleLeft, sortLeft) =
       bucketedTableTestSpecLeft
@@ -608,7 +609,7 @@ abstract class BucketedReadSuite extends QueryTest with SQLTestUtils {
     testBucketing(
       bucketedTableTestSpecLeft = bucketedTableTestSpecLeft,
       bucketedTableTestSpecRight = bucketedTableTestSpecRight,
-      joinType = "fullouter",
+      joinType = FullOuter,
       joinCondition = (left: DataFrame, right: DataFrame) => {
         val joinPredicates = Seq("i").map(col => left(col) === right(col)).reduce(_ && _)
         val filterLeft = left("i") === Literal("1")


### PR DESCRIPTION
## What changes were proposed in this pull request?
Tries the address the concern mentioned in [SPARK-26739](https://issues.apache.org/jira/browse/SPARK-26739)
To summarise, currently, in the join functions on DataFrames, the join types are defined via a string parameter called joinType. In order for a developer to know which joins are possible, they must look up the API call for join. While this works fine, it can cause the developer to make a typo resulting in improper joins and/or unexpected errors that aren't evident at compile time. The objective of this improvement would be to allow developers to use a common definition for join types (by enum or constants) called JoinTypes. This would contain the possible joins and remove the possibility of a typo. It would also allow Spark to alter the names of the joins in the future without impacting end-users.

## How was this patch tested?
Tested via Unit tests

