### PR TITLE
[MINOR][EXAMPLES] Add missing return keyword streaming word count example

### DIFF
--- a/examples/src/main/python/streaming/recoverable_network_wordcount.py
+++ b/examples/src/main/python/streaming/recoverable_network_wordcount.py
@@ -83,9 +83,9 @@ def createContext(host, port, outputPath):
         def filterFunc(wordCount):
             if wordCount[0] in blacklist.value:
                 droppedWordsCounter.add(wordCount[1])
-                False
+                return False
             else:
-                True
+                return True
 
         counts = "Counts at time %s %s" % (time, rdd.filter(filterFunc).collect())
         print(counts)


### PR DESCRIPTION
A few Python examples are missing a "return" keyword. They aren't tested per se but this is an obvious issue and fix.