### PR TITLE
[MINOR][SQL]remove oudated comment about HiveClientImpl.

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -378,11 +378,8 @@ private[hive] class HiveClientImpl(
 
       val bucketSpec = if (h.getNumBuckets > 0) {
         val sortColumnOrders = h.getSortCols.asScala
-        // Currently Spark only supports columns to be sorted in ascending order
-        // but Hive can support both ascending and descending order. If all the columns
-        // are sorted in ascending order, only then propagate the sortedness information
-        // to downstream processing / optimizations in Spark
-        // TODO: In future we can have Spark support columns sorted in descending order
+        // If all the columns are sorted in ascending order, only then propagate
+        // the sortedness information to downstream processing / optimizations in Spark
         val allAscendingSorted = sortColumnOrders.forall(_.getOrder == HIVE_COLUMN_ORDER_ASC)
 
         val sortColumnNames = if (allAscendingSorted) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`HiveClientImpl` contains the comment `Currently Spark only supports columns to be sorted in ascending order but Hive can support both ascending and descending order.`, I test this grammar and find Spark supports columns to be sorted in descending order too.
I think should remove oudated comment so that the comment is clearly.

## How was this patch tested?

No UT
