### PR TITLE
[SPARK-27214]Upgrading locality level when task set is starving

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -356,6 +356,10 @@ package object config {
     .timeConf(TimeUnit.MILLISECONDS)
     .createWithDefaultString("3s")
 
+  private[spark] val LOCALITY_GAIN_FACTOR = ConfigBuilder("spark.locality.gainFactor")
+    .doubleConf
+    .createWithDefault(0.1)
+
   private[spark] val SHUFFLE_SERVICE_ENABLED =
     ConfigBuilder("spark.shuffle.service.enabled").booleanConf.createWithDefault(false)
 

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -595,7 +595,8 @@ private[spark] class TaskSetManager(
         false
       } else {
         val actualNumTasksCanRun = math.min(allPendingTasks.size,
-          sched.backend.maxNumConcurrentTasks() - sched.runningTasksByExecutors.values.sum)
+          sched.defaultParallelism / sched.CPUS_PER_TASK -
+            sched.runningTasksByExecutors.values.sum)
         val probabilityOfNextLocalitySchedule = 0.5D
         val maxTolerableStarvationTime = actualNumTasksCanRun *
             successfulTaskDurations.median * localityGainFactor * probabilityOfNextLocalitySchedule

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -244,7 +244,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
   test("skip unsatisfiable locality levels") {
     sc = new SparkContext("local", "test")
     sched = new FakeTaskScheduler(sc, ("execA", "host1"), ("execC", "host2"))
-    sched.initialize(sc.schedulerBackend)
     val taskSet = FakeTask.createTaskSet(1, Seq(TaskLocation("host1", "execB")))
     val clock = new ManualClock
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
@@ -261,7 +260,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
   test("basic delay scheduling") {
     sc = new SparkContext("local", "test")
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"))
-    sched.initialize(sc.schedulerBackend)
     val taskSet = FakeTask.createTaskSet(4,
       Seq(TaskLocation("host1", "exec1")),
       Seq(TaskLocation("host2", "exec2")),
@@ -292,7 +290,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
   test("we do not need to delay scheduling when we only have noPref tasks in the queue") {
     sc = new SparkContext("local", "test")
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec3", "host2"))
-    sched.initialize(sc.schedulerBackend)
     val taskSet = FakeTask.createTaskSet(3,
       Seq(TaskLocation("host1", "exec1")),
       Seq(TaskLocation("host2", "exec3")),
@@ -311,7 +308,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     sc = new SparkContext("local", "test")
     sched = new FakeTaskScheduler(sc,
       ("exec1", "host1"), ("exec2", "host2"), ("exec3", "host3"))
-    sched.initialize(sc.schedulerBackend)
     val taskSet = FakeTask.createTaskSet(5,
       Seq(TaskLocation("host1")),
       Seq(TaskLocation("host2")),
@@ -352,7 +348,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     sc = new SparkContext("local", "test")
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"),
       ("exec3", "host3"))
-    sched.initialize(sc.schedulerBackend)
     val taskSet = FakeTask.createTaskSet(3,
       Seq(TaskLocation("host1")),
       Seq(TaskLocation("host2")),
@@ -389,7 +384,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
   test("task result lost") {
     sc = new SparkContext("local", "test")
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
-    sched.initialize(sc.schedulerBackend)
     val taskSet = FakeTask.createTaskSet(1)
     val clock = new ManualClock
     clock.advance(1)
@@ -408,7 +402,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
   test("repeated failures lead to task set abortion") {
     sc = new SparkContext("local", "test")
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
-    sched.initialize(sc.schedulerBackend)
     val taskSet = FakeTask.createTaskSet(1)
     val clock = new ManualClock
     clock.advance(1)
@@ -442,7 +435,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     // two executors on same host, one on different.
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"),
       ("exec1.1", "host1"), ("exec2", "host2"))
-    sched.initialize(sc.schedulerBackend)
     // affinity to exec1 on host1 - which we will fail.
     val taskSet = FakeTask.createTaskSet(1, Seq(TaskLocation("host1", "exec1")))
     val clock = new ManualClock
@@ -566,7 +558,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
   test("Executors exit for reason unrelated to currently running tasks") {
     sc = new SparkContext("local", "test")
     sched = new FakeTaskScheduler(sc)
-    sched.initialize(sc.schedulerBackend)
     val taskSet = FakeTask.createTaskSet(4,
       Seq(TaskLocation("host1", "execA")),
       Seq(TaskLocation("host1", "execB")),
@@ -603,7 +594,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     sc = new SparkContext("local", "test")
     sched = new FakeTaskScheduler(sc,
       ("execA", "host1"), ("execB", "host2"), ("execC", "host3"))
-    sched.initialize(sc.schedulerBackend)
     val taskSet = FakeTask.createTaskSet(2,
       Seq(TaskLocation("host1", "execA")),
       Seq(TaskLocation("host1", "execA")))
@@ -626,7 +616,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
   test("do not emit warning when serialized task is small") {
     sc = new SparkContext("local", "test")
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
-    sched.initialize(sc.schedulerBackend)
     val taskSet = FakeTask.createTaskSet(1)
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
 
@@ -640,7 +629,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
   test("emit warning when serialized task is large") {
     sc = new SparkContext("local", "test")
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
-    sched.initialize(sc.schedulerBackend)
 
     val taskSet = new TaskSet(Array(new LargeTask(0)), 0, 0, 0, null)
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
@@ -655,7 +643,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
   test("Not serializable exception thrown if the task cannot be serialized") {
     sc = new SparkContext("local", "test")
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
-    sched.initialize(sc.schedulerBackend)
 
     val taskSet = new TaskSet(
       Array(new NotSerializableFakeTask(1, 0), new NotSerializableFakeTask(0, 1)), 0, 0, 0, null)
@@ -870,7 +857,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     sc = new SparkContext("local", "test")
     sched = new FakeTaskScheduler(
       sc, ("execA", "host1"), ("execB", "host2"), ("execC", "host3"))
-    sched.initialize(sc.schedulerBackend)
     val taskSet = FakeTask.createTaskSet(4,
       Seq(TaskLocation("host1", "execA")),
       Seq(TaskLocation("host2"), TaskLocation("host1")),
@@ -899,7 +885,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     sc = new SparkContext("local", "test")
     sched = new FakeTaskScheduler(
       sc, ("execA", "host1"), ("execB", "host2"), ("execC", "host3"))
-    sched.initialize(sc.schedulerBackend)
     val taskSet = FakeTask.createTaskSet(4,
       Seq(TaskLocation("host1")),
       Seq(TaskLocation("host2")),
@@ -922,7 +907,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
   {
     sc = new SparkContext("local", "test")
     sched = new FakeTaskScheduler(sc, ("execA", "host1"), ("execB", "host2"))
-    sched.initialize(sc.schedulerBackend)
     val taskSet = FakeTask.createTaskSet(4,
       Seq(TaskLocation("host1")),
       Seq(TaskLocation("host2")),
@@ -944,7 +928,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
   test("SPARK-4939: no-pref tasks should be scheduled after process-local tasks finished") {
     sc = new SparkContext("local", "test")
     sched = new FakeTaskScheduler(sc, ("execA", "host1"), ("execB", "host2"))
-    sched.initialize(sc.schedulerBackend)
     val taskSet = FakeTask.createTaskSet(3,
       Seq(),
       Seq(ExecutorCacheTaskLocation("host1", "execA")),
@@ -966,7 +949,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     // Regression test for SPARK-2931
     sc = new SparkContext("local", "test")
     sched = new FakeTaskScheduler(sc)
-    sched.initialize(sc.schedulerBackend)
     val taskSet = FakeTask.createTaskSet(2,
       Seq(TaskLocation("host1", "execA")),
       Seq(TaskLocation("host2", "execB.1")))
@@ -1245,7 +1227,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
       set(config.BLACKLIST_ENABLED, true)
     sc = new SparkContext("local", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"))
-    sched.initialize(sc.schedulerBackend)
     val taskSet = FakeTask.createTaskSet(4)
     val tsm = new TaskSetManager(sched, taskSet, 4)
     // we need a spy so we can attach our mock blacklist
@@ -1286,7 +1267,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
       .set(config.BLACKLIST_FETCH_FAILURE_ENABLED, true)
     sc = new SparkContext("local", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"))
-    sched.initialize(sc.schedulerBackend)
     val taskSet = FakeTask.createTaskSet(4)
     val blacklistTracker = new BlacklistTracker(sc, None)
     val tsm = new TaskSetManager(sched, taskSet, 4, Some(blacklistTracker))
@@ -1325,7 +1305,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     val exec2 = "executor2"
     val host2 = "host2"
     sched = new FakeTaskScheduler(sc, (exec, host), (exec2, host2))
-    sched.initialize(sc.schedulerBackend)
     val taskSet = FakeTask.createTaskSet(1)
 
     val clock = new ManualClock
@@ -1624,7 +1603,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
       result.accumUpdates, info3)
   }
 
-  test("Upgrading locality level when task set is starving") {
+  test("SPARK-27214: Upgrading locality level when task set is starving") {
     sc = new SparkContext("local", "test")
     val clock = new ManualClock(10000L)
     var manager: TaskSetManager = null
@@ -1642,12 +1621,12 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
         this.backend = backend
         this.schedulableBuilder = new FIFOSchedulableBuilder(rootPool)
       }
-    }
-    sched.initialize(new FakeSchedulerBackend() {
-      override def maxNumConcurrentTasks(): Int = {
-        sched.executors.size / sched.CPUS_PER_TASK
+
+      override def defaultParallelism(): Int = {
+        sched.executors.size
       }
-    })
+    }
+    sched.initialize(new FakeSchedulerBackend())
     sc.conf.set(config.LOCALITY_GAIN_FACTOR, 1.0D)
     sc.conf.set(config.LOCALITY_WAIT.key, "3s")
     val taskSet = FakeTask.createTaskSet(20,

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -1629,7 +1629,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     val clock = new ManualClock(10000L)
     var manager: TaskSetManager = null
     sched = new FakeTaskScheduler(sc,
-      (0 until 20).map(i => (s"exec$i", s"host$i")): _*
+      (0 until 20).map(i => (s"exec$i", "host1")): _*
     ) {
       private var schedulableBuilder: SchedulableBuilder = null
 
@@ -1662,7 +1662,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     clock.advance(2000)
     val taskDescs1 = sched.resourceOffers(IndexedSeq(
       WorkerOffer("exec1", "host1", 1),
-      WorkerOffer("exec2", "host2", 1)
+      WorkerOffer("exec2", "host1", 1)
     )).flatten
     assert(taskDescs1.length === 1)
     assert(taskDescs1.head.executorId === "exec1")
@@ -1670,7 +1670,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     clock.advance(2000)
     val taskDescs2 = sched.resourceOffers(IndexedSeq(
       WorkerOffer("exec1", "host1", 1),
-      WorkerOffer("exec2", "host2", 1)
+      WorkerOffer("exec2", "host1", 1)
     )).flatten
     assert(taskDescs2.length === 1)
     assert(taskDescs2.head.executorId === "exec1")
@@ -1678,7 +1678,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     clock.advance(2000)
     val taskDescs3 = sched.resourceOffers(IndexedSeq(
       WorkerOffer("exec1", "host1", 1),
-      WorkerOffer("exec2", "host2", 1)
+      WorkerOffer("exec2", "host1", 1)
     )).flatten
     // Locality level upgraded to NODE_LOCAL
     assert(taskDescs3.length === 2)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, Spark locality wait mechanism is not friendly for large job, when number of tasks is large（e.g. 10000+）and with a large number of executors(e.g. 2000), executors may be launched on some nodes  where the locality is not the best(not the same nodes hold HDFS blocks). There are cases when `TaskSetManager.lastLaunchTime` is refreshed due to task finished within `spark.locality.wait` and re-launch new tasks, but due to there are only few of `PROCESS_LOCAL` executors, the launch rate is not fast enough to schedule all pending tasks soon, so that locality level could not be upgraded in time and lots of pending tasks will wait a long time. 

In this case, when `spark.dynamicAllocation.enabled=true`, then lots of executors may be removed by Driver due to become idle and finally slow down the job.

We encountered this issue in our production spark cluster, it caused lots of resources wasting and slowed down user's application.

This PR will optimize this by following formula:

Suppose numPendingTasks=10000, localityExecutionGainFactor=0.1, probabilityOfNextLocalitySchedule=0.5

```
maxTolerableStarvingTime = numTasksCanRun * medianOfTaskExecutionTime * localityExecutionGainFactor * probabilityOfNextLocalitySchedule

totalStarvingTime = sum(starvingTimeByTasks)

if (totalStarvingTime > maxTolerableStarvingTime)

{  upgrading locality level... }
```

## How was this patch tested?

Exist UT & added UT

Please review http://spark.apache.org/contributing.html before opening a pull request.
