### PR TITLE
Feature/spark 27062

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -17,25 +17,25 @@
 
 package org.apache.spark.sql.internal
 
-import scala.reflect.runtime.universe.TypeTag
-import scala.util.control.NonFatal
-
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalog.{Catalog, Column, Database, Function, Table}
-import org.apache.spark.sql.catalyst.{DefinedByConstructorParams, FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
+import org.apache.spark.sql.catalyst.{DefinedByConstructorParams, FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.execution.command.AlterTableRecoverPartitionsCommand
 import org.apache.spark.sql.execution.datasources.{CreateTable, DataSource}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.storage.StorageLevel
 
+import scala.reflect.runtime.universe.TypeTag
+import scala.util.control.NonFatal
+
 
 /**
- * Internal implementation of the user-facing `Catalog`.
- */
+  * Internal implementation of the user-facing `Catalog`.
+  */
 class CatalogImpl(sparkSession: SparkSession) extends Catalog {
 
   private def sessionCatalog: SessionCatalog = sparkSession.sessionState.catalog
@@ -53,13 +53,13 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
   }
 
   /**
-   * Returns the current default database in this session.
-   */
+    * Returns the current default database in this session.
+    */
   override def currentDatabase: String = sessionCatalog.getCurrentDatabase
 
   /**
-   * Sets the current default database in this session.
-   */
+    * Sets the current default database in this session.
+    */
   @throws[AnalysisException]("database does not exist")
   override def setCurrentDatabase(dbName: String): Unit = {
     requireDatabaseExists(dbName)
@@ -67,8 +67,8 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
   }
 
   /**
-   * Returns a list of databases available across all sessions.
-   */
+    * Returns a list of databases available across all sessions.
+    */
   override def listDatabases(): Dataset[Database] = {
     val databases = sessionCatalog.listDatabases().map(makeDatabase)
     CatalogImpl.makeDataset(databases, sparkSession)
@@ -83,17 +83,17 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
   }
 
   /**
-   * Returns a list of tables in the current database.
-   * This includes all temporary tables.
-   */
+    * Returns a list of tables in the current database.
+    * This includes all temporary tables.
+    */
   override def listTables(): Dataset[Table] = {
     listTables(currentDatabase)
   }
 
   /**
-   * Returns a list of tables in the specified database.
-   * This includes all temporary tables.
-   */
+    * Returns a list of tables in the specified database.
+    * This includes all temporary tables.
+    */
   @throws[AnalysisException]("database does not exist")
   override def listTables(dbName: String): Dataset[Table] = {
     val tables = sessionCatalog.listTables(dbName).map(makeTable)
@@ -101,14 +101,14 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
   }
 
   /**
-   * Returns a Table for the given table/view or temporary view.
-   *
-   * Note that this function requires the table already exists in the Catalog.
-   *
-   * If the table metadata retrieval failed due to any reason (e.g., table serde class
-   * is not accessible or the table type is not accepted by Spark SQL), this function
-   * still returns the corresponding Table without the description and tableType)
-   */
+    * Returns a Table for the given table/view or temporary view.
+    *
+    * Note that this function requires the table already exists in the Catalog.
+    *
+    * If the table metadata retrieval failed due to any reason (e.g., table serde class
+    * is not accessible or the table type is not accepted by Spark SQL), this function
+    * still returns the corresponding Table without the description and tableType)
+    */
   private def makeTable(tableIdent: TableIdentifier): Table = {
     val metadata = try {
       Some(sessionCatalog.getTempViewOrPermanentTableMetadata(tableIdent))
@@ -125,17 +125,17 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
   }
 
   /**
-   * Returns a list of functions registered in the current database.
-   * This includes all temporary functions
-   */
+    * Returns a list of functions registered in the current database.
+    * This includes all temporary functions
+    */
   override def listFunctions(): Dataset[Function] = {
     listFunctions(currentDatabase)
   }
 
   /**
-   * Returns a list of functions registered in the specified database.
-   * This includes all temporary functions
-   */
+    * Returns a list of functions registered in the specified database.
+    * This includes all temporary functions
+    */
   @throws[AnalysisException]("database does not exist")
   override def listFunctions(dbName: String): Dataset[Function] = {
     requireDatabaseExists(dbName)
@@ -156,8 +156,8 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
   }
 
   /**
-   * Returns a list of columns for the given table/view or temporary view.
-   */
+    * Returns a list of columns for the given table/view or temporary view.
+    */
   @throws[AnalysisException]("table does not exist")
   override def listColumns(tableName: String): Dataset[Column] = {
     val tableIdent = sparkSession.sessionState.sqlParser.parseTableIdentifier(tableName)
@@ -165,8 +165,8 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
   }
 
   /**
-   * Returns a list of columns for the given table/view or temporary view in the specified database.
-   */
+    * Returns a list of columns for the given table/view or temporary view in the specified database.
+    */
   @throws[AnalysisException]("database or table does not exist")
   override def listColumns(dbName: String, tableName: String): Dataset[Column] = {
     requireTableExists(dbName, tableName)
@@ -191,26 +191,26 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
   }
 
   /**
-   * Gets the database with the specified name. This throws an `AnalysisException` when no
-   * `Database` can be found.
-   */
+    * Gets the database with the specified name. This throws an `AnalysisException` when no
+    * `Database` can be found.
+    */
   override def getDatabase(dbName: String): Database = {
     makeDatabase(dbName)
   }
 
   /**
-   * Gets the table or view with the specified name. This table can be a temporary view or a
-   * table/view. This throws an `AnalysisException` when no `Table` can be found.
-   */
+    * Gets the table or view with the specified name. This table can be a temporary view or a
+    * table/view. This throws an `AnalysisException` when no `Table` can be found.
+    */
   override def getTable(tableName: String): Table = {
     val tableIdent = sparkSession.sessionState.sqlParser.parseTableIdentifier(tableName)
     getTable(tableIdent.database.orNull, tableIdent.table)
   }
 
   /**
-   * Gets the table or view with the specified name in the specified database. This throws an
-   * `AnalysisException` when no `Table` can be found.
-   */
+    * Gets the table or view with the specified name in the specified database. This throws an
+    * `AnalysisException` when no `Table` can be found.
+    */
   override def getTable(dbName: String, tableName: String): Table = {
     if (tableExists(dbName, tableName)) {
       makeTable(TableIdentifier(tableName, Option(dbName)))
@@ -220,70 +220,70 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
   }
 
   /**
-   * Gets the function with the specified name. This function can be a temporary function or a
-   * function. This throws an `AnalysisException` when no `Function` can be found.
-   */
+    * Gets the function with the specified name. This function can be a temporary function or a
+    * function. This throws an `AnalysisException` when no `Function` can be found.
+    */
   override def getFunction(functionName: String): Function = {
     val functionIdent = sparkSession.sessionState.sqlParser.parseFunctionIdentifier(functionName)
     getFunction(functionIdent.database.orNull, functionIdent.funcName)
   }
 
   /**
-   * Gets the function with the specified name. This returns `None` when no `Function` can be
-   * found.
-   */
+    * Gets the function with the specified name. This returns `None` when no `Function` can be
+    * found.
+    */
   override def getFunction(dbName: String, functionName: String): Function = {
     makeFunction(FunctionIdentifier(functionName, Option(dbName)))
   }
 
   /**
-   * Checks if the database with the specified name exists.
-   */
+    * Checks if the database with the specified name exists.
+    */
   override def databaseExists(dbName: String): Boolean = {
     sessionCatalog.databaseExists(dbName)
   }
 
   /**
-   * Checks if the table or view with the specified name exists. This can either be a temporary
-   * view or a table/view.
-   */
+    * Checks if the table or view with the specified name exists. This can either be a temporary
+    * view or a table/view.
+    */
   override def tableExists(tableName: String): Boolean = {
     val tableIdent = sparkSession.sessionState.sqlParser.parseTableIdentifier(tableName)
     tableExists(tableIdent.database.orNull, tableIdent.table)
   }
 
   /**
-   * Checks if the table or view with the specified name exists in the specified database.
-   */
+    * Checks if the table or view with the specified name exists in the specified database.
+    */
   override def tableExists(dbName: String, tableName: String): Boolean = {
     val tableIdent = TableIdentifier(tableName, Option(dbName))
     sessionCatalog.isTemporaryTable(tableIdent) || sessionCatalog.tableExists(tableIdent)
   }
 
   /**
-   * Checks if the function with the specified name exists. This can either be a temporary function
-   * or a function.
-   */
+    * Checks if the function with the specified name exists. This can either be a temporary function
+    * or a function.
+    */
   override def functionExists(functionName: String): Boolean = {
     val functionIdent = sparkSession.sessionState.sqlParser.parseFunctionIdentifier(functionName)
     functionExists(functionIdent.database.orNull, functionIdent.funcName)
   }
 
   /**
-   * Checks if the function with the specified name exists in the specified database.
-   */
+    * Checks if the function with the specified name exists in the specified database.
+    */
   override def functionExists(dbName: String, functionName: String): Boolean = {
     sessionCatalog.functionExists(FunctionIdentifier(functionName, Option(dbName)))
   }
 
   /**
-   * :: Experimental ::
-   * Creates a table from the given path and returns the corresponding DataFrame.
-   * It will use the default data source configured by spark.sql.sources.default.
-   *
-   * @group ddl_ops
-   * @since 2.2.0
-   */
+    * :: Experimental ::
+    * Creates a table from the given path and returns the corresponding DataFrame.
+    * It will use the default data source configured by spark.sql.sources.default.
+    *
+    * @group ddl_ops
+    * @since 2.2.0
+    */
   @Experimental
   override def createTable(tableName: String, path: String): DataFrame = {
     val dataSourceName = sparkSession.sessionState.conf.defaultDataSourceName
@@ -291,50 +291,50 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
   }
 
   /**
-   * :: Experimental ::
-   * Creates a table from the given path and returns the corresponding
-   * DataFrame.
-   *
-   * @group ddl_ops
-   * @since 2.2.0
-   */
+    * :: Experimental ::
+    * Creates a table from the given path and returns the corresponding
+    * DataFrame.
+    *
+    * @group ddl_ops
+    * @since 2.2.0
+    */
   @Experimental
   override def createTable(tableName: String, path: String, source: String): DataFrame = {
     createTable(tableName, source, Map("path" -> path))
   }
 
   /**
-   * :: Experimental ::
-   * (Scala-specific)
-   * Creates a table based on the dataset in a data source and a set of options.
-   * Then, returns the corresponding DataFrame.
-   *
-   * @group ddl_ops
-   * @since 2.2.0
-   */
+    * :: Experimental ::
+    * (Scala-specific)
+    * Creates a table based on the dataset in a data source and a set of options.
+    * Then, returns the corresponding DataFrame.
+    *
+    * @group ddl_ops
+    * @since 2.2.0
+    */
   @Experimental
   override def createTable(
-      tableName: String,
-      source: String,
-      options: Map[String, String]): DataFrame = {
+                            tableName: String,
+                            source: String,
+                            options: Map[String, String]): DataFrame = {
     createTable(tableName, source, new StructType, options)
   }
 
   /**
-   * :: Experimental ::
-   * (Scala-specific)
-   * Creates a table based on the dataset in a data source, a schema and a set of options.
-   * Then, returns the corresponding DataFrame.
-   *
-   * @group ddl_ops
-   * @since 2.2.0
-   */
+    * :: Experimental ::
+    * (Scala-specific)
+    * Creates a table based on the dataset in a data source, a schema and a set of options.
+    * Then, returns the corresponding DataFrame.
+    *
+    * @group ddl_ops
+    * @since 2.2.0
+    */
   @Experimental
   override def createTable(
-      tableName: String,
-      source: String,
-      schema: StructType,
-      options: Map[String, String]): DataFrame = {
+                            tableName: String,
+                            source: String,
+                            schema: StructType,
+                            options: Map[String, String]): DataFrame = {
     val tableIdent = sparkSession.sessionState.sqlParser.parseTableIdentifier(tableName)
     val storage = DataSource.buildStorageFormatFromOptions(options)
     val tableType = if (storage.locationUri.isDefined) {
@@ -355,13 +355,13 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
   }
 
   /**
-   * Drops the local temporary view with the given view name in the catalog.
-   * If the view has been cached/persisted before, it's also unpersisted.
-   *
-   * @param viewName the identifier of the temporary view to be dropped.
-   * @group ddl_ops
-   * @since 2.0.0
-   */
+    * Drops the local temporary view with the given view name in the catalog.
+    * If the view has been cached/persisted before, it's also unpersisted.
+    *
+    * @param viewName the identifier of the temporary view to be dropped.
+    * @group ddl_ops
+    * @since 2.0.0
+    */
   override def dropTempView(viewName: String): Boolean = {
     sparkSession.sessionState.catalog.getTempView(viewName).exists { viewDef =>
       sparkSession.sharedState.cacheManager.uncacheQuery(sparkSession, viewDef, blocking = true)
@@ -370,13 +370,13 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
   }
 
   /**
-   * Drops the global temporary view with the given view name in the catalog.
-   * If the view has been cached/persisted before, it's also unpersisted.
-   *
-   * @param viewName the identifier of the global temporary view to be dropped.
-   * @group ddl_ops
-   * @since 2.1.0
-   */
+    * Drops the global temporary view with the given view name in the catalog.
+    * If the view has been cached/persisted before, it's also unpersisted.
+    *
+    * @param viewName the identifier of the global temporary view to be dropped.
+    * @group ddl_ops
+    * @since 2.1.0
+    */
   override def dropGlobalTempView(viewName: String): Boolean = {
     sparkSession.sessionState.catalog.getGlobalTempView(viewName).exists { viewDef =>
       sparkSession.sharedState.cacheManager.uncacheQuery(sparkSession, viewDef, blocking = true)
@@ -385,15 +385,15 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
   }
 
   /**
-   * Recovers all the partitions in the directory of a table and update the catalog.
-   * Only works with a partitioned table, and not a temporary view.
-   *
-   * @param tableName is either a qualified or unqualified name that designates a table.
-   *                  If no database identifier is provided, it refers to a table in the
-   *                  current database.
-   * @group ddl_ops
-   * @since 2.1.1
-   */
+    * Recovers all the partitions in the directory of a table and update the catalog.
+    * Only works with a partitioned table, and not a temporary view.
+    *
+    * @param tableName is either a qualified or unqualified name that designates a table.
+    *                  If no database identifier is provided, it refers to a table in the
+    *                  current database.
+    * @group ddl_ops
+    * @since 2.1.1
+    */
   override def recoverPartitions(tableName: String): Unit = {
     val tableIdent = sparkSession.sessionState.sqlParser.parseTableIdentifier(tableName)
     sparkSession.sessionState.executePlan(
@@ -401,77 +401,77 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
   }
 
   /**
-   * Returns true if the table or view is currently cached in-memory.
-   *
-   * @group cachemgmt
-   * @since 2.0.0
-   */
+    * Returns true if the table or view is currently cached in-memory.
+    *
+    * @group cachemgmt
+    * @since 2.0.0
+    */
   override def isCached(tableName: String): Boolean = {
     sparkSession.sharedState.cacheManager.lookupCachedData(sparkSession.table(tableName)).nonEmpty
   }
 
   /**
-   * Caches the specified table or view in-memory.
-   *
-   * @group cachemgmt
-   * @since 2.0.0
-   */
+    * Caches the specified table or view in-memory.
+    *
+    * @group cachemgmt
+    * @since 2.0.0
+    */
   override def cacheTable(tableName: String): Unit = {
     sparkSession.sharedState.cacheManager.cacheQuery(sparkSession.table(tableName), Some(tableName))
   }
 
   /**
-   * Caches the specified table or view with the given storage level.
-   *
-   * @group cachemgmt
-   * @since 2.3.0
-   */
+    * Caches the specified table or view with the given storage level.
+    *
+    * @group cachemgmt
+    * @since 2.3.0
+    */
   override def cacheTable(tableName: String, storageLevel: StorageLevel): Unit = {
     sparkSession.sharedState.cacheManager.cacheQuery(
       sparkSession.table(tableName), Some(tableName), storageLevel)
   }
 
   /**
-   * Removes the specified table or view from the in-memory cache.
-   *
-   * @group cachemgmt
-   * @since 2.0.0
-   */
+    * Removes the specified table or view from the in-memory cache.
+    *
+    * @group cachemgmt
+    * @since 2.0.0
+    */
   override def uncacheTable(tableName: String): Unit = {
     sparkSession.sharedState.cacheManager.uncacheQuery(sparkSession.table(tableName))
   }
 
   /**
-   * Removes all cached tables or views from the in-memory cache.
-   *
-   * @group cachemgmt
-   * @since 2.0.0
-   */
+    * Removes all cached tables or views from the in-memory cache.
+    *
+    * @group cachemgmt
+    * @since 2.0.0
+    */
   override def clearCache(): Unit = {
     sparkSession.sharedState.cacheManager.clearCache()
   }
 
   /**
-   * Returns true if the [[Dataset]] is currently cached in-memory.
-   *
-   * @group cachemgmt
-   * @since 2.0.0
-   */
+    * Returns true if the [[Dataset]] is currently cached in-memory.
+    *
+    * @group cachemgmt
+    * @since 2.0.0
+    */
   protected[sql] def isCached(qName: Dataset[_]): Boolean = {
     sparkSession.sharedState.cacheManager.lookupCachedData(qName).nonEmpty
   }
 
   /**
-   * Invalidates and refreshes all the cached data and metadata of the given table or view.
-   * For Hive metastore table, the metadata is refreshed. For data source tables, the schema will
-   * not be inferred and refreshed.
-   *
-   * If this table is cached as an InMemoryRelation, drop the original cached version and make the
-   * new version cached lazily.
-   *
-   * @group cachemgmt
-   * @since 2.0.0
-   */
+    * Invalidates and refreshes all the cached data and metadata of the given table or view.
+    * For Hive metastore table, the metadata is refreshed. For data source tables, the schema will
+    * not be inferred and refreshed.
+    *
+    * If this table is cached as an InMemoryRelation, drop the original cached version and make the
+    * new version cached lazily.
+    *
+    * @group cachemgmt
+    * @since 2.0.0
+    */
   override def refreshTable(tableName: String): Unit = {
     val tableIdent = sparkSession.sessionState.sqlParser.parseTableIdentifier(tableName)
     val tableMetadata = sessionCatalog.getTempViewOrPermanentTableMetadata(tableIdent)
@@ -486,24 +486,29 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
       sessionCatalog.refreshTable(tableIdent)
     }
 
-    // If this table is cached as an InMemoryRelation, drop the original
-    // cached version and make the new version cached lazily.
-    if (isCached(table)) {
-      // Uncache the logicalPlan.
+    val cache = sparkSession.sharedState.cacheManager.lookupCachedData(table)
+    if (cache.nonEmpty) {
+
+      // save the cache name and cache level for recreation
+      val cacheName = cache.get.cachedRepresentation.tableName
+      val cacheLevel = cache.get.cachedRepresentation.storageLevel
+
+      // uncache the logical plan.
       sparkSession.sharedState.cacheManager.uncacheQuery(table, blocking = true)
-      // Cache it again.
-      sparkSession.sharedState.cacheManager.cacheQuery(table, Some(tableName))
+
+      // recache with the same name.
+      sparkSession.sharedState.cacheManager.cacheQuery(table, cacheName, cacheLevel)
     }
   }
 
   /**
-   * Refreshes the cache entry and the associated metadata for all Dataset (if any), that contain
-   * the given data source path. Path matching is by prefix, i.e. "/" would invalidate
-   * everything that is cached.
-   *
-   * @group cachemgmt
-   * @since 2.0.0
-   */
+    * Refreshes the cache entry and the associated metadata for all Dataset (if any), that contain
+    * the given data source path. Path matching is by prefix, i.e. "/" would invalidate
+    * everything that is cached.
+    *
+    * @group cachemgmt
+    * @since 2.0.0
+    */
   override def refreshByPath(resourcePath: String): Unit = {
     sparkSession.sharedState.cacheManager.recacheByPath(sparkSession, resourcePath)
   }
@@ -512,9 +517,9 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
 
 private[sql] object CatalogImpl {
 
-  def makeDataset[T <: DefinedByConstructorParams: TypeTag](
-      data: Seq[T],
-      sparkSession: SparkSession): Dataset[T] = {
+  def makeDataset[T <: DefinedByConstructorParams : TypeTag](
+                                                              data: Seq[T],
+                                                              sparkSession: SparkSession): Dataset[T] = {
     val enc = ExpressionEncoder[T]()
     val encoded = data.map(d => enc.toRow(d).copy())
     val plan = new LocalRelation(enc.schema.toAttributes, encoded)

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -492,7 +492,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
       // Uncache the logicalPlan.
       sparkSession.sharedState.cacheManager.uncacheQuery(table, blocking = true)
       // Cache it again.
-      sparkSession.sharedState.cacheManager.cacheQuery(table, Some(tableIdent.table))
+      sparkSession.sharedState.cacheManager.cacheQuery(table, Some(tableName))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -216,6 +216,20 @@ abstract class QueryTest extends PlanTest {
   }
 
   /**
+    * Asserts that a given [[Dataset]] will be executed using the given named cache.
+    */
+  def assertCached(query: Dataset[_], cachedName: String): Unit = {
+    val planWithCaching = query.queryExecution.withCachedData
+    val cachedTableNames = planWithCaching collect {
+      case cached: InMemoryRelation => cached.tableName.get
+    }
+
+    assert(
+      cachedTableNames.contains(cachedName),
+      s"Expected query to contain $cachedName, but it doesn't. It contains ${cachedTableNames.mkString(" ")} instead\n $planWithCaching")
+  }
+
+  /**
    * Asserts that a given [[Dataset]] does not have missing inputs in all the analyzed plans.
    */
   def assertEmptyMissingInput(query: Dataset[_]): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

If we refresh a cached table, the table cache will be first uncached and then recache (lazily). Currently, the logic is embedded in CatalogImpl.refreshTable method. 

The current implementation does not save the cache name and storage level. As a result, cache name and cache level could be changed after a REFERSH. IMHO, it is not what user expected. 

Therefore, this PR would like to fix this behavior by first save the cache name and storage level for recaching the table. 

## How was this patch tested?

Two new unit tests are added to "CachedTableSuite". To make sure cache name is not changed after table refreshing. Those test would fail without patching CatalogImpl with this PR.
