### PR TITLE
[SPARK-27204]SHS: Background caching for completed applications, when the disk store enabled

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -425,7 +425,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
       }
 
       if (diskStoreCacheEnabled) {
-        Seq(replayPool.get).foreach { executor =>
+        replayPool.foreach { executor =>
           executor.shutdown()
           if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
             executor.shutdownNow()

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServerDiskManager.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServerDiskManager.scala
@@ -260,6 +260,10 @@ private class HistoryServerDiskManager(
     }
   }
 
+  def isActiveStore(appId: String, attempId: Option[String]): Boolean = {
+    active.synchronized(active.contains(appId -> attempId))
+  }
+
   /** Visible for testing. Return the size of a directory. */
   private[history] def sizeOf(path: File): Long = FileUtils.sizeOf(path)
 

--- a/core/src/main/scala/org/apache/spark/internal/config/History.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/History.scala
@@ -79,6 +79,13 @@ private[spark] object History {
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("1m")
 
+  val DISK_BACKGROUND_CACHE_ENABLED = ConfigBuilder("spark.history.fs.disk.backgroundCache.enabled")
+    .doc("If enabled, when the store is disk, it will replay the eventLog of the completed" +
+      "applications in background once finished and create the cache. So, the first time loading" +
+      " of the application page would be faster")
+    .booleanConf
+    .createWithDefault(true)
+
   val DRIVER_LOG_CLEANER_ENABLED = ConfigBuilder("spark.history.fs.driverlog.cleaner.enabled")
     .fallbackConf(CLEANER_ENABLED)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
First time AppUI loading time will take time from the History server page, if the event log size is huge.
(Eg: 47 minutes for a 18GB eventlog file). Majority of time is consumed for replaying the event log.

In this pr, I'm proposing a background caching for disk store, where history provider will replay the event log once the application completed and creates a store cache. So, when the user try to access the application, they can directly get from the cache or, provider will wait till the time caching is completed.

Either case, the loading time will be lesser than or equal to the current one. Also, it is configurable and by default enabled. If disabled, behaviour will be same as before.

## How was this patch tested?
Manually tested and existing UT.
Event log size : 1.7 GB
**Before:**
 First time UI loading time = 391 sec 
**After:**
 First time UI loading time =  6 sec ( Best case: Already cached)
 First time UI loading time  =  344 sec (worst case: Immedietly after background caching started)
