### PR TITLE
[SPARK-27238][SQL] Add  fine-grained configurations to handle  `convertMetastoreParquet ` and  `convertMetastoreOrc`

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -185,8 +185,16 @@ case class RelationConversions(
 
   private def isConvertible(tableMeta: CatalogTable): Boolean = {
     val serde = tableMeta.storage.serde.getOrElse("").toLowerCase(Locale.ROOT)
-    serde.contains("parquet") && SQLConf.get.getConf(HiveUtils.CONVERT_METASTORE_PARQUET) ||
-      serde.contains("orc") && SQLConf.get.getConf(HiveUtils.CONVERT_METASTORE_ORC)
+    val excludedParquetTables =
+      SQLConf.get.getConf(HiveUtils.CONVERT_METASTORE_PARQUET_EXCLUDED_TABLES)
+    val excludedOrcTables =
+      SQLConf.get.getConf(HiveUtils.CONVERT_METASTORE_ORC_EXCLUDED_TABLES)
+    val tableName = tableMeta.identifier.table.toLowerCase(Locale.ROOT)
+
+    serde.contains("parquet") && SQLConf.get.getConf(HiveUtils.CONVERT_METASTORE_PARQUET) &&
+      !excludedParquetTables.toLowerCase(Locale.ROOT).split(",").contains(tableName) ||
+      serde.contains("orc") && SQLConf.get.getConf(HiveUtils.CONVERT_METASTORE_ORC) &&
+      !excludedOrcTables.toLowerCase(Locale.ROOT).split(",").contains(tableName)
   }
 
   private val metastoreCatalog = sessionCatalog.metastoreCatalog

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -97,6 +97,13 @@ private[spark] object HiveUtils extends Logging {
     .booleanConf
     .createWithDefault(true)
 
+  val CONVERT_METASTORE_PARQUET_EXCLUDED_TABLES =
+    buildConf("spark.sql.hive.convertMetastoreParquet.excludedTables")
+    .doc("A comma-separated list of Parquet table names, which do not use the built-in Parquet" +
+      "reader and writer when \"spark.sql.hive.convertMetastoreParquet\" is true.")
+    .stringConf
+    .createWithDefault("")
+
   val CONVERT_METASTORE_PARQUET_WITH_SCHEMA_MERGING =
     buildConf("spark.sql.hive.convertMetastoreParquet.mergeSchema")
       .doc("When true, also tries to merge possibly different but compatible Parquet schemas in " +
@@ -110,6 +117,13 @@ private[spark] object HiveUtils extends Logging {
       "ORC tables created by using the HiveQL syntax, instead of Hive serde.")
     .booleanConf
     .createWithDefault(true)
+
+  val CONVERT_METASTORE_ORC_EXCLUDED_TABLES =
+    buildConf("spark.sql.hive.convertMetastoreOrc.excludedTables")
+      .doc("A comma-separated list of ORC table names, which do not use the built-in ORC" +
+        "reader and writer when \"spark.sql.hive.convertMetastoreOrc\" is true.")
+      .stringConf
+      .createWithDefault("")
 
   val CONVERT_METASTORE_CTAS = buildConf("spark.sql.hive.convertMetastoreCtas")
     .doc("When set to true,  Spark will try to use built-in data source writer " +

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetSourceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetSourceSuite.scala
@@ -178,6 +178,46 @@ class HiveParquetSourceSuite extends ParquetPartitioningTest {
     }
   }
 
+  test("Verify the PARQUET conversion parameter: CONVERT_METASTORE_PARQUET_EXCLUDED_TABLES") {
+    withTempView("single") {
+      val singleRowDF = Seq((0, "foo")).toDF("key", "value")
+      singleRowDF.createOrReplaceTempView("single")
+
+      val tableName = "test_parquet_ctas"
+      Seq(tableName + ",others", "").foreach { parquetConversion =>
+        withSQLConf(HiveUtils.CONVERT_METASTORE_PARQUET_EXCLUDED_TABLES.key -> parquetConversion) {
+          withTable(tableName) {
+            sql(
+              s"""
+                 |CREATE TABLE $tableName STORED AS PARQUET
+                 |AS SELECT tmp.key, tmp.value FROM single tmp
+               """.stripMargin)
+
+            val df = spark.sql(s"SELECT * FROM $tableName WHERE key=0")
+            checkAnswer(df, singleRowDF)
+
+            val queryExecution = df.queryExecution
+            if (!parquetConversion.split(",").contains(tableName)) {
+              queryExecution.analyzed.collectFirst {
+                case _: LogicalRelation =>
+              }.getOrElse {
+                fail(s"Expecting the query plan to convert parquet to data sources, " +
+                  s"but got:\n$queryExecution")
+              }
+            } else {
+              queryExecution.analyzed.collectFirst {
+                case _: HiveTableRelation =>
+              }.getOrElse {
+                fail(s"Expecting no conversion from parquet to data sources, " +
+                  s"but got:\n$queryExecution")
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   test("values in arrays and maps stored in parquet are always nullable") {
     val df = createDataFrame(Tuple2(Map(2 -> 3), Seq(4, 5, 6)) :: Nil).toDF("m", "a")
     val mapType1 = MapType(IntegerType, IntegerType, valueContainsNull = false)


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the same APP, TableA and TableB are both hive Parquet tables, but TableA can't use the built-in Parquet reader and writer.
In this situation,  `spark.sql.hive.convertMetastoreParquet` can't control this well, so I think we can add a fine-grained configuration to handle this case.


## How was this patch tested?
Add a unit test
