### PR TITLE
[SPARK-27233] [SQL]DF schema should match with table schema when converted to table

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ArrayType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ArrayType.scala
@@ -90,7 +90,7 @@ case class ArrayType(elementType: DataType, containsNull: Boolean) extends DataT
   override def sql: String = s"ARRAY<${elementType.sql}>"
 
   override private[spark] def asNullable: ArrayType =
-    ArrayType(elementType.asNullable, containsNull = true)
+    ArrayType(elementType.asNullable, containsNull)
 
   override private[spark] def existsRecursively(f: (DataType) => Boolean): Boolean = {
     f(this) || elementType.existsRecursively(f)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3014,6 +3014,15 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
       sql("reset")
     }
   }
+
+  test("SPARK-27233 match schema when DF is converted to table") {
+    withTable("testSchema") {
+      val df = Seq(Some(Seq(1L, 2L, 3L)), None).toDF("seq")
+      df.write.format("parquet").saveAsTable("testSchema")
+      val res = sqlContext.table("testSchema")
+      assert(df.schema === res.schema)
+    }
+  }
 }
 
 case class Foo(bar: Option[String])


### PR DESCRIPTION


## What changes were proposed in this pull request?

`ArrayType.asNullable` functions overwrites containsNull to `true`, need to use the existing value

## How was this patch tested?
Added UT
