### PR TITLE
[SPARK-27241][SQL] Support map_keys and map_values in SelectedField

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SelectedField.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SelectedField.scala
@@ -97,6 +97,19 @@ object SelectedField {
         val MapType(keyType, _, valueContainsNull) = child.dataType
         val opt = dataTypeOpt.map(dt => MapType(keyType, dt, valueContainsNull))
         selectField(child, opt)
+      case MapKeys(child) =>
+        val MapType(_, valueType, valueContainsNull) = child.dataType
+        // MapKeys does not select a field from a struct (i.e. prune the struct) so it can't be
+        // the top-level extractor. However it can be part of an extractor chain.
+        val newKeyType = dataTypeOpt match {
+          case None => None
+          case Some(ArrayType(dataType, _)) => Some(dataType)
+          case Some(x) =>
+            // This should not happen.
+            throw new AnalysisException(s"DataType '$x' is not supported by MapKeys.")
+        }
+        val opt = dataTypeOpt.map(dt => MapType(newKeyType.get, valueType, valueContainsNull))
+        selectField(child, opt)
       case GetArrayItem(child, _) =>
         // GetArrayItem does not select a field from a struct (i.e. prune the struct) so it can't be
         // the top-level extractor. However it can be part of an extractor chain.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SelectedField.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SelectedField.scala
@@ -97,18 +97,27 @@ object SelectedField {
         val MapType(keyType, _, valueContainsNull) = child.dataType
         val opt = dataTypeOpt.map(dt => MapType(keyType, dt, valueContainsNull))
         selectField(child, opt)
+      case MapValues(child) =>
+        val MapType(keyType, _, valueContainsNull) = child.dataType
+        // MapValues does not select a field from a struct (i.e. prune the struct) so it can't be
+        // the top-level extractor. However it can be part of an extractor chain.
+        val opt = dataTypeOpt.map {
+          case ArrayType(dataType, _) => MapType(keyType, dataType, valueContainsNull)
+          case x =>
+            // This should not happen.
+            throw new AnalysisException(s"DataType '$x' is not supported by MapValues.")
+        }
+        selectField(child, opt)
       case MapKeys(child) =>
         val MapType(_, valueType, valueContainsNull) = child.dataType
         // MapKeys does not select a field from a struct (i.e. prune the struct) so it can't be
         // the top-level extractor. However it can be part of an extractor chain.
-        val newKeyType = dataTypeOpt match {
-          case None => None
-          case Some(ArrayType(dataType, _)) => Some(dataType)
-          case Some(x) =>
+        val opt = dataTypeOpt.map {
+          case ArrayType(dataType, _) => MapType(dataType, valueType, valueContainsNull)
+          case x =>
             // This should not happen.
             throw new AnalysisException(s"DataType '$x' is not supported by MapKeys.")
         }
-        val opt = dataTypeOpt.map(dt => MapType(newKeyType.get, valueType, valueContainsNull))
         selectField(child, opt)
       case GetArrayItem(child, _) =>
         // GetArrayItem does not select a field from a struct (i.e. prune the struct) so it can't be

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SelectedFieldSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SelectedFieldSuite.scala
@@ -416,30 +416,31 @@ class SelectedFieldSuite extends AnalysisTest {
   //  |    |    |    |    |-- subfield1: integer (nullable = true)
   //  |    |    |    |    |-- subfield2: integer (nullable = true)
   private val mapWithStructKey = StructType(Array(ignoredField,
-    StructField("col2", MapType(StructType(
-      StructField("field1", StringType) ::
+    StructField("col2", MapType(
+      StructType(
+        StructField("field1", StringType) ::
         StructField("field2", IntegerType) :: Nil),
       ArrayType(StructType(
-      StructField("field3", StructType(
-        StructField("subfield1", IntegerType) ::
+        StructField("field3", StructType(
+          StructField("subfield1", IntegerType) ::
           StructField("subfield2", IntegerType) :: Nil)) :: Nil), containsNull = false)))))
 
   testSelect(mapWithStructKey, "map_keys(col2).field1 as foo") {
-    StructField("col2", MapType(StructType(
-      StructField("field1", StringType) :: Nil),
+    StructField("col2", MapType(
+      StructType(StructField("field1", StringType) :: Nil),
       ArrayType(StructType(
         StructField("field3", StructType(
           StructField("subfield1", IntegerType) ::
-            StructField("subfield2", IntegerType) :: Nil)) :: Nil), containsNull = false)))
+          StructField("subfield2", IntegerType) :: Nil)) :: Nil), containsNull = false)))
   }
 
   testSelect(mapWithStructKey, "map_keys(col2).field2 as foo") {
-    StructField("col2", MapType(StructType(
-      StructField("field2", IntegerType) :: Nil),
+    StructField("col2", MapType(
+      StructType(StructField("field2", IntegerType) :: Nil),
       ArrayType(StructType(
         StructField("field3", StructType(
           StructField("subfield1", IntegerType) ::
-            StructField("subfield2", IntegerType) :: Nil)) :: Nil), containsNull = false)))
+          StructField("subfield2", IntegerType) :: Nil)) :: Nil), containsNull = false)))
   }
 
   //  |-- col1: string (nullable = false)
@@ -456,38 +457,36 @@ class SelectedFieldSuite extends AnalysisTest {
   //  |    |    |    |    |-- subfield3: integer (nullable = true)
   //  |    |    |    |    |-- subfield4: integer (nullable = true)
   private val mapWithArrayOfStructKey = StructType(Array(ignoredField,
-    StructField("col2", MapType(ArrayType(
-      StructType(
+    StructField("col2", MapType(
+      ArrayType(StructType(
         StructField("field1", StringType) ::
         StructField("field2", StructType(
           StructField("subfield1", IntegerType) ::
-            StructField("subfield2", LongType) :: Nil
-        )) :: Nil), containsNull = false),
+          StructField("subfield2", LongType) :: Nil)) :: Nil), containsNull = false),
       ArrayType(StructType(
         StructField("field3", StructType(
           StructField("subfield3", IntegerType) ::
-            StructField("subfield4", IntegerType) :: Nil)) :: Nil), containsNull = false)))))
+          StructField("subfield4", IntegerType) :: Nil)) :: Nil), containsNull = false)))))
 
   testSelect(mapWithArrayOfStructKey, "map_keys(col2)[0].field1 as foo") {
-    StructField("col2", MapType(ArrayType(
-      StructType(
+    StructField("col2", MapType(
+      ArrayType(StructType(
         StructField("field1", StringType) :: Nil), containsNull = false),
       ArrayType(StructType(
         StructField("field3", StructType(
           StructField("subfield3", IntegerType) ::
-            StructField("subfield4", IntegerType) :: Nil)) :: Nil), containsNull = false)))
+          StructField("subfield4", IntegerType) :: Nil)) :: Nil), containsNull = false)))
   }
 
   testSelect(mapWithArrayOfStructKey, "map_keys(col2)[0].field2.subfield1 as foo") {
-    StructField("col2", MapType(ArrayType(
-      StructType(
+    StructField("col2", MapType(
+      ArrayType(StructType(
         StructField("field2", StructType(
-          StructField("subfield1", IntegerType) :: Nil
-        )) :: Nil), containsNull = false),
+          StructField("subfield1", IntegerType) :: Nil)) :: Nil), containsNull = false),
       ArrayType(StructType(
         StructField("field3", StructType(
           StructField("subfield3", IntegerType) ::
-            StructField("subfield4", IntegerType) :: Nil)) :: Nil), containsNull = false)))
+          StructField("subfield4", IntegerType) :: Nil)) :: Nil), containsNull = false)))
   }
 
   def assertResult(expected: StructField)(actual: StructField)(selectExpr: String): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`SelectedField` doesn't support map_keys and map_values for now. When map key or value is complex struct, we should be able to prune unnecessary fields from keys/values. This proposes to add map_keys and map_values support to `SelectedField`.

## How was this patch tested?

Added tests.