### PR TITLE
[SPARK-27250][test-maven][BUILD] Scala 2.11 maven compile should target Java 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2031,7 +2031,7 @@
               <arg>-feature</arg>
               <arg>-explaintypes</arg>
               <arg>-Yno-adapted-args</arg>
-              <arg>-target:jvm-${java.version}</arg>
+              <arg>-target:jvm-1.8</arg>
             </args>
             <jvmArgs>
               <jvmArg>-Xms1024m</jvmArg>

--- a/pom.xml
+++ b/pom.xml
@@ -2031,6 +2031,7 @@
               <arg>-feature</arg>
               <arg>-explaintypes</arg>
               <arg>-Yno-adapted-args</arg>
+              <arg>-target:jvm-${java.version}</arg>
             </args>
             <jvmArgs>
               <jvmArg>-Xms1024m</jvmArg>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix Scala 2.11 maven build issue after merging SPARK-26946.

## How was this patch tested?

Maven Scala 2.11 and 2.12 builds with `-Phadoop-provided -Phadoop-2.7 -Pyarn -Phive -Phive-thriftserver`.