### PR TITLE
[SPARK-27258][K8S]Add the prefix 'spark-' for resourceNamePrefix that starts with number

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -78,7 +78,10 @@ private[spark] class KubernetesDriverConf(
 
   override val resourceNamePrefix: String = {
     val custom = if (Utils.isTesting) get(KUBERNETES_DRIVER_POD_NAME_PREFIX) else None
-    custom.getOrElse(KubernetesConf.getResourceNamePrefix(appName))
+    val resourceNamePrefix = custom.getOrElse(KubernetesConf.getResourceNamePrefix(appName))
+    // If the first character of resourceNamePrefix is number,add the extra prefix : "spark-".
+    val prefix = "spark-" + resourceNamePrefix.charAt(0)
+    resourceNamePrefix.replaceAll("^[0-9]", prefix)
   }
 
   override def labels: Map[String, String] = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

For [SPARK-27258](https://issues.apache.org/jira/browse/SPARK-27258)


The value of "spark.app.name" or "--name" starts with number , which causes resourceName does not match regular expression  `[a-z]([-a-z0-9]*[a-z0-9])?)`.

For example : the appName = "1min-machinereg-yf"
Exception :
`
Exception in thread "main" io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: POST at: https://xxx:xxx/api/v1/namespaces/xxx/services. Message: Service "1min-machinereg-yf-1544604108931-driver-svc" is invalid: metadata.name: Invalid value: "1min-machinereg-yf-1544604108931-driver-svc": a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?'). Received status: Status(apiVersion=v1, code=422, details=StatusDetails(causes=[StatusCause(field=metadata.name, message=Invalid value: "1min-machinereg-yf-1544604108931-driver-svc": a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?'), reason=FieldValueInvalid, additionalProperties={})], group=null, kind=Service, name=1min-machinereg-yf-1544604108931-driver-svc, retryAfterSeconds=null, uid=null, additionalProperties={}).
`