### PR TITLE
[SPARK-27253][SQL] Prioritizes parent session's SQLConf over SparkConf when cloning a session

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -85,9 +85,11 @@ abstract class BaseSessionStateBuilder(
    * merged with its [[SparkConf]].
    */
   protected lazy val conf: SQLConf = {
-    val conf = parentState.map(_.conf.clone()).getOrElse(new SQLConf)
-    mergeSparkConf(conf, session.sparkContext.conf)
-    conf
+    parentState.map(_.conf.clone()).getOrElse {
+      val conf = new SQLConf
+      mergeSparkConf(conf, session.sparkContext.conf)
+      conf
+    }
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Cloned session should prioritize `SQLConf` from parent's over `SparkConf`. Currently, when cloning a session, the child session has configuration set in `SparkConf` even when the same properties are set to its parent `SQLConf`.

Currently, when a Spark session is cloned, `mergeSparkConf` in `BaseSessionStateBuilder`'s `conf` overwrites  `SQLConf` values as set in `SparkConf`.

This PR proposes to call `mergeSparkConf` only when the parent session is empty.

See below codes to read.

1. Parent's `sessionState`

https://github.com/apache/spark/blob/c26379b446e90b3104ebe36f288be483f613a652/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala#L268

https://github.com/apache/spark/blob/c26379b446e90b3104ebe36f288be483f613a652/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala#L157-L161

https://github.com/apache/spark/blob/5dab5f651fcf3a9b8c4d6900e45718dc041c54af/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala#L88-L90

2. Child `sessionState`

https://github.com/apache/spark/blob/c26379b446e90b3104ebe36f288be483f613a652/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala#L269

https://github.com/apache/spark/blob/c26379b446e90b3104ebe36f288be483f613a652/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala#L155

https://github.com/apache/spark/blob/c26379b446e90b3104ebe36f288be483f613a652/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala#L102

https://github.com/apache/spark/blob/c26379b446e90b3104ebe36f288be483f613a652/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala#L74

https://github.com/apache/spark/blob/5dab5f651fcf3a9b8c4d6900e45718dc041c54af/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala#L305

https://github.com/apache/spark/blob/5dab5f651fcf3a9b8c4d6900e45718dc041c54af/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala#L283

https://github.com/apache/spark/blob/5dab5f651fcf3a9b8c4d6900e45718dc041c54af/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala#L292

https://github.com/apache/spark/blob/5dab5f651fcf3a9b8c4d6900e45718dc041c54af/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala#L88-L90


## How was this patch tested?
Added UT and with existing Unit Tests.