### PR TITLE
[SPARK-27263][HistoryServer] Hide `Hadoop Properties` table in Environment page if it's empty

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
@@ -84,7 +84,7 @@ private[ui] class EnvironmentPage(
         <div class="aggregated-hadoopProperties collapsible-table collapsed">
           {hadoopPropertiesTable}
         </div>
-         }}
+        }}
         <span class="collapse-aggregated-systemProperties collapse-table"
             onClick="collapseTable('collapse-aggregated-systemProperties',
             'aggregated-systemProperties')">

--- a/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
@@ -72,6 +72,7 @@ private[ui] class EnvironmentPage(
         <div class="aggregated-sparkProperties collapsible-table">
           {sparkPropertiesTable}
         </div>
+        {if (appEnv.hadoopProperties.nonEmpty) {
         <span class="collapse-aggregated-hadoopProperties collapse-table"
               onClick="collapseTable('collapse-aggregated-hadoopProperties',
             'aggregated-hadoopProperties')">
@@ -80,9 +81,10 @@ private[ui] class EnvironmentPage(
             <a>Hadoop Properties</a>
           </h4>
         </span>
-        <div class="aggregated-hadoopProperties collapsible-table collapsed">
-          {hadoopPropertiesTable}
-        </div>
+          <div class="aggregated-hadoopProperties collapsible-table collapsed">
+            {hadoopPropertiesTable}
+          </div>
+         }}
         <span class="collapse-aggregated-systemProperties collapse-table"
             onClick="collapseTable('collapse-aggregated-systemProperties',
             'aggregated-systemProperties')">

--- a/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
@@ -81,9 +81,9 @@ private[ui] class EnvironmentPage(
             <a>Hadoop Properties</a>
           </h4>
         </span>
-          <div class="aggregated-hadoopProperties collapsible-table collapsed">
-            {hadoopPropertiesTable}
-          </div>
+        <div class="aggregated-hadoopProperties collapsible-table collapsed">
+          {hadoopPropertiesTable}
+        </div>
          }}
         <span class="collapse-aggregated-systemProperties collapse-table"
             onClick="collapseTable('collapse-aggregated-systemProperties',


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hadoop Properties in Environment Page is introduced in spark 3.0 version. if we open the older version event log with spark 3.0 history server, hadoop properties tab is showing empty.
To make same as older version, if the hadoop properties table is empty, we are not showing empty table.

## How was this patch tested?
manually tested, added the test snap
Before fix
![Issue](https://user-images.githubusercontent.com/7912929/54879092-0f77a300-4e5b-11e9-901f-2414a7fc4faa.png)

After Fix
![AfterFixing](https://user-images.githubusercontent.com/7912929/54879173-e572b080-4e5b-11e9-85f4-aa3691567c20.png)

Please review http://spark.apache.org/contributing.html before opening a pull request.
