### PR TITLE
[SPARK-27244][CORE] Redact Passwords While Using Option logConf=true

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -606,7 +606,7 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging with Seria
    * configuration out for debugging.
    */
   def toDebugString: String = {
-    getAll.sorted.map{case (k, v) => k + "=" + v}.mkString("\n")
+    Utils.redact(this, getAll).sorted.map { case (k, v) => k + "=" + v }.mkString("\n")
   }
 
 }

--- a/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
@@ -359,9 +359,8 @@ class SparkConfSuite extends SparkFunSuite with LocalSparkContext with ResetSyst
     val conf = new SparkConf().set("dummy.password", "dummy-password")
     conf.validateSettings()
 
-    val debugString = conf.toDebugString
     assert(conf.get("dummy.password") === "dummy-password")
-    assert(debugString.contains(EXPECTED_LOG))
+    assert(conf.toDebugString.contains(EXPECTED_LOG))
   }
 
   val defaultIllegalValue = "SomeIllegalValue"

--- a/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
@@ -355,12 +355,11 @@ class SparkConfSuite extends SparkFunSuite with LocalSparkContext with ResetSyst
   }
 
   test("SPARK-27244 toDebugString should redact passwords") {
-    val EXPECTED_LOG = s"dummy.password=${Utils.REDACTION_REPLACEMENT_TEXT}"
     val conf = new SparkConf().set("dummy.password", "dummy-password")
     conf.validateSettings()
 
     assert(conf.get("dummy.password") === "dummy-password")
-    assert(conf.toDebugString.contains(EXPECTED_LOG))
+    assert(conf.toDebugString.contains(s"dummy.password=${Utils.REDACTION_REPLACEMENT_TEXT}"))
   }
 
   val defaultIllegalValue = "SomeIllegalValue"


### PR DESCRIPTION
## What changes were proposed in this pull request?

When logConf is set to true, config keys that contain password were printed in cleartext in driver log. This change uses the already present redact method in Utils, to redact all the passwords based on redact pattern in SparkConf and then print the conf to driver log thus ensuring that sensitive information like passwords is not printed in clear text. 

## How was this patch tested?
This patch was tested through `SparkConfSuite` & then entire unit test through sbt

Please review http://spark.apache.org/contributing.html before opening a pull request.
