### PR TITLE
[SPARK-27268][SQL] Add map_keys and map_values support in nested schema pruning.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ProjectionOverSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ProjectionOverSchema.scala
@@ -49,6 +49,10 @@ case class ProjectionOverSchema(schema: StructType) {
               s"unmatched child schema for GetArrayStructFields: ${projSchema.toString}"
             )
         }
+      case MapKeys(child) =>
+        getProjection(child).map { projection => MapKeys(projection) }
+      case MapValues(child) =>
+        getProjection(child).map { projection => MapValues(projection) }
       case GetMapValue(child, key) =>
         getProjection(child).map { projection => GetMapValue(projection, key) }
       case GetStructFieldObject(child, field: StructField) =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
@@ -259,15 +259,13 @@ abstract class SchemaPruningSuite
 
   testSchemaPruning("select nested field from a complex map key using map_keys") {
     val query = sql("select map_keys(relations).middle[0], p from contacts")
-    checkScan(query,
-    "struct<relations:map<struct<middle:string>,string>>")
+    checkScan(query, "struct<relations:map<struct<middle:string>,string>>")
     checkAnswer(query, Row("Y.", 1) :: Row("X.", 1) :: Row(null, 2) :: Row(null, 2) :: Nil)
   }
 
   testSchemaPruning("select nested field from a complex map value using map_values") {
     val query = sql("select map_values(relatives).middle[0], p from contacts")
-    checkScan(query,
-      "struct<relatives:map<string,struct<middle:string>>>")
+    checkScan(query, "struct<relatives:map<string,struct<middle:string>>>")
     checkAnswer(query, Row("Y.", 1) :: Row("X.", 1) :: Row(null, 2) :: Row(null, 2) :: Nil)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
@@ -45,7 +45,8 @@ abstract class SchemaPruningSuite
     pets: Int,
     friends: Array[FullName] = Array.empty,
     relatives: Map[String, FullName] = Map.empty,
-    employer: Employer = null)
+    employer: Employer = null,
+    relations: Map[FullName, String] = Map.empty)
 
   val janeDoe = FullName("Jane", "X.", "Doe")
   val johnDoe = FullName("John", "Y.", "Doe")
@@ -56,9 +57,10 @@ abstract class SchemaPruningSuite
 
   val contacts =
     Contact(0, janeDoe, "123 Main Street", 1, friends = Array(susanSmith),
-      relatives = Map("brother" -> johnDoe), employer = employer) ::
+      relatives = Map("brother" -> johnDoe), employer = employer,
+      relations = Map(johnDoe -> "brother")) ::
     Contact(1, johnDoe, "321 Wall Street", 3, relatives = Map("sister" -> janeDoe),
-      employer = employerWithNullCompany) :: Nil
+      employer = employerWithNullCompany, relations = Map(janeDoe -> "sister")) :: Nil
 
   case class Name(first: String, last: String)
   case class BriefContact(id: Int, name: Name, address: String)
@@ -75,13 +77,15 @@ abstract class SchemaPruningSuite
     friends: Array[FullName] = Array(),
     relatives: Map[String, FullName] = Map(),
     employer: Employer = null,
+    relations: Map[FullName, String] = Map(),
     p: Int)
 
   case class BriefContactWithDataPartitionColumn(id: Int, name: Name, address: String, p: Int)
 
   val contactsWithDataPartitionColumn =
-    contacts.map { case Contact(id, name, address, pets, friends, relatives, employer) =>
-      ContactWithDataPartitionColumn(id, name, address, pets, friends, relatives, employer, 1) }
+    contacts.map {case Contact(id, name, address, pets, friends, relatives, employer, relations) =>
+      ContactWithDataPartitionColumn(id, name, address, pets, friends, relatives, employer,
+        relations, 1) }
   val briefContactsWithDataPartitionColumn =
     briefContacts.map { case BriefContact(id, name, address) =>
       BriefContactWithDataPartitionColumn(id, name, address, 2) }
@@ -253,6 +257,20 @@ abstract class SchemaPruningSuite
     checkAnswer(query, Row(1) :: Nil)
   }
 
+  testSchemaPruning("select nested field from a complex map key using map_keys") {
+    val query = sql("select map_keys(relations).middle[0], p from contacts")
+    checkScan(query,
+    "struct<relations:map<struct<middle:string>,string>>")
+    checkAnswer(query, Row("Y.", 1) :: Row("X.", 1) :: Row(null, 2) :: Row(null, 2) :: Nil)
+  }
+
+  testSchemaPruning("select nested field from a complex map value using map_values") {
+    val query = sql("select map_values(relatives).middle[0], p from contacts")
+    checkScan(query,
+      "struct<relatives:map<string,struct<middle:string>>>")
+    checkAnswer(query, Row("Y.", 1) :: Row("X.", 1) :: Row(null, 2) :: Row(null, 2) :: Nil)
+  }
+
   protected def testSchemaPruning(testName: String)(testThunk: => Unit) {
     test(s"Spark vectorized reader - without partition data column - $testName") {
       withSQLConf(vectorizedReaderEnabledKey -> "true") {
@@ -290,7 +308,8 @@ abstract class SchemaPruningSuite
         "`address` STRING,`pets` INT,`friends` ARRAY<STRUCT<`first`: STRING, `middle`: STRING, " +
         "`last`: STRING>>,`relatives` MAP<STRING, STRUCT<`first`: STRING, `middle`: STRING, " +
         "`last`: STRING>>,`employer` STRUCT<`id`: INT, `company`: STRUCT<`name`: STRING, " +
-        "`address`: STRING>>,`p` INT"
+        "`address`: STRING>>,`relations` MAP<STRUCT<`first`: STRING, `middle`: STRING, " +
+        "`last`: STRING>,STRING>,`p` INT"
       spark.read.format(dataSourceName).schema(schema).load(path + "/contacts")
         .createOrReplaceTempView("contacts")
 
@@ -311,7 +330,8 @@ abstract class SchemaPruningSuite
         "`address` STRING,`pets` INT,`friends` ARRAY<STRUCT<`first`: STRING, `middle`: STRING, " +
         "`last`: STRING>>,`relatives` MAP<STRING, STRUCT<`first`: STRING, `middle`: STRING, " +
         "`last`: STRING>>,`employer` STRUCT<`id`: INT, `company`: STRUCT<`name`: STRING, " +
-        "`address`: STRING>>,`p` INT"
+        "`address`: STRING>>,`relations` MAP<STRUCT<`first`: STRING, `middle`: STRING, " +
+        "`last`: STRING>,STRING>,`p` INT"
       spark.read.format(dataSourceName).schema(schema).load(path + "/contacts")
         .createOrReplaceTempView("contacts")
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

We need to add `map_keys` and `map_values` into `ProjectionOverSchema` to support those methods in nested schema pruning. This also adds end-to-end tests to SchemaPruningSuite.

## How was this patch tested?

Added tests.