### PR TITLE
[SPARK-27229][SQL] GroupBy Placement in Intersect Distinct

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1717,6 +1717,11 @@ object SQLConf {
       "and java.sql.Date are used for the same purpose.")
     .booleanConf
     .createWithDefault(false)
+
+  val INTERSECT_WITH_GROUPBY_PLACEMENT = buildConf("spark.sql.intersect.groupby.placement")
+    .doc("When true, group by will be placed under intersect")
+    .booleanConf
+    .createWithDefault(false)
 }
 
 /**
@@ -2162,6 +2167,8 @@ class SQLConf extends Serializable with Logging {
   def setCommandRejectsSparkCoreConfs: Boolean =
     getConf(SQLConf.SET_COMMAND_REJECTS_SPARK_CORE_CONFS)
 
+  def intersectWithGroupByPlacement: Boolean =
+    getConf(INTERSECT_WITH_GROUPBY_PLACEMENT)
   /** ********************** SQLConf functionality methods ************ */
 
   /** Set Spark SQL configuration properties. */


### PR DESCRIPTION
## What changes were proposed in this pull request?

Intersect  operator will be replace by Left Semi Join in Optimizer.

for example:
```
SELECT a1, a2 FROM Tab1 INTERSECT SELECT b1, b2 FROM Tab2
 ==>  SELECT DISTINCT a1, a2 FROM Tab1 LEFT SEMI JOIN Tab2 ON a1<=>b1 AND a2<=>b2
```

if Tabe1 and Tab2 are too large, the join will be very slow, we can reduce the table data before
Join by place groupby operator under join, that is 
```
==>  
SELECT a1, a2 FROM 
   (SELECT a1,a2 FROM Tab1 GROUP BY a1,a2) X
   LEFT SEMI JOIN 
   (SELECT b1,b2 FROM Tab2 GROUP BY b1,b2) Y
ON X.a1<=>Y.b1 AND X.a2<=>Y.b2
```

then we can have smaller table data when execute join, because  group by has cut lots of 
 data.
 
## How was this patch tested?
uinit test added
