### PR TITLE
[SPARK-26288][CORE][FOLLOW-UP][DOC] Fix broken tag in the doc.

### DIFF
--- a/docs/spark-standalone.md
+++ b/docs/spark-standalone.md
@@ -262,7 +262,7 @@ SPARK_WORKER_OPTS supports the following system properties:
   </td>
 </tr>
 <tr>
-  <td><spark.shuffle.service.db.enabled</code></td>
+  <td><code>spark.shuffle.service.db.enabled</code></td>
   <td>true</td>
   <td>
     Store External Shuffle service state on local disk so that when the external shuffle service is restarted, it will


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr is a follow-up of #23393.
The HTML in the doc is broken so fixing the broken `code` tag.

## How was this patch tested?

Existing tests.
