### PR TITLE
[SPARK-27258][K8S]Deal with the k8s resource names that don't match their own regular expression 

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -198,5 +198,6 @@ private[spark] object KubernetesConf {
       .replaceAll("\\.", "-")
       .replaceAll("[^a-z0-9\\-]", "")
       .replaceAll("-+", "-")
+      .replaceAll("^-", "")
   }
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStep.scala
@@ -38,15 +38,21 @@ private[spark] class DriverServiceFeatureStep(
     s"$DRIVER_HOST_KEY is not supported in Kubernetes mode, as the driver's hostname will be " +
       "managed via a Kubernetes service.")
 
+  def isDigit(char: Char) : Boolean = {
+    char >= '0' && char <= '9'
+  }
+
   private val preferredServiceName = s"${kubernetesConf.resourceNamePrefix}$DRIVER_SVC_POSTFIX"
-  private val resolvedServiceName = if (preferredServiceName.length <= MAX_SERVICE_NAME_LENGTH) {
+  private val resolvedServiceName = if (preferredServiceName.length <= MAX_SERVICE_NAME_LENGTH
+    && !isDigit(preferredServiceName.charAt(0))) {
     preferredServiceName
   } else {
     val randomServiceId = KubernetesUtils.uniqueID(clock = clock)
     val shorterServiceName = s"spark-$randomServiceId$DRIVER_SVC_POSTFIX"
     logWarning(s"Driver's hostname would preferably be $preferredServiceName, but this is " +
-      s"too long (must be <= $MAX_SERVICE_NAME_LENGTH characters). Falling back to use " +
-      s"$shorterServiceName as the driver service's name.")
+      s"too long (must be <= $MAX_SERVICE_NAME_LENGTH characters) " +
+      s"or the first character of $preferredServiceName is digit which is not support." +
+      s" Falling back to use $shorterServiceName as the driver service's name.")
     shorterServiceName
   }
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStep.scala
@@ -40,14 +40,14 @@ private[spark] class DriverServiceFeatureStep(
 
   private val preferredServiceName = s"${kubernetesConf.resourceNamePrefix}$DRIVER_SVC_POSTFIX"
   private val resolvedServiceName = if (preferredServiceName.length <= MAX_SERVICE_NAME_LENGTH
-    && !Character.isDigit(preferredServiceName.charAt(0))) {
+    && Character.isLetter(preferredServiceName.charAt(0))) {
     preferredServiceName
   } else {
     val randomServiceId = KubernetesUtils.uniqueID(clock = clock)
     val shorterServiceName = s"spark-$randomServiceId$DRIVER_SVC_POSTFIX"
     logWarning(s"Driver's hostname would preferably be $preferredServiceName, but this is " +
       s"too long (must be <= $MAX_SERVICE_NAME_LENGTH characters) " +
-      s"or the first character of $preferredServiceName is digit which is not support." +
+      s"or the first character of $preferredServiceName is not letter which is not support." +
       s" Falling back to use $shorterServiceName as the driver service's name.")
     shorterServiceName
   }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStep.scala
@@ -38,13 +38,9 @@ private[spark] class DriverServiceFeatureStep(
     s"$DRIVER_HOST_KEY is not supported in Kubernetes mode, as the driver's hostname will be " +
       "managed via a Kubernetes service.")
 
-  def isDigit(char: Char) : Boolean = {
-    char >= '0' && char <= '9'
-  }
-
   private val preferredServiceName = s"${kubernetesConf.resourceNamePrefix}$DRIVER_SVC_POSTFIX"
   private val resolvedServiceName = if (preferredServiceName.length <= MAX_SERVICE_NAME_LENGTH
-    && !isDigit(preferredServiceName.charAt(0))) {
+    && !Character.isDigit(preferredServiceName.charAt(0))) {
     preferredServiceName
   } else {
     val randomServiceId = KubernetesUtils.uniqueID(clock = clock)


### PR DESCRIPTION
## What changes were proposed in this pull request?



The regex of Pod is `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*`.
 The regex of Servive is `^[a-z]([-a-z0-9]*[a-z0-9])?`.
The regex of Secret is `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*`.

If --name=-min, the first character is '-' ,which does not satisfy the regex for Pod ,Service,Secret.
if --name=1min, the first character is digit, which does not satisfy the regex for Service.

