### PR TITLE
[SPARK-27295][GraphX] Provision to provide the initial scores for source nodes while running Personalized Page Rank

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/GraphOps.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/GraphOps.scala
@@ -402,6 +402,15 @@ class GraphOps[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED]) extends Seriali
   }
 
   /**
+   * Run parallel personalized PageRank for a given array of source vertices and initial scores,
+   * such that all random walks are started relative to the source vertices
+   */
+  def staticParallelPersonalizedPageRank(sources: Array[(VertexId, Double)], numIter: Int,
+    resetProb: Double = 0.15) : Graph[Vector, Double] = {
+    PageRank.runParallelPersonalizedPageRank(graph, numIter, resetProb, sources)
+  }
+
+  /**
    * Run Personalized PageRank for a fixed number of iterations with
    * with all iterations originating at the source node
    * returning a graph with vertex attributes

--- a/graphx/src/main/scala/org/apache/spark/graphx/GraphOps.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/GraphOps.scala
@@ -405,6 +405,7 @@ class GraphOps[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED]) extends Seriali
    * Run parallel personalized PageRank for a given array of source vertices and initial scores,
    * such that all random walks are started relative to the source vertices
    */
+  @Since("3.0.0")
   def staticParallelPersonalizedPageRank(sources: Array[(VertexId, Double)], numIter: Int,
     resetProb: Double = 0.15) : Graph[Vector, Double] = {
     PageRank.runParallelPersonalizedPageRank(graph, numIter, resetProb, sources)

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
@@ -231,7 +231,7 @@ object PageRank extends Logging {
       s" but got ${sources.mkString("[", ",", "]")}")
 
     val zero = Vectors.sparse(sources.size, List()).asBreeze
-    // map of vid -> vector where for each vid, the _position of vid in source_ is set to 1.0
+    // map of vid -> vector where for each vid, the _position of vid in source_ is set to provided score
     val sourcesInitMap = sources.zipWithIndex.map { case (vid, i) =>
       val v = Vectors.sparse(sources.size, Array(i), Array(vid._2)).asBreeze
       (vid._1, v)

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
@@ -210,9 +210,8 @@ object PageRank extends Logging {
    *         containing the pagerank relative to all starting nodes (as a sparse vector
    *         indexed by the position of nodes in the sources list) and
    *         edge attributes the normalized edge weight
-   *
-   * @since 3.0.0
    */
+  @Since("3.0.0")
   def runParallelPersonalizedPageRank[VD: ClassTag, ED: ClassTag](
       graph: Graph[VD, ED],
       numIter: Int,

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
@@ -178,7 +178,7 @@ object PageRank extends Logging {
    * @param graph The graph on which to compute personalized pagerank
    * @param numIter The number of iterations to run
    * @param resetProb The random reset probability
-   * @param sources The list of sources to compute personalized pagerank from
+   * @param sources The list of (source, initial score) to compute personalized pagerank from
    * @return the graph with vertex attributes
    *         containing the pagerank relative to all starting nodes (as a sparse vector
    *         indexed by the position of nodes in the sources list) and
@@ -188,7 +188,7 @@ object PageRank extends Logging {
       graph: Graph[VD, ED],
       numIter: Int,
       resetProb: Double = 0.15,
-      sources: Array[VertexId]): Graph[Vector, Double] = {
+      sources: Array[(VertexId, Double)]): Graph[Vector, Double] = {
     require(numIter > 0, s"Number of iterations must be greater than 0," +
       s" but got ${numIter}")
     require(resetProb >= 0 && resetProb <= 1, s"Random reset probability must belong" +
@@ -199,8 +199,8 @@ object PageRank extends Logging {
     val zero = Vectors.sparse(sources.size, List()).asBreeze
     // map of vid -> vector where for each vid, the _position of vid in source_ is set to 1.0
     val sourcesInitMap = sources.zipWithIndex.map { case (vid, i) =>
-      val v = Vectors.sparse(sources.size, Array(i), Array(1.0)).asBreeze
-      (vid, v)
+      val v = Vectors.sparse(sources.size, Array(i), Array(vid._2)).asBreeze
+      (vid._1, v)
     }.toMap
 
     val sc = graph.vertices.sparkContext

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
@@ -224,7 +224,7 @@ object PageRank extends Logging {
       s" but got ${sources.mkString("[", ",", "]")}")
 
     val zero = Vectors.sparse(sources.size, List()).asBreeze
-    // map of vid -> vector where for each vid, the _position of vid in source_ is set to initial score
+    // map of vid -> vector where for each vid, the _position of vid in source_ is initial score
     val sourcesInitMap = sources.zipWithIndex.map { case ((vid, score), i) =>
       val v = Vectors.sparse(sources.size, Array(i), Array(score)).asBreeze
       (vid, v)

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
@@ -210,6 +210,8 @@ object PageRank extends Logging {
    *         containing the pagerank relative to all starting nodes (as a sparse vector
    *         indexed by the position of nodes in the sources list) and
    *         edge attributes the normalized edge weight
+   *
+   * @since 3.0.0
    */
   def runParallelPersonalizedPageRank[VD: ClassTag, ED: ClassTag](
       graph: Graph[VD, ED],

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
@@ -178,6 +178,40 @@ object PageRank extends Logging {
    * @param graph The graph on which to compute personalized pagerank
    * @param numIter The number of iterations to run
    * @param resetProb The random reset probability
+   * @param sources The list of sources to compute personalized pagerank from
+   * @return the graph with vertex attributes
+   *         containing the pagerank relative to all starting nodes (as a sparse vector
+   *         indexed by the position of nodes in the sources list) and
+   *         edge attributes the normalized edge weight
+   */
+  def runParallelPersonalizedPageRank[VD: ClassTag, ED: ClassTag](
+      graph: Graph[VD, ED],
+      numIter: Int,
+      resetProb: Double = 0.15,
+      sources: Array[VertexId]): Graph[Vector, Double] = {
+    require(numIter > 0, s"Number of iterations must be greater than 0," +
+      s" but got ${numIter}")
+    require(resetProb >= 0 && resetProb <= 1, s"Random reset probability must belong" +
+      s" to [0, 1], but got ${resetProb}")
+    require(sources.nonEmpty, s"The list of sources must be non-empty," +
+      s" but got ${sources.mkString("[", ",", "]")}")
+
+    val sourcesWithScores = sources zip Array.fill(sources.size)(1.0)
+    runParallelPersonalizedPageRank(graph, numIter, resetProb, sourcesWithScores)
+  }
+
+  /**
+   * Run Personalized PageRank for a fixed number of iterations, for a
+   * set of starting nodes in parallel. Returns a graph with vertex attributes
+   * containing the pagerank relative to all starting nodes (as a sparse vector) and
+   * edge attributes the normalized edge weight
+   *
+   * @tparam VD The original vertex attribute (not used)
+   * @tparam ED The original edge attribute (not used)
+   *
+   * @param graph The graph on which to compute personalized pagerank
+   * @param numIter The number of iterations to run
+   * @param resetProb The random reset probability
    * @param sources The list of (source, initial score) to compute personalized pagerank from
    * @return the graph with vertex attributes
    *         containing the pagerank relative to all starting nodes (as a sparse vector


### PR DESCRIPTION
## What changes were proposed in this pull request?

The present implementation of parallel personalized page rank algorithm takes only node ids as the starting nodes for algorithm. And then it assigns initial value of 1.0 to all those source nodes.

But the user might also be interested in specifying the initial values for each node.