### PR TITLE
[SPARK-27319][SQL] Filter out dir based on PathFilter before listing them

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -168,7 +168,7 @@ object InMemoryFileIndex extends Logging {
       filter: PathFilter,
       sparkSession: SparkSession): Seq[(Path, Seq[FileStatus])] = {
     // Filter out the directory before listing it leaf files
-    val filteredPaths = paths.filter(filter.accept(_))
+    val filteredPaths = paths.filter(filter.accept)
 
     // Short-circuits parallel listing when serial listing is likely to be faster.
     if (filteredPaths.size <= sparkSession.sessionState.conf.parallelPartitionDiscoveryThreshold) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -295,8 +295,12 @@ object InMemoryFileIndex extends Logging {
         case Some(session) =>
           bulkListLeafFiles(dirs.map(_.getPath), hadoopConf, filter, session).flatMap(_._2)
         case _ =>
-          dirs.filter(fileStatus => filter.accept(fileStatus.getPath))
-            .flatMap(dir => listLeafFiles(dir.getPath, hadoopConf, filter, sessionOpt))
+          val filteredDirs = if (filter != null) {
+            dirs.filter(fileStatus => filter.accept(fileStatus.getPath))
+          } else {
+            dirs
+          }
+          filteredDirs.flatMap(dir => listLeafFiles(dir.getPath, hadoopConf, filter, sessionOpt))
       }
       val allFiles = topLevelFiles ++ nestedFiles
       if (filter != null) allFiles.filter(f => filter.accept(f.getPath)) else allFiles

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -168,7 +168,11 @@ object InMemoryFileIndex extends Logging {
       filter: PathFilter,
       sparkSession: SparkSession): Seq[(Path, Seq[FileStatus])] = {
     // Filter out the directory before listing it leaf files
-    val filteredPaths = paths.filter(filter.accept)
+    val filteredPaths = if (filter != null) {
+      paths.filter(filter.accept)
+    } else {
+      paths
+    }
 
     // Short-circuits parallel listing when serial listing is likely to be faster.
     if (filteredPaths.size <= sparkSession.sessionState.conf.parallelPartitionDiscoveryThreshold) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -60,8 +60,8 @@ class FileIndexSuite extends SharedSQLContext {
       val schema = StructType(Seq(StructField("a", StringType, false)))
       val fileIndex = new InMemoryFileIndex(spark, Seq(path), Map.empty, Some(schema))
       val partitionValues = fileIndex.partitionSpec().partitions.map(_.values)
-      assert(partitionValues.length == 1 && partitionValues(0).numFields == 1 &&
-        partitionValues(0).getString(0) == "4d")
+      assert(partitionValues.length === 1 && partitionValues(0).numFields === 1 &&
+        partitionValues(0).getString(0) === "4d")
     }
   }
 
@@ -75,7 +75,8 @@ class FileIndexSuite extends SharedSQLContext {
       val schema = StructType(Seq(StructField("A", StringType, false)))
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
         val fileIndex = new InMemoryFileIndex(spark, Seq(path), Map.empty, Some(schema))
-        assert(fileIndex.partitionSchema.length == 1 && fileIndex.partitionSchema.head.name == "A")
+        assert(fileIndex.partitionSchema.length === 1 &&
+          fileIndex.partitionSchema.head.name === "A")
       }
     }
   }
@@ -95,7 +96,7 @@ class FileIndexSuite extends SharedSQLContext {
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
         val fileIndex = new InMemoryFileIndex(spark, Seq(path), Map.empty, None)
         val partitionValues = fileIndex.partitionSpec().partitions.map(_.values)
-        assert(partitionValues.length == 2)
+        assert(partitionValues.length === 2)
       }
 
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
@@ -123,13 +124,13 @@ class FileIndexSuite extends SharedSQLContext {
         val msg = intercept[RuntimeException] {
           fileIndex.partitionSpec()
         }.getMessage
-        assert(msg == "Failed to cast value `foo` to `IntegerType` for partition column `a`")
+        assert(msg === "Failed to cast value `foo` to `IntegerType` for partition column `a`")
       }
 
       withSQLConf(SQLConf.VALIDATE_PARTITION_COLUMNS.key -> "false") {
         val fileIndex = new InMemoryFileIndex(spark, Seq(path), Map.empty, Some(schema))
         val partitionValues = fileIndex.partitionSpec().partitions.map(_.values)
-        assert(partitionValues.length == 1 && partitionValues(0).numFields == 1 &&
+        assert(partitionValues.length === 1 && partitionValues(0).numFields === 1 &&
           partitionValues(0).isNullAt(0))
       }
     }
@@ -180,9 +181,9 @@ class FileIndexSuite extends SharedSQLContext {
           new Path(tmp.getCanonicalPath)
         }
         HiveCatalogMetrics.reset()
-        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() == 0)
+        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() === 0)
         new InMemoryFileIndex(spark, topLevelDirs, Map.empty, None)
-        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() == expectedNumPar)
+        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() === expectedNumPar)
       }
     }
   }
@@ -194,9 +195,9 @@ class FileIndexSuite extends SharedSQLContext {
           new File(dir, s"foo=$i.txt").mkdir()
         }
         HiveCatalogMetrics.reset()
-        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() == 0)
+        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() === 0)
         new InMemoryFileIndex(spark, Seq(new Path(dir.getCanonicalPath)), Map.empty, None)
-        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() == expectedNumPar)
+        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() === expectedNumPar)
       }
     }
   }
@@ -216,9 +217,9 @@ class FileIndexSuite extends SharedSQLContext {
           }
         }
         HiveCatalogMetrics.reset()
-        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() == 0)
+        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() === 0)
         new InMemoryFileIndex(spark, Seq(new Path(dir.getCanonicalPath)), Map.empty, None)
-        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() == expectedNumPar)
+        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() === expectedNumPar)
       }
     }
   }
@@ -301,11 +302,11 @@ class FileIndexSuite extends SharedSQLContext {
 
       catalog.refresh()
 
-      assert(catalog.leafFilePaths.size == 1)
-      assert(catalog.leafFilePaths.head == fs.makeQualified(new Path(file.getAbsolutePath)))
+      assert(catalog.leafFilePaths.size === 1)
+      assert(catalog.leafFilePaths.head === fs.makeQualified(new Path(file.getAbsolutePath)))
 
-      assert(catalog.leafDirPaths.size == 1)
-      assert(catalog.leafDirPaths.head == fs.makeQualified(dirPath))
+      assert(catalog.leafDirPaths.size === 1)
+      assert(catalog.leafDirPaths.head === fs.makeQualified(dirPath))
     }
   }
 
@@ -331,7 +332,7 @@ class FileIndexSuite extends SharedSQLContext {
         .range(1)
         .select(col("id").as(colToUnescape), col("id"))
         .write.partitionBy(colToUnescape).parquet(path.getAbsolutePath)
-      assert(spark.read.parquet(path.getAbsolutePath).schema.exists(_.name == colToUnescape))
+      assert(spark.read.parquet(path.getAbsolutePath).schema.exists(_.name === colToUnescape))
     }
   }
 
@@ -349,7 +350,7 @@ class FileIndexSuite extends SharedSQLContext {
         val blockLocations = inMemoryFileIndex.leafFileStatuses.flatMap(
           _.asInstanceOf[LocatedFileStatus].getBlockLocations)
 
-        assert(blockLocations.forall(_.getClass == classOf[BlockLocation]))
+        assert(blockLocations.forall(_.getClass === classOf[BlockLocation]))
       }
     }
   }
@@ -388,10 +389,10 @@ class FileIndexSuite extends SharedSQLContext {
             file.mkdir()
           }
           HiveCatalogMetrics.reset()
-          assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() == 0)
+          assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() === 0)
           new InMemoryFileIndex(spark, Seq(new Path(dir.getCanonicalPath)), Map.empty, None)
 
-          assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() == expectedNumPar)
+          assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() === expectedNumPar)
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -60,8 +60,8 @@ class FileIndexSuite extends SharedSQLContext {
       val schema = StructType(Seq(StructField("a", StringType, false)))
       val fileIndex = new InMemoryFileIndex(spark, Seq(path), Map.empty, Some(schema))
       val partitionValues = fileIndex.partitionSpec().partitions.map(_.values)
-      assert(partitionValues.length === 1 && partitionValues(0).numFields === 1 &&
-        partitionValues(0).getString(0) === "4d")
+      assert(partitionValues.length == 1 && partitionValues(0).numFields == 1 &&
+        partitionValues(0).getString(0) == "4d")
     }
   }
 
@@ -75,8 +75,7 @@ class FileIndexSuite extends SharedSQLContext {
       val schema = StructType(Seq(StructField("A", StringType, false)))
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
         val fileIndex = new InMemoryFileIndex(spark, Seq(path), Map.empty, Some(schema))
-        assert(fileIndex.partitionSchema.length === 1 &&
-          fileIndex.partitionSchema.head.name === "A")
+        assert(fileIndex.partitionSchema.length == 1 && fileIndex.partitionSchema.head.name == "A")
       }
     }
   }
@@ -96,7 +95,7 @@ class FileIndexSuite extends SharedSQLContext {
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
         val fileIndex = new InMemoryFileIndex(spark, Seq(path), Map.empty, None)
         val partitionValues = fileIndex.partitionSpec().partitions.map(_.values)
-        assert(partitionValues.length === 2)
+        assert(partitionValues.length == 2)
       }
 
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
@@ -124,13 +123,13 @@ class FileIndexSuite extends SharedSQLContext {
         val msg = intercept[RuntimeException] {
           fileIndex.partitionSpec()
         }.getMessage
-        assert(msg === "Failed to cast value `foo` to `IntegerType` for partition column `a`")
+        assert(msg == "Failed to cast value `foo` to `IntegerType` for partition column `a`")
       }
 
       withSQLConf(SQLConf.VALIDATE_PARTITION_COLUMNS.key -> "false") {
         val fileIndex = new InMemoryFileIndex(spark, Seq(path), Map.empty, Some(schema))
         val partitionValues = fileIndex.partitionSpec().partitions.map(_.values)
-        assert(partitionValues.length === 1 && partitionValues(0).numFields === 1 &&
+        assert(partitionValues.length == 1 && partitionValues(0).numFields == 1 &&
           partitionValues(0).isNullAt(0))
       }
     }
@@ -181,9 +180,9 @@ class FileIndexSuite extends SharedSQLContext {
           new Path(tmp.getCanonicalPath)
         }
         HiveCatalogMetrics.reset()
-        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() === 0)
+        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() == 0)
         new InMemoryFileIndex(spark, topLevelDirs, Map.empty, None)
-        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() === expectedNumPar)
+        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() == expectedNumPar)
       }
     }
   }
@@ -195,9 +194,9 @@ class FileIndexSuite extends SharedSQLContext {
           new File(dir, s"foo=$i.txt").mkdir()
         }
         HiveCatalogMetrics.reset()
-        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() === 0)
+        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() == 0)
         new InMemoryFileIndex(spark, Seq(new Path(dir.getCanonicalPath)), Map.empty, None)
-        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() === expectedNumPar)
+        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() == expectedNumPar)
       }
     }
   }
@@ -217,9 +216,9 @@ class FileIndexSuite extends SharedSQLContext {
           }
         }
         HiveCatalogMetrics.reset()
-        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() === 0)
+        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() == 0)
         new InMemoryFileIndex(spark, Seq(new Path(dir.getCanonicalPath)), Map.empty, None)
-        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() === expectedNumPar)
+        assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() == expectedNumPar)
       }
     }
   }
@@ -302,11 +301,11 @@ class FileIndexSuite extends SharedSQLContext {
 
       catalog.refresh()
 
-      assert(catalog.leafFilePaths.size === 1)
-      assert(catalog.leafFilePaths.head === fs.makeQualified(new Path(file.getAbsolutePath)))
+      assert(catalog.leafFilePaths.size == 1)
+      assert(catalog.leafFilePaths.head == fs.makeQualified(new Path(file.getAbsolutePath)))
 
-      assert(catalog.leafDirPaths.size === 1)
-      assert(catalog.leafDirPaths.head === fs.makeQualified(dirPath))
+      assert(catalog.leafDirPaths.size == 1)
+      assert(catalog.leafDirPaths.head == fs.makeQualified(dirPath))
     }
   }
 
@@ -332,7 +331,7 @@ class FileIndexSuite extends SharedSQLContext {
         .range(1)
         .select(col("id").as(colToUnescape), col("id"))
         .write.partitionBy(colToUnescape).parquet(path.getAbsolutePath)
-      assert(spark.read.parquet(path.getAbsolutePath).schema.exists(_.name === colToUnescape))
+      assert(spark.read.parquet(path.getAbsolutePath).schema.exists(_.name == colToUnescape))
     }
   }
 
@@ -350,7 +349,7 @@ class FileIndexSuite extends SharedSQLContext {
         val blockLocations = inMemoryFileIndex.leafFileStatuses.flatMap(
           _.asInstanceOf[LocatedFileStatus].getBlockLocations)
 
-        assert(blockLocations.forall(_.getClass === classOf[BlockLocation]))
+        assert(blockLocations.forall(_.getClass == classOf[BlockLocation]))
       }
     }
   }
@@ -389,10 +388,10 @@ class FileIndexSuite extends SharedSQLContext {
             file.mkdir()
           }
           HiveCatalogMetrics.reset()
-          assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() === 0)
+          assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() == 0)
           new InMemoryFileIndex(spark, Seq(new Path(dir.getCanonicalPath)), Map.empty, None)
 
-          assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() === expectedNumPar)
+          assert(HiveCatalogMetrics.METRIC_PARALLEL_LISTING_JOB_COUNT.getCount() == expectedNumPar)
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -371,8 +371,8 @@ class FileIndexSuite extends SharedSQLContext {
           def leafFilePaths: Seq[Path] = leafFiles.keys.toSeq
         }
         val leafFiles = inMemoryFileIndex.leafFilePaths
-        assert(leafFiles.size === 1)
-        assert(leafFiles.head.toUri.getPath === file1.getCanonicalPath)
+        assert(leafFiles.size == 1)
+        assert(leafFiles.head.toUri.getPath == file1.getCanonicalPath)
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `InMemoryFileIndex`, we should filter out dir based on PathFilter before listing them. This is useful in the following case: Consider we have the following data:
```
hdfs://name:port/root-dir/timestamp=2019-01-01/***
hdfs://name:port/root-dir/timestamp=2019-01-02/***
....
hdfs://name:port/root-dir/timestamp=2019-03-04/***
```
We can set a PathFilter when the only part of directories' data is needed. Before this patch, we may need to trigger a Spark job or many local threads to listing all the directories. After patch, we can filter out the directories before listing them.

## How was this patch tested?

Added new UT tests.
