### PR TITLE
[SPARK-27320][SQL]Replacing index with iterator to traverse the expressions list in AggregationIterator, which make it simpler

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggregationIterator.scala
@@ -74,8 +74,7 @@ abstract class AggregationIterator(
       startingInputBufferOffset: Int): Array[AggregateFunction] = {
     var mutableBufferOffset = 0
     var inputBufferOffset: Int = startingInputBufferOffset
-    val expressionsLength = expressions.length
-    val functions = new Array[AggregateFunction](expressionsLength)
+    val functions = new Array[AggregateFunction](expressions.length)
     var i = 0
     val inputAttributeSeq: AttributeSeq = inputAttributes
     for (expression <- expressions)  {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggregationIterator.scala
@@ -70,10 +70,11 @@ abstract class AggregationIterator(
   // Initialize all AggregateFunctions by binding references if necessary,
   // and set inputBufferOffset and mutableBufferOffset.
   protected def initializeAggregateFunctions(
-      expressions: Seq[AggregateExpression],
+      aggExpressions: Seq[AggregateExpression],
       startingInputBufferOffset: Int): Array[AggregateFunction] = {
     var mutableBufferOffset = 0
     var inputBufferOffset: Int = startingInputBufferOffset
+    val expressions = aggExpressions.toArray
     val expressionsLength = expressions.length
     val functions = new Array[AggregateFunction](expressionsLength)
     var i = 0
@@ -153,10 +154,11 @@ abstract class AggregationIterator(
 
   // Initializing functions used to process a row.
   protected def generateProcessRow(
-      expressions: Seq[AggregateExpression],
+      aggExpressions: Seq[AggregateExpression],
       functions: Seq[AggregateFunction],
       inputAttributes: Seq[Attribute]): (InternalRow, InternalRow) => Unit = {
     val joinedRow = new JoinedRow
+    val expressions = aggExpressions.toArray
     if (expressions.nonEmpty) {
       val mergeExpressions = functions.zipWithIndex.flatMap {
         case (ae: DeclarativeAggregate, i) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggregationIterator.scala
@@ -77,7 +77,7 @@ abstract class AggregationIterator(
     val functions = new Array[AggregateFunction](expressions.length)
     var i = 0
     val inputAttributeSeq: AttributeSeq = inputAttributes
-    for (expression <- expressions)  {
+    for (expression <- expressions) {
       val func = expression.aggregateFunction
       val funcWithBoundReferences: AggregateFunction = expression.mode match {
         case Partial | Complete if func.isInstanceOf[ImperativeAggregate] =>


### PR DESCRIPTION
## What changes were proposed in this pull request?
In AggregationIterator's loop function, we access the expressions by `expressions(i)`, the type of `expressions` is `::`, a subtype of list. 

```
while (i < expressionsLength) {
      val func = expressions(i).aggregateFunction
```


This PR replacing  index with iterator to access the expressions list, which make it simpler.



## How was this patch tested?
Existing tests.