### PR TITLE
[SPARK-27121][REPL] Resolve Scala compiler failure for Java 9+ in REPL

### DIFF
--- a/repl/src/test/scala/org/apache/spark/repl/ReplSuite.scala
+++ b/repl/src/test/scala/org/apache/spark/repl/ReplSuite.scala
@@ -20,7 +20,6 @@ package org.apache.spark.repl
 import java.io._
 import java.net.URLClassLoader
 
-import scala.collection.mutable.ArrayBuffer
 import scala.tools.nsc.interpreter.SimpleReader
 
 import org.apache.log4j.{Level, LogManager}
@@ -34,33 +33,33 @@ class ReplSuite extends SparkFunSuite {
   def runInterpreter(master: String, input: String): String = {
     val CONF_EXECUTOR_CLASSPATH = "spark.executor.extraClassPath"
 
-    val in = new BufferedReader(new StringReader(input + "\n"))
-    val out = new StringWriter()
+
     val cl = getClass.getClassLoader
-    var paths = new ArrayBuffer[String]
-    if (cl.isInstanceOf[URLClassLoader]) {
-      val urlLoader = cl.asInstanceOf[URLClassLoader]
-      for (url <- urlLoader.getURLs) {
-        if (url.getProtocol == "file") {
-          paths += url.getFile
-        }
-      }
-    }
-    val classpath = paths.map(new File(_).getAbsolutePath).mkString(File.pathSeparator)
 
     val oldExecutorClasspath = System.getProperty(CONF_EXECUTOR_CLASSPATH)
-    System.setProperty(CONF_EXECUTOR_CLASSPATH, classpath)
+    if (oldExecutorClasspath == null) {
+      System.clearProperty(CONF_EXECUTOR_CLASSPATH)
+    } else {
+      System.setProperty(CONF_EXECUTOR_CLASSPATH, oldExecutorClasspath)
+    }
+
+    val classpath = cl match {
+      case urlLoader: URLClassLoader =>
+        val paths = urlLoader.getURLs.filter(_.getProtocol == "file").map(_.getFile)
+        val classpath = paths.map(new File(_).getAbsolutePath).mkString(File.pathSeparator)
+        System.setProperty(CONF_EXECUTOR_CLASSPATH, classpath)
+        classpath
+      case _ => System.getProperty("java.class.path")
+    }
+
     Main.sparkContext = null
     Main.sparkSession = null // causes recreation of SparkContext for each test.
     Main.conf.set("spark.master", master)
-    Main.doMain(Array("-classpath", classpath), new SparkILoop(in, new PrintWriter(out)))
 
-    if (oldExecutorClasspath != null) {
-      System.setProperty(CONF_EXECUTOR_CLASSPATH, oldExecutorClasspath)
-    } else {
-      System.clearProperty(CONF_EXECUTOR_CLASSPATH)
-    }
-    return out.toString
+    val in = new BufferedReader(new StringReader(input + "\n"))
+    val out = new StringWriter()
+    Main.doMain(Array("-classpath", classpath), new SparkILoop(in, new PrintWriter(out)))
+    out.toString
   }
 
   // Simulate the paste mode in Scala REPL.

--- a/repl/src/test/scala/org/apache/spark/repl/SingletonReplSuite.scala
+++ b/repl/src/test/scala/org/apache/spark/repl/SingletonReplSuite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.repl
 
 import java.io._
-import java.net.URLClassLoader
 
 import org.apache.commons.lang3.StringEscapeUtils
 
@@ -40,16 +39,8 @@ class SingletonReplSuite extends SparkFunSuite {
   override def beforeAll(): Unit = {
     super.beforeAll()
 
-    val cl = getClass.getClassLoader
-
-    val classpath = cl match {
-      case urlLoader: URLClassLoader =>
-        val paths = urlLoader.getURLs.filter(_.getProtocol == "file").map(_.getFile)
-        val classpath = paths.map(new File(_).getAbsolutePath).mkString(File.pathSeparator)
-        System.setProperty(CONF_EXECUTOR_CLASSPATH, classpath)
-        classpath
-      case _ => System.getProperty("java.class.path")
-    }
+    val classpath = System.getProperty("java.class.path")
+    System.setProperty(CONF_EXECUTOR_CLASSPATH, classpath)
 
     Main.conf.set("spark.master", "local-cluster[2,1,1024]")
     val interp = new SparkILoop(

--- a/repl/src/test/scala/org/apache/spark/repl/SingletonReplSuite.scala
+++ b/repl/src/test/scala/org/apache/spark/repl/SingletonReplSuite.scala
@@ -20,8 +20,6 @@ package org.apache.spark.repl
 import java.io._
 import java.net.URLClassLoader
 
-import scala.collection.mutable.ArrayBuffer
-
 import org.apache.commons.lang3.StringEscapeUtils
 
 import org.apache.spark.SparkFunSuite
@@ -43,18 +41,16 @@ class SingletonReplSuite extends SparkFunSuite {
     super.beforeAll()
 
     val cl = getClass.getClassLoader
-    var paths = new ArrayBuffer[String]
-    if (cl.isInstanceOf[URLClassLoader]) {
-      val urlLoader = cl.asInstanceOf[URLClassLoader]
-      for (url <- urlLoader.getURLs) {
-        if (url.getProtocol == "file") {
-          paths += url.getFile
-        }
-      }
-    }
-    val classpath = paths.map(new File(_).getAbsolutePath).mkString(File.pathSeparator)
 
-    System.setProperty(CONF_EXECUTOR_CLASSPATH, classpath)
+    val classpath = cl match {
+      case urlLoader: URLClassLoader =>
+        val paths = urlLoader.getURLs.filter(_.getProtocol == "file").map(_.getFile)
+        val classpath = paths.map(new File(_).getAbsolutePath).mkString(File.pathSeparator)
+        System.setProperty(CONF_EXECUTOR_CLASSPATH, classpath)
+        classpath
+      case _ => System.getProperty("java.class.path")
+    }
+
     Main.conf.set("spark.master", "local-cluster[2,1,1024]")
     val interp = new SparkILoop(
       new BufferedReader(new InputStreamReader(new PipedInputStream(in))),


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid trying to extract the classpath of the environment from a URLClassLoader in Java 11, as the default classloader isn't one. Use `java.class.path` instead.

## How was this patch tested?

Existing tests, manually tested under Java 11.