### PR TITLE
[SPARK-27267][CORE] Update snappy to avoid error when decompressing empty serialized data

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -182,7 +182,7 @@ slf4j-api-1.7.16.jar
 slf4j-log4j12-1.7.16.jar
 snakeyaml-1.23.jar
 snappy-0.2.jar
-snappy-java-1.1.7.1.jar
+snappy-java-1.1.7.3.jar
 spire-macros_2.12-0.13.0.jar
 spire_2.12-0.13.0.jar
 stax-api-1.0-2.jar

--- a/dev/deps/spark-deps-hadoop-3.2
+++ b/dev/deps/spark-deps-hadoop-3.2
@@ -202,7 +202,7 @@ slf4j-api-1.7.16.jar
 slf4j-log4j12-1.7.16.jar
 snakeyaml-1.23.jar
 snappy-0.2.jar
-snappy-java-1.1.7.1.jar
+snappy-java-1.1.7.3.jar
 spire-macros_2.12-0.13.0.jar
 spire_2.12-0.13.0.jar
 stax-api-1.0.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
     <scalafmt.skip>true</scalafmt.skip>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
     <fasterxml.jackson.version>2.9.8</fasterxml.jackson.version>
-    <snappy.version>1.1.7.1</snappy.version>
+    <snappy.version>1.1.7.3</snappy.version>
     <netlib.java.version>1.1.2</netlib.java.version>
     <commons-codec.version>1.10</commons-codec.version>
     <commons-io.version>2.4</commons-io.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

(See JIRA for problem statement)

Update snappy 1.1.7.1 -> 1.1.7.3 to pick up an empty-stream and Java 9 fix.

There appear to be no other changes of consequence:
https://github.com/xerial/snappy-java/blob/master/Milestone.md

## How was this patch tested?

Existing tests