### PR TITLE
[SPARK-27325][SQL] Add implicit encoders for LocalDate and Instant

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoders.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoders.scala
@@ -111,7 +111,7 @@ object Encoders {
 
   /**
    * Creates an encoder that serializes instances of the `java.time.LocalDate` class
-   * to the internal representation of Catalyst's DateType.
+   * to the internal representation of nullable Catalyst's DateType.
    *
    * @since 3.0.0
    */
@@ -126,7 +126,7 @@ object Encoders {
 
   /**
    * Creates an encoder that serializes instances of the `java.time.Instant` class
-   * to the internal representation of Catalyst's TimestampType.
+   * to the internal representation of nullable Catalyst's TimestampType.
    *
    * @since 3.0.0
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoders.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoders.scala
@@ -110,7 +110,8 @@ object Encoders {
   def DATE: Encoder[java.sql.Date] = ExpressionEncoder()
 
   /**
-   * An encoder for nullable date type.
+   * Creates an encoder that serializes instances of the `java.time.LocalDate` class
+   * to the internal representation of Catalyst's DateType.
    *
    * @since 3.0.0
    */
@@ -124,7 +125,8 @@ object Encoders {
   def TIMESTAMP: Encoder[java.sql.Timestamp] = ExpressionEncoder()
 
   /**
-   * An encoder for nullable timestamp type.
+   * Creates an encoder that serializes instances of the `java.time.Instant` class
+   * to the internal representation of Catalyst's TimestampType.
    *
    * @since 3.0.0
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoders.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoders.scala
@@ -110,11 +110,25 @@ object Encoders {
   def DATE: Encoder[java.sql.Date] = ExpressionEncoder()
 
   /**
+   * An encoder for nullable date type.
+   *
+   * @since 3.0.0
+   */
+  def LOCALDATE: Encoder[java.time.LocalDate] = ExpressionEncoder()
+
+  /**
    * An encoder for nullable timestamp type.
    *
    * @since 1.6.0
    */
   def TIMESTAMP: Encoder[java.sql.Timestamp] = ExpressionEncoder()
+
+  /**
+   * An encoder for nullable timestamp type.
+   *
+   * @since 3.0.0
+   */
+  def INSTANT: Encoder[java.time.Instant] = ExpressionEncoder()
 
   /**
    * An encoder for arrays of bytes.

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
@@ -81,9 +81,14 @@ abstract class SQLImplicits extends LowPrioritySQLImplicits {
   /** @since 2.2.0 */
   implicit def newDateEncoder: Encoder[java.sql.Date] = Encoders.DATE
 
+  /** @since 3.0.0 */
+  implicit def newLocalDateEncoder: Encoder[java.time.LocalDate] = Encoders.LOCALDATE
+
   /** @since 2.2.0 */
   implicit def newTimeStampEncoder: Encoder[java.sql.Timestamp] = Encoders.TIMESTAMP
 
+  /** @since 3.0.0 */
+  implicit def newInstantEncoder: Encoder[java.time.Instant] = Encoders.INSTANT
 
   // Boxed primitives
 

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -21,6 +21,8 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.util.*;
 
 import org.apache.spark.sql.streaming.GroupStateTimeout;
@@ -396,6 +398,16 @@ public class JavaDatasetSuite implements Serializable {
           Date.valueOf("1970-01-01"), new Timestamp(System.currentTimeMillis()), Float.MAX_VALUE));
     Dataset<Tuple5<Double, BigDecimal, Date, Timestamp, Float>> ds =
       spark.createDataset(data, encoder);
+    Assert.assertEquals(data, ds.collectAsList());
+  }
+
+  @Test
+  public void testLocalDateAndInstantEncoders() {
+    Encoder<Tuple2<LocalDate, Instant>> encoder =
+      Encoders.tuple(Encoders.LOCALDATE(), Encoders.INSTANT());
+    List<Tuple2<LocalDate, Instant>> data =
+            Arrays.asList(new Tuple2<>(LocalDate.ofEpochDay(0), Instant.ofEpochSecond(0)));
+    Dataset<Tuple2<LocalDate, Instant>> ds = spark.createDataset(data, encoder);
     Assert.assertEquals(data, ds.collectAsList());
   }
 

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -406,7 +406,7 @@ public class JavaDatasetSuite implements Serializable {
     Encoder<Tuple2<LocalDate, Instant>> encoder =
       Encoders.tuple(Encoders.LOCALDATE(), Encoders.INSTANT());
     List<Tuple2<LocalDate, Instant>> data =
-            Arrays.asList(new Tuple2<>(LocalDate.ofEpochDay(0), Instant.ofEpochSecond(0)));
+      Arrays.asList(new Tuple2<>(LocalDate.ofEpochDay(0), Instant.ofEpochSecond(0)));
     Dataset<Tuple2<LocalDate, Instant>> ds = spark.createDataset(data, encoder);
     Assert.assertEquals(data, ds.collectAsList());
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1733,10 +1733,10 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
 
   test("implicit encoder for LocalDate and Instant") {
     val localDate = java.time.LocalDate.of(2019, 3, 30)
-    assert(spark.range(1).map { _ => localDate }.head == localDate)
+    assert(spark.range(1).map { _ => localDate }.head === localDate)
 
     val instant = java.time.Instant.parse("2019-03-30T09:54:00Z")
-    assert(spark.range(1).map { _ => instant }.head == instant)
+    assert(spark.range(1).map { _ => instant }.head === instant)
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1730,6 +1730,11 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     def assertExecutionId: UserDefinedFunction = udf(AssertExecutionId.apply _)
     spark.range(10).select(assertExecutionId($"id")).localCheckpoint(true)
   }
+
+  test("implicit encoder for LocalDate") {
+    val localDate = java.time.LocalDate.of(2019, 3, 30)
+    assert(spark.range(1).map { x => localDate }.head == localDate)
+  }
 }
 
 object AssertExecutionId {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1731,9 +1731,12 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     spark.range(10).select(assertExecutionId($"id")).localCheckpoint(true)
   }
 
-  test("implicit encoder for LocalDate") {
+  test("implicit encoder for LocalDate and Instant") {
     val localDate = java.time.LocalDate.of(2019, 3, 30)
-    assert(spark.range(1).map { x => localDate }.head == localDate)
+    assert(spark.range(1).map { _ => localDate }.head == localDate)
+
+    val instant = java.time.Instant.parse("2019-03-30T09:54:00Z")
+    assert(spark.range(1).map { _ => instant }.head == instant)
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added implicit encoders for the `java.time.LocalDate` and `java.time.Instant` classes. This allows creation of datasets from instances of the types.

## How was this patch tested?

Added new tests to `JavaDatasetSuite` and `DatasetSuite`.