### PR TITLE
[SPARK-27267][FOLLOWUP][BRANCH-2.4] Update hadoop-2.6 dependency manifest

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -180,7 +180,7 @@ slf4j-api-1.7.16.jar
 slf4j-log4j12-1.7.16.jar
 snakeyaml-1.15.jar
 snappy-0.2.jar
-snappy-java-1.1.7.1.jar
+snappy-java-1.1.7.3.jar
 spire-macros_2.11-0.13.0.jar
 spire_2.11-0.13.0.jar
 stax-api-1.0-2.jar


### PR DESCRIPTION
## What changes were proposed in this pull request?

This updates `hadoop-2.6` dependency manifest in `branch-2.4`, too.

- https://amplab.cs.berkeley.edu/jenkins/view/Spark%20QA%20Test%20(Dashboard)/job/spark-branch-2.4-test-sbt-hadoop-2.7/351/
- https://amplab.cs.berkeley.edu/jenkins/view/Spark%20QA%20Test%20(Dashboard)/job/spark-branch-2.4-test-sbt-hadoop-2.6/345/

## How was this patch tested?

Pass the Jenkins. Or, `dev/test-dependencies.sh`.