### PR TITLE
[SPARK-27329][SQL] Pruning nested field in map of map key and value from object serializers

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/objects.scala
@@ -175,30 +175,24 @@ object ObjectSerializerPruning extends Rule[LogicalPlan] {
       serializer: NamedExpression,
       prunedDataType: DataType): NamedExpression = {
     val prunedStructTypes = collectStructType(prunedDataType, ArrayBuffer.empty[StructType])
-    var structTypeIndex = 0
+      .toIterator
 
-    val transformedSerializer = serializer.transformDown {
+    def transformer: PartialFunction[Expression, Expression] = {
       case m: ExternalMapToCatalyst =>
-        val prunedKeyConverter = m.keyConverter.transformDown {
-          case s: CreateNamedStruct if structTypeIndex < prunedStructTypes.size =>
-            val prunedType = prunedStructTypes(structTypeIndex)
-            structTypeIndex += 1
-            pruneNamedStruct(s, prunedType)
-        }
-        val prunedValueConverter = m.valueConverter.transformDown {
-          case s: CreateNamedStruct if structTypeIndex < prunedStructTypes.size =>
-            val prunedType = prunedStructTypes(structTypeIndex)
-            structTypeIndex += 1
-            pruneNamedStruct(s, prunedType)
-        }
+        val prunedKeyConverter = m.keyConverter.transformDown(transformer)
+        val prunedValueConverter = m.valueConverter.transformDown(transformer)
+
         m.copy(keyConverter = alignNullTypeInIf(prunedKeyConverter),
           valueConverter = alignNullTypeInIf(prunedValueConverter))
-      case s: CreateNamedStruct if structTypeIndex < prunedStructTypes.size =>
-        val prunedType = prunedStructTypes(structTypeIndex)
-        structTypeIndex += 1
+
+      case s: CreateNamedStruct if prunedStructTypes.hasNext =>
+        val prunedType = prunedStructTypes.next()
         pruneNamedStruct(s, prunedType)
+
+      case other => other
     }
 
+    val transformedSerializer = serializer.transformDown(transformer)
     val prunedSerializer = alignNullTypeInIf(transformedSerializer).asInstanceOf[NamedExpression]
 
     if (prunedSerializer.dataType.sameType(prunedDataType)) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/objects.scala
@@ -188,8 +188,6 @@ object ObjectSerializerPruning extends Rule[LogicalPlan] {
       case s: CreateNamedStruct if prunedStructTypes.hasNext =>
         val prunedType = prunedStructTypes.next()
         pruneNamedStruct(s, prunedType)
-
-      case other => other
     }
 
     val transformedSerializer = serializer.transformDown(transformer)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetOptimizationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetOptimizationSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.sql.catalyst.expressions.CreateNamedStruct
+import org.apache.spark.sql.catalyst.expressions.{CreateNamedStruct, Expression}
 import org.apache.spark.sql.catalyst.expressions.objects.ExternalMapToCatalyst
 import org.apache.spark.sql.catalyst.plans.logical.SerializeFromObject
 import org.apache.spark.sql.functions.expr
@@ -47,16 +47,16 @@ class DatasetOptimizationSuite extends QueryTest with SharedSQLContext {
       case s: SerializeFromObject => s
     }.head
 
+    def collectNamedStruct: PartialFunction[Expression, Seq[CreateNamedStruct]] = {
+      case c: CreateNamedStruct => Seq(c)
+      case m: ExternalMapToCatalyst =>
+        m.keyConverter.collect(collectNamedStruct).flatten ++
+          m.valueConverter.collect(collectNamedStruct).flatten
+      case _ => Seq.empty
+    }
+
     serializer.serializer.zip(structFields).foreach { case (serializer, fields) =>
-      val structs = serializer.collect {
-        case c: CreateNamedStruct => Seq(c)
-        case m: ExternalMapToCatalyst =>
-          m.keyConverter.collect {
-            case c: CreateNamedStruct => c
-          } ++ m.valueConverter.collect {
-            case c: CreateNamedStruct => c
-          }
-      }.flatten
+      val structs: Seq[CreateNamedStruct] = serializer.collect(collectNamedStruct).flatten
       assert(structs.size == fields.size)
       structs.zip(fields).foreach { case (struct, fieldNames) =>
         assert(struct.names.map(_.toString) == fieldNames)
@@ -138,6 +138,27 @@ class DatasetOptimizationSuite extends QueryTest with SharedSQLContext {
         (Map((("3", 3), "c_1")), 3))
       val mapDs = mapData.toDS().map(t => (t._1, t._2 + 1))
       val df1 = mapDs.select(expr("map_keys(_1)._1[0]"))
+      testSerializer(df1, Seq(Seq("_1")))
+      checkAnswer(df1, Seq(Row("1"), Row("2"), Row("3")))
+    }
+  }
+
+  test("Pruned nested serializers: map of map value") {
+    withSQLConf(SQLConf.SERIALIZER_NESTED_SCHEMA_PRUNING_ENABLED.key -> "true") {
+      val mapData = Seq((Map(("k", Map(("k2", ("a_1", 11))))), 1),
+        (Map(("k", Map(("k2", ("b_1", 22))))), 2), (Map(("k", Map(("k2", ("c_1", 33))))), 3))
+      val mapDs = mapData.toDS().map(t => (t._1, t._2 + 1))
+      val df1 = mapDs.select("_1.k.k2._1")
+      testSerializer(df1, Seq(Seq("_1")))
+    }
+  }
+
+  test("Pruned nested serializers: map of map key") {
+    withSQLConf(SQLConf.SERIALIZER_NESTED_SCHEMA_PRUNING_ENABLED.key -> "true") {
+      val mapData = Seq((Map((Map((("1", 1), "val1")), "a_1")), 1),
+        (Map((Map((("2", 2), "val2")), "b_1")), 2), (Map((Map((("3", 3), "val3")), "c_1")), 3))
+      val mapDs = mapData.toDS().map(t => (t._1, t._2 + 1))
+      val df1 = mapDs.select(expr("map_keys(map_keys(_1)[0])._1[0]"))
       testSerializer(df1, Seq(Seq("_1")))
       checkAnswer(df1, Seq(Row("1"), Row("2"), Row("3")))
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

If object serializer has map of map key/value, pruning nested field should work.

Previously object serializer pruner don't recursively prunes nested fields if it is deeply located in map key or value. This patch proposed to address it by slightly factoring the pruning logic.

## How was this patch tested?

Added tests.