### PR TITLE
[SPARK-27344][SQL][TEST] Support the LocalDate and Instant classes in Java Bean encoders

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoders.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoders.scala
@@ -149,7 +149,7 @@ object Encoders {
    *  - boxed types: Boolean, Integer, Double, etc.
    *  - String
    *  - java.math.BigDecimal, java.math.BigInteger
-   *  - time related: java.sql.Date, java.sql.Timestamp
+   *  - time related: java.sql.Date, java.sql.Timestamp, java.time.LocalDate, java.time.Instant
    *  - collection types: only array and java.util.List currently, map support is in progress
    *  - nested java bean.
    *

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Row.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Row.scala
@@ -270,11 +270,25 @@ trait Row extends Serializable {
   def getDate(i: Int): java.sql.Date = getAs[java.sql.Date](i)
 
   /**
+   * Returns the value at position i of date type as java.time.LocalDate.
+   *
+   * @throws ClassCastException when data type does not match.
+   */
+  def getLocalDate(i: Int): java.time.LocalDate = getAs[java.time.LocalDate](i)
+
+  /**
    * Returns the value at position i of date type as java.sql.Timestamp.
    *
    * @throws ClassCastException when data type does not match.
    */
   def getTimestamp(i: Int): java.sql.Timestamp = getAs[java.sql.Timestamp](i)
+
+  /**
+   * Returns the value at position i of date type as java.time.Instant.
+   *
+   * @throws ClassCastException when data type does not match.
+   */
+  def getInstant(i: Int): java.time.Instant = getAs[java.time.Instant](i)
 
   /**
    * Returns the value at position i of array type as a Scala Seq.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
@@ -102,7 +102,9 @@ object JavaTypeInference {
 
       case c: Class[_] if c == classOf[java.math.BigDecimal] => (DecimalType.SYSTEM_DEFAULT, true)
       case c: Class[_] if c == classOf[java.math.BigInteger] => (DecimalType.BigIntDecimal, true)
+      case c: Class[_] if c == classOf[java.time.LocalDate] => (DateType, true)
       case c: Class[_] if c == classOf[java.sql.Date] => (DateType, true)
+      case c: Class[_] if c == classOf[java.time.Instant] => (TimestampType, true)
       case c: Class[_] if c == classOf[java.sql.Timestamp] => (TimestampType, true)
 
       case _ if typeToken.isArray =>

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaBeanDeserializationSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaBeanDeserializationSuite.java
@@ -516,29 +516,29 @@ public class JavaBeanDeserializationSuite implements Serializable {
   }
 
   @Test
-  public void testSpark30() {
+  public void testBeanWithLocalDateAndInstant() {
     String originConf = spark.conf().get(SQLConf.DATETIME_JAVA8API_ENABLED().key());
     try {
       spark.conf().set(SQLConf.DATETIME_JAVA8API_ENABLED().key(), "true");
       List<Row> inputRows = new ArrayList<>();
-      List<RecordSpark30> expectedRecords = new ArrayList<>();
+      List<LocalDateInstantRecord> expectedRecords = new ArrayList<>();
 
       for (long idx = 0 ; idx < 5 ; idx++) {
-        Row row = createRecordSpark30Row(idx);
+        Row row = createLocalDateInstantRow(idx);
         inputRows.add(row);
-        expectedRecords.add(createRecordSpark30(row));
+        expectedRecords.add(createLocalDateInstantRecord(row));
       }
 
-      Encoder<RecordSpark30> encoder = Encoders.bean(RecordSpark30.class);
+      Encoder<LocalDateInstantRecord> encoder = Encoders.bean(LocalDateInstantRecord.class);
 
       StructType schema = new StructType()
         .add("localDateField", DataTypes.DateType)
         .add("instantField", DataTypes.TimestampType);
 
       Dataset<Row> dataFrame = spark.createDataFrame(inputRows, schema);
-      Dataset<RecordSpark30> dataset = dataFrame.as(encoder);
+      Dataset<LocalDateInstantRecord> dataset = dataFrame.as(encoder);
 
-      List<RecordSpark30> records = dataset.collectAsList();
+      List<LocalDateInstantRecord> records = dataset.collectAsList();
 
       Assert.assertEquals(expectedRecords, records);
     } finally {
@@ -546,11 +546,11 @@ public class JavaBeanDeserializationSuite implements Serializable {
     }
   }
 
-  public static final class RecordSpark30 {
+  public static final class LocalDateInstantRecord {
     private String localDateField;
     private String instantField;
 
-    public RecordSpark30() { }
+    public LocalDateInstantRecord() { }
 
     public String getLocalDateField() {
       return localDateField;
@@ -572,7 +572,7 @@ public class JavaBeanDeserializationSuite implements Serializable {
     public boolean equals(Object o) {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
-      RecordSpark30 that = (RecordSpark30) o;
+      LocalDateInstantRecord that = (LocalDateInstantRecord) o;
       return Objects.equals(localDateField, that.localDateField) &&
         Objects.equals(instantField, that.instantField);
     }
@@ -591,13 +591,13 @@ public class JavaBeanDeserializationSuite implements Serializable {
     }
   }
 
-  private static Row createRecordSpark30Row(Long index) {
+  private static Row createLocalDateInstantRow(Long index) {
     Object[] values = new Object[] { LocalDate.ofEpochDay(42), Instant.ofEpochSecond(42) };
     return new GenericRow(values);
   }
 
-  private static RecordSpark30 createRecordSpark30(Row recordRow) {
-    RecordSpark30 record = new RecordSpark30();
+  private static LocalDateInstantRecord createLocalDateInstantRecord(Row recordRow) {
+    LocalDateInstantRecord record = new LocalDateInstantRecord();
     record.setLocalDateField(String.valueOf(recordRow.getLocalDate(0)));
     Instant instant = recordRow.getInstant(1);
     TimestampFormatter formatter = TimestampFormatter.getFractionFormatter(


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Added new test for Java Bean encoder of the classes: `java.time.LocalDate` and `java.time.Instant`.
- Updated comment for `Encoders.bean`
- New Row getters: `getLocalDate` and `getInstant`
- Extended `inferDataType` to infer types for `java.time.LocalDate` -> `DateType` and `java.time.Instant` -> `TimestampType`.

## How was this patch tested?

By `JavaBeanDeserializationSuite`
