### PR TITLE
[SPARK-27253][SQL][FOLLOW-UP] Add a note about parent-session configuration priority in migration guide

### DIFF
--- a/docs/sql-migration-guide-upgrade.md
+++ b/docs/sql-migration-guide-upgrade.md
@@ -124,6 +124,8 @@ license: |
 
   - Since Spark 3.0, `TIMESTAMP` literals are converted to strings using the SQL config `spark.sql.session.timeZone`, and `DATE` literals are formatted using the UTC time zone. In Spark version 2.4 and earlier, both conversions use the default time zone of the Java virtual machine.
 
+  - In Spark version 2.4 and earlier, the configurations of `SparkContext` are prioritized over its parent `SparkSession` when cloning it via `cloneSession()` if the same configurations are found in both `SparkContext` and the parent `SparkSession`. Since Spark 3.0, the configurations of a parent `SparkSession` have a higher priority.
+
 ## Upgrading From Spark SQL 2.3 to 2.4
 
   - In Spark version 2.3 and earlier, the second parameter to array_contains function is implicitly promoted to the element type of first array type parameter. This type promotion can be lossy and may cause `array_contains` function to return wrong result. This problem has been addressed in 2.4 by employing a safer type promotion mechanism. This can cause some change in behavior and are illustrated in the table below.

--- a/docs/sql-migration-guide-upgrade.md
+++ b/docs/sql-migration-guide-upgrade.md
@@ -124,7 +124,7 @@ license: |
 
   - Since Spark 3.0, `TIMESTAMP` literals are converted to strings using the SQL config `spark.sql.session.timeZone`, and `DATE` literals are formatted using the UTC time zone. In Spark version 2.4 and earlier, both conversions use the default time zone of the Java virtual machine.
 
-  - In Spark version 2.4 and earlier, the configurations of `SparkContext` are prioritized over its parent `SparkSession` when cloning it via `cloneSession()` if the same configurations are found in both `SparkContext` and the parent `SparkSession`. Since Spark 3.0, the configurations of a parent `SparkSession` have a higher priority.
+  - In Spark version 2.4, when a spark session is created via `cloneSession()`, the newly created spark session inherits its configuration from its parent `SparkContext` even though the same configuration may exist with a different value in its parent spark session. Since Spark 3.0, the configurations of a parent `SparkSession` have a higher precedence over the parent `SparkContext`.
 
 ## Upgrading From Spark SQL 2.3 to 2.4
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a followup of https://github.com/apache/spark/pull/24189. It adds a note about parent-session configuration priority.

## How was this patch tested?

Manually built the site and checked.
