### PR TITLE
[SPARK-27338][CORE][FOLLOWUP] remove trailing space

### DIFF
--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
@@ -584,7 +584,7 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
               // method locks the `TaskMemoryManager`, and it's a bad idea to lock 2 objects in
               // sequence. We may hit dead lock if another thread locks `TaskMemoryManager` and
               // `SpillableIterator` in sequence, which may happen in
-              // `TaskMemoryManager.acquireExecutionMemory`. 
+              // `TaskMemoryManager.acquireExecutionMemory`.
               pageToFree = lastPage;
               lastPage = null;
             }


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://github.com/apache/spark/pull/24265 breaks the lint check, because it has trailing space. (not sure why it passed jenkins). This PR fixes it.

## How was this patch tested?

N/A