### PR TITLE
[SPARK-27385][SQL]add mapPartitionWithIndex to Dataframe

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -1428,6 +1428,15 @@ class DataFrame private[sql](
   }
 
   /**
+    * Returns a new RDD by applying a function to each partition of this DataFrame, while tracking the index
+    * of the original partition.
+    * @group rdd
+    */
+  def mapPartitionsWithIndex[R: ClassTag](f: Iterator[Row] => Iterator[R]): RDD[R] = {
+    rdd.mapPartitionsWithIndex(f)
+  }
+
+  /**
    * Applies a function `f` to all rows.
    * @group rdd
    * @since 1.3.0


### PR DESCRIPTION
modify comment

## What changes were proposed in this pull request?

This pr add mapPartitionsWithIndex to Dataframe.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
