### PR TITLE
[SPARK-27391][SS] Don't initialize a lazy val in ContinuousExecution job.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
@@ -251,12 +251,8 @@ class ContinuousExecution(
 
       updateStatusMessage("Running")
       reportTimeTaken("runContinuous") {
-        SQLExecution.withNewExecutionId(
-          sparkSessionForQuery, lastExecution) {
-          // Materialize `executedPlan` so that accessing it when `toRdd` is running doesn't need to
-          // wait for a lock
-          lastExecution.executedPlan
-          lastExecution.toRdd
+        SQLExecution.withNewExecutionId(sparkSessionForQuery, lastExecution) {
+          lastExecution.executedPlan.execute()
         }
       }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix a potential deadlock in ContinuousExecution by not initializing the toRDD lazy val.