### PR TITLE
[SPARK-27394][WebUI]Flush LiveEntity if necessary when receiving SparkListenerExecutorMetricsUpdate

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/Status.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Status.scala
@@ -29,6 +29,16 @@ private[spark] object Status {
     .timeConf(TimeUnit.NANOSECONDS)
     .createWithDefaultString("100ms")
 
+  val LIVE_ENTITY_UPDATE_STALENESS_LIMIT = ConfigBuilder("spark.ui.liveUpdate.stalenessLimit")
+    .internal()
+    .doc(
+      """A time limit before we force to flush all live entities. When the last flush does't past
+        |this limit, UI will not trigger a heavy flush to sync the states since it may slow down
+        |Spark events processing significantly. Otherwise, UI will try to flush as soon as possible.
+      """.stripMargin)
+    .timeConf(TimeUnit.NANOSECONDS)
+    .createWithDefaultString("1s")
+
   val MAX_RETAINED_JOBS = ConfigBuilder("spark.ui.retainedJobs")
     .intConf
     .createWithDefault(1000)

--- a/core/src/main/scala/org/apache/spark/internal/config/Status.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Status.scala
@@ -32,7 +32,7 @@ private[spark] object Status {
   val LIVE_ENTITY_UPDATE_STALENESS_LIMIT = ConfigBuilder("spark.ui.liveUpdate.stalenessLimit")
     .internal()
     .doc(
-      """A time limit before we force to flush all live entities. When the last flush does't past
+      """A time limit before we force to flush all live entities. When the last flush doesn't past
         |this limit, UI will not trigger a heavy flush to sync the states since it may slow down
         |Spark events processing significantly. Otherwise, UI will try to flush as soon as possible.
       """.stripMargin)

--- a/core/src/main/scala/org/apache/spark/internal/config/Status.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Status.scala
@@ -29,13 +29,9 @@ private[spark] object Status {
     .timeConf(TimeUnit.NANOSECONDS)
     .createWithDefaultString("100ms")
 
-  val LIVE_ENTITY_UPDATE_STALENESS_LIMIT = ConfigBuilder("spark.ui.liveUpdate.stalenessLimit")
-    .internal()
-    .doc(
-      """A time limit before we force to flush all live entities. When the last flush doesn't past
-        |this limit, UI will not trigger a heavy flush to sync the states since it may slow down
-        |Spark events processing significantly. Otherwise, UI will try to flush as soon as possible.
-      """.stripMargin)
+  val LIVE_ENTITY_UPDATE_MIN_FLUSH_PERIOD = ConfigBuilder("spark.ui.liveUpdate.minFlushPeriod")
+    .doc("Minimum time elapsed before stale UI data is flushed. This avoids UI staleness when " +
+      "incoming task events are not fired frequently.")
     .timeConf(TimeUnit.NANOSECONDS)
     .createWithDefaultString("1s")
 

--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -58,6 +58,14 @@ private[spark] class AppStatusListener(
   // operations that we can live without when rapidly processing incoming task events.
   private val liveUpdatePeriodNs = if (live) conf.get(LIVE_ENTITY_UPDATE_PERIOD) else -1L
 
+  /**
+   * A time limit before we force to flush all live entities. When the last flush does't past
+   * this limit, UI will not trigger a heavy flush to sync the states since it may slow down Spark
+   * events processing significantly. Otherwise, UI will try to flush when receiving the next
+   * executor heartbeat.
+   */
+  private val liveUpdateStalenessLimit = conf.get(LIVE_ENTITY_UPDATE_STALENESS_LIMIT)
+
   private val maxTasksPerStage = conf.get(MAX_RETAINED_TASKS_PER_STAGE)
   private val maxGraphRootNodes = conf.get(MAX_RETAINED_ROOT_NODES)
 
@@ -836,9 +844,9 @@ private[spark] class AppStatusListener(
       }
     }
     // Flush updates if necessary. Executor heartbeat is an event that happens periodically. Flush
-    // here to ensure the staleness of Spark UI doesn't last more that the executor heartbeat
-    // interval.
-    if (now - lastFlushTimeNs > liveUpdatePeriodNs) {
+    // here to ensure the staleness of Spark UI doesn't last more than
+    // `max(heartbeat interval, liveUpdateStalenessLimit)`.
+    if (now - lastFlushTimeNs > liveUpdateStalenessLimit) {
       flush(maybeUpdate(_, now))
       // Re-get the current system time because `flush` may be slow and `now` is stale.
       lastFlushTimeNs = System.nanoTime()

--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -59,7 +59,7 @@ private[spark] class AppStatusListener(
   private val liveUpdatePeriodNs = if (live) conf.get(LIVE_ENTITY_UPDATE_PERIOD) else -1L
 
   /**
-   * A time limit before we force to flush all live entities. When the last flush does't past
+   * A time limit before we force to flush all live entities. When the last flush doesn't past
    * this limit, UI will not trigger a heavy flush to sync the states since it may slow down Spark
    * events processing significantly. Otherwise, UI will try to flush when receiving the next
    * executor heartbeat.

--- a/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
@@ -736,6 +736,7 @@ class UISeleniumSuite extends SparkFunSuite with WebBrowser with Matchers with B
       additionalConfs = Map(
         EXECUTOR_HEARTBEAT_INTERVAL.key -> "10ms",
         LIVE_ENTITY_UPDATE_STALENESS_LIMIT.key -> "10ms"))) { sc =>
+      sc.setLocalProperty(SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL, "true")
       val f = sc.parallelize(1 to 1000, 1000).foreachAsync { _ =>
         // Make the task never finish so there won't be any task start/end events after the first 2
         // tasks start.

--- a/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
@@ -100,14 +100,18 @@ class UISeleniumSuite extends SparkFunSuite with WebBrowser with Matchers with B
    * Create a test SparkContext with the SparkUI enabled.
    * It is safe to `get` the SparkUI directly from the SparkContext returned here.
    */
-  private def newSparkContext(killEnabled: Boolean = true): SparkContext = {
+  private def newSparkContext(
+      killEnabled: Boolean = true,
+      master: String = "local",
+      additionalConfs: Map[String, String] = Map.empty): SparkContext = {
     val conf = new SparkConf()
-      .setMaster("local")
+      .setMaster(master)
       .setAppName("test")
       .set(UI_ENABLED, true)
       .set(UI_PORT, 0)
       .set(UI_KILL_ENABLED, killEnabled)
       .set(MEMORY_OFFHEAP_SIZE.key, "64m")
+    additionalConfs.foreach { case (k, v) => conf.set(k, v) }
     val sc = new SparkContext(conf)
     assert(sc.ui.isDefined)
     sc
@@ -722,6 +726,28 @@ class UISeleniumSuite extends SparkFunSuite with WebBrowser with Matchers with B
       stagesJson.children.size should be (4)
       val stagesStatus = stagesJson.children.map(_ \ "status")
       stagesStatus.count(_ == JString(StageStatus.SKIPPED.name())) should be (1)
+    }
+  }
+
+  test("Staleness of Spark UI should not last minutes or hours") {
+    withSpark(newSparkContext(
+      master = "local[2]",
+      // Set a small heart beat interval to make the test fast
+      additionalConfs = Map(EXECUTOR_HEARTBEAT_INTERVAL.key -> "10ms"))) { sc =>
+      val f = sc.parallelize(1 to 1000, 1000).foreachAsync { _ =>
+        // Make the task never finish so there won't be any task start/end events after the first 2
+        // tasks start.
+        Thread.sleep(300000)
+      }
+      try {
+        eventually(timeout(10.seconds)) {
+          val jobsJson = getJson(sc.ui.get, "jobs")
+          jobsJson.children.length should be (1)
+          (jobsJson.children.head \ "numActiveTasks").extract[Int] should be (2)
+        }
+      } finally {
+        f.cancel()
+      }
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
@@ -735,7 +735,7 @@ class UISeleniumSuite extends SparkFunSuite with WebBrowser with Matchers with B
       // Set a small heart beat interval to make the test fast
       additionalConfs = Map(
         EXECUTOR_HEARTBEAT_INTERVAL.key -> "10ms",
-        LIVE_ENTITY_UPDATE_STALENESS_LIMIT.key -> "10ms"))) { sc =>
+        LIVE_ENTITY_UPDATE_MIN_FLUSH_PERIOD.key -> "10ms"))) { sc =>
       sc.setLocalProperty(SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL, "true")
       val f = sc.parallelize(1 to 1000, 1000).foreachAsync { _ =>
         // Make the task never finish so there won't be any task start/end events after the first 2

--- a/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
@@ -733,7 +733,9 @@ class UISeleniumSuite extends SparkFunSuite with WebBrowser with Matchers with B
     withSpark(newSparkContext(
       master = "local[2]",
       // Set a small heart beat interval to make the test fast
-      additionalConfs = Map(EXECUTOR_HEARTBEAT_INTERVAL.key -> "10ms"))) { sc =>
+      additionalConfs = Map(
+        EXECUTOR_HEARTBEAT_INTERVAL.key -> "10ms",
+        LIVE_ENTITY_UPDATE_STALENESS_LIMIT.key -> "10ms"))) { sc =>
       val f = sc.parallelize(1 to 1000, 1000).foreachAsync { _ =>
         // Make the task never finish so there won't be any task start/end events after the first 2
         // tasks start.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -875,6 +875,14 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.ui.liveUpdate.minFlushPeriod</code></td>
+  <td>1s</td>
+  <td>
+    Minimum time elapsed before stale UI data is flushed. This avoids UI staleness when incoming
+    task events are not fired frequently.
+  </td>
+</tr>
+<tr>
   <td><code>spark.ui.port</code></td>
   <td>4040</td>
   <td>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR updates `AppStatusListener` to flush `LiveEntity` if necessary when receiving `SparkListenerExecutorMetricsUpdate`. This will ensure the staleness of Spark UI doesn't last more than the executor heartbeat interval.

## How was this patch tested?

The new unit test.