### PR TITLE
[MINOR][DOC] Fix html tag broken in configuration.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1001,7 +1001,7 @@ Apart from these, the following properties are also available, and may be useful
   <td>
     The maximum allowed size for a HTTP request header, in bytes unless otherwise specified.
     This setting applies for the Spark History Server too.
-  <td>
+  </td>
 </tr>
 </table>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch fixes wrong HTML tag in configuration.md which breaks the table tag.

This is originally reported in dev mailing list: https://lists.apache.org/thread.html/744bdc83b3935776c8d91bf48fdf80d9a3fed3858391e60e343206f9@%3Cdev.spark.apache.org%3E

## How was this patch tested?

This change is one-liner and pretty obvious so I guess we may be able to skip testing.