### PR TITLE
[SPARK-27402][SQL][TEST] Support HiveExternalCatalog backward compatibility test

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
@@ -196,6 +196,8 @@ class HiveExternalCatalogVersionsSuite extends SparkSubmitTestUtils {
       "--name", "HiveExternalCatalog backward compatibility test",
       "--master", "local[2]",
       "--conf", "spark.ui.enabled=false",
+      "--conf", "spark.sql.hive.metastore.version=1.2.1",
+      "--conf", "spark.sql.hive.metastore.jars=maven",
       "--conf", "spark.master.rest.enabled=false",
       "--conf", s"spark.sql.warehouse.dir=${wareHousePath.getCanonicalPath}",
       "--driver-java-options", s"-Dderby.system.home=${wareHousePath.getCanonicalPath}",


### PR DESCRIPTION
## What changes were proposed in this pull request?

When we upgrade the built-in Hive to 2.3.4, the default `spark.sql.hive.metastore.version` should be 2.3.4. This will not be compatible with [spark-2.3.3-bin-hadoop2.7.tgz](https://www.apache.org/dyn/closer.lua/spark/spark-2.3.3/spark-2.3.3-bin-hadoop2.7.tgz) and [spark-2.4.1-bin-hadoop2.7.tgz](https://www.apache.org/dyn/closer.lua/spark/spark-2.4.1/spark-2.4.1-bin-hadoop2.7.tgz). This PR specifies the `spark.sql.hive.metastore.version` to 1.2.1 to work around this issue.


## How was this patch tested?

manual tests:
Upgrade built-in Hive to 2.3.4 and run:
```
build/sbt "hive/testOnly *.HiveExternalCatalogVersionsSuite" -Phadoop-3.2
```
