### PR TITLE
[SPARK-27445][SQL][TEST] Update SQLQueryTestSuite to process files ending with `.sql`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -108,8 +108,10 @@ class SQLQueryTestSuite extends QueryTest with SharedSQLContext {
   /** List of test cases to ignore, in lower cases. */
   private val blackList = Set(
     "blacklist.sql",  // Do NOT remove this one. It is here to test the blacklist functionality.
-    ".DS_Store"       // A meta-file that may be created on Mac by Finder App.
+    ".DS_Store",      // A meta-file that may be created on Mac by Finder App.
                       // We should ignore this file from processing.
+    ".swp",           // Temporary files created by vi or vim are ignored from processing.
+    ".swo"            // Temporary files created by vi or vim are ignored from processing.
   )
 
   // Create all the test cases.

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -105,6 +105,8 @@ class SQLQueryTestSuite extends QueryTest with SharedSQLContext {
   private val inputFilePath = new File(baseResourcePath, "inputs").getAbsolutePath
   private val goldenFilePath = new File(baseResourcePath, "results").getAbsolutePath
 
+  private val validTestFileExtensionsRegEx = ".*\\.sql"
+
   /** List of test cases to ignore, in lower cases. */
   private val blackList = Set(
     "blacklist.sql",  // Do NOT remove this one. It is here to test the blacklist functionality.
@@ -331,7 +333,8 @@ class SQLQueryTestSuite extends QueryTest with SharedSQLContext {
   /** Returns all the files (not directories) in a directory, recursively. */
   private def listFilesRecursively(path: File): Seq[File] = {
     val (dirs, files) = path.listFiles().partition(_.isDirectory)
-    files ++ dirs.flatMap(listFilesRecursively)
+    val filteredFiles = files.filter (_.getName matches validTestFileExtensionsRegEx)
+    filteredFiles ++ dirs.flatMap(listFilesRecursively)
   }
 
   /** Load built-in test tables into the SparkSession. */

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -21,6 +21,7 @@ import java.io.File
 import java.util.{Locale, TimeZone}
 
 import scala.util.control.NonFatal
+import scala.util.matching.Regex
 
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -105,7 +106,7 @@ class SQLQueryTestSuite extends QueryTest with SharedSQLContext {
   private val inputFilePath = new File(baseResourcePath, "inputs").getAbsolutePath
   private val goldenFilePath = new File(baseResourcePath, "results").getAbsolutePath
 
-  private val validTestFileExtensionsRegEx = ".*\\.sql"
+  private val validFileExtensionsPattern = ".*\\.sql$".r
 
   /** List of test cases to ignore, in lower cases. */
   private val blackList = Set(
@@ -329,7 +330,13 @@ class SQLQueryTestSuite extends QueryTest with SharedSQLContext {
   /** Returns all the files (not directories) in a directory, recursively. */
   private def listFilesRecursively(path: File): Seq[File] = {
     val (dirs, files) = path.listFiles().partition(_.isDirectory)
-    val filteredFiles = files.filter (_.getName matches validTestFileExtensionsRegEx)
+    val filteredFiles = files.filter { f =>
+      validFileExtensionsPattern.findFirstMatchIn(f.getName.toLowerCase(Locale.ROOT)) match {
+        case Some(_) => true
+        case None => false
+
+      }
+    }
     filteredFiles ++ dirs.flatMap(listFilesRecursively)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -110,10 +110,8 @@ class SQLQueryTestSuite extends QueryTest with SharedSQLContext {
   /** List of test cases to ignore, in lower cases. */
   private val blackList = Set(
     "blacklist.sql",  // Do NOT remove this one. It is here to test the blacklist functionality.
-    ".DS_Store",      // A meta-file that may be created on Mac by Finder App.
+    ".DS_Store"       // A meta-file that may be created on Mac by Finder App.
                       // We should ignore this file from processing.
-    ".swp",           // Temporary files created by vi or vim are ignored from processing.
-    ".swo"            // Temporary files created by vi or vim are ignored from processing.
   )
 
   // Create all the test cases.

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -109,9 +109,7 @@ class SQLQueryTestSuite extends QueryTest with SharedSQLContext {
 
   /** List of test cases to ignore, in lower cases. */
   private val blackList = Set(
-    "blacklist.sql",  // Do NOT remove this one. It is here to test the blacklist functionality.
-    ".DS_Store"       // A meta-file that may be created on Mac by Finder App.
-                      // We should ignore this file from processing.
+    "blacklist.sql"   // Do NOT remove this one. It is here to test the blacklist functionality.
   )
 
   // Create all the test cases.

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -21,7 +21,6 @@ import java.io.File
 import java.util.{Locale, TimeZone}
 
 import scala.util.control.NonFatal
-import scala.util.matching.Regex
 
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -106,7 +105,7 @@ class SQLQueryTestSuite extends QueryTest with SharedSQLContext {
   private val inputFilePath = new File(baseResourcePath, "inputs").getAbsolutePath
   private val goldenFilePath = new File(baseResourcePath, "results").getAbsolutePath
 
-  private val validFileExtensionsPattern = ".*\\.sql$".r
+  private val validFileExtensions = ".sql"
 
   /** List of test cases to ignore, in lower cases. */
   private val blackList = Set(
@@ -330,13 +329,9 @@ class SQLQueryTestSuite extends QueryTest with SharedSQLContext {
   /** Returns all the files (not directories) in a directory, recursively. */
   private def listFilesRecursively(path: File): Seq[File] = {
     val (dirs, files) = path.listFiles().partition(_.isDirectory)
-    val filteredFiles = files.filter { f =>
-      validFileExtensionsPattern.findFirstMatchIn(f.getName.toLowerCase(Locale.ROOT)) match {
-        case Some(_) => true
-        case None => false
-
-      }
-    }
+    // Filter out test files with invalid extensions such as temp files created
+    // by vi (.swp), Mac (.DS_Store) etc.
+    val filteredFiles = files.filter(_.getName.endsWith(validFileExtensions))
     filteredFiles ++ dirs.flatMap(listFilesRecursively)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
While using vi or vim to edit the test files the .swp or .swo files are created and attempt to run the test suite in the presence of these files causes errors like below :
```
nfo] - subquery/exists-subquery/.exists-basic.sql.swp *** FAILED *** (117 milliseconds)
[info]   java.io.FileNotFoundException: /Users/dbiswal/mygit/apache/spark/sql/core/target/scala-2.12/test-classes/sql-tests/results/subquery/exists-subquery/.exists-basic.sql.swp.out (No such file or directory)
[info]   at java.io.FileInputStream.open0(Native Method)
[info]   at java.io.FileInputStream.open(FileInputStream.java:195)
[info]   at java.io.FileInputStream.<init>(FileInputStream.java:138)
[info]   at org.apache.spark.sql.catalyst.util.package$.fileToString(package.scala:49)
[info]   at org.apache.spark.sql.SQLQueryTestSuite.runQueries(SQLQueryTestSuite.scala:247)
[info]   at org.apache.spark.sql.SQLQueryTestSuite.$anonfun$runTest$11(SQLQueryTestSuite.scala:192)
```
~~This minor pr adds these temp files in the ignore list.~~
While computing the list of test files to process, only consider files with `.sql` extension. This makes sure the unwanted temp files created from various editors are ignored from processing.
## How was this patch tested?
Verified manually.