### PR TITLE
[SPARK-27436][SQL] Add spark.sql.optimizer.nonExcludedRules

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.StaticSQLConf.OPTIMIZER_NON_EXCLUDABLE_RULES
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
@@ -218,7 +219,8 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
       RewriteCorrelatedScalarSubquery.ruleName ::
       RewritePredicateSubquery.ruleName ::
       PullOutPythonUDFInJoinCondition.ruleName ::
-      NormalizeFloatingNumbers.ruleName :: Nil
+      NormalizeFloatingNumbers.ruleName :: Nil ++
+      SQLConf.get.getConf(OPTIMIZER_NON_EXCLUDABLE_RULES).toSeq.flatMap(Utils.stringToSeq)
 
   /**
    * Optimize all the subqueries inside expression.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -138,4 +138,11 @@ object StaticSQLConf {
     .intConf
     .checkValue(_ >= 0, "Must be set greater or equal to zero")
     .createWithDefault(Int.MaxValue)
+
+  val OPTIMIZER_NON_EXCLUDABLE_RULES = buildStaticConf("spark.sql.optimizer.nonExcludedRules")
+    .doc("Configures a list of rules to be kept in the optimizer, in which the rules are " +
+      "specified by their rule names and separated by comma. This prevent users from " +
+      "excluding rules dynamically by using `spark.sql.optimizer.excludedRules` configuration.")
+    .stringConf
+    .createOptional
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerRuleExclusionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerRuleExclusionSuite.scala
@@ -21,7 +21,9 @@ import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.OPTIMIZER_EXCLUDED_RULES
+import org.apache.spark.sql.internal.StaticSQLConf.OPTIMIZER_NON_EXCLUDABLE_RULES
 
 
 class OptimizerRuleExclusionSuite extends PlanTest {
@@ -84,6 +86,20 @@ class OptimizerRuleExclusionSuite extends PlanTest {
     verifyExcludedRules(
       new SimpleTestOptimizer(),
       Seq(
+        ReplaceIntersectWithSemiJoin.ruleName,
+        PullupCorrelatedPredicates.ruleName,
+        RewriteCorrelatedScalarSubquery.ruleName,
+        RewritePredicateSubquery.ruleName,
+        RewriteExceptAll.ruleName,
+        RewriteIntersectAll.ruleName))
+  }
+
+  test("Try to exclude some non-excludable rules defined by nonExcludedRules") {
+    SQLConf.get.setConfString(OPTIMIZER_NON_EXCLUDABLE_RULES.key, PushPredicateThroughJoin.ruleName)
+    verifyExcludedRules(
+      new SimpleTestOptimizer(),
+      Seq(
+        PushPredicateThroughJoin.ruleName,
         ReplaceIntersectWithSemiJoin.ruleName,
         PullupCorrelatedPredicates.ruleName,
         RewriteCorrelatedScalarSubquery.ruleName,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, users can remove optimizer rule dynamically. This PR aims to add a new feature with `spark.sql.optimizer.nonExcludedRules` static configuration to prevent accidental rule exclusion by users in SQL environment dynamically. This is useful for admin to protect custom optimizer rules.

**AS IS**
```sql
$ bin/spark-sql \
--conf spark.sql.optimizer.planChangeLog.level=ERROR \
--conf spark.sql.optimizer.planChangeLog.batches=OptimizeLimitZero \
--conf spark.sql.optimizer.planChangeLog.rules=org.apache.spark.sql.catalyst.optimizer.OptimizeLimitZero
Spark master: local[*], Application Id: local-1554952359955
spark-sql> select 1 limit 0;
=== Applying Rule org.apache.spark.sql.catalyst.optimizer.OptimizeLimitZero ===
!GlobalLimit 0              LocalRelation <empty>, [1#0]
!+- LocalLimit 0
!   +- Project [1 AS 1#0]
!      +- OneRowRelation

=== Result of Batch OptimizeLimitZero ===
!GlobalLimit 0              LocalRelation <empty>, [1#0]
!+- LocalLimit 0
!   +- Project [1 AS 1#0]
!      +- OneRowRelation

Time taken: 1.426 seconds

spark-sql> set spark.sql.optimizer.excludedRules=org.apache.spark.sql.catalyst.optimizer.OptimizeLimitZero;

spark-sql> select 1 limit 0;
Time taken: 0.226 seconds
```

**AFTER (with spark.sql.optimizer.nonExcludedRules)**
```sql
$ bin/spark-shell \
--conf spark.sql.optimizer.planChangeLog.level=ERROR \
--conf spark.sql.optimizer.planChangeLog.batches=OptimizeLimitZero \
--conf spark.sql.optimizer.planChangeLog.rules=org.apache.spark.sql.catalyst.optimizer.OptimizeLimitZero \
--conf spark.sql.optimizer.nonExcludedRules=org.apache.spark.sql.catalyst.optimizer.OptimizeLimitZero
Spark master: local[*], Application Id: local-1554952378462
spark-sql> set spark.sql.optimizer.excludedRules=org.apache.spark.sql.catalyst.optimizer.OptimizeLimitZero;
Time taken: 1.563 seconds, Fetched 1 row(s)

spark-sql> select 1 limit 0;
=== Applying Rule org.apache.spark.sql.catalyst.optimizer.OptimizeLimitZero ===
!GlobalLimit 0              LocalRelation <empty>, [1#4]
!+- LocalLimit 0
!   +- Project [1 AS 1#4]
!      +- OneRowRelation

=== Result of Batch OptimizeLimitZero ===
!GlobalLimit 0              LocalRelation <empty>, [1#4]
!+- LocalLimit 0
!   +- Project [1 AS 1#4]
!      +- OneRowRelation
```

## How was this patch tested?

Pass the Jenkins with a newly added test case.