### PR TITLE
[SPARK-27437][SQL] check the parquet column format

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
@@ -292,4 +292,14 @@ class CreateTableAsSelectSuite
       assert(e.contains("Schema may not be specified in a Create Table As Select (CTAS)"))
     }
   }
+
+	test("check the parquet column format") {
+		withTable("t") {
+			val e = intercept[AnalysisException] {
+				sql("CREATE TABLE t USING parquet AS SELECT count(1), 2")
+			}.getMessage
+			assert(e.contains("contains invalid character(s) among \" ,;{}()\\n\\t=\""))
+		}
+	}
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When I tested the parquest, I found that count(1) would have an exception because it contained invalid characters.

## How was this patch tested?

Add a  test check the parquet column format in CreateTableAsSelectSuite.scala

Please review http://spark.apache.org/contributing.html before opening a pull request.
