### PR TITLE
[SPARK-27454][ML][SQL] Spark image datasource fail when encounter some illegal images

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/image/ImageSchema.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/image/ImageSchema.scala
@@ -133,7 +133,13 @@ object ImageSchema {
    */
   private[spark] def decode(origin: String, bytes: Array[Byte]): Option[Row] = {
 
-    val img = ImageIO.read(new ByteArrayInputStream(bytes))
+    val img = try {
+      ImageIO.read(new ByteArrayInputStream(bytes))
+    } catch {
+      // Catch runtime exception because `ImageIO` may throw unexcepted `RuntimeException`.
+      // But do not catch the declared `IOException` (regareded as FileSystem failure)
+      case _: RuntimeException => null
+    }
 
     if (img == null) {
       None

--- a/mllib/src/main/scala/org/apache/spark/ml/image/ImageSchema.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/image/ImageSchema.scala
@@ -137,7 +137,7 @@ object ImageSchema {
       ImageIO.read(new ByteArrayInputStream(bytes))
     } catch {
       // Catch runtime exception because `ImageIO` may throw unexcepted `RuntimeException`.
-      // But do not catch the declared `IOException` (regareded as FileSystem failure)
+      // But do not catch the declared `IOException` (regarded as FileSystem failure)
       case _: RuntimeException => null
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix in Spark image datasource fail when encounter some illegal images.

This related to bugs inside `ImageIO.read` so in spark code I add exception handling for it.

## How was this patch tested?

N/A

Please review http://spark.apache.org/contributing.html before opening a pull request.
