### PR TITLE
[SPARK-27473][SQL] Support filter push down for status fields in binary file data source

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
@@ -79,9 +79,9 @@ class BinaryFileFormatSuite extends QueryTest with SharedSQLContext with SQLTest
       .option("pathGlobFilter", pathGlobFilter)
       .load(testDir)
       .select(
-        col("status.path"),
-        col("status.modificationTime"),
-        col("status.length"),
+        col("path"),
+        col("modificationTime"),
+        col("length"),
         col("content"),
         col("year") // this is a partition column
       )
@@ -138,6 +138,37 @@ class BinaryFileFormatSuite extends QueryTest with SharedSQLContext with SQLTest
       }
       assert(thrown.getMessage.contains("Write is not supported for binary file data source"))
     }
+  }
+
+
+  test("filter") {
+    println("filter version: 6")
+    /*
+    val resultDF = spark.read.format("binaryFile")
+      .load(testDir)
+      .select(
+        col("status.path"),
+        col("status.modificationTime"),
+        col("status.length"),
+        col("content"),
+        col("year") // this is a partition column
+      ).filter(col("length") < 30000L
+              && col("modificationTime") <= new Timestamp(12345678L))
+    */
+
+    val resultDF = spark.read.format("binaryFile")
+      .load(testDir)
+      .filter(col("length") < 30000L
+              && col("modificationTime") <= new Timestamp(12345678L))
+
+
+    /*
+    val resultDF = spark.read.format("binaryFile")
+      .load(testDir)
+      .filter(col("content").isNotNull)
+      */
+    resultDF.collect()
+
   }
 
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
@@ -200,7 +200,7 @@ class BinaryFileFormatSuite extends QueryTest with SharedSQLContext with SQLTest
       Seq(Or(LessThanOrEqual(LENGTH, 1L), GreaterThanOrEqual(LENGTH, 3L))),
       Seq((l1, true), (l2, false), (l3, true)))
 
-    // test filter applied on `length` column
+    // test filter applied on `modificationTime` column
     val t1 = mockFileStatus(0L, 1L)
     val t2 = mockFileStatus(0L, 2L)
     val t3 = mockFileStatus(0L, 3L)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
@@ -24,10 +24,12 @@ import java.sql.Timestamp
 import scala.collection.JavaConverters._
 
 import com.google.common.io.{ByteStreams, Closeables}
-import org.apache.hadoop.fs.{FileSystem, GlobFilter, Path}
+import org.apache.hadoop.fs.{FileStatus, FileSystem, GlobFilter, Path}
 
-import org.apache.spark.sql.{QueryTest, Row}
-import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.{Column, QueryTest, Row}
+import org.apache.spark.sql.functions.{col, lit}
+import org.apache.spark.sql.sources.{And, Filter, GreaterThan, GreaterThanOrEqual,
+  LessThan, LessThanOrEqual}
 import org.apache.spark.sql.test.{SharedSQLContext, SQLTestUtils}
 import org.apache.spark.util.Utils
 
@@ -38,6 +40,12 @@ class BinaryFileFormatSuite extends QueryTest with SharedSQLContext with SQLTest
   private var fsTestDir: Path = _
 
   private var fs: FileSystem = _
+
+  private var file1Status: FileStatus = _
+  private var file2Status: FileStatus = _
+  private var file3Status: FileStatus = _
+  private var file4Status: FileStatus = _
+  private var fileStatusSet: Set[FileStatus] = _
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -51,44 +59,67 @@ class BinaryFileFormatSuite extends QueryTest with SharedSQLContext with SQLTest
     val year2015Dir = new File(testDir, "year=2015")
     year2015Dir.mkdir()
 
+    val file1 = new File(year2014Dir, "data.txt")
     Files.write(
-      new File(year2014Dir, "data.txt").toPath,
-      Seq("2014-test").asJava,
+      file1.toPath,
+      Seq("2014-test").asJava, // file length = 10
       StandardOpenOption.CREATE, StandardOpenOption.WRITE
     )
-    Files.write(
-      new File(year2014Dir, "data2.bin").toPath,
-      "2014-test-bin".getBytes,
-      StandardOpenOption.CREATE, StandardOpenOption.WRITE
-    )
+    file1Status = fs.getFileStatus(new Path(file1.getAbsolutePath))
 
+    val file2 = new File(year2014Dir, "data2.bin")
     Files.write(
-      new File(year2015Dir, "bool.csv").toPath,
-      Seq("bool", "True", "False", "true").asJava,
+      file2.toPath,
+      "2014-test-bin".getBytes, // file length = 13
       StandardOpenOption.CREATE, StandardOpenOption.WRITE
     )
+    file2Status = fs.getFileStatus(new Path(file2.getAbsolutePath))
+
+    // sleep 1s to make the gen file modificationTime different,
+    // for unit-test for push down filters on modificationTime column.
+    Thread.sleep(1000)
+
+    val file3 = new File(year2015Dir, "bool.csv")
     Files.write(
-      new File(year2015Dir, "data.txt").toPath,
-      "2015-test".getBytes,
+      file3.toPath,
+      Seq("bool", "True", "False", "true").asJava, // file length = 21
       StandardOpenOption.CREATE, StandardOpenOption.WRITE
     )
+    file3Status = fs.getFileStatus(new Path(file3.getAbsolutePath))
+
+    val file4 = new File(year2015Dir, "data.bin")
+    Files.write(
+      file4.toPath,
+      "2015-test".getBytes, // file length = 9
+      StandardOpenOption.CREATE, StandardOpenOption.WRITE
+    )
+    file4Status = fs.getFileStatus(new Path(file4.getAbsolutePath))
+
+    fileStatusSet = Set(file1Status, file2Status, file3Status, file4Status)
   }
 
-  def testBinaryFileDataSource(pathGlobFilter: String): Unit = {
-    val resultDF = spark.read.format("binaryFile")
-      .option("pathGlobFilter", pathGlobFilter)
-      .load(testDir)
-      .select(
+  def testBinaryFileDataSource(
+      pathGlobFilter: String,
+      sqlFilter: Column,
+      expectedFilter: FileStatus => Boolean): Unit = {
+    val dfReader = spark.read.format("binaryFile")
+    if (pathGlobFilter != null) {
+      dfReader.option("pathGlobFilter", pathGlobFilter)
+    }
+    var resultDF = dfReader.load(testDir).select(
         col("path"),
         col("modificationTime"),
         col("length"),
         col("content"),
         col("year") // this is a partition column
       )
+    if (sqlFilter != null) {
+      resultDF = resultDF.filter(sqlFilter)
+    }
 
     val expectedRowSet = new collection.mutable.HashSet[Row]()
 
-    val globFilter = new GlobFilter(pathGlobFilter)
+    val globFilter = if (pathGlobFilter == null) null else new GlobFilter(pathGlobFilter)
     for (partitionDirStatus <- fs.listStatus(fsTestDir)) {
       val dirPath = partitionDirStatus.getPath
 
@@ -96,7 +127,8 @@ class BinaryFileFormatSuite extends QueryTest with SharedSQLContext with SQLTest
       val year = partitionName.toInt // partition column "year" value which is `Int` type
 
       for (fileStatus <- fs.listStatus(dirPath)) {
-        if (globFilter.accept(fileStatus.getPath)) {
+        if ((globFilter == null || globFilter.accept(fileStatus.getPath))
+          && (expectedFilter == null || expectedFilter(fileStatus))) {
           val fpath = fileStatus.getPath.toString.replace("file:/", "file:///")
           val flen = fileStatus.getLen
           val modificationTime = new Timestamp(fileStatus.getModificationTime)
@@ -121,11 +153,34 @@ class BinaryFileFormatSuite extends QueryTest with SharedSQLContext with SQLTest
   }
 
   test("binary file data source test") {
-    testBinaryFileDataSource(pathGlobFilter = "*.*")
-    testBinaryFileDataSource(pathGlobFilter = "*.bin")
-    testBinaryFileDataSource(pathGlobFilter = "*.txt")
-    testBinaryFileDataSource(pathGlobFilter = "*.{txt,csv}")
-    testBinaryFileDataSource(pathGlobFilter = "*.json")
+    testBinaryFileDataSource(null, null, null)
+    testBinaryFileDataSource("*.*", null, null)
+    testBinaryFileDataSource("*.bin", null, null)
+    testBinaryFileDataSource("*.txt", null, null)
+    testBinaryFileDataSource("*.{txt,csv}", null, null)
+    testBinaryFileDataSource("*.json", null, null)
+
+    testBinaryFileDataSource(null, col("length") > 10, _.getLen > 10)
+    testBinaryFileDataSource(null, col("length") >= 10, _.getLen >= 10)
+    testBinaryFileDataSource(null, col("length") < 13, _.getLen < 13)
+    testBinaryFileDataSource(null, col("length") <= 13, _.getLen <= 13)
+
+    testBinaryFileDataSource(null,
+      col("modificationTime") > new Timestamp(file2Status.getModificationTime),
+      _.getModificationTime > file2Status.getModificationTime)
+    testBinaryFileDataSource(null,
+      col("modificationTime") >= new Timestamp(file2Status.getModificationTime),
+      _.getModificationTime >= file2Status.getModificationTime)
+    testBinaryFileDataSource(null,
+      col("modificationTime") < new Timestamp(file3Status.getModificationTime),
+      _.getModificationTime < file3Status.getModificationTime)
+    testBinaryFileDataSource(null,
+      col("modificationTime") <= new Timestamp(file3Status.getModificationTime),
+      _.getModificationTime <= file3Status.getModificationTime)
+
+    testBinaryFileDataSource(null,
+      col("length") >= 10 && col("length") <= 13,
+      s => s.getLen >= 10 && s.getLen <= 13)
   }
 
   test ("binary file data source do not support write operation") {
@@ -141,34 +196,44 @@ class BinaryFileFormatSuite extends QueryTest with SharedSQLContext with SQLTest
   }
 
 
-  test("filter") {
-    println("filter version: 6")
-    /*
-    val resultDF = spark.read.format("binaryFile")
-      .load(testDir)
-      .select(
-        col("status.path"),
-        col("status.modificationTime"),
-        col("status.length"),
-        col("content"),
-        col("year") // this is a partition column
-      ).filter(col("length") < 30000L
-              && col("modificationTime") <= new Timestamp(12345678L))
-    */
+  def testCreateFilterFunctions(
+      sourceFilter: Filter,
+      expectedFilterFunc: FileStatus => Boolean): Unit = {
+    val filterFuncList = BinaryFileFormat.createFilterFunctions(sourceFilter)
+    val result = fileStatusSet.filter(fileStatus => filterFuncList.forall(_.apply(fileStatus)))
+    val expectedResult = fileStatusSet.filter(expectedFilterFunc.apply(_))
+    assert(result === expectedResult)
+  }
 
-    val resultDF = spark.read.format("binaryFile")
-      .load(testDir)
-      .filter(col("length") < 30000L
-              && col("modificationTime") <= new Timestamp(12345678L))
+  test("test createFilterFunctions") {
+    // file1 length = 10
+    // file2 length = 13
+    // file3 length = 21
+    // file4 length = 9
+    testCreateFilterFunctions(LessThan("length", 13L), _.getLen < 13L)
+    testCreateFilterFunctions(LessThanOrEqual("length", 13L), _.getLen <= 13L)
+    testCreateFilterFunctions(GreaterThan("length", 10L), _.getLen > 10L)
+    testCreateFilterFunctions(GreaterThanOrEqual("length", 10L), _.getLen >= 10L)
 
+    // file modificationTime: file1 < file2 < file3 < file4
+    testCreateFilterFunctions(
+      LessThan("modificationTime", new Timestamp(file3Status.getModificationTime)),
+      _.getModificationTime < file3Status.getModificationTime)
+    testCreateFilterFunctions(
+      LessThanOrEqual("modificationTime", new Timestamp(file3Status.getModificationTime)),
+      _.getModificationTime <= file3Status.getModificationTime)
+    testCreateFilterFunctions(
+      GreaterThan("modificationTime", new Timestamp(file2Status.getModificationTime)),
+      _.getModificationTime > file2Status.getModificationTime)
+    testCreateFilterFunctions(
+      GreaterThanOrEqual("modificationTime", new Timestamp(file2Status.getModificationTime)),
+      _.getModificationTime >= file2Status.getModificationTime)
 
-    /*
-    val resultDF = spark.read.format("binaryFile")
-      .load(testDir)
-      .filter(col("content").isNotNull)
-      */
-    resultDF.collect()
-
+    // test AND filter
+    testCreateFilterFunctions(
+      And(GreaterThan("length", 9L), LessThanOrEqual("length", 13L)),
+      s => s.getLen > 9L && s.getLen <= 13L
+    )
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support 5 kinds of filters with and/or:
- LessThan
- LessThanOrEqual
- GreatThan
- GreatThanOrEqual
- EqualTo

Support filters applied on 2 columns:
- modificationTime
- length

Note:
In order to support datasource filter push-down, I flatten schema to be:
```
val schema = StructType(
    StructField("path", StringType, false) ::
    StructField("modificationTime", TimestampType, false) ::
    StructField("length", LongType, false) ::
    StructField("content", BinaryType, true) :: Nil)
```

## How was this patch tested?

To be added.

Please review http://spark.apache.org/contributing.html before opening a pull request.
