### PR TITLE
[SPARK-27468][Core][WEBUI] BlockUpdate replication event shouldn't overwrite storage level description in the UI

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -918,25 +918,6 @@ private[spark] class AppStatusListener(
     // can update the executor information too.
     liveRDDs.get(block.rddId).foreach { rdd =>
 
-      if (updatedStorageLevel.isDefined) {
-        // Replicated block update events will have `storageLevel.replication=1`.
-        // To avoid overwriting the block replicated event in the store, we need to
-        // have a check for whether the event is block replication or not.
-        // Default value of  `storageInfo.replication = 1` and hence if
-        // `storeLevel.replication = 2`, the replicated events won't overwrite in the store.
-        val storageInfo = rdd.storageInfo
-        val isReplicatedBlockUpdateEvent = storageLevel.replication < storageInfo.replication &&
-          (storageInfo.useDisk == storageLevel.useDisk &&
-            storageInfo.useMemory == storageLevel.useMemory &&
-            storageInfo.deserialized == storageLevel.deserialized &&
-            storageInfo.useOffHeap == storageLevel.useOffHeap)
-
-        if (!isReplicatedBlockUpdateEvent) {
-          rdd.storageInfo = storageLevel
-          rdd.setStorageLevel(updatedStorageLevel.get)
-        }
-      }
-
       val partition = rdd.partition(block.name)
 
       val executors = if (updatedStorageLevel.isDefined) {

--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -917,8 +917,24 @@ private[spark] class AppStatusListener(
     // Update the block entry in the RDD info, keeping track of the deltas above so that we
     // can update the executor information too.
     liveRDDs.get(block.rddId).foreach { rdd =>
+
       if (updatedStorageLevel.isDefined) {
-        rdd.setStorageLevel(updatedStorageLevel.get)
+        // Replicated block update events will have `storageLevel.replication=1`.
+        // To avoid overwriting the block replicated event in the store, we need to
+        // have a check for whether the event is block replication or not.
+        // Default value of  `storageInfo.replication = 1` and hence if
+        // `storeLevel.replication = 2`, the replicated events won't overwrite in the store.
+        val storageInfo = rdd.storageInfo
+        val isReplicatedBlockUpdateEvent = storageLevel.replication < storageInfo.replication &&
+          (storageInfo.useDisk == storageLevel.useDisk &&
+            storageInfo.useMemory == storageLevel.useMemory &&
+            storageInfo.deserialized == storageLevel.deserialized &&
+            storageInfo.useOffHeap == storageLevel.useOffHeap)
+
+        if (!isReplicatedBlockUpdateEvent) {
+          rdd.storageInfo = storageLevel
+          rdd.setStorageLevel(updatedStorageLevel.get)
+        }
       }
 
       val partition = rdd.partition(block.name)

--- a/core/src/main/scala/org/apache/spark/status/LiveEntity.scala
+++ b/core/src/main/scala/org/apache/spark/status/LiveEntity.scala
@@ -29,7 +29,7 @@ import org.apache.spark.JobExecutionStatus
 import org.apache.spark.executor.{ExecutorMetrics, TaskMetrics}
 import org.apache.spark.scheduler.{AccumulableInfo, StageInfo, TaskInfo}
 import org.apache.spark.status.api.v1
-import org.apache.spark.storage.{RDDInfo, StorageLevel}
+import org.apache.spark.storage.RDDInfo
 import org.apache.spark.ui.SparkUI
 import org.apache.spark.util.AccumulatorContext
 import org.apache.spark.util.collection.OpenHashSet
@@ -507,18 +507,16 @@ private class LiveRDD(val info: RDDInfo) extends LiveEntity {
 
   import LiveEntityHelpers._
 
-  var storageLevel: String = weakIntern(info.storageLevel.description)
   var memoryUsed = 0L
   var diskUsed = 0L
-  var storageInfo: StorageLevel = info.storageLevel
 
   private val partitions = new HashMap[String, LiveRDDPartition]()
   private val partitionSeq = new RDDPartitionSeq()
 
   private val distributions = new HashMap[String, LiveRDDDistribution]()
 
-  def setStorageLevel(level: String): Unit = {
-    this.storageLevel = weakIntern(level)
+  def storageLevel: String = {
+    weakIntern(info.storageLevel.description)
   }
 
   def partition(blockName: String): LiveRDDPartition = {

--- a/core/src/main/scala/org/apache/spark/status/LiveEntity.scala
+++ b/core/src/main/scala/org/apache/spark/status/LiveEntity.scala
@@ -29,7 +29,7 @@ import org.apache.spark.JobExecutionStatus
 import org.apache.spark.executor.{ExecutorMetrics, TaskMetrics}
 import org.apache.spark.scheduler.{AccumulableInfo, StageInfo, TaskInfo}
 import org.apache.spark.status.api.v1
-import org.apache.spark.storage.RDDInfo
+import org.apache.spark.storage.{RDDInfo, StorageLevel}
 import org.apache.spark.ui.SparkUI
 import org.apache.spark.util.AccumulatorContext
 import org.apache.spark.util.collection.OpenHashSet
@@ -510,6 +510,7 @@ private class LiveRDD(val info: RDDInfo) extends LiveEntity {
   var storageLevel: String = weakIntern(info.storageLevel.description)
   var memoryUsed = 0L
   var diskUsed = 0L
+  var storageInfo: StorageLevel = new StorageLevel()
 
   private val partitions = new HashMap[String, LiveRDDPartition]()
   private val partitionSeq = new RDDPartitionSeq()

--- a/core/src/main/scala/org/apache/spark/status/LiveEntity.scala
+++ b/core/src/main/scala/org/apache/spark/status/LiveEntity.scala
@@ -510,7 +510,7 @@ private class LiveRDD(val info: RDDInfo) extends LiveEntity {
   var storageLevel: String = weakIntern(info.storageLevel.description)
   var memoryUsed = 0L
   var diskUsed = 0L
-  var storageInfo: StorageLevel = new StorageLevel()
+  var storageInfo: StorageLevel = info.storageLevel
 
   private val partitions = new HashMap[String, LiveRDDPartition]()
   private val partitionSeq = new RDDPartitionSeq()

--- a/core/src/test/scala/org/apache/spark/status/AppStatusListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/AppStatusListenerSuite.scala
@@ -1547,10 +1547,12 @@ class AppStatusListenerSuite extends SparkFunSuite with BeforeAndAfter {
       BlockUpdatedInfo(bm1, rddBlock.blockId, level, rddBlock.memSize, rddBlock.diskSize)))
     // Block update event, where replication = 1
     listener.onBlockUpdated(SparkListenerBlockUpdated(
-      BlockUpdatedInfo(bm2, rddBlock.blockId, levelBlockReplica, rddBlock.memSize, rddBlock.diskSize)))
+      BlockUpdatedInfo(bm2, rddBlock.blockId, levelBlockReplica, rddBlock.memSize,
+        rddBlock.diskSize)))
 
     check[RDDStorageInfoWrapper](rddBlock.rddId) { wrapper =>
-      val partitionInfo = wrapper.info.partitions.get.find(_.blockName === rddBlock.blockId.name).get
+      val partitionInfo = wrapper.info.partitions.get.find(_.blockName === rddBlock.blockId.name)
+        .get
       assert(partitionInfo.storageLevel === level.description)
       assert(partitionInfo.memoryUsed === 2 * rddBlock.memSize)
       assert(partitionInfo.diskUsed === 2 * rddBlock.diskSize)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Test steps to reproduce this:

1) bin/spark-shell local-cluster[2,1,1024]
```
scala> import org.apache.spark.storage.StorageLevel
scala> val rdd = sc.parallelize(1 to 10, 1).persist(StorageLevel.MEMORY_ONLY_2)
scala> rdd.count
```
Events generated are shown like below
```
event: SparkListenerBlockUpdated(BlockUpdatedInfo(BlockManagerId(1, 10.8.132.160, 65473, None),rdd_0_0,StorageLevel(memory, deserialized, 2 replicas),56,0))
event: SparkListenerBlockUpdated(BlockUpdatedInfo(BlockManagerId(0, 10.8.132.160, 65474, None),rdd_0_0,StorageLevel(memory, deserialized, 1 replicas),56,0))
```
But in the UI, in the storage tab it displays in the description like,
  "Memory Deserialized 1x Replicated", even though we have given replication as 2.

The root cause is that, the replication block update events will have replication factor 1. Hence in the AppStatusListener class, we overwrite whatever event comes later. If the replication event comes later, then we update replication factor as 1. 

In the PR, I am fixing from the AppStatusListener class side, as we need to detect if the event is replication or not. Else we need to update the rdd store.



## How was this patch tested?

Added UT and Manually tested.

Before patch:

![Screenshot from 2019-04-18 14-50-06](https://user-images.githubusercontent.com/23054875/56342031-6d44a400-61e9-11e9-916d-b4040b0ffd7c.png)

After patch:
![Screenshot from 2019-04-18 14-51-04](https://user-images.githubusercontent.com/23054875/56342037-7170c180-61e9-11e9-9ef0-71b4ec0da9ec.png)

