### PR TITLE
[SPARK-27503][DStream] JobGenerator thread exit for some fatal errors but application keeps running

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/EventLoop.scala
+++ b/core/src/main/scala/org/apache/spark/util/EventLoop.scala
@@ -100,10 +100,12 @@ private[spark] abstract class EventLoop[E](name: String) extends Logging {
    * Put the event into the event queue. The event thread will process it later.
    */
   def post(event: E): Unit = {
-    if (eventThread.isAlive && !stopped.get) {
-      eventQueue.put(event)
-    } else if (!stopped.get) {
-      onError(new IllegalStateException(s"$name has already been stopped accidentally."))
+    if (!stopped.get) {
+      if (eventThread.isAlive) {
+        eventQueue.put(event)
+      } else {
+        onError(new IllegalStateException(s"$name has already been stopped accidentally."))
+      }
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/util/EventLoop.scala
+++ b/core/src/main/scala/org/apache/spark/util/EventLoop.scala
@@ -100,7 +100,11 @@ private[spark] abstract class EventLoop[E](name: String) extends Logging {
    * Put the event into the event queue. The event thread will process it later.
    */
   def post(event: E): Unit = {
-    eventQueue.put(event)
+    if (eventThread.isAlive && !stopped.get) {
+      eventQueue.put(event)
+    } else {
+      onError(new IllegalStateException(s"$name has already been stopped."))
+    }
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/util/EventLoop.scala
+++ b/core/src/main/scala/org/apache/spark/util/EventLoop.scala
@@ -102,8 +102,8 @@ private[spark] abstract class EventLoop[E](name: String) extends Logging {
   def post(event: E): Unit = {
     if (eventThread.isAlive && !stopped.get) {
       eventQueue.put(event)
-    } else {
-      onError(new IllegalStateException(s"$name has already been stopped."))
+    } else if (!stopped.get) {
+      onError(new IllegalStateException(s"$name has already been stopped accidentally."))
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In some corner cases, `JobGenerator` thread (including some other EventLoop threads) may exit for some fatal error, like OOM, but Spark Streaming job keep running with no batch job generating. Currently, we only report any non-fatal error. 

```
override def run(): Unit = {
      try {
        while (!stopped.get) {
          val event = eventQueue.take()
          try {
            onReceive(event)
          } catch {
            case NonFatal(e) =>
              try {
                onError(e)
              } catch {
                case NonFatal(e) => logError("Unexpected error in " + name, e)
              }
          }
        }
      } catch {
        case ie: InterruptedException => // exit even if eventQueue is not empty
        case NonFatal(e) => logError("Unexpected error in " + name, e)
      }
    }
```

In this PR, we double check if event thread alive when post Event

## How was this patch tested?

existing unit tests