### PR TITLE
[SPARK-27460][TESTS][FollowUp] Add HiveClientVersions to parallel test suite list

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -466,6 +466,7 @@ object SparkParallelTestGrouping {
     "org.apache.spark.sql.hive.StatisticsSuite",
     "org.apache.spark.sql.hive.execution.HiveCompatibilitySuite",
     "org.apache.spark.sql.hive.client.VersionsSuite",
+    "org.apache.spark.sql.hive.client.HiveClientVersions",
     "org.apache.spark.sql.hive.HiveExternalCatalogVersionsSuite",
     "org.apache.spark.ml.classification.LogisticRegressionSuite",
     "org.apache.spark.ml.classification.LinearSVCSuite",

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types.{BooleanType, IntegerType, LongType, StructType}
+import org.apache.spark.util.Utils
 
 // TODO: Refactor this to `HivePartitionFilteringSuite`
 class HiveClientSuite(version: String)
@@ -39,8 +40,9 @@ class HiveClientSuite(version: String)
   private val testPartitionCount = 3 * 5 * 4
 
   private def init(tryDirectSql: Boolean): HiveClient = {
+    val location = Some(Utils.createTempDir().toURI)
     val storageFormat = CatalogStorageFormat(
-      locationUri = None,
+      locationUri = location,
       inputFormat = None,
       outputFormat = None,
       serde = None,
@@ -54,11 +56,11 @@ class HiveClientSuite(version: String)
       new StructType().add("value", "int").add("ds", "int").add("h", "int").add("chunk", "string")
     val table = CatalogTable(
       identifier = TableIdentifier("test", Some("default")),
-      tableType = CatalogTableType.MANAGED,
+      tableType = CatalogTableType.EXTERNAL,
       schema = tableSchema,
       partitionColumnNames = Seq("ds", "h", "chunk"),
       storage = CatalogStorageFormat(
-        locationUri = None,
+        locationUri = location,
         inputFormat = Some(classOf[TextInputFormat].getName),
         outputFormat = Some(classOf[HiveIgnoreKeyTextOutputFormat[_, _]].getName),
         serde = Some(classOf[LazySimpleSerDe].getName()),


### PR DESCRIPTION
## What changes were proposed in this pull request?

The test time of `HiveClientVersions` is around 3.5 minutes.
This PR is to add it into the parallel test suite list. To make sure there is no colliding warehouse location,  we can change the warehouse path to a temporary directory.

## How was this patch tested?

Unit test
