### PR TITLE
[MINOR][TEST] Expand spark-submit test to allow python2/3 executable

### DIFF
--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -158,7 +158,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
 
     Map<String, String> env = new HashMap<>();
     List<String> cmd = buildCommand(sparkSubmitArgs, env);
-    assertEquals("python", cmd.get(cmd.size() - 1));
+    assertTrue(Arrays.asList("python", "python2", "python3").contains(cmd.get(cmd.size() - 1)));
     assertEquals(
       String.format("\"%s\" \"foo\" \"%s\" \"bar\" \"%s\"",
         parser.MASTER, parser.DEPLOY_MODE, SparkSubmitCommandBuilder.PYSPARK_SHELL_RESOURCE),


### PR DESCRIPTION
## What changes were proposed in this pull request?

This backports a tiny part of another change:
https://github.com/apache/spark/commit/4bdfda92a1c570d7a1142ee30eb41e37661bc240#diff-3c792ce7265b69b448a984caf629c96bR161
... which just works around the possibility that the local python interpreter is 'python3' or 'python2' when running the spark-submit tests.

I'd like to backport to 2.3 too.

This otherwise prevents this test from passing on my mac, though I have a custom install with brew. But may affect others.

## How was this patch tested?

Existing tests.