### PR TITLE
[SPARK-27513][BUILD] files in tarball should have uid/gid 0

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -179,7 +179,7 @@ if [[ "$1" == "package" ]]; then
     rm -r spark-$SPARK_VERSION/licenses-binary
   fi
 
-  tar cvzf spark-$SPARK_VERSION.tgz spark-$SPARK_VERSION
+  tar cvzf spark-$SPARK_VERSION.tgz --numeric-owner --owner=0 --group=0 spark-$SPARK_VERSION
   echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --armour --output spark-$SPARK_VERSION.tgz.asc \
     --detach-sig spark-$SPARK_VERSION.tgz
   echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --print-md \

--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -286,6 +286,6 @@ if [ "$MAKE_TGZ" == "true" ]; then
   TARDIR="$SPARK_HOME/$TARDIR_NAME"
   rm -rf "$TARDIR"
   cp -r "$DISTDIR" "$TARDIR"
-  tar czf "spark-$VERSION-bin-$NAME.tgz" -C "$SPARK_HOME" "$TARDIR_NAME"
+  tar czf "spark-$VERSION-bin-$NAME.tgz" --numeric-owner --owner=0 --group=0 -C "$SPARK_HOME" "$TARDIR_NAME"
   rm -rf "$TARDIR"
 fi


### PR DESCRIPTION
## What changes were proposed in this pull request?

build tarball with all files having uid/gui 0

## How was this patch tested?

i build tarball with:
`$ dev/make-distribution.sh --name provided --tgz -Phadoop-2.7 -Dhadoop.version=2.7.0 -Pyarn -Phadoop-provided`
and verified uid/pid with:
```
$ tar -ztvf spark-3.0.0-SNAPSHOT-bin-provided.tgz | head
drwxrwxr-x 0/0               0 2019-04-18 15:10 spark-3.0.0-SNAPSHOT-bin-provided/
drwxrwxr-x 0/0               0 2019-04-18 15:10 spark-3.0.0-SNAPSHOT-bin-provided/jars/
-rw-rw-r-- 0/0           65261 2019-04-18 15:10 spark-3.0.0-SNAPSHOT-bin-provided/jars/oro-2.0.8.jar
-rw-rw-r-- 0/0           95806 2019-04-18 15:10 spark-3.0.0-SNAPSHOT-bin-provided/jars/javax.servlet-api-3.1.0.jar
-rw-rw-r-- 0/0          174351 2019-04-18 15:10 spark-3.0.0-SNAPSHOT-bin-provided/jars/stream-2.7.0.jar
-rw-rw-r-- 0/0           58633 2019-04-18 15:10 spark-3.0.0-SNAPSHOT-bin-provided/jars/chill-java-0.9.3.jar
-rw-rw-r-- 0/0           39283 2019-04-18 15:10 spark-3.0.0-SNAPSHOT-bin-provided/jars/metrics-jvm-3.1.5.jar
-rw-rw-r-- 0/0           72733 2019-04-18 15:10 spark-3.0.0-SNAPSHOT-bin-provided/jars/jersey-media-jaxb-2.22.2.jar
-rw-rw-r-- 0/0          812313 2019-04-18 15:10 spark-3.0.0-SNAPSHOT-bin-provided/jars/orc-mapreduce-1.5.5-nohive.jar
-rw-rw-r-- 0/0           66894 2019-04-18 15:10 spark-3.0.0-SNAPSHOT-bin-provided/jars/jackson-annotations-2.9.8.jar
```