### PR TITLE
[SPARK-27518][SQL][Web UI] Show statistics in Optimized Logical Plan in the "Details" On SparkSQL ui page when CBO is enabled

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -21,7 +21,6 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
 import org.apache.spark.SparkContext
-
 import org.apache.spark.internal.config.Tests.IS_TESTING
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.ui.{SparkListenerSQLExecutionEnd, SparkListenerSQLExecutionStart}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -21,9 +21,11 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
 import org.apache.spark.SparkContext
+
 import org.apache.spark.internal.config.Tests.IS_TESTING
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.ui.{SparkListenerSQLExecutionEnd, SparkListenerSQLExecutionStart}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.StaticSQLConf.SQL_EVENT_TRUNCATE_LENGTH
 import org.apache.spark.util.Utils
 
@@ -92,7 +94,8 @@ object SQLExecution {
             executionId = executionId,
             description = desc,
             details = callSite.longForm,
-            physicalPlanDescription = queryExecution.toString,
+            physicalPlanDescription = queryExecution.planString(
+              addStats = sc.conf.get(SQLConf.CBO_ENABLED)),
             // `queryExecution.executedPlan` triggers query planning. If it fails, the exception
             // will be caught and reported in the `SparkListenerSQLExecutionEnd`
             sparkPlanInfo = SparkPlanInfo.fromSparkPlan(queryExecution.executedPlan),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
@@ -167,7 +167,7 @@ case class ExplainCommand(
       } else if (extended) {
         queryExecution.toString
       } else if (cost) {
-        queryExecution.stringWithStats
+        queryExecution.planString(addParsed = false, addAnalyzed = false, addStats = true)
       } else {
         queryExecution.simpleString
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/DataSourceScanExecRedactionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/DataSourceScanExecRedactionSuite.scala
@@ -57,7 +57,7 @@ class DataSourceScanExecRedactionSuite extends QueryTest with SharedSQLContext {
   private def isIncluded(queryExecution: QueryExecution, msg: String): Boolean = {
     queryExecution.toString.contains(msg) ||
     queryExecution.simpleString.contains(msg) ||
-    queryExecution.stringWithStats.contains(msg)
+    queryExecution.planString(addStats = true).contains(msg)
   }
 
   test("explain is redacted using SQLConf") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
@@ -138,4 +138,21 @@ class QueryExecutionSuite extends SharedSQLContext {
     val error = intercept[Error](qe.toString)
     assert(error.getMessage.contains("error"))
   }
+
+  test("test planString") {
+    val parsedKeywords = "Parsed Logical Plan"
+    val analyzedKeywords = "Analyzed Logical Plan"
+    val optimizedKeywords = "Optimized Logical Plan"
+    val statsKeywords = "Statistics"
+
+    def qe: QueryExecution = new QueryExecution(spark, OneRowRelation())
+    val planString = qe.planString()
+    assert(
+      planString.contains(parsedKeywords) && planString.contains(analyzedKeywords) && planString
+        .contains(optimizedKeywords) && !planString.contains(statsKeywords))
+    assert(!qe.planString(addParsed = false).contains(parsedKeywords))
+    assert(!qe.planString(addAnalyzed = false).contains(analyzedKeywords))
+    assert(!qe.planString(addOptimized = false).contains(optimizedKeywords))
+    assert(qe.planString(addStats = true).contains(statsKeywords))
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -25,8 +25,8 @@ import java.util.{Locale, Set}
 
 import com.google.common.io.Files
 import org.apache.hadoop.fs.{FileSystem, Path}
-import org.apache.spark.{SparkException, TestUtils}
 
+import org.apache.spark.{SparkException, TestUtils}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, FunctionRegistry}

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -25,8 +25,8 @@ import java.util.{Locale, Set}
 
 import com.google.common.io.Files
 import org.apache.hadoop.fs.{FileSystem, Path}
-
 import org.apache.spark.{SparkException, TestUtils}
+
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, FunctionRegistry}
@@ -2329,8 +2329,8 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
         sql("insert into all_null values (null, null)")
         sql("analyze table all_null compute statistics for columns attr1, attr2")
         // check if the stats can be calculated without Cast exception.
-        sql("select * from all_null where attr1 < 1").queryExecution.stringWithStats
-        sql("select * from all_null where attr1 < attr2").queryExecution.stringWithStats
+        sql("select * from all_null where attr1 < 1").queryExecution.planString(addStats = true)
+        sql("select * from all_null where attr1 < attr2").queryExecution.planString(addStats = true)
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Statistics snapshot info with current query is really helpful to find out why the query runs slowly, especially caused by bad rejoin order when CBO is enabled. This PR is to show statistics in Optimized Logical Plan in the "Details" On SparkSQL ui page when CBO is enabled.

Main changes:
1. Refactoring `QueryExecution` String method to avoid duplicate code
2. Add statistic info to physicalPlanDescription when CBO is enabled

![SPARK-27518-1](https://user-images.githubusercontent.com/1247590/56405131-5c556a80-629d-11e9-94ef-d5e460e46088.jpg)

## How was this patch tested?
Manual test & according UT has been added 