### PR TITLE
[SPARK-27522][SQL][TEST] Test migration from INT96 to TIMESTAMP_MICROS for timestamps in parquet

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
@@ -884,45 +884,35 @@ class ParquetQuerySuite extends QueryTest with ParquetTest with SharedSQLContext
 
   test("Migration from INT96 to TIMESTAMP_MICROS timestamp type") {
     def testMigration(fromTsType: String, toTsType: String): Unit = {
-      def data(start: Int, end: Int): Seq[Row] = (start to end).map { i =>
-        val ts = new java.sql.Timestamp(TimeUnit.SECONDS.toMillis(i))
-        ts.setNanos(123456000)
-        Row(ts)
-      }
-      val schema = new StructType().add("time", TimestampType)
-      val df1 = spark.createDataFrame(sparkContext.parallelize(data(0, 1)), schema)
-      val df2 = spark.createDataFrame(sparkContext.parallelize(data(2, 10)), schema)
-      val expected = df1.unionAll(df2)
-
-      withTempPath { file =>
-        withSQLConf(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key -> fromTsType) {
-          df1.write.parquet(file.getCanonicalPath)
+      def checkAppend(write: DataFrameWriter[_] => Unit, readback: => DataFrame): Unit = {
+        def data(start: Int, end: Int): Seq[Row] = (start to end).map { i =>
+          val ts = new java.sql.Timestamp(TimeUnit.SECONDS.toMillis(i))
+          ts.setNanos(123456000)
+          Row(ts)
         }
+        val schema = new StructType().add("time", TimestampType)
+        val df1 = spark.createDataFrame(sparkContext.parallelize(data(0, 1)), schema)
+        withSQLConf(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key -> fromTsType) {
+          write(df1.write)
+        }
+        val df2 = spark.createDataFrame(sparkContext.parallelize(data(2, 10)), schema)
         withSQLConf(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key -> toTsType) {
-          df2.write.mode(SaveMode.Append).parquet(file.getCanonicalPath)
+          write(df2.write.mode(SaveMode.Append))
         }
         Seq("true", "false").foreach { vectorized =>
           withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> vectorized) {
-            val readback = spark.read.parquet(file.getCanonicalPath)
-            checkAnswer(readback, expected)
+            checkAnswer(readback, df1.unionAll(df2))
           }
         }
+      }
+
+      withTempPath { file =>
+        checkAppend(_.parquet(file.getCanonicalPath), spark.read.parquet(file.getCanonicalPath))
       }
 
       val tableName = "parquet_timestamp_migration"
       withTable(tableName) {
-        withSQLConf(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key -> fromTsType) {
-          df1.write.saveAsTable(tableName)
-        }
-        withSQLConf(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key -> toTsType) {
-          df2.write.mode(SaveMode.Append).saveAsTable(tableName)
-        }
-        Seq("true", "false").foreach { vectorized =>
-          withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> vectorized) {
-            val readback = spark.table(tableName)
-            checkAnswer(readback, expected)
-          }
-        }
+        checkAppend(_.saveAsTable(tableName), spark.table(tableName))
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added tests to check migration from `INT96` to `TIMESTAMP_MICROS` (`INT64`) for timestamps in parquet files. In particular:
- Append `TIMESTAMP_MICROS` timestamps to **existing parquet** files with `INT96` timestamps
- Append `TIMESTAMP_MICROS` timestamps to a table with `INT96` timestamps
- Append `INT96` to `TIMESTAMP_MICROS` timestamps in **parquet files**
- Append `INT96` to `TIMESTAMP_MICROS` timestamps in a **table**

