### PR TITLE
[SPARK-12312][SQL]Support Kerberos login in JDBC connector

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -190,6 +190,15 @@ class JDBCOptions(
 
   // An option to allow/disallow pushing down predicate into JDBC data source
   val pushDownPredicate = parameters.getOrElse(JDBC_PUSHDOWN_PREDICATE, "true").toBoolean
+
+  // ------------------------------------------------------------
+  // Optional parameters for Kerberos
+  // ------------------------------------------------------------
+  // The HDFS path of user's keytab file, which is assumed to be pre-uploaded to
+  // HDFS by user and distributed to executors by the --file option of spark-submit
+  val keytab = parameters.getOrElse(JDBC_KEYTAB, null)
+  // The principal name of user's keytab file
+  val principal = parameters.getOrElse(JDBC_PRINCIPAL, null)
 }
 
 class JdbcOptionsInWrite(
@@ -242,4 +251,6 @@ object JDBCOptions {
   val JDBC_TXN_ISOLATION_LEVEL = newOption("isolationLevel")
   val JDBC_SESSION_INIT_STATEMENT = newOption("sessionInitStatement")
   val JDBC_PUSHDOWN_PREDICATE = newOption("pushDownPredicate")
+  val JDBC_KEYTAB = newOption("keytab")
+  val JDBC_PRINCIPAL = newOption("principal")
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use the provided principal and keytab to do Kerberos login before setting up the JDBC connection.

## How was this patch tested?

Step 1: Configure Microsoft SQL Server

Step 2: Start spark shell 
/spark/bin/spark-shell --master yarn \
  --files hdfs:///spark/admin.keytab

Step 3: Run the following Scala code in spark shell
import java.util.Properties

val dataSrc = "jdbc"
val hostname = "master-0.azdata.local"
val port = 1433
val database = "spark"
val url = s"jdbc:sqlserver://${hostname}:${port};database=${database};integratedSecurity=true;authenticationScheme=JavaKerberos"

val df = Seq(
  (8, "bat"),
  (64, "mouse"),
  (-27, "horse")
).toDF("number", "word")

import org.apache.spark.sql.SaveMode  

df.write.mode(SaveMode.Overwrite).format("jdbc").option("principal", "admin@AZDATA.LOCAL").option("keytab", "hdfs:///spark/admin.keytab").option("url", url).option("dbtable", "spark").save()

val outDf = spark.read.format("jdbc").option("principal", "admin@AZDATA.LOCAL").option("keytab", "admin.keytab").option("url", url).option("dbtable", "spark").load()

outDf.show()