### PR TITLE
[SPARK-27532][Doc] Correct the default value in the Documentation for "spark.redaction.regex"

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -472,7 +472,7 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.redaction.regex</code></td>
-  <td>(?i)secret|password</td>
+  <td>(?i)secret|password|token</td>
   <td>
     Regex to decide which Spark configuration properties and environment variables in driver and
     executor environments contain sensitive information. When this regex matches a property key or


### PR DESCRIPTION
## What changes were proposed in this pull request?

Corrected the default value in the Documentation for "spark.redaction.regex" 

## How was this patch tested?

NA
