### PR TITLE
[SPARK-27545] [SQL] Uncache table needs to delete the temporary view …

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.internal
 
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.control.NonFatal
+import scala.util.Try
+
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalog.{Catalog, Column, Database, Function, Table}
@@ -30,9 +32,6 @@ import org.apache.spark.sql.execution.command.AlterTableRecoverPartitionsCommand
 import org.apache.spark.sql.execution.datasources.{CreateTable, DataSource}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.storage.StorageLevel
-
-import scala.util.Try
-
 
 /**
  * Internal implementation of the user-facing `Catalog`.

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.execution.datasources.{CreateTable, DataSource}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.storage.StorageLevel
 
+
 /**
  * Internal implementation of the user-facing `Catalog`.
  */
@@ -442,8 +443,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
   override def uncacheTable(tableName: String): Unit = {
     val tableIdent = sparkSession.sessionState.sqlParser.parseTableIdentifier(tableName)
     val cascade = !sessionCatalog.isTemporaryTable(tableIdent)
-    val wasCached = Try(sparkSession.catalog.isCached(tableIdent.unquotedString)).getOrElse(false)
-    if (wasCached) {
+    if (isCached(tableName)) {
       sparkSession.sharedState.cacheManager.uncacheQuery(sparkSession.table(tableIdent), cascade)
       sparkSession.sessionState.catalog.dropTempView(tableIdent.table)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.internal
 
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.control.NonFatal
-import scala.util.Try
 
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql._

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -113,6 +113,15 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with SharedSQLContext
     }
   }
 
+  test("SPARK-27545 Uncache table needs to delete the temporary view") {
+    withTempView("testCacheTable") {
+      sql("CACHE TABLE testCacheTable AS SELECT key FROM testData LIMIT 10")
+      assertCached(spark.table("testCacheTable"))
+      sql("UNCACHE TABLE testCacheTable")
+      sql("CACHE TABLE testCacheTable AS SELECT key FROM testData LIMIT 10")
+    }
+  }
+
   test("unpersist an uncached table will not raise exception") {
     assert(None == spark.sharedState.cacheManager.lookupCachedData(testData))
     testData.unpersist(blocking = true)


### PR DESCRIPTION
…created when the cache table is executed

## What changes were proposed in this pull request?

When executing the uncache table, delete the temporary table created when the cache table is executed.

## How was this patch tested?

 unit tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
