### PR TITLE
[SPARK-27540][MLlib] Add 'meanAveragePrecision_at_k' metric to RankingMetrics

### DIFF
--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaRankingMetricsExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaRankingMetricsExample.java
@@ -109,6 +109,10 @@ public class JavaRankingMetricsExample {
 
     // Mean average precision
     System.out.format("Mean average precision = %f\n", metrics.meanAveragePrecision());
+    for (Integer k : kVector) {
+      System.out.format("Mean average precision at %d = %f\n", k,
+        metrics.meanAveragePrecisionAt(k));
+    }
 
     // Evaluate the model using numerical ratings and regression metrics
     JavaRDD<Tuple2<Object, Object>> userProducts =

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/RankingMetricsExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/RankingMetricsExample.scala
@@ -84,6 +84,11 @@ object RankingMetricsExample {
     // Mean average precision
     println(s"Mean average precision = ${metrics.meanAveragePrecision}")
 
+    // Mean average precision at K
+    Array(1, 3, 5).foreach { k =>
+      println(s"Mean average precision at $k = ${metrics.meanAveragePrecisionAt(k)}")
+    }
+
     // Normalized discounted cumulative gain
     Array(1, 3, 5).foreach { k =>
       println(s"NDCG at $k = ${metrics.ndcgAt(k)}")

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
@@ -70,26 +70,42 @@ class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T])]
    */
   lazy val meanAveragePrecision: Double = {
     predictionAndLabels.map { case (pred, lab) =>
-      val labSet = lab.toSet
-
-      if (labSet.nonEmpty) {
-        var i = 0
-        var cnt = 0
-        var precSum = 0.0
-        val n = pred.length
-        while (i < n) {
-          if (labSet.contains(pred(i))) {
-            cnt += 1
-            precSum += cnt.toDouble / (i + 1)
-          }
-          i += 1
-        }
-        precSum / labSet.size
-      } else {
-        logWarning("Empty ground truth set, check input data")
-        0.0
-      }
+      computeMeanAveragePrecisonAtK(pred, lab, pred.length)
     }.mean()
+  }
+
+  /**
+   * Returns mean average precision truncated at position k.
+   *
+   * If a query has an empty ground truth set, the value will be zero and a log
+   * warning is generated.
+   *
+   * @param pred predicted ranking
+   * @param lab ground truth
+   * @param k use the top k predicted ranking, must be positive
+   * @return mean average precision of first k ranking positions
+   */
+  private def computeMeanAveragePrecisonAtK(pred: Array[T],
+                                            lab: Array[T],
+                                            k: Int): Double = {
+    val labSet = lab.toSet
+    if (labSet.nonEmpty) {
+      var i = 0
+      var cnt = 0
+      var precSum = 0.0
+      val n = math.min(pred.length, k)
+      while (i < n) {
+        if (labSet.contains(pred(i))) {
+          cnt += 1
+          precSum += cnt.toDouble / (i + 1)
+        }
+        i += 1
+      }
+      precSum / labSet.size
+    } else {
+      logWarning("Empty ground truth set, check input data")
+      0.0
+    }
   }
 
   /**
@@ -197,6 +213,23 @@ class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T])]
       logWarning("Empty ground truth set, check input data")
       0.0
     }
+  }
+
+  /**
+   * Compute the mean average precision (MAP) of all the queries, truncated at ranking position k.
+   *
+   * If for a query, the ranking algorithm returns n (n is less than k) results, the MAP value will
+   * be computed as MAP at n.
+   *
+   * If a query has an empty ground truth set, the average precision will be zero and a log
+   * warning is generated.
+   */
+  @Since("3.0.0")
+  def meanAveragePrecisionAt(k: Int): Double = {
+    require(k > 0, "ranking position k should be positive")
+    predictionAndLabels.map { case (pred, lab) =>
+      computeMeanAveragePrecisonAtK(pred, lab, k)
+    }.mean()
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/mllib/evaluation/RankingMetricsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/evaluation/RankingMetricsSuite.scala
@@ -57,6 +57,14 @@ class RankingMetricsSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(metrics.recallAt(5) ~== 16.0/45 absTol eps)
     assert(metrics.recallAt(10) ~== 2.0/3 absTol eps)
     assert(metrics.recallAt(15) ~== 2.0/3 absTol eps)
+
+    assert(metrics.meanAveragePrecisionAt(1) ~== 1.0/15 absTol eps)
+    assert(metrics.meanAveragePrecisionAt(2) ~== 11.0/90 absTol eps)
+    assert(metrics.meanAveragePrecisionAt(3) ~== 1.0/6 absTol eps)
+    assert(metrics.meanAveragePrecisionAt(4) ~== 1.0/6 absTol eps)
+    assert(metrics.meanAveragePrecisionAt(5) ~== 19.0/90 absTol eps)
+    assert(metrics.meanAveragePrecisionAt(10) ~== 671.0/1890 absTol eps)
+    assert(metrics.meanAveragePrecisionAt(15) ~== 671.0/1890 absTol eps)
   }
 
   test("MAP, NDCG, Recall with few predictions (SPARK-14886)") {
@@ -74,6 +82,8 @@ class RankingMetricsSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(metrics.ndcgAt(2) ~== 0.30657 absTol eps)
     assert(metrics.recallAt(1) ~== 0.1 absTol eps)
     assert(metrics.recallAt(2) ~== 0.1 absTol eps)
+    assert(metrics.meanAveragePrecisionAt(1) ~== 0.1 absTol eps)
+    assert(metrics.meanAveragePrecisionAt(2) ~== 0.1 absTol eps)
   }
 
 }

--- a/python/pyspark/mllib/evaluation.py
+++ b/python/pyspark/mllib/evaluation.py
@@ -450,6 +450,20 @@ class RankingMetrics(JavaModelWrapper):
         """
         return self.call("recallAt", int(k))
 
+    @since('3.0.0')
+    def meanAveragePrecisionAt(self, k):
+        """
+        Compute the mean average precision (MAP) of all the queries, truncated at ranking
+        position k.
+
+        If for a query, the ranking algorithm returns n (n is less than k) results, the MAP value
+        will be computed as MAP at n.
+
+        If a query has an empty ground truth set, the average precision will be zero and a log
+        warning is generated.
+        """
+        return self.call("meanAveragePrecisionAt", int(k))
+
 
 class MultilabelMetrics(JavaModelWrapper):
     """


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add 'meanAveragePrecision_at_k' metric to RankingMetrics

## How was this patch tested?

Add test to RankingMetricsSuite.
