### PR TITLE
[SPARK-26268][CORE] Do not resubmit tasks when executors are lost

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -216,11 +216,13 @@ private[spark] class ExecutorAllocationManager(
     if (cachedExecutorIdleTimeoutS < 0) {
       throw new SparkException(s"${DYN_ALLOCATION_CACHED_EXECUTOR_IDLE_TIMEOUT.key} must be >= 0!")
     }
-    // Require external shuffle service for dynamic allocation
+    // Require external shuffle for dynamic allocation
     // Otherwise, we may lose shuffle files when killing executors
-    if (!conf.get(config.SHUFFLE_SERVICE_ENABLED) && !testing) {
-      throw new SparkException("Dynamic allocation of executors requires the external " +
-        "shuffle service. You may enable this through spark.shuffle.service.enabled.")
+    if (!conf.get(config.SHUFFLE_SERVICE_ENABLED) &&
+        !conf.get(config.EXTERNAL_SHUFFLE_ENABLED) && !testing) {
+      throw new SparkException("Dynamic allocation of executors requires external " +
+        "shuffle. You may enable this through spark.shuffle.service.enabled or" +
+        "spark.shuffle.external.enabled.")
     }
 
     if (executorAllocationRatio > 1.0 || executorAllocationRatio <= 0.0) {

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -366,6 +366,12 @@ package object config {
       .booleanConf
       .createWithDefault(true)
 
+  private[spark] val EXTERNAL_SHUFFLE_ENABLED =
+    ConfigBuilder("spark.shuffle.external.enabled")
+      .doc("Whether the shuffle manager is running externally to the Spark deployment.")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val SHUFFLE_SERVICE_PORT =
     ConfigBuilder("spark.shuffle.service.port").intConf.createWithDefault(7337)
 

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1791,7 +1791,8 @@ private[spark] class DAGScheduler(
     // if the cluster manager explicitly tells us that the entire worker was lost, then
     // we know to unregister shuffle output.  (Note that "worker" specifically refers to the process
     // from a Standalone cluster, where the shuffle service lives in the Worker.)
-    val fileLost = workerLost || !env.blockManager.externalShuffleServiceEnabled
+    val fileLost = !sc.conf.get(config.EXTERNAL_SHUFFLE_ENABLED) &&
+        (workerLost || !env.blockManager.externalShuffleServiceEnabled)
     removeExecutorAndUnregisterOutputs(
       execId = execId,
       fileLost = fileLost,

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -998,6 +998,7 @@ private[spark] class TaskSetManager(
     // The reason is the next stage wouldn't be able to fetch the data from this dead executor
     // so we would need to rerun these tasks on other executors.
     if (tasks(0).isInstanceOf[ShuffleMapTask] && !env.blockManager.externalShuffleServiceEnabled
+        && !conf.get(config.EXTERNAL_SHUFFLE_ENABLED)
         && !isZombie) {
       for ((tid, info) <- taskInfos if info.executorId == execId) {
         val index = taskInfos(tid).index


### PR DESCRIPTION
The DAGScheduler assumes that shuffle data is lost if an executor is lost and the Spark external shuffle service is not enabled. However, external shuffle managers other than the default external shuffle service can store shuffle data outside of the Spark cluster itself. In this case, completed map taks are not rerun even if the corresponding executors are lost.

The new `spark.shuffle.external.enabled` property allows this new external shuffle behavior to be toggled (independently off the built-in Spark external shuffle service).