### PR TITLE
[SPARK-27568][CORE] Fix readLock leak while calling take()/first() on a cached rdd

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala
@@ -91,7 +91,7 @@ private[spark] class ResultTask[T, U](
     val iter = rdd.iterator(partition, context).asInstanceOf[InterruptibleIterator[T]]
     val res = func(context, iter)
     // SPARK-27568: operations like take() could not consume all elements when func() finished,
-    // which would lead to readLock on blocks leaked. So, we manually call completion() for
+    // which would lead to readLock on block leaked. So, we manually call completion() for
     // those operations here.
     if (iter.hasNext && iter.delegate.isInstanceOf[CompletionIterator[T, Iterator[T]]]) {
       iter.delegate.asInstanceOf[CompletionIterator[T, Iterator[T]]].completion()

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -731,6 +731,15 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
       resetSparkContext()
     }
   }
+
+  test("call take() on a cached rdd should not leak readLock on the block") {
+    val conf = new SparkConf()
+      .setAppName("test")
+      .setMaster("local")
+      .set("spark.storage.exceptionOnPinLeak", "true")
+    sc = new SparkContext(conf)
+    assert(sc.parallelize(Range(0, 10), 1).cache().take(1).head === 0)
+  }
 }
 
 object SparkContextSuite {

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -732,13 +732,15 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
     }
   }
 
-  test("call take() on a cached rdd should not leak readLock on the block") {
+  test("SPARK-27568: call take()/first() on a cached rdd should not leak readLock on the block") {
     val conf = new SparkConf()
       .setAppName("test")
       .setMaster("local")
       .set("spark.storage.exceptionOnPinLeak", "true")
     sc = new SparkContext(conf)
+    // No exception, no pin leak
     assert(sc.parallelize(Range(0, 10), 1).cache().take(1).head === 0)
+    assert(sc.parallelize(Range(0, 10), 1).cache().first() === 0)
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, if we run the code below in Spark:
```
sc.parallelize(Range(0, 10), 1).cache().take(1)
```
 we'll see the line below in log:

**19/04/25 23:48:54 INFO Executor: 1 block locks were not released by TID = 0:
[rdd_0_0]**

 and, If we set "spark.storage.exceptionOnPinLeak"=true, job will fail.

Normally, we'll always release readLock for the block once we consumed all elements in a `CompletionIterator`. 
However, operation like take()/first() do not need to consume all, which lead to the release behaviour
can't be triggered.

This pr suggests to manually call `completion()` for the `CompletionIterator` if the iterator still has next
element after task finished, so that readLock could be released within `competion()`.

## How was this patch tested?

Added.
