### PR TITLE
[SPARK-27578][SQL] Support INTERVAL ... HOUR TO SECOND syntax

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/CalendarInterval.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/CalendarInterval.java
@@ -56,7 +56,7 @@ public final class CalendarInterval implements Serializable {
   private static Pattern dayTimePattern =
     Pattern.compile("^(?:['|\"])?([+|-])?(\\d+) (\\d+):(\\d+):(\\d+)(\\.(\\d+))?(?:['|\"])?$");
 
-  private static Pattern hourTimePattern =
+  private static final Pattern hourTimePattern =
           Pattern.compile("^(?:['|\"])?(\\d+):(\\d+):(\\d+)(\\.(\\d+))?(?:['|\"])?$");
 
   private static Pattern quoteTrimPattern = Pattern.compile("^(?:['|\"])?(.*?)(?:['|\"])?$");
@@ -172,7 +172,6 @@ public final class CalendarInterval implements Serializable {
    *
    */
   public static CalendarInterval fromHourTimeString(String s) throws IllegalArgumentException {
-    CalendarInterval result;
     if (s == null) {
       throw new IllegalArgumentException("Interval hour-time string was null");
     }
@@ -188,14 +187,13 @@ public final class CalendarInterval implements Serializable {
         long seconds = toLongWithRange("second", m.group(3), 0, 59);
         // Hive allow nanosecond precision interval
         long nanos = toLongWithRange("nanosecond", m.group(5), 0L, 999999999L);
-        result = new CalendarInterval(0, hours * MICROS_PER_HOUR +
+        return new CalendarInterval(0, hours * MICROS_PER_HOUR +
                 minutes * MICROS_PER_MINUTE + seconds * MICROS_PER_SECOND + nanos / 1000L);
       } catch (Exception e) {
         throw new IllegalArgumentException(
                 "Error parsing interval hour-time string: " + e.getMessage(), e);
       }
     }
-    return result;
   }
 
   public static CalendarInterval fromSingleUnitString(String unit, String s)

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/CalendarInterval.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/CalendarInterval.java
@@ -147,7 +147,8 @@ public final class CalendarInterval implements Serializable {
     } else {
       try {
         int sign = m.group(1) != null && m.group(1).equals("-") ? -1 : 1;
-        long days = m.group(2) == null ? 0 : toLongWithRange("day", m.group(3), 0, Integer.MAX_VALUE);
+        long days = m.group(2) == null ? 0 : toLongWithRange("day", m.group(3),
+          0, Integer.MAX_VALUE);
         long hours = toLongWithRange("hour", m.group(4), 0, 23);
         long minutes = toLongWithRange("minute", m.group(5), 0, 59);
         long seconds = toLongWithRange("second", m.group(6), 0, 59);

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/CalendarInterval.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/CalendarInterval.java
@@ -57,7 +57,7 @@ public final class CalendarInterval implements Serializable {
     Pattern.compile("^(?:['|\"])?([+|-])?(\\d+) (\\d+):(\\d+):(\\d+)(\\.(\\d+))?(?:['|\"])?$");
 
   private static final Pattern hourTimePattern =
-          Pattern.compile("^(?:['|\"])?(\\d+):(\\d+):(\\d+)(\\.(\\d+))?(?:['|\"])?$");
+    Pattern.compile("^(?:['|\"])?([+|-])?(\\d+):(\\d+):(\\d+)(\\.(\\d+))?(?:['|\"])?$");
 
   private static Pattern quoteTrimPattern = Pattern.compile("^(?:['|\"])?(.*?)(?:['|\"])?$");
 
@@ -169,7 +169,6 @@ public final class CalendarInterval implements Serializable {
 
   /**
    * Parse dayTime string in form: HH:mm:ss.nnnnnnnnn
-   *
    */
   public static CalendarInterval fromHourTimeString(String s) throws IllegalArgumentException {
     if (s == null) {
@@ -179,19 +178,20 @@ public final class CalendarInterval implements Serializable {
     Matcher m = hourTimePattern.matcher(s);
     if (!m.matches()) {
       throw new IllegalArgumentException(
-              "Interval string does not match hour-time format of 'h:m:s.n': " + s);
+        "Interval string does not match hour-time format of 'h:m:s.n': " + s);
     } else {
       try {
-        long hours = toLongWithRange("hour", m.group(1), 0, 23);
-        long minutes = toLongWithRange("minute", m.group(2), 0, 59);
-        long seconds = toLongWithRange("second", m.group(3), 0, 59);
+        int sign = m.group(1) != null && m.group(1).equals("-") ? -1 : 1;
+        long hours = toLongWithRange("hour", m.group(2), 0, 23);
+        long minutes = toLongWithRange("minute", m.group(3), 0, 59);
+        long seconds = toLongWithRange("second", m.group(4), 0, 59);
         // Hive allow nanosecond precision interval
-        long nanos = toLongWithRange("nanosecond", m.group(5), 0L, 999999999L);
-        return new CalendarInterval(0, hours * MICROS_PER_HOUR +
-                minutes * MICROS_PER_MINUTE + seconds * MICROS_PER_SECOND + nanos / 1000L);
+        long nanos = toLongWithRange("nanosecond", m.group(6), 0L, 999999999L);
+        return new CalendarInterval(0, sign * (hours * MICROS_PER_HOUR +
+          minutes * MICROS_PER_MINUTE + seconds * MICROS_PER_SECOND + nanos / 1000L));
       } catch (Exception e) {
         throw new IllegalArgumentException(
-                "Error parsing interval hour-time string: " + e.getMessage(), e);
+          "Error parsing interval hour-time string: " + e.getMessage(), e);
       }
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1788,7 +1788,7 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
         case ("day", Some("second")) =>
           CalendarInterval.fromDayTimeString(s)
         case ("hour", Some("second")) =>
-          CalendarInterval.fromHourTimeString(s)
+          CalendarInterval.fromDayTimeString(s)
         case (from, Some(t)) =>
           throw new ParseException(s"Intervals FROM $from TO $t are not supported.", ctx)
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1770,7 +1770,7 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
    * Create a [[CalendarInterval]] for a unit value pair. Two unit configuration types are
    * supported:
    * - Single unit.
-   * - From-To unit (only 'YEAR TO MONTH' and 'DAY TO SECOND' are supported).
+   * - From-To unit (only 'YEAR TO MONTH' and 'DAY TO SECOND' and 'HOUR to SECOND' are supported).
    */
   override def visitIntervalField(ctx: IntervalFieldContext): CalendarInterval = withOrigin(ctx) {
     import ctx._

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1787,6 +1787,8 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
           CalendarInterval.fromYearMonthString(s)
         case ("day", Some("second")) =>
           CalendarInterval.fromDayTimeString(s)
+        case ("hour", Some("second")) =>
+          CalendarInterval.fromHourTimeString(s)
         case (from, Some(t)) =>
           throw new ParseException(s"Intervals FROM $from TO $t are not supported.", ctx)
       }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -653,12 +653,11 @@ class ExpressionParserSuite extends PlanTest {
       checkIntervals(s"'$value' day to second", result)
     }
 
-    // Day-Time intervals.
+    // Hour-Time intervals.
     val hourTimeValues = Seq(
       "11:22:33.123456789",
-      "11:22:33.123456789",
       "9:8:7.123456789",
-      "0:0:0",
+      "-19:18:17.123456789",
       "0:0:0",
       "0:0:1")
     hourTimeValues.foreach { value =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -661,7 +661,7 @@ class ExpressionParserSuite extends PlanTest {
       "0:0:0",
       "0:0:1")
     hourTimeValues.foreach { value =>
-      val result = Literal(CalendarInterval.fromHourTimeString(value))
+      val result = Literal(CalendarInterval.fromDayTimeString(value))
       checkIntervals(s"'$value' hour to second", result)
     }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -653,6 +653,19 @@ class ExpressionParserSuite extends PlanTest {
       checkIntervals(s"'$value' day to second", result)
     }
 
+    // Day-Time intervals.
+    val hourTimeValues = Seq(
+      "11:22:33.123456789",
+      "11:22:33.123456789",
+      "9:8:7.123456789",
+      "0:0:0",
+      "0:0:0",
+      "0:0:1")
+    hourTimeValues.foreach { value =>
+      val result = Literal(CalendarInterval.fromHourTimeString(value))
+      checkIntervals(s"'$value' hour to second", result)
+    }
+
     // Unknown FROM TO intervals
     intercept("interval 10 month to second",
       "Intervals FROM month TO second are not supported.")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
@@ -1245,6 +1245,8 @@ class DDLParserSuite extends PlanTest with SharedSQLContext {
       "month 32 outside range [0, 11]")
     assertError("select interval '5 49:12:15' day to second",
       "hour 49 outside range [0, 23]")
+    assertError("select interval '23:61:15' hour to second",
+      "minute 61 outside range [0, 59]")
     assertError("select interval '.1111111111' second",
       "nanosecond 1111111111 outside range")
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1183,6 +1183,9 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     checkAnswer(sql("select interval '20 15:40:32.99899999' day to second"),
       Row(CalendarInterval.fromString("interval 2 weeks 6 days 15 hours 40 minutes " +
         "32 seconds 99 milliseconds 899 microseconds")))
+    checkAnswer(sql("select interval '15:40:32.99899999' hour to second"),
+      Row(CalendarInterval.fromString("interval 15 hours 40 minutes 32 seconds 99 milliseconds " +
+        "899 microseconds")))
     checkAnswer(sql("select interval '30' year"),
       Row(CalendarInterval.fromString("interval 30 years")))
     checkAnswer(sql("select interval '25' month"),


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, SparkSQL can support interval format like this. 
```sql
SELECT INTERVAL '0 23:59:59.155' DAY TO SECOND
 ```

Like Presto/Teradata, this PR aims to support grammar like below.
```sql
SELECT INTERVAL '23:59:59.155' HOUR TO SECOND
```

Although we can add a new function for this pattern, we had better extend the existing code to handle a missing day case. So, the following is also supported.
```sql
SELECT INTERVAL '23:59:59.155' DAY TO SECOND
SELECT INTERVAL '1 23:59:59.155' HOUR TO SECOND
```
Currently Vertica/Teradata/Postgresql/SQL Server have fully support of below interval functions.
- interval ... year to month
- interval ... day to hour
- interval ... day to minute
- interval ... day to second
- interval ... hour to minute
- interval ... hour to second
- interval ... minute to second

https://www.vertica.com/docs/9.2.x/HTML/Content/Authoring/SQLReferenceManual/LanguageElements/Literals/interval-qualifier.htm
https://github.com/postgres/postgres/blob/df1a699e5ba3232f373790b2c9485ddf720c4a70/src/test/regress/sql/interval.sql#L180-L203
https://docs.teradata.com/reader/S0Fw2AVH8ff3MDA0wDOHlQ/KdCtT3pYFo~_enc8~kGKVw
https://docs.microsoft.com/en-us/sql/odbc/reference/appendixes/interval-literals?view=sql-server-2017


## How was this patch tested?

Pass the Jenkins with the updated test cases.