### PR TITLE
[SPARK-27534][SQL] Do not load `content` column in binary data source if it is not selected

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
@@ -316,10 +316,10 @@ class BinaryFileFormatSuite extends QueryTest with SharedSQLContext with SQLTest
     Files.write(file.toPath, content, StandardOpenOption.CREATE, StandardOpenOption.WRITE)
 
     read(file, getRequiredSchema(MODIFICATION_TIME, CONTENT, LENGTH, PATH)) match {
-      case Row(t, c, l, p) =>
+      case Row(t, c, len, p) =>
         assert(t === new Timestamp(file.lastModified()))
         assert(c === content)
-        assert(l === content.length)
+        assert(len === content.length)
         assert(p.asInstanceOf[String].endsWith(file.getAbsolutePath))
     }
     file.setReadable(false)


### PR DESCRIPTION
## What changes were proposed in this pull request?

A follow-up task from SPARK-25348. To save I/O cost, Spark shouldn't attempt to read the file if users didn't request the `content` column. For example:
```
spark.read.format("binaryFile").load(path).filter($"length" < 1000000).count()
```

## How was this patch tested?

Unit test added.

Please review http://spark.apache.org/contributing.html before opening a pull request.
