### PR TITLE
[SPARK-27607][SQL] Improve Row.toString performance

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Row.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Row.scala
@@ -465,16 +465,34 @@ trait Row extends Serializable {
   }
 
   /** Displays all elements of this sequence in a string (without a separator). */
-  def mkString: String = toSeq.mkString
+  def mkString: String = mkString("")
 
   /** Displays all elements of this sequence in a string using a separator string. */
-  def mkString(sep: String): String = toSeq.mkString(sep)
+  def mkString(sep: String): String = mkString("", sep, "")
 
   /**
    * Displays all elements of this traversable or iterator in a string using
    * start, end, and separator strings.
    */
-  def mkString(start: String, sep: String, end: String): String = toSeq.mkString(start, sep, end)
+  def mkString(start: String, sep: String, end: String): String = {
+    var first = true
+    var i = 0
+    val n = length
+    val builder = new StringBuilder
+    builder.append(start)
+    while (i < n) {
+      if (first) {
+        builder.append(get(i))
+        first = false
+      } else {
+        builder.append(sep)
+        builder.append(get(i))
+      }
+      i += 1
+    }
+    builder.append(end)
+    builder.toString()
+  }
 
   /**
    * Returns the value at position i.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Row.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Row.scala
@@ -475,20 +475,17 @@ trait Row extends Serializable {
    * start, end, and separator strings.
    */
   def mkString(start: String, sep: String, end: String): String = {
-    var first = true
-    var i = 0
     val n = length
     val builder = new StringBuilder
     builder.append(start)
-    while (i < n) {
-      if (first) {
-        builder.append(get(i))
-        first = false
-      } else {
+    if (n > 0) {
+      builder.append(get(0))
+      var i = 1
+      while (i < n) {
         builder.append(sep)
         builder.append(get(i))
+        i += 1
       }
-      i += 1
     }
     builder.append(end)
     builder.toString()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Row.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Row.scala
@@ -372,7 +372,7 @@ trait Row extends Serializable {
     }.toMap
   }
 
-  override def toString: String = s"[${this.mkString(",")}]"
+  override def toString: String = this.mkString("[", ",", "]")
 
   /**
    * Make a copy of the current [[Row]] object.

--- a/sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala
@@ -84,4 +84,14 @@ class RowSuite extends SparkFunSuite with SharedSQLContext {
     val r3 = Row("World")
     assert(r3.hashCode() != r1.hashCode())
   }
+
+  test("toString") {
+    val r1 = Row(2147483647, 21474.83647, (-5).toShort, "this is a string", true, null)
+    assert(r1.toString == "[2147483647,21474.83647,-5,this is a string,true,null]")
+    val r2 = Row(null, Int.MinValue, Double.NaN, Short.MaxValue, "", false)
+    assert(r2.toString == "[null,-2147483648,NaN,32767,,false]")
+    val r3 = Row(r1, Seq(1, 2, 3), Map(1 -> "a", 2 -> "b"), new java.sql.Timestamp(1556700000000L))
+    assert(r3.toString == "[[2147483647,21474.83647,-5,this is a string,true,null]," +
+      "List(1, 2, 3),Map(1 -> a, 2 -> b),2019-05-01 10:40:00.0]")
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala
@@ -86,14 +86,22 @@ class RowSuite extends SparkFunSuite with SharedSQLContext {
   }
 
   test("toString") {
-    val r1 = Row(2147483647, 21474.83647, (-5).toShort, "this is a string", true, null)
-    assert(r1.toString == "[2147483647,21474.83647,-5,this is a string,true,null]")
+    val r1 = Row(2147483647, 21474.8364, (-5).toShort, "this is a string", true, null)
+    assert(r1.toString == "[2147483647,21474.8364,-5,this is a string,true,null]")
     val r2 = Row(null, Int.MinValue, Double.NaN, Short.MaxValue, "", false)
     assert(r2.toString == "[null,-2147483648,NaN,32767,,false]")
     val tsString = "2019-05-01 17:30:12.0"
-    val r3 = Row(r1, Seq(1, 2, 3), Map(1 -> "a", 2 -> "b"), java.sql.Timestamp.valueOf(tsString))
-    assert(r3.toString == "[[2147483647,21474.83647,-5,this is a string,true,null]," +
-      s"List(1, 2, 3),Map(1 -> a, 2 -> b),$tsString]")
+    val dtString = "2019-05-01"
+    val r3 = Row(
+      r1,
+      Seq(1, 2, 3),
+      Map(1 -> "a", 2 -> "b"),
+      java.sql.Timestamp.valueOf(tsString),
+      java.sql.Date.valueOf(dtString),
+      BigDecimal("1234567890.1234567890"),
+      (-1).toByte)
+    assert(r3.toString == "[[2147483647,21474.8364,-5,this is a string,true,null],List(1, 2, 3)," +
+      s"Map(1 -> a, 2 -> b),$tsString,$dtString,1234567890.1234567890,-1]")
     val empty = Row()
     assert(empty.toString == "[]")
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala
@@ -93,5 +93,7 @@ class RowSuite extends SparkFunSuite with SharedSQLContext {
     val r3 = Row(r1, Seq(1, 2, 3), Map(1 -> "a", 2 -> "b"), new java.sql.Timestamp(1556700000000L))
     assert(r3.toString == "[[2147483647,21474.83647,-5,this is a string,true,null]," +
       "List(1, 2, 3),Map(1 -> a, 2 -> b),2019-05-01 10:40:00.0]")
+    val empty = Row()
+    assert(empty.toString == "[]")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala
@@ -90,9 +90,10 @@ class RowSuite extends SparkFunSuite with SharedSQLContext {
     assert(r1.toString == "[2147483647,21474.83647,-5,this is a string,true,null]")
     val r2 = Row(null, Int.MinValue, Double.NaN, Short.MaxValue, "", false)
     assert(r2.toString == "[null,-2147483648,NaN,32767,,false]")
-    val r3 = Row(r1, Seq(1, 2, 3), Map(1 -> "a", 2 -> "b"), new java.sql.Timestamp(1556700000000L))
+    val tsString = "2019-05-01 17:30:12.0"
+    val r3 = Row(r1, Seq(1, 2, 3), Map(1 -> "a", 2 -> "b"), java.sql.Timestamp.valueOf(tsString))
     assert(r3.toString == "[[2147483647,21474.83647,-5,this is a string,true,null]," +
-      "List(1, 2, 3),Map(1 -> a, 2 -> b),2019-05-01 10:40:00.0]")
+      s"List(1, 2, 3),Map(1 -> a, 2 -> b),$tsString]")
     val empty = Row()
     assert(empty.toString == "[]")
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`Row.toString` is currently causing the useless creation of an `Array` containing all the values in the row before generating the string containing it. This operation adds a considerable overhead.

The PR proposes to avoid this operation in order to get a faster implementation.

## How was this patch tested?

Run

```scala
test("Row toString perf test") {
    val n = 100000
    val rows = (1 to n).map { i =>
      Row(i, i.toDouble, i.toString, i.toShort, true, null)
    }
    // warmup
    (1 to 10).foreach { _ => rows.foreach(_.toString) }

    val times = (1 to 100).map { _ =>
      val t0 = System.nanoTime()
      rows.foreach(_.toString)
      val t1 = System.nanoTime()
      t1 - t0
    }
    // scalastyle:off println
    println(s"Avg time on ${times.length} iterations for $n toString:" +
      s" ${times.sum.toDouble / times.length / 1e6} ms")
    // scalastyle:on println
  }
```
Before the PR:
```
Avg time on 100 iterations for 100000 toString: 61.08408419 ms
```
After the PR:
```
Avg time on 100 iterations for 100000 toString: 38.16539432 ms
```
This means the new implementation is about 1.60X faster than the original one.

