### PR TITLE
[SPARK-24708][Doc] Document the default spark url of master in standalone is "spark://localhost:7070"

### DIFF
--- a/docs/spark-standalone.md
+++ b/docs/spark-standalone.md
@@ -42,7 +42,7 @@ Once started, the master will print out a `spark://HOST:PORT` URL for itself, wh
 or pass as the "master" argument to `SparkContext`. You can also find this URL on
 the master's web UI, which is [http://localhost:8080](http://localhost:8080) by default.
 
-Similarly, you can start one or more workers and connect them to the master via:
+Similarly, you can start one or more workers and connect them to the master's spark URL (default: spark://<master>:7070) via:
 
     ./sbin/start-slave.sh <master-spark-URL>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added the details about default master URL in the section "Starting a Cluster Manually".

## How was this patch tested?
NA, as it is only document updation
