### PR TITLE
[SPARK-14083][WIP] Basic bytecode analyzer to speed up Datasets

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -97,7 +97,7 @@ jackson-xc-1.9.13.jar
 jakarta.activation-api-1.2.1.jar
 jakarta.xml.bind-api-2.3.2.jar
 janino-3.0.11.jar
-javassist-3.18.1-GA.jar
+javassist-3.25.0-GA.jar
 javax.annotation-api-1.2.jar
 javax.inject-1.jar
 javax.inject-2.4.0-b34.jar

--- a/dev/deps/spark-deps-hadoop-3.2
+++ b/dev/deps/spark-deps-hadoop-3.2
@@ -99,7 +99,7 @@ jackson-module-scala_2.12-2.9.8.jar
 jakarta.activation-api-1.2.1.jar
 jakarta.xml.bind-api-2.3.2.jar
 janino-3.0.11.jar
-javassist-3.18.1-GA.jar
+javassist-3.25.0-GA.jar
 javax.annotation-api-1.2.jar
 javax.inject-1.jar
 javax.inject-2.4.0-b34.jar

--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -109,6 +109,11 @@
       <version>2.7.3</version>
       <type>jar</type>
     </dependency>
+    <dependency>
+      <groupId>org.javassist</groupId>
+      <artifactId>javassist</artifactId>
+      <version>3.25.0-GA</version>
+    </dependency>
   </dependencies>
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -620,6 +620,9 @@ object ScalaReflection extends ScalaReflection {
       throw new UnsupportedOperationException(s"Attributes for type $others is not supported")
   }
 
+  /** Returns a catalyst DataType and its nullability for the given Scala class using reflection. */
+  def schemaFor[T](clazz: Class[T]): Schema = schemaFor(getTypeFromClass(clazz))
+
   /** Returns a catalyst DataType and its nullability for the given Scala Type using reflection. */
   def schemaFor[T: TypeTag]: Schema = schemaFor(localTypeOf[T])
 
@@ -699,6 +702,12 @@ object ScalaReflection extends ScalaReflection {
       case other =>
         throw new UnsupportedOperationException(s"Schema for type $other is not supported")
     }
+  }
+
+  private def getTypeFromClass[T](clazz: Class[T]): Type = {
+    val m = runtimeMirror(clazz.getClassLoader)
+    val classSymbol = m.classSymbol(clazz)
+    classSymbol.toType
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/bytecode/BehaviorConverter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/bytecode/BehaviorConverter.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.bytecode
+
+import org.apache.spark.sql.catalyst.bytecode.InstructionHandler.{Complete, Continue, Jump}
+import org.apache.spark.sql.catalyst.expressions.Expression
+
+/**
+ * The object that converts JVM [[Behavior]]s into Catalyst expressions.
+ */
+private[bytecode] object BehaviorConverter {
+
+  def convert(behavior: Behavior, localVars: LocalVarArray): Option[Expression] = {
+    if (SpecialInstanceMethodHandler.canHandle(behavior)) {
+      SpecialInstanceMethodHandler.handle(behavior, localVars)
+    } else if (SpecialStaticMethodHandler.canHandle(behavior)) {
+      SpecialStaticMethodHandler.handle(behavior, localVars)
+    } else {
+      convert(0, behavior, new OperandStack(), localVars)
+    }
+  }
+
+  def convert(
+      index: Int,
+      behavior: Behavior,
+      operandStack: OperandStack,
+      localVars: LocalVarArray): Option[Expression] = {
+
+    val codeIter = behavior.newCodeIterator()
+    codeIter.move(index)
+    while (codeIter.hasNext) {
+      val index = codeIter.next()
+      val opcode = codeIter.byteAt(index)
+      val instruction = Instruction(opcode, index, behavior)
+      InstructionHandler.handle(instruction, operandStack, localVars) match {
+        case Complete(returnValue) =>
+          return returnValue
+        case Jump(targetIndex) =>
+          codeIter.move(targetIndex)
+        case Continue =>
+          // continue the conversion
+      }
+    }
+    throw new RuntimeException("Could not complete the conversion: no instructions left")
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/bytecode/ClosureUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/bytecode/ClosureUtils.scala
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.bytecode
+
+import scala.util.Try
+
+import javassist.CtClass
+import javassist.bytecode.Descriptor
+
+import org.apache.spark.api.java.function.{FilterFunction, MapFunction}
+import org.apache.spark.util.Utils
+
+/**
+ * The utility object for working with closures.
+ */
+private[bytecode] object ClosureUtils {
+
+  def getMethodDescriptor(argClasses: Seq[Class[_]], returnClass: Class[_]): String = {
+    val argCtClasses = argClasses.map(CtClassPool.getCtClass)
+    val returnCtClass = CtClassPool.getCtClass(returnClass)
+    Descriptor.ofMethod(returnCtClass, argCtClasses.toArray)
+  }
+
+  def getConstructorDescriptor(argClasses: Seq[Class[_]]): String = {
+    val argCtClasses = argClasses.map(CtClassPool.getCtClass)
+    Descriptor.ofConstructor(argCtClasses.toArray)
+  }
+
+  // TODO: Java operations
+  // TODO: cases when Scala closures are still compiled into separate classes in 2.12
+  def getMethod(closure: AnyRef, argClass: Class[_], returnClass: Class[_]): Behavior = {
+    closure match {
+      case _: MapFunction[_, _] =>
+        throw new RuntimeException("Java map closures are not supported now")
+      case _: FilterFunction[_] =>
+        throw new RuntimeException("Java filter closures are not supported now")
+      case _ =>
+        Utils.getSerializedLambda(closure) match {
+          case Some(lambda) if lambda.getCapturedArgCount > 0 =>
+            // TODO: support outer immutable/stateless classes/objects
+            throw new RuntimeException("Closures with outer variables are not supported now")
+          case Some(lambda) =>
+            val capturingClassName = lambda.getCapturingClass.replace('/', '.')
+            val capturingClass = Utils.classForName(capturingClassName)
+            CtClassPool.addClassPathFor(capturingClass)
+            val ctClass = CtClassPool.getCtClass(capturingClass)
+            val implMethodName = lambda.getImplMethodName
+            val implMethodSignature = lambda.getImplMethodSignature
+            val implMethod = ctClass.getMethod(implMethodName, implMethodSignature)
+            // boxing semantics in Scala is different from Java (e.g., unboxing nulls),
+            // so Scala relies on "adapted" methods to encapsulate this difference
+            // "adapted" methods are used for LMF
+            // if we know our args are primitive, we can fetch the non-adapted
+            // method and call it directly to avoid a round of boxing/unboxing
+            if (implMethodName.endsWith("$adapted")) {
+              val nonAdaptedMethod = getNonAdaptedMethod(ctClass, implMethod, argClass, returnClass)
+              nonAdaptedMethod.getOrElse(implMethod)
+            } else {
+              implMethod
+            }
+          case _ =>
+            throw new RuntimeException("Could not get a serialized lambda from the closure")
+        }
+    }
+  }
+
+  private def getNonAdaptedMethod(
+      ctClass: CtClass,
+      adaptedMethod: Behavior,
+      argClass: Class[_],
+      returnClass: Class[_]): Option[Behavior] = {
+
+    val Array(adaptedParamCtClass) = adaptedMethod.parameterTypes
+    val paramCtClass = argClass match {
+      case c if c.isPrimitive => CtClassPool.getCtClass(argClass)
+      case _ => adaptedParamCtClass
+    }
+    val returnCtClass = returnClass match {
+      case c if c.isPrimitive => CtClassPool.getCtClass(returnClass)
+      case _ => adaptedMethod.returnType.get
+    }
+    val nonAdaptedMethodDescriptor = Descriptor.ofMethod(returnCtClass, Array(paramCtClass))
+    val nonAdaptedMethodName = adaptedMethod.name.stripSuffix("$adapted")
+    Try[Behavior](ctClass.getMethod(nonAdaptedMethodName, nonAdaptedMethodDescriptor)).toOption
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/bytecode/CtClassPool.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/bytecode/CtClassPool.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.bytecode
+
+import javassist.{ClassClassPath, ClassPool, CtClass}
+
+/**
+ * An object that wraps javassist [[ClassPool]] and allows to retrieve [[CtClass]]es.
+ */
+private[bytecode] object CtClassPool {
+
+  private lazy val classPool = ClassPool.getDefault
+
+  def addClassPathFor(clazz: Class[_]): Unit = {
+    val closureClassPath = new ClassClassPath(clazz)
+    classPool.insertClassPath(closureClassPath)
+  }
+
+  def getCtClass(name: String): CtClass = {
+    classPool.get(name)
+  }
+
+  def getCtClass(clazz: Class[_]): CtClass = {
+    classPool.get(clazz.getName)
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/bytecode/TypedOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/bytecode/TypedOperations.scala
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.bytecode
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.ScalaReflection
+import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, GetStructField, If, Literal, NonSQLExpression}
+import org.apache.spark.sql.catalyst.expressions.objects.{AssertNotNull, Invoke, LambdaVariable, MapObjects, NewInstance, StaticInvoke}
+import org.apache.spark.sql.catalyst.plans.logical.{DeserializeToObject, Filter, MapElements, Project, SerializeFromObject, TypedFilter}
+import org.apache.spark.sql.types.{BooleanType, ObjectType, StringType, StructType}
+import org.apache.spark.util.Utils
+
+object TypedOperations extends Logging {
+
+  /**
+   * Converts a typed map transformation with a user-defined closure to an equivalent untyped
+   * map operation with Catalyst expressions by analyzing the closure bytecode.
+   *
+   * If the conversion cannot be performed, the result will be [[None]].
+   *
+   * @param serialize converts output of the typed map transformation into unsafe rows.
+   * @param map the typed map transformation to apply.
+   * @param deserialize converts unsafe rows into objects for the typed map transformation.
+   * @return an optional [[Project]] with native Catalyst expressions.
+   */
+  def convertMapElements(
+      serialize: SerializeFromObject,
+      map: MapElements,
+      deserialize: DeserializeToObject): Option[Project] = {
+    try {
+      val argClass = map.argumentClass
+      val returnClass = getClass(map.outputObjAttr)
+      val method = ClosureUtils.getMethod(map.func, argClass, returnClass)
+
+      val thisRef = getThisRef(method)
+      val argExpr = getArgExpr(method, deserialize.deserializer, argClass)
+      val localVars = newLocalVarArray(method, thisRef, Seq(argExpr))
+
+      val outputAttrs = serialize.output
+      val untypedMapExpr = BehaviorConverter.convert(method, localVars)
+      untypedMapExpr.flatMap {
+        case e: Ref if e.dataType.isInstanceOf[StructType] =>
+          val structType = e.dataType.asInstanceOf[StructType]
+          val structExpr = resolveRefs(e)
+          val aliases = outputAttrs.map { attr =>
+            val fieldIndex = structType.fieldIndex(attr.name)
+            Alias(GetStructField(structExpr, fieldIndex), attr.name)(exprId = attr.exprId)
+          }
+          Some(Project(aliases, deserialize.child))
+        case e if outputAttrs.size == 1 && outputAttrs.head.dataType == e.dataType =>
+          val outAttr = outputAttrs.head
+          val alias = Alias(resolveRefs(e), outAttr.name)(exprId = outAttr.exprId)
+          Some(Project(Seq(alias), deserialize.child))
+        case e =>
+          logWarning(s"$e cannot represent $outputAttrs")
+          None
+      }
+    } catch {
+      case e: Exception =>
+        logWarning("Could not convert the typed map operation", e)
+        None
+    }
+  }
+
+  /**
+   * Converts a typed filter with a user-defined closure to an equivalent untyped
+   * filter with Catalyst expressions by analyzing the closure bytecode.
+   *
+   * If the conversion cannot be performed, the result will be [[None]].
+   *
+   * @param typedFilter the typed filter to convert.
+   * @return an optional [[Filter]] with native Catalyst expressions.
+   */
+  def convertFilter(typedFilter: TypedFilter): Option[Filter] = {
+    try {
+      val argClass = typedFilter.argumentClass
+      val returnClass = ScalaReflection.dataTypeJavaClass(BooleanType)
+      val method = ClosureUtils.getMethod(typedFilter.func, argClass, returnClass)
+
+      val thisRef = getThisRef(method)
+      val argExpr = getArgExpr(method, typedFilter.deserializer, argClass)
+      val localVars = newLocalVarArray(method, thisRef, Seq(argExpr))
+
+      val untypedFilterExpr = BehaviorConverter.convert(method, localVars)
+      untypedFilterExpr.foreach(e => require(e.dataType == BooleanType))
+      untypedFilterExpr.map(e => Filter(resolveRefs(e), typedFilter.child))
+    } catch {
+      case e: Exception =>
+        logWarning("Could not convert the typed filter", e)
+        None
+    }
+  }
+
+  private def getThisRef(behavior: Behavior): Option[Expression] = behavior match {
+    case b: Behavior if b.isStatic =>
+      None
+    case b: Behavior if b.isConstructor =>
+      val clazz = Utils.classForName(behavior.declaringClass.getName)
+      Some(StructRef(clazz))
+    case _ =>
+      throw new RuntimeException("instance methods are not supported now")
+  }
+
+  private def getArgExpr(
+      method: Behavior,
+      deserializer: Expression,
+      argClass: Class[_]): Expression = {
+
+    val value = resolveRefs(convertDeserializer(deserializer))
+    // we don't support outer variables so the number of params will be always 1 in our case
+    val Array(paramType) = method.parameterTypes
+    require(argClass.isPrimitive == paramType.isPrimitive)
+    if (!argClass.isPrimitive) {
+      // it is safe to assume argClass is precise because Datasets in Spark are not polymorphic
+      ObjectRef(value, argClass)
+    } else {
+      value
+    }
+  }
+
+  private def convertDeserializer(deserializer: Expression): Expression = deserializer transformUp {
+    case Invoke(targetObject, methodName, outType, args, _, _) =>
+      val argClasses = getClasses(args)
+      val returnClass = ScalaReflection.dataTypeJavaClass(outType)
+      val methodDescriptor = ClosureUtils.getMethodDescriptor(argClasses, returnClass)
+      val clazz = ScalaReflection.dataTypeJavaClass(targetObject.dataType)
+      val ctClass = CtClassPool.getCtClass(clazz)
+      val method = ctClass.getMethod(methodName, methodDescriptor)
+      val thisRef = Some(targetObject)
+      val localVars = newLocalVarArray(method, thisRef, args)
+      BehaviorConverter.convert(method, localVars).get
+    case StaticInvoke(clazz, outType, methodName, args, _, _) =>
+      val argClasses = getClasses(args)
+      val returnClass = ScalaReflection.dataTypeJavaClass(outType)
+      val methodDescriptor = ClosureUtils.getMethodDescriptor(argClasses, returnClass)
+      val ctClass = CtClassPool.getCtClass(clazz)
+      val method = ctClass.getMethod(methodName, methodDescriptor)
+      val localVars = newLocalVarArray(method, None, args)
+      BehaviorConverter.convert(method, localVars).get
+    case NewInstance(clazz, args, _, _, _) =>
+      val argClasses = getClasses(args)
+      val constructorDescriptor = ClosureUtils.getConstructorDescriptor(argClasses)
+      val ctClass = CtClassPool.getCtClass(clazz)
+      val constructor = ctClass.getConstructor(constructorDescriptor)
+      val thisRef = getThisRef(constructor)
+      val localVars = newLocalVarArray(constructor, thisRef, args)
+      BehaviorConverter.convert(constructor, localVars)
+      // return initialized `this` that was passed to the constructor
+      thisRef.get
+    case l @ Literal(null, ObjectType(clazz)) =>
+      // we need to transform null object literals inside deserializer expressions into StructRefs,
+      // as invoke-like expressions such as `newInstance(class com.user.Item)` are also
+      // converted into StructRefs and we must preserve the same data types for all if branches.
+      // e.g., consider an example below, where both `if` branches must have the same data type.
+      // `if (isnull(item#10)) null else newInstance(class com.user.Item)`
+      ScalaReflection.schemaFor(clazz).dataType match {
+        case st: StructType => ObjectRef(Literal(null, st), clazz)
+        case _ => l
+      }
+    case e: AssertNotNull => e
+    case e: LambdaVariable => e
+    case e: MapObjects => e
+    case e: NonSQLExpression =>
+      throw new RuntimeException(s"$e is not supported in the deserializer")
+  }
+
+  private def getClasses(exprs: Seq[Expression]): Seq[Class[_]] = exprs.map(getClass)
+
+  private def getClass(expr: Expression): Class[_] = expr match {
+    case If(_, trueValue, falseValue) =>
+      val trueValueClass = getClass(trueValue)
+      val falseValueClass = getClass(falseValue)
+      require(trueValueClass == falseValueClass)
+      trueValueClass
+    case e: Ref =>
+      e.clazz
+    case e if e.dataType == StringType =>
+      classOf[String]
+    case other =>
+      ScalaReflection.dataTypeJavaClass(other.dataType)
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/bytecode/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/bytecode/expressions.scala
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.bytecode
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.catalyst.ScalaReflection
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, CreateNamedStructUnsafe, Expression, LeafExpression, Literal, Unevaluable}
+import org.apache.spark.sql.types.{DataType, ObjectType, StructType}
+
+/**
+ * A base trait for all expressions that represent references to JVM objects.
+ */
+private[bytecode] trait Ref extends LeafExpression with Unevaluable {
+  def clazz: Class[_]
+  def resolve(): Expression
+}
+
+/**
+ * An expression that represents a reference to a JVM object.
+ *
+ * @param value the reference value.
+ * @param clazz the Java class.
+ */
+private[bytecode] case class ObjectRef(var value: Expression, clazz: Class[_]) extends Ref {
+  // TODO: better way?
+  lazy val isBoxedPrimitive: Boolean = boxedPrimitiveClasses.contains(clazz.getName)
+  override def nullable: Boolean = value.nullable
+  override def dataType: DataType = value.dataType
+  override def resolve(): Expression = resolveRefs(value)
+}
+
+/**
+ * An expression that represents a reference to a Scala object such as [[scala.Predef]].
+ *
+ * @param clazz the Java class.
+ */
+private[bytecode] case class ScalaObjectRef(clazz: Class[_]) extends Ref {
+  override def nullable: Boolean = false
+  override def dataType: DataType = ObjectType(clazz)
+  override def resolve(): Expression = {
+    throw new RuntimeException("ScalaObjectRef cannot be resolved")
+  }
+}
+
+/**
+ * An expression that represents a reference to an object that maps into a struct
+ * in Catalyst (e.g., case classes, POJOs).
+ *
+ * At the bytecode level, we first need to push a reference onto the operand stack and then call
+ * a dedicated constructor to handle the creation of new objects. Later on, other operations might
+ * read/modify field values.
+ *
+ * @param clazz the runtime Java class.
+ */
+private[bytecode] case class StructRef(clazz: Class[_]) extends Ref {
+
+  private val fieldValueMap = new mutable.HashMap[String, Expression]()
+  private val structType: StructType = getStructType(clazz)
+
+  override def nullable: Boolean = false
+  override def dataType: DataType = structType
+
+  def setFieldValue(fieldName: String, value: Expression): Unit = {
+    fieldValueMap(fieldName) = value
+  }
+
+  def getFieldValue(fieldName: String): Expression = {
+    fieldValueMap(fieldName)
+  }
+
+  override def resolve(): Expression = {
+    // we need to preserve the order of the fields
+    val structExprs = structType.fields.toSeq.flatMap { field =>
+      val fieldName = Literal(field.name)
+      val fieldValue = resolveRefs(fieldValueMap(field.name))
+      Seq[Expression](fieldName, fieldValue)
+    }
+    CreateNamedStructUnsafe(structExprs)
+  }
+
+  private def getStructType(clazz: Class[_]): StructType = {
+    ScalaReflection.schemaFor(clazz).dataType match {
+      case st: StructType => st
+      case _ => throw new RuntimeException(s"$clazz cannot be represented as a struct")
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/bytecode/instructionHandlers.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/bytecode/instructionHandlers.scala
@@ -1,0 +1,847 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.bytecode
+
+import scala.util.Try
+
+import javassist.CtField
+import javassist.bytecode.ConstPool
+import javassist.bytecode.Opcode._
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.ScalaReflection
+import org.apache.spark.sql.catalyst.bytecode.BehaviorConverter.convert
+import org.apache.spark.sql.catalyst.bytecode.InstructionHandler.{Action, Complete, Continue, Jump}
+import org.apache.spark.sql.catalyst.expressions.{Add, CaseWhen, Cast, Divide, EqualTo, Expression, GetStructField, GreaterThan, GreaterThanOrEqual, If, IntegralDivide, IsNaN, IsNotNull, IsNull, LessThan, LessThanOrEqual, Literal, Multiply, Not, Or, Remainder, Subtract}
+import org.apache.spark.sql.catalyst.expressions.objects.AssertNotNull
+import org.apache.spark.sql.types._
+import org.apache.spark.util.Utils
+
+/**
+ * A bytecode instruction within a given [[Behavior]].
+ *
+ * @param opcode the opcode of this instruction.
+ * @param index the index of this instruction in the behavior.
+ * @param behavior the behavior.
+ */
+private[bytecode] case class Instruction(opcode: Int, index: Int, behavior: Behavior)
+
+/**
+ * The main class that handles bytecode instructions.
+ */
+private[bytecode] object InstructionHandler {
+
+  sealed trait Action
+  final case class Complete(returnValue: Option[Expression]) extends Action
+  final case class Jump(index: Int) extends Action
+  final case object Continue extends Action
+
+  private val handler: InstructionHandler = LocalVarHandler orElse
+    ConstantHandler orElse
+    TypeConversionHandler orElse
+    MathOperationHandler orElse
+    IfStatementHandler orElse
+    ComparisonHandler orElse
+    InstanceMethodCallHandler orElse
+    InstanceMethodCallWithDispatchHandler orElse
+    StaticMethodCallHandler orElse
+    StaticFieldHandler orElse
+    ObjectFieldHandler orElse
+    ObjectCreationHandler orElse
+    MiscInstructionHandler orElse
+    ReturnHandler
+
+  def handle(
+      instruction: Instruction,
+      operandStack: OperandStack,
+      localVars: LocalVarArray): Action = {
+
+    handler.tryToHandle(instruction, operandStack, localVars) match {
+      case Some(action) => action
+      case None =>
+        throw new RuntimeException(
+          s"""The opcode at index ${instruction.index} is not supported:
+             |${instruction.behavior.toDebugString}""".stripMargin)
+    }
+  }
+}
+
+/**
+ * The base trait for all instruction handlers.
+ *
+ * Each handler must implement the `tryToHandle` method. If a handler can process an instruction,
+ * it performs actions on the local variable array and the operand stack and returns [[Some]]
+ * with a particular [[Action]], which defines next steps. If a handler cannot
+ * process an instruction, `tryToHandle` should return None.
+ *
+ * Handlers can be chained via `orElse`.
+ */
+private[bytecode] trait InstructionHandler {
+
+  def tryToHandle(
+      instruction: Instruction,
+      operandStack: OperandStack,
+      localVars: LocalVarArray): Option[Action]
+
+  def orElse(anotherHandler: InstructionHandler): InstructionHandler = {
+    val currentHandler = this
+
+    (i: Instruction, s: OperandStack, l: LocalVarArray) => {
+      currentHandler.tryToHandle(i, s, l).orElse(anotherHandler.tryToHandle(i, s, l))
+    }
+  }
+}
+
+/**
+ * The handler that deals with all instructions related to loading local vars onto the operand stack
+ * or storing values from the operand stack into the local variable array.
+ */
+private[bytecode] object LocalVarHandler extends InstructionHandler {
+
+  override def tryToHandle(
+      instruction: Instruction,
+      operandStack: OperandStack,
+      localVars: LocalVarArray): Option[Action] = {
+
+    instruction.opcode match {
+      case ALOAD_0 | ILOAD_0 | LLOAD_0 | FLOAD_0 | DLOAD_0 =>
+        operandStack.push(localVars(0))
+      case ALOAD_1 | ILOAD_1 | LLOAD_1 | FLOAD_1 | DLOAD_1 =>
+        operandStack.push(localVars(1))
+      case ALOAD_2 | ILOAD_2 | LLOAD_2 | FLOAD_2 | DLOAD_2 =>
+        operandStack.push(localVars(2))
+      case ALOAD_3 | ILOAD_3 | LLOAD_3 | FLOAD_3 | DLOAD_3 =>
+        operandStack.push(localVars(3))
+      case ALOAD | ILOAD | LLOAD | FLOAD | DLOAD =>
+        val codeIter = instruction.behavior.newCodeIterator()
+        val localVarIndex = codeIter.byteAt(instruction.index + 1)
+        operandStack.push(localVars(localVarIndex))
+      case ASTORE_0 | ISTORE_0 | LSTORE_0 | FSTORE_0 | DSTORE_0 =>
+        localVars(0) = operandStack.pop()
+      case ASTORE_1 | ISTORE_1 | LSTORE_1 | FSTORE_1 | DSTORE_1 =>
+        localVars(1) = operandStack.pop()
+      case ASTORE_2 | ISTORE_2 | LSTORE_2 | FSTORE_2 | DSTORE_2 =>
+        localVars(2) = operandStack.pop()
+      case ASTORE_3 | ISTORE_3 | LSTORE_3 | FSTORE_3 | DSTORE_3 =>
+        localVars(3) = operandStack.pop()
+      case ASTORE | ISTORE | LSTORE | FSTORE | DSTORE =>
+        val codeIter = instruction.behavior.newCodeIterator()
+        val localVarIndex = codeIter.byteAt(instruction.index + 1)
+        localVars(localVarIndex) = operandStack.pop()
+      case _ =>
+        return None
+    }
+
+    Some(Continue)
+  }
+}
+
+/**
+ * The handler that deals with pushing constants onto the operand stack.
+ */
+private[bytecode] object ConstantHandler extends InstructionHandler {
+
+  override def tryToHandle(
+      instruction: Instruction,
+      operandStack: OperandStack,
+      localVars: LocalVarArray): Option[Action] = {
+
+    instruction.opcode match {
+      case ICONST_M1 =>
+        operandStack.push(Literal(-1))
+      case ICONST_0 =>
+        operandStack.push(Literal(0))
+      case ICONST_1 =>
+        operandStack.push(Literal(1))
+      case ICONST_2 =>
+        operandStack.push(Literal(2))
+      case ICONST_3 =>
+        operandStack.push(Literal(3))
+      case ICONST_4 =>
+        operandStack.push(Literal(4))
+      case ICONST_5 =>
+        operandStack.push(Literal(5))
+      case LCONST_0 =>
+        operandStack.push(Literal(0L))
+      case LCONST_1 =>
+        operandStack.push(Literal(1L))
+      case FCONST_0 =>
+        operandStack.push(Literal(0.0F))
+      case FCONST_1 =>
+        operandStack.push(Literal(1.0F))
+      case FCONST_2 =>
+        operandStack.push(Literal(2.0F))
+      case DCONST_0 =>
+        operandStack.push(Literal(0.0))
+      case DCONST_1 =>
+        operandStack.push(Literal(1.0))
+      case LDC =>
+        val codeIter = instruction.behavior.newCodeIterator()
+        val constantIndex = codeIter.byteAt(instruction.index + 1)
+        val constant = getConstant(constantIndex, instruction.behavior.constPool)
+        operandStack.push(Literal(constant))
+      case LDC_W | LDC2_W =>
+        val codeIter = instruction.behavior.newCodeIterator()
+        val constantIndex = codeIter.u16bitAt(instruction.index + 1)
+        val constant = getConstant(constantIndex, instruction.behavior.constPool)
+        val expr = constant match {
+          case c if c.isInstanceOf[String] => ObjectRef(Literal(c), classOf[String])
+          case c => Literal(c)
+        }
+        operandStack.push(expr)
+      case BIPUSH =>
+        val codeIter = instruction.behavior.newCodeIterator()
+        val byteValue = codeIter.signedByteAt(instruction.index + 1)
+        operandStack.push(Literal(byteValue, IntegerType))
+      // TODO: WARNING! It is not OK to keep it NullType, we need a proper type
+      // case ACONST_NULL =>
+      //   operandStack.push(Literal(null, NullType))
+      case _ =>
+        return None
+    }
+
+    Some(Continue)
+  }
+
+  private def getConstant(index: Int, constPool: ConstPool): Any = {
+    constPool.getTag(index) match {
+      case ConstPool.CONST_Double => constPool.getDoubleInfo(index)
+      case ConstPool.CONST_Float => constPool.getFloatInfo(index)
+      case ConstPool.CONST_Integer => constPool.getIntegerInfo(index)
+      case ConstPool.CONST_Long => constPool.getLongInfo(index)
+      case ConstPool.CONST_String => constPool.getStringInfo(index)
+    }
+  }
+}
+
+/**
+ * The handler that deals with type conversions.
+ */
+private[bytecode] object TypeConversionHandler extends InstructionHandler {
+
+  override def tryToHandle(
+      instruction: Instruction,
+      operandStack: OperandStack,
+      localVars: LocalVarArray): Option[Action] = {
+
+    instruction.opcode match {
+      case L2I | F2I | D2I =>
+        operandStack.push(Cast(operandStack.pop(), IntegerType))
+      case I2L | F2L | D2L =>
+        operandStack.push(Cast(operandStack.pop(), LongType))
+      case I2F | L2F | D2F =>
+        operandStack.push(Cast(operandStack.pop(), FloatType))
+      case I2D | L2D | F2D =>
+        operandStack.push(Cast(operandStack.pop(), DoubleType))
+      case I2B =>
+        operandStack.push(Cast(operandStack.pop(), ByteType))
+      case I2S =>
+        operandStack.push(Cast(operandStack.pop(), ShortType))
+      case I2C =>
+        // TODO: string vs char type
+        operandStack.push(Cast(operandStack.pop(), StringType))
+      case _ =>
+        return None
+    }
+
+    Some(Continue)
+  }
+}
+
+/**
+ * The handler that deals with basic math operations.
+ */
+// TODO: nulls are handled differently in all expressions
+// TODO: division by zero and other edge cases
+private[bytecode] object MathOperationHandler extends InstructionHandler {
+
+  override def tryToHandle(
+      instruction: Instruction,
+      operandStack: OperandStack,
+      localVars: LocalVarArray): Option[Action] = {
+
+    instruction.opcode match {
+      case IADD =>
+        compute(Add, IntegerType, operandStack)
+      case LADD =>
+        compute(Add, LongType, operandStack)
+      case FADD =>
+        compute(Add, FloatType, operandStack)
+      case DADD =>
+        compute(Add, DoubleType, operandStack)
+      case ISUB =>
+        compute(Subtract, IntegerType, operandStack)
+      case LSUB =>
+        compute(Subtract, LongType, operandStack)
+      case FSUB =>
+        compute(Subtract, FloatType, operandStack)
+      case DSUB =>
+        compute(Subtract, DoubleType, operandStack)
+      case IMUL =>
+        compute(Multiply, IntegerType, operandStack)
+      case LMUL =>
+        compute(Multiply, LongType, operandStack)
+      case FMUL =>
+        compute(Multiply, FloatType, operandStack)
+      case DMUL =>
+        compute(Multiply, DoubleType, operandStack)
+      case IDIV =>
+        compute((left, right) => IntegralDivide(left, right), IntegerType, operandStack)
+      case LDIV =>
+        compute((left, right) => IntegralDivide(left, right), LongType, operandStack)
+      case FDIV =>
+        // TODO
+        // for now, fetch as doubles because Divide can process only doubles and decimals
+        compute((left, right) => Cast(Divide(left, right), FloatType), DoubleType, operandStack)
+      case DDIV =>
+        compute(Divide, DoubleType, operandStack)
+      case IREM =>
+        compute(Remainder, IntegerType, operandStack)
+      case LREM =>
+        compute(Remainder, LongType, operandStack)
+      case FREM =>
+        compute(Remainder, FloatType, operandStack)
+      case DREM =>
+        compute(Remainder, DoubleType, operandStack)
+      case _ =>
+        return None
+    }
+
+    Some(Continue)
+  }
+
+  private def compute(
+      func: (Expression, Expression) => Expression,
+      dataType: AtomicType,
+      operandStack: OperandStack): Unit = {
+
+    val rightOperand = getOperand(dataType, operandStack)
+    val leftOperand = getOperand(dataType, operandStack)
+    operandStack.push(func(leftOperand, rightOperand))
+  }
+
+  // when we have "1.toByte + 1", we need to promote the byte value to Int (just as Java/Scala do)
+  // otherwise, the result expression will be unresolved
+  private def getOperand(targetType: AtomicType, operandStack: OperandStack): Expression = {
+    val operand = operandStack.pop()
+    operand.dataType match {
+      case operandType: AtomicType if operandType != targetType =>
+        require(Cast.canSafeCast(operandType, targetType))
+        Cast(operand, targetType)
+      case operandType: AtomicType if operandType == targetType =>
+        operand
+      case _ =>
+        throw new RuntimeException(s"$operand cannot be safely cast to $targetType")
+    }
+  }
+}
+
+/**
+ * The handler that deals with if statements. As some if conditions cannot be evaluated right away,
+ * we need to recursively transform both true and false branches and then construct an if statement.
+ */
+// TODO: this logic must be absolutely revisited!
+// TODO: avoid recursion if the condition can be evaluated immediately
+private[bytecode] object IfStatementHandler extends InstructionHandler {
+
+  override def tryToHandle(
+      instruction: Instruction,
+      operandStack: OperandStack,
+      localVars: LocalVarArray): Option[Action] = {
+
+    def computeIfExpression(cond: Expression): Option[Action] = {
+      val behavior = instruction.behavior
+      val codeIter = behavior.newCodeIterator()
+
+      val trueExprIndex = codeIter.s16bitAt(instruction.index + 1) + instruction.index
+      val trueExpr = convert(trueExprIndex, behavior, operandStack.clone(), localVars)
+
+      val falseExprIndex = instruction.index + 3
+      val falseExpr = convert(falseExprIndex, behavior, operandStack.clone(), localVars)
+
+      if (trueExpr.isEmpty || falseExpr.isEmpty) {
+        throw new RuntimeException("If statements with void branches are not supported")
+      }
+
+      val returnValue = If(cond, trueExpr.get, falseExpr.get) match {
+        case e if !e.resolved =>
+          throw new RuntimeException(s"$e is not supported")
+        case e @ If(_, t: Ref, f: Ref) if t.clazz != f.clazz =>
+          throw new RuntimeException(s"$e is not supported")
+        case e @ If(_, t: Ref, _: Ref) =>
+          ObjectRef(e, t.clazz)
+        case e @ If(_, _: Ref, _) =>
+          throw new RuntimeException(s"$e is not supported")
+        case e @ If(_, _, _: Ref) =>
+          throw new RuntimeException(s"$e is not supported")
+        case e =>
+          e
+      }
+
+      Some(Complete(Some(returnValue)))
+    }
+
+    instruction.opcode match {
+      case IFEQ =>
+        val top = operandStack.pop()
+        computeIfExpression(EqualTo(top, Cast(Literal(0), top.dataType)))
+      case IFNE =>
+        val top = operandStack.pop()
+        computeIfExpression(Not(EqualTo(top, Cast(Literal(0), top.dataType))))
+      case IFGT =>
+        val top = operandStack.pop()
+        computeIfExpression(GreaterThan(top, Cast(Literal(0), top.dataType)))
+      case IFGE =>
+        val top = operandStack.pop()
+        computeIfExpression(GreaterThanOrEqual(top, Cast(Literal(0), top.dataType)))
+      case IFLT =>
+        val top = operandStack.pop()
+        computeIfExpression(LessThan(top, Cast(Literal(0), top.dataType)))
+      case IFLE =>
+        val top = operandStack.pop()
+        computeIfExpression(LessThanOrEqual(top, Cast(Literal(0), top.dataType)))
+      case IFNONNULL =>
+        val top = operandStack.pop()
+        computeIfExpression(IsNotNull(top))
+      case IFNULL =>
+        val top = operandStack.pop()
+        computeIfExpression(IsNull(top))
+      case IF_ACMPEQ | IF_ICMPEQ =>
+        val (rightOperand, leftOperand) = (operandStack.pop(), operandStack.pop())
+        computeIfExpression(EqualTo(leftOperand, rightOperand))
+      case IF_ACMPNE | IF_ICMPNE =>
+        val (rightOperand, leftOperand) = (operandStack.pop(), operandStack.pop())
+        computeIfExpression(Not(EqualTo(leftOperand, rightOperand)))
+      case IF_ICMPGE =>
+        val (rightOperand, leftOperand) = (operandStack.pop(), operandStack.pop())
+        computeIfExpression(GreaterThanOrEqual(leftOperand, rightOperand))
+      case IF_ICMPGT =>
+        val (rightOperand, leftOperand) = (operandStack.pop(), operandStack.pop())
+        computeIfExpression(GreaterThan(leftOperand, rightOperand))
+      case IF_ICMPLE =>
+        val (rightOperand, leftOperand) = (operandStack.pop(), operandStack.pop())
+        computeIfExpression(LessThanOrEqual(leftOperand, rightOperand))
+      case IF_ICMPLT =>
+        val (rightOperand, leftOperand) = (operandStack.pop(), operandStack.pop())
+        computeIfExpression(LessThan(leftOperand, rightOperand))
+      case _ =>
+        None
+    }
+  }
+}
+
+/**
+ * The handler that is responsible for comparing items on the operand stack.
+ *
+ * FCMPG vs FCMPL and DCMPG vs DCMPL differ only in handling NaN values.
+ */
+private[bytecode] object ComparisonHandler extends InstructionHandler {
+
+  override def tryToHandle(
+      instruction: Instruction,
+      operandStack: OperandStack,
+      localVars: LocalVarArray): Option[Action] = {
+
+    instruction.opcode match {
+      case LCMP =>
+        // TODO is it OK to have positive/negative or we need to have -1,0,1 only?
+        val (rightOperand, leftOperand) = (operandStack.pop(), operandStack.pop())
+        operandStack.push(Subtract(leftOperand, rightOperand))
+      case FCMPG | DCMPG =>
+        val (rightOperand, leftOperand) = (operandStack.pop(), operandStack.pop())
+        val branches = Seq(
+          Or(IsNaN(leftOperand), IsNaN(rightOperand)) -> Literal(1),
+          GreaterThan(leftOperand, rightOperand) -> Literal(1),
+          LessThan(leftOperand, rightOperand) -> Literal(-1))
+        operandStack.push(CaseWhen(branches, Literal(0)))
+      case FCMPL | DCMPL =>
+        val (rightOperand, leftOperand) = (operandStack.pop(), operandStack.pop())
+        val branches = Seq(
+          Or(IsNaN(leftOperand), IsNaN(rightOperand)) -> Literal(-1),
+          GreaterThan(leftOperand, rightOperand) -> Literal(1),
+          LessThan(leftOperand, rightOperand) -> Literal(-1))
+        operandStack.push(CaseWhen(branches, Literal(0)))
+      case _ =>
+        return None
+    }
+
+    Some(Continue)
+  }
+}
+
+/**
+ * The base trait for handlers that deal with fields.
+ */
+private[bytecode] trait FieldHandler extends InstructionHandler {
+
+  protected def getField(fieldIndex: Int, constPool: ConstPool): CtField = {
+    val className = constPool.getFieldrefClassName(fieldIndex)
+    val fieldName = constPool.getFieldrefName(fieldIndex)
+    val ctClass = CtClassPool.getCtClass(className)
+    ctClass.getField(fieldName)
+  }
+}
+
+/**
+ * The handler that deals with static variables.
+ */
+private[bytecode] object StaticFieldHandler extends FieldHandler {
+
+  override def tryToHandle(
+      instruction: Instruction,
+      operandStack: OperandStack,
+      localVars: LocalVarArray): Option[Action] = {
+
+    // TODO: Java statics
+    instruction.opcode match {
+      case GETSTATIC =>
+        val codeIter = instruction.behavior.newCodeIterator()
+        val constPool = instruction.behavior.constPool
+        val fieldIndex = codeIter.u16bitAt(instruction.index + 1)
+        val field = getField(fieldIndex, constPool)
+        // right now, only Scala objects are supported
+        if (field.getName == "MODULE$") {
+          // TODO: handle stateful objects
+          val className = field.getDeclaringClass.getName
+          val scalaObjectRef = ScalaObjectRef(Utils.classForName(className))
+          operandStack.push(scalaObjectRef)
+          Some(Continue)
+        } else {
+          throw new RuntimeException(s"Getting arbitrary static fields is not supported: $field")
+        }
+      case PUTSTATIC =>
+        throw new RuntimeException(s"Setting static fields is not supported")
+      case _ =>
+        None
+    }
+  }
+}
+
+/**
+ * The handler that deals with object fields.
+ */
+private[bytecode] object ObjectFieldHandler extends FieldHandler {
+
+  override def tryToHandle(
+      instruction: Instruction,
+      operandStack: OperandStack,
+      localVars: LocalVarArray): Option[Action] = {
+
+    instruction.opcode match {
+      case GETFIELD =>
+        val codeIter = instruction.behavior.newCodeIterator()
+        val constPool = instruction.behavior.constPool
+        val fieldIndex = codeIter.u16bitAt(instruction.index + 1)
+        val field = getField(fieldIndex, constPool)
+        val fieldName = field.getName
+        val obj = operandStack.pop()
+        val fieldValue = getFieldValue(obj, fieldName)
+        operandStack.push(fieldValue)
+        Some(Continue)
+      case PUTFIELD =>
+        val codeIter = instruction.behavior.newCodeIterator()
+        val constPool = instruction.behavior.constPool
+        val fieldIndex = codeIter.u16bitAt(instruction.index + 1)
+        val field = getField(fieldIndex, constPool)
+        val fieldName = field.getName
+        val (fieldValue, obj) = (operandStack.pop(), operandStack.pop())
+        setFieldValue(obj, fieldName, fieldValue)
+        Some(Continue)
+      case _ =>
+        None
+    }
+  }
+
+  private def getFieldValue(operand: Expression, fieldName: String): Expression = operand match {
+    case ObjectRef(Literal(null, structType: StructType), _) =>
+      val field = structType(fieldName)
+      AssertNotNull(Literal(null, field.dataType))
+    case e: StructRef =>
+      e.getFieldValue(fieldName)
+    case e: ObjectRef if e.isBoxedPrimitive && fieldName == "value" =>
+      e.value
+    case e: ObjectRef if e.dataType.isInstanceOf[StructType] =>
+      val ctClass = CtClassPool.getCtClass(e.clazz)
+      val structType = e.dataType.asInstanceOf[StructType]
+      val fieldIndex = structType.fieldIndex(fieldName)
+      // TODO: field desc?
+      val ctField = ctClass.getField(fieldName)
+      val fieldValue = GetStructField(e.value, fieldIndex)
+      if (ctField.getType.isPrimitive) {
+        fieldValue
+      } else {
+        val fieldClazz = Utils.classForName(ctField.getType.getName)
+        ObjectRef(fieldValue, fieldClazz)
+      }
+    case _ =>
+      throw new RuntimeException(s"Cannot get field '$fieldName' from '$operand'")
+  }
+
+  private def setFieldValue(obj: Expression, fieldName: String, value: Expression): Unit = {
+    obj match {
+      case e: StructRef =>
+        e.setFieldValue(fieldName, value)
+      // TODO: proper validation
+      case e: ObjectRef if e.isBoxedPrimitive && fieldName == "value" =>
+        e.value = value
+      case _ =>
+        throw new RuntimeException(s"Cannot set '$fieldName' in '$obj'")
+    }
+  }
+}
+
+/**
+ * The handler that deals with creating new objects.
+ */
+private[bytecode] object ObjectCreationHandler extends InstructionHandler {
+
+  override def tryToHandle(
+      instruction: Instruction,
+      operandStack: OperandStack,
+      localVars: LocalVarArray): Option[Action] = {
+
+    instruction.opcode match {
+      case NEW =>
+        val codeIter = instruction.behavior.newCodeIterator()
+        val constPool = instruction.behavior.constPool
+        val classIndex = codeIter.u16bitAt(instruction.index + 1)
+        val className = constPool.getClassInfo(classIndex)
+        val clazz = Utils.classForName(className)
+        if (boxedPrimitiveClasses.contains(className)) {
+          operandStack.push(newNullObjectRef(clazz))
+        } else {
+          operandStack.push(StructRef(clazz))
+        }
+        Some(Continue)
+      case _ =>
+        None
+    }
+  }
+
+  private def newNullObjectRef(clazz: Class[_]): ObjectRef = {
+    val dataType = ScalaReflection.schemaFor(clazz).dataType
+    val value = Literal(null, dataType)
+    ObjectRef(value, clazz)
+  }
+}
+
+/**
+ * The base trait for handlers that deal with method/constructor invocations.
+ */
+private[bytecode] trait InvokeHandler extends InstructionHandler {
+
+  protected def getInvokeTarget(instruction: Instruction): Behavior = {
+    val codeIter = instruction.behavior.newCodeIterator()
+    val constPool = instruction.behavior.constPool
+    val targetIndex = codeIter.u16bitAt(instruction.index + 1)
+    val targetName = constPool.getMethodrefName(targetIndex)
+    val targetClassName = constPool.getMethodrefClassName(targetIndex)
+    val descriptor = constPool.getMethodrefType(targetIndex)
+    val ctClass = CtClassPool.getCtClass(targetClassName)
+    val method = Try(ctClass.getMethod(targetName, descriptor))
+    val constructor = Try(ctClass.getConstructor(descriptor))
+    Behavior(method.orElse(constructor).get)
+  }
+
+  protected def popArguments(number: Int, operandStack: OperandStack): Array[Expression] = {
+    val args = new Array[Expression](number)
+    for (index <- number - 1 to 0 by -1) {
+      args(index) = operandStack.pop()
+    }
+    args
+  }
+}
+
+/**
+ * The handler that deals with instance method calls without method dispatch.
+ */
+private[bytecode] object InstanceMethodCallHandler extends InvokeHandler {
+
+  override def tryToHandle(
+      instruction: Instruction,
+      operandStack: OperandStack,
+      localVars: LocalVarArray): Option[Action] = {
+
+    // TODO: proper null handling
+    instruction.opcode match {
+      case INVOKESPECIAL =>
+        val target = getInvokeTarget(instruction)
+        val argsNum = target.numParameters
+        val args = popArguments(argsNum, operandStack)
+        val thisRef = operandStack.pop()
+        val targetLocalVars = newLocalVarArray(target, Some(thisRef), args)
+        val targetResult = convert(target, targetLocalVars)
+        targetResult.foreach(operandStack.push)
+        Some(Continue)
+      case _ =>
+        None
+    }
+  }
+}
+
+/**
+ * The handler that deals with instance method calls with method dispatch.
+ */
+private[bytecode] object InstanceMethodCallWithDispatchHandler extends InvokeHandler {
+
+  override def tryToHandle(
+      instruction: Instruction,
+      operandStack: OperandStack,
+      localVars: LocalVarArray): Option[Action] = {
+
+    // TODO: proper null handling
+    instruction.opcode match {
+      case INVOKEVIRTUAL | INVOKEINTERFACE =>
+        val compileTarget = getInvokeTarget(instruction)
+        val argsNum = compileTarget.numParameters
+        val args = popArguments(argsNum, operandStack)
+        val thisRef = operandStack.pop()
+        // we simulate method dispatch
+        val runtimeTarget = thisRef match {
+          case ObjectRef(Literal(null, _), _) =>
+            throw new AnalysisException(s"Calling '${compileTarget.name}' on a null reference")
+          case e: Ref =>
+            val runtimeClass = CtClassPool.getCtClass(e.clazz)
+            runtimeClass.getMethod(compileTarget.name, compileTarget.signature)
+          case _ =>
+            throw new RuntimeException(s"Unsupported `thisRef` for invokevirtual: $thisRef")
+        }
+        val targetLocalVars = newLocalVarArray(runtimeTarget, Some(thisRef), args)
+        val targetResult = convert(runtimeTarget, targetLocalVars)
+        targetResult.foreach(operandStack.push)
+        Some(Continue)
+      case _ =>
+        None
+    }
+  }
+}
+
+/**
+ * The handler that deals with static method calls.
+ */
+private[bytecode] object StaticMethodCallHandler extends InvokeHandler {
+
+  override def tryToHandle(
+      instruction: Instruction,
+      operandStack: OperandStack,
+      localVars: LocalVarArray): Option[Action] = {
+
+    instruction.opcode match {
+      case INVOKESTATIC =>
+        val target = getInvokeTarget(instruction)
+        val argsNum = target.numParameters
+        val args = popArguments(argsNum, operandStack)
+        val targetLocalVars = newLocalVarArray(target, None, args)
+        val targetResult = convert(target, targetLocalVars)
+        targetResult.foreach(operandStack.push)
+        Some(Continue)
+      case _ =>
+        None
+    }
+
+  }
+}
+
+/**
+ * The handler that deals with miscellaneous instructions.
+ */
+private[bytecode] object MiscInstructionHandler extends InstructionHandler {
+
+  override def tryToHandle(
+      instruction: Instruction,
+      operandStack: OperandStack,
+      localVars: LocalVarArray): Option[Action] = {
+
+    instruction.opcode match {
+      case DUP =>
+        operandStack.push(operandStack.top)
+        Some(Continue)
+      case DUP2 =>
+        operandStack.top match {
+          case _: Ref =>
+            val (topOperand, nextOperand) = (operandStack.pop(), operandStack.pop())
+            operandStack.push(nextOperand)
+            operandStack.push(topOperand)
+            operandStack.push(nextOperand)
+            operandStack.push(topOperand)
+          case e if e.dataType == LongType || e.dataType == DoubleType =>
+            operandStack.push(operandStack.top)
+        }
+        Some(Continue)
+      case POP =>
+        operandStack.pop()
+        Some(Continue)
+      case POP2 =>
+        operandStack.top match {
+          case _: Ref =>
+            operandStack.pop()
+            operandStack.pop()
+          case e if e.dataType == LongType || e.dataType == DoubleType =>
+            operandStack.pop()
+        }
+        Some(Continue)
+      case GOTO =>
+        val codeIter = instruction.behavior.newCodeIterator()
+        val targetIndex = codeIter.s16bitAt(instruction.index + 1) + instruction.index
+        Some(Jump(targetIndex))
+      case CHECKCAST =>
+        val codeIter = instruction.behavior.newCodeIterator()
+        val classIndex = codeIter.u16bitAt(instruction.index + 1)
+        val constPool = instruction.behavior.constPool
+        val className = constPool.getClassInfo(classIndex)
+        val clazz = Utils.classForName(className)
+        val dataType = ScalaReflection.schemaFor(clazz).dataType
+        // TODO: this should throw ClassCastException in JVM
+        require(operandStack.top.dataType == dataType)
+        Some(Continue)
+      case _ =>
+        None
+    }
+  }
+}
+
+/**
+ * The handler that deals with return statements.
+ */
+private[bytecode] object ReturnHandler extends InstructionHandler {
+
+  override def tryToHandle(
+      instruction: Instruction,
+      operandStack: OperandStack,
+      localVars: LocalVarArray): Option[Action] = {
+
+    val behavior = instruction.behavior
+    val returnType = behavior.returnType
+
+    instruction.opcode match {
+      case IRETURN if returnType.exists(_.getName == "boolean") =>
+        // TODO: will it be always 1 or 0? Can we simply replace it with true/false?
+        Some(Complete(returnValue = Some(Cast(operandStack.pop, BooleanType))))
+      case IRETURN if returnType.exists(_.getName == "byte") =>
+        Some(Complete(returnValue = Some(Cast(operandStack.pop, ByteType))))
+      case IRETURN if returnType.exists(_.getName == "short") =>
+        Some(Complete(returnValue = Some(Cast(operandStack.pop, ShortType))))
+      case ARETURN | IRETURN | LRETURN | FRETURN | DRETURN =>
+        Some(Complete(returnValue = Some(operandStack.pop)))
+      case RETURN =>
+        Some(Complete(returnValue = None))
+      case _ =>
+        None
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/bytecode/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/bytecode/package.scala
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst
+
+import scala.collection.mutable
+
+import javassist.{CtBehavior, CtClass, CtConstructor, CtMethod, Modifier}
+import javassist.bytecode.{CodeIterator, ConstPool}
+import javassist.bytecode.InstructionPrinter.instructionString
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+
+// TODO: what about accessibility?
+package object bytecode {
+
+  type LocalVarArray = Array[Expression]
+  type OperandStack = mutable.ArrayStack[Expression]
+
+  // TODO: what about other ways to represent this? classOf?
+  val JAVA_BOOLEAN_CLASS = "java.lang.Boolean"
+  val JAVA_BYTE_CLASS = "java.lang.Byte"
+  val JAVA_SHORT_CLASS = "java.lang.Short"
+  val JAVA_INTEGER_CLASS = "java.lang.Integer"
+  val JAVA_LONG_CLASS = "java.lang.Long"
+  val JAVA_FLOAT_CLASS = "java.lang.Float"
+  val JAVA_DOUBLE_CLASS = "java.lang.Double"
+  val JAVA_STRING_CLASS = "java.lang.String"
+  val JAVA_OBJECT_CLASS = "java.lang.Object"
+  val SPARK_UTF8_STRING_CLASS = "org.apache.spark.unsafe.types.UTF8String"
+
+  val boxedPrimitiveClasses: Seq[String] = Seq(JAVA_BOOLEAN_CLASS, JAVA_BYTE_CLASS,
+    JAVA_SHORT_CLASS, JAVA_INTEGER_CLASS, JAVA_LONG_CLASS, JAVA_FLOAT_CLASS, JAVA_DOUBLE_CLASS)
+
+  /**
+   * This is a wrapper around [[CtBehavior]] to simplify the interaction.
+   */
+  // TODO: refactor
+  implicit class Behavior(ctBehavior: CtBehavior) {
+
+    lazy val name: String = ctBehavior.getName
+    lazy val declaringClass: CtClass = ctBehavior.getDeclaringClass
+    lazy val localVarArraySize: Int = ctBehavior.getMethodInfo.getCodeAttribute.getMaxLocals
+    lazy val constPool: ConstPool = ctBehavior.getMethodInfo.getConstPool
+    lazy val isStatic: Boolean = Modifier.isStatic(ctBehavior.getModifiers)
+    lazy val isConstructor: Boolean = ctBehavior.isInstanceOf[CtConstructor]
+    lazy val numParameters: Int = ctBehavior.getParameterTypes.length
+    lazy val signature: String = ctBehavior.getSignature
+    lazy val parameterTypes: Array[CtClass] = ctBehavior.getParameterTypes
+    lazy val returnType: Option[CtClass] = ctBehavior match {
+      case method: CtMethod => Some(method.getReturnType)
+      case _ => None
+    }
+
+    def newCodeIterator(): CodeIterator =
+      ctBehavior.getMethodInfo.getCodeAttribute.iterator()
+
+    def toDebugString: String = {
+      val stringBuilder = new StringBuilder()
+
+      stringBuilder.append(
+        s"""### Behavior ###
+           |name: $name,
+           |class: ${declaringClass.getName},
+           |isStatic: $isStatic,
+           |isConstructor: $isConstructor,
+           |signature: $signature\n""".stripMargin)
+
+      val codeIter = newCodeIterator()
+      while (codeIter.hasNext) {
+        val pos = codeIter.next()
+        val code = instructionString(codeIter, pos, constPool)
+        stringBuilder.append(s"$pos: $code\n")
+      }
+
+      stringBuilder.toString()
+    }
+  }
+
+  def newLocalVarArray(
+      behavior: Behavior,
+      thisRef: Option[Expression],
+      args: Seq[Expression]): LocalVarArray = {
+
+    // `thisRef` must be None for static behaviors
+    require(behavior.isStatic == thisRef.isEmpty)
+
+    val localVars = new LocalVarArray(behavior.localVarArraySize)
+    var localVarIndex = 0
+
+    thisRef.foreach { ref =>
+      localVars(0) = ref
+      localVarIndex += 1
+    }
+
+    args.zip(behavior.parameterTypes).foreach { case (arg, argCtClass) =>
+      localVars(localVarIndex) = arg
+      localVarIndex += 1
+      // primitive longs and doubles occupy two slots in the local variable array
+      if (argCtClass.getName == "long" || argCtClass.getName == "double") {
+        localVars(localVarIndex) = null
+        localVarIndex += 1
+      }
+    }
+
+    localVars
+  }
+
+  def resolveRefs(e: Expression): Expression = e.transformUp {
+    case e: Ref => e.resolve()
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/bytecode/specialBehaviorHandlers.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/bytecode/specialBehaviorHandlers.scala
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.bytecode
+
+import org.apache.spark.sql.catalyst.expressions.{Cast, Concat, EqualTo, Expression}
+import org.apache.spark.sql.catalyst.expressions.objects.AssertNotNull
+import org.apache.spark.sql.types.{IntegerType, LongType, StringType}
+
+// TODO: code style
+// TODO: this is temporary, we need a proper solution, edge cases are not handled
+private[bytecode] object SpecialStaticMethodHandler {
+
+  private val handler: PartialFunction[Behavior, LocalVarArray => Option[Expression]] = {
+    case b if b.declaringClass.getName == JAVA_LONG_CLASS && b.name == "valueOf" &&
+      (b.parameterTypes sameElements Array(CtClassPool.getCtClass("long"))) =>
+      localVars =>
+        val value = localVars(0)
+        require(value.dataType == LongType)
+        Some(ObjectRef(value, classOf[java.lang.Long]))
+    case b if b.declaringClass.getName == JAVA_LONG_CLASS && b.name == "valueOf" =>
+      localVars =>
+        val value = Cast(localVars(0), LongType)
+        Some(ObjectRef(value, classOf[java.lang.Long]))
+    case b if b.declaringClass.getName == JAVA_LONG_CLASS && b.name == "toString" =>
+      localVars =>
+        val value = Cast(localVars(0), StringType)
+        Some(ObjectRef(value, classOf[String]))
+    case b if b.declaringClass.getName == JAVA_INTEGER_CLASS && b.name == "valueOf" &&
+      (b.parameterTypes sameElements Array(CtClassPool.getCtClass("int"))) =>
+      localVars =>
+        val value = localVars(0)
+        require(value.dataType == IntegerType)
+        Some(ObjectRef(value, classOf[java.lang.Integer]))
+    case b if b.declaringClass.getName == JAVA_INTEGER_CLASS && b.name == "valueOf" =>
+      localVars =>
+        val value = Cast(localVars(0), IntegerType)
+        Some(ObjectRef(value, classOf[java.lang.Integer]))
+    case b if b.declaringClass.getName == JAVA_INTEGER_CLASS && b.name == "toString" =>
+      localVars =>
+        val value = Cast(localVars(0), StringType)
+        Some(ObjectRef(value, classOf[String]))
+  }
+
+  def canHandle(behavior: Behavior): Boolean = {
+    behavior.isStatic && handler.isDefinedAt(behavior)
+  }
+
+  def handle(behavior: Behavior, localVars: LocalVarArray): Option[Expression] = {
+    handler(behavior)(localVars)
+  }
+}
+
+// TODO: code style
+// TODO: this is temporary, we need a proper solution, edge cases are not handled
+private[bytecode] object SpecialInstanceMethodHandler {
+
+  private val handler: PartialFunction[Behavior, LocalVarArray => Option[Expression]] = {
+    case b if b.declaringClass.getName == JAVA_STRING_CLASS && b.name == "concat" =>
+      localVars =>
+        val value = Concat(Seq(AssertNotNull(localVars(0)), AssertNotNull(localVars(1))))
+        Some(ObjectRef(value, classOf[String]))
+    case b if b.declaringClass.getName == SPARK_UTF8_STRING_CLASS && b.name == "toString" =>
+      localVars =>
+        val value = localVars(0)
+        Some(ObjectRef(AssertNotNull(value), classOf[String]))
+    case b if b.declaringClass.getName == JAVA_STRING_CLASS && b.name == "equals" =>
+      localVars =>
+        val value = localVars(0)
+        val anotherValue = localVars(1)
+        val equalsExpr = EqualTo(AssertNotNull(value), anotherValue)
+        Some(ObjectRef(equalsExpr, classOf[String]))
+  }
+
+  def canHandle(behavior: Behavior): Boolean = {
+    !behavior.isStatic && handler.isDefinedAt(behavior)
+  }
+
+  def handle(behavior: Behavior, localVars: LocalVarArray): Option[Expression] = {
+    handler(behavior)(localVars)
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/ComplexTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/ComplexTypes.scala
@@ -37,6 +37,9 @@ object SimplifyExtractValueOps extends Rule[LogicalPlan] {
     case a: Aggregate => a
     case p => p.transformExpressionsUp {
       // Remove redundant field extraction.
+      case GetStructField(If(cond, trueExpr, falseExpr), ordinal, name) =>
+        If(cond, GetStructField(trueExpr, ordinal, name), GetStructField(falseExpr, ordinal, name))
+
       case GetStructField(createNamedStructLike: CreateNamedStructLike, ordinal, _) =>
         createNamedStructLike.valExprs(ordinal)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1752,6 +1752,14 @@ object SQLConf {
     .internal()
     .intConf
     .createWithDefault(Int.MaxValue)
+
+  val BYTECODE_ANALYSIS_ENABLED =
+    buildConf("spark.sql.bytecodeAnalysis.enabled")
+      .doc("Enables or disables closure bytecode analysis. When true, Spark will try to convert " +
+        "user-defined closures into Catalyst expressions in order to apply more optimizations " +
+        "on typed Datasets")
+      .booleanConf
+      .createWithDefault(false)
 }
 
 /**
@@ -2092,6 +2100,8 @@ class SQLConf extends Serializable with Logging {
   def joinReorderCardWeight: Double = getConf(SQLConf.JOIN_REORDER_CARD_WEIGHT)
 
   def joinReorderDPStarFilter: Boolean = getConf(SQLConf.JOIN_REORDER_DP_STAR_FILTER)
+
+  def bytecodeAnalysisEnabled: Boolean = getConf(SQLConf.BYTECODE_ANALYSIS_ENABLED)
 
   def windowExecBufferInMemoryThreshold: Int = getConf(WINDOW_EXEC_BUFFER_IN_MEMORY_THRESHOLD)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetBytecodeAnalysisBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetBytecodeAnalysisBenchmark.scala
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
+import org.apache.spark.sql.internal.SQLConf
+
+object DatasetBytecodeAnalysisBenchmark extends SqlBasedBenchmark {
+
+  import spark.implicits._
+
+  case class Data(l: Long, s: String)
+  case class NestedData(i: Int, data: Data)
+  case class Event(userId: Long, deviceId: String, counts: Long) {
+    def doSmth(): Boolean = true
+  }
+
+  private def runBackToBackMapsBenchmark(numRows: Long, minNumIters: Int): Unit = {
+    val benchmarkName = "back-to-back maps (longs)"
+    val benchmark = new Benchmark(benchmarkName, numRows, minNumIters)
+
+    benchmark.addCase("DataFrame") { _ =>
+      val res = spark.range(1, numRows).toDF("l")
+        .select($"l" + 1 as "l")
+        .select($"l" + 2 as "l")
+        .select($"l" + 3 as "l")
+        .select($"l" + 4 as "l")
+        .select($"l" + 5 as "l")
+        .select($"l" + 6 as "l")
+      res.queryExecution.toRdd.foreach(_ => Unit)
+    }
+
+    def datasetQuery(): Unit = {
+      val res = spark.range(1, numRows).as[Long]
+        .map(l => l + 1)
+        .map(l => l + 2)
+        .map(l => l + 3)
+        .map(l => l + 4)
+        .map(l => l + 5)
+        .map(l => l + 6)
+      res.queryExecution.toRdd.foreach(_ => Unit)
+    }
+
+    benchmark.addCase("Dataset (w/o bytecode analysis)") { _ =>
+      withSQLConf(SQLConf.BYTECODE_ANALYSIS_ENABLED.key -> "false") {
+        datasetQuery()
+      }
+    }
+
+    benchmark.addCase("Dataset (with bytecode analysis)") { _ =>
+      withSQLConf(SQLConf.BYTECODE_ANALYSIS_ENABLED.key -> "true") {
+        datasetQuery()
+      }
+    }
+
+    benchmark.run()
+  }
+
+  private def runFilterMapFilterBenchmark(numRows: Long, minNumIters: Int): Unit = {
+    val benchmarkName = "filter -> map -> filter (longs)"
+    val benchmark = new Benchmark(benchmarkName, numRows, minNumIters)
+
+    benchmark.addCase("DataFrame") { _ =>
+      val res = spark.range(1, numRows).toDF("l")
+        .filter($"l" >= 5000000)
+        .select($"l" + 1 as "l")
+        .filter($"l" <= 5000001)
+      res.queryExecution.toRdd.foreach(_ => Unit)
+    }
+
+    def datasetQuery(): Unit = {
+      val res = spark.range(1, numRows).as[Long]
+        .filter(l => l >= 5000000)
+        .map(l => l + 1)
+        .filter(l => l <= 5000001)
+      res.queryExecution.toRdd.foreach(_ => Unit)
+    }
+
+    benchmark.addCase("Dataset (w/o bytecode analysis)") { _ =>
+      withSQLConf(SQLConf.BYTECODE_ANALYSIS_ENABLED.key -> "false") {
+        datasetQuery()
+      }
+    }
+
+    benchmark.addCase("Dataset (with bytecode analysis)") { _ =>
+      withSQLConf(SQLConf.BYTECODE_ANALYSIS_ENABLED.key -> "true") {
+        datasetQuery()
+      }
+    }
+
+    benchmark.run()
+  }
+
+  private def runTrivialMapCaseClassesBenchmark(numRows: Long, minNumIters: Int): Unit = {
+    def datasetQuery(): Unit = {
+      val res = spark.range(1, numRows).as[Long]
+        .map(l => Data(l, l.toString))
+        .map(_.l)
+        .map(l => l + 13)
+        .map(l => l + 22)
+      res.queryExecution.toRdd.foreach(_ => Unit)
+    }
+    runDatasetBenchmark(datasetQuery, "trivial map transforms (case classes)", numRows, minNumIters)
+  }
+
+  private def runMapCaseClassesBenchmark(numRows: Long, minNumIters: Int): Unit = {
+    def datasetQuery(): Unit = {
+      val res = spark.range(1, numRows).as[Long]
+        .map(n => Data(n, n.toString))
+        .map(_.l)
+        .map(l => l + 13)
+        .map(l => Data(l, l.toString))
+        .map(data => Event(data.l, data.s, data.l))
+      res.queryExecution.toRdd.foreach(_ => Unit)
+    }
+    runDatasetBenchmark(datasetQuery, "map transforms (case classes)", numRows, minNumIters)
+  }
+
+  private def runMapFilterCaseClassesBenchmark(numRows: Long, minNumIters: Int): Unit = {
+    val func = (l: Long) => Event(l, l.toString, 0)
+    def datasetQuery(): Unit = {
+      val res = spark.range(1, numRows).as[Long]
+        .map(func)
+        .map(event => Event(event.userId, event.deviceId, event.counts + 1))
+        .filter(_.userId < 10)
+      res.queryExecution.toRdd.foreach(_ => Unit)
+    }
+    runDatasetBenchmark(datasetQuery, "map -> filter (case classes)", numRows, minNumIters)
+  }
+
+  private def runNestedDataBenchmark(numRows: Long, minNumIters: Int): Unit = {
+    def datasetQuery(): Unit = {
+      val res = spark.range(1, numRows).as[Long]
+        .map(l => Data(l, l.toString))
+        .map(data => NestedData(data.l.toInt + 10, data))
+        .filter(nestedData => nestedData.data.l < 5)
+      res.queryExecution.toRdd.foreach(_ => Unit)
+    }
+    runDatasetBenchmark(datasetQuery, "nested data", numRows, minNumIters)
+  }
+
+  private def runDatasetBenchmark(
+      closure: () => Unit,
+      name: String,
+      numRows: Long,
+      minNumIters: Int): Unit = {
+
+    val benchmark = new Benchmark(name, numRows, minNumIters)
+
+    benchmark.addCase("Dataset (w/o bytecode analysis)") { _ =>
+      withSQLConf(SQLConf.BYTECODE_ANALYSIS_ENABLED.key -> "false") {
+        closure()
+      }
+    }
+
+    benchmark.addCase("Dataset (with bytecode analysis)") { _ =>
+      withSQLConf(SQLConf.BYTECODE_ANALYSIS_ENABLED.key -> "true") {
+        closure()
+      }
+    }
+
+    benchmark.run()
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    val numRows = 100000000
+    val minNumIters = 5
+
+    runBackToBackMapsBenchmark(numRows, minNumIters)
+    runFilterMapFilterBenchmark(numRows, minNumIters)
+    runTrivialMapCaseClassesBenchmark(numRows, minNumIters)
+    runMapCaseClassesBenchmark(numRows, minNumIters)
+    runMapFilterCaseClassesBenchmark(numRows, minNumIters)
+    runNestedDataBenchmark(numRows, minNumIters)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/bytecode/BytecodeAnalysisSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/bytecode/BytecodeAnalysisSuite.scala
@@ -1,0 +1,616 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.bytecode
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.{AnalysisException, QueryTest}
+import org.apache.spark.sql.catalyst.expressions.objects.Invoke
+import org.apache.spark.sql.execution.{DeserializeToObjectExec, FilterExec, ObjectConsumerExec, ObjectProducerExec, ProjectExec, SerializeFromObjectExec, SparkPlan}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSQLContext
+
+
+class BytecodeAnalysisSuite extends QueryTest with SharedSQLContext {
+  import testImplicits._
+
+  // TODO: the support for arithmetic operations must be revisited because of edge cases
+  test("map transformations with basic arithmetic operations") {
+    withSQLConf(SQLConf.BYTECODE_ANALYSIS_ENABLED.key -> "true") {
+      val byteDS = Seq(1.toByte, 2.toByte).toDS()
+        .map(b => (b + 1).toByte)
+        .map(b => (b - 6).toByte)
+        .map(b => (b * 1).toByte)
+        .map(b => (b / 2).toByte)
+        .map(b => (b % 2).toByte)
+      val bytePlan = byteDS.queryExecution.executedPlan
+      // TODO: the field `value` is nullable as Divide is always nullable
+      // we break the schema here
+      // assert(bytePlan.schema == byteDS.schema)
+      assertNoTypedOperations(bytePlan)
+      assert(bytePlan.collect { case p: ProjectExec => p }.size == 1)
+      checkDataset(byteDS, 0.toByte, -1.toByte)
+
+      val shortDS = Seq(1.toShort, 2.toShort).toDS()
+        .map(s => (s + 1).toShort)
+        .map(s => (s - 6).toShort)
+        .map(s => (s * 1).toShort)
+        .map(s => (s / 2).toShort)
+        .map(s => (s % 2).toShort)
+      val shortPlan = shortDS.queryExecution.executedPlan
+      // TODO: the field `value` is nullable as Divide is always nullable
+      // we break the schema here
+      // assert(shortPlan.schema == shortDS.schema)
+      assertNoTypedOperations(shortPlan)
+      assert(shortPlan.collect { case p: ProjectExec => p }.size == 1)
+      checkDataset(shortDS, 0.toShort, -1.toShort)
+
+      val intDS = Seq(1, 2).toDS()
+        .map(i => i + 1)
+        .map(i => i - 6)
+        .map(i => i * 1)
+        .map(i => i / 2)
+        .map(i => i % 2)
+      val intPlan = intDS.queryExecution.executedPlan
+      // TODO: the field `value` is nullable as Divide is always nullable
+      // we break the schema here
+      // assert(intPlan.schema == intDS.schema)
+      assertNoTypedOperations(intPlan)
+      assert(intPlan.collect { case p: ProjectExec => p }.size == 1)
+      checkDataset(intDS, 0, -1)
+
+      val longDS = spark.range(1, 3).as[Long]
+        .map(l => l + 1)
+        .map(l => l - 6)
+        .map(l => l * 1)
+        .map(l => l / 2)
+        .map(l => l % 2)
+      val longPlan = longDS.queryExecution.executedPlan
+      // TODO: the field `value` is nullable as Divide is always nullable
+      // we break the schema here
+      // assert(longPlan.schema == longDS.schema)
+      assertNoTypedOperations(longPlan)
+      assert(longPlan.collect { case p: ProjectExec => p }.size == 1)
+      checkDataset(longDS, 0L, -1L)
+
+      val floatDS = Seq(1.0F, 2.0F).toDS()
+        .map(f => f + 1)
+        .map(f => f - 6)
+        .map(f => f * 1)
+        .map(f => f / 2)
+        .map(f => f % 2)
+      val floatPlan = floatDS.queryExecution.executedPlan
+      // TODO: the field `value` is nullable as Divide is always nullable
+      // we break the schema here
+      // assert(floatPlan.schema == floatDS.schema)
+      assertNoTypedOperations(floatPlan)
+      assert(floatPlan.collect { case p: ProjectExec => p }.size == 1)
+      checkDataset(floatDS, -0.0F, -1.5F)
+
+      val doubleDS = Seq(1.0, 2.0).toDS()
+        .map(d => d + 1)
+        .map(d => d - 6)
+        .map(d => d * 1)
+        .map(d => d / 2)
+        .map(d => d % 2)
+      val doublePlan = doubleDS.queryExecution.executedPlan
+      // TODO: the field `value` is nullable as Divide is always nullable
+      // we break the schema here
+      // assert(doublePlan.schema == doubleDS.schema)
+      assertNoTypedOperations(doublePlan)
+      assert(doublePlan.collect { case p: ProjectExec => p }.size == 1)
+      checkDataset(doubleDS, -0.0, -1.5)
+    }
+
+    // TODO: other types
+  }
+
+  test("map transformations with mixed types") {
+    withSQLConf(SQLConf.BYTECODE_ANALYSIS_ENABLED.key -> "true") {
+      val ds1 = Seq(1, 2).toDS()
+        .map(v => v + 1.5)
+        .filter(v => v > 3)
+      val plan1 = ds1.queryExecution.executedPlan
+      assertNoTypedOperations(plan1)
+      checkDataset(ds1, 3.5)
+
+      // TODO: more cases
+    }
+  }
+
+  test("filters with basic arithmetic operations") {
+    // TODO
+  }
+
+  // TODO: this one is broken as edge cases are not handled
+  ignore("edge cases for arithmetic operations") {
+    withSQLConf(SQLConf.BYTECODE_ANALYSIS_ENABLED.key -> "true") {
+
+      // TODO: 1 / 0 -> An arithmetic exception
+      val byteDS = Seq(1.toByte, 2.toByte).toDS()
+      byteDS.map(b => b / 0).show()
+
+      // TODO: 1 / 0.0 -> Infinity
+      val doubleDS = Seq(1.0, 2.0).toDS()
+      doubleDS.map(d => d / 0.0).show()
+
+      // TODO: other edge cases
+    }
+  }
+
+  test("map transformations with java.lang.Long") {
+    withSQLConf(SQLConf.BYTECODE_ANALYSIS_ENABLED.key -> "true") {
+      val ds1 = Seq(java.lang.Long.valueOf(1L), java.lang.Long.valueOf(3L)).toDS()
+        .map { l => JavaLongWrapper(l) }
+        .map { w =>
+          val oldNumber: java.lang.Long = w.number
+          val additionalValue = new java.lang.Long(3)
+          val finalValue = w.add(oldNumber, additionalValue)
+          JavaLongWrapper(finalValue)
+        }
+      val plan1 = ds1.queryExecution.executedPlan
+      assertNoTypedOperations(plan1)
+      checkDataset(ds1, JavaLongWrapper(5L), JavaLongWrapper(9L))
+
+      val ds2 = Seq(java.lang.Long.valueOf(1L), java.lang.Long.valueOf(3L)).toDS()
+        .map { l => JavaLongWrapper(l) }
+        .map { w =>
+          val oldNumber: java.lang.Long = w.number
+          val primitiveValue: Long = 3L
+          val additionalValue = w.number + primitiveValue
+          val finalValue = w.add(oldNumber, additionalValue)
+          JavaLongWrapper(finalValue)
+        }
+      val plan2 = ds2.queryExecution.executedPlan
+      assertNoTypedOperations(plan2)
+      checkDataset(ds2, JavaLongWrapper(6L), JavaLongWrapper(12L))
+
+      // TODO: call methods on java.lang.Long
+    }
+  }
+
+  test("map transformations with String") {
+    withSQLConf(SQLConf.BYTECODE_ANALYSIS_ENABLED.key -> "true") {
+      val ds1 = Seq(1L, 2L).toDS()
+        .map(l => l.toString)
+        .map(s => s.concat("-XXX"))
+      val plan1 = ds1.queryExecution.executedPlan
+      assertNoTypedOperations(plan1)
+      checkDataset(ds1, "1-XXX", "2-XXX")
+
+      val ds2 = Seq(1L, 4L).toDS()
+        .map { l =>
+          val b = if (l > 2) "" else l.toString
+          b.toString
+        }
+      val plan2 = ds2.queryExecution.executedPlan
+      assertNoTypedOperations(plan2)
+      checkDataset(ds2, "1", "")
+
+      // TODO: more cases
+    }
+  }
+
+  test("map transformations with case classes") {
+    withSQLConf(SQLConf.BYTECODE_ANALYSIS_ENABLED.key -> "true") {
+      val ds1 = Seq(1L, 2L).toDS()
+        .map(l => Event(l, l.toString))
+        .map(e => Data(e.l))
+      val plan1 = ds1.queryExecution.executedPlan
+      assert(plan1.schema == ds1.schema)
+      assertNoTypedOperations(plan1)
+      assert(plan1.collect { case p: ProjectExec => p }.size == 1)
+      checkDataset(ds1, Data(1), Data(2))
+
+      val ds2 = Seq(Event(1L, "1L")).toDS()
+        .map(e => Data(e.l))
+        .map(d => Event(d.l, d.l.toString))
+      val plan2 = ds2.queryExecution.executedPlan
+      // TODO: we derive a more precise schema in this case
+      // assert(plan2.schema == ds2.schema)
+      assertNoTypedOperations(plan2)
+      assert(plan2.collect { case p: ProjectExec => p }.size == 1)
+      checkDataset(ds2, Event(1L, "1"))
+
+      val ds3 = Seq(1, 2).toDS()
+        .map { i =>
+          val value = if (i == 1) Data(-1L) else Data(0L)
+          value.l
+        }
+      val plan3 = ds3.queryExecution.executedPlan
+      assert(plan3.schema == ds3.schema)
+      assertNoTypedOperations(plan3)
+      checkDataset(ds3, -1L, 0L)
+    }
+  }
+
+  test("map transformations with nested data") {
+    withSQLConf(SQLConf.BYTECODE_ANALYSIS_ENABLED.key -> "true") {
+      val ds1 = Seq(1L, 2L).toDS()
+        .map { l => NestedData(l.toString, Data(l)) }
+        .map { nd => nd.data.l }
+      val plan1 = ds1.queryExecution.executedPlan
+      assert(plan1.schema == ds1.schema)
+      assertNoTypedOperations(plan1)
+      checkDataset(ds1, 1L, 2L)
+
+      val ds2 = Seq(1L, 2L).toDS()
+        .map { l => NestedData(l.toString, Data(l)) }
+        .map { nd => Event(nd.data.l, nd.name) }
+      val plan2 = ds2.queryExecution.executedPlan
+      // TODO: we derive a more precise schema in this case
+      // assert(plan2.schema == q2.schema)
+      assertNoTypedOperations(plan2)
+      assert(plan2.collect { case p: ProjectExec => p }.size == 1)
+      checkDataset(ds2, Event(1, "1"), Event(2, "2"))
+
+      val ds3 = Seq(1L, 2L).toDS()
+        .map { l => NestedData(l.toString, Data(l)) }
+        .map { nd => DeeplyNestedData(10, nd) }
+        .map { dnd => dnd.nestedData.data.l }
+      val plan3 = ds3.queryExecution.executedPlan
+      assert(plan3.schema == ds3.schema)
+      assertNoTypedOperations(plan3)
+      checkDataset(ds3, 1L, 2L)
+    }
+  }
+
+  test("filters with case classes") {
+    withSQLConf(SQLConf.BYTECODE_ANALYSIS_ENABLED.key -> "true") {
+      val ds1 = Seq(1L, 2L).toDS()
+        .map(l => Data(l))
+        .filter(_.l > 1L)
+      val plan1 = ds1.queryExecution.executedPlan
+      assert(plan1.schema == ds1.schema)
+      assertNoTypedOperations(plan1)
+      checkDataset(ds1, Data(2L))
+
+      // TODO: more cases
+    }
+  }
+
+  // TODO: nulls are not properly handled
+  ignore("null handling") {
+    withSQLConf(SQLConf.BYTECODE_ANALYSIS_ENABLED.key -> "true") {
+      val ds1 = Seq(java.lang.Long.valueOf(1L)).toDS()
+        .map { _ =>
+          val longValue: java.lang.Long = null
+          longValue.toString
+        }
+      ds1.collect()
+
+      val ds2 = spark.range(1L, 10L).as[Long]
+        .map(l => Event(l, null))
+        .map(event => event.s.concat("suffix"))
+      val plan2 = ds2.queryExecution.executedPlan
+      assert(plan2.schema == ds2.schema)
+      assertNoTypedOperations(plan2)
+      val thrownException2 = intercept[SparkException] {
+        ds2.collect()
+      }
+      assert(thrownException2.getCause.isInstanceOf[NullPointerException])
+
+      val ds3 = spark.range(1L, 10L).as[Long]
+        .map { l =>
+          val e: Event = null
+          e.doSmth()
+          Event(l, l.toString)
+        }
+      // TODO: this throws an analysis exception without execution
+      // val plan3 = ds3.queryExecution.executedPlan
+      // assert(plan3.schema == ds3.schema)
+      val thrownException3 = intercept[AnalysisException] {
+        ds3.collect()
+      }
+      assert(thrownException3.message == "Calling 'doSmth' on a null reference")
+
+      val ds4 = spark.range(1L, 10L).as[Long]
+        .map { l =>
+          val e: Event = EventHelper.nullEvent()
+          e.copy(l = l + 1)
+        }
+      // TODO: this throws an analysis exception without execution
+      // val plan4 = ds4.queryExecution.executedPlan
+      // assert(plan4.schema == ds4.schema)
+      val thrownException4 = intercept[AnalysisException] {
+        ds4.collect()
+      }
+      assert(thrownException4.message == "Calling 'copy$default$2' on a null reference")
+
+      val ds5 = spark.range(1L, 10L).as[Long]
+        .map { l =>
+          val e = Event(l, l.toString)
+          val newE = e.generateNull()
+          newE.copy(l = l + 1)
+        }
+      // TODO: this throws an analysis exception without execution
+      // val plan5 = ds5.queryExecution.executedPlan
+      // assert(plan5.schema == ds5.schema)
+      val thrownException5 = intercept[AnalysisException] {
+        ds5.collect()
+      }
+      assert(thrownException5.message == "Calling 'copy$default$2' on a null reference")
+
+      val ds6 = spark.range(1L, 10L).as[Long]
+        .map { l =>
+          if (l % 2 == 0) NestedData(l.toString, Data(l)) else NestedData(l.toString, null)
+        }
+        .map { nd => Event(nd.data.l, nd.name) }
+      val plan6 = ds6.queryExecution.executedPlan
+      assert(plan6.schema == ds6.schema)
+      assertNoTypedOperations(plan6)
+      val thrownException6 = intercept[SparkException] {
+        ds6.collect()
+      }
+      assert(thrownException6.getCause.isInstanceOf[NullPointerException])
+
+      val ds7 = Seq(java.lang.Long.valueOf(1L), java.lang.Long.valueOf(2L)).toDS()
+        .map { l => if (l == 1) l else null }
+        .map { l => l.toString }
+      ds7.explain(true)
+      ds7.show()
+    }
+  }
+
+  test("no additional serialization is introduced") {
+    withSQLConf(SQLConf.BYTECODE_ANALYSIS_ENABLED.key -> "true") {
+      val ds1 = spark.range(1, 10).as[Long]
+        .map { l => println("unsupported"); l + 1 } // scalastyle:ignore
+        .map { l => l + 6 }
+        .map { l => println("unsupported"); l + 5 } // scalastyle:ignore
+      val plan1 = ds1.queryExecution.executedPlan
+      assert(plan1.collect { case d: DeserializeToObjectExec => d }.size == 1)
+      assert(plan1.collect { case s: SerializeFromObjectExec => s }.size == 1)
+      assert(plan1.collect { case p: ProjectExec => p }.isEmpty)
+
+      val ds2 = spark.range(1, 10).as[Long]
+        .map { l => println("unsupported"); l + 1 } // scalastyle:ignore
+        .filter(_ > 4)
+        .map { l => println("unsupported"); l + 5 } // scalastyle:ignore
+      val plan2 = ds2.queryExecution.executedPlan
+      assert(plan2.collect { case d: DeserializeToObjectExec => d }.size == 1)
+      assert(plan2.collect { case s: SerializeFromObjectExec => s }.size == 1)
+      assert(plan2.collect { case f: FilterExec if f.condition.isInstanceOf[Invoke] => f }.nonEmpty)
+
+      val ds3 = spark.range(1, 10).as[Long]
+        .map { l => println("unsupported"); l + 1 } // scalastyle:ignore
+        .filter(_ > 4)
+      val plan3 = ds3.queryExecution.executedPlan
+      assert(plan3.collect { case d: DeserializeToObjectExec => d }.size == 1)
+      assert(plan3.collect { case s: SerializeFromObjectExec => s }.size == 1)
+      assert(plan3.collect { case f: FilterExec if f.condition.isInstanceOf[Invoke] => f }.isEmpty)
+
+      val ds4 = spark.range(1, 10).as[Long]
+        .map { l => println("unsupported"); Event(l, l.toString) } // scalastyle:ignore
+        .map { event => Event(event.l + 1, event.s) }
+        .map { event => println("unsupported"); event.l } // scalastyle:ignore
+      val plan4 = ds4.queryExecution.executedPlan
+      assert(plan4.collect { case d: DeserializeToObjectExec => d }.size == 1)
+      assert(plan4.collect { case s: SerializeFromObjectExec => s }.size == 1)
+      assert(plan4.collect { case p: ProjectExec => p }.isEmpty)
+    }
+  }
+
+  test("invokeinterface") {
+    withSQLConf(SQLConf.BYTECODE_ANALYSIS_ENABLED.key -> "true") {
+      val ds1 = Seq(1L, 2L).toDS()
+        .map { _ =>
+          val obj: BaseTrait = ChildObject
+          obj.number
+        }
+      val plan1 = ds1.queryExecution.executedPlan
+      assert(plan1.schema == ds1.schema)
+      assertNoTypedOperations(plan1)
+      checkDataset(ds1, 2, 2)
+
+      val func = (b: BaseTrait) => b.number
+      val ds2 = Seq(ChildClass(1), ChildClass(0)).toDS()
+        .map(func)
+      val plan2 = ds2.queryExecution.executedPlan
+      assert(plan2.schema == ds2.schema)
+      assertNoTypedOperations(plan2)
+      checkDataset(ds2, 1, 0)
+    }
+  }
+
+  test("invokevirtual") {
+    withSQLConf(SQLConf.BYTECODE_ANALYSIS_ENABLED.key -> "true") {
+      val ds1 = spark.range(1L, 3L)
+        .map { v =>
+          val obj: Object = JavaLongWrapper(java.lang.Long.valueOf(v))
+          obj.toString
+        }
+      val plan1 = ds1.queryExecution.executedPlan
+      // TODO: we derive a more precise schema in this case
+      // assert(plan1.schema == ds1.schema)
+      assertNoTypedOperations(plan1)
+      checkDataset(ds1, "XXX", "XXX")
+    }
+  }
+
+  test("outer variables") {
+    withSQLConf(SQLConf.BYTECODE_ANALYSIS_ENABLED.key -> "true") {
+      // TODO: decide what to do with outer variables
+      val outerObj = ChildObject
+      val ds1 = spark.range(1L, 3L)
+        .map { l => l + outerObj.number }
+      val plan1 = ds1.queryExecution.executedPlan
+      assert(plan1.collect { case p: ProjectExec => p } == Nil)
+    }
+  }
+
+  test("if statements") {
+    withSQLConf(SQLConf.BYTECODE_ANALYSIS_ENABLED.key -> "true") {
+      val ds1 = Seq(1, 2, 3).toDS()
+        .map { l => if (l == 2) -2 else if (l == 1) -1 else 0 }
+      val plan1 = ds1.queryExecution.executedPlan
+      assertNoTypedOperations(plan1)
+      checkDataset(ds1, -1, -2, 0)
+
+      val ds2 = Seq(1, 2, 3).toDS()
+        .map { l =>
+          val value = if (l == 2) -2 else if (l == 1) -1 else 0
+          val expr = ChildObject.number
+          Data(value.toLong + expr)
+        }
+        .map { data => data.l }
+      val plan2 = ds2.queryExecution.executedPlan
+      assertNoTypedOperations(plan2)
+      checkDataset(ds2, 1L, 0L, 2L)
+
+      val ds3 = Seq(1, 2, 3).toDS()
+        .map { l =>
+          if (l > 2) {
+            val event = Event(100, "CASE_1")
+            val newResult = event.multiply(2)
+            Event(newResult, event.s)
+          } else {
+            val event = Event(-50, "CASE_2")
+            val newResult = event.multiply(-3)
+            Event(newResult, event.s)
+          }
+        }
+      val plan3 = ds3.queryExecution.executedPlan
+      assertNoTypedOperations(plan3)
+      checkDataset(ds3, Event(150, "CASE_2"), Event(150, "CASE_2"), Event(200, "CASE_1"))
+    }
+  }
+
+  // TODO: support tableswitch and lookupswitch in case of attributes
+  ignore("pattern matching") {
+    withSQLConf(SQLConf.BYTECODE_ANALYSIS_ENABLED.key -> "true") {
+      val ds1 = Seq(1, 2, 3).toDS()
+        .map { l =>
+          val strValue = l match {
+            case 1 => "100"
+            case 2 => "200"
+            case 3 => "300"
+            case _ => "XXX"
+          }
+          Event(l, strValue)
+        }
+      val plan1 = ds1.queryExecution.executedPlan
+      assertNoTypedOperations(plan1)
+
+      val ds2 = Seq(1, 2, 3).toDS()
+        .map { l =>
+          val number = ChildObject.number
+          val strValue = l match {
+            case 1 if number == 1 => "100"
+            case 2 if number == 2 => "200"
+            case 3 if number == 3 => "300"
+            case _ => "XXX"
+          }
+          Event(l, strValue)
+        }
+      val plan2 = ds2.queryExecution.executedPlan
+      assertNoTypedOperations(plan2)
+    }
+  }
+
+  test("case classes with collections") {
+    withSQLConf(SQLConf.BYTECODE_ANALYSIS_ENABLED.key -> "true") {
+      val a1 = Address(1, "Cody Way", "San Jose", "CA", "95112")
+      val a2 = Address(2, "Parkwood", "New York", "NY", "95014")
+
+      val h1 = Home(a1, Facts(140, 1400, 1982), List())
+      val h2 = Home(a2, Facts(150, 1100, 1983), List())
+
+      val ds1 = Seq(h1, h2).toDS()
+        .map(_.address)
+      val plan1 = ds1.queryExecution.executedPlan
+      // TODO: houseNumber becomes nullable after the conversion
+      // assert(plan1.schema == ds1.schema)
+      assertNoTypedOperations(plan1)
+      checkDataset(ds1, a1, a2)
+
+      val ds2 = Seq(h1, h2).toDS()
+        .map(_.address.city)
+      val plan2 = ds2.queryExecution.executedPlan
+      assert(plan2.schema == ds2.schema)
+      assertNoTypedOperations(plan2)
+      checkDataset(ds2, "San Jose", "New York")
+
+      val ds3 = Seq(h1, h2).toDS()
+        .filter(_.address.city == "San Jose")
+        .map(_.address.state)
+      val plan3 = ds3.queryExecution.executedPlan
+      assert(plan3.schema == ds3.schema)
+      assertNoTypedOperations(plan3)
+      checkDataset(ds3, "CA")
+    }
+  }
+
+  // TODO: more tests for method calls
+
+  private def assertNoTypedOperations(plan: SparkPlan): Unit = {
+    val typedOperations = plan.collect {
+      case p: ObjectProducerExec => p
+      case c: ObjectConsumerExec => c
+      case f @ FilterExec(_: Invoke, _) => f
+    }
+    assert(typedOperations.isEmpty)
+  }
+}
+
+case class Address(
+    houseNumber: Int,
+    streetAddress: String,
+    city: String,
+    state: String,
+    zipCode: String)
+
+case class Facts(price: Int, size: Int, yearBuilt: Int)
+
+case class School(name: String)
+
+case class Home(address: Address, facts: Facts, schools: List[School])
+
+case class Data(l: Long)
+case class NestedData(name: String, data: Data)
+case class DeeplyNestedData(index: Int, nestedData: NestedData)
+
+case class Event(l: Long, s: String) {
+  def doSmth(): Long = l * 2
+  def generateNull(): Event = null
+  def voidFunc(): Unit = {}
+  def multiply(times: Int): Long = {
+    times * l
+  }
+}
+
+object EventHelper {
+  def nullEvent(): Event = null
+}
+
+trait BaseTrait {
+  def number: Int = 4
+}
+object ChildObject extends BaseTrait {
+  override def number: Int = 2
+}
+case class ChildClass(value: Int) extends BaseTrait {
+  override def number: Int = value
+}
+
+case class JavaLongWrapper(number: java.lang.Long) {
+  def add(firstNumber: java.lang.Long, secondNumber: java.lang.Long): java.lang.Long = {
+    number + firstNumber + secondNumber
+  }
+
+  override def toString: String = "XXX"
+}


### PR DESCRIPTION
**Disclaimer!** The purpose of this PoC PR is to trigger a discussion on whether it is feasible to leverage bytecode analysis to speed up Datasets. This PR shows what can be achieved by interpreting stack-based bytecode directly. The current version does not handle all edge cases. If the community agrees that bytecode analysis can give substantial benefits, we will need to define the scope (i.e., which cases we are targeting) and decide which approach to take (e.g., stack-based bytecode interpretation, flow-control graphs, AST, Jimple). I would like to emphasize that this PR doesn't answer those questions. Instead, it shows what can be done with the simplest approach. Also, there is no intention to integrate this logic into Spark directly. It might be a separate package.

### Scope

Bytecode analysis can be used for several purposes:
- Provide information on what's going on inside closures so that Spark can perform additional optimizations while still relying on closures during execution (e.g., analyze which fields are accessed/modified and use that information to optimize the plan).
- Replace typed operations that rely on closures with equivalent untyped operations that rely on Catalyst expressions.

Rewriting closures is challenging but gives more benefits. So, this PR focuses on the second use case.

Right now, the code covers typed map and filter operations that involve primitive values, boxed values (not all are implemented), objects that are represented as structs (e.g., case classes). The same logic can be applied to UDFs/UDAFs and other operations.

### Algorithm

There are two ways to derive Catalyst expressions:
- Translate stack-based bytecode directly.
- Convert bytecode into an intermediate format that it is easier to work with (e.g., flow-control graphs, AST, Jimple).

Both approaches have their own tradeoffs, which are well-described in comments to [SPARK-14083](https://issues.apache.org/jira/browse/SPARK-14083). This PR translates stack-based bytecode directly and simulates what happens to the operand stack. The optimizer is supposed to simplify the derived expression. I think it is valid to start with the simplest approach and evaluate its limitations before considering a more advanced implementation.

Originally, we wanted to cover trivial cases. However, the current scope is much bigger, so we should consider an intermediate format and will be glad to hear more opinions. As it was mentioned before, the decision highly depends on our target use cases.

This PR adds a new optimizer rule `RewriteTypedOperations` that uses `TypedOperations` in order to convert typed operations into untyped. `TypedOperations` follows a trivial algorithm that is described below.

#### Step 1: Get closure bytecode

First of all, we need to get bytecode for the closure. Scala 2.12 migrated to Java lambdas and uses `LambdaMetafactory` (LMF) (seems like there are rare cases when Scala doesn't use LMF). This PR relies on the existing logic in Spark to obtain `SerializedLambda`, which has enough information to get bytecode for closures.

Scala uses "adapted" methods for LMF to encapsulate differences in boxing semantics (i.e., unboxing null in Scala gives 0 and NPE in Java). The current code will obtain bytecode of the non-adapted method whenever the args are primitives to avoid a round of unnecessary boxing/unboxing.

See `ClosureUtils$getMethod` for more information.

#### Step 2: Build a correct local variable array

Once we have bytecode for our closure, we need to build a local variable array that references correct Catalyst expressions. This can be achieved by translating the deserializer for a typed operation. Deserializers define how data is converted from the Spark internal format into Java objects. Frequently, deserializers contain `StaticInvoke`, `Invoke`, `NewInstance` expressions, which can be translated using the same algorithm.

See `TypedOperations$convertDeserializer` for more information.

#### Step 3: Create an operand stack

The next step is to create an operand stack for storing partial Catalyst expressions. The current code uses `mutable.ArrayStack[Expression]` for this purpose.

#### Step 4: Interpret instructions

Once we have bytecode, the array of local variables and the operand stack, we can follow our bytecode instructions one by one and simulate what happens to the operand stack.

#### Step 5: Assign the result back to the expected attributes

Once we have the result expression, we need to assign it to columns. At this point, the serializer is important as it contains information about the expected attributes and their data types.

### Trying things out

`DatasetBytecodeAnalysisBenchmark` and `BytecodeAnalysisSuite` show currently supported cases. The focus is on the conceptual approach and not on addressing every possible method/instruction.

### Open Questions

- We need to discuss the scope of this work. As mentioned before, we can either translate closures into Catalyst expressions or just derive additional information about the content of closures (if that's useful enough).
- We need to discuss the overall approach we want to take (e.g., bytecode interpretation, control-flow graphs, AST, Jimple).
- We need to discuss which library (if any) to use.
- We need to handle too complicated result expressions as they can slow down the computation. For example, we can introduce some thresholds. Apart from that, we can introduce more optimization rules to simplify expressions.
- We need to ensure the conversion is lightweight and doesn't slow down the job planning time.
- We need to handle cases when the conversion doesn't terminate (e.g., infinite recursion).
- We need to ensure that edge cases work properly (e.g., null handling, exceptions, arithmetic expressions).
- We need to decide how to properly handle flow control instructions (e.g., if statements). The current code handles them via recursion and jumps.