### PR TITLE
[SPARK-27612][PYTHON] Use Python's default protocol instead of highest protocol

### DIFF
--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -435,7 +435,10 @@ class BatchedSerializer(Serializer):
                 yield items
 
     def dump_stream(self, iterator, stream):
-        self.serializer.dump_stream(self._batched(iterator), stream)
+        a = list(self._batched(iterator))
+        for i in a:
+            print(i)
+        self.serializer.dump_stream(a, stream)
 
     def load_stream(self, stream):
         return chain.from_iterable(self._load_stream_without_unbatching(stream))

--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -62,11 +62,12 @@ import itertools
 if sys.version < '3':
     import cPickle as pickle
     from itertools import izip as zip, imap as map
+    pickle_protocol = 2
 else:
     import pickle
     basestring = unicode = str
     xrange = range
-pickle_protocol = pickle.HIGHEST_PROTOCOL
+    pickle_protocol = 3
 
 from pyspark import cloudpickle
 from pyspark.util import _exception_message
@@ -435,10 +436,7 @@ class BatchedSerializer(Serializer):
                 yield items
 
     def dump_stream(self, iterator, stream):
-        a = list(self._batched(iterator))
-        for i in a:
-            print(i)
-        self.serializer.dump_stream(a, stream)
+        self.serializer.dump_stream(self._batched(iterator), stream)
 
     def load_stream(self, stream):
         return chain.from_iterable(self._load_stream_without_unbatching(stream))

--- a/python/pyspark/sql/tests/test_serde.py
+++ b/python/pyspark/sql/tests/test_serde.py
@@ -19,9 +19,8 @@ import datetime
 import shutil
 import tempfile
 import time
-import unittest
 
-from pyspark.sql import Row, SparkSession
+from pyspark.sql import Row
 from pyspark.sql.functions import lit
 from pyspark.sql.types import *
 from pyspark.testing.sqlutils import ReusedSQLTestCase, UTCOffsetTimezone

--- a/python/pyspark/sql/tests/test_serde.py
+++ b/python/pyspark/sql/tests/test_serde.py
@@ -19,8 +19,9 @@ import datetime
 import shutil
 import tempfile
 import time
+import unittest
 
-from pyspark.sql import Row
+from pyspark.sql import Row, SparkSession
 from pyspark.sql.functions import lit
 from pyspark.sql.types import *
 from pyspark.testing.sqlutils import ReusedSQLTestCase, UTCOffsetTimezone
@@ -125,6 +126,12 @@ class SerdeTests(ReusedSQLTestCase):
                 [bytearray(b'')]]
         df = self.spark.createDataFrame(data, schema=schema)
         df.collect()
+
+    def test_int_array_serialization(self):
+        # Note that this test seems dependent on parallelism.
+        data = self.spark.sparkContext.parallelize([[1, 2, 3, 4]] * 100, numSlices=12)
+        df = self.spark.createDataFrame(data, "array<integer>")
+        self.assertEqual(len(list(filter(lambda r: None in r.value, df.collect()))), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR partially reverts https://github.com/apache/spark/pull/20691

After we changed the Python protocol to highest ones, seems like it introduced a correctness bug. This potentially affects all Python related code paths.

I suspect a bug related to Pryolite (maybe opcodes `MEMOIZE`, `FRAME` and/or our `RowPickler`). I would like to stick to default protocol for now and investigate the issue separately.

I will separately investigate later to bring highest protocol back.


Update:
I can almost confirm that this is a bug in Pyrolite.

1. Python lists are chunked via `BatchedSerializer` at `parallelize` (in `createDataFrame`), for instance, as below (each line is each batch):

    ```bash
    [[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]]
    [[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]]
    ...
    [[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]]
    ```

    Here is opcodes for each batch (separated by `===..`) with protocol 4:
    <details>

    ```
    ==============================
        0: \x80 PROTO      4
        2: \x95 FRAME      47
       11: ]    EMPTY_LIST
       12: \x94 MEMOIZE    (as 0)
       13: (    MARK
       14: ]        EMPTY_LIST
       15: \x94     MEMOIZE    (as 1)
       16: (        MARK
       17: K            BININT1    1
       19: K            BININT1    2
       21: K            BININT1    3
       23: K            BININT1    4
       25: e            APPENDS    (MARK at 16)
       26: \x85     TUPLE1
       27: \x94     MEMOIZE    (as 2)
       28: h        BINGET     1
       30: \x85     TUPLE1
       31: \x94     MEMOIZE    (as 3)
       32: h        BINGET     1
       34: \x85     TUPLE1
       35: \x94     MEMOIZE    (as 4)
       36: h        BINGET     1
       38: \x85     TUPLE1
       39: \x94     MEMOIZE    (as 5)
       40: h        BINGET     1
       42: \x85     TUPLE1
       43: \x94     MEMOIZE    (as 6)
       44: h        BINGET     1
       46: \x85     TUPLE1
       47: \x94     MEMOIZE    (as 7)
       48: h        BINGET     1
       50: \x85     TUPLE1
       51: \x94     MEMOIZE    (as 8)
       52: h        BINGET     1
       54: \x85     TUPLE1
       55: \x94     MEMOIZE    (as 9)
       56: e        APPENDS    (MARK at 13)
       57: .    STOP
    highest protocol among opcodes = 4
    ==============================
    ==============================
        0: \x80 PROTO      4
        2: \x95 FRAME      47
       11: ]    EMPTY_LIST
       12: \x94 MEMOIZE    (as 0)
       13: (    MARK
       14: ]        EMPTY_LIST
       15: \x94     MEMOIZE    (as 1)
       16: (        MARK
       17: K            BININT1    1
       19: K            BININT1    2
       21: K            BININT1    3
       23: K            BININT1    4
       25: e            APPENDS    (MARK at 16)
       26: \x85     TUPLE1
       27: \x94     MEMOIZE    (as 2)
       28: h        BINGET     1
       30: \x85     TUPLE1
       31: \x94     MEMOIZE    (as 3)
       32: h        BINGET     1
       34: \x85     TUPLE1
       35: \x94     MEMOIZE    (as 4)
       36: h        BINGET     1
       38: \x85     TUPLE1
       39: \x94     MEMOIZE    (as 5)
       40: h        BINGET     1
       42: \x85     TUPLE1
       43: \x94     MEMOIZE    (as 6)
       44: h        BINGET     1
       46: \x85     TUPLE1
       47: \x94     MEMOIZE    (as 7)
       48: h        BINGET     1
       50: \x85     TUPLE1
       51: \x94     MEMOIZE    (as 8)
       52: h        BINGET     1
       54: \x85     TUPLE1
       55: \x94     MEMOIZE    (as 9)
       56: e        APPENDS    (MARK at 13)
       57: .    STOP
    highest protocol among opcodes = 4
    ==============================
    ...
    ==============================
        0: \x80 PROTO      4
        2: \x95 FRAME      31
       11: ]    EMPTY_LIST
       12: \x94 MEMOIZE    (as 0)
       13: (    MARK
       14: ]        EMPTY_LIST
       15: \x94     MEMOIZE    (as 1)
       16: (        MARK
       17: K            BININT1    1
       19: K            BININT1    2
       21: K            BININT1    3
       23: K            BININT1    4
       25: e            APPENDS    (MARK at 16)
       26: \x85     TUPLE1
       27: \x94     MEMOIZE    (as 2)
       28: h        BINGET     1
       30: \x85     TUPLE1
       31: \x94     MEMOIZE    (as 3)
       32: h        BINGET     1
       34: \x85     TUPLE1
       35: \x94     MEMOIZE    (as 4)
       36: h        BINGET     1
       38: \x85     TUPLE1
       39: \x94     MEMOIZE    (as 5)
       40: e        APPENDS    (MARK at 13)
       41: .    STOP
    highest protocol among opcodes = 4
    ==============================
    ```
    </details>

2. Those batches become binary in an RDD at `parallelize` - so far results look fine

3. `rdd._to_java_object_rdd` -> `SerDeUtil.pythonToJava` -> `Unpickler.loads`

4. Here, Pryolite `Unpickler.loads` converts each Python object batch into Java objects

5. The converted Java objects look a bit odd from Pryolite as below (see the last three lists):

    ```
    [1, 2, 3, 4]
    [1, 2, 3, 4]
    ...
    [[[1, 2, 3, 4]], [[1, 2, 3, 4]]]
    [[[1, 2, 3, 4]], [[1, 2, 3, 4]]]
    [[[1, 2, 3, 4]], [[1, 2, 3, 4]]]
    ```

6. Last three nested lists are ignored via `EvaluatePython.makeFromJava` and becomes `null` -> `None`.

7. So the Jenkins test was failed at https://github.com/apache/spark/pull/24519#issuecomment-488913729 as below:

    ```
    Traceback (most recent call last):
      File "/home/jenkins/workspace/SparkPullRequestBuilder/python/pyspark/sql/tests/test_serde.py", line 134, in test_int_array_serialization
        self.assertEqual(len(list(filter(lambda r: None in r.value, df.collect()))), 0)
    AssertionError: 3 != 0
    ```

## How was this patch tested?

Unittest was added.

```bash
./run-tests --python-executables=python3.7 --testname "pyspark.sql.tests.test_serde SerdeTests.test_int_array_serialization"
```
