### PR TITLE
[SPARK-27631][SQL] Avoid repeating calculate table statistics

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -1073,7 +1073,7 @@ private[client] class Shim_v2_0 extends Shim_v1_2 {
 private[client] class Shim_v2_1 extends Shim_v2_0 {
 
   // true if there is any following stats task
-  protected lazy val hasFollowingStatsTask = Boolean.box(SQLConf.get.autoSizeUpdateEnabled)
+  protected lazy val hasFollowingStatsTask = JBoolean.FALSE
   // TODO: Now, always set environmentContext to null. In the future, we should avoid setting
   // hive-generated stats to -1 when altering tables by using environmentContext. See Hive-12730
   protected lazy val environmentContextInAlterTable = null

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -1073,7 +1073,7 @@ private[client] class Shim_v2_0 extends Shim_v1_2 {
 private[client] class Shim_v2_1 extends Shim_v2_0 {
 
   // true if there is any following stats task
-  protected lazy val hasFollowingStatsTask = JBoolean.FALSE
+  protected lazy val hasFollowingStatsTask = Boolean.box(SQLConf.get.autoSizeUpdateEnabled)
   // TODO: Now, always set environmentContext to null. In the future, we should avoid setting
   // hive-generated stats to -1 when altering tables by using environmentContext. See Hive-12730
   protected lazy val environmentContextInAlterTable = null


### PR DESCRIPTION
## What changes were proposed in this pull request?
It will repeating calculate table statistics in 2 cases.
1. Insert into a Hive table with`spark.sql.statistics.size.autoUpdate.enabled=false` and `table.stats.nonEmpty`. The first time called by `Hive.loadTable` and the  second time called by `Hive.alterTable`. The stacktrace:
![image](https://user-images.githubusercontent.com/5399861/57791191-d549c400-776e-11e9-93e1-564b8790484a.png)
![image](https://user-images.githubusercontent.com/5399861/57791272-032f0880-776f-11e9-832a-397b88ebe41d.png)


2. Insert into a Hive table with`spark.sql.statistics.size.autoUpdate.enabled=true`. The first time called by `Hive.loadTable` and the second time called by `CommandUtils.updateTableStats -> Hive.alterTable`

The PR update the logic to avoid repeating calculate table statistics.

## How was this patch tested?
It's difficult to add a unit test. So manual test this pr:
```shell
build/sbt clean package -Phive
export SPARK_PREPEND_CLASSES=true
bin/spark-shell --conf spark.sql.statistics.size.autoUpdate.enabled=true
```
```scala
sc.setLogLevel("INFO")
spark.sql("create table t1(id int) using hive")
spark.sql("insert into t1 values(1)")
```
It will show:
```
19/05/09 06:40:03 INFO CommandUtils: Skip to update statistics for default.t1 as it updated by Hive.
```
