### PR TITLE
[SPARK-27603][CORE]Make the BlockTransferService for shuffle fetch pluggable

### DIFF
--- a/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
@@ -53,14 +53,15 @@ private[spark] class NettyBlockTransferService(
   extends BlockTransferService {
 
   // TODO: Don't use Java serialization, use a more cross-version compatible serialization format.
-  private val serializer = new JavaSerializer(conf)
-  private val authEnabled = securityManager.isAuthenticationEnabled()
-  private val transportConf = SparkTransportConf.fromSparkConf(conf, "shuffle", numCores)
+  private[netty] val serializer = new JavaSerializer(conf)
+  private[netty] val authEnabled = securityManager.isAuthenticationEnabled()
+  private[netty] val transportConf =
+    SparkTransportConf.fromSparkConf(conf, "shuffle", numCores)
 
-  private[this] var transportContext: TransportContext = _
-  private[this] var server: TransportServer = _
-  private[this] var clientFactory: TransportClientFactory = _
-  private[this] var appId: String = _
+  private[netty] var transportContext: TransportContext = _
+  private[netty] var server: TransportServer = _
+  private[netty] var clientFactory: TransportClientFactory = _
+  private[netty] var appId: String = _
 
   override def init(blockDataManager: BlockDataManager): Unit = {
     val rpcHandler = new NettyBlockRpcServer(conf.getAppId, serializer, blockDataManager)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Shuffle manager is pluggable in Spark, however, some service closely related to the shuffle functionality is constrained to 1 or 2 implementations. One example is `NettyBlockTransferService`, it is used in BlockManager to fetch remote bytes, and to fetch shuffle data in non-external shuffle. The 2 functionalities are coupled together. Actually the latter functionality to fetch shuffle data should be pluggable/extensible.

A custom Spark shuffle manager may need the set of service, including the RPC servers, clients and context that `NettyBlockTransferService` has constructed(constructing a new set of connections between executors is redundant), but also a new `NettyBlockTransferService` with custom need. For example, a remote shuffle manager under disaggregated compute and storage architecture may only need the service to transfer index files from other executors(for cache purpose) through Netty, but read data files directly from the globally-accessible storage.

We propose to make this transfer service for shuffle pluggable, also make some fields in `NettyBlockTransferService` wider accessible for developers to extend.

## How was this patch tested?

Existing tests.