### PR TITLE
[SPARK-27634][Structured Streaming] deleteCheckpointOnStop should be configurable

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -934,6 +934,11 @@ object SQLConf {
     .stringConf
     .createOptional
 
+  val DELETE_CHECKPOINT_LOCATION = buildConf("spark.sql.streaming.delete.checkpointLocation")
+    .doc("whether to delete checkpoint when streaming is stoped.")
+    .booleanConf
+    .createWithDefault(false)
+
   val FORCE_DELETE_TEMP_CHECKPOINT_LOCATION =
     buildConf("spark.sql.streaming.forceDeleteTempCheckpointLocation")
       .doc("When true, enable temporary checkpoint locations force delete.")
@@ -1801,6 +1806,8 @@ class SQLConf extends Serializable with Logging {
   def stateStoreMinDeltasForSnapshot: Int = getConf(STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT)
 
   def checkpointLocation: Option[String] = getConf(CHECKPOINT_LOCATION)
+
+  def isDeleteCheckpoint: Option[Boolean] = getConf(DELETE_CHECKPOINT_LOCATION)
 
   def isUnsupportedOperationCheckEnabled: Boolean = getConf(UNSUPPORTED_OPERATION_CHECK_ENABLED)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
@@ -215,7 +215,7 @@ class StreamingQueryManager private[sql] (sparkSession: SparkSession) extends Lo
       recoverFromCheckpointLocation: Boolean,
       trigger: Trigger,
       triggerClock: Clock): StreamingQueryWrapper = {
-    var deleteCheckpointOnStop = false
+    var deleteCheckpointOnStop = sparkSession.sessionState.conf.isDeleteCheckpoint.getOrElse(false)
     val checkpointLocation = userSpecifiedCheckpointLocation.map { userSpecified =>
       new Path(userSpecified).toString
     }.orElse {


### PR DESCRIPTION
## What changes were proposed in this pull request?

we need to delete checkpoint file after running the stream application multiple times, so deleteCheckpointOnStop should be configurable

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
