### PR TITLE
[SPARK-27520][CORE][WIP] Introduce a global config system to replace hadoopConfiguration

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -286,7 +286,13 @@ class SparkContext(config: SparkConf) extends Logging {
    * @note As it will be reused in all Hadoop RDDs, it's better not to modify it unless you
    * plan to set some global configurations for all Hadoop RDDs.
    */
+  @deprecated("please use SparkHadoopConf.get().get or hadoopConf.get.", "3.0.0")
   def hadoopConfiguration: Configuration = SparkHadoopConf.get().get
+
+  /**
+   * A global Hadoop Conf used to set, track hadoop related configurations.
+   */
+  def hadoopConf: SparkHadoopConf = SparkHadoopConf.get()
 
   private[spark] def executorMemory: Int = _executorMemory
 

--- a/core/src/main/scala/org/apache/spark/SparkHadoopConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkHadoopConf.scala
@@ -1,0 +1,31 @@
+package org.apache.spark
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.deploy.SparkHadoopUtil
+
+/**
+ * Hadoop Configuration for the Hadoop code (e.g. file systems).
+ */
+class SparkHadoopConf {
+
+
+}
+
+object SparkHadoopConf {
+  private var hadoopConf: ThreadLocal[Configuration] = _
+  def apply(conf: SparkConf): SparkHadoopConf = {
+    hadoopConf = new ThreadLocal[Configuration]() {
+      override def initialValue: Configuration = {
+        SparkHadoopUtil.get.newConfiguration(conf)
+      }
+    }
+    new SparkHadoopConf
+  }
+
+  def get(): ThreadLocal[Configuration] = hadoopConf
+
+  def newHadoopConf(map: scala.collection.Map[String, String], conf: Configuration)
+  : Configuration = {
+    new Configuration()
+  }
+}

--- a/core/src/main/scala/org/apache/spark/SparkHadoopConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkHadoopConf.scala
@@ -1,31 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark
 
+import java.net.URL
+
 import org.apache.hadoop.conf.Configuration
+
 import org.apache.spark.deploy.SparkHadoopUtil
 
 /**
  * Hadoop Configuration for the Hadoop code (e.g. file systems).
  */
-class SparkHadoopConf {
 
+class SparkHadoopConf(conf: Configuration) {
 
+  def get: Configuration = conf
+
+  def get(name: String): String = conf.get(name)
+
+  def set(conf: Configuration, entries: (String, String)*): Unit = {
+    entries.foreach { case (name, value) =>
+      conf.set(name, value)
+    }
+  }
+
+  def set(entries: (String, String)*): Unit = {
+    set(conf, entries: _*)
+  }
+
+  def set(name: String, value: String): Unit = set(conf, name -> value)
+
+  def unset(name: String): Unit = conf.unset(name)
+
+  def addResource(url: URL): Unit = conf.addResource(url)
 }
 
 object SparkHadoopConf {
-  private var hadoopConf: ThreadLocal[Configuration] = _
-  def apply(conf: SparkConf): SparkHadoopConf = {
-    hadoopConf = new ThreadLocal[Configuration]() {
-      override def initialValue: Configuration = {
-        SparkHadoopUtil.get.newConfiguration(conf)
+  private var hadoopConf: ThreadLocal[SparkHadoopConf] = _
+
+  def init(conf: SparkConf): Unit = {
+    hadoopConf = new ThreadLocal[SparkHadoopConf]() {
+      override def initialValue: SparkHadoopConf = {
+        val hconf = SparkHadoopUtil.get.newConfiguration(conf)
+        // Performance optimization: this dummy call to .size() triggers eager evaluation of
+        // Configuration's internal  `properties` field, guaranteeing that it will be computed and
+        // cached before SessionState.newHadoopConf() uses `sc.hadoopConfiguration` to create
+        // a new per-session Configuration. If `properties` has not been computed by that time
+        // then each newly-created Configuration will perform its own expensive IO and XML
+        // parsing to load configuration defaults and populate its own properties. By ensuring
+        // that we've pre-computed the parent's properties, the child Configuration will simply
+        // clone the parent's properties.
+        hconf.size()
+        new SparkHadoopConf(hconf)
       }
     }
-    new SparkHadoopConf
   }
 
-  def get(): ThreadLocal[Configuration] = hadoopConf
+  def get(): SparkHadoopConf = hadoopConf.get()
 
-  def newHadoopConf(map: scala.collection.Map[String, String], conf: Configuration)
-  : Configuration = {
-    new Configuration()
-  }
+  def set(conf: SparkHadoopConf): Unit = hadoopConf.set(conf)
+
+
+
 }

--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -600,8 +600,16 @@ class JavaSparkContext(val sc: SparkContext) extends Closeable {
    * @note As it will be reused in all Hadoop RDDs, it's better not to modify it unless you
    * plan to set some global configurations for all Hadoop RDDs.
    */
+  @deprecated("please use hadoopConf().get()", "3.0.0")
   def hadoopConfiguration(): Configuration = {
-    SparkHadoopConf.get().get
+    sc.hadoopConfiguration
+  }
+
+  /**
+   * A global Hadoop Conf used to set, track hadoop related configurations.
+   */
+  def hadoopConf(): SparkHadoopConf = {
+    SparkHadoopConf.get()
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -600,8 +600,8 @@ class JavaSparkContext(val sc: SparkContext) extends Closeable {
    * @note As it will be reused in all Hadoop RDDs, it's better not to modify it unless you
    * plan to set some global configurations for all Hadoop RDDs.
    */
-  def hadoopConfiguration(): Configuration = {
-    sc.hadoopConfiguration
+  def getHadoopConf(): Configuration = {
+    sc.getHadoopConf.get
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -609,7 +609,7 @@ class JavaSparkContext(val sc: SparkContext) extends Closeable {
    * A global Hadoop Conf used to set, track hadoop related configurations.
    */
   def hadoopConf(): SparkHadoopConf = {
-    SparkHadoopConf.get()
+    SparkHadoopConf.get
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -600,8 +600,8 @@ class JavaSparkContext(val sc: SparkContext) extends Closeable {
    * @note As it will be reused in all Hadoop RDDs, it's better not to modify it unless you
    * plan to set some global configurations for all Hadoop RDDs.
    */
-  def getHadoopConf(): Configuration = {
-    sc.getHadoopConf.get
+  def hadoopConfiguration(): Configuration = {
+    SparkHadoopConf.get().get
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -282,7 +282,7 @@ private[spark] object PythonRDD extends Logging {
     val kc = Utils.classForName[K](keyClass)
     val vc = Utils.classForName[V](valueClass)
     val rdd = sc.sc.sequenceFile[K, V](path, kc, vc, minSplits)
-    val confBroadcasted = sc.sc.broadcast(new SerializableConfiguration(sc.getHadoopConf()))
+    val confBroadcasted = sc.sc.broadcast(new SerializableConfiguration(SparkHadoopConf.get().get))
     val converted = convertRDD(rdd, keyConverterClass, valueConverterClass,
       new WritableToJavaConverter(confBroadcasted))
     JavaRDD.fromRDD(SerDeUtil.pairRDDToPython(converted, batchSize))
@@ -304,7 +304,7 @@ private[spark] object PythonRDD extends Logging {
       valueConverterClass: String,
       confAsMap: java.util.HashMap[String, String],
       batchSize: Int): JavaRDD[Array[Byte]] = {
-    val mergedConf = getMergedConf(confAsMap, sc.getHadoopConf())
+    val mergedConf = getMergedConf(confAsMap, SparkHadoopConf.get().get)
     val rdd =
       newAPIHadoopRDDFromClassNames[K, V, F](sc,
         Some(path), inputFormatClass, keyClass, valueClass, mergedConf)
@@ -373,7 +373,7 @@ private[spark] object PythonRDD extends Logging {
       valueConverterClass: String,
       confAsMap: java.util.HashMap[String, String],
       batchSize: Int): JavaRDD[Array[Byte]] = {
-    val mergedConf = getMergedConf(confAsMap, sc.getHadoopConf())
+    val mergedConf = getMergedConf(confAsMap, SparkHadoopConf.get().get)
     val rdd =
       hadoopRDDFromClassNames[K, V, F](sc,
         Some(path), inputFormatClass, keyClass, valueClass, mergedConf)
@@ -558,7 +558,7 @@ private[spark] object PythonRDD extends Logging {
     val rdd = SerDeUtil.pythonToPairRDD(pyRDD, batchSerialized)
     val (kc, vc) = getKeyValueTypes(keyClass, valueClass).getOrElse(
       inferKeyValueTypes(rdd, keyConverterClass, valueConverterClass))
-    val mergedConf = getMergedConf(confAsMap, pyRDD.context.getHadoopConf.get)
+    val mergedConf = getMergedConf(confAsMap, SparkHadoopConf.get().get)
     val codec = Option(compressionCodecClass).map(Utils.classForName(_).asInstanceOf[Class[C]])
     val converted = convertRDD(rdd, keyConverterClass, valueConverterClass,
       new JavaToWritableConverter)
@@ -588,7 +588,7 @@ private[spark] object PythonRDD extends Logging {
     val rdd = SerDeUtil.pythonToPairRDD(pyRDD, batchSerialized)
     val (kc, vc) = getKeyValueTypes(keyClass, valueClass).getOrElse(
       inferKeyValueTypes(rdd, keyConverterClass, valueConverterClass))
-    val mergedConf = getMergedConf(confAsMap, pyRDD.context.getHadoopConf.get)
+    val mergedConf = getMergedConf(confAsMap, SparkHadoopConf.get().get)
     val converted = convertRDD(rdd, keyConverterClass, valueConverterClass,
       new JavaToWritableConverter)
     val fc = Utils.classForName(outputFormatClass).asInstanceOf[Class[F]]

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -282,7 +282,7 @@ private[spark] object PythonRDD extends Logging {
     val kc = Utils.classForName[K](keyClass)
     val vc = Utils.classForName[V](valueClass)
     val rdd = sc.sc.sequenceFile[K, V](path, kc, vc, minSplits)
-    val confBroadcasted = sc.sc.broadcast(new SerializableConfiguration(SparkHadoopConf.get().get))
+    val confBroadcasted = sc.sc.broadcast(new SerializableConfiguration(SparkHadoopConf.get.conf))
     val converted = convertRDD(rdd, keyConverterClass, valueConverterClass,
       new WritableToJavaConverter(confBroadcasted))
     JavaRDD.fromRDD(SerDeUtil.pairRDDToPython(converted, batchSize))
@@ -304,7 +304,7 @@ private[spark] object PythonRDD extends Logging {
       valueConverterClass: String,
       confAsMap: java.util.HashMap[String, String],
       batchSize: Int): JavaRDD[Array[Byte]] = {
-    val mergedConf = getMergedConf(confAsMap, SparkHadoopConf.get().get)
+    val mergedConf = getMergedConf(confAsMap, SparkHadoopConf.get.conf)
     val rdd =
       newAPIHadoopRDDFromClassNames[K, V, F](sc,
         Some(path), inputFormatClass, keyClass, valueClass, mergedConf)
@@ -373,7 +373,7 @@ private[spark] object PythonRDD extends Logging {
       valueConverterClass: String,
       confAsMap: java.util.HashMap[String, String],
       batchSize: Int): JavaRDD[Array[Byte]] = {
-    val mergedConf = getMergedConf(confAsMap, SparkHadoopConf.get().get)
+    val mergedConf = getMergedConf(confAsMap, SparkHadoopConf.get.conf)
     val rdd =
       hadoopRDDFromClassNames[K, V, F](sc,
         Some(path), inputFormatClass, keyClass, valueClass, mergedConf)
@@ -558,7 +558,7 @@ private[spark] object PythonRDD extends Logging {
     val rdd = SerDeUtil.pythonToPairRDD(pyRDD, batchSerialized)
     val (kc, vc) = getKeyValueTypes(keyClass, valueClass).getOrElse(
       inferKeyValueTypes(rdd, keyConverterClass, valueConverterClass))
-    val mergedConf = getMergedConf(confAsMap, SparkHadoopConf.get().get)
+    val mergedConf = getMergedConf(confAsMap, SparkHadoopConf.get.conf)
     val codec = Option(compressionCodecClass).map(Utils.classForName(_).asInstanceOf[Class[C]])
     val converted = convertRDD(rdd, keyConverterClass, valueConverterClass,
       new JavaToWritableConverter)
@@ -588,7 +588,7 @@ private[spark] object PythonRDD extends Logging {
     val rdd = SerDeUtil.pythonToPairRDD(pyRDD, batchSerialized)
     val (kc, vc) = getKeyValueTypes(keyClass, valueClass).getOrElse(
       inferKeyValueTypes(rdd, keyConverterClass, valueConverterClass))
-    val mergedConf = getMergedConf(confAsMap, SparkHadoopConf.get().get)
+    val mergedConf = getMergedConf(confAsMap, SparkHadoopConf.get.conf)
     val converted = convertRDD(rdd, keyConverterClass, valueConverterClass,
       new JavaToWritableConverter)
     val fc = Utils.classForName(outputFormatClass).asInstanceOf[Class[F]]

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -282,7 +282,7 @@ private[spark] object PythonRDD extends Logging {
     val kc = Utils.classForName[K](keyClass)
     val vc = Utils.classForName[V](valueClass)
     val rdd = sc.sc.sequenceFile[K, V](path, kc, vc, minSplits)
-    val confBroadcasted = sc.sc.broadcast(new SerializableConfiguration(sc.hadoopConfiguration()))
+    val confBroadcasted = sc.sc.broadcast(new SerializableConfiguration(sc.getHadoopConf()))
     val converted = convertRDD(rdd, keyConverterClass, valueConverterClass,
       new WritableToJavaConverter(confBroadcasted))
     JavaRDD.fromRDD(SerDeUtil.pairRDDToPython(converted, batchSize))
@@ -304,7 +304,7 @@ private[spark] object PythonRDD extends Logging {
       valueConverterClass: String,
       confAsMap: java.util.HashMap[String, String],
       batchSize: Int): JavaRDD[Array[Byte]] = {
-    val mergedConf = getMergedConf(confAsMap, sc.hadoopConfiguration())
+    val mergedConf = getMergedConf(confAsMap, sc.getHadoopConf())
     val rdd =
       newAPIHadoopRDDFromClassNames[K, V, F](sc,
         Some(path), inputFormatClass, keyClass, valueClass, mergedConf)
@@ -373,7 +373,7 @@ private[spark] object PythonRDD extends Logging {
       valueConverterClass: String,
       confAsMap: java.util.HashMap[String, String],
       batchSize: Int): JavaRDD[Array[Byte]] = {
-    val mergedConf = getMergedConf(confAsMap, sc.hadoopConfiguration())
+    val mergedConf = getMergedConf(confAsMap, sc.getHadoopConf())
     val rdd =
       hadoopRDDFromClassNames[K, V, F](sc,
         Some(path), inputFormatClass, keyClass, valueClass, mergedConf)
@@ -558,7 +558,7 @@ private[spark] object PythonRDD extends Logging {
     val rdd = SerDeUtil.pythonToPairRDD(pyRDD, batchSerialized)
     val (kc, vc) = getKeyValueTypes(keyClass, valueClass).getOrElse(
       inferKeyValueTypes(rdd, keyConverterClass, valueConverterClass))
-    val mergedConf = getMergedConf(confAsMap, pyRDD.context.hadoopConfiguration)
+    val mergedConf = getMergedConf(confAsMap, pyRDD.context.getHadoopConf.get)
     val codec = Option(compressionCodecClass).map(Utils.classForName(_).asInstanceOf[Class[C]])
     val converted = convertRDD(rdd, keyConverterClass, valueConverterClass,
       new JavaToWritableConverter)
@@ -588,7 +588,7 @@ private[spark] object PythonRDD extends Logging {
     val rdd = SerDeUtil.pythonToPairRDD(pyRDD, batchSerialized)
     val (kc, vc) = getKeyValueTypes(keyClass, valueClass).getOrElse(
       inferKeyValueTypes(rdd, keyConverterClass, valueConverterClass))
-    val mergedConf = getMergedConf(confAsMap, pyRDD.context.hadoopConfiguration)
+    val mergedConf = getMergedConf(confAsMap, pyRDD.context.getHadoopConf.get)
     val converted = convertRDD(rdd, keyConverterClass, valueConverterClass,
       new JavaToWritableConverter)
     val fc = Utils.classForName(outputFormatClass).asInstanceOf[Class[F]]

--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -989,7 +989,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
       keyClass: Class[_],
       valueClass: Class[_],
       outputFormatClass: Class[_ <: NewOutputFormat[_, _]],
-      conf: Configuration = SparkHadoopConf.get().get): Unit = self.withScope {
+      conf: Configuration = SparkHadoopConf.get.conf): Unit = self.withScope {
     // Rename this as hadoopConf internally to avoid shadowing (see SPARK-2038).
     val hadoopConf = conf
     val job = NewAPIHadoopJob.getInstance(hadoopConf)
@@ -1012,7 +1012,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
       outputFormatClass: Class[_ <: OutputFormat[_, _]],
       codec: Class[_ <: CompressionCodec]): Unit = self.withScope {
     saveAsHadoopFile(path, keyClass, valueClass, outputFormatClass,
-      new JobConf(SparkHadoopConf.get().get), Option(codec))
+      new JobConf(SparkHadoopConf.get.conf), Option(codec))
   }
 
   /**
@@ -1029,7 +1029,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
       keyClass: Class[_],
       valueClass: Class[_],
       outputFormatClass: Class[_ <: OutputFormat[_, _]],
-      conf: JobConf = new JobConf(SparkHadoopConf.get().get),
+      conf: JobConf = new JobConf(SparkHadoopConf.get.conf),
       codec: Option[Class[_ <: CompressionCodec]] = None): Unit = self.withScope {
     // Rename this as hadoopConf internally to avoid shadowing (see SPARK-2038).
     val hadoopConf = conf

--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -989,7 +989,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
       keyClass: Class[_],
       valueClass: Class[_],
       outputFormatClass: Class[_ <: NewOutputFormat[_, _]],
-      conf: Configuration = self.context.getHadoopConf.get): Unit = self.withScope {
+      conf: Configuration = SparkHadoopConf.get().get): Unit = self.withScope {
     // Rename this as hadoopConf internally to avoid shadowing (see SPARK-2038).
     val hadoopConf = conf
     val job = NewAPIHadoopJob.getInstance(hadoopConf)
@@ -1012,7 +1012,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
       outputFormatClass: Class[_ <: OutputFormat[_, _]],
       codec: Class[_ <: CompressionCodec]): Unit = self.withScope {
     saveAsHadoopFile(path, keyClass, valueClass, outputFormatClass,
-      new JobConf(self.context.getHadoopConf.get), Option(codec))
+      new JobConf(SparkHadoopConf.get().get), Option(codec))
   }
 
   /**
@@ -1029,7 +1029,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
       keyClass: Class[_],
       valueClass: Class[_],
       outputFormatClass: Class[_ <: OutputFormat[_, _]],
-      conf: JobConf = new JobConf(self.context.getHadoopConf.get),
+      conf: JobConf = new JobConf(SparkHadoopConf.get().get),
       codec: Option[Class[_ <: CompressionCodec]] = None): Unit = self.withScope {
     // Rename this as hadoopConf internally to avoid shadowing (see SPARK-2038).
     val hadoopConf = conf

--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -989,7 +989,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
       keyClass: Class[_],
       valueClass: Class[_],
       outputFormatClass: Class[_ <: NewOutputFormat[_, _]],
-      conf: Configuration = self.context.hadoopConfiguration): Unit = self.withScope {
+      conf: Configuration = self.context.getHadoopConf.get): Unit = self.withScope {
     // Rename this as hadoopConf internally to avoid shadowing (see SPARK-2038).
     val hadoopConf = conf
     val job = NewAPIHadoopJob.getInstance(hadoopConf)
@@ -1012,7 +1012,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
       outputFormatClass: Class[_ <: OutputFormat[_, _]],
       codec: Class[_ <: CompressionCodec]): Unit = self.withScope {
     saveAsHadoopFile(path, keyClass, valueClass, outputFormatClass,
-      new JobConf(self.context.hadoopConfiguration), Option(codec))
+      new JobConf(self.context.getHadoopConf.get), Option(codec))
   }
 
   /**
@@ -1029,7 +1029,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
       keyClass: Class[_],
       valueClass: Class[_],
       outputFormatClass: Class[_ <: OutputFormat[_, _]],
-      conf: JobConf = new JobConf(self.context.hadoopConfiguration),
+      conf: JobConf = new JobConf(self.context.getHadoopConf.get),
       codec: Option[Class[_ <: CompressionCodec]] = None): Unit = self.withScope {
     // Rename this as hadoopConf internally to avoid shadowing (see SPARK-2038).
     val hadoopConf = conf

--- a/core/src/main/scala/org/apache/spark/rdd/ReliableCheckpointRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ReliableCheckpointRDD.scala
@@ -41,7 +41,7 @@ private[spark] class ReliableCheckpointRDD[T: ClassTag](
     _partitioner: Option[Partitioner] = None
   ) extends CheckpointRDD[T](sc) {
 
-  @transient private val hadoopConf = sc.hadoopConfiguration
+  @transient private val hadoopConf = sc.getHadoopConf.get
   @transient private val cpath = new Path(checkpointPath)
   @transient private val fs = cpath.getFileSystem(hadoopConf)
   private val broadcastedConf = sc.broadcast(new SerializableConfiguration(hadoopConf))
@@ -128,14 +128,14 @@ private[spark] object ReliableCheckpointRDD extends Logging {
 
     // Create the output path for the checkpoint
     val checkpointDirPath = new Path(checkpointDir)
-    val fs = checkpointDirPath.getFileSystem(sc.hadoopConfiguration)
+    val fs = checkpointDirPath.getFileSystem(sc.getHadoopConf.get)
     if (!fs.mkdirs(checkpointDirPath)) {
       throw new SparkException(s"Failed to create checkpoint path $checkpointDirPath")
     }
 
     // Save to file, and reload it as an RDD
     val broadcastedConf = sc.broadcast(
-      new SerializableConfiguration(sc.hadoopConfiguration))
+      new SerializableConfiguration(sc.getHadoopConf.get))
     // TODO: This is expensive because it computes the RDD again unnecessarily (SPARK-8582)
     sc.runJob(originalRDD,
       writePartitionToCheckpointFile[T](checkpointDirPath.toString, broadcastedConf) _)
@@ -223,7 +223,7 @@ private[spark] object ReliableCheckpointRDD extends Logging {
     try {
       val partitionerFilePath = new Path(checkpointDirPath, checkpointPartitionerFileName)
       val bufferSize = sc.conf.get(BUFFER_SIZE)
-      val fs = partitionerFilePath.getFileSystem(sc.hadoopConfiguration)
+      val fs = partitionerFilePath.getFileSystem(sc.getHadoopConf.get)
       val fileOutputStream = fs.create(partitionerFilePath, false, bufferSize)
       val serializer = SparkEnv.get.serializer.newInstance()
       val serializeStream = serializer.serializeStream(fileOutputStream)
@@ -251,7 +251,7 @@ private[spark] object ReliableCheckpointRDD extends Logging {
     try {
       val bufferSize = sc.conf.get(BUFFER_SIZE)
       val partitionerFilePath = new Path(checkpointDirPath, checkpointPartitionerFileName)
-      val fs = partitionerFilePath.getFileSystem(sc.hadoopConfiguration)
+      val fs = partitionerFilePath.getFileSystem(sc.getHadoopConf.get)
       val fileInputStream = fs.open(partitionerFilePath, bufferSize)
       val serializer = SparkEnv.get.serializer.newInstance()
       val partitioner = Utils.tryWithSafeFinally {

--- a/core/src/main/scala/org/apache/spark/rdd/ReliableCheckpointRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ReliableCheckpointRDD.scala
@@ -41,7 +41,7 @@ private[spark] class ReliableCheckpointRDD[T: ClassTag](
     _partitioner: Option[Partitioner] = None
   ) extends CheckpointRDD[T](sc) {
 
-  @transient private val hadoopConf = SparkHadoopConf.get().get
+  @transient private val hadoopConf = SparkHadoopConf.get.conf
   @transient private val cpath = new Path(checkpointPath)
   @transient private val fs = cpath.getFileSystem(hadoopConf)
   private val broadcastedConf = sc.broadcast(new SerializableConfiguration(hadoopConf))
@@ -128,14 +128,14 @@ private[spark] object ReliableCheckpointRDD extends Logging {
 
     // Create the output path for the checkpoint
     val checkpointDirPath = new Path(checkpointDir)
-    val fs = checkpointDirPath.getFileSystem(SparkHadoopConf.get().get)
+    val fs = checkpointDirPath.getFileSystem(SparkHadoopConf.get.conf)
     if (!fs.mkdirs(checkpointDirPath)) {
       throw new SparkException(s"Failed to create checkpoint path $checkpointDirPath")
     }
 
     // Save to file, and reload it as an RDD
     val broadcastedConf = sc.broadcast(
-      new SerializableConfiguration(SparkHadoopConf.get().get))
+      new SerializableConfiguration(SparkHadoopConf.get.conf))
     // TODO: This is expensive because it computes the RDD again unnecessarily (SPARK-8582)
     sc.runJob(originalRDD,
       writePartitionToCheckpointFile[T](checkpointDirPath.toString, broadcastedConf) _)
@@ -223,7 +223,7 @@ private[spark] object ReliableCheckpointRDD extends Logging {
     try {
       val partitionerFilePath = new Path(checkpointDirPath, checkpointPartitionerFileName)
       val bufferSize = sc.conf.get(BUFFER_SIZE)
-      val fs = partitionerFilePath.getFileSystem(SparkHadoopConf.get().get)
+      val fs = partitionerFilePath.getFileSystem(SparkHadoopConf.get.conf)
       val fileOutputStream = fs.create(partitionerFilePath, false, bufferSize)
       val serializer = SparkEnv.get.serializer.newInstance()
       val serializeStream = serializer.serializeStream(fileOutputStream)
@@ -251,7 +251,7 @@ private[spark] object ReliableCheckpointRDD extends Logging {
     try {
       val bufferSize = sc.conf.get(BUFFER_SIZE)
       val partitionerFilePath = new Path(checkpointDirPath, checkpointPartitionerFileName)
-      val fs = partitionerFilePath.getFileSystem(SparkHadoopConf.get().get)
+      val fs = partitionerFilePath.getFileSystem(SparkHadoopConf.get.conf)
       val fileInputStream = fs.open(partitionerFilePath, bufferSize)
       val serializer = SparkEnv.get.serializer.newInstance()
       val partitioner = Utils.tryWithSafeFinally {

--- a/core/src/main/scala/org/apache/spark/rdd/ReliableRDDCheckpointData.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ReliableRDDCheckpointData.scala
@@ -81,7 +81,7 @@ private[spark] object ReliableRDDCheckpointData extends Logging {
   /** Clean up the files associated with the checkpoint data for this RDD. */
   def cleanCheckpoint(sc: SparkContext, rddId: Int): Unit = {
     checkpointPath(sc, rddId).foreach { path =>
-      path.getFileSystem(SparkHadoopConf.get().get).delete(path, true)
+      path.getFileSystem(SparkHadoopConf.get.conf).delete(path, true)
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/rdd/ReliableRDDCheckpointData.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ReliableRDDCheckpointData.scala
@@ -81,7 +81,7 @@ private[spark] object ReliableRDDCheckpointData extends Logging {
   /** Clean up the files associated with the checkpoint data for this RDD. */
   def cleanCheckpoint(sc: SparkContext, rddId: Int): Unit = {
     checkpointPath(sc, rddId).foreach { path =>
-      path.getFileSystem(sc.hadoopConfiguration).delete(path, true)
+      path.getFileSystem(sc.getHadoopConf.get).delete(path, true)
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/rdd/ReliableRDDCheckpointData.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ReliableRDDCheckpointData.scala
@@ -81,7 +81,7 @@ private[spark] object ReliableRDDCheckpointData extends Logging {
   /** Clean up the files associated with the checkpoint data for this RDD. */
   def cleanCheckpoint(sc: SparkContext, rddId: Int): Unit = {
     checkpointPath(sc, rddId).foreach { path =>
-      path.getFileSystem(sc.getHadoopConf.get).delete(path, true)
+      path.getFileSystem(SparkHadoopConf.get().get).delete(path, true)
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/rdd/SequenceFileRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/SequenceFileRDDFunctions.scala
@@ -64,7 +64,7 @@ class SequenceFileRDDFunctions[K <% Writable: ClassTag, V <% Writable : ClassTag
     logInfo("Saving as sequence file of type " +
       s"(${_keyWritableClass.getSimpleName},${_valueWritableClass.getSimpleName})" )
     val format = classOf[SequenceFileOutputFormat[Writable, Writable]]
-    val jobConf = new JobConf(self.context.hadoopConfiguration)
+    val jobConf = new JobConf(self.context.getHadoopConf.get)
     if (!convertKey && !convertValue) {
       self.saveAsHadoopFile(path, _keyWritableClass, _valueWritableClass, format, jobConf, codec)
     } else if (!convertKey && convertValue) {

--- a/core/src/main/scala/org/apache/spark/rdd/SequenceFileRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/SequenceFileRDDFunctions.scala
@@ -65,7 +65,7 @@ class SequenceFileRDDFunctions[K <% Writable: ClassTag, V <% Writable : ClassTag
     logInfo("Saving as sequence file of type " +
       s"(${_keyWritableClass.getSimpleName},${_valueWritableClass.getSimpleName})" )
     val format = classOf[SequenceFileOutputFormat[Writable, Writable]]
-    val jobConf = new JobConf(SparkHadoopConf.get().get)
+    val jobConf = new JobConf(SparkHadoopConf.get.conf)
     if (!convertKey && !convertValue) {
       self.saveAsHadoopFile(path, _keyWritableClass, _valueWritableClass, format, jobConf, codec)
     } else if (!convertKey && convertValue) {

--- a/core/src/main/scala/org/apache/spark/rdd/SequenceFileRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/SequenceFileRDDFunctions.scala
@@ -23,6 +23,7 @@ import org.apache.hadoop.io.compress.CompressionCodec
 import org.apache.hadoop.mapred.JobConf
 import org.apache.hadoop.mapred.SequenceFileOutputFormat
 
+import org.apache.spark.SparkHadoopConf
 import org.apache.spark.internal.Logging
 
 /**
@@ -64,7 +65,7 @@ class SequenceFileRDDFunctions[K <% Writable: ClassTag, V <% Writable : ClassTag
     logInfo("Saving as sequence file of type " +
       s"(${_keyWritableClass.getSimpleName},${_valueWritableClass.getSimpleName})" )
     val format = classOf[SequenceFileOutputFormat[Writable, Writable]]
-    val jobConf = new JobConf(self.context.getHadoopConf.get)
+    val jobConf = new JobConf(SparkHadoopConf.get().get)
     if (!convertKey && !convertValue) {
       self.saveAsHadoopFile(path, _keyWritableClass, _valueWritableClass, format, jobConf, codec)
     } else if (!convertKey && convertValue) {

--- a/core/src/main/scala/org/apache/spark/util/PeriodicCheckpointer.scala
+++ b/core/src/main/scala/org/apache/spark/util/PeriodicCheckpointer.scala
@@ -172,7 +172,7 @@ private[spark] abstract class PeriodicCheckpointer[T](
     val old = checkpointQueue.dequeue()
     // Since the old checkpoint is not deleted by Spark, we manually delete it.
     getCheckpointFiles(old).foreach(
-      PeriodicCheckpointer.removeCheckpointFile(_, sc.hadoopConfiguration))
+      PeriodicCheckpointer.removeCheckpointFile(_, sc.getHadoopConf.get))
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/util/PeriodicCheckpointer.scala
+++ b/core/src/main/scala/org/apache/spark/util/PeriodicCheckpointer.scala
@@ -22,7 +22,7 @@ import scala.collection.mutable
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkContext, SparkHadoopConf}
 import org.apache.spark.internal.Logging
 import org.apache.spark.storage.StorageLevel
 
@@ -172,7 +172,7 @@ private[spark] abstract class PeriodicCheckpointer[T](
     val old = checkpointQueue.dequeue()
     // Since the old checkpoint is not deleted by Spark, we manually delete it.
     getCheckpointFiles(old).foreach(
-      PeriodicCheckpointer.removeCheckpointFile(_, sc.getHadoopConf.get))
+      PeriodicCheckpointer.removeCheckpointFile(_, SparkHadoopConf.get().get))
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/util/PeriodicCheckpointer.scala
+++ b/core/src/main/scala/org/apache/spark/util/PeriodicCheckpointer.scala
@@ -172,7 +172,7 @@ private[spark] abstract class PeriodicCheckpointer[T](
     val old = checkpointQueue.dequeue()
     // Since the old checkpoint is not deleted by Spark, we manually delete it.
     getCheckpointFiles(old).foreach(
-      PeriodicCheckpointer.removeCheckpointFile(_, SparkHadoopConf.get().get))
+      PeriodicCheckpointer.removeCheckpointFile(_, SparkHadoopConf.get.conf))
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/CheckpointSuite.scala
+++ b/core/src/test/scala/org/apache/spark/CheckpointSuite.scala
@@ -293,7 +293,7 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
       if (corruptPartitionerFile) {
         // Overwrite the partitioner file with garbage data
         val checkpointDir = new Path(rddWithPartitioner.getCheckpointFile.get)
-        val fs = checkpointDir.getFileSystem(SparkHadoopConf.get().get)
+        val fs = checkpointDir.getFileSystem(SparkHadoopConf.get.conf)
         val partitionerFile = fs.listStatus(checkpointDir)
             .find(_.getPath.getName.contains("partitioner"))
             .map(_.getPath)
@@ -601,7 +601,7 @@ class CheckpointCompressionSuite extends SparkFunSuite with LocalSparkContext {
       assert(rdd.firstParent.isInstanceOf[ReliableCheckpointRDD[_]])
 
       val checkpointPath = new Path(rdd.getCheckpointFile.get)
-      val fs = checkpointPath.getFileSystem(SparkHadoopConf.get().get)
+      val fs = checkpointPath.getFileSystem(SparkHadoopConf.get.conf)
       val checkpointFile =
         fs.listStatus(checkpointPath).map(_.getPath).find(_.getName.startsWith("part-")).get
 

--- a/core/src/test/scala/org/apache/spark/CheckpointSuite.scala
+++ b/core/src/test/scala/org/apache/spark/CheckpointSuite.scala
@@ -293,7 +293,7 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
       if (corruptPartitionerFile) {
         // Overwrite the partitioner file with garbage data
         val checkpointDir = new Path(rddWithPartitioner.getCheckpointFile.get)
-        val fs = checkpointDir.getFileSystem(sc.hadoopConfiguration)
+        val fs = checkpointDir.getFileSystem(sc.getHadoopConf.get)
         val partitionerFile = fs.listStatus(checkpointDir)
             .find(_.getPath.getName.contains("partitioner"))
             .map(_.getPath)
@@ -601,7 +601,7 @@ class CheckpointCompressionSuite extends SparkFunSuite with LocalSparkContext {
       assert(rdd.firstParent.isInstanceOf[ReliableCheckpointRDD[_]])
 
       val checkpointPath = new Path(rdd.getCheckpointFile.get)
-      val fs = checkpointPath.getFileSystem(sc.hadoopConfiguration)
+      val fs = checkpointPath.getFileSystem(sc.getHadoopConf.get)
       val checkpointFile =
         fs.listStatus(checkpointPath).map(_.getPath).find(_.getName.startsWith("part-")).get
 

--- a/core/src/test/scala/org/apache/spark/CheckpointSuite.scala
+++ b/core/src/test/scala/org/apache/spark/CheckpointSuite.scala
@@ -293,7 +293,7 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
       if (corruptPartitionerFile) {
         // Overwrite the partitioner file with garbage data
         val checkpointDir = new Path(rddWithPartitioner.getCheckpointFile.get)
-        val fs = checkpointDir.getFileSystem(sc.getHadoopConf.get)
+        val fs = checkpointDir.getFileSystem(SparkHadoopConf.get().get)
         val partitionerFile = fs.listStatus(checkpointDir)
             .find(_.getPath.getName.contains("partitioner"))
             .map(_.getPath)
@@ -601,7 +601,7 @@ class CheckpointCompressionSuite extends SparkFunSuite with LocalSparkContext {
       assert(rdd.firstParent.isInstanceOf[ReliableCheckpointRDD[_]])
 
       val checkpointPath = new Path(rdd.getCheckpointFile.get)
-      val fs = checkpointPath.getFileSystem(sc.getHadoopConf.get)
+      val fs = checkpointPath.getFileSystem(SparkHadoopConf.get().get)
       val checkpointFile =
         fs.listStatus(checkpointPath).map(_.getPath).find(_.getName.startsWith("part-")).get
 

--- a/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
@@ -220,7 +220,7 @@ class ContextCleanerSuite extends ContextCleanerSuiteBase {
       // Confirm the checkpoint directory exists
       assert(ReliableRDDCheckpointData.checkpointPath(sc, rddId).isDefined)
       val path = ReliableRDDCheckpointData.checkpointPath(sc, rddId).get
-      val fs = path.getFileSystem(sc.hadoopConfiguration)
+      val fs = path.getFileSystem(sc.getHadoopConf.get)
       assert(fs.exists(path))
 
       // the checkpoint is not cleaned by default (without the configuration set)

--- a/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
@@ -220,7 +220,7 @@ class ContextCleanerSuite extends ContextCleanerSuiteBase {
       // Confirm the checkpoint directory exists
       assert(ReliableRDDCheckpointData.checkpointPath(sc, rddId).isDefined)
       val path = ReliableRDDCheckpointData.checkpointPath(sc, rddId).get
-      val fs = path.getFileSystem(SparkHadoopConf.get().get)
+      val fs = path.getFileSystem(SparkHadoopConf.get.conf)
       assert(fs.exists(path))
 
       // the checkpoint is not cleaned by default (without the configuration set)

--- a/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
@@ -220,7 +220,7 @@ class ContextCleanerSuite extends ContextCleanerSuiteBase {
       // Confirm the checkpoint directory exists
       assert(ReliableRDDCheckpointData.checkpointPath(sc, rddId).isDefined)
       val path = ReliableRDDCheckpointData.checkpointPath(sc, rddId).get
-      val fs = path.getFileSystem(sc.getHadoopConf.get)
+      val fs = path.getFileSystem(SparkHadoopConf.get().get)
       assert(fs.exists(path))
 
       // the checkpoint is not cleaned by default (without the configuration set)

--- a/core/src/test/scala/org/apache/spark/FileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FileSuite.scala
@@ -327,9 +327,9 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
     sc = new SparkContext("local", "test")
     val testOutput = Array[Byte](1, 2, 3, 4, 5)
     val outFile = writeBinaryData(testOutput, 1)
-    SparkHadoopConf.get().get.setLong(
+    SparkHadoopConf.get.conf.setLong(
       "mapreduce.input.fileinputformat.split.minsize.per.node", 5123456)
-    SparkHadoopConf.get().get.setLong(
+    SparkHadoopConf.get.conf.setLong(
       "mapreduce.input.fileinputformat.split.minsize.per.rack", 5123456)
 
     val (_, data) = sc.binaryFiles(outFile.getAbsolutePath).collect().head
@@ -451,7 +451,7 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
     sc = new SparkContext("local", "test")
     val randomRDD = sc.parallelize(
       Array(("key1", "a"), ("key2", "a"), ("key3", "b"), ("key4", "c")), 1)
-    val job = Job.getInstance(SparkHadoopConf.get().get)
+    val job = Job.getInstance(SparkHadoopConf.get.conf)
     job.setOutputKeyClass(classOf[String])
     job.setOutputValueClass(classOf[String])
     job.setOutputFormatClass(classOf[NewTextOutputFormat[String, String]])

--- a/core/src/test/scala/org/apache/spark/FileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FileSuite.scala
@@ -327,9 +327,9 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
     sc = new SparkContext("local", "test")
     val testOutput = Array[Byte](1, 2, 3, 4, 5)
     val outFile = writeBinaryData(testOutput, 1)
-    sc.getHadoopConf.get.setLong(
+    SparkHadoopConf.get().get.setLong(
       "mapreduce.input.fileinputformat.split.minsize.per.node", 5123456)
-    sc.getHadoopConf.get.setLong(
+    SparkHadoopConf.get().get.setLong(
       "mapreduce.input.fileinputformat.split.minsize.per.rack", 5123456)
 
     val (_, data) = sc.binaryFiles(outFile.getAbsolutePath).collect().head
@@ -451,7 +451,7 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
     sc = new SparkContext("local", "test")
     val randomRDD = sc.parallelize(
       Array(("key1", "a"), ("key2", "a"), ("key3", "b"), ("key4", "c")), 1)
-    val job = Job.getInstance(sc.getHadoopConf.get)
+    val job = Job.getInstance(SparkHadoopConf.get().get)
     job.setOutputKeyClass(classOf[String])
     job.setOutputValueClass(classOf[String])
     job.setOutputFormatClass(classOf[NewTextOutputFormat[String, String]])

--- a/core/src/test/scala/org/apache/spark/FileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FileSuite.scala
@@ -327,9 +327,9 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
     sc = new SparkContext("local", "test")
     val testOutput = Array[Byte](1, 2, 3, 4, 5)
     val outFile = writeBinaryData(testOutput, 1)
-    sc.hadoopConfiguration.setLong(
+    sc.getHadoopConf.get.setLong(
       "mapreduce.input.fileinputformat.split.minsize.per.node", 5123456)
-    sc.hadoopConfiguration.setLong(
+    sc.getHadoopConf.get.setLong(
       "mapreduce.input.fileinputformat.split.minsize.per.rack", 5123456)
 
     val (_, data) = sc.binaryFiles(outFile.getAbsolutePath).collect().head
@@ -451,7 +451,7 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
     sc = new SparkContext("local", "test")
     val randomRDD = sc.parallelize(
       Array(("key1", "a"), ("key2", "a"), ("key3", "b"), ("key4", "c")), 1)
-    val job = Job.getInstance(sc.hadoopConfiguration)
+    val job = Job.getInstance(sc.getHadoopConf.get)
     job.setOutputKeyClass(classOf[String])
     job.setOutputValueClass(classOf[String])
     job.setOutputFormatClass(classOf[NewTextOutputFormat[String, String]])

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -47,20 +47,6 @@ import org.apache.spark.util.{ThreadUtils, Utils}
 
 class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventually {
 
-  test("withHadoopConf") {
-    val conf = new SparkConf().setAppName("test").setMaster("local")
-    sc = new SparkContext(conf)
-    sc.setHadoopConf("key", "value") // global
-    SparkContext.withHadoopConf(Map("k1" -> "v1", "k2" -> "v2")) { // temp
-      val rdd = sc.parallelize(Range.apply(0, 10), 2)
-      val arr = rdd.take(2)
-      // scalastyle:off
-      println(arr.head)
-      println(arr.last)
-      // scalastyle:on
-    }
-  }
-
   test("Only one SparkContext may be active at a time") {
     // Regression test for SPARK-4180
     val conf = new SparkConf().setAppName("test").setMaster("local")

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -47,6 +47,20 @@ import org.apache.spark.util.{ThreadUtils, Utils}
 
 class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventually {
 
+  test("withHadoopConf") {
+    val conf = new SparkConf().setAppName("test").setMaster("local")
+    sc = new SparkContext(conf)
+    sc.setHadoopConf("key", "value") // global
+    SparkContext.withHadoopConf(Map("k1" -> "v1", "k2" -> "v2")) { // temp
+      val rdd = sc.parallelize(Range.apply(0, 10), 2)
+      val arr = rdd.take(2)
+      // scalastyle:off
+      println(arr.head)
+      println(arr.last)
+      // scalastyle:on
+    }
+  }
+
   test("Only one SparkContext may be active at a time") {
     // Regression test for SPARK-4180
     val conf = new SparkConf().setAppName("test").setMaster("local")

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -433,7 +433,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
     sc = new SparkContext("local", "test", myConf)
     val logDirUri = logDir.toURI
     val logDirPath = new Path(logDirUri)
-    val fs = FileSystem.get(logDirUri, sc.hadoopConfiguration)
+    val fs = FileSystem.get(logDirUri, sc.getHadoopConf.get)
 
     def listDir(dir: Path): Seq[FileStatus] = {
       val statuses = fs.listStatus(dir)

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -433,7 +433,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
     sc = new SparkContext("local", "test", myConf)
     val logDirUri = logDir.toURI
     val logDirPath = new Path(logDirUri)
-    val fs = FileSystem.get(logDirUri, sc.getHadoopConf.get)
+    val fs = FileSystem.get(logDirUri, SparkHadoopConf.get().get)
 
     def listDir(dir: Path): Seq[FileStatus] = {
       val statuses = fs.listStatus(dir)

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -433,7 +433,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
     sc = new SparkContext("local", "test", myConf)
     val logDirUri = logDir.toURI
     val logDirPath = new Path(logDirUri)
-    val fs = FileSystem.get(logDirUri, SparkHadoopConf.get().get)
+    val fs = FileSystem.get(logDirUri, SparkHadoopConf.get.conf)
 
     def listDir(dir: Path): Seq[FileStatus] = {
       val statuses = fs.listStatus(dir)

--- a/core/src/test/scala/org/apache/spark/input/WholeTextFileInputFormatSuite.scala
+++ b/core/src/test/scala/org/apache/spark/input/WholeTextFileInputFormatSuite.scala
@@ -63,9 +63,9 @@ class WholeTextFileInputFormatSuite extends SparkFunSuite with BeforeAndAfterAll
       logInfo(s"Local disk address is ${dir.toString}.")
 
       // Set the minsize per node and rack to be larger than the size of the input file.
-      sc.hadoopConfiguration.setLong(
+      sc.getHadoopConf.get.setLong(
         "mapreduce.input.fileinputformat.split.minsize.per.node", 123456)
-      sc.hadoopConfiguration.setLong(
+      sc.getHadoopConf.get.setLong(
         "mapreduce.input.fileinputformat.split.minsize.per.rack", 123456)
 
       WholeTextFileInputFormatSuite.files.foreach { case (filename, contents) =>

--- a/core/src/test/scala/org/apache/spark/input/WholeTextFileInputFormatSuite.scala
+++ b/core/src/test/scala/org/apache/spark/input/WholeTextFileInputFormatSuite.scala
@@ -63,9 +63,9 @@ class WholeTextFileInputFormatSuite extends SparkFunSuite with BeforeAndAfterAll
       logInfo(s"Local disk address is ${dir.toString}.")
 
       // Set the minsize per node and rack to be larger than the size of the input file.
-      SparkHadoopConf.get().get.setLong(
+      SparkHadoopConf.get.conf.setLong(
         "mapreduce.input.fileinputformat.split.minsize.per.node", 123456)
-      SparkHadoopConf.get().get.setLong(
+      SparkHadoopConf.get.conf.setLong(
         "mapreduce.input.fileinputformat.split.minsize.per.rack", 123456)
 
       WholeTextFileInputFormatSuite.files.foreach { case (filename, contents) =>

--- a/core/src/test/scala/org/apache/spark/input/WholeTextFileInputFormatSuite.scala
+++ b/core/src/test/scala/org/apache/spark/input/WholeTextFileInputFormatSuite.scala
@@ -23,7 +23,7 @@ import scala.collection.immutable.IndexedSeq
 
 import org.scalatest.BeforeAndAfterAll
 
-import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
+import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite, SparkHadoopConf}
 import org.apache.spark.internal.Logging
 import org.apache.spark.util.Utils
 
@@ -63,9 +63,9 @@ class WholeTextFileInputFormatSuite extends SparkFunSuite with BeforeAndAfterAll
       logInfo(s"Local disk address is ${dir.toString}.")
 
       // Set the minsize per node and rack to be larger than the size of the input file.
-      sc.getHadoopConf.get.setLong(
+      SparkHadoopConf.get().get.setLong(
         "mapreduce.input.fileinputformat.split.minsize.per.node", 123456)
-      sc.getHadoopConf.get.setLong(
+      SparkHadoopConf.get().get.setLong(
         "mapreduce.input.fileinputformat.split.minsize.per.rack", 123456)
 
       WholeTextFileInputFormatSuite.files.foreach { case (filename, contents) =>

--- a/core/src/test/scala/org/apache/spark/input/WholeTextFileRecordReaderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/input/WholeTextFileRecordReaderSuite.scala
@@ -53,10 +53,10 @@ class WholeTextFileRecordReaderSuite extends SparkFunSuite with BeforeAndAfterAl
     sc = new SparkContext("local", "test", conf)
 
     // Set the block size of local file system to test whether files are split right or not.
-    sc.hadoopConfiguration.setLong("fs.local.block.size", 32)
-    sc.hadoopConfiguration.set("io.compression.codecs",
+    sc.getHadoopConf.get.setLong("fs.local.block.size", 32)
+    sc.getHadoopConf.get.set("io.compression.codecs",
       "org.apache.hadoop.io.compress.GzipCodec,org.apache.hadoop.io.compress.DefaultCodec")
-    factory = new CompressionCodecFactory(sc.hadoopConfiguration)
+    factory = new CompressionCodecFactory(sc.getHadoopConf.get)
   }
 
   override def afterAll() {

--- a/core/src/test/scala/org/apache/spark/input/WholeTextFileRecordReaderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/input/WholeTextFileRecordReaderSuite.scala
@@ -27,7 +27,7 @@ import org.apache.hadoop.io.Text
 import org.apache.hadoop.io.compress.{CompressionCodecFactory, GzipCodec}
 import org.scalatest.BeforeAndAfterAll
 
-import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
+import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite, SparkHadoopConf}
 import org.apache.spark.internal.Logging
 import org.apache.spark.util.Utils
 
@@ -53,10 +53,10 @@ class WholeTextFileRecordReaderSuite extends SparkFunSuite with BeforeAndAfterAl
     sc = new SparkContext("local", "test", conf)
 
     // Set the block size of local file system to test whether files are split right or not.
-    sc.getHadoopConf.get.setLong("fs.local.block.size", 32)
-    sc.getHadoopConf.get.set("io.compression.codecs",
+    SparkHadoopConf.get().get.setLong("fs.local.block.size", 32)
+    SparkHadoopConf.get().get.set("io.compression.codecs",
       "org.apache.hadoop.io.compress.GzipCodec,org.apache.hadoop.io.compress.DefaultCodec")
-    factory = new CompressionCodecFactory(sc.getHadoopConf.get)
+    factory = new CompressionCodecFactory(SparkHadoopConf.get().get)
   }
 
   override def afterAll() {

--- a/core/src/test/scala/org/apache/spark/input/WholeTextFileRecordReaderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/input/WholeTextFileRecordReaderSuite.scala
@@ -53,10 +53,10 @@ class WholeTextFileRecordReaderSuite extends SparkFunSuite with BeforeAndAfterAl
     sc = new SparkContext("local", "test", conf)
 
     // Set the block size of local file system to test whether files are split right or not.
-    SparkHadoopConf.get().get.setLong("fs.local.block.size", 32)
-    SparkHadoopConf.get().get.set("io.compression.codecs",
+    SparkHadoopConf.get.conf.setLong("fs.local.block.size", 32)
+    SparkHadoopConf.get.conf.set("io.compression.codecs",
       "org.apache.hadoop.io.compress.GzipCodec,org.apache.hadoop.io.compress.DefaultCodec")
-    factory = new CompressionCodecFactory(SparkHadoopConf.get().get)
+    factory = new CompressionCodecFactory(SparkHadoopConf.get.conf)
   }
 
   override def afterAll() {

--- a/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
@@ -643,7 +643,7 @@ class PairRDDFunctionsSuite extends SparkFunSuite with SharedSparkContext {
     val pairs = sc.parallelize(Array((Integer.valueOf(1), Integer.valueOf(2))), 1)
 
     def saveRddWithPath(path: String): Unit = {
-      val job = NewJob.getInstance(new Configuration(sc.getHadoopConf.get))
+      val job = NewJob.getInstance(new Configuration(SparkHadoopConf.get().get))
       job.setOutputKeyClass(classOf[Integer])
       job.setOutputValueClass(classOf[Integer])
       job.setOutputFormatClass(classOf[NewFakeFormat])

--- a/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
@@ -643,7 +643,7 @@ class PairRDDFunctionsSuite extends SparkFunSuite with SharedSparkContext {
     val pairs = sc.parallelize(Array((Integer.valueOf(1), Integer.valueOf(2))), 1)
 
     def saveRddWithPath(path: String): Unit = {
-      val job = NewJob.getInstance(new Configuration(sc.hadoopConfiguration))
+      val job = NewJob.getInstance(new Configuration(sc.getHadoopConf.get))
       job.setOutputKeyClass(classOf[Integer])
       job.setOutputValueClass(classOf[Integer])
       job.setOutputFormatClass(classOf[NewFakeFormat])

--- a/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
@@ -643,7 +643,7 @@ class PairRDDFunctionsSuite extends SparkFunSuite with SharedSparkContext {
     val pairs = sc.parallelize(Array((Integer.valueOf(1), Integer.valueOf(2))), 1)
 
     def saveRddWithPath(path: String): Unit = {
-      val job = NewJob.getInstance(new Configuration(SparkHadoopConf.get().get))
+      val job = NewJob.getInstance(new Configuration(SparkHadoopConf.get.conf))
       job.setOutputKeyClass(classOf[Integer])
       job.setOutputValueClass(classOf[Integer])
       job.setOutputFormatClass(classOf[NewFakeFormat])

--- a/core/src/test/scala/org/apache/spark/util/PeriodicRDDCheckpointerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/PeriodicRDDCheckpointerSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.util
 
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.{SharedSparkContext, SparkContext, SparkFunSuite}
+import org.apache.spark.{SharedSparkContext, SparkContext, SparkFunSuite, SparkHadoopConf}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.rdd.util.PeriodicRDDCheckpointer
 import org.apache.spark.storage.StorageLevel
@@ -126,7 +126,7 @@ private object PeriodicRDDCheckpointerSuite {
     //       Instead, we check for the presence of the checkpoint files.
     //       This test should continue to work even after this rdd.isCheckpointed issue
     //       is fixed (though it can then be simplified and not look for the files).
-    val hadoopConf = rdd.sparkContext.getHadoopConf.get
+    val hadoopConf = SparkHadoopConf.get().get
     rdd.getCheckpointFile.foreach { checkpointFile =>
       val path = new Path(checkpointFile)
       val fs = path.getFileSystem(hadoopConf)

--- a/core/src/test/scala/org/apache/spark/util/PeriodicRDDCheckpointerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/PeriodicRDDCheckpointerSuite.scala
@@ -126,7 +126,7 @@ private object PeriodicRDDCheckpointerSuite {
     //       Instead, we check for the presence of the checkpoint files.
     //       This test should continue to work even after this rdd.isCheckpointed issue
     //       is fixed (though it can then be simplified and not look for the files).
-    val hadoopConf = rdd.sparkContext.hadoopConfiguration
+    val hadoopConf = rdd.sparkContext.getHadoopConf.get
     rdd.getCheckpointFile.foreach { checkpointFile =>
       val path = new Path(checkpointFile)
       val fs = path.getFileSystem(hadoopConf)

--- a/core/src/test/scala/org/apache/spark/util/PeriodicRDDCheckpointerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/PeriodicRDDCheckpointerSuite.scala
@@ -126,7 +126,7 @@ private object PeriodicRDDCheckpointerSuite {
     //       Instead, we check for the presence of the checkpoint files.
     //       This test should continue to work even after this rdd.isCheckpointed issue
     //       is fixed (though it can then be simplified and not look for the files).
-    val hadoopConf = SparkHadoopConf.get().get
+    val hadoopConf = SparkHadoopConf.get.conf
     rdd.getCheckpointFile.foreach { checkpointFile =>
       val path = new Path(checkpointFile)
       val fs = path.getFileSystem(hadoopConf)

--- a/docs/storage-openstack-swift.md
+++ b/docs/storage-openstack-swift.md
@@ -22,7 +22,7 @@ Spark's support for Hadoop InputFormat allows it to process data in OpenStack Sw
 same URI formats as in Hadoop. You can specify a path in Swift as input through a 
 URI of the form <code>swift://container.PROVIDER/path</code>. You will also need to set your 
 Swift security credentials, through <code>core-site.xml</code> or via
-<code>SparkContext.hadoopConfiguration</code>.
+<code>SparkContext.getHadoopConf.get</code>.
 The current Swift driver requires Swift to use the Keystone authentication method, or
 its Rackspace-specific predecessor.
 
@@ -150,4 +150,4 @@ Notice that
 <code>core-site.xml</code> is not always a good approach.
 We suggest to keep those parameters in <code>core-site.xml</code> for testing purposes when running Spark
 via <code>spark-shell</code>.
-For job submissions they should be provided via <code>sparkContext.hadoopConfiguration</code>.
+For job submissions they should be provided via <code>sparkContext.getHadoopConf.get</code>.

--- a/docs/storage-openstack-swift.md
+++ b/docs/storage-openstack-swift.md
@@ -22,7 +22,7 @@ Spark's support for Hadoop InputFormat allows it to process data in OpenStack Sw
 same URI formats as in Hadoop. You can specify a path in Swift as input through a 
 URI of the form <code>swift://container.PROVIDER/path</code>. You will also need to set your 
 Swift security credentials, through <code>core-site.xml</code> or via
-<code>SparkHadoopConf.get().get</code>.
+<code>SparkHadoopConf.get.conf</code>.
 The current Swift driver requires Swift to use the Keystone authentication method, or
 its Rackspace-specific predecessor.
 
@@ -150,4 +150,4 @@ Notice that
 <code>core-site.xml</code> is not always a good approach.
 We suggest to keep those parameters in <code>core-site.xml</code> for testing purposes when running Spark
 via <code>spark-shell</code>.
-For job submissions they should be provided via <code>SparkHadoopConf.get().get</code>.
+For job submissions they should be provided via <code>SparkHadoopConf.get.conf</code>.

--- a/docs/storage-openstack-swift.md
+++ b/docs/storage-openstack-swift.md
@@ -22,7 +22,7 @@ Spark's support for Hadoop InputFormat allows it to process data in OpenStack Sw
 same URI formats as in Hadoop. You can specify a path in Swift as input through a 
 URI of the form <code>swift://container.PROVIDER/path</code>. You will also need to set your 
 Swift security credentials, through <code>core-site.xml</code> or via
-<code>SparkContext.getHadoopConf.get</code>.
+<code>SparkHadoopConf.get().get</code>.
 The current Swift driver requires Swift to use the Keystone authentication method, or
 its Rackspace-specific predecessor.
 
@@ -150,4 +150,4 @@ Notice that
 <code>core-site.xml</code> is not always a good approach.
 We suggest to keep those parameters in <code>core-site.xml</code> for testing purposes when running Spark
 via <code>spark-shell</code>.
-For job submissions they should be provided via <code>sparkContext.getHadoopConf.get</code>.
+For job submissions they should be provided via <code>SparkHadoopConf.get().get</code>.

--- a/graphx/src/test/scala/org/apache/spark/graphx/util/PeriodicGraphCheckpointerSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/util/PeriodicGraphCheckpointerSuite.scala
@@ -145,7 +145,7 @@ private object PeriodicGraphCheckpointerSuite {
     //       Instead, we check for the presence of the checkpoint files.
     //       This test should continue to work even after this graph.isCheckpointed issue
     //       is fixed (though it can then be simplified and not look for the files).
-    val hadoopConf = SparkHadoopConf.get().get
+    val hadoopConf = SparkHadoopConf.get.conf
     graph.getCheckpointFiles.foreach { checkpointFile =>
       val path = new Path(checkpointFile)
       val fs = path.getFileSystem(hadoopConf)

--- a/graphx/src/test/scala/org/apache/spark/graphx/util/PeriodicGraphCheckpointerSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/util/PeriodicGraphCheckpointerSuite.scala
@@ -145,7 +145,7 @@ private object PeriodicGraphCheckpointerSuite {
     //       Instead, we check for the presence of the checkpoint files.
     //       This test should continue to work even after this graph.isCheckpointed issue
     //       is fixed (though it can then be simplified and not look for the files).
-    val hadoopConf = graph.vertices.sparkContext.hadoopConfiguration
+    val hadoopConf = graph.vertices.sparkContext.getHadoopConf.get
     graph.getCheckpointFiles.foreach { checkpointFile =>
       val path = new Path(checkpointFile)
       val fs = path.getFileSystem(hadoopConf)

--- a/graphx/src/test/scala/org/apache/spark/graphx/util/PeriodicGraphCheckpointerSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/util/PeriodicGraphCheckpointerSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.graphx.util
 
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.{SparkContext, SparkFunSuite}
+import org.apache.spark.{SparkContext, SparkFunSuite, SparkHadoopConf}
 import org.apache.spark.graphx.{Edge, Graph, LocalSparkContext}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.Utils
@@ -145,7 +145,7 @@ private object PeriodicGraphCheckpointerSuite {
     //       Instead, we check for the presence of the checkpoint files.
     //       This test should continue to work even after this graph.isCheckpointed issue
     //       is fixed (though it can then be simplified and not look for the files).
-    val hadoopConf = graph.vertices.sparkContext.getHadoopConf.get
+    val hadoopConf = SparkHadoopConf.get().get
     graph.getCheckpointFiles.foreach { checkpointFile =>
       val path = new Path(checkpointFile)
       val fs = path.getFileSystem(hadoopConf)

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
@@ -24,6 +24,7 @@ import org.json4s.DefaultFormats
 import org.json4s.JsonAST.JObject
 import org.json4s.jackson.JsonMethods._
 
+import org.apache.spark.SparkHadoopConf
 import org.apache.spark.annotation.{DeveloperApi, Since}
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.{Estimator, Model}
@@ -33,10 +34,7 @@ import org.apache.spark.ml.param.shared.{HasCheckpointInterval, HasFeaturesCol, 
 import org.apache.spark.ml.util._
 import org.apache.spark.ml.util.DefaultParamsReader.Metadata
 import org.apache.spark.ml.util.Instrumentation.instrumented
-import org.apache.spark.mllib.clustering.{DistributedLDAModel => OldDistributedLDAModel,
-  EMLDAOptimizer => OldEMLDAOptimizer, LDA => OldLDA, LDAModel => OldLDAModel,
-  LDAOptimizer => OldLDAOptimizer, LocalLDAModel => OldLocalLDAModel,
-  OnlineLDAOptimizer => OldOnlineLDAOptimizer}
+import org.apache.spark.mllib.clustering.{DistributedLDAModel => OldDistributedLDAModel, EMLDAOptimizer => OldEMLDAOptimizer, LDA => OldLDA, LDAModel => OldLDAModel, LDAOptimizer => OldLDAOptimizer, LocalLDAModel => OldLocalLDAModel, OnlineLDAOptimizer => OldOnlineLDAOptimizer}
 import org.apache.spark.mllib.linalg.{Vector => OldVector, Vectors => OldVectors}
 import org.apache.spark.mllib.linalg.MatrixImplicits._
 import org.apache.spark.mllib.linalg.VectorImplicits._
@@ -745,7 +743,7 @@ class DistributedLDAModel private[ml] (
   @DeveloperApi
   @Since("2.0.0")
   def deleteCheckpointFiles(): Unit = {
-    val hadoopConf = sparkSession.sparkContext.getHadoopConf.get
+    val hadoopConf = SparkHadoopConf.get().get
     _checkpointFiles.foreach(PeriodicCheckpointer.removeCheckpointFile(_, hadoopConf))
     _checkpointFiles = Array.empty[String]
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
@@ -745,7 +745,7 @@ class DistributedLDAModel private[ml] (
   @DeveloperApi
   @Since("2.0.0")
   def deleteCheckpointFiles(): Unit = {
-    val hadoopConf = sparkSession.sparkContext.hadoopConfiguration
+    val hadoopConf = sparkSession.sparkContext.getHadoopConf.get
     _checkpointFiles.foreach(PeriodicCheckpointer.removeCheckpointFile(_, hadoopConf))
     _checkpointFiles = Array.empty[String]
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
@@ -743,7 +743,7 @@ class DistributedLDAModel private[ml] (
   @DeveloperApi
   @Since("2.0.0")
   def deleteCheckpointFiles(): Unit = {
-    val hadoopConf = SparkHadoopConf.get().get
+    val hadoopConf = SparkHadoopConf.get.conf
     _checkpointFiles.foreach(PeriodicCheckpointer.removeCheckpointFile(_, hadoopConf))
     _checkpointFiles = Array.empty[String]
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
@@ -31,7 +31,7 @@ import org.apache.hadoop.fs.Path
 import org.json4s.DefaultFormats
 import org.json4s.JsonDSL._
 
-import org.apache.spark.{Dependency, Partitioner, ShuffleDependency, SparkContext}
+import org.apache.spark.{Dependency, Partitioner, ShuffleDependency, SparkContext, SparkHadoopConf}
 import org.apache.spark.annotation.{DeveloperApi, Since}
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.{Estimator, Model}
@@ -959,7 +959,7 @@ object ALS extends DefaultParamsReadable[ALS] with Logging {
       previousCheckpointFile.foreach { file =>
         try {
           val checkpointFile = new Path(file)
-          checkpointFile.getFileSystem(sc.getHadoopConf.get).delete(checkpointFile, true)
+          checkpointFile.getFileSystem(SparkHadoopConf.get().get).delete(checkpointFile, true)
         } catch {
           case e: IOException =>
             logWarning(s"Cannot delete checkpoint file $file:", e)

--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
@@ -959,7 +959,7 @@ object ALS extends DefaultParamsReadable[ALS] with Logging {
       previousCheckpointFile.foreach { file =>
         try {
           val checkpointFile = new Path(file)
-          checkpointFile.getFileSystem(sc.hadoopConfiguration).delete(checkpointFile, true)
+          checkpointFile.getFileSystem(sc.getHadoopConf.get).delete(checkpointFile, true)
         } catch {
           case e: IOException =>
             logWarning(s"Cannot delete checkpoint file $file:", e)

--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
@@ -959,7 +959,7 @@ object ALS extends DefaultParamsReadable[ALS] with Logging {
       previousCheckpointFile.foreach { file =>
         try {
           val checkpointFile = new Path(file)
-          checkpointFile.getFileSystem(SparkHadoopConf.get().get).delete(checkpointFile, true)
+          checkpointFile.getFileSystem(SparkHadoopConf.get.conf).delete(checkpointFile, true)
         } catch {
           case e: IOException =>
             logWarning(s"Cannot delete checkpoint file $file:", e)

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/NodeIdCache.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/NodeIdCache.scala
@@ -79,7 +79,7 @@ private[spark] class NodeIdCache(
   private val canCheckpoint = nodeIdsForInstances.sparkContext.getCheckpointDir.nonEmpty
 
   // Hadoop Configuration for deleting checkpoints as needed
-  private val hadoopConf = SparkHadoopConf.get().get
+  private val hadoopConf = SparkHadoopConf.get.conf
 
   /**
    * Update the node index values in the cache.

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/NodeIdCache.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/NodeIdCache.scala
@@ -78,7 +78,7 @@ private[spark] class NodeIdCache(
   private val canCheckpoint = nodeIdsForInstances.sparkContext.getCheckpointDir.nonEmpty
 
   // Hadoop Configuration for deleting checkpoints as needed
-  private val hadoopConf = nodeIdsForInstances.sparkContext.hadoopConfiguration
+  private val hadoopConf = nodeIdsForInstances.sparkContext.getHadoopConf.get
 
   /**
    * Update the node index values in the cache.

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/NodeIdCache.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/NodeIdCache.scala
@@ -23,6 +23,7 @@ import scala.collection.mutable
 
 import org.apache.hadoop.fs.Path
 
+import org.apache.spark.SparkHadoopConf
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.tree.{LearningNode, Split}
 import org.apache.spark.rdd.RDD
@@ -78,7 +79,7 @@ private[spark] class NodeIdCache(
   private val canCheckpoint = nodeIdsForInstances.sparkContext.getCheckpointDir.nonEmpty
 
   // Hadoop Configuration for deleting checkpoints as needed
-  private val hadoopConf = nodeIdsForInstances.sparkContext.getHadoopConf.get
+  private val hadoopConf = SparkHadoopConf.get().get
 
   /**
    * Update the node index values in the cache.

--- a/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
@@ -30,7 +30,7 @@ import org.json4s.{DefaultFormats, JObject}
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods._
 
-import org.apache.spark.{SparkContext, SparkException}
+import org.apache.spark.{SparkContext, SparkException, SparkHadoopConf}
 import org.apache.spark.annotation.{DeveloperApi, Since, Unstable}
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml._
@@ -674,7 +674,7 @@ private[ml] object MetaAlgorithmReadWrite {
 private[ml] class FileSystemOverwrite extends Logging {
 
   def handleOverwrite(path: String, shouldOverwrite: Boolean, sc: SparkContext): Unit = {
-    val hadoopConf = sc.getHadoopConf.get
+    val hadoopConf = SparkHadoopConf.get().get
     val outputPath = new Path(path)
     val fs = outputPath.getFileSystem(hadoopConf)
     val qualifiedOutputPath = outputPath.makeQualified(fs.getUri, fs.getWorkingDirectory)

--- a/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
@@ -674,7 +674,7 @@ private[ml] object MetaAlgorithmReadWrite {
 private[ml] class FileSystemOverwrite extends Logging {
 
   def handleOverwrite(path: String, shouldOverwrite: Boolean, sc: SparkContext): Unit = {
-    val hadoopConf = SparkHadoopConf.get().get
+    val hadoopConf = SparkHadoopConf.get.conf
     val outputPath = new Path(path)
     val fs = outputPath.getFileSystem(hadoopConf)
     val qualifiedOutputPath = outputPath.makeQualified(fs.getUri, fs.getWorkingDirectory)

--- a/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
@@ -674,7 +674,7 @@ private[ml] object MetaAlgorithmReadWrite {
 private[ml] class FileSystemOverwrite extends Logging {
 
   def handleOverwrite(path: String, shouldOverwrite: Boolean, sc: SparkContext): Unit = {
-    val hadoopConf = sc.hadoopConfiguration
+    val hadoopConf = sc.getHadoopConf.get
     val outputPath = new Path(path)
     val fs = outputPath.getFileSystem(hadoopConf)
     val qualifiedOutputPath = outputPath.makeQualified(fs.getUri, fs.getWorkingDirectory)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -149,7 +149,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
   }
 
   override protected def createTokenManager(): Option[HadoopDelegationTokenManager] = {
-    Some(new HadoopDelegationTokenManager(conf, sc.getHadoopConf.get, driverEndpoint))
+    Some(new HadoopDelegationTokenManager(conf, SparkHadoopConf.get().get, driverEndpoint))
   }
 
   private class KubernetesDriverEndpoint extends DriverEndpoint {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -149,7 +149,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
   }
 
   override protected def createTokenManager(): Option[HadoopDelegationTokenManager] = {
-    Some(new HadoopDelegationTokenManager(conf, sc.hadoopConfiguration, driverEndpoint))
+    Some(new HadoopDelegationTokenManager(conf, sc.getHadoopConf.get, driverEndpoint))
   }
 
   private class KubernetesDriverEndpoint extends DriverEndpoint {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -149,7 +149,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
   }
 
   override protected def createTokenManager(): Option[HadoopDelegationTokenManager] = {
-    Some(new HadoopDelegationTokenManager(conf, SparkHadoopConf.get().get, driverEndpoint))
+    Some(new HadoopDelegationTokenManager(conf, SparkHadoopConf.get.conf, driverEndpoint))
   }
 
   private class KubernetesDriverEndpoint extends DriverEndpoint {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -22,7 +22,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 import io.fabric8.kubernetes.client.KubernetesClient
 
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkContext, SparkHadoopConf}
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.deploy.security.HadoopDelegationTokenManager

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -772,7 +772,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
   }
 
   override protected def createTokenManager(): Option[HadoopDelegationTokenManager] = {
-    Some(new HadoopDelegationTokenManager(conf, sc.getHadoopConf.get, driverEndpoint))
+    Some(new HadoopDelegationTokenManager(conf, SparkHadoopConf.get().get, driverEndpoint))
   }
 
   private def numExecutors(): Int = {

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -772,7 +772,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
   }
 
   override protected def createTokenManager(): Option[HadoopDelegationTokenManager] = {
-    Some(new HadoopDelegationTokenManager(conf, sc.hadoopConfiguration, driverEndpoint))
+    Some(new HadoopDelegationTokenManager(conf, sc.getHadoopConf.get, driverEndpoint))
   }
 
   private def numExecutors(): Int = {

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -30,7 +30,7 @@ import scala.concurrent.Future
 import org.apache.mesos.Protos.{TaskInfo => MesosTaskInfo, _}
 import org.apache.mesos.SchedulerDriver
 
-import org.apache.spark.{SecurityManager, SparkConf, SparkContext, SparkException, TaskState}
+import org.apache.spark.{SecurityManager, SparkConf, SparkContext, SparkException, SparkHadoopConf, TaskState}
 import org.apache.spark.deploy.mesos.config._
 import org.apache.spark.deploy.security.HadoopDelegationTokenManager
 import org.apache.spark.internal.config

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -772,7 +772,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
   }
 
   override protected def createTokenManager(): Option[HadoopDelegationTokenManager] = {
-    Some(new HadoopDelegationTokenManager(conf, SparkHadoopConf.get().get, driverEndpoint))
+    Some(new HadoopDelegationTokenManager(conf, SparkHadoopConf.get.conf, driverEndpoint))
   }
 
   private def numExecutors(): Int = {

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterSchedulerBackend.scala
@@ -36,10 +36,10 @@ private[spark] class YarnClusterSchedulerBackend(
   }
 
   override def getDriverLogUrls: Option[Map[String, String]] = {
-    YarnContainerInfoHelper.getLogUrls(SparkHadoopConf.get().get, container = None)
+    YarnContainerInfoHelper.getLogUrls(SparkHadoopConf.get.conf, container = None)
   }
 
   override def getDriverAttributes: Option[Map[String, String]] = {
-    YarnContainerInfoHelper.getAttributes(SparkHadoopConf.get().get, container = None)
+    YarnContainerInfoHelper.getAttributes(SparkHadoopConf.get.conf, container = None)
   }
 }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterSchedulerBackend.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.scheduler.cluster
 
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkContext, SparkHadoopConf}
 import org.apache.spark.deploy.yarn.ApplicationMaster
 import org.apache.spark.scheduler.TaskSchedulerImpl
 import org.apache.spark.util.YarnContainerInfoHelper

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterSchedulerBackend.scala
@@ -36,10 +36,10 @@ private[spark] class YarnClusterSchedulerBackend(
   }
 
   override def getDriverLogUrls: Option[Map[String, String]] = {
-    YarnContainerInfoHelper.getLogUrls(sc.hadoopConfiguration, container = None)
+    YarnContainerInfoHelper.getLogUrls(sc.getHadoopConf.get, container = None)
   }
 
   override def getDriverAttributes: Option[Map[String, String]] = {
-    YarnContainerInfoHelper.getAttributes(sc.hadoopConfiguration, container = None)
+    YarnContainerInfoHelper.getAttributes(sc.getHadoopConf.get, container = None)
   }
 }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterSchedulerBackend.scala
@@ -36,10 +36,10 @@ private[spark] class YarnClusterSchedulerBackend(
   }
 
   override def getDriverLogUrls: Option[Map[String, String]] = {
-    YarnContainerInfoHelper.getLogUrls(sc.getHadoopConf.get, container = None)
+    YarnContainerInfoHelper.getLogUrls(SparkHadoopConf.get().get, container = None)
   }
 
   override def getDriverAttributes: Option[Map[String, String]] = {
-    YarnContainerInfoHelper.getAttributes(sc.getHadoopConf.get, container = None)
+    YarnContainerInfoHelper.getAttributes(SparkHadoopConf.get().get, container = None)
   }
 }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnScheduler.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnScheduler.scala
@@ -28,7 +28,7 @@ private[spark] class YarnScheduler(sc: SparkContext) extends TaskSchedulerImpl(s
 
   override val defaultRackValue: Option[String] = Some(NetworkTopology.DEFAULT_RACK)
 
-  private[spark] val resolver = SparkRackResolver.get(sc.hadoopConfiguration)
+  private[spark] val resolver = SparkRackResolver.get(sc.getHadoopConf.get)
 
   override def getRacksForHosts(hostPorts: Seq[String]): Seq[Option[String]] = {
     val hosts = hostPorts.map(Utils.parseHostPort(_)._1)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnScheduler.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnScheduler.scala
@@ -28,7 +28,7 @@ private[spark] class YarnScheduler(sc: SparkContext) extends TaskSchedulerImpl(s
 
   override val defaultRackValue: Option[String] = Some(NetworkTopology.DEFAULT_RACK)
 
-  private[spark] val resolver = SparkRackResolver.get(sc.getHadoopConf.get)
+  private[spark] val resolver = SparkRackResolver.get(SparkHadoopConf.get().get)
 
   override def getRacksForHosts(hostPorts: Seq[String]): Seq[Option[String]] = {
     val hosts = hostPorts.map(Utils.parseHostPort(_)._1)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnScheduler.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnScheduler.scala
@@ -28,7 +28,7 @@ private[spark] class YarnScheduler(sc: SparkContext) extends TaskSchedulerImpl(s
 
   override val defaultRackValue: Option[String] = Some(NetworkTopology.DEFAULT_RACK)
 
-  private[spark] val resolver = SparkRackResolver.get(SparkHadoopConf.get().get)
+  private[spark] val resolver = SparkRackResolver.get(SparkHadoopConf.get.conf)
 
   override def getRacksForHosts(hostPorts: Seq[String]): Seq[Option[String]] = {
     val hosts = hostPorts.map(Utils.parseHostPort(_)._1)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -204,7 +204,7 @@ private[spark] abstract class YarnSchedulerBackend(
   }
 
   override protected def createTokenManager(): Option[HadoopDelegationTokenManager] = {
-    Some(new HadoopDelegationTokenManager(sc.conf, sc.getHadoopConf.get, driverEndpoint))
+    Some(new HadoopDelegationTokenManager(sc.conf, SparkHadoopConf.get().get, driverEndpoint))
   }
 
   /**

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -29,7 +29,7 @@ import scala.util.control.NonFatal
 import org.apache.hadoop.yarn.api.records.{ApplicationAttemptId, ApplicationId}
 import org.eclipse.jetty.servlet.{FilterHolder, FilterMapping}
 
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkContext, SparkHadoopConf}
 import org.apache.spark.deploy.security.HadoopDelegationTokenManager
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -204,7 +204,7 @@ private[spark] abstract class YarnSchedulerBackend(
   }
 
   override protected def createTokenManager(): Option[HadoopDelegationTokenManager] = {
-    Some(new HadoopDelegationTokenManager(sc.conf, SparkHadoopConf.get().get, driverEndpoint))
+    Some(new HadoopDelegationTokenManager(sc.conf, SparkHadoopConf.get.conf, driverEndpoint))
   }
 
   /**

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -204,7 +204,7 @@ private[spark] abstract class YarnSchedulerBackend(
   }
 
   override protected def createTokenManager(): Option[HadoopDelegationTokenManager] = {
-    Some(new HadoopDelegationTokenManager(sc.conf, sc.hadoopConfiguration, driverEndpoint))
+    Some(new HadoopDelegationTokenManager(sc.conf, sc.getHadoopConf.get, driverEndpoint))
   }
 
   /**

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -464,7 +464,7 @@ private object YarnClusterDriver extends Logging with Matchers {
           )
         }
 
-        val yarnConf = new YarnConfiguration(sc.getHadoopConf.get)
+        val yarnConf = new YarnConfiguration(SparkHadoopConf.get().get)
         val containerId = YarnContainerInfoHelper.getContainerId(container = None)
         val user = Utils.getCurrentUserName()
 

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -464,7 +464,7 @@ private object YarnClusterDriver extends Logging with Matchers {
           )
         }
 
-        val yarnConf = new YarnConfiguration(SparkHadoopConf.get().get)
+        val yarnConf = new YarnConfiguration(SparkHadoopConf.get.conf)
         val containerId = YarnContainerInfoHelper.getContainerId(container = None)
         val user = Utils.getCurrentUserName()
 

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -464,7 +464,7 @@ private object YarnClusterDriver extends Logging with Matchers {
           )
         }
 
-        val yarnConf = new YarnConfiguration(sc.hadoopConfiguration)
+        val yarnConf = new YarnConfiguration(sc.getHadoopConf.get)
         val containerId = YarnContainerInfoHelper.getContainerId(container = None)
         val user = Utils.getCurrentUserName()
 

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -150,16 +150,16 @@ This file is divided into 3 sections:
       // scalastyle:on println]]></customMessage>
   </check>
 
-  <check customId="hadoopconfiguration" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
-    <parameters><parameter name="regex">spark(.sqlContext)?.sparkContext.hadoopConfiguration</parameter></parameters>
+  <check customId="getHadoopConf" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">spark(.sqlContext)?.sparkContext.getHadoopConf</parameter></parameters>
     <customMessage><![CDATA[
-      Are you sure that you want to use sparkContext.hadoopConfiguration? In most cases, you should use
+      Are you sure that you want to use sparkContext.getHadoopConf.get? In most cases, you should use
       spark.sessionState.newHadoopConf() instead, so that the hadoop configurations specified in Spark session
       configuration will come into effect.
-      If you must use sparkContext.hadoopConfiguration, wrap the code block with
-      // scalastyle:off hadoopconfiguration
-      spark.sparkContext.hadoopConfiguration...
-      // scalastyle:on hadoopconfiguration
+      If you must use sparkContext.getHadoopConf.get, wrap the code block with
+      // scalastyle:off getHadoopConf
+      spark.sparkContext.getHadoopConf.get...
+      // scalastyle:on getHadoopConf
     ]]></customMessage>
   </check>
 

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -150,16 +150,16 @@ This file is divided into 3 sections:
       // scalastyle:on println]]></customMessage>
   </check>
 
-  <check customId="getHadoopConf" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
-    <parameters><parameter name="regex">spark(.sqlContext)?.sparkContext.getHadoopConf</parameter></parameters>
+  <check customId="hadoopconfiguration" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">spark(.sqlContext)?.sparkContext.hadoopConfiguration</parameter></parameters>
     <customMessage><![CDATA[
-      Are you sure that you want to use sparkContext.getHadoopConf.get? In most cases, you should use
+      Are you sure that you want to use sparkContext.hadoopConfiguration ? In most cases, you should use
       spark.sessionState.newHadoopConf() instead, so that the hadoop configurations specified in Spark session
       configuration will come into effect.
-      If you must use sparkContext.getHadoopConf.get, wrap the code block with
-      // scalastyle:off getHadoopConf
-      spark.sparkContext.getHadoopConf.get...
-      // scalastyle:on getHadoopConf
+      If you must use sparkContext.hadoopConfiguration, wrap the code block with
+      // scalastyle:off hadoopconfiguration
+      spark.sparkContext.hadoopConfiguration...
+      // scalastyle:on hadoopconfiguration
     ]]></customMessage>
   </check>
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
@@ -162,7 +162,7 @@ case class StreamingSymmetricHashJoinExec(
   private val storeConf = new StateStoreConf(sqlContext.conf)
   private val hadoopConfBcast = sparkContext.broadcast(
     new SerializableConfiguration(SessionState.newHadoopConf(
-      SparkHadoopConf.get().get, sqlContext.conf)))
+      SparkHadoopConf.get.conf, sqlContext.conf)))
 
   val nullLeft = new GenericInternalRow(left.output.map(_.withNullability(true)).length)
   val nullRight = new GenericInternalRow(right.output.map(_.withNullability(true)).length)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.streaming
 
 import java.util.concurrent.TimeUnit.NANOSECONDS
 
+import org.apache.spark.SparkHadoopConf
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, GenericInternalRow, JoinedRow, Literal, UnsafeProjection, UnsafeRow}
@@ -161,7 +162,7 @@ case class StreamingSymmetricHashJoinExec(
   private val storeConf = new StateStoreConf(sqlContext.conf)
   private val hadoopConfBcast = sparkContext.broadcast(
     new SerializableConfiguration(SessionState.newHadoopConf(
-      sparkContext.getHadoopConf.get, sqlContext.conf)))
+      SparkHadoopConf.get().get, sqlContext.conf)))
 
   val nullLeft = new GenericInternalRow(left.output.map(_.withNullability(true)).length)
   val nullRight = new GenericInternalRow(right.output.map(_.withNullability(true)).length)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
@@ -161,7 +161,7 @@ case class StreamingSymmetricHashJoinExec(
   private val storeConf = new StateStoreConf(sqlContext.conf)
   private val hadoopConfBcast = sparkContext.broadcast(
     new SerializableConfiguration(SessionState.newHadoopConf(
-      sparkContext.hadoopConfiguration, sqlContext.conf)))
+      sparkContext.getHadoopConf.get, sqlContext.conf)))
 
   val nullLeft = new GenericInternalRow(left.output.map(_.withNullability(true)).length)
   val nullRight = new GenericInternalRow(right.output.map(_.withNullability(true)).length)

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -145,7 +145,7 @@ abstract class BaseSessionStateBuilder(
       () => session.sharedState.globalTempViewManager,
       functionRegistry,
       conf,
-      SessionState.newHadoopConf(SparkHadoopConf.get().get, conf),
+      SessionState.newHadoopConf(SparkHadoopConf.get.conf, conf),
       sqlParser,
       resourceLoader)
     parentState.foreach(_.catalog.copyStateTo(catalog))

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -145,7 +145,7 @@ abstract class BaseSessionStateBuilder(
       () => session.sharedState.globalTempViewManager,
       functionRegistry,
       conf,
-      SessionState.newHadoopConf(session.sparkContext.hadoopConfiguration, conf),
+      SessionState.newHadoopConf(session.sparkContext.getHadoopConf.get, conf),
       sqlParser,
       resourceLoader)
     parentState.foreach(_.catalog.copyStateTo(catalog))

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.internal
 
-import org.apache.spark.SparkConf
+import org.apache.spark.{SparkConf, SparkHadoopConf}
 import org.apache.spark.annotation.{Experimental, Unstable}
 import org.apache.spark.sql.{ExperimentalMethods, SparkSession, UDFRegistration, _}
 import org.apache.spark.sql.catalog.v2.CatalogPlugin
@@ -145,7 +145,7 @@ abstract class BaseSessionStateBuilder(
       () => session.sharedState.globalTempViewManager,
       functionRegistry,
       conf,
-      SessionState.newHadoopConf(session.sparkContext.getHadoopConf.get, conf),
+      SessionState.newHadoopConf(SparkHadoopConf.get().get, conf),
       sqlParser,
       resourceLoader)
     parentState.foreach(_.catalog.copyStateTo(catalog))

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
@@ -83,7 +83,7 @@ private[sql] class SessionState(
   lazy val resourceLoader: SessionResourceLoader = resourceLoaderBuilder()
 
   def newHadoopConf(): Configuration = SessionState.newHadoopConf(
-    sharedState.sparkContext.hadoopConfiguration,
+    sharedState.sparkContext.getHadoopConf.get,
     conf)
 
   def newHadoopConfWithOptions(options: Map[String, String]): Configuration = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
@@ -83,7 +83,7 @@ private[sql] class SessionState(
   lazy val resourceLoader: SessionResourceLoader = resourceLoaderBuilder()
 
   def newHadoopConf(): Configuration = SessionState.newHadoopConf(
-    SparkHadoopConf.get().get,
+    SparkHadoopConf.get.conf,
     conf)
 
   def newHadoopConfWithOptions(options: Map[String, String]): Configuration = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
@@ -22,7 +22,7 @@ import java.io.File
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkContext, SparkHadoopConf}
 import org.apache.spark.annotation.{Experimental, Unstable}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.{Analyzer, FunctionRegistry}
@@ -83,7 +83,7 @@ private[sql] class SessionState(
   lazy val resourceLoader: SessionResourceLoader = resourceLoaderBuilder()
 
   def newHadoopConf(): Configuration = SessionState.newHadoopConf(
-    sharedState.sparkContext.getHadoopConf.get,
+    SparkHadoopConf.get().get,
     conf)
 
   def newHadoopConfWithOptions(options: Map[String, String]): Configuration = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -54,13 +54,13 @@ private[sql] class SharedState(
     val configFile = Utils.getContextOrSparkClassLoader.getResource("hive-site.xml")
     if (configFile != null) {
       logInfo(s"loading hive config file: $configFile")
-      sparkContext.hadoopConfiguration.addResource(configFile)
+      sparkContext.getHadoopConf.addResource(configFile)
     }
 
     // hive.metastore.warehouse.dir only stay in hadoopConf
     sparkContext.conf.remove("hive.metastore.warehouse.dir")
     // Set the Hive metastore warehouse path to the one we use
-    val hiveWarehouseDir = sparkContext.hadoopConfiguration.get("hive.metastore.warehouse.dir")
+    val hiveWarehouseDir = sparkContext.getHadoopConf.get("hive.metastore.warehouse.dir")
     if (hiveWarehouseDir != null && !sparkContext.conf.contains(WAREHOUSE_PATH.key)) {
       // If hive.metastore.warehouse.dir is set and spark.sql.warehouse.dir is not set,
       // we will respect the value of hive.metastore.warehouse.dir.
@@ -77,7 +77,7 @@ private[sql] class SharedState(
       val sparkWarehouseDir = sparkContext.conf.get(WAREHOUSE_PATH)
       logInfo(s"Setting hive.metastore.warehouse.dir ('$hiveWarehouseDir') to the value of " +
         s"${WAREHOUSE_PATH.key} ('$sparkWarehouseDir').")
-      sparkContext.hadoopConfiguration.set("hive.metastore.warehouse.dir", sparkWarehouseDir)
+      sparkContext.getHadoopConf.set("hive.metastore.warehouse.dir", sparkWarehouseDir)
       sparkWarehouseDir
     }
   }
@@ -88,7 +88,7 @@ private[sql] class SharedState(
   // both spark conf and hadoop conf avoiding be affected by any SparkSession level options
   private val (conf, hadoopConf) = {
     val confClone = sparkContext.conf.clone()
-    val hadoopConfClone = new Configuration(sparkContext.hadoopConfiguration)
+    val hadoopConfClone = new Configuration(sparkContext.getHadoopConf.get)
     // If `SparkSession` is instantiated using an existing `SparkContext` instance and no existing
     // `SharedState`, all `SparkSession` level configurations have higher priority to generate a
     // `SharedState` instance. This will be done only once then shared across `SparkSession`s

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -54,13 +54,13 @@ private[sql] class SharedState(
     val configFile = Utils.getContextOrSparkClassLoader.getResource("hive-site.xml")
     if (configFile != null) {
       logInfo(s"loading hive config file: $configFile")
-      SparkHadoopConf.get().addResource(configFile)
+      SparkHadoopConf.get.addResource(configFile)
     }
 
     // hive.metastore.warehouse.dir only stay in hadoopConf
     sparkContext.conf.remove("hive.metastore.warehouse.dir")
     // Set the Hive metastore warehouse path to the one we use
-    val hiveWarehouseDir = SparkHadoopConf.get().get("hive.metastore.warehouse.dir")
+    val hiveWarehouseDir = SparkHadoopConf.get.get("hive.metastore.warehouse.dir")
     if (hiveWarehouseDir != null && !sparkContext.conf.contains(WAREHOUSE_PATH.key)) {
       // If hive.metastore.warehouse.dir is set and spark.sql.warehouse.dir is not set,
       // we will respect the value of hive.metastore.warehouse.dir.
@@ -77,7 +77,7 @@ private[sql] class SharedState(
       val sparkWarehouseDir = sparkContext.conf.get(WAREHOUSE_PATH)
       logInfo(s"Setting hive.metastore.warehouse.dir ('$hiveWarehouseDir') to the value of " +
         s"${WAREHOUSE_PATH.key} ('$sparkWarehouseDir').")
-      SparkHadoopConf.get().set("hive.metastore.warehouse.dir", sparkWarehouseDir)
+      SparkHadoopConf.get.set("hive.metastore.warehouse.dir", sparkWarehouseDir)
       sparkWarehouseDir
     }
   }
@@ -88,7 +88,7 @@ private[sql] class SharedState(
   // both spark conf and hadoop conf avoiding be affected by any SparkSession level options
   private val (conf, hadoopConf) = {
     val confClone = sparkContext.conf.clone()
-    val hadoopConfClone = new Configuration(SparkHadoopConf.get().get)
+    val hadoopConfClone = new Configuration(SparkHadoopConf.get.conf)
     // If `SparkSession` is instantiated using an existing `SparkContext` instance and no existing
     // `SharedState`, all `SparkSession` level configurations have higher priority to generate a
     // `SharedState` instance. This will be done only once then shared across `SparkSession`s

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql
 
 import org.scalatest.BeforeAndAfterEach
 
-import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
+import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite, SparkHadoopConf}
 import org.apache.spark.internal.config.UI.UI_ENABLED
 import org.apache.spark.sql.internal.SQLConf
 
@@ -138,7 +138,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
   test("SPARK-15887: hive-site.xml should be loaded") {
     val session = SparkSession.builder().master("local").getOrCreate()
     assert(session.sessionState.newHadoopConf().get("hive.in.test") == "true")
-    assert(session.sparkContext.getHadoopConf.get.get("hive.in.test") == "true")
+    assert(SparkHadoopConf.get().get.get("hive.in.test") == "true")
   }
 
   test("SPARK-15991: Set global Hadoop conf") {
@@ -146,10 +146,10 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     val mySpecialKey = "my.special.key.15991"
     val mySpecialValue = "msv"
     try {
-      session.sparkContext.getHadoopConf.get.set(mySpecialKey, mySpecialValue)
+      SparkHadoopConf.get().get.set(mySpecialKey, mySpecialValue)
       assert(session.sessionState.newHadoopConf().get(mySpecialKey) == mySpecialValue)
     } finally {
-      session.sparkContext.getHadoopConf.get.unset(mySpecialKey)
+      SparkHadoopConf.get().get.unset(mySpecialKey)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -138,7 +138,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
   test("SPARK-15887: hive-site.xml should be loaded") {
     val session = SparkSession.builder().master("local").getOrCreate()
     assert(session.sessionState.newHadoopConf().get("hive.in.test") == "true")
-    assert(session.sparkContext.hadoopConfiguration.get("hive.in.test") == "true")
+    assert(session.sparkContext.getHadoopConf.get.get("hive.in.test") == "true")
   }
 
   test("SPARK-15991: Set global Hadoop conf") {
@@ -146,10 +146,10 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     val mySpecialKey = "my.special.key.15991"
     val mySpecialValue = "msv"
     try {
-      session.sparkContext.hadoopConfiguration.set(mySpecialKey, mySpecialValue)
+      session.sparkContext.getHadoopConf.get.set(mySpecialKey, mySpecialValue)
       assert(session.sessionState.newHadoopConf().get(mySpecialKey) == mySpecialValue)
     } finally {
-      session.sparkContext.hadoopConfiguration.unset(mySpecialKey)
+      session.sparkContext.getHadoopConf.get.unset(mySpecialKey)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -138,7 +138,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
   test("SPARK-15887: hive-site.xml should be loaded") {
     val session = SparkSession.builder().master("local").getOrCreate()
     assert(session.sessionState.newHadoopConf().get("hive.in.test") == "true")
-    assert(SparkHadoopConf.get().get.get("hive.in.test") == "true")
+    assert(SparkHadoopConf.get.conf.get("hive.in.test") == "true")
   }
 
   test("SPARK-15991: Set global Hadoop conf") {
@@ -146,10 +146,10 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     val mySpecialKey = "my.special.key.15991"
     val mySpecialValue = "msv"
     try {
-      SparkHadoopConf.get().get.set(mySpecialKey, mySpecialValue)
+      SparkHadoopConf.get.conf.set(mySpecialKey, mySpecialValue)
       assert(session.sessionState.newHadoopConf().get(mySpecialKey) == mySpecialValue)
     } finally {
-      SparkHadoopConf.get().get.unset(mySpecialKey)
+      SparkHadoopConf.get.conf.unset(mySpecialKey)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
@@ -31,7 +31,6 @@ import org.apache.spark.{SparkException, SparkHadoopConf}
 import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.execution.datasources.PartitionedFile
-import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf.SOURCES_BINARY_FILE_MAX_LENGTH
 import org.apache.spark.sql.sources._
@@ -55,7 +54,7 @@ class BinaryFileFormatSuite extends QueryTest with SharedSQLContext with SQLTest
 
     testDir = Utils.createTempDir().getAbsolutePath
     fsTestDir = new Path(testDir)
-    fs = fsTestDir.getFileSystem(SparkHadoopConf.get().get)
+    fs = fsTestDir.getFileSystem(SparkHadoopConf.get.conf)
 
     val year2014Dir = new File(testDir, "year=2014")
     year2014Dir.mkdir()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
@@ -54,7 +54,7 @@ class BinaryFileFormatSuite extends QueryTest with SharedSQLContext with SQLTest
 
     testDir = Utils.createTempDir().getAbsolutePath
     fsTestDir = new Path(testDir)
-    fs = fsTestDir.getFileSystem(sparkContext.hadoopConfiguration)
+    fs = fsTestDir.getFileSystem(sparkContext.getHadoopConf.get)
 
     val year2014Dir = new File(testDir, "year=2014")
     year2014Dir.mkdir()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
@@ -27,10 +27,11 @@ import com.google.common.io.{ByteStreams, Closeables}
 import org.apache.hadoop.fs.{FileStatus, FileSystem, GlobFilter, Path}
 import org.mockito.Mockito.{mock, when}
 
-import org.apache.spark.SparkException
+import org.apache.spark.{SparkException, SparkHadoopConf}
 import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.execution.datasources.PartitionedFile
+import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf.SOURCES_BINARY_FILE_MAX_LENGTH
 import org.apache.spark.sql.sources._
@@ -54,7 +55,7 @@ class BinaryFileFormatSuite extends QueryTest with SharedSQLContext with SQLTest
 
     testDir = Utils.createTempDir().getAbsolutePath
     fsTestDir = new Path(testDir)
-    fs = fsTestDir.getFileSystem(sparkContext.getHadoopConf.get)
+    fs = fsTestDir.getFileSystem(SparkHadoopConf.get().get)
 
     val year2014Dir = new File(testDir, "year=2014")
     year2014Dir.mkdir()

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/v2/SimpleWritableDataSource.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/v2/SimpleWritableDataSource.scala
@@ -25,7 +25,7 @@ import scala.collection.JavaConverters._
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 
-import org.apache.spark.SparkContext
+import org.apache.spark.SparkHadoopConf
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.sources.v2.TableCapability._
 import org.apache.spark.sql.sources.v2.reader._
@@ -85,7 +85,7 @@ class SimpleWritableDataSource extends TableProvider with SessionConfigSupport {
 
     override def buildForBatch(): BatchWrite = {
       val hadoopPath = new Path(path)
-      val hadoopConf = SparkContext.getActive.get.getHadoopConf.get
+      val hadoopConf = SparkHadoopConf.get().get
       val fs = hadoopPath.getFileSystem(hadoopConf)
 
       if (needTruncate) {
@@ -134,7 +134,7 @@ class SimpleWritableDataSource extends TableProvider with SessionConfigSupport {
     extends SimpleBatchTable with SupportsWrite {
 
     private val path = options.get("path")
-    private val conf = SparkContext.getActive.get.getHadoopConf.get
+    private val conf = SparkHadoopConf.get().get
 
     override def schema(): StructType = tableSchema
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/v2/SimpleWritableDataSource.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/v2/SimpleWritableDataSource.scala
@@ -85,7 +85,7 @@ class SimpleWritableDataSource extends TableProvider with SessionConfigSupport {
 
     override def buildForBatch(): BatchWrite = {
       val hadoopPath = new Path(path)
-      val hadoopConf = SparkContext.getActive.get.hadoopConfiguration
+      val hadoopConf = SparkContext.getActive.get.getHadoopConf.get
       val fs = hadoopPath.getFileSystem(hadoopConf)
 
       if (needTruncate) {
@@ -134,7 +134,7 @@ class SimpleWritableDataSource extends TableProvider with SessionConfigSupport {
     extends SimpleBatchTable with SupportsWrite {
 
     private val path = options.get("path")
-    private val conf = SparkContext.getActive.get.hadoopConfiguration
+    private val conf = SparkContext.getActive.get.getHadoopConf.get
 
     override def schema(): StructType = tableSchema
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/v2/SimpleWritableDataSource.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/v2/SimpleWritableDataSource.scala
@@ -85,7 +85,7 @@ class SimpleWritableDataSource extends TableProvider with SessionConfigSupport {
 
     override def buildForBatch(): BatchWrite = {
       val hadoopPath = new Path(path)
-      val hadoopConf = SparkHadoopConf.get().get
+      val hadoopConf = SparkHadoopConf.get.conf
       val fs = hadoopPath.getFileSystem(hadoopConf)
 
       if (needTruncate) {
@@ -134,7 +134,7 @@ class SimpleWritableDataSource extends TableProvider with SessionConfigSupport {
     extends SimpleBatchTable with SupportsWrite {
 
     private val path = options.get("path")
-    private val conf = SparkHadoopConf.get().get
+    private val conf = SparkHadoopConf.get.conf
 
     override def schema(): StructType = tableSchema
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.hive
 
+import org.apache.spark.SparkHadoopConf
 import org.apache.spark.annotation.{Experimental, Unstable}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalog.v2.CatalogPlugin
@@ -58,7 +59,7 @@ class HiveSessionStateBuilder(session: SparkSession, parentState: Option[Session
       new HiveMetastoreCatalog(session),
       functionRegistry,
       conf,
-      SessionState.newHadoopConf(session.sparkContext.getHadoopConf.get, conf),
+      SessionState.newHadoopConf(SparkHadoopConf.get().get, conf),
       sqlParser,
       resourceLoader)
     parentState.foreach(_.catalog.copyStateTo(catalog))

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
@@ -58,7 +58,7 @@ class HiveSessionStateBuilder(session: SparkSession, parentState: Option[Session
       new HiveMetastoreCatalog(session),
       functionRegistry,
       conf,
-      SessionState.newHadoopConf(session.sparkContext.hadoopConfiguration, conf),
+      SessionState.newHadoopConf(session.sparkContext.getHadoopConf.get, conf),
       sqlParser,
       resourceLoader)
     parentState.foreach(_.catalog.copyStateTo(catalog))

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
@@ -59,7 +59,7 @@ class HiveSessionStateBuilder(session: SparkSession, parentState: Option[Session
       new HiveMetastoreCatalog(session),
       functionRegistry,
       conf,
-      SessionState.newHadoopConf(SparkHadoopConf.get().get, conf),
+      SessionState.newHadoopConf(SparkHadoopConf.get.conf, conf),
       sqlParser,
       resourceLoader)
     parentState.foreach(_.catalog.copyStateTo(catalog))

--- a/sql/hive/src/test/java/org/apache/spark/sql/hive/JavaMetastoreDataSourcesSuite.java
+++ b/sql/hive/src/test/java/org/apache/spark/sql/hive/JavaMetastoreDataSourcesSuite.java
@@ -73,7 +73,7 @@ public class JavaMetastoreDataSourcesSuite {
     }
     HiveSessionCatalog catalog = (HiveSessionCatalog) sqlContext.sessionState().catalog();
     hiveManagedPath = new Path(catalog.defaultTablePath(new TableIdentifier("javaSavedTable")));
-    fs = hiveManagedPath.getFileSystem(sc.getHadoopConf());
+    fs = hiveManagedPath.getFileSystem(sc.hadoopConfiguration());
     fs.delete(hiveManagedPath, true);
 
     List<String> jsonObjects = new ArrayList<>(10);

--- a/sql/hive/src/test/java/org/apache/spark/sql/hive/JavaMetastoreDataSourcesSuite.java
+++ b/sql/hive/src/test/java/org/apache/spark/sql/hive/JavaMetastoreDataSourcesSuite.java
@@ -73,7 +73,7 @@ public class JavaMetastoreDataSourcesSuite {
     }
     HiveSessionCatalog catalog = (HiveSessionCatalog) sqlContext.sessionState().catalog();
     hiveManagedPath = new Path(catalog.defaultTablePath(new TableIdentifier("javaSavedTable")));
-    fs = hiveManagedPath.getFileSystem(sc.hadoopConf().get());
+    fs = hiveManagedPath.getFileSystem(sc.hadoopConf().conf());
     fs.delete(hiveManagedPath, true);
 
     List<String> jsonObjects = new ArrayList<>(10);

--- a/sql/hive/src/test/java/org/apache/spark/sql/hive/JavaMetastoreDataSourcesSuite.java
+++ b/sql/hive/src/test/java/org/apache/spark/sql/hive/JavaMetastoreDataSourcesSuite.java
@@ -73,7 +73,7 @@ public class JavaMetastoreDataSourcesSuite {
     }
     HiveSessionCatalog catalog = (HiveSessionCatalog) sqlContext.sessionState().catalog();
     hiveManagedPath = new Path(catalog.defaultTablePath(new TableIdentifier("javaSavedTable")));
-    fs = hiveManagedPath.getFileSystem(sc.hadoopConfiguration());
+    fs = hiveManagedPath.getFileSystem(sc.hadoopConf().get());
     fs.delete(hiveManagedPath, true);
 
     List<String> jsonObjects = new ArrayList<>(10);

--- a/sql/hive/src/test/java/org/apache/spark/sql/hive/JavaMetastoreDataSourcesSuite.java
+++ b/sql/hive/src/test/java/org/apache/spark/sql/hive/JavaMetastoreDataSourcesSuite.java
@@ -73,7 +73,7 @@ public class JavaMetastoreDataSourcesSuite {
     }
     HiveSessionCatalog catalog = (HiveSessionCatalog) sqlContext.sessionState().catalog();
     hiveManagedPath = new Path(catalog.defaultTablePath(new TableIdentifier("javaSavedTable")));
-    fs = hiveManagedPath.getFileSystem(sc.hadoopConfiguration());
+    fs = hiveManagedPath.getFileSystem(sc.getHadoopConf());
     fs.delete(hiveManagedPath, true);
 
     List<String> jsonObjects = new ArrayList<>(10);

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveContextCompatibilitySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveContextCompatibilitySuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.hive
 
 import org.scalatest.BeforeAndAfterEach
 
-import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
+import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite, SparkHadoopConf}
 
 
 class HiveContextCompatibilitySuite extends SparkFunSuite with BeforeAndAfterEach {
@@ -32,7 +32,7 @@ class HiveContextCompatibilitySuite extends SparkFunSuite with BeforeAndAfterEac
     super.beforeAll()
     sc = SparkContext.getOrCreate(new SparkConf().setMaster("local").setAppName("test"))
     HiveUtils.newTemporaryConfiguration(useInMemoryDerby = true).foreach { case (k, v) =>
-      sc.getHadoopConf.get.set(k, v)
+      SparkHadoopConf.get().get.set(k, v)
     }
     hc = new HiveContext(sc)
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveContextCompatibilitySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveContextCompatibilitySuite.scala
@@ -32,7 +32,7 @@ class HiveContextCompatibilitySuite extends SparkFunSuite with BeforeAndAfterEac
     super.beforeAll()
     sc = SparkContext.getOrCreate(new SparkConf().setMaster("local").setAppName("test"))
     HiveUtils.newTemporaryConfiguration(useInMemoryDerby = true).foreach { case (k, v) =>
-      sc.hadoopConfiguration.set(k, v)
+      sc.getHadoopConf.get.set(k, v)
     }
     hc = new HiveContext(sc)
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveContextCompatibilitySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveContextCompatibilitySuite.scala
@@ -32,7 +32,7 @@ class HiveContextCompatibilitySuite extends SparkFunSuite with BeforeAndAfterEac
     super.beforeAll()
     sc = SparkContext.getOrCreate(new SparkConf().setMaster("local").setAppName("test"))
     HiveUtils.newTemporaryConfiguration(useInMemoryDerby = true).foreach { case (k, v) =>
-      SparkHadoopConf.get().get.set(k, v)
+      SparkHadoopConf.get.conf.set(k, v)
     }
     hc = new HiveContext(sc)
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSessionStateSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSessionStateSuite.scala
@@ -42,7 +42,7 @@ class HiveSessionStateSuite extends SessionStateSuite with TestHiveSingleton {
 
   test("Clone then newSession") {
     val sparkSession = hiveContext.sparkSession
-    val conf = SparkHadoopConf.get().get
+    val conf = SparkHadoopConf.get.conf
     val oldValue = conf.get(ConfVars.METASTORECONNECTURLKEY.varname)
     sparkSession.cloneSession()
     sparkSession.sharedState.externalCatalog.unwrapped.asInstanceOf[HiveExternalCatalog]

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSessionStateSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSessionStateSuite.scala
@@ -41,7 +41,7 @@ class HiveSessionStateSuite extends SessionStateSuite with TestHiveSingleton {
 
   test("Clone then newSession") {
     val sparkSession = hiveContext.sparkSession
-    val conf = sparkSession.sparkContext.hadoopConfiguration
+    val conf = sparkSession.sparkContext.getHadoopConf.get
     val oldValue = conf.get(ConfVars.METASTORECONNECTURLKEY.varname)
     sparkSession.cloneSession()
     sparkSession.sharedState.externalCatalog.unwrapped.asInstanceOf[HiveExternalCatalog]

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSessionStateSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSessionStateSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.hive
 
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars
 
+import org.apache.spark.SparkHadoopConf
 import org.apache.spark.sql._
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 
@@ -41,7 +42,7 @@ class HiveSessionStateSuite extends SessionStateSuite with TestHiveSingleton {
 
   test("Clone then newSession") {
     val sparkSession = hiveContext.sparkSession
-    val conf = sparkSession.sparkContext.getHadoopConf.get
+    val conf = SparkHadoopConf.get().get
     val oldValue = conf.get(ConfVars.METASTORECONNECTURLKEY.varname)
     sparkSession.cloneSession()
     sparkSession.sharedState.externalCatalog.unwrapped.asInstanceOf[HiveExternalCatalog]

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSharedStateSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSharedStateSuite.scala
@@ -48,7 +48,7 @@ class HiveSharedStateSuite extends SparkFunSuite {
     assert(state.warehousePath !== invalidPath, "warehouse path can't determine by session options")
     assert(sc.conf.get(WAREHOUSE_PATH.key) !== invalidPath,
       "warehouse conf in session options can't affect application wide spark conf")
-    assert(sc.hadoopConfiguration.get(ConfVars.METASTOREWAREHOUSE.varname) !== invalidPath,
+    assert(sc.getHadoopConf.get.get(ConfVars.METASTOREWAREHOUSE.varname) !== invalidPath,
       "warehouse conf in session options can't affect application wide hadoop conf")
 
     assert(!state.sparkContext.conf.contains("spark.foo"),

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSharedStateSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSharedStateSuite.scala
@@ -48,7 +48,7 @@ class HiveSharedStateSuite extends SparkFunSuite {
     assert(state.warehousePath !== invalidPath, "warehouse path can't determine by session options")
     assert(sc.conf.get(WAREHOUSE_PATH.key) !== invalidPath,
       "warehouse conf in session options can't affect application wide spark conf")
-    assert(SparkHadoopConf.get().get.get(ConfVars.METASTOREWAREHOUSE.varname) !== invalidPath,
+    assert(SparkHadoopConf.get.conf.get(ConfVars.METASTOREWAREHOUSE.varname) !== invalidPath,
       "warehouse conf in session options can't affect application wide hadoop conf")
 
     assert(!state.sparkContext.conf.contains("spark.foo"),

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSharedStateSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSharedStateSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.hive
 
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars
 
-import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
+import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite, SparkHadoopConf}
 import org.apache.spark.sql.internal.SharedState
 import org.apache.spark.sql.internal.StaticSQLConf._
 import org.apache.spark.util.Utils
@@ -48,7 +48,7 @@ class HiveSharedStateSuite extends SparkFunSuite {
     assert(state.warehousePath !== invalidPath, "warehouse path can't determine by session options")
     assert(sc.conf.get(WAREHOUSE_PATH.key) !== invalidPath,
       "warehouse conf in session options can't affect application wide spark conf")
-    assert(sc.getHadoopConf.get.get(ConfVars.METASTOREWAREHOUSE.varname) !== invalidPath,
+    assert(SparkHadoopConf.get().get.get(ConfVars.METASTOREWAREHOUSE.varname) !== invalidPath,
       "warehouse conf in session options can't affect application wide hadoop conf")
 
     assert(!state.sparkContext.conf.contains("spark.foo"),

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -2283,7 +2283,7 @@ class HiveDDLSuite
 
       case "parquet" =>
         val footer = ParquetFileReader.readFooter(
-          sparkContext.hadoopConfiguration, new Path(maybeFile.get.getPath), NO_FILTER)
+          sparkContext.getHadoopConf.get, new Path(maybeFile.get.getPath), NO_FILTER)
         footer.getBlocks.get(0).getColumns.get(0).getCodec.toString
     }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -25,7 +25,7 @@ import org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER
 import org.apache.parquet.hadoop.ParquetFileReader
 import org.scalatest.BeforeAndAfterEach
 
-import org.apache.spark.SparkException
+import org.apache.spark.{SparkException, SparkHadoopConf}
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row, SaveMode}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{NoSuchPartitionException, TableAlreadyExistsException}
@@ -2283,7 +2283,7 @@ class HiveDDLSuite
 
       case "parquet" =>
         val footer = ParquetFileReader.readFooter(
-          sparkContext.getHadoopConf.get, new Path(maybeFile.get.getPath), NO_FILTER)
+          SparkHadoopConf.get().get, new Path(maybeFile.get.getPath), NO_FILTER)
         footer.getBlocks.get(0).getColumns.get(0).getCodec.toString
     }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -2283,7 +2283,7 @@ class HiveDDLSuite
 
       case "parquet" =>
         val footer = ParquetFileReader.readFooter(
-          SparkHadoopConf.get().get, new Path(maybeFile.get.getPath), NO_FILTER)
+          SparkHadoopConf.get.conf, new Path(maybeFile.get.getPath), NO_FILTER)
         footer.getBlocks.get(0).getColumns.get(0).getCodec.toString
     }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1642,7 +1642,7 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     val path = new Path(
       new Path(s"file:$tempDir"),
       "drop_database_removes_partition_dirs_table2")
-    val fs = path.getFileSystem(sparkContext.hadoopConfiguration)
+    val fs = path.getFileSystem(sparkContext.getHadoopConf.get)
     // The partition dir is not empty.
     assert(fs.listStatus(new Path(path, "part=1")).nonEmpty)
 
@@ -1690,7 +1690,7 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       sql("select '1' as part, key, value from src")
     )
     val path = new Path(new Path(s"file:$tempDir"), "drop_table_removes_partition_dirs_table2")
-    val fs = path.getFileSystem(sparkContext.hadoopConfiguration)
+    val fs = path.getFileSystem(sparkContext.getHadoopConf.get)
     // The partition dir is not empty.
     assert(fs.listStatus(new Path(path, "part=1")).nonEmpty)
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1642,7 +1642,7 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     val path = new Path(
       new Path(s"file:$tempDir"),
       "drop_database_removes_partition_dirs_table2")
-    val fs = path.getFileSystem(SparkHadoopConf.get().get)
+    val fs = path.getFileSystem(SparkHadoopConf.get.conf)
     // The partition dir is not empty.
     assert(fs.listStatus(new Path(path, "part=1")).nonEmpty)
 
@@ -1690,7 +1690,7 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       sql("select '1' as part, key, value from src")
     )
     val path = new Path(new Path(s"file:$tempDir"), "drop_table_removes_partition_dirs_table2")
-    val fs = path.getFileSystem(SparkHadoopConf.get().get)
+    val fs = path.getFileSystem(SparkHadoopConf.get.conf)
     // The partition dir is not empty.
     assert(fs.listStatus(new Path(path, "part=1")).nonEmpty)
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -26,7 +26,7 @@ import java.util.{Locale, Set}
 import com.google.common.io.Files
 import org.apache.hadoop.fs.{FileSystem, Path}
 
-import org.apache.spark.{SparkException, TestUtils}
+import org.apache.spark.{SparkException, SparkHadoopConf, TestUtils}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, FunctionRegistry}
@@ -1642,7 +1642,7 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     val path = new Path(
       new Path(s"file:$tempDir"),
       "drop_database_removes_partition_dirs_table2")
-    val fs = path.getFileSystem(sparkContext.getHadoopConf.get)
+    val fs = path.getFileSystem(SparkHadoopConf.get().get)
     // The partition dir is not empty.
     assert(fs.listStatus(new Path(path, "part=1")).nonEmpty)
 
@@ -1690,7 +1690,7 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       sql("select '1' as part, key, value from src")
     )
     val path = new Path(new Path(s"file:$tempDir"), "drop_table_removes_partition_dirs_table2")
-    val fs = path.getFileSystem(sparkContext.getHadoopConf.get)
+    val fs = path.getFileSystem(SparkHadoopConf.get().get)
     // The partition dir is not empty.
     assert(fs.listStatus(new Path(path, "part=1")).nonEmpty)
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -102,7 +102,7 @@ private[hive] class TestHiveSharedState(
   override lazy val externalCatalog: ExternalCatalogWithListener = {
     new ExternalCatalogWithListener(new TestHiveExternalCatalog(
       sc.conf,
-      SparkHadoopConf.get().get,
+      SparkHadoopConf.get.conf,
       hiveClient))
   }
 }
@@ -203,12 +203,12 @@ private[hive] class TestHiveSparkSession(
       // After session cloning, the JDBC connect string for a JDBC metastore should not be changed.
       existingSharedState.map { state =>
         val connKey =
-          SparkHadoopConf.get().get(ConfVars.METASTORECONNECTURLKEY.varname)
+          SparkHadoopConf.get.get(ConfVars.METASTORECONNECTURLKEY.varname)
         ConfVars.METASTORECONNECTURLKEY.varname -> connKey
       }
 
     metastoreTempConf.foreach { case (k, v) =>
-      SparkHadoopConf.get().set(k, v)
+      SparkHadoopConf.get.set(k, v)
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -31,7 +31,7 @@ import org.apache.hadoop.hive.conf.HiveConf.ConfVars
 import org.apache.hadoop.hive.ql.exec.FunctionRegistry
 import org.apache.hadoop.hive.serde2.`lazy`.LazySimpleSerDe
 
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.{SparkConf, SparkContext, SparkHadoopConf}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config
 import org.apache.spark.internal.config.UI._
@@ -102,7 +102,7 @@ private[hive] class TestHiveSharedState(
   override lazy val externalCatalog: ExternalCatalogWithListener = {
     new ExternalCatalogWithListener(new TestHiveExternalCatalog(
       sc.conf,
-      sc.getHadoopConf.get,
+      SparkHadoopConf.get().get,
       hiveClient))
   }
 }
@@ -203,12 +203,12 @@ private[hive] class TestHiveSparkSession(
       // After session cloning, the JDBC connect string for a JDBC metastore should not be changed.
       existingSharedState.map { state =>
         val connKey =
-          state.sparkContext.getHadoopConf.get.get(ConfVars.METASTORECONNECTURLKEY.varname)
+          SparkHadoopConf.get().get(ConfVars.METASTORECONNECTURLKEY.varname)
         ConfVars.METASTORECONNECTURLKEY.varname -> connKey
       }
 
     metastoreTempConf.foreach { case (k, v) =>
-      sc.getHadoopConf.get.set(k, v)
+      SparkHadoopConf.get().set(k, v)
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -102,7 +102,7 @@ private[hive] class TestHiveSharedState(
   override lazy val externalCatalog: ExternalCatalogWithListener = {
     new ExternalCatalogWithListener(new TestHiveExternalCatalog(
       sc.conf,
-      sc.hadoopConfiguration,
+      sc.getHadoopConf.get,
       hiveClient))
   }
 }
@@ -203,12 +203,12 @@ private[hive] class TestHiveSparkSession(
       // After session cloning, the JDBC connect string for a JDBC metastore should not be changed.
       existingSharedState.map { state =>
         val connKey =
-          state.sparkContext.hadoopConfiguration.get(ConfVars.METASTORECONNECTURLKEY.varname)
+          state.sparkContext.getHadoopConf.get.get(ConfVars.METASTORECONNECTURLKEY.varname)
         ConfVars.METASTORECONNECTURLKEY.varname -> connKey
       }
 
     metastoreTempConf.foreach { case (k, v) =>
-      sc.hadoopConfiguration.set(k, v)
+      sc.getHadoopConf.get.set(k, v)
     }
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -126,7 +126,7 @@ class StreamingContext private[streaming] (
   def this(path: String, sparkContext: SparkContext) = {
     this(
       sparkContext,
-      CheckpointReader.read(path, sparkContext.conf, SparkHadoopConf.get().get).orNull,
+      CheckpointReader.read(path, sparkContext.conf, SparkHadoopConf.get.conf).orNull,
       null)
   }
 
@@ -237,7 +237,7 @@ class StreamingContext private[streaming] (
   def checkpoint(directory: String) {
     if (directory != null) {
       val path = new Path(directory)
-      val fs = path.getFileSystem(SparkHadoopConf.get().get)
+      val fs = path.getFileSystem(SparkHadoopConf.get.conf)
       fs.mkdirs(path)
       val fullPath = fs.getFileStatus(path).getPath().toString
       sc.setCheckpointDir(fullPath)
@@ -434,7 +434,7 @@ class StreamingContext private[streaming] (
   def binaryRecordsStream(
       directory: String,
       recordLength: Int): DStream[Array[Byte]] = withNamedScope("binary records stream") {
-    val conf = SparkHadoopConf.get().get
+    val conf = SparkHadoopConf.get.conf
     conf.setInt(FixedLengthBinaryInputFormat.RECORD_LENGTH_PROPERTY, recordLength)
     val br = fileStream[LongWritable, BytesWritable, FixedLengthBinaryInputFormat](
       directory, FileInputDStream.defaultFilter: Path => Boolean, newFilesOnly = true, conf)

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -126,7 +126,7 @@ class StreamingContext private[streaming] (
   def this(path: String, sparkContext: SparkContext) = {
     this(
       sparkContext,
-      CheckpointReader.read(path, sparkContext.conf, sparkContext.hadoopConfiguration).orNull,
+      CheckpointReader.read(path, sparkContext.conf, sparkContext.getHadoopConf.get).orNull,
       null)
   }
 
@@ -237,7 +237,7 @@ class StreamingContext private[streaming] (
   def checkpoint(directory: String) {
     if (directory != null) {
       val path = new Path(directory)
-      val fs = path.getFileSystem(sparkContext.hadoopConfiguration)
+      val fs = path.getFileSystem(sparkContext.getHadoopConf.get)
       fs.mkdirs(path)
       val fullPath = fs.getFileStatus(path).getPath().toString
       sc.setCheckpointDir(fullPath)
@@ -434,7 +434,7 @@ class StreamingContext private[streaming] (
   def binaryRecordsStream(
       directory: String,
       recordLength: Int): DStream[Array[Byte]] = withNamedScope("binary records stream") {
-    val conf = _sc.hadoopConfiguration
+    val conf = _sc.getHadoopConf.get
     conf.setInt(FixedLengthBinaryInputFormat.RECORD_LENGTH_PROPERTY, recordLength)
     val br = fileStream[LongWritable, BytesWritable, FixedLengthBinaryInputFormat](
       directory, FileInputDStream.defaultFilter: Path => Boolean, newFilesOnly = true, conf)

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -126,7 +126,7 @@ class StreamingContext private[streaming] (
   def this(path: String, sparkContext: SparkContext) = {
     this(
       sparkContext,
-      CheckpointReader.read(path, sparkContext.conf, sparkContext.getHadoopConf.get).orNull,
+      CheckpointReader.read(path, sparkContext.conf, SparkHadoopConf.get().get).orNull,
       null)
   }
 
@@ -237,7 +237,7 @@ class StreamingContext private[streaming] (
   def checkpoint(directory: String) {
     if (directory != null) {
       val path = new Path(directory)
-      val fs = path.getFileSystem(sparkContext.getHadoopConf.get)
+      val fs = path.getFileSystem(SparkHadoopConf.get().get)
       fs.mkdirs(path)
       val fullPath = fs.getFileStatus(path).getPath().toString
       sc.setCheckpointDir(fullPath)
@@ -434,7 +434,7 @@ class StreamingContext private[streaming] (
   def binaryRecordsStream(
       directory: String,
       recordLength: Int): DStream[Array[Byte]] = withNamedScope("binary records stream") {
-    val conf = _sc.getHadoopConf.get
+    val conf = SparkHadoopConf.get().get
     conf.setInt(FixedLengthBinaryInputFormat.RECORD_LENGTH_PROPERTY, recordLength)
     val br = fileStream[LongWritable, BytesWritable, FixedLengthBinaryInputFormat](
       directory, FileInputDStream.defaultFilter: Path => Boolean, newFilesOnly = true, conf)

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaPairDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaPairDStream.scala
@@ -823,7 +823,7 @@ class JavaPairDStream[K, V](val dstream: DStream[(K, V)])(
       keyClass: Class[_],
       valueClass: Class[_],
       outputFormatClass: Class[F],
-      conf: Configuration = SparkHadoopConf.get().get) {
+      conf: Configuration = SparkHadoopConf.get.conf) {
     dstream.saveAsNewAPIHadoopFiles(prefix, suffix, keyClass, valueClass, outputFormatClass, conf)
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaPairDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaPairDStream.scala
@@ -29,13 +29,12 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapred.{JobConf, OutputFormat}
 import org.apache.hadoop.mapreduce.{OutputFormat => NewOutputFormat}
 
-import org.apache.spark.Partitioner
+import org.apache.spark.{Partitioner, SparkHadoopConf}
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.api.java.{JavaPairRDD, JavaSparkContext, JavaUtils, Optional}
 import org.apache.spark.api.java.JavaPairRDD._
 import org.apache.spark.api.java.JavaSparkContext.fakeClassTag
-import org.apache.spark.api.java.function.{FlatMapFunction, Function => JFunction,
-  Function2 => JFunction2}
+import org.apache.spark.api.java.function.{FlatMapFunction, Function => JFunction, Function2 => JFunction2}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming._
@@ -824,7 +823,7 @@ class JavaPairDStream[K, V](val dstream: DStream[(K, V)])(
       keyClass: Class[_],
       valueClass: Class[_],
       outputFormatClass: Class[F],
-      conf: Configuration = dstream.context.sparkContext.getHadoopConf.get) {
+      conf: Configuration = SparkHadoopConf.get().get) {
     dstream.saveAsNewAPIHadoopFiles(prefix, suffix, keyClass, valueClass, outputFormatClass, conf)
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaPairDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaPairDStream.scala
@@ -824,7 +824,7 @@ class JavaPairDStream[K, V](val dstream: DStream[(K, V)])(
       keyClass: Class[_],
       valueClass: Class[_],
       outputFormatClass: Class[F],
-      conf: Configuration = dstream.context.sparkContext.hadoopConfiguration) {
+      conf: Configuration = dstream.context.sparkContext.getHadoopConf.get) {
     dstream.saveAsNewAPIHadoopFiles(prefix, suffix, keyClass, valueClass, outputFormatClass, conf)
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStreamCheckpointData.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStreamCheckpointData.scala
@@ -86,7 +86,7 @@ class DStreamCheckpointData[T: ClassTag](dstream: DStream[T])
             try {
               val path = new Path(file)
               if (fileSystem == null) {
-                fileSystem = path.getFileSystem(SparkHadoopConf.get().get)
+                fileSystem = path.getFileSystem(SparkHadoopConf.get.conf)
               }
               if (fileSystem.delete(path, true)) {
                 logInfo("Deleted checkpoint file '" + file + "' for time " + time)

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStreamCheckpointData.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStreamCheckpointData.scala
@@ -24,6 +24,7 @@ import scala.reflect.ClassTag
 
 import org.apache.hadoop.fs.{FileSystem, Path}
 
+import org.apache.spark.SparkHadoopConf
 import org.apache.spark.internal.Logging
 import org.apache.spark.streaming.Time
 import org.apache.spark.util.Utils
@@ -85,7 +86,7 @@ class DStreamCheckpointData[T: ClassTag](dstream: DStream[T])
             try {
               val path = new Path(file)
               if (fileSystem == null) {
-                fileSystem = path.getFileSystem(dstream.ssc.sparkContext.getHadoopConf.get)
+                fileSystem = path.getFileSystem(SparkHadoopConf.get().get)
               }
               if (fileSystem.delete(path, true)) {
                 logInfo("Deleted checkpoint file '" + file + "' for time " + time)

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStreamCheckpointData.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStreamCheckpointData.scala
@@ -85,7 +85,7 @@ class DStreamCheckpointData[T: ClassTag](dstream: DStream[T])
             try {
               val path = new Path(file)
               if (fileSystem == null) {
-                fileSystem = path.getFileSystem(dstream.ssc.sparkContext.hadoopConfiguration)
+                fileSystem = path.getFileSystem(dstream.ssc.sparkContext.getHadoopConf.get)
               }
               if (fileSystem.delete(path, true)) {
                 logInfo("Deleted checkpoint file '" + file + "' for time " + time)

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
@@ -26,6 +26,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 import org.apache.hadoop.mapreduce.{InputFormat => NewInputFormat}
 
+import org.apache.spark.SparkHadoopConf
 import org.apache.spark.rdd.{RDD, UnionRDD}
 import org.apache.spark.streaming._
 import org.apache.spark.streaming.scheduler.StreamInputInfo
@@ -302,7 +303,7 @@ class FileInputDStream[K, V, F <: NewInputFormat[K, V]](
   }
 
   private def fs: FileSystem = {
-    if (_fs == null) _fs = directoryPath.getFileSystem(ssc.sparkContext.getHadoopConf.get)
+    if (_fs == null) _fs = directoryPath.getFileSystem(SparkHadoopConf.get().get)
     _fs
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
@@ -303,7 +303,7 @@ class FileInputDStream[K, V, F <: NewInputFormat[K, V]](
   }
 
   private def fs: FileSystem = {
-    if (_fs == null) _fs = directoryPath.getFileSystem(SparkHadoopConf.get().get)
+    if (_fs == null) _fs = directoryPath.getFileSystem(SparkHadoopConf.get.conf)
     _fs
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
@@ -302,7 +302,7 @@ class FileInputDStream[K, V, F <: NewInputFormat[K, V]](
   }
 
   private def fs: FileSystem = {
-    if (_fs == null) _fs = directoryPath.getFileSystem(ssc.sparkContext.hadoopConfiguration)
+    if (_fs == null) _fs = directoryPath.getFileSystem(ssc.sparkContext.getHadoopConf.get)
     _fs
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/PairDStreamFunctions.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/PairDStreamFunctions.scala
@@ -755,7 +755,7 @@ class PairDStreamFunctions[K, V](self: DStream[(K, V)])
       keyClass: Class[_],
       valueClass: Class[_],
       outputFormatClass: Class[_ <: OutputFormat[_, _]],
-      conf: JobConf = new JobConf(ssc.sparkContext.hadoopConfiguration)
+      conf: JobConf = new JobConf(ssc.sparkContext.getHadoopConf.get)
     ): Unit = ssc.withScope {
     // Wrap conf in SerializableWritable so that ForeachDStream can be serialized for checkpoints
     val serializableConf = new SerializableJobConf(conf)
@@ -789,7 +789,7 @@ class PairDStreamFunctions[K, V](self: DStream[(K, V)])
       keyClass: Class[_],
       valueClass: Class[_],
       outputFormatClass: Class[_ <: NewOutputFormat[_, _]],
-      conf: Configuration = ssc.sparkContext.hadoopConfiguration
+      conf: Configuration = ssc.sparkContext.getHadoopConf.get
     ): Unit = ssc.withScope {
     // Wrap conf in SerializableWritable so that ForeachDStream can be serialized for checkpoints
     val serializableConf = new SerializableConfiguration(conf)

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/PairDStreamFunctions.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/PairDStreamFunctions.scala
@@ -755,7 +755,7 @@ class PairDStreamFunctions[K, V](self: DStream[(K, V)])
       keyClass: Class[_],
       valueClass: Class[_],
       outputFormatClass: Class[_ <: OutputFormat[_, _]],
-      conf: JobConf = new JobConf(SparkHadoopConf.get().get)
+      conf: JobConf = new JobConf(SparkHadoopConf.get.conf)
     ): Unit = ssc.withScope {
     // Wrap conf in SerializableWritable so that ForeachDStream can be serialized for checkpoints
     val serializableConf = new SerializableJobConf(conf)
@@ -789,7 +789,7 @@ class PairDStreamFunctions[K, V](self: DStream[(K, V)])
       keyClass: Class[_],
       valueClass: Class[_],
       outputFormatClass: Class[_ <: NewOutputFormat[_, _]],
-      conf: Configuration = SparkHadoopConf.get().get
+      conf: Configuration = SparkHadoopConf.get.conf
     ): Unit = ssc.withScope {
     // Wrap conf in SerializableWritable so that ForeachDStream can be serialized for checkpoints
     val serializableConf = new SerializableConfiguration(conf)

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/PairDStreamFunctions.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/PairDStreamFunctions.scala
@@ -24,7 +24,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapred.{JobConf, OutputFormat}
 import org.apache.hadoop.mapreduce.{OutputFormat => NewOutputFormat}
 
-import org.apache.spark.{HashPartitioner, Partitioner}
+import org.apache.spark.{HashPartitioner, Partitioner, SparkHadoopConf}
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming._
@@ -755,7 +755,7 @@ class PairDStreamFunctions[K, V](self: DStream[(K, V)])
       keyClass: Class[_],
       valueClass: Class[_],
       outputFormatClass: Class[_ <: OutputFormat[_, _]],
-      conf: JobConf = new JobConf(ssc.sparkContext.getHadoopConf.get)
+      conf: JobConf = new JobConf(SparkHadoopConf.get().get)
     ): Unit = ssc.withScope {
     // Wrap conf in SerializableWritable so that ForeachDStream can be serialized for checkpoints
     val serializableConf = new SerializableJobConf(conf)
@@ -789,7 +789,7 @@ class PairDStreamFunctions[K, V](self: DStream[(K, V)])
       keyClass: Class[_],
       valueClass: Class[_],
       outputFormatClass: Class[_ <: NewOutputFormat[_, _]],
-      conf: Configuration = ssc.sparkContext.getHadoopConf.get
+      conf: Configuration = SparkHadoopConf.get().get
     ): Unit = ssc.withScope {
     // Wrap conf in SerializableWritable so that ForeachDStream can be serialized for checkpoints
     val serializableConf = new SerializableConfiguration(conf)

--- a/streaming/src/main/scala/org/apache/spark/streaming/rdd/WriteAheadLogBackedBlockRDD.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/rdd/WriteAheadLogBackedBlockRDD.scala
@@ -93,7 +93,7 @@ class WriteAheadLogBackedBlockRDD[T: ClassTag](
       s" same as number of block Ids (${_blockIds.length})")
 
   // Hadoop configuration is not serializable, so broadcast it as a serializable.
-  @transient private val hadoopConfig = sc.hadoopConfiguration
+  @transient private val hadoopConfig = sc.getHadoopConf.get
   private val broadcastedHadoopConf = new SerializableConfiguration(hadoopConfig)
 
   override def isValid(): Boolean = true

--- a/streaming/src/main/scala/org/apache/spark/streaming/rdd/WriteAheadLogBackedBlockRDD.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/rdd/WriteAheadLogBackedBlockRDD.scala
@@ -93,7 +93,7 @@ class WriteAheadLogBackedBlockRDD[T: ClassTag](
       s" same as number of block Ids (${_blockIds.length})")
 
   // Hadoop configuration is not serializable, so broadcast it as a serializable.
-  @transient private val hadoopConfig = sc.getHadoopConf.get
+  @transient private val hadoopConfig = SparkHadoopConf.get().get
   private val broadcastedHadoopConf = new SerializableConfiguration(hadoopConfig)
 
   override def isValid(): Boolean = true

--- a/streaming/src/main/scala/org/apache/spark/streaming/rdd/WriteAheadLogBackedBlockRDD.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/rdd/WriteAheadLogBackedBlockRDD.scala
@@ -93,7 +93,7 @@ class WriteAheadLogBackedBlockRDD[T: ClassTag](
       s" same as number of block Ids (${_blockIds.length})")
 
   // Hadoop configuration is not serializable, so broadcast it as a serializable.
-  @transient private val hadoopConfig = SparkHadoopConf.get().get
+  @transient private val hadoopConfig = SparkHadoopConf.get.conf
   private val broadcastedHadoopConf = new SerializableConfiguration(hadoopConfig)
 
   override def isValid(): Boolean = true

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit
 
 import scala.util.{Failure, Success, Try}
 
+import org.apache.spark.SparkHadoopConf
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming.{Checkpoint, CheckpointWriter, Time}
@@ -67,7 +68,7 @@ class JobGenerator(jobScheduler: JobScheduler) extends Logging {
   private lazy val shouldCheckpoint = ssc.checkpointDuration != null && ssc.checkpointDir != null
 
   private lazy val checkpointWriter = if (shouldCheckpoint) {
-    new CheckpointWriter(this, ssc.conf, ssc.checkpointDir, ssc.sparkContext.getHadoopConf.get)
+    new CheckpointWriter(this, ssc.conf, ssc.checkpointDir, SparkHadoopConf.get().get)
   } else {
     null
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
@@ -68,7 +68,7 @@ class JobGenerator(jobScheduler: JobScheduler) extends Logging {
   private lazy val shouldCheckpoint = ssc.checkpointDuration != null && ssc.checkpointDir != null
 
   private lazy val checkpointWriter = if (shouldCheckpoint) {
-    new CheckpointWriter(this, ssc.conf, ssc.checkpointDir, SparkHadoopConf.get().get)
+    new CheckpointWriter(this, ssc.conf, ssc.checkpointDir, SparkHadoopConf.get.conf)
   } else {
     null
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
@@ -67,7 +67,7 @@ class JobGenerator(jobScheduler: JobScheduler) extends Logging {
   private lazy val shouldCheckpoint = ssc.checkpointDuration != null && ssc.checkpointDir != null
 
   private lazy val checkpointWriter = if (shouldCheckpoint) {
-    new CheckpointWriter(this, ssc.conf, ssc.checkpointDir, ssc.sparkContext.hadoopConfiguration)
+    new CheckpointWriter(this, ssc.conf, ssc.checkpointDir, ssc.sparkContext.getHadoopConf.get)
   } else {
     null
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
@@ -107,7 +107,7 @@ class ReceiverTracker(ssc: StreamingContext, skipReceiverLaunch: Boolean = false
   private val receiverInputStreamIds = receiverInputStreams.map { _.id }
   private val receivedBlockTracker = new ReceivedBlockTracker(
     ssc.sparkContext.conf,
-    ssc.sparkContext.getHadoopConf.get,
+    SparkHadoopConf.get().get,
     receiverInputStreamIds,
     ssc.scheduler.clock,
     ssc.isCheckpointPresent,
@@ -579,7 +579,7 @@ class ReceiverTracker(ssc: StreamingContext, skipReceiverLaunch: Boolean = false
 
       val checkpointDirOption = Option(ssc.checkpointDir)
       val serializableHadoopConf =
-        new SerializableConfiguration(ssc.sparkContext.getHadoopConf.get)
+        new SerializableConfiguration(SparkHadoopConf.get().get)
 
       // Function to start the receiver on the worker node
       val startReceiverFunc: Iterator[Receiver[_]] => Unit =

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
@@ -107,7 +107,7 @@ class ReceiverTracker(ssc: StreamingContext, skipReceiverLaunch: Boolean = false
   private val receiverInputStreamIds = receiverInputStreams.map { _.id }
   private val receivedBlockTracker = new ReceivedBlockTracker(
     ssc.sparkContext.conf,
-    SparkHadoopConf.get().get,
+    SparkHadoopConf.get.conf,
     receiverInputStreamIds,
     ssc.scheduler.clock,
     ssc.isCheckpointPresent,
@@ -579,7 +579,7 @@ class ReceiverTracker(ssc: StreamingContext, skipReceiverLaunch: Boolean = false
 
       val checkpointDirOption = Option(ssc.checkpointDir)
       val serializableHadoopConf =
-        new SerializableConfiguration(SparkHadoopConf.get().get)
+        new SerializableConfiguration(SparkHadoopConf.get.conf)
 
       // Function to start the receiver on the worker node
       val startReceiverFunc: Iterator[Receiver[_]] => Unit =

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
@@ -107,7 +107,7 @@ class ReceiverTracker(ssc: StreamingContext, skipReceiverLaunch: Boolean = false
   private val receiverInputStreamIds = receiverInputStreams.map { _.id }
   private val receivedBlockTracker = new ReceivedBlockTracker(
     ssc.sparkContext.conf,
-    ssc.sparkContext.hadoopConfiguration,
+    ssc.sparkContext.getHadoopConf.get,
     receiverInputStreamIds,
     ssc.scheduler.clock,
     ssc.isCheckpointPresent,
@@ -579,7 +579,7 @@ class ReceiverTracker(ssc: StreamingContext, skipReceiverLaunch: Boolean = false
 
       val checkpointDirOption = Option(ssc.checkpointDir)
       val serializableHadoopConf =
-        new SerializableConfiguration(ssc.sparkContext.hadoopConfiguration)
+        new SerializableConfiguration(ssc.sparkContext.getHadoopConf.get)
 
       // Function to start the receiver on the worker node
       val startReceiverFunc: Iterator[Receiver[_]] => Unit =

--- a/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
@@ -258,7 +258,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
 
       withStreamingContext(new StreamingContext(conf, batchDuration)) { ssc =>
         val sparkContext = ssc.sparkContext
-        val hc = sparkContext.hadoopConfiguration
+        val hc = sparkContext.getHadoopConf.get
         val fs = FileSystem.get(testPath.toUri, hc)
 
         fs.delete(testPath, true)

--- a/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
@@ -259,7 +259,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
 
       withStreamingContext(new StreamingContext(conf, batchDuration)) { ssc =>
         val sparkContext = ssc.sparkContext
-        val hc = SparkHadoopConf.get().get
+        val hc = SparkHadoopConf.get.conf
         val fs = FileSystem.get(testPath.toUri, hc)
 
         fs.delete(testPath, true)

--- a/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
@@ -35,6 +35,7 @@ import org.scalatest.Assertions
 import org.scalatest.BeforeAndAfter
 import org.scalatest.concurrent.Eventually._
 
+import org.apache.spark.SparkHadoopConf
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
@@ -258,7 +259,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
 
       withStreamingContext(new StreamingContext(conf, batchDuration)) { ssc =>
         val sparkContext = ssc.sparkContext
-        val hc = sparkContext.getHadoopConf.get
+        val hc = SparkHadoopConf.get().get
         val fs = FileSystem.get(testPath.toUri, hc)
 
         fs.delete(testPath, true)


### PR DESCRIPTION
## What changes were proposed in this pull request?

hadoopConf can be accessed via `SparkContext.hadoopConfiguration` from both user code and Spark internal. The configuration is mainly used to read files from hadoop-supported file system(eg. get URI/get FileSystem/add security credentials/get metastore connect url/etc.)
We shall keep a global config that users can set and use that to track the hadoop configurations.

This pr implements it with three main features showed below:

* using ThreadLocal to track Hadoop Configuration, so that concurrent jobs could use their own Hadoop Configurations

* provide set method by wrapping a Hadoop Configuration to allow user to modify Hadoop Configuration globally

* provide SparkContext.withHadoopConf(){} method to allow user to modify Hadoop Configuration temporary

## How was this patch tested?

TODO
