### PR TITLE
[SPARK-27636][MLLIB]Remove cached RDD blocks after PIC execution

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/PowerIterationClustering.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/PowerIterationClustering.scala
@@ -207,10 +207,9 @@ class PowerIterationClustering private[clustering] (
       case "random" => randomInit(w)
       case "degree" => initDegreeVector(w)
     }
-
-   // Materialized the graph w0 in randomInit/initDegreeVector, hence we can unpersist w.
-   w.unpersist()
-   pic(w0)
+    // Materialized the graph w0 in randomInit/initDegreeVector, hence we can unpersist w.
+    w.unpersist()
+    pic(w0)
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/PowerIterationClustering.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/PowerIterationClustering.scala
@@ -184,7 +184,6 @@ class PowerIterationClustering private[clustering] (
       case "degree" => initDegreeVector(w)
     }
     // Materialized the graph w0 in randomInit/initDegreeVector, hence we can unpersist w.
-    materialize(w0)
     w.unpersist()
     pic(w0)
   }
@@ -210,7 +209,6 @@ class PowerIterationClustering private[clustering] (
     }
 
    // Materialized the graph w0 in randomInit/initDegreeVector, hence we can unpersist w.
-   materialize(w0)
    w.unpersist()
    pic(w0)
   }

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/PowerIterationClustering.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/PowerIterationClustering.scala
@@ -417,13 +417,10 @@ object PowerIterationClustering extends Logging {
       v.unpersist()
       prevDelta = delta
     }
-    val eigenVectorRDD = curG.vertices.cache()
-    // materialize the eigen vector RDD and unpersist the graph
-    eigenVectorRDD.count()
-    curG.vertices.unpersist()
+
     curG.edges.unpersist()
 
-    eigenVectorRDD
+    curG.vertices
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/PowerIterationClustering.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/PowerIterationClustering.scala
@@ -183,6 +183,9 @@ class PowerIterationClustering private[clustering] (
       case "random" => randomInit(w)
       case "degree" => initDegreeVector(w)
     }
+    // Materialized the graph w0 in randomInit/initDegreeVector, hence we can unpersist w.
+    materialize(w0)
+    w.unpersist()
     pic(w0)
   }
 
@@ -205,7 +208,11 @@ class PowerIterationClustering private[clustering] (
       case "random" => randomInit(w)
       case "degree" => initDegreeVector(w)
     }
-    pic(w0)
+
+   // Materialized the graph w0 in randomInit/initDegreeVector, hence we can unpersist w.
+   materialize(w0)
+   w.unpersist()
+   pic(w0)
   }
 
   /**
@@ -326,7 +333,6 @@ object PowerIterationClustering extends Logging {
     val v0 = r.mapValues(x => x / sum)
     val graph = Graph(VertexRDD(v0), g.edges)
     materialize(graph)
-    g.unpersist()
     r.unpersist()
     graph
   }
@@ -345,7 +351,6 @@ object PowerIterationClustering extends Logging {
     val v0 = g.vertices.mapValues(_ / sum)
     val graph = Graph(VertexRDD(v0), g.edges)
     materialize(graph)
-    g.unpersist()
     graph
   }
 
@@ -414,8 +419,13 @@ object PowerIterationClustering extends Logging {
       v.unpersist()
       prevDelta = delta
     }
+    val eigenVectorRDD = curG.vertices.cache()
+    // materialize the eigen vector RDD and unpersist the graph
+    eigenVectorRDD.count()
+    curG.vertices.unpersist()
     curG.edges.unpersist()
-    curG.vertices
+
+    eigenVectorRDD
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/PowerIterationClustering.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/PowerIterationClustering.scala
@@ -443,8 +443,8 @@ object PowerIterationClustering extends Logging {
   }
 
   /**
-    * Forces materialization of a Graph by iterating its RDDs.
-    */
+   * Forces materialization of a Graph by iterating its RDDs.
+   */
   private def materialize(g: Graph[_, _]): Unit = {
     g.edges.foreachPartition(_ => {})
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Test steps to reproduce:

1) bin/spark-shell
```
val dataset = spark.createDataFrame(Seq(
                                    (0L, 1L, 1.0),
                                    (1L,2L,1.0),
                                    (3L, 4L,1.0),
                                    (4L,0L,0.1))).toDF("src", "dst", "weight")

val model = new PowerIterationClustering().
                           setMaxIter(10).
                           setInitMode("degree").
                          setWeightCol("weight")

val prediction = model.assignClusters(dataset).select("id", "cluster")
```

2) Open storage tab of the UI. We can see many RDD block cached, even after running the PIC.

In this PR, basically materializes the new graph before unpersisting the old ones. 
## How was this patch tested?
Manually tested and existing UTs.
Before patch:
![Screenshot from 2019-05-06 02-53-45](https://user-images.githubusercontent.com/23054875/57201033-daf61b80-6fb0-11e9-97ff-7534909ce2d3.png)

After patch:
![Screenshot from 2019-05-06 03-41-04](https://user-images.githubusercontent.com/23054875/57201043-07aa3300-6fb1-11e9-855b-f63ee18ea371.png)


