### PR TITLE
[SPARK-27646] [SQL] [WIP] Required refactoring for bytecode analysis

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -19,6 +19,7 @@ package org.apache.spark.util
 
 import java.io._
 import java.lang.{Byte => JByte}
+import java.lang.invoke.SerializedLambda
 import java.lang.management.{LockInfo, ManagementFactory, MonitorInfo, ThreadInfo}
 import java.lang.reflect.InvocationTargetException
 import java.math.{MathContext, RoundingMode}
@@ -2885,6 +2886,39 @@ private[spark] object Utils extends Logging {
   /** Returns whether the URI is a "local:" URI. */
   def isLocalUri(uri: String): Boolean = {
     uri.startsWith(s"$LOCAL_SCHEME:")
+  }
+
+  /**
+   * Try to get a serialized Lambda from the closure.
+   *
+   * @param closure the closure to check.
+   */
+  def getSerializedLambda(closure: AnyRef): Option[SerializedLambda] = {
+    def inspect(closure: AnyRef): SerializedLambda = {
+      val writeReplace = closure.getClass.getDeclaredMethod("writeReplace")
+      writeReplace.setAccessible(true)
+      writeReplace.invoke(closure).asInstanceOf[java.lang.invoke.SerializedLambda]
+    }
+
+    val isClosureCandidate =
+      closure.getClass.isSynthetic &&
+        closure
+          .getClass
+          .getInterfaces.exists(_.getName == "scala.Serializable")
+
+    if (isClosureCandidate) {
+      try {
+        Option(inspect(closure))
+      } catch {
+        case e: Exception =>
+          // no need to check if debug is enabled here the Spark
+          // logging api covers this.
+          logDebug("Closure is not a serialized lambda.", e)
+          None
+      }
+    } else {
+      None
+    }
   }
 }
 

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -96,7 +96,7 @@ jackson-module-scala_2.12-2.9.8.jar
 jackson-xc-1.9.13.jar
 jakarta.xml.bind-api-2.3.2.jar
 janino-3.0.11.jar
-javassist-3.18.1-GA.jar
+javassist-3.25.0-GA.jar
 javax.annotation-api-1.2.jar
 javax.inject-1.jar
 javax.inject-2.4.0-b34.jar

--- a/dev/deps/spark-deps-hadoop-3.2
+++ b/dev/deps/spark-deps-hadoop-3.2
@@ -98,7 +98,7 @@ jackson-module-paranamer-2.9.8.jar
 jackson-module-scala_2.12-2.9.8.jar
 jakarta.xml.bind-api-2.3.2.jar
 janino-3.0.11.jar
-javassist-3.18.1-GA.jar
+javassist-3.25.0-GA.jar
 javax.annotation-api-1.2.jar
 javax.inject-1.jar
 javax.inject-2.4.0-b34.jar

--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -114,6 +114,11 @@
       <version>2.7.3</version>
       <type>jar</type>
     </dependency>
+    <dependency>
+      <groupId>org.javassist</groupId>
+      <artifactId>javassist</artifactId>
+      <version>3.25.0-GA</version>
+    </dependency>
   </dependencies>
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
-
 /**
  * A helper trait to create [[org.apache.spark.sql.catalyst.encoders.ExpressionEncoder]]s
  * for classes whose fields are entirely defined by constructor params but should not be
@@ -622,6 +621,14 @@ object ScalaReflection extends ScalaReflection {
 
   /** Returns a catalyst DataType and its nullability for the given Scala Type using reflection. */
   def schemaFor[T: TypeTag]: Schema = schemaFor(localTypeOf[T])
+
+  /** Returns a catalyst DataType and its nullability for the given Scala class using reflection. */
+  def schemaFor(cls: Class[_]): Schema = schemaFor {
+    // ClassTag
+    val m = runtimeMirror(cls.getClassLoader)
+    val classSymbol = m.classSymbol(cls)
+    classSymbol.toType
+  }
 
   /** Returns a catalyst DataType and its nullability for the given Scala Type using reflection. */
   def schemaFor(tpe: `Type`): Schema = cleanUpReflectionObjects {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is the part of the essential changes in Spark to make **[SPARK-14083] Basic bytecode analyzer to speed up Datasets** work as an external module without copying and pasting. 

1. Makes `getSerializedLambda` public so bytecode analysis can use the same implementation.
2. `def schemaFor[T](clazz: Class[T]): Schema` is implemented in this PR.
3. `org.javassist` which Spark implicitly depends on from Jersey is now an explicit dependency and pined to latest version.

This PR is based on https://github.com/apache/spark/pull/24515 with more tests; it's a collaboration work with @aokolnychyi

## How was this patch tested?

More tests are added.