### PR TITLE
[SPARK-27650][SQL] separate the row iterator functionality from ColumnarBatch

### DIFF
--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -321,7 +321,11 @@ object MimaExcludes {
 
     // [SPARK-26616][MLlib] Expose document frequency in IDFModel
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.mllib.feature.IDFModel.this"),
-    ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.spark.mllib.feature.IDF#DocumentFrequencyAggregator.idf")
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.spark.mllib.feature.IDF#DocumentFrequencyAggregator.idf"),
+
+    // [SPARK-27650][SQL] sepate the row iterator functionality from ColumnarBatch
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.vectorized.ColumnarBatch.getRow"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.vectorized.ColumnarBatch.rowIterator")
   )
 
   // Exclude rules for 2.4.x

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -323,7 +323,7 @@ object MimaExcludes {
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.mllib.feature.IDFModel.this"),
     ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.spark.mllib.feature.IDF#DocumentFrequencyAggregator.idf"),
 
-    // [SPARK-27650][SQL] sepate the row iterator functionality from ColumnarBatch
+    // [SPARK-27650][SQL] separate the row iterator functionality from ColumnarBatch
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.vectorized.ColumnarBatch.getRow"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.vectorized.ColumnarBatch.rowIterator")
   )

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnarBatchRowView.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnarBatchRowView.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.vectorized;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * This class provides a row view of a {@link ColumnarBatch}, so that Spark can access the data
+ * row by row
+ */
+public final class ColumnarBatchRowView {
+
+  private final ColumnarBatch batch;
+
+  // Staging row returned from `getRow`.
+  private final MutableColumnarRow row;
+
+  public ColumnarBatchRowView(ColumnarBatch batch) {
+    this.batch = batch;
+    this.row = new MutableColumnarRow(batch.columns());
+  }
+
+  /**
+   * Returns an iterator over the rows in this batch.
+   */
+  public Iterator<InternalRow> rowIterator() {
+    final int maxRows = batch.numRows();
+    final MutableColumnarRow row = new MutableColumnarRow(batch.columns());
+    return new Iterator<InternalRow>() {
+      int rowId = 0;
+
+      @Override
+      public boolean hasNext() {
+        return rowId < maxRows;
+      }
+
+      @Override
+      public InternalRow next() {
+        if (rowId >= maxRows) {
+          throw new NoSuchElementException();
+        }
+        row.rowId = rowId++;
+        return row;
+      }
+
+      @Override
+      public void remove() {
+        throw new UnsupportedOperationException();
+      }
+    };
+  }
+
+  /**
+   * Returns the row in this batch at `rowId`. Returned row is reused across calls.
+   */
+  public InternalRow getRow(int rowId) {
+    assert(rowId >= 0 && rowId < batch.numRows());
+    row.rowId = rowId;
+    return row;
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/VectorizedHashMapGenerator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/VectorizedHashMapGenerator.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.aggregate
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator}
-import org.apache.spark.sql.execution.vectorized.{MutableColumnarRow, OnHeapColumnVector}
+import org.apache.spark.sql.execution.vectorized.{ColumnarBatchRowView, MutableColumnarRow, OnHeapColumnVector}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -212,7 +212,7 @@ class VectorizedHashMapGenerator(
     s"""
        |public java.util.Iterator<${classOf[InternalRow].getName}> rowIterator() {
        |  batch.setNumRows(numRows);
-       |  return batch.rowIterator();
+       |  return new ${classOf[ColumnarBatchRowView].getName}(batch).rowIterator();
        |}
      """.stripMargin
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowConverters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowConverters.scala
@@ -33,6 +33,7 @@ import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.vectorized.ColumnarBatchRowView
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch, ColumnVector}
 import org.apache.spark.util.{ByteBufferOutputStream, Utils}
@@ -172,7 +173,7 @@ private[sql] object ArrowConverters {
 
         val batch = new ColumnarBatch(columns)
         batch.setNumRows(root.getRowCount)
-        batch.rowIterator().asScala
+        new ColumnarBatchRowView(batch).rowIterator().asScala
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/AggregateInPandasExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/AggregateInPandasExec.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, ClusteredDistribution, Distribution, Partitioning}
 import org.apache.spark.sql.execution.{GroupedIterator, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.arrow.ArrowUtils
+import org.apache.spark.sql.execution.vectorized.ColumnarBatchRowView
 import org.apache.spark.sql.types.{DataType, StructField, StructType}
 import org.apache.spark.util.Utils
 
@@ -146,7 +147,7 @@ case class AggregateInPandasExec(
       val joined = new JoinedRow
       val resultProj = UnsafeProjection.create(resultExpressions, joinedAttributes)
 
-      columnarBatchIter.map(_.rowIterator.next()).map { aggOutputRow =>
+      columnarBatchIter.map(new ColumnarBatchRowView(_).getRow(0)).map { aggOutputRow =>
         val leftRow = queue.remove()
         val joinedRow = joined(leftRow, aggOutputRow)
         resultProj(joinedRow)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInPandasExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInPandasExec.scala
@@ -28,8 +28,9 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, ClusteredDistribution, Distribution, Partitioning}
 import org.apache.spark.sql.execution.{GroupedIterator, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.arrow.ArrowUtils
+import org.apache.spark.sql.execution.vectorized.ColumnarBatchRowView
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch, ColumnVector}
+import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch}
 
 /**
  * Physical node for [[org.apache.spark.sql.catalyst.plans.logical.FlatMapGroupsInPandas]]
@@ -154,7 +155,7 @@ case class FlatMapGroupsInPandasExec(
         val outputVectors = output.indices.map(structVector.getChild)
         val flattenedBatch = new ColumnarBatch(outputVectors.toArray)
         flattenedBatch.setNumRows(batch.numRows())
-        flattenedBatch.rowIterator.asScala
+        new ColumnarBatchRowView(flattenedBatch).rowIterator.asScala
       }.map(unsafeProj)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DataSourceReadBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DataSourceReadBenchmark.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.{DataFrame, DataFrameWriter, Row, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.execution.datasources.parquet.{SpecificParquetRecordReaderBase, VectorizedParquetRecordReader}
+import org.apache.spark.sql.execution.vectorized.ColumnarBatchRowView
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnVector
@@ -204,7 +205,7 @@ object DataSourceReadBenchmark extends BenchmarkBase with SQLHelper {
               reader.initialize(p, ("id" :: Nil).asJava)
               val batch = reader.resultBatch()
               while (reader.nextBatch()) {
-                val it = batch.rowIterator()
+                val it = new ColumnarBatchRowView(batch).rowIterator()
                 while (it.hasNext) {
                   val record = it.next()
                   if (!record.isNullAt(0)) aggregateValue(record)
@@ -459,7 +460,7 @@ object DataSourceReadBenchmark extends BenchmarkBase with SQLHelper {
               reader.initialize(p, ("c1" :: "c2" :: Nil).asJava)
               val batch = reader.resultBatch()
               while (reader.nextBatch()) {
-                val rowIterator = batch.rowIterator()
+                val rowIterator = new ColumnarBatchRowView(batch).rowIterator()
                 while (rowIterator.hasNext) {
                   val row = rowIterator.next()
                   val value = row.getUTF8String(0)


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ColumnarBatch` is user-facing, we should expose as fewer details as possible.

`ColumnarBatch` is used to carry the data from data source to Spark. Accessing the data in a row-wise style is not its responsibility.

This PR creates `ColumnarBatchRowView`, and moves the row iterator functionality from `ColumnarBatch` to `ColumnarBatchRowView`.

This PR avoids referring to internal classes(MutableColumnarRow) in `ColumnarBatch`, so that we can move DS v2 APIs to catalyst module later in https://github.com/apache/spark/pull/24416

## How was this patch tested?

existing tests