### PR TITLE
[SPARK-27655][SQL] Persistent the table statistics to metadata after fall back to hdfs

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
@@ -134,7 +134,8 @@ private[spark] object ThreadUtils {
    */
   def runInNewThread[T](
       threadName: String,
-      isDaemon: Boolean = true)(body: => T): T = {
+      isDaemon: Boolean = true,
+      isJoin: Boolean = true)(body: => T): T = {
     @volatile var exception: Option[Throwable] = None
     @volatile var result: T = null.asInstanceOf[T]
 
@@ -150,7 +151,9 @@ private[spark] object ThreadUtils {
     }
     thread.setDaemon(isDaemon)
     thread.start()
-    thread.join()
+    if (isJoin) {
+      thread.join()
+    }
 
     exception match {
       case Some(realException) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1162,6 +1162,14 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val ENABLE_PERSISTENT_STATS_AFTER_FALL_BACK =
+    buildConf("spark.sql.statistics.persistentStatsAfterFallBack")
+      .doc("Persistent the table statistics to metadata after fall back to hdfs." +
+        s"This configuration only has an effect when '${ENABLE_FALL_BACK_TO_HDFS_FOR_STATS.key}' " +
+        "is enabled.")
+      .booleanConf
+      .createWithDefault(false)
+
   val DEFAULT_SIZE_IN_BYTES = buildConf("spark.sql.defaultSizeInBytes")
     .internal()
     .doc("The default table size used in query planning. By default, it is set to Long.MaxValue " +
@@ -2078,6 +2086,9 @@ class SQLConf extends Serializable with Logging {
     getConf(SQLConf.PARALLEL_FILE_LISTING_IN_STATS_COMPUTATION)
 
   def fallBackToHdfsForStatsEnabled: Boolean = getConf(ENABLE_FALL_BACK_TO_HDFS_FOR_STATS)
+
+  def persistentStatsAfterFallBackEnabled: Boolean =
+    getConf(ENABLE_PERSISTENT_STATS_AFTER_FALL_BACK)
 
   def defaultSizeInBytes: Long = getConf(DEFAULT_SIZE_IN_BYTES)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

It's a real case. We need to join many times from different tables, but the statistics of some tables are incorrect. So this job need 43 min. It only need 3.7 min after `set spark.sql.statistics.persistentStatsAfterFallBack=true`. But the newly calculated statistics just for this SparkSession. So we need to recalculate statistics in the next time we start a new SparkSession.
This PR adds a switch to start a new thread to persistent statistics to the Hive metastore.

This is our job:

-  default(spark.sql.statistics.persistentStatsAfterFallBack=false):
![image](https://issues.apache.org/jira/secure/attachment/12968145/disableFallBackToHdfs.png)
-  spark.sql.statistics.persistentStatsAfterFallBack=true:
![image](https://issues.apache.org/jira/secure/attachment/12968144/enableFallBackToHdfs.png)
## How was this patch tested?

unit tests and manual tests