### PR TITLE
[SPARK-27604][SQL] Enhance constant propagation

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ConstantPropagationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ConstantPropagationSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.internal.SQLConf
 
 /**
  * Unit tests for constant propagation in expressions.
@@ -40,12 +41,13 @@ class ConstantPropagationSuite extends PlanTest {
           BooleanSimplification) :: Nil
   }
 
-  val testRelation = LocalRelation('a.int, 'b.int, 'c.int, 'd.int.notNull)
+  val testRelation = LocalRelation('a.int, 'b.int, 'c.int, 'd.int.notNull, 'e.int.notNull)
 
   private val columnA = 'a
   private val columnB = 'b
   private val columnC = 'c
   private val columnD = 'd
+  private val columnE = 'e
 
   test("basic test") {
     val query = testRelation
@@ -154,13 +156,11 @@ class ConstantPropagationSuite extends PlanTest {
 
   test("conflicting equality predicates") {
     val query = testRelation
-      .select(columnA)
       .where(
         columnA === Literal(1) && columnA === Literal(2) && columnB === Add(columnA, Literal(3)))
+      .analyze
 
-    val correctAnswer = testRelation
-      .select(columnA)
-      .where(columnA === Literal(1) && columnA === Literal(2) && columnB === Literal(5)).analyze
+    val correctAnswer = testRelation.where(Literal.FalseLiteral)
 
     comparePlans(Optimize.execute(query.analyze), correctAnswer)
   }
@@ -185,5 +185,95 @@ class ConstantPropagationSuite extends PlanTest {
       .where(true)
       .analyze
     comparePlans(Optimize.execute(query2), correctAnswer2)
+  }
+
+  test("Constant propagation in conflicting equalities") {
+    val query = testRelation
+      .select(columnA)
+      .where(columnA === Literal(1) && columnA === Literal(2))
+      .analyze
+    val correctAnswer = testRelation
+      .select(columnA)
+      .where(Literal.FalseLiteral)
+      .analyze
+    comparePlans(Optimize.execute(query), correctAnswer)
+  }
+
+  test("Enhanced constant propagation") {
+    def testSelect(expression: Expression, expected: Expression): Unit = {
+      val plan = testRelation.select(expression.as("x")).analyze
+      val expectedPlan = testRelation.select(expected.as("x")).analyze
+      comparePlans(Optimize.execute(plan), expectedPlan)
+    }
+
+    def testFilter(expression: Expression, expected: Expression): Unit = {
+      val plan = testRelation.select(columnA).where(expression).analyze
+      val expectedPlan = testRelation.select(columnA).where(expected).analyze
+      comparePlans(Optimize.execute(plan), expectedPlan)
+    }
+
+    val nullable =
+      abs(columnA) === Literal(1) && columnB === Literal(1) && abs(columnA) <= columnB
+    val reducedNullable = abs(columnA) === Literal(1) && columnB === Literal(1)
+
+    val nonNullable =
+      abs(columnD) === Literal(1) && columnE === Literal(1) && abs(columnD) <= columnE
+    val reducedNonNullable = abs(columnD) === Literal(1) && columnE === Literal(1)
+
+    val expression = nullable || nonNullable
+    val partlyReduced = nullable || reducedNonNullable
+    val reduced = reducedNullable || reducedNonNullable
+
+    val simplifiedNegatedNullable =
+      abs(columnA) =!= Literal(1) || columnB =!= Literal(1) || abs(columnA) > columnB
+    val reducedSimplifiedNegatedNullable = abs(columnA) =!= Literal(1) || columnB =!= Literal(1)
+
+    val reducedSimplifiedNegatedNonNullable = abs(columnD) =!= Literal(1) || columnE =!= Literal(1)
+
+    val partlyReducedSimplifiedNegated =
+      simplifiedNegatedNullable && reducedSimplifiedNegatedNonNullable
+    val reducedSimplifiedNegated =
+      reducedSimplifiedNegatedNullable && reducedSimplifiedNegatedNonNullable
+
+    testSelect(expression, partlyReduced)
+    testSelect(If(expression, expression, expression),
+      If(reduced, partlyReduced, partlyReduced))
+    testSelect(CaseWhen(Seq((expression, expression)), expression),
+      CaseWhen(Seq((reduced, partlyReduced)), partlyReduced))
+    testSelect(ArrayFilter(CreateArray(Seq(expression)), LambdaFunction(expression, Nil)),
+      ArrayFilter(CreateArray(Seq(partlyReduced)), LambdaFunction(reduced, Nil)))
+    Seq(true, false).foreach { tvl =>
+      withSQLConf(SQLConf.LEGACY_ARRAY_EXISTS_FOLLOWS_THREE_VALUED_LOGIC.key -> s"$tvl") {
+        testSelect(ArrayExists(CreateArray(Seq(expression)), LambdaFunction(expression, Nil)),
+          ArrayExists(CreateArray(Seq(partlyReduced)),
+            LambdaFunction(if (tvl) partlyReduced else reduced, Nil)))
+      }
+    }
+    testSelect(MapFilter(CreateMap(Seq(expression, expression)), LambdaFunction(expression, Nil)),
+      MapFilter(CreateMap(Seq(partlyReduced, partlyReduced)), LambdaFunction(reduced, Nil)))
+    testSelect(Not(If(expression, Not(expression), Not(expression))),
+      Not(If(reduced, partlyReducedSimplifiedNegated, partlyReducedSimplifiedNegated)))
+
+    testFilter(expression, reduced)
+    testFilter(If(expression, expression, expression),
+      If(reduced, reduced, reduced))
+    testFilter(CaseWhen(Seq((expression, expression)), expression),
+      CaseWhen(Seq((reduced, reduced)), reduced))
+    testFilter(
+      GetArrayItem(ArrayFilter(CreateArray(Seq(expression)), LambdaFunction(expression, Nil)), 1),
+      GetArrayItem(ArrayFilter(CreateArray(Seq(reduced)), LambdaFunction(reduced, Nil)), 1))
+    Seq(true, false).foreach { tvl =>
+      withSQLConf(SQLConf.LEGACY_ARRAY_EXISTS_FOLLOWS_THREE_VALUED_LOGIC.key -> s"$tvl") {
+        testFilter(ArrayExists(CreateArray(Seq(expression)), LambdaFunction(expression, Nil)),
+          ArrayExists(CreateArray(Seq(reduced)),
+            LambdaFunction(if (tvl) partlyReduced else reduced, Nil)))
+      }
+    }
+    testFilter(
+      GetMapValue(MapFilter(CreateMap(Seq(expression, expression)),
+        LambdaFunction(expression, Nil)), true),
+      GetMapValue(MapFilter(CreateMap(Seq(reduced, reduced)), LambdaFunction(reduced, Nil)), true))
+    testFilter(Not(If(expression, Not(expression), Not(expression))),
+      Not(If(reduced, reducedSimplifiedNegated, reducedSimplifiedNegated)))
   }
 }

--- a/sql/core/src/test/resources/sql-tests/results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain.sql.out
@@ -397,7 +397,7 @@ Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 Output: [key#x, val#x]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/explain_temp2]
-PushedFilters: [IsNotNull(key), IsNotNull(val), EqualTo(val,2)]
+PushedFilters: [IsNotNull(key), EqualTo(val,2)]
 ReadSchema: struct<key:int,val:int>
      
 (6) ColumnarToRow [codegen id : 1]
@@ -405,7 +405,7 @@ Input: [key#x, val#x]
      
 (7) Filter [codegen id : 1]
 Input     : [key#x, val#x]
-Condition : (((isnotnull(key#x) AND isnotnull(val#x)) AND (key#x = Subquery scalar-subquery#x, [id=#x])) AND (val#x = 2))
+Condition : ((isnotnull(key#x) AND (key#x = Subquery scalar-subquery#x, [id=#x])) AND (val#x = 2))
      
 (8) Project [codegen id : 1]
 Output    : [key#x]

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2337,9 +2337,9 @@ class DataFrameSuite extends QueryTest
     val nonNullable = abs(columnD) === 1 && columnE === 1 && abs(columnD) <= columnE
     val reducedNonNullable = abs(columnD) === 1 && columnE === 1
 
-    val column = rand() < 0 || nullable || nonNullable
-    val partlyReduced = rand() < 0 || nullable || reducedNonNullable
-    val reduced = rand() < 0 || reducedNullable || reducedNonNullable
+    val column = nullable || nonNullable
+    val partlyReduced = nullable || reducedNonNullable
+    val reduced = reducedNullable || reducedNonNullable
 
     val simplifiedNegatedNullable = abs(columnA) =!= 1 || columnB =!= 1 || abs(columnA) > columnB
     val reducedSimplifiedNegatedNullable = abs(columnA) =!= 1 || columnB =!= 1
@@ -2347,9 +2347,9 @@ class DataFrameSuite extends QueryTest
     val reducedSimplifiedNegatedNonNullable = abs(columnD) =!= 1 || columnE =!= 1
 
     val partlyReducedSimplifiedNegated =
-      rand() >= 0 && simplifiedNegatedNullable && reducedSimplifiedNegatedNonNullable
+      simplifiedNegatedNullable && reducedSimplifiedNegatedNonNullable
     val reducedSimplifiedNegated =
-      rand() >= 0 && reducedSimplifiedNegatedNullable && reducedSimplifiedNegatedNonNullable
+      reducedSimplifiedNegatedNullable && reducedSimplifiedNegatedNonNullable
 
     testSelect(column, partlyReduced)
     testSelect(new Column(If(column.expr, column.expr, column.expr)),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -183,7 +183,7 @@ class PlannerSuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
 
         withTempView("testPushed") {
           val exp = sql("select * from testPushed where key = 15").queryExecution.sparkPlan
-          assert(exp.toString.contains("PushedFilters: [IsNotNull(key), EqualTo(key,15)]"))
+          assert(exp.toString.contains("PushedFilters: [EqualTo(key,15)]"))
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -198,7 +198,7 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession with Pre
         "when checking partition values")
     }
     // Only the filters that do not contain the partition column should be pushed down
-    checkDataFilters(Set(IsNotNull("c1"), EqualTo("c1", 1)))
+    checkDataFilters(Set(EqualTo("c1", 1)))
   }
 
   test("partitioned table - case insensitive") {
@@ -225,7 +225,7 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession with Pre
           "when checking partition values")
       }
       // Only the filters that do not contain the partition column should be pushed down
-      checkDataFilters(Set(IsNotNull("c1"), EqualTo("c1", 1)))
+      checkDataFilters(Set(EqualTo("c1", 1)))
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR improves `ConstantPropagation` rule, the new implementation:
- Collects constants into a map directly, instead of a list that is then transformed into a map.
- Supports substituting in conflicting equalities:
  e.g. `a = 1 AND a = 2` => `a = 1 AND 1 = 2`
  Before this PR this unsatisfiable filter was not reduced:
  ```
  == Physical Plan ==
  *(1) Project [value#219 AS a#222]
  +- *(1) Filter ((isnotnull(value#219) AND (value#219 = 1)) AND (value#219 = 2))
     +- *(1) LocalTableScan [value#219]
  ```
  But after this PR it is:
  ```
  == Physical Plan ==
  LocalTableScan <empty>, [a#222]
  ```
- Extends propagation from attribute => constant mapping to deterministic expression => constant mapping:
  e.g. `abs(a) = 5 AND b = abs(a) + 3` => `abs(a) = 5 AND b = 8`
- Allows substitution in other than `EqualTo` and `EqualNullSafe` expressions:
  e.g. `a = 5 AND b < a + 3` => `a = 5 AND b < 8`
- Allows propagation of constant non-nullable expressions in `Project` and other nodes (except for `Join`):
  e.g. `SELECT a = 5 AND b = a + 3` => `SELECT a = 5 AND b = 8`
  Before this PR only `Filter` was supported.
- Allows deep constant propagation:
  e.g. `... WHERE IF(..., a = 5 AND b = a + 3, ...)` => `... WHERE IF(..., a = 5 AND b = 8, ...)`
  Before this PR only top level `And`/`Or`/`Not` nodes were supported.
- During expression tree traversal tracks a boolean context that controls if constant propagation of a nullable expression can be safely applied. 
  - E.g. in the case of `... WHERE a = c AND f(a)` or `IF(a = c AND f(a), ..., ...)` where `a` is a nullable expression and `c` is a constant the `null` result of `a = c AND f(a)` means the same as if it resulted `false` therefore constant propagation can be safely applied (`a = c AND f(a)` => `a = c AND f(c)`).
  - In the case of `SELECT a = c AND f(a)` the `null` result really means `null`. In this context constant propagation can't be applied safely.
  - There is also a 3rd context due to an enclosing `Not` in which the context flips. E.g. constant propagation can't be applied on `WHERE NOT(a = c AND f(a))` but can be again on `WHERE NOT(IF(..., NOT(a = c AND f(a)), ...)`.

## Why are the changes needed?
Improve performance.

## Does this PR introduce any user-facing change?
No.

## How was this patch tested?
New UTs.
