### PR TITLE
[SPARK-27617][SQL] Support creating managed table on user specified location

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -988,9 +988,10 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
       serde = rowStorage.serde.orElse(fileStorage.serde).orElse(defaultStorage.serde),
       compressed = false,
       properties = rowStorage.properties ++ fileStorage.properties)
-    // If location is defined, we'll assume this is an external table.
-    // Otherwise, we may accidentally delete existing data.
-    val tableType = if (external || location.isDefined) {
+    // If external is defined, we'll assume this is an external table.
+    // Otherwise, we may consider it as managed table where the data
+    // will be deleted on drop table command.
+    val tableType = if (external) {
       CatalogTableType.EXTERNAL
     } else {
       CatalogTableType.MANAGED

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1692,7 +1692,10 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     assert(fs.listStatus(new Path(path, "part=1")).nonEmpty)
 
     sql("drop table test_table")
-    assert(fs.exists(path), "This is an external table, so the data should not have been dropped")
+    assert(
+      !fs.exists(path),
+      "Once a managed table has been dropped, " +
+        "dirs of this table should also have been deleted.")
   }
 
   test("select partitioned table") {


### PR DESCRIPTION
## What changes were proposed in this pull request?
```
CREATE TABLE IF NOT EXISTS ext2 (name STRING) LOCATION 'D:/spark-2.4.1-bin-hadoop2.7/bin/spark-warehouse/abc_orc13'""")

CREATE EXTERNAL TABLE IF NOT EXISTS ext2 (name STRING) LOCATION 'D:/spark-2.4.1-bin-hadoop2.7/bin/spark-warehouse/abc_orc13'""")
```
Both commands creates an external table here , Where as in impala and hive behaves differently If 'EXTERNAL' keyword is been used in CREATE command, only then the table will be considered as external,
else it will be managed. this behavior is making below mentioned use-cases getting blocked.

usecase 1: user will not able to set an external location for a managed table.
usecase 2: compatibility issue with hive/impala which also cause problems in job migrations to spark.
The changes here i am proposing is when user creates table without 'External' keyword like below
CREATE TABLE IF NOT EXISTS ext2 (name STRING) LOCATION 'D:/spark-2.4.1-bin-hadoop2.7/bin/spark-warehouse/abc_orc13'""")

spark shall create a managed table which can refer any location specified by user and able to delete the metadata/data of user on drop table command similar to hive and impala system .


## How was this patch tested?
UT and also tested manually.

