### PR TITLE
[SPARK-27665][Core] Split fetch shuffle blocks protocol from OpenBlocks

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/Encoders.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/Encoders.java
@@ -89,4 +89,27 @@ public class Encoders {
       return strings;
     }
   }
+
+  /** Integer arrays are encoded with their length followed by integers. */
+  public static class IntArrays {
+    public static int encodedLength(int[] ints) {
+      return 4 + 4 * ints.length;
+    }
+
+    public static void encode(ByteBuf buf, int[] ints) {
+      buf.writeInt(ints.length);
+      for (int i : ints) {
+        buf.writeInt(i);
+      }
+    }
+
+    public static int[] decode(ByteBuf buf) {
+      int numInts = buf.readInt();
+      int[] ints = new int[numInts];
+      for (int i = 0; i < ints.length; i ++) {
+        ints[i] = buf.readInt();
+      }
+      return ints;
+    }
+  }
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -341,4 +341,13 @@ public class TransportConf {
     return (int) Math.ceil(threads * (chunkFetchHandlerThreadsPercent / 100.0));
   }
 
+  /**
+   * Whether to use the old protocol while doing the shuffle block fetching.
+   * It is only enabled while we need the compatibility in the scenario of new spark version
+   * job fetching blocks from old version external shuffle service.
+   */
+  public boolean useOldFetchProtocol() {
+    return conf.getBoolean("spark.shuffle.useOldFetchProtocol", false);
+  }
+
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
@@ -19,8 +19,11 @@ package org.apache.spark.network.shuffle;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 
+import com.google.common.primitives.Ints;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +34,7 @@ import org.apache.spark.network.client.StreamCallback;
 import org.apache.spark.network.client.TransportClient;
 import org.apache.spark.network.server.OneForOneStreamManager;
 import org.apache.spark.network.shuffle.protocol.BlockTransferMessage;
+import org.apache.spark.network.shuffle.protocol.FetchShuffleBlocks;
 import org.apache.spark.network.shuffle.protocol.OpenBlocks;
 import org.apache.spark.network.shuffle.protocol.StreamHandle;
 import org.apache.spark.network.util.TransportConf;
@@ -48,7 +52,7 @@ public class OneForOneBlockFetcher {
   private static final Logger logger = LoggerFactory.getLogger(OneForOneBlockFetcher.class);
 
   private final TransportClient client;
-  private final OpenBlocks openMessage;
+  private final BlockTransferMessage message;
   private final String[] blockIds;
   private final BlockFetchingListener listener;
   private final ChunkReceivedCallback chunkCallback;
@@ -76,12 +80,71 @@ public class OneForOneBlockFetcher {
       TransportConf transportConf,
       DownloadFileManager downloadFileManager) {
     this.client = client;
-    this.openMessage = new OpenBlocks(appId, execId, blockIds);
     this.blockIds = blockIds;
     this.listener = listener;
     this.chunkCallback = new ChunkCallback();
     this.transportConf = transportConf;
     this.downloadFileManager = downloadFileManager;
+    if (blockIds.length == 0) {
+      throw new IllegalArgumentException("Zero-sized blockIds array");
+    }
+    if (!transportConf.useOldFetchProtocol() && isShuffleBlocks(blockIds)) {
+      this.message = createFetchShuffleBlocksMsg(appId, execId, blockIds);
+    } else {
+      this.message = new OpenBlocks(appId, execId, blockIds);
+    }
+  }
+
+  private boolean isShuffleBlocks(String[] blockIds) {
+    for (String blockId : blockIds) {
+      if (!blockId.startsWith("shuffle_")) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Analyze the pass in blockIds and create FetchShuffleBlocks message.
+   * The blockIds has been sorted by mapId and reduceId. It's produced in
+   * org.apache.spark.MapOutputTracker.convertMapStatuses.
+   */
+  private FetchShuffleBlocks createFetchShuffleBlocksMsg(
+      String appId, String execId, String[] blockIds) {
+    int shuffleId = splitBlockId(blockIds[0])[0];
+    HashMap<Integer, ArrayList<Integer>> mapIdToReduceIds = new HashMap<>();
+    for (String blockId : blockIds) {
+      int[] blockIdParts = splitBlockId(blockId);
+      if (blockIdParts[0] != shuffleId) {
+        throw new IllegalArgumentException("Expected shuffleId=" + shuffleId +
+          ", got:" + blockId);
+      }
+      int mapId = blockIdParts[1];
+      if (!mapIdToReduceIds.containsKey(mapId)) {
+        mapIdToReduceIds.put(mapId, new ArrayList<>());
+      }
+      mapIdToReduceIds.get(mapId).add(blockIdParts[2]);
+    }
+    int[] mapIds = Ints.toArray(mapIdToReduceIds.keySet());
+    int[][] reduceIdArr = new int[mapIds.length][];
+    for (int i = 0; i < mapIds.length; i++) {
+      reduceIdArr[i] = Ints.toArray(mapIdToReduceIds.get(mapIds[i]));
+    }
+    return new FetchShuffleBlocks(appId, execId, shuffleId, mapIds, reduceIdArr);
+  }
+
+  /** Split the shuffleBlockId and return shuffleId, mapId and reduceId. */
+  private int[] splitBlockId(String blockId) {
+    String[] blockIdParts = blockId.split("_");
+    if (blockIdParts.length != 4 || !blockIdParts[0].equals("shuffle")) {
+      throw new IllegalArgumentException(
+        "Unexpected shuffle block id format: " + blockId);
+    }
+    return new int[] {
+      Integer.parseInt(blockIdParts[1]),
+      Integer.parseInt(blockIdParts[2]),
+      Integer.parseInt(blockIdParts[3])
+    };
   }
 
   /** Callback invoked on receipt of each chunk. We equate a single chunk to a single block. */
@@ -106,11 +169,7 @@ public class OneForOneBlockFetcher {
    * {@link StreamHandle}. We will send all fetch requests immediately, without throttling.
    */
   public void start() {
-    if (blockIds.length == 0) {
-      throw new IllegalArgumentException("Zero-sized blockIds array");
-    }
-
-    client.sendRpc(openMessage.toByteBuffer(), new RpcResponseCallback() {
+    client.sendRpc(message.toByteBuffer(), new RpcResponseCallback() {
       @Override
       public void onSuccess(ByteBuffer response) {
         try {

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/BlockTransferMessage.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/BlockTransferMessage.java
@@ -31,11 +31,13 @@ import org.apache.spark.network.shuffle.protocol.mesos.ShuffleServiceHeartbeat;
  * by Spark's NettyBlockTransferService.
  *
  * At a high level:
- *   - OpenBlock is handled by both services, but only services shuffle files for the external
- *     shuffle service. It returns a StreamHandle.
+ *   - OpenBlock is logically only handled by the NettyBlockTransferService, but for the capability
+ *     for old version Spark, we still keep it in external shuffle service.
+ *     It returns a StreamHandle.
  *   - UploadBlock is only handled by the NettyBlockTransferService.
  *   - RegisterExecutor is only handled by the external shuffle service.
  *   - RemoveBlocks is only handled by the external shuffle service.
+ *   - FetchShuffleBlocks is handled by both services for shuffle files. It returns a StreamHandle.
  */
 public abstract class BlockTransferMessage implements Encodable {
   protected abstract Type type();
@@ -43,7 +45,8 @@ public abstract class BlockTransferMessage implements Encodable {
   /** Preceding every serialized message is its type, which allows us to deserialize it. */
   public enum Type {
     OPEN_BLOCKS(0), UPLOAD_BLOCK(1), REGISTER_EXECUTOR(2), STREAM_HANDLE(3), REGISTER_DRIVER(4),
-    HEARTBEAT(5), UPLOAD_BLOCK_STREAM(6), REMOVE_BLOCKS(7), BLOCKS_REMOVED(8);
+    HEARTBEAT(5), UPLOAD_BLOCK_STREAM(6), REMOVE_BLOCKS(7), BLOCKS_REMOVED(8),
+    FETCH_SHUFFLE_BLOCKS(9);
 
     private final byte id;
 
@@ -71,6 +74,7 @@ public abstract class BlockTransferMessage implements Encodable {
         case 6: return UploadBlockStream.decode(buf);
         case 7: return RemoveBlocks.decode(buf);
         case 8: return BlocksRemoved.decode(buf);
+        case 9: return FetchShuffleBlocks.decode(buf);
         default: throw new IllegalArgumentException("Unknown message type: " + type);
       }
     }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/FetchShuffleBlocks.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/FetchShuffleBlocks.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle.protocol;
+
+import java.util.Arrays;
+
+import com.google.common.base.Objects;
+import io.netty.buffer.ByteBuf;
+
+import org.apache.spark.network.protocol.Encoders;
+
+// Needed by ScalaDoc. See SPARK-7726
+import static org.apache.spark.network.shuffle.protocol.BlockTransferMessage.Type;
+
+/** Request to read a set of blocks. Returns {@link StreamHandle}. */
+public class FetchShuffleBlocks extends BlockTransferMessage {
+  public final String appId;
+  public final String execId;
+  public final int shuffleId;
+  // The length of mapIds must equal to reduceIds.size(), for the i-th mapId in mapIds,
+  // it corresponds to the i-th int[] in reduceIds, which contains all reduce id for this map id.
+  public final int[] mapIds;
+  public final int[][] reduceIds;
+
+  public FetchShuffleBlocks(
+      String appId,
+      String execId,
+      int shuffleId,
+      int[] mapIds,
+      int[][] reduceIds) {
+    this.appId = appId;
+    this.execId = execId;
+    this.shuffleId = shuffleId;
+    this.mapIds = mapIds;
+    this.reduceIds = reduceIds;
+    assert(mapIds.length == reduceIds.length);
+  }
+
+  @Override
+  protected Type type() { return Type.FETCH_SHUFFLE_BLOCKS; }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("appId", appId)
+      .add("execId", execId)
+      .add("shuffleId", shuffleId)
+      .add("mapIds", Arrays.toString(mapIds))
+      .add("reduceIds", Arrays.deepToString(reduceIds))
+      .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    FetchShuffleBlocks that = (FetchShuffleBlocks) o;
+
+    if (shuffleId != that.shuffleId) return false;
+    if (!appId.equals(that.appId)) return false;
+    if (!execId.equals(that.execId)) return false;
+    if (!Arrays.equals(mapIds, that.mapIds)) return false;
+    return Arrays.deepEquals(reduceIds, that.reduceIds);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = appId.hashCode();
+    result = 31 * result + execId.hashCode();
+    result = 31 * result + shuffleId;
+    result = 31 * result + Arrays.hashCode(mapIds);
+    result = 31 * result + Arrays.deepHashCode(reduceIds);
+    return result;
+  }
+
+  @Override
+  public int encodedLength() {
+    int encodedLengthOfReduceIds = 0;
+    for (int[] ids: reduceIds) {
+      encodedLengthOfReduceIds += Encoders.IntArrays.encodedLength(ids);
+    }
+    return Encoders.Strings.encodedLength(appId)
+      + Encoders.Strings.encodedLength(execId)
+      + 4 /* encoded length of shuffleId */
+      + Encoders.IntArrays.encodedLength(mapIds)
+      + 4 /* encoded length of reduceIds.size() */
+      + encodedLengthOfReduceIds;
+  }
+
+  @Override
+  public void encode(ByteBuf buf) {
+    Encoders.Strings.encode(buf, appId);
+    Encoders.Strings.encode(buf, execId);
+    buf.writeInt(shuffleId);
+    Encoders.IntArrays.encode(buf, mapIds);
+    buf.writeInt(reduceIds.length);
+    for (int[] ids: reduceIds) {
+      Encoders.IntArrays.encode(buf, ids);
+    }
+  }
+
+  public static FetchShuffleBlocks decode(ByteBuf buf) {
+    String appId = Encoders.Strings.decode(buf);
+    String execId = Encoders.Strings.decode(buf);
+    int shuffleId = buf.readInt();
+    int[] mapIds = Encoders.IntArrays.decode(buf);
+    int reduceIdsSize = buf.readInt();
+    int[][] reduceIds = new int[reduceIdsSize][];
+    for (int i = 0; i < reduceIdsSize; i++) {
+      reduceIds[i] = Encoders.IntArrays.decode(buf);
+    }
+    return new FetchShuffleBlocks(appId, execId, shuffleId, mapIds, reduceIds);
+  }
+}

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/BlockTransferMessagesSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/BlockTransferMessagesSuite.java
@@ -28,6 +28,9 @@ public class BlockTransferMessagesSuite {
   @Test
   public void serializeOpenShuffleBlocks() {
     checkSerializeDeserialize(new OpenBlocks("app-1", "exec-2", new String[] { "b1", "b2" }));
+    checkSerializeDeserialize(new FetchShuffleBlocks(
+      "app-1", "exec-2", 0, new int[] {0, 1},
+      new int[][] {{ 0, 1 }, { 0, 1, 2 }}));
     checkSerializeDeserialize(new RegisterExecutor("app-1", "exec-2", new ExecutorShuffleInfo(
       new String[] { "/local1", "/local2" }, 32, "MyShuffleManager")));
     checkSerializeDeserialize(new UploadBlock("app-1", "exec-2", "block-3", new byte[] { 1, 2 },

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockFetcherSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockFetcherSuite.java
@@ -18,6 +18,7 @@
 package org.apache.spark.network.shuffle;
 
 import java.nio.ByteBuffer;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -44,6 +45,7 @@ import org.apache.spark.network.client.ChunkReceivedCallback;
 import org.apache.spark.network.client.RpcResponseCallback;
 import org.apache.spark.network.client.TransportClient;
 import org.apache.spark.network.shuffle.protocol.BlockTransferMessage;
+import org.apache.spark.network.shuffle.protocol.FetchShuffleBlocks;
 import org.apache.spark.network.shuffle.protocol.OpenBlocks;
 import org.apache.spark.network.shuffle.protocol.StreamHandle;
 import org.apache.spark.network.util.MapConfigProvider;
@@ -57,10 +59,54 @@ public class OneForOneBlockFetcherSuite {
   public void testFetchOne() {
     LinkedHashMap<String, ManagedBuffer> blocks = Maps.newLinkedHashMap();
     blocks.put("shuffle_0_0_0", new NioManagedBuffer(ByteBuffer.wrap(new byte[0])));
+    String[] blockIds = blocks.keySet().toArray(new String[blocks.size()]);
 
-    BlockFetchingListener listener = fetchBlocks(blocks);
+    BlockFetchingListener listener = fetchBlocks(
+      blocks,
+      blockIds,
+      new FetchShuffleBlocks("app-id", "exec-id", 0, new int[] { 0 }, new int[][] {{ 0 }}),
+      conf);
 
     verify(listener).onBlockFetchSuccess("shuffle_0_0_0", blocks.get("shuffle_0_0_0"));
+  }
+
+  @Test
+  public void testUseOldProtocol() {
+    LinkedHashMap<String, ManagedBuffer> blocks = Maps.newLinkedHashMap();
+    blocks.put("shuffle_0_0_0", new NioManagedBuffer(ByteBuffer.wrap(new byte[0])));
+    String[] blockIds = blocks.keySet().toArray(new String[blocks.size()]);
+
+    BlockFetchingListener listener = fetchBlocks(
+      blocks,
+      blockIds,
+      new OpenBlocks("app-id", "exec-id", blockIds),
+      new TransportConf("shuffle", new MapConfigProvider(
+        new HashMap<String, String>() {{
+          put("spark.shuffle.useOldFetchProtocol", "true");
+        }}
+      )));
+
+    verify(listener).onBlockFetchSuccess("shuffle_0_0_0", blocks.get("shuffle_0_0_0"));
+  }
+
+  @Test
+  public void testFetchThreeShuffleBlocks() {
+    LinkedHashMap<String, ManagedBuffer> blocks = Maps.newLinkedHashMap();
+    blocks.put("shuffle_0_0_0", new NioManagedBuffer(ByteBuffer.wrap(new byte[12])));
+    blocks.put("shuffle_0_0_1", new NioManagedBuffer(ByteBuffer.wrap(new byte[23])));
+    blocks.put("shuffle_0_0_2", new NettyManagedBuffer(Unpooled.wrappedBuffer(new byte[23])));
+    String[] blockIds = blocks.keySet().toArray(new String[blocks.size()]);
+
+    BlockFetchingListener listener = fetchBlocks(
+      blocks,
+      blockIds,
+      new FetchShuffleBlocks("app-id", "exec-id", 0, new int[] { 0 }, new int[][] {{ 0, 1, 2 }}),
+      conf);
+
+    for (int i = 0; i < 3; i ++) {
+      verify(listener, times(1)).onBlockFetchSuccess(
+        "shuffle_0_0_" + i, blocks.get("shuffle_0_0_" + i));
+    }
   }
 
   @Test
@@ -69,8 +115,13 @@ public class OneForOneBlockFetcherSuite {
     blocks.put("b0", new NioManagedBuffer(ByteBuffer.wrap(new byte[12])));
     blocks.put("b1", new NioManagedBuffer(ByteBuffer.wrap(new byte[23])));
     blocks.put("b2", new NettyManagedBuffer(Unpooled.wrappedBuffer(new byte[23])));
+    String[] blockIds = blocks.keySet().toArray(new String[blocks.size()]);
 
-    BlockFetchingListener listener = fetchBlocks(blocks);
+    BlockFetchingListener listener = fetchBlocks(
+      blocks,
+      blockIds,
+      new OpenBlocks("app-id", "exec-id", blockIds),
+      conf);
 
     for (int i = 0; i < 3; i ++) {
       verify(listener, times(1)).onBlockFetchSuccess("b" + i, blocks.get("b" + i));
@@ -83,8 +134,13 @@ public class OneForOneBlockFetcherSuite {
     blocks.put("b0", new NioManagedBuffer(ByteBuffer.wrap(new byte[12])));
     blocks.put("b1", null);
     blocks.put("b2", null);
+    String[] blockIds = blocks.keySet().toArray(new String[blocks.size()]);
 
-    BlockFetchingListener listener = fetchBlocks(blocks);
+    BlockFetchingListener listener = fetchBlocks(
+      blocks,
+      blockIds,
+      new OpenBlocks("app-id", "exec-id", blockIds),
+      conf);
 
     // Each failure will cause a failure to be invoked in all remaining block fetches.
     verify(listener, times(1)).onBlockFetchSuccess("b0", blocks.get("b0"));
@@ -98,8 +154,13 @@ public class OneForOneBlockFetcherSuite {
     blocks.put("b0", new NioManagedBuffer(ByteBuffer.wrap(new byte[12])));
     blocks.put("b1", null);
     blocks.put("b2", new NioManagedBuffer(ByteBuffer.wrap(new byte[21])));
+    String[] blockIds = blocks.keySet().toArray(new String[blocks.size()]);
 
-    BlockFetchingListener listener = fetchBlocks(blocks);
+    BlockFetchingListener listener = fetchBlocks(
+      blocks,
+      blockIds,
+      new OpenBlocks("app-id", "exec-id", blockIds),
+      conf);
 
     // We may call both success and failure for the same block.
     verify(listener, times(1)).onBlockFetchSuccess("b0", blocks.get("b0"));
@@ -111,7 +172,11 @@ public class OneForOneBlockFetcherSuite {
   @Test
   public void testEmptyBlockFetch() {
     try {
-      fetchBlocks(Maps.newLinkedHashMap());
+      fetchBlocks(
+        Maps.newLinkedHashMap(),
+        new String[] {},
+        new OpenBlocks("app-id", "exec-id", new String[] {}),
+        conf);
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals("Zero-sized blockIds array", e.getMessage());
@@ -126,12 +191,15 @@ public class OneForOneBlockFetcherSuite {
    *
    * If a block's buffer is "null", an exception will be thrown instead.
    */
-  private static BlockFetchingListener fetchBlocks(LinkedHashMap<String, ManagedBuffer> blocks) {
+  private static BlockFetchingListener fetchBlocks(
+      LinkedHashMap<String, ManagedBuffer> blocks,
+      String[] blockIds,
+      BlockTransferMessage expectMessage,
+      TransportConf transportConf) {
     TransportClient client = mock(TransportClient.class);
     BlockFetchingListener listener = mock(BlockFetchingListener.class);
-    String[] blockIds = blocks.keySet().toArray(new String[blocks.size()]);
     OneForOneBlockFetcher fetcher =
-      new OneForOneBlockFetcher(client, "app-id", "exec-id", blockIds, listener, conf);
+      new OneForOneBlockFetcher(client, "app-id", "exec-id", blockIds, listener, transportConf);
 
     // Respond to the "OpenBlocks" message with an appropriate ShuffleStreamHandle with streamId 123
     doAnswer(invocationOnMock -> {
@@ -139,7 +207,7 @@ public class OneForOneBlockFetcherSuite {
         (ByteBuffer) invocationOnMock.getArguments()[0]);
       RpcResponseCallback callback = (RpcResponseCallback) invocationOnMock.getArguments()[1];
       callback.onSuccess(new StreamHandle(123, blocks.size()).toByteBuffer());
-      assertEquals(new OpenBlocks("app-id", "exec-id", blockIds), message);
+      assertEquals(expectMessage, message);
       return null;
     }).when(client).sendRpc(any(ByteBuffer.class), any(RpcResponseCallback.class));
 

--- a/core/src/main/scala/org/apache/spark/network/netty/NettyBlockRpcServer.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/NettyBlockRpcServer.scala
@@ -29,7 +29,7 @@ import org.apache.spark.network.client.{RpcResponseCallback, StreamCallbackWithI
 import org.apache.spark.network.server.{OneForOneStreamManager, RpcHandler, StreamManager}
 import org.apache.spark.network.shuffle.protocol._
 import org.apache.spark.serializer.Serializer
-import org.apache.spark.storage.{BlockId, StorageLevel}
+import org.apache.spark.storage.{BlockId, ShuffleBlockId, StorageLevel}
 
 /**
  * Serves requests to open blocks by simply registering one chunk per block requested.
@@ -62,6 +62,20 @@ class NettyBlockRpcServer(
           client.getChannel)
         logTrace(s"Registered streamId $streamId with $blocksNum buffers")
         responseContext.onSuccess(new StreamHandle(streamId, blocksNum).toByteBuffer)
+
+      case fetchShuffleBlocks: FetchShuffleBlocks =>
+        val blocks = fetchShuffleBlocks.mapIds.zipWithIndex.flatMap { case (mapId, index) =>
+          fetchShuffleBlocks.reduceIds.apply(index).map { reduceId =>
+            blockManager.getBlockData(
+              ShuffleBlockId(fetchShuffleBlocks.shuffleId, mapId, reduceId))
+          }
+        }
+        val numBlockIds = fetchShuffleBlocks.reduceIds.map(_.length).sum
+        val streamId = streamManager.registerStream(appId, blocks.iterator.asJava,
+          client.getChannel)
+        logTrace(s"Registered streamId $streamId with $numBlockIds buffers")
+        responseContext.onSuccess(
+          new StreamHandle(streamId, numBlockIds).toByteBuffer)
 
       case uploadBlock: UploadBlock =>
         // StorageLevel and ClassTag are serialized as bytes using our JavaSerializer.

--- a/docs/sql-migration-guide-upgrade.md
+++ b/docs/sql-migration-guide-upgrade.md
@@ -136,6 +136,8 @@ license: |
 
   - Since Spark 3.0, when Avro files are written with user provided non-nullable schema, even the catalyst schema is nullable, Spark is still able to write the files. However, Spark will throw runtime NPE if any of the records contains null.
 
+  - Since Spark 3.0, we use a new protocol for fetching shuffle blocks, for external shuffle service users, we need to upgrade the server correspondingly. Otherwise, we'll get the error message `UnsupportedOperationException: Unexpected message: FetchShuffleBlocks`. If it is hard to upgrade the shuffle service right now, you can still use the old protocol by setting `spark.shuffle.useOldFetchProtocol` to `true`. 
+
 ## Upgrading from Spark SQL 2.4 to 2.4.1
 
   - The value of `spark.executor.heartbeatInterval`, when specified without units like "30" rather than "30s", was


### PR DESCRIPTION
## What changes were proposed in this pull request?

As the current approach in OneForOneBlockFetcher, we reuse the OpenBlocks protocol to describe the fetch request for shuffle blocks, and it causes the extension work for shuffle fetching like #19788 and #24110 very awkward.
In this PR, we split the fetch request for shuffle blocks from OpenBlocks which named FetchShuffleBlocks. It's a loose bind with ShuffleBlockId and can easily extend by adding new fields in this protocol.

## How was this patch tested?

Existing and new added UT.