### PR TITLE
[SPARK-27667][SQL] support display of current Database in the spark-sql CLI

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2072,7 +2072,7 @@ object SQLConf {
       .stringConf
       .createWithDefault(
         "https://maven-central.storage-download.googleapis.com/repos/central/data/")
-  
+
   val SPARK_SQL_CLI_SHOW_CURRENT_DB = buildConf("spark.sql.cli.show.current.db")
     .doc("when true, current DB name will be displayed in the cli prompt")
     .booleanConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2072,6 +2072,11 @@ object SQLConf {
       .stringConf
       .createWithDefault(
         "https://maven-central.storage-download.googleapis.com/repos/central/data/")
+  
+  val SPARK_SQL_CLI_SHOW_CURRENT_DB = buildConf("spark.sql.cli.show.current.db")
+    .doc("when true, current DB name will be displayed in the cli prompt")
+    .booleanConf
+    .createWithDefault(false)
 }
 
 /**
@@ -2572,6 +2577,8 @@ class SQLConf extends Serializable with Logging {
   def castDatetimeToString: Boolean = getConf(SQLConf.LEGACY_CAST_DATETIME_TO_STRING)
 
   def ignoreDataLocality: Boolean = getConf(SQLConf.IGNORE_DATA_LOCALITY)
+
+  def shouldShowDBName: Boolean = getConf(SQLConf.SPARK_SQL_CLI_SHOW_CURRENT_DB)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2072,11 +2072,6 @@ object SQLConf {
       .stringConf
       .createWithDefault(
         "https://maven-central.storage-download.googleapis.com/repos/central/data/")
-
-  val SPARK_SQL_CLI_SHOW_CURRENT_DB = buildConf("spark.sql.cli.show.current.db")
-    .doc("when true, current DB name will be displayed in the cli prompt")
-    .booleanConf
-    .createWithDefault(false)
 }
 
 /**
@@ -2577,8 +2572,6 @@ class SQLConf extends Serializable with Logging {
   def castDatetimeToString: Boolean = getConf(SQLConf.LEGACY_CAST_DATETIME_TO_STRING)
 
   def ignoreDataLocality: Boolean = getConf(SQLConf.IGNORE_DATA_LOCALITY)
-
-  def shouldShowDBName: Boolean = getConf(SQLConf.SPARK_SQL_CLI_SHOW_CURRENT_DB)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -168,4 +168,10 @@ object StaticSQLConf {
       .internal()
       .booleanConf
       .createWithDefault(true)
+
+  val SPARK_SQL_CLI_SHOW_CURRENT_DB_ENABLED =
+    buildStaticConf("spark.sql.cli.show.current.db.enabled")
+      .doc("when true, current DB name will be displayed in the cli prompt")
+      .booleanConf
+      .createWithDefault(false)
 }

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -258,9 +258,12 @@ private[hive] object SparkSQLCLIDriver extends Logging {
 
     var ret = 0
     var prefix = ""
-    val currentDB = ReflectionUtils.invokeStatic(classOf[CliDriver], "getFormattedDb",
-      classOf[HiveConf] -> conf, classOf[CliSessionState] -> sessionState)
-
+    def currentDB = if (sparkConf.getBoolean("spark.cli.print.current.db", false)) {
+      val currDB = SparkSQLEnv.sqlContext.sessionState.catalog.getCurrentDatabase
+      s" ($currDB)"
+    } else {
+      ""
+    }
     def promptWithCurrentDB: String = s"$prompt$currentDB"
     def continuedPromptWithDBSpaces: String = continuedPrompt + ReflectionUtils.invokeStatic(
       classOf[CliDriver], "spacesForString", classOf[String] -> currentDB)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -45,6 +45,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.hive.HiveUtils
 import org.apache.spark.sql.hive.security.HiveDelegationTokenProvider
+import org.apache.spark.sql.internal.StaticSQLConf
 import org.apache.spark.util.ShutdownHookManager
 
 /**
@@ -258,7 +259,8 @@ private[hive] object SparkSQLCLIDriver extends Logging {
 
     var ret = 0
     var prefix = ""
-    def currentDB = if (SparkSQLEnv.sqlContext.conf.shouldShowDBName) {
+    def currentDB = if (SparkSQLEnv.sqlContext.conf
+      .getConf(StaticSQLConf.SPARK_SQL_CLI_SHOW_CURRENT_DB_ENABLED)) {
       val currDB = SparkSQLEnv.sqlContext.sessionState.catalog.getCurrentDatabase
       s" ($currDB)"
     } else {

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -258,7 +258,7 @@ private[hive] object SparkSQLCLIDriver extends Logging {
 
     var ret = 0
     var prefix = ""
-    def currentDB = if (sparkConf.getBoolean("spark.cli.print.current.db", false)) {
+    def currentDB = if (SparkSQLEnv.sqlContext.conf.shouldShowDBName) {
       val currDB = SparkSQLEnv.sqlContext.sessionState.catalog.getCurrentDatabase
       s" ($currDB)"
     } else {

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -402,14 +402,15 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
   }
 
   test("SPARK-27667 test cli prompt using spark.cli.print.current.db") {
-    runCliWithin(1.minute, Seq("--conf", "spark.cli.print.current.db=true"))(
+    runCliWithin(1.minute, Seq("--conf", "spark.sql.cli.show.current.db=true"))(
       "show tables;" -> "spark-sql (default)",
       "CREATE DATABASE hive_test_db;"
         -> "",
       "USE hive_test_db;"
-        -> "spark-sql (hive_test_db)")
+        -> "spark-sql (hive_test_db)"
+    )
     // test with false
-    runCliWithin(1.minute, Seq("--conf", "spark.cli.print.current.db=false"))(
+    runCliWithin(1.minute, Seq("--conf", "spark.sql.cli.show.current.db=false"))(
       "show tables;" -> "spark-sql> show tables",
       "CREATE DATABASE hive_test_db;"
         -> "spark-sql> CREATE DATABASE hive_test_db",

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -32,6 +32,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.hive.test.HiveTestJars
+import org.apache.spark.sql.internal.StaticSQLConf
 import org.apache.spark.sql.test.ProcessTestUtils.ProcessOutputCapturer
 import org.apache.spark.util.{ThreadUtils, Utils}
 
@@ -401,20 +402,18 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
     )
   }
 
-  test("SPARK-27667 test cli prompt using spark.cli.print.current.db") {
-    runCliWithin(1.minute, Seq("--conf", "spark.sql.cli.show.current.db=true"))(
+  test("SPARK-27667: test cli prompt using spark.cli.print.current.db.enabled") {
+    runCliWithin(1.minute, Seq("--conf", s"${StaticSQLConf.SPARK_SQL_CLI_SHOW_CURRENT_DB_ENABLED
+      .key}=true"))(
       "show tables;" -> "spark-sql (default)",
-      "CREATE DATABASE hive_test_db;"
-        -> "",
-      "USE hive_test_db;"
-        -> "spark-sql (hive_test_db)"
+      "CREATE DATABASE hive_test_db;" -> "",
+      "USE hive_test_db;" -> "spark-sql (hive_test_db)"
     )
     // test with false
-    runCliWithin(1.minute, Seq("--conf", "spark.sql.cli.show.current.db=false"))(
+    runCliWithin(1.minute, Seq("--conf", s"${StaticSQLConf.SPARK_SQL_CLI_SHOW_CURRENT_DB_ENABLED
+      .key}=false"))(
       "show tables;" -> "spark-sql> show tables",
-      "CREATE DATABASE hive_test_db;"
-        -> "spark-sql> CREATE DATABASE hive_test_db",
-      "USE hive_test_db;"
-        -> "spark-sql> USE hive_test_db")
+      "CREATE DATABASE hive_test_db;" -> "spark-sql> CREATE DATABASE hive_test_db",
+      "USE hive_test_db;" -> "spark-sql> USE hive_test_db")
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -400,4 +400,20 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
         -> "1.000000000000000000"
     )
   }
+
+  test("SPARK-27667 test cli prompt using spark.cli.print.current.db") {
+    runCliWithin(1.minute, Seq("--conf", "spark.cli.print.current.db=true"))(
+      "show tables;" -> "spark-sql (default)",
+      "CREATE DATABASE hive_test_db;"
+        -> "",
+      "USE hive_test_db;"
+        -> "spark-sql (hive_test_db)")
+    // test with false
+    runCliWithin(1.minute, Seq("--conf", "spark.cli.print.current.db=false"))(
+      "show tables;" -> "spark-sql> show tables",
+      "CREATE DATABASE hive_test_db;"
+        -> "spark-sql> CREATE DATABASE hive_test_db",
+      "USE hive_test_db;"
+        -> "spark-sql> USE hive_test_db")
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Get the current database from the spark catalog instead of `CliSessionState`.Spark does not set the current database to `CliSessionState`.So it will always return empty.

## How was this patch tested?

Manually and added also with UT

**Before Fix**
![before](https://user-images.githubusercontent.com/35216143/57453478-2267fa80-7284-11e9-8302-87ffcdd56a40.png)

**After Fix**
![After](https://user-images.githubusercontent.com/35216143/57453510-36136100-7284-11e9-991c-c50508d1b0b3.png)
