### PR TITLE
[SPARK-27670][SQL]Add HA for HiveThriftServer2 based on HiveServer2.

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -118,7 +118,8 @@ object HiveThriftServer2 extends Logging {
           logWarning("HiveThriftServer2 HA is compatible with Hive metastore version is " +
               "0.14.0 or higher.")
         case _ =>
-          if (executionHive.conf.getBoolVar(ConfVars.HIVE_SERVER2_SUPPORT_DYNAMIC_SERVICE_DISCOVERY)) {
+          if (executionHive.conf.getBoolVar(
+            ConfVars.HIVE_SERVER2_SUPPORT_DYNAMIC_SERVICE_DISCOVERY)) {
             val method = server.getClass.getSuperclass.getDeclaredMethod(
                 "addServerInstanceToZooKeeper",
                 classOf[org.apache.hadoop.hive.conf.HiveConf])

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -107,6 +107,12 @@ object HiveThriftServer2 extends Logging {
       } else {
         None
       }
+      if (executionHive.conf.getBoolVar(ConfVars.HIVE_SERVER2_SUPPORT_DYNAMIC_SERVICE_DISCOVERY)) {
+        val method = server.getClass.getSuperclass.getDeclaredMethod("addServerInstanceToZooKeeper",
+            classOf[org.apache.hadoop.hive.conf.HiveConf])
+        method.setAccessible(true)
+        method.invoke(server, executionHive.conf)
+      }
       // If application was killed before HiveThriftServer2 start successfully then SparkSubmit
       // process can not exit, so check whether if SparkContext was stopped.
       if (SparkSQLEnv.sparkContext.stopped.get()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`HiveThriftServer2` is a multi-session managed service based on `HiveServer2`, which provides centralized management services for Hive.

Since `HiveThriftServer2` itself inherits from `HiveServer2`, `HiveServer2`'s own HA solution can also support `HiveThriftServer2`.

`HiveThriftServer2` does not support **HA**. Why is this?

The main method of `HiveServer2` is as follows:
```
  public static void main(String[] args) {
    HiveConf.setLoadHiveServer2Config(true);
    try {
      ServerOptionsProcessor oproc = new ServerOptionsProcessor("hiveserver2");
      ServerOptionsProcessorResponse oprocResponse = oproc.parse(args);
 
      // Omit irrelevant code
 
      // Call the executor which will execute the appropriate command based on the parsed options
      oprocResponse.getServerOptionsExecutor().execute();
    } catch (LogInitializationException e) {
      LOG.error("Error initializing log: " + e.getMessage(), e);
      System.exit(-1);
    }
  }
```
The above code first creates the `ServerOptionsProcessor` object and parses the parameters. The `parse` method parses the parameters and returns the `oprocResponse` object (type is `ServerOptionsProcessorResponse`). Then the object obtained by calling the `getServerOptionsExecutor` method of `oprocResponse` is actually `StartOptionExecutor`. Finally, the execute method of `StartOptionExecutor` is called. The implementation of StartOptionExecutor is as follows:
```
  static class StartOptionExecutor implements ServerOptionsExecutor {
    @Override
    public void execute() {
      try {
        startHiveServer2();
      } catch (Throwable t) {
        LOG.fatal("Error starting HiveServer2", t);
        System.exit(-1);
      }
    }
  }
```
It can be seen that the `execute` method of `StartOptionExecutor` actually calls the `startHiveServer2` method, and the code related to HA in the `startHiveServer2` method is as follows:
```
        if (hiveConf.getBoolVar(ConfVars.HIVE_SERVER2_SUPPORT_DYNAMIC_SERVICE_DISCOVERY)) {
          server.addServerInstanceToZooKeeper(hiveConf);
        }
```
You can see that the `addServerInstanceToZooKeeper` method of `HiveServer2` is called. The role of the `addServerInstanceToZooKeeper` is to create a persistent parent node as the HA namespace on the specified `ZooKeeper` cluster, and create a persistent node to save the `HiveServer2` instance information to the node.

But `HiveThriftServer2` can not call the `execute` method of `StartOptionExecutor` as Spark has its own logic. So I added some reflection code as to call the `addServerInstanceToZooKeeper` method of `HiveServer2`.

**Notice**:This PR can support Hive version as follows:
0.14.0 through 2.3.4
3.1.0 through 3.1.1

## How was this patch tested?

Exists UT.
