### PR TITLE
[Spark-27664][CORE] file status cache perf issue/branch 2.4

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -542,6 +542,17 @@ object SQLConf {
       .longConf
       .createWithDefault(250 * 1024 * 1024)
 
+  val HIVE_FILESOURCE_FILE_CACHE_CONCURRENCY_LEVEL =
+    buildConf("spark.sql.hive.filesourceFileCacheConcurrencyLevel")
+      .doc("Provide concurrency level for underlying guava cache. The default is 1." +
+        " Higher value may give better performance, when the number of " +
+        "entries in the cache is very large. This imposes a limit on the size of single entry" +
+        "in the cache, i.e. sizeLimit < totalCacheCapacity/concurrencyLevel. See SPARK-27664.")
+      .intConf
+      .checkValue(value => value >= 1 && value <= 64, "The concurrency level should be " +
+        "between 1 and 64.")
+      .createWithDefault(1)
+
   object HiveCaseSensitiveInferenceMode extends Enumeration {
     val INFER_AND_SAVE, INFER_ONLY, NEVER_INFER = Value
   }
@@ -1688,6 +1699,9 @@ class SQLConf extends Serializable with Logging {
   def manageFilesourcePartitions: Boolean = getConf(HIVE_MANAGE_FILESOURCE_PARTITIONS)
 
   def filesourcePartitionFileCacheSize: Long = getConf(HIVE_FILESOURCE_PARTITION_FILE_CACHE_SIZE)
+
+  def filesourceFileCacheConcurrencyLevel: Int =
+    getConf(HIVE_FILESOURCE_FILE_CACHE_CONCURRENCY_LEVEL)
 
   def caseSensitiveInferenceMode: HiveCaseSensitiveInferenceMode.Value =
     HiveCaseSensitiveInferenceMode.withName(getConf(HIVE_CASE_SENSITIVE_INFERENCE))


### PR DESCRIPTION
## What changes were proposed in this pull request?

__Targeted for branch 2.4, #24585__

Currently, Spark uses FileStatusCache to cache the listings while scanning a filesystem path. If this file system is on a remote storage like Object store (Amazon s3 or IBM COS), then this cache is of prime importance as it saves round trips of fetching listing over network over and over again.

FileStatusCache uses guava cache underneath, which is configured with reasonably high default value. But, when remote listing is large >100K, the size requirement of this cache is also very high. Currently, this underlying guava cache is configured with default concurrency level of 4. The effect of this is, that a single entry can only be as large as less than `maxSizeOfCache/concurrencyLevel` [1]. Quite often, users have everything listed under a single directory or path on an object store, and as a result the entire fileStatus array containing 100k + entries is inserted as a single entry in the cache. So cache requirement grows more than 4x. 

Please refer to Jira [link](https://issues.apache.org/jira/browse/SPARK-27664) for more detailed explanation. 

In this patch, we make default concurrency level for underlying guava cache as 1 and makes it configurable, as this cache stores only a few but very large entries in reality. So the performance penalty will be very less, if any.

I am open to work on an alternative solution as well, please feel free to discuss them.

[1]. https://github.com/google/guava/issues/3462 

## How was this patch tested?

Existing tests should pass.
Manually verified the expected behaviour against a path with large listing ~ 200K.