### PR TITLE
[SPARK-27679][SQL] Improve LIKE optimization

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -481,7 +481,7 @@ object LikeSimplification extends Rule[LogicalPlan] {
   private val equalTo = "([^_%]*)".r
   private val endsWithUnderscore = "([^_%]+)_".r
   private val startsWithUnderscore = "_([^_%]+)".r
-  private val containsSingleUnderscore = "([^_%]+)_([^_%]+)".r
+  private val startsAndEndsWithUnderscore = "([^_%]+)_([^_%]+)".r
 
   def apply(plan: LogicalPlan): LogicalPlan = plan transformAllExpressions {
     case Like(input, Literal(pattern, StringType)) =>
@@ -512,7 +512,7 @@ object LikeSimplification extends Rule[LogicalPlan] {
             And(EqualTo(Length(input), Literal(suffix.length + 1)),
               EndsWith(input, Literal(suffix)))
           // case: abc_xyz
-          case containsSingleUnderscore(prefix, suffix) =>
+          case startsAndEndsWithUnderscore(prefix, suffix) =>
             And(EqualTo(Length(input), Literal(prefix.length + suffix.length + 1)),
               And(StartsWith(input, Literal(prefix)), EndsWith(input, Literal(suffix))))
           case _ =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst.optimizer
 
 import scala.collection.immutable.HashSet
 import scala.collection.mutable.{ArrayBuffer, Stack}
+
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLiteral}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LikeSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LikeSimplificationSuite.scala
@@ -120,6 +120,19 @@ class LikeSimplificationSuite extends PlanTest {
       comparePlans(optimized, correctAnswer)
   }
 
+  test("optimize limit queries that end with single underscore.") {
+      val singleUnderscoreEndsWithQuery =
+        testRelation
+          .where('a like "abc_")
+      val optimized = Optimize.execute(singleUnderscoreEndsWithQuery.analyze)
+      val correctAnswer = testRelation
+        .where(
+            And(EqualTo(Length('a), Literal(4)),
+              StartsWith('a, Literal("abc"))))
+        .analyze
+      comparePlans(optimized, correctAnswer)
+  }
+
   test("expressions that start and end with single underscore, " +
     "underscore optimization should be ignored.") {
       val singleUnderscoreEndsWithQuery =
@@ -146,7 +159,7 @@ class LikeSimplificationSuite extends PlanTest {
       comparePlans(optimized, correctAnswer)
   }
 
-  test("Ignore multiple underscore characters") {
+  test("Ignore optimization in the case of multiple underscore characters") {
       val singleUnderscoreInQuery =
         testRelation
           .where('a like "abc__def")
@@ -157,7 +170,7 @@ class LikeSimplificationSuite extends PlanTest {
       comparePlans(optimized, correctAnswer)
   }
 
-  test("multiple underscore characters, underscore optimization should be ignored.") {
+  test("Ignore optimization in the case of multiple single underscore characters") {
       val singleUnderscoreInQuery =
         testRelation
           .where('a like "abc_def_ghi")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LikeSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LikeSimplificationSuite.scala
@@ -104,80 +104,80 @@ class LikeSimplificationSuite extends PlanTest {
   test("null pattern") {
     val originalQuery = testRelation.where('a like Literal(null, StringType)).analyze
     val optimized = Optimize.execute(originalQuery)
-    comparePlans(optimized, testRelation.where(Literal(false, BooleanType)).analyze)
+    comparePlans(optimized, testRelation.where(Literal(null, BooleanType)).analyze)
   }
 
   test("optimize limit queries that start with single underscore.") {
-      val singleUnderscoreStarsWithQuery =
-        testRelation
-          .where('a like "_abc")
-      val optimized = Optimize.execute(singleUnderscoreStarsWithQuery.analyze)
-      val correctAnswer = testRelation
-        .where(
-            And(EqualTo(Length('a), Literal(4)),
-              EndsWith('a, Literal("abc"))))
-        .analyze
-      comparePlans(optimized, correctAnswer)
+    val singleUnderscoreStarsWithQuery =
+      testRelation
+        .where('a like "_abc")
+    val optimized = Optimize.execute(singleUnderscoreStarsWithQuery.analyze)
+    val correctAnswer = testRelation
+      .where(
+        And(EqualTo(Length('a), Literal(4)),
+          EndsWith('a, Literal("abc"))))
+      .analyze
+    comparePlans(optimized, correctAnswer)
   }
 
   test("optimize limit queries that end with single underscore.") {
-      val singleUnderscoreEndsWithQuery =
-        testRelation
-          .where('a like "abc_")
-      val optimized = Optimize.execute(singleUnderscoreEndsWithQuery.analyze)
-      val correctAnswer = testRelation
-        .where(
-            And(EqualTo(Length('a), Literal(4)),
-              StartsWith('a, Literal("abc"))))
-        .analyze
-      comparePlans(optimized, correctAnswer)
+    val singleUnderscoreEndsWithQuery =
+      testRelation
+        .where(('a like "abc_") || ('a like "ghi\\_"))
+    val optimized = Optimize.execute(singleUnderscoreEndsWithQuery.analyze)
+    val correctAnswer = testRelation
+      .where(
+        And(EqualTo(Length('a), Literal(4)),
+          StartsWith('a, Literal("abc"))) || ('a like "ghi\\_"))
+      .analyze
+    comparePlans(optimized, correctAnswer)
   }
 
   test("expressions that start and end with single underscore, " +
     "underscore optimization should be ignored.") {
-      val singleUnderscoreEndsWithQuery =
-        testRelation
-          .where('a like "_abc_")
-      val optimized = Optimize.execute(singleUnderscoreEndsWithQuery.analyze)
-      val correctAnswer = testRelation
+    val singleUnderscoreEndsWithQuery =
+      testRelation
         .where('a like "_abc_")
-        .analyze
-      comparePlans(optimized, correctAnswer)
+    val optimized = Optimize.execute(singleUnderscoreEndsWithQuery.analyze)
+    val correctAnswer = testRelation
+      .where('a like "_abc_")
+      .analyze
+    comparePlans(optimized, correctAnswer)
   }
 
   test("optimize limit queries that have single underscore in between.") {
-      val singleUnderscoreInQuery =
-        testRelation
-          .where('a like "abc_def")
-      val optimized = Optimize.execute(singleUnderscoreInQuery.analyze)
-      val correctAnswer = testRelation
-        .where(
-          And(EqualTo(Length('a), Literal(7)),
-              And(StartsWith('a, Literal("abc")),
-                EndsWith('a, Literal("def")))))
-        .analyze
-      comparePlans(optimized, correctAnswer)
+    val singleUnderscoreInQuery =
+      testRelation
+        .where(('a like "abc_def") || ('a like "abc\\_def"))
+    val optimized = Optimize.execute(singleUnderscoreInQuery.analyze)
+    val correctAnswer = testRelation
+      .where(
+        And(EqualTo(Length('a), Literal(7)),
+          And(StartsWith('a, Literal("abc")),
+            EndsWith('a, Literal("def")))) || ('a like "abc\\_def"))
+      .analyze
+    comparePlans(optimized, correctAnswer)
   }
 
   test("Ignore optimization in the case of multiple underscore characters") {
-      val singleUnderscoreInQuery =
-        testRelation
-          .where('a like "abc__def")
-      val optimized = Optimize.execute(singleUnderscoreInQuery.analyze)
-      val correctAnswer = testRelation
+    val singleUnderscoreInQuery =
+      testRelation
         .where('a like "abc__def")
-        .analyze
-      comparePlans(optimized, correctAnswer)
+    val optimized = Optimize.execute(singleUnderscoreInQuery.analyze)
+    val correctAnswer = testRelation
+      .where('a like "abc__def")
+      .analyze
+    comparePlans(optimized, correctAnswer)
   }
 
   test("Ignore optimization in the case of multiple single underscore characters") {
-      val singleUnderscoreInQuery =
-        testRelation
-          .where('a like "abc_def_ghi")
-      val optimized = Optimize.execute(singleUnderscoreInQuery.analyze)
-      val correctAnswer = testRelation
+    val singleUnderscoreInQuery =
+      testRelation
         .where('a like "abc_def_ghi")
-        .analyze
-      comparePlans(optimized, correctAnswer)
+    val optimized = Optimize.execute(singleUnderscoreInQuery.analyze)
+    val correctAnswer = testRelation
+      .where('a like "abc_def_ghi")
+      .analyze
+    comparePlans(optimized, correctAnswer)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The following improvements are possible when simplifying `LIKE` expressions by adding support for underscore case optimization similar to '%' :

```
    Filter name#10 LIKE _abc → Filter (length(name#10) = 4 && EndsWith(name#10, abc))
    Filter name#10 LIKE abc_ → Filter (length(name#10) = 4 && StartsWith(name#10, abc))
    Filter name#10 LIKE abc_def -> Filter ((length(name#10) = 7) && (StartsWith(name#10, abc) && EndsWith(name#10, def)))
```

## How was this patch tested?

Added UTs.
