### PR TITLE
[SPARK-27703][K8S] kubernetes jobs are failing with Unsatisfiedlink error

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -48,6 +48,7 @@ COPY kubernetes/tests /opt/spark/tests
 COPY data /opt/spark/data
 
 ENV SPARK_HOME /opt/spark
+ENV LD_LIBRARY_PATH /lib64/
 
 WORKDIR /opt/spark/work-dir
 RUN chmod g+w /opt/spark/work-dir


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added LD_LIBRARY_PATH to avoid the issue as the required so file is present in /lib64 which is not added in the ldconfig
