### PR TITLE
[SPARK-27711][CORE] Unset InputFileBlockHolder at the end of tasks

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -25,6 +25,7 @@ import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.internal.config.APP_CALLER_CONTEXT
 import org.apache.spark.memory.{MemoryMode, TaskMemoryManager}
 import org.apache.spark.metrics.MetricsSystem
+import org.apache.spark.rdd.InputFileBlockHolder
 import org.apache.spark.util._
 
 /**
@@ -154,6 +155,7 @@ private[spark] abstract class Task[T](
           // Though we unset the ThreadLocal here, the context member variable itself is still
           // queried directly in the TaskRunner to check for FetchFailedExceptions.
           TaskContext.unset()
+          InputFileBlockHolder.unset()
         }
       }
     }

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -3188,21 +3188,21 @@ def pandas_udf(f=None, returnType=None, functionType=None):
     else:
         return _create_udf(f=f, returnType=return_type, evalType=eval_type)
 
-    def test_input_file_name_reset_for_rdd(self):
-        from pyspark.sql.functions import udf, input_file_name
-        rdd = self.sc.textFile('python/test_support/hello/hello.txt').map(lambda x: {'data': x})
-        df = self.spark.createDataFrame(rdd, StructType([StructField('data', StringType(), True)]))
-        df.select(input_file_name().alias('file')).collect()
+  def test_input_file_name_reset_for_rdd(self):
+      from pyspark.sql.functions import udf, input_file_name
+      rdd = self.sc.textFile('python/test_support/hello/hello.txt').map(lambda x: {'data': x})
+      df = self.spark.createDataFrame(rdd, StructType([StructField('data', StringType(), True)]))
+      df.select(input_file_name().alias('file')).collect()
 
-        non_file_df = self.spark.range(0, 100, 1, 100).select(input_file_name().alias('file'))
+      non_file_df = self.spark.range(0, 100, 1, 100).select(input_file_name().alias('file'))
 
-        results = non_file_df.collect()
-        self.assertTrue(len(results) == 100)
+      results = non_file_df.collect()
+      self.assertTrue(len(results) == 100)
 
-        # [SC-12160]: if everything was properly reset after the last job, this should return
-        # empty string rather than the file read in the last job.
-        for result in results:
-            assert(result[0] == '')
+      # [SC-12160]: if everything was properly reset after the last job, this should return
+      # empty string rather than the file read in the last job.
+      for result in results:
+          assert(result[0] == '')
 
 
 blacklist = ['map', 'since', 'ignore_unicode_prefix']

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -3188,22 +3188,6 @@ def pandas_udf(f=None, returnType=None, functionType=None):
     else:
         return _create_udf(f=f, returnType=return_type, evalType=eval_type)
 
-  def test_input_file_name_reset_for_rdd(self):
-      from pyspark.sql.functions import udf, input_file_name
-      rdd = self.sc.textFile('python/test_support/hello/hello.txt').map(lambda x: {'data': x})
-      df = self.spark.createDataFrame(rdd, StructType([StructField('data', StringType(), True)]))
-      df.select(input_file_name().alias('file')).collect()
-
-      non_file_df = self.spark.range(0, 100, 1, 100).select(input_file_name().alias('file'))
-
-      results = non_file_df.collect()
-      self.assertTrue(len(results) == 100)
-
-      # [SC-12160]: if everything was properly reset after the last job, this should return
-      # empty string rather than the file read in the last job.
-      for result in results:
-          assert(result[0] == '')
-
 
 blacklist = ['map', 'since', 'ignore_unicode_prefix']
 __all__ = [k for k, v in globals().items()

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -3188,7 +3188,6 @@ def pandas_udf(f=None, returnType=None, functionType=None):
     else:
         return _create_udf(f=f, returnType=return_type, evalType=eval_type)
 
-
     def test_input_file_name_reset_for_rdd(self):
         from pyspark.sql.functions import udf, input_file_name
         rdd = self.sc.textFile('python/test_support/hello/hello.txt').map(lambda x: {'data': x})

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -278,6 +278,22 @@ class FunctionsTests(ReusedSQLTestCase):
             df.select(df.name).orderBy(functions.desc_nulls_last('name')).collect(),
             [Row(name=u'Tom'), Row(name=u'Alice'), Row(name=None)])
 
+    def test_input_file_name_reset_for_rdd(self):
+        from pyspark.sql.functions import udf, input_file_name
+        rdd = self.sc.textFile('python/test_support/hello/hello.txt').map(lambda x: {'data': x})
+        df = self.spark.createDataFrame(rdd, StructType([StructField('data', StringType(), True)]))
+        df.select(input_file_name().alias('file')).collect()
+
+        non_file_df = self.spark.range(0, 100, 1, 100).select(input_file_name().alias('file'))
+
+        results = non_file_df.collect()
+        self.assertTrue(len(results) == 100)
+
+        # [SC-12160]: if everything was properly reset after the last job, this should return
+        # empty string rather than the file read in the last job.
+        for result in results:
+            assert(result[0] == '')
+
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -19,6 +19,7 @@ import datetime
 import sys
 
 from pyspark.sql import Row
+from pyspark.sql.types import *
 from pyspark.testing.sqlutils import ReusedSQLTestCase
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Unset InputFileBlockHolder at the end of tasks to stop the file name from leaking over to other tasks in the same thread. This happens in particular in Pyspark because of its complex threading model.

## How was this patch tested?

new pyspark test