### PR TITLE
[SPARK-27716][SQL] Complete the transactions support for part of jdbc datasource operations.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcPartitionSaveFailureException.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcPartitionSaveFailureException.scala
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.jdbc
+
+import org.apache.spark.SparkException
+
+private[sql] case class JdbcPartitionSaveFailureException(message: String)
+  extends SparkException(message)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/AggregatedDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/AggregatedDialect.scala
@@ -76,4 +76,8 @@ private class AggregatedDialect(dialects: List[JdbcDialect]) extends JdbcDialect
       cascade: Option[Boolean] = isCascadingTruncateTable): String = {
     dialects.head.getTruncateQuery(table, cascade)
   }
+
+  override def getRenameTableQuery(oldtable: String, newtable: String): String = {
+    dialects.head.getRenameTableQuery(oldtable, newtable)
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
@@ -49,4 +49,17 @@ private object DB2Dialect extends JdbcDialect {
   }
 
   override def isCascadingTruncateTable(): Option[Boolean] = Some(false)
+
+  /**
+   * The SQL query used to rename a table. For DB2, this behaviour only alter the
+   * origin table's name, does not change the schema.
+   *
+   * @param oldTable  The name of the origin table.
+   * @param newTable THe name of the new table.
+   * @return The SQL query to use for rename the table.
+   */
+  override def getRenameTableQuery(oldTable: String, newTable: String): String = {
+    val withOutSchemaName = newTable.split("\\.").last
+    s"RENAME  TABLE $oldTable TO $withOutSchemaName"
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -104,6 +104,18 @@ abstract class JdbcDialect extends Serializable {
   }
 
   /**
+   * Get the SQL query that should be used to rename a table to new name. Dialects can
+   * override this method to return a query that works best in a particular database.
+   * @param oldTable  The name of the origin table.
+   * @param newTable THe name of the new table.
+   * @return The SQL query to use for rename the table.
+   */
+  @Since("2.4.3")
+  def getRenameTableQuery(oldTable: String, newTable: String): String = {
+    s"RENAME TABLE $oldTable TO $newTable"
+  }
+
+  /**
    * The SQL query that should be used to discover the schema of a table. It only needs to
    * ensure that the result set has the same schema as the table, such as by calling
    * "SELECT * ...". Dialects can override this method to return a query that works best in a
@@ -246,4 +258,8 @@ object JdbcDialects {
  */
 private object NoopDialect extends JdbcDialect {
   override def canHandle(url : String): Boolean = true
+
+  override def getRenameTableQuery(oldTable: String, newTable: String): String = {
+    s"ALTER TABLE $oldTable RENAME TO $newTable"
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -91,6 +91,19 @@ private object PostgresDialect extends JdbcDialect {
   override def isCascadingTruncateTable(): Option[Boolean] = Some(false)
 
   /**
+   * The SQL query used to rename a table. For Postgres, this behaviour only alter the
+   * origin table's name, does not change the schema.
+   *
+   * @param oldTable  The name of the origin table.
+   * @param newTable THe name of the new table.
+   * @return The SQL query to use for rename the table.
+   */
+  override def getRenameTableQuery(oldTable: String, newTable: String): String = {
+    val withOutSchemaName = newTable.split("\\.").last
+    s"ALTER TABLE $oldTable RENAME TO $withOutSchemaName"
+  }
+
+  /**
    * The SQL query used to truncate a table. For Postgres, the default behaviour is to
    * also truncate any descendant tables. As this is a (possibly unwanted) side-effect,
    * the Postgres dialect adds 'ONLY' to truncate only the table in question

--- a/sql/hive-thriftserver/pom.xml
+++ b/sql/hive-thriftserver/pom.xml
@@ -85,6 +85,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_${scala.binary.version}</artifactId>
       <type>test-jar</type>

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/JdbcConnectionUriSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/JdbcConnectionUriSuite.scala
@@ -20,7 +20,12 @@ package org.apache.spark.sql.hive.thriftserver
 import java.sql.DriverManager
 
 import org.apache.hive.jdbc.HiveDriver
+import org.mockito.Mockito.{mock, when}
 
+import org.apache.spark.{Partition, TaskContext}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.execution.datasources.jdbc.{JdbcOptionsInWrite, JDBCPartition, JdbcPartitionSaveFailureException, JdbcUtils}
 import org.apache.spark.util.Utils
 
 class JdbcConnectionUriSuite extends HiveThriftServer2Test {
@@ -32,6 +37,8 @@ class JdbcConnectionUriSuite extends HiveThriftServer2Test {
   val USER = System.getProperty("user.name")
   val PASSWORD = ""
 
+  var spark: SparkSession = _
+
   override protected def beforeAll(): Unit = {
     super.beforeAll()
 
@@ -40,6 +47,7 @@ class JdbcConnectionUriSuite extends HiveThriftServer2Test {
     val statement = connection.createStatement()
     statement.execute(s"CREATE DATABASE $JDBC_TEST_DATABASE")
     connection.close()
+    spark = SparkSession.builder().enableHiveSupport().getOrCreate()
   }
 
   override protected def afterAll(): Unit = {
@@ -49,6 +57,9 @@ class JdbcConnectionUriSuite extends HiveThriftServer2Test {
       val statement = connection.createStatement()
       statement.execute(s"DROP DATABASE $JDBC_TEST_DATABASE")
       connection.close()
+      if (spark != null) {
+        spark.close()
+      }
     } finally {
       super.afterAll()
     }
@@ -62,6 +73,49 @@ class JdbcConnectionUriSuite extends HiveThriftServer2Test {
       val resultSet = statement.executeQuery("select current_database()")
       resultSet.next()
       assert(resultSet.getString(1) === JDBC_TEST_DATABASE)
+    } finally {
+      statement.close()
+      connection.close()
+    }
+  }
+
+  test("SPARK-27716 test transactional save table") {
+    val jdbcUri = s"jdbc:hive2://localhost:$serverPort/$JDBC_TEST_DATABASE"
+    val params = Map("url" -> jdbcUri, "dbtable" -> "test")
+    val options = new JdbcOptionsInWrite(params)
+
+    val mockRdd = new RDD[Row](spark.sparkContext, null) {
+      var partitions_ : Array[Partition] = Array(new JDBCPartition("id", 0))
+      override def getPartitions: Array[Partition] = partitions_
+      override def compute(split: Partition, context: TaskContext): Iterator[Row] = null
+      override def foreachPartition(f: Iterator[Row] => Unit): Unit = {}
+    }
+
+    val rdd = spark.sparkContext.parallelize(params.toSeq)
+    val df = spark.createDataFrame(rdd)
+    val schema = df.schema
+
+    val mockdf = mock(classOf[DataFrame])
+    when(mockdf.sparkSession).thenReturn(spark)
+    when(mockdf.schema).thenReturn(schema)
+    when(mockdf.rdd).thenReturn(mockRdd)
+    // Because the part num is 1, but accumulator's value is 0.
+    intercept[JdbcPartitionSaveFailureException](JdbcUtils.transactionalSaveTable(
+      mockdf, Some(schema), false, options))
+
+    val showTables = "show tables"
+    val connection = DriverManager.getConnection(jdbcUri, USER, PASSWORD)
+    val statement = connection.createStatement()
+    // This should consistent with the suffix of temp table name.
+    val tempTableSuffix = "temp"
+    try {
+      val result = statement.executeQuery(showTables)
+      while (result.next()) {
+        val tbl = result.getString(1)
+        // The transactional save table is failed, so the options.table has't been created and
+        // the temp table has been dropped.
+        assert(tbl != options.table && !tbl.endsWith(tempTableSuffix))
+      }
     } finally {
       statement.close()
       connection.close()


### PR DESCRIPTION
## What changes were proposed in this pull request?

With the jdbc datasource,  we can save a rdd to the database.

The comments for the function `saveTable` is that.

      /**
       * Saves the RDD to the database in a single transaction.
       */
      def saveTable(
          df: DataFrame,
          tableSchema: Option[StructType],
          isCaseSensitive: Boolean,
          options: JdbcOptionsInWrite)

In fact, it is not correct.

 The  savePartition operation is in a single transaction but  the saveTable operation is not in a single transaction.

There are several cases of data transmission:

- case1: Append data to origin existed gptable.
- case2: Overwrite origin gptable, but the table is a cascadingTruncateTable, so we can not drop the gptable, we have to truncate it and append data.
- case3: Overwrite origin existed table and the table is not a cascadingTruncateTable, so we can drop it first.
- case4: For an unexisted table, create and transmit data.



In this PR, I add a transactions support for case3 and case4.

For case3 and case4,  we can transmit the rdd to a temp table at first.

We use an accumulator to record the suceessful savePartition operations.

At last, we compare the value of accumulator with dataFrame's partitionNum.

If all the savePartition operations are successful,  we drop the origin table if it exists,  then we  alter the temp table rename to origin table.



## How was this patch tested?

Unit test.