### PR TITLE
[SPARK-27549][SS] Add support for committing kafka offsets per batch for supporting external tooling

### DIFF
--- a/docs/structured-streaming-kafka-integration.md
+++ b/docs/structured-streaming-kafka-integration.md
@@ -414,6 +414,16 @@ The following configurations are optional:
   issues, set the Kafka consumer session timeout (by setting option "kafka.session.timeout.ms") to
   be very small. When this is set, option "groupIdPrefix" will be ignored. </td>
 </tr>
+<tr>
+  <td>setCommitOffsetsOnCheckpoints</td>
+  <td>string</td>
+  <td>false</td>
+  <td>streaming</td>
+  <td>Whetherer to commit back the offsets read by the driver consumer per batch.
+  Due to the fact that each batch will get its offsets committed when a new is constructed there might be a lag
+  wrt last batch. 
+  </td>
+</tr>
 </table>
 
 ## Writing Data to Kafka

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaCommitsSource.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaCommitsSource.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.kafka010
+
+import com.codahale.metrics.{Counter, MetricRegistry}
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.metrics.source.Source
+
+class KafkaCommitsSource extends Source with Logging{
+
+  private val prefix = "structured-streaming-driver-kafka-consumer"
+
+  override implicit val metricRegistry: MetricRegistry = new MetricRegistry
+
+  override val sourceName = s"$prefix-offsets"
+
+  val SUCCESSFUL_COMMITS = getCounter(prefix, "successfulCommits")
+
+  val FAILED_COMMITS = getCounter(prefix, "failedCommits")
+
+  def getCounter(prefix: String, name: String)(implicit metricRegistry: MetricRegistry): Counter = {
+    metricRegistry.counter(MetricRegistry.name(prefix, name))
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

We introduce offsets commit per micro-batch. Since we cannot commit at the executor side (a batch can be repeated) we need to do this at the driver side. A result of this is that we dont have offset metadata info to use.
Inspired by the Flink approach although Flink matches the continuous mode which the PR does not cover. Also Flink does a more sophisticated management of the kafka commits since it tracks commit progress at the task side via the flink-kafka-connector. For more details about this PR, pls check the jira ticket. 
A new option is introduced namely `setCommitOffsetsOnCheckpoints` to turn on/off this feature and also we expose metrics about successful/failed commits as in Flink (useful for monitoring).

Note: this is used only for Kafka sources in streaming mode as written in the documentation.
StreamingQueryManager enforces checkpointing in any case so we dont rely on the written back offsets in any way, unlike Flink which supports auto.commit when checkpointing is disabled. 

## How was this patch tested?
Manually. Using spark shell.
```
import org.apache.spark.sql.streaming.Trigger
import spark.implicits._

case class GeneratedData(key: String, value: String)
  
val df = spark
  .readStream
  .format("kafka")
  .option("checkpointLocation", "/tmp/k4")
  .option("kafka.bootstrap.servers", "localhost:9092")
  .option("subscribe", "Topic4")
  .option("startingOffsets", "latest")
  .option("setCommitOffsetsOnCheckpoints", "true")
  .option("maxOffsetsPerTrigger", 100)
  .option("setCommitOffsetsOnCheckpoints", "true")
  .load()

val query = df.selectExpr("CAST(key AS STRING)", "CAST(value AS STRING)")
 .as[GeneratedData]
 .writeStream
 .format("console")
 .trigger(Trigger.ProcessingTime("5 seconds"))

query.start()
```

```
./kafka-console-consumer.sh  --formatter "kafka.coordinator.group.GroupMetadataManager\$OffsetsMessageFormatter" --bootstrap-server localhost:9092 --topic __consumer_offsets --from-beginning | grep spark

[spark-kafka-source-b595f412-1ec6-408f-b804-6d44ae763340-348116533-driver-0,Topic4,0]::[OffsetMetadata[0,NO_METADATA],CommitTime 1557910170072,ExpirationTime 1557996570072]
[spark-kafka-source-b595f412-1ec6-408f-b804-6d44ae763340-348116533-driver-0,Topic4,0]::[OffsetMetadata[1,NO_METADATA],CommitTime 1557910175019,ExpirationTime 1557996575019]
[spark-kafka-source-b595f412-1ec6-408f-b804-6d44ae763340-348116533-driver-0,Topic4,0]::[OffsetMetadata[2,NO_METADATA],CommitTime 1557910180035,ExpirationTime 1557996580035]
[spark-kafka-source-b595f412-1ec6-408f-b804-6d44ae763340-348116533-driver-0,Topic4,0]::[OffsetMetadata[6,NO_METADATA],CommitTime 1557910185014,ExpirationTime 1557996585014]
[spark-kafka-source-b595f412-1ec6-408f-b804-6d44ae763340-348116533-driver-0,Topic4,0]::[OffsetMetadata[10,NO_METADATA],CommitTime 1557910190014,ExpirationTime 1557996590014]


scala> -------------------------------------------
Batch: 0
-------------------------------------------
+---+-----+
|key|value|
+---+-----+
+---+-----+

-------------------------------------------
Batch: 1
-------------------------------------------
+----+------------+
| key|       value|
+----+------------+
|null|Hello, World|
+----+------------+

-------------------------------------------
Batch: 2
-------------------------------------------
+----+------------+
| key|       value|
+----+------------+
|null|Hello, World|
+----+------------+

-------------------------------------------
Batch: 3
-------------------------------------------
+----+------------+
| key|       value|
+----+------------+
|null|Hello, World|
|null|Hello, World|
|null|Hello, World|
|null|Hello, World|
+----+------------+

-------------------------------------------
Batch: 4
-------------------------------------------
+----+------------+
| key|       value|
+----+------------+
|null|Hello, World|
|null|Hello, World|
|null|Hello, World|
|null|Hello, World|
+----+------------+

-------------------------------------------
Batch: 5
-------------------------------------------
+----+------------+
| key|       value|
+----+------------+
|null|Hello, World|
|null|Hello, World|
|null|Hello, World|
+----+------------+

```
The last batch commit reported 10 as the offset, while the maximum in this case is 13, reason is that [MicroBatchExecution](https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala#L416) will only commit the previously completed batch offsets when a new batch is going to be processed. We do care about the committed ones so we dont report back something not done as seen by the engine (users can always compare with max offset if they care about the lag here). 
