### PR TITLE
[SPARK-27712][PySpark][SQL] Returns correct schema even under different column order when creating dataframe

### DIFF
--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -705,6 +705,12 @@ class DataFrameTests(ReusedSQLTestCase):
                     break
             self.assertEqual(df.take(8), result)
 
+    def test_different_col_order(self):
+        row = self.spark.createDataFrame(
+            self.sc.parallelize([Row(A="1", B="2")]), "B string, A string").first()
+        self.assertEqual(row['A'], "1")
+        self.assertEqual(row['B'], "2")
+
 
 class QueryExecutionListenerTests(unittest.TestCase, SQLTestUtils):
     # These tests are separate because it uses 'spark.sql.queryExecutionListeners' which is

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -613,6 +613,8 @@ class StructType(DataType):
                 return tuple(obj.get(n) for n in self.names)
             elif isinstance(obj, Row) and getattr(obj, "__from_dict__", False):
                 return tuple(obj[n] for n in self.names)
+            elif isinstance(obj, Row) and hasattr(obj, "__fields__"):
+                return tuple(obj[n] for n in self.names)
             elif isinstance(obj, (list, tuple)):
                 return tuple(obj)
             elif hasattr(obj, "__dict__"):


### PR DESCRIPTION
## What changes were proposed in this pull request?

In PySpark, `Row`'s `__from_dict__` is lost after pickle. But we rely on `__from_dict__` when converting `Row`s to internal by calling `toInternal`. It causes a weird behavior:

```python
>>> spark.createDataFrame([Row(A="1", B="2")], "B string, A string").first()
Row(B='2', A='1') # correct
>>> spark.createDataFrame(spark.sparkContext.parallelize([Row(A="1", B="2")]), "B string, A string").first()
Row(B='1', A='2') # incorrect                                                         
```

This patch tried to fix the issue.

## How was this patch tested?

Added test.