### PR TITLE
[SPARK-27726] [Core] Fix performance of ElementTrackingStore deletes when using InMemoryStore under high loads

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
@@ -132,13 +132,10 @@ public class InMemoryStore implements KVStore {
     private final KVTypeInfo.Accessor naturalKey;
     private final ConcurrentMap<Comparable<Object>, Object> data;
 
-    private int size;
-
     private InstanceList(Class<?> type) throws Exception {
       this.ti = new KVTypeInfo(type);
       this.naturalKey = ti.getAccessor(KVIndex.NATURAL_INDEX_NAME);
       this.data = new ConcurrentHashMap<>();
-      this.size = 0;
     }
 
     KVTypeInfo.Accessor getIndexAccessor(String indexName) {
@@ -158,13 +155,11 @@ public class InMemoryStore implements KVStore {
     }
 
     public void delete(Object key) {
-      if (data.remove(asKey(key)) != null) {
-        size--;
-      }
+      data.remove(asKey(key));
     }
 
     public int size() {
-      return size;
+      return data.size();
     }
 
     @SuppressWarnings("unchecked")

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
@@ -245,14 +245,14 @@ public class InMemoryStore implements KVStore {
 
     private static <T> Predicate<? super T> getPredicate(
         KVTypeInfo.Accessor getter,
-        Collection<?> keys) {
+        Collection<?> values) {
       if (Comparable.class.isAssignableFrom(getter.getType())) {
-        HashSet<?> set = new HashSet<>(keys);
+        HashSet<?> set = new HashSet<>(values);
 
         return (value) -> set.contains(indexValueForEntity(getter, value));
       } else {
-        HashSet<Comparable> set = new HashSet<>(keys.size());
-        for (Object key : keys) {
+        HashSet<Comparable> set = new HashSet<>(values.size());
+        for (Object key : values) {
           set.add(asKey(key));
         }
         return (value) -> set.contains(asKey(indexValueForEntity(getter, value)));
@@ -269,7 +269,7 @@ public class InMemoryStore implements KVStore {
   }
 
   private static class InMemoryView<T> extends KVStoreView<T> {
-    private static final InMemoryView EMPTY_VIEW =
+    private static final InMemoryView<?> EMPTY_VIEW =
       new InMemoryView<>(Collections.emptyList(), null);
 
     private final Collection<T> elements;

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStore.java
@@ -18,6 +18,7 @@
 package org.apache.spark.util.kvstore;
 
 import java.io.Closeable;
+import java.util.Collection;
 
 import org.apache.spark.annotation.Private;
 
@@ -126,4 +127,8 @@ public interface KVStore extends Closeable {
    */
   long count(Class<?> type, String index, Object indexedValue) throws Exception;
 
+  /**
+   * A cheaper way to remove multiple items from the KVStore
+   */
+  <T> boolean removeAllByKeys(Class<T> klass, String index, Collection keys) throws Exception;
 }

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStore.java
@@ -130,5 +130,6 @@ public interface KVStore extends Closeable {
   /**
    * A cheaper way to remove multiple items from the KVStore
    */
-  <T> boolean removeAllByKeys(Class<T> klass, String index, Collection keys) throws Exception;
+  <T> boolean removeAllByIndexValues(Class<T> klass, String index, Collection<?> indexValues)
+          throws Exception;
 }

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStore.java
@@ -131,5 +131,5 @@ public interface KVStore extends Closeable {
    * A cheaper way to remove multiple items from the KVStore
    */
   <T> boolean removeAllByIndexValues(Class<T> klass, String index, Collection<?> indexValues)
-          throws Exception;
+      throws Exception;
 }

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStoreView.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStoreView.java
@@ -38,8 +38,6 @@ import org.apache.spark.annotation.Private;
 @Private
 public abstract class KVStoreView<T> implements Iterable<T> {
 
-  final Class<T> type;
-
   boolean ascending = true;
   String index = KVIndex.NATURAL_INDEX_NAME;
   Object first = null;
@@ -47,10 +45,6 @@ public abstract class KVStoreView<T> implements Iterable<T> {
   Object parent = null;
   long skip = 0L;
   long max = Long.MAX_VALUE;
-
-  public KVStoreView(Class<T> type) {
-    this.type = type;
-  }
 
   /**
    * Reverses the order of iteration. By default, iterates in ascending order.

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVTypeInfo.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVTypeInfo.java
@@ -37,7 +37,7 @@ public class KVTypeInfo {
   private final Map<String, KVIndex> indices;
   private final Map<String, Accessor> accessors;
 
-  public KVTypeInfo(Class<?> type) throws Exception {
+  public KVTypeInfo(Class<?> type) {
     this.type = type;
     this.accessors = new HashMap<>();
     this.indices = new HashMap<>();
@@ -122,8 +122,9 @@ public class KVTypeInfo {
    */
   interface Accessor {
 
-    Object get(Object instance) throws Exception;
+    Object get(Object instance) throws ReflectiveOperationException;
 
+    Class getType();
   }
 
   private class FieldAccessor implements Accessor {
@@ -135,10 +136,14 @@ public class KVTypeInfo {
     }
 
     @Override
-    public Object get(Object instance) throws Exception {
+    public Object get(Object instance) throws ReflectiveOperationException {
       return field.get(instance);
     }
 
+    @Override
+    public Class getType() {
+      return field.getType();
+    }
   }
 
   private class MethodAccessor implements Accessor {
@@ -150,10 +155,14 @@ public class KVTypeInfo {
     }
 
     @Override
-    public Object get(Object instance) throws Exception {
+    public Object get(Object instance) throws ReflectiveOperationException {
       return method.invoke(instance);
     }
 
+    @Override
+    public Class getType() {
+      return method.getReturnType();
+    }
   }
 
 }

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
@@ -185,11 +185,11 @@ public class LevelDB implements KVStore {
 
   @Override
   public <T> KVStoreView<T> view(Class<T> type) throws Exception {
-    return new KVStoreView<T>(type) {
+    return new KVStoreView<T>() {
       @Override
       public Iterator<T> iterator() {
         try {
-          return new LevelDBIterator<>(LevelDB.this, this);
+          return new LevelDBIterator<>(type, LevelDB.this, this);
         } catch (Exception e) {
           throw Throwables.propagate(e);
         }

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
@@ -198,16 +198,16 @@ public class LevelDB implements KVStore {
   }
 
   @Override
-  public <T> boolean removeAllByKeys(
+  public <T> boolean removeAllByIndexValues(
       Class<T> klass,
       String index,
-      Collection keys) throws Exception {
+      Collection<?> indexValues) throws Exception {
     LevelDBTypeInfo.Index naturalIndex = getTypeInfo(klass).naturalIndex();
     boolean removed = false;
     KVStoreView<T> view = view(klass).index(index);
 
-    for (Object key : keys) {
-      for (T value: view.first(key).last(key)) {
+    for (Object indexValue : indexValues) {
+      for (T value: view.first(indexValue).last(indexValue)) {
         Object itemKey = naturalIndex.getValue(value);
         delete(klass, itemKey);
         removed = true;

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
@@ -19,10 +19,7 @@ package org.apache.spark.util.kvstore;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.NoSuchElementException;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -198,6 +195,26 @@ public class LevelDB implements KVStore {
         }
       }
     };
+  }
+
+  @Override
+  public <T> boolean removeAllByKeys(
+      Class<T> klass,
+      String index,
+      Collection keys) throws Exception {
+    LevelDBTypeInfo.Index naturalIndex = getTypeInfo(klass).naturalIndex();
+    boolean removed = false;
+    KVStoreView<T> view = view(klass).index(index);
+
+    for (Object key : keys) {
+      for (T value: view.first(key).last(key)) {
+        Object itemKey = naturalIndex.getValue(value);
+        delete(klass, itemKey);
+        removed = true;
+      }
+    }
+
+    return removed;
   }
 
   @Override

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java
@@ -45,11 +45,11 @@ class LevelDBIterator<T> implements KVStoreIterator<T> {
   private boolean closed;
   private long count;
 
-  LevelDBIterator(LevelDB db, KVStoreView<T> params) throws Exception {
+  LevelDBIterator(Class<T> type, LevelDB db, KVStoreView<T> params) throws Exception {
     this.db = db;
     this.ascending = params.ascending;
     this.it = db.db().iterator();
-    this.type = params.type;
+    this.type = type;
     this.ti = db.getTypeInfo(type);
     this.index = ti.index(params.index);
     this.max = params.max;
@@ -207,47 +207,43 @@ class LevelDBIterator<T> implements KVStoreIterator<T> {
       return null;
     }
 
-    try {
-      while (true) {
-        boolean hasNext = ascending ? it.hasNext() : it.hasPrev();
-        if (!hasNext) {
-          return null;
-        }
-
-        Map.Entry<byte[], byte[]> nextEntry;
-        try {
-          // Avoid races if another thread is updating the DB.
-          nextEntry = ascending ? it.next() : it.prev();
-        } catch (NoSuchElementException e) {
-          return null;
-        }
-
-        byte[] nextKey = nextEntry.getKey();
-        // Next key is not part of the index, stop.
-        if (!startsWith(nextKey, indexKeyPrefix)) {
-          return null;
-        }
-
-        // If the next key is an end marker, then skip it.
-        if (isEndMarker(nextKey)) {
-          continue;
-        }
-
-        // If there's a known end key and iteration has gone past it, stop.
-        if (end != null) {
-          int comp = compare(nextKey, end) * (ascending ? 1 : -1);
-          if (comp > 0) {
-            return null;
-          }
-        }
-
-        count++;
-
-        // Next element is part of the iteration, return it.
-        return nextEntry.getValue();
+    while (true) {
+      boolean hasNext = ascending ? it.hasNext() : it.hasPrev();
+      if (!hasNext) {
+        return null;
       }
-    } catch (Exception e) {
-      throw Throwables.propagate(e);
+
+      Map.Entry<byte[], byte[]> nextEntry;
+      try {
+        // Avoid races if another thread is updating the DB.
+        nextEntry = ascending ? it.next() : it.prev();
+      } catch (NoSuchElementException e) {
+        return null;
+      }
+
+      byte[] nextKey = nextEntry.getKey();
+      // Next key is not part of the index, stop.
+      if (!startsWith(nextKey, indexKeyPrefix)) {
+        return null;
+      }
+
+      // If the next key is an end marker, then skip it.
+      if (isEndMarker(nextKey)) {
+        continue;
+      }
+
+      // If there's a known end key and iteration has gone past it, stop.
+      if (end != null) {
+        int comp = compare(nextKey, end) * (ascending ? 1 : -1);
+        if (comp > 0) {
+          return null;
+        }
+      }
+
+      count++;
+
+      // Next element is part of the iteration, return it.
+      return nextEntry.getValue();
     }
   }
 

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/InMemoryStoreSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/InMemoryStoreSuite.java
@@ -17,6 +17,7 @@
 
 package org.apache.spark.util.kvstore;
 
+import java.util.HashSet;
 import java.util.NoSuchElementException;
 
 import org.junit.Test;
@@ -130,6 +131,48 @@ public class InMemoryStoreSuite {
     store.write(o);
     assertEquals(o, store.read(ArrayKeyIndexType.class, o.key));
     assertEquals(o, store.view(ArrayKeyIndexType.class).index("id").first(o.id).iterator().next());
+  }
+
+  @Test
+  public void testRemoveAll() throws Exception {
+    KVStore store = new InMemoryStore();
+
+    for (int i = 0; i < 2; i++) {
+      for (int j = 0; j < 2; j++) {
+        ArrayKeyIndexType o = new ArrayKeyIndexType();
+        o.key = new int[] { i, j, 0 };
+        o.id = new String[] { "things" };
+        store.write(o);
+
+        o = new ArrayKeyIndexType();
+        o.key = new int[] { i, j, 1 };
+        o.id = new String[] { "more things" };
+        store.write(o);
+      }
+    }
+
+    ArrayKeyIndexType o = new ArrayKeyIndexType();
+    o.key = new int[] { 2, 2, 2 };
+    o.id = new String[] { "things" };
+    store.write(o);
+
+    assertEquals(9, store.count(ArrayKeyIndexType.class));
+
+    HashSet set = new HashSet();
+    set.add(new int[] {0, 0, 0});
+    set.add(new int[] { 2, 2, 2 });
+    store.removeAllByKeys(ArrayKeyIndexType.class, KVIndex.NATURAL_INDEX_NAME, set);
+    assertEquals(7, store.count(ArrayKeyIndexType.class));
+
+    set.clear();
+    set.add(new String[] { "things" });
+    store.removeAllByKeys(ArrayKeyIndexType.class, "id", set);
+    assertEquals(4, store.count(ArrayKeyIndexType.class));
+
+    set.clear();
+    set.add(new String[] { "more things" });
+    store.removeAllByKeys(ArrayKeyIndexType.class, "id", set);
+    assertEquals(0, store.count(ArrayKeyIndexType.class));
   }
 
   @Test

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/InMemoryStoreSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/InMemoryStoreSuite.java
@@ -17,9 +17,9 @@
 
 package org.apache.spark.util.kvstore;
 
-import java.util.HashSet;
 import java.util.NoSuchElementException;
 
+import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -158,20 +158,23 @@ public class InMemoryStoreSuite {
 
     assertEquals(9, store.count(ArrayKeyIndexType.class));
 
-    HashSet set = new HashSet();
-    set.add(new int[] {0, 0, 0});
-    set.add(new int[] { 2, 2, 2 });
-    store.removeAllByIndexValues(ArrayKeyIndexType.class, KVIndex.NATURAL_INDEX_NAME, set);
+
+    store.removeAllByIndexValues(
+      ArrayKeyIndexType.class,
+      KVIndex.NATURAL_INDEX_NAME,
+      ImmutableSet.of(new int[] {0, 0, 0}, new int[] { 2, 2, 2 }));
     assertEquals(7, store.count(ArrayKeyIndexType.class));
 
-    set.clear();
-    set.add(new String[] { "things" });
-    store.removeAllByIndexValues(ArrayKeyIndexType.class, "id", set);
+    store.removeAllByIndexValues(
+      ArrayKeyIndexType.class,
+      "id",
+      ImmutableSet.of(new String [] { "things" }));
     assertEquals(4, store.count(ArrayKeyIndexType.class));
 
-    set.clear();
-    set.add(new String[] { "more things" });
-    store.removeAllByIndexValues(ArrayKeyIndexType.class, "id", set);
+    store.removeAllByIndexValues(
+      ArrayKeyIndexType.class,
+      "id",
+        ImmutableSet.of(new String [] { "more things" }));
     assertEquals(0, store.count(ArrayKeyIndexType.class));
   }
 

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/InMemoryStoreSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/InMemoryStoreSuite.java
@@ -161,17 +161,17 @@ public class InMemoryStoreSuite {
     HashSet set = new HashSet();
     set.add(new int[] {0, 0, 0});
     set.add(new int[] { 2, 2, 2 });
-    store.removeAllByKeys(ArrayKeyIndexType.class, KVIndex.NATURAL_INDEX_NAME, set);
+    store.removeAllByIndexValues(ArrayKeyIndexType.class, KVIndex.NATURAL_INDEX_NAME, set);
     assertEquals(7, store.count(ArrayKeyIndexType.class));
 
     set.clear();
     set.add(new String[] { "things" });
-    store.removeAllByKeys(ArrayKeyIndexType.class, "id", set);
+    store.removeAllByIndexValues(ArrayKeyIndexType.class, "id", set);
     assertEquals(4, store.count(ArrayKeyIndexType.class));
 
     set.clear();
     set.add(new String[] { "more things" });
-    store.removeAllByKeys(ArrayKeyIndexType.class, "id", set);
+    store.removeAllByIndexValues(ArrayKeyIndexType.class, "id", set);
     assertEquals(0, store.count(ArrayKeyIndexType.class));
   }
 

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -19,6 +19,7 @@ package org.apache.spark.util.kvstore;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
@@ -196,6 +197,46 @@ public class LevelDBSuite {
     assertEquals(1, db.count(t.getClass()));
     assertEquals(1, db.count(t.getClass(), "name", "anotherName"));
     assertEquals(0, db.count(t.getClass(), "name", "name"));
+  }
+
+  @Test
+  public void testRemoveAll() throws Exception {
+    for (int i = 0; i < 2; i++) {
+      for (int j = 0; j < 2; j++) {
+        ArrayKeyIndexType o = new ArrayKeyIndexType();
+        o.key = new int[] { i, j, 0 };
+        o.id = new String[] { "things" };
+        db.write(o);
+
+        o = new ArrayKeyIndexType();
+        o.key = new int[] { i, j, 1 };
+        o.id = new String[] { "more things" };
+        db.write(o);
+      }
+    }
+
+    ArrayKeyIndexType o = new ArrayKeyIndexType();
+    o.key = new int[] { 2, 2, 2 };
+    o.id = new String[] { "things" };
+    db.write(o);
+
+    assertEquals(9, db.count(ArrayKeyIndexType.class));
+
+    HashSet set = new HashSet();
+    set.add(new int[] {0, 0, 0});
+    set.add(new int[] { 2, 2, 2 });
+    db.removeAllByKeys(ArrayKeyIndexType.class, KVIndex.NATURAL_INDEX_NAME, set);
+    assertEquals(7, db.count(ArrayKeyIndexType.class));
+
+    set.clear();
+    set.add(new String[] { "things" });
+    db.removeAllByKeys(ArrayKeyIndexType.class, "id", set);
+    assertEquals(4, db.count(ArrayKeyIndexType.class));
+
+    set.clear();
+    set.add(new String[] { "more things" });
+    db.removeAllByKeys(ArrayKeyIndexType.class, "id", set);
+    assertEquals(0, db.count(ArrayKeyIndexType.class));
   }
 
   @Test

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -225,17 +225,17 @@ public class LevelDBSuite {
     HashSet set = new HashSet();
     set.add(new int[] {0, 0, 0});
     set.add(new int[] { 2, 2, 2 });
-    db.removeAllByKeys(ArrayKeyIndexType.class, KVIndex.NATURAL_INDEX_NAME, set);
+    db.removeAllByIndexValues(ArrayKeyIndexType.class, KVIndex.NATURAL_INDEX_NAME, set);
     assertEquals(7, db.count(ArrayKeyIndexType.class));
 
     set.clear();
     set.add(new String[] { "things" });
-    db.removeAllByKeys(ArrayKeyIndexType.class, "id", set);
+    db.removeAllByIndexValues(ArrayKeyIndexType.class, "id", set);
     assertEquals(4, db.count(ArrayKeyIndexType.class));
 
     set.clear();
     set.add(new String[] { "more things" });
-    db.removeAllByKeys(ArrayKeyIndexType.class, "id", set);
+    db.removeAllByIndexValues(ArrayKeyIndexType.class, "id", set);
     assertEquals(0, db.count(ArrayKeyIndexType.class));
   }
 

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -19,12 +19,12 @@ package org.apache.spark.util.kvstore;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.commons.io.FileUtils;
 import org.iq80.leveldb.DBIterator;
 import org.junit.After;
@@ -222,20 +222,22 @@ public class LevelDBSuite {
 
     assertEquals(9, db.count(ArrayKeyIndexType.class));
 
-    HashSet set = new HashSet();
-    set.add(new int[] {0, 0, 0});
-    set.add(new int[] { 2, 2, 2 });
-    db.removeAllByIndexValues(ArrayKeyIndexType.class, KVIndex.NATURAL_INDEX_NAME, set);
+    db.removeAllByIndexValues(
+      ArrayKeyIndexType.class,
+      KVIndex.NATURAL_INDEX_NAME,
+      ImmutableSet.of(new int[] {0, 0, 0}, new int[] { 2, 2, 2 }));
     assertEquals(7, db.count(ArrayKeyIndexType.class));
 
-    set.clear();
-    set.add(new String[] { "things" });
-    db.removeAllByIndexValues(ArrayKeyIndexType.class, "id", set);
+    db.removeAllByIndexValues(
+      ArrayKeyIndexType.class,
+      "id",
+      ImmutableSet.of(new String[] { "things" }));
     assertEquals(4, db.count(ArrayKeyIndexType.class));
 
-    set.clear();
-    set.add(new String[] { "more things" });
-    db.removeAllByIndexValues(ArrayKeyIndexType.class, "id", set);
+    db.removeAllByIndexValues(
+      ArrayKeyIndexType.class,
+      "id",
+      ImmutableSet.of(new String[] { "more things" }));
     assertEquals(0, db.count(ArrayKeyIndexType.class));
   }
 

--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -1144,7 +1144,7 @@ private[spark] class AppStatusListener(
       s.info.status != v1.StageStatus.ACTIVE && s.info.status != v1.StageStatus.PENDING
     }
 
-    val stageKeys = stages.map { s =>
+    val stageIndexValues = stages.map { s =>
       val key = Array(s.info.stageId, s.info.attemptId)
       kvstore.delete(s.getClass(), key)
 
@@ -1173,16 +1173,16 @@ private[spark] class AppStatusListener(
     }
 
     // Delete summaries in one pass, as deleting them for each stage is slow
-    val totalSummariesDeleted = kvstore.removeAllByKeys(
+    kvstore.removeAllByIndexValues(
       classOf[ExecutorStageSummaryWrapper],
       "stage",
-      stageKeys)
+      stageIndexValues)
 
     // Delete tasks for all stages in one pass, as deleting them for each stage individually is slow
-    kvstore.removeAllByKeys(
+    kvstore.removeAllByIndexValues(
       classOf[TaskDataWrapper],
       TaskIndexNames.STAGE,
-      stageKeys)
+      stageIndexValues)
   }
 
   private def cleanupTasks(stage: LiveStage): Unit = {

--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -1144,8 +1144,7 @@ private[spark] class AppStatusListener(
       s.info.status != v1.StageStatus.ACTIVE && s.info.status != v1.StageStatus.PENDING
     }
 
-    def stageKey(stageId: Int, attemptId: Int): Long =
-      stageId.toLong << 32 | (attemptId.toLong & 0x00000000ffffffffL)
+    logDebug(s"Cleanup stages ${stages.size} for total count of $count")
 
     val stageKeys = stages.map { s =>
       val key = Array(s.info.stageId, s.info.attemptId)
@@ -1172,28 +1171,20 @@ private[spark] class AppStatusListener(
       }
 
       cleanupCachedQuantiles(key)
-      stageKey(s.info.stageId, s.info.attemptId)
-    }.toSet
-
-    // We don't care about the index, so I use the easiest-to-sort index we have.  Ideally
-    // we'd be able to get an unsorted view, or even better, have a way to multiDelete based on
-    // partial identity match to a set of values, but for now, this avoids n^2 behavior, at least,
-    // and the nlogn behavior of the sort is as cheap as possible....
-    val execSummaries = kvstore.view(classOf[ExecutorStageSummaryWrapper]).asScala
-
-    execSummaries.foreach { e =>
-      if (stageKeys.contains(stageKey(e.stageId, e.stageAttemptId))) {
-        kvstore.delete(e.getClass(), e.id)
-      }
+      key
     }
+
+    // Delete summaries in one pass, as deleting them for each stage is slow
+    val totalSummariesDeleted = kvstore.removeAllByKeys(
+      classOf[ExecutorStageSummaryWrapper],
+      "stage",
+      stageKeys)
 
     // Delete tasks for all stages in one pass, as deleting them for each stage individually is slow
-    val tasks = kvstore.view(classOf[TaskDataWrapper]).asScala
-    tasks.foreach { t =>
-      if (stageKeys.contains(stageKey(t.stageId, t.stageAttemptId))) {
-        kvstore.delete(t.getClass(), t.taskId)
-      }
-    }
+    kvstore.removeAllByKeys(
+      classOf[TaskDataWrapper],
+      TaskIndexNames.STAGE,
+      stageKeys)
   }
 
   private def cleanupTasks(stage: LiveStage): Unit = {

--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -1144,8 +1144,6 @@ private[spark] class AppStatusListener(
       s.info.status != v1.StageStatus.ACTIVE && s.info.status != v1.StageStatus.PENDING
     }
 
-    logDebug(s"Cleanup stages ${stages.size} for total count of $count")
-
     val stageKeys = stages.map { s =>
       val key = Array(s.info.stageId, s.info.attemptId)
       kvstore.delete(s.getClass(), key)

--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -1144,7 +1144,7 @@ private[spark] class AppStatusListener(
       s.info.status != v1.StageStatus.ACTIVE && s.info.status != v1.StageStatus.PENDING
     }
 
-    val stageIndexValues = stages.map { s =>
+    val stageIds = stages.map { s =>
       val key = Array(s.info.stageId, s.info.attemptId)
       kvstore.delete(s.getClass(), key)
 
@@ -1173,16 +1173,10 @@ private[spark] class AppStatusListener(
     }
 
     // Delete summaries in one pass, as deleting them for each stage is slow
-    kvstore.removeAllByIndexValues(
-      classOf[ExecutorStageSummaryWrapper],
-      "stage",
-      stageIndexValues)
+    kvstore.removeAllByIndexValues(classOf[ExecutorStageSummaryWrapper], "stage", stageIds)
 
     // Delete tasks for all stages in one pass, as deleting them for each stage individually is slow
-    kvstore.removeAllByIndexValues(
-      classOf[TaskDataWrapper],
-      TaskIndexNames.STAGE,
-      stageIndexValues)
+    kvstore.removeAllByIndexValues(classOf[TaskDataWrapper], TaskIndexNames.STAGE, stageIds)
   }
 
   private def cleanupTasks(stage: LiveStage): Unit = {

--- a/core/src/main/scala/org/apache/spark/status/ElementTrackingStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/ElementTrackingStore.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.status
 
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable.{HashMap, ListBuffer}
 
@@ -25,6 +26,7 @@ import com.google.common.util.concurrent.MoreExecutors
 
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.config.Status._
+import org.apache.spark.status.ElementTrackingStore.{WriteQueueResult, WriteSkippedQueue}
 import org.apache.spark.util.{ThreadUtils, Utils}
 import org.apache.spark.util.kvstore._
 
@@ -46,7 +48,26 @@ import org.apache.spark.util.kvstore._
  */
 private[spark] class ElementTrackingStore(store: KVStore, conf: SparkConf) extends KVStore {
 
-  private val triggers = new HashMap[Class[_], Seq[Trigger[_]]]()
+  private class LatchedTriggers(val triggers: Seq[Trigger[_]]) {
+    val countDeferred = new AtomicInteger(0)
+
+    def fireOnce(f: Seq[Trigger[_]] => Unit): Boolean = {
+      val shouldExecute = countDeferred.compareAndSet(0, 1)
+      if (shouldExecute) {
+        doAsync {
+          countDeferred.set(0)
+          f(triggers)
+        }
+      }
+      shouldExecute
+    }
+
+    def :+(addlTrigger: Trigger[_]): LatchedTriggers = {
+      new LatchedTriggers(triggers :+ addlTrigger)
+    }
+  }
+
+  private val triggers = new HashMap[Class[_], LatchedTriggers]()
   private val flushTriggers = new ListBuffer[() => Unit]()
   private val executor = if (conf.get(ASYNC_TRACKING_ENABLED)) {
     ThreadUtils.newDaemonSingleThreadExecutor("element-tracking-store-worker")
@@ -66,8 +87,13 @@ private[spark] class ElementTrackingStore(store: KVStore, conf: SparkConf) exten
    *               of elements of the registered type currently known to be in the store.
    */
   def addTrigger(klass: Class[_], threshold: Long)(action: Long => Unit): Unit = {
-    val existing = triggers.getOrElse(klass, Seq())
-    triggers(klass) = existing :+ Trigger(threshold, action)
+    val newTrigger = Trigger(threshold, action)
+    triggers.get(klass) match {
+      case None =>
+        triggers(klass) = new LatchedTriggers(Seq(newTrigger))
+      case Some(latchedTrigger) =>
+        triggers(klass) = latchedTrigger :+ newTrigger
+    }
   }
 
   /**
@@ -96,20 +122,22 @@ private[spark] class ElementTrackingStore(store: KVStore, conf: SparkConf) exten
   override def write(value: Any): Unit = store.write(value)
 
   /** Write an element to the store, optionally checking for whether to fire triggers. */
-  def write(value: Any, checkTriggers: Boolean): Unit = {
+  def write(value: Any, checkTriggers: Boolean): WriteQueueResult = {
     write(value)
 
     if (checkTriggers && !stopped) {
-      triggers.get(value.getClass()).foreach { list =>
-        doAsync {
+      triggers.get(value.getClass()).map { latchedList =>
+        WriteQueueResult(latchedList.fireOnce { list =>
           val count = store.count(value.getClass())
           list.foreach { t =>
             if (count > t.threshold) {
               t.action(count)
             }
           }
-        }
-      }
+        })
+      }.getOrElse(WriteSkippedQueue)
+    } else {
+      WriteSkippedQueue
     }
   }
 
@@ -156,4 +184,24 @@ private[spark] class ElementTrackingStore(store: KVStore, conf: SparkConf) exten
       threshold: Long,
       action: Long => Unit)
 
+}
+
+private[spark] object ElementTrackingStore {
+  /**
+   * This trait is solely to assist testing the correctness of single-fire execution
+   * The result of write() is otherwise unused.
+   */
+  sealed trait WriteQueueResult
+  object WriteQueueResult {
+    def apply(b: Boolean): WriteQueueResult = {
+      if (b) {
+        WriteQueued
+      } else {
+        WriteSkippedQueue
+      }
+    }
+  }
+
+  object WriteQueued extends WriteQueueResult
+  object WriteSkippedQueue extends WriteQueueResult
 }

--- a/core/src/main/scala/org/apache/spark/status/ElementTrackingStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/ElementTrackingStore.scala
@@ -54,8 +54,7 @@ private[spark] class ElementTrackingStore(store: KVStore, conf: SparkConf) exten
     private val pending = new AtomicBoolean(false)
 
     def fireOnce(f: Seq[Trigger[_]] => Unit): WriteQueueResult = {
-      val shouldEnqueue = pending.compareAndSet(false, true)
-      if (shouldEnqueue) {
+      if (pending.compareAndSet(false, true)) {
         doAsync {
           pending.set(false)
           f(triggers)

--- a/core/src/test/scala/org/apache/spark/status/ElementTrackingStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/ElementTrackingStoreSuite.scala
@@ -17,13 +17,65 @@
 
 package org.apache.spark.status
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import org.mockito.Mockito._
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.internal.config.Status._
+import org.apache.spark.status.ElementTrackingStore._
 import org.apache.spark.util.kvstore._
 
 class ElementTrackingStoreSuite extends SparkFunSuite {
+
+  test("asynchronous tracking single-fire") {
+    val store = mock(classOf[KVStore])
+    val tracking = new ElementTrackingStore(store, new SparkConf()
+      .set(ASYNC_TRACKING_ENABLED, true))
+
+    val waiter = new Object()
+    var done = false
+    var type1 = new AtomicInteger(0)
+    var queued0: WriteQueueResult = null
+    var queued1: WriteQueueResult = null
+    var queued2: WriteQueueResult = null
+    var queued3: WriteQueueResult = null
+
+
+    tracking.addTrigger(classOf[Type1], 1) { count =>
+      val count = type1.getAndIncrement()
+
+      count match {
+        case 0 =>
+          // while in the asynchronous thread, attempt to increment twice.  The first should
+          // succeed, the second should be skipped
+          queued1 = tracking.write(new Type1, checkTriggers = true)
+          queued2 = tracking.write(new Type1, checkTriggers = true)
+        case 1 =>
+          // Verify that once we've started deliver again, that we can enqueue another
+          queued3 = tracking.write(new Type1, checkTriggers = true)
+        case 2 =>
+          waiter.synchronized {
+            done = true
+            waiter.notifyAll()
+          }
+      }
+    }
+
+    when(store.count(classOf[Type1])).thenReturn(2L)
+    queued0 = tracking.write(new Type1, checkTriggers = true)
+    waiter.synchronized {
+      if (!done) {
+        waiter.wait()
+      }
+      assert(done)
+    }
+    tracking.close(false)
+    assert(queued0 == WriteQueued)
+    assert(queued1 == WriteQueued)
+    assert(queued2 == WriteSkippedQueue)
+    assert(queued3 == WriteQueued)
+  }
 
   test("tracking for multiple types") {
     val store = mock(classOf[KVStore])

--- a/core/src/test/scala/org/apache/spark/status/ElementTrackingStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/ElementTrackingStoreSuite.scala
@@ -17,30 +17,30 @@
 
 package org.apache.spark.status
 
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 
 import org.mockito.Mockito._
+import org.scalatest.Matchers._
+import org.scalatest.concurrent.Eventually
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.internal.config.Status._
 import org.apache.spark.status.ElementTrackingStore._
 import org.apache.spark.util.kvstore._
 
-class ElementTrackingStoreSuite extends SparkFunSuite {
+class ElementTrackingStoreSuite extends SparkFunSuite with Eventually {
 
   test("asynchronous tracking single-fire") {
     val store = mock(classOf[KVStore])
     val tracking = new ElementTrackingStore(store, new SparkConf()
       .set(ASYNC_TRACKING_ENABLED, true))
 
-    val waiter = new Object()
-    var done = false
+    var done = new AtomicBoolean(false)
     var type1 = new AtomicInteger(0)
     var queued0: WriteQueueResult = null
     var queued1: WriteQueueResult = null
     var queued2: WriteQueueResult = null
     var queued3: WriteQueueResult = null
-
 
     tracking.addTrigger(classOf[Type1], 1) { count =>
       val count = type1.getAndIncrement()
@@ -55,21 +55,16 @@ class ElementTrackingStoreSuite extends SparkFunSuite {
           // Verify that once we've started deliver again, that we can enqueue another
           queued3 = tracking.write(new Type1, checkTriggers = true)
         case 2 =>
-          waiter.synchronized {
-            done = true
-            waiter.notifyAll()
-          }
+          done.set(true)
       }
     }
 
     when(store.count(classOf[Type1])).thenReturn(2L)
     queued0 = tracking.write(new Type1, checkTriggers = true)
-    waiter.synchronized {
-      if (!done) {
-        waiter.wait()
-      }
-      assert(done)
+    eventually {
+      done.get() shouldEqual true
     }
+
     tracking.close(false)
     assert(queued0 == WriteQueued)
     assert(queued1 == WriteQueued)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The details of the PR are explored in-depth in the sub-tasks of the umbrella jira SPARK-27726.
Briefly:
  1. Stop issuing asynchronous requests to cleanup elements in the tracking store when a request is already pending
  2. Fix a couple of thread-safety issues (mutable state and mis-ordered updates)
  3. Move Summary deletion outside of Stage deletion loop like Tasks already are
  4. Reimplement multi-delete in a removeAllKeys call which allows InMemoryStore to implement it in a performant manner.
  5. Some generic typing and exception handling cleanup

We see about five orders of magnitude improvement in the deletion code, which for us is the difference between a server that needs restarting daily, and one that is stable over weeks.

## How was this patch tested?

Unit tests for the fire-once asynchronous code and the removeAll calls in both LevelDB and InMemoryStore are supplied.  It was noted that the testing code for the LevelDB and InMemoryStore is highly repetitive, and should probably be merged, but we did not attempt that in this PR.

A version of this code was run in our production 2.3.3 and we were able to sustain higher throughput without going into GC overload (which was happening on a daily basis some weeks ago).

A version of this code was also put under a purpose-built Performance Suite of tests to verify performance under both types of Store implementations for both before and after code streams and for both total and partial delete cases (this code is not included in this PR).
