### PR TITLE
[WIP][SPARK-27738][BUILD][test-hadoop3.2] Upgrade the built-in Hive to 2.3.5 for hadoop-3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <hive.classifier></hive.classifier>
     <!-- Version used in Maven Hive dependency -->
     <hive.version>1.2.1.spark2</hive.version>
-    <hive23.version>2.3.4</hive23.version>
+    <hive23.version>2.3.5</hive23.version>
     <!-- Version used for internal directory structure -->
     <hive.version.short>1.2.1</hive.version.short>
     <!-- note that this should be compatible with Kafka brokers version 0.10 and up -->


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr should after https://github.com/apache/spark/pull/24620.

## How was this patch tested?

Exsting test
