### PR TITLE
[SPARK-27744][SQL] preserve spark properties on async subquery tasks

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Futures.scala
+++ b/core/src/main/scala/org/apache/spark/util/Futures.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+import scala.concurrent.{ExecutionContext, Future}
+
+import org.apache.spark.SparkContext
+
+
+private[spark] object Futures {
+  def withLocalProperties[T](
+    sc: SparkContext)(
+    body: => T)(
+    implicit executor: ExecutionContext): Future[T] = {
+    val properties = sc.getLocalProperties
+    Future {
+      val originalProperties = sc.getLocalProperties
+      try {
+        sc.setLocalProperties(properties)
+        body
+      } finally {
+        sc.setLocalProperties(originalProperties)
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -19,9 +19,11 @@ package org.apache.spark.sql
 
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, GenericInternalRow, Literal, SubqueryExpression, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan, Sort}
-import org.apache.spark.sql.execution.{ExecSubqueryExpression, FileSourceScanExec, ReusedSubqueryExec, ScalarSubquery, SubqueryExec, WholeStageCodegenExec}
+import org.apache.spark.sql.execution.{ExecSubqueryExpression, FileSourceScanExec, ReusedSubqueryExec, ScalarSubquery, SparkPlan, SparkPlanTest, SubqueryExec, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.datasources.FileScanRDD
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
@@ -1382,5 +1384,25 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
     }
     assert(subqueryExecs.forall(_.name.startsWith("scalar-subquery#")),
           "SubqueryExec name should start with scalar-subquery#")
+  }
+
+  test("SPARK-27744: Subquery execution preserves spark local properties") {
+    case class LocalPropertiesOperator(key: String, value: String) extends SparkPlan {
+      override protected def doExecute(): RDD[InternalRow] = {
+        assert(spark.sparkContext.getLocalProperty(key) == value)
+        sparkContext.parallelize(Seq(new UnsafeRow()))
+
+      }
+      override def output: Seq[Attribute] = Seq()
+      override def producedAttributes: AttributeSet = outputSet
+      override def children: Seq[SparkPlan] = Nil
+    }
+
+    spark.sparkContext.setLocalProperty("a", "1")
+    for (i <- 0 to SubqueryExec.THREADS) {
+      SubqueryExec("test", LocalPropertiesOperator("a", "1")).executeCollect()
+    }
+    spark.sparkContext.setLocalProperty("a", "2")
+    SubqueryExec("test", LocalPropertiesOperator("a", "2")).executeCollect()
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a new future helper method that copies over spark properties before submitting to a new thread, and sets the original properties back on exit. SubqueryExec now uses this method to create futures. Any task that is submitted to its thread pool will now use the spark properties of the submitting thread, instead of the spark properties that were on the thread pool worker thread

## How was this patch tested?

Added a test, which fails with current master but passes with this patch
