### PR TITLE
[SPARK-27777][ML] Eliminate uncessary sliding job in AreaUnderCurve

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/AreaUnderCurve.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/AreaUnderCurve.scala
@@ -44,20 +44,20 @@ private[evaluation] object AreaUnderCurve {
     val localAreas = curve.mapPartitions { iter =>
       if (iter.nonEmpty) {
         var localArea = 0.0
-        var cnt = 0L
+        var head = true
         var firstPoint = (Double.NaN, Double.NaN)
         var lastPoint = (Double.NaN, Double.NaN)
 
         iter.sliding(2).foreach { points =>
-          if (cnt == 0) {
+          if (head) {
             firstPoint = points.head
+            head = false
           }
           lastPoint = points.last
 
           if (points.length == 2) {
             localArea += trapezoid(points)
           }
-          cnt += 1
         }
         Iterator.single((localArea, (firstPoint, lastPoint)))
       } else {
@@ -65,12 +65,11 @@ private[evaluation] object AreaUnderCurve {
       }
     }.collect()
 
-    localAreas.map(_._1).sum +
-      localAreas.iterator.map(_._2)
-        .sliding(2).withPartial(false)
-        .map { case Seq((_, last1), (first2, _)) =>
-          trapezoid(Seq(last1, first2))
-        }.sum
+    localAreas.map(_._1).sum + localAreas.iterator.map(_._2)
+      .sliding(2).withPartial(false)
+      .map { case Seq((_, last1), (first2, _)) =>
+        trapezoid(Seq(last1, first2))
+      }.sum
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
compute AUC on one pass

## How was this patch tested?
existing tests

performance tests:
```
import org.apache.spark.mllib.evaluation._
val scoreAndLabels = sc.parallelize(Array.range(0, 100000).map{ i => (i.toDouble / 100000, (i % 2).toDouble) }, 4)
scoreAndLabels.persist()
scoreAndLabels.count()
val tic = System.currentTimeMillis
(0 until 100).foreach{i => val metrics = new BinaryClassificationMetrics(scoreAndLabels, 0); val auc = metrics.areaUnderROC; metrics.unpersist}
val toc = System.currentTimeMillis
toc - tic
```

|New| Existing|
|------|----------|
|87532|103644|

One-pass AUC saves about 16% computation time.
