### PR TITLE
[MINOR][EXAMPLES] Don't use internal Spark logging in user examples

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/graphx/Analytics.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/graphx/Analytics.scala
@@ -24,14 +24,13 @@ import org.apache.spark._
 import org.apache.spark.graphx._
 import org.apache.spark.graphx.PartitionStrategy._
 import org.apache.spark.graphx.lib._
-import org.apache.spark.internal.Logging
 import org.apache.spark.storage.StorageLevel
 
 
 /**
  * Driver program for running graph algorithms.
  */
-object Analytics extends Logging {
+object Analytics {
 
   def main(args: Array[String]): Unit = {
     if (args.length < 2) {
@@ -101,7 +100,7 @@ object Analytics extends Logging {
         println(s"GRAPHX: Total rank: ${pr.map(_._2).reduce(_ + _)}")
 
         if (!outFname.isEmpty) {
-          logWarning(s"Saving pageranks of pages to $outFname")
+          println(s"Saving pageranks of pages to $outFname")
           pr.map { case (id, r) => id + "\t" + r }.saveAsTextFile(outFname)
         }
 

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/CustomReceiver.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/CustomReceiver.scala
@@ -23,7 +23,6 @@ import java.net.Socket
 import java.nio.charset.StandardCharsets
 
 import org.apache.spark.SparkConf
-import org.apache.spark.internal.Logging
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.{Seconds, StreamingContext}
 import org.apache.spark.streaming.receiver.Receiver
@@ -63,7 +62,7 @@ object CustomReceiver {
 
 
 class CustomReceiver(host: String, port: Int)
-  extends Receiver[String](StorageLevel.MEMORY_AND_DISK_2) with Logging {
+  extends Receiver[String](StorageLevel.MEMORY_AND_DISK_2) {
 
   def onStart() {
     // Start the thread that receives data over a connection
@@ -82,9 +81,9 @@ class CustomReceiver(host: String, port: Int)
    var socket: Socket = null
    var userInput: String = null
    try {
-     logInfo(s"Connecting to $host : $port")
+     println(s"Connecting to $host : $port")
      socket = new Socket(host, port)
-     logInfo(s"Connected to $host : $port")
+     println(s"Connected to $host : $port")
      val reader = new BufferedReader(
        new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8))
      userInput = reader.readLine()
@@ -94,7 +93,7 @@ class CustomReceiver(host: String, port: Int)
      }
      reader.close()
      socket.close()
-     logInfo("Stopped receiving")
+     println("Stopped receiving")
      restart("Trying to connect again")
    } catch {
      case e: java.net.ConnectException =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Don't use internal Spark logging in user examples, because users shouldn't / can't use it directly anyway. These examples already use println in some cases. Note that the usage in StreamingExamples is on purpose.

## How was this patch tested?

N/A