### PR TITLE
[SPARK-27788][SQL] Session aware event log for Spark thrift server

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -334,7 +334,7 @@ private[spark] object EventLoggingListener extends Logging {
   val IN_PROGRESS = ".inprogress"
   val DEFAULT_LOG_DIR = "/tmp/spark-events"
 
-  private val LOG_FILE_PERMISSIONS = new FsPermission(Integer.parseInt("770", 8).toShort)
+  private[spark] val LOG_FILE_PERMISSIONS = new FsPermission(Integer.parseInt("770", 8).toShort)
 
   // A cache for compression codecs to avoid creating the same codec many times
   private val codecMap = Map.empty[String, CompressionCodec]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2074,6 +2074,12 @@ class SQLConf extends Serializable with Logging {
   def hiveThriftServerSingleSession: Boolean =
     getConf(StaticSQLConf.HIVE_THRIFT_SERVER_SINGLESESSION)
 
+  def hiveThriftServerEventLogEnabled: Boolean =
+    getConf(StaticSQLConf.HIVE_THRIFT_SERVER_EVENTLOG_ENABLED)
+
+  def hiveThriftServerEventLogDir: String =
+    getConf(StaticSQLConf.HIVE_THRIFT_SERVER_EVENTLOG_DIR)
+
   def orderByOrdinal: Boolean = getConf(ORDER_BY_ORDINAL)
 
   def groupByOrdinal: Boolean = getConf(GROUP_BY_ORDINAL)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.internal
 
+import org.apache.spark.scheduler.EventLoggingListener
 import org.apache.spark.util.Utils
 
 
@@ -97,6 +98,39 @@ object StaticSQLConf {
         "SQL configuration and the current database.")
       .booleanConf
       .createWithDefault(false)
+
+  val HIVE_THRIFT_SERVER_EVENTLOG_ENABLED =
+    buildStaticConf("spark.sql.hive.thriftServer.eventLog.enabled")
+      .doc("When set to true, Hive Thrift server event log will be enabled. " +
+        "Each session's event log will logged into standalone file.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val HIVE_THRIFT_SERVER_EVENTLOG_DIR =
+    buildStaticConf("spark.sql.hive.thriftServer.eventLog.dir")
+      .doc("Path to the directory in which devents are logged.")
+      .stringConf
+      .createWithDefault(EventLoggingListener.DEFAULT_LOG_DIR)
+
+  val HIVE_THRIFT_SERVER_EVENTLOG_COMPRESS =
+    buildStaticConf("spark.sql.hive.thriftServer.eventLog.compress")
+      .fallbackConf(org.apache.spark.internal.config.EVENT_LOG_OVERWRITE)
+
+  val HIVE_THRIFT_SERVER_EVENTLOG_OVERWRITE =
+    buildStaticConf("spark.sql.hive.thriftServer.eventLog.overwrite")
+      .fallbackConf(org.apache.spark.internal.config.EVENT_LOG_COMPRESS)
+
+  val HIVE_THRIFT_SERVER_EVENTLOG_TESTING =
+    buildStaticConf("spark.sql.hive.thriftServer.eventLog.testing")
+      .fallbackConf(org.apache.spark.internal.config.EVENT_LOG_TESTING)
+
+  val HIVE_THRIFT_SERVER_EVENTLOG_OUTPUT_BUFFER_SIZE =
+    buildStaticConf("spark.sql.hive.thriftServer.eventLog.buffer.kb")
+      .fallbackConf(org.apache.spark.internal.config.EVENT_LOG_OUTPUT_BUFFER_SIZE)
+
+  val HIVE_THRIFT_SERVER_EVENTLOG_STAGE_EXECUTOR_METRICS =
+    buildStaticConf("spark.sql.hive.thriftServer.eventLog.logStageExecutorMetrics.enabled")
+      .fallbackConf(org.apache.spark.internal.config.EVENT_LOG_STAGE_EXECUTOR_METRICS)
 
   val SPARK_SESSION_EXTENSIONS = buildStaticConf("spark.sql.extensions")
     .doc("A comma-separated list of classes that implement " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -749,6 +749,8 @@ class SQLContext private[sql](val sparkSession: SparkSession)
  */
 object SQLContext {
 
+  val SESSION_ID_KEY = "spark.sql.session.id"
+
   /**
    * Converts an iterator of Java Beans to InternalRow using the provided
    * bean info & schema. This is not related to the singleton, but is a static

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 import org.apache.spark.SparkContext
 import org.apache.spark.internal.config.Tests.IS_TESTING
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{SQLContext, SparkSession}
 import org.apache.spark.sql.execution.ui.{SparkListenerSQLExecutionEnd, SparkListenerSQLExecutionStart}
 import org.apache.spark.sql.internal.StaticSQLConf.SQL_EVENT_TRUNCATE_LENGTH
 import org.apache.spark.util.Utils
@@ -96,7 +96,8 @@ object SQLExecution {
             // `queryExecution.executedPlan` triggers query planning. If it fails, the exception
             // will be caught and reported in the `SparkListenerSQLExecutionEnd`
             sparkPlanInfo = SparkPlanInfo.fromSparkPlan(queryExecution.executedPlan),
-            time = System.currentTimeMillis()))
+            time = System.currentTimeMillis(),
+            Option(sparkSession.sparkContext.getLocalProperty(SQLContext.SESSION_ID_KEY))))
           body
         } catch {
           case e: Exception =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListener.scala
@@ -250,7 +250,7 @@ class SQLAppStatusListener(
 
   private def onExecutionStart(event: SparkListenerSQLExecutionStart): Unit = {
     val SparkListenerSQLExecutionStart(executionId, description, details,
-      physicalPlanDescription, sparkPlanInfo, time) = event
+      physicalPlanDescription, sparkPlanInfo, time, _) = event
 
     def toStoredNodes(nodes: Seq[SparkPlanGraphNode]): Seq[SparkPlanGraphNodeWrapper] = {
       nodes.map {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLListener.scala
@@ -34,7 +34,8 @@ case class SparkListenerSQLExecutionStart(
     details: String,
     physicalPlanDescription: String,
     sparkPlanInfo: SparkPlanInfo,
-    time: Long)
+    time: Long,
+    sessionId: Option[String] = None)
   extends SparkListenerEvent
 
 @DeveloperApi
@@ -98,3 +99,11 @@ private class LongLongTupleConverter extends Converter[(Object, Object), (Long, 
     typeFactory.constructSimpleType(classOf[(_, _)], Array(longType, longType))
   }
 }
+
+case class SparkListenerSQLSessionStart(
+    sessionId: String,
+    time: Long) extends SparkListenerEvent
+
+case class SparkListenerSQLSessionEnd(
+    sessionId: String,
+    time: Long) extends SparkListenerEvent

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SessionAwareEventLoggingListener.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SessionAwareEventLoggingListener.scala
@@ -1,0 +1,345 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.thriftserver
+
+import java.io._
+import java.net.URI
+import java.util.{EnumSet, Locale}
+
+import scala.collection.mutable
+import scala.collection.mutable.{ArrayBuffer, Map}
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, FSDataOutputStream, Path}
+import org.apache.hadoop.hdfs.DFSOutputStream
+import org.apache.hadoop.hdfs.client.HdfsDataOutputStream.SyncFlag
+import org.json4s.JsonAST.JValue
+import org.json4s.jackson.JsonMethods._
+
+import org.apache.spark.SparkConf
+import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.executor.ExecutorMetrics
+import org.apache.spark.internal.Logging
+import org.apache.spark.io.CompressionCodec
+import org.apache.spark.scheduler._
+import org.apache.spark.sql.execution.SQLExecution
+import org.apache.spark.sql.execution.ui.{SparkListenerSQLExecutionEnd, SparkListenerSQLExecutionStart, SparkListenerSQLSessionEnd, SparkListenerSQLSessionStart}
+import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
+import org.apache.spark.util.{JsonProtocol, Utils}
+
+private[spark] class SessionAwareEventLoggingListener(
+    appId: String,
+    appAttemptId : Option[String],
+    logBaseDir: URI,
+    sparkConf: SparkConf,
+    sqlConf: SQLConf,
+    hadoopConf: Configuration)
+  extends SparkListener with Logging {
+
+  import EventLoggingListener._
+
+  def this(appId: String, appAttemptId: Option[String], logBaseDir: URI,
+      sparkConf: SparkConf, sqlConf: SQLConf) =
+    this(appId, appAttemptId, logBaseDir, sparkConf, sqlConf,
+      SparkHadoopUtil.get.newConfiguration(sparkConf))
+
+  private val shouldCompress = sqlConf.getConf(StaticSQLConf.HIVE_THRIFT_SERVER_EVENTLOG_COMPRESS)
+  private val shouldOverwrite = sqlConf.getConf(StaticSQLConf.HIVE_THRIFT_SERVER_EVENTLOG_OVERWRITE)
+  private val shouldLogStageExecutorMetrics =
+    sqlConf.getConf(StaticSQLConf.HIVE_THRIFT_SERVER_EVENTLOG_STAGE_EXECUTOR_METRICS)
+  private val testing = sqlConf.getConf(StaticSQLConf.HIVE_THRIFT_SERVER_EVENTLOG_TESTING)
+  private val outputBufferSize =
+    sqlConf.getConf(StaticSQLConf.HIVE_THRIFT_SERVER_EVENTLOG_OUTPUT_BUFFER_SIZE).toInt
+  // should be synchronized
+  private val fileSystem = Utils.getHadoopFileSystem(logBaseDir, hadoopConf)
+  private val compressionCodec =
+    if (shouldCompress) {
+      Some(CompressionCodec.createCodec(sparkConf))
+    } else {
+      None
+    }
+  private val compressionCodecName = compressionCodec.map { c =>
+    CompressionCodec.getShortName(c.getClass.getName)
+  }
+  // Only defined if the file system scheme is not local
+  private val hadoopDataStreams = new mutable.HashMap[String, FSDataOutputStream]()
+  private val writers = new mutable.HashMap[String, PrintWriter]()
+  // For testing. Keep track of all JSON serialized events that have been logged.
+  private val loggedEvents = new mutable.HashMap[String, ArrayBuffer[JValue]]()
+  // Visible for tests only.
+  private val logPaths = mutable.HashMap[String, String]()
+
+  // map of (stageId, stageAttempt), to peak executor metrics for the stage
+  private val liveStageExecutorMetrics = Map.empty[(Int, Int), Map[String, ExecutorMetrics]]
+
+  private val executionIdToSessionId = new mutable.HashMap[String, String]()
+  private val jobIdToSessionId = new mutable.HashMap[Int, String]
+  private val stageIdToSessionId = new mutable.HashMap[(Int, Int), String]()
+
+  // Events that will be write ahead of each file
+  private var globalApplicationStart: SparkListenerApplicationStart = _
+  private var globalEnvironmentUpdate: SparkListenerEnvironmentUpdate = _
+
+  /**
+   * Creates the log file in the configured log directory.
+   */
+  private def startSession(sessionId: String): Unit = this.synchronized {
+    if (!fileSystem.getFileStatus(new Path(logBaseDir)).isDirectory) {
+      throw new IllegalArgumentException(s"Log directory $logBaseDir is not a directory.")
+    }
+    val logPath = getLogPath(
+      logBaseDir, appId, sessionId, appAttemptId, compressionCodecName)
+    val workingPath = logPath + IN_PROGRESS
+    val path = new Path(workingPath)
+    val uri = path.toUri
+    val defaultFs = FileSystem.getDefaultUri(hadoopConf).getScheme
+    val isDefaultLocal = defaultFs == null || defaultFs == "file"
+    if (shouldOverwrite && fileSystem.delete(path, true)) {
+      logWarning(s"Event log $path already exists. Overwriting...")
+    }
+    val dstream =
+      if ((isDefaultLocal && uri.getScheme == null) || uri.getScheme == "file") {
+        new FileOutputStream(uri.getPath)
+      } else {
+        val fs = fileSystem.create(path)
+        hadoopDataStreams.put(sessionId, fs)
+        fs
+      }
+    try {
+      val cstream = compressionCodec.map(_.compressedOutputStream(dstream)).getOrElse(dstream)
+      val bstream = new BufferedOutputStream(cstream, outputBufferSize)
+      val arrayBuffer = new ArrayBuffer[JValue]()
+      loggedEvents(sessionId) = arrayBuffer
+      initEventLog(bstream, testing, arrayBuffer)
+      fileSystem.setPermission(path, LOG_FILE_PERMISSIONS)
+      writers(sessionId) = new PrintWriter(bstream)
+      logInfo("Logging events to %s".format(logPaths))
+    } catch {
+      case e: Exception =>
+        dstream.close()
+        throw e
+    }
+    logPaths(sessionId) = logPath
+    val sparkAppStart = SparkListenerApplicationStart(globalApplicationStart.appName,
+      Some {
+        if (globalApplicationStart.appId.isDefined) {
+          globalApplicationStart.appId.get + "_" + sessionId
+        } else {
+          sessionId
+        }
+      },
+      System.currentTimeMillis(),
+      globalApplicationStart.sparkUser,
+      globalApplicationStart.appAttemptId,
+      globalApplicationStart.driverLogs
+    )
+    logEvent(sparkAppStart, flushLogger = true, sessionId)
+    logEvent(redactEvent(globalEnvironmentUpdate), flushLogger = true, sessionId)
+  }
+
+  /** Log the event as JSON. */
+  private def logEvent(event: SparkListenerEvent, flushLogger: Boolean = false, sessionId: String) {
+    val eventJson = JsonProtocol.sparkEventToJson(event)
+    // scalastyle:off println
+    writers.get(sessionId).foreach(_.println(compact(render(eventJson))))
+    // scalastyle:on println
+    if (flushLogger) {
+      writers.get(sessionId).foreach(_.flush())
+      hadoopDataStreams.get(sessionId).foreach(ds => ds.getWrappedStream match {
+        case wrapped: DFSOutputStream => wrapped.hsync(EnumSet.of(SyncFlag.UPDATE_LENGTH))
+        case _ => ds.hflush()
+      })
+    }
+    if (testing) {
+      loggedEvents.get(sessionId).foreach(_ += eventJson)
+    }
+  }
+
+  protected def withSession(event: SparkListenerEvent)(f: String => Unit): Unit = {
+    val s = event match {
+      case e: SparkListenerJobStart =>
+        val executionId = e.properties.getProperty(SQLExecution.EXECUTION_ID_KEY)
+        executionIdToSessionId.get(executionId)
+      case e: SparkListenerJobEnd =>
+        jobIdToSessionId.get(e.jobId)
+      case e: SparkListenerStageSubmitted =>
+        val executionId = e.properties.getProperty(SQLExecution.EXECUTION_ID_KEY)
+        executionIdToSessionId.get(executionId)
+      case e: SparkListenerStageCompleted =>
+        stageIdToSessionId.get((e.stageInfo.stageId, e.stageInfo.attemptNumber()))
+      case e: SparkListenerTaskStart =>
+        stageIdToSessionId.get((e.stageId, e.stageAttemptId))
+      case e: SparkListenerTaskEnd =>
+        stageIdToSessionId.get((e.stageId, e.stageAttemptId))
+      case _ =>
+        None
+
+    }
+    s.foreach(f(_))
+  }
+
+  // Events that be handled only once
+  override def onApplicationStart(event: SparkListenerApplicationStart): Unit = {
+    globalApplicationStart = event
+  }
+
+  override def onEnvironmentUpdate(event: SparkListenerEnvironmentUpdate): Unit = {
+    globalEnvironmentUpdate = event
+  }
+
+  override def onJobStart(event: SparkListenerJobStart): Unit = withSession(event) { sessionId =>
+    jobIdToSessionId(event.jobId) = sessionId
+    logEvent(event, flushLogger = true, sessionId)
+  }
+
+  override def onJobEnd(event: SparkListenerJobEnd): Unit = withSession(event) { sessionId =>
+    jobIdToSessionId.remove(event.jobId)
+    logEvent(event, flushLogger = true, sessionId)
+  }
+
+  override def onStageSubmitted(
+      event: SparkListenerStageSubmitted): Unit = withSession(event) { sessionId =>
+    stageIdToSessionId((event.stageInfo.stageId, event.stageInfo.attemptNumber())) = sessionId
+    logEvent(event, flushLogger = false, sessionId)
+    if (shouldLogStageExecutorMetrics) {
+      // record the peak metrics for the new stage
+      liveStageExecutorMetrics.put((event.stageInfo.stageId, event.stageInfo.attemptNumber()),
+        Map.empty[String, ExecutorMetrics])
+    }
+  }
+
+  override def onStageCompleted(
+      event: SparkListenerStageCompleted): Unit = withSession(event) { sessionId =>
+    stageIdToSessionId.remove((event.stageInfo.stageId, event.stageInfo.attemptNumber()))
+    if (shouldLogStageExecutorMetrics) {
+      // clear out any previous attempts, that did not have a stage completed event
+      val prevAttemptId = event.stageInfo.attemptNumber() - 1
+      for (attemptId <- 0 to prevAttemptId) {
+        liveStageExecutorMetrics.remove((event.stageInfo.stageId, attemptId))
+      }
+
+      // log the peak executor metrics for the stage, for each live executor,
+      // whether or not the executor is running tasks for the stage
+      val executorOpt = liveStageExecutorMetrics.remove(
+        (event.stageInfo.stageId, event.stageInfo.attemptNumber()))
+      executorOpt.foreach { execMap =>
+        execMap.foreach { case (executorId, peakExecutorMetrics) =>
+          logEvent(SparkListenerStageExecutorMetrics(executorId, event.stageInfo.stageId,
+            event.stageInfo.attemptNumber(), peakExecutorMetrics), flushLogger = false, sessionId)
+        }
+      }
+    }
+    logEvent(event, flushLogger = true, sessionId)
+  }
+
+  override def onTaskStart(event: SparkListenerTaskStart): Unit = withSession(event) { sessionId =>
+    logEvent(event, flushLogger = false, sessionId)
+  }
+
+  override def onTaskEnd(event: SparkListenerTaskEnd): Unit = withSession(event) { sessionId =>
+    logEvent(event, flushLogger = false, sessionId)
+  }
+
+  // No-op because logging every update would be overkill
+  override def onExecutorMetricsUpdate(event: SparkListenerExecutorMetricsUpdate): Unit = { }
+
+  override def onOtherEvent(event: SparkListenerEvent): Unit = {
+    event match {
+      case execStart: SparkListenerSQLExecutionStart =>
+        if (execStart.sessionId.isDefined) {
+          executionIdToSessionId(String.valueOf(execStart.executionId)) = execStart.sessionId.get
+          logEvent(event, flushLogger = true, execStart.sessionId.get)
+        }
+      case execEnd: SparkListenerSQLExecutionEnd =>
+        executionIdToSessionId.get(String.valueOf(execEnd.executionId)) match {
+          case Some(sessionId) =>
+            executionIdToSessionId.remove(String.valueOf(execEnd.executionId))
+            logEvent(event, flushLogger = true, sessionId)
+          case None =>
+            logInfo(s"Execution ${execEnd.executionId} doesn't belong to any session")
+        }
+      case sessionStart: SparkListenerSQLSessionStart =>
+        startSession(sessionStart.sessionId)
+      case sessionEnd: SparkListenerSQLSessionEnd =>
+        stopSession(sessionEnd.sessionId)
+      case _ =>
+    }
+  }
+
+  private def stopSession(sessionId: String): Unit = {
+    logEvent(
+      SparkListenerApplicationEnd(System.currentTimeMillis()), flushLogger = true, sessionId)
+    try {
+      writers.get(sessionId).foreach(_.close())
+      val target = new Path(logPaths(sessionId))
+      if (fileSystem.exists(target)) {
+        if (shouldOverwrite) {
+          logWarning(s"Event log $target already exists. Overwriting...")
+          if (!fileSystem.delete(target, true)) {
+            logWarning(s"Error deleting $target")
+          }
+        } else {
+          throw new IOException("Target log file already exists (%s)".format(logPaths(sessionId)))
+        }
+      }
+      fileSystem.rename(new Path(logPaths(sessionId) + IN_PROGRESS), target)
+      try {
+        fileSystem.setTimes(target, System.currentTimeMillis(), -1)
+      } catch {
+        case e: Exception => logDebug(s"failed to set time of $target", e)
+      }
+    } finally {
+      hadoopDataStreams.remove(sessionId).foreach(_.close())
+      writers.remove(sessionId).foreach(_.close())
+      logPaths.remove(sessionId)
+      loggedEvents.remove(sessionId)
+    }
+  }
+
+  def getLogPath(
+      logBaseDir: URI,
+      appId: String,
+      sessionId: String,
+      appAttemptId: Option[String],
+      compressionCodecName: Option[String] = None): String = {
+    val base = new Path(logBaseDir).toString.stripSuffix("/") + "/" + sanitize(appId)
+    val codec = compressionCodecName.map("." + _).getOrElse("")
+    val attempt = if (appAttemptId.isDefined) {
+      base + "_" + sanitize(appAttemptId.get) + codec
+    } else {
+      base + codec
+    }
+    attempt + "_" + sessionId
+  }
+
+  private def sanitize(str: String): String = {
+    str.replaceAll("[ :/]", "-").replaceAll("[.${}'\"]", "_").toLowerCase(Locale.ROOT)
+  }
+
+  private[spark] def redactEvent(
+      event: SparkListenerEnvironmentUpdate): SparkListenerEnvironmentUpdate = {
+    val redactedProps = event.environmentDetails.map{ case (name, props) =>
+      name -> Utils.redact(sparkConf, props)
+    }
+    SparkListenerEnvironmentUpdate(redactedProps)
+  }
+
+  def stop(): Unit = {
+    logPaths.keysIterator.foreach(stopSession)
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spark Thrift server is a long running service. If we enabled Spark event log, the log won't close util Spark Thrift server exits. This event log is always too big to be replayed by history server. So this feature of session aware event log writes a standalone event log for each session.

This PR doesn't change the original Spark Event log at all. It imports a new one.
To enable it, set `spark.sql.hive.thriftServer.eventLog.enabled` to `true`.

## How was this patch tested?

Manually test.

Two connections from beeline will generate two event logs like below:

> $ ls -l
total 528
-rwxrwx---  1 lajin  wheel  78499 May 21 16:13 local-1558423605808_4e223a3d-0c3a-48ab-a210-3a928e29712d
-rwxrwx---  1 lajin  wheel  74873 May 21 16:13 local-1558423605808_6594a337-02dc-4398-8df2-b738eedb45c3
