### PR TITLE
[SPARK-27789]Use stopEarly in codegen of ColumnarBatchScan

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarBatchScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarBatchScan.scala
@@ -136,7 +136,7 @@ private[sql] trait ColumnarBatchScan extends CodegenSupport {
        |if ($batch == null) {
        |  $nextBatchFuncName();
        |}
-       |while ($batch != null) {
+       |while ($batch != null && !stopEarly()) {
        |  int $numRows = $batch.numRows();
        |  int $localEnd = $numRows - $idx;
        |  for (int $localIdx = 0; $localIdx < $localEnd; $localIdx++) {
@@ -166,7 +166,7 @@ private[sql] trait ColumnarBatchScan extends CodegenSupport {
     }
     val inputRow = if (needsUnsafeRowConversion) null else row
     s"""
-       |while ($input.hasNext()) {
+       |while ($input.hasNext() && !stopEarly()) {
        |  InternalRow $row = (InternalRow) $input.next();
        |  $numOutputRows.add(1);
        |  ${consume(ctx, outputVars, inputRow).trim}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Suppose that we have a hive table created like this ```create table parquet_test (id int) using parquet```,  and our query sql is `select id from parquet_test limit 10`.

With `spark.sql.hive.convertMetastoreParquet`  set to false, the sql execution will go into `InputAdapter`, in its codegen, it can use `stopEarly` to accelerate local limit.

But if we set  `spark.sql.hive.convertMetastoreParquet`  to true, the sql exectuion will go into `ColumnarBatchScan`, which didn't optimize local limit.

In this patch, We use `stopEarly` in `ColumnarBatchScan` as well to accelerate local limit.

## How was this patch tested?

Test manually by codegen.

For sql `select id from parquet_test limit 10`,

the code generated before patch
![image](https://user-images.githubusercontent.com/1312321/58088452-4a951900-7bf5-11e9-945d-2071489583f6.png)

the code generated after patch
![image](https://user-images.githubusercontent.com/1312321/58088503-67315100-7bf5-11e9-94b3-bca5f0738080.png)
