### PR TITLE
[SPARK-27800][SQL][DOC] Fix wrong answer of example for BitwiseXor

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala
@@ -95,7 +95,7 @@ case class BitwiseOr(left: Expression, right: Expression) extends BinaryArithmet
   examples = """
     Examples:
       > SELECT 3 _FUNC_ 5;
-       2
+       6
   """)
 case class BitwiseXor(left: Expression, right: Expression) extends BinaryArithmetic {
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix example for bitwise xor function. 3 ^ 5 should be 6 rather than 2.
- See https://spark.apache.org/docs/latest/api/sql/index.html#_14

## How was this patch tested?

manual tests

