### PR TITLE
[SPARK-27811][Core][Docs]Improve docs about spark.driver.memoryOverhead and spark.executor.memoryOverhead.

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -60,8 +60,12 @@ package object config {
     .createWithDefaultString("1g")
 
   private[spark] val DRIVER_MEMORY_OVERHEAD = ConfigBuilder("spark.driver.memoryOverhead")
-    .doc("Amount of memory to be allocated outside the driver process in cluster mode, " +
-      "in MiB unless otherwise specified.")
+    .doc("Amount of non-heap memory to be allocated per driver process in cluster mode" +
+      " (e.g YARN and Kubernetes), in MiB unless otherwise specified." +
+      "Note: These non-heap memory including off-heap memory (when spark.memory.offHeap.enabled=true)" +
+      " and memory used by other non-driver processes running in the same container." +
+      "The maximum memory size of container to running driver is determined by the sum of" +
+      " spark.driver.memoryOverhead and spark.driver.memory.")
     .bytesConf(ByteUnit.MiB)
     .createOptional
 
@@ -185,8 +189,12 @@ package object config {
     .createWithDefaultString("1g")
 
   private[spark] val EXECUTOR_MEMORY_OVERHEAD = ConfigBuilder("spark.executor.memoryOverhead")
-    .doc("Amount of memory to be allocated outside per executor process in cluster mode, " +
-      "in MiB unless otherwise specified.")
+    .doc("Amount of non-heap memory to be allocated per executor process in cluster mode " +
+      "(e.g YARN and Kubernetes), in MiB unless otherwise specified." +
+      "Note: These non-heap memory including off-heap memory (when spark.memory.offHeap.enabled=true)" +
+      " and memory used by other non-executor processes running in the same container."
+      "The maximum memory size of container to running executor is determined by the sum of " +
+      "spark.executor.memoryOverhead and spark.executor.memory.")
     .bytesConf(ByteUnit.MiB)
     .createOptional
 
@@ -201,7 +209,10 @@ package object config {
 
   private[spark] val MEMORY_OFFHEAP_ENABLED = ConfigBuilder("spark.memory.offHeap.enabled")
     .doc("If true, Spark will attempt to use off-heap memory for certain operations. " +
-      "If off-heap memory use is enabled, then spark.memory.offHeap.size must be positive.")
+      "If off-heap memory use is enabled, then spark.memory.offHeap.size must be positive." +
+      "Note: If off-heap memory use is enabled or off-heap memory size is increased, " +
+      "recommend raising the non-heap memory size (e.g increase spark.driver.memoryOverhead " +
+      "or spark.executor.memoryOverhead).")
     .withAlternative("spark.unsafe.offHeap")
     .booleanConf
     .createWithDefault(false)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -185,7 +185,7 @@ package object config {
     .createWithDefaultString("1g")
 
   private[spark] val EXECUTOR_MEMORY_OVERHEAD = ConfigBuilder("spark.executor.memoryOverhead")
-    .doc("The amount of non-heap memory to be allocated per executor in cluster mode,  " +
+    .doc("The amount of non-heap memory to be allocated per executor in cluster mode, " +
       "in MiB unless otherwise specified.")
     .bytesConf(ByteUnit.MiB)
     .createOptional

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -62,7 +62,7 @@ package object config {
   private[spark] val DRIVER_MEMORY_OVERHEAD = ConfigBuilder("spark.driver.memoryOverhead")
     .doc("Amount of non-heap memory to be allocated per driver process in cluster mode" +
       " (e.g YARN and Kubernetes), in MiB unless otherwise specified." +
-      "Note: These non-heap memory including off-heap memory (when spark.memory.offHeap.enabled=true)" +
+      "Note: Non-heap memory including off-heap memory (when spark.memory.offHeap.enabled=true)" +
       " and memory used by other non-driver processes running in the same container." +
       "The maximum memory size of container to running driver is determined by the sum of " +
       "spark.driver.memoryOverhead and spark.driver.memory.")
@@ -191,7 +191,7 @@ package object config {
   private[spark] val EXECUTOR_MEMORY_OVERHEAD = ConfigBuilder("spark.executor.memoryOverhead")
     .doc("Amount of non-heap memory to be allocated per executor process in cluster mode " +
       "(e.g YARN and Kubernetes), in MiB unless otherwise specified." +
-      "Note: These non-heap memory including off-heap memory (when spark.memory.offHeap.enabled=true)" +
+      "Note: Non-heap memory including off-heap memory (when spark.memory.offHeap.enabled=true)" +
       " and memory used by other non-executor processes running in the same container." +
       "The maximum memory size of container to running executor is determined by the sum of " +
       "spark.executor.memoryOverhead and spark.executor.memory.")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -65,7 +65,7 @@ package object config {
       "Note: These non-heap memory including off-heap memory (when spark.memory.offHeap.enabled=true)" +
       " and memory used by other non-driver processes running in the same container." +
       "The maximum memory size of container to running driver is determined by the sum of" +
-      " spark.driver.memoryOverhead and spark.driver.memory.")
+      " `spark.driver.memoryOverhead` and `spark.driver.memory`.")
     .bytesConf(ByteUnit.MiB)
     .createOptional
 
@@ -194,7 +194,7 @@ package object config {
       "Note: These non-heap memory including off-heap memory (when spark.memory.offHeap.enabled=true)" +
       " and memory used by other non-executor processes running in the same container."
       "The maximum memory size of container to running executor is determined by the sum of" +
-      " spark.executor.memoryOverhead and spark.executor.memory.")
+      " `spark.executor.memoryOverhead` and `spark.executor.memory`.")
     .bytesConf(ByteUnit.MiB)
     .createOptional
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -60,7 +60,7 @@ package object config {
     .createWithDefaultString("1g")
 
   private[spark] val DRIVER_MEMORY_OVERHEAD = ConfigBuilder("spark.driver.memoryOverhead")
-    .doc("The amount of off-heap memory to be allocated per driver in cluster mode, " +
+    .doc("Amount of memory to be allocated outside the driver process in cluster mode, " +
       "in MiB unless otherwise specified.")
     .bytesConf(ByteUnit.MiB)
     .createOptional
@@ -185,7 +185,7 @@ package object config {
     .createWithDefaultString("1g")
 
   private[spark] val EXECUTOR_MEMORY_OVERHEAD = ConfigBuilder("spark.executor.memoryOverhead")
-    .doc("The amount of off-heap memory to be allocated per executor in cluster mode, " +
+    .doc("Amount of memory to be allocated outside per executor process in cluster mode, " +
       "in MiB unless otherwise specified.")
     .bytesConf(ByteUnit.MiB)
     .createOptional

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -193,8 +193,8 @@ package object config {
       "(e.g YARN and Kubernetes), in MiB unless otherwise specified." +
       "Note: These non-heap memory including off-heap memory (when spark.memory.offHeap.enabled=true)" +
       " and memory used by other non-executor processes running in the same container."
-      "The maximum memory size of container to running executor is determined by the sum of " +
-      "spark.executor.memoryOverhead and spark.executor.memory.")
+      "The maximum memory size of container to running executor is determined by the sum of" +
+      " spark.executor.memoryOverhead and spark.executor.memory.")
     .bytesConf(ByteUnit.MiB)
     .createOptional
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -60,12 +60,8 @@ package object config {
     .createWithDefaultString("1g")
 
   private[spark] val DRIVER_MEMORY_OVERHEAD = ConfigBuilder("spark.driver.memoryOverhead")
-    .doc("Amount of non-heap memory to be allocated per driver process in cluster mode" +
-      " (e.g YARN and Kubernetes), in MiB unless otherwise specified." +
-      "Note: Non-heap memory including off-heap memory (when spark.memory.offHeap.enabled=true)" +
-      " and memory used by other non-driver processes running in the same container." +
-      "The maximum memory size of container to running driver is determined by the sum of " +
-      "spark.driver.memoryOverhead and spark.driver.memory.")
+    .doc("The amount of non-heap memory to be allocated per driver in cluster mode, " +
+      "in MiB unless otherwise specified.")
     .bytesConf(ByteUnit.MiB)
     .createOptional
 
@@ -189,12 +185,8 @@ package object config {
     .createWithDefaultString("1g")
 
   private[spark] val EXECUTOR_MEMORY_OVERHEAD = ConfigBuilder("spark.executor.memoryOverhead")
-    .doc("Amount of non-heap memory to be allocated per executor process in cluster mode " +
-      "(e.g YARN and Kubernetes), in MiB unless otherwise specified." +
-      "Note: Non-heap memory including off-heap memory (when spark.memory.offHeap.enabled=true)" +
-      " and memory used by other non-executor processes running in the same container." +
-      "The maximum memory size of container to running executor is determined by the sum of " +
-      "spark.executor.memoryOverhead and spark.executor.memory.")
+    .doc("The amount of non-heap memory to be allocated per executor in cluster mode,  " +
+      "in MiB unless otherwise specified.")
     .bytesConf(ByteUnit.MiB)
     .createOptional
 
@@ -209,10 +201,7 @@ package object config {
 
   private[spark] val MEMORY_OFFHEAP_ENABLED = ConfigBuilder("spark.memory.offHeap.enabled")
     .doc("If true, Spark will attempt to use off-heap memory for certain operations. " +
-      "If off-heap memory use is enabled, then spark.memory.offHeap.size must be positive." +
-      "Note: If off-heap memory use is enabled or off-heap memory size is increased, " +
-      "recommend raising the non-heap memory size (e.g increase spark.driver.memoryOverhead " +
-      "or spark.executor.memoryOverhead).")
+      "If off-heap memory use is enabled, then spark.memory.offHeap.size must be positive.")
     .withAlternative("spark.unsafe.offHeap")
     .booleanConf
     .createWithDefault(false)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -64,8 +64,8 @@ package object config {
       " (e.g YARN and Kubernetes), in MiB unless otherwise specified." +
       "Note: These non-heap memory including off-heap memory (when spark.memory.offHeap.enabled=true)" +
       " and memory used by other non-driver processes running in the same container." +
-      "The maximum memory size of container to running driver is determined by the sum of" +
-      " `spark.driver.memoryOverhead` and `spark.driver.memory`.")
+      "The maximum memory size of container to running driver is determined by the sum of " +
+      "spark.driver.memoryOverhead and spark.driver.memory.")
     .bytesConf(ByteUnit.MiB)
     .createOptional
 
@@ -192,9 +192,9 @@ package object config {
     .doc("Amount of non-heap memory to be allocated per executor process in cluster mode " +
       "(e.g YARN and Kubernetes), in MiB unless otherwise specified." +
       "Note: These non-heap memory including off-heap memory (when spark.memory.offHeap.enabled=true)" +
-      " and memory used by other non-executor processes running in the same container."
-      "The maximum memory size of container to running executor is determined by the sum of" +
-      " `spark.executor.memoryOverhead` and `spark.executor.memory`.")
+      " and memory used by other non-executor processes running in the same container." +
+      "The maximum memory size of container to running executor is determined by the sum of " +
+      "spark.executor.memoryOverhead and spark.executor.memory.")
     .bytesConf(ByteUnit.MiB)
     .createOptional
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -185,7 +185,7 @@ of the most common options to set are:
     (e.g YARN, Mesos and Kubernetes.), in MiB unless otherwise specified. This is memory that
     accounts for things like VM overheads, interned strings, other native overheads, etc. 
     This tends to grow with the container size (typically 6-10%). 
-    <em>Note:</em> These non-heap memory including off-heap memory 
+    <em>Note:</em> Non-heap memory including off-heap memory 
     (when <code>spark.memory.offHeap.enabled=true</code>) and memory used by other non-driver 
     processes running in the same container. The maximum memory size of container to running 
     driver is determined by the sum of <code>spark.driver.memoryOverhead</code> 
@@ -225,7 +225,7 @@ of the most common options to set are:
     things like VM overheads, interned strings, other native overheads, etc. This tends to grow with 
     the executor size (typically 6-10%).This option is currently supported on YARN and Kubernetes.
     <br/>
-    <em>Note:</em> These non-heap memory including off-heap memory 
+    <em>Note:</em> Non-heap memory including off-heap memory 
     (when <code>spark.memory.offHeap.enabled=true</code>) and memory used by other non-executor 
     processes running in the same container. The maximum memory size of container to running executor 
     is determined by the sum of <code>spark.executor.memoryOverhead</code> and 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,7 +181,7 @@ of the most common options to set are:
   <td><code>spark.driver.memoryOverhead</code></td>
   <td>driverMemory * 0.10, with minimum of 384 </td>
   <td>
-    The amount of off-heap memory to be allocated per driver in cluster mode, in MiB unless
+    Amount of memory to be allocated outside the driver process in cluster mode, in MiB unless
     otherwise specified. This is memory that accounts for things like VM overheads, interned strings, 
     other native overheads, etc. This tends to grow with the container size (typically 6-10%). 
     This option is currently supported on YARN, Mesos and Kubernetes.
@@ -215,10 +215,10 @@ of the most common options to set are:
  <td><code>spark.executor.memoryOverhead</code></td>
   <td>executorMemory * 0.10, with minimum of 384 </td>
   <td>
-    The amount of off-heap memory to be allocated per executor, in MiB unless otherwise specified.
-    This is memory that accounts for things like VM overheads, interned strings, other native 
-    overheads, etc. This tends to grow with the executor size (typically 6-10%).
-    This option is currently supported on YARN and Kubernetes.
+    Amount of memory to be allocated outside per executor process in cluster mode, in MiB
+    unless otherwise specified.This is memory that accounts for things like VM overheads,
+    interned strings, other native overheads, etc. This tends to grow with the executor
+    size (typically 6-10%).This option is currently supported on YARN and Kubernetes.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,10 +181,10 @@ of the most common options to set are:
   <td><code>spark.driver.memoryOverhead</code></td>
   <td>driverMemory * 0.10, with minimum of 384 </td>
   <td>
-    Amount of non-heap memory to be allocated per driver process in cluster mode 
-    (e.g. YARN, Mesos and Kubernetes.), in MiB unless otherwise specified. This is memory that
-    accounts for things like VM overheads, interned strings, other native overheads, etc. 
-    This tends to grow with the container size (typically 6-10%). 
+    Amount of non-heap memory to be allocated per driver process in cluster mode, in MiB unless
+    otherwise specified. This is memory that accounts for things like VM overheads, interned strings,
+    other native overheads, etc. This tends to grow with the container size (typically 6-10%). 
+    This option is currently supported on YARN, Mesos and Kubernetes.
     <em>Note:</em> Non-heap memory includes off-heap memory 
     (when <code>spark.memory.offHeap.enabled=true</code>) and memory used by other driver processes
     (e.g. python process that goes with a PySpark driver) and memory used by other non-driver 
@@ -221,10 +221,10 @@ of the most common options to set are:
  <td><code>spark.executor.memoryOverhead</code></td>
   <td>executorMemory * 0.10, with minimum of 384 </td>
   <td>
-    Amount of non-heap memory to be allocated per executor process in cluster mode 
-    (e.g. YARN and Kubernetes), in MiB unless otherwise specified. This is memory that accounts for 
-    things like VM overheads, interned strings, other native overheads, etc. This tends to grow with 
-    the executor size (typically 6-10%).This option is currently supported on YARN and Kubernetes.
+    Amount of non-heap memory to be allocated per executor process in cluster mode, in MiB unless
+    otherwise specified. This is memory that accounts for things like VM overheads, interned strings,
+    other native overheads, etc. This tends to grow with the executor size (typically 6-10%).
+    This option is currently supported on YARN and Kubernetes.
     <br/>
     <em>Note:</em> Non-heap memory includes off-heap memory 
     (when <code>spark.memory.offHeap.enabled=true</code>) and memory used by other executor processes
@@ -1246,8 +1246,9 @@ Apart from these, the following properties are also available, and may be useful
   <td>
     If true, Spark will attempt to use off-heap memory for certain operations. If off-heap memory 
     use is enabled, then <code>spark.memory.offHeap.size</code> must be positive.
-    <em>Note:</em> If off-heap memory is enabled, raise the non-heap memory size (e.g. increase
-    <code>spark.driver.memoryOverhead</code> or <code>spark.executor.memoryOverhead</code>).
+    <em>Note:</em> If off-heap memory is enabled, you may need to raise the non-heap memory size
+    (e.g. increase <code>spark.driver.memoryOverhead</code> or
+    <code>spark.executor.memoryOverhead</code>).
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -186,7 +186,8 @@ of the most common options to set are:
     accounts for things like VM overheads, interned strings, other native overheads, etc. 
     This tends to grow with the container size (typically 6-10%). 
     <em>Note:</em> Non-heap memory including off-heap memory 
-    (when <code>spark.memory.offHeap.enabled=true</code>) and memory used by other non-driver 
+    (when <code>spark.memory.offHeap.enabled=true</code>) and memory used by other driver processes
+    (e.g python process that goes with a PySpark driver) and memory used by other non-driver 
     processes running in the same container. The maximum memory size of container to running 
     driver is determined by the sum of <code>spark.driver.memoryOverhead</code> 
     and <code>spark.driver.memory</code>.
@@ -226,7 +227,8 @@ of the most common options to set are:
     the executor size (typically 6-10%).This option is currently supported on YARN and Kubernetes.
     <br/>
     <em>Note:</em> Non-heap memory including off-heap memory 
-    (when <code>spark.memory.offHeap.enabled=true</code>) and memory used by other non-executor 
+    (when <code>spark.memory.offHeap.enabled=true</code>) and memory used by other executor processes
+    (e.g python process that goes with a PySpark executor) and memory used by other non-executor 
     processes running in the same container. The maximum memory size of container to running executor 
     is determined by the sum of <code>spark.executor.memoryOverhead</code> and 
     <code>spark.executor.memory</code>.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -182,12 +182,12 @@ of the most common options to set are:
   <td>driverMemory * 0.10, with minimum of 384 </td>
   <td>
     Amount of non-heap memory to be allocated per driver process in cluster mode 
-    (e.g YARN, Mesos and Kubernetes.), in MiB unless otherwise specified. This is memory that
+    (e.g. YARN, Mesos and Kubernetes.), in MiB unless otherwise specified. This is memory that
     accounts for things like VM overheads, interned strings, other native overheads, etc. 
     This tends to grow with the container size (typically 6-10%). 
     <em>Note:</em> Non-heap memory includes off-heap memory 
     (when <code>spark.memory.offHeap.enabled=true</code>) and memory used by other driver processes
-    (e.g python process that goes with a PySpark driver) and memory used by other non-driver 
+    (e.g. python process that goes with a PySpark driver) and memory used by other non-driver 
     processes running in the same container. The maximum memory size of container to running 
     driver is determined by the sum of <code>spark.driver.memoryOverhead</code> 
     and <code>spark.driver.memory</code>.
@@ -221,14 +221,14 @@ of the most common options to set are:
  <td><code>spark.executor.memoryOverhead</code></td>
   <td>executorMemory * 0.10, with minimum of 384 </td>
   <td>
-    Amount of non-heap memory to be allocated per executor process in cluster mode
-    (e.g YARN and Kubernetes), in MiB unless otherwise specified. This is memory that accounts for 
+    Amount of non-heap memory to be allocated per executor process in cluster mode 
+    (e.g. YARN and Kubernetes), in MiB unless otherwise specified. This is memory that accounts for 
     things like VM overheads, interned strings, other native overheads, etc. This tends to grow with 
     the executor size (typically 6-10%).This option is currently supported on YARN and Kubernetes.
     <br/>
     <em>Note:</em> Non-heap memory includes off-heap memory 
     (when <code>spark.memory.offHeap.enabled=true</code>) and memory used by other executor processes
-    (e.g python process that goes with a PySpark executor) and memory used by other non-executor 
+    (e.g. python process that goes with a PySpark executor) and memory used by other non-executor 
     processes running in the same container. The maximum memory size of container to running executor 
     is determined by the sum of <code>spark.executor.memoryOverhead</code> and 
     <code>spark.executor.memory</code>.
@@ -1246,9 +1246,8 @@ Apart from these, the following properties are also available, and may be useful
   <td>
     If true, Spark will attempt to use off-heap memory for certain operations. If off-heap memory 
     use is enabled, then <code>spark.memory.offHeap.size</code> must be positive.
-    <em>Note:</em> If off-heap memory use is enabled or off-heap memory size is increased, 
-    recommend raise the non-heap memory size(e.g increase <code>spark.driver.memoryOverhead</code>
-    or <code>spark.executor.memoryOverhead</code>).
+    <em>Note:</em> If off-heap memory is enabled, raise the non-heap memory size (e.g. increase
+    <code>spark.driver.memoryOverhead</code> or <code>spark.executor.memoryOverhead</code>).
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,10 +181,15 @@ of the most common options to set are:
   <td><code>spark.driver.memoryOverhead</code></td>
   <td>driverMemory * 0.10, with minimum of 384 </td>
   <td>
-    Amount of memory to be allocated outside the driver process in cluster mode, in MiB unless
-    otherwise specified. This is memory that accounts for things like VM overheads, interned strings, 
-    other native overheads, etc. This tends to grow with the container size (typically 6-10%). 
-    This option is currently supported on YARN, Mesos and Kubernetes.
+    Amount of non-heap memory to be allocated per driver process in cluster mode 
+    (e.g YARN, Mesos and Kubernetes.), in MiB unless otherwise specified. This is memory that
+    accounts for things like VM overheads, interned strings, other native overheads, etc. 
+    This tends to grow with the container size (typically 6-10%). 
+    <em>Note:</em> These non-heap memory including off-heap memory 
+    (when <code>spark.memory.offHeap.enabled=true</code>) and memory used by other non-driver 
+    processes running in the same container. The maximum memory size of container to running 
+    driver is determined by the sum of <code>spark.driver.memoryOverhead</code> 
+    and <code>spark.driver.memory</code>.
   </td>
 </tr>
 <tr>
@@ -215,10 +220,16 @@ of the most common options to set are:
  <td><code>spark.executor.memoryOverhead</code></td>
   <td>executorMemory * 0.10, with minimum of 384 </td>
   <td>
-    Amount of memory to be allocated outside per executor process in cluster mode, in MiB
-    unless otherwise specified.This is memory that accounts for things like VM overheads,
-    interned strings, other native overheads, etc. This tends to grow with the executor
-    size (typically 6-10%).This option is currently supported on YARN and Kubernetes.
+    Amount of non-heap memory to be allocated per executor process in cluster mode
+    (e.g YARN and Kubernetes), in MiB unless otherwise specified. This is memory that accounts for 
+    things like VM overheads, interned strings, other native overheads, etc. This tends to grow with 
+    the executor size (typically 6-10%).This option is currently supported on YARN and Kubernetes.
+    <br/>
+    <em>Note:</em> These non-heap memory including off-heap memory 
+    (when <code>spark.memory.offHeap.enabled=true</code>) and memory used by other non-executor 
+    processes running in the same container. The maximum memory size of container to running executor 
+    is determined by the sum of <code>spark.executor.memoryOverhead</code> and 
+    <code>spark.executor.memory</code>.
   </td>
 </tr>
 <tr>
@@ -1233,6 +1244,9 @@ Apart from these, the following properties are also available, and may be useful
   <td>
     If true, Spark will attempt to use off-heap memory for certain operations. If off-heap memory 
     use is enabled, then <code>spark.memory.offHeap.size</code> must be positive.
+    <em>Note:</em> If off-heap memory use is enabled or off-heap memory size is increased, 
+    recommend raising the non-heap memory size(e.g increase <code>spark.driver.memoryOverhead</code>
+    or <code>spark.executor.memoryOverhead</code>).
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1246,7 +1246,7 @@ Apart from these, the following properties are also available, and may be useful
   <td>
     If true, Spark will attempt to use off-heap memory for certain operations. If off-heap memory 
     use is enabled, then <code>spark.memory.offHeap.size</code> must be positive.
-    <em>Note:</em> If off-heap memory is enabled, you may need to raise the non-heap memory size
+    <em>Note:</em> If off-heap memory is enabled, may need to raise the non-heap memory size
     (e.g. increase <code>spark.driver.memoryOverhead</code> or
     <code>spark.executor.memoryOverhead</code>).
   </td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -185,7 +185,7 @@ of the most common options to set are:
     (e.g YARN, Mesos and Kubernetes.), in MiB unless otherwise specified. This is memory that
     accounts for things like VM overheads, interned strings, other native overheads, etc. 
     This tends to grow with the container size (typically 6-10%). 
-    <em>Note:</em> Non-heap memory including off-heap memory 
+    <em>Note:</em> Non-heap memory includes off-heap memory 
     (when <code>spark.memory.offHeap.enabled=true</code>) and memory used by other driver processes
     (e.g python process that goes with a PySpark driver) and memory used by other non-driver 
     processes running in the same container. The maximum memory size of container to running 
@@ -226,7 +226,7 @@ of the most common options to set are:
     things like VM overheads, interned strings, other native overheads, etc. This tends to grow with 
     the executor size (typically 6-10%).This option is currently supported on YARN and Kubernetes.
     <br/>
-    <em>Note:</em> Non-heap memory including off-heap memory 
+    <em>Note:</em> Non-heap memory includes off-heap memory 
     (when <code>spark.memory.offHeap.enabled=true</code>) and memory used by other executor processes
     (e.g python process that goes with a PySpark executor) and memory used by other non-executor 
     processes running in the same container. The maximum memory size of container to running executor 
@@ -1247,7 +1247,7 @@ Apart from these, the following properties are also available, and may be useful
     If true, Spark will attempt to use off-heap memory for certain operations. If off-heap memory 
     use is enabled, then <code>spark.memory.offHeap.size</code> must be positive.
     <em>Note:</em> If off-heap memory use is enabled or off-heap memory size is increased, 
-    recommend raising the non-heap memory size(e.g increase <code>spark.driver.memoryOverhead</code>
+    recommend raise the non-heap memory size(e.g increase <code>spark.driver.memoryOverhead</code>
     or <code>spark.executor.memoryOverhead</code>).
   </td>
 </tr>


### PR DESCRIPTION
## What changes were proposed in this pull request?

I found the docs of `spark.driver.memoryOverhead` and `spark.executor.memoryOverhead` exists a little ambiguity.
For example, the origin docs of `spark.driver.memoryOverhead` start with `The amount of off-heap memory to be allocated per driver in cluster mode`.
But `MemoryManager` also managed a memory area named off-heap used to allocate memory in tungsten mode.
So I think the description of `spark.driver.memoryOverhead` always make confused.

`spark.executor.memoryOverhead` has the same confused with `spark.driver.memoryOverhead`.

## How was this patch tested?

Exists UT.
