### PR TITLE
[SPARK-27805][PYTHON] Propagate SparkExceptions during toPandas with arrow enabled

### DIFF
--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -206,19 +206,17 @@ class ArrowCollectSerializer(Serializer):
         for batch in self.serializer.load_stream(stream):
             yield batch
 
-        # check success
-        success = read_bool(stream)
-        if success:
-            # load the batch order indices
-            num = read_int(stream)
-            batch_order = []
-            for i in xrange(num):
-                index = read_int(stream)
-                batch_order.append(index)
-            yield batch_order
-        else:
+        # load the batch order indices
+        num = read_int(stream)
+        if num == -1:
             error_msg = UTF8Deserializer().loads(stream)
-            raise RuntimeError("An error occurred while collecting: {}".format(error_msg))
+            raise RuntimeError("An error occurred while calling "
+                               "ArrowCollectSerializer.load_stream: {}".format(error_msg))
+        batch_order = []
+        for i in xrange(num):
+            index = read_int(stream)
+            batch_order.append(index)
+        yield batch_order
 
     def __repr__(self):
         return "ArrowCollectSerializer(%s)" % self.serializer

--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -206,13 +206,19 @@ class ArrowCollectSerializer(Serializer):
         for batch in self.serializer.load_stream(stream):
             yield batch
 
-        # load the batch order indices
-        num = read_int(stream)
-        batch_order = []
-        for i in xrange(num):
-            index = read_int(stream)
-            batch_order.append(index)
-        yield batch_order
+        # check success
+        success = read_bool(stream)
+        if success:
+            # load the batch order indices
+            num = read_int(stream)
+            batch_order = []
+            for i in xrange(num):
+                index = read_int(stream)
+                batch_order.append(index)
+            yield batch_order
+        else:
+            error_msg = UTF8Deserializer().loads(stream)
+            raise RuntimeError("An error occurred while collecting: {}".format(error_msg))
 
     def __repr__(self):
         return "ArrowCollectSerializer(%s)" % self.serializer

--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -206,7 +206,7 @@ class ArrowCollectSerializer(Serializer):
         for batch in self.serializer.load_stream(stream):
             yield batch
 
-        # load the batch order indices
+        # load the batch order indices or propagate any error that occurred in the JVM
         num = read_int(stream)
         if num == -1:
             error_msg = UTF8Deserializer().loads(stream)

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -200,7 +200,7 @@ class ArrowTests(ReusedSQLTestCase):
         exception_udf = udf(raise_exception, IntegerType())
         df = df.withColumn("error", exception_udf())
         with QuietTest(self.sc):
-            with self.assertRaisesRegexp(Exception, 'My error'):
+            with self.assertRaisesRegexp(RuntimeError, 'My error'):
                 df.toPandas()
 
     def _createDataFrame_toggle(self, pdf, schema=None):

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -23,6 +23,7 @@ import unittest
 import warnings
 
 from pyspark.sql import Row
+from pyspark.sql.functions import udf
 from pyspark.sql.types import *
 from pyspark.testing.sqlutils import ReusedSQLTestCase, have_pandas, have_pyarrow, \
     pandas_requirement_message, pyarrow_requirement_message
@@ -193,7 +194,6 @@ class ArrowTests(ReusedSQLTestCase):
 
     def test_propagates_spark_exception(self):
         df = self.spark.range(3).toDF("i")
-        from pyspark.sql.functions import udf
 
         def raise_exception():
             raise Exception("My error")

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -18,13 +18,14 @@
 package org.apache.spark.sql
 
 import java.io.{ByteArrayOutputStream, CharArrayWriter, DataOutputStream}
-import java.nio.charset.StandardCharsets
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 import scala.language.implicitConversions
 import scala.util.control.NonFatal
+
 import org.apache.commons.lang3.StringUtils
+
 import org.apache.spark.{SparkException, TaskContext}
 import org.apache.spark.annotation.{DeveloperApi, Evolving, Experimental, Stable, Unstable}
 import org.apache.spark.api.java.JavaRDD
@@ -39,7 +40,7 @@ import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
 import org.apache.spark.sql.catalyst.encoders._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateSafeProjection
-import org.apache.spark.sql.catalyst.json.{JSONOptions, JacksonGenerator}
+import org.apache.spark.sql.catalyst.json.{JacksonGenerator, JSONOptions}
 import org.apache.spark.sql.catalyst.optimizer.CombineUnions
 import org.apache.spark.sql.catalyst.parser.{ParseException, ParserUtils}
 import org.apache.spark.sql.catalyst.plans._


### PR DESCRIPTION
## What changes were proposed in this pull request?
Similar to https://github.com/apache/spark/pull/24070, we now propagate SparkExceptions that are encountered during the collect in the java process to the python process.

Fixes https://jira.apache.org/jira/browse/SPARK-27805

## How was this patch tested?
Added a new unit test
