### PR TITLE
[SPARK-27806][SQL] byName/byPosition should apply to struct fields as well

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2327,7 +2327,7 @@ class Analyzer(
         expected.flatMap { tableAttr =>
           query.resolveQuoted(tableAttr.name, resolver) match {
             case Some(queryExpr) =>
-              checkField(tableAttr, queryExpr, err => errors += err)
+              checkField(tableAttr, queryExpr, byName, err => errors += err)
             case None =>
               errors += s"Cannot find data for output column '${tableAttr.name}'"
               None
@@ -2345,7 +2345,7 @@ class Analyzer(
 
         query.output.zip(expected).flatMap {
           case (queryExpr, tableAttr) =>
-            checkField(tableAttr, queryExpr, err => errors += err)
+            checkField(tableAttr, queryExpr, byName, err => errors += err)
         }
       }
 
@@ -2360,11 +2360,12 @@ class Analyzer(
     private def checkField(
         tableAttr: Attribute,
         queryExpr: NamedExpression,
+        byName: Boolean,
         addError: String => Unit): Option[NamedExpression] = {
 
       // run the type check first to ensure type errors are present
       val canWrite = DataType.canWrite(
-        queryExpr.dataType, tableAttr.dataType, resolver, tableAttr.name, addError)
+        queryExpr.dataType, tableAttr.dataType, byName, resolver, tableAttr.name, addError)
 
       if (queryExpr.nullable && !tableAttr.nullable) {
         addError(s"Cannot write nullable values to non-null column '${tableAttr.name}'")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DataSourceV2AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DataSourceV2AnalysisSuite.scala
@@ -473,6 +473,43 @@ abstract class DataSourceV2AnalysisSuite extends AnalysisTest {
     }
   }
 
+  test("check fields of struct type column") {
+    val tableWithStructCol = TestRelation(
+      new StructType().add(
+        "col", new StructType().add("a", IntegerType).add("b", IntegerType)
+      ).toAttributes
+    )
+
+    val query = TestRelation(
+      new StructType().add(
+        "col", new StructType().add("x", IntegerType).add("y", IntegerType)
+      ).toAttributes
+    )
+
+    withClue("byName") {
+      val parsedPlan = byName(tableWithStructCol, query)
+      assertNotResolved(parsedPlan)
+      assertAnalysisError(parsedPlan, Seq(
+        "Cannot write incompatible data to table", "'table-name'",
+        "Struct 'col' 0-th field name does not match", "expected 'a', found 'x'",
+        "Struct 'col' 1-th field name does not match", "expected 'b', found 'y'"))
+    }
+
+    withClue("byPosition") {
+      val parsedPlan = byPosition(tableWithStructCol, query)
+      assertNotResolved(parsedPlan)
+
+      val expectedQuery = Project(Seq(Alias(
+        Cast(
+          query.output.head,
+          new StructType().add("a", IntegerType).add("b", IntegerType),
+          Some(conf.sessionLocalTimeZone)),
+        "col")()),
+        query)
+      checkAnalysis(parsedPlan, byPosition(tableWithStructCol, expectedQuery))
+    }
+  }
+
   def assertNotResolved(logicalPlan: LogicalPlan): Unit = {
     assert(!logicalPlan.resolved, s"Plan should not be resolved: $logicalPlan")
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When writing a query to data source v2, we have 2 modes to resolve the input query's output: byName or byPosition.

For byName mode, we would reorder the top level columns according to the name, and add type cast if possible. If the names don't match, we fail.

For byPosition mode, we don't do the reorder, and just add type cast directly if possible.

However, for struct type fields, we always apply byName mode. We should ignore the name difference if byPosition mode is used.

## How was this patch tested?

new tests
