### PR TITLE
[SPARK-27838][SQL] Support user provided non-nullable avro schema for nullable catalyst schema without any null record

### DIFF
--- a/docs/sql-migration-guide-upgrade.md
+++ b/docs/sql-migration-guide-upgrade.md
@@ -134,6 +134,8 @@ license: |
 
   - Since Spark 3.0, when Avro files are written with user provided schema, the fields will be matched by field names between catalyst schema and avro schema instead of positions.
 
+  - Since Spark 3.0, when Avro files are written with user provided non-nullable schema, even the catalyst schema is nullable, Spark is still able to write the files. However, Spark will throw runtime NPE if any of the records contains null.
+
 ## Upgrading from Spark SQL 2.4 to 2.4.1
 
   - The value of `spark.executor.heartbeatInterval`, when specified without units like "30" rather than "30s", was

--- a/docs/sql-migration-guide-upgrade.md
+++ b/docs/sql-migration-guide-upgrade.md
@@ -132,6 +132,8 @@ license: |
 
   - Since Spark 3.0, Spark will cast `String` to `Date/TimeStamp` in binary comparisons with dates/timestamps. The previous behaviour of casting `Date/Timestamp` to `String` can be restored by setting `spark.sql.legacy.typeCoercion.datetimeToString` to `true`.
 
+  - Since Spark 3.0, when Avro files are written with user provided schema, the fields will be matched by field names between catalyst schema and avro schema instead of positions.
+
 ## Upgrading from Spark SQL 2.4 to 2.4.1
 
   - The value of `spark.executor.heartbeatInterval`, when specified without units like "30" rather than "30s", was

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
@@ -236,20 +236,19 @@ class AvroSerializer(rootCatalystType: DataType, rootAvroType: Schema, nullable:
   }
 
   private def resolveNullableType(avroType: Schema, nullable: Boolean): Schema = {
-    (avroType.getType, nullable) match {
-      case (Type.UNION, true) =>
-        // avro uses union to represent nullable type.
-        val fields = avroType.getTypes.asScala
-        assert(fields.length == 2)
-        val actualType = fields.filter(_.getType != Type.NULL)
-        assert(actualType.length == 1)
-        actualType.head
-      case (_, true) =>
+    if (avroType.getType == Type.UNION && nullable) {
+      // avro uses union to represent nullable type.
+      val fields = avroType.getTypes.asScala
+      assert(fields.length == 2)
+      val actualType = fields.filter(_.getType != Type.NULL)
+      assert(actualType.length == 1)
+      actualType.head
+    } else {
+      if (nullable) {
         logWarning(s"Writing avro files with non-nullable avro schema with nullable catalyst " +
           s"schema will throw runtime exception if there is a record with null value.")
-        avroType
-      case _ =>
-        avroType
+      }
+      avroType
     }
   }
 }

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
@@ -21,16 +21,17 @@ import java.nio.ByteBuffer
 
 import scala.collection.JavaConverters._
 
-import org.apache.avro.{LogicalTypes, Schema}
 import org.apache.avro.Conversions.DecimalConversion
+import org.apache.avro.LogicalTypes
 import org.apache.avro.LogicalTypes.{TimestampMicros, TimestampMillis}
 import org.apache.avro.Schema
 import org.apache.avro.Schema.Type
 import org.apache.avro.Schema.Type._
-import org.apache.avro.generic.GenericData.{EnumSymbol, Fixed, Record}
+import org.apache.avro.generic.GenericData.{EnumSymbol, Fixed}
 import org.apache.avro.generic.GenericData.Record
 import org.apache.avro.util.Utf8
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{SpecializedGetters, SpecificInternalRow}
 import org.apache.spark.sql.types._
@@ -38,7 +39,8 @@ import org.apache.spark.sql.types._
 /**
  * A serializer to serialize data in catalyst format to data in avro format.
  */
-class AvroSerializer(rootCatalystType: DataType, rootAvroType: Schema, nullable: Boolean) {
+class AvroSerializer(rootCatalystType: DataType, rootAvroType: Schema, nullable: Boolean)
+  extends Logging {
 
   def serialize(catalystData: Any): Any = {
     converter.apply(catalystData)
@@ -234,15 +236,20 @@ class AvroSerializer(rootCatalystType: DataType, rootAvroType: Schema, nullable:
   }
 
   private def resolveNullableType(avroType: Schema, nullable: Boolean): Schema = {
-    if (avroType.getType == Type.UNION && nullable) {
-      // avro uses union to represent nullable type.
-      val fields = avroType.getTypes.asScala
-      assert(fields.length == 2)
-      val actualType = fields.filter(_.getType != Type.NULL)
-      assert(actualType.length == 1)
-      actualType.head
-    } else {
-      avroType
+    (avroType.getType, nullable) match {
+      case (Type.UNION, true) =>
+        // avro uses union to represent nullable type.
+        val fields = avroType.getTypes.asScala
+        assert(fields.length == 2)
+        val actualType = fields.filter(_.getType != Type.NULL)
+        assert(actualType.length == 1)
+        actualType.head
+      case (_, true) =>
+        logWarning(s"Writing avro files with non-nullable avro schema with nullable catalyst " +
+          s"schema will throw runtime exception if there is a record with null value.")
+        avroType
+      case _ =>
+        avroType
     }
   }
 }

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
@@ -245,8 +245,8 @@ class AvroSerializer(rootCatalystType: DataType, rootAvroType: Schema, nullable:
       actualType.head
     } else {
       if (nullable) {
-        logWarning(s"Writing avro files with non-nullable avro schema with nullable catalyst " +
-          s"schema will throw runtime exception if there is a record with null value.")
+        logWarning("Writing avro files with non-nullable avro schema with nullable catalyst " +
+          "schema will throw runtime exception if there is a record with null value.")
       }
       avroType
     }

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
@@ -234,7 +234,7 @@ class AvroSerializer(rootCatalystType: DataType, rootAvroType: Schema, nullable:
   }
 
   private def resolveNullableType(avroType: Schema, nullable: Boolean): Schema = {
-    if (nullable && avroType.getType != NULL) {
+    if (avroType.getType == Type.UNION && nullable) {
       // avro uses union to represent nullable type.
       val fields = avroType.getTypes.asScala
       assert(fields.length == 2)

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -764,7 +764,7 @@ class AvroSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
         dfWithNull.write.format("avro")
           .option("avroSchema", avroSchema).save(s"$tempDir/${UUID.randomUUID()}")
       }.getCause.getMessage
-      assert(message1.contains("org.apache.avro.AvroRuntimeException: Not a union:"))
+      assert(message1.contains("org.apache.avro.AvroTypeException: Not an enum: null"))
 
       // Writing df containing data not in the enum will throw an exception
       val message2 = intercept[SparkException] {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the data is read from the sources, the catalyst schema is always nullable. Since Avro uses Union type to represent nullable, when any non-nullable avro file is read and then written out, the schema will always be changed. 

This PR provides a solution for users to keep the Avro schema without being forced to use Union type.

## How was this patch tested?

One test is added.