### PR TITLE
[SPARK-27814][SQL] The cast operation for partition key may push down uncorrect filter, which  is fatal.

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -675,14 +675,12 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
     val useAdvanced = SQLConf.get.advancedPartitionPredicatePushdownEnabled
 
     object ExtractAttribute {
-      val partitionKeys = table.getPartitionKeys.asScala.map(_.getName).toSet
       var castToStr = false
 
       def unapply(expr: Expression): Option[Attribute] = {
         expr match {
           case attr: Attribute
-              if (!castToStr || !partitionKeys.contains(attr.name) ||
-                attr.dataType == StringType) =>
+              if (!castToStr || attr.dataType == StringType) =>
             castToStr = false
             Some(attr)
           case Cast(child @ AtomicType(), dt: AtomicType, _)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -2384,4 +2384,13 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       }
     }
   }
+
+  test("SPARK-27814: test cast operation for partition key") {
+    withTable("t1") {
+      sql("CREATE TABLE t1(c1 INT, c2 STRING) PARTITIONED BY (p1 INT)")
+      sql("INSERT INTO TABLE t1 PARTITION (p1 = 5) values(1, 'str')")
+      checkAnswer(sql("SELECT c1 FROM t1 WHERE CAST(p1 as STRING) = '5'"), Row(1))
+      checkAnswer(sql("SELECT c1 FROM t1 WHERE CAST( CAST(p1 AS BIGINT) AS STRING) = '5'"), Row(1))
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
For a partitioned table, such as:
```
table test (c1 int, c2 string) partitioned by (c3 Int)
```
If we use a cast operation in query, which casts the partition key, such as :
```
select * from test where (cast c3 as string)  = '0'
``` 
One predication of this query is ` cast(c3 as string) = ’0‘`.
It would invoke  this method to convert to a filter.
```
     case op @ SpecialBinaryComparison(
          ExtractAttribute(NonVarcharAttribute(name)), ExtractableLiteral(value)) =>
        Some(s"$name ${op.symbol} $value")
```
First, it invokes the ExtractAttribute.unapply to judge whether c3 can be casted to string, the result is yes.
Then it would invoke the origin NonVarcharAttribute, because the hivevar type of c3 is not  varchar,
 this prediction will be converted to  filter `c3 = "0"`, and pushed down.

But, Filtering is supported only on partition keys of type string, so it would trigger an exception.
In this PR,  I judge whether the attribute's catalyst type is StringType additionally.

## How was this patch tested?

unit test.
