### PR TITLE
[SPARK-27829][SQL] In Dataset.joinWith() inner joins, don't nest data before shuffling

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1133,8 +1133,8 @@ class Dataset[T] private[sql](
 
     if (joined.joinType.isInstanceOf[InnerLike]) {
       // For inner joins, we can directly perform the join and then can project the join
-      // results into structs. This ensures that data remains as flat as possible during
-      // shuffles / exchanges.
+      // results into structs. This ensures that data remains flat during shuffles /
+      // exchanges (unlike the outer join path, which nests the data before shuffling).
       withTypedPlan(Project(Seq(leftResultExpr, rightResultExpr), joined))
     } else { // outer joins
       // For both join side, combine all outputs into a single column and alias it with "_1

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1114,7 +1114,7 @@ class Dataset[T] private[sql](
       ExpressionEncoder.tuple(this.exprEnc, other.exprEnc)
 
     val leftResultExpr = {
-      if (this.exprEnc.isSerializedAsStructForTopLevel) {
+      if (!this.exprEnc.isSerializedAsStructForTopLevel) {
         assert(joined.left.output.length == 1)
         Alias(joined.left.output.head, "_1")()
       } else {
@@ -1123,7 +1123,7 @@ class Dataset[T] private[sql](
     }
 
     val rightResultExpr = {
-      if (other.exprEnc.isSerializedAsStructForTopLevel) {
+      if (!other.exprEnc.isSerializedAsStructForTopLevel) {
         assert(joined.right.output.length == 1)
         Alias(joined.right.output.head, "_2")()
       } else {
@@ -1148,14 +1148,14 @@ class Dataset[T] private[sql](
       // combine the outputs of each join side.
       val conditionExpr = joined.condition.get transformUp {
         case a: Attribute if joined.left.outputSet.contains(a) =>
-          if (this.exprEnc.isSerializedAsStructForTopLevel) {
+          if (!this.exprEnc.isSerializedAsStructForTopLevel) {
             left.output.head
           } else {
             val index = joined.left.output.indexWhere(_.exprId == a.exprId)
             GetStructField(left.output.head, index)
           }
         case a: Attribute if joined.right.outputSet.contains(a) =>
-          if (other.exprEnc.isSerializedAsStructForTopLevel) {
+          if (!other.exprEnc.isSerializedAsStructForTopLevel) {
             right.output.head
           } else {
             val index = joined.right.output.indexWhere(_.exprId == a.exprId)

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1137,15 +1137,15 @@ class Dataset[T] private[sql](
       // exchanges (unlike the outer join path, which nests the data before shuffling).
       withTypedPlan(Project(Seq(leftResultExpr, rightResultExpr), joined))
     } else { // outer joins
-      // For both join side, combine all outputs into a single column and alias it with "_1
+      // For both join sides, combine all outputs into a single column and alias it with "_1
       // or "_2", to match the schema for the encoder of the join result.
       // Note that we do this before joining them, to enable the join operator to return null
       // for one side, in cases like outer-join.
       val left = Project(leftResultExpr :: Nil, joined.left)
       val right = Project(rightResultExpr :: Nil, joined.right)
 
-      // Rewrites the join condition to make the attribute point to correct column/field, after we
-      // combine the outputs of each join side.
+      // Rewrites the join condition to make the attribute point to correct column/field,
+      // after we combine the outputs of each join side.
       val conditionExpr = joined.condition.get transformUp {
         case a: Attribute if joined.left.outputSet.contains(a) =>
           if (!this.exprEnc.isSerializedAsStructForTopLevel) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1110,53 +1110,61 @@ class Dataset[T] private[sql](
       throw new AnalysisException("Invalid join type in joinWith: " + joined.joinType.sql)
     }
 
-    // For both join side, combine all outputs into a single column and alias it with "_1" or "_2",
-    // to match the schema for the encoder of the join result.
-    // Note that we do this before joining them, to enable the join operator to return null for one
-    // side, in cases like outer-join.
-    val left = {
-      val combined = if (!this.exprEnc.isSerializedAsStructForTopLevel) {
+    implicit val tuple2Encoder: Encoder[(T, U)] =
+      ExpressionEncoder.tuple(this.exprEnc, other.exprEnc)
+
+    val leftResultExpr = {
+      if (this.exprEnc.isSerializedAsStructForTopLevel) {
         assert(joined.left.output.length == 1)
         Alias(joined.left.output.head, "_1")()
       } else {
         Alias(CreateStruct(joined.left.output), "_1")()
       }
-      Project(combined :: Nil, joined.left)
     }
 
-    val right = {
-      val combined = if (!other.exprEnc.isSerializedAsStructForTopLevel) {
+    val rightResultExpr = {
+      if (other.exprEnc.isSerializedAsStructForTopLevel) {
         assert(joined.right.output.length == 1)
         Alias(joined.right.output.head, "_2")()
       } else {
         Alias(CreateStruct(joined.right.output), "_2")()
       }
-      Project(combined :: Nil, joined.right)
     }
 
-    // Rewrites the join condition to make the attribute point to correct column/field, after we
-    // combine the outputs of each join side.
-    val conditionExpr = joined.condition.get transformUp {
-      case a: Attribute if joined.left.outputSet.contains(a) =>
-        if (!this.exprEnc.isSerializedAsStructForTopLevel) {
-          left.output.head
-        } else {
-          val index = joined.left.output.indexWhere(_.exprId == a.exprId)
-          GetStructField(left.output.head, index)
-        }
-      case a: Attribute if joined.right.outputSet.contains(a) =>
-        if (!other.exprEnc.isSerializedAsStructForTopLevel) {
-          right.output.head
-        } else {
-          val index = joined.right.output.indexWhere(_.exprId == a.exprId)
-          GetStructField(right.output.head, index)
-        }
+    if (joined.joinType.isInstanceOf[InnerLike]) {
+      // For inner joins, we can directly perform the join and then can project the join
+      // results into structs. This ensures that data remains as flat as possible during
+      // shuffles / exchanges.
+      withTypedPlan(Project(Seq(leftResultExpr, rightResultExpr), joined))
+    } else { // outer joins
+      // For both join side, combine all outputs into a single column and alias it with "_1
+      // or "_2", to match the schema for the encoder of the join result.
+      // Note that we do this before joining them, to enable the join operator to return null
+      // for one side, in cases like outer-join.
+      val left = Project(leftResultExpr :: Nil, joined.left)
+      val right = Project(rightResultExpr :: Nil, joined.right)
+
+      // Rewrites the join condition to make the attribute point to correct column/field, after we
+      // combine the outputs of each join side.
+      val conditionExpr = joined.condition.get transformUp {
+        case a: Attribute if joined.left.outputSet.contains(a) =>
+          if (this.exprEnc.isSerializedAsStructForTopLevel) {
+            left.output.head
+          } else {
+            val index = joined.left.output.indexWhere(_.exprId == a.exprId)
+            GetStructField(left.output.head, index)
+          }
+        case a: Attribute if joined.right.outputSet.contains(a) =>
+          if (other.exprEnc.isSerializedAsStructForTopLevel) {
+            right.output.head
+          } else {
+            val index = joined.right.output.indexWhere(_.exprId == a.exprId)
+            GetStructField(right.output.head, index)
+          }
+      }
+
+      withTypedPlan(Join(left, right, joined.joinType, Some(conditionExpr), JoinHint.NONE))
     }
-
-    implicit val tuple2Encoder: Encoder[(T, U)] =
-      ExpressionEncoder.tuple(this.exprEnc, other.exprEnc)
-
-    withTypedPlan(Join(left, right, joined.joinType, Some(conditionExpr), JoinHint.NONE))
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -446,7 +446,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
 
     val joined = ds1.joinWith(ds2, $"value" === $"_2")
 
-    // This is an inner join, so both fields are non-nullable
+    // This is an inner join, so both outputs fields are non-nullable
     val expectedSchema = StructType(Seq(
       StructField("_1", IntegerType, nullable = false),
       StructField("_2",


### PR DESCRIPTION
## What changes were proposed in this pull request?

In order to support outer joins with null top-level objects, SPARK-15441 modified Dataset.joinWith to project both inputs into single-column structs prior to the join.

For inner joins, however, this step is unnecessary and actually harms performance: performing the nesting before the join increases the shuffled data size. As an optimization for inner joins only, we can move this nesting to occur after the join (effectively switching back to the pre-SPARK-15441 behavior; see #13425).

## How was this patch tested?

Existing tests, which I strengthened to also make assertions about the join result's nullability (since this guards against a bug I almost introduced during prototyping).

Here's a quick `spark-shell` experiment demonstrating the reduction in shuffle size:

```scala
// With --conf spark.shuffle.compress=false
sql("set spark.sql.autoBroadcastJoinThreshold=-1") // for easier shuffle measurements
case class Foo(a: Long, b: Long)
val left = spark.range(10000).map(x => Foo(x, x))
val right = spark.range(10000).map(x => Foo(x, x))
left.joinWith(right, left("a") === right("a"), "inner").rdd.count()
left.joinWith(right, left("a") === right("a"), "left").rdd.count()
```

With inner join (which benefits from this PR's optimization) we shuffle 546.9 KiB. With left outer join (whose plan hasn't changed, therefore being a representation of the state before this PR) we shuffle 859.4 KiB. Shuffle compression (which is enabled by default) narrows this gap a bit: with compression, outer joins shuffle about 12% more than inner joins.