### PR TITLE
[SPARK-27830][CORE][UI] Show Spark version at app lists of Spark History UI

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/historypage-template.html
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage-template.html
@@ -20,6 +20,11 @@
   <thead>
     <tr>
       <th>
+        <span data-toggle="tooltip" data-placement="top" title="Spark version of this application.">
+          Version
+        </span>
+      </th>
+      <th>
         <span data-toggle="tooltip" data-placement="top" title="ID of this application.">
           App ID
         </span>
@@ -72,6 +77,7 @@
   <tbody>
   {{#applications}}
     <tr>
+      <td {{#hasMultipleAttempts}}style="background-color:#fff"{{/hasMultipleAttempts}}>{{version}}</td>
       <td {{#hasMultipleAttempts}}style="background-color:#fff"{{/hasMultipleAttempts}}><span title="{{id}}"><a href="{{uiroot}}/history/{{id}}/{{num}}/jobs/">{{id}}</a></span></td>
       <td {{#hasMultipleAttempts}}style="background-color:#fff"{{/hasMultipleAttempts}}>{{name}}</td>
       {{#attempts}}

--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -121,6 +121,10 @@ $(document).ready(function() {
         if (app["attempts"][0]["completed"] == requestedIncomplete) {
           continue; // if we want to show for Incomplete, we skip the completed apps; otherwise skip incomplete ones.
         }
+        var version = "Unknown"
+        if (app["attempts"].length > 0) {
+            version = app["attempts"][0]["appSparkVersion"]
+        }
         var id = app["id"];
         var name = app["name"];
         if (app["attempts"].length > 1) {
@@ -136,7 +140,7 @@ $(document).ready(function() {
             (attempt.hasOwnProperty("attemptId") ? attempt["attemptId"] + "/" : "") + "logs";
           attempt["durationMillisec"] = attempt["duration"];
           attempt["duration"] = formatDuration(attempt["duration"]);
-          var app_clone = {"id" : id, "name" : name, "num" : num, "attempts" : [attempt]};
+          var app_clone = {"id" : id, "name" : name, "version": version, "num" : num, "attempts" : [attempt]};
           array.push(app_clone);
         }
       }
@@ -161,6 +165,7 @@ $(document).ready(function() {
         var durationColumnName = 'duration';
         var conf = {
           "columns": [
+            {name: 'version'},
             {name: 'appId', type: "appid-numeric"},
             {name: 'appName'},
             {name: attemptIdColumnName},
@@ -177,6 +182,7 @@ $(document).ready(function() {
         if (hasMultipleAttempts) {
           conf.rowsGroup = [
             'appId:name',
+            'version:name',
             'appName:name'
           ];
         } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to show Spark version at application lists of Spark History UI.

From the following, the first `Version` column is added. When the application has multiple attempts, this will show the first attempt's version number.

**COMPLETED APPLICATION LIST**
![Screen Shot 2019-05-23 at 11 42 39 PM](https://user-images.githubusercontent.com/9700541/58308045-49aae580-7db5-11e9-93bd-63cb2d359fb0.png)

**INCOMPLETE APPLICATION LIST**
![Screen Shot 2019-05-23 at 11 42 48 PM](https://user-images.githubusercontent.com/9700541/58308336-2c2a4b80-7db6-11e9-873a-2868b9dbb835.png)


## How was this patch tested?

Manually launch Spark history server and see the UI. Please use *Private New Window (Safari)* or *New Incognito Window (Chrome)* to avoid browser caching.

```
sbin/start-history-server.sh
```