### PR TITLE
[SPARK-27362][K8S]  Resource Scheduling support for k8s

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -38,6 +38,7 @@ package object config {
   private[spark] val SPARK_RESOURCE_COUNT_SUFFIX = ".count"
   private[spark] val SPARK_RESOURCE_ADDRESSES_SUFFIX = ".addresses"
   private[spark] val SPARK_RESOURCE_DISCOVERY_SCRIPT_SUFFIX = ".discoveryScript"
+  private[spark] val SPARK_RESOURCE_VENDOR_SUFFIX = ".vendor"
 
   private[spark] val DRIVER_CLASS_PATH =
     ConfigBuilder(SparkLauncher.DRIVER_EXTRA_CLASSPATH).stringConf.createOptional

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -210,7 +210,10 @@ of the most common options to set are:
  <td><code>spark.driver.resource.{resourceName}.vendor</code></td>
   <td>None</td>
   <td>
-    Vendor of the resources to use for driver. This option is currently supported on Kubernetes.
+    Vendor of the resources to use for the driver. This option is currently
+    only supported on Kubernetes and is actually both the vendor and domain following
+    the Kubernetes device plugin naming convention. (e.g. For GPUs on Kubernetes
+    this config would be set to nvidia.com or amd.com)
   </td>
 </tr>
 <tr>
@@ -270,7 +273,10 @@ of the most common options to set are:
  <td><code>spark.executor.resource.{resourceName}.vendor</code></td>
   <td>None</td>
   <td>
-    Vendor of the resources to use for executors. This option is currently supported on Kubernetes.
+    Vendor of the resources to use for the executors. This option is currently
+    only supported on Kubernetes and is actually both the vendor and domain following
+    the Kubernetes device plugin naming convention. (e.g. For GPUs on Kubernetes
+    this config would be set to nvidia.com or amd.com)
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -207,6 +207,13 @@ of the most common options to set are:
   </td>
 </tr>
 <tr>
+ <td><code>spark.driver.resource.{resourceName}.vendor</code></td>
+  <td>None</td>
+  <td>
+    Vendor of the resources to use for driver. This option is currently supported on Kubernetes.
+  </td>
+</tr>
+<tr>
   <td><code>spark.executor.memory</code></td>
   <td>1g</td>
   <td>
@@ -257,6 +264,13 @@ of the most common options to set are:
     A script for the executor to run to discover a particular resource type. This should
     write to STDOUT a JSON string in the format of the ResourceInformation class. This has a
     name and an array of addresses.
+  </td>
+</tr>
+<tr>
+ <td><code>spark.executor.resource.{resourceName}.vendor</code></td>
+  <td>None</td>
+  <td>
+    Vendor of the resources to use for executors. This option is currently supported on Kubernetes.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1246,6 +1246,7 @@ The following affect the driver and executor containers. All other containers in
     The cpu limits are set by <code>spark.kubernetes.{driver,executor}.limit.cores</code>. The cpu is set by
     <code>spark.{driver,executor}.cores</code>. The memory request and limit are set by summing the values of
     <code>spark.{driver,executor}.memory</code> and <code>spark.{driver,executor}.memoryOverhead</code>.
+    Other resource limits are set by <code>spark.{driver,executor}.resources.{resourceName}.*</code> configs.
   </td>
 </tr>
 <tr>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -205,7 +205,7 @@ private[spark] object KubernetesConf {
    * convention of: vendor-domain/resource. For example, an Nvidia GPU is
    * advertised as nvidia.com/gpu.
    */
-  def buildKubernetesResourceName(vendor: String, resourceName: String): String = {
-    s"${vendor}/${resourceName}"
+  def buildKubernetesResourceName(vendorDomain: String, resourceName: String): String = {
+    s"${vendorDomain}/${resourceName}"
   }
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -201,10 +201,10 @@ private[spark] object KubernetesConf {
   }
 
   /**
-    * Build a resources name based on the vendor device plugin naming
-    * convention of: vendor-domain/resource. For example, an Nvidia GPU is
-    * advertised as nvidia.com/gpu.
-    */
+   * Build a resources name based on the vendor device plugin naming
+   * convention of: vendor-domain/resource. For example, an Nvidia GPU is
+   * advertised as nvidia.com/gpu.
+   */
   def buildKubernetesResourceName(vendor: String, resourceName: String): String = {
     s"${vendor}/${resourceName}"
   }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -199,4 +199,13 @@ private[spark] object KubernetesConf {
       .replaceAll("[^a-z0-9\\-]", "")
       .replaceAll("-+", "-")
   }
+
+  /**
+    * Build a resources name based on the vendor device plugin naming
+    * convention of: vendor-domain/resource. For example, an Nvidia GPU is
+    * advertised as nvidia.com/gpu.
+    */
+  def buildKubernetesResourceName(vendor: String, resourceName: String): String = {
+    s"${vendor}/${resourceName}"
+  }
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -202,7 +202,7 @@ private[spark] object KubernetesConf {
 
   /**
    * Build a resources name based on the vendor device plugin naming
-   * convention of: vendor-domain/resource. For example, an Nvidia GPU is
+   * convention of: vendor-domain/resource. For example, an NVIDIA GPU is
    * advertised as nvidia.com/gpu.
    */
   def buildKubernetesResourceName(vendorDomain: String, resourceName: String): String = {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -232,14 +232,14 @@ private[spark] object KubernetesUtils extends Logging {
     val uniqueResources = SparkConf.getBaseOfConfigs(allResources)
 
     uniqueResources.map { rName =>
-      val vendor = vendors.get(rName).getOrElse(throw new SparkException(s"Resource: $rName " +
-        "was requested, but vendor was not specified."))
+      val vendorDomain = vendors.get(rName).getOrElse(throw new SparkException("Resource: " +
+        s"$rName was requested, but vendor was not specified."))
       val amount = amounts.get(rName).getOrElse(throw new SparkException(s"Resource: $rName " +
         "was requested, but count was not specified."))
       val quantity = new QuantityBuilder(false)
         .withAmount(amount)
         .build()
-      (KubernetesConf.buildKubernetesResourceName(vendor, rName), quantity)
+      (KubernetesConf.buildKubernetesResourceName(vendorDomain, rName), quantity)
     }
   }
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -225,7 +225,7 @@ private[spark] object KubernetesUtils extends Logging {
    */
   def buildResourcesQuantities(
       componentName: String,
-      sparkConf: SparkConf): Set[(String, Quantity)] = {
+      sparkConf: SparkConf): Map[String, Quantity] = {
     val allResources = sparkConf.getAllWithPrefix(componentName)
     val vendors = SparkConf.getConfigsWithSuffix(allResources, SPARK_RESOURCE_VENDOR_SUFFIX).toMap
     val amounts = SparkConf.getConfigsWithSuffix(allResources, SPARK_RESOURCE_COUNT_SUFFIX).toMap
@@ -240,7 +240,7 @@ private[spark] object KubernetesUtils extends Logging {
         .withAmount(amount)
         .build()
       (KubernetesConf.buildKubernetesResourceName(vendorDomain, rName), quantity)
-    }
+    }.toMap
   }
 
   /**

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -219,8 +219,8 @@ private[spark] object KubernetesUtils extends Logging {
 
   /**
    * This function builds the Quantity objects for each resource in the Spark resource
-   * configs based on the component name(driver or executor). It assumes we can use the
-   * Kubernetes device plugin format: vendor-domain/resource.
+   * configs based on the component name(spark.driver.resource or spark.executor.resource).
+   * It assumes we can use the Kubernetes device plugin format: vendor-domain/resource.
    * It returns a set with a tuple of vendor-domain/resource and Quantity for each resource.
    */
   def buildResourcesQuantities(

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -316,31 +316,4 @@ private[spark] object KubernetesUtils extends Logging {
         throw new SparkException(s"Error uploading file ${src.getName}", e)
     }
   }
-
-  /**
-   * This function builds the Quantity objects for each resource in the Spark resource
-   * configs. It assumes we can use the Kubernetes device plugin format: vendor-domain/resource.
-   * It returns a set with a tuple of vendor-domain/resource and Quantity for each resource.
-   */
-  def buildResourcesQuantities(prefix: String, sparkConf: SparkConf): Set[(String, Quantity)] = {
-    val allResources = sparkConf.getAllWithPrefix(prefix)
-    val resourcesVendors =
-      SparkConf.getConfigsWithSuffix(allResources, SPARK_RESOURCE_VENDOR_SUFFIX).toMap
-    val resourcesAmounts =
-      SparkConf.getConfigsWithSuffix(allResources, SPARK_RESOURCE_COUNT_POSTFIX).toMap
-    val uniqueResources = SparkConf.getBaseOfConfigs(allResources)
-
-    uniqueResources.map { rName =>
-      val vendor = resourcesVendors.get(rName).
-        getOrElse(throw
-          new SparkException(s"Resource: $rName was requested, but vendor was not specified."))
-      val amount = resourcesAmounts.get(rName).
-        getOrElse(throw
-          new SparkException(s"Resource: $rName was requested, but count was not specified."))
-      val quantity = new QuantityBuilder(false)
-        .withAmount(amount)
-        .build()
-      (KubernetesConf.buildKubernetesResourceName(vendor, rName), quantity)
-    }
-  }
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
@@ -132,7 +132,7 @@ private[spark] class BasicDriverFeatureStep(conf: KubernetesDriverConf)
         .addToLimits(maybeCpuLimitQuantity.toMap.asJava)
         .addToRequests("memory", driverMemoryQuantity)
         .addToLimits("memory", driverMemoryQuantity)
-        .addToLimits(driverResourceQuantities.toMap.asJava)
+        .addToLimits(driverResourceQuantities.asJava)
         .endResources()
       .build()
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
@@ -88,6 +88,9 @@ private[spark] class BasicDriverFeatureStep(conf: KubernetesDriverConf)
       ("cpu", new QuantityBuilder(false).withAmount(limitCores).build())
     }
 
+    val driverResourceQuantities =
+      KubernetesUtils.buildResourcesQuantities(SPARK_DRIVER_RESOURCE_PREFIX, conf.sparkConf)
+
     val driverPort = conf.sparkConf.getInt(DRIVER_PORT.key, DEFAULT_DRIVER_PORT)
     val driverBlockManagerPort = conf.sparkConf.getInt(
       DRIVER_BLOCK_MANAGER_PORT.key,
@@ -129,6 +132,7 @@ private[spark] class BasicDriverFeatureStep(conf: KubernetesDriverConf)
         .addToLimits(maybeCpuLimitQuantity.toMap.asJava)
         .addToRequests("memory", driverMemoryQuantity)
         .addToLimits("memory", driverMemoryQuantity)
+        .addToLimits(driverResourceQuantities.toMap.asJava)
         .endResources()
       .build()
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -95,6 +95,10 @@ private[spark] class BasicExecutorFeatureStep(
       .withAmount(executorCoresRequest)
       .build()
 
+    val executorResourceQuantities =
+      KubernetesUtils.buildResourcesQuantities(SPARK_EXECUTOR_RESOURCE_PREFIX,
+        kubernetesConf.sparkConf)
+
     val executorEnv: Seq[EnvVar] = {
         (Seq(
           (ENV_DRIVER_URL, driverUrl),
@@ -168,11 +172,12 @@ private[spark] class BasicExecutorFeatureStep(
         .addToRequests("memory", executorMemoryQuantity)
         .addToLimits("memory", executorMemoryQuantity)
         .addToRequests("cpu", executorCpuQuantity)
+        .addToLimits(executorResourceQuantities.toMap.asJava)
         .endResources()
-        .addNewEnv()
-          .withName(ENV_SPARK_USER)
-          .withValue(Utils.getCurrentUserName())
-          .endEnv()
+      .addNewEnv()
+        .withName(ENV_SPARK_USER)
+        .withValue(Utils.getCurrentUserName())
+        .endEnv()
       .addAllToEnv(executorEnv.asJava)
       .withPorts(requiredPorts.asJava)
       .addToArgs("executor")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -172,7 +172,7 @@ private[spark] class BasicExecutorFeatureStep(
         .addToRequests("memory", executorMemoryQuantity)
         .addToLimits("memory", executorMemoryQuantity)
         .addToRequests("cpu", executorCpuQuantity)
-        .addToLimits(executorResourceQuantities.toMap.asJava)
+        .addToLimits(executorResourceQuantities.asJava)
         .endResources()
       .addNewEnv()
         .withName(ENV_SPARK_USER)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/KubernetesFeaturesTestUtils.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/KubernetesFeaturesTestUtils.scala
@@ -66,4 +66,6 @@ object KubernetesFeaturesTestUtils {
     val desired = implicitly[ClassTag[T]].runtimeClass
     list.filter(_.getClass() == desired).map(_.asInstanceOf[T])
   }
+
+  case class TestResourceInformation(rName: String, count: String, vendor: String)
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add ability to map the spark resource configs spark.{executor/driver}.resource.{resourceName} to kubernetes Container builder so that we request resources (gpu,s/fpgas/etc) from kubernetes.
Note that the spark configs will overwrite any resource configs users put into a pod template.
I added a generic vendor config which is only used by kubernetes right now.  I intentionally didn't put it into the kubernetes config namespace just to avoid adding more config prefixes. 

I will add more documentation for this under jira SPARK-27492. I think it will be easier to do all at once to get cohesive story.

## How was this patch tested?

Unit tests and manually testing on k8s cluster. 