### PR TITLE
[SPARK-22340][PYTHON] Save localProperties in thread.local

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -159,7 +159,12 @@ private[spark] object PythonRDD extends Logging {
    * @return 2-tuple (as a Java array) with the port number of a local socket which serves the
    *         data collected from this job, and the secret for authentication.
    */
-  def collectAndServe[T](rdd: RDD[T]): Array[Any] = {
+  def collectAndServe[T](
+    rdd: RDD[T],
+    localProperties: JMap[String, String]): Array[Any] = {
+    val sc = rdd.sparkContext
+    localProperties.asScala.foreach(kv => sc.setLocalProperty(kv._1, kv._2))
+
     serveIterator(rdd.collect().iterator, s"serve RDD ${rdd.id}")
   }
 

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -1031,7 +1031,7 @@ class SparkContext(object):
         if not hasattr(self.local, 'local_properties'):
             return ""
         else:
-            if not key in self.local.local_properties:
+            if key not in self.local.local_properties:
                 return ""
         return self.local.local_properties[key]
 

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -1039,7 +1039,7 @@ class SparkContext(object):
         """
         Set a human readable description of the current job.
         """
-        self.local.description = value
+        self.setLocalProperty("spark.job.description", value)
 
     def sparkUser(self):
         """

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -33,6 +33,8 @@ from itertools import chain
 from functools import reduce
 from math import sqrt, log, isinf, isnan, pow, ceil
 
+from py4j.java_collections import MapConverter
+
 if sys.version > '3':
     basestring = unicode = str
 else:
@@ -869,7 +871,10 @@ class RDD(object):
             to be small, as all the data is loaded into the driver's memory.
         """
         with SCCallSiteSync(self.context) as css:
-            sock_info = self.ctx._jvm.PythonRDD.collectAndServe(self._jrdd.rdd())
+            java_map = MapConverter().convert(self.context.getLocalProperties(),
+                                              self.context._gateway._gateway_client)
+            sock_info = self.ctx._jvm.PythonRDD.collectAndServe(
+                self._jrdd.rdd() ,java_map)
         return list(_load_from_socket(sock_info, self._jrdd_deserializer))
 
     def reduce(self, f):

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -873,8 +873,7 @@ class RDD(object):
         with SCCallSiteSync(self.context) as css:
             java_map = MapConverter().convert(self.context.getLocalProperties(),
                                               self.context._gateway._gateway_client)
-            sock_info = self.ctx._jvm.PythonRDD.collectAndServe(
-                self._jrdd.rdd() ,java_map)
+            sock_info = self.ctx._jvm.PythonRDD.collectAndServe(self._jrdd.rdd(), java_map)
         return list(_load_from_socket(sock_info, self._jrdd_deserializer))
 
     def reduce(self, f):

--- a/python/pyspark/tests/test_rdd.py
+++ b/python/pyspark/tests/test_rdd.py
@@ -819,7 +819,7 @@ class RDDTests(ReusedPySparkTestCase):
             else:
                 # make sure group B job succeeded.
                 self.assertFalse(is_job_cancelled[i],
-                                "Thread {i}: Job in group B didn't succeeded.".format(i=i))
+                                 "Thread {i}: Job in group B didn't succeeded.".format(i=i))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add `threading.local()` in `SparkContext`
- Save the value to thread local variables when calling `setLocalProperty`, `setJobGroup`,  and `setJobDescription`
- Add new API `getLocalProperties`
- Send local properties to jvm side when calling `collect`
- On jvm side `setLocalProperty` in `collectAndServe`

## How was this patch tested?

Add one unit test in test_rdd.py

Please review https://spark.apache.org/contributing.html before opening a pull request.
