### PR TITLE
[SPARK-27843][SQL] Remove duplicate logic of calculate table size

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoDir, InsertIntoTab
     ScriptTransformation}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.command.{CreateTableCommand, DDLUtils}
+import org.apache.spark.sql.execution.command.{CommandUtils, CreateTableCommand, DDLUtils}
 import org.apache.spark.sql.execution.datasources.CreateTable
 import org.apache.spark.sql.hive.execution._
 import org.apache.spark.sql.internal.{HiveSerDe, SQLConf}
@@ -118,21 +118,12 @@ class DetermineTableStats(session: SparkSession) extends Rule[LogicalPlan] {
         if DDLUtils.isHiveTable(relation.tableMeta) && relation.tableMeta.stats.isEmpty =>
       val table = relation.tableMeta
       val sizeInBytes = if (session.sessionState.conf.fallBackToHdfsForStatsEnabled) {
-        try {
-          val hadoopConf = session.sessionState.newHadoopConf()
-          val tablePath = new Path(table.location)
-          val fs: FileSystem = tablePath.getFileSystem(hadoopConf)
-          fs.getContentSummary(tablePath).getLength
-        } catch {
-          case e: IOException =>
-            logWarning("Failed to get table size from hdfs.", e)
-            session.sessionState.conf.defaultSizeInBytes
-        }
+        CommandUtils.calculateTotalSize(session, table)
       } else {
-        session.sessionState.conf.defaultSizeInBytes
+        BigInt(session.sessionState.conf.defaultSizeInBytes)
       }
 
-      val withStats = table.copy(stats = Some(CatalogStatistics(sizeInBytes = BigInt(sizeInBytes))))
+      val withStats = table.copy(stats = Some(CatalogStatistics(sizeInBytes = sizeInBytes)))
       relation.copy(tableMeta = withStats)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr removes duplicate logic of calculate table size.

## How was this patch tested?

Existing test:
https://github.com/apache/spark/blob/f3ddd6f9da27925607c06e55cdfb9a809633238b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala#L74-L117
