### PR TITLE
[SPARK-25944][R][BUILD] AppVeyor change to latest R version (3.6.0)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,6 +52,10 @@ build_script:
 
 environment:
   NOT_CRAN: true
+  # See SPARK-27848. Currently installing some dependent packagess causes
+  # "(converted from warning) unable to identify current timezone 'C':" for an unknown reason.
+  # This environment variable works around to test SparkR against a higher version.
+  R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
 
 test_script:
   - cmd: .\bin\spark-submit2.cmd --driver-java-options "-Dlog4j.configuration=file:///%CD:\=/%/R/log4j.properties" --conf spark.hadoop.fs.defaultFS="file:///" R\pkg\tests\run-all.R

--- a/dev/appveyor-install-dependencies.ps1
+++ b/dev/appveyor-install-dependencies.ps1
@@ -115,7 +115,7 @@ $env:Path += ";$env:HADOOP_HOME\bin"
 Pop-Location
 
 # ========================== R
-$rVer = "3.5.1"
+$rVer = "3.6.0"
 $rToolsVer = "3.5.1"
 
 InstallR


### PR DESCRIPTION
## What changes were proposed in this pull request?

R 3.6.0 is released 2019-04-26. This PR targets to change R version from 3.5.1 to 3.6.0 in AppVeyor.

This PR sets `R_REMOTES_NO_ERRORS_FROM_WARNINGS` to `true` to avoid the warnings below:

```
Error in strptime(xx, f, tz = tz) : 
  (converted from warning) unable to identify current timezone 'C':
please set environment variable 'TZ'
Error in i.p(...) : 
  (converted from warning) installation of package 'praise' had non-zero exit status
Calls: <Anonymous> ... with_rprofile_user -> with_envvar -> force -> force -> i.p
Execution halted
```

## How was this patch tested?

AppVeyor