### PR TITLE
[SPARK-27852][Spark Core] updateBytesWritten() operaton is missed

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockObjectWriter.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockObjectWriter.scala
@@ -250,6 +250,7 @@ private[spark] class DiskBlockObjectWriter(
     }
 
     bs.write(kvBytes, offs, len)
+    updateBytesWritten()   // the function is missed
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
one line code maybe missed in core/src/main/scala/org/apache/spark/storage/DiskBlockObjectWriter.scala


```
 override def write(kvBytes: Array[Byte], offs: Int, len: Int): Unit = {
     if (!streamOpen) {
       open()
     }
     bs.write(kvBytes, offs, len)
+    updateBytesWritten()   // the function is missed
 } 
```

[Possible Patch Link](https://github.com/apache/spark/commit/c4b698e6d9e01b840546a6fe8e1723bb07b55308)