### PR TITLE
[SPARK-27865][SQL] Support 1:N sort merge bucket join without shuffle

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -183,7 +183,7 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
 
       children = children.zip(requiredChildDistributions).zipWithIndex.map {
         case ((child, distribution), index) if childrenIndexes.contains(index) =>
-          if (child.outputPartitioning.numPartitions == targetNumPartitions) {
+          if (targetNumPartitions % child.outputPartitioning.numPartitions == 0) {
             child
           } else {
             val defaultPartitioning = distribution.createPartitioning(targetNumPartitions)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -648,7 +648,7 @@ case class SortMergeJoinExec(
       (evaluateVariables(leftVars), "")
     }
 
-    val result = s"""
+    s"""
        |while (findNextInnerJoinRows($leftInput, $rightInput)) {
        |  ${leftVarDecl.mkString("\n")}
        |  ${beforeLoop.trim}
@@ -662,8 +662,6 @@ case class SortMergeJoinExec(
        |  if (shouldStop()) return;
        |}
      """.stripMargin
-    println(result)
-    result
   }
 }
 


### PR DESCRIPTION
## Support 1:N sort merge bucket join without shuffle


## Test
Here is the code for verification
```scala
val spark = SparkSession.builder()
    .master("local[*]")
    .appName("TestBucketJoin")
    .config("spark.sql.autoBroadcastJoinThreshold", 1)
    .getOrCreate()

spark.sql(
    """create table tbl1(a int, b int)
      |using csv 
      |clustered by (a) 
      |sorted by (a) 
      |into 4 buckets
      |""".stripMargin)
  spark.sql(
    """create table tbl2(a int, b int)
      |using csv 
      |clustered by (a) 
      |sorted by (a) 
      |into 4 buckets
      |""".stripMargin)
  spark.sql(
    """create table tbl3(a int, b int)
      |using csv 
      |clustered by (a) 
      |sorted by (a) 
      |into 12 buckets
      |""".stripMargin)

  import spark.implicits._
  val data = spark.sparkContext.parallelize(0 until 12, 1)
  spark.createDataset(data).createOrReplaceTempView("data")

  spark.sql("insert overwrite table tbl1 select value, value from data")
  spark.sql("insert overwrite table tbl2 select value, value from data")
  spark.sql("insert overwrite table tbl3 select value, value from data")
  
  spark.sql("select * from tbl1 join tbl3 on tbl1.a = tbl3.a").show()
```

For the join in the last line, this feature make sure that the sort merge bucket join is used to join the two tables which has 4 and 12 buckets respectively.

With this feature, map-only sort merge bucket join is used as shown below
![1 N bucket join DAG](https://user-images.githubusercontent.com/3096874/58465000-5b9bd800-8169-11e9-9d0c-6031b7dc20d0.png)

Without this feature, shuffle based sort merge join is used
![1 N bucket join shuffle DAG](https://user-images.githubusercontent.com/3096874/58466960-53de3280-816d-11e9-914e-23603b4cddb5.png)


