### PR TITLE
[SPARK-27867][ML] RegressionEvaluator cache lastest RegressionMetrics to avoid duplicated computation

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/evaluation/RegressionEvaluator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/evaluation/RegressionEvaluator.scala
@@ -41,6 +41,9 @@ final class RegressionEvaluator @Since("1.4.0") (@Since("1.4.0") override val ui
 
   @transient private var prevMetrics: RegressionMetrics = _
   @transient private var prevDataset: Dataset[_] = _
+  @transient private var prevPredictionCol: String = _
+  @transient private var prevLabelCol: String = _
+  @transient private var prevWeightCol: String = _
 
   /**
    * Param for metric name in evaluation. Supports:
@@ -81,7 +84,8 @@ final class RegressionEvaluator @Since("1.4.0") (@Since("1.4.0") override val ui
 
   @Since("2.0.0")
   override def evaluate(dataset: Dataset[_]): Double = {
-    if (dataset != prevDataset) {
+    if (dataset != prevDataset || $(predictionCol) != prevPredictionCol
+      || $(labelCol) != prevLabelCol || $(weightCol) != prevWeightCol) {
       val schema = dataset.schema
       SchemaUtils.checkColumnTypes(schema, $(predictionCol), Seq(DoubleType, FloatType))
       SchemaUtils.checkNumericType(schema, $(labelCol))
@@ -95,6 +99,9 @@ final class RegressionEvaluator @Since("1.4.0") (@Since("1.4.0") override val ui
 
       prevMetrics = new RegressionMetrics(predictionAndLabelsWithWeights)
       prevDataset = dataset
+      prevPredictionCol = $(predictionCol)
+      prevLabelCol = $(labelCol)
+      prevWeightCol = $(weightCol)
     }
 
     $(metricName) match {

--- a/mllib/src/main/scala/org/apache/spark/ml/evaluation/RegressionEvaluator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/evaluation/RegressionEvaluator.scala
@@ -46,13 +46,9 @@ final class RegressionEvaluator @Since("1.4.0") (@Since("1.4.0") override val ui
   @transient private var prevWeightCol: String = _
 
   private def updateMetrics(dataset: Dataset[_]): Boolean = {
-    if (isDefined(weightCol)) {
-      dataset != prevDataset || $(predictionCol) != prevPredictionCol ||
-        $(labelCol) != prevLabelCol || $(weightCol) != prevWeightCol
-    } else {
-      dataset != prevDataset || $(predictionCol) != prevPredictionCol ||
-        $(labelCol) != prevLabelCol || null != prevWeightCol
-    }
+    prevMetrics == null || dataset != prevDataset || $(predictionCol) != prevPredictionCol ||
+      (isDefined(weightCol) && $(weightCol) != prevWeightCol) ||
+      (!isDefined(weightCol) && null != prevWeightCol)
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
cache the lastest `RegressionMetrics`, so that in the next calls if the inputs (except metricName) are not changed, the metric can be directly returned from the internal `RegressionMetrics`

## How was this patch tested?
existing tests and local test in spark-shell