### PR TITLE
[SPARK-27876][CORE] Split large shuffle partition to multi-segments to enable transfer oversize shuffle partition block

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockHandler.java
@@ -245,15 +245,17 @@ public class ExternalShuffleBlockHandler extends RpcHandler {
       String execId = msg.execId;
       String[] blockIds = msg.blockIds;
       String[] blockId0Parts = blockIds[0].split("_");
-      if ((blockId0Parts.length == 4 || blockId0Parts.length == 5) && blockId0Parts[0].equals("shuffle")) {
+      if ((blockId0Parts.length == 4 || blockId0Parts.length == 5) &&
+        blockId0Parts[0].equals("shuffle")) {
         final int shuffleId = Integer.parseInt(blockId0Parts[1]);
         shuffleFetchSplit = blockId0Parts.length == 5;
         if (shuffleFetchSplit) {
-          final int[] mapIdAndReduceIdSegmentIds = shuffleMapIdAndReduceIdSegmentIds(blockIds, shuffleId);
-          size = mapIdAndReduceIdSegmentIds.length;
+          final int[] mapIdReduceIdAndSegmentIds =
+            shuffleMapIdReduceIdAndSegmentIds(blockIds, shuffleId);
+          size = mapIdReduceIdAndSegmentIds.length;
           blockDataForIndexFn = index -> blockManager.getBlockSegmentData(appId, execId, shuffleId,
-            mapIdAndReduceIdSegmentIds[index], mapIdAndReduceIdSegmentIds[index + 1],
-            mapIdAndReduceIdSegmentIds[index +2]);
+            mapIdReduceIdAndSegmentIds[index], mapIdReduceIdAndSegmentIds[index + 1],
+            mapIdReduceIdAndSegmentIds[index +2]);
         } else {
           final int[] mapIdAndReduceIds = shuffleMapIdAndReduceIds(blockIds, shuffleId);
           size = mapIdAndReduceIds.length;
@@ -300,8 +302,8 @@ public class ExternalShuffleBlockHandler extends RpcHandler {
       return mapIdAndReduceIds;
     }
 
-    private int[] shuffleMapIdAndReduceIdSegmentIds(String[] blockIds, int shuffleId) {
-      final int[] mapIdAndReduceIdSegmentIds = new int[3 * blockIds.length];
+    private int[] shuffleMapIdReduceIdAndSegmentIds(String[] blockIds, int shuffleId) {
+      final int[] mapIdReduceIdAndSegmentIds = new int[3 * blockIds.length];
       for (int i = 0; i < blockIds.length; i++) {
         String[] blockIdParts = blockIds[i].split("_");
         if (blockIdParts.length != 5 ||!blockIdParts[0].equals("shuffle")) {
@@ -309,13 +311,13 @@ public class ExternalShuffleBlockHandler extends RpcHandler {
         }
         if (Integer.parseInt(blockIdParts[1]) != shuffleId) {
           throw new IllegalArgumentException("Expected shuffleId=" + shuffleId +
-                  ", got:" + blockIds[i]);
+            ", got:" + blockIds[i]);
         }
-        mapIdAndReduceIdSegmentIds[3 * i] = Integer.parseInt(blockIdParts[2]);
-        mapIdAndReduceIdSegmentIds[3 * i + 1] = Integer.parseInt(blockIdParts[3]);
-        mapIdAndReduceIdSegmentIds[3 * i + 2] = Integer.parseInt(blockIdParts[4]);
+        mapIdReduceIdAndSegmentIds[3 * i] = Integer.parseInt(blockIdParts[2]);
+        mapIdReduceIdAndSegmentIds[3 * i + 1] = Integer.parseInt(blockIdParts[3]);
+        mapIdReduceIdAndSegmentIds[3 * i + 2] = Integer.parseInt(blockIdParts[4]);
       }
-      return mapIdAndReduceIdSegmentIds;
+      return mapIdReduceIdAndSegmentIds;
     }
 
     ManagedBufferIterator(FetchShuffleBlocks msg, int numBlockIds) {

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockHandler.java
@@ -238,18 +238,28 @@ public class ExternalShuffleBlockHandler extends RpcHandler {
     private int index = 0;
     private final Function<Integer, ManagedBuffer> blockDataForIndexFn;
     private final int size;
+    private boolean shuffleFetchSplit = false;
 
     ManagedBufferIterator(OpenBlocks msg) {
       String appId = msg.appId;
       String execId = msg.execId;
       String[] blockIds = msg.blockIds;
       String[] blockId0Parts = blockIds[0].split("_");
-      if (blockId0Parts.length == 4 && blockId0Parts[0].equals("shuffle")) {
+      if ((blockId0Parts.length == 4 || blockId0Parts.length ==5) && blockId0Parts[0].equals("shuffle")) {
         final int shuffleId = Integer.parseInt(blockId0Parts[1]);
-        final int[] mapIdAndReduceIds = shuffleMapIdAndReduceIds(blockIds, shuffleId);
-        size = mapIdAndReduceIds.length;
-        blockDataForIndexFn = index -> blockManager.getBlockData(appId, execId, shuffleId,
-          mapIdAndReduceIds[index], mapIdAndReduceIds[index + 1]);
+        shuffleFetchSplit = blockId0Parts.length == 5;
+        if (shuffleFetchSplit) {
+          final int[] mapIdAndReduceIdSegmentIds = shuffleMapIdAndReduceIdSegmentIds(blockIds, shuffleId);
+          size = mapIdAndReduceIdSegmentIds.length;
+          blockDataForIndexFn = index -> blockManager.getBlockSegmentData(appId, execId, shuffleId,
+            mapIdAndReduceIdSegmentIds[index], mapIdAndReduceIdSegmentIds[index + 1],
+            mapIdAndReduceIdSegmentIds[index +2]);
+        } else {
+          final int[] mapIdAndReduceIds = shuffleMapIdAndReduceIds(blockIds, shuffleId);
+          size = mapIdAndReduceIds.length;
+          blockDataForIndexFn = index -> blockManager.getBlockData(appId, execId, shuffleId,
+            mapIdAndReduceIds[index], mapIdAndReduceIds[index + 1]);
+        }
       } else if (blockId0Parts.length == 3 && blockId0Parts[0].equals("rdd")) {
         final int[] rddAndSplitIds = rddAndSplitIds(blockIds);
         size = rddAndSplitIds.length;
@@ -290,6 +300,24 @@ public class ExternalShuffleBlockHandler extends RpcHandler {
       return mapIdAndReduceIds;
     }
 
+    private int[] shuffleMapIdAndReduceIdSegmentIds(String[] blockIds, int shuffleId) {
+      final int[] mapIdAndReduceIdSegmentIds = new int[3 * blockIds.length];
+      for (int i = 0; i < blockIds.length; i++) {
+        String[] blockIdParts = blockIds[i].split("_");
+        if ((blockIdParts.length != 4 && blockIdParts.length != 5) ||!blockIdParts[0].equals("shuffle")) {
+          throw new IllegalArgumentException("Unexpected shuffle block id format: " + blockIds[i]);
+        }
+        if (Integer.parseInt(blockIdParts[1]) != shuffleId) {
+          throw new IllegalArgumentException("Expected shuffleId=" + shuffleId +
+                  ", got:" + blockIds[i]);
+        }
+        mapIdAndReduceIdSegmentIds[3 * i] = Integer.parseInt(blockIdParts[2]);
+        mapIdAndReduceIdSegmentIds[3 * i + 1] = Integer.parseInt(blockIdParts[3]);
+        mapIdAndReduceIdSegmentIds[3 * i + 2] = shuffleFetchSplit ? Integer.parseInt(blockIdParts[4]) : 1;
+      }
+      return mapIdAndReduceIdSegmentIds;
+    }
+
     ManagedBufferIterator(FetchShuffleBlocks msg, int numBlockIds) {
       final int[] mapIdAndReduceIds = new int[2 * numBlockIds];
       int idx = 0;
@@ -313,7 +341,7 @@ public class ExternalShuffleBlockHandler extends RpcHandler {
     @Override
     public ManagedBuffer next() {
       final ManagedBuffer block = blockDataForIndexFn.apply(index);
-      index += 2;
+      index += (shuffleFetchSplit ? 3 : 2);
       metrics.blockTransferRateBytes.mark(block != null ? block.size() : 0);
       return block;
     }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockHandler.java
@@ -245,7 +245,7 @@ public class ExternalShuffleBlockHandler extends RpcHandler {
       String execId = msg.execId;
       String[] blockIds = msg.blockIds;
       String[] blockId0Parts = blockIds[0].split("_");
-      if ((blockId0Parts.length == 4 || blockId0Parts.length ==5) && blockId0Parts[0].equals("shuffle")) {
+      if ((blockId0Parts.length == 4 || blockId0Parts.length == 5) && blockId0Parts[0].equals("shuffle")) {
         final int shuffleId = Integer.parseInt(blockId0Parts[1]);
         shuffleFetchSplit = blockId0Parts.length == 5;
         if (shuffleFetchSplit) {
@@ -304,7 +304,7 @@ public class ExternalShuffleBlockHandler extends RpcHandler {
       final int[] mapIdAndReduceIdSegmentIds = new int[3 * blockIds.length];
       for (int i = 0; i < blockIds.length; i++) {
         String[] blockIdParts = blockIds[i].split("_");
-        if ((blockIdParts.length != 4 && blockIdParts.length != 5) ||!blockIdParts[0].equals("shuffle")) {
+        if (blockIdParts.length != 5 ||!blockIdParts[0].equals("shuffle")) {
           throw new IllegalArgumentException("Unexpected shuffle block id format: " + blockIds[i]);
         }
         if (Integer.parseInt(blockIdParts[1]) != shuffleId) {
@@ -313,7 +313,7 @@ public class ExternalShuffleBlockHandler extends RpcHandler {
         }
         mapIdAndReduceIdSegmentIds[3 * i] = Integer.parseInt(blockIdParts[2]);
         mapIdAndReduceIdSegmentIds[3 * i + 1] = Integer.parseInt(blockIdParts[3]);
-        mapIdAndReduceIdSegmentIds[3 * i + 2] = shuffleFetchSplit ? Integer.parseInt(blockIdParts[4]) : 1;
+        mapIdAndReduceIdSegmentIds[3 * i + 2] = Integer.parseInt(blockIdParts[4]);
       }
       return mapIdAndReduceIdSegmentIds;
     }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
@@ -202,7 +202,7 @@ public class ExternalShuffleBlockResolver {
     ExecutorShuffleInfo executor = executors.get(new AppExecId(appId, execId));
     if (executor == null) {
       throw new RuntimeException(
-              String.format("Executor is not registered (appId=%s, execId=%s)", appId, execId));
+        String.format("Executor is not registered (appId=%s, execId=%s)", appId, execId));
     }
     return getSortBasedShuffleBlockSegmentData(executor, shuffleId, mapId, reduceId, segmentId);
   }
@@ -347,7 +347,7 @@ public class ExternalShuffleBlockResolver {
   private ManagedBuffer getSortBasedShuffleBlockSegmentData(
           ExecutorShuffleInfo executor, int shuffleId, int mapId, int reduceId, int segmentId) {
     File indexFile = getFile(executor.localDirs, executor.subDirsPerLocalDir,
-            "shuffle_" + shuffleId + "_" + mapId + "_0.index");
+      "shuffle_" + shuffleId + "_" + mapId + "_0.index");
 
     try {
       ShuffleIndexInformation shuffleIndexInformation = shuffleIndexCache.get(indexFile);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
@@ -340,9 +340,10 @@ public class ExternalShuffleBlockResolver {
   }
 
   /**
-   * Sort-based shuffle segment data uses an index called "shuffle_ShuffleId_MapId_0.index" and segmentId
-   * into a data file called "shuffle_ShuffleId_MapId_0.data". This logic is from IndexShuffleBlockResolver,
-   * and the block id format is from ShuffleDataBlockId and ShuffleIndexBlockId.
+   * Sort-based shuffle segment data uses an index called "shuffle_ShuffleId_MapId_0.index" and
+   * segmentId into a data file called "shuffle_ShuffleId_MapId_0.data". This logic is from
+   * IndexShuffleBlockResolver, and the block id format is from ShuffleDataBlockId and
+   * ShuffleIndexBlockId.
    */
   private ManagedBuffer getSortBasedShuffleBlockSegmentData(
           ExecutorShuffleInfo executor, int shuffleId, int mapId, int reduceId, int segmentId) {
@@ -354,7 +355,7 @@ public class ExternalShuffleBlockResolver {
       ShuffleIndexRecord shuffleIndexRecord = shuffleIndexInformation.getIndex(reduceId);
       long offset = shuffleIndexRecord.getOffset() + segmentId * SHUFFLE_FETCH_THRESHOLD;
       long length = Math.min(shuffleIndexRecord.getLength() -
-              (segmentId * SHUFFLE_FETCH_THRESHOLD), SHUFFLE_FETCH_THRESHOLD);
+        (segmentId * SHUFFLE_FETCH_THRESHOLD), SHUFFLE_FETCH_THRESHOLD);
       return new FileSegmentManagedBuffer(
         conf,
         getFile(executor.localDirs, executor.subDirsPerLocalDir,

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/FetchShuffleBlocks.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/FetchShuffleBlocks.java
@@ -56,10 +56,10 @@ public class FetchShuffleBlocks extends BlockTransferMessage {
     this.shuffleFetchSplit = shuffleFetchSplit;
     if (shuffleFetchSplit) {
       this.segments = segments;
+      assert(mapIds.length == segments.length);
     } else {
-      this.segments = new int[mapIds.length][];
+      this.segments = new int[][] {{ 0 }};
     }
-    assert(mapIds.length == segments.length);
   }
 
   @Override

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/BlockTransferMessagesSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/BlockTransferMessagesSuite.java
@@ -30,7 +30,7 @@ public class BlockTransferMessagesSuite {
     checkSerializeDeserialize(new OpenBlocks("app-1", "exec-2", new String[] { "b1", "b2" }));
     checkSerializeDeserialize(new FetchShuffleBlocks(
       "app-1", "exec-2", 0, new int[] {0, 1},
-      new int[][] {{ 0, 1 }, { 0, 1, 2 }}));
+      new int[][] {{ 0, 1 }, { 0, 1, 2 }}, false, new int[][] {{ 0 }}));
     checkSerializeDeserialize(new RegisterExecutor("app-1", "exec-2", new ExecutorShuffleInfo(
       new String[] { "/local1", "/local2" }, 32, "MyShuffleManager")));
     checkSerializeDeserialize(new UploadBlock("app-1", "exec-2", "block-3", new byte[] { 1, 2 },

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockHandlerSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockHandlerSuite.java
@@ -101,7 +101,7 @@ public class ExternalShuffleBlockHandlerSuite {
     when(blockResolver.getBlockData("app0", "exec1", 0, 0, 1)).thenReturn(blockMarkers[1]);
 
     FetchShuffleBlocks fetchShuffleBlocks = new FetchShuffleBlocks(
-      "app0", "exec1", 0, new int[] { 0 }, new int[][] {{ 0, 1 }});
+      "app0", "exec1", 0, new int[] { 0 }, new int[][] {{ 0, 1 }}, false, new int[][] {{ 0 }});
     checkOpenBlocksReceive(fetchShuffleBlocks, blockMarkers);
 
     verify(blockResolver, times(1)).getBlockData("app0", "exec1", 0, 0, 0);

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockFetcherSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockFetcherSuite.java
@@ -64,7 +64,8 @@ public class OneForOneBlockFetcherSuite {
     BlockFetchingListener listener = fetchBlocks(
       blocks,
       blockIds,
-      new FetchShuffleBlocks("app-id", "exec-id", 0, new int[] { 0 }, new int[][] {{ 0 }}),
+      new FetchShuffleBlocks("app-id", "exec-id", 0, new int[] { 0 }, new int[][] {{ 0 }},
+        false, new int[][]{{ 0 }}),
       conf);
 
     verify(listener).onBlockFetchSuccess("shuffle_0_0_0", blocks.get("shuffle_0_0_0"));
@@ -100,7 +101,8 @@ public class OneForOneBlockFetcherSuite {
     BlockFetchingListener listener = fetchBlocks(
       blocks,
       blockIds,
-      new FetchShuffleBlocks("app-id", "exec-id", 0, new int[] { 0 }, new int[][] {{ 0, 1, 2 }}),
+      new FetchShuffleBlocks("app-id", "exec-id", 0, new int[] { 0 }, new int[][] {{ 0, 1, 2 }},
+        false, new int[][] {{ 0 }}),
       conf);
 
     for (int i = 0; i < 3; i ++) {

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -869,7 +869,6 @@ package object config {
 
   private[spark] val SHUFFLE_FETCH_SPLIT_ENABLED =
     ConfigBuilder("spark.shuffle.fetch.split")
-      .internal()
       .doc("Whether split large partition blocks to enable transfer oversize shuffle blocks.")
       .booleanConf
       .createWithDefault(false)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -867,6 +867,13 @@ package object config {
       .checkValue(v => v > 0, "The threshold should be positive.")
       .createWithDefault(10000000)
 
+  private[spark] val SHUFFLE_FETCH_SPLIT_ENABLED =
+    ConfigBuilder("spark.shuffle.fetch.split")
+      .internal()
+      .doc("Whether split large partition blocks to enable transfer oversize shuffle blocks.")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val MAX_RESULT_SIZE = ConfigBuilder("spark.driver.maxResultSize")
     .doc("Size limit for results.")
     .bytesConf(ByteUnit.BYTE)

--- a/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
@@ -120,7 +120,7 @@ private[spark] class CompressedMapStatus(
   extends MapStatus with Externalizable {
 
   protected def this() = this(null, null.asInstanceOf[Array[Byte]],
-    null.asInstanceOf[Map[Int, Short]])  // For deserialization only
+    null.asInstanceOf[scala.collection.Map[Int, Short]])  // For deserialization only
 
   def this(loc: BlockManagerId, uncompressedSizes: Array[Long]) {
     this(loc, uncompressedSizes.map(MapStatus.compressSize),

--- a/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
@@ -73,8 +73,9 @@ private[spark] object MapStatus {
 
   private[spark] val SHUFFLE_FETCH_THRESHOLD = Int.MaxValue
 
-  private[spark] val SHUFFLE_FETCH_SPLIT = SparkEnv.get.conf.getBoolean(
-    config.SHUFFLE_FETCH_SPLIT_ENABLED.key, false)
+  private[spark] val SHUFFLE_FETCH_SPLIT = Option(SparkEnv.get)
+    .map(_.conf.get(config.SHUFFLE_FETCH_SPLIT_ENABLED))
+    .getOrElse(config.SHUFFLE_FETCH_SPLIT_ENABLED.defaultValue.get)
 
   private[this] val LOG_BASE = 1.1
 

--- a/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
@@ -137,7 +137,7 @@ private[spark] class CompressedMapStatus(
   }
 
   override def getBlockSegments(reduceId: Int): Short = {
-    patitionSegments.getOrElse(reduceId, 1)
+    Option(patitionSegments).map(_.getOrElse(reduceId, 1.toShort)).getOrElse(1)
   }
 
   override def writeExternal(out: ObjectOutput): Unit = Utils.tryOrIOException {
@@ -210,7 +210,7 @@ private[spark] class HighlyCompressedMapStatus private (
   }
 
   override def getBlockSegments(reduceId: Int): Short = {
-    partitionSegments.getOrElse(reduceId, 1)
+    Option(partitionSegments).map(_.getOrElse(reduceId, 1.toShort)).getOrElse(1)
   }
 
   override def writeExternal(out: ObjectOutput): Unit = Utils.tryOrIOException {

--- a/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
@@ -45,9 +45,8 @@ private[spark] sealed trait MapStatus {
   def getSizeForBlock(reduceId: Int): Long
 
   /**
-   * If a partition's size is large than [[MapStatus.SHUFFLE_FETCH_THRESHOLD]],
-   * it should be fetched more than one time, this method return how many segments
-   * this partition should be split to fetch.
+   * If a partition's size is large than SHUFFLE_FETCH_THRESHOLD, it should be fetched more than
+   * one time, this method return how many segments this partition should be split to fetch.
    */
   def getBlockSegments(reduceId: Int): Short
 }
@@ -113,6 +112,7 @@ private[spark] object MapStatus {
  *
  * @param loc location where the task is being executed.
  * @param compressedSizes size of the blocks, indexed by reduce partition id.
+ * @param patitionSegments segments of partition blocks.
  */
 private[spark] class CompressedMapStatus(
     private[this] var loc: BlockManagerId,
@@ -177,6 +177,7 @@ private[spark] class CompressedMapStatus(
  * @param emptyBlocks a bitmap tracking which blocks are empty
  * @param avgSize average size of the non-empty and non-huge blocks
  * @param hugeBlockSizes sizes of huge blocks by their reduceId.
+ * @param partitionSegments segments of partition blocks.
  */
 private[spark] class HighlyCompressedMapStatus private (
     private[this] var loc: BlockManagerId,

--- a/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
@@ -56,7 +56,8 @@ private[spark] class BlockStoreShuffleReader[K, C](
       SparkEnv.get.conf.get(config.MAX_REMOTE_BLOCK_SIZE_FETCH_TO_MEM),
       SparkEnv.get.conf.get(config.SHUFFLE_DETECT_CORRUPT),
       SparkEnv.get.conf.get(config.SHUFFLE_DETECT_CORRUPT_MEMORY),
-      readMetrics).toCompletionIterator
+      readMetrics,
+      SparkEnv.get.conf.get(config.SHUFFLE_FETCH_SPLIT_ENABLED)).toCompletionIterator
 
     val serializerInstance = dep.serializer.newInstance()
 

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockResolver.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.shuffle
 
 import org.apache.spark.network.buffer.ManagedBuffer
-import org.apache.spark.storage.ShuffleBlockId
+import org.apache.spark.storage.{ShuffleBlockId, ShuffleBlockSegmentId}
 
 private[spark]
 /**
@@ -35,6 +35,13 @@ trait ShuffleBlockResolver {
    * throws an unspecified exception.
    */
   def getBlockData(blockId: ShuffleBlockId): ManagedBuffer
+
+  /**
+   * Retrieve the data for the specified block with segmentId. If the data for that block is not
+   * available, throws an unspecified exception.
+   */
+  def getBlockSegmentData(blockId: ShuffleBlockSegmentId): ManagedBuffer
+
 
   def stop(): Unit
 }

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockResolver.scala
@@ -42,6 +42,5 @@ trait ShuffleBlockResolver {
    */
   def getBlockSegmentData(blockId: ShuffleBlockSegmentId): ManagedBuffer
 
-
   def stop(): Unit
 }

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -544,6 +544,9 @@ private[spark] class BlockManager(
   override def getBlockData(blockId: BlockId): ManagedBuffer = {
     if (blockId.isShuffle) {
       shuffleManager.shuffleBlockResolver.getBlockData(blockId.asInstanceOf[ShuffleBlockId])
+    } else if (blockId.isShuffleSegment) {
+      shuffleManager.shuffleBlockResolver.getBlockSegmentData(
+        blockId.asInstanceOf[ShuffleBlockSegmentId])
     } else {
       getLocalBytes(blockId) match {
         case Some(blockData) =>

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -240,7 +240,7 @@ final class ShuffleBlockFetcherIterator(
 
     val blockIds = if (shuffleFetchSplit) {
       req.blocks.flatMap { case (blockId, (_, segments)) => (0 until segments).map(
-            i => blockId.asInstanceOf[ShuffleBlockId].getShuffleBlockSegmentId(i).toString) }
+        i => blockId.asInstanceOf[ShuffleBlockId].getShuffleBlockSegmentId(i).toString) }
     } else {
       req.blocks.map(_._1.toString)
     }

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -19,9 +19,11 @@ package org.apache.spark.storage
 
 import java.io.{InputStream, IOException, SequenceInputStream}
 import java.nio.ByteBuffer
-import java.util.concurrent.{LinkedBlockingQueue, TimeUnit}
+import java.util.concurrent.{ConcurrentHashMap, LinkedBlockingQueue, PriorityBlockingQueue, TimeUnit}
+import java.util.concurrent.atomic.AtomicInteger
 import javax.annotation.concurrent.GuardedBy
 
+import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet, Queue}
 
@@ -67,7 +69,7 @@ final class ShuffleBlockFetcherIterator(
     context: TaskContext,
     shuffleClient: ShuffleClient,
     blockManager: BlockManager,
-    blocksByAddress: Iterator[(BlockManagerId, Seq[(BlockId, Long)])],
+    blocksByAddress: Iterator[(BlockManagerId, Seq[(BlockId, (Long, Int))])],
     streamWrapper: (BlockId, InputStream) => InputStream,
     maxBytesInFlight: Long,
     maxReqsInFlight: Int,
@@ -75,7 +77,8 @@ final class ShuffleBlockFetcherIterator(
     maxReqSizeShuffleToMem: Long,
     detectCorrupt: Boolean,
     detectCorruptUseExtraMemory: Boolean,
-    shuffleMetrics: ShuffleReadMetricsReporter)
+    shuffleMetrics: ShuffleReadMetricsReporter,
+    shuffleFetchSplit: Boolean)
   extends Iterator[(BlockId, InputStream)] with DownloadFileManager with Logging {
 
   import ShuffleBlockFetcherIterator._
@@ -171,7 +174,7 @@ final class ShuffleBlockFetcherIterator(
   private[storage] def releaseCurrentResultBuffer(): Unit = {
     // Release the current buffer if necessary
     if (currentResult != null) {
-      currentResult.buf.release()
+      currentResult.bufs.foreach(_.release())
     }
     currentResult = null
   }
@@ -206,15 +209,14 @@ final class ShuffleBlockFetcherIterator(
     while (iter.hasNext) {
       val result = iter.next()
       result match {
-        case SuccessFetchResult(_, address, _, buf, _) =>
+        case SuccessFetchResult(_, address, _, bufs, _, _) =>
           if (address != blockManager.blockManagerId) {
-            shuffleMetrics.incRemoteBytesRead(buf.size)
-            if (buf.isInstanceOf[FileSegmentManagedBuffer]) {
-              shuffleMetrics.incRemoteBytesReadToDisk(buf.size)
-            }
+            shuffleMetrics.incRemoteBytesRead(bufs.map(_.size()).sum)
+            bufs.filter(_.isInstanceOf[FileSegmentManagedBuffer])
+              .foreach(buf => shuffleMetrics.incRemoteBytesReadToDisk(buf.size))
             shuffleMetrics.incRemoteBlocksFetched(1)
           }
-          buf.release()
+          bufs.foreach(_.release())
         case _ =>
       }
     }
@@ -232,14 +234,36 @@ final class ShuffleBlockFetcherIterator(
     reqsInFlight += 1
 
     // so we can look up the size of each blockID
-    val sizeMap = req.blocks.map { case (blockId, size) => (blockId.toString, size) }.toMap
-    val remainingBlocks = new HashSet[String]() ++= sizeMap.keys
-    val blockIds = req.blocks.map(_._1.toString)
+    val sizeMap = req.blocks.map { case (blockId, (size, _)) => (blockId.toString, size) }.toMap
+    val segmentsMap = req.blocks.map {
+      case (blockId, (_, segments)) => (blockId.toString, segments) }.toMap
+
+    val blockIds = if (shuffleFetchSplit) {
+      req.blocks.flatMap { case (blockId, (_, segments)) => (0 until segments).map(
+            i => blockId.asInstanceOf[ShuffleBlockId].getShuffleBlockSegmentId(i).toString) }
+    } else {
+      req.blocks.map(_._1.toString)
+    }
+
+    val remainingBlocks = new HashSet[String]() ++= blockIds
     val address = req.address
 
     val blockFetchingListener = new BlockFetchingListener {
-      override def onBlockFetchSuccess(blockId: String, buf: ManagedBuffer): Unit = {
-        // Only add the buffer to results queue if the iterator is not zombie,
+      case class SegmentManagedBuffer(
+          segmentId: Int,
+          buf: ManagedBuffer) extends Comparable[SegmentManagedBuffer] {
+        override def compareTo(o: SegmentManagedBuffer): Int = {
+          segmentId - o.segmentId
+        }
+      }
+
+      lazy val blockIdSegmentsCount =
+        req.blocks.map(kv => (kv._1.toString, new AtomicInteger(kv._2._2))).toMap
+      val blockIdSegmentBuffers =
+        new ConcurrentHashMap[String, PriorityBlockingQueue[SegmentManagedBuffer]]()
+
+      private def onBlockSegmentFetchSuccess(blockId: String, buf: ManagedBuffer): Unit = {
+        // Only add the buffer to block segment buffers queue if the iterator is not zombie,
         // i.e. cleanup() has not been called yet.
         ShuffleBlockFetcherIterator.this.synchronized {
           if (!isZombie) {
@@ -247,17 +271,64 @@ final class ShuffleBlockFetcherIterator(
             // This needs to be released after use.
             buf.retain()
             remainingBlocks -= blockId
-            results.put(new SuccessFetchResult(BlockId(blockId), address, sizeMap(blockId), buf,
-              remainingBlocks.isEmpty))
+
+            val blockSegmentId = BlockId(blockId).asInstanceOf[ShuffleBlockSegmentId]
+            val shuffleBlockId = blockSegmentId.getShuffleBlockId.toString
+            val segmentBufs = blockIdSegmentBuffers.getOrDefault(shuffleBlockId,
+              new PriorityBlockingQueue[SegmentManagedBuffer]())
+            segmentBufs.offer(SegmentManagedBuffer(blockSegmentId.segmentId, buf))
+            blockIdSegmentBuffers.put(shuffleBlockId, segmentBufs)
+
+            if (blockIdSegmentsCount.get(shuffleBlockId).get.decrementAndGet() == 0) {
+              val bufs = for (i <- (0 until segmentBufs.size())) yield segmentBufs.poll().buf
+              assert(bufs.size == segmentsMap(shuffleBlockId))
+              results.put(new SuccessFetchResult(BlockId(shuffleBlockId), address,
+                sizeMap(shuffleBlockId), bufs, remainingBlocks.isEmpty,
+                segmentsMap(shuffleBlockId)))
+              blockIdSegmentBuffers.remove(shuffleBlockId)
+              logTrace(s"Got remote block $shuffleBlockId after " +
+                s"${Utils.getUsedTimeNs(startTimeNs)}")
+            }
             logDebug("remainingBlocks: " + remainingBlocks)
           }
         }
-        logTrace(s"Got remote block $blockId after ${Utils.getUsedTimeNs(startTimeNs)}")
+      }
+
+      override def onBlockFetchSuccess(blockId: String, buf: ManagedBuffer): Unit = {
+        if (BlockId(blockId).isShuffleSegment) {
+          onBlockSegmentFetchSuccess(blockId, buf)
+        } else {
+          // Only add the buffer to results queue if the iterator is not zombie,
+          // i.e. cleanup() has not been called yet.
+          ShuffleBlockFetcherIterator.this.synchronized {
+            if (!isZombie) {
+              // Increment the ref count because we need to pass this to a different thread.
+              // This needs to be released after use.
+              buf.retain()
+              remainingBlocks -= blockId
+              results.put(new SuccessFetchResult(BlockId(blockId), address, sizeMap(blockId),
+                Seq(buf), remainingBlocks.isEmpty))
+              logDebug("remainingBlocks: " + remainingBlocks)
+            }
+          }
+          logTrace(s"Got remote block $blockId after ${Utils.getUsedTimeNs(startTimeNs)}")
+        }
+      }
+
+      private def onBlockSegmentFetchFailure(blockId: String, e: Throwable): Unit = {
+        val shuffleBlockId = BlockId(blockId).asInstanceOf[ShuffleBlockSegmentId].getShuffleBlockId
+        blockIdSegmentBuffers.remove(shuffleBlockId.toString)
+        logError(s"Failed to get block(s) from ${req.address.host}:${req.address.port}", e)
+        results.put(new FailureFetchResult(shuffleBlockId, address, e))
       }
 
       override def onBlockFetchFailure(blockId: String, e: Throwable): Unit = {
-        logError(s"Failed to get block(s) from ${req.address.host}:${req.address.port}", e)
-        results.put(new FailureFetchResult(BlockId(blockId), address, e))
+        if (BlockId(blockId).isShuffleSegment) {
+          onBlockSegmentFetchFailure(blockId, e)
+        } else {
+          logError(s"Failed to get block(s) from ${req.address.host}:${req.address.port}", e)
+          results.put(new FailureFetchResult(BlockId(blockId), address, e))
+        }
       }
     }
 
@@ -289,29 +360,29 @@ final class ShuffleBlockFetcherIterator(
 
     for ((address, blockInfos) <- blocksByAddress) {
       if (address.executorId == blockManager.blockManagerId.executorId) {
-        blockInfos.find(_._2 <= 0) match {
-          case Some((blockId, size)) if size < 0 =>
+        blockInfos.find(_._2._1 <= 0) match {
+          case Some((blockId, (size, _))) if size < 0 =>
             throw new BlockException(blockId, "Negative block size " + size)
-          case Some((blockId, size)) if size == 0 =>
+          case Some((blockId, (size, _))) if size == 0 =>
             throw new BlockException(blockId, "Zero-sized blocks should be excluded.")
           case None => // do nothing.
         }
         localBlocks ++= blockInfos.map(_._1)
-        localBlockBytes += blockInfos.map(_._2).sum
+        localBlockBytes += blockInfos.map(_._2._1).sum
         numBlocksToFetch += localBlocks.size
       } else {
         val iterator = blockInfos.iterator
         var curRequestSize = 0L
-        var curBlocks = new ArrayBuffer[(BlockId, Long)]
+        var curBlocks = new ArrayBuffer[(BlockId, (Long, Int))]
         while (iterator.hasNext) {
-          val (blockId, size) = iterator.next()
+          val (blockId, (size, segments)) = iterator.next()
           remoteBlockBytes += size
           if (size < 0) {
             throw new BlockException(blockId, "Negative block size " + size)
           } else if (size == 0) {
             throw new BlockException(blockId, "Zero-sized blocks should be excluded.")
           } else {
-            curBlocks += ((blockId, size))
+            curBlocks += ((blockId, (size, segments)))
             remoteBlocks += blockId
             numBlocksToFetch += 1
             curRequestSize += size
@@ -322,7 +393,7 @@ final class ShuffleBlockFetcherIterator(
             remoteRequests += new FetchRequest(address, curBlocks)
             logDebug(s"Creating fetch request of $curRequestSize at $address "
               + s"with ${curBlocks.size} blocks")
-            curBlocks = new ArrayBuffer[(BlockId, Long)]
+            curBlocks = new ArrayBuffer[(BlockId, (Long, Int))]
             curRequestSize = 0
           }
         }
@@ -355,7 +426,7 @@ final class ShuffleBlockFetcherIterator(
         shuffleMetrics.incLocalBytesRead(buf.size)
         buf.retain()
         results.put(new SuccessFetchResult(blockId, blockManager.blockManagerId,
-          buf.size(), buf, false))
+          buf.size(), Seq(buf), false))
       } catch {
         case e: Exception =>
           // If we see an exception, stop immediately.
@@ -420,13 +491,12 @@ final class ShuffleBlockFetcherIterator(
       shuffleMetrics.incFetchWaitTime(fetchWaitTime)
 
       result match {
-        case r @ SuccessFetchResult(blockId, address, size, buf, isNetworkReqDone) =>
+        case r @ SuccessFetchResult(blockId, address, size, bufs, isNetworkReqDone, segments) =>
           if (address != blockManager.blockManagerId) {
             numBlocksInFlightPerAddress(address) = numBlocksInFlightPerAddress(address) - 1
-            shuffleMetrics.incRemoteBytesRead(buf.size)
-            if (buf.isInstanceOf[FileSegmentManagedBuffer]) {
-              shuffleMetrics.incRemoteBytesReadToDisk(buf.size)
-            }
+            shuffleMetrics.incRemoteBytesRead(bufs.map(_.size).sum)
+            bufs.filter(_.isInstanceOf[FileSegmentManagedBuffer])
+                .foreach(buf => shuffleMetrics.incRemoteBytesReadToDisk(buf.size))
             shuffleMetrics.incRemoteBlocksFetched(1)
           }
           if (!localBlocks.contains(blockId)) {
@@ -437,7 +507,7 @@ final class ShuffleBlockFetcherIterator(
             logDebug("Number of requests in flight " + reqsInFlight)
           }
 
-          if (buf.size == 0) {
+          if (bufs == null || bufs.size == 0 || bufs.exists(_.size == 0)) {
             // We will never legitimately receive a zero-size block. All blocks with zero records
             // have zero size and all zero-size blocks have no records (and hence should never
             // have been requested in the first place). This statement relies on behaviors of the
@@ -457,13 +527,13 @@ final class ShuffleBlockFetcherIterator(
           }
 
           val in = try {
-            buf.createInputStream()
+            new SequenceInputStream(bufs.toIterator.map(_.createInputStream()).asJavaEnumeration)
           } catch {
             // The exception could only be throwed by local shuffle block
             case e: IOException =>
-              assert(buf.isInstanceOf[FileSegmentManagedBuffer])
+              assert(bufs.forall(_.isInstanceOf[FileSegmentManagedBuffer]))
               logError("Failed to create input stream from local block", e)
-              buf.release()
+              bufs.foreach(_.release())
               throwFetchFailedException(blockId, address, e)
           }
           try {
@@ -479,14 +549,14 @@ final class ShuffleBlockFetcherIterator(
             }
           } catch {
             case e: IOException =>
-              buf.release()
-              if (buf.isInstanceOf[FileSegmentManagedBuffer]
+              bufs.foreach(_.release())
+              if (bufs.exists(_.isInstanceOf[FileSegmentManagedBuffer])
                   || corruptedBlocks.contains(blockId)) {
                 throwFetchFailedException(blockId, address, e)
               } else {
                 logWarning(s"got an corrupted block $blockId from $address, fetch again", e)
                 corruptedBlocks += blockId
-                fetchRequests += FetchRequest(address, Array((blockId, size)))
+                fetchRequests += FetchRequest(address, Array((blockId, (size, segments))))
                 result = null
               }
           } finally {
@@ -692,10 +762,11 @@ object ShuffleBlockFetcherIterator {
    * A request to fetch blocks from a remote BlockManager.
    * @param address remote BlockManager to fetch from.
    * @param blocks Sequence of tuple, where the first element is the block id,
-   *               and the second element is the estimated size, used to calculate bytesInFlight.
+   *               and the second element is a tuple of estimated size and segments number of block,
+   *               used to calculate bytesInFlight and fetch times.
    */
-  case class FetchRequest(address: BlockManagerId, blocks: Seq[(BlockId, Long)]) {
-    val size = blocks.map(_._2).sum
+  case class FetchRequest(address: BlockManagerId, blocks: Seq[(BlockId, (Long, Int))]) {
+    val size = blocks.map(_._2._1).sum
   }
 
   /**
@@ -712,16 +783,18 @@ object ShuffleBlockFetcherIterator {
    * @param address BlockManager that the block was fetched from.
    * @param size estimated size of the block. Note that this is NOT the exact bytes.
    *             Size of remote block is used to calculate bytesInFlight.
-   * @param buf `ManagedBuffer` for the content.
+   * @param bufs a sequence of `ManagedBuffer` for the content.
+   * @param segments number of this block when fetching, 1 for local blocks.
    * @param isNetworkReqDone Is this the last network request for this host in this fetch request.
    */
   private[storage] case class SuccessFetchResult(
       blockId: BlockId,
       address: BlockManagerId,
       size: Long,
-      buf: ManagedBuffer,
-      isNetworkReqDone: Boolean) extends FetchResult {
-    require(buf != null)
+      bufs: Seq[ManagedBuffer],
+      isNetworkReqDone: Boolean,
+      segments: Int = 1) extends FetchResult {
+    require(bufs != null && bufs.size != 0 && !bufs.exists(_ == null))
     require(size >= 0)
   }
 

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -68,10 +68,9 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     tracker.registerMapOutput(10, 1, MapStatus(BlockManagerId("b", "hostB", 1000),
         Array(10000L, 1000L)))
     val statuses = tracker.getMapSizesByExecutorId(10, 0)
-    assert(statuses.toSet ===
-      Seq((BlockManagerId("a", "hostA", 1000), ArrayBuffer((ShuffleBlockId(10, 0, 0), size1000))),
-          (BlockManagerId("b", "hostB", 1000), ArrayBuffer((ShuffleBlockId(10, 1, 0), size10000))))
-        .toSet)
+    assert(statuses.toSet === Seq((BlockManagerId("a", "hostA", 1000), ArrayBuffer(
+      (ShuffleBlockId(10, 0, 0), (size1000, 1)))), (BlockManagerId("b", "hostB", 1000),
+      ArrayBuffer((ShuffleBlockId(10, 1, 0), (size10000, 1))))).toSet)
     assert(0 == tracker.getNumCachedSerializedBroadcast)
     tracker.stop()
     rpcEnv.shutdown()
@@ -149,8 +148,8 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     masterTracker.registerMapOutput(10, 0, MapStatus(
       BlockManagerId("a", "hostA", 1000), Array(1000L)))
     slaveTracker.updateEpoch(masterTracker.getEpoch)
-    assert(slaveTracker.getMapSizesByExecutorId(10, 0).toSeq ===
-      Seq((BlockManagerId("a", "hostA", 1000), ArrayBuffer((ShuffleBlockId(10, 0, 0), size1000)))))
+    assert(slaveTracker.getMapSizesByExecutorId(10, 0).toSeq === Seq((BlockManagerId("a", "hostA",
+      1000), ArrayBuffer((ShuffleBlockId(10, 0, 0), (size1000, 1))))))
     assert(0 == masterTracker.getNumCachedSerializedBroadcast)
 
     val masterTrackerEpochBeforeLossOfMapOutput = masterTracker.getEpoch
@@ -317,10 +316,10 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     assert(tracker.containsShuffle(10))
     assert(tracker.getMapSizesByExecutorId(10, 0, 4).toSeq ===
         Seq(
-          (BlockManagerId("a", "hostA", 1000),
-              Seq((ShuffleBlockId(10, 0, 1), size1000), (ShuffleBlockId(10, 0, 3), size10000))),
-          (BlockManagerId("b", "hostB", 1000),
-              Seq((ShuffleBlockId(10, 1, 0), size10000), (ShuffleBlockId(10, 1, 2), size1000)))
+          (BlockManagerId("a", "hostA", 1000), Seq((ShuffleBlockId(10, 0, 1), (size1000, 1)),
+            (ShuffleBlockId(10, 0, 3), (size10000, 1)))),
+          (BlockManagerId("b", "hostB", 1000), Seq((ShuffleBlockId(10, 1, 0), (size10000, 1)),
+            (ShuffleBlockId(10, 1, 2), (size1000, 1))))
         )
     )
 

--- a/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
@@ -74,7 +74,7 @@ abstract class ShuffleSuite extends SparkFunSuite with Matchers with LocalSparkC
     // All blocks must have non-zero size
     (0 until NUM_BLOCKS).foreach { id =>
       val statuses = SparkEnv.get.mapOutputTracker.getMapSizesByExecutorId(shuffleId, id)
-      assert(statuses.forall(_._2.forall(blockIdSizePair => blockIdSizePair._2 > 0)))
+      assert(statuses.forall(_._2.forall(blockIdSizePair => blockIdSizePair._2._1 > 0)))
     }
   }
 
@@ -115,7 +115,7 @@ abstract class ShuffleSuite extends SparkFunSuite with Matchers with LocalSparkC
       val statuses = SparkEnv.get.mapOutputTracker.getMapSizesByExecutorId(shuffleId, id)
       statuses.flatMap(_._2.map(_._2))
     }
-    val nonEmptyBlocks = blockSizes.filter(x => x > 0)
+    val nonEmptyBlocks = blockSizes.filter(x => x._1 > 0)
 
     // We should have at most 4 non-zero sized partitions
     assert(nonEmptyBlocks.size <= 4)
@@ -140,7 +140,7 @@ abstract class ShuffleSuite extends SparkFunSuite with Matchers with LocalSparkC
       val statuses = SparkEnv.get.mapOutputTracker.getMapSizesByExecutorId(shuffleId, id)
       statuses.flatMap(_._2.map(_._2))
     }
-    val nonEmptyBlocks = blockSizes.filter(x => x > 0)
+    val nonEmptyBlocks = blockSizes.filter(x => x._1 > 0)
 
     // We should have at most 4 non-zero sized partitions
     assert(nonEmptyBlocks.size <= 4)

--- a/core/src/test/scala/org/apache/spark/shuffle/BlockStoreShuffleReaderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/BlockStoreShuffleReaderSuite.scala
@@ -107,7 +107,7 @@ class BlockStoreShuffleReaderSuite extends SparkFunSuite with LocalSparkContext 
       // for the code to read data over the network.
       val shuffleBlockIdsAndSizes = (0 until numMaps).map { mapId =>
         val shuffleBlockId = ShuffleBlockId(shuffleId, mapId, reduceId)
-        (shuffleBlockId, byteOutputStream.size().toLong)
+        (shuffleBlockId, (byteOutputStream.size().toLong, 1))
       }
       Seq((localBlockManagerId, shuffleBlockIdsAndSizes)).toIterator
     }

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -98,9 +98,9 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
 
     val transfer = createMockTransfer(remoteBlocks)
 
-    val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, Long)])](
-      (localBmId, localBlocks.keys.map(blockId => (blockId, 1.asInstanceOf[Long])).toSeq),
-      (remoteBmId, remoteBlocks.keys.map(blockId => (blockId, 1.asInstanceOf[Long])).toSeq)
+    val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, (Long, Int))])](
+      (localBmId, localBlocks.keys.map(blockId => (blockId, (1.asInstanceOf[Long], 1))).toSeq),
+      (remoteBmId, remoteBlocks.keys.map(blockId => (blockId, (1.asInstanceOf[Long], 1))).toSeq)
     ).toIterator
 
     val taskContext = TaskContext.empty()
@@ -117,7 +117,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       false,
-      metrics)
+      metrics,
+      false)
 
     // 3 local blocks fetched in initialization
     verify(blockManager, times(3)).getBlockData(any())
@@ -179,8 +180,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
         }
       })
 
-    val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, Long)])](
-      (remoteBmId, blocks.keys.map(blockId => (blockId, 1.asInstanceOf[Long])).toSeq)).toIterator
+    val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, (Long, Int))])](
+      (remoteBmId, blocks.keys.map(blockId => (blockId, (1.asInstanceOf[Long], 1))).toSeq)).toIterator
 
     val taskContext = TaskContext.empty()
     val iterator = new ShuffleBlockFetcherIterator(
@@ -195,7 +196,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       false,
-      taskContext.taskMetrics.createTempShuffleReadMetrics())
+      taskContext.taskMetrics.createTempShuffleReadMetrics(),
+      false)
 
     verify(blocks(ShuffleBlockId(0, 0, 0)), times(0)).release()
     iterator.next()._2.close() // close() first block's input stream
@@ -246,8 +248,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
         }
       })
 
-    val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, Long)])](
-      (remoteBmId, blocks.keys.map(blockId => (blockId, 1.asInstanceOf[Long])).toSeq)).toIterator
+    val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, (Long, Int))])](
+      (remoteBmId, blocks.keys.map(blockId => (blockId, (1.asInstanceOf[Long], 1))).toSeq)).toIterator
 
     val taskContext = TaskContext.empty()
     val iterator = new ShuffleBlockFetcherIterator(
@@ -262,7 +264,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       false,
-      taskContext.taskMetrics.createTempShuffleReadMetrics())
+      taskContext.taskMetrics.createTempShuffleReadMetrics(),
+      false)
 
 
     assert(iterator.hasNext)
@@ -305,8 +308,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
         }
       })
 
-    val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, Long)])](
-      (remoteBmId, blocks.keys.map(blockId => (blockId, 1.asInstanceOf[Long])).toSeq)).toIterator
+    val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, (Long, Int))])](
+      (remoteBmId, blocks.keys.map(blockId => (blockId, (1.asInstanceOf[Long], 1))).toSeq)).toIterator
 
     val taskContext = TaskContext.empty()
     val iterator = new ShuffleBlockFetcherIterator(
@@ -321,7 +324,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       false,
-      taskContext.taskMetrics.createTempShuffleReadMetrics())
+      taskContext.taskMetrics.createTempShuffleReadMetrics(),
+      false)
 
     // Continue only after the mock calls onBlockFetchFailure
     sem.acquire()
@@ -394,8 +398,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
         }
       })
 
-    val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, Long)])](
-      (remoteBmId, blocks.keys.map(blockId => (blockId, 1.asInstanceOf[Long])).toSeq)).toIterator
+    val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, (Long, Int))])](
+      (remoteBmId, blocks.keys.map(blockId => (blockId, (1.asInstanceOf[Long], 1))).toSeq)).toIterator
 
     val taskContext = TaskContext.empty()
     val iterator = new ShuffleBlockFetcherIterator(
@@ -410,7 +414,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       true,
-      taskContext.taskMetrics.createTempShuffleReadMetrics())
+      taskContext.taskMetrics.createTempShuffleReadMetrics(),
+      false)
 
     // Continue only after the mock calls onBlockFetchFailure
     sem.acquire()
@@ -462,9 +467,9 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
 
     val transfer = createMockTransfer(
       Map(shuffleBlockId1 -> corruptBuffer1, shuffleBlockId2 -> corruptBuffer2))
-    val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, Long)])](
-      (blockManagerId1, blockLengths1),
-      (blockManagerId2, blockLengths2)
+    val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, (Long, Int))])](
+      (blockManagerId1, blockLengths1.map(kv => (kv._1, (kv._2, 1)))),
+      (blockManagerId2, blockLengths2.map(kv => (kv._1, (kv._2, 1))))
     ).toIterator
     val taskContext = TaskContext.empty()
     val maxBytesInFlight = 3 * 1024
@@ -480,7 +485,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       true,
-      taskContext.taskMetrics.createTempShuffleReadMetrics())
+      taskContext.taskMetrics.createTempShuffleReadMetrics(),
+      false)
 
     // We'll get back the block which has corruption after maxBytesInFlight/3 because the other
     // block will detect corruption on first fetch, and then get added to the queue again for
@@ -527,8 +533,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       ShuffleBlockId(0, 0, 0) -> 10000
     )
     val transfer = createMockTransfer(Map(ShuffleBlockId(0, 0, 0) -> managedBuffer))
-    val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, Long)])](
-      (localBmId, localBlockLengths)
+    val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, (Long, Int))])](
+      (localBmId, localBlockLengths.map(kv => (kv._1, (kv._2, 1))))
     ).toIterator
 
     val taskContext = TaskContext.empty()
@@ -544,7 +550,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       true,
-      taskContext.taskMetrics.createTempShuffleReadMetrics())
+      taskContext.taskMetrics.createTempShuffleReadMetrics(),
+      false)
     val (id, st) = iterator.next()
     // Check that the test setup is correct -- make sure we have a concatenated stream.
     assert (st.asInstanceOf[BufferReleasingInputStream].delegate.isInstanceOf[SequenceInputStream])
@@ -589,8 +596,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
         }
       })
 
-    val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, Long)])](
-      (remoteBmId, blocks.keys.map(blockId => (blockId, 1.asInstanceOf[Long])).toSeq)).toIterator
+    val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, (Long, Int))])](
+      (remoteBmId, blocks.keys.map(blockId => (blockId, (1.asInstanceOf[Long], 1))).toSeq)).toIterator
 
     val taskContext = TaskContext.empty()
     val iterator = new ShuffleBlockFetcherIterator(
@@ -605,7 +612,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       false,
-      taskContext.taskMetrics.createTempShuffleReadMetrics())
+      taskContext.taskMetrics.createTempShuffleReadMetrics(),
+      false)
 
     // Continue only after the mock calls onBlockFetchFailure
     sem.acquire()
@@ -649,7 +657,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       })
 
     def fetchShuffleBlock(
-        blocksByAddress: Iterator[(BlockManagerId, Seq[(BlockId, Long)])]): Unit = {
+        blocksByAddress: Iterator[(BlockManagerId, Seq[(BlockId, (Long, Int))])]): Unit = {
       // Set `maxBytesInFlight` and `maxReqsInFlight` to `Int.MaxValue`, so that during the
       // construction of `ShuffleBlockFetcherIterator`, all requests to fetch remote shuffle blocks
       // are issued. The `maxReqSizeShuffleToMem` is hard-coded as 200 here.
@@ -666,18 +674,19 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
         maxReqSizeShuffleToMem = 200,
         detectCorrupt = true,
         false,
-        taskContext.taskMetrics.createTempShuffleReadMetrics())
+        taskContext.taskMetrics.createTempShuffleReadMetrics(),
+        false)
     }
 
-    val blocksByAddress1 = Seq[(BlockManagerId, Seq[(BlockId, Long)])](
-      (remoteBmId, remoteBlocks.keys.map(blockId => (blockId, 100L)).toSeq)).toIterator
+    val blocksByAddress1 = Seq[(BlockManagerId, Seq[(BlockId, (Long, Int))])](
+      (remoteBmId, remoteBlocks.keys.map(blockId => (blockId, (100L, 1))).toSeq)).toIterator
     fetchShuffleBlock(blocksByAddress1)
     // `maxReqSizeShuffleToMem` is 200, which is greater than the block size 100, so don't fetch
     // shuffle block to disk.
     assert(tempFileManager == null)
 
-    val blocksByAddress2 = Seq[(BlockManagerId, Seq[(BlockId, Long)])](
-      (remoteBmId, remoteBlocks.keys.map(blockId => (blockId, 300L)).toSeq)).toIterator
+    val blocksByAddress2 = Seq[(BlockManagerId, Seq[(BlockId, (Long, Int))])](
+      (remoteBmId, remoteBlocks.keys.map(blockId => (blockId, (300L, 1))).toSeq)).toIterator
     fetchShuffleBlock(blocksByAddress2)
     // `maxReqSizeShuffleToMem` is 200, which is smaller than the block size 300, so fetch
     // shuffle block to disk.
@@ -698,8 +707,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
 
     val transfer = createMockTransfer(blocks.mapValues(_ => createMockManagedBuffer(0)))
 
-    val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, Long)])](
-      (remoteBmId, blocks.keys.map(blockId => (blockId, 1.asInstanceOf[Long])).toSeq))
+    val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, (Long, Int))])](
+      (remoteBmId, blocks.keys.map(blockId => (blockId, (1.asInstanceOf[Long], 1))).toSeq))
 
     val taskContext = TaskContext.empty()
     val iterator = new ShuffleBlockFetcherIterator(
@@ -714,7 +723,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       false,
-      taskContext.taskMetrics.createTempShuffleReadMetrics())
+      taskContext.taskMetrics.createTempShuffleReadMetrics(),
+      false)
 
     // All blocks fetched return zero length and should trigger a receive-side error:
     val e = intercept[FetchFailedException] { iterator.next() }

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -38,7 +38,6 @@ import org.apache.spark.network.util.LimitedInputStream
 import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.util.Utils
 
-
 class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodTester {
 
   private def doReturn(value: Any) = org.mockito.Mockito.doReturn(value, Seq.empty: _*)
@@ -181,7 +180,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       })
 
     val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, (Long, Int))])](
-      (remoteBmId, blocks.keys.map(blockId => (blockId, (1.asInstanceOf[Long], 1))).toSeq)).toIterator
+      (remoteBmId, blocks.keys.map(blockId => (blockId, (1.asInstanceOf[Long], 1))).toSeq))
+      .toIterator
 
     val taskContext = TaskContext.empty()
     val iterator = new ShuffleBlockFetcherIterator(
@@ -249,7 +249,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       })
 
     val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, (Long, Int))])](
-      (remoteBmId, blocks.keys.map(blockId => (blockId, (1.asInstanceOf[Long], 1))).toSeq)).toIterator
+      (remoteBmId, blocks.keys.map(blockId => (blockId, (1.asInstanceOf[Long], 1))).toSeq))
+      .toIterator
 
     val taskContext = TaskContext.empty()
     val iterator = new ShuffleBlockFetcherIterator(
@@ -309,7 +310,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       })
 
     val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, (Long, Int))])](
-      (remoteBmId, blocks.keys.map(blockId => (blockId, (1.asInstanceOf[Long], 1))).toSeq)).toIterator
+      (remoteBmId, blocks.keys.map(blockId => (blockId, (1.asInstanceOf[Long], 1))).toSeq))
+      .toIterator
 
     val taskContext = TaskContext.empty()
     val iterator = new ShuffleBlockFetcherIterator(
@@ -399,7 +401,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       })
 
     val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, (Long, Int))])](
-      (remoteBmId, blocks.keys.map(blockId => (blockId, (1.asInstanceOf[Long], 1))).toSeq)).toIterator
+      (remoteBmId, blocks.keys.map(blockId => (blockId, (1.asInstanceOf[Long], 1))).toSeq))
+      .toIterator
 
     val taskContext = TaskContext.empty()
     val iterator = new ShuffleBlockFetcherIterator(
@@ -597,7 +600,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       })
 
     val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, (Long, Int))])](
-      (remoteBmId, blocks.keys.map(blockId => (blockId, (1.asInstanceOf[Long], 1))).toSeq)).toIterator
+      (remoteBmId, blocks.keys.map(blockId => (blockId, (1.asInstanceOf[Long], 1))).toSeq))
+      .toIterator
 
     val taskContext = TaskContext.empty()
     val iterator = new ShuffleBlockFetcherIterator(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -821,6 +821,13 @@ Apart from these, the following properties are also available, and may be useful
     When we fail to register to the external shuffle service, we will retry for maxAttempts times.
   </td>
 </tr>
+<tr>
+  <td><code>spark.shuffle.fetch.split</code></td>
+  <td>false</td>
+  <td>
+    Whether split large partition blocks to enable transfer oversize shuffle blocks.
+  </td>
+</tr>
 </table>
 
 ### Spark UI


### PR DESCRIPTION
## What changes were proposed in this pull request?

There is a limit for shuffle read. 

If a shuffle partition block's size is large than Integer.MaxValue(2GB) and this block is fetched from remote, an Exception will be thrown.
```
    2019-05-24 06:46:30,333 [9935] - WARN [shuffle-client-6-2:TransportChannelHandler@78] - Exception in connection from hadoop3747.jd.163.org/10.196.76.172:7337
    java.lang.IllegalArgumentException: Too large frame: 2991947178
    at org.spark_project.guava.base.Preconditions.checkArgument(Preconditions.java:119)
    at org.apache.spark.network.util.TransportFrameDecoder.decodeNext(TransportFrameDecoder.java:133)
    at org.apache.spark.network.util.TransportFrameDecoder.channelRead(TransportFrameDecoder.java:81)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
```
Then this task would throw a fetchFailedException.

This task will retry and it would execute successfully only when this task was reScheduled to a executor whose host is same to this oversize shuffle partition block.

However, if there are more than one oversize(>2GB) shuffle partitions block, this task would never execute successfully and it may cause the failure of application.

In this PR, I propose a new method to fetch shuffle block, it would fetch multi times when the relative shuffle partition block is oversize.

The simple brief introduction:

1. Set a shuffle fetch threshold(SHUFFLE_FETCH_THRESHOLD) to Int.MaxValue(2GB)
2. Set a parameter spark.shuffle.fetch.split to control whether enable fetch large partition multi times
3. When creating mapStatus, caucluate the segemens of shuffle block (`Math.ceil(size /SHUFFLE_FETCH_THRESHOLD )`), and only record the segment number which is large than 1.
4. Define a new BlockId type, `ShuffleBlockSegmentId`, used to identifiy the fetch method.
5. When spark.shuffle.fetch.split is enabled,  send ShuffleBlockSegmentId message to shuffleService instead of ShuffleBlockId message.
6. For a ShuffleBlockId, use a sequence of ManagedBuffers to present received blocks instead of a ManagedBuffer.
7. In ShuffleBlockFetcherIterator,  create a PriorityBlockQueue for a ShuffleBlockId to store the fetched SegmentManagedBuffer, when all segments of a ShuffleBlockId are fetched,  take  relative sequence of managedBuffers(which are ordered by segmentId) as a successResult for a ShuffleBlockID.
8. In the shuffle serivice side, if the blockId of openBlocks is a ShuffleBlockSegmentId,  response a segment managedBuffer of block , if the blockId is a ShuffleBlockId response a whole managedBuffer of block as before.

## How was this patch tested?

manual test
