### PR TITLE
[SPARK-27849][SQL][FollowUp][test-maven] Fix the testing regex in DataSourceScanRedactionTest

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/DataSourceScanExecRedactionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/DataSourceScanExecRedactionSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.test.SharedSQLContext
 abstract class DataSourceScanRedactionTest extends QueryTest with SharedSQLContext {
 
   override protected def sparkConf: SparkConf = super.sparkConf
-    .set("spark.redaction.string.regex", "file:/[\\w-_@/]+")
+    .set("spark.redaction.string.regex", "file:/[^\\]\\s]+")
 
   final protected def isIncluded(queryExecution: QueryExecution, msg: String): Boolean = {
     queryExecution.toString.contains(msg) ||


### PR DESCRIPTION
## What changes were proposed in this pull request?

As explained in https://github.com/apache/spark/pull/24719#pullrequestreview-243064785, the regex `file:/[\\w-_@/]+` contains possible characters I have met in the Jenkins tests. 
However, we still miss the  `.` symbol:
https://amplab.cs.berkeley.edu/jenkins/view/Spark%20QA%20Test%20(Dashboard)/job/spark-master-test-maven-hadoop-2.7/6415/testReport/junit/org.apache.spark.sql.execution/DataSourceV2ScanExecRedactionSuite/treeString_is_redacted/ :
```
orc *********(redacted).7/sql/core/target/tmp/spark-7ff5f81d-069a-4b5d-9d9a-808addeef115
```

This PR is to fix it by matching any character except `]` or spaces.
## How was this patch tested?

Unit test
