### PR TITLE
[SPARK-27772][SQL][TEST] Refactor SQLTestUtils to use `tryWithSafeFinally`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
@@ -259,7 +259,7 @@ private[sql] trait SQLTestUtilsBase
       viewNames.foreach { viewName =>
         try spark.catalog.dropTempView(viewName) catch {
           // If the test failed part way, we don't want to mask the failure by failing to remove
-          // global temp views that never got created.
+          // temp views that never got created.
           case _: NoSuchTableException =>
         }
       }
@@ -274,7 +274,7 @@ private[sql] trait SQLTestUtilsBase
       viewNames.foreach { viewName =>
         try spark.catalog.dropGlobalTempView(viewName) catch {
           // If the test failed part way, we don't want to mask the failure by failing to remove
-          // temp views that never got created.
+          // global temp views that never got created.
           case _: NoSuchTableException =>
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
@@ -259,7 +259,7 @@ private[sql] trait SQLTestUtilsBase
       viewNames.foreach { viewName =>
         try spark.catalog.dropTempView(viewName) catch {
           // If the test failed part way, we don't want to mask the failure by failing to remove
-          // temp views that never got created.
+          // global temp views that never got created.
           case _: NoSuchTableException =>
         }
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current `SQLTestUtils` created many `withXXX` utility functions to clean up tables/views/caches created for testing purpose. This PR standardizes those 'withXXX' function to use`Utils.tryWithSafeFinally` function. This function executes a block of code, then a finally block.  If exceptions happen in the finally block, this function does not suppress the original exception.
   
The purpose of this proposal is to help developers to identify what actually breaks their tests. For example, the below test should fail with a `ParserException`. However, without this patch, the `NullPointerException` throwing from finally block suppresses the true exception `ParserException`

```
test("SPARK-27772") {
    spark.range(1, 10).toDF("key").withColumn("value", 'key * 2)
      .write.format("json").saveAsTable("t")
    withTempView("d1.t1", "d2.t2", null) {
      sql("CACHE TABLE t")
      sql("CACHE TABLE d1.t1 AS SELECT * FROM t WHERE key > 1")
      sql("CACHE TABLE d2.t2 AS SELECT * FROM d1.t1 WHERE value > 1")

      assert(spark.catalog.isCached("t"))
      assert(spark.catalog.isCached("d1.t1"))
      assert(spark.catalog.isCached("d2.t2"))
      sql("UNCACHE TABLE t")
      assert(!spark.catalog.isCached("t"))
      assert(!spark.catalog.isCached("d1.t1"))
      assert(!spark.catalog.isCached("d2.t2"))
    }
  }
```

It is the stacktrack before applying this patch:
```
[info] - SPARK-27772 *** FAILED *** (3 seconds, 447 milliseconds)
[info]   java.lang.NullPointerException:
[info]   at org.apache.spark.sql.catalyst.catalog.SessionCatalog.formatTableName(SessionCatalog.scala:124)
[info]   at org.apache.spark.sql.catalyst.catalog.SessionCatalog.getTempView(SessionCatalog.scala:536)
[info]   at org.apache.spark.sql.internal.CatalogImpl.dropTempView(CatalogImpl.scala:366)
[info]   at org.apache.spark.sql.test.SQLTestUtilsBase.$anonfun$withTempView$1(SQLTestUtils.scala:260)
[info]   at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36)
```

And it is the stacktrace after applying this patch:
```
[info] - SPARK-27772 *** FAILED *** (3 seconds, 617 milliseconds)
[info]   org.apache.spark.sql.catalyst.parser.ParseException: It is not allowed to add database prefix `d1` to the table name in CACHE TABLE AS SELECT(line 1, pos 0)
[info]
[info] == SQL ==
[info] CACHE TABLE d1.t1 AS SELECT * FROM t WHERE key > 1
[info] ^^^
[info]   at org.apache.spark.sql.execution.SparkSqlAstBuilder.$anonfun$visitCacheTable$1(SparkSqlParser.scala:283)
[info]   at org.apache.spark.sql.catalyst.parser.ParserUtils$.withOrigin(ParserUtils.scala:108)
[info]   at org.apache.spark.sql.execution.SparkSqlAstBuilder.visitCacheTable(SparkSqlParser.scala:277)
[info]   at org.apache.spark.sql.execution.SparkSqlAstBuilder.visitCacheTable(SparkSqlParser.scala:55)
[info]   at org.apache.spark.sql.catalyst.parser.SqlBaseParser$CacheTableContext.accept(SqlBaseParser.java:2296)
[info]   at org.antlr.v4.runtime.tree.AbstractParseTreeVisitor.visit(AbstractParseTreeVisitor.java:18)
[info]   at org.apache.spark.sql.catalyst.parser.AstBuilder.$anonfun$visitSingleStatement$1(AstBuilder.scala:75)
[info]   at org.apache.spark.sql.catalyst.parser.ParserUtils$.withOrigin(ParserUtils.scala:108)
```

## How was this patch tested?
Existing testcases.