### PR TITLE
[MINOR] Fix typo: isSplitable -> isSplittable

### DIFF
--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroFileFormat.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroFileFormat.scala
@@ -130,7 +130,7 @@ private[avro] class AvroFileFormat extends FileFormat
 
   override def toString(): String = "Avro"
 
-  override def isSplitable(
+  override def isSplittable(
       sparkSession: SparkSession,
       options: Map[String, String],
       path: Path): Boolean = true

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -429,13 +429,13 @@ case class FileSourceScanExec(
       partition.files.flatMap { file =>
         // getPath() is very expensive so we only want to call it once in this block:
         val filePath = file.getPath
-        val isSplitable = relation.fileFormat.isSplitable(
+        val isSplittable = relation.fileFormat.isSplittable(
           relation.sparkSession, relation.options, filePath)
         PartitionedFileUtil.splitFiles(
           sparkSession = relation.sparkSession,
           file = file,
           filePath = filePath,
-          isSplitable = isSplitable,
+          isSplittable = isSplittable,
           maxSplitBytes = maxSplitBytes,
           partitionValues = partition.values
         )

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/PartitionedFileUtil.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/PartitionedFileUtil.scala
@@ -28,10 +28,10 @@ object PartitionedFileUtil {
       sparkSession: SparkSession,
       file: FileStatus,
       filePath: Path,
-      isSplitable: Boolean,
+      isSplittable: Boolean,
       maxSplitBytes: Long,
       partitionValues: InternalRow): Seq[PartitionedFile] = {
-    if (isSplitable) {
+    if (isSplittable) {
       (0L until file.getLen by maxSplitBytes).map { offset =>
         val remaining = file.getLen - offset
         val size = if (remaining > maxSplitBytes) maxSplitBytes else remaining

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
@@ -79,7 +79,7 @@ trait FileFormat {
   /**
    * Returns whether a file with `path` could be split or not.
    */
-  def isSplitable(
+  def isSplittable(
       sparkSession: SparkSession,
       options: Map[String, String],
       path: Path): Boolean = {
@@ -170,7 +170,7 @@ trait FileFormat {
 abstract class TextBasedFileFormat extends FileFormat {
   private var codecFactory: CompressionCodecFactory = _
 
-  override def isSplitable(
+  override def isSplittable(
       sparkSession: SparkSession,
       options: Map[String, String],
       path: Path): Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormat.scala
@@ -71,7 +71,7 @@ class BinaryFileFormat extends FileFormat with DataSourceRegister {
     throw new UnsupportedOperationException("Write is not supported for binary file data source")
   }
 
-  override def isSplitable(
+  override def isSplittable(
       sparkSession: SparkSession,
       options: Map[String, String],
       path: Path): Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
@@ -44,7 +44,7 @@ import org.apache.spark.sql.types.StructType
  * Common functions for parsing CSV files
  */
 abstract class CSVDataSource extends Serializable {
-  def isSplitable: Boolean
+  def isSplittable: Boolean
 
   /**
    * Parse a [[PartitionedFile]] into [[InternalRow]] instances.
@@ -87,7 +87,7 @@ object CSVDataSource extends Logging {
 }
 
 object TextInputCSVDataSource extends CSVDataSource {
-  override val isSplitable: Boolean = true
+  override val isSplittable: Boolean = true
 
   override def readFile(
       conf: Configuration,
@@ -170,7 +170,7 @@ object TextInputCSVDataSource extends CSVDataSource {
 }
 
 object MultiLineCSVDataSource extends CSVDataSource {
-  override val isSplitable: Boolean = false
+  override val isSplittable: Boolean = false
 
   override def readFile(
       conf: Configuration,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
@@ -41,7 +41,7 @@ class CSVFileFormat extends TextBasedFileFormat with DataSourceRegister {
 
   override def shortName(): String = "csv"
 
-  override def isSplitable(
+  override def isSplittable(
       sparkSession: SparkSession,
       options: Map[String, String],
       path: Path): Boolean = {
@@ -50,7 +50,7 @@ class CSVFileFormat extends TextBasedFileFormat with DataSourceRegister {
       columnPruning = sparkSession.sessionState.conf.csvColumnPruning,
       sparkSession.sessionState.conf.sessionLocalTimeZone)
     val csvDataSource = CSVDataSource(parsedOptions)
-    csvDataSource.isSplitable && super.isSplitable(sparkSession, options, path)
+    csvDataSource.isSplittable && super.isSplittable(sparkSession, options, path)
   }
 
   override def inferSchema(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonDataSource.scala
@@ -46,7 +46,7 @@ import org.apache.spark.util.Utils
  * Common functions for parsing JSON files
  */
 abstract class JsonDataSource extends Serializable {
-  def isSplitable: Boolean
+  def isSplittable: Boolean
 
   /**
    * Parse a [[PartitionedFile]] into 0 or more [[InternalRow]] instances
@@ -85,7 +85,7 @@ object JsonDataSource {
 }
 
 object TextInputJsonDataSource extends JsonDataSource {
-  override val isSplitable: Boolean = {
+  override val isSplittable: Boolean = {
     // splittable if the underlying source is
     true
   }
@@ -150,7 +150,7 @@ object TextInputJsonDataSource extends JsonDataSource {
 }
 
 object MultiLineJsonDataSource extends JsonDataSource {
-  override val isSplitable: Boolean = {
+  override val isSplittable: Boolean = {
     false
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -37,7 +37,7 @@ import org.apache.spark.util.SerializableConfiguration
 class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
   override val shortName: String = "json"
 
-  override def isSplitable(
+  override def isSplittable(
       sparkSession: SparkSession,
       options: Map[String, String],
       path: Path): Boolean = {
@@ -46,7 +46,7 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
       sparkSession.sessionState.conf.sessionLocalTimeZone,
       sparkSession.sessionState.conf.columnNameOfCorruptRecord)
     val jsonDataSource = JsonDataSource(parsedOptions)
-    jsonDataSource.isSplitable && super.isSplitable(sparkSession, options, path)
+    jsonDataSource.isSplittable && super.isSplittable(sparkSession, options, path)
   }
 
   override def inferSchema(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -139,7 +139,7 @@ class OrcFileFormat
       schema.forall(_.dataType.isInstanceOf[AtomicType])
   }
 
-  override def isSplitable(
+  override def isSplittable(
       sparkSession: SparkSession,
       options: Map[String, String],
       path: Path): Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -285,7 +285,7 @@ class ParquetFileFormat
     ))
   }
 
-  override def isSplitable(
+  override def isSplittable(
       sparkSession: SparkSession,
       options: Map[String, String],
       path: Path): Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextFileFormat.scala
@@ -49,12 +49,12 @@ class TextFileFormat extends TextBasedFileFormat with DataSourceRegister {
     }
   }
 
-  override def isSplitable(
+  override def isSplittable(
       sparkSession: SparkSession,
       options: Map[String, String],
       path: Path): Boolean = {
     val textOptions = new TextOptions(options)
-    super.isSplitable(sparkSession, options, path) && !textOptions.wholeText
+    super.isSplittable(sparkSession, options, path) && !textOptions.wholeText
   }
 
   override def inferSchema(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
@@ -40,7 +40,7 @@ abstract class FileScan(
   /**
    * Returns whether a file with `path` could be split or not.
    */
-  def isSplitable(path: Path): Boolean = {
+  def isSplittable(path: Path): Boolean = {
     false
   }
 
@@ -85,7 +85,7 @@ abstract class FileScan(
           sparkSession = sparkSession,
           file = file,
           filePath = filePath,
-          isSplitable = isSplitable(filePath),
+          isSplittable = isSplittable(filePath),
           maxSplitBytes = maxSplitBytes,
           partitionValues = partitionValues
         )

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/TextBasedFileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/TextBasedFileScan.scala
@@ -35,7 +35,7 @@ abstract class TextBasedFileScan(
   extends FileScan(sparkSession, fileIndex, readDataSchema, readPartitionSchema) {
   private var codecFactory: CompressionCodecFactory = _
 
-  override def isSplitable(path: Path): Boolean = {
+  override def isSplittable(path: Path): Boolean = {
     if (codecFactory == null) {
       codecFactory = new CompressionCodecFactory(
         sparkSession.sessionState.newHadoopConfWithOptions(options.asScala.toMap))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVScan.scala
@@ -46,8 +46,8 @@ case class CSVScan(
     sparkSession.sessionState.conf.sessionLocalTimeZone,
     sparkSession.sessionState.conf.columnNameOfCorruptRecord)
 
-  override def isSplitable(path: Path): Boolean = {
-    CSVDataSource(parsedOptions).isSplitable && super.isSplitable(path)
+  override def isSplittable(path: Path): Boolean = {
+    CSVDataSource(parsedOptions).isSplittable && super.isSplittable(path)
   }
 
   override def createReaderFactory(): PartitionReaderFactory = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonScan.scala
@@ -46,8 +46,8 @@ case class JsonScan(
     sparkSession.sessionState.conf.sessionLocalTimeZone,
     sparkSession.sessionState.conf.columnNameOfCorruptRecord)
 
-  override def isSplitable(path: Path): Boolean = {
-    JsonDataSource(parsedOptions).isSplitable && super.isSplitable(path)
+  override def isSplittable(path: Path): Boolean = {
+    JsonDataSource(parsedOptions).isSplittable && super.isSplittable(path)
   }
 
   override def createReaderFactory(): PartitionReaderFactory = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScan.scala
@@ -38,7 +38,7 @@ case class OrcScan(
     options: CaseInsensitiveStringMap,
     pushedFilters: Array[Filter])
   extends FileScan(sparkSession, fileIndex, readDataSchema, readPartitionSchema) {
-  override def isSplitable(path: Path): Boolean = true
+  override def isSplittable(path: Path): Boolean = true
 
   override def createReaderFactory(): PartitionReaderFactory = {
     val broadcastedConf = sparkSession.sparkContext.broadcast(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/text/TextScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/text/TextScan.scala
@@ -40,8 +40,8 @@ case class TextScan(
   private val optionsAsScala = options.asScala.toMap
   private lazy val textOptions: TextOptions = new TextOptions(optionsAsScala)
 
-  override def isSplitable(path: Path): Boolean = {
-    super.isSplitable(path) && !textOptions.wholeText
+  override def isSplittable(path: Path): Boolean = {
+    super.isSplittable(path) && !textOptions.wholeText
   }
 
   override def createReaderFactory(): PartitionReaderFactory = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
@@ -94,7 +94,7 @@ class BinaryFileFormatSuite extends QueryTest with SharedSQLContext with SQLTest
   test("BinaryFileFormat methods") {
     val format = new BinaryFileFormat
     assert(format.shortName() === "binaryFile")
-    assert(format.isSplitable(spark, Map.empty, new Path("any")) === false)
+    assert(format.isSplittable(spark, Map.empty, new Path("any")) === false)
     assert(format.inferSchema(spark, Map.empty, Seq.empty) === Some(BinaryFileFormat.schema))
     assert(BinaryFileFormat.schema === StructType(Seq(
       StructField("path", StringType, false),

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileFormat.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileFormat.scala
@@ -115,7 +115,7 @@ class OrcFileFormat extends FileFormat with DataSourceRegister with Serializable
     }
   }
 
-  override def isSplitable(
+  override def isSplittable(
       sparkSession: SparkSession,
       options: Map[String, String],
       path: Path): Boolean = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix a typo in `splitable`. In particular, `isSplitable` is replaced by `isSplittable` (double `t`). See https://www.yourdictionary.com/splittable