### PR TITLE
[SPARK-27907][SQL] HiveUDAF should return NULL in case of 0 rows

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -474,10 +474,7 @@ private[hive] case class HiveUDAFFunction(
   override def serialize(buffer: HiveUDAFBuffer): Array[Byte] = {
     // Serializes an `AggregationBuffer` that holds partial aggregation results so that we can
     // shuffle it for global aggregation later.
-    aggBufferSerDe.serialize(Option(buffer) match {
-      case Some(buffer) => buffer.buf
-      case None => null
-    })
+    aggBufferSerDe.serialize(if (buffer == null) null else buffer.buf)
   }
 
   override def deserialize(bytes: Array[Byte]): HiveUDAFBuffer = {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -468,7 +468,13 @@ private[hive] case class HiveUDAFFunction(
   }
 
   override def eval(buffer: HiveUDAFBuffer): Any = {
-    resultUnwrapper(finalHiveEvaluator.evaluator.terminate(buffer.buf))
+    resultUnwrapper(finalHiveEvaluator.evaluator.terminate(
+      if (buffer == null) {
+        HiveUDAFBuffer(partial1HiveEvaluator.evaluator.getNewAggregationBuffer, false).buf
+      } else {
+        buffer.buf
+      }
+    ))
   }
 
   override def serialize(buffer: HiveUDAFBuffer): Array[Byte] = {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -470,7 +470,7 @@ private[hive] case class HiveUDAFFunction(
   override def eval(buffer: HiveUDAFBuffer): Any = {
     resultUnwrapper(finalHiveEvaluator.evaluator.terminate(
       if (buffer == null) {
-        HiveUDAFBuffer(finalHiveEvaluator.evaluator.getNewAggregationBuffer, false).buf
+        finalHiveEvaluator.evaluator.getNewAggregationBuffer
       } else {
         buffer.buf
       }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -470,7 +470,7 @@ private[hive] case class HiveUDAFFunction(
   override def eval(buffer: HiveUDAFBuffer): Any = {
     resultUnwrapper(finalHiveEvaluator.evaluator.terminate(
       if (buffer == null) {
-        HiveUDAFBuffer(partial1HiveEvaluator.evaluator.getNewAggregationBuffer, false).buf
+        HiveUDAFBuffer(finalHiveEvaluator.evaluator.getNewAggregationBuffer, false).buf
       } else {
         buffer.buf
       }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -474,7 +474,10 @@ private[hive] case class HiveUDAFFunction(
   override def serialize(buffer: HiveUDAFBuffer): Array[Byte] = {
     // Serializes an `AggregationBuffer` that holds partial aggregation results so that we can
     // shuffle it for global aggregation later.
-    aggBufferSerDe.serialize(buffer.buf)
+    aggBufferSerDe.serialize(Option(buffer) match {
+      case Some(buffer) => buffer.buf
+      case None => null
+    })
   }
 
   override def deserialize(bytes: Array[Byte]): HiveUDAFBuffer = {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDAFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDAFSuite.scala
@@ -150,14 +150,14 @@ class HiveUDAFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
     }
   }
 
-  test("HiveUDAF with 0 rows throws NPE") {
-    sql("create table abc(a int)")
-    checkAnswer(sql("select histogram_numeric(a,2) from abc"), Row.fromSeq(Seq.fill(1)(null)))
-    sql("insert into abc values (1)")
-    checkAnswer(sql("select histogram_numeric(a,2) from abc"),
-      Row.fromSeq(Seq(Row.fromTuple((1.0, 1.0))) :: Nil))
-    checkAnswer(sql("select histogram_numeric(a,2) from abc where a=3"),
-      Row.fromSeq(Seq.fill(1)(null)))
+  test("SPARK-27907 HiveUDAF with 0 rows throws NPE") {
+    withTable("abc") {
+      sql("create table abc(a int)")
+      checkAnswer(sql("select histogram_numeric(a,2) from abc"), Row(null))
+      sql("insert into abc values (1)")
+      checkAnswer(sql("select histogram_numeric(a,2) from abc"), Row(Row(1.0, 1.0) :: Nil))
+      checkAnswer(sql("select histogram_numeric(a,2) from abc where a=3"), Row(null))
+    }
   }
 }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDAFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDAFSuite.scala
@@ -152,8 +152,8 @@ class HiveUDAFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
 
   test("HiveUDAF with 0 rows throws NPE") {
     sql("create table abc(a int)")
+    sql("select histogram_numeric(a,2) from abc").show
     sql("insert into abc values (1)")
-    sql("insert into abc values (2)")
     sql("select histogram_numeric(a,2) from abc").show
     sql("select histogram_numeric(a,2) from abc where a=3").show
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDAFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDAFSuite.scala
@@ -152,10 +152,12 @@ class HiveUDAFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
 
   test("HiveUDAF with 0 rows throws NPE") {
     sql("create table abc(a int)")
-    sql("select histogram_numeric(a,2) from abc").show
+    checkAnswer(sql("select histogram_numeric(a,2) from abc"), Row.fromSeq(Seq.fill(1)(null)))
     sql("insert into abc values (1)")
-    sql("select histogram_numeric(a,2) from abc").show
-    sql("select histogram_numeric(a,2) from abc where a=3").show
+    checkAnswer(sql("select histogram_numeric(a,2) from abc"),
+      Row.fromSeq(Seq(Row.fromTuple((1.0, 1.0))) :: Nil))
+    checkAnswer(sql("select histogram_numeric(a,2) from abc where a=3"),
+      Row.fromSeq(Seq.fill(1)(null)))
   }
 }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDAFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDAFSuite.scala
@@ -149,6 +149,14 @@ class HiveUDAFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
       }
     }
   }
+
+  test("HiveUDAF with 0 rows throws NPE") {
+    sql("create table abc(a int)")
+    sql("insert into abc values (1)")
+    sql("insert into abc values (2)")
+    sql("select histogram_numeric(a,2) from abc").show
+    sql("select histogram_numeric(a,2) from abc where a=3").show
+  }
 }
 
 /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

When query returns zero rows, the HiveUDAFFunction throws NPE

## CASE 1:
create table abc(a int)
select histogram_numeric(a,2) from abc // NPE
```
Job aborted due to stage failure: Task 0 in stage 1.0 failed 1 times, most recent failure: Lost task 0.0 in stage 1.0 (TID 0, localhost, executor driver): java.lang.NullPointerException
	at org.apache.spark.sql.hive.HiveUDAFFunction.eval(hiveUDFs.scala:471)
	at org.apache.spark.sql.hive.HiveUDAFFunction.eval(hiveUDFs.scala:315)
	at org.apache.spark.sql.catalyst.expressions.aggregate.TypedImperativeAggregate.eval(interfaces.scala:543)
	at org.apache.spark.sql.execution.aggregate.AggregationIterator.$anonfun$generateResultProjection$5(AggregationIterator.scala:231)
	at org.apache.spark.sql.execution.aggregate.ObjectAggregationIterator.outputForEmptyGroupingKeyWithoutInput(ObjectAggregationIterator.scala:97)
	at org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec.$anonfun$doExecute$2(ObjectHashAggregateExec.scala:132)
	at org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec.$anonfun$doExecute$2$adapted(ObjectHashAggregateExec.scala:107)
	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsWithIndexInternal$2(RDD.scala:839)
	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsWithIndexInternal$2$adapted(RDD.scala:839)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:327)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:291)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:327)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:291)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:327)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:291)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:122)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:425)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1350)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:428)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```  

## CASE 2:
create table abc(a int)
insert into abc values (1)
select histogram_numeric(a,2) from abc where a=3 // NPE

```
Job aborted due to stage failure: Task 0 in stage 4.0 failed 1 times, most recent failure: Lost task 0.0 in stage 4.0 (TID 5, localhost, executor driver): java.lang.NullPointerException
at org.apache.spark.sql.hive.HiveUDAFFunction.serialize(hiveUDFs.scala:477)
at org.apache.spark.sql.hive.HiveUDAFFunction.serialize(hiveUDFs.scala:315)
at org.apache.spark.sql.catalyst.expressions.aggregate.TypedImperativeAggregate.serializeAggregateBufferInPlace(interfaces.scala:570)
at org.apache.spark.sql.execution.aggregate.AggregationIterator.$anonfun$generateResultProjection$6(AggregationIterator.scala:254)
at org.apache.spark.sql.execution.aggregate.ObjectAggregationIterator.outputForEmptyGroupingKeyWithoutInput(ObjectAggregationIterator.scala:97)
at org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec.$anonfun$doExecute$2(ObjectHashAggregateExec.scala:132)
at org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec.$anonfun$doExecute$2$adapted(ObjectHashAggregateExec.scala:107)
at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsWithIndexInternal$2(RDD.scala:839)
at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsWithIndexInternal$2$adapted(RDD.scala:839)
at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:327)
at org.apache.spark.rdd.RDD.iterator(RDD.scala:291)
at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:327)
at org.apache.spark.rdd.RDD.iterator(RDD.scala:291)
at org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:59)
at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:94)
at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:52)
at org.apache.spark.scheduler.Task.run(Task.scala:122)
at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:425)
at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1350)
at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:428)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
at java.lang.Thread.run(Thread.java:745)
```  

Hence add a check not avoid NPE

## How was this patch tested?

Added new UT case