### PR TITLE
[SPARK-18570][ML][R] RFormula support * and ^ operators

### DIFF
--- a/R/pkg/R/mllib_classification.R
+++ b/R/pkg/R/mllib_classification.R
@@ -50,7 +50,7 @@ setClass("NaiveBayesModel", representation(jobj = "jobj"))
 #'
 #' @param data SparkDataFrame for training.
 #' @param formula A symbolic description of the model to be fitted. Currently only a few formula
-#'                operators are supported, including '~', '.', ':', '+', and '-'.
+#'                operators are supported, including '~', '.', ':', '+', '-', '*', and '^'.
 #' @param regParam The regularization parameter. Only supports L2 regularization currently.
 #' @param maxIter Maximum iteration number.
 #' @param tol Convergence tolerance of iterations.

--- a/R/pkg/R/mllib_clustering.R
+++ b/R/pkg/R/mllib_clustering.R
@@ -55,7 +55,7 @@ setClass("PowerIterationClustering", slots = list(jobj = "jobj"))
 #'
 #' @param data a SparkDataFrame for training.
 #' @param formula a symbolic description of the model to be fitted. Currently only a few formula
-#'                operators are supported, including '~', '.', ':', '+', and '-'.
+#'                operators are supported, including '~', '.', ':', '+', '-', '*', and '^'.
 #'                Note that the response variable of formula is empty in spark.bisectingKmeans.
 #' @param k the desired number of leaf clusters. Must be > 1.
 #'          The actual number could be smaller if there are no divisible leaf clusters.

--- a/R/pkg/R/mllib_regression.R
+++ b/R/pkg/R/mllib_regression.R
@@ -44,7 +44,7 @@ setClass("IsotonicRegressionModel", representation(jobj = "jobj"))
 #'
 #' @param data a SparkDataFrame for training.
 #' @param formula a symbolic description of the model to be fitted. Currently only a few formula
-#'                operators are supported, including '~', '.', ':', '+', and '-'.
+#'                operators are supported, including '~', '.', ':', '+', '-', '*', and '^'.
 #' @param family a description of the error distribution and link function to be used in the model.
 #'               This can be a character string naming a family function, a family function or
 #'               the result of a call to a family function. Refer R family at

--- a/R/pkg/R/mllib_tree.R
+++ b/R/pkg/R/mllib_tree.R
@@ -135,7 +135,7 @@ print.summary.decisionTree <- function(x) {
 #'
 #' @param data a SparkDataFrame for training.
 #' @param formula a symbolic description of the model to be fitted. Currently only a few formula
-#'                operators are supported, including '~', ':', '+', and '-'.
+#'                operators are supported, including '~', ':', '+', '-', '*', and '^'.
 #' @param type type of model, one of "regression" or "classification", to fit
 #' @param maxDepth Maximum depth of the tree (>= 0).
 #' @param maxBins Maximum number of bins used for discretizing continuous features and for choosing

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
@@ -35,10 +35,7 @@ import org.apache.spark.sql.types._
 /**
  * Base trait for [[RFormula]] and [[RFormulaModel]].
  */
-private[feature] trait RFormulaBase
-    extends HasFeaturesCol
-    with HasLabelCol
-    with HasHandleInvalid {
+private[feature] trait RFormulaBase extends HasFeaturesCol with HasLabelCol with HasHandleInvalid {
 
   /**
    * R formula parameter. The formula is provided in string form.
@@ -60,9 +57,7 @@ private[feature] trait RFormulaBase
    * @group param
    */
   @Since("2.1.0")
-  val forceIndexLabel: BooleanParam = new BooleanParam(
-    this,
-    "forceIndexLabel",
+  val forceIndexLabel: BooleanParam = new BooleanParam(this, "forceIndexLabel",
     "Force to index label whether it is numeric or string")
   setDefault(forceIndexLabel -> false)
 
@@ -79,12 +74,10 @@ private[feature] trait RFormulaBase
    * @group param
    */
   @Since("2.3.0")
-  override val handleInvalid: Param[String] = new Param[String](
-    this,
-    "handleInvalid",
+  override val handleInvalid: Param[String] = new Param[String](this, "handleInvalid",
     "How to handle invalid data (unseen or NULL values) in features and label column of string " +
-      "type. Options are 'skip' (filter out rows with invalid data), error (throw an error), " +
-      "or 'keep' (put invalid data in a special additional bucket, at index numLabels).",
+    "type. Options are 'skip' (filter out rows with invalid data), error (throw an error), " +
+    "or 'keep' (put invalid data in a special additional bucket, at index numLabels).",
     ParamValidators.inArray(StringIndexer.supportedHandleInvalids))
   setDefault(handleInvalid, StringIndexer.ERROR_INVALID)
 
@@ -112,14 +105,12 @@ private[feature] trait RFormulaBase
    * @group param
    */
   @Since("2.3.0")
-  final val stringIndexerOrderType: Param[String] = new Param(
-    this,
-    "stringIndexerOrderType",
+  final val stringIndexerOrderType: Param[String] = new Param(this, "stringIndexerOrderType",
     "How to order categories of a string FEATURE column used by StringIndexer. " +
-      "The last category after ordering is dropped when encoding strings. " +
-      s"Supported options: ${StringIndexer.supportedStringOrderType.mkString(", ")}. " +
-      "The default value is 'frequencyDesc'. When the ordering is set to 'alphabetDesc', " +
-      "RFormula drops the same category as R when encoding strings.",
+    "The last category after ordering is dropped when encoding strings. " +
+    s"Supported options: ${StringIndexer.supportedStringOrderType.mkString(", ")}. " +
+    "The default value is 'frequencyDesc'. When the ordering is set to 'alphabetDesc', " +
+    "RFormula drops the same category as R when encoding strings.",
     ParamValidators.inArray(StringIndexer.supportedStringOrderType))
   setDefault(stringIndexerOrderType, StringIndexer.frequencyDesc)
 
@@ -168,10 +159,8 @@ private[feature] trait RFormulaBase
  */
 @Experimental
 @Since("1.5.0")
-class RFormula @Since("1.5.0")(@Since("1.5.0") override val uid: String)
-    extends Estimator[RFormulaModel]
-    with RFormulaBase
-    with DefaultParamsWritable {
+class RFormula @Since("1.5.0") (@Since("1.5.0") override val uid: String)
+  extends Estimator[RFormulaModel] with RFormulaBase with DefaultParamsWritable {
 
   @Since("1.5.0")
   def this() = this(Identifiable.randomUID("rFormula"))
@@ -301,7 +290,7 @@ class RFormula @Since("1.5.0")(@Since("1.5.0") override val uid: String)
     encoderStages += new ColumnPruner(tempColumns.toSet)
 
     if ((dataset.schema.fieldNames.contains(resolvedFormula.label) &&
-        dataset.schema(resolvedFormula.label).dataType == StringType) || $(forceIndexLabel)) {
+      dataset.schema(resolvedFormula.label).dataType == StringType) || $(forceIndexLabel)) {
       encoderStages += new StringIndexer()
         .setInputCol(resolvedFormula.label)
         .setOutputCol($(labelCol))
@@ -315,15 +304,13 @@ class RFormula @Since("1.5.0")(@Since("1.5.0") override val uid: String)
   @Since("1.5.0")
   // optimistic schema; does not contain any ML attributes
   override def transformSchema(schema: StructType): StructType = {
-    require(
-      !hasLabelCol(schema) || ! $(forceIndexLabel),
+    require(!hasLabelCol(schema) || !$(forceIndexLabel),
       "If label column already exists, forceIndexLabel can not be set with true.")
     if (hasLabelCol(schema)) {
       StructType(schema.fields :+ StructField($(featuresCol), new VectorUDT, true))
     } else {
-      StructType(
-        schema.fields :+ StructField($(featuresCol), new VectorUDT, true) :+
-          StructField($(labelCol), DoubleType, true))
+      StructType(schema.fields :+ StructField($(featuresCol), new VectorUDT, true) :+
+        StructField($(labelCol), DoubleType, true))
     }
   }
 
@@ -351,13 +338,11 @@ object RFormula extends DefaultParamsReadable[RFormula] {
  */
 @Experimental
 @Since("1.5.0")
-class RFormulaModel private[feature] (
+class RFormulaModel private[feature](
     @Since("1.5.0") override val uid: String,
     private[ml] val resolvedFormula: ResolvedRFormula,
     private[ml] val pipelineModel: PipelineModel)
-    extends Model[RFormulaModel]
-    with RFormulaBase
-    with MLWritable {
+  extends Model[RFormulaModel] with RFormulaBase with MLWritable {
 
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
@@ -415,8 +400,7 @@ class RFormulaModel private[feature] (
     val columnNames = schema.map(_.name)
     require(!columnNames.contains($(featuresCol)), "Features column already exists.")
     require(
-      !columnNames.contains($(labelCol)) || schema($(labelCol)).dataType
-        .isInstanceOf[NumericType],
+      !columnNames.contains($(labelCol)) || schema($(labelCol)).dataType.isInstanceOf[NumericType],
       s"Label column already exists and is not of type ${NumericType.simpleString}.")
   }
 
@@ -441,11 +425,8 @@ object RFormulaModel extends MLReadable[RFormulaModel] {
       DefaultParamsWriter.saveMetadata(instance, path, sc)
       // Save model data: resolvedFormula
       val dataPath = new Path(path, "data").toString
-      sparkSession
-        .createDataFrame(Seq(instance.resolvedFormula))
-        .repartition(1)
-        .write
-        .parquet(dataPath)
+      sparkSession.createDataFrame(Seq(instance.resolvedFormula))
+        .repartition(1).write.parquet(dataPath)
       // Save pipeline model
       val pmPath = new Path(path, "pipelineModel").toString
       instance.pipelineModel.save(pmPath)
@@ -461,8 +442,7 @@ object RFormulaModel extends MLReadable[RFormulaModel] {
       val metadata = DefaultParamsReader.loadMetadata(path, sc, className)
 
       val dataPath = new Path(path, "data").toString
-      val data =
-        sparkSession.read.parquet(dataPath).select("label", "terms", "hasIntercept").head()
+      val data = sparkSession.read.parquet(dataPath).select("label", "terms", "hasIntercept").head()
       val label = data.getString(0)
       val terms = data.getAs[Seq[Seq[String]]](1)
       val hasIntercept = data.getBoolean(2)
@@ -484,8 +464,7 @@ object RFormulaModel extends MLReadable[RFormulaModel] {
  * TODO(ekl) make this a public transformer
  */
 private class ColumnPruner(override val uid: String, val columnsToPrune: Set[String])
-    extends Transformer
-    with MLWritable {
+  extends Transformer with MLWritable {
 
   def this(columnsToPrune: Set[String]) =
     this(Identifiable.randomUID("columnPruner"), columnsToPrune)
@@ -558,8 +537,7 @@ private class VectorAttributeRewriter(
     override val uid: String,
     val vectorCol: String,
     val prefixesToRewrite: Map[String, String])
-    extends Transformer
-    with MLWritable {
+  extends Transformer with MLWritable {
 
   def this(vectorCol: String, prefixesToRewrite: Map[String, String]) =
     this(Identifiable.randomUID("vectorAttrRewriter"), vectorCol, prefixesToRewrite)
@@ -569,9 +547,8 @@ private class VectorAttributeRewriter(
       val group = AttributeGroup.fromStructField(dataset.schema(vectorCol))
       val attrs = group.attributes.get.map { attr =>
         if (attr.name.isDefined) {
-          val name = prefixesToRewrite.foldLeft(attr.name.get) {
-            case (curName, (from, to)) =>
-              curName.replace(from, to)
+          val name = prefixesToRewrite.foldLeft(attr.name.get) { case (curName, (from, to)) =>
+            curName.replace(from, to)
           }
           attr.withName(name)
         } else {
@@ -582,13 +559,13 @@ private class VectorAttributeRewriter(
     }
     val otherCols = dataset.columns.filter(_ != vectorCol).map(dataset.col)
     val rewrittenCol = dataset.col(vectorCol).as(vectorCol, metadata)
-    dataset.select(otherCols :+ rewrittenCol: _*)
+    dataset.select(otherCols :+ rewrittenCol : _*)
   }
 
   override def transformSchema(schema: StructType): StructType = {
     StructType(
       schema.fields.filter(_.name != vectorCol) ++
-        schema.fields.filter(_.name == vectorCol))
+      schema.fields.filter(_.name == vectorCol))
   }
 
   override def copy(extra: ParamMap): VectorAttributeRewriter = defaultCopy(extra)
@@ -603,9 +580,8 @@ private object VectorAttributeRewriter extends MLReadable[VectorAttributeRewrite
   override def load(path: String): VectorAttributeRewriter = super.load(path)
 
   /** [[MLWriter]] instance for [[VectorAttributeRewriter]] */
-  private[VectorAttributeRewriter] class VectorAttributeRewriterWriter(
-      instance: VectorAttributeRewriter)
-      extends MLWriter {
+  private[VectorAttributeRewriter]
+  class VectorAttributeRewriterWriter(instance: VectorAttributeRewriter) extends MLWriter {
 
     private case class Data(vectorCol: String, prefixesToRewrite: Map[String, String])
 
@@ -628,8 +604,7 @@ private object VectorAttributeRewriter extends MLReadable[VectorAttributeRewrite
       val metadata = DefaultParamsReader.loadMetadata(path, sc, className)
 
       val dataPath = new Path(path, "data").toString
-      val data =
-        sparkSession.read.parquet(dataPath).select("vectorCol", "prefixesToRewrite").head()
+      val data = sparkSession.read.parquet(dataPath).select("vectorCol", "prefixesToRewrite").head()
       val vectorCol = data.getString(0)
       val prefixesToRewrite = data.getAs[Map[String, String]](1)
       val rewriter = new VectorAttributeRewriter(metadata.uid, vectorCol, prefixesToRewrite)

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormulaParser.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormulaParser.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.types._
  * Represents a parsed R formula.
  */
 private[ml] case class ParsedRFormula(label: ColumnRef, terms: Seq[Term]) {
+
   /**
    * Resolves formula terms into column names. A schema is necessary for inferring the meaning
    * of the special '.' term. Duplicate terms will be removed during resolution.
@@ -34,11 +35,18 @@ private[ml] case class ParsedRFormula(label: ColumnRef, terms: Seq[Term]) {
   def resolve(schema: StructType): ResolvedRFormula = {
     val dotTerms = expandDot(schema)
     var includedTerms = Seq[Seq[String]]()
+    val seen = mutable.Set[Set[String]]()
     terms.foreach {
       case col: ColumnRef =>
         includedTerms :+= Seq(col.value)
       case ColumnInteraction(cols) =>
-        includedTerms ++= expandInteraction(schema, cols)
+        expandInteraction(schema, cols) foreach { t =>
+          // add equivalent interaction terms only once
+          if (!seen.contains(t.toSet)) {
+            includedTerms :+= t
+            seen += t.toSet
+          }
+        }
       case Dot =>
         includedTerms ++= dotTerms.map(Seq(_))
       case Deletion(term: Term) =>
@@ -57,8 +65,12 @@ private[ml] case class ParsedRFormula(label: ColumnRef, terms: Seq[Term]) {
           case _: Deletion =>
             throw new RuntimeException("Deletion terms cannot be nested")
           case _: Intercept =>
+          case _: Terms =>
+          case EmptyTerm =>
         }
       case _: Intercept =>
+      case _: Terms =>
+      case EmptyTerm =>
     }
     ResolvedRFormula(label.value, includedTerms.distinct, hasIntercept)
   }
@@ -81,7 +93,8 @@ private[ml] case class ParsedRFormula(label: ColumnRef, terms: Seq[Term]) {
 
   // expands the Dot operators in interaction terms
   private def expandInteraction(
-      schema: StructType, terms: Seq[InteractableTerm]): Seq[Seq[String]] = {
+      schema: StructType,
+      terms: Seq[InteractableTerm]): Seq[Seq[String]] = {
     if (terms.isEmpty) {
       return Seq(Nil)
     }
@@ -100,21 +113,26 @@ private[ml] case class ParsedRFormula(label: ColumnRef, terms: Seq[Term]) {
 
     // Deduplicates feature interactions, for example, a:b is the same as b:a.
     val seen = mutable.Set[Set[String]]()
-    validInteractions.flatMap {
-      case t if seen.contains(t.toSet) =>
-        None
-      case t =>
-        seen += t.toSet
-        Some(t)
-    }.sortBy(_.length)
+    validInteractions
+      .flatMap {
+        case t if seen.contains(t.toSet) =>
+          None
+        case t =>
+          seen += t.toSet
+          Some(t)
+      }
+      .sortBy(_.length)
   }
 
   // the dot operator excludes complex column types
   private def expandDot(schema: StructType): Seq[String] = {
-    schema.fields.filter(_.dataType match {
-      case _: NumericType | StringType | BooleanType | _: VectorUDT => true
-      case _ => false
-    }).map(_.name).filter(_ != label.value)
+    schema.fields
+      .filter(_.dataType match {
+        case _: NumericType | StringType | BooleanType | _: VectorUDT => true
+        case _ => false
+      })
+      .map(_.name)
+      .filter(_ != label.value)
   }
 }
 
@@ -126,7 +144,9 @@ private[ml] case class ParsedRFormula(label: ColumnRef, terms: Seq[Term]) {
  * @param hasIntercept whether the formula specifies fitting with an intercept.
  */
 private[ml] case class ResolvedRFormula(
-  label: String, terms: Seq[Seq[String]], hasIntercept: Boolean) {
+    label: String,
+    terms: Seq[Seq[String]],
+    hasIntercept: Boolean) {
 
   override def toString: String = {
     val ts = terms.map {
@@ -144,10 +164,50 @@ private[ml] case class ResolvedRFormula(
  * R formula terms. See the R formula docs here for more information:
  * http://stat.ethz.ch/R-manual/R-patched/library/stats/html/formula.html
  */
-private[ml] sealed trait Term
+private[ml] sealed trait Term {
+
+  /** Default representation of a single Term as a part of summed terms. */
+  def asTerms: Terms = Terms(Seq(this))
+
+  /** Creates a summation term by concatenation of terms. */
+  def add(other: Term): Term = Terms(this.asTerms.terms ++ other.asTerms.terms)
+
+  /**
+   * Fold by adding deletion terms to the left. Double negation
+   * doesn't cancel deletion in order not to add extra terms, e.g.
+   * a - (b - c) = a - Deletion(b) - Deletion(c) = a
+   */
+  def subtract(other: Term): Term = {
+    other.asTerms.terms.foldLeft(this) {
+      case (left, right) =>
+        right match {
+          case t: Deletion => left add t
+          case t: Term => left add Deletion(t)
+        }
+    }
+  }
+
+  /** Default interactions of a Term */
+  def interact(other: Term): Term = EmptyTerm
+}
+
+/** Placeholder term for the result of undefined interactions, e.g. '1:1' or 'a:1' */
+private[ml] case object EmptyTerm extends Term
 
 /** A term that may be part of an interaction, e.g. 'x' in 'x:y' */
-private[ml] sealed trait InteractableTerm extends Term
+private[ml] sealed trait InteractableTerm extends Term {
+
+  /** Convert to ColumnInteraction to wrap all interactions. */
+  def asInteraction: ColumnInteraction = ColumnInteraction(Seq(this))
+
+  /** Interactions of interactable terms. */
+  override def interact(other: Term): Term = other match {
+    case t: InteractableTerm => this.asInteraction interact t.asInteraction
+    case t: ColumnInteraction => this.asInteraction interact t
+    case t: Terms => this.asTerms interact t
+    case t: Term => t interact this // Deletion or non-interactable term
+  }
+}
 
 /* R formula reference to all available columns, e.g. "." in a formula */
 private[ml] case object Dot extends InteractableTerm
@@ -156,19 +216,68 @@ private[ml] case object Dot extends InteractableTerm
 private[ml] case class ColumnRef(value: String) extends InteractableTerm
 
 /* R formula interaction of several columns, e.g. "Sepal_Length:Species" in a formula */
-private[ml] case class ColumnInteraction(terms: Seq[InteractableTerm]) extends Term
+private[ml] case class ColumnInteraction(terms: Seq[InteractableTerm]) extends Term {
+
+  // Convert to ColumnInteraction and concat terms
+  override def interact(other: Term): Term = other match {
+    case t: InteractableTerm => this interact t.asInteraction
+    case t: ColumnInteraction => ColumnInteraction(terms ++ t.terms)
+    case t: Terms => this.asTerms interact t
+    case t: Term => t interact this
+  }
+}
 
 /* R formula intercept toggle, e.g. "+ 0" in a formula */
 private[ml] case class Intercept(enabled: Boolean) extends Term
 
 /* R formula deletion of a variable, e.g. "- Species" in a formula */
-private[ml] case class Deletion(term: Term) extends Term
+private[ml] case class Deletion(term: Term) extends Term {
+
+  // Unnest the deletion and interact
+  override def interact(other: Term): Term = other match {
+    case Deletion(t) => Deletion(term interact t)
+    case t: Term => Deletion(term interact t)
+  }
+}
+
+/* Wrapper for multiple terms in a formula. */
+private[ml] case class Terms(terms: Seq[Term]) extends Term {
+
+  override def asTerms: Terms = this
+
+  override def interact(other: Term): Term = {
+    val interactions = for {
+      left <- terms
+      right <- other.asTerms.terms
+    } yield left interact right
+    Terms(interactions)
+  }
+}
 
 /**
- * Limited implementation of R formula parsing. Currently supports: '~', '+', '-', '.', ':'.
+ * Limited implementation of R formula parsing. Currently supports: '~', '+', '-', '.', ':',
+ * '*', '^'.
  */
 private[ml] object RFormulaParser extends RegexParsers {
-  private val intercept: Parser[Intercept] =
+
+  private def add(left: Term, right: Term) = left add right
+
+  private def subtract(left: Term, right: Term) = left subtract right
+
+  private def interact(left: Term, right: Term) = left interact right
+
+  private def cross(left: Term, right: Term) = left add right add (left interact right)
+
+  private def power(base: Term, degree: Int): Term = {
+    val exprs = List.fill(degree)(base)
+    exprs match {
+      case Nil => EmptyTerm
+      case x :: Nil => x
+      case x :: xs => xs.foldLeft(x)(cross _)
+    }
+  }
+
+  private val intercept: Parser[Term] =
     "([01])".r ^^ { case a => Intercept(a == "1") }
 
   private val columnRef: Parser[ColumnRef] =
@@ -178,26 +287,31 @@ private[ml] object RFormulaParser extends RegexParsers {
 
   private val label: Parser[ColumnRef] = columnRef | empty
 
-  private val dot: Parser[InteractableTerm] = "\\.".r ^^ { case _ => Dot }
+  private val dot: Parser[Term] = "\\.".r ^^ { case _ => Dot }
 
-  private val interaction: Parser[List[InteractableTerm]] = rep1sep(columnRef | dot, ":")
+  private val parens: Parser[Term] = "(" ~> expr <~ ")"
 
-  private val term: Parser[Term] = intercept |
-    interaction ^^ { case terms => ColumnInteraction(terms) } | dot | columnRef
+  private val term: Parser[Term] = parens | intercept | columnRef | dot
 
-  private val terms: Parser[List[Term]] = (term ~ rep("+" ~ term | "-" ~ term)) ^^ {
-    case op ~ list => list.foldLeft(List(op)) {
-      case (left, "+" ~ right) => left ++ Seq(right)
-      case (left, "-" ~ right) => left ++ Seq(Deletion(right))
-    }
-  }
+  private val pow: Parser[Term] = term ~ "^" ~ "^[1-9]\\d*".r ^^ {
+    case base ~ "^" ~ degree => power(base, degree.toInt)
+  } | term
+
+  private val interaction: Parser[Term] = pow * (":" ^^^ { interact _ })
+
+  private val factor = interaction * ("*" ^^^ { cross _ })
+
+  private val sum = factor * ("+" ^^^ { add _ } |
+    "-" ^^^ { subtract _ })
+
+  private val expr = (sum | term)
 
   private val formula: Parser[ParsedRFormula] =
-    (label ~ "~" ~ terms) ^^ { case r ~ "~" ~ t => ParsedRFormula(r, t) }
+    (label ~ "~" ~ expr) ^^ { case r ~ "~" ~ t => ParsedRFormula(r, t.asTerms.terms) }
 
   def parse(value: String): ParsedRFormula = parseAll(formula, value) match {
     case Success(result, _) => result
-    case failure: NoSuccess => throw new IllegalArgumentException(
-      "Could not parse formula: " + value)
+    case failure: NoSuccess =>
+      throw new IllegalArgumentException("Could not parse formula: " + value)
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormulaParser.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormulaParser.scala
@@ -93,8 +93,7 @@ private[ml] case class ParsedRFormula(label: ColumnRef, terms: Seq[Term]) {
 
   // expands the Dot operators in interaction terms
   private def expandInteraction(
-      schema: StructType,
-      terms: Seq[InteractableTerm]): Seq[Seq[String]] = {
+      schema: StructType, terms: Seq[InteractableTerm]): Seq[Seq[String]] = {
     if (terms.isEmpty) {
       return Seq(Nil)
     }
@@ -113,26 +112,21 @@ private[ml] case class ParsedRFormula(label: ColumnRef, terms: Seq[Term]) {
 
     // Deduplicates feature interactions, for example, a:b is the same as b:a.
     val seen = mutable.Set[Set[String]]()
-    validInteractions
-      .flatMap {
-        case t if seen.contains(t.toSet) =>
-          None
-        case t =>
-          seen += t.toSet
-          Some(t)
-      }
-      .sortBy(_.length)
+    validInteractions.flatMap {
+      case t if seen.contains(t.toSet) =>
+        None
+      case t =>
+        seen += t.toSet
+        Some(t)
+    }.sortBy(_.length)
   }
 
   // the dot operator excludes complex column types
   private def expandDot(schema: StructType): Seq[String] = {
-    schema.fields
-      .filter(_.dataType match {
-        case _: NumericType | StringType | BooleanType | _: VectorUDT => true
-        case _ => false
-      })
-      .map(_.name)
-      .filter(_ != label.value)
+    schema.fields.filter(_.dataType match {
+      case _: NumericType | StringType | BooleanType | _: VectorUDT => true
+      case _ => false
+    }).map(_.name).filter(_ != label.value)
   }
 }
 
@@ -144,9 +138,7 @@ private[ml] case class ParsedRFormula(label: ColumnRef, terms: Seq[Term]) {
  * @param hasIntercept whether the formula specifies fitting with an intercept.
  */
 private[ml] case class ResolvedRFormula(
-    label: String,
-    terms: Seq[Seq[String]],
-    hasIntercept: Boolean) {
+  label: String, terms: Seq[Seq[String]], hasIntercept: Boolean) {
 
   override def toString: String = {
     val ts = terms.map {
@@ -311,7 +303,7 @@ private[ml] object RFormulaParser extends RegexParsers {
 
   def parse(value: String): ParsedRFormula = parseAll(formula, value) match {
     case Success(result, _) => result
-    case failure: NoSuccess =>
-      throw new IllegalArgumentException("Could not parse formula: " + value)
+    case failure: NoSuccess => throw new IllegalArgumentException(
+      "Could not parse formula: " + value)
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormulaParser.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormulaParser.scala
@@ -27,7 +27,6 @@ import org.apache.spark.sql.types._
  * Represents a parsed R formula.
  */
 private[ml] case class ParsedRFormula(label: ColumnRef, terms: Seq[Term]) {
-
   /**
    * Resolves formula terms into column names. A schema is necessary for inferring the meaning
    * of the special '.' term. Duplicate terms will be removed during resolution.

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaParserSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaParserSuite.scala
@@ -90,10 +90,46 @@ class RFormulaParserSuite extends SparkFunSuite {
 
   test("parse interactions") {
     checkParse("y ~ a:b", "y", Seq("a:b"))
+    checkParse("y ~ a:b + b:a", "y", Seq("a:b"))
     checkParse("y ~ ._a:._x", "y", Seq("._a:._x"))
     checkParse("y ~ foo:bar", "y", Seq("foo:bar"))
     checkParse("y ~ a : b : c", "y", Seq("a:b:c"))
     checkParse("y ~ q + a:b:c + b:c + c:d + z", "y", Seq("q", "a:b:c", "b:c", "c:d", "z"))
+  }
+
+  test("parse factor cross") {
+    checkParse("y ~ a*b", "y", Seq("a", "b", "a:b"))
+    checkParse("y ~ a*b + b*a", "y", Seq("a", "b", "a:b"))
+    checkParse("y ~ ._a*._x", "y", Seq("._a", "._x", "._a:._x"))
+    checkParse("y ~ foo*bar", "y", Seq("foo", "bar", "foo:bar"))
+    checkParse("y ~ a * b * c", "y", Seq("a", "b", "a:b", "c", "a:c", "b:c", "a:b:c"))
+  }
+
+  test("interaction distributive") {
+    checkParse("y ~ (a + b):c", "y", Seq("a:c", "b:c"))
+    checkParse("y ~ c:(a + b)", "y", Seq("c:a", "c:b"))
+  }
+
+  test("factor cross distributive") {
+    checkParse("y ~ (a + b)*c", "y", Seq("a", "b", "c", "a:c", "b:c"))
+    checkParse("y ~ c*(a + b)", "y", Seq("c", "a", "b", "c:a", "c:b"))
+  }
+
+  test("parse power") {
+    val schema = (new StructType)
+      .add("a", "int", true)
+      .add("b", "long", false)
+      .add("c", "string", true)
+      .add("d", "string", true)
+    checkParse("a ~ (a + b)^2", "a", Seq("a", "b", "a:b"))
+    checkParse("a ~ .^2", "a", Seq("b", "c", "d", "b:c", "b:d", "c:d"), schema)
+    checkParse("a ~ .^3", "a", Seq("b", "c", "d", "b:c", "b:d", "c:d", "b:c:d"), schema)
+    checkParse("a ~ .^3-.", "a", Seq("b:c", "b:d", "c:d", "b:c:d"), schema)
+  }
+
+  test("operator precedence") {
+    checkParse("y ~ a*b:c", "y", Seq("a", "b:c", "a:b:c"))
+    checkParse("y ~ (a*b):c", "y", Seq("a:c", "b:c", "a:b:c"))
   }
 
   test("parse basic interactions with dot") {

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -3423,7 +3423,8 @@ class RFormula(JavaEstimator, HasFeaturesCol, HasLabelCol, HasHandleInvalid,
 
     Implements the transforms required for fitting a dataset against an
     R model formula. Currently we support a limited subset of the R
-    operators, including '~', '.', ':', '+', and '-'. Also see the `R formula docs
+    operators, including '~', '.', ':', '+', '-', '*', and '^'.
+    Also see the `R formula docs
     <http://stat.ethz.ch/R-manual/R-patched/library/stats/html/formula.html>`_.
 
     >>> df = spark.createDataFrame([


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added support for `*` and `^` operators, along with expressions within parentheses. New operators just expand to already supported terms, such as;

 - y ~ a * b = y ~ a + b + a : b
 - y ~ (a+b+c)^3 = y ~ a + b + c + a : b + a : c + a :b : c 

## How was this patch tested?

Added new unit tests to RFormulaParserSuite

@mengxr @yanboliang 