### PR TITLE
[SPARK-27915][SQL][WIP] Update logical Filter's output nullability based on IsNotNull conditions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -130,14 +130,13 @@ case class Generate(
 case class Filter(condition: Expression, child: LogicalPlan)
   extends OrderPreservingUnaryNode with PredicateHelper {
 
-  private val impliedNotNullExprIds: Set[ExprId] = {
-    splitConjunctivePredicates(condition)
-      .collect { case isNotNull: IsNotNull => isNotNull }
-      .map(getImpliedNotNullExprIds)
-      .foldLeft(Set.empty[ExprId])(_ ++ _)
-  }
-
   override def output: Seq[Attribute] = {
+    val impliedNotNullExprIds: Set[ExprId] = {
+      splitConjunctivePredicates(condition)
+        .collect { case isNotNull: IsNotNull => isNotNull }
+        .map(getImpliedNotNullExprIds)
+        .foldLeft(Set.empty[ExprId])(_ ++ _)
+    }
     child.output.map { a =>
       if (a.nullable && impliedNotNullExprIds.contains(a.exprId)) {
         a.withNullability(false)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -129,7 +129,10 @@ case class Generate(
 
 case class Filter(condition: Expression, child: LogicalPlan)
   extends OrderPreservingUnaryNode with PredicateHelper {
-  override def output: Seq[Attribute] = child.output
+
+  override def output: Seq[Attribute] = {
+    updateAttributeNullabilityFromNonNullConstraints(child.output, condition)
+  }
 
   override def maxRows: Option[Long] = child.maxRows
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -134,7 +134,7 @@ case class Filter(condition: Expression, child: LogicalPlan)
     splitConjunctivePredicates(condition)
       .collect { case isNotNull: IsNotNull => isNotNull }
       .map(getImpliedNotNullExprIds)
-      .reduce(_ ++ _)
+      .foldLeft(Set.empty[ExprId])(_ ++ _)
   }
 
   override def output: Seq[Attribute] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -98,7 +98,7 @@ case class FilterExec(condition: Expression, child: SparkPlan)
       .map { case n: IsNotNull => getImpliedNotNullExprIds(n) }
       .foldLeft(Set.empty[ExprId])(_ ++ _)
   }
-    
+
   // Mark this as empty. We'll evaluate the input during doConsume(). We don't want to evaluate
   // all the variables at the beginning to take advantage of short circuiting.
   override def usedInputs: AttributeSet = AttributeSet.empty

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -87,33 +87,12 @@ case class ProjectExec(projectList: Seq[NamedExpression], child: SparkPlan)
 case class FilterExec(condition: Expression, child: SparkPlan)
   extends UnaryExecNode with CodegenSupport with PredicateHelper {
 
-  // Split out all the IsNotNulls from condition.
-  private val (notNullPreds, otherPreds) = splitConjunctivePredicates(condition).partition {
-    case IsNotNull(a) => isNullIntolerant(a) && a.references.subsetOf(child.outputSet)
-    case _ => false
-  }
-
-  // If one expression and its children are null intolerant, it is null intolerant.
-  private def isNullIntolerant(expr: Expression): Boolean = expr match {
-    case e: NullIntolerant => e.children.forall(isNullIntolerant)
-    case _ => false
-  }
-
-  // The columns that will filtered out by `IsNotNull` could be considered as not nullable.
-  private val notNullAttributes = notNullPreds.flatMap(_.references).distinct.map(_.exprId)
-
   // Mark this as empty. We'll evaluate the input during doConsume(). We don't want to evaluate
   // all the variables at the beginning to take advantage of short circuiting.
   override def usedInputs: AttributeSet = AttributeSet.empty
 
   override def output: Seq[Attribute] = {
-    child.output.map { a =>
-      if (a.nullable && notNullAttributes.contains(a.exprId)) {
-        a.withNullability(false)
-      } else {
-        a
-      }
-    }
+    updateAttributeNullabilityFromNonNullConstraints(child.output, condition)
   }
 
   override lazy val metrics = Map(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -151,7 +151,7 @@ case class FilterExec(condition: Expression, child: SparkPlan)
 
     // To generate the predicates we will follow this algorithm.
     // For each predicate that is not IsNotNull, we will generate them one by one loading attributes
-    // as necessary. For each attribute, if there is an IsNotNull predicate we will
+    // as necessary. For each of both attributes, if there is an IsNotNull predicate we will
     // generate that check *before* the predicate. After all of these predicates, we will generate
     // the remaining IsNotNull checks that were not part of other predicates.
     // This has the property of not doing redundant IsNotNull checks and taking better advantage of

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -97,8 +97,11 @@ case class FilterExec(condition: Expression, child: SparkPlan)
     case _ => false
   }
 
-  private val impliedNotNullExprIds: Set[ExprId] =
-    notNullPreds.map { case n: IsNotNull => getImpliedNotNullExprIds(n) }.reduce(_ ++ _)
+  private val impliedNotNullExprIds: Set[ExprId] = {
+    notNullPreds
+      .map { case n: IsNotNull => getImpliedNotNullExprIds(n) }
+      .foldLeft(Set.empty[ExprId])(_ ++ _)
+  }
 
   override def output: Seq[Attribute] = {
     child.output.map { a =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR changes the logical `Filter` operator to update its outputs' nullability when filter conditions imply that outputs cannot be null. 

In addition, I refined similar existing logic in the physical `FilterExec` (changing the existing code to be more precise / less conservative in its non-nullability inference) and improved propagation of inferred nullability information in `Project`.

This is useful because of how it composes with other optimizations: Spark has several logical and physical optimizations which leverage non-nullability, so improving nullability inference increases the value of those existing optimizations.

:warning: **Disclaimers** :warning:

 - This is a work-in-progress / skunkworks side project; I'm not working on this full time.
 - Nullability has been a major source of bugs in the past: this PR requires careful review.
 - I haven't run analyzer / optimizer performance benchmarks, so there's a decent chance that this WIP changeset regresses query planning performance.
 - DataFrames / Datasets / queries' `.schema` may change as a result of this optimization: this may have consequences in case nullability information is used by downstream systems (e.g. for `CREATE TABLE` DDL).
 - The schemas of analyzed and optimized logical plans may now differ in terms of field nullability (because optimization might infer additional constraints which allow us to prove that fields are non-null).
 
### Examples

Consider the query

```
SELECT key
FROM t
WHERE key IS NOT NULL
```

where `t.key` is nullable.

Because of the `key IS NOT NULL` filter condition, `key` will always be non-null. Prior to this patch, this query's result schema was overly-conservative, continuing to mark  `key` as nullable. However, if we take advantage of the `key IS NOT NULL` condition we can set `nullable = false` for `key`.

This was a somewhat trivial example, so let's look at some more complicated cases:

Consider 

```
SELECT A.key, A.value
FROM A, B
WHERE
    A.key = B.key AND
    (A.num + B.num) > 0
```

where all columns of `A` and `B` are nullable. Because of the equality join condition, we know that `key` must be non-null in both tables. In addition, the condition `(A.num + B.num) > 0` can only hold if both `num` values are not null: addition is a _null-intolerant_ operator, meaning that it returns `null` if any of its operands is null.

Leveraging this, we should be able to mark both `key` and `value` as non-null in the join result's schema (even though both values are nullable in the underlying input relation).

Finally, let's look at an example of a **non** null-intolerant operator: `coalesce(a, b) IS NOT NULL` could still mean that `a` or `b` is null, so in

```
SELECT key, foo, COALESCE(foo, bar) as qux
FROM A
WHERE COALESCE(foo, bar) > 0
```

we can infer that `qux` is not null but cannot make any claims about `foo` or `bar`'s nullability.


### Description of changes

- Introduce `PredicateHelper.getImpliedNotNullExprIds(IsNotNull)` helper, which takes an `IsNotNull` expression and returns the `ExprId`s of expressions which cannot be null. This handles simple cases like `IsNotNull(columnFromTable)`, as well as more complex cases involving expression trees (properly accounting for null-(in)tolerance).
  - There was similar existing logic in `FilterExec`, but I think it was overly conservative: given `IsNotNull(x)`, it would claim that `x` _and all of its descendants_ were not null if and only if every ancestor of `x` was `NullIntolerant`. However, even if `x` is null-tolerant we can still make claims about `x`'s non-nullability even if we can't make further claims about its children.
- Update `logical.Filter` to leverage this new function to update output nullability.
- Modify `FilterExec` to re-use this logic. This part is a bit tricky because the `FilterExec` code looks at `IsNotNull` expressions both for optimizing the order of expression evaluation _and_ for refining nullability to elide null checks in downstream operators.
- Modify `logical.Project` so that inferred non-nullability information from child operators is preserved.
 
### Background on related historical changes / bugs

While developing this patch, I found the following historical PRs to be useful references (note: many of these original PRs contained correctness bugs which were subsequently fixed in later PRs):

- #10844 first introduced constraint inference and propagation in Spark SQL (including basic extraction of `IsNotNull` conditions from expressions).
- #11585 modified `FilterExec` to update output nullability based on `IsNotNull` conditions.
- #11792 modified `FilterExec` to add special handling for `IsNotNull` expression codegen, altering evaluation order to allow for better short-circuiting.
- #11809 introduced the `NullIntolerant` trait to generalize the `IsNotNull` extraction logic.
- #11810 updates `FilterExec`'s `IsNotNull`-handling path to use `NullIntolerant`
- #15523 fixed a bug in `FilterExec`'s logic: it did not properly account for null-tolerant operators which were ancestors of `IsNotNull` expressions.
- #16067 fixed a bug related to negation and `IsNotNull`.



## How was this patch tested?

Added new tests for the added `PredicateHelper.getImpliedNotNullExprIds`.

**TODO**: add new end-to-end tests reflecting the examples listed above (in order to properly test the integration of this new logic into `logical.Filter` and `logical.Project`).