### PR TITLE
[SPARK-27873][SQL][BRANCH-2.4] columnNameOfCorruptRecord should not be checked with column names in CSV header when disabling enforceSchema

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
@@ -210,7 +210,11 @@ object TextInputCSVDataSource extends CSVDataSource {
       // Note: if there are only comments in the first block, the header would probably
       // be not extracted.
       CSVUtils.extractHeader(lines, parser.options).foreach { header =>
-        val schema = if (columnPruning) requiredSchema else dataSchema
+        val actualRequiredSchema =
+          StructType(requiredSchema.filterNot(_.name == parser.options.columnNameOfCorruptRecord))
+        val actualDataSchema =
+          StructType(dataSchema.filterNot(_.name == parser.options.columnNameOfCorruptRecord))
+        val schema = if (columnPruning) actualRequiredSchema else actualDataSchema
         val columnNames = parser.tokenizer.parseLine(header)
         CSVDataSource.checkHeaderColumnNames(
           schema,
@@ -297,7 +301,11 @@ object MultiLineCSVDataSource extends CSVDataSource {
       caseSensitive: Boolean,
       columnPruning: Boolean): Iterator[InternalRow] = {
     def checkHeader(header: Array[String]): Unit = {
-      val schema = if (columnPruning) requiredSchema else dataSchema
+      val actualRequiredSchema =
+        StructType(requiredSchema.filterNot(_.name == parser.options.columnNameOfCorruptRecord))
+      val actualDataSchema =
+        StructType(dataSchema.filterNot(_.name == parser.options.columnNameOfCorruptRecord))
+      val schema = if (columnPruning) actualRequiredSchema else actualDataSchema
       CSVDataSource.checkHeaderColumnNames(
         schema,
         header,


### PR DESCRIPTION
## What changes were proposed in this pull request?

If we want to keep corrupt record when reading CSV, we provide a new column into the schema, that is `columnNameOfCorruptRecord`. But this new column isn't actually a column in CSV header. So if `enforceSchema` is disabled, `CSVHeaderChecker` throws a exception complaining that number of column in CSV header isn't equal to that in the schema.

This backports the fix into branch-2.4.

## How was this patch tested?

Added test.