### PR TITLE
[SPARK-27899][SQL] Make HiveMetastoreClient.getTableObjectsByName available in ExternalCatalog/SessionCatalog API

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -128,7 +128,7 @@ trait ExternalCatalog {
 
   def getTable(db: String, table: String): CatalogTable
 
-  def getTablesByNames(db: String, tables: Seq[String]): Seq[CatalogTable]
+  def getTablesByName(db: String, tables: Seq[String]): Seq[CatalogTable]
 
   def tableExists(db: String, table: String): Boolean
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -130,8 +130,6 @@ trait ExternalCatalog {
 
   def getTablesByNames(db: String, tables: Seq[String]): Seq[CatalogTable]
 
-  def getAllTables(db: String): Seq[CatalogTable]
-
   def tableExists(db: String, table: String): Boolean
 
   def listTables(db: String): Seq[String]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -128,6 +128,10 @@ trait ExternalCatalog {
 
   def getTable(db: String, table: String): CatalogTable
 
+  def getTablesByNames(db: String, tables: Seq[String]): Seq[CatalogTable]
+
+  def getAllTables(db: String): Seq[CatalogTable]
+
   def tableExists(db: String, table: String): Boolean
 
   def listTables(db: String): Seq[String]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
@@ -138,8 +138,8 @@ class ExternalCatalogWithListener(delegate: ExternalCatalog)
     delegate.getTable(db, table)
   }
 
-  override def getTablesByNames(db: String, tables: Seq[String]): Seq[CatalogTable] = {
-    delegate.getTablesByNames(db, tables)
+  override def getTablesByName(db: String, tables: Seq[String]): Seq[CatalogTable] = {
+    delegate.getTablesByName(db, tables)
   }
 
   override def tableExists(db: String, table: String): Boolean = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
@@ -142,10 +142,6 @@ class ExternalCatalogWithListener(delegate: ExternalCatalog)
     delegate.getTablesByNames(db, tables)
   }
 
-  override def getAllTables(db: String): Seq[CatalogTable] = {
-    delegate.getAllTables(db)
-  }
-
   override def tableExists(db: String, table: String): Boolean = {
     delegate.tableExists(db, table)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
@@ -138,6 +138,14 @@ class ExternalCatalogWithListener(delegate: ExternalCatalog)
     delegate.getTable(db, table)
   }
 
+  override def getTablesByNames(db: String, tables: Seq[String]): Seq[CatalogTable] = {
+    delegate.getTablesByNames(db, tables)
+  }
+
+  override def getAllTables(db: String): Seq[CatalogTable] = {
+    delegate.getAllTables(db)
+  }
+
   override def tableExists(db: String, table: String): Boolean = {
     delegate.tableExists(db, table)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -332,11 +332,6 @@ class InMemoryCatalog(
     tables.map(catalog(db).tables(_).table)
   }
 
-  override def getAllTables(db: String): Seq[CatalogTable] = {
-    requireDbExists(db)
-    catalog(db).tables.valuesIterator.map(_.table).toSeq
-  }
-
   override def tableExists(db: String, table: String): Boolean = synchronized {
     requireDbExists(db)
     catalog(db).tables.contains(table)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -329,7 +329,7 @@ class InMemoryCatalog(
 
   override def getTablesByName(db: String, tables: Seq[String]): Seq[CatalogTable] = {
     requireDbExists(db)
-    tables.map(catalog(db).tables(_).table)
+    tables.flatMap(catalog(db).tables.get).map(_.table)
   }
 
   override def tableExists(db: String, table: String): Boolean = synchronized {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -327,6 +327,14 @@ class InMemoryCatalog(
     catalog(db).tables(table).table
   }
 
+  override def getTablesByNames(db: String, tables: Seq[String]): Seq[CatalogTable] = {
+    tables.map(catalog(db).tables(_).table)
+  }
+
+  override def getAllTables(db: String): Seq[CatalogTable] = {
+    catalog(db).tables.valuesIterator.map(_.table).toSeq
+  }
+
   override def tableExists(db: String, table: String): Boolean = synchronized {
     requireDbExists(db)
     catalog(db).tables.contains(table)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -327,7 +327,7 @@ class InMemoryCatalog(
     catalog(db).tables(table).table
   }
 
-  override def getTablesByNames(db: String, tables: Seq[String]): Seq[CatalogTable] = {
+  override def getTablesByName(db: String, tables: Seq[String]): Seq[CatalogTable] = {
     requireDbExists(db)
     tables.map(catalog(db).tables(_).table)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -328,10 +328,12 @@ class InMemoryCatalog(
   }
 
   override def getTablesByNames(db: String, tables: Seq[String]): Seq[CatalogTable] = {
+    requireDbExists(db)
     tables.map(catalog(db).tables(_).table)
   }
 
   override def getAllTables(db: String): Seq[CatalogTable] = {
+    requireDbExists(db)
     catalog(db).tables.valuesIterator.map(_.table).toSeq
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -440,10 +440,18 @@ class SessionCatalog(
    */
   @throws[NoSuchDatabaseException]
   def getTablesByNames(names: Seq[TableIdentifier]): Seq[CatalogTable] = {
-    val db = formatDatabaseName(names(0).database.getOrElse(getCurrentDatabase))
-    val tables = names.map(name => formatTableName(name.table))
+    val db = if (names.nonEmpty) {
+      formatDatabaseName(names.head.database.getOrElse(getCurrentDatabase))
+    } else {
+      getCurrentDatabase
+    }
     requireDbExists(db)
-    externalCatalog.getTablesByNames(db, tables)
+    if (names.nonEmpty) {
+      val tables = names.map(name => formatTableName(name.table))
+      externalCatalog.getTablesByNames(db, tables)
+    } else {
+      getAllTables(db)
+    }
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -439,12 +439,12 @@ class SessionCatalog(
    * assume the table/view is in the current database.
    */
   @throws[NoSuchDatabaseException]
-  def getTablesByNames(names: Seq[TableIdentifier]): Seq[CatalogTable] = {
+  def getTablesByName(names: Seq[TableIdentifier]): Seq[CatalogTable] = {
     if (names.nonEmpty) {
       val db = formatDatabaseName(names.head.database.getOrElse(getCurrentDatabase))
       requireDbExists(db)
       val tables = names.map(name => formatTableName(name.table))
-      externalCatalog.getTablesByNames(db, tables)
+      externalCatalog.getTablesByName(db, tables)
     } else {
       Seq.empty
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -446,8 +446,11 @@ class SessionCatalog(
     if (names.nonEmpty) {
       val dbs = names.map(_.database.getOrElse(getCurrentDatabase))
       if (dbs.distinct.size != 1) {
+        val tables = names.map(name => formatTableName(name.table))
+        dbs.zip(tables).map { case (d, t) => QualifiedTableName(d, t)}
         throw new AnalysisException(
-          s"Only the tables/views belong to one same database can be retrieved."
+          s"Only the tables/views belong to one same database can be retrieved. Querying " +
+          s"tables/views are ${dbs.zip(tables).map { case (d, t) => QualifiedTableName(d, t)}}"
         )
       }
       val db = formatDatabaseName(dbs.head)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -446,18 +446,8 @@ class SessionCatalog(
       val tables = names.map(name => formatTableName(name.table))
       externalCatalog.getTablesByNames(db, tables)
     } else {
-      val db = getCurrentDatabase
-      requireDbExists(db)
-      getAllTables(db)
+      Seq.empty
     }
-  }
-
-  /**
-   * Retrieve the metadata of an existing permanent table/view. If no database is specified,
-   * assume the table/view is in the current database.
-   */
-  def getAllTables(dbName: String = getCurrentDatabase): Seq[CatalogTable] = {
-    externalCatalog.getAllTables(dbName)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -437,7 +437,7 @@ class SessionCatalog(
   /**
    * Retrieve all metadata of existing permanent tables/views. If no database is specified,
    * assume the table/view is in the current database.
-   * Only the tables/views belong to one same database that can be retrieved are returned.
+   * Only the tables/views belong to the same database that can be retrieved are returned.
    * For example, if none of the requested tables could be retrieved, an empty list is returned.
    * There is no guarantee of ordering of the returned tables.
    */
@@ -447,10 +447,10 @@ class SessionCatalog(
       val dbs = names.map(_.database.getOrElse(getCurrentDatabase))
       if (dbs.distinct.size != 1) {
         val tables = names.map(name => formatTableName(name.table))
-        dbs.zip(tables).map { case (d, t) => QualifiedTableName(d, t)}
+        val qualifiedTableNames = dbs.zip(tables).map { case (d, t) => QualifiedTableName(d, t)}
         throw new AnalysisException(
-          s"Only the tables/views belong to one same database can be retrieved. Querying " +
-          s"tables/views are ${dbs.zip(tables).map { case (d, t) => QualifiedTableName(d, t)}}"
+          s"Only the tables/views belong to the same database can be retrieved. Querying " +
+          s"tables/views are $qualifiedTableNames"
         )
       }
       val db = formatDatabaseName(dbs.head)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -442,6 +442,7 @@ class SessionCatalog(
   def getTablesByNames(names: Seq[TableIdentifier]): Seq[CatalogTable] = {
     val db = formatDatabaseName(names(0).database.getOrElse(getCurrentDatabase))
     val tables = names.map(name => formatTableName(name.table))
+    requireDbExists(db)
     externalCatalog.getTablesByNames(db, tables)
   }
 
@@ -790,34 +791,6 @@ class SessionCatalog(
       StringUtils.filterPattern(tempViews.keys.toSeq, pattern).map { name =>
         TableIdentifier(name)
       }
-    }
-    dbTables ++ localTempViews
-  }
-
-  /**
-   * List all tables in the specified database, including local temporary views.
-   *
-   * Note that, if the specified database is global temporary view database, we will list global
-   * temporary views.
-   */
-  def listTableNames(db: String): Seq[String] = listTableNames(db, "*")
-
-  /**
-   * List all matching table names in the specified database, including local temporary views.
-   *
-   * Note that, if the specified database is global temporary view database, we will list global
-   * temporary views.
-   */
-  def listTableNames(db: String, pattern: String): Seq[String] = {
-    val dbName = formatDatabaseName(db)
-    val dbTables = if (dbName == globalTempViewManager.database) {
-      globalTempViewManager.listViewNames(pattern)
-    } else {
-      requireDbExists(dbName)
-      externalCatalog.listTables(dbName, pattern)
-    }
-    val localTempViews = synchronized {
-      StringUtils.filterPattern(tempViews.keys.toSeq, pattern)
     }
     dbTables ++ localTempViews
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -440,16 +440,14 @@ class SessionCatalog(
    */
   @throws[NoSuchDatabaseException]
   def getTablesByNames(names: Seq[TableIdentifier]): Seq[CatalogTable] = {
-    val db = if (names.nonEmpty) {
-      formatDatabaseName(names.head.database.getOrElse(getCurrentDatabase))
-    } else {
-      getCurrentDatabase
-    }
-    requireDbExists(db)
     if (names.nonEmpty) {
+      val db = formatDatabaseName(names.head.database.getOrElse(getCurrentDatabase))
+      requireDbExists(db)
       val tables = names.map(name => formatTableName(name.table))
       externalCatalog.getTablesByNames(db, tables)
     } else {
+      val db = getCurrentDatabase
+      requireDbExists(db)
       getAllTables(db)
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
@@ -277,6 +277,20 @@ abstract class ExternalCatalogSuite extends SparkFunSuite with BeforeAndAfterEac
     }
   }
 
+  test("get tables by name") {
+    assert(newBasicCatalog().getTablesByName("db2", Seq("tbl1", "tbl2"))
+      .map(_.identifier.table) == Seq("tbl1", "tbl2"))
+  }
+
+  test("get tables by name when some tables do not exists") {
+    assert(newBasicCatalog().getTablesByName("db2", Seq("tbl1", "tblnotexist"))
+      .map(_.identifier.table) == Seq("tbl1"))
+  }
+
+  test("get tables by name when empty table list") {
+    assert(newBasicCatalog().getTablesByName("db2", Seq.empty).isEmpty)
+  }
+
   test("list tables without pattern") {
     val catalog = newBasicCatalog()
     intercept[AnalysisException] { catalog.listTables("unknown_db") }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
@@ -287,6 +287,14 @@ abstract class ExternalCatalogSuite extends SparkFunSuite with BeforeAndAfterEac
       .map(_.identifier.table) == Seq("tbl1"))
   }
 
+  test("get tables by name when contains invalid name") {
+    // scalastyle:off
+    val name = "砖"
+    // scalastyle:on
+    assert(newBasicCatalog().getTablesByName("db2", Seq("tbl1", name))
+      .map(_.identifier.table) == Seq("tbl1"))
+  }
+
   test("get tables by name when empty table list") {
     assert(newBasicCatalog().getTablesByName("db2", Seq.empty).isEmpty)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -547,6 +547,28 @@ abstract class SessionCatalogSuite extends AnalysisTest {
     }
   }
 
+  test("get tables by name when contains invalid name") {
+    // scalastyle:off
+    val name = "砖"
+    // scalastyle:on
+    withBasicCatalog { catalog =>
+      assert(catalog.getTablesByName(
+        Seq(
+          TableIdentifier("tbl1", Some("db2")),
+          TableIdentifier(name, Some("db2"))
+        )
+      ) == catalog.externalCatalog.getTablesByName("db2", Seq("tbl1")))
+      // Get table without explicitly specifying database
+      catalog.setCurrentDatabase("db2")
+      assert(catalog.getTablesByName(
+        Seq(
+          TableIdentifier("tbl1"),
+          TableIdentifier(name)
+        )
+      ) == catalog.externalCatalog.getTablesByName("db2", Seq("tbl1")))
+    }
+  }
+
   test("get tables by name when empty") {
     withBasicCatalog { catalog =>
       assert(catalog.getTablesByName(Seq.empty)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -509,6 +509,74 @@ abstract class SessionCatalogSuite extends AnalysisTest {
     }
   }
 
+  test("get tables by name") {
+    withBasicCatalog { catalog =>
+      assert(catalog.getTablesByName(
+        Seq(
+          TableIdentifier("tbl1", Some("db2")),
+          TableIdentifier("tbl2", Some("db2"))
+        )
+      ) == catalog.externalCatalog.getTablesByName("db2", Seq("tbl1", "tbl2")))
+      // Get table without explicitly specifying database
+      catalog.setCurrentDatabase("db2")
+      assert(catalog.getTablesByName(
+        Seq(
+          TableIdentifier("tbl1"),
+          TableIdentifier("tbl2")
+        )
+      ) == catalog.externalCatalog.getTablesByName("db2", Seq("tbl1", "tbl2")))
+    }
+  }
+
+  test("get tables by name when some tables do not exist") {
+    withBasicCatalog { catalog =>
+      assert(catalog.getTablesByName(
+        Seq(
+          TableIdentifier("tbl1", Some("db2")),
+          TableIdentifier("tblnotexit", Some("db2"))
+        )
+      ) == catalog.externalCatalog.getTablesByName("db2", Seq("tbl1")))
+      // Get table without explicitly specifying database
+      catalog.setCurrentDatabase("db2")
+      assert(catalog.getTablesByName(
+        Seq(
+          TableIdentifier("tbl1"),
+          TableIdentifier("tblnotexit")
+        )
+      ) == catalog.externalCatalog.getTablesByName("db2", Seq("tbl1")))
+    }
+  }
+
+  test("get tables by name when empty") {
+    withBasicCatalog { catalog =>
+      assert(catalog.getTablesByName(Seq.empty)
+        == catalog.externalCatalog.getTablesByName("db2", Seq.empty))
+      // Get table without explicitly specifying database
+      catalog.setCurrentDatabase("db2")
+      assert(catalog.getTablesByName(Seq.empty)
+        == catalog.externalCatalog.getTablesByName("db2", Seq.empty))
+    }
+  }
+
+  test("get tables by name when tables belong to different databases") {
+    withBasicCatalog { catalog =>
+      intercept[AnalysisException](catalog.getTablesByName(
+        Seq(
+          TableIdentifier("tbl1", Some("db1")),
+          TableIdentifier("tbl2", Some("db2"))
+        )
+      ))
+      // Get table without explicitly specifying database
+      catalog.setCurrentDatabase("db2")
+      intercept[AnalysisException](catalog.getTablesByName(
+        Seq(
+          TableIdentifier("tbl1", Some("db1")),
+          TableIdentifier("tbl2")
+        )
+      ))
+    }
+  }
+
   test("lookup table relation") {
     withBasicCatalog { catalog =>
       val tempTable1 = Range(1, 10, 1, 10)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkGetTablesOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkGetTablesOperation.scala
@@ -74,7 +74,7 @@ private[hive] class SparkGetTablesOperation(
 
     val tablePattern = convertIdentifierPattern(tableName, true)
     matchingDbs.foreach { dbName =>
-      catalog.getTablesByNames(catalog.listTables(dbName, tablePattern)).foreach { catalogTable =>
+      catalog.getTablesByName(catalog.listTables(dbName, tablePattern)).foreach { catalogTable =>
         val tableType = tableTypeString(catalogTable.tableType)
         if (tableTypes == null || tableTypes.isEmpty || tableTypes.contains(tableType)) {
           val rowData = Array[AnyRef](

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkGetTablesOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkGetTablesOperation.scala
@@ -74,8 +74,7 @@ private[hive] class SparkGetTablesOperation(
 
     val tablePattern = convertIdentifierPattern(tableName, true)
     matchingDbs.foreach { dbName =>
-      catalog.listTables(dbName, tablePattern).foreach { tableIdentifier =>
-        val catalogTable = catalog.getTableMetadata(tableIdentifier)
+      catalog.getTablesByNames(catalog.listTables(dbName, tablePattern)).foreach { catalogTable =>
         val tableType = tableTypeString(catalogTable.tableType)
         if (tableTypes == null || tableTypes.isEmpty || tableTypes.contains(tableType)) {
           val rowData = Array[AnyRef](

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkMetadataOperationSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkMetadataOperationSuite.scala
@@ -148,7 +148,6 @@ class SparkMetadataOperationSuite extends HiveThriftJdbcTest {
 
     withJdbcStatement("table1", "table2") { statement =>
       Seq(
-        "DROP VIEW IF EXISTS view1",
         "CREATE TABLE table1(key INT, val STRING)",
         "CREATE TABLE table2(key INT, val STRING)",
         "CREATE VIEW view1 AS SELECT * FROM table2").foreach(statement.execute)

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkMetadataOperationSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkMetadataOperationSuite.scala
@@ -148,6 +148,7 @@ class SparkMetadataOperationSuite extends HiveThriftJdbcTest {
 
     withJdbcStatement("table1", "table2") { statement =>
       Seq(
+        "DROP VIEW IF EXISTS view1",
         "CREATE TABLE table1(key INT, val STRING)",
         "CREATE TABLE table2(key INT, val STRING)",
         "CREATE VIEW view1 AS SELECT * FROM table2").foreach(statement.execute)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -124,10 +124,6 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     client.getTablesByNames(db, tables)
   }
 
-  private[hive] def getAllRawTables(db: String): Seq[CatalogTable] = {
-    client.getAllTables(db)
-  }
-
   /**
    * If the given table properties contains datasource properties, throw an exception. We will do
    * this check when create or alter a table, i.e. when we try to write table metadata to Hive
@@ -712,10 +708,6 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
 
   override def getTablesByNames(db: String, tables: Seq[String]): Seq[CatalogTable] = withClient {
     getRawTablesByName(db, tables).map(restoreTableMetadata)
-  }
-
-  override def getAllTables(db: String): Seq[CatalogTable] = withClient {
-    getAllRawTables(db).map(restoreTableMetadata)
   }
 
   /**

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -120,8 +120,8 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     client.getTable(db, table)
   }
 
-  private[hive] def getRawTablesByName(db: String, tables: Seq[String]): Seq[CatalogTable] = {
-    client.getTablesByNames(db, tables)
+  private[hive] def getRawTablesByNames(db: String, tables: Seq[String]): Seq[CatalogTable] = {
+    client.getTablesByName(db, tables)
   }
 
   /**
@@ -706,8 +706,8 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     restoreTableMetadata(getRawTable(db, table))
   }
 
-  override def getTablesByNames(db: String, tables: Seq[String]): Seq[CatalogTable] = withClient {
-    getRawTablesByName(db, tables).map(restoreTableMetadata)
+  override def getTablesByName(db: String, tables: Seq[String]): Seq[CatalogTable] = withClient {
+    getRawTablesByNames(db, tables).map(restoreTableMetadata)
   }
 
   /**

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -120,6 +120,14 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     client.getTable(db, table)
   }
 
+  private[hive] def getRawTablesByName(db: String, tables: Seq[String]): Seq[CatalogTable] = {
+    client.getTablesByNames(db, tables)
+  }
+
+  private[hive] def getAllRawTables(db: String): Seq[CatalogTable] = {
+    client.getAllTables(db)
+  }
+
   /**
    * If the given table properties contains datasource properties, throw an exception. We will do
    * this check when create or alter a table, i.e. when we try to write table metadata to Hive
@@ -700,6 +708,14 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
 
   override def getTable(db: String, table: String): CatalogTable = withClient {
     restoreTableMetadata(getRawTable(db, table))
+  }
+
+  override def getTablesByNames(db: String, tables: Seq[String]): Seq[CatalogTable] = withClient {
+    getRawTablesByName(db, tables).map(restoreTableMetadata)
+  }
+
+  override def getAllTables(db: String): Seq[CatalogTable] = withClient {
+    getAllRawTables(db).map(restoreTableMetadata)
   }
 
   /**

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
@@ -84,6 +84,7 @@ private[hive] trait HiveClient {
   /** Returns the metadata for the specified table or None if it doesn't exist. */
   def getTableOption(dbName: String, tableName: String): Option[CatalogTable]
 
+  /** Returns metadata of existing permanent tables/views for given names. */
   def getTablesByName(dbName: String, tableNames: Seq[String]): Seq[CatalogTable]
 
   /** Creates a table with the given metadata. */

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
@@ -84,6 +84,10 @@ private[hive] trait HiveClient {
   /** Returns the metadata for the specified table or None if it doesn't exist. */
   def getTableOption(dbName: String, tableName: String): Option[CatalogTable]
 
+  def getTablesByNames(dbName: String, tableNames: Seq[String]): Seq[CatalogTable]
+
+  def getAllTables(dbName: String): Seq[CatalogTable]
+
   /** Creates a table with the given metadata. */
   def createTable(table: CatalogTable, ignoreIfExists: Boolean): Unit
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
@@ -84,7 +84,7 @@ private[hive] trait HiveClient {
   /** Returns the metadata for the specified table or None if it doesn't exist. */
   def getTableOption(dbName: String, tableName: String): Option[CatalogTable]
 
-  def getTablesByNames(dbName: String, tableNames: Seq[String]): Seq[CatalogTable]
+  def getTablesByName(dbName: String, tableNames: Seq[String]): Seq[CatalogTable]
 
   /** Creates a table with the given metadata. */
   def createTable(table: CatalogTable, ignoreIfExists: Boolean): Unit

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
@@ -86,8 +86,6 @@ private[hive] trait HiveClient {
 
   def getTablesByNames(dbName: String, tableNames: Seq[String]): Seq[CatalogTable]
 
-  def getAllTables(dbName: String): Seq[CatalogTable]
-
   /** Creates a table with the given metadata. */
   def createTable(table: CatalogTable, ignoreIfExists: Boolean): Unit
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -401,7 +401,7 @@ private[hive] class HiveClientImpl(
     getRawTableOption(dbName, tableName).nonEmpty
   }
 
-  override def getTablesByNames(
+  override def getTablesByName(
       dbName: String,
       tableNames: Seq[String]): Seq[CatalogTable] = withHiveState {
     getRawTablesByNames(dbName, tableNames).map(convertHiveTableToCatalogTable)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -388,7 +388,7 @@ private[hive] class HiveClientImpl(
     Option(client.getTable(dbName, tableName, false /* do not throw exception */))
   }
 
-  private def getRawTablesByNames(dbName: String, tableNames: Seq[String]): Seq[HiveTable] = {
+  private def getRawTablesByName(dbName: String, tableNames: Seq[String]): Seq[HiveTable] = {
     try {
       msClient.getTableObjectsByName(dbName, tableNames.asJava).asScala.map(new HiveTable(_))
     } catch {
@@ -404,7 +404,7 @@ private[hive] class HiveClientImpl(
   override def getTablesByName(
       dbName: String,
       tableNames: Seq[String]): Seq[CatalogTable] = withHiveState {
-    getRawTablesByNames(dbName, tableNames).map(convertHiveTableToCatalogTable)
+    getRawTablesByName(dbName, tableNames).map(convertHiveTableToCatalogTable)
   }
 
   override def getTableOption(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -392,18 +392,8 @@ private[hive] class HiveClientImpl(
     try {
       msClient.getTableObjectsByName(dbName, tableNames.asJava).asScala.map(new HiveTable(_))
     } catch {
-      case e: Exception =>
-        throw new HiveException(s"Unable to fetch tables of db $dbName", e);
-    }
-  }
-
-  private def getAllRawTables(dbName: String): Seq[HiveTable] = {
-    try {
-      msClient.getTableObjectsByName(dbName, msClient.getAllTables(dbName)).asScala
-        .map(new HiveTable(_))
-    } catch {
-      case e: Exception =>
-        throw new HiveException(s"Unable to fetch tables of db $dbName", e);
+      case ex: Exception =>
+        throw new HiveException(s"Unable to fetch tables of db $dbName", ex);
     }
   }
 
@@ -415,10 +405,6 @@ private[hive] class HiveClientImpl(
       dbName: String,
       tableNames: Seq[String]): Seq[CatalogTable] = withHiveState {
     getRawTablesByNames(dbName, tableNames).map(convertHiveTableToCatalogTable)
-  }
-
-  override def getAllTables(dbName: String): Seq[CatalogTable] = withHiveState {
-    getAllRawTables(dbName).map(convertHiveTableToCatalogTable)
   }
 
   override def getTableOption(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -1124,22 +1124,24 @@ private[hive] object HiveClientImpl {
     // For non-views, we need to do some extra fixes
     if (!(HiveTableType.VIRTUAL_VIEW.toString == tTable.getTableType)) {
       // Fix the non-printable chars
-      val parameters: JMap[String, String] = tTable.getSd.getParameters
-      val sf: String = parameters.get(serdeConstants.SERIALIZATION_FORMAT)
-      if (sf != null) {
-        val b: Array[Char] = sf.toCharArray
-        if ((b.length == 1) && (b(0) < 10)) { // ^A, ^B, ^C, ^D, \t
-          parameters.put(serdeConstants.SERIALIZATION_FORMAT, Integer.toString(b(0)))
+      val parameters = tTable.getSd.getParameters
+      if (parameters != null) {
+        val sf = parameters.get(serdeConstants.SERIALIZATION_FORMAT)
+        if (sf != null) {
+          val b: Array[Char] = sf.toCharArray
+          if ((b.length == 1) && (b(0) < 10)) { // ^A, ^B, ^C, ^D, \t
+            parameters.put(serdeConstants.SERIALIZATION_FORMAT, Integer.toString(b(0)))
+          }
         }
       }
       // Use LazySimpleSerDe for MetadataTypedColumnsetSerDe.
       // NOTE: LazySimpleSerDe does not support tables with a single column of col
       // of type "array<string>". This happens when the table is created using
       // an earlier version of Hive.
-      if (classOf[MetadataTypedColumnsetSerDe].getName
-            == tTable.getSd.getSerdeInfo.getSerializationLib
-            && tTable.getSd.getColsSize > 0
-            && tTable.getSd.getCols.get(0).getType.indexOf('<') == -1) {
+      if (classOf[MetadataTypedColumnsetSerDe].getName ==
+        tTable.getSd.getSerdeInfo.getSerializationLib &&
+        tTable.getSd.getColsSize > 0 &&
+        tTable.getSd.getCols.get(0).getType.indexOf('<') == -1) {
         tTable.getSd.getSerdeInfo.setSerializationLib(classOf[LazySimpleSerDe].getName)
       }
     }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -28,6 +28,7 @@ import scala.util.control.NonFatal
 
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.hive.conf.HiveConf
+import org.apache.hadoop.hive.metastore.IMetaStoreClient
 import org.apache.hadoop.hive.metastore.api.{EnvironmentContext, Function => HiveFunction, FunctionType}
 import org.apache.hadoop.hive.metastore.api.{MetaException, PrincipalType, ResourceType, ResourceUri}
 import org.apache.hadoop.hive.ql.Driver
@@ -160,6 +161,8 @@ private[client] sealed abstract class Shim {
     method
   }
 
+  def getMSC(hive: Hive): IMetaStoreClient
+
   protected def findMethod(klass: Class[_], name: String, args: Class[_]*): Method = {
     klass.getMethod(name, args: _*)
   }
@@ -170,6 +173,17 @@ private[client] class Shim_v0_12 extends Shim with Logging {
   protected lazy val holdDDLTime = JBoolean.FALSE
   // deletes the underlying data along with metadata
   protected lazy val deleteDataInDropIndex = JBoolean.TRUE
+
+  protected lazy val getMSCMethod = {
+    // Since getMSC() in Hive 0.12 is private, findMethod() could not work here
+    val msc = classOf[Hive].getDeclaredMethod("getMSC")
+    msc.setAccessible(true)
+    msc
+  }
+
+  override def getMSC(hive: Hive): IMetaStoreClient = {
+    getMSCMethod.invoke(hive).asInstanceOf[IMetaStoreClient]
+  }
 
   private lazy val startMethod =
     findStaticMethod(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
@@ -252,6 +252,14 @@ class VersionsSuite extends SparkFunSuite with Logging {
         .map(_.identifier.table) == Seq("src"))
     }
 
+    test(s"$version: getTablesByName when contains invalid name") {
+      // scalastyle:off
+      val name = "砖"
+      // scalastyle:on
+      assert(client.getTablesByName("default", Seq("src", name))
+        .map(_.identifier.table) == Seq("src"))
+    }
+
     test(s"$version: getTablesByName when empty") {
       assert(client.getTablesByName("default", Seq.empty).isEmpty)
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
@@ -237,12 +237,8 @@ class VersionsSuite extends SparkFunSuite with Logging {
       assert(client.getTableOption("default", "src").isDefined)
     }
 
-    test(s"$version: getTablesByNames") {
-      assert(client.getTablesByNames("default", Seq("src")).nonEmpty)
-    }
-
-    test(s"$version: getAllTables") {
-      assert(client.getAllTables("default").nonEmpty)
+    test(s"$version: getTablesByName") {
+      assert(client.getTablesByName("default", Seq("src")).nonEmpty)
     }
 
     test(s"$version: alterTable(table: CatalogTable)") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
@@ -237,6 +237,14 @@ class VersionsSuite extends SparkFunSuite with Logging {
       assert(client.getTableOption("default", "src").isDefined)
     }
 
+    test(s"$version: getTablesByNames") {
+      assert(client.getTablesByNames("default", Seq("src")).nonEmpty)
+    }
+
+    test(s"$version: getAllTables") {
+      assert(client.getAllTables("default").nonEmpty)
+    }
+
     test(s"$version: alterTable(table: CatalogTable)") {
       val newTable = client.getTable("default", "src").copy(properties = Map("changed" -> ""))
       client.alterTable(newTable)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
@@ -238,8 +238,13 @@ class VersionsSuite extends SparkFunSuite with Logging {
     }
 
     test(s"$version: getTablesByName") {
-      assert(client.getTablesByName("default", Seq("src", "tgt"))
-        .map(_.identifier.table) == Seq("src", "tgt"))
+      assert(client.getTablesByName("default", Seq("src")).head
+        == client.getTableOption("default", "src").get)
+    }
+
+    test(s"$version: getTablesByName when multiple tables") {
+      assert(client.getTablesByName("default", Seq("src", "temporary"))
+        .map(_.identifier.table) == Seq("src", "temporary"))
     }
 
     test(s"$version: getTablesByName when some tables do not exist") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
@@ -238,7 +238,17 @@ class VersionsSuite extends SparkFunSuite with Logging {
     }
 
     test(s"$version: getTablesByName") {
-      assert(client.getTablesByName("default", Seq("src")).nonEmpty)
+      assert(client.getTablesByName("default", Seq("src", "tgt"))
+        .map(_.identifier.table) == Seq("src", "tgt"))
+    }
+
+    test(s"$version: getTablesByName when some tables do not exist") {
+      assert(client.getTablesByName("default", Seq("src", "notexist"))
+        .map(_.identifier.table) == Seq("src"))
+    }
+
+    test(s"$version: getTablesByName when empty") {
+      assert(client.getTablesByName("default", Seq.empty).isEmpty)
     }
 
     test(s"$version: alterTable(table: CatalogTable)") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The new Spark ThriftServer SparkGetTablesOperation implemented in https://github.com/apache/spark/pull/22794 does a catalog.getTableMetadata request for every table. This can get very slow for large schemas (~50ms per table with an external Hive metastore).
Hive ThriftServer GetTablesOperation uses HiveMetastoreClient.getTableObjectsByName to get table information in bulk, but we don't expose that through our APIs that go through Hive -> HiveClientImpl (HiveClient) -> HiveExternalCatalog (ExternalCatalog) -> SessionCatalog.

If we added and exposed getTableObjectsByName through our catalog APIs, we could resolve that performance problem in SparkGetTablesOperation.

## How was this patch tested?

Add UT
