### PR TITLE
[Minor][ML] add missing since annotation of meanAveragePrecision

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
@@ -68,6 +68,7 @@ class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T])]
    * If a query has an empty ground truth set, the average precision will be zero and a log
    * warning is generated.
    */
+  @Since("1.2.0")
   lazy val meanAveragePrecision: Double = {
     predictionAndLabels.map { case (pred, lab) =>
       val labSet = lab.toSet


### PR DESCRIPTION
## What changes were proposed in this pull request?
add missing since annotation of meanAveragePrecision

## How was this patch tested?
existing tests