### PR TITLE
[SPARK-26388][SQL][WIP]_implement_hive_ddl_alter_table_replace_columns

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -115,6 +115,8 @@ statement
         (identifier | FOR COLUMNS identifierSeq | FOR ALL COLUMNS)?    #analyze
     | ALTER TABLE tableIdentifier
         ADD COLUMNS '(' columns=colTypeList ')'                        #addTableColumns
+    | ALTER TABLE tableIdentifier
+        REPLACE COLUMNS '(' columns=colTypeList ')'                    #replaceTableColumns
     | ALTER (TABLE | VIEW) from=tableIdentifier
         RENAME TO to=tableIdentifier                                   #renameTable
     | ALTER (TABLE | VIEW) tableIdentifier
@@ -232,7 +234,6 @@ unsupportedHiveNativeCommands
     | kw1=ALTER kw2=TABLE tableIdentifier partitionSpec? kw3=COMPACT
     | kw1=ALTER kw2=TABLE tableIdentifier partitionSpec? kw3=CONCATENATE
     | kw1=ALTER kw2=TABLE tableIdentifier partitionSpec? kw3=SET kw4=FILEFORMAT
-    | kw1=ALTER kw2=TABLE tableIdentifier partitionSpec? kw3=REPLACE kw4=COLUMNS
     | kw1=START kw2=TRANSACTION
     | kw1=COMMIT
     | kw1=ROLLBACK

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -113,9 +113,9 @@ trait ExternalCatalog {
   def alterTable(tableDefinition: CatalogTable): Unit
 
   /**
-   * Alter the data schema of a table identified by the provided database and table name. The new
-   * data schema should not have conflict column names with the existing partition columns, and
-   * should still contain all the existing data columns.
+   * Alter the data schema of a table identified by the provided database and table name.
+   * The new data schema should not have conflicting column names with existing partition columns.
+   * The existing data schema will be overwritten with the new data schema provided.
    *
    * @param db Database that table to alter schema for exists in
    * @param table Name of table to alter schema for

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -359,9 +359,9 @@ class SessionCatalog(
   }
 
   /**
-   * Alter the data schema of a table identified by the provided table identifier. The new data
-   * schema should not have conflict column names with the existing partition columns, and should
-   * still contain all the existing data columns.
+   * Alter the data schema of a table identified by the provided table identifier.
+   * The new data schema should not have conflicting column names with existing partition columns.
+   * The existing data schema will be overwritten with the new data schema provided.
    *
    * @param identifier TableIdentifier
    * @param newDataSchema Updated data schema to be used for the table
@@ -374,19 +374,6 @@ class SessionCatalog(
     val tableIdentifier = TableIdentifier(table, Some(db))
     requireDbExists(db)
     requireTableExists(tableIdentifier)
-
-    val catalogTable = externalCatalog.getTable(db, table)
-    val oldDataSchema = catalogTable.dataSchema
-    // not supporting dropping columns yet
-    val nonExistentColumnNames =
-      oldDataSchema.map(_.name).filterNot(columnNameResolved(newDataSchema, _))
-    if (nonExistentColumnNames.nonEmpty) {
-      throw new AnalysisException(
-        s"""
-           |Some existing schema fields (${nonExistentColumnNames.mkString("[", ",", "]")}) are
-           |not present in the new schema. We don't support dropping columns yet.
-         """.stripMargin)
-    }
 
     externalCatalog.alterTableDataSchema(db, table, newDataSchema)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -479,11 +479,8 @@ abstract class SessionCatalogSuite extends AnalysisTest {
     withBasicCatalog { sessionCatalog =>
       sessionCatalog.createTable(newTable("t1", "default"), ignoreIfExists = false)
       val oldTab = sessionCatalog.externalCatalog.getTable("default", "t1")
-      val e = intercept[AnalysisException] {
-        sessionCatalog.alterTableDataSchema(
-          TableIdentifier("t1", Some("default")), StructType(oldTab.dataSchema.drop(1)))
-      }.getMessage
-      assert(e.contains("We don't support dropping columns yet."))
+      sessionCatalog.alterTableDataSchema(
+        TableIdentifier("t1", Some("default")), StructType(oldTab.dataSchema.drop(1)))
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -678,6 +678,23 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
   }
 
   /**
+   * Create a [[AlterTableReplaceColumnsCommand]] command.
+   *
+   * For example:
+   * {{{
+   *   ALTER TABLE table1
+   *   REPLACE COLUMNS (col_name data_type [COMMENT col_comment], ...);
+   * }}}
+   */
+  override def visitReplaceTableColumns(ctx: ReplaceTableColumnsContext):
+    LogicalPlan = withOrigin(ctx) {
+      AlterTableReplaceColumnsCommand(
+        visitTableIdentifier(ctx.tableIdentifier),
+        visitColTypeList(ctx.columns)
+      )
+  }
+
+  /**
    * Create an [[AlterTableSetPropertiesCommand]] command.
    *
    * For example:

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -259,7 +259,7 @@ case class AlterTableAddColumnsCommand(
 
   // Text format doesn't need ADD COLUMNS as text datasource can have only one column
   override val supportedDatasourceFormats = Seq("ParquetFileFormat", "OrcFileFormat",
-    "OrcDataSourceV2", "JsonDataSourceV2", "CSVDataSourceV2")
+    "OrcDataSourceV2", "JsonFileFormat", "JsonDataSourceV2", "CSVFileFormat", "CSVDataSourceV2")
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
@@ -296,7 +296,7 @@ case class AlterTableReplaceColumnsCommand(
   // Csv format not supported by REPLACE COLUMNS as csv datasource is read positionally
   // and a new replacement column would reference an old replaced column's data
   override val supportedDatasourceFormats = Seq("ParquetFileFormat", "OrcFileFormat",
-    "OrcDataSourceV2", "JsonDataSourceV2", "TextDataSourceV2")
+    "OrcDataSourceV2", "JsonFileFormat", "JsonDataSourceV2", "TextFileFormat", "TextDataSourceV2")
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
@@ -840,14 +840,6 @@ class DDLParserSuite extends AnalysisTest with SharedSQLContext {
     assertUnsupported("ALTER TABLE table_name SKEWED BY (key) ON (1,5,6) STORED AS DIRECTORIES")
   }
 
-  test("alter table: replace columns (not allowed)") {
-    assertUnsupported(
-      """
-       |ALTER TABLE table_name REPLACE COLUMNS (new_col1 INT
-       |COMMENT 'test_comment', new_col2 LONG COMMENT 'test_comment2') RESTRICT
-      """.stripMargin)
-  }
-
   test("show databases") {
     val sql1 = "SHOW DATABASES"
     val sql2 = "SHOW DATABASES LIKE 'defau*'"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2589,7 +2589,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
       val e = intercept[AnalysisException] {
         sql("ALTER TABLE t1 ADD COLUMNS (c2 int)")
       }.getMessage
-      assert(e.contains("ALTER ADD COLUMNS does not support datasource table with type"))
+      assert(e.contains("ALTER [ADD|REPLACE] COLUMNS do not support datasource table with type"))
     }
   }
 
@@ -2599,7 +2599,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
       val e = intercept[AnalysisException] {
         sql("ALTER TABLE tmp_v ADD COLUMNS (c3 INT)")
       }
-      assert(e.message.contains("ALTER ADD COLUMNS does not support views"))
+      assert(e.message.contains("ALTER [ADD|REPLACE] COLUMNS do not support views"))
     }
   }
 
@@ -2609,7 +2609,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
       val e = intercept[AnalysisException] {
         sql("ALTER TABLE v1 ADD COLUMNS (c3 INT)")
       }
-      assert(e.message.contains("ALTER ADD COLUMNS does not support views"))
+      assert(e.message.contains("ALTER [ADD|REPLACE] COLUMNS do not support views"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2678,13 +2678,20 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
     }
   }
 
-  val supportedNativeFileFormatsForAlterTableReplaceColumns = Seq("parquet", "orc", "json", "text")
+  val supportedNativeFileFormatsForAlterTableReplaceColumns = Seq("parquet", "orc", "json", "text",
+    "org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat",
+    "org.apache.spark.sql.execution.datasources.orc.OrcFileFormat",
+    "org.apache.spark.sql.execution.datasources.json.JsonFileFormat",
+    "org.apache.spark.sql.execution.datasources.text.TextFileFormat")
   supportedNativeFileFormatsForAlterTableReplaceColumns.foreach { provider =>
     test(s"alter datasource table replace columns - $provider") {
-      if (provider == "text") testReplaceColumnTextProvider() else testReplaceColumn(provider)
+      if (provider == "text" | provider.endsWith("TextFileFormat")) testReplaceColumnTextProvider()
+      else testReplaceColumn(provider)
     }
     test(s"alter datasource table replace columns - partitioned - $provider") {
-      if (provider == "text") testReplaceColumnPartitionedTextProvider()
+      if (provider == "text" | provider.endsWith("TextFileFormat")) {
+        testReplaceColumnPartitionedTextProvider()
+      }
       else testReplaceColumn(provider)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2572,17 +2572,17 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
     "org.apache.spark.sql.execution.datasources.json.JsonFileFormat",
     "org.apache.spark.sql.execution.datasources.csv.CSVFileFormat")
   supportedNativeFileFormatsForAlterTableAddColumns.foreach { provider =>
-    test(s"alter datasource table add columns - $provider") {
+    test(s"alter table add columns ddl - $provider") {
       testAddColumn(provider)
     }
-    test(s"alter datasource table add columns - partitioned - $provider") {
+    test(s"alter table add columns ddl - partitioned - $provider") {
       testAddColumnPartitioned(provider)
     }
   }
 
   // alter table add columns for text datasource is not needed
   // text datasource can have only one column
-  test("alter datasource table add columns - text format not supported") {
+  test("alter table add columns ddl - text format not supported") {
     withTable("t1") {
       sql("CREATE TABLE t1 (c1 string) USING text")
       val e = intercept[AnalysisException] {
@@ -2709,11 +2709,11 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
     "org.apache.spark.sql.execution.datasources.json.JsonFileFormat",
     "org.apache.spark.sql.execution.datasources.text.TextFileFormat")
   supportedNativeFileFormatsForAlterTableReplaceColumns.foreach { provider =>
-    test(s"alter datasource table replace columns - $provider") {
+    test(s"alter table replace columns ddl - $provider") {
       if (provider == "text" | provider.endsWith("TextFileFormat")) testReplaceColumnTextProvider()
       else testReplaceColumn(provider)
     }
-    test(s"alter datasource table replace columns - partitioned - $provider") {
+    test(s"alter table replace columns ddl - partitioned - $provider") {
       if (provider == "text" | provider.endsWith("TextFileFormat")) {
         testReplaceColumnPartitionedTextProvider()
       }
@@ -2723,7 +2723,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
 
   // alter table replace columns for csv datasource not supported
   // csv datasource is positional: a new column would reference a replaced column's data
-  test("alter datasource table replace columns - csv format not supported") {
+  test("alter table replace columns ddl - csv format not supported") {
     withTable("t1") {
       sql("CREATE TABLE t1 (c1 string) USING csv")
       val e = intercept[AnalysisException] {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -642,9 +642,9 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
   }
 
   /**
-   * Alter the data schema of a table identified by the provided database and table name. The new
-   * data schema should not have conflict column names with the existing partition columns, and
-   * should still contain all the existing data columns.
+   * Alter the data schema of a table identified by the provided database and table name.
+   * The new data schema should not have conflicting column names with existing partition columns.
+   * The existing data schema will be overwritten with the new data schema provided.
    */
   override def alterTableDataSchema(
       db: String,


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add support for `ALTER TABLE REPLACE COLUMNS`
- drop column if not preset in the new schema
- add column if not preset in the table’s schema
- keep column if `column.name` and `column.dataType` match between table and new schemas
- raise exception if trying to replace an existing column with a different data type

This patch is inspired and mostly based on the work done by @xwu0226 in this PR: https://github.com/apache/spark/pull/16626

#### PR highlights:
- dropping columns is now allowed (b04f94a)
- `AlterTableAddColumnsCommand` refactored to be more generic and support the implementation of `AlterTableReplaceColumnsCommand` (f8cbb96, 00f6376, da16d3e)
- refactored how supported datasource formats for add and replace columns commands are validated (da16d3e)
- implemented a `SchemaUtils` check to comparte two schemas and raise an exception if columns with the same name have different data types (8b6da23). This is based on the work done by @maropu here: f3dea60793d86212ba1068e88ad89cb3dcf07801, 647963a26a2d4468ebd9b68111ebe68bee501fde

#### Known issues:
- `AlterTableReplaceColumnsCommand` does not support CSV datasource format (13e3823)
-  If a column is dropped, then re-added later with a different data type, this would be allowed but likely to fail when querying the table, depending on the datasource format and the data types used.
-- However, this is actually not different from dropping the whole table and re-creating it with a schema that doesn’t match the underlying data. 
-- In any case, if the underlying data doesn't match the table metadata, issues are likely. Hive DDL documentation specifically warns about this possibility and remits the responsibility to ensure constancy between data and metadata the user : https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-Add/ReplaceColumns

#### TODO:
- agree on requirements and best approach
- add tests for replacing comments
- add tests for complex data types
- add test for columns re-ordering

## How was this patch tested?
- added tests cases
- manually tested
- run `testOnly org.apache.spark.sql.*` tests suite. all tests passing locally
