### PR TITLE
[MINOR] [DOC] Avro data source documentation change

### DIFF
--- a/docs/sql-data-sources-avro.md
+++ b/docs/sql-data-sources-avro.md
@@ -199,7 +199,7 @@ Data source options of Avro can be set via:
     <td><code>avroSchema</code></td>
     <td>None</td>
     <td>Optional Avro schema provided by a user in JSON format. The date type and naming of record fields
-    should match the input Avro data or Catalyst data, otherwise the read/write action will fail.</td>
+    should match the input Avro data or Spark's internal data type, otherwise the read/write action will fail.</td>
     <td>read and write</td>
   </tr>
   <tr>

--- a/docs/sql-data-sources-avro.md
+++ b/docs/sql-data-sources-avro.md
@@ -198,8 +198,8 @@ Data source options of Avro can be set via:
   <tr>
     <td><code>avroSchema</code></td>
     <td>None</td>
-    <td>Optional Avro schema provided by a user in JSON format. The date type and naming of record fields
-    should match the input Avro data or Spark's internal data type (e.g., StringType, IntegerType)., otherwise the read/write action will fail.</td>
+    <td>Optional Avro schema provided by a user in JSON format. The data type and naming of record fields
+    should match the Avro data type when reading from Avro or match the Spark's internal data type (e.g., StringType, IntegerType) when writing to Avro files; otherwise, the read/write action will fail.</td>
     <td>read and write</td>
   </tr>
   <tr>

--- a/docs/sql-data-sources-avro.md
+++ b/docs/sql-data-sources-avro.md
@@ -199,7 +199,7 @@ Data source options of Avro can be set via:
     <td><code>avroSchema</code></td>
     <td>None</td>
     <td>Optional Avro schema provided by a user in JSON format. The date type and naming of record fields
-    should match the input Avro data or Spark's internal data type, otherwise the read/write action will fail.</td>
+    should match the input Avro data or Spark's internal data type (e.g., StringType, IntegerType)., otherwise the read/write action will fail.</td>
     <td>read and write</td>
   </tr>
   <tr>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a minor documentation change whereby the https://spark.apache.org/docs/latest/sql-data-sources-avro.html mentions "The date type and naming of record fields should match the input Avro data or Catalyst data,"

The term Catalyst data is confusing. It should instead say, Spark's internal data type such as String
Type or IntegerType.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
There are no code changes; only doc changes.
Please review https://spark.apache.org/contributing.html before opening a pull request.
