### PR TITLE
[SPARK-27942][DOCS][PYTHON] Note that Python 2.7 is deprecated in Spark documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,7 @@ locally on one machine --- all you need is to have `java` installed on your syst
 or the `JAVA_HOME` environment variable pointing to a Java installation.
 
 Spark runs on Java 8+, Scala 2.12, Python 2.7+/3.4+ and R 3.1+.
+Python 2 support is deprecated as of Spark 3.0.0.
 R prior to version 3.4 support is deprecated as of Spark 3.0.0.
 For the Scala API, Spark {{site.SPARK_VERSION}}
 uses Scala {{site.SCALA_BINARY_VERSION}}. You will need to use a compatible Scala version

--- a/docs/rdd-programming-guide.md
+++ b/docs/rdd-programming-guide.md
@@ -104,7 +104,7 @@ import org.apache.spark.SparkConf;
 Spark {{site.SPARK_VERSION}} works with Python 2.7+ or Python 3.4+. It can use the standard CPython interpreter,
 so C libraries like NumPy can be used. It also works with PyPy 2.3+.
 
-Python 2.6 support was removed in Spark 2.2.0.
+Note that Python 2 support is deprecated as of Spark 3.0.0.
 
 Spark applications in Python can either be run with the `bin/spark-submit` script which includes Spark at runtime, or by including it in your setup.py as:
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds deprecation notes in Spark documentation.

## How was this patch tested?

git grep -r "python 2.6"
git grep -r "Python 2.6"
git grep -r "python 2.7"
git grep -r "Python 2.7"
