### PR TITLE
[SPARK-27773][FOLLOWUP][DOC] Add numCaughtExceptions metric to monitoring doc

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1097,6 +1097,7 @@ Note: applies to the shuffle service
 - blockTransferRateBytes (meter)
 - numActiveConnections.count
 - numRegisteredConnections.count
+- numCaughtExceptions.count
 - openBlockRequestLatencyMillis (histogram)
 - registerExecutorRequestLatencyMillis (histogram)
 - registeredExecutorsSize


### PR DESCRIPTION
## What changes were proposed in this pull request?

SPARK-27773 has introduced a new metric (counter) numCaughtExceptions to the Spark Dropwizard monitoring system. This PR adds an entry in the monitoring documentation to document this.  
