### PR TITLE
[SPARK-27900][CORE] Add uncaught exception handler to the driver

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/ShutdownHookManager.scala
+++ b/core/src/main/scala/org/apache/spark/util/ShutdownHookManager.scala
@@ -45,7 +45,7 @@ private[spark] object ShutdownHookManager extends Logging {
    */
   val TEMP_DIR_SHUTDOWN_PRIORITY = 25
 
-  private lazy val shutdownHooks = {
+  private[spark] lazy val shutdownHooks = {
     val manager = new SparkShutdownHookManager()
     manager.install()
     manager
@@ -204,6 +204,11 @@ private [util] class SparkShutdownHookManager {
     hooks.synchronized { hooks.remove(ref) }
   }
 
+  def clear(): Unit = {
+    hooks.synchronized {
+      hooks.clear()
+    }
+  }
 }
 
 private class SparkShutdownHook(private val priority: Int, hook: () => Unit)

--- a/core/src/main/scala/org/apache/spark/util/SparkExitCode.scala
+++ b/core/src/main/scala/org/apache/spark/util/SparkExitCode.scala
@@ -29,4 +29,6 @@ private[spark] object SparkExitCode {
       OutOfMemoryError. */
   val OOM = 52
 
+  val VM_ERROR = 53
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
In case of jvm errors the driver will not exit properly as there is no UnCaughtException handler. This causes issues when Spark is run in a container, as jvm will not exit due to still running threads, errors  are not propagated to K8s runtime and pods will run forever. This also makes impossible for the Spark Operator to report back a failed job.
As described in the related jira jvm errors may cause deadlocks and we cannot assume a healthy jvm
to do a proper shutdown, so we avoid the registred shutdown hooks, it is the equivalent of setting `-XX:+ExitOnOutOfMemoryError`. For example the DAG event loop thread is a daemon thread and in the scenario described in the jira becomes unresponsive while the main thread also is stuck in the `runJob()` method waiting forever to make a job submission. However, this PR does not change the logic for the handler for the master, workers in standalone mode and the Spark executors. It only adds a special behavior for the driver where we exit immediately. 

## How was this patch tested?

Manually by running a Spark Job.
This will make the job example in the jira fail and the container will exit with:
```
State:          Terminated
  Reason:       Error
  Exit Code:    52
```