### PR TITLE
Detecting key in map type when value type is complex

### DIFF
--- a/R/pkg/R/schema.R
+++ b/R/pkg/R/schema.R
@@ -162,7 +162,7 @@ checkType <- function(type) {
             },
             m = {
               # Map type
-              m <- regexec("^map<(.+),(.+)>$", type)
+              m <- regexec("map<(string|character),(.+)>", type)
               matchedStrings <- regmatches(type, m)
               if (length(matchedStrings[[1]]) >= 3) {
                 keyType <- matchedStrings[[1]][2]


### PR DESCRIPTION
Regex used to extract key failed when one had more complex types like `map<string,struct<description:string,ip:string,struct<a:integer>>>`.  As we accept only string or character for the field I suggest using them directly in regex.

## What changes were proposed in this pull request?

Corrected regex for detecting key in map type when value type is complex

## How was this patch tested?

This patch was manually tested with SparkR 2.4.3

Please review https://spark.apache.org/contributing.html before opening a pull request.
