### PR TITLE
[SPARK-27950][DSTREAMS][Kinesis] dynamoDBEndpointUrl and cloudWatchMetricsLevel for Kinesis

### DIFF
--- a/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisInputDStream.scala
+++ b/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisInputDStream.scala
@@ -274,24 +274,24 @@ object KinesisInputDStream {
     }
 
     /**
-      * Sets the AWS DynamoDB endpoint URL. Defaults to
-      * "https://dynamodb.us-east-1.amazonaws.com" if no custom value is specified
-      *
-      * @param url DynamoDB endpoint URL to use
-      * @return Reference to this [[KinesisInputDStream.Builder]]
-      */
+     * Sets the AWS DynamoDB endpoint URL. Defaults to
+     * "https://dynamodb.us-east-1.amazonaws.com" if no custom value is specified
+     *
+     * @param url DynamoDB endpoint URL to use
+     * @return Reference to this [[KinesisInputDStream.Builder]]
+     */
     def dynamoDBEndpointUrl(url: String): Builder = {
       dynamoDBEndpointUrl = Option(url)
       this
     }
 
     /**
-      * Sets the AWS CloudWatch MetricsLevel. Defaults to
-      * MetricsLevel.DETAILED if no custom value is specified
-      *
-      * @param metricsLevel CloudWatch MetricsLevel to use
-      * @return Reference to this [[KinesisInputDStream.Builder]]
-      */
+     * Sets the AWS CloudWatch MetricsLevel. Defaults to
+     * MetricsLevel.DETAILED if no custom value is specified
+     *
+     * @param metricsLevel CloudWatch MetricsLevel to use
+     * @return Reference to this [[KinesisInputDStream.Builder]]
+     */
     def cloudWatchMetricsLevel(metricsLevel: MetricsLevel): Builder = {
       cloudWatchMetricsLevel = Option(metricsLevel)
       this

--- a/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisUtils.scala
+++ b/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisUtils.scala
@@ -75,7 +75,7 @@ object KinesisUtils {
       new KinesisInputDStream[T](ssc, streamName, endpointUrl, validateRegion(regionName),
         KinesisInitialPositions.fromKinesisInitialPosition(initialPositionInStream),
         kinesisAppName, checkpointInterval, storageLevel,
-        cleanedHandler, DefaultCredentials, None, None)
+        cleanedHandler, DefaultCredentials, None, None, None, None)
     }
   }
 
@@ -132,7 +132,7 @@ object KinesisUtils {
       new KinesisInputDStream[T](ssc, streamName, endpointUrl, validateRegion(regionName),
         KinesisInitialPositions.fromKinesisInitialPosition(initialPositionInStream),
         kinesisAppName, checkpointInterval, storageLevel,
-        cleanedHandler, kinesisCredsProvider, None, None)
+        cleanedHandler, kinesisCredsProvider, None, None, None, None)
     }
   }
 
@@ -202,7 +202,7 @@ object KinesisUtils {
       new KinesisInputDStream[T](ssc, streamName, endpointUrl, validateRegion(regionName),
         KinesisInitialPositions.fromKinesisInitialPosition(initialPositionInStream),
         kinesisAppName, checkpointInterval, storageLevel,
-        cleanedHandler, kinesisCredsProvider, None, None)
+        cleanedHandler, kinesisCredsProvider, None, None, None, None)
     }
   }
 
@@ -248,7 +248,7 @@ object KinesisUtils {
       new KinesisInputDStream[Array[Byte]](ssc, streamName, endpointUrl, validateRegion(regionName),
         KinesisInitialPositions.fromKinesisInitialPosition(initialPositionInStream),
         kinesisAppName, checkpointInterval, storageLevel,
-        KinesisInputDStream.defaultMessageHandler, DefaultCredentials, None, None)
+        KinesisInputDStream.defaultMessageHandler, DefaultCredentials, None, None, None, None)
     }
   }
 
@@ -299,7 +299,7 @@ object KinesisUtils {
       new KinesisInputDStream[Array[Byte]](ssc, streamName, endpointUrl, validateRegion(regionName),
         KinesisInitialPositions.fromKinesisInitialPosition(initialPositionInStream),
         kinesisAppName, checkpointInterval, storageLevel,
-        KinesisInputDStream.defaultMessageHandler, kinesisCredsProvider, None, None)
+        KinesisInputDStream.defaultMessageHandler, kinesisCredsProvider, None, None, None, None)
     }
   }
 

--- a/external/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisInputDStreamBuilderSuite.scala
+++ b/external/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisInputDStreamBuilderSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.streaming.kinesis
 import java.util.Calendar
 
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStream
+import com.amazonaws.services.kinesis.metrics.interfaces.MetricsLevel
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.mockito.MockitoSugar
 
@@ -80,8 +81,10 @@ class KinesisInputDStreamBuilderSuite extends TestSuiteBase with BeforeAndAfterE
     assert(dstream.checkpointInterval == batchDuration)
     assert(dstream._storageLevel == DEFAULT_STORAGE_LEVEL)
     assert(dstream.kinesisCreds == DefaultCredentials)
-    assert(dstream.dynamoDBCreds == None)
-    assert(dstream.cloudWatchCreds == None)
+    assert(dstream.dynamoDBCreds.isEmpty)
+    assert(dstream.cloudWatchCreds.isEmpty)
+    assert(dstream.dynamoDBEndpointUrl.isEmpty)
+    assert(dstream.cloudWatchMetricsLevel.isEmpty)
   }
 
   test("should propagate custom non-auth values to KinesisInputDStream") {
@@ -94,6 +97,8 @@ class KinesisInputDStreamBuilderSuite extends TestSuiteBase with BeforeAndAfterE
     val customKinesisCreds = mock[SparkAWSCredentials]
     val customDynamoDBCreds = mock[SparkAWSCredentials]
     val customCloudWatchCreds = mock[SparkAWSCredentials]
+    val customDynamoDBEndpointUrl = "https://dynamodb.us-west-2.amazonaws.com"
+    val customCloudWatchMetricsLevel = MetricsLevel.NONE
 
     val dstream = builder
       .endpointUrl(customEndpointUrl)
@@ -105,6 +110,8 @@ class KinesisInputDStreamBuilderSuite extends TestSuiteBase with BeforeAndAfterE
       .kinesisCredentials(customKinesisCreds)
       .dynamoDBCredentials(customDynamoDBCreds)
       .cloudWatchCredentials(customCloudWatchCreds)
+      .dynamoDBEndpointUrl(customDynamoDBEndpointUrl)
+      .cloudWatchMetricsLevel(customCloudWatchMetricsLevel)
       .build()
     assert(dstream.endpointUrl == customEndpointUrl)
     assert(dstream.regionName == customRegion)
@@ -115,6 +122,8 @@ class KinesisInputDStreamBuilderSuite extends TestSuiteBase with BeforeAndAfterE
     assert(dstream.kinesisCreds == customKinesisCreds)
     assert(dstream.dynamoDBCreds == Option(customDynamoDBCreds))
     assert(dstream.cloudWatchCreds == Option(customCloudWatchCreds))
+    assert(dstream.dynamoDBEndpointUrl == Option(customDynamoDBEndpointUrl))
+    assert(dstream.cloudWatchMetricsLevel == Option(customCloudWatchMetricsLevel))
 
     // Testing with AtTimestamp
     val cal = Calendar.getInstance()


### PR DESCRIPTION
## What changes were proposed in this pull request?

I was researching getting Spark’s Kinesis integration running locally against `localstack`. We found this issue, and it creates a complication: https://github.com/localstack/localstack/issues/677

Effectively, we need to be able to redirect calls for Kinesis, DynamoDB and Cloudwatch in order for the KCL to properly use the `localstack` infrastructure. We have successfully done this with the KCL (both 1.x and 2.x), but with Spark’s integration we are unable to configure DynamoDB and Cloudwatch’s endpoints:

https://github.com/apache/spark/blob/master/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisReceiver.scala#L162

This PR adds optional configuration values to the interfaces for dynamoDBEndpointUrl and cloudWatchMetricsLevel. 

Why cloudWatchMetricsLevel instead of cloudWatchEndpointUrl? Because the 1.x version of the KCL does not expose a means of configuring the cloudWatchEndpointUrl. Localstack users can instead disable metrics entirely by setting the cloudWatchMetricsLevel to Some(MetricsLevel.NONE)

## How was this patch tested?

Existing unit tests were expanded to check that these values were set.

Please review https://spark.apache.org/contributing.html before opening a pull request.
