### PR TITLE
[SPARK-27973][MINOR] [EXAMPLES]correct DirectKafkaWordCount usage text with groupId

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/streaming/DirectKafkaWordCount.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/DirectKafkaWordCount.scala
@@ -40,7 +40,7 @@ object DirectKafkaWordCount {
   def main(args: Array[String]) {
     if (args.length < 3) {
       System.err.println(s"""
-        |Usage: DirectKafkaWordCount <brokers> <topics>
+        |Usage: DirectKafkaWordCount <brokers> <groupId> <topics>
         |  <brokers> is a list of one or more Kafka brokers
         |  <groupId> is a consumer group name to consume from topics
         |  <topics> is a list of one or more kafka topics to consume from


### PR DESCRIPTION
## What changes were proposed in this pull request?


Usage: DirectKafkaWordCount <brokers> <topics>
--
<brokers> is a list of one or more Kafka brokers
<groupId> is a consumer group name to consume from topics
<topics> is a list of one or more kafka topics to consume from


## How was this patch tested?
N/A.

Please review https://spark.apache.org/contributing.html before opening a pull request.
