### PR TITLE
Revert "[SPARK-27870][SQL][PYSPARK] Flush batch timely for pandas UDF (for improving pandas UDFs pipeline)"

### DIFF
--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -99,9 +99,6 @@ class ByteArrayOutput(object):
     def write(self, b):
         self.buffer += b
 
-    def flush(self):
-        pass
-
     def close(self):
         pass
 

--- a/python/pyspark/tests/test_serializers.py
+++ b/python/pyspark/tests/test_serializers.py
@@ -225,16 +225,6 @@ class SerializersTest(unittest.TestCase):
                 # ends with a -1
                 self.assertEqual(dest.buffer[-4:], write_int(-1))
 
-    def test_chunked_stream_flush(self):
-        wrapped = ByteArrayOutput()
-        stream = serializers.ChunkedStream(wrapped, 10)
-        stream.write(bytearray([0]))
-        self.assertEqual(len(wrapped.buffer), 0, "small write should be buffered")
-        stream.flush()
-        # Expect buffer size 4 bytes + buffer data 1 byte.
-        self.assertEqual(len(wrapped.buffer), 5, "flush should work")
-        stream.close()
-
 
 if __name__ == "__main__":
     from pyspark.tests.test_serializers import *


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR reverts https://github.com/apache/spark/commit/9c4eb99c52803f2488ac3787672aa8d3e4d1544e for the reasons below:

1. An alternative was not considered properly, https://github.com/apache/spark/pull/24734#issuecomment-500101639 https://github.com/apache/spark/pull/24734#issuecomment-500102340 https://github.com/apache/spark/pull/24734#issuecomment-499202982 - I opened a PR https://github.com/apache/spark/pull/24826

2. https://github.com/apache/spark/commit/9c4eb99c52803f2488ac3787672aa8d3e4d1544e fixed timely flushing which behaviour is somewhat hacky and the timing isn't also guaranteed (in case each batch takes longer to process).

3. For pipelining for smaller batches, looks it's better to allow to configure buffer size rather than having another factor to flush

## How was this patch tested?

N/A