### PR TITLE
[SPARK-27992][PYTHON] Allow Python to join with connection thread to propagate errors

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -138,8 +138,8 @@ private[spark] object PythonRDD extends Logging {
    * or to enable local execution.
    *
    * @return 3-tuple (as a Java array) with the port number of a local socket which serves the
-   *         data collected from this job, the secret for authentication, and a server object
-   *         that can be used to sync the JVM serving thread in Python.
+   *         data collected from this job, the secret for authentication, and a socket auth
+   *         server object that can be used to join the JVM serving thread in Python.
    */
   def runJob(
       sc: SparkContext,
@@ -158,8 +158,8 @@ private[spark] object PythonRDD extends Logging {
    * A helper function to collect an RDD as an iterator, then serve it via socket.
    *
    * @return 3-tuple (as a Java array) with the port number of a local socket which serves the
-   *         data collected from this job, the secret for authentication, and a server object
-   *         that can be used to sync the JVM serving thread in Python.
+   *         data collected from this job, the secret for authentication, and a socket auth
+   *         server object that can be used to join the JVM serving thread in Python.
    */
   def collectAndServe[T](rdd: RDD[T]): Array[Any] = {
     serveIterator(rdd.collect().iterator, s"serve RDD ${rdd.id}")
@@ -170,12 +170,12 @@ private[spark] object PythonRDD extends Logging {
    * are collected as separate jobs, by order of index. Partition data is first requested by a
    * non-zero integer to start a collection job. The response is prefaced by an integer with 1
    * meaning partition data will be served, 0 meaning the local iterator has been consumed,
-   * and -1 meaining an error occurred during collection. This function is used by
+   * and -1 meaning an error occurred during collection. This function is used by
    * pyspark.rdd._local_iterator_from_socket().
    *
    * @return 3-tuple (as a Java array) with the port number of a local socket which serves the
-   *         data collected from this job, the secret for authentication, and a server object
-   *         that can be used to sync the JVM serving thread in Python.
+   *         data collected from this job, the secret for authentication, and a socket auth
+   *         server object that can be used to join the JVM serving thread in Python.
    */
   def toLocalIteratorAndServe[T](rdd: RDD[T]): Array[Any] = {
     val handleFunc = (sock: Socket) => {
@@ -447,8 +447,8 @@ private[spark] object PythonRDD extends Logging {
    * The thread will terminate after all the data are sent or any exceptions happen.
    *
    * @return 3-tuple (as a Java array) with the port number of a local socket which serves the
-   *         data collected from this job, the secret for authentication, and a server object
-   *         that can be used to sync the JVM serving thread in Python.
+   *         data collected from this job, the secret for authentication, and a socket auth
+   *         server object that can be used to join the JVM serving thread in Python.
    */
   def serveIterator(items: Iterator[_], threadName: String): Array[Any] = {
     serveToStream(threadName) { out =>
@@ -470,8 +470,8 @@ private[spark] object PythonRDD extends Logging {
    * exceptions happen.
    *
    * @return 3-tuple (as a Java array) with the port number of a local socket which serves the
-   *         data collected from this job, the secret for authentication, and a server object
-   *         that can be used to sync the JVM serving thread in Python.
+   *         data collected from this job, the secret for authentication, and a socket auth
+   *         server object that can be used to join the JVM serving thread in Python.
    */
   private[spark] def serveToStream(
       threadName: String)(writeFunc: OutputStream => Unit): Array[Any] = {

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -191,10 +191,8 @@ private[spark] object PythonRDD extends Logging {
         var complete = false
         while (!complete) {
 
-          // Read request for data
+          // Read request for data, value of zero will stop iteration or non-zero to continue
           if (in.readInt() == 0) {
-
-            // Client requested to stop iteration
             complete = true
           } else if (collectPartitionIter.hasNext) {
 
@@ -209,7 +207,6 @@ private[spark] object PythonRDD extends Logging {
             out.writeInt(SpecialLengths.END_OF_DATA_SECTION)
             out.flush()
           } else {
-
             // Send response there are no more partitions to read and close
             out.writeInt(0)
             complete = true

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -24,10 +24,12 @@ import java.util.{ArrayList => JArrayList, List => JList, Map => JMap}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io.compress.CompressionCodec
 import org.apache.hadoop.mapred.{InputFormat, JobConf, OutputFormat}
 import org.apache.hadoop.mapreduce.{InputFormat => NewInputFormat, OutputFormat => NewOutputFormat}
+
 import org.apache.spark._
 import org.apache.spark.api.java.{JavaPairRDD, JavaRDD, JavaSparkContext}
 import org.apache.spark.broadcast.Broadcast

--- a/core/src/main/scala/org/apache/spark/api/r/RRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RRDD.scala
@@ -29,7 +29,7 @@ import org.apache.spark.api.java.{JavaPairRDD, JavaRDD, JavaSparkContext}
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
-import org.apache.spark.security.{SocketAuthHelper, SocketAuthServer}
+import org.apache.spark.security.SocketAuthServer
 
 private abstract class BaseRRDD[T: ClassTag, U: ClassTag](
     parent: RDD[T],
@@ -166,7 +166,7 @@ private[spark] object RRDD {
 
   private[spark] def serveToStream(
       threadName: String)(writeFunc: OutputStream => Unit): Array[Any] = {
-    SocketAuthHelper.serveToStream(threadName, new RAuthHelper(SparkEnv.get.conf))(writeFunc)
+    SocketAuthServer.serveToStream(threadName, new RAuthHelper(SparkEnv.get.conf))(writeFunc)
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/security/SocketAuthHelper.scala
+++ b/core/src/main/scala/org/apache/spark/security/SocketAuthHelper.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.security
 
-import java.io.{BufferedOutputStream, DataInputStream, DataOutputStream, OutputStream}
+import java.io.{DataInputStream, DataOutputStream}
 import java.net.Socket
 import java.nio.charset.StandardCharsets.UTF_8
 
@@ -112,22 +112,5 @@ private[spark] class SocketAuthHelper(conf: SparkConf) {
     dout.writeInt(bytes.length)
     dout.write(bytes, 0, bytes.length)
     dout.flush()
-  }
-
-}
-
-private[spark] object SocketAuthHelper {
-  def serveToStream(
-      threadName: String,
-      authHelper: SocketAuthHelper)(writeFunc: OutputStream => Unit): Array[Any] = {
-    val (port, secret) = SocketAuthServer.setupOneConnectionServer(authHelper, threadName) { s =>
-      val out = new BufferedOutputStream(s.getOutputStream())
-      Utils.tryWithSafeFinally {
-        writeFunc(out)
-      } {
-        out.close()
-      }
-    }
-    Array(port, secret)
   }
 }

--- a/core/src/main/scala/org/apache/spark/security/SocketAuthServer.scala
+++ b/core/src/main/scala/org/apache/spark/security/SocketAuthServer.scala
@@ -104,7 +104,7 @@ private[spark] class SocketFuncServer(
 private[spark] object SocketAuthServer {
 
   /**
-   * Convienince function to create a socket server and run a user function in a background
+   * Convenience function to create a socket server and run a user function in a background
    * thread to write to an output stream.
    *
    * @param threadName Name for the background serving thread.

--- a/core/src/main/scala/org/apache/spark/security/SocketAuthServer.scala
+++ b/core/src/main/scala/org/apache/spark/security/SocketAuthServer.scala
@@ -22,7 +22,6 @@ import java.net.{InetAddress, ServerSocket, Socket}
 import scala.concurrent.Promise
 import scala.concurrent.duration.Duration
 import scala.util.Try
-
 import org.apache.spark.SparkEnv
 import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.ThreadUtils
@@ -64,6 +63,21 @@ private[spark] abstract class SocketAuthServer[T](
     ThreadUtils.awaitResult(promise.future, wait)
   }
 
+}
+
+/**
+ * Create a socket server class and run user function on the socket in a background thread.
+ * This is the same as calling SocketAuthServer.setupOneConnectionServer except it creates
+ * a server object that can then be synced from Python.
+ */
+private [spark] class SocketFuncServer(
+    authHelper: SocketAuthHelper,
+    threadName: String,
+    func: Socket => Unit) extends SocketAuthServer[Unit](authHelper, threadName) {
+
+  override def handleConnection(sock: Socket): Unit = {
+    func(sock)
+  }
 }
 
 private[spark] object SocketAuthServer {

--- a/core/src/main/scala/org/apache/spark/security/SocketAuthServer.scala
+++ b/core/src/main/scala/org/apache/spark/security/SocketAuthServer.scala
@@ -22,6 +22,7 @@ import java.net.{InetAddress, ServerSocket, Socket}
 import scala.concurrent.Promise
 import scala.concurrent.duration.Duration
 import scala.util.Try
+
 import org.apache.spark.SparkEnv
 import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.ThreadUtils

--- a/core/src/main/scala/org/apache/spark/security/SocketAuthServer.scala
+++ b/core/src/main/scala/org/apache/spark/security/SocketAuthServer.scala
@@ -23,6 +23,7 @@ import java.net.{InetAddress, ServerSocket, Socket}
 import scala.concurrent.Promise
 import scala.concurrent.duration.Duration
 import scala.util.Try
+
 import org.apache.spark.SparkEnv
 import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.{ThreadUtils, Utils}

--- a/core/src/main/scala/org/apache/spark/security/SocketAuthServer.scala
+++ b/core/src/main/scala/org/apache/spark/security/SocketAuthServer.scala
@@ -17,15 +17,15 @@
 
 package org.apache.spark.security
 
+import java.io.{BufferedOutputStream, OutputStream}
 import java.net.{InetAddress, ServerSocket, Socket}
 
 import scala.concurrent.Promise
 import scala.concurrent.duration.Duration
 import scala.util.Try
-
 import org.apache.spark.SparkEnv
 import org.apache.spark.network.util.JavaUtils
-import org.apache.spark.util.ThreadUtils
+import org.apache.spark.util.{ThreadUtils, Utils}
 
 
 /**
@@ -41,9 +41,29 @@ private[spark] abstract class SocketAuthServer[T](
 
   private val promise = Promise[T]()
 
-  val (port, secret) = SocketAuthServer.setupOneConnectionServer(authHelper, threadName) { sock =>
-    promise.complete(Try(handleConnection(sock)))
+  private def startServer(): (Int, String) = {
+    val serverSocket = new ServerSocket(0, 1, InetAddress.getByAddress(Array(127, 0, 0, 1)))
+    // Close the socket if no connection in 15 seconds
+    serverSocket.setSoTimeout(15000)
+
+    new Thread(threadName) {
+      setDaemon(true)
+      override def run(): Unit = {
+        var sock: Socket = null
+        try {
+          sock = serverSocket.accept()
+          authHelper.authClient(sock)
+          promise.complete(Try(handleConnection(sock)))
+        } finally {
+          JavaUtils.closeQuietly(serverSocket)
+          JavaUtils.closeQuietly(sock)
+        }
+      }
+    }.start()
+    (serverSocket.getLocalPort, authHelper.secret)
   }
+
+  val (port, secret) = startServer()
 
   /**
    * Handle a connection which has already been authenticated.  Any error from this function
@@ -71,7 +91,7 @@ private[spark] abstract class SocketAuthServer[T](
  * This is the same as calling SocketAuthServer.setupOneConnectionServer except it creates
  * a server object that can then be synced from Python.
  */
-private [spark] class SocketFuncServer(
+private[spark] class SocketFuncServer(
     authHelper: SocketAuthHelper,
     threadName: String,
     func: Socket => Unit) extends SocketAuthServer[Unit](authHelper, threadName) {
@@ -84,39 +104,27 @@ private [spark] class SocketFuncServer(
 private[spark] object SocketAuthServer {
 
   /**
-   * Create a socket server and run user function on the socket in a background thread.
+   * Convienince function to create a socket server and run a user function in a background
+   * thread to write to an output stream.
    *
-   * The socket server can only accept one connection, or close if no connection
-   * in 15 seconds.
-   *
-   * The thread will terminate after the supplied user function, or if there are any exceptions.
-   *
-   * If you need to get a result of the supplied function, create a subclass of [[SocketAuthServer]]
-   *
-   * @return The port number of a local socket and the secret for authentication.
+   * @param threadName Name for the background serving thread.
+   * @param authHelper SocketAuthHelper for authentication
+   * @param writeFunc User function to write to a given OutputStream
+   * @return
    */
-  def setupOneConnectionServer(
-      authHelper: SocketAuthHelper,
-      threadName: String)
-      (func: Socket => Unit): (Int, String) = {
-    val serverSocket = new ServerSocket(0, 1, InetAddress.getByAddress(Array(127, 0, 0, 1)))
-    // Close the socket if no connection in 15 seconds
-    serverSocket.setSoTimeout(15000)
-
-    new Thread(threadName) {
-      setDaemon(true)
-      override def run(): Unit = {
-        var sock: Socket = null
-        try {
-          sock = serverSocket.accept()
-          authHelper.authClient(sock)
-          func(sock)
-        } finally {
-          JavaUtils.closeQuietly(serverSocket)
-          JavaUtils.closeQuietly(sock)
-        }
+  def serveToStream(
+      threadName: String,
+      authHelper: SocketAuthHelper)(writeFunc: OutputStream => Unit): Array[Any] = {
+    val handleFunc = (sock: Socket) => {
+      val out = new BufferedOutputStream(sock.getOutputStream())
+      Utils.tryWithSafeFinally {
+        writeFunc(out)
+      } {
+        out.close()
       }
-    }.start()
-    (serverSocket.getLocalPort, authHelper.secret)
+    }
+
+    val server = new SocketFuncServer(authHelper, threadName, handleFunc)
+    Array(server.port, server.secret, server)
   }
 }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1389,7 +1389,9 @@ private[spark] object Utils extends Logging {
         originalThrowable = cause
         try {
           logError("Aborting task", originalThrowable)
-          TaskContext.get().markTaskFailed(originalThrowable)
+          if (TaskContext.get() != null) {
+            TaskContext.get().markTaskFailed(originalThrowable)
+          }
           catchBlock
         } catch {
           case t: Throwable =>

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -1080,9 +1080,8 @@ class SparkContext(object):
         # by runJob() in order to avoid having to pass a Python lambda into
         # SparkContext#runJob.
         mappedRDD = rdd.mapPartitions(partitionFunc)
-        port, auth_secret, _ = self._jvm.PythonRDD.runJob(self._jsc.sc(), mappedRDD._jrdd,
-                                                          partitions)
-        return list(_load_from_socket(port, auth_secret, mappedRDD._jrdd_deserializer))
+        socket_info = self._jvm.PythonRDD.runJob(self._jsc.sc(), mappedRDD._jrdd, partitions)
+        return list(_load_from_socket(socket_info, mappedRDD._jrdd_deserializer))
 
     def show_profiles(self):
         """ Print the profile stats to stdout """

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -1080,8 +1080,8 @@ class SparkContext(object):
         # by runJob() in order to avoid having to pass a Python lambda into
         # SparkContext#runJob.
         mappedRDD = rdd.mapPartitions(partitionFunc)
-        socket_info = self._jvm.PythonRDD.runJob(self._jsc.sc(), mappedRDD._jrdd, partitions)
-        return list(_load_from_socket(socket_info, mappedRDD._jrdd_deserializer))
+        sock_info = self._jvm.PythonRDD.runJob(self._jsc.sc(), mappedRDD._jrdd, partitions)
+        return list(_load_from_socket(sock_info, mappedRDD._jrdd_deserializer))
 
     def show_profiles(self):
         """ Print the profile stats to stdout """

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -1080,8 +1080,9 @@ class SparkContext(object):
         # by runJob() in order to avoid having to pass a Python lambda into
         # SparkContext#runJob.
         mappedRDD = rdd.mapPartitions(partitionFunc)
-        sock_info = self._jvm.PythonRDD.runJob(self._jsc.sc(), mappedRDD._jrdd, partitions)
-        return list(_load_from_socket(sock_info, mappedRDD._jrdd_deserializer))
+        port, auth_secret, _ = self._jvm.PythonRDD.runJob(self._jsc.sc(), mappedRDD._jrdd,
+                                                          partitions)
+        return list(_load_from_socket(port, auth_secret, mappedRDD._jrdd_deserializer))
 
     def show_profiles(self):
         """ Print the profile stats to stdout """

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -139,15 +139,15 @@ def _parse_memory(s):
     return int(float(s[:-1]) * units[s[-1].lower()])
 
 
-def _create_local_socket(socket_info):
+def _create_local_socket(sock_info):
     """
     Create a local socket that can be used to load deserialized data from the JVM
 
-    :param socket_info: Tuple of the port number and authentication secret of a local socket.
+    :param sock_info: Tuple of the port number and authentication secret of a local socket.
     :return: sockfile file descriptor of the local socket
     """
-    port = socket_info[0]
-    auth_secret = socket_info[1]
+    port = sock_info[0]
+    auth_secret = sock_info[1]
     sockfile, sock = local_connect_and_auth(port, auth_secret)
     # The RDD materialization time is unpredictable, if we set a timeout for socket reading
     # operation, it will very possibly fail. See SPARK-18281.
@@ -155,26 +155,26 @@ def _create_local_socket(socket_info):
     return sockfile
 
 
-def _load_from_socket(socket_info, serializer):
+def _load_from_socket(sock_info, serializer):
     """
     Connect to a local socket described by sock_info and use the given serializer to yield data
 
-    :param socket_info: Tuple of the port number and authentication secret of a local socket.
+    :param sock_info: Tuple of the port number and authentication secret of a local socket.
     :param serializer: The PySpark serializer to use
     :return: result of Serializer.load_stream, usually a generator that yields deserialized data
     """
-    sockfile = _create_local_socket(socket_info)
+    sockfile = _create_local_socket(sock_info)
     # The socket will be automatically closed when garbage-collected.
     return serializer.load_stream(sockfile)
 
 
-def _local_iterator_from_socket(socket_info, serializer):
+def _local_iterator_from_socket(sock_info, serializer):
 
     class PyLocalIterable(object):
         """ Create a synchronous local iterable over a socket """
 
-        def __init__(self, _socket_info, _serializer):
-            self._sockfile = _create_local_socket(_socket_info)
+        def __init__(self, _sock_info, _serializer):
+            self._sockfile = _create_local_socket(_sock_info)
             self._serializer = _serializer
             self._read_iter = iter([])  # Initialize as empty iterator
             self._read_status = 1
@@ -214,7 +214,7 @@ def _local_iterator_from_socket(socket_info, serializer):
                     # Ignore any errors, socket is automatically closed when garbage-collected
                     pass
 
-    return iter(PyLocalIterable(socket_info, serializer))
+    return iter(PyLocalIterable(sock_info, serializer))
 
 
 def ignore_unicode_prefix(f):
@@ -885,8 +885,8 @@ class RDD(object):
             to be small, as all the data is loaded into the driver's memory.
         """
         with SCCallSiteSync(self.context) as css:
-            socket_info = self.ctx._jvm.PythonRDD.collectAndServe(self._jrdd.rdd())
-        return list(_load_from_socket(socket_info, self._jrdd_deserializer))
+            sock_info = self.ctx._jvm.PythonRDD.collectAndServe(self._jrdd.rdd())
+        return list(_load_from_socket(sock_info, self._jrdd_deserializer))
 
     def reduce(self, f):
         """
@@ -2455,8 +2455,8 @@ class RDD(object):
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         """
         with SCCallSiteSync(self.context) as css:
-            socket_info = self.ctx._jvm.PythonRDD.toLocalIteratorAndServe(self._jrdd.rdd())
-        return _local_iterator_from_socket(socket_info, self._jrdd_deserializer)
+            sock_info = self.ctx._jvm.PythonRDD.toLocalIteratorAndServe(self._jrdd.rdd())
+        return _local_iterator_from_socket(sock_info, self._jrdd_deserializer)
 
     def barrier(self):
         """

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -174,7 +174,7 @@ def _local_iterator_from_socket(sock_info, serializer):
         """ Create a synchronous local iterable over a socket """
 
         def __init__(self, _sock_info, _serializer):
-            port, auth_secret, self.jserver_obj = _sock_info
+            port, auth_secret, self.jsocket_auth_server = _sock_info
             self._sockfile = _create_local_socket((port, auth_secret))
             self._serializer = _serializer
             self._read_iter = iter([])  # Initialize as empty iterator
@@ -197,7 +197,7 @@ def _local_iterator_from_socket(sock_info, serializer):
 
                 # An error occurred, join serving thread and raise any exceptions from the JVM
                 elif self._read_status == -1:
-                    self.jserver_obj.getResult()
+                    self.jsocket_auth_server.getResult()
 
         def __del__(self):
             # If local iterator is not fully consumed,

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -139,14 +139,15 @@ def _parse_memory(s):
     return int(float(s[:-1]) * units[s[-1].lower()])
 
 
-def _create_local_socket(port, auth_secret):
+def _create_local_socket(socket_info):
     """
     Create a local socket that can be used to load deserialized data from the JVM
 
-    :param port: The port number of the local socket
-    :param auth_secret: Secret used for authentication of the socket
+    :param socket_info: Tuple of the port number and authentication secret of a local socket.
     :return: sockfile file descriptor of the local socket
     """
+    port = socket_info[0]
+    auth_secret = socket_info[1]
     sockfile, sock = local_connect_and_auth(port, auth_secret)
     # The RDD materialization time is unpredictable, if we set a timeout for socket reading
     # operation, it will very possibly fail. See SPARK-18281.
@@ -154,27 +155,26 @@ def _create_local_socket(port, auth_secret):
     return sockfile
 
 
-def _load_from_socket(port, auth_secret, serializer):
+def _load_from_socket(socket_info, serializer):
     """
     Connect to a local socket described by sock_info and use the given serializer to yield data
 
-    :param port: The port number of the local socket
-    :param auth_secret: Secret used for authentication of the socket
+    :param socket_info: Tuple of the port number and authentication secret of a local socket.
     :param serializer: The PySpark serializer to use
     :return: result of Serializer.load_stream, usually a generator that yields deserialized data
     """
-    sockfile = _create_local_socket(port, auth_secret)
+    sockfile = _create_local_socket(socket_info)
     # The socket will be automatically closed when garbage-collected.
     return serializer.load_stream(sockfile)
 
 
-def _local_iterator_from_socket(port, auth_secret, serializer):
+def _local_iterator_from_socket(socket_info, serializer):
 
     class PyLocalIterable(object):
         """ Create a synchronous local iterable over a socket """
 
-        def __init__(self, _port, _auth_secret, _serializer):
-            self._sockfile = _create_local_socket(_port, _auth_secret)
+        def __init__(self, _socket_info, _serializer):
+            self._sockfile = _create_local_socket(_socket_info)
             self._serializer = _serializer
             self._read_iter = iter([])  # Initialize as empty iterator
             self._read_status = 1
@@ -214,7 +214,7 @@ def _local_iterator_from_socket(port, auth_secret, serializer):
                     # Ignore any errors, socket is automatically closed when garbage-collected
                     pass
 
-    return iter(PyLocalIterable(port, auth_secret, serializer))
+    return iter(PyLocalIterable(socket_info, serializer))
 
 
 def ignore_unicode_prefix(f):
@@ -885,8 +885,8 @@ class RDD(object):
             to be small, as all the data is loaded into the driver's memory.
         """
         with SCCallSiteSync(self.context) as css:
-            port, auth_secret, _ = self.ctx._jvm.PythonRDD.collectAndServe(self._jrdd.rdd())
-        return list(_load_from_socket(port, auth_secret, self._jrdd_deserializer))
+            socket_info = self.ctx._jvm.PythonRDD.collectAndServe(self._jrdd.rdd())
+        return list(_load_from_socket(socket_info, self._jrdd_deserializer))
 
     def reduce(self, f):
         """
@@ -2455,8 +2455,8 @@ class RDD(object):
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         """
         with SCCallSiteSync(self.context) as css:
-            port, auth_secret, _ = self.ctx._jvm.PythonRDD.toLocalIteratorAndServe(self._jrdd.rdd())
-        return _local_iterator_from_socket(port, auth_secret, self._jrdd_deserializer)
+            socket_info = self.ctx._jvm.PythonRDD.toLocalIteratorAndServe(self._jrdd.rdd())
+        return _local_iterator_from_socket(socket_info, self._jrdd_deserializer)
 
     def barrier(self):
         """

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2200,14 +2200,14 @@ class DataFrame(object):
         .. note:: Experimental.
         """
         with SCCallSiteSync(self._sc) as css:
-            port, auth_secret, jserver_obj = self._jdf.collectAsArrowToPython()
+            port, auth_secret, jsocket_auth_server = self._jdf.collectAsArrowToPython()
 
         # Collect list of un-ordered batches where last element is a list of correct order indices
         try:
             results = list(_load_from_socket((port, auth_secret), ArrowCollectSerializer()))
         finally:
             # Join serving thread and raise any exceptions from collectAsArrowToPython
-            jserver_obj.getResult()
+            jsocket_auth_server.getResult()
 
         # Separate RecordBatches from batch order indices in results
         batches = results[:-1]

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -379,9 +379,9 @@ class DataFrame(object):
             self._support_repr_html = True
         if self.sql_ctx._conf.isReplEagerEvalEnabled():
             max_num_rows = max(self.sql_ctx._conf.replEagerEvalMaxNumRows(), 0)
-            socket_info = self._jdf.getRowsToPython(
+            sock_info = self._jdf.getRowsToPython(
                 max_num_rows, self.sql_ctx._conf.replEagerEvalTruncate())
-            rows = list(_load_from_socket(socket_info, BatchedSerializer(PickleSerializer())))
+            rows = list(_load_from_socket(sock_info, BatchedSerializer(PickleSerializer())))
             head = rows[0]
             row_data = rows[1:]
             has_more_data = len(row_data) > max_num_rows
@@ -513,8 +513,8 @@ class DataFrame(object):
         [Row(age=2, name=u'Alice'), Row(age=5, name=u'Bob')]
         """
         with SCCallSiteSync(self._sc) as css:
-            socket_info = self._jdf.collectToPython()
-        return list(_load_from_socket(socket_info, BatchedSerializer(PickleSerializer())))
+            sock_info = self._jdf.collectToPython()
+        return list(_load_from_socket(sock_info, BatchedSerializer(PickleSerializer())))
 
     @ignore_unicode_prefix
     @since(2.0)
@@ -527,8 +527,8 @@ class DataFrame(object):
         [Row(age=2, name=u'Alice'), Row(age=5, name=u'Bob')]
         """
         with SCCallSiteSync(self._sc) as css:
-            socket_info = self._jdf.toPythonIterator()
-        return _local_iterator_from_socket(socket_info, BatchedSerializer(PickleSerializer()))
+            sock_info = self._jdf.toPythonIterator()
+        return _local_iterator_from_socket(sock_info, BatchedSerializer(PickleSerializer()))
 
     @ignore_unicode_prefix
     @since(1.3)

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -214,7 +214,7 @@ class ArrowTests(ReusedSQLTestCase):
         exception_udf = udf(raise_exception, IntegerType())
         df = df.withColumn("error", exception_udf())
         with QuietTest(self.sc):
-            with self.assertRaisesRegexp(RuntimeError, 'My error'):
+            with self.assertRaisesRegexp(Exception, 'My error'):
                 df.toPandas()
 
     def _createDataFrame_toggle(self, pdf, schema=None):

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -26,7 +26,7 @@ import scala.util.control.NonFatal
 
 import org.apache.commons.lang3.StringUtils
 
-import org.apache.spark.{SparkException, TaskContext}
+import org.apache.spark.TaskContext
 import org.apache.spark.annotation.{DeveloperApi, Evolving, Experimental, Stable, Unstable}
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.api.java.function._
@@ -3304,7 +3304,7 @@ class Dataset[T] private[sql](
     val timeZoneId = sparkSession.sessionState.conf.sessionLocalTimeZone
 
     withAction("collectAsArrowToPython", queryExecution) { plan =>
-      PythonRDD.serveToStreamWithSync("serve-Arrow") { outputStream =>
+      PythonRDD.serveToStream("serve-Arrow") { outputStream =>
         val out = new DataOutputStream(outputStream)
         val batchWriter = new ArrowBatchStreamWriter(schema, out, timeZoneId)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently with `toLocalIterator()` and `toPandas()` with Arrow enabled, if the Spark job being run in the background serving thread errors, it will be caught and sent to Python through the PySpark serializer. 
This is not the ideal solution because it is only catch a SparkException, it won't handle an error that occurs in the serializer, and each method has to have it's own special handling to propagate the error.

This PR instead returns the Python Server object along with the serving port and authentication info, so that it allows the Python caller to join with the serving thread. During the call to join, the serving thread Future is completed either successfully or with an exception. In the latter case, the exception will be propagated to Python through the Py4j call.

## How was this patch tested?

Existing tests