### PR TITLE
[SPARK-27258][K8S]Deal with the k8s resource names that don't match their own regular expression

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -198,6 +198,7 @@ private[spark] object KubernetesConf {
       .replaceAll("\\.", "-")
       .replaceAll("[^a-z0-9\\-]", "")
       .replaceAll("-+", "-")
+      .replaceAll("^-", "")
   }
 
   /**

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStep.scala
@@ -39,14 +39,15 @@ private[spark] class DriverServiceFeatureStep(
       "managed via a Kubernetes service.")
 
   private val preferredServiceName = s"${kubernetesConf.resourceNamePrefix}$DRIVER_SVC_POSTFIX"
-  private val resolvedServiceName = if (preferredServiceName.length <= MAX_SERVICE_NAME_LENGTH) {
+  private val resolvedServiceName = if (preferredServiceName.length <= MAX_SERVICE_NAME_LENGTH
+    && Character.isLetter(preferredServiceName.charAt(0))) {
     preferredServiceName
   } else {
     val randomServiceId = KubernetesUtils.uniqueID(clock = clock)
     val shorterServiceName = s"spark-$randomServiceId$DRIVER_SVC_POSTFIX"
     logWarning(s"Driver's hostname would preferably be $preferredServiceName, but this is " +
-      s"too long (must be <= $MAX_SERVICE_NAME_LENGTH characters). Falling back to use " +
-      s"$shorterServiceName as the driver service's name.")
+      s"too long (must be <= $MAX_SERVICE_NAME_LENGTH characters) or is not a valid service name." +
+      s"Falling back to use $shorterServiceName as the driver service's name.")
     shorterServiceName
   }
 


### PR DESCRIPTION

## What changes were proposed in this pull request?
The regex of Pod is ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*.
The regex of Servive is ^[a-z]([-a-z0-9]*[a-z0-9])?.
The regex of Secret is ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*.

If --name=-min, the first character is '-' ,which does not satisfy the regex for Pod ,Service,Secret.
if --name=1min, the first character is digit, which does not satisfy the regex for Service.

[Previous Conflict PR](https://github.com/apache/spark/pull/24219)

