### PR TITLE
[SPARK-27998][SQL] Column alias should support quote string

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -592,7 +592,7 @@ functionIdentifier
     ;
 
 namedExpression
-    : expression (AS? (identifier | identifierList))?
+    : expression (AS? (identifier | STRING | identifierList))?
     ;
 
 namedExpressionSeq

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1030,6 +1030,8 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
     val e = expression(ctx.expression)
     if (ctx.identifier != null) {
       Alias(e, ctx.identifier.getText)()
+    } else if (ctx.STRING() != null) {
+      Alias(e, ctx.STRING().getText)()
     } else if (ctx.identifierList != null) {
       MultiAlias(e, visitIdentifierList(ctx.identifierList))
     } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

According to the ANSI SQL standard, column alias can be double quote string but SparkSQL only support backquote string.
```sql 
SELECT au_fname AS "First name", 
au_lname AS 'Last name', 
city AS City, 
state, 
zip 'Postal code' FROM authors;
 ```

However, SparkSQL's syntax is different from others DB engines.

- MySQL support Backquote(``), Single quote (''), Double quote("").
- SQL Server support Single quote (''), Double quote("").
- Teradata, Oracle, PostgreSQL only support  Double quote("").


## How was this patch tested?

Pass the Jenkins with the updated test cases.