### PR TITLE
[SPARK-28003][PYTHON] Allow NaT values when creating Spark dataframe from pandas with Arrow

### DIFF
--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -296,8 +296,7 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
             mask = s.isnull()
             # Ensure timestamp series are in expected form for Spark internal representation
             if t is not None and pa.types.is_timestamp(t):
-                s = _check_series_convert_timestamps_internal(s.fillna(0), self._timezone)
-
+                s = _check_series_convert_timestamps_internal(s, self._timezone)
             try:
                 array = pa.Array.from_pandas(s, mask=mask, type=t, safe=self._safecheck)
             except pa.ArrowException as e:

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -383,6 +383,7 @@ class ArrowTests(ReusedSQLTestCase):
         assert_frame_equal(pdf, df_from_python.toPandas())
         assert_frame_equal(pdf, df_from_pandas.toPandas())
 
+    # Regression test for SPARK-28003
     def test_timestamp_nat(self):
         dt = [pd.NaT, pd.Timestamp('2019-06-11'), None] * 100
         pdf = pd.DataFrame({'time': dt})

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -384,17 +384,16 @@ class ArrowTests(ReusedSQLTestCase):
         assert_frame_equal(pdf, df_from_pandas.toPandas())
 
     def test_timestamp_nat(self):
-        import pandas as pd
-        dt1 = [pd.NaT, pd.Timestamp('2019-06-11')] * 100
-        dt2 = [None, pd.Timestamp('2019-06-11')] * 100
-        pdf1 = pd.DataFrame({'time': dt1})
-        pdf2 = pd.DataFrame({'time': dt2})
+        dt = [pd.NaT, pd.Timestamp('2019-06-11'), None] * 100
+        pdf = pd.DataFrame({'time': dt})
 
-        df1 = self.spark.createDataFrame(pdf1)
-        df2 = self.spark.createDataFrame(pdf2)
+        with self.sql_conf({'spark.sql.execution.arrow.pyspark.enabled': "false"}):
+            df = self.spark.createDataFrame(pdf)
+            assert_frame_equal(pdf, df.toPandas())
 
-        assert_frame_equal(pdf1, df1.toPandas())
-        assert_frame_equal(pdf2, df2.toPandas())
+        with self.sql_conf({'spark.sql.execution.arrow.pyspark.enabled': "true"}):
+            df = self.spark.createDataFrame(pdf)
+            assert_frame_equal(pdf, df.toPandas())
 
     def test_toPandas_batch_order(self):
 

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -387,11 +387,10 @@ class ArrowTests(ReusedSQLTestCase):
     def test_timestamp_nat(self):
         dt = [pd.NaT, pd.Timestamp('2019-06-11'), None] * 100
         pdf = pd.DataFrame({'time': dt})
+        df_no_arrow, df_arrow = self._createDataFrame_toggle(pdf)
 
-        for arrow_enabled in [False, True]:
-            with self.sql_conf({'spark.sql.execution.arrow.pyspark.enabled': arrow_enabled}):
-                df = self.spark.createDataFrame(pdf)
-                assert_frame_equal(pdf, df.toPandas())
+        assert_frame_equal(pdf, df_no_arrow.toPandas())
+        assert_frame_equal(pdf, df_arrow.toPandas())
 
     def test_toPandas_batch_order(self):
 

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -388,13 +388,10 @@ class ArrowTests(ReusedSQLTestCase):
         dt = [pd.NaT, pd.Timestamp('2019-06-11'), None] * 100
         pdf = pd.DataFrame({'time': dt})
 
-        with self.sql_conf({'spark.sql.execution.arrow.pyspark.enabled': "false"}):
-            df = self.spark.createDataFrame(pdf)
-            assert_frame_equal(pdf, df.toPandas())
-
-        with self.sql_conf({'spark.sql.execution.arrow.pyspark.enabled': "true"}):
-            df = self.spark.createDataFrame(pdf)
-            assert_frame_equal(pdf, df.toPandas())
+        for arrow_enabled in [False, True]:
+            with self.sql_conf({'spark.sql.execution.arrow.pyspark.enabled': arrow_enabled}):
+                df = self.spark.createDataFrame(pdf)
+                assert_frame_equal(pdf, df.toPandas())
 
     def test_toPandas_batch_order(self):
 

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -383,6 +383,19 @@ class ArrowTests(ReusedSQLTestCase):
         assert_frame_equal(pdf, df_from_python.toPandas())
         assert_frame_equal(pdf, df_from_pandas.toPandas())
 
+    def test_timestamp_nat(self):
+        import pandas as pd
+        dt1 = [pd.NaT, pd.Timestamp('2019-06-11')] * 100
+        dt2 = [None, pd.Timestamp('2019-06-11')] * 100
+        pdf1 = pd.DataFrame({'time': dt1})
+        pdf2 = pd.DataFrame({'time': dt2})
+
+        df1 = self.spark.createDataFrame(pdf1)
+        df2 = self.spark.createDataFrame(pdf2)
+
+        assert_frame_equal(pdf1, df1.toPandas())
+        assert_frame_equal(pdf2, df2.toPandas())
+
     def test_toPandas_batch_order(self):
 
         def delay_first_part(partition_index, iterator):


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch removes `fillna(0)` when creating ArrowBatch from a pandas Series.

With `fillna(0)`, the original code would turn a timestamp type into object type, which pyarrow will complain later:
```
>>> s = pd.Series([pd.NaT, pd.Timestamp('2015-01-01')])
>>> s.dtypes
dtype('<M8[ns]')
>>> s.fillna(0)
0                      0
1    2015-01-01 00:00:00
dtype: object
```

## How was this patch tested?

Added `test_timestamp_nat`