### PR TITLE
[SPARK-28012][SQL] Hive UDF supports struct type foldable expression

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -847,6 +847,8 @@ private[hive] trait HiveInspectors {
 
         ObjectInspectorFactory.getStandardConstantMapObjectInspector(keyOI, valueOI, jmap)
       }
+    case Literal(_, dt: StructType) =>
+      toInspector(dt)
     // We will enumerate all of the possible constant expressions, throw exception if we missed
     case Literal(_, dt) => sys.error(s"Hive doesn't support the constant type [$dt].")
     // ideally, we don't test the foldable here(but in optimizer), however, some of the

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -652,13 +652,13 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
       }
     }
   }
-  test("SPARK-28012 Hive UDF supports literal struct type") {
-    withUserDefinedFunction("testLiteralStructType" -> false) {
+  test("SPARK-28012 Hive UDF supports struct type foldable expression") {
+    withUserDefinedFunction("testUDFStructType" -> false) {
       // Simulate a hive udf that supports struct parameters
-      sql("CREATE FUNCTION testLiteralStructType AS '" +
+      sql("CREATE FUNCTION testUDFStructType AS '" +
         s"${classOf[GenericUDFArray].getName}'")
       checkAnswer(
-        sql("SELECT testLiteralStructType(named_struct('name', 'xx', 'value', 1))[0].value"),
+        sql("SELECT testUDFStructType(named_struct('name', 'xx', 'value', 1))[0].value"),
         Seq(Row(1)))
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -652,6 +652,16 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
       }
     }
   }
+  test("SPARK-25768 Hive UDF supports literal struct type") {
+    withUserDefinedFunction("testLiteralStructType" -> false) {
+      // Simulate a hive udf that supports struct parameters
+      sql(s"CREATE FUNCTION testLiteralStructType AS '" +
+        s"${classOf[GenericUDFArray].getName}'")
+      checkAnswer(
+        sql("SELECT testLiteralStructType(named_struct('name', 'xx', 'value', 1))[0].value"),
+        Seq(Row(1)))
+    }
+  }
 }
 
 class TestPair(x: Int, y: Int) extends Writable with Serializable {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -655,7 +655,7 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
   test("SPARK-28012 Hive UDF supports literal struct type") {
     withUserDefinedFunction("testLiteralStructType" -> false) {
       // Simulate a hive udf that supports struct parameters
-      sql(s"CREATE FUNCTION testLiteralStructType AS '" +
+      sql("CREATE FUNCTION testLiteralStructType AS '" +
         s"${classOf[GenericUDFArray].getName}'")
       checkAnswer(
         sql("SELECT testLiteralStructType(named_struct('name', 'xx', 'value', 1))[0].value"),

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -652,7 +652,7 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
       }
     }
   }
-  test("SPARK-25768 Hive UDF supports literal struct type") {
+  test("SPARK-28012 Hive UDF supports literal struct type") {
     withUserDefinedFunction("testLiteralStructType" -> false) {
       // Simulate a hive udf that supports struct parameters
       sql(s"CREATE FUNCTION testLiteralStructType AS '" +

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -662,6 +662,7 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
         Seq(Row(1)))
     }
   }
+
 }
 
 class TestPair(x: Int, y: Int) extends Writable with Serializable {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently using hive udf, the parameter is struct type, there will be an exception thrown.

No handler for Hive UDF 'xxxUDF': java.lang.RuntimeException: Hive doesn't support the constant type [StructType(StructField(name,StringType,true), StructField(value,DecimalType(3,1),true))]

## How was this patch tested?
added new UT