### PR TITLE
[SPARK-28014][core] All waiting apps will be changed to the wrong state of Running after master changed.

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -561,7 +561,7 @@ private[deploy] class Master(
     apps.filter(_.state == ApplicationState.UNKNOWN).foreach(finishApplication)
 
     // Update the state of recovered apps to RUNNING
-    apps.filter(_.state == ApplicationState.WAITING).foreach(_.state = ApplicationState.RUNNING)
+    apps.filter(_.coresLeft == 0).foreach(_.state = ApplicationState.RUNNING)
 
     // Reschedule drivers which were not claimed by any workers
     drivers.filter(_.worker.isEmpty).foreach { d =>

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -561,7 +561,7 @@ private[deploy] class Master(
     apps.filter(_.state == ApplicationState.UNKNOWN).foreach(finishApplication)
 
     // Update the state of recovered apps to RUNNING
-    apps.filter(_.coresLeft == 0).foreach(_.state = ApplicationState.RUNNING)
+    apps.filter(_.coresGranted > 0).foreach(_.state = ApplicationState.RUNNING)
 
     // Reschedule drivers which were not claimed by any workers
     drivers.filter(_.worker.isEmpty).foreach { d =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

These waiting apps which granted 0 cores will be changed to Running state after master changed, that is a little weird.

currently:
![image](https://user-images.githubusercontent.com/24823338/59333239-828e0880-8d2a-11e9-84ae-478fe118c5ee.png)

fixed:
![image](https://user-images.githubusercontent.com/24823338/59333330-ad785c80-8d2a-11e9-9587-45b8f63691fc.png)




 

## How was this patch tested?

update tests
