### PR TITLE
[SPARK-28018][SQL] Allow upcasting decimal to double/float

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalType.scala
@@ -77,6 +77,7 @@ case class DecimalType(precision: Int, scale: Int) extends FractionalType {
       (precision - scale) >= (dt.precision - dt.scale) && scale >= dt.scale
     case dt: IntegralType =>
       isWiderThan(DecimalType.forType(dt))
+    // For DoubleType/FloatType, the value can be NaN, PositiveInfinity or NegativeInfinity.
     case _ => false
   }
 
@@ -87,7 +88,7 @@ case class DecimalType(precision: Int, scale: Int) extends FractionalType {
   private[sql] def isTighterThan(other: DataType): Boolean = other match {
     case dt: DecimalType =>
       (precision - scale) <= (dt.precision - dt.scale) && scale <= dt.scale
-    case dt: IntegralType =>
+    case dt: NumericType =>
       isTighterThan(DecimalType.forType(dt))
     case _ => false
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -1004,6 +1004,30 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
   }
 
+  test("up-cast decimal to float") {
+    // DecimalType(14, 7) is compatible with FloatType.
+    assert(Cast.canUpCast(DecimalType(3, 0), FloatType))
+    assert(Cast.canUpCast(DecimalType(3, 1), FloatType))
+    assert(Cast.canUpCast(DecimalType(13, 6), FloatType))
+    assert(Cast.canUpCast(DecimalType(13, 7), FloatType))
+    assert(Cast.canUpCast(DecimalType(14, 7), FloatType))
+    assert(!Cast.canUpCast(DecimalType(9, 8), FloatType))
+    assert(!Cast.canUpCast(DecimalType(14, 6), FloatType))
+    assert(!Cast.canUpCast(DecimalType(20, 1), FloatType))
+  }
+
+  test("up-cast decimal to double") {
+    // DecimalType(30, 15) is compatible with DoubleType.
+    assert(Cast.canUpCast(DecimalType(3, 0), DoubleType))
+    assert(Cast.canUpCast(DecimalType(3, 1), DoubleType))
+    assert(Cast.canUpCast(DecimalType(29, 14), DoubleType))
+    assert(Cast.canUpCast(DecimalType(29, 15), DoubleType))
+    assert(Cast.canUpCast(DecimalType(30, 15), DoubleType))
+    assert(!Cast.canUpCast(DecimalType(16, 16), DoubleType))
+    assert(!Cast.canUpCast(DecimalType(31, 15), DoubleType))
+    assert(!Cast.canUpCast(DecimalType(30, 14), DoubleType))
+  }
+
   test("SPARK-27671: cast from nested null type in struct") {
     import DataTypeTestUtils._
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, Spark only allows upcasting DecimalType to IntegralType or DecimalType.

This PR proposes: if the target DecimalType is tighter than DoubleType or FloatType, we can upcast it as well.
The upcasting matters because it blocks https://github.com/apache/spark/pull/24806. E.g, if there is a table "t" with only one column of double type, 
```
INSERT INTO TABLE t SELECT 10.0
```
The data type of value 10.0 is DecimalType(3, 1). In the current code, Spark can't upcast the decimal to the column of double type.


## How was this patch tested?

Unit test 
