### PR TITLE
[MINOR][SQL] Avoid wildcard import Network in KafkaRDD.

### DIFF
--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/KafkaRDD.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/KafkaRDD.scala
@@ -24,7 +24,7 @@ import org.apache.kafka.common.TopicPartition
 
 import org.apache.spark.{Partition, SparkContext, TaskContext}
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.Network._
+import org.apache.spark.internal.config.Network.NETWORK_TIMEOUT
 import org.apache.spark.partial.{BoundedDouble, PartialResult}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.scheduler.ExecutorCacheTaskLocation


### PR DESCRIPTION
## What changes were proposed in this pull request?

KafkaRDD exists import with wildcard, I think this is a minor task. but it's OK.

## How was this patch tested?

Exists UT.