### PR TITLE
[SPARK-27100][SQL] Use `Array` instead of `Seq` in `FilePartition` to prevent `StackOverflowError `

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -381,7 +381,7 @@ case class FileSourceScanExec(
       fsRelation: HadoopFsRelation): RDD[InternalRow] = {
     logInfo(s"Planning with ${bucketSpec.numBuckets} buckets")
     val filesGroupedToBuckets =
-      selectedPartitions.flatMap { p =>
+      selectedPartitions.toArray.flatMap { p =>
         p.files.map { f =>
           PartitionedFileUtil.getPartitionedFile(f, f.getPath, p.values)
         }
@@ -401,7 +401,7 @@ case class FileSourceScanExec(
     }
 
     val filePartitions = Seq.tabulate(bucketSpec.numBuckets) { bucketId =>
-      FilePartition(bucketId, prunedFilesGroupedToBuckets.getOrElse(bucketId, Nil))
+      FilePartition(bucketId, prunedFilesGroupedToBuckets.getOrElse(bucketId, Array.empty))
     }
 
     new FileScanRDD(fsRelation.sparkSession, readFile, filePartitions)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FilePartition.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FilePartition.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.sources.v2.reader.InputPartition
  * A collection of file blocks that should be read as a single task
  * (possibly from multiple partitioned directories).
  */
-case class FilePartition(index: Int, files: Seq[PartitionedFile])
+case class FilePartition(index: Int, files: Array[PartitionedFile])
   extends Partition with InputPartition {
   override def preferredLocations(): Array[String] = {
     // Computes total number of bytes can be retrieved from each host.
@@ -62,7 +62,7 @@ object FilePartition extends Logging {
     def closePartition(): Unit = {
       if (currentFiles.nonEmpty) {
         // Copy to a new Array.
-        val newPartition = FilePartition(partitions.size, currentFiles.toArray.toSeq)
+        val newPartition = FilePartition(partitions.size, currentFiles.toArray)
         partitions += newPartition
       }
       currentFiles.clear()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -279,7 +279,7 @@ class FileSourceStrategySuite extends QueryTest with SharedSQLContext with Predi
   }
 
   test("Locality support for FileScanRDD") {
-    val partition = FilePartition(0, Seq(
+    val partition = FilePartition(0, Array(
       PartitionedFile(InternalRow.empty, "fakePath0", 0, 10, Array("host0", "host1")),
       PartitionedFile(InternalRow.empty, "fakePath0", 10, 20, Array("host1", "host2")),
       PartitionedFile(InternalRow.empty, "fakePath1", 0, 5, Array("host3")),

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
@@ -744,7 +744,7 @@ abstract class BucketedReadSuite extends QueryTest with SQLTestUtils {
     val nCount = 20000
     // reshuffle data so that many small files are created
     val nShufflePartitions = 10000
-    // and with one table partition, should result in 6000 files in one partition
+    // and with one table partition, should result in 10000 files in one partition
     val nPartitions = 1
     val nBuckets = 2
     val dfPartitioned = (0 until nCount)

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
@@ -760,7 +760,6 @@ abstract class BucketedReadSuite extends QueryTest with SQLTestUtils with Privat
       val fakeHadoopFsRelation =
         HadoopFsRelation(null, schema, schema, null, new ParquetFileFormat, null)(sparkSession)
       val optionalBucketSet = null
-      val bucketSpec = BucketSpec(1, Seq("a"), Seq("b"))
       val files = (0 until numFilesInPartition).toStream.map { i =>
         new FileStatus(10, false, 1, 512, 1000, new Path(s"file${i}_0.zzz"))
       }
@@ -777,6 +776,7 @@ abstract class BucketedReadSuite extends QueryTest with SQLTestUtils with Privat
       val inputRDD = if (isBucketed) {
         // Create a Bucketed RDD. This is a private method so we need to call this indirectly.
         val createBucketedReadRDD = PrivateMethod[RDD[InternalRow]]('createBucketedReadRDD)
+        val bucketSpec = BucketSpec(1, Seq("a"), Seq("b"))
 
         fileSource.invokePrivate(createBucketedReadRDD(bucketSpec,
           (_: PartitionedFile) => Seq(InternalRow(1)).toIterator,

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
@@ -741,9 +741,9 @@ abstract class BucketedReadSuite extends QueryTest with SQLTestUtils {
   //  overflow if the files list is stored in a recursive data structure
   //  This test is ignored because it takes long to run (~3 min)
   ignore("SPARK-27100 stack overflow: read data with large partitions") {
-    val nCount = 12000
+    val nCount = 20000
     // reshuffle data so that many small files are created
-    val nShufflePartitions = 6000
+    val nShufflePartitions = 10000
     // and with one table partition, should result in 6000 files in one partition
     val nPartitions = 1
     val nBuckets = 2


### PR DESCRIPTION
## What changes were proposed in this pull request?

ShuffleMapTask's partition field is a FilePartition and FilePartition's 'files' field is a Stream$cons which is essentially a linked list. It is therefore serialized recursively.
If the number of files in each partition is, say, 10000 files, recursing into a linked list of length 10000 overflows the stack

The problem is only in Bucketed partitions. The corresponding implementation for non Bucketed partitions uses a StreamBuffer. The proposed change applies the same for Bucketed partitions.

## How was this patch tested?

Existing unit tests. Added new unit test. The unit test fails without the patch. Manual testing on dataset used to reproduce the problem.
