### PR TITLE
[SPARK-28053][INFRA] Handle a corner case where there is no `Link` header

### DIFF
--- a/dev/github_jira_sync.py
+++ b/dev/github_jira_sync.py
@@ -77,8 +77,8 @@ def get_jira_prs():
                 result = result + [(jira, pull)]
 
         # Check if there is another page
-        link_header = filter(lambda k: k.startswith("Link"), page.info().headers)[0]
-        if "next" not in link_header:
+        link_headers = filter(lambda k: k.startswith("Link"), page.info().headers)
+        if not link_headers or "next" not in link_headers[0]:
             has_next_page = False
         else:
             page_num += 1


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, `github_jira_sync.py` assumes that there is `Link` always. However, it will fail when the number of the open PR is less than 100 (the default paging number). It will not happen in Apache Spark, but we had better fix that because it happens during review process for `github_jira_sync.py` script.
```
Traceback (most recent call last):
  File "dev/github_jira_sync.py", line 139, in <module>
    jira_prs = get_jira_prs()
  File "dev/github_jira_sync.py", line 83, in get_jira_prs
    link_header = filter(lambda k: k.startswith("Link"), page.info().headers)[0]
IndexError: list index out of range
```

## How was this patch tested?

Manually check with another repo which has small number of open PRs (< 100).
```
$ export JIRA_PASSWORD=...
$ export GITHUB_API_BASE='https://api.github.com/repos/your-id/spark'
$ dev/github_jira_sync.py
```