### PR TITLE
[SPARK-28042][K8S] Support using hostpath volume mount as local storage

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesDriverBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesDriverBuilder.scala
@@ -43,12 +43,12 @@ private[spark] class KubernetesDriverBuilder {
       new DriverServiceFeatureStep(conf),
       new MountSecretsFeatureStep(conf),
       new EnvSecretsFeatureStep(conf),
-      new LocalDirsFeatureStep(conf),
       new MountVolumesFeatureStep(conf),
       new DriverCommandFeatureStep(conf),
       new HadoopConfDriverFeatureStep(conf),
       new KerberosConfDriverFeatureStep(conf),
-      new PodTemplateConfigMapStep(conf))
+      new PodTemplateConfigMapStep(conf),
+      new LocalDirsFeatureStep(conf))
 
     val spec = KubernetesDriverSpec(
       initialPod,

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
@@ -43,8 +43,8 @@ private[spark] class KubernetesExecutorBuilder {
       new BasicExecutorFeatureStep(conf, secMgr),
       new MountSecretsFeatureStep(conf),
       new EnvSecretsFeatureStep(conf),
-      new LocalDirsFeatureStep(conf),
-      new MountVolumesFeatureStep(conf))
+      new MountVolumesFeatureStep(conf),
+      new LocalDirsFeatureStep(conf))
 
     features.foldLeft(initialPod) { case (pod, feature) => feature.configurePod(pod) }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr is used to support using hostpath/PV volume mounts as local storage. In KubernetesExecutorBuilder.scala, the LocalDrisFeatureStep is built before MountVolumesFeatureStep which means we cannot use any volumes mount later. This pr adjust the order of feature building steps which moves localDirsFeature at last so that we can check if directories in SPARK_LOCAL_DIRS are set to volumes mounted such as hostPath, PV, or others.

## How was this patch tested?

Unit tests
