### PR TITLE
[SPARK-28042][K8S] Support using volume mount as local storage

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -285,7 +285,16 @@ The configuration properties for mounting volumes into the executor pods use pre
 
 ## Local Storage
 
-Spark uses temporary scratch space to spill data to disk during shuffles and other operations.  When using Kubernetes as the resource manager the pods will be created with an [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) volume mounted for each directory listed in `SPARK_LOCAL_DIRS`.  If no directories are explicitly specified then a default directory is created and configured appropriately.
+Spark supports using volumes to spill data during shuffles and other operations. To use a volume as local storage, the volume's name should be set with `spark-local-dir` prefix and mount path should be set in the `spark.local.dir`, for example:
+
+```
+--conf spark.kubernetes.driver.volumes.[VolumeType].spark-local-dir-[VolumeName].mount.path=<mount path>
+--conf spark.kubernetes.driver.volumes.[VolumeType].spark-local-dir-[VolumeName].mount.readOnly=false
+--conf spark.local.dir=<mount path>
+```
+
+
+If no volume is set as local storage, Spark uses temporary scratch space to spill data to disk during shuffles and other operations.  When using Kubernetes as the resource manager the pods will be created with an [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) volume mounted for each directory listed in `SPARK_LOCAL_DIRS`.  If no directories are explicitly specified then a default directory is created and configured appropriately.
 
 `emptyDir` volumes use the ephemeral storage feature of Kubernetes and do not persist beyond the life of the pod.
 

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -285,12 +285,11 @@ The configuration properties for mounting volumes into the executor pods use pre
 
 ## Local Storage
 
-Spark supports using volumes to spill data during shuffles and other operations. To use a volume as local storage, the volume's name should starts with `spark-local-dir-` and the mount path should be set in the spark configuration `spark.local.dir` or in the pod environment variable `SPARK_LOCAL_DIRS`, for example:
+Spark supports using volumes to spill data during shuffles and other operations. To use a volume as local storage, the volume's name should starts with `spark-local-dir-`, for example:
 
 ```
 --conf spark.kubernetes.driver.volumes.[VolumeType].spark-local-dir-[VolumeName].mount.path=<mount path>
 --conf spark.kubernetes.driver.volumes.[VolumeType].spark-local-dir-[VolumeName].mount.readOnly=false
---conf spark.local.dir=<mount path>
 ```
 
 

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -293,7 +293,7 @@ Spark supports using volumes to spill data during shuffles and other operations.
 ```
 
 
-If none volume is set as local storage, Spark uses temporary scratch space to spill data to disk during shuffles and other operations. When using Kubernetes as the resource manager the pods will be created with an [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) volume mounted for each directory listed in `SPARK_LOCAL_DIRS`.  If no directories are explicitly specified then a default directory is created and configured appropriately.
+If no volume is set as local storage, Spark uses temporary scratch space to spill data to disk during shuffles and other operations. When using Kubernetes as the resource manager the pods will be created with an [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) volume mounted for each directory listed in `spark.local.dir` or the environment variable `SPARK_LOCAL_DIRS` .  If no directories are explicitly specified then a default directory is created and configured appropriately.
 
 `emptyDir` volumes use the ephemeral storage feature of Kubernetes and do not persist beyond the life of the pod.
 

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -285,7 +285,7 @@ The configuration properties for mounting volumes into the executor pods use pre
 
 ## Local Storage
 
-Spark supports using volumes to spill data during shuffles and other operations. To use a volume as local storage, the volume's name should be set with `spark-local-dir` prefix and mount path should be set in the `spark.local.dir`, for example:
+Spark supports using volumes to spill data during shuffles and other operations. To use a volume as local storage, the volume's name should starts with `spark-local-dir-` and the mount path should be set in the spark configuration `spark.local.dir` or in the pod environment variable `SPARK_LOCAL_DIRS`, for example:
 
 ```
 --conf spark.kubernetes.driver.volumes.[VolumeType].spark-local-dir-[VolumeName].mount.path=<mount path>
@@ -294,7 +294,7 @@ Spark supports using volumes to spill data during shuffles and other operations.
 ```
 
 
-If no volume is set as local storage, Spark uses temporary scratch space to spill data to disk during shuffles and other operations.  When using Kubernetes as the resource manager the pods will be created with an [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) volume mounted for each directory listed in `SPARK_LOCAL_DIRS`.  If no directories are explicitly specified then a default directory is created and configured appropriately.
+If none volume is set as local storage, Spark uses temporary scratch space to spill data to disk during shuffles and other operations. When using Kubernetes as the resource manager the pods will be created with an [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) volume mounted for each directory listed in `SPARK_LOCAL_DIRS`.  If no directories are explicitly specified then a default directory is created and configured appropriately.
 
 `emptyDir` volumes use the ephemeral storage feature of Kubernetes and do not persist beyond the life of the pod.
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStep.scala
@@ -19,7 +19,7 @@ package org.apache.spark.deploy.k8s.features
 import java.util.UUID
 
 import collection.JavaConverters._
-import io.fabric8.kubernetes.api.model.{ContainerBuilder, PodBuilder, Volume, VolumeBuilder, VolumeMount, VolumeMountBuilder}
+import io.fabric8.kubernetes.api.model._
 
 import org.apache.spark.deploy.k8s.{KubernetesConf, SparkPod}
 import org.apache.spark.deploy.k8s.Config._
@@ -44,7 +44,8 @@ private[spark] class LocalDirsFeatureStep(
     val prefix = "spark-local-dir-"
     val localDirVolumes = resolvedLocalDirs
       .zipWithIndex
-      .map { case (localDir, index) => findVolumeMount(pod, prefix, localDir) match {
+      .map {
+        case (localDir, index) => findVolumeMount(pod, prefix, localDir) match {
           case Some(volumeMount) => findVolume(pod, volumeMount.getName).get
           case None =>
             new VolumeBuilder()
@@ -83,7 +84,6 @@ private[spark] class LocalDirsFeatureStep(
     SparkPod(podWithLocalDirVolumes, containerWithLocalDirVolumeMounts)
   }
 
-
   def findVolume(pod: SparkPod, name: String): Option[Volume] = {
     pod.pod.getSpec.getVolumes.asScala.find(v => v.getName.equals(name))
   }
@@ -92,5 +92,4 @@ private[spark] class LocalDirsFeatureStep(
     pod.container.getVolumeMounts.asScala
       .find(m => m.getName.startsWith(prefix) && m.getMountPath.equals(path))
   }
-
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesDriverBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesDriverBuilder.scala
@@ -43,12 +43,12 @@ private[spark] class KubernetesDriverBuilder {
       new DriverServiceFeatureStep(conf),
       new MountSecretsFeatureStep(conf),
       new EnvSecretsFeatureStep(conf),
-      new LocalDirsFeatureStep(conf),
       new MountVolumesFeatureStep(conf),
       new DriverCommandFeatureStep(conf),
       new HadoopConfDriverFeatureStep(conf),
       new KerberosConfDriverFeatureStep(conf),
-      new PodTemplateConfigMapStep(conf))
+      new PodTemplateConfigMapStep(conf),
+      new LocalDirsFeatureStep(conf))
 
     val spec = KubernetesDriverSpec(
       initialPod,

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
@@ -43,8 +43,8 @@ private[spark] class KubernetesExecutorBuilder {
       new BasicExecutorFeatureStep(conf, secMgr),
       new MountSecretsFeatureStep(conf),
       new EnvSecretsFeatureStep(conf),
-      new LocalDirsFeatureStep(conf),
-      new MountVolumesFeatureStep(conf))
+      new MountVolumesFeatureStep(conf),
+      new LocalDirsFeatureStep(conf))
 
     features.foldLeft(initialPod) { case (pod, feature) => feature.configurePod(pod) }
   }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStepSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.deploy.k8s.features
 import io.fabric8.kubernetes.api.model.{EnvVarBuilder, VolumeBuilder, VolumeMountBuilder}
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
-import org.apache.spark.deploy.k8s.{KubernetesHostPathVolumeConf, KubernetesTestConf, KubernetesVolumeSpec, SparkPod}
+import org.apache.spark.deploy.k8s._
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.util.SparkConfWithEnv
 
@@ -124,13 +124,10 @@ class LocalDirsFeatureStepSuite extends SparkFunSuite {
       false,
       KubernetesHostPathVolumeConf("/hostPath/tmp")
     )
-    val mountVolumeConf = KubernetesTestConf.createDriverConf(volumes = Seq(volumeConf))
-    val mountVolumeStep = new MountVolumesFeatureStep(mountVolumeConf)
+    val kubernetesConf = KubernetesTestConf.createDriverConf(volumes = Seq(volumeConf))
+    val mountVolumeStep = new MountVolumesFeatureStep(kubernetesConf)
     val configuredPod = mountVolumeStep.configurePod(SparkPod.initialPod())
-
-    val sparkConf = new SparkConfWithEnv(Map())
-    val localDirConf = KubernetesTestConf.createDriverConf(sparkConf)
-    val localDirStep = new LocalDirsFeatureStep(localDirConf, defaultLocalDir)
+    val localDirStep = new LocalDirsFeatureStep(kubernetesConf, defaultLocalDir)
     val newConfiguredPod = localDirStep.configurePod(configuredPod)
 
     assert(newConfiguredPod.pod.getSpec.getVolumes.size() === 1)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStepSuite.scala
@@ -118,7 +118,7 @@ class LocalDirsFeatureStepSuite extends SparkFunSuite {
 
   test("local dir on mounted volume") {
     val volumeConf = KubernetesVolumeSpec(
-      "spark-local-dir-1",
+      "spark-local-dir-test",
       "/tmp",
       "",
       false,
@@ -129,7 +129,7 @@ class LocalDirsFeatureStepSuite extends SparkFunSuite {
     val configuredPod = mountVolumeStep.configurePod(SparkPod.initialPod())
 
     val sparkConf = new SparkConfWithEnv(Map("SPARK_LOCAL_DIRS" -> "/tmp"))
-    val localDirConf = KubernetesTestConf.createDriverConf(sparkConf = sparkConf)
+    val localDirConf = KubernetesTestConf.createDriverConf(sparkConf)
     val localDirStep = new LocalDirsFeatureStep(localDirConf, defaultLocalDir)
     val newConfiguredPod = localDirStep.configurePod(configuredPod)
 
@@ -137,6 +137,6 @@ class LocalDirsFeatureStepSuite extends SparkFunSuite {
     assert(newConfiguredPod.pod.getSpec.getVolumes.get(0).getHostPath.getPath === "/hostPath/tmp")
     assert(newConfiguredPod.container.getVolumeMounts.size() === 1)
     assert(newConfiguredPod.container.getVolumeMounts.get(0).getMountPath === "/tmp")
-    assert(newConfiguredPod.container.getVolumeMounts.get(0).getName === "spark-local-dir-1")
+    assert(newConfiguredPod.container.getVolumeMounts.get(0).getName === "spark-local-dir-test")
   }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStepSuite.scala
@@ -128,7 +128,7 @@ class LocalDirsFeatureStepSuite extends SparkFunSuite {
     val mountVolumeStep = new MountVolumesFeatureStep(mountVolumeConf)
     val configuredPod = mountVolumeStep.configurePod(SparkPod.initialPod())
 
-    val sparkConf = new SparkConfWithEnv(Map("SPARK_LOCAL_DIRS" -> "/tmp"))
+    val sparkConf = new SparkConfWithEnv(Map())
     val localDirConf = KubernetesTestConf.createDriverConf(sparkConf)
     val localDirStep = new LocalDirsFeatureStep(localDirConf, defaultLocalDir)
     val newConfiguredPod = localDirStep.configurePod(configuredPod)
@@ -138,5 +138,10 @@ class LocalDirsFeatureStepSuite extends SparkFunSuite {
     assert(newConfiguredPod.container.getVolumeMounts.size() === 1)
     assert(newConfiguredPod.container.getVolumeMounts.get(0).getMountPath === "/tmp")
     assert(newConfiguredPod.container.getVolumeMounts.get(0).getName === "spark-local-dir-test")
+    assert(newConfiguredPod.container.getEnv.get(0) ===
+      new EnvVarBuilder()
+        .withName("SPARK_LOCAL_DIRS")
+        .withValue("/tmp")
+        .build())
   }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStepSuite.scala
@@ -137,6 +137,6 @@ class LocalDirsFeatureStepSuite extends SparkFunSuite {
     assert(newConfiguredPod.pod.getSpec.getVolumes.get(0).getHostPath.getPath === "/hostPath/tmp")
     assert(newConfiguredPod.container.getVolumeMounts.size() === 1)
     assert(newConfiguredPod.container.getVolumeMounts.get(0).getMountPath === "/tmp")
-    assert(newConfiguredPod.container.getVolumeMounts.get(0).getName === "testVolume")
+    assert(newConfiguredPod.container.getVolumeMounts.get(0).getName === "spark-local-dir-1")
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr is used to support using hostpath/PV volume mounts as local storage. In KubernetesExecutorBuilder.scala, the LocalDrisFeatureStep is built before MountVolumesFeatureStep which means we cannot use any volumes mount later. This pr adjust the order of feature building steps which moves localDirsFeature at last so that we can check if directories in SPARK_LOCAL_DIRS are set to volumes mounted such as hostPath, PV, or others.

## How was this patch tested?
Unit tests
