### PR TITLE
[SPARK-28063][SQL] Replace deprecated `.newInstance()` in DSv2 `Catalogs`

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalog/v2/Catalogs.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalog/v2/Catalogs.java
@@ -23,6 +23,7 @@ import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.apache.spark.util.Utils;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -66,7 +67,7 @@ public class Catalogs {
             name, pluginClassName));
       }
 
-      CatalogPlugin plugin = CatalogPlugin.class.cast(pluginClass.newInstance());
+      CatalogPlugin plugin = CatalogPlugin.class.cast(pluginClass.getDeclaredConstructor().newInstance());
 
       plugin.initialize(name, catalogOptions(name, conf));
 
@@ -76,6 +77,11 @@ public class Catalogs {
       throw new SparkException(String.format(
           "Cannot find catalog plugin class for catalog '%s': %s", name, pluginClassName));
 
+    } catch (NoSuchMethodException e) {
+      throw new SparkException(String.format(
+          "Failed to find public no-arg constructor for catalog '%s': %s", name, pluginClassName),
+          e);
+
     } catch (IllegalAccessException e) {
       throw new SparkException(String.format(
           "Failed to call public no-arg constructor for catalog '%s': %s", name, pluginClassName),
@@ -83,7 +89,12 @@ public class Catalogs {
 
     } catch (InstantiationException e) {
       throw new SparkException(String.format(
-          "Failed while instantiating plugin for catalog '%s': %s", name, pluginClassName),
+          "Cannot instantiate abstract catalog plugin class for catalog '%s': %s", name, pluginClassName),
+          e.getCause());
+
+    } catch (InvocationTargetException e) {
+      throw new SparkException(String.format(
+          "Failed during instantiating constructor for catalog '%s': %s", name, pluginClassName),
           e.getCause());
     }
   }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalog/v2/Catalogs.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalog/v2/Catalogs.java
@@ -67,7 +67,8 @@ public class Catalogs {
             name, pluginClassName));
       }
 
-      CatalogPlugin plugin = CatalogPlugin.class.cast(pluginClass.getDeclaredConstructor().newInstance());
+      CatalogPlugin plugin =
+        CatalogPlugin.class.cast(pluginClass.getDeclaredConstructor().newInstance());
 
       plugin.initialize(name, catalogOptions(name, conf));
 
@@ -89,8 +90,8 @@ public class Catalogs {
 
     } catch (InstantiationException e) {
       throw new SparkException(String.format(
-          "Cannot instantiate abstract catalog plugin class for catalog '%s': %s", name, pluginClassName),
-          e.getCause());
+          "Cannot instantiate abstract catalog plugin class for catalog '%s': %s", name,
+          pluginClassName), e.getCause());
 
     } catch (InvocationTargetException e) {
       throw new SparkException(String.format(

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalog/v2/CatalogLoadingSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalog/v2/CatalogLoadingSuite.java
@@ -113,10 +113,12 @@ public class CatalogLoadingSuite {
     String invalidClassName = ConstructorFailureCatalogPlugin.class.getCanonicalName();
     conf.setConfString("spark.sql.catalog.invalid", invalidClassName);
 
-    RuntimeException exc = intercept(RuntimeException.class, () -> Catalogs.load("invalid", conf));
+    SparkException exc = intercept(SparkException.class, () -> Catalogs.load("invalid", conf));
 
+    Assert.assertTrue("Should identify the constructor error",
+        exc.getMessage().contains("Failed during instantiating constructor for catalog"));
     Assert.assertTrue("Should have expected error message",
-        exc.getMessage().contains("Expected failure"));
+        exc.getCause().getMessage().contains("Expected failure"));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to replace deprecated `.newInstance()` in DSv2 `Catalogs` and distinguish the plugin class errors more. According to the JDK11 build log, there is no other new instance.
- https://amplab.cs.berkeley.edu/jenkins/view/Spark%20QA%20Test%20(Dashboard)/job/spark-master-test-maven-hadoop-2.7-jdk-11-ubuntu-testing/978/consoleFull

SPARK-25984 removes all instances of the deprecated `.newInstance()` usages at Nov 10, 2018, but this was added at SPARK-24252 on March 8, 2019.

## How was this patch tested?

Pass the Jenkins with the updated test case.