### PR TITLE
[SPARK-25341][Core] Support rolling back a shuffle map stage and re-generate the shuffle files

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -344,7 +344,7 @@ public class TransportConf {
   /**
    * Whether to use the old protocol while doing the shuffle block fetching.
    * It is only enabled while we need the compatibility in the scenario of new spark version
-   * job fetching blocks from old version external shuffle service.
+   * job fetching shuffle blocks from old version external shuffle service.
    */
   public boolean useOldFetchProtocol() {
     return conf.getBoolean("spark.shuffle.useOldFetchProtocol", false);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
@@ -38,6 +38,7 @@ public abstract class BlockStoreClient implements Closeable {
    * @param host the host of the remote node.
    * @param port the port of the remote node.
    * @param execId the executor id.
+   * @param shuffleGenerationId the shuffle generation id for all block ids to fetch.
    * @param blockIds block ids to fetch.
    * @param listener the listener to receive block fetching status.
    * @param downloadFileManager DownloadFileManager to create and clean temp files.
@@ -49,6 +50,7 @@ public abstract class BlockStoreClient implements Closeable {
       String host,
       int port,
       String execId,
+      int shuffleGenerationId,
       String[] blockIds,
       BlockFetchingListener listener,
       DownloadFileManager downloadFileManager);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
@@ -29,7 +29,7 @@ import com.codahale.metrics.MetricSet;
 public abstract class BlockStoreClient implements Closeable {
 
   /**
-   * Fetch a sequence of blocks from a remote node asynchronously,
+   * Fetch a sequence of shuffle blocks from a remote node asynchronously,
    *
    * Note that this API takes a sequence so the implementation can batch requests, and does not
    * return a future so the underlying implementation can invoke onBlockFetchSuccess as soon as
@@ -46,7 +46,7 @@ public abstract class BlockStoreClient implements Closeable {
    *                        into temp shuffle files to reduce the memory usage, otherwise,
    *                        they will be kept in memory.
    */
-  public abstract void fetchBlocks(
+  public abstract void fetchShuffleBlocks(
       String host,
       int port,
       String execId,

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
@@ -56,7 +56,18 @@ public abstract class BlockStoreClient implements Closeable {
       DownloadFileManager downloadFileManager);
 
   /**
-   * Get the shuffle MetricsSet from BlockStoreClient, this will be used in MetricsSystem to
+   * Fetch a sequence of non-shuffle blocks from a remote node asynchronously.
+   */
+  public abstract void fetchDataBlocks(
+      String host,
+      int port,
+      String execId,
+      String[] blockIds,
+      BlockFetchingListener listener,
+      DownloadFileManager downloadFileManager);
+
+  /**
+   * Get the shuffle MetricsSet from ShuffleClient, this will be used in MetricsSystem to
    * get the Shuffle related metrics.
    */
   public MetricSet shuffleMetrics() {

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
@@ -311,7 +311,8 @@ public class ExternalBlockHandler extends RpcHandler {
       assert(idx == 2 * numBlockIds);
       size = mapIdAndReduceIds.length;
       blockDataForIndexFn = index -> blockManager.getBlockData(msg.appId, msg.execId,
-        msg.shuffleId, mapIdAndReduceIds[index], mapIdAndReduceIds[index + 1]);
+        msg.shuffleId, msg.shuffleGenerationId, mapIdAndReduceIds[index],
+        mapIdAndReduceIds[index + 1]);
     }
 
     @Override

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -101,7 +101,7 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
   }
 
   @Override
-  public void fetchBlocks(
+  public void fetchShuffleBlocks(
       String host,
       int port,
       String execId,
@@ -146,7 +146,7 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
         blockFetchStarter.createAndStart(blockIds, listener);
       }
     } catch (Exception e) {
-      logger.error("Exception while beginning fetchBlocks", e);
+      logger.error("Exception while beginning fetchShuffleBlocks", e);
       for (String blockId : blockIds) {
         listener.onBlockFetchFailure(blockId, e);
       }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -94,6 +94,7 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
       String host,
       int port,
       String execId,
+      int shuffleGenerationId,
       String[] blockIds,
       BlockFetchingListener listener,
       DownloadFileManager downloadFileManager) {
@@ -103,7 +104,7 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
       RetryingBlockFetcher.BlockFetchStarter blockFetchStarter =
           (blockIds1, listener1) -> {
             TransportClient client = clientFactory.createClient(host, port);
-            new OneForOneBlockFetcher(client, appId, execId,
+            new OneForOneBlockFetcher(client, appId, execId, shuffleGenerationId,
               blockIds1, listener1, conf, downloadFileManager).start();
           };
 

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneDataBlockFetcher.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneDataBlockFetcher.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle;
+
+import org.apache.spark.network.client.TransportClient;
+import org.apache.spark.network.shuffle.protocol.BlockTransferMessage;
+import org.apache.spark.network.shuffle.protocol.OpenBlocks;
+import org.apache.spark.network.util.TransportConf;
+
+public class OneForOneDataBlockFetcher extends OneForOneBlockFetcher {
+  public OneForOneDataBlockFetcher(
+      TransportClient client,
+      String appId,
+      String execId,
+      String[] blockIds,
+      BlockFetchingListener listener,
+      TransportConf transportConf,
+      DownloadFileManager downloadFileManager) {
+    super(client, appId, execId, blockIds, listener, transportConf, downloadFileManager);
+  }
+
+  /**
+   * Create the corresponding message for this fetcher.
+   * For non shuffle blocks, just use OpenBlocks message for all cases.
+   */
+  @Override
+  public BlockTransferMessage createBlockTransferMessage() {
+    return new OpenBlocks(appId, execId, blockIds);
+  }
+}

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneShuffleBlockFetcher.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneShuffleBlockFetcher.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle;
+
+import com.google.common.primitives.Ints;
+import org.apache.spark.network.client.TransportClient;
+import org.apache.spark.network.shuffle.protocol.BlockTransferMessage;
+import org.apache.spark.network.shuffle.protocol.FetchShuffleBlocks;
+import org.apache.spark.network.shuffle.protocol.OpenBlocks;
+import org.apache.spark.network.util.TransportConf;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class OneForOneShuffleBlockFetcher extends OneForOneBlockFetcher {
+  private final int shuffleGenerationId;
+
+  public OneForOneShuffleBlockFetcher(
+      TransportClient client,
+      String appId,
+      String execId,
+      int shuffleGenerationId,
+      String[] blockIds,
+      BlockFetchingListener listener,
+      TransportConf transportConf,
+      DownloadFileManager downloadFileManager) {
+    super(client, appId, execId, blockIds, listener, transportConf, downloadFileManager);
+    this.shuffleGenerationId = shuffleGenerationId;
+  }
+
+  /**
+   * Create the corresponding message for this fetcher.
+   * For shuffle blocks, we choose different message base on whether to use the old protocol.
+   * If `spark.shuffle.useOldFetchProtocol` set to true, we use OpenBlocks for shuffle blocks.
+   * Otherwise, we analyze the pass in blockIds and create FetchShuffleBlocks message.
+   * The blockIds has been sorted by mapId and reduceId. It's produced in
+   * org.apache.spark.MapOutputTracker.convertMapStatuses.
+   */
+  @Override
+  public BlockTransferMessage createBlockTransferMessage() {
+    if (transportConf.useOldFetchProtocol()) {
+      return new OpenBlocks(appId, execId, blockIds);
+    } else {
+      int shuffleId = splitBlockId(blockIds[0])[0];
+      HashMap<Integer, ArrayList<Integer>> mapIdToReduceIds = new HashMap<>();
+      for (String blockId : blockIds) {
+        int[] blockIdParts = splitBlockId(blockId);
+        if (blockIdParts[0] != shuffleId) {
+          throw new IllegalArgumentException("Expected shuffleId=" + shuffleId +
+            ", got:" + blockId);
+        }
+        int mapId = blockIdParts[1];
+        if (!mapIdToReduceIds.containsKey(mapId)) {
+          mapIdToReduceIds.put(mapId, new ArrayList<>());
+        }
+        mapIdToReduceIds.get(mapId).add(blockIdParts[2]);
+      }
+      int[] mapIds = Ints.toArray(mapIdToReduceIds.keySet());
+      int[][] reduceIdArr = new int[mapIds.length][];
+      for (int i = 0; i < mapIds.length; i++) {
+        reduceIdArr[i] = Ints.toArray(mapIdToReduceIds.get(mapIds[i]));
+      }
+      return new FetchShuffleBlocks(
+        appId, execId, shuffleId, shuffleGenerationId, mapIds, reduceIdArr);
+    }
+  }
+
+  /** Split the shuffleBlockId and return shuffleId, mapId and reduceId. */
+  private int[] splitBlockId(String blockId) {
+    String[] blockIdParts = blockId.split("_");
+    if (blockIdParts.length != 4 || !blockIdParts[0].equals("shuffle")) {
+      throw new IllegalArgumentException(
+          "Unexpected shuffle block id format: " + blockId);
+    }
+    return new int[] {
+      Integer.parseInt(blockIdParts[1]),
+      Integer.parseInt(blockIdParts[2]),
+      Integer.parseInt(blockIdParts[3])
+    };
+  }
+}

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/sasl/SaslIntegrationSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/sasl/SaslIntegrationSuite.java
@@ -48,6 +48,7 @@ import org.apache.spark.network.shuffle.BlockFetchingListener;
 import org.apache.spark.network.shuffle.ExternalBlockHandler;
 import org.apache.spark.network.shuffle.ExternalShuffleBlockResolver;
 import org.apache.spark.network.shuffle.OneForOneBlockFetcher;
+import org.apache.spark.network.shuffle.OneForOneShuffleBlockFetcher;
 import org.apache.spark.network.shuffle.protocol.BlockTransferMessage;
 import org.apache.spark.network.shuffle.protocol.ExecutorShuffleInfo;
 import org.apache.spark.network.shuffle.protocol.OpenBlocks;
@@ -203,7 +204,8 @@ public class SaslIntegrationSuite {
 
       String[] blockIds = { "shuffle_0_1_2", "shuffle_0_3_4" };
       OneForOneBlockFetcher fetcher =
-          new OneForOneBlockFetcher(client1, "app-2", "0", blockIds, listener, conf);
+        new OneForOneShuffleBlockFetcher(
+          client1, "app-2", "0", -1, blockIds, listener, conf, null);
       fetcher.start();
       blockFetchLatch.await();
       checkSecurityException(exception.get());

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/BlockTransferMessagesSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/BlockTransferMessagesSuite.java
@@ -29,7 +29,7 @@ public class BlockTransferMessagesSuite {
   public void serializeOpenShuffleBlocks() {
     checkSerializeDeserialize(new OpenBlocks("app-1", "exec-2", new String[] { "b1", "b2" }));
     checkSerializeDeserialize(new FetchShuffleBlocks(
-      "app-1", "exec-2", 0, new int[] {0, 1},
+      "app-1", "exec-2", 0, -1, new int[] {0, 1},
       new int[][] {{ 0, 1 }, { 0, 1, 2 }}));
     checkSerializeDeserialize(new RegisterExecutor("app-1", "exec-2", new ExecutorShuffleInfo(
       new String[] { "/local1", "/local2" }, 32, "MyShuffleManager")));

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/CleanupNonShuffleServiceServedFilesSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/CleanupNonShuffleServiceServedFilesSuite.java
@@ -243,7 +243,7 @@ public class CleanupNonShuffleServiceServedFilesSuite {
     Random rand = new Random(123);
     dataContext.insertSortShuffleData(rand.nextInt(1000), rand.nextInt(1000), new byte[][] {
         "ABC".getBytes(StandardCharsets.UTF_8),
-        "DEF".getBytes(StandardCharsets.UTF_8)});
+        "DEF".getBytes(StandardCharsets.UTF_8)}, false);
     dataContext.insertCachedRddData(12, 34, new byte[] { 42 });
   }
 

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalBlockHandlerSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalBlockHandlerSuite.java
@@ -97,15 +97,15 @@ public class ExternalBlockHandlerSuite {
 
   @Test
   public void testFetchShuffleBlocks() {
-    when(blockResolver.getBlockData("app0", "exec1", 0, 0, 0)).thenReturn(blockMarkers[0]);
-    when(blockResolver.getBlockData("app0", "exec1", 0, 0, 1)).thenReturn(blockMarkers[1]);
+    when(blockResolver.getBlockData("app0", "exec1", 0, 1, 0, 0)).thenReturn(blockMarkers[0]);
+    when(blockResolver.getBlockData("app0", "exec1", 0, 1, 0, 1)).thenReturn(blockMarkers[1]);
 
     FetchShuffleBlocks fetchShuffleBlocks = new FetchShuffleBlocks(
-      "app0", "exec1", 0, new int[] { 0 }, new int[][] {{ 0, 1 }});
+      "app0", "exec1", 0, 1, new int[] { 0 }, new int[][] {{ 0, 1 }});
     checkOpenBlocksReceive(fetchShuffleBlocks, blockMarkers);
 
-    verify(blockResolver, times(1)).getBlockData("app0", "exec1", 0, 0, 0);
-    verify(blockResolver, times(1)).getBlockData("app0", "exec1", 0, 0, 1);
+    verify(blockResolver, times(1)).getBlockData("app0", "exec1", 0, 1, 0, 0);
+    verify(blockResolver, times(1)).getBlockData("app0", "exec1", 0, 1, 0, 1);
     verifyOpenBlockLatencyMetrics();
   }
 

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
@@ -53,7 +53,10 @@ public class ExternalShuffleBlockResolverSuite {
     // Write some sort data.
     dataContext.insertSortShuffleData(0, 0, new byte[][] {
         sortBlock0.getBytes(StandardCharsets.UTF_8),
-        sortBlock1.getBytes(StandardCharsets.UTF_8)});
+        sortBlock1.getBytes(StandardCharsets.UTF_8)}, false);
+    dataContext.insertSortShuffleData(0, 0, new byte[][] {
+        sortBlock0.getBytes(StandardCharsets.UTF_8),
+        sortBlock1.getBytes(StandardCharsets.UTF_8)}, true);
   }
 
   @AfterClass
@@ -109,6 +112,27 @@ public class ExternalShuffleBlockResolverSuite {
         "app0", "exec0", 0, 0, 1).createInputStream()) {
       String block1 =
         CharStreams.toString(new InputStreamReader(block1Stream, StandardCharsets.UTF_8));
+      assertEquals(sortBlock1, block1);
+    }
+  }
+
+  @Test
+  public void testIndeterminateSortShuffleBlocks() throws IOException {
+    ExternalShuffleBlockResolver resolver = new ExternalShuffleBlockResolver(conf, null);
+    resolver.registerExecutor("app0", "exec0",
+        dataContext.createExecutorInfo(SORT_MANAGER));
+
+    try (InputStream block0Stream = resolver.getBlockData(
+        "app0", "exec0", 0, 0, 0, 0).createInputStream()) {
+      String block0 =
+          CharStreams.toString(new InputStreamReader(block0Stream, StandardCharsets.UTF_8));
+      assertEquals(sortBlock0, block0);
+    }
+
+    try (InputStream block1Stream = resolver.getBlockData(
+        "app0", "exec0", 0, 0, 0, 1).createInputStream()) {
+      String block1 =
+          CharStreams.toString(new InputStreamReader(block1Stream, StandardCharsets.UTF_8));
       assertEquals(sortBlock1, block1);
     }
   }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleCleanupSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleCleanupSuite.java
@@ -142,7 +142,7 @@ public class ExternalShuffleCleanupSuite {
     dataContext.create();
     dataContext.insertSortShuffleData(rand.nextInt(1000), rand.nextInt(1000), new byte[][] {
         "ABC".getBytes(StandardCharsets.UTF_8),
-        "DEF".getBytes(StandardCharsets.UTF_8)});
+        "DEF".getBytes(StandardCharsets.UTF_8)}, false);
     return dataContext;
   }
 }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleIntegrationSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleIntegrationSuite.java
@@ -218,7 +218,7 @@ public class ExternalShuffleIntegrationSuite {
           }
         };
       if (isShuffleBlocks) {
-        client.fetchBlocks(TestUtils.getLocalHost(), port, execId, shuffleGenerationId, blockIds,
+        client.fetchShuffleBlocks(TestUtils.getLocalHost(), port, execId, shuffleGenerationId, blockIds,
           listener, null);
       } else {
         client.fetchDataBlocks(TestUtils.getLocalHost(), port, execId, blockIds, listener, null);

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleIntegrationSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleIntegrationSuite.java
@@ -218,8 +218,8 @@ public class ExternalShuffleIntegrationSuite {
           }
         };
       if (isShuffleBlocks) {
-        client.fetchShuffleBlocks(TestUtils.getLocalHost(), port, execId, shuffleGenerationId, blockIds,
-          listener, null);
+        client.fetchShuffleBlocks(
+          TestUtils.getLocalHost(), port, execId, shuffleGenerationId, blockIds, listener, null);
       } else {
         client.fetchDataBlocks(TestUtils.getLocalHost(), port, execId, blockIds, listener, null);
       }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockFetcherSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockFetcherSuite.java
@@ -64,7 +64,7 @@ public class OneForOneBlockFetcherSuite {
     BlockFetchingListener listener = fetchBlocks(
       blocks,
       blockIds,
-      new FetchShuffleBlocks("app-id", "exec-id", 0, new int[] { 0 }, new int[][] {{ 0 }}),
+      new FetchShuffleBlocks("app-id", "exec-id", 0, -1, new int[] { 0 }, new int[][] {{ 0 }}),
       conf);
 
     verify(listener).onBlockFetchSuccess("shuffle_0_0_0", blocks.get("shuffle_0_0_0"));
@@ -100,7 +100,8 @@ public class OneForOneBlockFetcherSuite {
     BlockFetchingListener listener = fetchBlocks(
       blocks,
       blockIds,
-      new FetchShuffleBlocks("app-id", "exec-id", 0, new int[] { 0 }, new int[][] {{ 0, 1, 2 }}),
+      new FetchShuffleBlocks(
+        "app-id", "exec-id", 0, -1, new int[] { 0 }, new int[][] {{ 0, 1, 2 }}),
       conf);
 
     for (int i = 0; i < 3; i ++) {

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/TestShuffleDataContext.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/TestShuffleDataContext.java
@@ -67,8 +67,10 @@ public class TestShuffleDataContext {
   }
 
   /** Creates reducer blocks in a sort-based data format within our local dirs. */
-  public void insertSortShuffleData(int shuffleId, int mapId, byte[][] blocks) throws IOException {
+  public void insertSortShuffleData(
+      int shuffleId, int mapId, byte[][] blocks, boolean indeterminateBlock) throws IOException {
     String blockId = "shuffle_" + shuffleId + "_" + mapId + "_0";
+    if (indeterminateBlock) blockId += "_0";
 
     OutputStream dataStream = null;
     DataOutputStream indexStream = null;

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShuffleExecutorComponents.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShuffleExecutorComponents.java
@@ -39,16 +39,20 @@ public interface ShuffleExecutorComponents {
   /**
    * Called once per map task to create a writer that will be responsible for persisting all the
    * partitioned bytes written by that map task.
-   *  @param shuffleId Unique identifier for the shuffle the map task is a part of
+   * @param shuffleId Unique identifier for the shuffle the map task is a part of
+   * @param shuffleGenerationId The shuffle generation ID of the stage that this task belongs to,
+   *                            it equals the stage attempt number while the stage is indeterminate
+   *                            and -1 on the contrary.
    * @param mapId Within the shuffle, the identifier of the map task
    * @param mapTaskAttemptId Identifier of the task attempt. Multiple attempts of the same map task
- *                         with the same (shuffleId, mapId) pair can be distinguished by the
- *                         different values of mapTaskAttemptId.
+   *                         with the same (shuffleId, mapId) pair can be distinguished by the
+   *                         different values of mapTaskAttemptId.
    * @param numPartitions The number of partitions that will be written by the map task. Some of
-*                      these partitions may be empty.
+   *                      these partitions may be empty.
    */
   ShuffleMapOutputWriter createMapOutputWriter(
       int shuffleId,
+      int shuffleGenerationId,
       int mapId,
       long mapTaskAttemptId,
       int numPartitions) throws IOException;

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShuffleMapOutputWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShuffleMapOutputWriter.java
@@ -39,7 +39,7 @@ public interface ShuffleMapOutputWriter {
    * for the same partition within any given map task. The partition identifier will be in the
    * range of precisely 0 (inclusive) to numPartitions (exclusive), where numPartitions was
    * provided upon the creation of this map output writer via
-   * {@link ShuffleExecutorComponents#createMapOutputWriter(int, int, long, int)}.
+   * {@link ShuffleExecutorComponents#createMapOutputWriter(int, int, int, long, int)}.
    * <p>
    * Calls to this method will be invoked with monotonically increasing reducePartitionIds; each
    * call to this method will be called with a reducePartitionId that is strictly greater than

--- a/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.spark.Partitioner;
 import org.apache.spark.ShuffleDependency;
 import org.apache.spark.SparkConf;
+import org.apache.spark.TaskContext;
 import org.apache.spark.shuffle.api.ShuffleExecutorComponents;
 import org.apache.spark.shuffle.api.ShuffleMapOutputWriter;
 import org.apache.spark.shuffle.api.ShufflePartitionWriter;
@@ -85,6 +86,7 @@ final class BypassMergeSortShuffleWriter<K, V> extends ShuffleWriter<K, V> {
   private final Partitioner partitioner;
   private final ShuffleWriteMetricsReporter writeMetrics;
   private final int shuffleId;
+  private final int shuffleGenerationId;
   private final int mapId;
   private final long mapTaskAttemptId;
   private final Serializer serializer;
@@ -107,7 +109,7 @@ final class BypassMergeSortShuffleWriter<K, V> extends ShuffleWriter<K, V> {
       BlockManager blockManager,
       BypassMergeSortShuffleHandle<K, V> handle,
       int mapId,
-      long mapTaskAttemptId,
+      TaskContext taskContext,
       SparkConf conf,
       ShuffleWriteMetricsReporter writeMetrics,
       ShuffleExecutorComponents shuffleExecutorComponents) {
@@ -117,8 +119,9 @@ final class BypassMergeSortShuffleWriter<K, V> extends ShuffleWriter<K, V> {
     this.blockManager = blockManager;
     final ShuffleDependency<K, V, V> dep = handle.dependency();
     this.mapId = mapId;
-    this.mapTaskAttemptId = mapTaskAttemptId;
+    this.mapTaskAttemptId = taskContext.taskAttemptId();
     this.shuffleId = dep.shuffleId();
+    this.shuffleGenerationId = taskContext.getShuffleGenerationId(dep.shuffleId());
     this.partitioner = dep.partitioner();
     this.numPartitions = partitioner.numPartitions();
     this.writeMetrics = writeMetrics;

--- a/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
@@ -132,8 +132,8 @@ final class BypassMergeSortShuffleWriter<K, V> extends ShuffleWriter<K, V> {
   @Override
   public void write(Iterator<Product2<K, V>> records) throws IOException {
     assert (partitionWriters == null);
-    ShuffleMapOutputWriter mapOutputWriter = shuffleExecutorComponents
-        .createMapOutputWriter(shuffleId, mapId, mapTaskAttemptId, numPartitions);
+    ShuffleMapOutputWriter mapOutputWriter = shuffleExecutorComponents.createMapOutputWriter(
+        shuffleId, shuffleGenerationId, mapId, mapTaskAttemptId, numPartitions);
     try {
       if (!records.hasNext()) {
         partitionLengths = new long[numPartitions];

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleExecutorComponents.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleExecutorComponents.java
@@ -58,6 +58,7 @@ public class LocalDiskShuffleExecutorComponents implements ShuffleExecutorCompon
   @Override
   public ShuffleMapOutputWriter createMapOutputWriter(
       int shuffleId,
+      int shuffleGenerationId,
       int mapId,
       long mapTaskAttemptId,
       int numPartitions) {
@@ -66,6 +67,6 @@ public class LocalDiskShuffleExecutorComponents implements ShuffleExecutorCompon
           "Executor components must be initialized before getting writers.");
     }
     return new LocalDiskShuffleMapOutputWriter(
-        shuffleId, mapId, numPartitions, blockResolver, sparkConf);
+        shuffleId, shuffleGenerationId, mapId, numPartitions, blockResolver, sparkConf);
   }
 }

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriter.java
@@ -48,6 +48,7 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
     LoggerFactory.getLogger(LocalDiskShuffleMapOutputWriter.class);
 
   private final int shuffleId;
+  private final int shuffleGenerationId;
   private final int mapId;
   private final IndexShuffleBlockResolver blockResolver;
   private final long[] partitionLengths;
@@ -63,18 +64,20 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
 
   public LocalDiskShuffleMapOutputWriter(
       int shuffleId,
+      int shuffleGenerationId,
       int mapId,
       int numPartitions,
       IndexShuffleBlockResolver blockResolver,
       SparkConf sparkConf) {
     this.shuffleId = shuffleId;
+    this.shuffleGenerationId = shuffleGenerationId;
     this.mapId = mapId;
     this.blockResolver = blockResolver;
     this.bufferSize =
       (int) (long) sparkConf.get(
         package$.MODULE$.SHUFFLE_UNSAFE_FILE_OUTPUT_BUFFER_SIZE()) * 1024;
     this.partitionLengths = new long[numPartitions];
-    this.outputFile = blockResolver.getDataFile(shuffleId, mapId);
+    this.outputFile = blockResolver.getDataFile(shuffleId, shuffleGenerationId, mapId);
     this.outputTempFile = null;
   }
 
@@ -99,7 +102,8 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
   public void commitAllPartitions() throws IOException {
     cleanUp();
     File resolvedTmp = outputTempFile != null && outputTempFile.isFile() ? outputTempFile : null;
-    blockResolver.writeIndexFileAndCommit(shuffleId, mapId, partitionLengths, resolvedTmp);
+    blockResolver.writeIndexFileAndCommit(
+        shuffleId, shuffleGenerationId, mapId, partitionLengths, resolvedTmp);
   }
 
   @Override

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2591,6 +2591,7 @@ object SparkContext extends Logging {
   private[spark] val SPARK_SCHEDULER_POOL = "spark.scheduler.pool"
   private[spark] val RDD_SCOPE_KEY = "spark.rdd.scope"
   private[spark] val RDD_SCOPE_NO_OVERRIDE_KEY = "spark.rdd.scope.noOverride"
+  private[spark] val SHUFFLE_GENERATION_ID_PREFIX = "_shuffle_generation_id_"
 
   /**
    * Executor id for the driver.  In earlier versions of Spark, this was `<driver>`, but this was

--- a/core/src/main/scala/org/apache/spark/TaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContext.scala
@@ -185,6 +185,15 @@ abstract class TaskContext extends Serializable {
   @Evolving
   def resources(): Map[String, ResourceInformation]
 
+  /**
+   * The shuffle generation ID of the stage that this task belongs to, it returns the stage
+   * attempt number while the stage is not determinate and returns -1 on the contrary.
+   */
+  private[spark] def getShuffleGenerationId(shuffleId: Int): Int = {
+    Option(getLocalProperty(SparkContext.SHUFFLE_GENERATION_ID_PREFIX + shuffleId))
+      .map(_.toInt).getOrElse(-1)
+  }
+
   @DeveloperApi
   def taskMetrics(): TaskMetrics
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1030,6 +1030,14 @@ package object config {
       .checkValue(v => v > 0, "The value should be a positive integer.")
       .createWithDefault(2000)
 
+  private[spark] val SHUFFLE_USE_OLD_FETCH_PROTOCOL =
+    ConfigBuilder("spark.shuffle.useOldFetchProtocol")
+      .doc("Whether to use the old protocol while doing the shuffle block fetching. " +
+        "It is only enabled while we need the compatibility in the scenario of new spark " +
+        "version job fetching shuffle blocks from old version external shuffle service.")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val MEMORY_MAP_LIMIT_FOR_TESTS =
     ConfigBuilder("spark.storage.memoryMapLimitForTests")
       .internal()

--- a/core/src/main/scala/org/apache/spark/network/BlockDataManager.scala
+++ b/core/src/main/scala/org/apache/spark/network/BlockDataManager.scala
@@ -34,6 +34,16 @@ trait BlockDataManager {
   def getBlockData(blockId: BlockId): ManagedBuffer
 
   /**
+   * Interface to get shuffle block data. Throws an exception if the block cannot be found or
+   * cannot be read successfully.
+   */
+  def getShuffleBlockData(
+      shuffleId: Int,
+      shuffleGenerationId: Int,
+      mapId: Int,
+      reduceId: Int): ManagedBuffer
+
+  /**
    * Put the block locally, using the given storage level.
    *
    * Returns true if the block was stored and false if the put operation failed or the block

--- a/core/src/main/scala/org/apache/spark/network/BlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/BlockTransferService.scala
@@ -38,7 +38,7 @@ abstract class BlockTransferService extends BlockStoreClient with Logging {
 
   /**
    * Initialize the transfer service by giving it the BlockDataManager that can be used to fetch
-   * local blocks or put local blocks. The fetchBlocks method in [[BlockStoreClient]] also
+   * local blocks or put local blocks. The fetchShuffleBlocks method in [[BlockStoreClient]] also
    * available only after this is invoked.
    */
   def init(blockDataManager: BlockDataManager): Unit
@@ -54,34 +54,6 @@ abstract class BlockTransferService extends BlockStoreClient with Logging {
   def hostName: String
 
   /**
-   * Fetch a sequence of shuffle blocks from a remote node asynchronously,
-   * available only after [[init]] is invoked.
-   *
-   * Note that this API takes a sequence so the implementation can batch requests, and does not
-   * return a future so the underlying implementation can invoke onBlockFetchSuccess as soon as
-   * the data of a block is fetched, rather than waiting for all blocks to be fetched.
-   */
-  override def fetchBlocks(
-      host: String,
-      port: Int,
-      execId: String,
-      shuffleGenerationId: Int,
-      blockIds: Array[String],
-      listener: BlockFetchingListener,
-      tempFileManager: DownloadFileManager): Unit
-
-  /**
-   * Fetch a sequence of non-shuffle blocks from a remote node asynchronously.
-   */
-  override def fetchDataBlocks(
-      host: String,
-      port: Int,
-      execId: String,
-      blockIds: Array[String],
-      listener: BlockFetchingListener,
-      tempFileManager: DownloadFileManager): Unit
-
-  /**
    * Upload a single block to a remote node, available only after [[init]] is invoked.
    */
   def uploadBlock(
@@ -94,7 +66,7 @@ abstract class BlockTransferService extends BlockStoreClient with Logging {
       classTag: ClassTag[_]): Future[Unit]
 
   /**
-   * A special case of [[fetchBlocks]], as it fetches only one block and is blocking.
+   * A special case of [[fetchDataBlocks]], as it fetches only one block and is blocking.
    *
    * It is also only available after [[init]] is invoked.
    */
@@ -104,7 +76,7 @@ abstract class BlockTransferService extends BlockStoreClient with Logging {
       execId: String,
       blockId: String,
       tempFileManager: DownloadFileManager): ManagedBuffer = {
-    // Make sure ShuffleBlockId will not enter this function, so we call fetchBlocks with the
+    // Make sure ShuffleBlockId will not enter this function, so we call fetchShuffleBlocks with the
     // invalid shuffleGenerationId -1 here for this special case of fetching a non-shuffle block.
     assert(!BlockId.apply(blockId).isShuffle)
     // A monitor for the thread to wait on.

--- a/core/src/main/scala/org/apache/spark/network/BlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/BlockTransferService.scala
@@ -54,7 +54,7 @@ abstract class BlockTransferService extends BlockStoreClient with Logging {
   def hostName: String
 
   /**
-   * Fetch a sequence of blocks from a remote node asynchronously,
+   * Fetch a sequence of shuffle blocks from a remote node asynchronously,
    * available only after [[init]] is invoked.
    *
    * Note that this API takes a sequence so the implementation can batch requests, and does not
@@ -66,6 +66,17 @@ abstract class BlockTransferService extends BlockStoreClient with Logging {
       port: Int,
       execId: String,
       shuffleGenerationId: Int,
+      blockIds: Array[String],
+      listener: BlockFetchingListener,
+      tempFileManager: DownloadFileManager): Unit
+
+  /**
+   * Fetch a sequence of non-shuffle blocks from a remote node asynchronously.
+   */
+  override def fetchDataBlocks(
+      host: String,
+      port: Int,
+      execId: String,
       blockIds: Array[String],
       listener: BlockFetchingListener,
       tempFileManager: DownloadFileManager): Unit
@@ -98,7 +109,7 @@ abstract class BlockTransferService extends BlockStoreClient with Logging {
     assert(!BlockId.apply(blockId).isShuffle)
     // A monitor for the thread to wait on.
     val result = Promise[ManagedBuffer]()
-    fetchBlocks(host, port, execId, -1, Array(blockId),
+    fetchDataBlocks(host, port, execId, Array(blockId),
       new BlockFetchingListener {
         override def onBlockFetchFailure(blockId: String, exception: Throwable): Unit = {
           result.failure(exception)

--- a/core/src/main/scala/org/apache/spark/network/netty/NettyBlockRpcServer.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/NettyBlockRpcServer.scala
@@ -66,8 +66,9 @@ class NettyBlockRpcServer(
       case fetchShuffleBlocks: FetchShuffleBlocks =>
         val blocks = fetchShuffleBlocks.mapIds.zipWithIndex.flatMap { case (mapId, index) =>
           fetchShuffleBlocks.reduceIds.apply(index).map { reduceId =>
-            blockManager.getBlockData(
-              ShuffleBlockId(fetchShuffleBlocks.shuffleId, mapId, reduceId))
+            blockManager.getShuffleBlockData(
+              fetchShuffleBlocks.shuffleId, fetchShuffleBlocks.shuffleGenerationId,
+              mapId, reduceId)
           }
         }
         val numBlockIds = fetchShuffleBlocks.reduceIds.map(_.length).sum

--- a/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
@@ -110,6 +110,7 @@ private[spark] class NettyBlockTransferService(
       host: String,
       port: Int,
       execId: String,
+      shuffleGenerationId: Int,
       blockIds: Array[String],
       listener: BlockFetchingListener,
       tempFileManager: DownloadFileManager): Unit = {
@@ -119,8 +120,8 @@ private[spark] class NettyBlockTransferService(
         override def createAndStart(blockIds: Array[String], listener: BlockFetchingListener) {
           val client = clientFactory.createClient(host, port)
           try {
-            new OneForOneBlockFetcher(client, appId, execId, blockIds, listener,
-              transportConf, tempFileManager).start()
+            new OneForOneBlockFetcher(client, appId, execId, shuffleGenerationId, blockIds,
+              listener, transportConf, tempFileManager).start()
           } catch {
             case e: IOException =>
               Try {

--- a/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
@@ -106,7 +106,7 @@ private[spark] class NettyBlockTransferService(
     }
   }
 
-  override def fetchBlocks(
+  override def fetchShuffleBlocks(
       host: String,
       port: Int,
       execId: String,
@@ -173,7 +173,7 @@ private[spark] class NettyBlockTransferService(
       }
     } catch {
       case e: Exception =>
-        logError("Exception while beginning fetchBlocks", e)
+        logError("Exception while beginning fetchShuffleBlocks", e)
         blockIds.foreach(listener.onBlockFetchFailure(_, e))
     }
   }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1257,8 +1257,8 @@ private[spark] class DAGScheduler(
       logInfo(s"Submitting ${tasks.size} missing tasks from $stage (${stage.rdd}) (first 15 " +
         s"tasks are for partitions ${tasks.take(15).map(_.partitionId)})")
       taskScheduler.submitTasks(new TaskSet(
-        tasks.toArray, stage.id, stage.latestInfo.attemptNumber,
-        jobId, properties, stage.isIndeterminate))
+        tasks.toArray, stage.id, stage.latestInfo.attemptNumber, jobId, properties,
+        stage.latestInfo.attemptNumber > 0 && stage.isIndeterminate))
     } else {
       // Because we posted SparkListenerStageSubmitted earlier, we should mark
       // the stage as completed here in case there are no tasks to run

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1101,6 +1101,8 @@ private[spark] class DAGScheduler(
     logDebug("submitMissingTasks(" + stage + ")")
 
     // Before find missing partition, do the intermediate state clean work first.
+    // The operation here can make sure for the intermediate stage, `findMissingPartitions()`
+    // returns all partitions every time.
     stage match {
       case sms: ShuffleMapStage if stage.isIndeterminate() =>
         mapOutputTracker.unregisterAllMapOutput(sms.shuffleDep.shuffleId)

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1257,7 +1257,8 @@ private[spark] class DAGScheduler(
       logInfo(s"Submitting ${tasks.size} missing tasks from $stage (${stage.rdd}) (first 15 " +
         s"tasks are for partitions ${tasks.take(15).map(_.partitionId)})")
       taskScheduler.submitTasks(new TaskSet(
-        tasks.toArray, stage.id, stage.latestInfo.attemptNumber, jobId, properties))
+        tasks.toArray, stage.id, stage.latestInfo.attemptNumber,
+        jobId, properties, stage.isIndeterminate))
     } else {
       // Because we posted SparkListenerStageSubmitted earlier, we should mark
       // the stage as completed here in case there are no tasks to run

--- a/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapStage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapStage.scala
@@ -87,10 +87,7 @@ private[spark] class ShuffleMapStage(
    */
   def isAvailable: Boolean = numAvailableOutputs == numPartitions
 
-  /**
-   * Returns the sequence of partition ids that are missing (i.e. needs to be computed).
-   * If the current stage is indeterminate, missing partition is all partitions every time.
-   */
+  /** Returns the sequence of partition ids that are missing (i.e. needs to be computed). */
   override def findMissingPartitions(): Seq[Int] = {
     mapOutputTrackerMaster
       .findMissingPartitions(shuffleDep.shuffleId)

--- a/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapStage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapStage.scala
@@ -87,7 +87,10 @@ private[spark] class ShuffleMapStage(
    */
   def isAvailable: Boolean = numAvailableOutputs == numPartitions
 
-  /** Returns the sequence of partition ids that are missing (i.e. needs to be computed). */
+  /**
+   * Returns the sequence of partition ids that are missing (i.e. needs to be computed).
+   * If the current stage is indeterminate, missing partition is all partitions every time.
+   */
   override def findMissingPartitions(): Seq[Int] = {
     mapOutputTrackerMaster
       .findMissingPartitions(shuffleDep.shuffleId)

--- a/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
@@ -21,7 +21,7 @@ import scala.collection.mutable.HashSet
 
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.internal.Logging
-import org.apache.spark.rdd.RDD
+import org.apache.spark.rdd.{DeterministicLevel, RDD}
 import org.apache.spark.util.CallSite
 
 /**
@@ -116,4 +116,8 @@ private[scheduler] abstract class Stage(
 
   /** Returns the sequence of partition ids that are missing (i.e. needs to be computed). */
   def findMissingPartitions(): Seq[Int]
+
+  def isIndeterminate(): Boolean = {
+    rdd.outputDeterministicLevel == DeterministicLevel.INDETERMINATE
+  }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSet.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSet.scala
@@ -29,7 +29,7 @@ private[spark] class TaskSet(
     val stageAttemptId: Int,
     val priority: Int,
     val properties: Properties,
-    val isIndeterminate: Boolean = false) {
+    val isIndeterminateRerun: Boolean = false) {
   val id: String = stageId + "." + stageAttemptId
 
   override def toString: String = "TaskSet " + id

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSet.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSet.scala
@@ -28,7 +28,8 @@ private[spark] class TaskSet(
     val stageId: Int,
     val stageAttemptId: Int,
     val priority: Int,
-    val properties: Properties) {
+    val properties: Properties,
+    val isIndeterminate: Boolean = false) {
   val id: String = stageId + "." + stageAttemptId
 
   override def toString: String = "TaskSet " + id

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -958,7 +958,7 @@ private[spark] class TaskSetManager(
     // zombie or is from a barrier stage. Also, for the scenario of indeterminate stage rerunning,
     // speculation will cause correctness bugs, see more details in SPARK-23243.
     if (isZombie || isBarrier || numTasks == 1 ||
-        (taskSet.stageAttemptId > 0 && taskSet.isIndeterminate)) {
+        (taskSet.stageAttemptId > 0 && taskSet.isIndeterminateRerun)) {
       return false
     }
     var foundTasks = false

--- a/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
@@ -56,7 +56,8 @@ private[spark] class BlockStoreShuffleReader[K, C](
       SparkEnv.get.conf.get(config.MAX_REMOTE_BLOCK_SIZE_FETCH_TO_MEM),
       SparkEnv.get.conf.get(config.SHUFFLE_DETECT_CORRUPT),
       SparkEnv.get.conf.get(config.SHUFFLE_DETECT_CORRUPT_MEMORY),
-      readMetrics).toCompletionIterator
+      readMetrics,
+      context.getShuffleGenerationId(handle.shuffleId)).toCompletionIterator
 
     val serializerInstance = dep.serializer.newInstance()
 

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockResolver.scala
@@ -34,7 +34,7 @@ trait ShuffleBlockResolver {
    * Retrieve the data for the specified block. If the data for that block is not available,
    * throws an unspecified exception.
    */
-  def getBlockData(blockId: ShuffleBlockId): ManagedBuffer
+  def getBlockData(shuffleGenerationId: Int, blockId: ShuffleBlockId): ManagedBuffer
 
   def stop(): Unit
 }

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockResolver.scala
@@ -34,7 +34,11 @@ trait ShuffleBlockResolver {
    * Retrieve the data for the specified block. If the data for that block is not available,
    * throws an unspecified exception.
    */
-  def getBlockData(shuffleGenerationId: Int, blockId: ShuffleBlockId): ManagedBuffer
+  def getBlockData(
+    shuffleId: ShuffleId,
+    shuffleGenerationId: Int,
+    mapId: Int,
+    reduceId: Int): ManagedBuffer
 
   def stop(): Unit
 }

--- a/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala
@@ -47,6 +47,8 @@ private[spark] class SortShuffleWriter[K, V, C](
 
   private val writeMetrics = context.taskMetrics().shuffleWriteMetrics
 
+  private val shuffleGenerationId = context.getShuffleGenerationId(handle.shuffleId)
+
   /** Write a bunch of records to this task's output */
   override def write(records: Iterator[Product2[K, V]]): Unit = {
     sorter = if (dep.mapSideCombine) {
@@ -64,12 +66,16 @@ private[spark] class SortShuffleWriter[K, V, C](
     // Don't bother including the time to open the merged output file in the shuffle write time,
     // because it just opens a single file, so is typically too fast to measure accurately
     // (see SPARK-3570).
-    val output = shuffleBlockResolver.getDataFile(dep.shuffleId, mapId)
+    val output = shuffleBlockResolver.getDataFile(dep.shuffleId, shuffleGenerationId, mapId)
     val tmp = Utils.tempFileWith(output)
     try {
-      val blockId = ShuffleBlockId(dep.shuffleId, mapId, IndexShuffleBlockResolver.NOOP_REDUCE_ID)
+      val blockId = ShuffleBlockId(
+        dep.shuffleId,
+        mapId,
+        IndexShuffleBlockResolver.NOOP_REDUCE_ID)
       val partitionLengths = sorter.writePartitionedFile(blockId, tmp)
-      shuffleBlockResolver.writeIndexFileAndCommit(dep.shuffleId, mapId, partitionLengths, tmp)
+      shuffleBlockResolver.writeIndexFileAndCommit(
+        dep.shuffleId, shuffleGenerationId, mapId, partitionLengths, tmp)
       mapStatus = MapStatus(blockManager.shuffleServerId, partitionLengths)
     } finally {
       if (tmp.exists() && !tmp.delete()) {

--- a/core/src/main/scala/org/apache/spark/storage/BlockId.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockId.scala
@@ -98,7 +98,7 @@ private[spark] case class TestBlockId(id: String) extends BlockId {
 
 @DeveloperApi
 class UnrecognizedBlockId(name: String)
-    extends SparkException(s"Failed to parse $name into a block ID")
+  extends SparkException(s"Failed to parse $name into a block ID")
 
 @DeveloperApi
 object BlockId {

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -552,7 +552,9 @@ private[spark] class BlockManager(
       // to fetch shuffle blocks. After Spark 3.0, all shuffle block fetching will use new
       // protocol FetchShuffleBlocks and use getShuffleBlockData in BlockManager.
       // See more details in SPARK-27665.
-      shuffleManager.shuffleBlockResolver.getBlockData(-1, blockId.asInstanceOf[ShuffleBlockId])
+      val shuffleBlockId = blockId.asInstanceOf[ShuffleBlockId]
+      shuffleManager.shuffleBlockResolver.getBlockData(
+        shuffleBlockId.shuffleId, -1, shuffleBlockId.mapId, shuffleBlockId.reduceId)
     } else {
       getLocalBytes(blockId) match {
         case Some(blockData) =>
@@ -576,8 +578,8 @@ private[spark] class BlockManager(
       shuffleGenerationId: Int,
       mapId: Int,
       reduceId: Int): ManagedBuffer = {
-    val shuffleBlockId = ShuffleBlockId(shuffleId, mapId, reduceId)
-    shuffleManager.shuffleBlockResolver.getBlockData(shuffleGenerationId, shuffleBlockId)
+    shuffleManager.shuffleBlockResolver.getBlockData(
+      shuffleId, shuffleGenerationId, mapId, reduceId)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -259,10 +259,10 @@ final class ShuffleBlockFetcherIterator(
     // already encrypted and compressed over the wire(w.r.t. the related configs), we can just fetch
     // the data and write it to file directly.
     if (req.size > maxReqSizeShuffleToMem) {
-      shuffleClient.fetchBlocks(address.host, address.port, address.executorId,
+      shuffleClient.fetchShuffleBlocks(address.host, address.port, address.executorId,
         shuffleGenerationId, blockIds.toArray, blockFetchingListener, this)
     } else {
-      shuffleClient.fetchBlocks(address.host, address.port, address.executorId,
+      shuffleClient.fetchShuffleBlocks(address.host, address.port, address.executorId,
         shuffleGenerationId, blockIds.toArray, blockFetchingListener, null)
     }
   }

--- a/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
+++ b/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
@@ -131,15 +131,17 @@ public class UnsafeShuffleWriterSuite {
         );
       });
 
-    when(shuffleBlockResolver.getDataFile(anyInt(), anyInt())).thenReturn(mergedOutputFile);
+    when(shuffleBlockResolver.getDataFile(
+      anyInt(), anyInt(), anyInt())).thenReturn(mergedOutputFile);
     doAnswer(invocationOnMock -> {
-      partitionSizesInMergedFile = (long[]) invocationOnMock.getArguments()[2];
-      File tmp = (File) invocationOnMock.getArguments()[3];
+      partitionSizesInMergedFile = (long[]) invocationOnMock.getArguments()[3];
+      File tmp = (File) invocationOnMock.getArguments()[4];
       mergedOutputFile.delete();
       tmp.renameTo(mergedOutputFile);
       return null;
     }).when(shuffleBlockResolver)
-      .writeIndexFileAndCommit(anyInt(), anyInt(), any(long[].class), any(File.class));
+      .writeIndexFileAndCommit(
+        anyInt(), anyInt(), anyInt(), any(long[].class), any(File.class));
 
     when(diskBlockManager.createTempShuffleBlock()).thenAnswer(invocationOnMock -> {
       TempShuffleBlockId blockId = new TempShuffleBlockId(UUID.randomUUID());

--- a/core/src/test/scala/org/apache/spark/deploy/ExternalShuffleServiceDbSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/ExternalShuffleServiceDbSuite.scala
@@ -59,7 +59,7 @@ class ExternalShuffleServiceDbSuite extends SparkFunSuite {
     // Write some sort data.
     dataContext.insertSortShuffleData(0, 0,
       Array[Array[Byte]](sortBlock0.getBytes(StandardCharsets.UTF_8),
-        sortBlock1.getBytes(StandardCharsets.UTF_8)))
+        sortBlock1.getBytes(StandardCharsets.UTF_8)), false)
     registerExecutor()
   }
 

--- a/core/src/test/scala/org/apache/spark/network/BlockTransferServiceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/network/BlockTransferServiceSuite.scala
@@ -47,11 +47,10 @@ class BlockTransferServiceSuite extends SparkFunSuite with TimeLimits {
 
       override def hostName: String = "localhost-unused"
 
-      override def fetchBlocks(
+      override def fetchDataBlocks(
           host: String,
           port: Int,
           execId: String,
-          shuffleGenerationId: Int,
           blockIds: Array[String],
           listener: BlockFetchingListener,
           tempFileManager: DownloadFileManager): Unit = {
@@ -91,6 +90,18 @@ class BlockTransferServiceSuite extends SparkFunSuite with TimeLimits {
           classTag: ClassTag[_]): Future[Unit] = {
         // This method is unused in this test
         throw new UnsupportedOperationException("uploadBlock")
+      }
+
+      override def fetchBlocks(
+          host: String,
+          port: Int,
+          execId: String,
+          shuffleGenerationId: Int,
+          blockIds: Array[String],
+          listener: BlockFetchingListener,
+          tempFileManager: DownloadFileManager): Unit = {
+        // This method is unused in this test
+        throw new UnsupportedOperationException("fetchBlocks")
       }
     }
 

--- a/core/src/test/scala/org/apache/spark/network/BlockTransferServiceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/network/BlockTransferServiceSuite.scala
@@ -92,7 +92,7 @@ class BlockTransferServiceSuite extends SparkFunSuite with TimeLimits {
         throw new UnsupportedOperationException("uploadBlock")
       }
 
-      override def fetchBlocks(
+      override def fetchShuffleBlocks(
           host: String,
           port: Int,
           execId: String,
@@ -101,7 +101,7 @@ class BlockTransferServiceSuite extends SparkFunSuite with TimeLimits {
           listener: BlockFetchingListener,
           tempFileManager: DownloadFileManager): Unit = {
         // This method is unused in this test
-        throw new UnsupportedOperationException("fetchBlocks")
+        throw new UnsupportedOperationException("fetchShuffleBlocks")
       }
     }
 

--- a/core/src/test/scala/org/apache/spark/network/BlockTransferServiceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/network/BlockTransferServiceSuite.scala
@@ -51,6 +51,7 @@ class BlockTransferServiceSuite extends SparkFunSuite with TimeLimits {
           host: String,
           port: Int,
           execId: String,
+          shuffleGenerationId: Int,
           blockIds: Array[String],
           listener: BlockFetchingListener,
           tempFileManager: DownloadFileManager): Unit = {
@@ -96,7 +97,7 @@ class BlockTransferServiceSuite extends SparkFunSuite with TimeLimits {
     val e = intercept[SparkException] {
       failAfter(10.seconds) {
         blockTransferService.fetchBlockSync(
-          "localhost-unused", 0, "exec-id-unused", "block-id-unused", null)
+          "localhost-unused", 0, "exec-id-unused", "test_block-id-unused", null)
       }
     }
     assert(e.getCause.isInstanceOf[IllegalArgumentException])

--- a/core/src/test/scala/org/apache/spark/network/netty/NettyBlockTransferSecuritySuite.scala
+++ b/core/src/test/scala/org/apache/spark/network/netty/NettyBlockTransferSecuritySuite.scala
@@ -122,7 +122,8 @@ class NettyBlockTransferSecuritySuite extends SparkFunSuite with MockitoSugar wi
     val blockString = "Hello, world!"
     val blockBuffer = new NioManagedBuffer(ByteBuffer.wrap(
       blockString.getBytes(StandardCharsets.UTF_8)))
-    when(blockManager.getBlockData(blockId)).thenReturn(blockBuffer)
+    when(blockManager.getShuffleBlockData(blockId.shuffleId, -1, blockId.mapId, blockId.reduceId))
+      .thenReturn(blockBuffer)
 
     val securityManager0 = new SecurityManager(conf0)
     val exec0 = new NettyBlockTransferService(conf0, securityManager0, "localhost", "localhost", 0,
@@ -158,7 +159,7 @@ class NettyBlockTransferSecuritySuite extends SparkFunSuite with MockitoSugar wi
 
     val promise = Promise[ManagedBuffer]()
 
-    self.fetchBlocks(from.hostName, from.port, execId, Array(blockId.toString),
+    self.fetchBlocks(from.hostName, from.port, execId, -1, Array(blockId.toString),
       new BlockFetchingListener {
         override def onBlockFetchFailure(blockId: String, exception: Throwable): Unit = {
           promise.failure(exception)

--- a/core/src/test/scala/org/apache/spark/network/netty/NettyBlockTransferSecuritySuite.scala
+++ b/core/src/test/scala/org/apache/spark/network/netty/NettyBlockTransferSecuritySuite.scala
@@ -159,7 +159,7 @@ class NettyBlockTransferSecuritySuite extends SparkFunSuite with MockitoSugar wi
 
     val promise = Promise[ManagedBuffer]()
 
-    self.fetchBlocks(from.hostName, from.port, execId, -1, Array(blockId.toString),
+    self.fetchShuffleBlocks(from.hostName, from.port, execId, -1, Array(blockId.toString),
       new BlockFetchingListener {
         override def onBlockFetchFailure(blockId: String, exception: Throwable): Unit = {
           promise.failure(exception)

--- a/core/src/test/scala/org/apache/spark/network/netty/NettyBlockTransferServiceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/network/netty/NettyBlockTransferServiceSuite.scala
@@ -121,8 +121,8 @@ class NettyBlockTransferServiceSuite
     clientFactoryField.setAccessible(true)
     clientFactoryField.set(service0, clientFactory)
 
-    service0.fetchBlocks("localhost", port, "exec1", -1,
-      Array("block1"), listener, mock(classOf[DownloadFileManager]))
+    service0.fetchDataBlocks("localhost", port, "exec1", Array("block1"),
+      listener, mock(classOf[DownloadFileManager]))
     assert(createClientCount === 1)
     assert(hitExecutorDeadException)
   }

--- a/core/src/test/scala/org/apache/spark/network/netty/NettyBlockTransferServiceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/network/netty/NettyBlockTransferServiceSuite.scala
@@ -121,7 +121,7 @@ class NettyBlockTransferServiceSuite
     clientFactoryField.setAccessible(true)
     clientFactoryField.set(service0, clientFactory)
 
-    service0.fetchBlocks("localhost", port, "exec1",
+    service0.fetchBlocks("localhost", port, "exec1", -1,
       Array("block1"), listener, mock(classOf[DownloadFileManager]))
     assert(createClientCount === 1)
     assert(hitExecutorDeadException)

--- a/core/src/test/scala/org/apache/spark/scheduler/FakeTask.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/FakeTask.scala
@@ -57,7 +57,7 @@ object FakeTask {
     val tasks = Array.tabulate[Task[_]](numTasks) { i =>
       new FakeTask(stageId, i, if (prefLocs.size != 0) prefLocs(i) else Nil)
     }
-    new TaskSet(tasks, stageId, stageAttemptId, priority = 0, null)
+    new TaskSet(tasks, stageId, stageAttemptId, priority = 0, new Properties())
   }
 
   def createShuffleMapTaskSet(
@@ -92,6 +92,6 @@ object FakeTask {
     val tasks = Array.tabulate[Task[_]](numTasks) { i =>
       new FakeTask(stageId, i, if (prefLocs.size != 0) prefLocs(i) else Nil, isBarrier = true)
     }
-    new TaskSet(tasks, stageId, stageAttempId, priority = 0, null)
+    new TaskSet(tasks, stageId, stageAttempId, priority = 0, new Properties())
   }
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.scheduler
 
 import java.nio.ByteBuffer
+import java.util.Properties
 
 import scala.collection.mutable.{ArrayBuffer, HashMap}
 import scala.concurrent.duration._
@@ -202,7 +203,8 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
       config.CPUS_PER_TASK.key -> taskCpus.toString)
     val numFreeCores = 1
     val taskSet = new TaskSet(
-      Array(new NotSerializableFakeTask(1, 0), new NotSerializableFakeTask(0, 1)), 0, 0, 0, null)
+      Array(new NotSerializableFakeTask(1, 0), new NotSerializableFakeTask(0, 1)),
+      0, 0, 0, new Properties())
     val multiCoreWorkerOffers = IndexedSeq(new WorkerOffer("executor0", "host0", taskCpus),
       new WorkerOffer("executor1", "host1", numFreeCores))
     taskScheduler.submitTasks(taskSet)
@@ -216,7 +218,8 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     // still be processed without error
     taskScheduler.submitTasks(FakeTask.createTaskSet(1))
     val taskSet2 = new TaskSet(
-      Array(new NotSerializableFakeTask(1, 0), new NotSerializableFakeTask(0, 1)), 1, 0, 0, null)
+      Array(new NotSerializableFakeTask(1, 0), new NotSerializableFakeTask(0, 1)),
+      1, 0, 0, new Properties())
     taskScheduler.submitTasks(taskSet2)
     taskDescriptions = taskScheduler.resourceOffers(multiCoreWorkerOffers).flatten
     assert(taskDescriptions.map(_.executorId) === Seq("executor0"))

--- a/core/src/test/scala/org/apache/spark/shuffle/BlockStoreShuffleReaderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/BlockStoreShuffleReaderSuite.scala
@@ -94,8 +94,8 @@ class BlockStoreShuffleReaderSuite extends SparkFunSuite with LocalSparkContext 
 
       // Setup the blockManager mock so the buffer gets returned when the shuffle code tries to
       // fetch shuffle data.
-      val shuffleBlockId = ShuffleBlockId(shuffleId, mapId, reduceId)
-      when(blockManager.getBlockData(shuffleBlockId)).thenReturn(managedBuffer)
+      when(blockManager.getShuffleBlockData(shuffleId, -1, mapId, reduceId))
+        .thenReturn(managedBuffer)
       managedBuffer
     }
 

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriterSuite.scala
@@ -73,14 +73,15 @@ class BypassMergeSortShuffleWriterSuite extends SparkFunSuite with BeforeAndAfte
     when(dependency.partitioner).thenReturn(new HashPartitioner(7))
     when(dependency.serializer).thenReturn(new JavaSerializer(conf))
     when(taskContext.taskMetrics()).thenReturn(taskMetrics)
-    when(blockResolver.getDataFile(0, 0)).thenReturn(outputFile)
+    when(taskContext.getShuffleGenerationId(any[Int])).thenReturn(-1)
+    when(blockResolver.getDataFile(0, -1, 0)).thenReturn(outputFile)
     when(blockManager.diskBlockManager).thenReturn(diskBlockManager)
     when(taskContext.taskMemoryManager()).thenReturn(taskMemoryManager)
 
     when(blockResolver.writeIndexFileAndCommit(
-      anyInt, anyInt, any(classOf[Array[Long]]), any(classOf[File])))
+      anyInt, anyInt, anyInt(), any(classOf[Array[Long]]), any(classOf[File])))
       .thenAnswer { invocationOnMock =>
-        val tmp = invocationOnMock.getArguments()(3).asInstanceOf[File]
+        val tmp = invocationOnMock.getArguments()(4).asInstanceOf[File]
         if (tmp != null) {
           outputFile.delete
           tmp.renameTo(outputFile)
@@ -140,7 +141,7 @@ class BypassMergeSortShuffleWriterSuite extends SparkFunSuite with BeforeAndAfte
       blockManager,
       shuffleHandle,
       0, // MapId
-      0L, // MapTaskAttemptId
+      taskContext,
       conf,
       taskContext.taskMetrics().shuffleWriteMetrics,
       shuffleExecutorComponents)
@@ -167,7 +168,7 @@ class BypassMergeSortShuffleWriterSuite extends SparkFunSuite with BeforeAndAfte
         blockManager,
         shuffleHandle,
         0, // MapId
-        0L,
+        taskContext,
         transferConf,
         taskContext.taskMetrics().shuffleWriteMetrics,
         shuffleExecutorComponents)
@@ -203,7 +204,7 @@ class BypassMergeSortShuffleWriterSuite extends SparkFunSuite with BeforeAndAfte
       blockManager,
       shuffleHandle,
       0, // MapId
-      0L,
+      taskContext,
       conf,
       taskContext.taskMetrics().shuffleWriteMetrics,
       shuffleExecutorComponents)
@@ -225,7 +226,7 @@ class BypassMergeSortShuffleWriterSuite extends SparkFunSuite with BeforeAndAfte
       blockManager,
       shuffleHandle,
       0, // MapId
-      0L,
+      taskContext,
       conf,
       taskContext.taskMetrics().shuffleWriteMetrics,
       shuffleExecutorComponents)

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/SortShuffleWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/SortShuffleWriterSuite.scala
@@ -70,7 +70,7 @@ class SortShuffleWriterSuite extends SparkFunSuite with SharedSparkContext with 
       context)
     writer.write(Iterator.empty)
     writer.stop(success = true)
-    val dataFile = shuffleBlockResolver.getDataFile(shuffleId, 1)
+    val dataFile = shuffleBlockResolver.getDataFile(shuffleId, -1, 1)
     val writeMetrics = context.taskMetrics().shuffleWriteMetrics
     assert(!dataFile.exists())
     assert(writeMetrics.bytesWritten === 0)
@@ -87,7 +87,7 @@ class SortShuffleWriterSuite extends SparkFunSuite with SharedSparkContext with 
       context)
     writer.write(records.toIterator)
     writer.stop(success = true)
-    val dataFile = shuffleBlockResolver.getDataFile(shuffleId, 2)
+    val dataFile = shuffleBlockResolver.getDataFile(shuffleId, -1, 2)
     val writeMetrics = context.taskMetrics().shuffleWriteMetrics
     assert(dataFile.exists())
     assert(dataFile.length() === writeMetrics.bytesWritten)

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriterSuite.scala
@@ -77,8 +77,8 @@ class LocalDiskShuffleMapOutputWriterSuite extends SparkFunSuite with BeforeAndA
     when(blockResolver.writeIndexFileAndCommit(
       anyInt, anyInt, anyInt, any(classOf[Array[Long]]), any(classOf[File])))
       .thenAnswer { invocationOnMock =>
-        partitionSizesInMergedFile = invocationOnMock.getArguments()(2).asInstanceOf[Array[Long]]
-        val tmp: File = invocationOnMock.getArguments()(3).asInstanceOf[File]
+        partitionSizesInMergedFile = invocationOnMock.getArguments()(3).asInstanceOf[Array[Long]]
+        val tmp: File = invocationOnMock.getArguments()(4).asInstanceOf[File]
         if (tmp != null) {
           mergedOutputFile.delete()
           tmp.renameTo(mergedOutputFile)

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriterSuite.scala
@@ -73,9 +73,9 @@ class LocalDiskShuffleMapOutputWriterSuite extends SparkFunSuite with BeforeAndA
     conf = new SparkConf()
       .set("spark.app.id", "example.spark.app")
       .set("spark.shuffle.unsafe.file.output.buffer", "16k")
-    when(blockResolver.getDataFile(anyInt, anyInt)).thenReturn(mergedOutputFile)
+    when(blockResolver.getDataFile(anyInt, anyInt, anyInt)).thenReturn(mergedOutputFile)
     when(blockResolver.writeIndexFileAndCommit(
-      anyInt, anyInt, any(classOf[Array[Long]]), any(classOf[File])))
+      anyInt, anyInt, anyInt, any(classOf[Array[Long]]), any(classOf[File])))
       .thenAnswer { invocationOnMock =>
         partitionSizesInMergedFile = invocationOnMock.getArguments()(2).asInstanceOf[Array[Long]]
         val tmp: File = invocationOnMock.getArguments()(3).asInstanceOf[File]
@@ -87,6 +87,7 @@ class LocalDiskShuffleMapOutputWriterSuite extends SparkFunSuite with BeforeAndA
       }
     mapOutputWriter = new LocalDiskShuffleMapOutputWriter(
       0,
+      -1,
       0,
       NUM_PARTITIONS,
       blockResolver,

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -1657,6 +1657,16 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
       listener.onBlockFetchSuccess("mockBlockId", new NioManagedBuffer(ByteBuffer.allocate(1)))
     }
 
+    override def fetchDataBlocks(
+        host: String,
+        port: Int,
+        execId: String,
+        blockIds: Array[String],
+        listener: BlockFetchingListener,
+        tempFileManager: DownloadFileManager): Unit = {
+      listener.onBlockFetchSuccess("mockBlockId", new NioManagedBuffer(ByteBuffer.allocate(1)))
+    }
+
     override def close(): Unit = {}
 
     override def hostName: String = { "MockBlockTransferServiceHost" }

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -1646,7 +1646,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
 
     override def init(blockDataManager: BlockDataManager): Unit = {}
 
-    override def fetchBlocks(
+    override def fetchShuffleBlocks(
         host: String,
         port: Int,
         execId: String,

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -1650,6 +1650,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
         host: String,
         port: Int,
         execId: String,
+        shuffleGenerationId: Int,
         blockIds: Array[String],
         listener: BlockFetchingListener,
         tempFileManager: DownloadFileManager): Unit = {

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -49,7 +49,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
   /** Creates a mock [[BlockTransferService]] that returns data from the given map. */
   private def createMockTransfer(data: Map[BlockId, ManagedBuffer]): BlockTransferService = {
     val transfer = mock(classOf[BlockTransferService])
-    when(transfer.fetchBlocks(any(), any(), any(), any(), any(), any(), any())).thenAnswer(
+    when(transfer.fetchShuffleBlocks(any(), any(), any(), any(), any(), any(), any())).thenAnswer(
       (invocation: InvocationOnMock) => {
         val blocks = invocation.getArguments()(4).asInstanceOf[Array[String]]
         val listener = invocation.getArguments()(5).asInstanceOf[BlockFetchingListener]
@@ -146,9 +146,9 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     }
 
     // 3 local blocks, and 2 remote blocks
-    // (but from the same block manager so one call to fetchBlocks)
+    // (but from the same block manager so one call to fetchShuffleBlocks)
     verify(blockManager, times(3)).getShuffleBlockData(any(), any(), any(), any())
-    verify(transfer, times(1)).fetchBlocks(any(), any(), any(), any(), any(), any(), any())
+    verify(transfer, times(1)).fetchShuffleBlocks(any(), any(), any(), any(), any(), any(), any())
   }
 
   test("release current unexhausted buffer in case the task completes early") {
@@ -167,7 +167,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     val sem = new Semaphore(0)
 
     val transfer = mock(classOf[BlockTransferService])
-    when(transfer.fetchBlocks(any(), any(), any(), any(), any(), any(), any()))
+    when(transfer.fetchShuffleBlocks(any(), any(), any(), any(), any(), any(), any()))
       .thenAnswer((invocation: InvocationOnMock) => {
         val listener = invocation.getArguments()(5).asInstanceOf[BlockFetchingListener]
         Future {
@@ -235,7 +235,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     val sem = new Semaphore(0)
 
     val transfer = mock(classOf[BlockTransferService])
-    when(transfer.fetchBlocks(any(), any(), any(), any(), any(), any(), any()))
+    when(transfer.fetchShuffleBlocks(any(), any(), any(), any(), any(), any(), any()))
       .thenAnswer((invocation: InvocationOnMock) => {
         val listener = invocation.getArguments()(5).asInstanceOf[BlockFetchingListener]
         Future {
@@ -324,7 +324,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     val corruptLocalBuffer = new FileSegmentManagedBuffer(null, new File("a"), 0, 100)
 
     val transfer = mock(classOf[BlockTransferService])
-    when(transfer.fetchBlocks(any(), any(), any(), any(), any(), any(), any()))
+    when(transfer.fetchShuffleBlocks(any(), any(), any(), any(), any(), any(), any()))
       .thenAnswer((invocation: InvocationOnMock) => {
         val listener = invocation.getArguments()(5).asInstanceOf[BlockFetchingListener]
         Future {
@@ -364,7 +364,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     val (id1, _) = iterator.next()
     assert(id1 === ShuffleBlockId(0, 0, 0))
 
-    when(transfer.fetchBlocks(any(), any(), any(), any(), any(), any(), any()))
+    when(transfer.fetchShuffleBlocks(any(), any(), any(), any(), any(), any(), any()))
       .thenAnswer((invocation: InvocationOnMock) => {
         val listener = invocation.getArguments()(5).asInstanceOf[BlockFetchingListener]
         Future {
@@ -519,7 +519,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     val sem = new Semaphore(0)
 
     val transfer = mock(classOf[BlockTransferService])
-    when(transfer.fetchBlocks(any(), any(), any(), any(), any(), any(), any()))
+    when(transfer.fetchShuffleBlocks(any(), any(), any(), any(), any(), any(), any()))
       .thenAnswer((invocation: InvocationOnMock) => {
         val listener = invocation.getArguments()(5).asInstanceOf[BlockFetchingListener]
         Future {
@@ -583,7 +583,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       ShuffleBlockId(0, 0, 0) -> createMockManagedBuffer())
     val transfer = mock(classOf[BlockTransferService])
     var tempFileManager: DownloadFileManager = null
-    when(transfer.fetchBlocks(any(), any(), any(), any(), any(), any(), any()))
+    when(transfer.fetchShuffleBlocks(any(), any(), any(), any(), any(), any(), any()))
       .thenAnswer((invocation: InvocationOnMock) => {
         val listener = invocation.getArguments()(5).asInstanceOf[BlockFetchingListener]
         tempFileManager = invocation.getArguments()(6).asInstanceOf[DownloadFileManager]


### PR DESCRIPTION
After the newly added shuffle block fetching protocol in #24565, we can keep this work by extending the FetchShuffleBlocks message.

## What changes were proposed in this pull request?

This is a follow-up work for #22112's future improvment[1]: `Currently we can't rollback and rerun a shuffle map stage, and just fail.`

Spark will rerun a finished shuffle write stage while meeting fetch failures, currently, the rerun shuffle map stage will only resubmit the task for missing partitions and reuse the output of other partitions. This logic is fine in most scenarios, but for indeterministic operations(like repartition), multiple shuffle write attempts may write different data, only rerun the missing partition will lead a correctness bug. So for the shuffle map stage of indeterministic operations, we need to support rolling back the shuffle map stage and re-generate the shuffle files. In this patch, we achieve this by adding the indeterministic tag in the stage, for the indeterministic stage, when the stage resubmits, we'll clear all existing map status and rerun all partitions. We also add properties in task LocalProperties to record the message for the retried indeterminate stage, so that the shuffle file which generated from retried indeterministic stage will keep the shuffle generation id in the file name. The corresponding reduce side will specify which shuffle generation id of shuffle it wants to read. The shuffle generation id marked the retried times of this stage, so we reuse the stage attempt id as the shuffle generation id while meeting the indeterminate stage reran.

All changes are summarized as follows:
- Extend FetchShuffleBlock message with shuffleGenerationId.
- Add corresponding support for ShuffleBlockResolver, if the shuffle file generated from the indeterminate stage, its name will contain the indeterminateAttemptId, otherwise the file name just as before.
- Add the retried indeterminate stage info in TaskContext.localProperties and use it in Shuffle Reader and Writer.
- Add the determinate flag in Stage and use it in DAGScheduler and the cleaning work for the intermediate stage.

## How was this patch tested?

- UT: Add UT for all changing code and newly added function.
- Manual Test: Also providing a manual test to verify the effect.
```
import scala.sys.process._
import org.apache.spark.TaskContext

val determinateStage0 = sc.parallelize(0 until 1000 * 1000 * 100, 10)
val indeterminateStage1 = determinateStage0.repartition(200)
val indeterminateStage2 = indeterminateStage1.repartition(200)
val indeterminateStage3 = indeterminateStage2.repartition(100)
val indeterminateStage4 = indeterminateStage3.repartition(300)
val fetchFailIndeterminateStage4 = indeterminateStage4.map { x =>
if (TaskContext.get.attemptNumber == 0 && TaskContext.get.partitionId == 190 && 
  TaskContext.get.stageAttemptNumber == 0) {
  throw new Exception("pkill -f -n java".!!)
  }
  x
}
val indeterminateStage5 = fetchFailIndeterminateStage4.repartition(200)
val finalStage6 = indeterminateStage5.repartition(100).collect().distinct.length
``` 
It's a simple job with multi indeterminate stage, it will get a wrong answer while using old Spark version like 2.2/2.3, and will be killed after #22112. With this fix, the job can retry all indeterminate stage as below screenshot and get the right result.
![image](https://user-images.githubusercontent.com/4833765/54444941-c058b080-477e-11e9-8bad-bea13ed21b9e.png)