### PR TITLE
[SPARK-28058][DOC] Add a note to doc of mode of CSV for column pruning

### DIFF
--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -441,7 +441,12 @@ class DataFrameReader(OptionUtils):
                   When it meets a record having fewer tokens than the length of the schema, \
                   sets ``null`` to extra fields. When the record has more tokens than the \
                   length of the schema, it drops extra tokens.
-                * ``DROPMALFORMED`` : ignores the whole corrupted records.
+                * ``DROPMALFORMED`` : ignores the whole corrupted records. Note that when CSV \
+                  parser column pruning (``spark.sql.csv.parser.columnPruning.enabled``) is \
+                  enabled (it is enabled by default), the malformed columns can be ignored during \
+                  parsing if they are pruned, resulting the corrupted records are not dropped. \
+                  Disabling the column pruning feature can drop corrupted records even malformed \
+                  columns are not read.
                 * ``FAILFAST`` : throws an exception when it meets corrupted records.
 
         :param columnNameOfCorruptRecord: allows renaming the new field having malformed string

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -430,7 +430,11 @@ class DataFrameReader(OptionUtils):
         :param maxMalformedLogPerPartition: this parameter is no longer used since Spark 2.2.0.
                                             If specified, it is ignored.
         :param mode: allows a mode for dealing with corrupt records during parsing. If None is
-                     set, it uses the default value, ``PERMISSIVE``.
+                     set, it uses the default value, ``PERMISSIVE``. Note that Spark tries to
+                     parse only required columns in CSV under column pruning. Therefore, corrupt
+                     records can be different based on required set of fields. This behavior can
+                     be controlled by ``spark.sql.csv.parser.columnPruning.enabled``
+                     (enabled by default).
 
                 * ``PERMISSIVE`` : when it meets a corrupted record, puts the malformed string \
                   into a field configured by ``columnNameOfCorruptRecord``, and sets malformed \
@@ -441,12 +445,7 @@ class DataFrameReader(OptionUtils):
                   When it meets a record having fewer tokens than the length of the schema, \
                   sets ``null`` to extra fields. When the record has more tokens than the \
                   length of the schema, it drops extra tokens.
-                * ``DROPMALFORMED`` : ignores the whole corrupted records. Note that when CSV \
-                  parser column pruning (``spark.sql.csv.parser.columnPruning.enabled``) is \
-                  enabled (it is enabled by default), the malformed columns can be ignored during \
-                  parsing if they are pruned, resulting the corrupted records are not dropped. \
-                  Disabling the column pruning feature can drop corrupted records even malformed \
-                  columns are not read.
+                * ``DROPMALFORMED`` : ignores the whole corrupted records.
                 * ``FAILFAST`` : throws an exception when it meets corrupted records.
 
         :param columnNameOfCorruptRecord: allows renaming the new field having malformed string

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -637,7 +637,11 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    *     than schema is not a corrupted record to CSV. When it meets a record having fewer
    *     tokens than the length of the schema, sets `null` to extra fields. When the record
    *     has more tokens than the length of the schema, it drops extra tokens.</li>
-   *     <li>`DROPMALFORMED` : ignores the whole corrupted records.</li>
+   *     <li>`DROPMALFORMED` : ignores the whole corrupted records. Note that when CSV parser
+   *     column pruning (`spark.sql.csv.parser.columnPruning.enabled`) is enabled
+   *     (it is enabled by default), the malformed columns can be ignored during parsing if
+   *     they are pruned, resulting the corrupted records are not dropped. Disabling the
+   *     column pruning feature can drop corrupted records even malformed columns are not read.</li>
    *     <li>`FAILFAST` : throws an exception when it meets corrupted records.</li>
    *   </ul>
    * </li>

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -627,7 +627,10 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    * <li>`maxCharsPerColumn` (default `-1`): defines the maximum number of characters allowed
    * for any given value being read. By default, it is -1 meaning unlimited length</li>
    * <li>`mode` (default `PERMISSIVE`): allows a mode for dealing with corrupt records
-   *    during parsing. It supports the following case-insensitive modes.
+   *    during parsing. It supports the following case-insensitive modes. Note that Spark tries
+   *    to parse only required columns in CSV under column pruning. Therefore, corrupt records
+   *    can be different based on required set of fields. This behavior can be controlled by
+   *    `spark.sql.csv.parser.columnPruning.enabled` (enabled by default).
    *   <ul>
    *     <li>`PERMISSIVE` : when it meets a corrupted record, puts the malformed string into a
    *     field configured by `columnNameOfCorruptRecord`, and sets malformed fields to `null`.
@@ -637,11 +640,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    *     than schema is not a corrupted record to CSV. When it meets a record having fewer
    *     tokens than the length of the schema, sets `null` to extra fields. When the record
    *     has more tokens than the length of the schema, it drops extra tokens.</li>
-   *     <li>`DROPMALFORMED` : ignores the whole corrupted records. Note that when CSV parser
-   *     column pruning (`spark.sql.csv.parser.columnPruning.enabled`) is enabled
-   *     (it is enabled by default), the malformed columns can be ignored during parsing if
-   *     they are pruned, resulting the corrupted records are not dropped. Disabling the
-   *     column pruning feature can drop corrupted records even malformed columns are not read.</li>
+   *     <li>`DROPMALFORMED` : ignores the whole corrupted records.</li>
    *     <li>`FAILFAST` : throws an exception when it meets corrupted records.</li>
    *   </ul>
    * </li>


### PR DESCRIPTION
## What changes were proposed in this pull request?

When using `DROPMALFORMED` mode, corrupted records aren't dropped if malformed columns aren't read. This behavior is due to CSV parser column pruning. Current doc of `DROPMALFORMED` doesn't mention the effect of column pruning. Users will be confused by the fact that `DROPMALFORMED` mode doesn't work as expected.

Column pruning also affects other modes. This is a doc improvement to add a note to doc of `mode` to explain it.

## How was this patch tested?

N/A. This is just doc change.