### PR TITLE
[WIP][SPARK-28006] User-defined grouped transform pandas_udf for window operations

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -47,6 +47,7 @@ private[spark] object PythonEvalType {
   val SQL_GROUPED_AGG_PANDAS_UDF = 202
   val SQL_WINDOW_AGG_PANDAS_UDF = 203
   val SQL_SCALAR_PANDAS_ITER_UDF = 204
+  val SQL_GROUPED_XFORM_PANDAS_UDF = 205
 
   def toString(pythonEvalType: Int): String = pythonEvalType match {
     case NON_UDF => "NON_UDF"
@@ -55,6 +56,7 @@ private[spark] object PythonEvalType {
     case SQL_GROUPED_MAP_PANDAS_UDF => "SQL_GROUPED_MAP_PANDAS_UDF"
     case SQL_GROUPED_AGG_PANDAS_UDF => "SQL_GROUPED_AGG_PANDAS_UDF"
     case SQL_WINDOW_AGG_PANDAS_UDF => "SQL_WINDOW_AGG_PANDAS_UDF"
+    case SQL_GROUPED_XFORM_PANDAS_UDF => "SQL_GROUPED_XFORM_PANDAS_UDF"
     case SQL_SCALAR_PANDAS_ITER_UDF => "SQL_SCALAR_PANDAS_ITER_UDF"
   }
 }

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -74,6 +74,7 @@ class PythonEvalType(object):
     SQL_GROUPED_AGG_PANDAS_UDF = 202
     SQL_WINDOW_AGG_PANDAS_UDF = 203
     SQL_SCALAR_PANDAS_ITER_UDF = 204
+    SQL_GROUPED_XFORM_PANDAS_UDF = 205
 
 
 def portable_hash(x):

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2802,6 +2802,9 @@ class PandasUDFType(object):
 
     GROUPED_AGG = PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF
 
+    # Experimental type
+    GROUPED_XFORM = PythonEvalType.SQL_GROUPED_XFORM_PANDAS_UDF
+
 
 @since(1.3)
 def udf(f=None, returnType=StringType()):
@@ -3182,7 +3185,8 @@ def pandas_udf(f=None, returnType=None, functionType=None):
     if eval_type not in [PythonEvalType.SQL_SCALAR_PANDAS_UDF,
                          PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF,
                          PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF,
-                         PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF]:
+                         PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF,
+                         PythonEvalType.SQL_GROUPED_XFORM_PANDAS_UDF]:
         raise ValueError("Invalid functionType: "
                          "functionType must be one the values from PandasUDFType")
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -206,6 +206,15 @@ def wrap_bounded_window_agg_pandas_udf(f, return_type):
     return lambda *a: (wrapped(*a), arrow_return_type)
 
 
+def wrap_window_xform_pandas_udf(f, return_type):
+    arrow_return_type = to_arrow_type(return_type)
+
+    def wrapped(*series):
+        result = f(*series)
+        return result
+    return lambda *a: (wrapped(*a), arrow_return_type)
+
+
 def read_single_udf(pickleSer, infile, eval_type, runner_conf, udf_index):
     num_arg = read_int(infile)
     arg_offsets = [read_int(infile) for i in range(num_arg)]
@@ -236,6 +245,8 @@ def read_single_udf(pickleSer, infile, eval_type, runner_conf, udf_index):
         return arg_offsets, wrap_grouped_agg_pandas_udf(func, return_type)
     elif eval_type == PythonEvalType.SQL_WINDOW_AGG_PANDAS_UDF:
         return arg_offsets, wrap_window_agg_pandas_udf(func, return_type, runner_conf, udf_index)
+    elif eval_type == PythonEvalType.SQL_GROUPED_XFORM_PANDAS_UDF:
+        return arg_offsets, wrap_window_xform_pandas_udf(func, return_type)
     elif eval_type == PythonEvalType.SQL_BATCHED_UDF:
         return arg_offsets, wrap_udf(func, return_type)
     else:
@@ -249,7 +260,8 @@ def read_udfs(pickleSer, infile, eval_type):
                      PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF,
                      PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF,
                      PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF,
-                     PythonEvalType.SQL_WINDOW_AGG_PANDAS_UDF):
+                     PythonEvalType.SQL_WINDOW_AGG_PANDAS_UDF,
+                     PythonEvalType.SQL_GROUPED_XFORM_PANDAS_UDF):
 
         # Load conf used for pandas_udf evaluation
         num_conf = read_int(infile)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
@@ -40,9 +40,15 @@ object PythonUDF {
       e.asInstanceOf[PythonUDF].evalType == PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF
   }
 
+  def isGroupedXformPandasUDF(e: Expression): Boolean = {
+    e.isInstanceOf[PythonUDF] &&
+      e.asInstanceOf[PythonUDF].evalType == PythonEvalType.SQL_GROUPED_XFORM_PANDAS_UDF
+  }
+
   // This is currently same as GroupedAggPandasUDF, but we might support new types in the future,
   // e.g, N -> N transform.
-  def isWindowPandasUDF(e: Expression): Boolean = isGroupedAggPandasUDF(e)
+  def isWindowPandasUDF(e: Expression): Boolean =
+    isGroupedAggPandasUDF(e) || isGroupedXformPandasUDF(e)
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/WindowInPandasExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/WindowInPandasExec.scala
@@ -210,6 +210,8 @@ case class WindowInPandasExec(
     val (pyFuncs, inputs) = udfExpressions.map(collectFunctions).unzip
     require(pyFuncs.length == expressions.length)
 
+    var evalType = udfExpressions.head.evalType
+
     val udfWindowBoundTypes = pyFuncs.indices.map(i =>
       frameWindowBoundTypes(expressionIndexToFrameIndex(i)))
     val pythonRunnerConf: Map[String, String] = (ArrowUtils.getPythonRunnerConfMap(conf)
@@ -384,9 +386,13 @@ case class WindowInPandasExec(
         }
       }
 
+      if (evalType == PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF) {
+        evalType = PythonEvalType.SQL_WINDOW_AGG_PANDAS_UDF
+      }
+
       val windowFunctionResult = new ArrowPythonRunner(
         pyFuncs,
-        PythonEvalType.SQL_WINDOW_AGG_PANDAS_UDF,
+        evalType,
         argOffsets,
         pythonInputSchema,
         sessionLocalTimeZone,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, pandas_udf supports "grouped aggregate" type that can be used with unbounded and unbounded windows. There is another set of use cases that can benefit from a "grouped transform" type pandas_udf.

Grouped transform is defined as a N -> N mapping over a group. For example, "compute zscore for values in the group using the grouped mean and grouped stdev", or "rank the values in the group".

Currently, in order to do this, user needs to use "grouped apply", for example:
```
@pandas_udf(schema, GROUPED_MAP)
def subtract_mean(pdf)
    v = pdf['v']
    pdf['v'] = v - v.mean()
    return pdf

df.groupby('id').apply(subtract_mean)
# +---+----+
# | id|   v|
# +---+----+
# |  1|-0.5|
# |  1| 0.5|
# |  2|-3.0|
# |  2|-1.0|
# |  2| 4.0|
# +---+----+
```
This approach has a few downside:

Specifying the full return schema is complicated for the user although the function only changes one column.
* The column name 'v' inside as part of the udf, makes the udf less reusable.
* The entire dataframe is serialized to pass to Python although only one column is needed.
* Here we propose a new type of pandas_udf to work with these types of use cases:

Here we propose a new type of pandas_udf to work with these types of use cases:
```
df = spark.createDataFrame(
    [(1, 1.0), (1, 2.0), (2, 3.0), (2, 5.0), (2, 10.0)],
    ("id", "v"))

@pandas_udf('double', GROUPED_XFORM)
def subtract_mean(v):
    return v - v.mean()

w = Window.partitionBy('id')

df = df.withColumn('v', subtract_mean(df['v']).over(w))
# +---+----+
# | id|   v|
# +---+----+
# |  1|-0.5|
# |  1| 0.5|
# |  2|-3.0|
# |  2|-1.0|
# |  2| 4.0|
# +---+----+
```
Which addresses the above downsides.

* The user only needs to specify the output type of a single column.
* The column being zscored is decoupled from the udf implementation
* We only need to send one column to Python worker and concat the result with the original dataframe (this is what grouped aggregate is doing already)

This is similar to groupby transform in pandas, hence the name "grouped transform"

```
>>> df = pd.DataFrame({'id': [1, 1, 2, 2, 2], 'value': [1., 2., 3., 5., 10.]})

>>> df
   id  value

0   1    1.0
1   1    2.0
2   2    3.0
3   2    5.0
4   2   10.0

>>> df['value_demean'] = df.groupby('id')['value'].transform(lambda x: x - x.mean())
>>> df

   id  value  value_demean
0   1    1.0          -0.5
1   1    2.0           0.5
2   2    3.0          -3.0
3   2    5.0          -1.0
4   2   10.0           4.0
```

## How was this patch tested?

Add new tests in test_pandas_udf_window