### PR TITLE
[SPARK-28096][SQL] Convert defs to lazy vals to avoid expensive `output` computation in QueryPlans

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -46,7 +46,8 @@ case class UnresolvedRelation(multipartIdentifier: Seq[String]) extends LeafNode
   /** Returns a `.` separated name for this relation. */
   def tableName: String = multipartIdentifier.quoted
 
-  override def output: Seq[Attribute] = Nil
+  @transient
+  override lazy val output: Seq[Attribute] = Nil
 
   override lazy val resolved = false
 }
@@ -70,7 +71,8 @@ case class UnresolvedInlineTable(
 
   lazy val expressionsResolved: Boolean = rows.forall(_.forall(_.resolved))
   override lazy val resolved = false
-  override def output: Seq[Attribute] = Nil
+  @transient
+  override lazy val output: Seq[Attribute] = Nil
 }
 
 /**
@@ -93,7 +95,8 @@ case class UnresolvedTableValuedFunction(
     outputNames: Seq[String])
   extends LeafNode {
 
-  override def output: Seq[Attribute] = Nil
+  @transient
+  override lazy val output: Seq[Attribute] = Nil
 
   override lazy val resolved = false
 }
@@ -467,7 +470,8 @@ case class UnresolvedSubqueryColumnAliases(
     child: LogicalPlan)
   extends UnaryNode {
 
-  override def output: Seq[Attribute] = Nil
+  @transient
+  override lazy val output: Seq[Attribute] = Nil
 
   override lazy val resolved = false
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -593,7 +593,8 @@ object CatalogTypes {
 case class UnresolvedCatalogRelation(tableMeta: CatalogTable) extends LeafNode {
   assert(tableMeta.identifier.database.isDefined)
   override lazy val resolved: Boolean = false
-  override def output: Seq[Attribute] = Nil
+  @transient
+  override lazy val output: Seq[Attribute] = Nil
 }
 
 /**
@@ -610,7 +611,8 @@ case class HiveTableRelation(
   assert(tableMeta.dataSchema.sameType(dataCols.toStructType))
 
   // The partition column should always appear after data columns.
-  override def output: Seq[AttributeReference] = dataCols ++ partitionCols
+  @transient
+  override lazy val output: Seq[AttributeReference] = dataCols ++ partitionCols
 
   def isPartitioned: Boolean = partitionCols.nonEmpty
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CostBasedJoinReorder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CostBasedJoinReorder.scala
@@ -108,7 +108,8 @@ case class OrderedJoin(
     right: LogicalPlan,
     joinType: JoinType,
     condition: Option[Expression]) extends BinaryNode {
-  override def output: Seq[Attribute] = left.output ++ right.output
+  @transient
+  override lazy val output: Seq[Attribute] = left.output ++ right.output
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/hints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/hints.scala
@@ -31,7 +31,8 @@ case class UnresolvedHint(name: String, parameters: Seq[Any], child: LogicalPlan
   extends UnaryNode {
 
   override lazy val resolved: Boolean = false
-  override def output: Seq[Attribute] = child.output
+  @transient
+  override lazy val output: Seq[Attribute] = child.output
 }
 
 /**
@@ -41,7 +42,8 @@ case class UnresolvedHint(name: String, parameters: Seq[Any], child: LogicalPlan
 case class ResolvedHint(child: LogicalPlan, hints: HintInfo = HintInfo())
   extends UnaryNode {
 
-  override def output: Seq[Attribute] = child.output
+  @transient
+  override lazy val output: Seq[Attribute] = child.output
 
   override def doCanonicalize(): LogicalPlan = child.canonicalized
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/object.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/object.scala
@@ -54,7 +54,8 @@ trait ObjectProducer extends LogicalPlan {
   // The attribute that reference to the single object field this operator outputs.
   def outputObjAttr: Attribute
 
-  override def output: Seq[Attribute] = outputObjAttr :: Nil
+  @transient
+  override lazy val output: Seq[Attribute] = outputObjAttr :: Nil
 
   override def producedAttributes: AttributeSet = AttributeSet(outputObjAttr)
 }
@@ -89,7 +90,8 @@ case class SerializeFromObject(
     serializer: Seq[NamedExpression],
     child: LogicalPlan) extends ObjectConsumer {
 
-  override def output: Seq[Attribute] = serializer.map(_.toAttribute)
+  @transient
+  override lazy val output: Seq[Attribute] = serializer.map(_.toAttribute)
 }
 
 object MapPartitions {
@@ -236,7 +238,8 @@ case class TypedFilter(
     deserializer: Expression,
     child: LogicalPlan) extends UnaryNode {
 
-  override def output: Seq[Attribute] = child.output
+  @transient
+  override lazy val output: Seq[Attribute] = child.output
 
   def withObjectProducerChild(obj: LogicalPlan): Filter = {
     assert(obj.output.length == 1)
@@ -331,7 +334,8 @@ case class AppendColumns(
     serializer: Seq[NamedExpression],
     child: LogicalPlan) extends UnaryNode {
 
-  override def output: Seq[Attribute] = child.output ++ newColumns
+  @transient
+  override lazy val output: Seq[Attribute] = child.output ++ newColumns
 
   def newColumns: Seq[Attribute] = serializer.map(_.toAttribute)
 }
@@ -345,7 +349,9 @@ case class AppendColumnsWithObject(
     newColumnsSerializer: Seq[NamedExpression],
     child: LogicalPlan) extends ObjectConsumer {
 
-  override def output: Seq[Attribute] = (childSerializer ++ newColumnsSerializer).map(_.toAttribute)
+  @transient
+  override lazy val output: Seq[Attribute] =
+    (childSerializer ++ newColumnsSerializer).map(_.toAttribute)
 }
 
 /** Factory for constructing new `MapGroups` nodes. */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/pythonLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/pythonLogicalOperators.scala
@@ -45,7 +45,8 @@ trait BaseEvalPython extends UnaryNode {
 
   def resultAttrs: Seq[Attribute]
 
-  override def output: Seq[Attribute] = child.output ++ resultAttrs
+  @transient
+  override lazy val output: Seq[Attribute] = child.output ++ resultAttrs
 
   @transient
   override lazy val references: AttributeSet = AttributeSet(udfs.flatMap(_.references))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/sql/DropTableStatement.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/sql/DropTableStatement.scala
@@ -28,7 +28,8 @@ case class DropTableStatement(
     ifExists: Boolean,
     purge: Boolean) extends ParsedStatement {
 
-  override def output: Seq[Attribute] = Seq.empty
+  @transient
+  override lazy val output: Seq[Attribute] = Seq.empty
 
   override def children: Seq[LogicalPlan] = Seq.empty
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/sql/DropViewStatement.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/sql/DropViewStatement.scala
@@ -27,7 +27,8 @@ case class DropViewStatement(
     viewName: Seq[String],
     ifExists: Boolean) extends ParsedStatement {
 
-  override def output: Seq[Attribute] = Seq.empty
+  @transient
+  override lazy val output: Seq[Attribute] = Seq.empty
 
   override def children: Seq[LogicalPlan] = Seq.empty
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/sql/ParsedStatement.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/sql/ParsedStatement.scala
@@ -41,7 +41,8 @@ private[sql] abstract class ParsedStatement extends LogicalPlan {
     case other => other
   }
 
-  override def output: Seq[Attribute] = Seq.empty
+  @transient
+  override lazy val output: Seq[Attribute] = Seq.empty
 
   override def children: Seq[LogicalPlan] = Seq.empty
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
The original `output` implementation in a few `QueryPlan` sub-classes are methods, which means unnecessary re-computation can happen at times. This PR resolves this problem by making these method `lazy val`s.

The overall planning time of TPC-DS was reduced by 9.3% (compared with the optimized version as in https://github.com/apache/spark/pull/24866). The detailed stats are shown in the following figure.
![chart(1)](https://user-images.githubusercontent.com/12269969/59805408-153c2380-92a6-11e9-8c22-68c106efe970.png)


## How was this patch tested?
Existing UTs.