### PR TITLE
[SPARK-28128][PYTHON][SQL] Pandas Grouped UDFs skip empty partitions

### DIFF
--- a/python/pyspark/sql/tests/test_pandas_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/test_pandas_udf_grouped_agg.py
@@ -18,6 +18,7 @@
 import unittest
 
 from pyspark.rdd import PythonEvalType
+from pyspark.sql import Row
 from pyspark.sql.functions import array, explode, col, lit, mean, sum, \
     udf, pandas_udf, PandasUDFType
 from pyspark.sql.types import *
@@ -460,6 +461,18 @@ class GroupedAggPandasUDFTests(ReusedSQLTestCase):
         actual = sorted(map(lambda r: r[0], self.spark.sql(q).collect()))
         expected = [1, 5]
         self.assertEqual(actual, expected)
+
+    def test_grouped_with_empty_partition(self):
+        data = [Row(id=1, x=2), Row(id=1, x=3), Row(id=2, x=4)]
+        expected = [Row(id=1, sum=5), Row(id=2, x=4)]
+        num_parts = len(data) + 1
+        df = self.spark.createDataFrame(self.sc.parallelize(data, numSlices=num_parts))
+
+        f = pandas_udf(lambda x: x.sum(),
+                       'int', PandasUDFType.GROUPED_AGG)
+
+        result = df.groupBy('id').agg(f(df['x']).alias('sum')).collect()
+        self.assertEqual(result, expected)
 
 
 if __name__ == "__main__":

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/AggregateInPandasExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/AggregateInPandasExec.scala
@@ -105,58 +105,53 @@ case class AggregateInPandasExec(
       StructField(s"_$i", dt)
     })
 
-    inputRDD.mapPartitionsInternal { iter =>
+    // Map grouped rows to ArrowPythonRunner results, Only execute if partition is not empty
+    inputRDD.mapPartitionsInternal { iter => if (iter.isEmpty) iter else {
+      val prunedProj = UnsafeProjection.create(allInputs, child.output)
 
-      // Only execute on non-empty partitions
-      if (iter.nonEmpty) {
-        val prunedProj = UnsafeProjection.create(allInputs, child.output)
-
-        val grouped = if (groupingExpressions.isEmpty) {
-          // Use an empty unsafe row as a place holder for the grouping key
-          Iterator((new UnsafeRow(), iter))
-        } else {
-          GroupedIterator(iter, groupingExpressions, child.output)
-        }.map { case (key, rows) =>
-          (key, rows.map(prunedProj))
-        }
-
-        val context = TaskContext.get()
-
-        // The queue used to buffer input rows so we can drain it to
-        // combine input with output from Python.
-        val queue = HybridRowQueue(context.taskMemoryManager(),
-          new File(Utils.getLocalDir(SparkEnv.get.conf)), groupingExpressions.length)
-        context.addTaskCompletionListener[Unit] { _ =>
-          queue.close()
-        }
-
-        // Add rows to queue to join later with the result.
-        val projectedRowIter = grouped.map { case (groupingKey, rows) =>
-          queue.add(groupingKey.asInstanceOf[UnsafeRow])
-          rows
-        }
-
-        val columnarBatchIter = new ArrowPythonRunner(
-          pyFuncs,
-          PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF,
-          argOffsets,
-          aggInputSchema,
-          sessionLocalTimeZone,
-          pythonRunnerConf).compute(projectedRowIter, context.partitionId(), context)
-
-        val joinedAttributes =
-          groupingExpressions.map(_.toAttribute) ++ udfExpressions.map(_.resultAttribute)
-        val joined = new JoinedRow
-        val resultProj = UnsafeProjection.create(resultExpressions, joinedAttributes)
-
-        columnarBatchIter.map(_.rowIterator.next()).map { aggOutputRow =>
-          val leftRow = queue.remove()
-          val joinedRow = joined(leftRow, aggOutputRow)
-          resultProj(joinedRow)
-        }
+      val grouped = if (groupingExpressions.isEmpty) {
+        // Use an empty unsafe row as a place holder for the grouping key
+        Iterator((new UnsafeRow(), iter))
       } else {
-        Iterator.empty
+        GroupedIterator(iter, groupingExpressions, child.output)
+      }.map { case (key, rows) =>
+        (key, rows.map(prunedProj))
       }
-    }
+
+      val context = TaskContext.get()
+
+      // The queue used to buffer input rows so we can drain it to
+      // combine input with output from Python.
+      val queue = HybridRowQueue(context.taskMemoryManager(),
+        new File(Utils.getLocalDir(SparkEnv.get.conf)), groupingExpressions.length)
+      context.addTaskCompletionListener[Unit] { _ =>
+        queue.close()
+      }
+
+      // Add rows to queue to join later with the result.
+      val projectedRowIter = grouped.map { case (groupingKey, rows) =>
+        queue.add(groupingKey.asInstanceOf[UnsafeRow])
+        rows
+      }
+
+      val columnarBatchIter = new ArrowPythonRunner(
+        pyFuncs,
+        PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF,
+        argOffsets,
+        aggInputSchema,
+        sessionLocalTimeZone,
+        pythonRunnerConf).compute(projectedRowIter, context.partitionId(), context)
+
+      val joinedAttributes =
+        groupingExpressions.map(_.toAttribute) ++ udfExpressions.map(_.resultAttribute)
+      val joined = new JoinedRow
+      val resultProj = UnsafeProjection.create(resultExpressions, joinedAttributes)
+
+      columnarBatchIter.map(_.rowIterator.next()).map { aggOutputRow =>
+        val leftRow = queue.remove()
+        val joinedRow = joined(leftRow, aggOutputRow)
+        resultProj(joinedRow)
+      }
+    }}
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInPandasExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInPandasExec.scala
@@ -126,36 +126,44 @@ case class FlatMapGroupsInPandasExec(
     val dedupSchema = StructType.fromAttributes(dedupAttributes)
 
     inputRDD.mapPartitionsInternal { iter =>
-      val grouped = if (groupingAttributes.isEmpty) {
-        Iterator(iter)
-      } else {
-        val groupedIter = GroupedIterator(iter, groupingAttributes, child.output)
-        val dedupProj = UnsafeProjection.create(dedupAttributes, child.output)
-        groupedIter.map {
-          case (_, groupedRowIter) => groupedRowIter.map(dedupProj)
+
+      // Only execute on non-empty partitions
+      if (iter.nonEmpty) {
+
+        val grouped = if (groupingAttributes.isEmpty) {
+          Iterator(iter)
+        } else {
+          val groupedIter = GroupedIterator(iter, groupingAttributes, child.output)
+          val dedupProj = UnsafeProjection.create(dedupAttributes, child.output)
+          groupedIter.map {
+            case (_, groupedRowIter) => groupedRowIter.map(dedupProj)
+          }
         }
+
+        val context = TaskContext.get()
+
+        val columnarBatchIter = new ArrowPythonRunner(
+          chainedFunc,
+          PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF,
+          argOffsets,
+          dedupSchema,
+          sessionLocalTimeZone,
+          pythonRunnerConf).compute(grouped, context.partitionId(), context)
+
+        val unsafeProj = UnsafeProjection.create(output, output)
+
+        columnarBatchIter.flatMap { batch =>
+          // Grouped Map UDF returns a StructType column in ColumnarBatch, select the children here
+          val structVector = batch.column(0).asInstanceOf[ArrowColumnVector]
+          val outputVectors = output.indices.map(structVector.getChild)
+          val flattenedBatch = new ColumnarBatch(outputVectors.toArray)
+          flattenedBatch.setNumRows(batch.numRows())
+          flattenedBatch.rowIterator.asScala
+        }.map(unsafeProj)
+
+      } else {
+        Iterator.empty
       }
-
-      val context = TaskContext.get()
-
-      val columnarBatchIter = new ArrowPythonRunner(
-        chainedFunc,
-        PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF,
-        argOffsets,
-        dedupSchema,
-        sessionLocalTimeZone,
-        pythonRunnerConf).compute(grouped, context.partitionId(), context)
-
-      val unsafeProj = UnsafeProjection.create(output, output)
-
-      columnarBatchIter.flatMap { batch =>
-        // Grouped Map UDF returns a StructType column in ColumnarBatch, select the children here
-        val structVector = batch.column(0).asInstanceOf[ArrowColumnVector]
-        val outputVectors = output.indices.map(structVector.getChild)
-        val flattenedBatch = new ColumnarBatch(outputVectors.toArray)
-        flattenedBatch.setNumRows(batch.numRows())
-        flattenedBatch.rowIterator.asScala
-      }.map(unsafeProj)
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When running FlatMapGroupsInPandasExec or AggregateInPandasExec the shuffle uses a default number of partitions of 200 in "spark.sql.shuffle.partitions". If the data is small, e.g. in testing, many of the partitions will be empty but are treated just the same.

This PR checks the `mapPartitionsInternal` iterator to be non-empty before calling `ArrowPythonRunner` to start computation on the iterator.

## How was this patch tested?

Existing tests. Ran the following benchmarks a simple example where most partitions are empty:

```python
from pyspark.sql.functions import pandas_udf, PandasUDFType
from pyspark.sql.types import *

df = spark.createDataFrame( 
     [(1, 1.0), (1, 2.0), (2, 3.0), (2, 5.0), (2, 10.0)], 
     ("id", "v"))

@pandas_udf("id long, v double", PandasUDFType.GROUPED_MAP)
def normalize(pdf):
    v = pdf.v
    return pdf.assign(v=(v - v.mean()) / v.std())

df.groupby("id").apply(normalize).count()
```

**Before**
```
In [4]: %timeit df.groupby("id").apply(normalize).count()                                                                    
1.58 s ± 62.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)             

In [5]: %timeit df.groupby("id").apply(normalize).count()                                                                    
1.52 s ± 29.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)             

In [6]: %timeit df.groupby("id").apply(normalize).count()                                                                    
1.52 s ± 37.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

**After this Change**
```
In [2]: %timeit df.groupby("id").apply(normalize).count()                                                                    
646 ms ± 89.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)             

In [3]: %timeit df.groupby("id").apply(normalize).count()                                                                    
408 ms ± 84.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [4]: %timeit df.groupby("id").apply(normalize).count()                                                                    
381 ms ± 29.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```