### PR TITLE
[SPARK-28124] [SS] SQS source for Structured Streaming

### DIFF
--- a/external/s3-sqs/pom.xml
+++ b/external/s3-sqs/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Licensed to the Apache Software Foundation (ASF) under one or more
+~ contributor license agreements.  See the NOTICE file distributed with
+~ this work for additional information regarding copyright ownership.
+~ The ASF licenses this file to You under the Apache License, Version 2.0
+~ (the "License"); you may not use this file except in compliance with
+~ the License.  You may obtain a copy of the License at
+~
+~    http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.spark</groupId>
+    <artifactId>spark-parent_2.12</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>spark-s3-sqs_2.12</artifactId>
+  <packaging>jar</packaging>
+  <name>Sqs Integration for Structured Streaming</name>
+
+  <properties>
+    <sbt.project.name>s3-sqs</sbt.project.name>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-sqs</artifactId>
+      <version>${aws.java.sdk.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-tags_${scala.binary.version}</artifactId>
+    </dependency>
+    <!--
+      This spark-tags test-dep is needed even though it isn't used in this module, otherwise testing-cmds that exclude
+      them will yield errors.
+    -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-tags_${scala.binary.version}</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>3.1.0</version>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>shade</goal>
+              </goals>
+              <configuration>
+                <artifactSet>
+                  <includes>
+                    <include>com.amazonaws:aws-java-sdk-sqs:*</include>
+                    <include>com.amazonaws:aws-java-sdk-core:*</include>
+                  </includes>
+                </artifactSet>
+                <filters>
+                  <filter>
+                    <artifact>*:*</artifact>
+                    <excludes>
+                      <exclude>META-INF/maven/**</exclude>
+                      <exclude>META-INF/MANIFEST.MF</exclude>
+                    </excludes>
+                  </filter>
+                </filters>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>        
+    </pluginManagement>
+    <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
+    <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
+  </build>
+</project>

--- a/external/s3-sqs/src/main/java/org/apache/spark/sql/sqs/BasicAWSCredentialsProvider.java
+++ b/external/s3-sqs/src/main/java/org/apache/spark/sql/sqs/BasicAWSCredentialsProvider.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.sqs;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.AWSCredentials;
+import org.apache.commons.lang.StringUtils;
+
+public class BasicAWSCredentialsProvider implements AWSCredentialsProvider {
+  private final String accessKey;
+  private final String secretKey;
+
+  public BasicAWSCredentialsProvider(String accessKey, String secretKey) {
+    this.accessKey = accessKey;
+    this.secretKey = secretKey;
+  }
+
+  public AWSCredentials getCredentials() {
+    if (!StringUtils.isEmpty(accessKey) && !StringUtils.isEmpty(secretKey)) {
+      return new BasicAWSCredentials(accessKey, secretKey);
+    }
+    throw new AmazonClientException(
+        "Access key or secret key is null");
+  }
+
+  public void refresh() {}
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName();
+  }
+
+}

--- a/external/s3-sqs/src/main/java/org/apache/spark/sql/sqs/InstanceProfileCredentialsProviderWithRetries.java
+++ b/external/s3-sqs/src/main/java/org/apache/spark/sql/sqs/InstanceProfileCredentialsProviderWithRetries.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+ package org.apache.spark.sql.sqs;
+
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.InstanceProfileCredentialsProvider;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+public class InstanceProfileCredentialsProviderWithRetries extends InstanceProfileCredentialsProvider {
+
+    private static final Log LOG = LogFactory.getLog(InstanceProfileCredentialsProviderWithRetries.class);
+
+    public AWSCredentials getCredentials() {
+        int retries = 10;
+        int sleep = 500;
+        while(retries > 0) {
+            try {
+                return super.getCredentials();
+            }
+            catch (RuntimeException re) {
+                LOG.error("Got an exception while fetching credentials " + re);
+                --retries;
+                try {
+                    Thread.sleep(sleep);
+                } catch (InterruptedException ie) {
+                }
+                if (sleep < 10000) {
+                    sleep *= 2;
+                }
+            }
+            catch (Error error) {
+                LOG.error("Got an exception while fetching credentials " + error);
+                --retries;
+                try {
+                    Thread.sleep(sleep);
+                } catch (InterruptedException ie) {
+                }
+                if (sleep < 10000) {
+                    sleep *= 2;
+                }
+            }
+        }
+        throw new AmazonClientException("Unable to load credentials.");
+    }
+}

--- a/external/s3-sqs/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/external/s3-sqs/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,0 +1,1 @@
+org.apache.spark.sql.sqs.SqsSourceProvider

--- a/external/s3-sqs/src/main/resources/log4j.properties
+++ b/external/s3-sqs/src/main/resources/log4j.properties
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+log4j.rootCategory=WARN, console
+
+# File appender
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.append=false
+log4j.appender.file.file=target/unit-tests.log
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS} %p %c{1}: %m%n
+
+# Console appender
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.out
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.sparkproject.jetty=WARN
+log4j.logger.org.sparkproject.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO

--- a/external/s3-sqs/src/main/scala/org/apache/spark/sql/sqs/SqsClient.scala
+++ b/external/s3-sqs/src/main/scala/org/apache/spark/sql/sqs/SqsClient.scala
@@ -43,6 +43,7 @@ class SqsClient(sourceOptions: SqsSourceOptions,
   private val sqsMaxRetries = sourceOptions.maxRetries
   private val maxConnections = sourceOptions.maxConnections
   private val ignoreFileDeletion = sourceOptions.ignoreFileDeletion
+  private val region = sourceOptions.region
   val sqsUrl = sourceOptions.sqsUrl
 
   @volatile var exception: Option[Exception] = None
@@ -210,6 +211,7 @@ class SqsClient(sourceOptions: SqsSourceOptions,
           .standard()
           .withClientConfiguration(new ClientConfiguration().withMaxConnections(maxConnections))
           .withCredentials(basicAwsCredentialsProvider)
+          .withRegion(region)
           .build()
       } else {
         logInfo("Using the credentials attached to the instance")

--- a/external/s3-sqs/src/main/scala/org/apache/spark/sql/sqs/SqsClient.scala
+++ b/external/s3-sqs/src/main/scala/org/apache/spark/sql/sqs/SqsClient.scala
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.sqs
+
+import java.text.SimpleDateFormat
+import java.util.TimeZone
+import java.util.concurrent.TimeUnit
+
+import scala.collection.JavaConverters._
+
+import com.amazonaws.{AmazonClientException, AmazonServiceException, ClientConfiguration}
+import com.amazonaws.services.sqs.{AmazonSQS, AmazonSQSClientBuilder}
+import com.amazonaws.services.sqs.model.{DeleteMessageBatchRequestEntry, Message, ReceiveMessageRequest}
+import org.apache.hadoop.conf.Configuration
+import org.json4s.{DefaultFormats, MappingException}
+import org.json4s.JsonAST.JValue
+import org.json4s.jackson.JsonMethods.parse
+
+import org.apache.spark.SparkException
+import org.apache.spark.internal.Logging
+import org.apache.spark.util.ThreadUtils
+
+class SqsClient(sourceOptions: SqsSourceOptions,
+                hadoopConf: Configuration) extends Logging {
+
+  private val sqsFetchIntervalSeconds = sourceOptions.fetchIntervalSeconds
+  private val sqsLongPollWaitTimeSeconds = sourceOptions.longPollWaitTimeSeconds
+  private val sqsMaxRetries = sourceOptions.maxRetries
+  private val maxConnections = sourceOptions.maxConnections
+  private val ignoreFileDeletion = sourceOptions.ignoreFileDeletion
+  val sqsUrl = sourceOptions.sqsUrl
+
+  @volatile var exception: Option[Exception] = None
+
+  private val timestampFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") // ISO8601
+  timestampFormat.setTimeZone(TimeZone.getTimeZone("UTC"))
+  private var retriesOnFailure = 0
+  private val sqsClient = createSqsClient()
+
+  val sqsScheduler = ThreadUtils.newDaemonSingleThreadScheduledExecutor("sqs-scheduler")
+
+  val sqsFileCache = new SqsFileCache(sourceOptions.maxFileAgeMs, sourceOptions.fileNameOnly)
+
+  val deleteMessageQueue = new java.util.concurrent.ConcurrentLinkedQueue[String]()
+
+  private val sqsFetchMessagesThread = new Runnable {
+    override def run(): Unit = {
+      try {
+        // Fetching messages from Amazon SQS
+        val newMessages = sqsFetchMessages()
+
+        // Filtering the new messages which are already not seen
+        if (newMessages.nonEmpty) {
+          newMessages.filter(message => sqsFileCache.isNewFile(message._1, message._2))
+            .foreach(message =>
+              sqsFileCache.add(message._1, MessageDescription(message._2, false, message._3)))
+        }
+      } catch {
+        case e: Exception =>
+          exception = Some(e)
+      }
+    }
+  }
+
+  sqsScheduler.scheduleWithFixedDelay(
+    sqsFetchMessagesThread,
+    0,
+    sqsFetchIntervalSeconds,
+    TimeUnit.SECONDS)
+
+  private def sqsFetchMessages(): Seq[(String, Long, String)] = {
+    val messageList = try {
+      val receiveMessageRequest = new ReceiveMessageRequest()
+        .withQueueUrl(sqsUrl)
+        .withWaitTimeSeconds(sqsLongPollWaitTimeSeconds)
+      val messages = sqsClient.receiveMessage(receiveMessageRequest).getMessages.asScala
+      retriesOnFailure = 0
+      logDebug(s"successfully received ${messages.size} messages")
+      messages
+    } catch {
+      case ase: AmazonServiceException =>
+        val message =
+        """
+          |Caught an AmazonServiceException, which means your request made it to Amazon SQS,
+          | rejected with an error response for some reason.
+        """.stripMargin
+        logWarning(message)
+        logWarning(s"Error Message: ${ase.getMessage}")
+        logWarning(s"HTTP Status Code: ${ase.getStatusCode}, AWS Error Code: ${ase.getErrorCode}")
+        logWarning(s"Error Type: ${ase.getErrorType}, Request ID: ${ase.getRequestId}")
+        evaluateRetries()
+        List.empty
+      case ace: AmazonClientException =>
+        val message =
+        """
+           |Caught an AmazonClientException, which means, the client encountered a serious
+           | internal problem while trying to communicate with Amazon SQS, such as not
+           |  being able to access the network.
+        """.stripMargin
+        logWarning(message)
+        logWarning(s"Error Message: ${ace.getMessage()}")
+        evaluateRetries()
+        List.empty
+      case e: Exception =>
+        val message = "Received unexpected error from SQS"
+        logWarning(message)
+        logWarning(s"Error Message: ${e.getMessage()}")
+        evaluateRetries()
+        List.empty
+    }
+    if (messageList.nonEmpty) {
+      parseSqsMessages(messageList)
+    } else {
+      Seq.empty
+    }
+  }
+
+  private def parseSqsMessages(messageList: Seq[Message]): Seq[(String, Long, String)] = {
+    val errorMessages = scala.collection.mutable.ListBuffer[String]()
+    val parsedMessages = messageList.foldLeft(Seq[(String, Long, String)]()) { (list, message) =>
+      implicit val formats = DefaultFormats
+      try {
+        val messageReceiptHandle = message.getReceiptHandle
+        val messageJson = parse(message.getBody).extract[JValue]
+        val bucketName = (
+          messageJson \ "Records" \ "s3" \ "bucket" \ "name").extract[Array[String]].head
+        val eventName = (messageJson \ "Records" \ "eventName").extract[Array[String]].head
+        if (eventName.contains("ObjectCreated")) {
+          val timestamp = (messageJson \ "Records" \ "eventTime").extract[Array[String]].head
+          val timestampMills = convertTimestampToMills(timestamp)
+          val path = "s3://" +
+            bucketName + "/" +
+            (messageJson \ "Records" \ "s3" \ "object" \ "key").extract[Array[String]].head
+          logDebug("Successfully parsed sqs message")
+          list :+ ((path, timestampMills, messageReceiptHandle))
+        } else {
+          if (eventName.contains("ObjectRemoved")) {
+            if (!ignoreFileDeletion) {
+              exception = Some(new SparkException("ObjectDelete message detected in SQS"))
+            } else {
+              logInfo("Ignoring file deletion message since ignoreFileDeletion is true")
+            }
+          } else {
+            logWarning("Ignoring unexpected message detected in SQS")
+          }
+          errorMessages.append(messageReceiptHandle)
+          list
+        }
+      } catch {
+        case me: MappingException =>
+          errorMessages.append(message.getReceiptHandle)
+          logWarning(s"Error in parsing SQS message ${me.getMessage}")
+          list
+        case e: Exception =>
+          errorMessages.append(message.getReceiptHandle)
+          logWarning(s"Unexpected error while parsing SQS message ${e.getMessage}")
+          list
+      }
+    }
+    if (errorMessages.nonEmpty) {
+      addToDeleteMessageQueue(errorMessages.toList)
+    }
+    parsedMessages
+  }
+
+  private def convertTimestampToMills(timestamp: String): Long = {
+    val timeInMillis = timestampFormat.parse(timestamp).getTime()
+    timeInMillis
+  }
+
+  private def evaluateRetries(): Unit = {
+    retriesOnFailure += 1
+    if (retriesOnFailure >= sqsMaxRetries) {
+      logError("Max retries reached")
+      exception = Some(new SparkException("Unable to receive Messages from SQS for " +
+        s"${sqsMaxRetries} times Giving up. Check logs for details."))
+    } else {
+      logWarning(s"Attempt ${retriesOnFailure}." +
+        s"Will reattempt after ${sqsFetchIntervalSeconds} seconds")
+    }
+  }
+
+  private def createSqsClient(): AmazonSQS = {
+    try {
+      val isClusterOnEc2Role = hadoopConf.getBoolean(
+        "fs.s3.isClusterOnEc2Role", false) || hadoopConf.getBoolean(
+        "fs.s3n.isClusterOnEc2Role", false) || sourceOptions.useInstanceProfileCredentials
+      if (!isClusterOnEc2Role) {
+        val accessKey = hadoopConf.getTrimmed("fs.s3n.awsAccessKeyId")
+        val secretAccessKey = new String(hadoopConf.getPassword("fs.s3n.awsSecretAccessKey")).trim
+        logInfo("Using credentials from keys provided")
+        val basicAwsCredentialsProvider = new BasicAWSCredentialsProvider(
+          accessKey, secretAccessKey)
+        AmazonSQSClientBuilder
+          .standard()
+          .withClientConfiguration(new ClientConfiguration().withMaxConnections(maxConnections))
+          .withCredentials(basicAwsCredentialsProvider)
+          .build()
+      } else {
+        logInfo("Using the credentials attached to the instance")
+        val instanceProfileCredentialsProvider = new InstanceProfileCredentialsProviderWithRetries()
+        AmazonSQSClientBuilder
+          .standard()
+          .withClientConfiguration(new ClientConfiguration().withMaxConnections(maxConnections))
+          .withCredentials(instanceProfileCredentialsProvider)
+          .build()
+      }
+    } catch {
+      case e: Exception =>
+        throw new SparkException(s"Error occured while creating Amazon SQS Client ${e.getMessage}")
+    }
+  }
+
+  def addToDeleteMessageQueue(messageReceiptHandles: List[String]): Unit = {
+    deleteMessageQueue.addAll(messageReceiptHandles.asJava)
+  }
+
+  def deleteMessagesFromQueue(): Unit = {
+    try {
+      var count = -1
+      val messageReceiptHandles = deleteMessageQueue.asScala.toList
+      val messageGroups = messageReceiptHandles.sliding(10, 10).toList
+      messageGroups.foreach { messageGroup =>
+        val requestEntries = messageGroup.foldLeft(List[DeleteMessageBatchRequestEntry]()) {
+          (list, messageReceiptHandle) =>
+            count = count + 1
+            list :+ new DeleteMessageBatchRequestEntry(count.toString, messageReceiptHandle)
+        }.asJava
+        val batchResult = sqsClient.deleteMessageBatch(sqsUrl, requestEntries)
+        if (!batchResult.getFailed.isEmpty) {
+          batchResult.getFailed.asScala.foreach { entry =>
+            sqsClient.deleteMessage(
+              sqsUrl, requestEntries.get(entry.getId.toInt).getReceiptHandle)
+          }
+        }
+      }
+    } catch {
+      case e: Exception =>
+        logWarning(s"Unable to delete message from SQS ${e.getMessage}")
+    }
+    deleteMessageQueue.clear()
+  }
+
+  def assertSqsIsWorking(): Unit = {
+    if (exception.isDefined) {
+      throw exception.get
+    }
+  }
+
+}

--- a/external/s3-sqs/src/main/scala/org/apache/spark/sql/sqs/SqsFileCache.scala
+++ b/external/s3-sqs/src/main/scala/org/apache/spark/sql/sqs/SqsFileCache.scala
@@ -103,7 +103,7 @@ class SqsFileCache(maxAgeMs: Long, fileNameOnly: Boolean) extends Logging {
       uncommittedFiles.toList
     }
 
-    protected def reportTimeTaken[T](operation: String)(body: => T): T = {
+    private def reportTimeTaken[T](operation: String)(body: => T): T = {
       val startTime = System.currentTimeMillis()
       val result = body
       val endTime = System.currentTimeMillis()

--- a/external/s3-sqs/src/main/scala/org/apache/spark/sql/sqs/SqsFileCache.scala
+++ b/external/s3-sqs/src/main/scala/org/apache/spark/sql/sqs/SqsFileCache.scala
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.sqs
+
+import java.net.URI
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.internal.Logging
+
+  /**
+    * A custom hash map used to track the list of files seen. This map is thread-safe.
+    *
+    * To prevent the hash map from growing indefinitely, a purge function is available to
+    * remove files "maxAgeMs" older than the latest file.
+    */
+
+class SqsFileCache(maxAgeMs: Long, fileNameOnly: Boolean) extends Logging {
+  require(maxAgeMs >= 0)
+  if (fileNameOnly) {
+    logWarning("'fileNameOnly' is enabled. Make sure your file names are unique (e.g. using " +
+      "UUID), otherwise, files with the same name but under different paths will be considered " +
+      "the same and causes data lost.")
+  }
+
+  /** Mapping from file path to its message description. */
+  private val sqsMap = new ConcurrentHashMap[String, MessageDescription]
+
+  /** Timestamp for the last purge operation. */
+  private var lastPurgeTimestamp: Long = 0L
+
+  /** Timestamp of the latest file. */
+  private var latestTimestamp: Long = 0L
+
+  @inline private def stripPathIfNecessary(path: String) = {
+    if (fileNameOnly) new Path(new URI(path)).getName else path
+  }
+
+  /**
+    * Returns true if we should consider this file a new file. The file is only considered "new"
+    * if it is new enough that we are still tracking, and we have not seen it before.
+    */
+  def isNewFile(path: String, timestamp: Long): Boolean = {
+    timestamp >= lastPurgeTimestamp && !sqsMap.containsKey(stripPathIfNecessary(path))
+  }
+
+  /** Add a new file to the map. */
+  def add(path: String, fileStatus: MessageDescription): Unit = {
+    sqsMap.put(stripPathIfNecessary(path), fileStatus)
+    if (fileStatus.timestamp > latestTimestamp) {
+      latestTimestamp = fileStatus.timestamp
+    }
+  }
+
+  /**
+    * Returns all the new files found - ignore aged files and files that we have already seen.
+    * Sorts the files by timestamp.
+    */
+  def getUncommittedFiles(maxFilesPerTrigger: Option[Int],
+                             shouldSortFiles: Boolean): Seq[(String, Long, String)] = {
+    if (shouldSortFiles) {
+      val uncommittedFiles = filterAllUncommittedFiles()
+      val sortedFiles = reportTimeTaken("Sorting Files") {
+         uncommittedFiles.sortWith(_._2 < _._2)
+      }
+      if (maxFilesPerTrigger.nonEmpty) sortedFiles.take(maxFilesPerTrigger.get) else sortedFiles
+    } else {
+      if (maxFilesPerTrigger.isEmpty) {
+        filterAllUncommittedFiles()
+      } else {
+        filterTopUncommittedFiles(maxFilesPerTrigger.get)
+      }
+    }
+  }
+    private def filterTopUncommittedFiles(maxFilesPerTrigger: Int): List[(String, Long, String)] = {
+      val iterator = sqsMap.asScala.iterator
+      val uncommittedFiles = ListBuffer[(String, Long, String)]()
+      while (uncommittedFiles.length < maxFilesPerTrigger && iterator.hasNext) {
+        val file = iterator.next()
+        if (file._2.isCommitted && file._2.timestamp >= lastPurgeTimestamp) {
+          uncommittedFiles += ((file._1, file._2.timestamp, file._2.messageReceiptHandle))
+        }
+      }
+      uncommittedFiles.toList
+    }
+
+    protected def reportTimeTaken[T](operation: String)(body: => T): T = {
+      val startTime = System.currentTimeMillis()
+      val result = body
+      val endTime = System.currentTimeMillis()
+      val timeTaken = math.max(endTime - startTime, 0)
+
+      logDebug(s"$operation took $timeTaken ms")
+      result
+    }
+
+    private def filterAllUncommittedFiles(): List[(String, Long, String)] = {
+      sqsMap.asScala.foldLeft(List[(String, Long, String)]()) {
+        (list, file) =>
+          if (!file._2.isCommitted && file._2.timestamp >= lastPurgeTimestamp) {
+            list :+ ((file._1, file._2.timestamp, file._2.messageReceiptHandle))
+          } else {
+            list
+          }
+      }
+    }
+
+  /** Removes aged entries and returns the number of files removed. */
+  def purge(): Int = {
+    lastPurgeTimestamp = latestTimestamp - maxAgeMs
+    var count = 0
+    sqsMap.asScala.foreach { fileEntry =>
+      if (fileEntry._2.timestamp < lastPurgeTimestamp) {
+        sqsMap.remove(fileEntry._1)
+        count += 1
+      }
+    }
+    count
+  }
+
+  /** Mark file entry as committed or already processed */
+  def markCommitted(path: String): Unit = {
+    sqsMap.replace(path, MessageDescription(
+      sqsMap.get(path).timestamp, true, sqsMap.get(path).messageReceiptHandle))
+  }
+
+  def size: Int = sqsMap.size()
+
+}
+
+  /**
+    * A case class to store file metadata. Metadata includes file timestamp, file status -
+    * committed or not committed and message reciept handle used for deleting message from
+    * Amazon SQS
+    */
+case class MessageDescription(timestamp: Long,
+                              isCommitted: Boolean = false,
+                              messageReceiptHandle: String)

--- a/external/s3-sqs/src/main/scala/org/apache/spark/sql/sqs/SqsSource.scala
+++ b/external/s3-sqs/src/main/scala/org/apache/spark/sql/sqs/SqsSource.scala
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.sqs
+
+import java.net.URI
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
+import org.apache.spark.sql.execution.datasources.{DataSource, LogicalRelation}
+import org.apache.spark.sql.execution.streaming._
+import org.apache.spark.sql.execution.streaming.FileStreamSource._
+import org.apache.spark.sql.types.StructType
+
+
+class SqsSource(sparkSession: SparkSession,
+                metadataPath: String,
+                options: Map[String, String],
+                override val schema: StructType) extends Source with Logging {
+
+  private val sourceOptions = new SqsSourceOptions(options)
+
+  private val hadoopConf = sparkSession.sessionState.newHadoopConf()
+
+  private val metadataLog =
+    new FileStreamSourceLog(FileStreamSourceLog.VERSION, sparkSession, metadataPath)
+  private var metadataLogCurrentOffset = metadataLog.getLatest().map(_._1).getOrElse(-1L)
+
+  private val maxFilesPerTrigger = sourceOptions.maxFilesPerTrigger
+
+  private val maxFileAgeMs: Long = sourceOptions.maxFileAgeMs
+
+  private val fileFormatClassName = sourceOptions.fileFormatClassName
+
+  private val shouldSortFiles = sourceOptions.shouldSortFiles
+
+  private val sqsClient = new SqsClient(sourceOptions, hadoopConf)
+
+  metadataLog.allFiles().foreach { entry =>
+    sqsClient.sqsFileCache.add(entry.path, MessageDescription(entry.timestamp, true, ""))
+  }
+  sqsClient.sqsFileCache.purge()
+
+  logInfo(s"maxFilesPerBatch = $maxFilesPerTrigger, maxFileAgeMs = $maxFileAgeMs")
+
+  /**
+    * Returns the data that is between the offsets (`start`, `end`].
+    */
+  override def getBatch(start: Option[Offset], end: Offset): DataFrame = {
+    val startOffset = start.map(FileStreamSourceOffset(_).logOffset).getOrElse(-1L)
+    val endOffset = FileStreamSourceOffset(end).logOffset
+
+    assert(startOffset <= endOffset)
+    val files = metadataLog.get(Some(startOffset + 1), Some(endOffset)).flatMap(_._2)
+    logInfo(s"Processing ${files.length} files from ${startOffset + 1}:$endOffset")
+    logTrace(s"Files are:\n\t" + files.mkString("\n\t"))
+    val newDataSource =
+      DataSource(
+        sparkSession,
+        paths = files.map(f => new Path(new URI(f.path)).toString),
+        userSpecifiedSchema = Some(schema),
+        className = fileFormatClassName,
+        options = options)
+    Dataset.ofRows(sparkSession, LogicalRelation(newDataSource.resolveRelation(
+      checkFilesExist = false), isStreaming = true))
+  }
+
+  private def fetchMaxOffset(): FileStreamSourceOffset = synchronized {
+
+    sqsClient.assertSqsIsWorking()
+    /* All the new files found - ignore aged files and files that we have seen.
+     *  Obey user's setting to limit the number of files in this batch trigger.
+     */
+    val batchFiles = sqsClient.sqsFileCache.getUncommittedFiles(maxFilesPerTrigger, shouldSortFiles)
+
+    if (batchFiles.nonEmpty) {
+      metadataLogCurrentOffset += 1
+      metadataLog.add(metadataLogCurrentOffset, batchFiles.map {
+        case (path, timestamp, receiptHandle) =>
+          FileEntry(path = path, timestamp = timestamp, batchId = metadataLogCurrentOffset)
+      }.toArray)
+      logInfo(s"Log offset set to $metadataLogCurrentOffset with ${batchFiles.size} new files")
+      val messageReceiptHandles = batchFiles.map {
+        case (path, timestamp, receiptHandle) =>
+          sqsClient.sqsFileCache.markCommitted(path)
+          logDebug(s"New file: $path")
+          receiptHandle
+      }.toList
+      sqsClient.addToDeleteMessageQueue(messageReceiptHandles)
+    }
+
+    val numPurged = sqsClient.sqsFileCache.purge()
+
+    if (!sqsClient.deleteMessageQueue.isEmpty) {
+      sqsClient.deleteMessagesFromQueue()
+    }
+
+    logTrace(
+      s"""
+         |Number of files selected for batch = ${batchFiles.size}
+         |Number of files purged from tracking map = $numPurged
+       """.stripMargin)
+
+    FileStreamSourceOffset(metadataLogCurrentOffset)
+  }
+
+  override def getOffset: Option[Offset] = Some(fetchMaxOffset()).filterNot(_.logOffset == -1)
+
+  override def commit(end: Offset): Unit = {
+    // No-op for now; SqsSource currently garbage-collects files based on timestamp
+    // and the value of the maxFileAge parameter.
+  }
+
+  override def stop(): Unit = {
+    if (!sqsClient.sqsScheduler.isTerminated) {
+      sqsClient.sqsScheduler.shutdownNow()
+    }
+  }
+
+  override def toString: String = s"SqsSource[${sqsClient.sqsUrl}]"
+
+}
+

--- a/external/s3-sqs/src/main/scala/org/apache/spark/sql/sqs/SqsSourceOptions.scala
+++ b/external/s3-sqs/src/main/scala/org/apache/spark/sql/sqs/SqsSourceOptions.scala
@@ -84,6 +84,10 @@ class SqsSourceOptions(parameters: CaseInsensitiveMap[String]) extends Logging {
     throw new IllegalArgumentException("SQS Url is not specified")
   }
 
+  val region: String = parameters.get("region").getOrElse {
+    throw new IllegalArgumentException("Region is not specified")
+  }
+
   val fileFormatClassName: String = parameters.get("fileFormat").getOrElse {
     throw new IllegalArgumentException("Specifying file format is mandatory with sqs source")
   }

--- a/external/s3-sqs/src/main/scala/org/apache/spark/sql/sqs/SqsSourceOptions.scala
+++ b/external/s3-sqs/src/main/scala/org/apache/spark/sql/sqs/SqsSourceOptions.scala
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.sqs
+
+import scala.util.Try
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
+import org.apache.spark.util.Utils
+
+/**
+ * User specified options for sqs source.
+ */
+class SqsSourceOptions(parameters: CaseInsensitiveMap[String]) extends Logging {
+
+  def this(parameters: Map[String, String]) = this(CaseInsensitiveMap(parameters))
+
+  val maxFilesPerTrigger: Option[Int] = parameters.get("maxFilesPerTrigger").map { str =>
+    Try(str.toInt).toOption.filter(_ > 0).getOrElse {
+      throw new IllegalArgumentException(
+        s"Invalid value '$str' for option 'maxFilesPerTrigger', must be a positive integer")
+    }
+  }
+
+  /**
+   * Maximum age of a file that can be found in this directory, before it is ignored. For the
+   * first batch all files will be considered valid.
+   *
+   * The max age is specified with respect to the timestamp of the latest file, and not the
+   * timestamp of the current system. That this means if the last file has timestamp 1000, and the
+   * current system time is 2000, and max age is 200, the system will purge files older than
+   * 800 (rather than 1800) from the internal state.
+   *
+   * Default to a week.
+   */
+  val maxFileAgeMs: Long =
+    Utils.timeStringAsMs(parameters.getOrElse("maxFileAge", "7d"))
+
+  val fetchIntervalSeconds: Int = parameters.get("sqsFetchIntervalSeconds").map { str =>
+    Try(str.toInt).toOption.filter(_ > 0).getOrElse {
+      throw new IllegalArgumentException(
+        s"Invalid value '$str' for option 'sqsFetchIntervalSeconds', must be a positive integer")
+    }
+  }.getOrElse(10)
+
+  val longPollWaitTimeSeconds: Int = parameters.get("sqsLongPollingWaitTimeSeconds").map { str =>
+    Try(str.toInt).toOption.filter(x => x >= 0 && x <= 20).getOrElse {
+      throw new IllegalArgumentException(
+        s"Invalid value '$str' for option 'sqsLongPollingWaitTimeSeconds'," +
+          "must be an integer between 0 and 20")
+    }
+  }.getOrElse(20)
+
+  val maxRetries: Int = parameters.get("sqsMaxRetries").map { str =>
+    Try(str.toInt).toOption.filter(_ > 0).getOrElse {
+      throw new IllegalArgumentException(
+        s"Invalid value '$str' for option 'sqsMaxRetries', must be a positive integer")
+    }
+  }.getOrElse(10)
+
+  val maxConnections: Int = parameters.get("sqsMaxConnections").map { str =>
+    Try(str.toInt).toOption.filter(_ > 0).getOrElse {
+      throw new IllegalArgumentException(
+        s"Invalid value '$str' for option 'sqsMaxConnections', must be a positive integer")
+    }
+  }.getOrElse(1)
+
+  val sqsUrl: String = parameters.get("sqsUrl").getOrElse{
+    throw new IllegalArgumentException("SQS Url is not specified")
+  }
+
+  val fileFormatClassName: String = parameters.get("fileFormat").getOrElse {
+    throw new IllegalArgumentException("Specifying file format is mandatory with sqs source")
+  }
+
+  val ignoreFileDeletion: Boolean = withBooleanParameter("ignoreFileDeletion", false)
+
+  /**
+    * Whether to check new files based on only the filename instead of on the full path.
+    *
+    * With this set to `true`, the following files would be considered as the same file, because
+    * their filenames, "dataset.txt", are the same:
+    * - "file:///dataset.txt"
+    * - "s3://a/dataset.txt"
+    * - "s3n://a/b/dataset.txt"
+    * - "s3a://a/b/c/dataset.txt"
+    */
+  val fileNameOnly: Boolean = withBooleanParameter("fileNameOnly", false)
+
+  val shouldSortFiles: Boolean = withBooleanParameter("shouldSortFiles", true)
+
+  val useInstanceProfileCredentials: Boolean = withBooleanParameter(
+    "useInstanceProfileCredentials", false)
+
+  private def withBooleanParameter(name: String, default: Boolean) = {
+    parameters.get(name).map { str =>
+      try {
+        str.toBoolean
+      } catch {
+        case _: IllegalArgumentException =>
+          throw new IllegalArgumentException(
+            s"Invalid value '$str' for option '$name', must be true or false")
+      }
+    }.getOrElse(default)
+  }
+
+}

--- a/external/s3-sqs/src/main/scala/org/apache/spark/sql/sqs/SqsSourceProvider.scala
+++ b/external/s3-sqs/src/main/scala/org/apache/spark/sql/sqs/SqsSourceProvider.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.sqs
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.execution.streaming.Source
+import org.apache.spark.sql.sources.{DataSourceRegister, StreamSourceProvider}
+import org.apache.spark.sql.types.StructType
+
+class SqsSourceProvider extends DataSourceRegister
+  with StreamSourceProvider
+  with Logging {
+
+  override def shortName(): String = "s3-sqs"
+
+  override def sourceSchema(sqlContext: SQLContext,
+                            schema: Option[StructType],
+                            providerName: String,
+                            parameters: Map[String, String]): (String, StructType) = {
+
+    require(schema.isDefined, "Sqs source doesn't support empty schema")
+    (shortName(), schema.get)
+  }
+
+  override def createSource(sqlContext: SQLContext,
+                            metadataPath: String,
+                            schema: Option[StructType],
+                            providerName: String,
+                            parameters: Map[String, String]): Source = {
+
+    new SqsSource(
+      sqlContext.sparkSession,
+      metadataPath,
+      parameters,
+      schema.get)
+  }
+}

--- a/external/s3-sqs/src/test/resources/log4j.properties
+++ b/external/s3-sqs/src/test/resources/log4j.properties
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set everything to be logged to the file target/unit-tests.log
+log4j.rootCategory=INFO, file
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.append=true
+log4j.appender.file.file=target/unit-tests.log
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
+
+# Ignore messages below warning level from Jetty, because it's a bit verbose
+log4j.logger.org.sparkproject.jetty=WARN

--- a/external/s3-sqs/src/test/scala/org/apache/spark/sql/sqs/SqsSourceOptionsSuite.scala
+++ b/external/s3-sqs/src/test/scala/org/apache/spark/sql/sqs/SqsSourceOptionsSuite.scala
@@ -37,6 +37,7 @@ class SqsSourceOptionsSuite extends StreamTest {
             .option("fileFormat", "json")
             .schema(dummySchema)
             .option("sqsUrl", "https://DUMMY_URL")
+            .option("region", "us-east-1")
             .option(option._1, option._2)
             .load()
 
@@ -78,7 +79,7 @@ class SqsSourceOptionsSuite extends StreamTest {
 
   test("missing mandatory options") {
 
-    def testMissingMandatoryOptions(options: (String, String))(expectedMsg: String): Unit = {
+    def testMissingMandatoryOptions(options: List[(String, String)])(expectedMsg: String): Unit = {
 
       var query: StreamingQuery = null
 
@@ -89,10 +90,12 @@ class SqsSourceOptionsSuite extends StreamTest {
             .readStream
             .format("s3-sqs")
             .schema(dummySchema)
-            .option(options._1, options._2)
-            .load()
 
-          query = reader.writeStream
+          val readerWithOptions = options.map { option =>
+           reader.option(option._1, option._2)
+          }.last.load()
+
+          query = readerWithOptions.writeStream
             .format("memory")
             .queryName("missingMandatoryOptions")
             .start()
@@ -109,11 +112,11 @@ class SqsSourceOptionsSuite extends StreamTest {
     }
 
     // No fileFormat specified
-    testMissingMandatoryOptions("sqsUrl" -> "https://DUMMY_URL")(
+    testMissingMandatoryOptions(List("sqsUrl" -> "https://DUMMY_URL", "region"->"us-east-1"))(
       "Specifying file format is mandatory with sqs source")
 
     // Sqs URL not specified
-    testMissingMandatoryOptions("fileFormat" -> "json")(
+    testMissingMandatoryOptions(List("fileFormat" -> "json", "region"->"us-east-1"))(
       "SQS Url is not specified")
   }
 
@@ -130,6 +133,7 @@ class SqsSourceOptionsSuite extends StreamTest {
           .format("s3-sqs")
           .option("sqsUrl", "https://DUMMY_URL")
           .option("fileFormat", "json")
+          .option("region", "us-east-1")
           .load()
 
         query = reader.writeStream

--- a/external/s3-sqs/src/test/scala/org/apache/spark/sql/sqs/SqsSourceOptionsSuite.scala
+++ b/external/s3-sqs/src/test/scala/org/apache/spark/sql/sqs/SqsSourceOptionsSuite.scala
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.sqs
+
+import java.util.Locale
+
+import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryException, StreamTest}
+import org.apache.spark.sql.types.StructType
+
+class SqsSourceOptionsSuite extends StreamTest {
+
+  test("bad source options") {
+    def testBadOptions(option: (String, String))(expectedMsg: String): Unit = {
+
+      var query : StreamingQuery = null
+
+      try {
+        val errorMessage = intercept[StreamingQueryException] {
+          val dummySchema = new StructType
+          val reader = spark
+            .readStream
+            .format("s3-sqs")
+            .option("fileFormat", "json")
+            .schema(dummySchema)
+            .option("sqsUrl", "https://DUMMY_URL")
+            .option(option._1, option._2)
+            .load()
+
+          query = reader.writeStream
+            .format("memory")
+            .queryName("badOptionsTest")
+            .start()
+
+          query.processAllAvailable()
+        }.getMessage
+        assert(errorMessage.toLowerCase(Locale.ROOT).contains(expectedMsg.toLowerCase(Locale.ROOT)))
+      } finally {
+        if (query != null) {
+          // terminating streaming query if necessary
+          query.stop()
+        }
+
+      }
+    }
+
+    testBadOptions("sqsFetchIntervalSeconds" -> "-2")("Invalid value '-2' " +
+      "for option 'sqsFetchIntervalSeconds', must be a positive integer")
+    testBadOptions("sqsLongPollingWaitTimeSeconds" -> "-5")("Invalid value '-5' " +
+      "for option 'sqsLongPollingWaitTimeSeconds',must be an integer between 0 and 20")
+    testBadOptions("sqsMaxConnections" -> "-2")("Invalid value '-2' " +
+      "for option 'sqsMaxConnections', must be a positive integer")
+    testBadOptions("maxFilesPerTrigger" -> "-50")("Invalid value '-50' " +
+      "for option 'maxFilesPerTrigger', must be a positive integer")
+    testBadOptions("ignoreFileDeletion" -> "x")("Invalid value 'x' " +
+      "for option 'ignoreFileDeletion', must be true or false")
+    testBadOptions("fileNameOnly" -> "x")("Invalid value 'x' " +
+      "for option 'fileNameOnly', must be true or false")
+    testBadOptions("shouldSortFiles" -> "x")("Invalid value 'x' " +
+      "for option 'shouldSortFiles', must be true or false")
+    testBadOptions("useInstanceProfileCredentials" -> "x")("Invalid value 'x' " +
+      "for option 'useInstanceProfileCredentials', must be true or false")
+
+  }
+
+  test("missing mandatory options") {
+
+    def testMissingMandatoryOptions(options: (String, String))(expectedMsg: String): Unit = {
+
+      var query: StreamingQuery = null
+
+      try {
+        val errorMessage = intercept[StreamingQueryException] {
+          val dummySchema = new StructType
+          val reader = spark
+            .readStream
+            .format("s3-sqs")
+            .schema(dummySchema)
+            .option(options._1, options._2)
+            .load()
+
+          query = reader.writeStream
+            .format("memory")
+            .queryName("missingMandatoryOptions")
+            .start()
+
+          query.processAllAvailable()
+        }.getMessage
+        assert(errorMessage.toLowerCase(Locale.ROOT).contains(expectedMsg.toLowerCase(Locale.ROOT)))
+      } finally {
+        if (query != null) {
+          // terminating streaming query if necessary
+          query.stop()
+        }
+      }
+    }
+
+    // No fileFormat specified
+    testMissingMandatoryOptions("sqsUrl" -> "https://DUMMY_URL")(
+      "Specifying file format is mandatory with sqs source")
+
+    // Sqs URL not specified
+    testMissingMandatoryOptions("fileFormat" -> "json")(
+      "SQS Url is not specified")
+  }
+
+  test("schema not specified") {
+
+    var query: StreamingQuery = null
+
+    val expectedMsg = "Sqs source doesn't support empty schema"
+
+    try {
+      val errorMessage = intercept[IllegalArgumentException] {
+        val reader = spark
+          .readStream
+          .format("s3-sqs")
+          .option("sqsUrl", "https://DUMMY_URL")
+          .option("fileFormat", "json")
+          .load()
+
+        query = reader.writeStream
+          .format("memory")
+          .queryName("missingSchema")
+          .start()
+
+        query.processAllAvailable()
+      }.getMessage
+      assert(errorMessage.toLowerCase(Locale.ROOT).contains(expectedMsg.toLowerCase(Locale.ROOT)))
+    } finally {
+      if (query != null) {
+        // terminating streaming query if necessary
+        query.stop()
+      }
+    }
+
+  }
+
+}
+

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
     <module>external/kafka-0-10-assembly</module>
     <module>external/kafka-0-10-sql</module>
     <module>external/avro</module>
+    <module>external/s3-sqs</module>
     <module>graph/api</module>
     <module>graph/cypher</module>
     <module>graph/graph</module>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Using FileStreamSource to read files from a S3 bucket has problems both in terms of costs and latency:

- **Latency**: Listing all the files in S3 buckets every microbatch can be both slow and resource intensive.
- **Costs**: Making List API requests to S3 every microbatch can be costly.

The solution is to use Amazon Simple Queue Service (SQS) which lets you find new files written to S3 bucket without the need to list all the files every microbatch.

S3 buckets can be configured to send notification to an Amazon SQS Queue on Object Create / Object Delete events. For details see AWS documentation here [Configuring S3 Event Notifications](https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html) 

Spark can leverage this to find new files written to S3 bucket by reading notifications from SQS queue instead of listing files every microbatch.

This PR adds a new SQSSource which uses Amazon SQS queue to find new files every microbatch.

## Usage
`val inputDf = spark
.readStream
.format("s3-sqs")
.schema(schema)
.option("fileFormat", "json")
.option("sqsUrl", "https://QUEUE_URL")
.option("region", "us-east-1")
.load()`

## Implementation Details

We create a scheduled thread which runs asynchronously with the streaming query thread and periodically fetches messages from the SQS Queue. Key information related to file path & timestamp is extracted from the SQS messages and the new files are stored in a thread safe SQS file cache.

Streaming Query thread gets the files from SQS File Cache and filters out the new files. Based on the maxFilesPerTrigger condition, all or a part of the new files are added to the offset log and marked as processed in the SQS File Cache. The corresponding SQS messages for the processed files are deleted from the Amazon SQS Queue and the offset value is incremented and returned.

![SQS Design (1)](https://user-images.githubusercontent.com/43843989/59924375-3c842380-9453-11e9-9a4e-6f3fa6faf3fb.jpg)

## How was this patch tested?

Added new unit tests in SqsSourceOptionsSuite which test various SqsSourceOptions. Will add more tests after some initial feedback on design approach and functionality.