### PR TITLE
[SPARK-24634][SS] Add a new metric regarding number of rows later than watermark plus allowed delay

### DIFF
--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -1674,6 +1674,11 @@ Any of the stateful operation(s) after any of below stateful operations can have
 As Spark cannot check the state function of `mapGroupsWithState`/`flatMapGroupsWithState`, Spark assumes that the state function
 emits late rows if the operator uses Append mode.
 
+Spark provides two ways to check the number of late rows on stateful operators which would help you identify the issue:
+
+1. On Spark UI: check the metrics in "CountLateRows" node in query execution details page in SQL tab
+2. On Streaming Query Listener: check "numLateInputRows" in "stateOperators" in QueryProcessEvent
+
 There's a known workaround: split your streaming query into multiple queries per stateful operator, and ensure
 end-to-end exactly once per query. Ensuring end-to-end exactly once for the last query is optional.
 

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -38,7 +38,11 @@ object MimaExcludes {
   lazy val v31excludes = v30excludes ++ Seq(
     // [SPARK-31077] Remove ChiSqSelector dependency on mllib.ChiSqSelectorModel
     // private constructor
-    ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.spark.ml.feature.ChiSqSelectorModel.this")
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.spark.ml.feature.ChiSqSelectorModel.this"),
+
+    // [SPARK-24634][SQL] Add a new metric regarding number of rows later than watermark
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.spark.sql.streaming.StateOperatorProgress.<init>$default$4"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.streaming.StateOperatorProgress.<init>$default$4")
   )
 
   // Exclude rules for 3.0.x

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -132,6 +132,9 @@ class IncrementalExecution(
     }
 
     override def apply(plan: SparkPlan): SparkPlan = plan transform {
+      case m: CountLateRowsExec =>
+        m.copy(eventTimeWatermark = Some(offsetSeqMetadata.batchWatermarkMs))
+
       case StateStoreSaveExec(keys, None, None, None, stateFormatVersion,
              UnaryExecNode(agg,
                StateStoreRestoreExec(_, None, _, child))) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
@@ -222,7 +222,7 @@ trait ProgressReporter extends Logging {
     lastExecution.executedPlan.collect {
       case p if p.isInstanceOf[StateStoreWriter] =>
         val progress = p.asInstanceOf[StateStoreWriter].getProgress()
-        if (hasExecuted) progress else progress.copy(newNumRowsUpdated = 0)
+        if (hasExecuted) progress else progress.copy(newNumRowsUpdated = 0, newNumLateInputRows = 0)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/progress.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/progress.scala
@@ -42,6 +42,7 @@ import org.apache.spark.sql.streaming.SinkProgress.DEFAULT_NUM_OUTPUT_ROWS
 class StateOperatorProgress private[sql](
     val numRowsTotal: Long,
     val numRowsUpdated: Long,
+    val numLateInputRows: Long,
     val memoryUsedBytes: Long,
     val customMetrics: ju.Map[String, JLong] = new ju.HashMap()
   ) extends Serializable {
@@ -52,12 +53,14 @@ class StateOperatorProgress private[sql](
   /** The pretty (i.e. indented) JSON representation of this progress. */
   def prettyJson: String = pretty(render(jsonValue))
 
-  private[sql] def copy(newNumRowsUpdated: Long): StateOperatorProgress =
-    new StateOperatorProgress(numRowsTotal, newNumRowsUpdated, memoryUsedBytes, customMetrics)
+  private[sql] def copy(newNumRowsUpdated: Long, newNumLateInputRows: Long): StateOperatorProgress =
+    new StateOperatorProgress(numRowsTotal, newNumRowsUpdated, newNumLateInputRows, memoryUsedBytes,
+      customMetrics)
 
   private[sql] def jsonValue: JValue = {
     ("numRowsTotal" -> JInt(numRowsTotal)) ~
     ("numRowsUpdated" -> JInt(numRowsUpdated)) ~
+    ("numLateInputRows" -> JInt(numLateInputRows)) ~
     ("memoryUsedBytes" -> JInt(memoryUsedBytes)) ~
     ("customMetrics" -> {
       if (!customMetrics.isEmpty) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FlatMapGroupsWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FlatMapGroupsWithStateSuite.scala
@@ -626,20 +626,20 @@ class FlatMapGroupsWithStateSuite extends StateStoreMetricsTest {
     testStream(result, Update)(
       AddData(inputData, "a"),
       CheckNewAnswer(("a", "1")),
-      assertNumStateRows(total = 1, updated = 1),
+      assertNumStateRows(total = 1, updated = 1, lateInput = 0),
       AddData(inputData, "a", "b"),
       CheckNewAnswer(("a", "2"), ("b", "1")),
-      assertNumStateRows(total = 2, updated = 2),
+      assertNumStateRows(total = 2, updated = 2, lateInput = 0),
       StopStream,
       StartStream(),
       AddData(inputData, "a", "b"), // should remove state for "a" and not return anything for a
       CheckNewAnswer(("b", "2")),
-      assertNumStateRows(total = 1, updated = 2),
+      assertNumStateRows(total = 1, updated = 2, lateInput = 0),
       StopStream,
       StartStream(),
       AddData(inputData, "a", "c"), // should recreate state for "a" and return count as 1 and
       CheckNewAnswer(("a", "1"), ("c", "1")),
-      assertNumStateRows(total = 3, updated = 2)
+      assertNumStateRows(total = 3, updated = 2, lateInput = 0)
     )
   }
 
@@ -768,17 +768,17 @@ class FlatMapGroupsWithStateSuite extends StateStoreMetricsTest {
       AddData(inputData, "a"),
       AdvanceManualClock(1 * 1000),
       CheckNewAnswer(("a", "1")),
-      assertNumStateRows(total = 1, updated = 1),
+      assertNumStateRows(total = 1, updated = 1, lateInput = 0),
 
       AddData(inputData, "b"),
       AdvanceManualClock(1 * 1000),
       CheckNewAnswer(("b", "1")),
-      assertNumStateRows(total = 2, updated = 1),
+      assertNumStateRows(total = 2, updated = 1, lateInput = 0),
 
       AddData(inputData, "b"),
       AdvanceManualClock(10 * 1000),
       CheckNewAnswer(("a", "-1"), ("b", "2")),
-      assertNumStateRows(total = 1, updated = 2),
+      assertNumStateRows(total = 1, updated = 2, lateInput = 0),
 
       StopStream,
       StartStream(Trigger.ProcessingTime("1 second"), triggerClock = clock),
@@ -786,7 +786,7 @@ class FlatMapGroupsWithStateSuite extends StateStoreMetricsTest {
       AddData(inputData, "c"),
       AdvanceManualClock(11 * 1000),
       CheckNewAnswer(("b", "-1"), ("c", "1")),
-      assertNumStateRows(total = 1, updated = 2),
+      assertNumStateRows(total = 1, updated = 2, lateInput = 0),
 
       AdvanceManualClock(12 * 1000),
       AssertOnQuery { _ => clock.getTimeMillis() == 35000 },
@@ -798,7 +798,7 @@ class FlatMapGroupsWithStateSuite extends StateStoreMetricsTest {
         }
       },
       CheckNewAnswer(("c", "-1")),
-      assertNumStateRows(total = 0, updated = 1)
+      assertNumStateRows(total = 0, updated = 1, lateInput = 0)
     )
   }
 
@@ -978,20 +978,20 @@ class FlatMapGroupsWithStateSuite extends StateStoreMetricsTest {
     testStream(result, Update)(
       AddData(inputData, "a"),
       CheckNewAnswer(("a", "1")),
-      assertNumStateRows(total = 1, updated = 1),
+      assertNumStateRows(total = 1, updated = 1, lateInput = 0),
       AddData(inputData, "a", "b"),
       CheckNewAnswer(("a", "2"), ("b", "1")),
-      assertNumStateRows(total = 2, updated = 2),
+      assertNumStateRows(total = 2, updated = 2, lateInput = 0),
       StopStream,
       StartStream(),
       AddData(inputData, "a", "b"), // should remove state for "a" and return count as -1
       CheckNewAnswer(("a", "-1"), ("b", "2")),
-      assertNumStateRows(total = 1, updated = 2),
+      assertNumStateRows(total = 1, updated = 2, lateInput = 0),
       StopStream,
       StartStream(),
       AddData(inputData, "a", "c"), // should recreate state for "a" and return count as 1
       CheckNewAnswer(("a", "1"), ("c", "1")),
-      assertNumStateRows(total = 3, updated = 2)
+      assertNumStateRows(total = 3, updated = 2, lateInput = 0)
     )
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryStatusAndProgressSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryStatusAndProgressSuite.scala
@@ -63,6 +63,7 @@ class StreamingQueryStatusAndProgressSuite extends StreamTest with Eventually {
         |  "stateOperators" : [ {
         |    "numRowsTotal" : 0,
         |    "numRowsUpdated" : 1,
+        |    "numLateInputRows" : 0,
         |    "memoryUsedBytes" : 3,
         |    "customMetrics" : {
         |      "loadedMapCacheHitCount" : 1,
@@ -113,6 +114,7 @@ class StreamingQueryStatusAndProgressSuite extends StreamTest with Eventually {
          |  "stateOperators" : [ {
          |    "numRowsTotal" : 0,
          |    "numRowsUpdated" : 1,
+         |    "numLateInputRows" : 0,
          |    "memoryUsedBytes" : 2
          |  } ],
          |  "sources" : [ {
@@ -321,7 +323,7 @@ object StreamingQueryStatusAndProgressSuite {
       "avg" -> "2016-12-05T20:54:20.827Z",
       "watermark" -> "2016-12-05T20:54:20.827Z").asJava),
     stateOperators = Array(new StateOperatorProgress(
-      numRowsTotal = 0, numRowsUpdated = 1, memoryUsedBytes = 3,
+      numRowsTotal = 0, numRowsUpdated = 1, numLateInputRows = 0, memoryUsedBytes = 3,
       customMetrics = new java.util.HashMap(Map("stateOnCurrentVersionSizeBytes" -> 2L,
         "loadedMapCacheHitCount" -> 1L, "loadedMapCacheMissCount" -> 0L)
         .mapValues(long2Long).asJava)
@@ -353,7 +355,7 @@ object StreamingQueryStatusAndProgressSuite {
     // empty maps should be handled correctly
     eventTime = new java.util.HashMap(Map.empty[String, String].asJava),
     stateOperators = Array(new StateOperatorProgress(
-      numRowsTotal = 0, numRowsUpdated = 1, memoryUsedBytes = 2)),
+      numRowsTotal = 0, numRowsUpdated = 1, numLateInputRows = 0, memoryUsedBytes = 2)),
     sources = Array(
       new SourceProgress(
         description = "source",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Please refer https://issues.apache.org/jira/browse/SPARK-24634 to see rationalization of the issue.

This patch adds a new metric to count the number of rows arrived later than watermark plus allowed delay. To count the number of rows correctly, this patch adds a new physical node before stateful operator node(s) which counts the number of input rows later than watermark plus allowed delay. 

Note that it doesn't mean these rows will be always discarded, since there're some cases we don't discard late input rows, e.g. non-window streaming aggregation.

The metric will be exposed to two places:

* streaming query listener - numLateInputRows in stateOperators
* SQL tab in UI - `number of input rows later than watermark plus allowed delay` in CountLateRowsExec

This is a revised version of #21617.

## How was this patch tested?

Modified UT, and ran manual test reproducing [SPARK-28094](https://issues.apache.org/jira/browse/SPARK-28094).

I've picked the specific case on "B outer C outer D" which is enough to represent the "intermediate late row" issue due to global watermark.

https://gist.github.com/jammann/b58bfbe0f4374b89ecea63c1e32c8f17

Spark logs warning message on the query which means [SPARK-28074](https://issues.apache.org/jira/browse/SPARK-28074) is working correctly,

```
19/10/01 15:38:53 WARN UnsupportedOperationChecker: Detected pattern of possible 'correctness' issue due to global watermark. The query contains stateful operation which can emit rows older than the current watermark plus allowed late record delay, which are "late rows" in downstream stateful operations and these rows can be discarded. Please refer the programming guide doc for more details.;
Project [B_ID#58 AS key#166, to_json(named_struct(B_ID, B_ID#58, B_LAST_MOD, B_LAST_MOD#59-T30000ms, C_FK, C_FK#60, D_FK, D_FK#61, C_ID, C_ID#91, C_LAST_MOD, C_LAST_MOD#92-T30000ms, D_ID, D_ID#120, D_LAST_MOD, D_LAST_MOD#121-T30000ms), Some(UTC)) AS value#167]
+- Join LeftOuter, ((D_FK#61 = D_ID#120) AND (B_LAST_MOD#59-T30000ms = D_LAST_MOD#121-T30000ms))
   :- Join LeftOuter, ((C_FK#60 = C_ID#91) AND (B_LAST_MOD#59-T30000ms = C_LAST_MOD#92-T30000ms))
   :  :- EventTimeWatermark B_LAST_MOD#59: timestamp, interval 30 seconds
   :  :  +- Project [v#56.B_ID AS B_ID#58, v#56.B_LAST_MOD AS B_LAST_MOD#59, v#56.C_FK AS C_FK#60, v#56.D_FK AS D_FK#61]
   :  :     +- Project [from_json(StructField(B_ID,StringType,false), StructField(B_LAST_MOD,TimestampType,false), StructField(C_FK,StringType,true), StructField(D_FK,StringType,true), value#54, Some(UTC)) AS v#56]
   :  :        +- Project [cast(value#41 as string) AS value#54]
   :  :           +- StreamingRelationV2 org.apache.spark.sql.kafka010.KafkaSourceProvider@5b3848b3, kafka, org.apache.spark.sql.kafka010.KafkaSourceProvider$KafkaTable@63c5a407, org.apache.spark.sql.util.CaseInsensitiveStringMap@f2c4a44e, [key#40, value#41, topic#42, partition#43, offset#44L, timestamp#45, timestampType#46], StreamingRelation DataSource(org.apache.spark.sql.SparkSession@69a2d6bd,kafka,List(),None,List(),None,Map(inferSchema -> true, startingOffsets -> latest, subscribe -> B, kafka.bootstrap.servers -> localhost:9092),None), kafka, [key#33, value#34, topic#35, partition#36, offset#37L, timestamp#38, timestampType#39]
   :  +- EventTimeWatermark C_LAST_MOD#92: timestamp, interval 30 seconds
   :     +- Project [v#89.C_ID AS C_ID#91, v#89.C_LAST_MOD AS C_LAST_MOD#92]
   :        +- Project [from_json(StructField(C_ID,StringType,false), StructField(C_LAST_MOD,TimestampType,false), value#87, Some(UTC)) AS v#89]
   :           +- Project [cast(value#74 as string) AS value#87]
   :              +- StreamingRelationV2 org.apache.spark.sql.kafka010.KafkaSourceProvider@79573aa5, kafka, org.apache.spark.sql.kafka010.KafkaSourceProvider$KafkaTable@6bf1c0c, org.apache.spark.sql.util.CaseInsensitiveStringMap@f2c4a44f, [key#73, value#74, topic#75, partition#76, offset#77L, timestamp#78, timestampType#79], StreamingRelation DataSource(org.apache.spark.sql.SparkSession@69a2d6bd,kafka,List(),None,List(),None,Map(inferSchema -> true, startingOffsets -> latest, subscribe -> C, kafka.bootstrap.servers -> localhost:9092),None), kafka, [key#66, value#67, topic#68, partition#69, offset#70L, timestamp#71, timestampType#72]
   +- EventTimeWatermark D_LAST_MOD#121: timestamp, interval 30 seconds
      +- Project [v#118.D_ID AS D_ID#120, v#118.D_LAST_MOD AS D_LAST_MOD#121]
         +- Project [from_json(StructField(D_ID,StringType,false), StructField(D_LAST_MOD,TimestampType,false), value#116, Some(UTC)) AS v#118]
            +- Project [cast(value#103 as string) AS value#116]
               +- StreamingRelationV2 org.apache.spark.sql.kafka010.KafkaSourceProvider@6fa59acf, kafka, org.apache.spark.sql.kafka010.KafkaSourceProvider$KafkaTable@3aa208b7, org.apache.spark.sql.util.CaseInsensitiveStringMap@f2c4a454, [key#102, value#103, topic#104, partition#105, offset#106L, timestamp#107, timestampType#108], StreamingRelation DataSource(org.apache.spark.sql.SparkSession@69a2d6bd,kafka,List(),None,List(),None,Map(inferSchema -> true, startingOffsets -> latest, subscribe -> D, kafka.bootstrap.servers -> localhost:9092),None), kafka, [key#95, value#96, topic#97, partition#98, offset#99L, timestamp#100, timestampType#101]
```

and query plan represents CountLateRows with the number of late rows. Empty batch runs for batch 4 as follows:

![Screen Shot 2019-10-01 at 4 47 21 PM](https://user-images.githubusercontent.com/1317309/65944035-cd639580-e46b-11e9-83e0-bf8574cc6b8b.png)

The boxed node in the detail page for batch 4 represents there're 4 rows emitted from left side of join (B inner C) which rows are all later than watermark + allowed delay.

![Screen Shot 2019-10-01 at 16 50 06](https://user-images.githubusercontent.com/1317309/65944094-ec622780-e46b-11e9-9248-c821342722af.png)

The number of late rows are also reported as streaming query listener as follow (check `numLateInputRows`):

```
{
  "id" : "7c5d10b5-1ae0-4a25-8b2b-f8b8eb4a4b6b",
  "runId" : "1f7375af-63b0-4272-9b87-4e59928d04d8",
  "name" : "B_outer_C_outer_D",
  "timestamp" : "2019-10-01T07:43:40.001Z",
  "batchId" : 4,
  "numInputRows" : 0,
  "inputRowsPerSecond" : 0.0,
  "processedRowsPerSecond" : 0.0,
  "durationMs" : {
    "addBatch" : 1034,
    "getBatch" : 0,
    "latestOffset" : 14,
    "queryPlanning" : 459,
    "triggerExecution" : 1714,
    "walCommit" : 113
  },
  "eventTime" : {
    "watermark" : "2019-06-01T18:36:58.769Z"
  },
  "stateOperators" : [ {
    "numRowsTotal" : 2,
    "numRowsUpdated" : 0,
    "numLateInputRows" : 4,
    "memoryUsedBytes" : 3710,
    "customMetrics" : {
      "loadedMapCacheHitCount" : 8,
      "loadedMapCacheMissCount" : 0,
      "stateOnCurrentVersionSizeBytes" : 702
    }
  }, {
    "numRowsTotal" : 5,
    "numRowsUpdated" : 0,
    "numLateInputRows" : 0,
    "memoryUsedBytes" : 7453,
    "customMetrics" : {
      "loadedMapCacheHitCount" : 8,
      "loadedMapCacheMissCount" : 0,
      "stateOnCurrentVersionSizeBytes" : 1485
    }
  } ],
  "sources" : [ {
    "description" : "KafkaV2[Subscribe[B]]",
    "startOffset" : {
      "B" : {
        "2" : 10,
        "4" : 10,
        "1" : 10,
        "3" : 10,
        "0" : 10
      }
    },
    "endOffset" : {
      "B" : {
        "2" : 10,
        "4" : 10,
        "1" : 10,
        "3" : 10,
        "0" : 10
      }
    },
    "numInputRows" : 0,
    "inputRowsPerSecond" : 0.0,
    "processedRowsPerSecond" : 0.0
  }, {
    "description" : "KafkaV2[Subscribe[C]]",
    "startOffset" : {
      "C" : {
        "2" : 3,
        "4" : 3,
        "1" : 2,
        "3" : 3,
        "0" : 4
      }
    },
    "endOffset" : {
      "C" : {
        "2" : 3,
        "4" : 3,
        "1" : 2,
        "3" : 3,
        "0" : 4
      }
    },
    "numInputRows" : 0,
    "inputRowsPerSecond" : 0.0,
    "processedRowsPerSecond" : 0.0
  }, {
    "description" : "KafkaV2[Subscribe[D]]",
    "startOffset" : {
      "D" : {
        "2" : 0,
        "4" : 2,
        "1" : 2,
        "3" : 1,
        "0" : 0
      }
    },
    "endOffset" : {
      "D" : {
        "2" : 0,
        "4" : 2,
        "1" : 2,
        "3" : 1,
        "0" : 0
      }
    },
    "numInputRows" : 0,
    "inputRowsPerSecond" : 0.0,
    "processedRowsPerSecond" : 0.0
  } ],
  "sink" : {
    "description" : "org.apache.spark.sql.kafka010.KafkaSourceProvider$KafkaTable@11edae5f",
    "numOutputRows" : 2
  }
}
```