### PR TITLE
[SPARK-28135] Better double support in SQL ceil/floor functions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2758,7 +2758,7 @@ object TimeWindowing extends Rule[LogicalPlan] {
         def getWindow(i: Int, overlappingWindows: Int): Expression = {
           val division = (PreciseTimestampConversion(
             window.timeColumn, TimestampType, LongType) - window.startTime) / window.slideDuration
-          val ceil = Ceil(division)
+          val ceil = Cast(Ceil(division), LongType)
           // if the division is equal to the ceiling, our record is the start of a window
           val windowId = CaseWhen(Seq((ceil === division, ceil + 1)), Some(ceil))
           val windowStart = (windowId + i - overlappingWindows) *

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
@@ -232,7 +232,8 @@ case class Ceil(child: Expression) extends UnaryMathExpression(math.ceil, "CEIL"
     case dt @ DecimalType.Fixed(_, 0) => dt
     case DecimalType.Fixed(precision, scale) =>
       DecimalType.bounded(precision - scale + 1, 0)
-    case _ => LongType
+    case LongType => LongType
+    case _ => DoubleType
   }
 
   override def inputTypes: Seq[AbstractDataType] =
@@ -240,7 +241,7 @@ case class Ceil(child: Expression) extends UnaryMathExpression(math.ceil, "CEIL"
 
   protected override def nullSafeEval(input: Any): Any = child.dataType match {
     case LongType => input.asInstanceOf[Long]
-    case DoubleType => f(input.asInstanceOf[Double]).toLong
+    case DoubleType => f(input.asInstanceOf[Double])
     case DecimalType.Fixed(_, _) => input.asInstanceOf[Decimal].ceil
   }
 
@@ -250,7 +251,7 @@ case class Ceil(child: Expression) extends UnaryMathExpression(math.ceil, "CEIL"
       case DecimalType.Fixed(_, _) =>
         defineCodeGen(ctx, ev, c => s"$c.ceil()")
       case LongType => defineCodeGen(ctx, ev, c => s"$c")
-      case _ => defineCodeGen(ctx, ev, c => s"(long)(java.lang.Math.${funcName}($c))")
+      case _ => defineCodeGen(ctx, ev, c => s"(double)(java.lang.Math.${funcName}($c))")
     }
   }
 }
@@ -363,7 +364,8 @@ case class Floor(child: Expression) extends UnaryMathExpression(math.floor, "FLO
     case dt @ DecimalType.Fixed(_, 0) => dt
     case DecimalType.Fixed(precision, scale) =>
       DecimalType.bounded(precision - scale + 1, 0)
-    case _ => LongType
+    case LongType => LongType
+    case _ => DoubleType
   }
 
   override def inputTypes: Seq[AbstractDataType] =
@@ -371,7 +373,7 @@ case class Floor(child: Expression) extends UnaryMathExpression(math.floor, "FLO
 
   protected override def nullSafeEval(input: Any): Any = child.dataType match {
     case LongType => input.asInstanceOf[Long]
-    case DoubleType => f(input.asInstanceOf[Double]).toLong
+    case DoubleType => f(input.asInstanceOf[Double])
     case DecimalType.Fixed(_, _) => input.asInstanceOf[Decimal].floor
   }
 
@@ -381,7 +383,7 @@ case class Floor(child: Expression) extends UnaryMathExpression(math.floor, "FLO
       case DecimalType.Fixed(_, _) =>
         defineCodeGen(ctx, ev, c => s"$c.floor()")
       case LongType => defineCodeGen(ctx, ev, c => s"$c")
-      case _ => defineCodeGen(ctx, ev, c => s"(long)(java.lang.Math.${funcName}($c))")
+      case _ => defineCodeGen(ctx, ev, c => s"(double)(java.lang.Math.${funcName}($c))")
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MathExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MathExpressionsSuite.scala
@@ -265,7 +265,7 @@ class MathExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("ceil") {
-    testUnary(Ceil, (d: Double) => math.ceil(d).toLong)
+    testUnary(Ceil, math.ceil)
     checkConsistencyBetweenInterpretedAndCodegen(Ceil, DoubleType)
 
     testUnary(Ceil, (d: Decimal) => d.ceil, (-20 to 20).map(x => Decimal(x * 0.1)))
@@ -278,24 +278,28 @@ class MathExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     val longLit: Long = 12345678901234567L
     val nullLit = Literal.create(null, NullType)
     val floatNullLit = Literal.create(null, FloatType)
-    checkEvaluation(checkDataTypeAndCast(Ceil(doublePi)), 4L, EmptyRow)
-    checkEvaluation(checkDataTypeAndCast(Ceil(floatPi)), 4L, EmptyRow)
+    val largeDouble: Double = 1.2345678901234e+200
+
+    checkEvaluation(checkDataTypeAndCast(Ceil(doublePi)), 4.0, EmptyRow)
+    checkEvaluation(checkDataTypeAndCast(Ceil(floatPi)), 4.0, EmptyRow)
     checkEvaluation(checkDataTypeAndCast(Ceil(longLit)), longLit, EmptyRow)
-    checkEvaluation(checkDataTypeAndCast(Ceil(-doublePi)), -3L, EmptyRow)
-    checkEvaluation(checkDataTypeAndCast(Ceil(-floatPi)), -3L, EmptyRow)
+    checkEvaluation(checkDataTypeAndCast(Ceil(largeDouble)), largeDouble, EmptyRow)
+    checkEvaluation(checkDataTypeAndCast(Ceil(-doublePi)), -3.0, EmptyRow)
+    checkEvaluation(checkDataTypeAndCast(Ceil(-floatPi)), -3.0, EmptyRow)
     checkEvaluation(checkDataTypeAndCast(Ceil(-longLit)), -longLit, EmptyRow)
+    checkEvaluation(checkDataTypeAndCast(Ceil(-largeDouble)), -largeDouble, EmptyRow)
 
     checkEvaluation(checkDataTypeAndCast(Ceil(nullLit)), null, EmptyRow)
     checkEvaluation(checkDataTypeAndCast(Ceil(floatNullLit)), null, EmptyRow)
-    checkEvaluation(checkDataTypeAndCast(Ceil(0)), 0L, EmptyRow)
-    checkEvaluation(checkDataTypeAndCast(Ceil(1)), 1L, EmptyRow)
+    checkEvaluation(checkDataTypeAndCast(Ceil(0L)), 0L, EmptyRow)
+    checkEvaluation(checkDataTypeAndCast(Ceil(1L)), 1L, EmptyRow)
     checkEvaluation(checkDataTypeAndCast(Ceil(1234567890123456L)), 1234567890123456L, EmptyRow)
-    checkEvaluation(checkDataTypeAndCast(Ceil(0.01)), 1L, EmptyRow)
-    checkEvaluation(checkDataTypeAndCast(Ceil(-0.10)), 0L, EmptyRow)
+    checkEvaluation(checkDataTypeAndCast(Ceil(0.01)), 1.0, EmptyRow)
+    checkEvaluation(checkDataTypeAndCast(Ceil(-0.10)), -0.0, EmptyRow)
   }
 
   test("floor") {
-    testUnary(Floor, (d: Double) => math.floor(d).toLong)
+    testUnary(Floor, math.floor)
     checkConsistencyBetweenInterpretedAndCodegen(Floor, DoubleType)
 
     testUnary(Floor, (d: Decimal) => d.floor, (-20 to 20).map(x => Decimal(x * 0.1)))
@@ -308,20 +312,24 @@ class MathExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     val longLit: Long = 12345678901234567L
     val nullLit = Literal.create(null, NullType)
     val floatNullLit = Literal.create(null, FloatType)
-    checkEvaluation(checkDataTypeAndCast(Floor(doublePi)), 3L, EmptyRow)
-    checkEvaluation(checkDataTypeAndCast(Floor(floatPi)), 3L, EmptyRow)
+    val largeDouble: Double = 1.2345678901234e+200
+
+    checkEvaluation(checkDataTypeAndCast(Floor(doublePi)), 3.0, EmptyRow)
+    checkEvaluation(checkDataTypeAndCast(Floor(floatPi)), 3.0, EmptyRow)
     checkEvaluation(checkDataTypeAndCast(Floor(longLit)), longLit, EmptyRow)
-    checkEvaluation(checkDataTypeAndCast(Floor(-doublePi)), -4L, EmptyRow)
-    checkEvaluation(checkDataTypeAndCast(Floor(-floatPi)), -4L, EmptyRow)
+    checkEvaluation(checkDataTypeAndCast(Floor(largeDouble)), largeDouble, EmptyRow)
+    checkEvaluation(checkDataTypeAndCast(Floor(-doublePi)), -4.0, EmptyRow)
+    checkEvaluation(checkDataTypeAndCast(Floor(-floatPi)), -4.0, EmptyRow)
     checkEvaluation(checkDataTypeAndCast(Floor(-longLit)), -longLit, EmptyRow)
+    checkEvaluation(checkDataTypeAndCast(Floor(-largeDouble)), -largeDouble, EmptyRow)
 
     checkEvaluation(checkDataTypeAndCast(Floor(nullLit)), null, EmptyRow)
     checkEvaluation(checkDataTypeAndCast(Floor(floatNullLit)), null, EmptyRow)
-    checkEvaluation(checkDataTypeAndCast(Floor(0)), 0L, EmptyRow)
-    checkEvaluation(checkDataTypeAndCast(Floor(1)), 1L, EmptyRow)
+    checkEvaluation(checkDataTypeAndCast(Floor(0L)), 0L, EmptyRow)
+    checkEvaluation(checkDataTypeAndCast(Floor(1L)), 1L, EmptyRow)
     checkEvaluation(checkDataTypeAndCast(Floor(1234567890123456L)), 1234567890123456L, EmptyRow)
-    checkEvaluation(checkDataTypeAndCast(Floor(0.01)), 0L, EmptyRow)
-    checkEvaluation(checkDataTypeAndCast(Floor(-0.10)), -1L, EmptyRow)
+    checkEvaluation(checkDataTypeAndCast(Floor(0.01)), 0.0, EmptyRow)
+    checkEvaluation(checkDataTypeAndCast(Floor(-0.10)), -1.0, EmptyRow)
   }
 
   test("factorial") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
@@ -297,7 +297,7 @@ object CommandUtils extends Logging {
         struct(
           ndv, nullLit, nullLit, numNulls,
           // Set avg/max size to default size if all the values are null or there is no value.
-          Coalesce(Seq(Ceil(Average(Length(col))), defaultSize)),
+          Coalesce(Seq(Cast(Ceil(Average(Length(col))), LongType), defaultSize)),
           Coalesce(Seq(Cast(Max(Length(col)), LongType), defaultSize)),
           nullArray)
       case _ =>

--- a/sql/core/src/test/resources/sql-tests/results/operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/operators.sql.out
@@ -229,17 +229,17 @@ struct<COT(CAST(-1 AS DOUBLE)):double>
 -- !query 28
 select ceiling(0)
 -- !query 28 schema
-struct<CEIL(CAST(0 AS DOUBLE)):bigint>
+struct<CEIL(CAST(0 AS DOUBLE)):double>
 -- !query 28 output
-0
+0.0
 
 
 -- !query 29
 select ceiling(1)
 -- !query 29 schema
-struct<CEIL(CAST(1 AS DOUBLE)):bigint>
+struct<CEIL(CAST(1 AS DOUBLE)):double>
 -- !query 29 output
-1
+1.0
 
 
 -- !query 30
@@ -277,17 +277,17 @@ struct<CEIL(-0.10):decimal(1,0)>
 -- !query 34
 select floor(0)
 -- !query 34 schema
-struct<FLOOR(CAST(0 AS DOUBLE)):bigint>
+struct<FLOOR(CAST(0 AS DOUBLE)):double>
 -- !query 34 output
-0
+0.0
 
 
 -- !query 35
 select floor(1)
 -- !query 35 schema
-struct<FLOOR(CAST(1 AS DOUBLE)):bigint>
+struct<FLOOR(CAST(1 AS DOUBLE)):double>
 -- !query 35 output
-1
+1.0
 
 
 -- !query 36

--- a/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
@@ -169,10 +169,10 @@ class MathFunctionsSuite extends QueryTest with SharedSQLContext {
   }
 
   test("ceil and ceiling") {
-    testOneToOneMathFunction(ceil, (d: Double) => math.ceil(d).toLong)
+    testOneToOneMathFunction(ceil, math.ceil)
     checkAnswer(
       sql("SELECT ceiling(0), ceiling(1), ceiling(1.5)"),
-      Row(0L, 1L, 2L))
+      Row(0, 1, 2.0))
   }
 
   test("conv") {
@@ -188,7 +188,7 @@ class MathFunctionsSuite extends QueryTest with SharedSQLContext {
   }
 
   test("floor") {
-    testOneToOneMathFunction(floor, (d: Double) => math.floor(d).toLong)
+    testOneToOneMathFunction(floor, math.floor)
   }
 
   test("factorial") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The existing Ceil and Floor case classes in SQL mathExpressions.scala doesn't support double well.
When using large doubles in the query, LongType max will be returned instead of the correct large double values (e.g. select ceil(double(1.2345678901234e+200)), ceiling(double(1.2345678901234e+200)), floor(double(1.2345678901234e+200)); used in the ticket).

In this patch, better double support is added. Now the data overflow bug has been fixed by this patch, also now Ceil and Floor has correct semantics in certain use cases, e.g. double should be returned when input param is double. In the existing code, long will be the default return type regardless of the input data types.

## How was this patch tested?

All spark unit tests:
./build/sbt test

All SQL tests:
./build/sbt "testOnly org.apache.spark.sql.*"

@wangyum @mgaido91 @HyukjinKwon 