### PR TITLE
[SPARK-27234][SS][PYTHON] Use InheritableThreadLocal for current epoch in EpochTracker (to support Python UDFs)

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousCoalesceRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousCoalesceRDD.scala
@@ -110,8 +110,8 @@ class ContinuousCoalesceRDD(
               context.getLocalProperty(ContinuousExecution.START_EPOCH_KEY).toLong)
             while (!context.isInterrupted() && !context.isCompleted()) {
               writer.write(prev.compute(prevSplit, context).asInstanceOf[Iterator[UnsafeRow]])
-              // Note that current epoch is a inheritable thread local but makes a clone, so
-              // each writer thread can properly increment its own epoch without affecting
+              // Note that current epoch is a inheritable thread local but makes another instance,
+              // so each writer thread can properly increment its own epoch without affecting
               // the main task thread.
               EpochTracker.incrementCurrentEpoch()
             }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousCoalesceRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousCoalesceRDD.scala
@@ -110,8 +110,9 @@ class ContinuousCoalesceRDD(
               context.getLocalProperty(ContinuousExecution.START_EPOCH_KEY).toLong)
             while (!context.isInterrupted() && !context.isCompleted()) {
               writer.write(prev.compute(prevSplit, context).asInstanceOf[Iterator[UnsafeRow]])
-              // Note that current epoch is a non-inheritable thread local, so each writer thread
-              // can properly increment its own epoch without affecting the main task thread.
+              // Note that current epoch is a inheritable thread local but makes a clone, so
+              // each writer thread can properly increment its own epoch without affecting
+              // the main task thread.
               EpochTracker.incrementCurrentEpoch()
             }
           }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/EpochTracker.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/EpochTracker.scala
@@ -19,8 +19,6 @@ package org.apache.spark.sql.execution.streaming.continuous
 
 import java.util.concurrent.atomic.AtomicLong
 
-import org.apache.commons.lang3.SerializationUtils
-
 /**
  * Tracks the current continuous processing epoch within a task. Call
  * EpochTracker.getCurrentEpoch to get the current epoch.
@@ -31,9 +29,9 @@ object EpochTracker {
   private val currentEpoch: InheritableThreadLocal[AtomicLong] = {
     new InheritableThreadLocal[AtomicLong] {
       override protected def childValue(parent: AtomicLong): AtomicLong = {
-        // Note: make a clone such that changes in the parent epoch aren't reflected in
+        // Note: make another instance so that changes in the parent epoch aren't reflected in
         // those in the children threads. This is required at `ContinuousCoalesceRDD`.
-        SerializationUtils.clone(parent)
+        new AtomicLong(parent.get)
       }
       override def initialValue() = new AtomicLong(-1)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousSuite.scala
@@ -262,8 +262,9 @@ class ContinuousSuite extends ContinuousSuiteBase {
         udf.isInstanceOf[TestScalaUDF])
 
       val input = ContinuousMemoryStream[Int]
+      val df = input.toDF()
 
-      testStream(input.toDF().select(udf($"value").cast("int")))(
+      testStream(df.select(udf(df("value")).cast("int")))(
         AddData(input, 0, 1, 2),
         CheckAnswer(0, 1, 2),
         StopStream,

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousSuite.scala
@@ -85,6 +85,7 @@ class ContinuousSuiteBase extends StreamTest {
 }
 
 class ContinuousSuite extends ContinuousSuiteBase {
+  import IntegratedUDFTestUtils._
   import testImplicits._
 
   test("basic") {
@@ -251,6 +252,25 @@ class ContinuousSuite extends ContinuousSuiteBase {
     val results = spark.read.table("noharness").collect()
     assert(expected.map(Row(_)).subsetOf(results.toSet),
       s"Result set ${results.toSet} are not a superset of $expected!")
+  }
+
+  Seq(TestScalaUDF("udf"), TestPythonUDF("udf"), TestScalarPandasUDF("udf")).foreach { udf =>
+    test(s"continuous mode with various UDFs - ${udf.prettyName}") {
+      assume(
+        shouldTestScalarPandasUDFs && udf.isInstanceOf[TestScalarPandasUDF] ||
+        shouldTestPythonUDFs && udf.isInstanceOf[TestPythonUDF] ||
+        udf.isInstanceOf[TestScalaUDF])
+
+      val input = ContinuousMemoryStream[Int]
+
+      testStream(input.toDF().select(udf($"value").cast("int")))(
+        AddData(input, 0, 1, 2),
+        CheckAnswer(0, 1, 2),
+        StopStream,
+        AddData(input, 3, 4, 5),
+        StartStream(),
+        CheckAnswer(0, 1, 2, 3, 4, 5))
+    }
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to use `InheritableThreadLocal` instead of `ThreadLocal` for current epoch in `EpochTracker`. Python UDF needs threads to write out to and read it from Python processes and when there are new threads, previously set epoch is lost.

After this PR, Python UDFs can be used at Structured Streaming with the continuous mode.

## How was this patch tested?

The test cases were written on the top of https://github.com/apache/spark/pull/24945.
Unit tests were added.

Manual tests.