### PR TITLE
[SPARK-28143][SQL] Expressions without proper constructors should throw AnalysisException

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -581,11 +581,11 @@ object FunctionRegistry {
         val params = Seq.fill(expressions.size)(classOf[Expression])
         val f = constructors.find(_.getParameterTypes.toSeq == params).getOrElse {
           val validParametersCount = constructors
-            .filter(_.getParameterTypes.forall { t =>
-              t == classOf[Expression] || t == classOf[Seq[Expression]]
-            })
+            .filter(_.getParameterTypes.forall(_ == classOf[Expression]))
             .map(_.getParameterCount).distinct.sorted
-          val expectedNumberOfParameters = if (validParametersCount.length == 1) {
+          val expectedNumberOfParameters = if (validParametersCount.length == 0) {
+            throw new AnalysisException(s"$name is an invalid function.")
+          } else if (validParametersCount.length == 1) {
             validParametersCount.head.toString
           } else {
             validParametersCount.init.mkString("one of ", ", ", " and ") +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -581,7 +581,6 @@ object FunctionRegistry {
         val params = Seq.fill(expressions.size)(classOf[Expression])
         val f = constructors.find(_.getParameterTypes.toSeq == params).getOrElse {
           val validParametersCount = constructors
-            .filter(_.getParameterTypes.forall(_ == classOf[Expression]))
             .map(_.getParameterCount).distinct.sorted
           val expectedNumberOfParameters = if (validParametersCount.length == 1) {
             validParametersCount.head.toString

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -583,8 +583,8 @@ object FunctionRegistry {
           val validParametersCount = constructors
             .filter(_.getParameterTypes.forall(_ == classOf[Expression]))
             .map(_.getParameterCount).distinct.sorted
-          val expectedNumberOfParameters = if (validParametersCount.length == 0) {
-            throw new AnalysisException(s"$name is an invalid function.")
+          val expectedNumberOfParameters = if (validParametersCount.isEmpty) {
+            constructors.headOption.map(_.getParameterCount).getOrElse(0).toString
           } else if (validParametersCount.length == 1) {
             validParametersCount.head.toString
           } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -581,6 +581,9 @@ object FunctionRegistry {
         val params = Seq.fill(expressions.size)(classOf[Expression])
         val f = constructors.find(_.getParameterTypes.toSeq == params).getOrElse {
           val validParametersCount = constructors
+            .filter(_.getParameterTypes.forall { t =>
+              t == classOf[Expression] || t == classOf[Seq[Expression]]
+            })
             .map(_.getParameterCount).distinct.sorted
           val expectedNumberOfParameters = if (validParametersCount.length == 1) {
             validParametersCount.head.toString

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -106,6 +106,12 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
     checkKeywordsExist(sql("describe functioN abcadf"), "Function: abcadf not found.")
   }
 
+  test("SPARK-28143: IN expression missing attribute should throw analysis exception") {
+    val query = "select 1 from where in ()"
+    val e = intercept[AnalysisException](sql(query))
+    assert(e.getMessage.startsWith("Invalid number of arguments for function in."))
+  }
+
   test("SPARK-14415: All functions should have own descriptions") {
     for (f <- spark.sessionState.functionRegistry.listFunction()) {
       if (!Seq("cube", "grouping", "grouping_id", "rollup", "window").contains(f.unquotedString)) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -110,7 +110,7 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
     // missing attribute, which actually might be `select 1 where a in ()`
     val query = "select 1 where in ()"
     val e = intercept[AnalysisException](sql(query))
-    assert(e.getMessage.startsWith("in"))
+    assert(e.getMessage.startsWith("Invalid number of arguments for function in"))
   }
 
   test("SPARK-14415: All functions should have own descriptions") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -107,9 +107,10 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
   }
 
   test("SPARK-28143: IN expression missing attribute should throw analysis exception") {
-    val query = "select 1 from where in ()"
+    // missing attribute, which actually might be `select 1 where a in ()`
+    val query = "select 1 where in ()"
     val e = intercept[AnalysisException](sql(query))
-    assert(e.getMessage.startsWith("Invalid number of arguments for function in."))
+    assert(e.getMessage.startsWith("in"))
   }
 
   test("SPARK-14415: All functions should have own descriptions") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

SQL queries like `select 1 where in ()`, which miss the attribute name should throw `AnalysisException` with `Invalid number of arguments for function in` as debug message rather than `java.lang.UnsupportedOperationException: empty.init`.

This problem I guess is related to this pr - https://github.com/apache/spark/pull/21226


## How was this patch tested?

1. add ut
2. Manually

**Before**

```scala
select 1 where in ();
19/06/24 13:37:33 ERROR SparkSQLDriver: Failed in [select 1 where in ()]
java.lang.UnsupportedOperationException: empty.init
```

**After**

```
Invalid number of arguments for function in. Expected: 2; Found: 0
```