### PR TITLE
[MINOR][BUILD] Exclude pyspark-coverage-site/ dir from RAT

### DIFF
--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -44,6 +44,7 @@ jsonFormatter.min.js
 .*json
 .*data
 .*log
+pyspark-coverage-site/
 cloudpickle.py
 heapq3.py
 join.py


### PR DESCRIPTION
## What changes were proposed in this pull request?

Looks like a directory `pyspark-site-coverage/` is now (?) generated and fails RAT checks. It should just be excluded. See: https://amplab.cs.berkeley.edu/jenkins/view/Spark%20QA%20Test%20(Dashboard)/job/spark-master-test-sbt-hadoop-2.7/6029/console

## How was this patch tested?

N/A