### PR TITLE
[SPARK-28157][CORE] Make SHS check Spark event log file permission changes

### DIFF
--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -1139,6 +1139,13 @@ class FsHistoryProviderSuite extends SparkFunSuite with Matchers with Logging {
     }
     val accessDeniedPath = new Path(accessDenied.getPath)
     assert(mockedProvider.isBlacklisted(accessDeniedPath))
+    (1 to 100).foreach { round =>
+      clock.advance(UPDATE_INTERVAL_S.defaultValue.get * 1000)
+      updateAndCheck(mockedProvider) { _ =>
+        assert(mockedProvider.isBlacklisted(accessDeniedPath))
+        assert(mockedProvider.isSecondChance(accessDeniedPath) == (round % 10 == 0))
+      }
+    }
     clock.advance(24 * 60 * 60 * 1000 + 1) // add a bit more than 1d
     mockedProvider.cleanLogs()
     assert(!mockedProvider.isBlacklisted(accessDeniedPath))


### PR DESCRIPTION
## What changes were proposed in this pull request?

At Spark 2.4.0/2.3.2/2.2.3, [SPARK-24948](https://issues.apache.org/jira/browse/SPARK-24948) delegated access permission checks to the file system, and maintains a permanent blacklist for all event log files failed once at reading. Although this reduces a lot of invalid accesses, there is no way to see this log files back after the permissions are recovered correctly. The only way has been restarting SHS.

Apache Spark is unable to know the permission recovery. However, we had better give a second chances for those blacklisted files in a regular manner.

## How was this patch tested?

Pass the Jenkins with the newly added updated test case.