### PR TITLE
[SPARK-28149][K8S] Added variable to disable negative DNS caching

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
@@ -78,7 +78,18 @@ case "$1" in
       -Xms$SPARK_EXECUTOR_MEMORY
       -Xmx$SPARK_EXECUTOR_MEMORY
       -cp "$SPARK_CLASSPATH"
-      org.apache.spark.executor.CoarseGrainedExecutorBackend
+    )
+
+    #Disable negative dns reslolution https://docs.oracle.com/javase/8/docs/technotes/guides/net/properties.html
+    if ! [ -z ${DISABLE_DNS_NEGATIVE_CACHING+x} ]; then
+      MOD_OPTS_PATH=/tmp/jvm.java.security
+      sed -e 's/networkaddress.cache.negative.ttl=10/networkaddress.cache.negative.ttl=0/g' \
+        /usr/lib/jvm/java-1.8-openjdk/jre/lib/security/java.security > ${MOD_OPTS_PATH}
+      CMD+=(-Djava.security.properties=${MOD_OPTS_PATH})
+    fi
+
+
+    CMD+=( org.apache.spark.executor.CoarseGrainedExecutorBackend
       --driver-url $SPARK_DRIVER_URL
       --executor-id $SPARK_EXECUTOR_ID
       --cores $SPARK_EXECUTOR_CORES


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR makes possible disable the negative dns caching in JVM by adding a variable.

## How was this patch tested?
I could not see a place to run this tests automatically, so I run them manually by executing
docker run:

```
josemsmac:spark jopedros$ docker run --rm -it --env "DISABLE_DNS_NEGATIVE_CACHING=1" spark:latest executor
++ id -u
+ myuid=185
++ id -g
+ mygid=0
+ set +e
++ getent passwd 185
+ uidentry=
+ set -e
+ '[' -z '' ']'
+ '[' -w /etc/passwd ']'
+ echo '185:x:185:0:anonymous uid:/opt/spark:/bin/false'
+ SPARK_CLASSPATH=':/opt/spark/jars/*'
+ env
+ grep SPARK_JAVA_OPT_
+ sort -t_ -k4 -n
+ sed 's/[^=]*=\(.*\)/\1/g'
+ readarray -t SPARK_EXECUTOR_JAVA_OPTS
+ '[' -n '' ']'
+ '[' '' == 2 ']'
+ '[' '' == 3 ']'
+ '[' -z ']'
+ case "$1" in
+ shift 1
+ CMD=(${JAVA_HOME}/bin/java "${SPARK_EXECUTOR_JAVA_OPTS[@]}" -Xms$SPARK_EXECUTOR_MEMORY -Xmx$SPARK_EXECUTOR_MEMORY -cp "$SPARK_CLASSPATH")
+ '[' -z x ']'
+ MOD_OPTS_PATH=/tmp/jvm.java.security
+ sed -e s/networkaddress.cache.negative.ttl=10/networkaddress.cache.negative.ttl=0/g /usr/lib/jvm/java-1.8-openjdk/jre/lib/security/java.security
+ CMD+=(-Djava.security.properties=${MOD_OPTS_PATH})
+ CMD+=(org.apache.spark.executor.CoarseGrainedExecutorBackend --driver-url $SPARK_DRIVER_URL --executor-id $SPARK_EXECUTOR_ID --cores $SPARK_EXECUTOR_CORES --app-id $SPARK_APPLICATION_ID --hostname $SPARK_EXECUTOR_POD_IP)
+ exec /sbin/tini -s -- /usr/lib/jvm/java-1.8-openjdk/bin/java -Xms -Xmx -cp ':/opt/spark/jars/*' -Djava.security.properties=/tmp/jvm.java.security org.apache.spark.executor.CoarseGrainedExecutorBackend --driver-url --executor-id --cores --app-id --hostname
```

