### PR TITLE
[SPARK-28159][ML] Make the transform natively in ml framework to avoid extra conversion

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
@@ -457,14 +457,14 @@ abstract class LDAModel private[ml] (
    */
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
-    if ($(topicDistributionCol).nonEmpty) {
+    transformSchema(dataset.schema, logging = true)
 
-      // TODO: Make the transformer natively in ml framework to avoid extra conversion.
+    if ($(topicDistributionCol).nonEmpty) {
       val transformer = oldLocalModel.getTopicDistributionMethod
 
-      val t = udf { (v: Vector) => transformer(OldVectors.fromML(v)).asML }
+      val t = udf { v: Vector => transformer(v) }
       dataset.withColumn($(topicDistributionCol),
-        t(DatasetUtils.columnToVector(dataset, getFeaturesCol))).toDF()
+        t(DatasetUtils.columnToVector(dataset, getFeaturesCol)))
     } else {
       logWarning("LDAModel.transform was called without any output columns. Set an output column" +
         " such as topicDistributionCol to produce results.")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
@@ -19,10 +19,6 @@ package org.apache.spark.ml.feature
 
 import java.{util => ju}
 
-import org.json4s.JsonDSL._
-import org.json4s.JValue
-import org.json4s.jackson.JsonMethods._
-
 import org.apache.spark.SparkException
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.Model

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
@@ -22,7 +22,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml._
 import org.apache.spark.ml.attribute.{AttributeGroup, _}
-import org.apache.spark.ml.linalg.{Vector, VectorUDT}
+import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
 import org.apache.spark.ml.util._
@@ -266,10 +266,22 @@ final class ChiSqSelectorModel private[ml] (
   override def transform(dataset: Dataset[_]): DataFrame = {
     val outputSchema = transformSchema(dataset.schema, logging = true)
 
-    val transformer: Vector => Vector = v => chiSqSelector.compress(v)
+    val newSize = selectedFeatures.length
+    val func = { vector: Vector =>
+      vector match {
+        case SparseVector(_, indices, values) =>
+          val (newIndices, newValues) = chiSqSelector.compressSparse(indices, values)
+          Vectors.sparse(newSize, newIndices, newValues)
+        case DenseVector(values) =>
+          Vectors.dense(chiSqSelector.compressDense(values))
+        case other =>
+          throw new UnsupportedOperationException(
+            s"Only sparse and dense vectors are supported but got ${other.getClass}.")
+      }
+    }
 
-    val selector = udf(transformer)
-    dataset.withColumn($(outputCol), selector(col($(featuresCol))),
+    val transformer = udf(func)
+    dataset.withColumn($(outputCol), transformer(col($(featuresCol))),
       outputSchema($(outputCol)).metadata)
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
@@ -264,14 +264,13 @@ final class ChiSqSelectorModel private[ml] (
 
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
-    val transformedSchema = transformSchema(dataset.schema, logging = true)
-    val newField = transformedSchema.last
+    val outputSchema = transformSchema(dataset.schema, logging = true)
 
-    // TODO: Make the transformer natively in ml framework to avoid extra conversion.
-    val transformer: Vector => Vector = v => chiSqSelector.transform(OldVectors.fromML(v)).asML
+    val transformer: Vector => Vector = v => chiSqSelector.compress(v)
 
     val selector = udf(transformer)
-    dataset.withColumn($(outputCol), selector(col($(featuresCol))), newField.metadata)
+    dataset.withColumn($(outputCol), selector(col($(featuresCol))),
+      outputSchema($(outputCol)).metadata)
   }
 
   @Since("1.6.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
@@ -169,7 +169,8 @@ class StandardScalerModel private[ml] (
           case d: DenseVector => d.values.clone()
           case v: Vector => v.toArray
         }
-        Vectors.dense(scaler.transfromWithMean(values))
+        val newValues = scaler.transfromWithMean(values)
+        Vectors.dense(newValues)
     } else if ($(withStd)) {
       vector: Vector =>
         vector match {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
@@ -21,7 +21,7 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml._
-import org.apache.spark.ml.linalg.{Vector, VectorUDT}
+import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
 import org.apache.spark.ml.util._
@@ -162,11 +162,33 @@ class StandardScalerModel private[ml] (
     transformSchema(dataset.schema, logging = true)
     val scaler = new feature.StandardScalerModel(std, mean, $(withStd), $(withMean))
 
-    // TODO: Make the transformer natively in ml framework to avoid extra conversion.
-    val transformer: Vector => Vector = v => scaler.transform(OldVectors.fromML(v)).asML
+    val func = if ($(withMean)) {
+      vector: Vector =>
+        val values = vector match {
+          // specially handle DenseVector because its toArray does not clone already
+          case d: DenseVector => d.values.clone()
+          case v: Vector => v.toArray
+        }
+        Vectors.dense(scaler.transfromWithMean(values))
+    } else if ($(withStd)) {
+      vector: Vector =>
+        vector match {
+          case DenseVector(values) =>
+            val newValues = scaler.transformDenseWithStd(values)
+            Vectors.dense(newValues)
+          case SparseVector(size, indices, values) =>
+            val (newIndices, newValues) = scaler.transformSparseWithStd(indices, values)
+            Vectors.sparse(size, newIndices, newValues)
+          case other =>
+            throw new UnsupportedOperationException(
+              s"Only sparse and dense vectors are supported but got ${other.getClass}.")
+        }
+    } else {
+      vector: Vector => vector
+    }
 
-    val scale = udf(transformer)
-    dataset.withColumn($(outputCol), scale(col($(inputCol))))
+    val transformer = udf(func)
+    dataset.withColumn($(outputCol), transformer(col($(inputCol))))
   }
 
   @Since("1.4.0")

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAModel.scala
@@ -28,7 +28,6 @@ import org.apache.spark.SparkContext
 import org.apache.spark.annotation.Since
 import org.apache.spark.api.java.{JavaPairRDD, JavaRDD}
 import org.apache.spark.graphx.{Edge, EdgeContext, Graph, VertexId}
-import org.apache.spark.ml.linalg.{Vector => NewVector, Vectors => NewVectors}
 import org.apache.spark.mllib.linalg.{Matrices, Matrix, Vector, Vectors}
 import org.apache.spark.mllib.util.{Loader, Saveable}
 import org.apache.spark.rdd.RDD
@@ -195,7 +194,7 @@ class LocalLDAModel private[spark] (
     override protected[spark] val gammaShape: Double = 100)
   extends LDAModel with Serializable {
 
-  private var seed: Long = Utils.random.nextLong()
+  private[spark] var seed: Long = Utils.random.nextLong()
 
   @Since("1.3.0")
   override def k: Int = topics.numCols
@@ -385,31 +384,6 @@ class LocalLDAModel private[spark] (
         (id, Vectors.dense(normalize(gamma, 1.0).toArray))
       }
     }
-  }
-
-  /**
-   * Get a method usable as a UDF for `topicDistributions()`
-   */
-  private[spark] def getTopicDistributionMethod: NewVector => NewVector = {
-    val expElogbeta = exp(LDAUtils.dirichletExpectation(topicsMatrix.asBreeze.toDenseMatrix.t).t)
-    val docConcentrationBrz = this.docConcentration.asBreeze
-    val gammaShape = this.gammaShape
-    val k = this.k
-    val gammaSeed = this.seed
-
-    termCounts: NewVector =>
-      if (termCounts.numNonzeros == 0) {
-        NewVectors.zeros(k)
-      } else {
-        val (gamma, _, _) = OnlineLDAOptimizer.variationalTopicInference(
-          termCounts,
-          expElogbeta,
-          docConcentrationBrz,
-          gammaShape,
-          k,
-          gammaSeed)
-        NewVectors.dense(normalize(gamma, 1.0).toArray)
-      }
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAModel.scala
@@ -397,9 +397,9 @@ class LocalLDAModel private[spark] (
     val k = this.k
     val gammaSeed = this.seed
 
-    (termCounts: NewVector) =>
+    termCounts: NewVector =>
       if (termCounts.numNonzeros == 0) {
-        Vectors.zeros(k)
+        NewVectors.zeros(k)
       } else {
         val (gamma, _, _) = OnlineLDAOptimizer.variationalTopicInference(
           termCounts,

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAModel.scala
@@ -28,6 +28,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.annotation.Since
 import org.apache.spark.api.java.{JavaPairRDD, JavaRDD}
 import org.apache.spark.graphx.{Edge, EdgeContext, Graph, VertexId}
+import org.apache.spark.ml.linalg.{Vector => NewVector, Vectors => NewVectors}
 import org.apache.spark.mllib.linalg.{Matrices, Matrix, Vector, Vectors}
 import org.apache.spark.mllib.util.{Loader, Saveable}
 import org.apache.spark.rdd.RDD
@@ -389,14 +390,14 @@ class LocalLDAModel private[spark] (
   /**
    * Get a method usable as a UDF for `topicDistributions()`
    */
-  private[spark] def getTopicDistributionMethod: Vector => Vector = {
+  private[spark] def getTopicDistributionMethod: NewVector => NewVector = {
     val expElogbeta = exp(LDAUtils.dirichletExpectation(topicsMatrix.asBreeze.toDenseMatrix.t).t)
     val docConcentrationBrz = this.docConcentration.asBreeze
     val gammaShape = this.gammaShape
     val k = this.k
     val gammaSeed = this.seed
 
-    (termCounts: Vector) =>
+    (termCounts: NewVector) =>
       if (termCounts.numNonzeros == 0) {
         Vectors.zeros(k)
       } else {
@@ -407,7 +408,7 @@ class LocalLDAModel private[spark] (
           gammaShape,
           k,
           gammaSeed)
-        Vectors.dense(normalize(gamma, 1.0).toArray)
+        NewVectors.dense(normalize(gamma, 1.0).toArray)
       }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAOptimizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAOptimizer.scala
@@ -27,8 +27,6 @@ import org.apache.spark.annotation.{DeveloperApi, Since}
 import org.apache.spark.graphx._
 import org.apache.spark.graphx.util.PeriodicGraphCheckpointer
 import org.apache.spark.internal.Logging
-import org.apache.spark.ml.linalg.{DenseVector => NewDenseVector,
-  SparseVector => NewSparseVector, Vector => NewVector}
 import org.apache.spark.mllib.linalg.{DenseVector, Matrices, SparseVector, Vector, Vectors}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
@@ -597,7 +595,7 @@ final class OnlineLDAOptimizer extends LDAOptimizer with Logging {
  * Serializable companion object containing helper methods and shared code for
  * [[OnlineLDAOptimizer]] and [[LocalLDAModel]].
  */
-private[clustering] object OnlineLDAOptimizer {
+private[spark] object OnlineLDAOptimizer {
   /**
    * Uses variational inference to infer the topic distribution `gammad` given the term counts
    * for a document. `termCounts` must contain at least one non-zero entry, otherwise Breeze will
@@ -610,7 +608,7 @@ private[clustering] object OnlineLDAOptimizer {
    * @return Returns a tuple of `gammad` - estimate of gamma, the topic distribution, `sstatsd` -
    *         statistics for updating lambda and `ids` - list of termCounts vector indices.
    */
-  private[clustering] def variationalTopicInference(
+  private[spark] def variationalTopicInference(
       indices: List[Int],
       values: Array[Double],
       expElogbeta: BDM[Double],
@@ -654,20 +652,6 @@ private[clustering] object OnlineLDAOptimizer {
     val (ids: List[Int], cts: Array[Double]) = termCounts match {
       case v: DenseVector => ((0 until v.size).toList, v.values)
       case v: SparseVector => (v.indices.toList, v.values)
-    }
-    variationalTopicInference(ids, cts, expElogbeta, alpha, gammaShape, k, seed)
-  }
-
-  private[clustering] def variationalTopicInference(
-      termCounts: NewVector,
-      expElogbeta: BDM[Double],
-      alpha: breeze.linalg.Vector[Double],
-      gammaShape: Double,
-      k: Int,
-      seed: Long): (BDV[Double], BDM[Double], List[Int]) = {
-    val (ids: List[Int], cts: Array[Double]) = termCounts match {
-      case v: NewDenseVector => ((0 until v.size).toList, v.values)
-      case v: NewSparseVector => (v.indices.toList, v.values)
     }
     variationalTopicInference(ids, cts, expElogbeta, alpha, gammaShape, k, seed)
   }

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAUtils.scala
@@ -22,7 +22,7 @@ import breeze.numerics._
 /**
  * Utility methods for LDA.
  */
-private[clustering] object LDAUtils {
+private[spark] object LDAUtils {
   /**
    * Log Sum Exp with overflow protection using the identity:
    * For any a: $\log \sum_{n=1}^N \exp\{x_n\} = a + \log \sum_{n=1}^N \exp\{x_n - a\}$
@@ -44,7 +44,7 @@ private[clustering] object LDAUtils {
    * Computes [[dirichletExpectation()]] row-wise, assuming each row of alpha are
    * Dirichlet parameters.
    */
-  private[clustering] def dirichletExpectation(alpha: BDM[Double]): BDM[Double] = {
+  private[spark] def dirichletExpectation(alpha: BDM[Double]): BDM[Double] = {
     val rowSum = sum(alpha(breeze.linalg.*, ::))
     val digAlpha = digamma(alpha)
     val digRowSum = digamma(rowSum)

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/ChiSqSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/ChiSqSelector.scala
@@ -25,6 +25,8 @@ import org.json4s.jackson.JsonMethods._
 
 import org.apache.spark.SparkContext
 import org.apache.spark.annotation.Since
+import org.apache.spark.ml.linalg.{DenseVector => NewDenseVector,
+  SparseVector => NewSparseVector, Vector => NewVector, Vectors => NewVectors}
 import org.apache.spark.mllib.linalg.{DenseVector, SparseVector, Vector, Vectors}
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.stat.Statistics
@@ -75,38 +77,59 @@ class ChiSqSelectorModel @Since("1.3.0") (
   private def compress(features: Vector): Vector = {
     features match {
       case SparseVector(size, indices, values) =>
-        val newSize = filterIndices.length
-        val newValues = new ArrayBuilder.ofDouble
-        val newIndices = new ArrayBuilder.ofInt
-        var i = 0
-        var j = 0
-        var indicesIdx = 0
-        var filterIndicesIdx = 0
-        while (i < indices.length && j < filterIndices.length) {
-          indicesIdx = indices(i)
-          filterIndicesIdx = filterIndices(j)
-          if (indicesIdx == filterIndicesIdx) {
-            newIndices += j
-            newValues += values(i)
-            j += 1
-            i += 1
-          } else {
-            if (indicesIdx > filterIndicesIdx) {
-              j += 1
-            } else {
-              i += 1
-            }
-          }
-        }
-        // TODO: Sparse representation might be ineffective if (newSize ~= newValues.size)
-        Vectors.sparse(newSize, newIndices.result(), newValues.result())
+        val (newIndices, newValues) = compressSparse(indices, values)
+        Vectors.sparse(filterIndices.length, newIndices, newValues)
       case DenseVector(values) =>
-        val values = features.toArray
-        Vectors.dense(filterIndices.map(i => values(i)))
+        Vectors.dense(compressDense(values))
       case other =>
         throw new UnsupportedOperationException(
           s"Only sparse and dense vectors are supported but got ${other.getClass}.")
     }
+  }
+
+  private[spark] def compress(features: NewVector): NewVector = {
+    features match {
+      case NewSparseVector(size, indices, values) =>
+        val (newIndices, newValues) = compressSparse(indices, values)
+        NewVectors.sparse(filterIndices.length, newIndices, newValues)
+      case NewDenseVector(values) =>
+        NewVectors.dense(compressDense(values))
+      case other =>
+        throw new UnsupportedOperationException(
+          s"Only sparse and dense vectors are supported but got ${other.getClass}.")
+    }
+  }
+
+  private def compressSparse(indices: Array[Int],
+                             values: Array[Double]): (Array[Int], Array[Double]) = {
+    val newValues = new ArrayBuilder.ofDouble
+    val newIndices = new ArrayBuilder.ofInt
+    var i = 0
+    var j = 0
+    var indicesIdx = 0
+    var filterIndicesIdx = 0
+    while (i < indices.length && j < filterIndices.length) {
+      indicesIdx = indices(i)
+      filterIndicesIdx = filterIndices(j)
+      if (indicesIdx == filterIndicesIdx) {
+        newIndices += j
+        newValues += values(i)
+        j += 1
+        i += 1
+      } else {
+        if (indicesIdx > filterIndicesIdx) {
+          j += 1
+        } else {
+          i += 1
+        }
+      }
+    }
+    // TODO: Sparse representation might be ineffective if (newSize ~= newValues.size)
+    (newIndices.result(), newValues.result())
+  }
+
+  private def compressDense(values: Array[Double]): Array[Double] = {
+    filterIndices.map(i => values(i))
   }
 
   @Since("1.6.0")

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/ChiSqSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/ChiSqSelector.scala
@@ -25,8 +25,6 @@ import org.json4s.jackson.JsonMethods._
 
 import org.apache.spark.SparkContext
 import org.apache.spark.annotation.Since
-import org.apache.spark.ml.linalg.{DenseVector => NewDenseVector,
-  SparseVector => NewSparseVector, Vector => NewVector, Vectors => NewVectors}
 import org.apache.spark.mllib.linalg.{DenseVector, SparseVector, Vector, Vectors}
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.stat.Statistics
@@ -87,21 +85,8 @@ class ChiSqSelectorModel @Since("1.3.0") (
     }
   }
 
-  private[spark] def compress(features: NewVector): NewVector = {
-    features match {
-      case NewSparseVector(size, indices, values) =>
-        val (newIndices, newValues) = compressSparse(indices, values)
-        NewVectors.sparse(filterIndices.length, newIndices, newValues)
-      case NewDenseVector(values) =>
-        NewVectors.dense(compressDense(values))
-      case other =>
-        throw new UnsupportedOperationException(
-          s"Only sparse and dense vectors are supported but got ${other.getClass}.")
-    }
-  }
-
-  private def compressSparse(indices: Array[Int],
-                             values: Array[Double]): (Array[Int], Array[Double]) = {
+  private[spark] def compressSparse(indices: Array[Int],
+                                    values: Array[Double]): (Array[Int], Array[Double]) = {
     val newValues = new ArrayBuilder.ofDouble
     val newIndices = new ArrayBuilder.ofInt
     var i = 0
@@ -128,7 +113,7 @@ class ChiSqSelectorModel @Since("1.3.0") (
     (newIndices.result(), newValues.result())
   }
 
-  private def compressDense(values: Array[Double]): Array[Double] = {
+  private[spark] def compressDense(values: Array[Double]): Array[Double] = {
     filterIndices.map(i => values(i))
   }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/ElementwiseProduct.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/ElementwiseProduct.scala
@@ -70,7 +70,7 @@ class ElementwiseProduct @Since("1.4.0") (
     val dim = newValues.length
     var i = 0
     while (i < dim) {
-      values(i) *= scalingVec(indices(i))
+      newValues(i) *= scalingVec(indices(i))
       i += 1
     }
     (indices, newValues)

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/ElementwiseProduct.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/ElementwiseProduct.scala
@@ -54,25 +54,25 @@ class ElementwiseProduct @Since("1.4.0") (
   }
 
   private[spark] def transformDense(values: Array[Double]): Array[Double] = {
-    val array = values.clone()
+    val newValues = values.clone()
     val dim = scalingVec.size
     var i = 0
     while (i < dim) {
-      array(i) *= scalingVec(i)
+      newValues(i) *= scalingVec(i)
       i += 1
     }
-    array
+    newValues
   }
 
   private[spark] def transformSparse(indices: Array[Int],
                                      values: Array[Double]): (Array[Int], Array[Double]) = {
-    val array = values.clone()
-    val dim = array.length
+    val newValues = values.clone()
+    val dim = newValues.length
     var i = 0
     while (i < dim) {
       values(i) *= scalingVec(indices(i))
       i += 1
     }
-    (indices, array)
+    (indices, newValues)
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/ElementwiseProduct.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/ElementwiseProduct.scala
@@ -41,25 +41,38 @@ class ElementwiseProduct @Since("1.4.0") (
     require(vector.size == scalingVec.size,
       s"vector sizes do not match: Expected ${scalingVec.size} but found ${vector.size}")
     vector match {
-      case dv: DenseVector =>
-        val values: Array[Double] = dv.values.clone()
-        val dim = scalingVec.size
-        var i = 0
-        while (i < dim) {
-          values(i) *= scalingVec(i)
-          i += 1
-        }
-        Vectors.dense(values)
-      case SparseVector(size, indices, vs) =>
-        val values = vs.clone()
-        val dim = values.length
-        var i = 0
-        while (i < dim) {
-          values(i) *= scalingVec(indices(i))
-          i += 1
-        }
-        Vectors.sparse(size, indices, values)
-      case v => throw new IllegalArgumentException("Does not support vector type " + v.getClass)
+      case DenseVector(values) =>
+        val newValues = transformDense(values)
+        Vectors.dense(newValues)
+      case SparseVector(size, indices, values) =>
+        val (newIndices, newValues) = transformSparse(indices, values)
+        Vectors.sparse(size, newIndices, newValues)
+      case other =>
+        throw new UnsupportedOperationException(
+          s"Only sparse and dense vectors are supported but got ${other.getClass}.")
     }
+  }
+
+  private[spark] def transformDense(values: Array[Double]): Array[Double] = {
+    val array = values.clone()
+    val dim = scalingVec.size
+    var i = 0
+    while (i < dim) {
+      array(i) *= scalingVec(i)
+      i += 1
+    }
+    array
+  }
+
+  private[spark] def transformSparse(indices: Array[Int],
+                                     values: Array[Double]): (Array[Int], Array[Double]) = {
+    val array = values.clone()
+    val dim = array.length
+    var i = 0
+    while (i < dim) {
+      values(i) *= scalingVec(indices(i))
+      i += 1
+    }
+    (indices, array)
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/HashingTF.scala
@@ -94,6 +94,11 @@ class HashingTF(val numFeatures: Int) extends Serializable {
    */
   @Since("1.1.0")
   def transform(document: Iterable[_]): Vector = {
+    val seq = transformImpl(document)
+    Vectors.sparse(numFeatures, seq)
+  }
+
+  private[spark] def transformImpl(document: Iterable[_]): Seq[(Int, Double)] = {
     val termFrequencies = mutable.HashMap.empty[Int, Double]
     val setTF = if (binary) (i: Int) => 1.0 else (i: Int) => termFrequencies.getOrElse(i, 0.0) + 1.0
     val hashFunc: Any => Int = getHashFunction
@@ -101,7 +106,7 @@ class HashingTF(val numFeatures: Int) extends Serializable {
       val i = Utils.nonNegativeMod(hashFunc(term), numFeatures)
       termFrequencies.put(i, setTF(i))
     }
-    Vectors.sparse(numFeatures, termFrequencies.toSeq)
+    termFrequencies.toSeq
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
@@ -203,7 +203,7 @@ class IDFModel private[spark](@Since("1.1.0") val idf: Vector,
   }
 }
 
-private object IDFModel {
+private[spark] object IDFModel {
 
   /**
    * Transforms a term frequency (TF) vector to a TF-IDF vector with a IDF vector
@@ -213,28 +213,41 @@ private object IDFModel {
    * @return a TF-IDF vector
    */
   def transform(idf: Vector, v: Vector): Vector = {
-    val n = v.size
     v match {
       case SparseVector(size, indices, values) =>
-        val nnz = indices.length
-        val newValues = new Array[Double](nnz)
-        var k = 0
-        while (k < nnz) {
-          newValues(k) = values(k) * idf(indices(k))
-          k += 1
-        }
-        Vectors.sparse(n, indices, newValues)
+        val (newIndices, newValues) = transformSparse(idf, indices, values)
+        Vectors.sparse(size, newIndices, newValues)
       case DenseVector(values) =>
-        val newValues = new Array[Double](n)
-        var j = 0
-        while (j < n) {
-          newValues(j) = values(j) * idf(j)
-          j += 1
-        }
+        val newValues = transformDense(idf, values)
         Vectors.dense(newValues)
       case other =>
         throw new UnsupportedOperationException(
           s"Only sparse and dense vectors are supported but got ${other.getClass}.")
     }
+  }
+
+  private[spark] def transformDense(idf: Vector,
+                                    values: Array[Double]): Array[Double] = {
+    val n = values.length
+    val newValues = new Array[Double](n)
+    var j = 0
+    while (j < n) {
+      newValues(j) = values(j) * idf(j)
+      j += 1
+    }
+    newValues
+  }
+
+  private[spark] def transformSparse(idf: Vector,
+                                     indices: Array[Int],
+                                     values: Array[Double]): (Array[Int], Array[Double]) = {
+    val nnz = indices.length
+    val newValues = new Array[Double](nnz)
+    var k = 0
+    while (k < nnz) {
+      newValues(k) = values(k) * idf(indices(k))
+      k += 1
+    }
+    (indices, newValues)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Make the transform natively in ml framework to avoid extra conversion.
There are many TODOs in current ml module, like `// TODO: Make the transformer natively in ml framework to avoid extra conversion.` in ChiSqSelector.
This PR is to make ml algs no longer need to convert ml-vector to mllib-vector in transforms.
Including: LDA/ChiSqSelector/ElementwiseProduct/HashingTF/IDF/Normalizer/PCA/StandardScaler.


## How was this patch tested?
existing testsuites
