### PR TITLE
[SPARK-28157][CORE] Make SHS clear KVStore `LogInfo`s for the blacklisted entries

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -177,7 +177,6 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
    */
   private def clearBlacklist(expireTimeInSeconds: Long): Unit = {
     val expiredThreshold = clock.getTimeMillis() - expireTimeInSeconds * 1000
-    blacklist.asScala.retain((_, creationTime) => creationTime >= expiredThreshold)
     blacklist.asScala.retain { (fileName, creationTime) =>
       val isCleared = creationTime >= expiredThreshold
       if (isCleared) {

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -1141,8 +1141,8 @@ class FsHistoryProviderSuite extends SparkFunSuite with Matchers with Logging {
     mockedProvider.cleanLogs()
     updateAndCheck(mockedProvider) { list =>
       assert(!mockedProvider.isBlacklisted(accessDeniedPath))
-      list.exists(_.name == "accessDenied")
-      list.exists(_.name == "accessGranted")
+      assert(list.exists(_.name == "accessDenied"))
+      assert(list.exists(_.name == "accessGranted"))
       list.size should be(2)
     }
   }

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -1141,6 +1141,8 @@ class FsHistoryProviderSuite extends SparkFunSuite with Matchers with Logging {
     mockedProvider.cleanLogs()
     updateAndCheck(mockedProvider) { list =>
       assert(!mockedProvider.isBlacklisted(accessDeniedPath))
+      list.exists(_.name == "accessDenied")
+      list.exists(_.name == "accessGranted")
       list.size should be(2)
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

At Spark 2.4.0/2.3.2/2.2.3, [SPARK-24948](https://issues.apache.org/jira/browse/SPARK-24948) delegated access permission checks to the file system, and maintains a blacklist for all event log files failed once at reading. The blacklisted log files are released back after `CLEAN_INTERVAL_S` seconds.

However, the released files whose sizes don't changes are ignored forever due to `info.fileSize < entry.getLen()` condition (previously [here](https://github.com/apache/spark/commit/3c96937c7b1d7a010b630f4b98fd22dafc37808b#diff-a7befb99e7bd7e3ab5c46c2568aa5b3eR454) and now at [shouldReloadLog](https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala#L571)) which returns `false` always when the size is the same with the existing value in `KVStore`. This is recovered only via SHS restart.

This PR aims to remove the existing entry from `KVStore` when it goes to the blacklist.

## How was this patch tested?

Pass the Jenkins with the updated test case.