### PR TITLE
[SPARK-28054][SQL][FOLLOW-UP] Fix error when insert Hive partitioned table dynamically where partition name is upper case

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/SaveAsHiveFile.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/SaveAsHiveFile.scala
@@ -89,7 +89,7 @@ private[hive] trait SaveAsHiveFile extends DataWritingCommand {
     // we also need to lowercase the column names in written partition paths.
     // scalastyle:off caselocale
     val hiveCompatiblePartitionColumns = partitionAttributes.map { attr =>
-     attr.withName(attr.name.toLowerCase)
+      attr.withName(attr.name.toLowerCase)
     }
     // scalastyle:on caselocale
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -1190,19 +1190,20 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
   }
 
   test("SPARK-28054: Unable to insert partitioned table when partition name is upper case") {
-    withTable("spark_28054_test") {
-      sql("set hive.exec.dynamic.partition.mode=nonstrict")
-      sql("CREATE TABLE spark_28054_test (KEY STRING, VALUE STRING) PARTITIONED BY (DS STRING)")
+    withSQLConf("hive.exec.dynamic.partition.mode" -> "nonstrict") {
+      withTable("spark_28054_test") {
+        sql("CREATE TABLE spark_28054_test (KEY STRING, VALUE STRING) PARTITIONED BY (DS STRING)")
 
-      sql("INSERT INTO TABLE spark_28054_test PARTITION(DS) SELECT 'k' KEY, 'v' VALUE, '1' DS")
+        sql("INSERT INTO TABLE spark_28054_test PARTITION(DS) SELECT 'k' KEY, 'v' VALUE, '1' DS")
 
-      assertResult(Array(Row("k", "v", "1"))) {
-        sql("SELECT * from spark_28054_test").collect()
-      }
+        assertResult(Array(Row("k", "v", "1"))) {
+          sql("SELECT * from spark_28054_test").collect()
+        }
 
-      sql("INSERT INTO TABLE spark_28054_test PARTITION(ds) SELECT 'k' key, 'v' value, '2' ds")
-      assertResult(Array(Row("k", "v", "1"), Row("k", "v", "2"))) {
-        sql("SELECT * from spark_28054_test").collect()
+        sql("INSERT INTO TABLE spark_28054_test PARTITION(ds) SELECT 'k' key, 'v' value, '2' ds")
+        assertResult(Array(Row("k", "v", "1"), Row("k", "v", "2"))) {
+          sql("SELECT * from spark_28054_test").collect()
+        }
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a small follow-up for SPARK-28054 to fix wrong indent and use `withSQLConf` as suggested by @gatorsmile.

## How was this patch tested?

Existing tests.