### PR TITLE
[SPARK-28164] Fix usage description of `start-slave.sh`

### DIFF
--- a/sbin/start-slave.sh
+++ b/sbin/start-slave.sh
@@ -40,7 +40,7 @@ fi
 CLASS="org.apache.spark.deploy.worker.Worker"
 
 if [[ $# -lt 1 ]] || [[ "$@" = *--help ]] || [[ "$@" = *-h ]]; then
-  echo "Usage: ./sbin/start-slave.sh [options] <master>"
+  echo "Usage: ./sbin/start-slave.sh <master> [options]"
   pattern="Usage:"
   pattern+="\|Using Spark's default log4j profile:"
   pattern+="\|Started daemon with process name"


### PR DESCRIPTION
## What changes were proposed in this pull request?

updated the usage message in sbin/start-slave.sh. 
<masterURL> argument moved to first

## How was this patch tested?
tested locally with 
Starting master
starting slave with (./start-slave.sh spark://<IP>:<PORT> -c 1
and opening spark shell with ./spark-shell --master spark://<IP>:<PORT> 