### PR TITLE
[SPARK-28174][BUILD][SS] Upgrade to Kafka 2.3.0

### DIFF
--- a/external/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/mocks/MockTime.scala
+++ b/external/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/mocks/MockTime.scala
@@ -17,7 +17,9 @@
 
 package org.apache.spark.streaming.kafka010.mocks
 
+import java.lang
 import java.util.concurrent._
+import java.util.function.Supplier
 
 import org.apache.kafka.common.utils.Time
 
@@ -47,6 +49,9 @@ private[kafka010] class MockTime(@volatile private var currentMs: Long) extends 
     this.currentMs += ms
     scheduler.tick()
   }
+
+  override def waitObject(obj: Any, condition: Supplier[lang.Boolean], timeoutMs: Long): Unit =
+    throw new UnsupportedOperationException
 
   override def toString(): String = s"MockTime($milliseconds)"
 

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
     <!-- Version used for internal directory structure -->
     <hive.version.short>1.2.1</hive.version.short>
     <!-- note that this should be compatible with Kafka brokers version 0.10 and up -->
-    <kafka.version>2.2.1</kafka.version>
+    <kafka.version>2.3.0</kafka.version>
     <derby.version>10.12.1.1</derby.version>
     <parquet.version>1.10.1</parquet.version>
     <orc.version>1.5.5</orc.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This issue updates Kafka dependency to 2.3.0 to bring the following 9 client-side patches at least. Among them, the blocker issue [KAFKA-7703](https://issues.apache.org/jira/browse/KAFKA-7703) was reported by Apache Spark community. This dependency update will help us remove the workaround later.
- https://issues.apache.org/jira/issues/?jql=project%20%3D%20KAFKA%20AND%20fixVersion%20%3D%202.3.0%20AND%20fixVersion%20NOT%20IN%20(2.2.0%2C%202.2.1)%20AND%20component%20%3D%20clients

The following is the full release note.
- https://www.apache.org/dist/kafka/2.3.0/RELEASE_NOTES.html

## How was this patch tested?

Pass the Jenkins.