### PR TITLE
[SPARK-28181][CORE] Add a filter interface to KVStore to speed up the entities retrieve

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
@@ -107,6 +107,12 @@ public class InMemoryStore implements KVStore {
   }
 
   @Override
+  public <T> KVStoreView<T> viewWithCondition(Class<T> type, Predicate<T> condition) {
+    InstanceList<T> list = inMemoryLists.get(type);
+    return list != null ? list.viewWithCondition(condition) : emptyView();
+  }
+
+  @Override
   public void close() {
     metadata = null;
     inMemoryLists.clear();
@@ -242,6 +248,12 @@ public class InMemoryStore implements KVStore {
 
     public InMemoryView<T> view() {
       return new InMemoryView<>(data.values(), ti);
+    }
+
+    public InMemoryView<T> viewWithCondition(Predicate<T> condition) {
+      return new InMemoryView<>(
+        data.values().stream().filter(condition).collect(Collectors.toList()),
+        ti);
     }
 
     private static <T> Predicate<? super T> getPredicate(

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStore.java
@@ -19,6 +19,7 @@ package org.apache.spark.util.kvstore;
 
 import java.io.Closeable;
 import java.util.Collection;
+import java.util.function.Predicate;
 
 import org.apache.spark.annotation.Private;
 
@@ -116,6 +117,11 @@ public interface KVStore extends Closeable {
    * Returns a configurable view for iterating over entities of the given type.
    */
   <T> KVStoreView<T> view(Class<T> type) throws Exception;
+
+  /**
+   * Returns a configurable view with condition for iterating over entities of the given type.
+   */
+  <T> KVStoreView<T> viewWithCondition(Class<T> type, Predicate<T> condition) throws Exception;
 
   /**
    * Returns the number of items of the given type currently in the store.

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
@@ -24,8 +24,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -207,10 +205,8 @@ public class LevelDB implements KVStore {
       @Override
       public Iterator<T> iterator() {
         try {
-          Iterator<T> base = new LevelDBIterator<>(type, LevelDB.this, this);
-          Iterable<T> iterable = () -> base;
-          Stream<T> toStream = StreamSupport.stream(iterable.spliterator(), false);
-          return toStream.filter(condition).iterator();
+          return new LevelDBFilterItertor(
+            new LevelDBIterator<>(type, LevelDB.this, this), condition);
         } catch (Exception e) {
           throw Throwables.propagate(e);
         }

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
@@ -205,7 +205,7 @@ public class LevelDB implements KVStore {
       @Override
       public Iterator<T> iterator() {
         try {
-          return new LevelDBFilterItertor(
+          return new LevelDBFilterIterator(
             new LevelDBIterator<>(type, LevelDB.this, this), condition);
         } catch (Exception e) {
           throw Throwables.propagate(e);

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBFilterIterator.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBFilterIterator.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Predicate;
 
-class LevelDBFilterItertor<T> implements KVStoreIterator<T>  {
+class LevelDBFilterIterator<T> implements KVStoreIterator<T>  {
 
   /** The LevelDBIterator being used */
   private final LevelDBIterator<T> iterator;
@@ -34,7 +34,7 @@ class LevelDBFilterItertor<T> implements KVStoreIterator<T>  {
   /** Whether the next object has been calculated yet */
   private boolean nextObjectSet = false;
 
-  LevelDBFilterItertor(LevelDBIterator<T> iterator, Predicate<T> predicate) {
+  LevelDBFilterIterator(LevelDBIterator<T> iterator, Predicate<T> predicate) {
     this.iterator = iterator;
     this.predicate = predicate;
   }

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBFilterItertor.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBFilterItertor.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util.kvstore;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.function.Predicate;
+
+class LevelDBFilterItertor<T> implements KVStoreIterator<T>  {
+
+  /** The LevelDBIterator being used */
+  private final LevelDBIterator<T> iterator;
+  private final Predicate<? super T> predicate;
+
+  /** The next object in the iteration */
+  private T nextObject;
+  /** Whether the next object has been calculated yet */
+  private boolean nextObjectSet = false;
+
+  LevelDBFilterItertor(LevelDBIterator<T> iterator, Predicate<T> predicate) {
+    this.iterator = iterator;
+    this.predicate = predicate;
+  }
+
+  /**
+   * Returns true if the underlying iterator contains an object that
+   * matches the predicate.
+   */
+  @Override
+  public boolean hasNext() {
+    return nextObjectSet || setNextObject();
+  }
+
+  /**
+   * Returns the next object that matches the predicate.
+   */
+  @Override
+  public T next() {
+    if (!nextObjectSet && !setNextObject()) {
+      throw new NoSuchElementException();
+    }
+    nextObjectSet = false;
+    return nextObject;
+  }
+
+  @Override
+  public List<T> next(int max) {
+    List<T> list = new ArrayList<>(max);
+    while (hasNext() && list.size() < max) {
+      list.add(next());
+    }
+    return list;
+  }
+
+  @Override
+  public boolean skip(long n) {
+    return iterator.skip(n);
+  }
+
+  @Override
+  public void close() throws IOException {
+    iterator.close();
+  }
+
+  @Override
+  public void remove() {
+    iterator.remove();
+  }
+
+  /**
+   * Set nextObject to the next object. If there are no more
+   * objects then return false. Otherwise, return true.
+   */
+  private boolean setNextObject() {
+    while (iterator.hasNext()) {
+      final T object = iterator.next();
+      if (predicate.test(object)) {
+        nextObject = object;
+        nextObjectSet = true;
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/InMemoryStoreSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/InMemoryStoreSuite.java
@@ -17,7 +17,11 @@
 
 package org.apache.spark.util.kvstore;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
@@ -204,4 +208,30 @@ public class InMemoryStoreSuite {
     assertFalse(store.view(t1.getClass()).first(t2.id).skip(1).iterator().hasNext());
   }
 
+  @Test
+  public void testRetrieveWithCondition() throws Exception {
+    KVStore store = new InMemoryStore();
+
+    List<Integer> expected = Arrays.asList(0, 2, 4, 6, 8);
+    for (int i = 0; i < 10; i++) {
+      store.write(createCustomType1(i));
+    }
+
+    KVStoreView<CustomType1> actual = store.viewWithCondition(CustomType1.class,
+      c -> c.num % 2 == 0);
+
+    assertEquals(expected, StreamSupport.stream(actual.spliterator(), false)
+      .map(e -> e.num)
+      .collect(Collectors.toList()));
+  }
+
+  private CustomType1 createCustomType1(int i) {
+    CustomType1 t = new CustomType1();
+    t.key = "key" + i;
+    t.id = "id" + i;
+    t.name = "name" + i;
+    t.num = i;
+    t.child = "child" + i;
+    return t;
+  }
 }

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -276,6 +276,21 @@ public class LevelDBSuite {
     assertEquals(expected, results);
   }
 
+  @Test
+  public void testRetrieveWithCondition() throws Exception {
+    List<Integer> expected = Arrays.asList(0, 2, 4, 6, 8);
+    for (int i = 0; i < 10; i++) {
+      db.write(createCustomType1(i));
+    }
+
+    KVStoreView<CustomType1> actual = db.viewWithCondition(CustomType1.class,
+      c -> c.num % 2 == 0);
+
+    assertEquals(expected, StreamSupport.stream(actual.spliterator(), false)
+      .map(e -> e.num)
+      .collect(Collectors.toList()));
+  }
+
   private CustomType1 createCustomType1(int i) {
     CustomType1 t = new CustomType1();
     t.key = "key" + i;

--- a/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
@@ -45,12 +45,9 @@ private[spark] class AppStatusStore(
   }
 
   def jobsList(statuses: JList[JobExecutionStatus]): Seq[v1.JobData] = {
-    val it = store.view(classOf[JobDataWrapper]).reverse().asScala.map(_.info)
-    if (statuses != null && !statuses.isEmpty()) {
-      it.filter { job => statuses.contains(job.status) }.toSeq
-    } else {
-      it.toSeq
-    }
+    store.viewWithCondition(classOf[JobDataWrapper], (j: JobDataWrapper) =>
+      if (statuses != null && !statuses.isEmpty()) statuses.contains(j.info.status) else true
+    ).reverse().asScala.map(_.info).toSeq
   }
 
   def job(jobId: Int): v1.JobData = {
@@ -87,12 +84,9 @@ private[spark] class AppStatusStore(
   }
 
   def stageList(statuses: JList[v1.StageStatus]): Seq[v1.StageData] = {
-    val it = store.view(classOf[StageDataWrapper]).reverse().asScala.map(_.info)
-    if (statuses != null && !statuses.isEmpty()) {
-      it.filter { s => statuses.contains(s.status) }.toSeq
-    } else {
-      it.toSeq
-    }
+    store.viewWithCondition(classOf[StageDataWrapper], (s: StageDataWrapper) =>
+      if (statuses != null && !statuses.isEmpty()) statuses.contains(s.info.status) else true
+    ).reverse().asScala.map(_.info).toSeq
   }
 
   def stageData(stageId: Int, details: Boolean = false): Seq[v1.StageData] = {

--- a/core/src/main/scala/org/apache/spark/status/ElementTrackingStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/ElementTrackingStore.scala
@@ -20,6 +20,7 @@ package org.apache.spark.status
 import java.util.Collection
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.function.Predicate
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.{HashMap, ListBuffer}
@@ -197,6 +198,9 @@ private[spark] class ElementTrackingStore(store: KVStore, conf: SparkConf) exten
       threshold: Long,
       action: Long => Unit)
 
+  override def viewWithCondition[T](klass: Class[T], condition: Predicate[T]): KVStoreView[T] = {
+    store.viewWithCondition(klass, condition)
+  }
 }
 
 private[spark] object ElementTrackingStore {

--- a/core/src/main/scala/org/apache/spark/status/KVUtils.scala
+++ b/core/src/main/scala/org/apache/spark/status/KVUtils.scala
@@ -82,6 +82,18 @@ private[spark] object KVUtils extends Logging {
     }
   }
 
+  /** Turns a KVStoreView into a Scala sequence. */
+  def viewToSeqPurely[T](
+      view: KVStoreView[T],
+      max: Int): Seq[T] = {
+    val iter = view.closeableIterator()
+    try {
+      iter.asScala.take(max).toSeq
+    } finally {
+      iter.close()
+    }
+  }
+
   private[spark] class MetadataMismatchException extends Exception
 
 }

--- a/core/src/main/scala/org/apache/spark/status/api/v1/StagesResource.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/StagesResource.scala
@@ -96,8 +96,9 @@ private[v1] class StagesResource extends BaseAppResource {
       @PathParam("stageAttemptId") stageAttemptId: Int,
       @DefaultValue("0") @QueryParam("offset") offset: Int,
       @DefaultValue("20") @QueryParam("length") length: Int,
-      @DefaultValue("ID") @QueryParam("sortBy") sortBy: TaskSorting): Seq[TaskData] = {
-    withUI(_.store.taskList(stageId, stageAttemptId, offset, length, sortBy))
+      @DefaultValue("ID") @QueryParam("sortBy") sortBy: TaskSorting,
+      @QueryParam("status") status: String): Seq[TaskData] = {
+    withUI(_.store.taskList(stageId, stageAttemptId, offset, length, sortBy, Option(status)))
   }
 
   // This api needs to stay formatted exactly as it is below, since, it is being used by the

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListener.scala
@@ -379,8 +379,9 @@ class SQLAppStatusListener(
       return
     }
 
-    val view = kvstore.view(classOf[SQLExecutionUIData]).index("completionTime").first(0L)
-    val toDelete = KVUtils.viewToSeq(view, countToDelete.toInt)(_.completionTime.isDefined)
+    val view = kvstore.viewWithCondition(classOf[SQLExecutionUIData], (e: SQLExecutionUIData) =>
+      e.completionTime.isDefined).index("completionTime").first(0L)
+    val toDelete = KVUtils.viewToSeqPurely(view, countToDelete.toInt)
     toDelete.foreach { e =>
       kvstore.delete(e.getClass(), e.executionId)
       kvstore.delete(classOf[SparkPlanGraphWrapper], e.executionId)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Current entities in KVStore only could be retrieved all or none by `KVStore.view`. This ticket adding a filter interface to KVStore to speed up the entities retrieve.

#24984 is a case that needs to filter in KVStore. Filtering after pagination could not work as expected. (Assume 100 items per page, filtering after pagination may get four pages but each of page only contains several items. Actually one page could contains all the filtered item).

## How was this patch tested?

Add UTs.
