### PR TITLE
[SPARK-28184][SQL][TEST] Avoid creating new sessions in SparkMetadataOperationSuite

### DIFF
--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkMetadataOperationSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkMetadataOperationSuite.scala
@@ -25,16 +25,12 @@ class SparkMetadataOperationSuite extends HiveThriftJdbcTest {
 
   test("Spark's own GetSchemasOperation(SparkGetSchemasOperation)") {
     def checkResult(rs: ResultSet, dbNames: Seq[String]): Unit = {
-      if (dbNames.nonEmpty) {
-        for (i <- dbNames.indices) {
-          assert(rs.next())
-          assert(rs.getString("TABLE_SCHEM") === dbNames(i))
-        }
-        // Make sure there are no more elements
-        assert(!rs.next())
-      } else {
-        assert(!rs.next())
+      for (i <- dbNames.indices) {
+        assert(rs.next())
+        assert(rs.getString("TABLE_SCHEM") === dbNames(i))
       }
+      // Make sure there are no more elements
+      assert(!rs.next())
     }
 
     withDatabase("db1", "db2") { statement =>
@@ -52,16 +48,12 @@ class SparkMetadataOperationSuite extends HiveThriftJdbcTest {
 
   test("Spark's own GetTablesOperation(SparkGetTablesOperation)") {
     def checkResult(rs: ResultSet, tableNames: Seq[String]): Unit = {
-      if (tableNames.nonEmpty) {
-        for (i <- tableNames.indices) {
-          assert(rs.next())
-          assert(rs.getString("TABLE_NAME") === tableNames(i))
-        }
-        // Make sure there are no more elements
-        assert(!rs.next())
-      } else {
-        assert(!rs.next())
+      for (i <- tableNames.indices) {
+        assert(rs.next())
+        assert(rs.getString("TABLE_NAME") === tableNames(i))
       }
+      // Make sure there are no more elements
+      assert(!rs.next())
     }
 
     withJdbcStatement("table1", "table2", "view1") { statement =>
@@ -97,21 +89,17 @@ class SparkMetadataOperationSuite extends HiveThriftJdbcTest {
     def checkResult(
         rs: ResultSet,
         columns: Seq[(String, String, String, String, String)]) : Unit = {
-      if (columns.nonEmpty) {
-        for (i <- columns.indices) {
-          assert(rs.next())
-          val col = columns(i)
-          assert(rs.getString("TABLE_NAME") === col._1)
-          assert(rs.getString("COLUMN_NAME") === col._2)
-          assert(rs.getString("DATA_TYPE") === col._3)
-          assert(rs.getString("TYPE_NAME") === col._4)
-          assert(rs.getString("REMARKS") === col._5)
-        }
-        // Make sure there are no more elements
-        assert(!rs.next())
-      } else {
-        assert(!rs.next())
+      for (i <- columns.indices) {
+        assert(rs.next())
+        val col = columns(i)
+        assert(rs.getString("TABLE_NAME") === col._1)
+        assert(rs.getString("COLUMN_NAME") === col._2)
+        assert(rs.getString("DATA_TYPE") === col._3)
+        assert(rs.getString("TYPE_NAME") === col._4)
+        assert(rs.getString("REMARKS") === col._5)
       }
+      // Make sure there are no more elements
+      assert(!rs.next())
     }
 
     withJdbcStatement("table1", "table2", "view1") { statement =>

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkMetadataOperationSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkMetadataOperationSuite.scala
@@ -17,63 +17,21 @@
 
 package org.apache.spark.sql.hive.thriftserver
 
-import java.util.{Arrays => JArrays, List => JList, Properties}
-
-import org.apache.hive.jdbc.{HiveConnection, HiveQueryResultSet}
-import org.apache.hive.service.auth.PlainSaslHelper
-import org.apache.thrift.protocol.TBinaryProtocol
-import org.apache.thrift.transport.TSocket
+import java.sql.ResultSet
 
 class SparkMetadataOperationSuite extends HiveThriftJdbcTest {
 
   override def mode: ServerMode.Value = ServerMode.binary
 
   test("Spark's own GetSchemasOperation(SparkGetSchemasOperation)") {
-    def testGetSchemasOperation(
-        catalog: String,
-        schemaPattern: String)(f: HiveQueryResultSet => Unit): Unit = {
-      val rawTransport = new TSocket("localhost", serverPort)
-      val connection = new HiveConnection(s"jdbc:hive2://localhost:$serverPort", new Properties)
-      val user = System.getProperty("user.name")
-      val transport = PlainSaslHelper.getPlainTransport(user, "anonymous", rawTransport)
-      val client = new ThriftserverShimUtils.Client(new TBinaryProtocol(transport))
-      transport.open()
-      var rs: HiveQueryResultSet = null
-      try {
-        val openResp = client.OpenSession(new ThriftserverShimUtils.TOpenSessionReq)
-        val sessHandle = openResp.getSessionHandle
-        val schemaReq = new ThriftserverShimUtils.TGetSchemasReq(sessHandle)
-
-        if (catalog != null) {
-          schemaReq.setCatalogName(catalog)
-        }
-
-        if (schemaPattern == null) {
-          schemaReq.setSchemaName("%")
-        } else {
-          schemaReq.setSchemaName(schemaPattern)
-        }
-
-        rs = new HiveQueryResultSet.Builder(connection)
-          .setClient(client)
-          .setSessionHandle(sessHandle)
-          .setStmtHandle(client.GetSchemas(schemaReq).getOperationHandle)
-          .build()
-        f(rs)
-      } finally {
-        rs.close()
-        connection.close()
-        transport.close()
-        rawTransport.close()
-      }
-    }
-
-    def checkResult(dbNames: Seq[String], rs: HiveQueryResultSet): Unit = {
+    def checkResult(rs: ResultSet, dbNames: Seq[String]): Unit = {
       if (dbNames.nonEmpty) {
         for (i <- dbNames.indices) {
           assert(rs.next())
           assert(rs.getString("TABLE_SCHEM") === dbNames(i))
         }
+        // Make sure there are no more elements
+        assert(!rs.next())
       } else {
         assert(!rs.next())
       }
@@ -82,65 +40,25 @@ class SparkMetadataOperationSuite extends HiveThriftJdbcTest {
     withDatabase("db1", "db2") { statement =>
       Seq("CREATE DATABASE db1", "CREATE DATABASE db2").foreach(statement.execute)
 
-      testGetSchemasOperation(null, "%") { rs =>
-        checkResult(Seq("db1", "db2"), rs)
-      }
-      testGetSchemasOperation(null, "db1") { rs =>
-        checkResult(Seq("db1"), rs)
-      }
-      testGetSchemasOperation(null, "db_not_exist") { rs =>
-        checkResult(Seq.empty, rs)
-      }
-      testGetSchemasOperation(null, "db*") { rs =>
-        checkResult(Seq("db1", "db2"), rs)
-      }
+      val metaData = statement.getConnection.getMetaData
+
+      checkResult(metaData.getSchemas(null, "%"),
+        Seq("db1", "db2", "default"))
+      checkResult(metaData.getSchemas(null, "db1"), Seq("db1"))
+      checkResult(metaData.getSchemas(null, "db_not_exist"), Seq.empty)
+      checkResult(metaData.getSchemas(null, "db*"), Seq("db1", "db2"))
     }
   }
 
   test("Spark's own GetTablesOperation(SparkGetTablesOperation)") {
-    def testGetTablesOperation(
-        schema: String,
-        tableNamePattern: String,
-        tableTypes: JList[String])(f: HiveQueryResultSet => Unit): Unit = {
-      val rawTransport = new TSocket("localhost", serverPort)
-      val connection = new HiveConnection(s"jdbc:hive2://localhost:$serverPort", new Properties)
-      val user = System.getProperty("user.name")
-      val transport = PlainSaslHelper.getPlainTransport(user, "anonymous", rawTransport)
-      val client = new ThriftserverShimUtils.Client(new TBinaryProtocol(transport))
-      transport.open()
-
-      var rs: HiveQueryResultSet = null
-
-      try {
-        val openResp = client.OpenSession(new ThriftserverShimUtils.TOpenSessionReq)
-        val sessHandle = openResp.getSessionHandle
-
-        val getTableReq = new ThriftserverShimUtils.TGetTablesReq(sessHandle)
-        getTableReq.setSchemaName(schema)
-        getTableReq.setTableName(tableNamePattern)
-        getTableReq.setTableTypes(tableTypes)
-
-        rs = new HiveQueryResultSet.Builder(connection)
-          .setClient(client)
-          .setSessionHandle(sessHandle)
-          .setStmtHandle(client.GetTables(getTableReq).getOperationHandle)
-          .build()
-
-        f(rs)
-      } finally {
-        rs.close()
-        connection.close()
-        transport.close()
-        rawTransport.close()
-      }
-    }
-
-    def checkResult(tableNames: Seq[String], rs: HiveQueryResultSet): Unit = {
+    def checkResult(rs: ResultSet, tableNames: Seq[String]): Unit = {
       if (tableNames.nonEmpty) {
         for (i <- tableNames.indices) {
           assert(rs.next())
           assert(rs.getString("TABLE_NAME") === tableNames(i))
         }
+        // Make sure there are no more elements
+        assert(!rs.next())
       } else {
         assert(!rs.next())
       }
@@ -150,75 +68,35 @@ class SparkMetadataOperationSuite extends HiveThriftJdbcTest {
       Seq(
         "CREATE TABLE table1(key INT, val STRING)",
         "CREATE TABLE table2(key INT, val STRING)",
-        "CREATE VIEW view1 AS SELECT * FROM table2").foreach(statement.execute)
+        "CREATE VIEW view1 AS SELECT * FROM table2",
+        "CREATE OR REPLACE GLOBAL TEMPORARY VIEW view_global_temp_1 AS SELECT 1 AS col1",
+        "CREATE OR REPLACE TEMPORARY VIEW view_temp_1 AS SELECT 1 as col1"
+      ).foreach(statement.execute)
 
-      testGetTablesOperation("%", "%", null) { rs =>
-        checkResult(Seq("table1", "table2", "view1"), rs)
-      }
+      val metaData = statement.getConnection.getMetaData
 
-      testGetTablesOperation("%", "table1", null) { rs =>
-        checkResult(Seq("table1"), rs)
-      }
+      checkResult(metaData.getTables(null, "%", "%", null),
+        Seq("table1", "table2", "view1"))
 
-      testGetTablesOperation("%", "table_not_exist", null) { rs =>
-        checkResult(Seq.empty, rs)
-      }
+      checkResult(metaData.getTables(null, "%", "table1", null), Seq("table1"))
 
-      testGetTablesOperation("%", "%", JArrays.asList("TABLE")) { rs =>
-        checkResult(Seq("table1", "table2"), rs)
-      }
+      checkResult(metaData.getTables(null, "%", "table_not_exist", null), Seq.empty)
 
-      testGetTablesOperation("%", "%", JArrays.asList("VIEW")) { rs =>
-        checkResult(Seq("view1"), rs)
-      }
+      checkResult(metaData.getTables(null, "%", "%", Array("TABLE")),
+        Seq("table1", "table2"))
 
-      testGetTablesOperation("%", "%", JArrays.asList("TABLE", "VIEW")) { rs =>
-        checkResult(Seq("table1", "table2", "view1"), rs)
-      }
+      checkResult(metaData.getTables(null, "%", "%", Array("VIEW")),
+        Seq("view1"))
+
+      checkResult(metaData.getTables(null, "%", "%", Array("TABLE", "VIEW")),
+        Seq("table1", "table2", "view1"))
     }
   }
 
   test("Spark's own GetColumnsOperation(SparkGetColumnsOperation)") {
-    def testGetColumnsOperation(
-        schema: String,
-        tableNamePattern: String,
-        columnNamePattern: String)(f: HiveQueryResultSet => Unit): Unit = {
-      val rawTransport = new TSocket("localhost", serverPort)
-      val connection = new HiveConnection(s"jdbc:hive2://localhost:$serverPort", new Properties)
-      val user = System.getProperty("user.name")
-      val transport = PlainSaslHelper.getPlainTransport(user, "anonymous", rawTransport)
-      val client = new ThriftserverShimUtils.Client(new TBinaryProtocol(transport))
-      transport.open()
-
-      var rs: HiveQueryResultSet = null
-
-      try {
-        val openResp = client.OpenSession(new ThriftserverShimUtils.TOpenSessionReq)
-        val sessHandle = openResp.getSessionHandle
-
-        val getColumnsReq = new ThriftserverShimUtils.TGetColumnsReq(sessHandle)
-        getColumnsReq.setSchemaName(schema)
-        getColumnsReq.setTableName(tableNamePattern)
-        getColumnsReq.setColumnName(columnNamePattern)
-
-        rs = new HiveQueryResultSet.Builder(connection)
-          .setClient(client)
-          .setSessionHandle(sessHandle)
-          .setStmtHandle(client.GetColumns(getColumnsReq).getOperationHandle)
-          .build()
-
-        f(rs)
-      } finally {
-        rs.close()
-        connection.close()
-        transport.close()
-        rawTransport.close()
-      }
-    }
-
     def checkResult(
-        columns: Seq[(String, String, String, String, String)],
-        rs: HiveQueryResultSet) : Unit = {
+        rs: ResultSet,
+        columns: Seq[(String, String, String, String, String)]) : Unit = {
       if (columns.nonEmpty) {
         for (i <- columns.indices) {
           assert(rs.next())
@@ -229,6 +107,8 @@ class SparkMetadataOperationSuite extends HiveThriftJdbcTest {
           assert(rs.getString("TYPE_NAME") === col._4)
           assert(rs.getString("REMARKS") === col._5)
         }
+        // Make sure there are no more elements
+        assert(!rs.next())
       } else {
         assert(!rs.next())
       }
@@ -238,33 +118,30 @@ class SparkMetadataOperationSuite extends HiveThriftJdbcTest {
       Seq(
         "CREATE TABLE table1(key INT comment 'Int column', val STRING comment 'String column')",
         "CREATE TABLE table2(key INT, val DECIMAL comment 'Decimal column')",
-        "CREATE VIEW view1 AS SELECT key FROM table1"
+        "CREATE VIEW view1 AS SELECT key FROM table1",
+        "CREATE OR REPLACE GLOBAL TEMPORARY VIEW view_global_temp_1 AS SELECT 2 AS col2",
+        "CREATE OR REPLACE TEMPORARY VIEW view_temp_1 AS SELECT 2 as col2"
       ).foreach(statement.execute)
 
-      testGetColumnsOperation("%", "%", null) { rs =>
-        checkResult(
-          Seq(
-            ("table1", "key", "4", "INT", "Int column"),
-            ("table1", "val", "12", "STRING", "String column"),
-            ("table2", "key", "4", "INT", ""),
-            ("table2", "val", "3", "DECIMAL(10,0)", "Decimal column"),
-            ("view1", "key", "4", "INT", "Int column")), rs)
-      }
+      val metaData = statement.getConnection.getMetaData
 
-      testGetColumnsOperation("%", "table1", null) { rs =>
-        checkResult(
-          Seq(
-            ("table1", "key", "4", "INT", "Int column"),
-            ("table1", "val", "12", "STRING", "String column")), rs)
-      }
+      checkResult(metaData.getColumns(null, "%", "%", null),
+        Seq(
+          ("table1", "key", "4", "INT", "Int column"),
+          ("table1", "val", "12", "STRING", "String column"),
+          ("table2", "key", "4", "INT", ""),
+          ("table2", "val", "3", "DECIMAL(10,0)", "Decimal column"),
+          ("view1", "key", "4", "INT", "Int column")))
 
-      testGetColumnsOperation("%", "table1", "key") { rs =>
-        checkResult(Seq(("table1", "key", "4", "INT", "Int column")), rs)
-      }
+      checkResult(metaData.getColumns(null, "%", "table1", null),
+        Seq(
+          ("table1", "key", "4", "INT", "Int column"),
+          ("table1", "val", "12", "STRING", "String column")))
 
-      testGetColumnsOperation("%", "table_not_exist", null) { rs =>
-        checkResult(Seq.empty, rs)
-      }
+      checkResult(metaData.getColumns(null, "%", "table1", "key"),
+        Seq(("table1", "key", "4", "INT", "Int column")))
+
+      checkResult(metaData.getColumns(null, "%", "table_not_exist", null), Seq.empty)
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

To make the #24972 change smaller. This pr improves `SparkMetadataOperationSuite` to avoid creating new sessions when getSchemas/getTables/getColumns.

## How was this patch tested?

N/A
