### PR TITLE
[SPARK-28185][PYTHON][SQL] Closes the generator when Python UDFs stop early

### DIFF
--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -68,8 +68,6 @@ else:
     xrange = range
 pickle_protocol = pickle.HIGHEST_PROTOCOL
 
-from types import GeneratorType
-
 from pyspark import cloudpickle
 from pyspark.util import _exception_message
 
@@ -237,12 +235,6 @@ class ArrowStreamSerializer(Serializer):
                 if writer is None:
                     writer = pa.RecordBatchStreamWriter(stream, batch.schema)
                 writer.write_batch(batch)
-        except BaseException as be:
-            if isinstance(iterator, GeneratorType):
-                # if the iterator is a generator, it may include some code for
-                # closing resources.
-                iterator.close()
-            raise be
         finally:
             if writer is not None:
                 writer.close()

--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -68,6 +68,8 @@ else:
     xrange = range
 pickle_protocol = pickle.HIGHEST_PROTOCOL
 
+from types import GeneratorType
+
 from pyspark import cloudpickle
 from pyspark.util import _exception_message
 
@@ -235,6 +237,12 @@ class ArrowStreamSerializer(Serializer):
                 if writer is None:
                     writer = pa.RecordBatchStreamWriter(stream, batch.schema)
                 writer.write_batch(batch)
+        except BaseException as be:
+            if isinstance(iterator, GeneratorType):
+                # if the iterator is a generator, it may include some code for
+                # closing resources.
+                iterator.close()
+            raise be
         finally:
             if writer is not None:
                 writer.close()

--- a/python/pyspark/sql/tests/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/test_pandas_udf_scalar.py
@@ -850,6 +850,36 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
             with self.assertRaisesRegexp(Exception, "reached finally block"):
                 self.spark.range(1).select(test_close(col("id"))).collect()
 
+    def test_scalar_iter_udf_close_early(self):
+        tmp_dir = tempfile.mkdtemp()
+
+        @pandas_udf('int', PandasUDFType.SCALAR_ITER)
+        def test_close(batch_iter):
+            generator_exit_caught = False
+            try:
+                for batch in batch_iter:
+                    yield batch
+                    time.sleep(0.5)
+            except GeneratorExit as ge:
+                generator_exit_caught = True
+                raise ge
+            finally:
+                assert generator_exit_caught, "Generator exit exception was not caught."
+                open(tmp_dir + '/reach_finally_block', 'a').close()
+
+        with QuietTest(self.sc):
+            with self.sql_conf({"spark.sql.execution.arrow.maxRecordsPerBatch": 1,
+                                "spark.sql.pandas.udf.buffer.size": 4}):
+                self.spark.range(10).repartition(1) \
+                    .select(test_close(col("id"))).limit(2).collect()
+                # sleep here because python udf worker will take some time to detect
+                # jvm side socket closed and then will trigger `GenerateExit` raised.
+                time.sleep(3.0)
+                assert os.path.exists(tmp_dir + '/reach_finally_block'), \
+                    "finally block not reached."
+
+        shutil.rmtree(tmp_dir)
+
     # Regression test for SPARK-23314
     def test_timestamp_dst(self):
         # Daylight saving time for Los Angeles for 2015 is Sun, Nov 1 at 2:00 am

--- a/python/pyspark/sql/tests/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/test_pandas_udf_scalar.py
@@ -852,6 +852,7 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
 
     def test_scalar_iter_udf_close_early(self):
         tmp_dir = tempfile.mkdtemp()
+        tmp_file = tmp_dir + '/reach_finally_block'
 
         @pandas_udf('int', PandasUDFType.SCALAR_ITER)
         def test_close(batch_iter):
@@ -859,23 +860,28 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
             try:
                 for batch in batch_iter:
                     yield batch
-                    time.sleep(0.5)
+                time.sleep(10.0) # avoid the function finish too fast.
             except GeneratorExit as ge:
                 generator_exit_caught = True
                 raise ge
             finally:
                 assert generator_exit_caught, "Generator exit exception was not caught."
-                open(tmp_dir + '/reach_finally_block', 'a').close()
+                open(tmp_file, 'a').close()
 
         with QuietTest(self.sc):
             with self.sql_conf({"spark.sql.execution.arrow.maxRecordsPerBatch": 1,
                                 "spark.sql.pandas.udf.buffer.size": 4}):
                 self.spark.range(10).repartition(1) \
                     .select(test_close(col("id"))).limit(2).collect()
-                # sleep here because python udf worker will take some time to detect
+                # wait here because python udf worker will take some time to detect
                 # jvm side socket closed and then will trigger `GenerateExit` raised.
-                time.sleep(3.0)
-                assert os.path.exists(tmp_dir + '/reach_finally_block'), \
+                # wait timeout is 10s.
+                for i in range(100):
+                    time.sleep(0.1)
+                    if os.path.exists(tmp_file):
+                        break
+
+                assert os.path.exists(tmp_file), \
                     "finally block not reached."
 
         shutil.rmtree(tmp_dir)

--- a/python/pyspark/sql/tests/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/test_pandas_udf_scalar.py
@@ -852,39 +852,40 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
 
     def test_scalar_iter_udf_close_early(self):
         tmp_dir = tempfile.mkdtemp()
-        tmp_file = tmp_dir + '/reach_finally_block'
+        try:
+            tmp_file = tmp_dir + '/reach_finally_block'
 
-        @pandas_udf('int', PandasUDFType.SCALAR_ITER)
-        def test_close(batch_iter):
-            generator_exit_caught = False
-            try:
-                for batch in batch_iter:
-                    yield batch
-                time.sleep(10.0)  # avoid the function finish too fast.
-            except GeneratorExit as ge:
-                generator_exit_caught = True
-                raise ge
-            finally:
-                assert generator_exit_caught, "Generator exit exception was not caught."
-                open(tmp_file, 'a').close()
+            @pandas_udf('int', PandasUDFType.SCALAR_ITER)
+            def test_close(batch_iter):
+                generator_exit_caught = False
+                try:
+                    for batch in batch_iter:
+                        yield batch
+                        time.sleep(1.0)  # avoid the function finish too fast.
+                except GeneratorExit as ge:
+                    generator_exit_caught = True
+                    raise ge
+                finally:
+                    assert generator_exit_caught, "Generator exit exception was not caught."
+                    open(tmp_file, 'a').close()
 
-        with QuietTest(self.sc):
-            with self.sql_conf({"spark.sql.execution.arrow.maxRecordsPerBatch": 1,
-                                "spark.sql.pandas.udf.buffer.size": 4}):
-                self.spark.range(10).repartition(1) \
-                    .select(test_close(col("id"))).limit(2).collect()
-                # wait here because python udf worker will take some time to detect
-                # jvm side socket closed and then will trigger `GenerateExit` raised.
-                # wait timeout is 10s.
-                for i in range(100):
-                    time.sleep(0.1)
-                    if os.path.exists(tmp_file):
-                        break
+            with QuietTest(self.sc):
+                with self.sql_conf({"spark.sql.execution.arrow.maxRecordsPerBatch": 1,
+                                    "spark.sql.pandas.udf.buffer.size": 4}):
+                    self.spark.range(10).repartition(1) \
+                        .select(test_close(col("id"))).limit(2).collect()
+                    # wait here because python udf worker will take some time to detect
+                    # jvm side socket closed and then will trigger `GenerateExit` raised.
+                    # wait timeout is 10s.
+                    for i in range(100):
+                        time.sleep(0.1)
+                        if os.path.exists(tmp_file):
+                            break
 
-                assert os.path.exists(tmp_file), \
-                    "finally block not reached."
+                    assert os.path.exists(tmp_file), "finally block not reached."
 
-        shutil.rmtree(tmp_dir)
+        finally:
+            shutil.rmtree(tmp_dir)
 
     # Regression test for SPARK-23314
     def test_timestamp_dst(self):

--- a/python/pyspark/sql/tests/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/test_pandas_udf_scalar.py
@@ -860,7 +860,7 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
             try:
                 for batch in batch_iter:
                     yield batch
-                time.sleep(10.0) # avoid the function finish too fast.
+                time.sleep(10.0)  # avoid the function finish too fast.
             except GeneratorExit as ge:
                 generator_exit_caught = True
                 raise ge

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -29,7 +29,6 @@ try:
 except ImportError:
     has_resource_module = False
 import traceback
-from types import GeneratorType
 
 from pyspark.accumulators import _accumulatorRegistry
 from pyspark.broadcast import Broadcast, _broadcastRegistry
@@ -486,7 +485,7 @@ def main(infile, outfile):
             try:
                 serializer.dump_stream(out_iter, outfile)
             finally:
-                if isinstance(out_iter, GeneratorType):
+                if hasattr(out_iter, 'close'):
                     out_iter.close()
 
         if profiler:


### PR DESCRIPTION
## What changes were proposed in this pull request?

 Closes the generator when Python UDFs stop early.

### Manually verification on pandas iterator UDF and mapPartitions

```python
from pyspark.sql import SparkSession
from pyspark.sql.functions import pandas_udf, PandasUDFType
from pyspark.sql.functions import col, udf
from pyspark.taskcontext import TaskContext
import time
import os

spark.conf.set('spark.sql.execution.arrow.maxRecordsPerBatch', '1')
spark.conf.set('spark.sql.pandas.udf.buffer.size', '4')

@pandas_udf("int", PandasUDFType.SCALAR_ITER)
def fi1(it):
    try:
        for batch in it:
            yield batch + 100
            time.sleep(1.0)
    except BaseException as be:
        print("Debug: exception raised: " + str(type(be)))
        raise be
    finally:
        open("/tmp/000001.tmp", "a").close()

df1 = spark.range(10).select(col('id').alias('a')).repartition(1)

# will see log Debug: exception raised: <class 'GeneratorExit'>
# and file "/tmp/000001.tmp" generated.
df1.select(col('a'), fi1('a')).limit(2).collect()

def mapper(it):
    try:
        for batch in it:
                yield batch
    except BaseException as be:
        print("Debug: exception raised: " + str(type(be)))
        raise be
    finally:
        open("/tmp/000002.tmp", "a").close()

df2 = spark.range(10000000).repartition(1)

# will see log Debug: exception raised: <class 'GeneratorExit'>
# and file "/tmp/000002.tmp" generated.
df2.rdd.mapPartitions(mapper).take(2)

```


## How was this patch tested?

Unit test added.

Please review https://spark.apache.org/contributing.html before opening a pull request.
