### PR TITLE
[SPARK-28188] Materialize Dataframe API

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -209,7 +209,7 @@ abstract class RDD[T: ClassTag](
    */
   def cache(): this.type = persist()
 
-  def materialize(): RDD[T] = withScope{
+  def noOpRun(): RDD[T] = withScope{
     sc.runJob(this, Utils.getIteratorSize _)
     this
   }

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -209,6 +209,11 @@ abstract class RDD[T: ClassTag](
    */
   def cache(): this.type = persist()
 
+  def materialize(): RDD[T] = withScope{
+    sc.runJob(this, Utils.getIteratorSize _)
+    this
+  }
+
   /**
    * Mark the RDD as non-persistent, and remove all blocks for it from memory and disk.
    *

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -326,11 +326,11 @@ class RDD(object):
         self._jrdd.unpersist(blocking)
         return self
 
-    def materialize(self):
+    def noOpRun(self):
         """
-        Action to force materialization of this RDD. Returns a new RDD.
+        Action to run the job until this point. Returns a new RDD.
         """
-        return RDD(self._jrdd.rdd().materialize(), self.ctx, self._jrdd_deserializer)
+        return RDD(self._jrdd.rdd().noOpRun(), self.ctx, self._jrdd_deserializer)
 
     def checkpoint(self):
         """

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -326,6 +326,12 @@ class RDD(object):
         self._jrdd.unpersist(blocking)
         return self
 
+    def materialize(self):
+        """
+        Action to force materialization of this RDD. Returns a new RDD.
+        """
+        return RDD(self._jrdd.rdd().materialize(), self.ctx, self._jrdd_deserializer)
+
     def checkpoint(self):
         """
         Mark this RDD for checkpointing. It will be saved to a file inside the

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -602,6 +602,14 @@ class DataFrame(object):
         self._jdf.persist(javaStorageLevel)
         return self
 
+    def materialize(self):
+        """
+        Action to force materialization of this DF.
+
+        Returns a new DF based on the underlying materialized RDD.
+        """
+        return DataFrame(self._jdf.materialize(), self.sql_ctx)
+
     @property
     @since(2.1)
     def storageLevel(self):

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -602,13 +602,11 @@ class DataFrame(object):
         self._jdf.persist(javaStorageLevel)
         return self
 
-    def materialize(self):
+    def noOpRun(self):
         """
-        Action to force materialization of this DF.
-
-        Returns a new DF based on the underlying materialized RDD.
+        Action to run the job until this point and return a new DF.
         """
-        return DataFrame(self._jdf.materialize(), self.sql_ctx)
+        return DataFrame(self._jdf.noOpRun(), self.sql_ctx)
 
     @property
     @since(2.1)

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2949,11 +2949,11 @@ class Dataset[T] private[sql](
    */
   def cache(): this.type = persist()
 
-  def materialize(): Dataset[T] = withAction("materialize", queryExecution) { _ =>
+  def noOpRun(): Dataset[T] = withAction("noOpRun", queryExecution) { _ =>
     withNewExecutionId {
-      var materializedRDD = queryExecution.toRdd.materialize().map(
+      var resultRDD = queryExecution.toRdd.noOpRun().map(
         exprEnc.resolveAndBind(logicalPlan.output, sparkSession.sessionState.analyzer).fromRow)
-      sparkSession.createDataset(materializedRDD)
+      sparkSession.createDataset(resultRDD)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add materialize API to dataframes. Materialize is a Spark action. It is a way to let Spark explicitly know that the dataframe has already been computed. Once a dataframe is materialized, Spark skips all stages prior to the materialize when the dataframe is reused later on. 
Please refer to [SPARK-28188](https://issues.apache.org/jira/browse/SPARK-28188) for the rationale behind adding the materialize API 

## How was this patch tested?
Tested manually
