### PR TITLE
[SPARK-28142][SS][TEST][FOLLOWUP] Add configuration check test on Kafka continuous stream

### DIFF
--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
@@ -59,14 +59,9 @@ class KafkaSourceProviderSuite
     }
 
     val expectedValue = 1000L
-    val mapToTest = Seq(
+    buildCaseInsensitiveStringMapForUpperAndLowerKey(
       KafkaSourceProvider.CONSUMER_POLL_TIMEOUT -> expectedValue.toString,
       KafkaSourceProvider.MAX_OFFSET_PER_TRIGGER -> expectedValue.toString)
-
-    Seq(
-      mapToTest.map(entry => (entry._1.toUpperCase(Locale.ROOT), entry._2)),
-      mapToTest.map(entry => (entry._1.toLowerCase(Locale.ROOT), entry._2)))
-      .map(buildKafkaSourceCaseInsensitiveStringMap)
       .foreach(verifyFieldsInMicroBatchStream(_, expectedValue, Some(expectedValue)))
   }
 
@@ -80,13 +75,16 @@ class KafkaSourceProviderSuite
     }
 
     val expectedValue = 1000
-    val mapToTest = Seq(KafkaSourceProvider.CONSUMER_POLL_TIMEOUT -> expectedValue.toString)
-
-    Seq(
-      mapToTest.map(entry => (entry._1.toUpperCase(Locale.ROOT), entry._2)),
-      mapToTest.map(entry => (entry._1.toLowerCase(Locale.ROOT), entry._2)))
-      .map(buildKafkaSourceCaseInsensitiveStringMap)
+    buildCaseInsensitiveStringMapForUpperAndLowerKey(
+      KafkaSourceProvider.CONSUMER_POLL_TIMEOUT -> expectedValue.toString)
       .foreach(verifyFieldsInContinuousStream(_, expectedValue))
+  }
+
+  private def buildCaseInsensitiveStringMapForUpperAndLowerKey(
+      options: (String, String)*): Seq[CaseInsensitiveStringMap] = {
+    Seq(options.map(entry => (entry._1.toUpperCase(Locale.ROOT), entry._2)),
+      options.map(entry => (entry._1.toLowerCase(Locale.ROOT), entry._2)))
+      .map(buildKafkaSourceCaseInsensitiveStringMap)
   }
 
   private def buildKafkaSourceCaseInsensitiveStringMap(

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
@@ -28,16 +28,14 @@ import org.apache.spark.{SparkConf, SparkEnv, SparkFunSuite}
 import org.apache.spark.sql.sources.v2.reader.Scan
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
-class KafkaSourceProviderSuite
-  extends SparkFunSuite
-  with BeforeAndAfterEach
-  with PrivateMethodTester {
+class KafkaSourceProviderSuite extends SparkFunSuite with PrivateMethodTester {
 
   private val pollTimeoutMsMethod = PrivateMethod[Long]('pollTimeoutMs)
   private val maxOffsetsPerTriggerMethod = PrivateMethod[Option[Long]]('maxOffsetsPerTrigger)
 
   override protected def afterEach(): Unit = {
     SparkEnv.set(null)
+    super.afterEach()
   }
 
   test("micro-batch mode - options should be handled as case-insensitive") {

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.kafka010
+
+import java.util.Locale
+
+import scala.collection.JavaConverters._
+
+import org.scalatest.PrivateMethodTester
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.sources.v2.reader.Scan
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+class KafkaSourceProviderSuite extends SparkFunSuite with PrivateMethodTester {
+  private val pollTimeoutMsMethod = PrivateMethod[Long]('pollTimeoutMs)
+
+  test("SPARK-28142 - continuous mode - options should be handled as case-insensitive") {
+    def getPollTimeoutMsFromContinuousStream(options: CaseInsensitiveStringMap): Long = {
+      val scan = getKafkaDataSourceScan(options)
+      val stream = scan.toContinuousStream("dummy").asInstanceOf[KafkaContinuousStream]
+      stream.invokePrivate(pollTimeoutMsMethod())
+    }
+
+    // we're trying to read the value of "pollTimeout" to see whether option is handled correctly
+
+    // upper-case
+    val expectedValue = 1000
+    val mapWithUppercase = buildCaseInsensitiveStringMap(
+      KafkaSourceProvider.CONSUMER_POLL_TIMEOUT.toUpperCase(Locale.ROOT) -> expectedValue.toString)
+    assert(expectedValue === getPollTimeoutMsFromContinuousStream(mapWithUppercase))
+
+    // lower-case
+    val mapWithLowercase = buildCaseInsensitiveStringMap(
+      KafkaSourceProvider.CONSUMER_POLL_TIMEOUT.toLowerCase(Locale.ROOT) -> expectedValue.toString)
+    assert(expectedValue === getPollTimeoutMsFromContinuousStream(mapWithLowercase))
+  }
+
+  private def getKafkaDataSourceScan(options: CaseInsensitiveStringMap): Scan = {
+    val provider = new KafkaSourceProvider()
+    provider.getTable(options).newScanBuilder(options).build()
+  }
+
+  private def buildCaseInsensitiveStringMap(
+      options: (String, String)*): CaseInsensitiveStringMap = {
+    val requiredOptions = Map("kafka.bootstrap.servers" -> "dummy", "subscribe" -> "dummy")
+    new CaseInsensitiveStringMap((options.toMap ++ requiredOptions).asJava)
+  }
+}

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
@@ -58,20 +58,16 @@ class KafkaSourceProviderSuite
       assert(expectedMaxOffsetsPerTrigger === getField(stream, maxOffsetsPerTriggerMethod))
     }
 
-    // upper-case
     val expectedValue = 1000L
-    val mapWithUppercase = buildKafkaSourceCaseInsensitiveStringMap(
-      KafkaSourceProvider.CONSUMER_POLL_TIMEOUT.toUpperCase(Locale.ROOT) -> expectedValue.toString,
-      KafkaSourceProvider.MAX_OFFSET_PER_TRIGGER.toUpperCase(Locale.ROOT) -> expectedValue.toString
-    )
-    verifyFieldsInMicroBatchStream(mapWithUppercase, expectedValue, Some(expectedValue))
+    val mapToTest = Seq(
+      KafkaSourceProvider.CONSUMER_POLL_TIMEOUT -> expectedValue.toString,
+      KafkaSourceProvider.MAX_OFFSET_PER_TRIGGER -> expectedValue.toString)
 
-    // lower-case
-    val mapWithLowercase = buildKafkaSourceCaseInsensitiveStringMap(
-      KafkaSourceProvider.CONSUMER_POLL_TIMEOUT.toLowerCase(Locale.ROOT) -> expectedValue.toString,
-      KafkaSourceProvider.MAX_OFFSET_PER_TRIGGER.toLowerCase(Locale.ROOT) -> expectedValue.toString
-    )
-    verifyFieldsInMicroBatchStream(mapWithLowercase, expectedValue, Some(expectedValue))
+    Seq(
+      mapToTest.map(entry => (entry._1.toUpperCase(Locale.ROOT), entry._2)),
+      mapToTest.map(entry => (entry._1.toLowerCase(Locale.ROOT), entry._2)))
+      .map(buildKafkaSourceCaseInsensitiveStringMap)
+      .foreach(verifyFieldsInMicroBatchStream(_, expectedValue, Some(expectedValue)))
   }
 
   test("SPARK-28142 - continuous mode - options should be handled as case-insensitive") {
@@ -83,16 +79,14 @@ class KafkaSourceProviderSuite
       assert(expectedPollTimeoutMs === getField(stream, pollTimeoutMsMethod))
     }
 
-    // upper-case
     val expectedValue = 1000
-    val mapWithUppercase = buildKafkaSourceCaseInsensitiveStringMap(
-      KafkaSourceProvider.CONSUMER_POLL_TIMEOUT.toUpperCase(Locale.ROOT) -> expectedValue.toString)
-    verifyFieldsInContinuousStream(mapWithUppercase, expectedValue)
+    val mapToTest = Seq(KafkaSourceProvider.CONSUMER_POLL_TIMEOUT -> expectedValue.toString)
 
-    // lower-case
-    val mapWithLowercase = buildKafkaSourceCaseInsensitiveStringMap(
-      KafkaSourceProvider.CONSUMER_POLL_TIMEOUT.toLowerCase(Locale.ROOT) -> expectedValue.toString)
-    verifyFieldsInContinuousStream(mapWithLowercase, expectedValue)
+    Seq(
+      mapToTest.map(entry => (entry._1.toUpperCase(Locale.ROOT), entry._2)),
+      mapToTest.map(entry => (entry._1.toLowerCase(Locale.ROOT), entry._2)))
+      .map(buildKafkaSourceCaseInsensitiveStringMap)
+      .foreach(verifyFieldsInContinuousStream(_, expectedValue))
   }
 
   private def buildKafkaSourceCaseInsensitiveStringMap(

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
@@ -33,7 +33,7 @@ class KafkaSourceProviderSuite extends SparkFunSuite with PrivateMethodTester {
   test("SPARK-28142 - continuous mode - options should be handled as case-insensitive") {
     def getPollTimeoutMsFromContinuousStream(options: CaseInsensitiveStringMap): Long = {
       val scan = getKafkaDataSourceScan(options)
-      val stream = getKafkaContinuousStream(scan)
+      val stream = scan.toContinuousStream("dummy").asInstanceOf[KafkaContinuousStream]
       getValue(stream, pollTimeoutMsMethod)
     }
 
@@ -60,10 +60,6 @@ class KafkaSourceProviderSuite extends SparkFunSuite with PrivateMethodTester {
   private def getKafkaDataSourceScan(options: CaseInsensitiveStringMap): Scan = {
     val provider = new KafkaSourceProvider()
     provider.getTable(options).newScanBuilder(options).build()
-  }
-
-  private def getKafkaContinuousStream(scan: Scan): KafkaContinuousStream = {
-    scan.toContinuousStream("dummy").asInstanceOf[KafkaContinuousStream]
   }
 
   private def getValue[T](obj: AnyRef, method: PrivateMethod[T]): T = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch adds missing UT which tests the changed behavior of original patch #24942.

## How was this patch tested?

Newly added UT.