### PR TITLE
[SPARK-28205][SQL] useV1SourceList configuration should be for all data sources

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -37,7 +37,8 @@ import org.apache.spark.sql.execution.datasources.DataSource
 import org.apache.spark.sql.execution.datasources.csv._
 import org.apache.spark.sql.execution.datasources.jdbc._
 import org.apache.spark.sql.execution.datasources.json.TextInputJsonDataSource
-import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, DataSourceV2Utils, FileDataSourceV2}
+import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, DataSourceV2Utils}
+import org.apache.spark.sql.sources.DataSourceRegister
 import org.apache.spark.sql.sources.v2._
 import org.apache.spark.sql.sources.v2.TableCapability._
 import org.apache.spark.sql.types.StructType
@@ -205,15 +206,13 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
 
     val useV1Sources =
       sparkSession.sessionState.conf.useV1SourceReaderList.toLowerCase(Locale.ROOT).split(",")
-    val lookupCls = DataSource.lookupDataSource(source, sparkSession.sessionState.conf)
-    val cls = lookupCls.newInstance() match {
-      case f: FileDataSourceV2 if useV1Sources.contains(f.shortName()) ||
-        useV1Sources.contains(lookupCls.getCanonicalName.toLowerCase(Locale.ROOT)) =>
-        f.fallbackFileFormat
-      case _ => lookupCls
+    val cls = DataSource.lookupDataSource(source, sparkSession.sessionState.conf)
+    val shouldUseV1Source = cls.newInstance() match {
+      case f: DataSourceRegister if useV1Sources.contains(f.shortName()) => true
+      case _ => useV1Sources.contains(cls.getCanonicalName.toLowerCase(Locale.ROOT))
     }
 
-    if (classOf[TableProvider].isAssignableFrom(cls)) {
+    if (!shouldUseV1Source && classOf[TableProvider].isAssignableFrom(cls)) {
       val provider = cls.getConstructor().newInstance().asInstanceOf[TableProvider]
       val sessionOptions = DataSourceV2Utils.extractSessionConfigs(
         source = provider, conf = sparkSession.sessionState.conf)

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -208,7 +208,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
       sparkSession.sessionState.conf.useV1SourceReaderList.toLowerCase(Locale.ROOT).split(",")
     val cls = DataSource.lookupDataSource(source, sparkSession.sessionState.conf)
     val shouldUseV1Source = cls.newInstance() match {
-      case f: DataSourceRegister if useV1Sources.contains(f.shortName()) => true
+      case d: DataSourceRegister if useV1Sources.contains(d.shortName()) => true
       case _ => useV1Sources.contains(cls.getCanonicalName.toLowerCase(Locale.ROOT))
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -253,7 +253,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
       session.sessionState.conf.useV1SourceWriterList.toLowerCase(Locale.ROOT).split(",")
     val cls = DataSource.lookupDataSource(source, session.sessionState.conf)
     val shouldUseV1Source = cls.newInstance() match {
-      case f: DataSourceRegister if useV1Sources.contains(f.shortName()) => true
+      case d: DataSourceRegister if useV1Sources.contains(d.shortName()) => true
       case _ => useV1Sources.contains(cls.getCanonicalName.toLowerCase(Locale.ROOT))
     }
     // In Data Source V2 project, partitioning is still under development.

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.execution.command.DDLUtils
 import org.apache.spark.sql.execution.datasources.{CreateTable, DataSource, DataSourceUtils, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.v2._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.sources.BaseRelation
+import org.apache.spark.sql.sources.{BaseRelation, DataSourceRegister}
 import org.apache.spark.sql.sources.v2._
 import org.apache.spark.sql.sources.v2.TableCapability._
 import org.apache.spark.sql.types.StructType
@@ -251,17 +251,16 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
     val session = df.sparkSession
     val useV1Sources =
       session.sessionState.conf.useV1SourceWriterList.toLowerCase(Locale.ROOT).split(",")
-    val lookupCls = DataSource.lookupDataSource(source, session.sessionState.conf)
-    val cls = lookupCls.newInstance() match {
-      case f: FileDataSourceV2 if useV1Sources.contains(f.shortName()) ||
-        useV1Sources.contains(lookupCls.getCanonicalName.toLowerCase(Locale.ROOT)) =>
-        f.fallbackFileFormat
-      case _ => lookupCls
+    val cls = DataSource.lookupDataSource(source, session.sessionState.conf)
+    val shouldUseV1Source = cls.newInstance() match {
+      case f: DataSourceRegister if useV1Sources.contains(f.shortName()) => true
+      case _ => useV1Sources.contains(cls.getCanonicalName.toLowerCase(Locale.ROOT))
     }
     // In Data Source V2 project, partitioning is still under development.
     // Here we fallback to V1 if partitioning columns are specified.
     // TODO(SPARK-26778): use V2 implementations when partitioning feature is supported.
-    if (classOf[TableProvider].isAssignableFrom(cls) && partitioningColumns.isEmpty) {
+    if (!shouldUseV1Source && classOf[TableProvider].isAssignableFrom(cls) &&
+      partitioningColumns.isEmpty) {
       val provider = cls.getConstructor().newInstance().asInstanceOf[TableProvider]
       val sessionOptions = DataSourceV2Utils.extractSessionConfigs(
         provider, session.sessionState.conf)

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/v2/FileDataSourceV2FallBackSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/v2/FileDataSourceV2FallBackSuite.scala
@@ -17,17 +17,21 @@
 package org.apache.spark.sql.sources.v2
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.{AnalysisException, QueryTest}
-import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.{FileSourceScanExec, QueryExecution}
+import org.apache.spark.sql.execution.datasources.{FileFormat, InsertIntoHadoopFsRelationCommand}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.execution.datasources.v2.FileDataSourceV2
+import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetDataSourceV2
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.v2.reader.ScanBuilder
 import org.apache.spark.sql.sources.v2.writer.WriteBuilder
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.sql.util.{CaseInsensitiveStringMap, QueryExecutionListener}
 
 class DummyReadOnlyFileDataSourceV2 extends FileDataSourceV2 {
 
@@ -167,6 +171,43 @@ class FileDataSourceV2FallBackSuite extends QueryTest with SharedSQLContext {
           df.write.format(dummyParquetWriterV2).save(path)
         }
         assert(exception.message.equals("Dummy file writer"))
+      }
+    }
+  }
+
+  test("Fallback Parquet V2 to V1") {
+    Seq("parquet", classOf[ParquetDataSourceV2].getCanonicalName).foreach { format =>
+      withSQLConf(SQLConf.USE_V1_SOURCE_READER_LIST.key -> format,
+        SQLConf.USE_V1_SOURCE_WRITER_LIST.key -> format) {
+        val commands = ArrayBuffer.empty[(String, LogicalPlan)]
+        val exceptions = ArrayBuffer.empty[(String, Exception)]
+        val listener = new QueryExecutionListener {
+          override def onFailure(
+              funcName: String,
+              qe: QueryExecution,
+              exception: Exception): Unit = {
+            exceptions += funcName -> exception
+          }
+
+          override def onSuccess(funcName: String, qe: QueryExecution, duration: Long): Unit = {
+            commands += funcName -> qe.logical
+          }
+        }
+        spark.listenerManager.register(listener)
+
+        withTempPath { path =>
+          val inputData = spark.range(10)
+          inputData.write.format(format).save(path.getCanonicalPath)
+          sparkContext.listenerBus.waitUntilEmpty(1000)
+          assert(commands.length == 1)
+          assert(commands.head._1 == "save")
+          assert(commands.head._2.isInstanceOf[InsertIntoHadoopFsRelationCommand])
+          assert(commands.head._2.asInstanceOf[InsertIntoHadoopFsRelationCommand]
+            .fileFormat.isInstanceOf[ParquetFileFormat])
+          val df = spark.read.format(format).load(path.getCanonicalPath)
+          checkAnswer(df, inputData.toDF())
+          assert(df.queryExecution.executedPlan.find(_.isInstanceOf[FileSourceScanExec]).isDefined)
+        }
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the migration PR of Kafka V2: https://github.com/apache/spark/pull/24738/files/ac16c9a9ef1c68db5aeda6c7001ae9abe96a358a#r298470645
We find that the useV1SourceList configuration(spark.sql.sources.read.useV1SourceList and spark.sql.sources.write.useV1SourceList) should be for all data sources, instead of file source V2 only.

This PR is to fix it in DataFrameWriter/DataFrameReader.
## How was this patch tested?

Unit test
