### PR TITLE
[SPARK-28056.2] [PYTHON] [SQL] add docstring/doctest for SCALAR_ITER Pandas UDF

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2951,7 +2951,107 @@ def pandas_udf(f=None, returnType=None, functionType=None):
            Therefore, this can be used, for example, to ensure the length of each returned
            `pandas.Series`, and can not be used as the column length.
 
-    2. GROUPED_MAP
+    2. SCALAR_ITER
+
+       A scalar iterator UDF is semantically the same as the scalar Pandas UDF above except that the
+       wrapped Python function takes an iterator of batches as input instead of a single batch and,
+       instead of returning a single output batch, it yields output batches or explicitly returns an
+       generator or an iterator of output batches.
+       It is useful when the UDF execution requires initializing some state, e.g., loading a machine
+       learning model file to apply inference to every input batch.
+
+       .. note:: It is not guaranteed that one invocation of a scalar iterator UDF will process all
+           batches from one partition, although it is currently implemented this way.
+           Your code shall not rely on this behavior because it might change in the future for
+           further optimization, e.g., one invocation processes multiple partitions.
+
+       Scalar iterator UDFs are used with :meth:`pyspark.sql.DataFrame.withColumn` and
+       :meth:`pyspark.sql.DataFrame.select`.
+
+       >>> import pandas as pd
+       >>> from pyspark.sql.functions import col, pandas_udf, struct, PandasUDFType
+       >>> pdf = pd.DataFrame([1, 2, 3], columns=["x"])
+       >>> df = spark.createDataFrame(pdf)
+
+       When the UDF is called with a single column that is not `StructType`, the input to the
+       underlying function is an iterator of `pd.Series`.
+
+       >>> @pandas_udf("long", PandasUDFType.SCALAR_ITER)
+       ... def plus_one(batch_iter):
+       ...     for x in batch_iter:
+       ...         yield x + 1
+       ...
+       >>> df.select(plus_one(col("x"))).show()
+       +-----------+
+       |plus_one(x)|
+       +-----------+
+       |          2|
+       |          3|
+       |          4|
+       +-----------+
+
+       When the UDF is called with more than one columns, the input to the underlying function is an
+       iterator of `pd.Series` tuple.
+
+       >>> @pandas_udf("long", PandasUDFType.SCALAR_ITER)
+       ... def multiply_two_cols(batch_iter):
+       ...     for a, b in batch_iter:
+       ...         yield a * b
+       ...
+       >>> df.select(multiply_two_cols(col("x"), col("x"))).show()
+       +-----------------------+
+       |multiply_two_cols(x, x)|
+       +-----------------------+
+       |                      1|
+       |                      4|
+       |                      9|
+       +-----------------------+
+
+       When the UDF is called with a single column that is `StructType`, the input to the underlying
+       function is an iterator of `pd.DataFrame`.
+
+       >>> @pandas_udf("long", PandasUDFType.SCALAR_ITER)
+       ... def multiply_two_nested_cols(pdf_iter):
+       ...    for pdf in pdf_iter:
+       ...        yield pdf["a"] * pdf["b"]
+       ...
+       >>> df.select(
+       ...     multiply_two_nested_cols(
+       ...         struct(col("x").alias("a"), col("x").alias("b"))
+       ...     ).alias("y")
+       ... ).show()
+       +---+
+       |  y|
+       +---+
+       |  1|
+       |  4|
+       |  9|
+       +---+
+
+       In the UDF, you can initialize some states before processing batches, wrap your code with
+       `try ... finally ...` or use context managers to ensure the release of resources at the end
+       or in case of early termination.
+
+       >>> y_bc = spark.sparkContext.broadcast(1)
+       >>> @pandas_udf("long", PandasUDFType.SCALAR_ITER)
+       ... def plus_y(batch_iter):
+       ...     y = y_bc.value  # initialize some state
+       ...     try:
+       ...         for x in batch_iter:
+       ...             yield x + y
+       ...     finally:
+       ...         pass  # release resources here, if any
+       ...
+       >>> df.select(plus_y(col("x"))).show()
+       +---------+
+       |plus_y(x)|
+       +---------+
+       |        2|
+       |        3|
+       |        4|
+       +---------+
+
+    3. GROUPED_MAP
 
        A grouped map UDF defines transformation: A `pandas.DataFrame` -> A `pandas.DataFrame`
        The returnType should be a :class:`StructType` describing the schema of the returned
@@ -3030,7 +3130,7 @@ def pandas_udf(f=None, returnType=None, functionType=None):
 
        .. seealso:: :meth:`pyspark.sql.GroupedData.apply`
 
-    3. GROUPED_AGG
+    4. GROUPED_AGG
 
        A grouped aggregate UDF defines a transformation: One or more `pandas.Series` -> A scalar
        The `returnType` should be a primitive data type, e.g., :class:`DoubleType`.

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2968,20 +2968,20 @@ def pandas_udf(f=None, returnType=None, functionType=None):
        Scalar iterator UDFs are used with :meth:`pyspark.sql.DataFrame.withColumn` and
        :meth:`pyspark.sql.DataFrame.select`.
 
-       >>> import pandas as pd
+       >>> import pandas as pd  # doctest: +SKIP
        >>> from pyspark.sql.functions import col, pandas_udf, struct, PandasUDFType
-       >>> pdf = pd.DataFrame([1, 2, 3], columns=["x"])
-       >>> df = spark.createDataFrame(pdf)
+       >>> pdf = pd.DataFrame([1, 2, 3], columns=["x"])  # doctest: +SKIP
+       >>> df = spark.createDataFrame(pdf)  # doctest: +SKIP
 
        When the UDF is called with a single column that is not `StructType`, the input to the
        underlying function is an iterator of `pd.Series`.
 
-       >>> @pandas_udf("long", PandasUDFType.SCALAR_ITER)
+       >>> @pandas_udf("long", PandasUDFType.SCALAR_ITER)  # doctest: +SKIP
        ... def plus_one(batch_iter):
        ...     for x in batch_iter:
        ...         yield x + 1
        ...
-       >>> df.select(plus_one(col("x"))).show()
+       >>> df.select(plus_one(col("x"))).show()  # doctest: +SKIP
        +-----------+
        |plus_one(x)|
        +-----------+
@@ -2993,12 +2993,12 @@ def pandas_udf(f=None, returnType=None, functionType=None):
        When the UDF is called with more than one columns, the input to the underlying function is an
        iterator of `pd.Series` tuple.
 
-       >>> @pandas_udf("long", PandasUDFType.SCALAR_ITER)
+       >>> @pandas_udf("long", PandasUDFType.SCALAR_ITER)  # doctest: +SKIP
        ... def multiply_two_cols(batch_iter):
        ...     for a, b in batch_iter:
        ...         yield a * b
        ...
-       >>> df.select(multiply_two_cols(col("x"), col("x"))).show()
+       >>> df.select(multiply_two_cols(col("x"), col("x"))).show()  # doctest: +SKIP
        +-----------------------+
        |multiply_two_cols(x, x)|
        +-----------------------+
@@ -3010,7 +3010,7 @@ def pandas_udf(f=None, returnType=None, functionType=None):
        When the UDF is called with a single column that is `StructType`, the input to the underlying
        function is an iterator of `pd.DataFrame`.
 
-       >>> @pandas_udf("long", PandasUDFType.SCALAR_ITER)
+       >>> @pandas_udf("long", PandasUDFType.SCALAR_ITER)  # doctest: +SKIP
        ... def multiply_two_nested_cols(pdf_iter):
        ...    for pdf in pdf_iter:
        ...        yield pdf["a"] * pdf["b"]
@@ -3019,7 +3019,7 @@ def pandas_udf(f=None, returnType=None, functionType=None):
        ...     multiply_two_nested_cols(
        ...         struct(col("x").alias("a"), col("x").alias("b"))
        ...     ).alias("y")
-       ... ).show()
+       ... ).show()  # doctest: +SKIP
        +---+
        |  y|
        +---+
@@ -3032,8 +3032,8 @@ def pandas_udf(f=None, returnType=None, functionType=None):
        `try ... finally ...` or use context managers to ensure the release of resources at the end
        or in case of early termination.
 
-       >>> y_bc = spark.sparkContext.broadcast(1)
-       >>> @pandas_udf("long", PandasUDFType.SCALAR_ITER)
+       >>> y_bc = spark.sparkContext.broadcast(1)  # doctest: +SKIP
+       >>> @pandas_udf("long", PandasUDFType.SCALAR_ITER)  # doctest: +SKIP
        ... def plus_y(batch_iter):
        ...     y = y_bc.value  # initialize some state
        ...     try:
@@ -3042,7 +3042,7 @@ def pandas_udf(f=None, returnType=None, functionType=None):
        ...     finally:
        ...         pass  # release resources here, if any
        ...
-       >>> df.select(plus_y(col("x"))).show()
+       >>> df.select(plus_y(col("x"))).show()  # doctest: +SKIP
        +---------+
        |plus_y(x)|
        +---------+


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add docstring/doctest for `SCALAR_ITER` Pandas UDF. I explicitly mentioned that per-partition execution is an implementation detail, not guaranteed. I will submit another PR to add the same to user guide, just to keep this PR minimal.

I didn't add "doctest: +SKIP" in the first commit so it is easy to test locally.

cc: @HyukjinKwon @gatorsmile @icexelloss @BryanCutler @WeichenXu123 

![Screen Shot 2019-06-28 at 9 52 41 AM](https://user-images.githubusercontent.com/829644/60358349-b0aa5400-998a-11e9-9ebf-8481dfd555b5.png)
![Screen Shot 2019-06-28 at 9 53 19 AM](https://user-images.githubusercontent.com/829644/60358355-b1db8100-998a-11e9-8f6f-00a11bdbdc4d.png)


## How was this patch tested?

doctest
