### PR TITLE
[SPARK-28215][SQL][R] as_tibble was removed from Arrow R API

### DIFF
--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -1203,7 +1203,7 @@ setMethod("collect",
               requireNamespace1 <- requireNamespace
               if (requireNamespace1("arrow", quietly = TRUE)) {
                 read_arrow <- get("read_arrow", envir = asNamespace("arrow"), inherits = FALSE)
-                as_tibble <- get("as_tibble", envir = asNamespace("arrow"))
+                as_tibble <- get0("as_tibble", envir = asNamespace("arrow"), ifnotfound = NULL)
 
                 portAuth <- callJMethod(x@sdf, "collectAsArrowToR")
                 port <- portAuth[[1]]
@@ -1213,7 +1213,11 @@ setMethod("collect",
                 output <- tryCatch({
                   doServerAuth(conn, authSecret)
                   arrowTable <- read_arrow(readRaw(conn))
-                  as.data.frame(as_tibble(arrowTable), stringsAsFactors = stringsAsFactors)
+                  if (is.null(as_tibble)) {
+                    as.data.frame(arrowTable, stringsAsFactors = stringsAsFactors)
+                  } else {
+                    as.data.frame(as_tibble(arrowTable), stringsAsFactors = stringsAsFactors)
+                  }
                 }, finally = {
                   close(conn)
                 })

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -1204,7 +1204,7 @@ setMethod("collect",
               if (requireNamespace1("arrow", quietly = TRUE)) {
                 read_arrow <- get("read_arrow", envir = asNamespace("arrow"), inherits = FALSE)
                 # Arrow drops `as_tibble` since 0.14.0, see ARROW-5190.
-                as_tibble <- get0("as_tibble", envir = asNamespace("arrow"), ifnotfound = NULL)
+                useAsTibble <- exists("as_tibble", envir = asNamespace("arrow"))
 
                 portAuth <- callJMethod(x@sdf, "collectAsArrowToR")
                 port <- portAuth[[1]]
@@ -1214,10 +1214,11 @@ setMethod("collect",
                 output <- tryCatch({
                   doServerAuth(conn, authSecret)
                   arrowTable <- read_arrow(readRaw(conn))
-                  if (is.null(as_tibble)) {
-                    as.data.frame(arrowTable, stringsAsFactors = stringsAsFactors)
-                  } else {
+                  if (useAsTibble) {
+                    as_tibble <- get("as_tibble", envir = asNamespace("arrow"))
                     as.data.frame(as_tibble(arrowTable), stringsAsFactors = stringsAsFactors)
+                  } else {
+                    as.data.frame(arrowTable, stringsAsFactors = stringsAsFactors)
                   }
                 }, finally = {
                   close(conn)

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -1203,6 +1203,7 @@ setMethod("collect",
               requireNamespace1 <- requireNamespace
               if (requireNamespace1("arrow", quietly = TRUE)) {
                 read_arrow <- get("read_arrow", envir = asNamespace("arrow"), inherits = FALSE)
+                # Arrow drops `as_tibble` since 0.14.0, see ARROW-5190.
                 as_tibble <- get0("as_tibble", envir = asNamespace("arrow"), ifnotfound = NULL)
 
                 portAuth <- callJMethod(x@sdf, "collectAsArrowToR")

--- a/R/pkg/R/deserialize.R
+++ b/R/pkg/R/deserialize.R
@@ -238,7 +238,9 @@ readDeserializeInArrow <- function(inputCon) {
     RecordBatchStreamReader <- get(
       "RecordBatchStreamReader", envir = asNamespace("arrow"), inherits = FALSE)
     # Arrow drops `as_tibble` since 0.14.0, see ARROW-5190.
+    # nolint start
     as_tibble <- get0("as_tibble", envir = asNamespace("arrow"), ifnotfound = NULL)
+    # nolint end
 
     # Currently, there looks no way to read batch by batch by socket connection in R side,
     # See ARROW-4512. Therefore, it reads the whole Arrow streaming-formatted binary at once

--- a/R/pkg/R/deserialize.R
+++ b/R/pkg/R/deserialize.R
@@ -238,9 +238,8 @@ readDeserializeInArrow <- function(inputCon) {
     RecordBatchStreamReader <- get(
       "RecordBatchStreamReader", envir = asNamespace("arrow"), inherits = FALSE)
     # Arrow drops `as_tibble` since 0.14.0, see ARROW-5190.
-    # nolint start
-    as_tibble <- get0("as_tibble", envir = asNamespace("arrow"), ifnotfound = NULL)
-    # nolint end
+    useAsTibble <- exists("as_tibble", envir = asNamespace("arrow"))
+
 
     # Currently, there looks no way to read batch by batch by socket connection in R side,
     # See ARROW-4512. Therefore, it reads the whole Arrow streaming-formatted binary at once
@@ -249,11 +248,12 @@ readDeserializeInArrow <- function(inputCon) {
     arrowData <- readBin(inputCon, raw(), as.integer(dataLen), endian = "big")
     batches <- RecordBatchStreamReader(arrowData)$batches()
 
-    if (is.null(as_tibble)) {
-      lapply(batches, function(batch) as.data.frame(batch))
-    } else {
+    if (useAsTibble) {
+      as_tibble <- get("as_tibble", envir = asNamespace("arrow"))
       # Read all groupped batches. Tibble -> data.frame is cheap.
       lapply(batches, function(batch) as.data.frame(as_tibble(batch)))
+    } else {
+      lapply(batches, function(batch) as.data.frame(batch))
     }
   } else {
     stop("'arrow' package should be installed.")


### PR DESCRIPTION
## What changes were proposed in this pull request?

New R api of Arrow has removed `as_tibble` as of https://github.com/apache/arrow/commit/2ef96c8623cbad1770f82e97df733bd881ab967b. Arrow optimization for DataFrame in R doesn't work due to the change.

This can be tested as below, after installing latest Arrow:

```
./bin/sparkR --conf spark.sql.execution.arrow.sparkr.enabled=true
```

```
> collect(createDataFrame(mtcars))
```

Before this PR:
```
> collect(createDataFrame(mtcars))
 Error in get("as_tibble", envir = asNamespace("arrow")) :
   object 'as_tibble' not found
```

After:
```
> collect(createDataFrame(mtcars))
    mpg cyl  disp  hp drat    wt  qsec vs am gear carb                          
1  21.0   6 160.0 110 3.90 2.620 16.46  0  1    4    4
2  21.0   6 160.0 110 3.90 2.875 17.02  0  1    4    4
3  22.8   4 108.0  93 3.85 2.320 18.61  1  1    4    1
...
```

## How was this patch tested?

Manual test.