### PR TITLE
[SPARK-28217][SQL] Allow a pluggable statistics plan visitor for a logical plan.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1825,7 +1825,7 @@ object SQLConf {
       .createWithDefault(true)
 
   val STATS_PLAN_VISITOR_CLASS = buildConf("spark.sql.catalyst.statsPlanVisitorClass")
-    .doc("Name of custom LogicalPlanVisitor[Statistics] class.")
+    .doc("The class that calculates statistics for a logical plan.")
     .stringConf
     .createOptional
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1823,6 +1823,11 @@ object SQLConf {
       .doc("When true, the ArrayExists will follow the three-valued boolean logic.")
       .booleanConf
       .createWithDefault(true)
+
+  val STATS_PLAN_VISITOR_CLASS = buildConf("spark.sql.catalyst.statsPlanVisitorClass")
+    .doc("Name of custom LogicalPlanVisitor[Statistics] class.")
+    .stringConf
+    .createOptional
 }
 
 /**
@@ -2294,6 +2299,8 @@ class SQLConf extends Serializable with Logging {
   def castDatetimeToString: Boolean = getConf(SQLConf.LEGACY_CAST_DATETIME_TO_STRING)
 
   def defaultV2Catalog: Option[String] = getConf(DEFAULT_V2_CATALOG)
+
+  def statsPlanVisitorClass: Option[String] = getConf(STATS_PLAN_VISITOR_CLASS)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/BasicStatsEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/BasicStatsEstimationSuite.scala
@@ -115,6 +115,19 @@ class BasicStatsEstimationSuite extends PlanTest with StatsEstimationTestBase {
       plan, expectedStatsCboOn = expectedCboStats, expectedStatsCboOff = expectedDefaultStats)
   }
 
+  test("custom stats plan visitor") {
+    // TODO: Add missing comments here
+    val range = Range(1, 5, 1, None)
+    val rangeStats = Statistics(sizeInBytes = 999)
+
+    withSQLConf(
+      SQLConf.STATS_PLAN_VISITOR_CLASS.key ->
+        "org.apache.spark.sql.catalyst.statsEstimation.CustomStatsPlanVisitor") {
+      range.invalidateStatsCache()
+      assert(range.stats == rangeStats)
+    }
+  }
+
   /** Check estimated stats when cbo is turned on/off. */
   private def checkStats(
       plan: LogicalPlan,
@@ -149,4 +162,45 @@ private case class DummyLogicalPlan(
   override def output: Seq[Attribute] = Nil
 
   override def computeStats(): Statistics = if (conf.cboEnabled) cboStats else defaultStats
+}
+
+// TODO: Add comments
+class CustomStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
+  override def default(p: LogicalPlan): Statistics = Statistics(sizeInBytes = 999)
+
+  override def visitAggregate(p: Aggregate): Statistics = default(p)
+
+  override def visitDistinct(p: Distinct): Statistics = default(p)
+
+  override def visitExcept(p: Except): Statistics = default(p)
+
+  override def visitExpand(p: Expand): Statistics = default(p)
+
+  override def visitFilter(p: Filter): Statistics = default(p)
+
+  override def visitGenerate(p: Generate): Statistics = default(p)
+
+  override def visitGlobalLimit(p: GlobalLimit): Statistics = default(p)
+
+  override def visitIntersect(p: Intersect): Statistics = default(p)
+
+  override def visitJoin(p: Join): Statistics = default(p)
+
+  override def visitLocalLimit(p: LocalLimit): Statistics = default(p)
+
+  override def visitPivot(p: Pivot): Statistics = default(p)
+
+  override def visitProject(p: Project): Statistics = default(p)
+
+  override def visitRepartition(p: Repartition): Statistics = default(p)
+
+  override def visitRepartitionByExpr(p: RepartitionByExpression): Statistics = default(p)
+
+  override def visitSample(p: Sample): Statistics = default(p)
+
+  override def visitScriptTransform(p: ScriptTransformation): Statistics = default(p)
+
+  override def visitUnion(p: Union): Statistics = default(p)
+
+  override def visitWindow(p: Window): Statistics = default(p)
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Spark currently has two built-in statistics plan visitor: `SizeInBytesOnlyStatsPlanVisitor` and `BasicStatsPlanVisitor`. However, this is a bit limited since there is no way to plug in a custom plan visitor from which a query optimizer can benefit.

This PR allowers the user to specify a custom stat plan visitor via a Spark conf to override the built-in one:

```Scala
// First create your custom stat plan visitor.
class MyStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
  // Implement LogicalPlanVisitor[Statistics] trait
}

// Set the visitor via Spark conf.
spark.conf.set("spark.sql.catalyst.statsPlanVisitorClass", "MyStatsPlanVisitor")

// Now, stat() on a LogicalPlan object will use MyStatsPlanVisitor as the stat plan visitor.
```

## How was this patch tested?
Existing and new unit tests.

cc: @rapoth