### PR TITLE
[SPARK-28195][SQL] Fix CheckAnalysis not working for InsertIntoDataSourceDirCommand and report misleading error message

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -87,6 +87,10 @@ trait CheckAnalysis extends PredicateHelper {
     // of the result of cascading resolution failures.
     plan.foreachUp {
 
+      // Skip checking analysis for view, for it's only a wrapper for sub child plan and it will be
+      // eliminated in EliminateView rule
+      case v: View => checkAnalysis(v.child)
+
       case p if p.analyzed => // Skip already analyzed sub-plans
 
       case u: UnresolvedRelation =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{ColumnarRule, QueryExecution, SparkOptimizer, SparkPlanner, SparkSqlParser}
+import org.apache.spark.sql.execution.command.InsertIntoDataSourceDirCommand
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.v2.{V2StreamingScanSupportCheck, V2WriteSupportCheck}
 import org.apache.spark.sql.streaming.StreamingQueryManager
@@ -188,6 +189,15 @@ abstract class BaseSessionStateBuilder(
         customCheckRules
 
     override protected def lookupCatalog(name: String): CatalogPlugin = session.catalog(name)
+
+    override def checkAnalysis(plan: LogicalPlan): Unit = {
+      // We should check it's innerChildren for InsertIntoDataSourceDirCommand
+      val planToCheck = plan match {
+        case e: InsertIntoDataSourceDirCommand => e.query
+        case _ => plan
+      }
+      super.checkAnalysis(planToCheck)
+    }
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CommandAnalysisSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CommandAnalysisSuite.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.command
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.QueryPlanningTracker
+import org.apache.spark.sql.catalyst.analysis.{Analyzer, FunctionRegistry}
+import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.SparkSqlParser
+import org.apache.spark.sql.test.SharedSQLContext
+
+class CommandAnalysisSuite extends PlanTest with SharedSQLContext {
+  val parser = new SparkSqlParser(conf)
+  val catalog = new SessionCatalog(new InMemoryCatalog, FunctionRegistry.builtin, conf)
+  val analyzer = new Analyzer(catalog, conf) {
+    override def checkAnalysis(plan: LogicalPlan): Unit = {
+      val planToCheck = plan match {
+        case e: InsertIntoDataSourceDirCommand => e.query
+        case _ => plan
+      }
+      super.checkAnalysis(planToCheck)
+    }
+  }
+
+  test("SPARK-28195: checkAnalysis should work for InsertIntoDataSourceDirCommand") {
+    val query = "insert overwrite directory '/path' using parquet select * from table1"
+    val exception = intercept[AnalysisException](
+      analyzer.executeAndCheck(parser.parsePlan(query), new QueryPlanningTracker))
+    assert(exception.getMessage.contains("Table or view not found: table1"))
+  }
+}

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.execution.command.InsertIntoDataSourceDirCommand
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.v2.{V2StreamingScanSupportCheck, V2WriteSupportCheck}
 import org.apache.spark.sql.hive.client.HiveClient
-import org.apache.spark.sql.hive.execution.{InsertIntoHiveDirCommand, InsertIntoHiveTable}
 import org.apache.spark.sql.internal.{BaseSessionStateBuilder, SessionResourceLoader, SessionState}
 
 /**
@@ -98,12 +97,9 @@ class HiveSessionStateBuilder(session: SparkSession, parentState: Option[Session
     override protected def lookupCatalog(name: String): CatalogPlugin = session.catalog(name)
 
     override def checkAnalysis(plan: LogicalPlan): Unit = {
-      // We should check it's innerChildren for Command like logical plan
-      // (e.g. InsertIntoDataSourceDirCommand)
+      // We should check it's innerChildren for InsertIntoDataSourceDirCommand
       val planToCheck = plan match {
         case e: InsertIntoDataSourceDirCommand => e.query
-        case e: InsertIntoHiveDirCommand => e.query
-        case e: InsertIntoHiveTable => e.query
         case _ => plan
       }
       super.checkAnalysis(planToCheck)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR will try to fix the issue that the sub plan of InsertDataSourceDirCommand is not being checked for analysis and sometimes will report misleading error message.
An example sql is like 
`insert overwrite directory '/path' using parquet select * from table1`

When "table1" does not exists, we will finally got a misleading error message:
```
Caused by: org.apache.spark.sql.catalyst.analysis.UnresolvedException: Invalid call to dataType on unresolved object, tree: 'kr.objective_id
at org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute.dataType(unresolved.scala:105)
at org.apache.spark.sql.types.StructType$$anonfun$fromAttributes$1.apply(StructType.scala:440)
at org.apache.spark.sql.types.StructType$$anonfun$fromAttributes$1.apply(StructType.scala:440)
at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
at scala.collection.immutable.List.foreach(List.scala:381)
at scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
at scala.collection.immutable.List.map(List.scala:285)
at org.apache.spark.sql.types.StructType$.fromAttributes(StructType.scala:440)
at org.apache.spark.sql.catalyst.plans.QueryPlan.schema$lzycompute(QueryPlan.scala:159)
at org.apache.spark.sql.catalyst.plans.QueryPlan.schema(QueryPlan.scala:159)
at org.apache.spark.sql.execution.datasources.DataSource.planForWriting(DataSource.scala:544)
at org.apache.spark.sql.execution.command.InsertIntoDataSourceDirCommand.run(InsertIntoDataSourceDirCommand.scala:70)
at org.apache.spark.sql.execution.command.ExecutedCommandExec.sideEffectResult$lzycompute(commands.scala:70)
at org.apache.spark.sql.execution.command.ExecutedCommandExec.sideEffectResult(commands.scala:68)
at org.apache.spark.sql.execution.command.ExecutedCommandExec.executeCollect(commands.scala:79)
at org.apache.spark.sql.execution.adaptive.QueryStage.executeCollect(QueryStage.scala:246)
at org.apache.spark.sql.Dataset$$anonfun$6.apply(Dataset.scala:190)
at org.apache.spark.sql.Dataset$$anonfun$6.apply(Dataset.scala:190)
at org.apache.spark.sql.Dataset$$anonfun$52.apply(Dataset.scala:3277)
at org.apache.spark.sql.execution.SQLExecution$.withNewExecutionId(SQLExecution.scala:77)
at org.apache.spark.sql.Dataset.withAction(Dataset.scala:3276)
at org.apache.spark.sql.Dataset.&lt;init&gt;(Dataset.scala:190)
at org.apache.spark.sql.Dataset$.ofRows(Dataset.scala:75)
at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:642)
at org.apache.spark.sql.SQLContext.sql(SQLContext.scala:694)
at org.apache.spark.sql.hive.thriftserver.SparkExecuteStatementOperation.org$apache$spark$sql$hive$thriftserver$SparkExecuteStatementOperation$$execute(SparkExecuteStatementOperation.scala:277)
... 11 more
```

## How was this patch tested?

exist UT(AnalysisSuite)
