### PR TITLE
[SPARK-28220][SQL] Fix foldable join condition not pushed down when parent filter is wholly pushed down

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersFromConstraintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersFromConstraintsSuite.scala
@@ -31,6 +31,7 @@ class InferFiltersFromConstraintsSuite extends PlanTest {
     val batches =
       Batch("InferAndPushDownFilters", FixedPoint(100),
         PushPredicateThroughJoin,
+        PruneFilters,
         PushDownPredicate,
         InferFiltersFromConstraints,
         CombineFilters,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OuterJoinEliminationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OuterJoinEliminationSuite.scala
@@ -33,7 +33,8 @@ class OuterJoinEliminationSuite extends PlanTest {
         EliminateSubqueryAliases) ::
       Batch("Outer Join Elimination", Once,
         EliminateOuterJoin,
-        PushPredicateThroughJoin) :: Nil
+        PushPredicateThroughJoin,
+        PruneFilters) :: Nil
   }
 
   val testRelation = LocalRelation('a.int, 'b.int, 'c.int)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PruneFiltersSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PruneFiltersSuite.scala
@@ -36,7 +36,8 @@ class PruneFiltersSuite extends PlanTest {
         CombineFilters,
         PruneFilters,
         PushDownPredicate,
-        PushPredicateThroughJoin) :: Nil
+        PushPredicateThroughJoin,
+        PruneFilters) :: Nil
   }
 
   val testRelation = LocalRelation('a.int, 'b.int, 'c.int)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Optimizer rule `PushPredicateThroughJoin` will try to push parent filter down though the join, however, when the parent filter is wholly pushed down through the join, the join will become the top node, and then the `transform` method will skip the join to apply the rule. 

Suppose we have two tables: table1 and table2:

```
table1: (a: string, b: string, c: string)

table2: (d: string)
```

sql as:

`select * from table1 left join (select d, 'w1' as r from table2) on a = d and r = 'w2' where b = 2`
 

let's focus on the following optimizer rules:

```
PushPredicateThroughJoin

FodablePropagation

BooleanSimplification

PruneFilters
```

 

In the above case, on the first iteration of these rules:

PushPredicateThroughJoin -> 
`
select * from table1 where b=2 left join (select d, 'w1' as r from table2) on a = d and r = 'w2'`
FodablePropagation ->

`select * from table1 where b=2 left join (select d, 'w1' as r from table2) on a = d and 'w1' = 'w2'`
BooleanSimplification ->

`select * from table1 where b=2 left join (select d, 'w1' as r from table2) on false`
PruneFilters -> No effective

 

After several iteration of these rules, the join condition will still never be pushed to the 

right hand of the left join. thus, in some case(e.g. Large right table), the `BroadcastNestedLoopJoin` may be slow or oom.

This PR will fix this problem!

## How was this patch tested?

exist UT
