### PR TITLE
[SPARK-28227][SQL] Support TRANSFORM with aggregation.

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -439,7 +439,9 @@ fromStatementBody
 querySpecification
     : transformClause
       fromClause?
-      whereClause?                                                          #transformQuerySpecification
+      whereClause?
+      aggregationClause?
+      havingClause?                                                        #transformQuerySpecification
     | selectClause
       fromClause?
       lateralView*

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -144,6 +144,8 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
         ctx,
         ctx.transformClause,
         ctx.whereClause,
+        ctx.aggregationClause,
+        ctx.havingClause,
         plan
       )
     } else {
@@ -429,7 +431,7 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
     val from = OneRowRelation().optional(ctx.fromClause) {
       visitFromClause(ctx.fromClause)
     }
-    withTransformQuerySpecification(ctx, ctx.transformClause, ctx.whereClause, from)
+    withTransformQuerySpecification(ctx, ctx.transformClause, ctx.whereClause, ctx.aggregationClause, ctx.havingClause, from)
   }
 
   override def visitRegularQuerySpecification(
@@ -484,6 +486,8 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
       ctx: ParserRuleContext,
       transformClause: TransformClauseContext,
       whereClause: WhereClauseContext,
+      aggregationClause: AggregationClauseContext,
+      havingClause: HavingClauseContext,
     relation: LogicalPlan): LogicalPlan = withOrigin(ctx) {
     // Add where.
     val withFilter = relation.optionalMap(whereClause)(withWhereClause)
@@ -506,12 +510,39 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
         AttributeReference("value", StringType)()), true)
     }
 
+    val namedExpressions = expressions.map {
+      case e: NamedExpression => e
+      case e: Expression => UnresolvedAlias(e)
+    }
+
+    def createProject() = if (namedExpressions.nonEmpty) {
+      Project(namedExpressions, withFilter)
+    } else {
+      withFilter
+    }
+
+    val withProject = if (aggregationClause == null && havingClause != null) {
+      if (conf.getConf(SQLConf.LEGACY_HAVING_WITHOUT_GROUP_BY_AS_WHERE)) {
+        // If the legacy conf is set, treat HAVING without GROUP BY as WHERE.
+        withHavingClause(havingClause, createProject())
+      } else {
+        // According to SQL standard, HAVING without GROUP BY means global aggregate.
+        withHavingClause(havingClause, Aggregate(Nil, namedExpressions, withFilter))
+      }
+    } else if (aggregationClause != null) {
+      val aggregate = withAggregationClause(aggregationClause, namedExpressions, withFilter)
+      aggregate.optionalMap(havingClause)(withHavingClause)
+    } else {
+      // When hitting this branch, `having` must be null.
+      createProject()
+    }
+
     // Create the transform.
     ScriptTransformation(
-      expressions,
+      withProject.output,
       string(transformClause.script),
       attributes,
-      withFilter,
+      withProject,
       withScriptIOSchema(
         ctx,
         transformClause.inRowFormat,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -550,10 +550,9 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
     }
 
     val childOutput = withProject match {
-      case f: Filter if f.child.isInstanceOf[UnresolvedRelation] =>
-        expressions
-      case f: Filter if !f.child.isInstanceOf[UnresolvedRelation] =>
+      case f: Filter =>
         f.child match {
+          case r: UnresolvedRelation => expressions
           case agg: Aggregate => agg.aggregateExpressions
           case project: Project => project.projectList
           // actually it won't happen
@@ -566,10 +565,8 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
 
     // Get ScripTransformation's child's output cols
     val input = childOutput.map {
-      case a: Alias =>
-        UnresolvedAttribute(a.name)
+      case a: Alias => UnresolvedAttribute(a.name)
       case e: UnresolvedAlias => assignAliases(e)
-      case e: UnresolvedAttribute => e
       case e: Expression => e
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
@@ -1167,6 +1167,25 @@ class DDLParserSuite extends AnalysisTest with SharedSQLContext {
       p.copy(output = Seq('c.int, 'd.decimal(10, 0))))
   }
 
+  test("SPARK-28227 transform with aggregate"){
+    //   val plan = parser.parsePlan(
+    //      """SELECT TRANSFORM(t.c, SUM(t.a) as x)
+    //        |USING 'func' AS (c1 string, a1 string )
+    //    val plan = parser.parsePlan(
+    //      """SELECT t.c, SUM(t.a) as
+    //        |FROM DEFAULT.TEST t
+    //        |GROUP BY t.c
+    //      """.stripMargin)
+    val plan = parser.parsePlan(
+      """SELECT TRANSFORM(t.c, SUM(t.a) as x)
+        |USING 'func' AS (c1 string, a1 string )
+        |FROM DEFAULT.TEST t
+        |WHERE t.c > 0
+        |GROUP BY t.c
+      """.stripMargin)
+    println(plan)
+  }
+
   test("use backticks in output of Script Transform") {
     parser.parsePlan(
       """SELECT `t`.`thing1`


### PR DESCRIPTION
## What changes were proposed in this pull request?
For Spark SQL, it can't support sql like :
`SELECT TRANSFORM ( d2, max(d1) as maxd1, cast(sum(d3) as string))`
`USING 'cat' AS (a,b,c)`
`FROM script_trans`
`WHERE d1 <= 100`
`GROUP BY d2`
`HAVING maxd1 > 0`

But in hive, it can support this kind SQL.
This makes our SQL migration difficult and complex。
This PR is to support use Aggregation with TRANSFORM and make SQL migration from Hive to Sparkeasier.


## How was this patch tested?

Added unit test.