### PR TITLE
[SPARK-28233][BUILD] Upgrade maven-jar-plugin and maven-source-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2431,7 +2431,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.1.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -2441,7 +2441,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.1.0</version>
           <configuration>
             <attach>true</attach>
           </configuration>
@@ -2600,7 +2600,7 @@
                   <pluginExecutionFilter>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <versionRange>3.1.0</versionRange>
+                    <versionRange>3.1.2</versionRange>
                     <goals>
                       <goal>test-jar</goal>
                     </goals>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr upgrade `maven-jar-plugin` to 3.1.2 and `maven-source-plugin` to 3.1.0 to avoid:
- [MJAR-259](https://issues.apache.org/jira/browse/MJAR-259) – Archiving to jar is very slow
- [MSOURCES-119](https://issues.apache.org/jira/browse/MSOURCES-119) – Archiving to jar is very slow

Release notes:
https://blogs.apache.org/maven/entry/apache-maven-source-plugin-version
https://blogs.apache.org/maven/entry/apache-maven-jar-plugin-version2
https://blogs.apache.org/maven/entry/apache-maven-jar-plugin-version1

## How was this patch tested?

N/A
