### PR TITLE
[SPARK-28224][SQL] Check overflow in decimal Sum aggregate

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
@@ -91,8 +91,7 @@ case class Sum(child: Expression) extends DeclarativeAggregate with ImplicitCast
   }
 
   override lazy val evaluateExpression: Expression = resultType match {
-    case DecimalType.Fixed(precision, scale) =>
-      CheckOverflow(sum, DecimalType(precision, scale), SQLConf.get.decimalOperationsNullOnOverflow)
+    case d: DecimalType => CheckOverflow(sum, d, SQLConf.get.decimalOperationsNullOnOverflow)
     case _ => sum
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
@@ -90,7 +90,7 @@ case class Sum(child: Expression) extends DeclarativeAggregate with ImplicitCast
     )
   }
 
-  override lazy val evaluateExpression: Expression = dataType match {
+  override lazy val evaluateExpression: Expression = resultType match {
     case DecimalType.Fixed(precision, scale) =>
       CheckOverflow(sum, DecimalType(precision, scale), SQLConf.get.decimalOperationsNullOnOverflow)
     case _ => sum

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -156,7 +156,7 @@ class DataFrameSuite extends QueryTest with SharedSparkSession {
       structDf.select(xxhash64($"a", $"record.*")))
   }
 
-  test("SPARK-28224: Aggregate sum large big decimal") {
+  test("SPARK-28224: Aggregate sum big decimal overflow") {
     for {
       nullOnOverflow <- Seq(true, false)
     } yield {
@@ -173,6 +173,16 @@ class DataFrameSuite extends QueryTest with SharedSparkSession {
         }
       }
     }
+  }
+
+  test("Aggregate sum integers") {
+    val structDf = largeAndSmallInts.select("a").agg(sum("a"))
+    checkAnswer(structDf, Row(BigInt("6442450941")))
+  }
+
+  test("Aggregate sum double") {
+    val structDf = salary.select("salary").agg(sum("salary"))
+    checkAnswer(structDf, Row(3000.0d))
   }
 
   test("Star Expansion - explode should fail with a meaningful message if it takes a star") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -157,9 +157,7 @@ class DataFrameSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SPARK-28224: Aggregate sum big decimal overflow") {
-    for {
-      nullOnOverflow <- Seq(true, false)
-    } yield {
+    Seq(true, false).foreach { nullOnOverflow =>
       withSQLConf((SQLConf.DECIMAL_OPERATIONS_NULL_ON_OVERFLOW.key, nullOnOverflow.toString)) {
         val structDf = largeDecimals.select("a").agg(sum("a"))
         if (nullOnOverflow) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -163,7 +163,7 @@ class DataFrameSuite extends QueryTest with SharedSparkSession {
         if (nullOnOverflow) {
           checkAnswer(structDf, Row(null))
         } else {
-          val e = intercept[Exception] {
+          val e = intercept[SparkException] {
             structDf.collect
           }
           assert(e.getCause.getClass.equals(classOf[ArithmeticException]))

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ReusedExc
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.{ExamplePoint, ExamplePointUDT, SharedSparkSession}
-import org.apache.spark.sql.test.SQLTestData.{NullStrings, TestData2}
+import org.apache.spark.sql.test.SQLTestData.{DecimalData, NullStrings, TestData2}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 import org.apache.spark.util.random.XORShiftRandom
@@ -157,6 +157,10 @@ class DataFrameSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SPARK-28224: Aggregate sum big decimal overflow") {
+    val largeDecimals = spark.sparkContext.parallelize(
+      DecimalData(BigDecimal("1"* 20 + ".123"), BigDecimal("1"* 20 + ".123")) ::
+        DecimalData(BigDecimal("9"* 20 + ".123"), BigDecimal("9"* 20 + ".123")) :: Nil).toDF()
+
     Seq(true, false).foreach { nullOnOverflow =>
       withSQLConf((SQLConf.DECIMAL_OPERATIONS_NULL_ON_OVERFLOW.key, nullOnOverflow.toString)) {
         val structDf = largeDecimals.select("a").agg(sum("a"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -173,16 +173,6 @@ class DataFrameSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("Aggregate sum integers") {
-    val structDf = largeAndSmallInts.select("a").agg(sum("a"))
-    checkAnswer(structDf, Row(BigInt("6442450941")))
-  }
-
-  test("Aggregate sum double") {
-    val structDf = salary.select("salary").agg(sum("salary"))
-    checkAnswer(structDf, Row(3000.0d))
-  }
-
   test("Star Expansion - explode should fail with a meaningful message if it takes a star") {
     val df = Seq(("1,2"), ("4"), ("7,8,9")).toDF("csv")
     val e = intercept[AnalysisException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
@@ -92,11 +92,9 @@ private[sql] trait SQLTestData { self =>
   }
 
   protected lazy val largeDecimals: DataFrame = {
-    val df = spark.sparkContext.parallelize(
+    spark.sparkContext.parallelize(
       DecimalData(BigDecimal("1"* 20 + ".123"), BigDecimal("1"* 20 + ".123")) ::
       DecimalData(BigDecimal("9"* 20 + ".123"), BigDecimal("9"* 20 + ".123")) :: Nil).toDF()
-    df.createOrReplaceTempView("largeDecimals")
-    df
   }
 
   protected lazy val decimalData: DataFrame = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
@@ -298,6 +298,7 @@ private[sql] trait SQLTestData { self =>
     testData3
     negativeData
     largeAndSmallInts
+    largeDecimals
     decimalData
     binaryData
     upperCaseData

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
@@ -91,6 +91,14 @@ private[sql] trait SQLTestData { self =>
     df
   }
 
+  protected lazy val largeDecimals: DataFrame = {
+    val df = spark.sparkContext.parallelize(
+      DecimalData(BigDecimal("1"* 20 + ".123"), BigDecimal("1"* 20 + ".123")) ::
+      DecimalData(BigDecimal("9"* 20 + ".123"), BigDecimal("9"* 20 + ".123")) :: Nil).toDF()
+    df.createOrReplaceTempView("largeDecimals")
+    df
+  }
+
   protected lazy val decimalData: DataFrame = {
     val df = spark.sparkContext.parallelize(
       DecimalData(1, 1) ::

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
@@ -91,12 +91,6 @@ private[sql] trait SQLTestData { self =>
     df
   }
 
-  protected lazy val largeDecimals: DataFrame = {
-    spark.sparkContext.parallelize(
-      DecimalData(BigDecimal("1"* 20 + ".123"), BigDecimal("1"* 20 + ".123")) ::
-      DecimalData(BigDecimal("9"* 20 + ".123"), BigDecimal("9"* 20 + ".123")) :: Nil).toDF()
-  }
-
   protected lazy val decimalData: DataFrame = {
     val df = spark.sparkContext.parallelize(
       DecimalData(1, 1) ::
@@ -296,7 +290,6 @@ private[sql] trait SQLTestData { self =>
     testData3
     negativeData
     largeAndSmallInts
-    largeDecimals
     decimalData
     binaryData
     upperCaseData


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Currently `sum` in aggregates for decimal type can overflow and return null.
  - `Sum` expression codegens arithmetic on `sql.Decimal` and the output which preserves scale and precision goes into `UnsafeRowWriter`. Here overflowing will be converted to null when writing out.
  - It also does not go through this branch in `DecimalAggregates` because it's expecting precision of the sum (not the elements to be summed) to be less than 5.
https://github.com/apache/spark/blob/4ebff5b6d68f26cc1ff9265a5489e0d7c2e05449/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala#L1400-L1403

- This PR adds the check at the final result of the sum operator itself.
https://github.com/apache/spark/blob/4ebff5b6d68f26cc1ff9265a5489e0d7c2e05449/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala#L372-L376

https://issues.apache.org/jira/browse/SPARK-28224

## How was this patch tested?

- Added an integration test on dataframe suite

cc @mgaido91 @JoshRosen 