### PR TITLE
[SPARK-28235][SQL] Sum of decimals should return a decimal with MAX_PRECISION

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
@@ -50,8 +50,8 @@ case class Sum(child: Expression) extends DeclarativeAggregate with ImplicitCast
     TypeUtils.checkForNumericExpr(child.dataType, "function sum")
 
   private lazy val resultType = child.dataType match {
-    case DecimalType.Fixed(precision, scale) =>
-      DecimalType.bounded(precision + 10, scale)
+    case DecimalType.Fixed(_, scale) =>
+      DecimalType.bounded(DecimalType.MAX_PRECISION, scale)
     case _: IntegralType => LongType
     case _ => DoubleType
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1386,7 +1386,7 @@ object DecimalAggregates extends Rule[LogicalPlan] {
       case we @ WindowExpression(ae @ AggregateExpression(af, _, _, _), _) => af match {
         case Sum(e @ DecimalType.Expression(prec, scale)) if prec + 10 <= MAX_LONG_DIGITS =>
           MakeDecimal(we.copy(windowFunction = ae.copy(aggregateFunction = Sum(UnscaledValue(e)))),
-            prec + 10, scale)
+            DecimalType.MAX_PRECISION, scale)
 
         case Average(e @ DecimalType.Expression(prec, scale)) if prec + 4 <= MAX_DOUBLE_DIGITS =>
           val newAggExpr =
@@ -1399,7 +1399,8 @@ object DecimalAggregates extends Rule[LogicalPlan] {
       }
       case ae @ AggregateExpression(af, _, _, _) => af match {
         case Sum(e @ DecimalType.Expression(prec, scale)) if prec + 10 <= MAX_LONG_DIGITS =>
-          MakeDecimal(ae.copy(aggregateFunction = Sum(UnscaledValue(e))), prec + 10, scale)
+          MakeDecimal(
+            ae.copy(aggregateFunction = Sum(UnscaledValue(e))), DecimalType.MAX_PRECISION, scale)
 
         case Average(e @ DecimalType.Expression(prec, scale)) if prec + 4 <= MAX_DOUBLE_DIGITS =>
           val newAggExpr = ae.copy(aggregateFunction = Average(UnscaledValue(e)))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -435,8 +435,8 @@ class AnalysisSuite extends AnalysisTest with Matchers {
     assertExpressionType(sum(Divide(1.0, 2.0)), DoubleType)
     assertExpressionType(sum(Divide(1, 2.0f)), DoubleType)
     assertExpressionType(sum(Divide(1.0f, 2)), DoubleType)
-    assertExpressionType(sum(Divide(1, Decimal(2))), DecimalType(22, 11))
-    assertExpressionType(sum(Divide(Decimal(1), 2)), DecimalType(26, 6))
+    assertExpressionType(sum(Divide(1, Decimal(2))), DecimalType(38, 11))
+    assertExpressionType(sum(Divide(Decimal(1), 2)), DecimalType(38, 6))
     assertExpressionType(sum(Divide(Decimal(1), 2.0)), DoubleType)
     assertExpressionType(sum(Divide(1.0, Decimal(2.0))), DoubleType)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecisionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecisionSuite.scala
@@ -86,7 +86,7 @@ class DecimalPrecisionSuite extends AnalysisTest with BeforeAndAfter {
     checkType(Divide(d2, d1), DecimalType(10, 6))
     checkType(Remainder(d1, d2), DecimalType(3, 2))
     checkType(Remainder(d2, d1), DecimalType(3, 2))
-    checkType(Sum(d1), DecimalType(12, 1))
+    checkType(Sum(d1), DecimalType(DecimalType.MAX_PRECISION, 1))
     checkType(Average(d1), DecimalType(6, 5))
 
     checkType(Add(Add(d1, d2), d1), DecimalType(7, 2))
@@ -97,7 +97,7 @@ class DecimalPrecisionSuite extends AnalysisTest with BeforeAndAfter {
     checkType(Subtract(Subtract(d2, d1), d1), DecimalType(7, 2))
     checkType(Multiply(Multiply(d1, d1), d2), DecimalType(11, 4))
     checkType(Divide(d2, Add(d1, d1)), DecimalType(10, 6))
-    checkType(Sum(Add(d1, d1)), DecimalType(13, 1))
+    checkType(Sum(Add(d1, d1)), DecimalType(DecimalType.MAX_PRECISION, 1))
   }
 
   test("Comparison operations") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/DecimalAggregatesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/DecimalAggregatesSuite.scala
@@ -38,7 +38,7 @@ class DecimalAggregatesSuite extends PlanTest {
     val originalQuery = testRelation.select(sum('a))
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer = testRelation
-      .select(MakeDecimal(sum(UnscaledValue('a)), 12, 1).as("sum(a)")).analyze
+      .select(MakeDecimal(sum(UnscaledValue('a)), 38, 1).as("sum(a)")).analyze
 
     comparePlans(optimized, correctAnswer)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/DecimalAggregatesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/DecimalAggregatesSuite.scala
@@ -75,7 +75,7 @@ class DecimalAggregatesSuite extends PlanTest {
     val correctAnswer = testRelation
       .select('a)
       .window(
-        Seq(MakeDecimal(windowExpr(sum(UnscaledValue('a)), spec), 12, 1).as('sum_a)),
+        Seq(MakeDecimal(windowExpr(sum(UnscaledValue('a)), spec), 38, 1).as('sum_a)),
         Seq('a),
         Nil)
       .select('a, 'sum_a, 'sum_a)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
@@ -171,8 +171,8 @@ class DataFramePivotSuite extends QueryTest with SharedSQLContext {
       .select("year", "dotNET", "Java")
 
     assertResult(IntegerType)(df.schema("year").dataType)
-    assertResult(DecimalType(20, 2))(df.schema("Java").dataType)
-    assertResult(DecimalType(20, 2))(df.schema("dotNET").dataType)
+    assertResult(DecimalType(38, 2))(df.schema("Java").dataType)
+    assertResult(DecimalType(38, 2))(df.schema("dotNET").dataType)
 
     checkAnswer(df, Row(2012, BigDecimal(1500000, 2), BigDecimal(2000000, 2)) ::
       Row(2013, BigDecimal(4800000, 2), BigDecimal(3000000, 2)) :: Nil)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spark's decimal operations implementation follows what SQLServer does. This is not true for the `Sum` operation. In that case, SQLServer returns `DECIMAL(38, s)` where `s` is the scale of the input of the sum operator. Spark instead, uses as precision of the result type `p + 10` where `p` is the precision of the input type. This can cause overflows, which can be avoided with a higher precision: it happens in particular with sums of many decimals with a small precision.

## How was this patch tested?

changed UTs