### PR TITLE
[WIP][SPARK-28237][SQL] Add an Idempotent batch strategy to catch potential bugs in corresponding rules

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -147,7 +147,7 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
     Batch("LocalRelation early", fixedPoint,
       ConvertToLocalRelation,
       PropagateEmptyRelation) ::
-    Batch("Pullup Correlated Expressions", Once,
+    Batch("Pullup Correlated Expressions", FixedPoint(1),
       PullupCorrelatedPredicates) ::
     Batch("Subquery", Once,
       OptimizeSubqueries) ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -134,7 +134,10 @@ object ExtractEquiJoinKeys extends Logging with PredicateHelper {
         case Equality(l, r) =>
           canEvaluate(l, left) && canEvaluate(r, right) ||
             canEvaluate(l, right) && canEvaluate(r, left)
-        case _ => false
+        case EqualNullSafe(l, r) =>
+          canEvaluate(l, left) && canEvaluate(r, right) ||
+            canEvaluate(l, right) && canEvaluate(r, left)
+        case other => false
       }
 
       if (joinKeys.nonEmpty) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
@@ -145,10 +145,17 @@ abstract class RuleExecutor[TreeType <: TreeNode[_]] extends Logging {
             }
           }
           // Run idempotence checker for batches with Idempotent Strategy
-          if (Utils.isTesting && batch.strategy == Idempotent) {
+          if (Utils.isTesting && batch.strategy == Once) {
             val checkPlan = batch.rules.foldLeft(curPlan) { case (plan, rule) => rule(plan) }
             if (!checkPlan.fastEquals(curPlan)) {
-              val message = s"Idempotent batch ${batch.name} failed idempotence checker"
+              val message =
+                s"""|Idempotent batch ${batch.name} failed idempotence checker
+                    |previous
+                    |${curPlan}
+                    |
+                    |after
+                    |${checkPlan}
+                 """.stripMargin
               throw new TreeNodeException(curPlan, message, null)
             }
           }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NormalizeFloatingPointNumbersSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NormalizeFloatingPointNumbersSuite.scala
@@ -84,10 +84,9 @@ class NormalizeFloatingPointNumbersSuite extends PlanTest {
 
     val optimized = Optimize.execute(query)
     val doubleOptimized = Optimize.execute(optimized)
-    val joinCond = IsNull(a) === IsNull(b) &&
-      KnownFloatingPointNormalized(NormalizeNaNAndZero(coalesce(a, 0.0))) ===
-        KnownFloatingPointNormalized(NormalizeNaNAndZero(coalesce(b, 0.0)))
-    val correctAnswer = testRelation1.join(testRelation2, condition = Some(joinCond))
+    val joinCond = Some(KnownFloatingPointNormalized(NormalizeNaNAndZero(coalesce(a, 0.0)))
+       === KnownFloatingPointNormalized(NormalizeNaNAndZero(coalesce(b, 0.0))))
+    val correctAnswer = testRelation1.join(testRelation2, condition = joinCond)
 
     comparePlans(doubleOptimized, correctAnswer)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current RuleExecutor system contains two kinds of strategies: Once and FixedPoint. The Once strategy is supposed to run once. However, for particular rules (e.g. PullOutNondeterministic/ResolveUDFs), they are designed to be idempotent, but Spark currently lacks corresponding mechanism to prevent such kind of non-idempotent behavior from happening.

This PR added infrastructure to make these checks possible.

## How was this patch tested?
New UTs.
