### PR TITLE
[SPARK-28247][SS] Fix flaky test "query without test harness" on ContinuousSuite 

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousRateStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousRateStreamSource.scala
@@ -38,8 +38,8 @@ class RateStreamContinuousStream(rowsPerSecond: Long, numPartitions: Int) extend
 
   val perPartitionRate = rowsPerSecond.toDouble / numPartitions.toDouble
 
-  val highestCommittedValue = new AtomicLong(Long.MinValue)
-  val firstCommittedTime = new AtomicLong(Long.MinValue)
+  private[sql] val highestCommittedValue = new AtomicLong(Long.MinValue)
+  private[sql] val firstCommittedTime = new AtomicLong(Long.MinValue)
 
   override def mergeOffsets(offsets: Array[PartitionOffset]): Offset = {
     assert(offsets.length == numPartitions)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousRateStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousRateStreamSource.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.execution.streaming.continuous
 
-import java.util.concurrent.atomic.AtomicLong
-
 import org.json4s.DefaultFormats
 import org.json4s.jackson.Serialization
 
@@ -37,9 +35,6 @@ class RateStreamContinuousStream(rowsPerSecond: Long, numPartitions: Int) extend
   val creationTime = System.currentTimeMillis()
 
   val perPartitionRate = rowsPerSecond.toDouble / numPartitions.toDouble
-
-  private[sql] val highestCommittedValue = new AtomicLong(Long.MinValue)
-  private[sql] val firstCommittedTime = new AtomicLong(Long.MinValue)
 
   override def mergeOffsets(offsets: Array[PartitionOffset]): Offset = {
     assert(offsets.length == numPartitions)
@@ -87,16 +82,7 @@ class RateStreamContinuousStream(rowsPerSecond: Long, numPartitions: Int) extend
     RateStreamContinuousReaderFactory
   }
 
-  override def commit(end: Offset): Unit = {
-    end.asInstanceOf[RateStreamOffset].partitionToValueAndRunTimeMs.foreach {
-      case (_, ValueRunTimeMsPair(value, _)) =>
-        if (highestCommittedValue.get() < value) {
-          highestCommittedValue.set(value)
-        }
-    }
-    firstCommittedTime.compareAndSet(Long.MinValue, System.currentTimeMillis())
-  }
-
+  override def commit(end: Offset): Unit = {}
   override def stop(): Unit = {}
 
   private def createInitialOffset(numPartitions: Int, creationTimeMs: Long) = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousRateStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousRateStreamSource.scala
@@ -39,6 +39,7 @@ class RateStreamContinuousStream(rowsPerSecond: Long, numPartitions: Int) extend
   val perPartitionRate = rowsPerSecond.toDouble / numPartitions.toDouble
 
   val highestCommittedValue = new AtomicLong(Long.MinValue)
+  val firstCommittedTime = new AtomicLong(Long.MinValue)
 
   override def mergeOffsets(offsets: Array[PartitionOffset]): Offset = {
     assert(offsets.length == numPartitions)
@@ -93,6 +94,7 @@ class RateStreamContinuousStream(rowsPerSecond: Long, numPartitions: Int) extend
           highestCommittedValue.set(value)
         }
     }
+    firstCommittedTime.compareAndSet(Long.MinValue, System.currentTimeMillis())
   }
 
   override def stop(): Unit = {}

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousSuite.scala
@@ -63,11 +63,12 @@ class ContinuousSuiteBase extends StreamTest {
         }.get
 
         val startTime = System.currentTimeMillis()
-        while (System.currentTimeMillis() < (startTime + maxWaitTimeMs) &&
+        val maxWait = startTime + maxWaitTimeMs
+        while (System.currentTimeMillis() < maxWait &&
           reader.highestCommittedValue.get() < desiredValue) {
           Thread.sleep(100)
         }
-        if (System.currentTimeMillis() > (startTime + maxWaitTimeMs)) {
+        if (System.currentTimeMillis() > maxWait) {
           logWarning(s"Couldn't reach desired value in $maxWaitTimeMs milliseconds!" +
             s"Current highest committed value is ${reader.highestCommittedValue}")
         }
@@ -238,9 +239,9 @@ class ContinuousSuite extends ContinuousSuiteBase {
       .queryName("noharness")
       .trigger(Trigger.Continuous(100))
       .start()
-    val ce =
+    val continuousExecution =
       query.asInstanceOf[StreamingQueryWrapper].streamingQuery.asInstanceOf[ContinuousExecution]
-    waitForRateSourceCommittedValue(ce, 3, 20 * 1000)
+    waitForRateSourceCommittedValue(continuousExecution, 3, 20 * 1000)
     query.stop()
 
     val results = spark.read.table("noharness").collect()

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousSuite.scala
@@ -254,7 +254,7 @@ class ContinuousSuite extends ContinuousSuiteBase {
 
     val results = spark.read.table("noharness").collect()
     assert(expected.map(Row(_)).subsetOf(results.toSet),
-    s"Result set ${results.toSet} are not a superset of $expected!")
+      s"Result set ${results.toSet} are not a superset of $expected!")
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousSuite.scala
@@ -45,7 +45,12 @@ class ContinuousSuiteBase extends StreamTest {
           case ContinuousScanExec(_, _, r: RateStreamContinuousStream, _) => r
         }.get
 
-        val deltaMs = numTriggers * 1000 + 300
+        // Adding 3s in case of slow initialization of partition reader - rows will be committed
+        // on epoch which they're written.
+        // Since previous epochs should be committed before to commit the epoch which output rows
+        // are written, slow initialization of partition reader and tiny trigger interval leads
+        // output rows to wait long time to be committed.
+        val deltaMs = numTriggers * 1000 + 3000
         while (System.currentTimeMillis < reader.creationTime + deltaMs) {
           Thread.sleep(reader.creationTime + deltaMs - System.currentTimeMillis)
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousSuite.scala
@@ -250,13 +250,16 @@ class ContinuousSuite extends ContinuousSuiteBase {
       .queryName("noharness")
       .trigger(Trigger.Continuous(100))
       .start()
+
+    val expected = Set(0, 1, 2, 3)
     val continuousExecution =
       query.asInstanceOf[StreamingQueryWrapper].streamingQuery.asInstanceOf[ContinuousExecution]
-    waitForRateSourceCommittedValue(continuousExecution, 3, 20 * 1000)
+    waitForRateSourceCommittedValue(continuousExecution, expected.max, 20 * 1000)
     query.stop()
 
     val results = spark.read.table("noharness").collect()
-    assert(Set(0, 1, 2, 3).map(Row(_)).subsetOf(results.toSet))
+    assert(expected.map(Row(_)).subsetOf(results.toSet),
+    s"Result set ${results.toSet} are not a superset of $expected!")
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch fixes the flaky test "query without test harness" on ContinuousSuite, via adding some more gaps on waiting query to commit the epoch which writes output rows.

The observation of this issue is below (injected some debug logs to get them):

```
reader creation time                                   1562225320210
epoch 1 launched                                       1562225320593 (+380ms from reader creation time)
epoch 13 launched                                      1562225321702 (+1.5s from reader creation time)
partition reader creation time                         1562225321715 (+1.5s from reader creation time)

next read time for first next call                     1562225321210 (+1s from reader creation time)
first next called in partition reader                  1562225321746 (immediately after creation of partition reader)
wait finished in next called in partition reader       1562225321746 (no wait)

second next called in partition reader                 1562225321747 (immediately after first next())

epoch 0 commit started                                 1562225321861

writing rows (0, 1) (belong to epoch 13)               1562225321866 (+100ms after first next())

wait start in waitForRateSourceTriggers(2)             1562225322059

next read time for second next call                    1562225322210 (+1s from previous "next read time")
wait finished in next called in partition reader       1562225322211 (+450ms wait)

writing rows (2, 3) (belong to epoch 13)               1562225322211 (immediately after next())

epoch 14 launched                                      1562225322246

desired wait time in waitForRateSourceTriggers(2)      1562225322510 (+2.3s from reader creation time)

epoch 12 committed                                     1562225323034
```

These rows were written within desired wait time, but the epoch 13 couldn't be committed within it. Interestingly, epoch 12 was lucky to be committed within a gap between finished waiting in waitForRateSourceTriggers and query.stop() - but even suppose the rows were written in epoch 12, it would be just in luck and epoch should be committed within desired wait time.

This patch modifies Rate continuous stream to track the highest committed value, so that test can wait until desired value is reported to the stream as committed.

This patch also modifies Rate continuous stream to track the timestamp at stream gets the first committed offset, and let `waitForRateSourceTriggers` use the timestamp. This also relies on waiting for specific period, but safer approach compared to current based on the observation above. Based on the change, this patch saves couple of seconds in test time.

## How was this patch tested?

10 sequential test runs succeeded locally.