### PR TITLE
[SPARK-28189][SQL] Use semanticEquals in Dataset drop method for attributes comparison

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2322,7 +2322,7 @@ class Dataset[T] private[sql](
     }
     val attrs = this.logicalPlan.output
     val colsAfterDrop = attrs.filter { attr =>
-      attr != expression
+      !attr.semanticEquals(expression)
     }.map(attr => Column(attr))
     select(colsAfterDrop : _*)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -573,6 +573,7 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
   }
 
   test("SPARK-28189 drop column using drop with column reference with case-insensitive names") {
+    // With SQL config caseSensitive OFF, case insensitive column name should work
     withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
       val col1 = testData("KEY")
       val df1 = testData.drop(col1)
@@ -583,6 +584,14 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
       val df2 = testData.drop(col2)
       checkAnswer(df2, testData.selectExpr("value"))
       assert(df2.schema.map(_.name) === Seq("value"))
+    }
+
+    // With SQL config caseSensitive ON, AnalysisException should be thrown
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+      val e = intercept[AnalysisException] {
+        testData("KEY")
+      }.getMessage
+      assert(e.contains("Cannot resolve column name"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -572,20 +572,18 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     assert(df.schema.map(_.name) === Seq("value"))
   }
 
-  test("drop column using drop with column reference with case-insensitive names") {
-    val col1 = testData("KEY")
-    val df1 = testData.drop(col1)
-    checkAnswer(
-      df1,
-      testData.collect().map(x => Row(x.getString(1))).toSeq)
-    assert(df1.schema.map(_.name) === Seq("value"))
+  test("SPARK-28189 drop column using drop with column reference with case-insensitive names") {
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
+      val col1 = testData("KEY")
+      val df1 = testData.drop(col1)
+      checkAnswer(df1, testData.selectExpr("value"))
+      assert(df1.schema.map(_.name) === Seq("value"))
 
-    val col2 = testData("Key")
-    val df2 = testData.drop(col2)
-    checkAnswer(
-      df2,
-      testData.collect().map(x => Row(x.getString(1))).toSeq)
-    assert(df2.schema.map(_.name) === Seq("value"))
+      val col2 = testData("Key")
+      val df2 = testData.drop(col2)
+      checkAnswer(df2, testData.selectExpr("value"))
+      assert(df2.schema.map(_.name) === Seq("value"))
+    }
   }
 
   test("drop unknown column (no-op) with column reference") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -572,6 +572,22 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     assert(df.schema.map(_.name) === Seq("value"))
   }
 
+  test("drop column using drop with column reference with case-insensitive names") {
+    val col1 = testData("KEY")
+    val df1 = testData.drop(col1)
+    checkAnswer(
+      df1,
+      testData.collect().map(x => Row(x.getString(1))).toSeq)
+    assert(df1.schema.map(_.name) === Seq("value"))
+
+    val col2 = testData("Key")
+    val df2 = testData.drop(col2)
+    checkAnswer(
+      df2,
+      testData.collect().map(x => Row(x.getString(1))).toSeq)
+    assert(df2.schema.map(_.name) === Seq("value"))
+  }
+
   test("drop unknown column (no-op) with column reference") {
     val col = Column("random")
     val df = testData.drop(col)


### PR DESCRIPTION
## What changes were proposed in this pull request?

In Dataset drop(col: Column) method, the `equals` comparison method was used instead of `semanticEquals`, which caused the problem of abnormal case-sensitivity behavior. When attributes of LogicalPlan are checked for equality, `semanticEquals` should be used instead.

A similar PR I referred to: https://github.com/apache/spark/pull/22713 created by @mgaido91 

## How was this patch tested?

- Added new unit test case in DataFrameSuite
- ./build/sbt "testOnly org.apache.spark.sql.*"
- The python code from ticket reporter at https://issues.apache.org/jira/browse/SPARK-28189

