### PR TITLE
[SPARK-28239][SHUFFLE] Allow TCP connections created by shuffle service auto close on YARN NodeManagers

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
@@ -130,6 +130,10 @@ public class TransportServer implements Closeable {
       bootstrap.childOption(ChannelOption.SO_KEEPALIVE, true);
     }
 
+    if (conf.enableTcpAutoClose()) {
+      bootstrap.childOption(ChannelOption.AUTO_CLOSE, true);
+    }
+
     bootstrap.childHandler(new ChannelInitializer<SocketChannel>() {
       @Override
       protected void initChannel(SocketChannel ch) {

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -43,6 +43,7 @@ public class TransportConf {
   private final String SPARK_NETWORK_IO_LAZYFD_KEY;
   private final String SPARK_NETWORK_VERBOSE_METRICS;
   private final String SPARK_NETWORK_IO_ENABLETCPKEEPALIVE_KEY;
+  private final String SPARK_NETWORK_IO_ENABLETCPAUTOCLOSE_KEY;
 
   private final ConfigProvider conf;
 
@@ -66,6 +67,7 @@ public class TransportConf {
     SPARK_NETWORK_IO_LAZYFD_KEY = getConfKey("io.lazyFD");
     SPARK_NETWORK_VERBOSE_METRICS = getConfKey("io.enableVerboseMetrics");
     SPARK_NETWORK_IO_ENABLETCPKEEPALIVE_KEY = getConfKey("io.enableTcpKeepAlive");
+    SPARK_NETWORK_IO_ENABLETCPAUTOCLOSE_KEY = getConfKey("io.enableTcpAutoClose");
   }
 
   public int getInt(String name, int defaultValue) {
@@ -181,6 +183,15 @@ public class TransportConf {
    */
   public boolean enableTcpKeepAlive() {
     return conf.getBoolean(SPARK_NETWORK_IO_ENABLETCPKEEPALIVE_KEY, false);
+  }
+
+  /**
+   * Whether to enable TCP auto-close. If true, the TCP auto-close are enabled, which removes
+   * connections automatically.
+   * See [SPARK-23182] for details.
+   */
+  public boolean enableTcpAutoClose() {
+    return conf.getBoolean(SPARK_NETWORK_IO_ENABLETCPAUTOCLOSE_KEY, false);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make it possible to close TCP connections on YARN NodeManager automatically.
It will fix connections piling up on NodeManagers and NodeManagers getting slow.

## How was this patch tested?

Manually tested.
Build Spark and deploy as [Configuring the External Shuffle Service](http://spark.apache.org/docs/latest/running-on-yarn.html#configuring-the-external-shuffle-service)
Set spark.shuffle.io.enableTcpAutoClose to true.

Then execute command `lsof -i:7337 |wc -l` on NodeManagers. The results will like :

![image](https://user-images.githubusercontent.com/25916266/60579060-ed27e680-9db4-11e9-9d9c-29c75fadcea7.png)

It keeps in a range and won't increase continuously.

Environment:
Hadoop2.6.0-CDH5.8.3(netty3)
Spark2.4.0(netty4)

Configs:
spark.dynamicAllocation.enabled=true
spark.shuffle.service.enabled=true
