### PR TITLE
[SPARK-21067][SQL] Fix Thrift Server - CTAS fail with Unable to move source

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -675,6 +675,12 @@ object SQLConf {
     .intConf
     .createWithDefault(200)
 
+  val THRIFTSERVER_HDFS_DISABLE_CACHE = buildConf("spark.sql.thriftserver.hdfs.disable.cache")
+    .doc("Whether disable FileSystem connection cache of HDFS. When true, it will fix " +
+      "`FileSystem Closed` exception when using CTAS. See [SPARK-21067] for details.")
+    .booleanConf
+    .createWithDefault(false)
+
   // This is used to set the default data source
   val DEFAULT_DATA_SOURCE_NAME = buildConf("spark.sql.sources.default")
     .doc("The default data source to use in input/output.")
@@ -2145,6 +2151,8 @@ class SQLConf extends Serializable with Logging {
 
   def hiveThriftServerSingleSession: Boolean =
     getConf(StaticSQLConf.HIVE_THRIFT_SERVER_SINGLESESSION)
+
+  def thriftServerHdfsDisableCache: Boolean = getConf(THRIFTSERVER_HDFS_DISABLE_CACHE)
 
   def orderByOrdinal: Boolean = getConf(ORDER_BY_ORDINAL)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -87,6 +87,9 @@ private[sql] class SharedState(
   // to load hive-site.xml into hadoopConf and determine the warehouse path which will be set into
   // both spark conf and hadoop conf avoiding be affected by any SparkSession level options
   private val (conf, hadoopConf) = {
+    if (sparkContext.conf.getBoolean("spark.sql.thriftserver.hdfs.disable.cache", false)) {
+      sparkContext.hadoopConfiguration.setBoolean("fs.hdfs.impl.disable.cache", true)
+    }
     val confClone = sparkContext.conf.clone()
     val hadoopConfClone = new Configuration(sparkContext.hadoopConfiguration)
     // If `SparkSession` is instantiated using an existing `SparkContext` instance and no existing


### PR DESCRIPTION
## What changes were proposed in this pull request?

When we close a session of STS, FileSystem(cached by default) on HDFS will be closed. 
Then if we do CTAS and trigger `Hive.moveFile`, DFSClient will do `checkOpen` and throw `java.io.IOException: Filesystem closed`.

So we add a Spark config `spark.sql.thriftserver.hdfs.disable.cache` to control whether disable the FileSystem connection cache of HDFS.

## How was this patch tested?

Manually tested.