### PR TITLE
[SPARK-28262][SQL] Support `DROP GLOBAL TEMPORARY VIEW`

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -157,7 +157,7 @@ statement
     | ALTER TABLE tableIdentifier partitionSpec SET locationSpec       #setPartitionLocation
     | ALTER TABLE tableIdentifier RECOVER PARTITIONS                   #recoverPartitions
     | DROP TABLE (IF EXISTS)? multipartIdentifier PURGE?               #dropTable
-    | DROP VIEW (IF EXISTS)? multipartIdentifier                       #dropView
+    | DROP (GLOBAL? TEMPORARY)? VIEW (IF EXISTS)? multipartIdentifier  #dropView
     | CREATE (OR REPLACE)? (GLOBAL? TEMPORARY)?
         VIEW (IF NOT EXISTS)? tableIdentifier
         identifierCommentList?


### PR DESCRIPTION
## What changes were proposed in this pull request?

We create global temporary view by:
```sql
CREATE GLOBAL TEMPORARY VIEW temp_view AS SELECT 1 AS col1;
```
But we need to specify `spark.sql.globalTempDatabase` when drop it:
```sql
DROP VIEW global_temp.temp_view;
```
Which is not very convenient, this PR add support `DROP GLOBAL TEMPORARY VIEW` and `DROP TEMPORARY VIEW`.
Arter this PR:
```sql
DROP GLOBAL TEMPORARY VIEW temp_view;
```


Drop view related code:
https://github.com/apache/spark/blob/447bfdec830ba5eaaee791e86caad39f4f6661eb/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala#L194-L219

## How was this patch tested?

unit tests
