### PR TITLE
[SPARK-28267][DOC] Update building-spark.md(support build with hadoop-3.2)

### DIFF
--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -70,8 +70,6 @@ This will build Spark distribution along with Python pip and R packages. For mor
 
 ## Specifying the Hadoop Version and Enabling YARN
 
-You can enable the exact profile of Hadoop to compile against through `-Phadoop-2.7`(default) and `-Phadoop-3.2`.
-
 You can specify the exact version of Hadoop to compile against through the `hadoop.version` property. 
 
 You can enable the `yarn` profile and optionally set the `yarn.version` property if it is different 

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -85,7 +85,7 @@ Example:
 
 To enable Hive integration for Spark SQL along with its JDBC server and CLI,
 add the `-Phive` and `Phive-thriftserver` profiles to your existing build options.
-By default, Spark will build hadoop-2.7 with Hive 1.2.1 and hadoop-3.2 with Hive 2.3.5.
+By default, Spark will build hadoop-2.7 with Hive 1.2.1, and can build hadoop-3.2 with Hive 2.3.5 optionally.
 
     # With Hive 1.2.1 support
     ./build/mvn -Pyarn -Phive -Phive-thriftserver -DskipTests clean package

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -70,6 +70,8 @@ This will build Spark distribution along with Python pip and R packages. For mor
 
 ## Specifying the Hadoop Version and Enabling YARN
 
+You can enable the exact profile of Hadoop to compile against through `-Phadoop-2.7`(default) and `-Phadoop-3.2`.
+
 You can specify the exact version of Hadoop to compile against through the `hadoop.version` property. 
 
 You can enable the `yarn` profile and optionally set the `yarn.version` property if it is different 
@@ -79,14 +81,22 @@ Example:
 
     ./build/mvn -Pyarn -Dhadoop.version=2.8.5 -DskipTests clean package
 
+    ./build/mvn -Pyarn -Phadoop-3.2 -Dhadoop.version=3.1.2 -DskipTests clean package
+
 ## Building With Hive and JDBC Support
 
 To enable Hive integration for Spark SQL along with its JDBC server and CLI,
 add the `-Phive` and `Phive-thriftserver` profiles to your existing build options.
-By default Spark will build with Hive 1.2.1 bindings.
+By default, Spark will build hadoop-2.7 with Hive 1.2.1 and hadoop-3.2 with Hive 2.3.5.
 
     # With Hive 1.2.1 support
     ./build/mvn -Pyarn -Phive -Phive-thriftserver -DskipTests clean package
+
+    # With Hive 2.3.5 support
+    ./build/mvn -Pyarn -Phive -Phive-thriftserver -Phadoop-3.2 -DskipTests clean package
+
+    # Hadoop 2.7 with Hive 2.3.5 support
+    ./build/mvn -Pyarn -Phive -Phive-thriftserver -Phadoop-3.2 -Dhadoop.version=2.7.4 -Dcurator.version=2.7.1 -Dzookeeper.version=3.4.6 -DskipTests clean package
 
 ## Packaging without Hadoop Dependencies for YARN
 

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -95,9 +95,6 @@ By default, Spark will build hadoop-2.7 with Hive 1.2.1 and hadoop-3.2 with Hive
     # With Hive 2.3.5 support
     ./build/mvn -Pyarn -Phive -Phive-thriftserver -Phadoop-3.2 -DskipTests clean package
 
-    # Hadoop 2.7 with Hive 2.3.5 support
-    ./build/mvn -Pyarn -Phive -Phive-thriftserver -Phadoop-3.2 -Dhadoop.version=2.7.4 -Dcurator.version=2.7.1 -Dzookeeper.version=3.4.6 -DskipTests clean package
-
 ## Packaging without Hadoop Dependencies for YARN
 
 The assembly directory produced by `mvn package` will, by default, include all of Spark's

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -79,13 +79,11 @@ Example:
 
     ./build/mvn -Pyarn -Dhadoop.version=2.8.5 -DskipTests clean package
 
-    ./build/mvn -Pyarn -Phadoop-3.2 -Dhadoop.version=3.1.2 -DskipTests clean package
-
 ## Building With Hive and JDBC Support
 
 To enable Hive integration for Spark SQL along with its JDBC server and CLI,
 add the `-Phive` and `Phive-thriftserver` profiles to your existing build options.
-By default, Spark will build hadoop-2.7 with Hive 1.2.1, and can build hadoop-3.2 with Hive 2.3.5 optionally.
+By default, Spark will use Hive 1.2.1 with the `hadoop-2.7` profile, and Hive 2.3.5 with the `hadoop-3.2` profile.
 
     # With Hive 1.2.1 support
     ./build/mvn -Pyarn -Phive -Phive-thriftserver -DskipTests clean package


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since [SPARK-23710](https://issues.apache.org/jira/browse/SPARK-23710), Hadoop 3.x can support Hive. This PR add _build with `hadoop-3.2`_ to building-spark.md.

## How was this patch tested?

manual tests
```
cd docs
SKIP_API=1 jekyll build
```
![image](https://user-images.githubusercontent.com/5399861/60942057-cf5a0480-a313-11e9-9534-4765520e799f.png)



