### PR TITLE
[SPARK-28268][SQL] Rewrite non-correlated Semi/Anti join as Filter

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -187,6 +187,8 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
       ColumnPruning,
       CollapseProject,
       RemoveNoopOperators) :+
+    Batch("ReplaceSemiAntiJoinWithFilter", Once,
+      ReplaceLeftSemiAntiJoinWithFilter) :+
     // This batch must be executed after the `RewriteSubquery` batch, which creates joins.
     Batch("NormalizeFloatingNumbers", Once, NormalizeFloatingNumbers)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceLeftSemiAntiJoinWithFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceLeftSemiAntiJoinWithFilter.scala
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftSemi, LeftSemiOrAnti}
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules.Rule
+
+/**
+ * This rule replaces non-correlated [[LeftSemi]]/[[LeftAnti]] [[Join]] with [[Filter]].
+ * When the `condition` of a semi/anti join can be split by [[And]] into expressions
+ * where each expression only refers to attributes from one side, we can turn it
+ * into a [[Filter]] with a non-correlated [[Exists]] subquery.
+ * For example,
+ * {{{
+ *   SELECT t1a FROM t1 LEFT SEMI JOIN t2 ON (t1a = 1 AND t2b > 10)
+ *   ==>  SELECT t1a FROM t1 WHERE t1a = 1 AND EXISTS(SELECT 1 FROM t2 WHERE t2b > 10)
+ * }}}
+ * As for [[LeftAnti]][[Join]],
+ * {{{
+ *   SELECT t1a FROM t1 LEFT ANTI JOIN t2 ON (t1b < 10)
+ *   ==>  SELECT t1a FROM t1 WHERE NOT(t1b < 10 AND EXISTS(SELECT 1 FROM t2))
+ * }}}
+ *
+ */
+object ReplaceLeftSemiAntiJoinWithFilter extends Rule[LogicalPlan] with PredicateHelper {
+  /**
+   * Split the join condition by [[And]] into three parts:
+   * 1. expressions that only refer to attributes from the left plan
+   * 2. expressions that only refer to attributes from the right plan
+   * 3. expressions that refer to attributes from both sides
+   * Note: if the expression has no [[AttributeReference]], it will be split into the first part.
+   */
+  def splitConditionByReferenceSide(
+    condition: Option[Expression],
+    leftPlan: LogicalPlan,
+    rightPlan: LogicalPlan): (Seq[Expression], Seq[Expression], Seq[Expression]) = {
+    condition match {
+      case None =>
+        (Nil, Nil, Nil)
+      case Some(expr) =>
+        val expressions = splitConjunctivePredicates(expr)
+        val (hasRightReference, noRightReference) =
+          expressions.partition(_.references.intersect(rightPlan.outputSet).nonEmpty)
+        val (hasBothSideReference, onlyRightReference) =
+          hasRightReference.partition(_.references.intersect(leftPlan.outputSet).nonEmpty)
+        (noRightReference, onlyRightReference, hasBothSideReference)
+    }
+  }
+
+  def apply(plan: LogicalPlan): LogicalPlan = plan transform {
+    case j @ Join(leftPlan, rightPlan, LeftSemiOrAnti(joinType), joinCond, hint) =>
+      val (leftCond, rightCond, bothCond) =
+        splitConditionByReferenceSide(joinCond, leftPlan, rightPlan)
+      if (bothCond.nonEmpty) {
+        // Has correlated join condition
+        j
+      } else {
+        // Push down the right condition into `Exists` subquery
+        val existsPlan = if (rightCond.isEmpty) {
+          rightPlan
+        } else {
+          Filter(rightCond.reduce(And), rightPlan)
+        }
+        // Construct the filter condition
+        val filterCond = (leftCond :+ Exists(existsPlan)).reduce(And)
+        joinType match {
+          case LeftSemi =>
+            Filter(filterCond, leftPlan)
+          case LeftAnti =>
+            Filter(Not(filterCond), leftPlan)
+          case _ => // won't happen
+            leftPlan
+        }
+      }
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceLeftSemiAntiJoinWithFilterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceLeftSemiAntiJoinWithFilterSuite.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.Exists
+import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftSemi, PlanTest}
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+
+class ReplaceLeftSemiAntiJoinWithFilterSuite extends PlanTest {
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("Replace Left Semi/Anti Join With Filter", Once,
+        ReplaceLeftSemiAntiJoinWithFilter) :: Nil
+  }
+
+  val testRelation = LocalRelation('t1a.int, 't1b.int)
+  val testRelation2 = LocalRelation('t2a.int, 't2b.int)
+
+  test("Replace left semi join with filter") {
+    val plan = testRelation.join(
+      testRelation2,
+      LeftSemi,
+      Some(('t1a === 1) && ('t2b > 2))
+    )
+    val answer = testRelation.where(('t1a === 1) && Exists(
+      testRelation2.where('t2b > 2)
+    )).analyze
+    comparePlans(Optimize.execute(plan.analyze), answer)
+  }
+
+  test("Replace left anti join with filter") {
+    val plan = testRelation.join(
+      testRelation2,
+      LeftAnti,
+      Some(('t1a === 1) && ('t2b > 2))
+    )
+    val answer = testRelation.where(!(('t1a === 1) && Exists(
+      testRelation2.where('t2b > 2)
+    ))).analyze
+    comparePlans(Optimize.execute(plan.analyze), answer)
+  }
+
+
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -779,7 +779,7 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with SharedSQLContext
         """
           |SELECT * FROM t1
           |WHERE
-          |NOT EXISTS (SELECT * FROM t1)
+          |NOT EXISTS (SELECT * FROM t1 AS t2 WHERE t1.c1 = t2.c1)
         """.stripMargin
       val ds = sql(sqlText)
       assert(getNumInMemoryRelations(ds) == 2)

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -76,7 +76,6 @@ class JoinSuite extends QueryTest with SharedSQLContext {
       Seq(
         ("SELECT * FROM testData LEFT SEMI JOIN testData2 ON key = a",
           classOf[SortMergeJoinExec]),
-        ("SELECT * FROM testData LEFT SEMI JOIN testData2", classOf[BroadcastNestedLoopJoinExec]),
         ("SELECT * FROM testData JOIN testData2", classOf[CartesianProductExec]),
         ("SELECT * FROM testData JOIN testData2 WHERE key = 2", classOf[CartesianProductExec]),
         ("SELECT * FROM testData LEFT JOIN testData2", classOf[BroadcastNestedLoopJoinExec]),
@@ -109,8 +108,7 @@ class JoinSuite extends QueryTest with SharedSQLContext {
           classOf[BroadcastNestedLoopJoinExec]),
         ("SELECT * FROM testData full JOIN testData2 ON (key * a != key + a)",
           classOf[BroadcastNestedLoopJoinExec]),
-        ("SELECT * FROM testData ANTI JOIN testData2 ON key = a", classOf[SortMergeJoinExec]),
-        ("SELECT * FROM testData LEFT ANTI JOIN testData2", classOf[BroadcastNestedLoopJoinExec])
+        ("SELECT * FROM testData ANTI JOIN testData2 ON key = a", classOf[SortMergeJoinExec])
       ).foreach(assertJoin)
     }
   }
@@ -509,8 +507,6 @@ class JoinSuite extends QueryTest with SharedSQLContext {
       Seq(
         ("SELECT * FROM testData LEFT SEMI JOIN testData2 ON key = a",
           classOf[SortMergeJoinExec]),
-        ("SELECT * FROM testData LEFT SEMI JOIN testData2",
-          classOf[BroadcastNestedLoopJoinExec]),
         ("SELECT * FROM testData JOIN testData2",
           classOf[BroadcastNestedLoopJoinExec]),
         ("SELECT * FROM testData JOIN testData2 WHERE key = 2",


### PR DESCRIPTION
## What changes were proposed in this pull request?

When semi/anti join has a non-correlated join condition, we can convert it to a Filter with a non-correlated Exists subquery. As the Exists subquery is non-correlated, we can use a physical plan for it to avoid join.

Actually, this optimization is mainly for the non-correlated subqueries (Exists/In). We currently rewrite Exists/InSubquery as semi/anti/existential join, whether it is correlated or not. And they are mostly executed using a BroadcastNestedLoopJoin which is really not a good choice.

Here are some examples:
1. 
``` SQL
SELECT t1a
FROM    t1  
SEMI JOIN t2
ON t2a > 10 OR t2b = 'a'
```
=>
```SQL
SELECT t1a
FROM t1
WHERE EXISTS(SELECT 1 
             FROM t2 
             WHERE t2a > 10 OR t2b = 'a')
```
2.
```SQL
SELECT t1a
FROM  t1
ANTI JOIN t2
ON t1b > 10 AND t2b = 'b'
```
=>
```SQL
SELECT t1a
FROM t1
WHERE NOT(t1b > 10 
          AND EXISTS(SELECT 1
                     FROM  t2
                     WHERE t2b = 'b'))
```

This PR adds a new optimize rule : `ReplaceLeftSemiAntiJoinWithFilter`.
This rule replaces non-correlated `LeftSemi/LeftAnti Join` with `Filter`. When the `condition` of a semi/anti join can be split by `And` into expressions where each expression only refers to attributes from one side, we can turn it into a `Filter` with a non-correlated `Exists` subquery.

Besides, this PR adds a physical plan for non-correlated Exists.

## How was this patch tested?
ut
