### PR TITLE
[SPARK-28314][SQL] Use the same MemoryManager when building HashedRelation

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -93,13 +93,7 @@ private[execution] object HashedRelation {
       sizeEstimate: Int = 64,
       taskMemoryManager: TaskMemoryManager = null): HashedRelation = {
     val mm = Option(taskMemoryManager).getOrElse {
-      new TaskMemoryManager(
-        new UnifiedMemoryManager(
-          new SparkConf().set(MEMORY_OFFHEAP_ENABLED.key, "false"),
-          Long.MaxValue,
-          Long.MaxValue / 2,
-          1),
-        0)
+      new TaskMemoryManager(SparkEnv.get.memoryManager, 0)
     }
 
     if (key.length == 1 && key.head.dataType == LongType) {
@@ -226,13 +220,7 @@ private[joins] class UnsafeHashedRelation(
     // This is used in Broadcast, shared by multiple tasks, so we use on-heap memory
     // TODO(josh): This needs to be revisited before we merge this patch; making this change now
     // so that tests compile:
-    val taskMemoryManager = new TaskMemoryManager(
-      new UnifiedMemoryManager(
-        new SparkConf().set(MEMORY_OFFHEAP_ENABLED.key, "false"),
-        Long.MaxValue,
-        Long.MaxValue / 2,
-        1),
-      0)
+    val taskMemoryManager = new TaskMemoryManager(SparkEnv.get.memoryManager, 0)
 
     val pageSizeBytes = Option(SparkEnv.get).map(_.memoryManager.pageSizeBytes)
       .getOrElse(new SparkConf().get(BUFFER_PAGESIZE).getOrElse(16L * 1024 * 1024))
@@ -390,13 +378,7 @@ private[execution] final class LongToUnsafeRowMap(val mm: TaskMemoryManager, cap
   // needed by serializer
   def this() = {
     this(
-      new TaskMemoryManager(
-        new UnifiedMemoryManager(
-          new SparkConf().set(MEMORY_OFFHEAP_ENABLED.key, "false"),
-          Long.MaxValue,
-          Long.MaxValue / 2,
-          1),
-        0),
+      new TaskMemoryManager(SparkEnv.get.memoryManager, 0),
       0)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -93,7 +93,7 @@ private[execution] object HashedRelation {
       sizeEstimate: Int = 64,
       taskMemoryManager: TaskMemoryManager = null): HashedRelation = {
     val mm = Option(taskMemoryManager).getOrElse {
-      new TaskMemoryManager(SparkEnv.get.memoryManager, 0)
+      new TaskMemoryManager(UnifiedMemoryManager(SparkEnv.get.conf, 1), 0)
     }
 
     if (key.length == 1 && key.head.dataType == LongType) {
@@ -220,7 +220,7 @@ private[joins] class UnsafeHashedRelation(
     // This is used in Broadcast, shared by multiple tasks, so we use on-heap memory
     // TODO(josh): This needs to be revisited before we merge this patch; making this change now
     // so that tests compile:
-    val taskMemoryManager = new TaskMemoryManager(SparkEnv.get.memoryManager, 0)
+    val taskMemoryManager = new TaskMemoryManager(UnifiedMemoryManager(SparkEnv.get.conf, 1), 0)
 
     val pageSizeBytes = Option(SparkEnv.get).map(_.memoryManager.pageSizeBytes)
       .getOrElse(new SparkConf().get(BUFFER_PAGESIZE).getOrElse(16L * 1024 * 1024))
@@ -378,7 +378,7 @@ private[execution] final class LongToUnsafeRowMap(val mm: TaskMemoryManager, cap
   // needed by serializer
   def this() = {
     this(
-      new TaskMemoryManager(SparkEnv.get.memoryManager, 0),
+      new TaskMemoryManager(UnifiedMemoryManager(SparkEnv.get.conf, 1), 0),
       0)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Broadcasting some tables with a large number of rows may cause infinite recursion loop in ```TaskMemoryManager#allocatePage```.
This is because ```HashedRelation``` uses ```Long.MaxValue``` to construct ```MemoryManager``` instead of memory configured by driver.
```MemoryAllocator#allocate``` throws OOM,```TaskMemoryManager#allocatePage``` captures OOM and continues to call ```allocatePage```.

## How was this patch tested?
add UT
