### PR TITLE
[SPARK-28332][SQL] SQLMetric wrong initValue

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
@@ -110,7 +110,7 @@ object SQLMetrics {
     // The final result of this metric in physical operator UI may look like:
     // data size total (min, med, max):
     // 100GB (100MB, 1GB, 10GB)
-    val acc = new SQLMetric(SIZE_METRIC, -1)
+    val acc = new SQLMetric(SIZE_METRIC)
     acc.register(sc, name = Some(s"$name total (min, med, max)"), countFailedValues = false)
     acc
   }
@@ -119,14 +119,14 @@ object SQLMetrics {
     // The final result of this metric in physical operator UI may looks like:
     // duration(min, med, max):
     // 5s (800ms, 1s, 2s)
-    val acc = new SQLMetric(TIMING_METRIC, -1)
+    val acc = new SQLMetric(TIMING_METRIC)
     acc.register(sc, name = Some(s"$name total (min, med, max)"), countFailedValues = false)
     acc
   }
 
   def createNanoTimingMetric(sc: SparkContext, name: String): SQLMetric = {
     // Same with createTimingMetric, just normalize the unit of time to millisecond.
-    val acc = new SQLMetric(NS_TIMING_METRIC, -1)
+    val acc = new SQLMetric(NS_TIMING_METRIC)
     acc.register(sc, name = Some(s"$name total (min, med, max)"), countFailedValues = false)
     acc
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently SQLMetrics.createSizeMetric create a SQLMetric with initValue set to -1.

If there is a ShuffleMapStage with lots of Tasks which read 0 bytes data, these tasks will send the metric(the metric value still be the initValue with -1) to Driver,  then Driver do metric merge for this Stage in DAGScheduler.updateAccumulators, this will cause the merged metric value of this Stage set to be a negative value. 

This is incorrect， we should set the initValue to 0 .

Another same case in SQLMetrics.createTimingMetric/createNanoTimingMetric

## How was this patch tested?
No more tests