### PR TITLE
[SPARK-28337][spark-assembly]add commons-jxpath dependency for assembly.

### DIFF
--- a/launcher/pom.xml
+++ b/launcher/pom.xml
@@ -67,6 +67,11 @@
       <artifactId>spark-tags_${scala.binary.version}</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>commons-jxpath</groupId>
+      <artifactId>commons-jxpath</artifactId>
+    </dependency>
+
     <!--
       This spark-tags test-dep is needed even though it isn't used in this module, otherwise testing-cmds that exclude
       them will yield errors.

--- a/pom.xml
+++ b/pom.xml
@@ -2208,6 +2208,11 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>commons-jxpath</groupId>
+        <artifactId>commons-jxpath</artifactId>
+        <version>1.3</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR add `commons-jxpath:commons-jxpath` dependency for assembly it into jars directory.
Spark contains `commons-configuration-1.6.jar` in the jars directory after assembly, and `commons-configuration-1.6.jar` depends on `commons-jxpath:commons-jxpath`. For spark application which use `XPathExpressionEngine`, a ClassNotFound exception will be thrown even though the classes of commons-jxpath:commons-jxpath are shaded inside the app jar. Becase class `XPathExpressionEngine`
is loader by the **Launcher$AppClassLoader** in jars directory, so when the classloader need to load **NodePointerFactory**(which need by `XPathExpressionEngine`) class, user spark app jar is not in the path for searching.
## How was this patch tested?
manual tests.
