### PR TITLE
[SPARK-28342][SQL][TESTS] Replace REL_12_BETA1 to REL_12_BETA2 in PostgresSQL SQL tests

### DIFF
--- a/sql/core/src/test/resources/sql-tests/inputs/pgSQL/aggregates_part1.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/pgSQL/aggregates_part1.sql
@@ -3,7 +3,7 @@
 --
 --
 -- AGGREGATES [Part 1]
--- https://github.com/postgres/postgres/blob/REL_12_BETA1/src/test/regress/sql/aggregates.sql#L1-L143
+-- https://github.com/postgres/postgres/blob/REL_12_BETA2/src/test/regress/sql/aggregates.sql#L1-L143
 
 -- avoid bit-exact output here because operations may not be bit-exact.
 -- SET extra_float_digits = 0;

--- a/sql/core/src/test/resources/sql-tests/inputs/pgSQL/aggregates_part2.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/pgSQL/aggregates_part2.sql
@@ -3,7 +3,7 @@
 --
 --
 -- AGGREGATES [Part 2]
--- https://github.com/postgres/postgres/blob/REL_12_BETA1/src/test/regress/sql/aggregates.sql#L145-L350
+-- https://github.com/postgres/postgres/blob/REL_12_BETA2/src/test/regress/sql/aggregates.sql#L145-L350
 
 create temporary view int4_tbl as select * from values
   (0),

--- a/sql/core/src/test/resources/sql-tests/inputs/pgSQL/boolean.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/pgSQL/boolean.sql
@@ -3,7 +3,7 @@
 --
 --
 -- BOOLEAN
--- https://github.com/postgres/postgres/blob/REL_12_BETA1/src/test/regress/sql/boolean.sql
+-- https://github.com/postgres/postgres/blob/REL_12_BETA2/src/test/regress/sql/boolean.sql
 
 --
 -- sanity check - if this fails go insane!

--- a/sql/core/src/test/resources/sql-tests/inputs/pgSQL/case.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/pgSQL/case.sql
@@ -3,7 +3,7 @@
 --
 --
 -- CASE
--- https://github.com/postgres/postgres/blob/REL_12_BETA1/src/test/regress/sql/case.sql
+-- https://github.com/postgres/postgres/blob/REL_12_BETA2/src/test/regress/sql/case.sql
 -- Test the CASE statement
 --
 -- This test suite contains two Cartesian products without using explicit CROSS JOIN syntax.

--- a/sql/core/src/test/resources/sql-tests/inputs/pgSQL/float4.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/pgSQL/float4.sql
@@ -3,7 +3,7 @@
 --
 --
 -- FLOAT4
--- https://github.com/postgres/postgres/blob/REL_12_BETA1/src/test/regress/sql/float4.sql
+-- https://github.com/postgres/postgres/blob/REL_12_BETA2/src/test/regress/sql/float4.sql
 
 CREATE TABLE FLOAT4_TBL (f1  float) USING parquet;
 

--- a/sql/core/src/test/resources/sql-tests/inputs/pgSQL/int4.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/pgSQL/int4.sql
@@ -3,7 +3,7 @@
 --
 --
 -- INT4
--- https://github.com/postgres/postgres/blob/REL_12_BETA1/src/test/regress/sql/int4.sql
+-- https://github.com/postgres/postgres/blob/REL_12_BETA2/src/test/regress/sql/int4.sql
 --
 
 CREATE TABLE INT4_TBL(f1 int) USING parquet;

--- a/sql/core/src/test/resources/sql-tests/inputs/udf/pgSQL/udf-aggregates_part1.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/udf/pgSQL/udf-aggregates_part1.sql
@@ -3,7 +3,7 @@
 --
 --
 -- AGGREGATES [Part 1]
--- https://github.com/postgres/postgres/blob/REL_12_BETA1/src/test/regress/sql/aggregates.sql#L1-L143
+-- https://github.com/postgres/postgres/blob/REL_12_BETA2/src/test/regress/sql/aggregates.sql#L1-L143
 
 -- avoid bit-exact output here because operations may not be bit-exact.
 -- SET extra_float_digits = 0;

--- a/sql/core/src/test/resources/sql-tests/inputs/udf/pgSQL/udf-aggregates_part2.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/udf/pgSQL/udf-aggregates_part2.sql
@@ -3,7 +3,7 @@
 --
 --
 -- AGGREGATES [Part 2]
--- https://github.com/postgres/postgres/blob/REL_12_BETA1/src/test/regress/sql/aggregates.sql#L145-L350
+-- https://github.com/postgres/postgres/blob/REL_12_BETA2/src/test/regress/sql/aggregates.sql#L145-L350
 --
 -- This test file was converted from pgSQL/aggregates_part2.sql.
 -- Note that currently registered UDF returns a string. So there are some differences, for instance

--- a/sql/core/src/test/resources/sql-tests/inputs/udf/pgSQL/udf-case.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/udf/pgSQL/udf-case.sql
@@ -3,7 +3,7 @@
 --
 --
 -- CASE
--- https://github.com/postgres/postgres/blob/REL_12_BETA1/src/test/regress/sql/case.sql
+-- https://github.com/postgres/postgres/blob/REL_12_BETA2/src/test/regress/sql/case.sql
 -- Test the CASE statement
 --
 -- This test suite contains two Cartesian products without using explicit CROSS JOIN syntax.


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to replace `REL_12_BETA1` to `REL_12_BETA2` which is latest.

## How was this patch tested?

Manually checked each link and checked via `git grep -r REL_12_BETA1` as well.