### PR TITLE
[SPARK-28346][SQL] clone the query plan between analyzer, optimizer and planner

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -429,8 +429,15 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
   private def makeCopy(
       newArgs: Array[AnyRef],
       allowEmptyArgs: Boolean): BaseType = attachTree(this, "makeCopy") {
+    val allCtors = getClass.getConstructors
+    if (newArgs.isEmpty && allCtors.isEmpty) {
+      // This is a singleton object which doesn't have any constructor. Just return `this` as we
+      // can't copy it.
+      return this
+    }
+
     // Skip no-arg constructors that are just there for kryo.
-    val ctors = getClass.getConstructors.filter(allowEmptyArgs || _.getParameterTypes.size != 0)
+    val ctors = allCtors.filter(allowEmptyArgs || _.getParameterTypes.size != 0)
     if (ctors.isEmpty) {
       sys.error(s"No valid constructor for $nodeName")
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.trees
 
 import java.util.UUID
 
-import scala.collection.Map
+import scala.collection.{mutable, Map}
 import scala.reflect.ClassTag
 
 import org.apache.commons.lang3.ClassUtils
@@ -88,18 +88,18 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
    * A mutable map for holding auxiliary information of this tree node. It will be carried over
    * when this node is copied via `makeCopy`, or transformed via `transformUp`/`transformDown`.
    */
-  private val tags = new java.util.concurrent.ConcurrentHashMap[TreeNodeTag[_], Any]()
+  private val tags: mutable.Map[TreeNodeTag[_], Any] = mutable.Map.empty
 
   protected def copyTagsFrom(other: BaseType): Unit = {
-    tags.putAll(other.tags)
+    tags ++= other.tags
   }
 
   def setTagValue[T](tag: TreeNodeTag[T], value: T): Unit = {
-    tags.put(tag, value)
+    tags(tag) = value
   }
 
   def getTagValue[T](tag: TreeNodeTag[T]): Option[T] = {
-    Option(tags.get(tag)).map(_.asInstanceOf[T])
+    tags.get(tag).map(_.asInstanceOf[T])
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.analysis.UnsupportedOperationChecker
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, ReturnAnswer}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.util.StringUtils.{PlanStringConcat, StringConcat}
+import org.apache.spark.sql.catalyst.util.StringUtils.PlanStringConcat
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.execution.adaptive.InsertAdaptiveSparkPlan
 import org.apache.spark.sql.execution.exchange.{EnsureRequirements, ReuseExchange}
@@ -66,30 +66,24 @@ class QueryExecution(
   lazy val withCachedData: LogicalPlan = {
     assertAnalyzed()
     assertSupported()
-    sparkSession.sharedState.cacheManager.useCachedData(analyzed)
+    sparkSession.sharedState.cacheManager.useCachedData(analyzed.clone())
   }
 
   lazy val optimizedPlan: LogicalPlan = tracker.measurePhase(QueryPlanningTracker.OPTIMIZATION) {
-    sparkSession.sessionState.optimizer.executeAndTrack(withCachedData, tracker)
+    sparkSession.sessionState.optimizer.executeAndTrack(withCachedData.clone(), tracker)
   }
 
   lazy val sparkPlan: SparkPlan = tracker.measurePhase(QueryPlanningTracker.PLANNING) {
     SparkSession.setActiveSession(sparkSession)
-    // Runtime re-optimization requires a unique instance of every node in the logical plan.
-    val logicalPlan = if (sparkSession.sessionState.conf.adaptiveExecutionEnabled) {
-      optimizedPlan.clone()
-    } else {
-      optimizedPlan
-    }
     // TODO: We use next(), i.e. take the first plan returned by the planner, here for now,
     //       but we will implement to choose the best plan.
-    planner.plan(ReturnAnswer(logicalPlan)).next()
+    planner.plan(ReturnAnswer(optimizedPlan.clone())).next()
   }
 
   // executedPlan should not be used to initialize any SparkPlan. It should be
   // only used for execution.
   lazy val executedPlan: SparkPlan = tracker.measurePhase(QueryPlanningTracker.PLANNING) {
-    prepareForExecution(sparkPlan)
+    prepareForExecution(sparkPlan.clone())
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -60,6 +60,7 @@ class QueryExecution(
 
   lazy val analyzed: LogicalPlan = tracker.measurePhase(QueryPlanningTracker.ANALYSIS) {
     SparkSession.setActiveSession(sparkSession)
+    // We can't clone `logical` here, which will reset the `_analyzed` flag.
     sparkSession.sessionState.analyzer.executeAndCheck(logical, tracker)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -27,7 +27,6 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical
 import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, LogicalPlan, Statistics}
-import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.storage.StorageLevel
@@ -150,14 +149,14 @@ object InMemoryRelation {
       logicalPlan: LogicalPlan): InMemoryRelation = {
     val cacheBuilder = CachedRDDBuilder(useCompression, batchSize, storageLevel, child, tableName)
     val relation = new InMemoryRelation(child.output, cacheBuilder, logicalPlan.outputOrdering)
-    relation.setStatsOfPlanToCache(logicalPlan.stats)
+    relation.statsOfPlanToCache = logicalPlan.stats
     relation
   }
 
   def apply(cacheBuilder: CachedRDDBuilder, logicalPlan: LogicalPlan): InMemoryRelation = {
     val relation = new InMemoryRelation(
       cacheBuilder.cachedPlan.output, cacheBuilder, logicalPlan.outputOrdering)
-    relation.setStatsOfPlanToCache(logicalPlan.stats)
+    relation.statsOfPlanToCache = logicalPlan.stats
     relation
   }
 
@@ -167,11 +166,9 @@ object InMemoryRelation {
       outputOrdering: Seq[SortOrder],
       statsOfPlanToCache: Statistics): InMemoryRelation = {
     val relation = InMemoryRelation(output, cacheBuilder, outputOrdering)
-    relation.setStatsOfPlanToCache(statsOfPlanToCache)
+    relation.statsOfPlanToCache = statsOfPlanToCache
     relation
   }
-
-  val STATS_OF_PLAN_TO_CACHE_TAG = new TreeNodeTag[Statistics]("stats_of_plan_to_cache")
 }
 
 case class InMemoryRelation(
@@ -179,15 +176,8 @@ case class InMemoryRelation(
     @transient cacheBuilder: CachedRDDBuilder,
     override val outputOrdering: Seq[SortOrder])
   extends logical.LeafNode with MultiInstanceRelation {
-  import InMemoryRelation.STATS_OF_PLAN_TO_CACHE_TAG
 
-  def setStatsOfPlanToCache(statsOfPlanToCache: Statistics): Unit = {
-    setTagValue(STATS_OF_PLAN_TO_CACHE_TAG, statsOfPlanToCache)
-  }
-
-  def getStatsOfPlanToCache(): Statistics = {
-    getTagValue(STATS_OF_PLAN_TO_CACHE_TAG).get
-  }
+  @volatile var statsOfPlanToCache: Statistics = null
 
   override protected def innerChildren: Seq[SparkPlan] = Seq(cachedPlan)
 
@@ -203,20 +193,19 @@ case class InMemoryRelation(
   private[sql] def updateStats(
       rowCount: Long,
       newColStats: Map[Attribute, ColumnStat]): Unit = this.synchronized {
-    val statsOfPlanToCache = getStatsOfPlanToCache()
     val newStats = statsOfPlanToCache.copy(
       rowCount = Some(rowCount),
       attributeStats = AttributeMap((statsOfPlanToCache.attributeStats ++ newColStats).toSeq)
     )
-    setStatsOfPlanToCache(newStats)
+    statsOfPlanToCache = newStats
   }
 
   override def computeStats(): Statistics = {
     if (!cacheBuilder.isCachedColumnBuffersLoaded) {
       // Underlying columnar RDD hasn't been materialized, use the stats from the plan to cache.
-      getStatsOfPlanToCache()
+      statsOfPlanToCache
     } else {
-      getStatsOfPlanToCache().copy(
+      statsOfPlanToCache.copy(
         sizeInBytes = cacheBuilder.sizeInBytesStats.value.longValue,
         rowCount = Some(cacheBuilder.rowCountStats.value.longValue)
       )
@@ -224,14 +213,20 @@ case class InMemoryRelation(
   }
 
   def withOutput(newOutput: Seq[Attribute]): InMemoryRelation =
-    InMemoryRelation(newOutput, cacheBuilder, outputOrdering, getStatsOfPlanToCache())
+    InMemoryRelation(newOutput, cacheBuilder, outputOrdering, statsOfPlanToCache)
 
   override def newInstance(): this.type = {
     InMemoryRelation(
       output.map(_.newInstance()),
       cacheBuilder,
       outputOrdering,
-      getStatsOfPlanToCache()).asInstanceOf[this.type]
+      statsOfPlanToCache).asInstanceOf[this.type]
+  }
+
+  override def clone(): LogicalPlan = {
+    val cloned = this.copy()
+    cloned.statsOfPlanToCache = this.statsOfPlanToCache
+    cloned
   }
 
   override def simpleString(maxFields: Int): String =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -223,6 +223,7 @@ case class InMemoryRelation(
       statsOfPlanToCache).asInstanceOf[this.type]
   }
 
+  // override `clone` since the default implementation won't carry over mutable states.
   override def clone(): LogicalPlan = {
     val cloned = this.copy()
     cloned.statsOfPlanToCache = this.statsOfPlanToCache

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
@@ -168,6 +168,4 @@ case object ResetCommand extends RunnableCommand with IgnoreCachedData {
     sparkSession.sessionState.conf.clear()
     Seq.empty[Row]
   }
-
-  override def clone(): LogicalPlan = this
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.command
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.plans.logical.IgnoreCachedData
+import org.apache.spark.sql.catalyst.plans.logical.{IgnoreCachedData, LogicalPlan}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
@@ -168,4 +168,6 @@ case object ResetCommand extends RunnableCommand with IgnoreCachedData {
     sparkSession.sessionState.conf.clear()
     Seq.empty[Row]
   }
+
+  override def clone(): LogicalPlan = this
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/cache.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/cache.scala
@@ -89,4 +89,6 @@ case object ClearCacheCommand extends RunnableCommand with IgnoreCachedData {
     sparkSession.catalog.clearCache()
     Seq.empty[Row]
   }
+
+  override def clone(): LogicalPlan = this
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/cache.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/cache.scala
@@ -89,6 +89,4 @@ case object ClearCacheCommand extends RunnableCommand with IgnoreCachedData {
     sparkSession.catalog.clearCache()
     Seq.empty[Row]
   }
-
-  override def clone(): LogicalPlan = this
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommand.scala
@@ -52,4 +52,8 @@ case class SaveIntoDataSourceCommand(
     val redacted = SQLConf.get.redactOptions(options)
     s"SaveIntoDataSourceCommand ${dataSource}, ${redacted}, ${mode}"
   }
+
+  override def clone(): LogicalPlan = {
+    SaveIntoDataSourceCommand(query.clone(), dataSource, options, mode)
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommand.scala
@@ -53,6 +53,8 @@ case class SaveIntoDataSourceCommand(
     s"SaveIntoDataSourceCommand ${dataSource}, ${redacted}, ${mode}"
   }
 
+  // Override `clone` since the default implementation will turn `CaseInsensitiveMap` to a normal
+  // map.
   override def clone(): LogicalPlan = {
     SaveIntoDataSourceCommand(query.clone(), dataSource, options, mode)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/PartitionBatchPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/PartitionBatchPruningSuite.scala
@@ -187,7 +187,7 @@ class PartitionBatchPruningSuite
     val result = df.collect().map(_(0)).toArray
     assert(result.length === 1)
 
-    val (readPartitions, readBatches) = df.queryExecution.sparkPlan.collect {
+    val (readPartitions, readBatches) = df.queryExecution.executedPlan.collect {
         case in: InMemoryTableScanExec => (in.readPartitions.value, in.readBatches.value)
       }.head
     assert(readPartitions === 5)
@@ -208,7 +208,7 @@ class PartitionBatchPruningSuite
         df.collect().map(_(0)).toArray
       }
 
-      val (readPartitions, readBatches) = df.queryExecution.sparkPlan.collect {
+      val (readPartitions, readBatches) = df.queryExecution.executedPlan.collect {
         case in: InMemoryTableScanExec => (in.readPartitions.value, in.readBatches.value)
       }.head
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

query plan was designed to be immutable, but sometimes we do allow it to carry mutable states, because of the complexity of the SQL system. One example is `TreeNodeTag`. It's a state of `TreeNode` and can be carried over during copy and transform. The adaptive execution framework relies on it to link the logical and physical plans.

This leads to a problem: when we get `QueryExecution#analyzed`, the plan can be changed unexpectedly because it's mutable. I hit a real issue in https://github.com/apache/spark/pull/25107 : I use `TreeNodeTag` to carry dataset id in logical plans. However, the analyzed plan ends up with many duplicated dataset id tags in different nodes. It turns out that, the optimizer transforms the logical plan and add the tag to more nodes.

For example, the logical plan is `SubqueryAlias(Filter(...))`, and I expect only the `SubqueryAlais` has the dataset id tag. However, the optimizer removes `SubqueryAlias` and carries over the dataset id tag to `Filter`. When I go back to the analyzed plan, both `SubqueryAlias` and `Filter` has the dataset id tag, which breaks my assumption.

Since now query plan is mutable, I think it's better to limit the life cycle of a query plan instance. We can clone the query plan between analyzer, optimizer and planner, so that the life cycle is limited in one stage.

## How was this patch tested?

new test