### PR TITLE
[SPARK-28347][K8S] Add gcompat to spark k8s Dockerfile

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -29,7 +29,7 @@ ARG spark_uid=185
 RUN set -ex && \
     apk upgrade --no-cache && \
     ln -s /lib /lib64 && \
-    apk add --no-cache bash tini libc6-compat linux-pam krb5 krb5-libs nss && \
+    apk add --no-cache bash tini libc6-compat gcompat linux-pam krb5 krb5-libs nss && \
     mkdir -p /opt/spark && \
     mkdir -p /opt/spark/examples && \
     mkdir -p /opt/spark/work-dir && \


### PR DESCRIPTION
## What changes were proposed in this pull request?

I want to run TPC-DS in K8S, when generating data on HDFS, with following error: 

ERROR Utils: Aborting task
java.lang.UnsatisfiedLinkError: /tmp/snappy-1.1.7-91d7ec9a-6e2d-47af-90ae-84c00d143b6d-libsnappyjava.so: Error loading shared library ld-linux-x86-64.so.2: No such file or directory

Looking into the executor pod, ld-linux-x86-64.so.2 is existed in /lib64 but not in /lib :
ls -al /lib/ld*
-rwxr-xr-x 1 root root 584304 Mar 19 09:56 /lib/ld-musl-x86_64.so.1
ls -al /lib64/ld*
lrwxrwxrwx 1 root root 26 Jul 2 09:05 /lib64/ld-linux-x86-64.so.2 -> /lib/libc.musl-x86_64.so.1

After adding the gcompat in Dockerfile,  ld-linux-x86-64.so.2 exists in both lib and lib64 folders and no more error:

ls -al /lib/ld*
-rwxr-xr-x 1 root root 18512 Dec 24 2018 /lib/ld-linux-x86-64.so.2
-rwxr-xr-x 1 root root 584304 Mar 19 09:56 /lib/ld-musl-x86_64.so.1
ls -al /lib64/ld*
lrwxrwxrwx 1 root root 26 Jul 11 02:06 /lib64/ld-linux-x86-64.so.2 -> /lib/libc.musl-x86_64.so.1 

## How was this patch tested?

manual test
