### PR TITLE
[SPARK-28354][INFRA] Use JIRA user name instead of JIRA user key

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -353,7 +353,7 @@ def choose_jira_assignee(issue, asf_jira):
                 except:
                     # assume it's a user id, and try to assign (might fail, we just prompt again)
                     assignee = asf_jira.user(raw_assignee)
-                asf_jira.assign_issue(issue.key, assignee.key)
+                asf_jira.assign_issue(issue.key, assignee.name)
                 return assignee
         except KeyboardInterrupt:
             raise


### PR DESCRIPTION
## What changes were proposed in this pull request?

`dev/merge_spark_pr.py` script always fail for some users because they have different `name` and `key`.

- https://issues.apache.org/jira/rest/api/2/user?username=yumwang

JIRA Client expects `name`, but we are using `key`. This PR fixes it.
```python
# This is JIRA client code `/usr/local/lib/python2.7/site-packages/jira/client.py`
def assign_issue(self, issue, assignee):
    """Assign an issue to a user. None will set it to unassigned. -1 will set it to Automatic.

    :param issue: the issue ID or key to assign
    :param assignee: the user to assign the issue to

    :type issue: int or str
    :type assignee: str

    :rtype: bool
    """
    url = self._options['server'] + \
        '/rest/api/latest/issue/' + str(issue) + '/assignee'
    payload = {'name': assignee}
    r = self._session.put(
        url, data=json.dumps(payload))
    raise_on_error(r)
    return True
```

## How was this patch tested?

Manual with the committer ID/password.

```python
import jira.client
asf_jira = jira.client.JIRA({'server': 'https://issues.apache.org/jira'}, basic_auth=('yourid', 'passwd'))
asf_jira.assign_issue("SPARK-28354", "q79969786")   # This will raise exception.
asf_jira.assign_issue("SPARK-28354", "yumwang")     # This works.
```