### PR TITLE
[SPARK-28366][CORE] Logging in driver when loading single large unsplittable file

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1180,6 +1180,13 @@ package object config {
       .intConf
       .createWithDefault(1)
 
+  private[spark] val IO_FILE_UNSPLITTABLE_WARNING_THRESHOLD =
+    ConfigBuilder("spark.io.file.unsplittable.warning.threshold")
+    .doc("When spark loading one single large unsplittable file, if file size exceed this " +
+      "threshold, then log warning.")
+    .longConf
+    .createWithDefault(1024 * 1024 * 1024)
+
   private[spark] val EVENT_LOG_COMPRESSION_CODEC =
     ConfigBuilder("spark.eventLog.compression.codec")
       .doc("The codec used to compress event log. By default, Spark provides four codecs: " +

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1182,10 +1182,11 @@ package object config {
 
   private[spark] val IO_FILE_UNSPLITTABLE_WARNING_THRESHOLD =
     ConfigBuilder("spark.io.file.unsplittable.warning.threshold")
-    .doc("When spark loading one single large unsplittable file, if file size exceed this " +
-      "threshold, then log warning.")
-    .longConf
-    .createWithDefault(1024 * 1024 * 1024)
+      .internal()
+      .doc("When spark loading one single large unsplittable file, if file size exceed this " +
+        "threshold, then log warning.")
+      .longConf
+      .createWithDefault(1024 * 1024 * 1024)
 
   private[spark] val EVENT_LOG_COMPRESSION_CODEC =
     ConfigBuilder("spark.eventLog.compression.codec")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1180,8 +1180,8 @@ package object config {
       .intConf
       .createWithDefault(1)
 
-  private[spark] val IO_LOAD_LARGE_FILE_WARNING_THRESHOLD =
-    ConfigBuilder("spark.io.loadLargeFile.warning.threshold")
+  private[spark] val IO_WARNING_LARGEFILETHRESHOLD =
+    ConfigBuilder("spark.io.warning.largeFileThreshold")
       .internal()
       .doc("When spark loading one single large file, if file size exceed this " +
         "threshold, then log warning with possible reasons.")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1180,11 +1180,11 @@ package object config {
       .intConf
       .createWithDefault(1)
 
-  private[spark] val IO_FILE_UNSPLITTABLE_WARNING_THRESHOLD =
-    ConfigBuilder("spark.io.file.unsplittable.warning.threshold")
+  private[spark] val IO_LOAD_LARGE_FILE_WARNING_THRESHOLD =
+    ConfigBuilder("spark.io.loadLargeFile.warning.threshold")
       .internal()
-      .doc("When spark loading one single large unsplittable file, if file size exceed this " +
-        "threshold, then log warning.")
+      .doc("When spark loading one single large file, if file size exceed this " +
+        "threshold, then log warning with possible reasons.")
       .longConf
       .createWithDefault(1024 * 1024 * 1024)
 

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -197,8 +197,6 @@ class HadoopRDD[K, V](
     newInputFormat
   }
 
-  @transient private lazy val codecFactory = new CompressionCodecFactory(getJobConf())
-
   override def getPartitions: Array[Partition] = {
     val jobConf = getJobConf()
     // add the credentials here as this can be called before SparkContext initialized
@@ -213,7 +211,8 @@ class HadoopRDD[K, V](
       if (inputSplits.length == 1 && inputSplits(0).isInstanceOf[FileSplit]) {
         val fileSplit = inputSplits(0).asInstanceOf[FileSplit]
         val path = fileSplit.getPath
-        if (fileSplit.getLength > conf.get(IO_LOAD_LARGE_FILE_WARNING_THRESHOLD)) {
+        if (fileSplit.getLength > conf.get(IO_WARNING_LARGEFILETHRESHOLD)) {
+          val codecFactory = new CompressionCodecFactory(jobConf)
           if (Utils.isFileSplittable(path, codecFactory)) {
             logWarning(s"Loading one large file ${path.toString} with only one partition, " +
               s"we can increase partition numbers by the `minPartitions` argument in method " +

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -215,8 +215,9 @@ class HadoopRDD[K, V](
         val path = fileSplit.getPath
         if (fileSplit.getLength > conf.get(IO_LOAD_LARGE_FILE_WARNING_THRESHOLD)) {
           if (Utils.isFileSplittable(path, codecFactory)) {
-            logWarning("Loading one large file by one partition is slow, we can increase " +
-              "partition numbers by the `minPartitions` argument in method `sc.textFile`")
+            logWarning(s"Loading one large file ${path.toString} with only one partition, " +
+              s"we can increase partition numbers by the `minPartitions` argument in method " +
+              "`sc.textFile`")
           } else {
             logWarning(s"Loading one large unsplittable file ${path.toString} with only one " +
               s"partition, because the file is compressed by unsplittable compression codec.")

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -210,13 +210,13 @@ class HadoopRDD[K, V](
       } else {
         allInputSplits
       }
-      if (inputSplits.length == 1) {
+      if (inputSplits.length == 1 && inputSplits(0).isInstanceOf[FileSplit]) {
         val fileSplit = inputSplits(0).asInstanceOf[FileSplit]
         val path = fileSplit.getPath
         if (Utils.isFileSplittable(path, codecFactory)
           && fileSplit.getLength > conf.get(IO_FILE_UNSPLITTABLE_WARNING_THRESHOLD)) {
-          logWarning(s"File ${path.toString} is large and unsplittable so the corresponding " +
-            s"rdd partition have to deal with the whole file and consume large time.")
+          logWarning(s"Loading one large unsplittable File ${path.toString} with only one " +
+            s"partition, because the file is compressed by unsplittable compression codec.")
         }
       }
       val array = new Array[Partition](inputSplits.size)

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -197,8 +197,6 @@ class HadoopRDD[K, V](
     newInputFormat
   }
 
-  private val UNSPLITTABLE_FILE_SIZE_LOG_THRESHOLD = 1024 * 1024 * 1024
-
   @transient private lazy val codecFactory = new CompressionCodecFactory(getJobConf())
 
   override def getPartitions: Array[Partition] = {

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -213,10 +213,14 @@ class HadoopRDD[K, V](
       if (inputSplits.length == 1 && inputSplits(0).isInstanceOf[FileSplit]) {
         val fileSplit = inputSplits(0).asInstanceOf[FileSplit]
         val path = fileSplit.getPath
-        if (Utils.isFileSplittable(path, codecFactory)
-          && fileSplit.getLength > conf.get(IO_FILE_UNSPLITTABLE_WARNING_THRESHOLD)) {
-          logWarning(s"Loading one large unsplittable File ${path.toString} with only one " +
-            s"partition, because the file is compressed by unsplittable compression codec.")
+        if (fileSplit.getLength > conf.get(IO_LOAD_LARGE_FILE_WARNING_THRESHOLD)) {
+          if (Utils.isFileSplittable(path, codecFactory)) {
+            logWarning("Loading one large file by one partition is slow, we can increase " +
+              "partition numbers by the `minPartitions` argument in method `sc.textFile`")
+          } else {
+            logWarning(s"Loading one large unsplittable file ${path.toString} with only one " +
+              s"partition, because the file is compressed by unsplittable compression codec.")
+          }
         }
       }
       val array = new Array[Partition](inputSplits.size)

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -51,6 +51,7 @@ import com.google.common.net.InetAddresses
 import org.apache.commons.lang3.SystemUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, FileUtil, Path}
+import org.apache.hadoop.io.compress.{CompressionCodecFactory, SplittableCompressionCodec}
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.eclipse.jetty.util.MultiException
@@ -2894,6 +2895,12 @@ private[spark] object Utils extends Logging {
   /** Returns whether the URI is a "local:" URI. */
   def isLocalUri(uri: String): Boolean = {
     uri.startsWith(s"$LOCAL_SCHEME:")
+  }
+
+  /** Check whether the file of the path is splittable. */
+  def isFileSplittable(path: Path, codecFactory: CompressionCodecFactory): Boolean = {
+    val codec = codecFactory.getCodec(path)
+    codec == null || codec.isInstanceOf[SplittableCompressionCodec]
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
@@ -46,8 +46,12 @@ abstract class FileScan(
     false
   }
 
-  def getFileUnSplittableReason(path: Path): String = {
-    "Undefined"
+  /**
+   * If a file with `path` is unsplittable, return the unsplittable reason,
+   * otherwise return `None`.
+   */
+  def getFileUnSplittableReason(path: Path): Option[String] = {
+    if (!isSplitable(path)) Some("Undefined") else None
   }
 
   override def description(): String = {
@@ -103,7 +107,7 @@ abstract class FileScan(
       if (!isSplitable(path) && splitFiles(0).length >
         sparkSession.sparkContext.getConf.get(IO_WARNING_LARGEFILETHRESHOLD)) {
         logWarning(s"Loading one large unsplittable file ${path.toString} with only one " +
-          s"partition, the reason is: ${getFileUnSplittableReason(path)}")
+          s"partition, the reason is: ${getFileUnSplittableReason(path).get}")
       }
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
@@ -46,6 +46,10 @@ abstract class FileScan(
     false
   }
 
+  def getFileUnSplittableReason(path: Path): String = {
+    "Unknown"
+  }
+
   override def description(): String = {
     val locationDesc =
       fileIndex.getClass.getSimpleName + fileIndex.rootPaths.mkString("[", ", ", "]")
@@ -98,8 +102,8 @@ abstract class FileScan(
       val path = new Path(splitFiles(0).filePath)
       if (isSplitable(path) && splitFiles(0).length >
         sparkSession.sparkContext.getConf.get(IO_FILE_UNSPLITTABLE_WARNING_THRESHOLD)) {
-        logWarning(s"File ${path.toString} is large and unsplittable so the corresponding " +
-          s"rdd partition have to deal with the whole file and consume large time.")
+        logWarning(s"Loading one large unsplittable File ${path.toString} with only one " +
+          s"partition, the reason is: ${getFileUnSplittableReason(path)}")
       }
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
@@ -21,17 +21,15 @@ import java.util.{Locale, OptionalLong}
 import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.internal.config.IO_FILE_UNSPLITTABLE_WARNING_THRESHOLD
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.IO_FILE_UNSPLITTABLE_WARNING_THRESHOLD
 import org.apache.spark.sql.{AnalysisException, SparkSession}
-import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
 import org.apache.spark.sql.execution.PartitionedFileUtil
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.sources.v2.reader._
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.Utils
 
 abstract class FileScan(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.IO_FILE_UNSPLITTABLE_WARNING_THRESHOLD
+import org.apache.spark.internal.config.IO_LOAD_LARGE_FILE_WARNING_THRESHOLD
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
 import org.apache.spark.sql.execution.PartitionedFileUtil
@@ -47,7 +47,7 @@ abstract class FileScan(
   }
 
   def getFileUnSplittableReason(path: Path): String = {
-    "Unknown"
+    "Undefined"
   }
 
   override def description(): String = {
@@ -100,9 +100,9 @@ abstract class FileScan(
 
     if (splitFiles.length == 1) {
       val path = new Path(splitFiles(0).filePath)
-      if (isSplitable(path) && splitFiles(0).length >
-        sparkSession.sparkContext.getConf.get(IO_FILE_UNSPLITTABLE_WARNING_THRESHOLD)) {
-        logWarning(s"Loading one large unsplittable File ${path.toString} with only one " +
+      if (!isSplitable(path) && splitFiles(0).length >
+        sparkSession.sparkContext.getConf.get(IO_LOAD_LARGE_FILE_WARNING_THRESHOLD)) {
+        logWarning(s"Loading one large unsplittable file ${path.toString} with only one " +
           s"partition, the reason is: ${getFileUnSplittableReason(path)}")
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.IO_LOAD_LARGE_FILE_WARNING_THRESHOLD
+import org.apache.spark.internal.config.IO_WARNING_LARGEFILETHRESHOLD
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
 import org.apache.spark.sql.execution.PartitionedFileUtil
@@ -101,7 +101,7 @@ abstract class FileScan(
     if (splitFiles.length == 1) {
       val path = new Path(splitFiles(0).filePath)
       if (!isSplitable(path) && splitFiles(0).length >
-        sparkSession.sparkContext.getConf.get(IO_LOAD_LARGE_FILE_WARNING_THRESHOLD)) {
+        sparkSession.sparkContext.getConf.get(IO_WARNING_LARGEFILETHRESHOLD)) {
         logWarning(s"Loading one large unsplittable file ${path.toString} with only one " +
           s"partition, the reason is: ${getFileUnSplittableReason(path)}")
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
@@ -51,7 +51,8 @@ abstract class FileScan(
    * otherwise return `None`.
    */
   def getFileUnSplittableReason(path: Path): Option[String] = {
-    if (!isSplitable(path)) Some("Undefined") else None
+    assert(!isSplitable(path))
+    Some("undefined")
   }
 
   override def description(): String = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
@@ -50,9 +50,9 @@ abstract class FileScan(
    * If a file with `path` is unsplittable, return the unsplittable reason,
    * otherwise return `None`.
    */
-  def getFileUnSplittableReason(path: Path): Option[String] = {
+  def getFileUnSplittableReason(path: Path): String = {
     assert(!isSplitable(path))
-    Some("undefined")
+    "undefined"
   }
 
   override def description(): String = {
@@ -108,7 +108,7 @@ abstract class FileScan(
       if (!isSplitable(path) && splitFiles(0).length >
         sparkSession.sparkContext.getConf.get(IO_WARNING_LARGEFILETHRESHOLD)) {
         logWarning(s"Loading one large unsplittable file ${path.toString} with only one " +
-          s"partition, the reason is: ${getFileUnSplittableReason(path).get}")
+          s"partition, the reason is: ${getFileUnSplittableReason(path)}")
       }
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/TextBasedFileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/TextBasedFileScan.scala
@@ -39,11 +39,11 @@ abstract class TextBasedFileScan(
 
   override def isSplitable(path: Path): Boolean = Utils.isFileSplittable(path, codecFactory)
 
-  override def getFileUnSplittableReason(path: Path): String = {
+  override def getFileUnSplittableReason(path: Path): Option[String] = {
     if (!isSplitable(path)) {
-      "the file is compressed by unsplittable compression codec"
+      Some("the file is compressed by unsplittable compression codec")
     } else {
-      null
+      None
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/TextBasedFileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/TextBasedFileScan.scala
@@ -43,7 +43,7 @@ abstract class TextBasedFileScan(
     if (!isSplitable(path)) {
       "the file is compressed by unsplittable compression codec"
     } else {
-      throw new UnsupportedOperationException("Undefined method getFileUnSplittableReason")
+      null
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/TextBasedFileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/TextBasedFileScan.scala
@@ -38,4 +38,12 @@ abstract class TextBasedFileScan(
     sparkSession.sessionState.newHadoopConfWithOptions(options.asScala.toMap))
 
   override def isSplitable(path: Path): Boolean = Utils.isFileSplittable(path, codecFactory)
+
+  override def getFileUnSplittableReason(path: Path): String = {
+    if (!isSplitable(path)) {
+      "the file is compressed by unsplittable compression codec"
+    } else {
+      null
+    }
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/TextBasedFileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/TextBasedFileScan.scala
@@ -43,7 +43,7 @@ abstract class TextBasedFileScan(
     if (!isSplitable(path)) {
       "the file is compressed by unsplittable compression codec"
     } else {
-      null
+      throw new UnsupportedOperationException("Undefined method getFileUnSplittableReason")
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/TextBasedFileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/TextBasedFileScan.scala
@@ -19,12 +19,13 @@ package org.apache.spark.sql.execution.datasources.v2
 import scala.collection.JavaConverters._
 
 import org.apache.hadoop.fs.Path
-import org.apache.hadoop.io.compress.{CompressionCodecFactory, SplittableCompressionCodec}
+import org.apache.hadoop.io.compress.CompressionCodecFactory
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.util.Utils
 
 abstract class TextBasedFileScan(
     sparkSession: SparkSession,
@@ -33,14 +34,8 @@ abstract class TextBasedFileScan(
     readPartitionSchema: StructType,
     options: CaseInsensitiveStringMap)
   extends FileScan(sparkSession, fileIndex, readDataSchema, readPartitionSchema) {
-  private var codecFactory: CompressionCodecFactory = _
+  @transient private lazy val codecFactory: CompressionCodecFactory = new CompressionCodecFactory(
+    sparkSession.sessionState.newHadoopConfWithOptions(options.asScala.toMap))
 
-  override def isSplitable(path: Path): Boolean = {
-    if (codecFactory == null) {
-      codecFactory = new CompressionCodecFactory(
-        sparkSession.sessionState.newHadoopConfWithOptions(options.asScala.toMap))
-    }
-    val codec = codecFactory.getCodec(path)
-    codec == null || codec.isInstanceOf[SplittableCompressionCodec]
-  }
+  override def isSplitable(path: Path): Boolean = Utils.isFileSplittable(path, codecFactory)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/TextBasedFileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/TextBasedFileScan.scala
@@ -39,11 +39,8 @@ abstract class TextBasedFileScan(
 
   override def isSplitable(path: Path): Boolean = Utils.isFileSplittable(path, codecFactory)
 
-  override def getFileUnSplittableReason(path: Path): Option[String] = {
-    if (!isSplitable(path)) {
-      Some("the file is compressed by unsplittable compression codec")
-    } else {
-      None
-    }
+  override def getFileUnSplittableReason(path: Path): String = {
+    assert(!isSplitable(path))
+    "the file is compressed by unsplittable compression codec"
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVScan.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.csv.CSVOptions
 import org.apache.spark.sql.catalyst.expressions.ExprUtils
 import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
-import org.apache.spark.sql.execution.datasources.csv.CSVDataSource
+import org.apache.spark.sql.execution.datasources.csv.{CSVDataSource, MultiLineCSVDataSource}
 import org.apache.spark.sql.execution.datasources.v2.TextBasedFileScan
 import org.apache.spark.sql.sources.v2.reader.PartitionReaderFactory
 import org.apache.spark.sql.types.{DataType, StructType}
@@ -48,6 +48,18 @@ case class CSVScan(
 
   override def isSplitable(path: Path): Boolean = {
     CSVDataSource(parsedOptions).isSplitable && super.isSplitable(path)
+  }
+
+  override def getFileUnSplittableReason(path: Path): String = {
+    if (!super.isSplitable(path)) {
+      super.getFileUnSplittableReason(path)
+    } else {
+      if (!CSVDataSource(parsedOptions).isSplitable) {
+        "the csv datasource is set multiLine mode"
+      } else {
+        ""
+      }
+    }
   }
 
   override def createReaderFactory(): PartitionReaderFactory = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVScan.scala
@@ -57,7 +57,7 @@ case class CSVScan(
       if (!CSVDataSource(parsedOptions).isSplitable) {
         "the csv datasource is set multiLine mode"
       } else {
-        ""
+        null
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVScan.scala
@@ -50,14 +50,14 @@ case class CSVScan(
     CSVDataSource(parsedOptions).isSplitable && super.isSplitable(path)
   }
 
-  override def getFileUnSplittableReason(path: Path): String = {
+  override def getFileUnSplittableReason(path: Path): Option[String] = {
     if (!super.isSplitable(path)) {
       super.getFileUnSplittableReason(path)
     } else {
       if (!CSVDataSource(parsedOptions).isSplitable) {
-        "the csv datasource is set multiLine mode"
+        Some("the csv datasource is set multiLine mode")
       } else {
-        null
+        None
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVScan.scala
@@ -50,15 +50,12 @@ case class CSVScan(
     CSVDataSource(parsedOptions).isSplitable && super.isSplitable(path)
   }
 
-  override def getFileUnSplittableReason(path: Path): Option[String] = {
+  override def getFileUnSplittableReason(path: Path): String = {
+    assert(!isSplitable(path))
     if (!super.isSplitable(path)) {
       super.getFileUnSplittableReason(path)
     } else {
-      if (!CSVDataSource(parsedOptions).isSplitable) {
-        Some("the csv datasource is set multiLine mode")
-      } else {
-        None
-      }
+      "the csv datasource is set multiLine mode"
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonScan.scala
@@ -57,7 +57,7 @@ case class JsonScan(
       if (!JsonDataSource(parsedOptions).isSplitable) {
         "the json datasource is set multiLine mode"
       } else {
-        ""
+        null
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonScan.scala
@@ -50,6 +50,18 @@ case class JsonScan(
     JsonDataSource(parsedOptions).isSplitable && super.isSplitable(path)
   }
 
+  override def getFileUnSplittableReason(path: Path): String = {
+    if (!super.isSplitable(path)) {
+      super.getFileUnSplittableReason(path)
+    } else {
+      if (!JsonDataSource(parsedOptions).isSplitable) {
+        "the json datasource is set multiLine mode"
+      } else {
+        ""
+      }
+    }
+  }
+
   override def createReaderFactory(): PartitionReaderFactory = {
     // Check a field requirement for corrupt records here to throw an exception in a driver side
     ExprUtils.verifyColumnNameOfCorruptRecord(dataSchema, parsedOptions.columnNameOfCorruptRecord)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonScan.scala
@@ -50,14 +50,14 @@ case class JsonScan(
     JsonDataSource(parsedOptions).isSplitable && super.isSplitable(path)
   }
 
-  override def getFileUnSplittableReason(path: Path): String = {
+  override def getFileUnSplittableReason(path: Path): Option[String] = {
     if (!super.isSplitable(path)) {
       super.getFileUnSplittableReason(path)
     } else {
       if (!JsonDataSource(parsedOptions).isSplitable) {
-        "the json datasource is set multiLine mode"
+        Some("the json datasource is set multiLine mode")
       } else {
-        null
+        None
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonScan.scala
@@ -50,15 +50,12 @@ case class JsonScan(
     JsonDataSource(parsedOptions).isSplitable && super.isSplitable(path)
   }
 
-  override def getFileUnSplittableReason(path: Path): Option[String] = {
+  override def getFileUnSplittableReason(path: Path): String = {
+    assert(!isSplitable(path))
     if (!super.isSplitable(path)) {
       super.getFileUnSplittableReason(path)
     } else {
-      if (!JsonDataSource(parsedOptions).isSplitable) {
-        Some("the json datasource is set multiLine mode")
-      } else {
-        None
-      }
+      "the json datasource is set multiLine mode"
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/text/TextScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/text/TextScan.scala
@@ -44,14 +44,14 @@ case class TextScan(
     super.isSplitable(path) && !textOptions.wholeText
   }
 
-  override def getFileUnSplittableReason(path: Path): String = {
-    if (!isSplitable(path)) {
+  override def getFileUnSplittableReason(path: Path): Option[String] = {
+    if (!super.isSplitable(path)) {
       super.getFileUnSplittableReason(path)
     } else {
       if (textOptions.wholeText) {
-        "the text datasource is set wholetext mode"
+        Some("the text datasource is set wholetext mode")
       } else {
-        null
+        None
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/text/TextScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/text/TextScan.scala
@@ -44,6 +44,18 @@ case class TextScan(
     super.isSplitable(path) && !textOptions.wholeText
   }
 
+  override def getFileUnSplittableReason(path: Path): String = {
+    if (!isSplitable(path)) {
+      super.getFileUnSplittableReason(path)
+    } else {
+      if (textOptions.wholeText) {
+        "the text datasource is set wholetext mode"
+      } else {
+        null
+      }
+    }
+  }
+
   override def createReaderFactory(): PartitionReaderFactory = {
     assert(
       readDataSchema.length <= 1,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/text/TextScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/text/TextScan.scala
@@ -44,15 +44,12 @@ case class TextScan(
     super.isSplitable(path) && !textOptions.wholeText
   }
 
-  override def getFileUnSplittableReason(path: Path): Option[String] = {
+  override def getFileUnSplittableReason(path: Path): String = {
+    assert(!isSplitable(path))
     if (!super.isSplitable(path)) {
       super.getFileUnSplittableReason(path)
     } else {
-      if (textOptions.wholeText) {
-        Some("the text datasource is set wholetext mode")
-      } else {
-        None
-      }
+      "the text datasource is set wholetext mode"
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Logging in driver when loading single large unsplittable file via `sc.textFile` or csv/json datasouce.
Current condition triggering logging is
* only generate one partition
* file is unsplittable, possible reason is:
   - compressed by unsplittable compression algo such as gzip.
   - multiLine mode in csv/json datasource
   - wholeText mode in text datasource
* file size exceed the config threshold `spark.io.warning.largeFileThreshold` (default value is 1GB)

## How was this patch tested?

Manually test.
Generate one gzip file exceeding 1GB,
```
base64 -b 50 /dev/urandom | head -c 2000000000 > file1.txt
cat file1.txt | gzip > file1.gz
```
then launch spark-shell,

run
```
sc.textFile("file:///path/to/file1.gz").count()
```
Will print log like:
```
WARN HadoopRDD: Loading one large unsplittable file file:/.../f1.gz with only one partition, because the file is compressed by unsplittable compression codec
```

run
```
sc.textFile("file:///path/to/file1.txt").count()
```
Will print log like:
```
WARN HadoopRDD: Loading one large file file:/.../f1.gz with only one partition, we can increase partition numbers by the `minPartitions` argument in method `sc.textFile
```

run
```
spark.read.csv("file:///path/to/file1.gz").count
```
Will print log like:
```
WARN CSVScan: Loading one large unsplittable file file:/.../f1.gz with only one partition, the reason is: the file is compressed by unsplittable compression codec
```

run
```
spark.read.option("multiLine", true).csv("file:///path/to/file1.gz").count
```
Will print log like:
```
WARN CSVScan: Loading one large unsplittable file file:/.../f1.gz with only one partition, the reason is: the csv datasource is set multiLine mode
```

JSON and Text datasource also tested with similar cases.

Please review https://spark.apache.org/contributing.html before opening a pull request.
