### PR TITLE
[SPARK-28367][SS] Use new KafkaConsumer.poll API in Kafka connector

### DIFF
--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaDataConsumer.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaDataConsumer.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.kafka010
 
 import java.{util => ju}
+import java.time.Duration
 import java.util.concurrent.TimeoutException
 
 import scala.collection.JavaConverters._
@@ -471,7 +472,7 @@ private[kafka010] case class InternalKafkaConsumer(
   private def fetchData(offset: Long, pollTimeoutMs: Long): Unit = {
     // Seek to the offset because we may call seekToBeginning or seekToEnd before this.
     seek(offset)
-    val p = consumer.poll(pollTimeoutMs)
+    val p = consumer.poll(Duration.ofMillis(pollTimeoutMs))
     val r = p.records(topicPartition)
     logDebug(s"Polled $groupId ${p.partitions()}  ${r.size}")
     val offsetAfterPoll = consumer.position(topicPartition)

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReader.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReader.scala
@@ -422,8 +422,11 @@ private[kafka010] class KafkaOffsetReader(
     val startTimeMs = System.currentTimeMillis()
     while (partitions.isEmpty && System.currentTimeMillis() - startTimeMs < pollTimeoutMs) {
       // Poll to get the latest assigned partitions
-      consumer.poll(jt.Duration.ofMillis(100))
+      consumer.poll(jt.Duration.ZERO)
       partitions = consumer.assignment()
+      if (partitions.isEmpty) {
+        Thread.sleep(100)
+      }
     }
     require(!partitions.isEmpty)
     logDebug(s"Partitions assigned to consumer: $partitions")

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReader.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReader.scala
@@ -418,17 +418,15 @@ private[kafka010] class KafkaOffsetReader(
   }
 
   private def getPartitions(): ju.Set[TopicPartition] = {
-    var partitions = Set.empty[TopicPartition].asJava
+    consumer.poll(jt.Duration.ZERO)
+    var partitions = consumer.assignment()
     val startTimeMs = System.currentTimeMillis()
     while (partitions.isEmpty && System.currentTimeMillis() - startTimeMs < pollTimeoutMs) {
       // Poll to get the latest assigned partitions
-      consumer.poll(jt.Duration.ZERO)
+      consumer.poll(jt.Duration.ofMillis(100))
       partitions = consumer.assignment()
-      if (partitions.isEmpty) {
-        Thread.sleep(100)
-      }
     }
-    require(!partitions.isEmpty)
+    require(!partitions.isEmpty, "Partitions assigned to the Kafka consumer can't be null")
     logDebug(s"Partitions assigned to consumer: $partitions")
     partitions
   }

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReader.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReader.scala
@@ -422,7 +422,7 @@ private[kafka010] class KafkaOffsetReader(
     val startTimeMs = System.currentTimeMillis()
     while (partitions.isEmpty && System.currentTimeMillis() - startTimeMs < pollTimeoutMs) {
       // Poll to get the latest assigned partitions
-      consumer.poll(jt.Duration.ZERO)
+      consumer.poll(jt.Duration.ofMillis(100))
       partitions = consumer.assignment()
     }
     require(!partitions.isEmpty)

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReader.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReader.scala
@@ -426,7 +426,8 @@ private[kafka010] class KafkaOffsetReader(
       consumer.poll(jt.Duration.ofMillis(100))
       partitions = consumer.assignment()
     }
-    require(!partitions.isEmpty, "Partitions assigned to the Kafka consumer can't be null")
+    require(!partitions.isEmpty, "Partitions assigned to the Kafka consumer can't be empty. " +
+      "Setting kafkaConsumer.pollTimeoutMs to a too low value can potentially cause this.")
     logDebug(s"Partitions assigned to consumer: $partitions")
     partitions
   }

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaDontFailOnDataLossSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaDontFailOnDataLossSuite.scala
@@ -114,7 +114,7 @@ class KafkaDontFailOnDataLossSuite extends StreamTest with KafkaMissingOffsetsTe
         "subscribe" -> topic,
         "startingOffsets" -> s"""{"$topic":{"0":0}}""",
         "failOnDataLoss" -> "false",
-        "kafkaConsumer.pollTimeoutMs" -> "1000")
+        "kafkaConsumer.pollTimeoutMs" -> "5000")
       val df =
         if (testStreamingQuery) {
           val reader = spark.readStream.format("kafka")

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -568,7 +568,7 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
       // If a topic is deleted and we try to poll data starting from offset 0,
       // the Kafka consumer will just block until timeout and return an empty result.
       // So set the timeout to 1 second to make this test fast.
-      .option("kafkaConsumer.pollTimeoutMs", "1000")
+      .option("kafkaConsumer.pollTimeoutMs", "5000")
       .option("startingOffsets", "earliest")
       .option("failOnDataLoss", "false")
     val kafka = reader.load()

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
@@ -33,6 +33,12 @@ class KafkaSourceProviderSuite extends SparkFunSuite with PrivateMethodTester {
   private val pollTimeoutMsMethod = PrivateMethod[Long]('pollTimeoutMs)
   private val maxOffsetsPerTriggerMethod = PrivateMethod[Option[Long]]('maxOffsetsPerTrigger)
 
+  override protected def beforeEach(): Unit = {
+    val sparkEnv = mock(classOf[SparkEnv])
+    when(sparkEnv.conf).thenReturn(new SparkConf())
+    SparkEnv.set(sparkEnv)
+  }
+
   override protected def afterEach(): Unit = {
     SparkEnv.set(null)
     super.afterEach()
@@ -43,11 +49,6 @@ class KafkaSourceProviderSuite extends SparkFunSuite with PrivateMethodTester {
         options: CaseInsensitiveStringMap,
         expectedPollTimeoutMs: Long,
         expectedMaxOffsetsPerTrigger: Option[Long]): Unit = {
-      // KafkaMicroBatchStream reads Spark conf from SparkEnv for default value
-      // hence we set mock SparkEnv here before creating KafkaMicroBatchStream
-      val sparkEnv = mock(classOf[SparkEnv])
-      when(sparkEnv.conf).thenReturn(new SparkConf())
-      SparkEnv.set(sparkEnv)
 
       val scan = getKafkaDataSourceScan(options)
       val stream = scan.toMicroBatchStream("dummy").asInstanceOf[KafkaMicroBatchStream]


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spark uses an old and deprecated API named `KafkaConsumer.poll(long)` which never returns and stays in live lock if metadata is not updated (for instance when broker disappears at consumer creation). Please see [Kafka documentation](https://kafka.apache.org/23/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#poll-long-) and [standalone test application](https://github.com/gaborgsomogyi/kafka-get-assignment) for further details.

In this PR I've applied the new `KafkaConsumer.poll(Duration)` API.

## How was this patch tested?

Existing unit tests + started Kafka to Kafka query on cluster.
