### PR TITLE
[SPARK-26175][PYTHON] Redirect the standard input of the forked child to devnull in daemon

### DIFF
--- a/python/pyspark/daemon.py
+++ b/python/pyspark/daemon.py
@@ -160,6 +160,7 @@ def manager():
                 if pid == 0:
                     # in child process
                     listen_sock.close()
+                    stdin_bin.close()
                     try:
                         # Acknowledge that the fork was successful
                         outfile = sock.makefile(mode="wb")

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -617,14 +617,12 @@ class UDFTests(ReusedSQLTestCase):
         self.spark.range(1).select(f()).collect()
 
     def test_worker_original_stdin_closed(self):
-        # Test the original stdin of worker inherit from daemon is closed
-        # and is replaced with '/dev/null'.
-        # See SPARK-26175
+        # Test if it closes the original standard input of worker inherited from the daemon,
+        # and replaces it with '/dev/null'.  See SPARK-26175.
         def task(iterator):
             import sys
             res = sys.stdin.read()
-            # Because the stdin is replaced with '/dev/null'
-            # Read data from it will get EOF
+            # Because the standard input is '/dev/null', it reaches to EOF.
             assert res == '', "Expect read EOF from stdin."
             return iterator
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

PySpark worker daemon reads from stdin the worker PIDs to kill. https://github.com/apache/spark/blob/1bb60ab8392adf8b896cc04fb1d060620cf09d8a/python/pyspark/daemon.py#L127

However, the worker process is a forked process from the worker daemon process and we didn't close stdin on the child after fork. This means the child and user program can read stdin as well, which blocks daemon from receiving the PID to kill. This can cause issues because the task reaper might detect the task was not terminated and eventually kill the JVM.

This PR fix this by redirecting the standard input of the forked child to devnull.

## How was this patch tested?

Manually test.

In `pyspark`, run:
```
import subprocess
def task(_):
  subprocess.check_output(["cat"])

sc.parallelize(range(1), 1).mapPartitions(task).count()
```

Before:
The job will get stuck and press Ctrl+C to exit the job but the python worker process do not exit.
After:
The job finish correctly. The "cat" print nothing (because the dummay stdin is "/dev/null").
The python worker process exit normally.

Please review https://spark.apache.org/contributing.html before opening a pull request.
