### PR TITLE
[SPARK-28333][SQL] NULLS FIRST for DESC and NULLS LAST for ASC	

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -120,6 +120,7 @@ package object dsl {
     def asc_nullsLast: SortOrder = SortOrder(expr, Ascending, NullsLast, Set.empty)
     def desc: SortOrder = SortOrder(expr, Descending)
     def desc_nullsFirst: SortOrder = SortOrder(expr, Descending, NullsFirst, Set.empty)
+    def desc_nullsLast: SortOrder = SortOrder(expr, Descending, NullsLast, Set.empty)
     def as(alias: String): NamedExpression = Alias(expr, alias)()
     def as(alias: Symbol): NamedExpression = Alias(expr, alias.name)()
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
@@ -36,12 +36,12 @@ abstract sealed class NullOrdering {
 
 case object Ascending extends SortDirection {
   override def sql: String = "ASC"
-  override def defaultNullOrdering: NullOrdering = NullsFirst
+  override def defaultNullOrdering: NullOrdering = NullsLast
 }
 
 case object Descending extends SortDirection {
   override def sql: String = "DESC"
-  override def defaultNullOrdering: NullOrdering = NullsLast
+  override def defaultNullOrdering: NullOrdering = NullsFirst
 }
 
 case object NullsFirst extends NullOrdering{

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveRedundantSortsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveRedundantSortsSuite.scala
@@ -45,7 +45,7 @@ class RemoveRedundantSortsSuite extends PlanTest {
   }
 
   test("do not remove sort if the order is different") {
-    val orderedPlan = testRelation.select('a, 'b).orderBy('a.asc, 'b.desc_nullsFirst)
+    val orderedPlan = testRelation.select('a, 'b).orderBy('a.asc, 'b.desc_nullsLast)
     val reorderedDifferently = orderedPlan.limit(2).select('a).orderBy('a.asc, 'b.desc)
     val optimized = Optimize.execute(reorderedDifferently.analyze)
     val correctAnswer = reorderedDifferently.analyze


### PR DESCRIPTION
## What changes were proposed in this pull request?

changed the default null ordering for ACS and DESC, and updated the corresponding tests

## How was this patch tested?

Ran sql/catalyst module UT and updated the test case


