### PR TITLE
[SPARK-28394][SCHEDULER]: Performance Metrics for Driver

### DIFF
--- a/core/src/main/java/org/apache/spark/SparkFirehoseListener.java
+++ b/core/src/main/java/org/apache/spark/SparkFirehoseListener.java
@@ -163,6 +163,11 @@ public class SparkFirehoseListener implements SparkListenerInterface {
   }
 
   @Override
+  public void onDriverMetricsUpdate(SparkDriverMetricsUpdate onDriverMetricsUpdate) {
+    onEvent(onDriverMetricsUpdate);
+  }
+
+  @Override
   public void onOtherEvent(SparkListenerEvent event) {
     onEvent(event);
   }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1338,4 +1338,24 @@ package object config {
     .bytesConf(ByteUnit.BYTE)
     .createOptional
 
+  private[spark] val SCHEDULERS_METRICS_INTERVAL_LENGTH =
+    ConfigBuilder("spark.scheduler.metric.compute.intervalLength")
+      .doc("The length of an interval ")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("10s")
+
+  private[spark] val SCHEDULERS_METRICS_NUM_TOP_BUSIEST_INTERVALS =
+    ConfigBuilder("spark.scheduler.metric.compute.numTopBusiestIntervals")
+      .doc("The number of top busiest intervals that are kept")
+      .longConf
+      .createWithDefault(5)
+
+  private[spark] val SCHEDULERS_METRICS_BUSY_INTERVAL_THRESHOLD =
+    ConfigBuilder("spark.scheduler.metric.compute.busyIntervalThreshold")
+      .doc("The threshold (in percent) for an interval to be considered busy." +
+        "An interval is considered busy if the total time used in this interval is" +
+        "greater than this threshold*interval_length/100")
+      .intConf
+      .createWithDefault(70)
+
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -277,6 +277,10 @@ private[spark] class EventLoggingListener(
     }
   }
 
+  override def onDriverMetricsUpdate(event: SparkDriverMetricsUpdate): Unit = {
+    logEvent(event, flushLogger = true)
+  }
+
   override def onOtherEvent(event: SparkListenerEvent): Unit = {
     if (event.logEvent) {
       logEvent(event, flushLogger = true)

--- a/core/src/main/scala/org/apache/spark/scheduler/SchedulerMetricsManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SchedulerMetricsManager.scala
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler
+
+import java.util.concurrent.{LinkedBlockingQueue, TimeUnit}
+
+import scala.collection.mutable
+
+import org.apache.spark.SparkContext
+import org.apache.spark.internal.{config, Logging}
+import org.apache.spark.status.api.v1.{SchedulerEventHandlingMetric, SchedulerMetricInfo}
+import org.apache.spark.util.Utils
+
+/**
+ * This class manages the schedulers' metrics of the Driver.
+ */
+class SchedulerMetricsManager(val sc: SparkContext) extends Logging {
+
+  private trait SchedulerMetricsManagerMessage
+  private case class RegisterEventMessage(eventTypeName: String)
+    extends SchedulerMetricsManagerMessage
+  private case class IncreasingNumPendingEventMessage(eventTypeName: String)
+    extends SchedulerMetricsManagerMessage
+  private case class UpdateMetricAfterHandlingEventMessage(eventTypeString: String, usedTime: Long)
+    extends SchedulerMetricsManagerMessage
+
+  /** Message to stop the background thread. */
+  private object STOP_MESSAGE extends SchedulerMetricsManagerMessage
+
+  /** The length of each interval. */
+  private lazy val intervalLength: Long = sc.conf.get(config.SCHEDULERS_METRICS_INTERVAL_LENGTH)
+
+  /** The number of busiest intervals to be kept. */
+  private lazy val numTopBusiestIntervals: Long =
+    sc.conf.get(config.SCHEDULERS_METRICS_NUM_TOP_BUSIEST_INTERVALS)
+
+  /** The threshold (in percentage) for an interval to be considered busy. */
+  private lazy val busyIntervalThreshold: Int =
+    sc.conf.get(config.SCHEDULERS_METRICS_BUSY_INTERVAL_THRESHOLD)
+
+  /** The map of event type to metric tracker for that type. */
+  lazy val metricTrackerPerEventType =
+    new mutable.HashMap[String, SchedulerEventHandlingMetricTracker]()
+
+  /**
+   *  Queue of metrics for each event. This is added by the scheduler, and
+   * processed by the background thread.
+   */
+  private val eventMetricsQueue = new LinkedBlockingQueue[SchedulerMetricsManagerMessage]()
+
+  /**
+   *  The background thread that collects the metrics
+   * and post to listener bus when the interval ends.
+   */
+  private var metricUpdateThread: Thread = _
+
+  /** The time when the current interval ends. */
+  var currentIntervalEndTime = 0L
+
+  def start(): Unit = {
+    // Start background thread
+    metricUpdateThread = new Thread() {
+      currentIntervalEndTime = System.currentTimeMillis() + intervalLength
+      override def run(): Unit = {
+        try {
+          var shouldStop = false
+          while (!shouldStop) {
+            var currentTime = System.currentTimeMillis()
+            // Keep dequeuing and processing message from the queue until
+            // the current interval ends or encounter the stop message
+            while(currentTime < currentIntervalEndTime && !shouldStop) {
+              val waitTime = currentIntervalEndTime - currentTime
+              eventMetricsQueue.poll(waitTime, TimeUnit.MILLISECONDS) match {
+                case RegisterEventMessage(eventTypeName) =>
+                  if (!metricTrackerPerEventType.contains(eventTypeName)) {
+                    metricTrackerPerEventType(eventTypeName) =
+                      new SchedulerEventHandlingMetricTracker(eventTypeName)
+                  }
+                case IncreasingNumPendingEventMessage(eventTypeName) =>
+                  if (metricTrackerPerEventType.contains(eventTypeName)) {
+                    metricTrackerPerEventType(eventTypeName).increaseNumPendingEvent()
+                  }
+                case UpdateMetricAfterHandlingEventMessage(eventTypeName, usedTime) =>
+                  if (metricTrackerPerEventType.contains(eventTypeName)) {
+                    metricTrackerPerEventType(eventTypeName).
+                      updateMetricAfterHandlingEvent(usedTime)
+                  }
+                case STOP_MESSAGE =>
+                  shouldStop = true
+                case _ =>
+              }
+              currentTime = System.currentTimeMillis()
+            }
+            // Collect the metrics for this interval and post to the listener bus
+            var metrics: Seq[SchedulerEventHandlingMetric] = Seq()
+            metricTrackerPerEventType.values.foreach(metricTracker => {
+              metricTracker.accumulateMetricForCurrentInterval(
+                intervalLength,
+                numTopBusiestIntervals,
+                busyIntervalThreshold)
+              metrics :+= metricTracker.getSchedulerEventHandlingMetric
+            })
+            sc.listenerBus.post(SparkDriverMetricsUpdate(metrics))
+            currentIntervalEndTime = currentTime + intervalLength
+          }
+        } catch {
+          case e: InterruptedException =>
+        }
+      }
+    }
+    metricUpdateThread.start()
+  }
+
+  /** Stop the background thread. */
+  def stop(): Unit = {
+    if (metricUpdateThread != null) {
+      eventMetricsQueue.offer(STOP_MESSAGE)
+      // Interrupt if it takes too long to for the
+      // background thread to stop itself
+      metricUpdateThread.join(3000)
+      if (metricUpdateThread.isAlive) {
+        metricUpdateThread.interrupt()
+      }
+      metricUpdateThread = null
+    }
+  }
+
+  /** Add an event type to the metricPerEventType and start keeping track of it. */
+  def registerEvent(eventTypeName: String): Unit = {
+    eventMetricsQueue.offer(RegisterEventMessage(eventTypeName))
+  }
+
+  /** This method increases the number of pending events for the given event type. */
+  def increaseNumPendingEvent(eventTypeName: String): Unit = {
+    eventMetricsQueue.offer(IncreasingNumPendingEventMessage(eventTypeName))
+  }
+
+  /** This method updates the metrics for handling the given event. */
+  def updateMetricAfterHandlingEvent(eventTypeName: String, usedTime: Long): Unit = {
+    eventMetricsQueue.offer(UpdateMetricAfterHandlingEventMessage(eventTypeName, usedTime))
+  }
+}
+
+object SchedulerMetricsManager {
+  /** This method compute the name of event type given the scheduler component and event. */
+  def computeEventTypeString(schedulerComponent: AnyRef, event: AnyRef): String = {
+    event match {
+      case eventType: String =>
+        Utils.getFormattedClassName(schedulerComponent) + " " + eventType
+      case _ =>
+        Utils.getFormattedClassName(schedulerComponent) + " " + Utils.getFormattedClassName(event)
+    }
+  }
+}
+
+class SchedulerEventHandlingMetricTracker private[spark] (
+  val name: String,
+  private var averageHandlingTimePerEvent: Float = 0,
+  private var totalNumHandledEvents: Long = 0,
+  private var usedTimeCurrentInterval: Long = 0,
+  private var numHandledEventsCurrentInterval: Long = 0,
+  private var numPendingEvents: Option[Long] = None) {
+
+  /** Queue of top busiest intervals. */
+  private val busiestIntervalsQueue: mutable.PriorityQueue[SchedulerMetricInfo] =
+    new mutable.PriorityQueue[SchedulerMetricInfo]()(Ordering.by
+      [SchedulerMetricInfo, Float](x => - x.handlingTimePerEvent * x.numHandledEvents))
+
+  /** Get all the summary and busiest intervals. */
+  def getSchedulerEventHandlingMetric: SchedulerEventHandlingMetric = {
+    val summary = SchedulerMetricInfo(averageHandlingTimePerEvent,
+      totalNumHandledEvents,
+      numPendingEvents,
+      System.currentTimeMillis())
+    val busiestIntervals = busiestIntervalsQueue.toSeq
+    SchedulerEventHandlingMetric(name, summary, busiestIntervals)
+  }
+
+  /** Check if the current interval has any new update for this event type. */
+  def hasNewUpdate: Boolean = {
+    (numHandledEventsCurrentInterval > 0) || (numPendingEvents.getOrElse(0L) > 0)
+  }
+
+  /** Increasing the number of pending events when received an event. */
+  def increaseNumPendingEvent(): Unit = {
+    numPendingEvents = Some(numPendingEvents.getOrElse(0L) + 1)
+  }
+
+  /** Update the metric after handling an event. */
+  def updateMetricAfterHandlingEvent(usedTime: Long): Unit = {
+    usedTimeCurrentInterval += usedTime
+    numHandledEventsCurrentInterval += 1
+    if (numPendingEvents.isDefined) {
+      numPendingEvents = Some(numPendingEvents.getOrElse(0L) - 1)
+    }
+  }
+
+  /** Accumulate the information when the interval ends. */
+  def accumulateMetricForCurrentInterval(intervalLength: Long,
+    numTopBusiestIntervals: Long,
+    busyIntervalThreshold: Int): Unit = {
+
+    // Only update if there's at least 1 event being handled during this interval.
+    if (numHandledEventsCurrentInterval > 0) {
+      val handlingTimePerEvent = usedTimeCurrentInterval.toFloat / numHandledEventsCurrentInterval
+      val newTotalNumHandledEvents = totalNumHandledEvents + numHandledEventsCurrentInterval
+
+      // Update the average time for handling this event among all intervals.
+      averageHandlingTimePerEvent = (averageHandlingTimePerEvent * totalNumHandledEvents
+        + usedTimeCurrentInterval) / newTotalNumHandledEvents
+
+      // Compute the usage percentage for this interval and add update the busyIntervals queue.
+      // Note that this can be greater than 100 when there're many threads handling the same
+      // handling the event type in parallel
+      val usagePercentage =
+      100*usedTimeCurrentInterval.toFloat / intervalLength
+
+      // Check if this interval is busy
+      if (usagePercentage > busyIntervalThreshold) {
+        busiestIntervalsQueue.enqueue(SchedulerMetricInfo(
+          handlingTimePerEvent,
+          numHandledEventsCurrentInterval,
+          numPendingEvents,
+          System.currentTimeMillis()))
+        while (busiestIntervalsQueue.size > numTopBusiestIntervals) {
+          busiestIntervalsQueue.dequeue()
+        }
+      }
+      totalNumHandledEvents = newTotalNumHandledEvents
+    }
+
+    usedTimeCurrentInterval = 0
+    numHandledEventsCurrentInterval = 0
+  }
+}

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -28,6 +28,7 @@ import org.apache.spark.TaskEndReason
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.executor.{ExecutorMetrics, TaskMetrics}
 import org.apache.spark.scheduler.cluster.ExecutorInfo
+import org.apache.spark.status.api.v1.SchedulerEventHandlingMetric
 import org.apache.spark.storage.{BlockManagerId, BlockUpdatedInfo}
 
 @DeveloperApi
@@ -203,6 +204,10 @@ case class SparkListenerApplicationEnd(time: Long) extends SparkListenerEvent
 @DeveloperApi
 case class SparkListenerLogStart(sparkVersion: String) extends SparkListenerEvent
 
+@DeveloperApi
+case class SparkDriverMetricsUpdate(schedulerMetrics: Seq[SchedulerEventHandlingMetric])
+  extends SparkListenerEvent
+
 /**
  * Interface for listening to events from the Spark scheduler. Most applications should probably
  * extend SparkListener or SparkFirehoseListener directly, rather than implementing this class.
@@ -341,6 +346,11 @@ private[spark] trait SparkListenerInterface {
   def onSpeculativeTaskSubmitted(speculativeTask: SparkListenerSpeculativeTaskSubmitted): Unit
 
   /**
+   * Called when driver metrics thread is scheduled
+   */
+  def onDriverMetricsUpdate(event: SparkDriverMetricsUpdate): Unit
+
+  /**
    * Called when other events like SQL-specific events are posted.
    */
   def onOtherEvent(event: SparkListenerEvent): Unit
@@ -415,6 +425,8 @@ abstract class SparkListener extends SparkListenerInterface {
 
   override def onSpeculativeTaskSubmitted(
       speculativeTask: SparkListenerSpeculativeTaskSubmitted): Unit = { }
+
+  override def onDriverMetricsUpdate(event: SparkDriverMetricsUpdate): Unit = { }
 
   override def onOtherEvent(event: SparkListenerEvent): Unit = { }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListenerBus.scala
@@ -79,6 +79,8 @@ private[spark] trait SparkListenerBus
         listener.onBlockUpdated(blockUpdated)
       case speculativeTaskSubmitted: SparkListenerSpeculativeTaskSubmitted =>
         listener.onSpeculativeTaskSubmitted(speculativeTaskSubmitted)
+      case driverMetricsUpdate: SparkDriverMetricsUpdate =>
+        listener.onDriverMetricsUpdate(driverMetricsUpdate)
       case _ => listener.onOtherEvent(event)
     }
   }

--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -876,6 +876,11 @@ private[spark] class AppStatusListener(
     }
   }
 
+  override def onDriverMetricsUpdate(event: SparkDriverMetricsUpdate): Unit = {
+    val metrics = v1.DriverMetrics(event.schedulerMetrics)
+    kvstore.write(new DriverMetricsWrapper(metrics))
+  }
+
   /** Go through all `LiveEntity`s and use `entityFlushFunc(entity)` to flush them. */
   private def flush(entityFlushFunc: LiveEntity => Unit): Unit = {
     liveStages.values.asScala.foreach { stage =>

--- a/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
@@ -136,6 +136,14 @@ private[spark] class AppStatusStore(
     store.read(classOf[StageDataWrapper], Array(stageId, stageAttemptId)).locality
   }
 
+  def driverMetrics(): v1.DriverMetrics = {
+    if (store.count(classOf[DriverMetricsWrapper]) > 0) {
+      store.read(classOf[DriverMetricsWrapper], 1).info
+    } else {
+      null
+    }
+  }
+
   /**
    * Calculates a summary of the task metrics for the given stage attempt, returning the
    * requested quantiles for the recorded metrics.

--- a/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
@@ -360,6 +360,20 @@ class AccumulableInfo private[spark](
     val update: Option[String],
     val value: String)
 
+case class SchedulerMetricInfo(
+  handlingTimePerEvent: Float,
+  numHandledEvents: Long,
+  @JsonDeserialize(contentAs = classOf[JLong])
+  numPendingEvents: Option[Long],
+  timeStamp: Long)
+
+case class SchedulerEventHandlingMetric(
+  eventType: String,
+  summary: SchedulerMetricInfo,
+  busiestIntervals: Seq[SchedulerMetricInfo])
+
+case class DriverMetrics private[spark] (metrics: Seq[SchedulerEventHandlingMetric])
+
 class VersionInfo private[spark](
   val spark: String)
 

--- a/core/src/main/scala/org/apache/spark/status/storeTypes.scala
+++ b/core/src/main/scala/org/apache/spark/status/storeTypes.scala
@@ -425,6 +425,11 @@ private[spark] class RDDOperationGraphWrapper(
 
 }
 
+private [spark] class DriverMetricsWrapper(val info: DriverMetrics) {
+  @JsonIgnore @KVIndex
+  def id: Int = 1
+}
+
 private[spark] class PoolData(
     @KVIndexParam val name: String,
     val stageIds: Set[Int])

--- a/core/src/main/scala/org/apache/spark/ui/ToolTips.scala
+++ b/core/src/main/scala/org/apache/spark/ui/ToolTips.scala
@@ -99,4 +99,13 @@ private[spark] object ToolTips {
        dynamic allocation is enabled. The number of granted executors may exceed the limit
        ephemerally when executors are being killed.
     """
+
+  val DRIVER_METRICS_BUSY_INTERVALS =
+    """Busy intervals are the interval in which the scheduler spends lots of time to handle
+        this type of event (defined when the total time for handling all events of this type
+        is greater than a threshold (by default 70% of the interval length).
+     """
+
+  val DRIVER_METRICS_SUMMARY =
+    """Aggregated metric over all intervals."""
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Description
This PR added the framework for monitoring the schedulers and displaying performance metrics to the UI. More specifically, for each event type that is handled by the DAGScheduler, CoarsedGrainedSchedulerBackend, and TaskResultGetter, it keeps track of the following information: number of handled events of this type, number of pending events of this type, average time to handle an event of this type, total time spending on handling all events of this type.

-----------
Design and implementation:
General Idea: 
For each event type, every time we handle an event of this type, we collect the information (e.g. the time taken to handle this event, number of pending events,...), and having a background thread that periodically collects the information and display to the UI.

UI Explanation
<img width="1422" alt="Screen Shot 2019-06-18 at 11 08 39 PM" src="https://user-images.githubusercontent.com/15680678/61195997-50592900-a691-11e9-8e8b-5a4faa5ecc05.png">

Explanation of columns:
- Event Type: The type of event that the information in this row below to
- Number of Handled Events: The number of events of this type that is handled
- Number of Pending Events: The number of events of this type that is pending in the queue
- Processing Speed: The average time that is used to handle an event of this type
- Total time: The total time that is used to handled all events of this type
- Timestamp: The time at the end of the interval that we collect the information displayed in this row.

Driver Schedulers Summary Metrics table
- This table contains information accumulatively collected since the application starts (e.g. the “Number of Handled Events” is the total number of events that are handled since the application starts)

Driver Schedulers Busy Intervals Metrics table
- This table contains the information for only some busy intervals. The purpose of this table is to pinpoint the time that the scheduler is busy. An interval is considered busy if the total time spending on handling all events of a type during this interval is greater than 70% of the interval length (This 70% is configurable). And the information displayed is the information collected during that interval only (e.g. the “Number of Handled Events” is the number of events that are handled during that interval). Note that we only keep track of top 5 busiest intervals sorted by the “total time” (This number 5 is configurable). 

An example of how to read the table and how it can be useful for monitoring and debugging the application:
For an example shown in the figure below, let’s look at the first row of the “Driver Schedulers Busy Intervals Metrics” table. This row contains the information about the ReviveOffers event that is handled by the CoarseGrainedSchedulerBackend. There are 12 ReviveOffers events that is handled by the CoarseGrainedSchedulerBackend during the interval the ends at "2019/06/19 04:03:13". The number of ReviveOffers events that are pending is N/A (This is because getting the number of pending events that are waiting to be handled by the CoarseGrainedSchedulerBackend is difficult, so I leave it as N/A for now). The time for the CoarseGrainedSchedulerBackend to handle an ReviveOffers is 763ms. The total time spending on handling all 12 ReviveOffers events during this interval is 9s (For this example, the interval length is 10s). Finally, this interval ends at 2019/06/19 04:03:13.

From the information above, we can easily see that it takes too long for the CoarseGrainedSchedulerBackend to handle the event ReviveOffers (for some interval, it takes up to 700ms to handle just one ReviveOffers event).  This is actually an issue that is mentioned in [SPARK-26755](https://issues.apache.org/jira/browse/SPARK-26755). And this example is the application mentioned in [PR #23677](https://github.com/apache/spark/pull/23677). We can see that having these metrics can help to identify the bottleneck for the application. 

-----------
Implementation:
Introduce 2 new classes:
- SchedulerEventHandlingMetricTracker: This is used to keep track of the information for an event type
- SchedulerMetricsManager: This is used to manage all the SchedulerEventHandlingMetricTracker for all event types
---------------------
Configurations:
spark.scheduler.metric.compute.enabled: Indicate if this feature is enable or not (default value is false)
spark.scheduler.metric.compute.interval: This is the interval length (default value is 10s)
spark.scheduler.metric.compute.numTopBusiestInterval: This is the number of busiest intervals that we will keep (default value is 5)
spark.scheduler.metric.compute.busyIntervalThreshold: This is the threshold (in percent) for an interval to be considered busy (default value is 70%). 

## How was this patch tested?
This patch was manually tested with some applications. Please let me know if there's any specific tests that are needed to be done.

Thank you!