### PR TITLE
[WIP][SPARK-28396][SQL] Add PathCatalog for data source V2

### DIFF
--- a/external/avro/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/external/avro/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,1 +1,1 @@
-org.apache.spark.sql.v2.avro.AvroDataSourceV2
+org.apache.spark.sql.v2.avro.AvroCatalog

--- a/external/avro/src/main/scala/org/apache/spark/sql/v2/avro/AvroCatalog.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/v2/avro/AvroCatalog.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.v2.avro
+
+import org.apache.spark.sql.execution.datasources.v2.{FileCatalog, FileDataSourceV2}
+
+class AvroCatalog extends FileCatalog {
+  override def getTableProvider: FileDataSourceV2 = new AvroDataSourceV2
+
+  override def shortName(): String = "avro"
+}

--- a/external/avro/src/main/scala/org/apache/spark/sql/v2/avro/AvroDataSourceV2.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/v2/avro/AvroDataSourceV2.scala
@@ -27,8 +27,6 @@ class AvroDataSourceV2 extends FileDataSourceV2 {
 
   override def fallbackFileFormat: Class[_ <: FileFormat] = classOf[AvroFileFormat]
 
-  override def shortName(): String = "avro"
-
   override def getTable(options: CaseInsensitiveStringMap): Table = {
     val paths = getPaths(options)
     val tableName = getTableName(paths)

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalog/v2/Catalogs.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalog/v2/Catalogs.java
@@ -26,7 +26,6 @@ import org.apache.spark.util.Utils;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalog/v2/Catalogs.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalog/v2/Catalogs.java
@@ -26,6 +26,7 @@ import org.apache.spark.util.Utils;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalog/v2/PathCatalog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalog/v2/PathCatalog.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalog.v2;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Catalog trait for file paths.
+ * <p>
+ * PathCatalog is a specific type of TableCatalog:
+ * 1. The table namespace is always empty.
+ * 2. The table name contains one or more file paths.
+ *   2.1 if there is only one path, the table name is the path.
+ *   2.2 otherwise, the table name is file paths joined by semicolon, e.g. "path1;path2;path3".
+ */
+public interface PathCatalog extends TableCatalog {
+  default Identifier getTableIdentifier(String[] paths) {
+    Preconditions.checkNotNull(paths, "Paths cannot be null");
+    Preconditions.checkArgument(paths.length > 0, "Paths cannot be empty");
+    String name = String.join(";", paths);
+    return new IdentifierImpl(new String[]{}, name);
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1565,7 +1565,7 @@ object SQLConf {
       " register class names for which data source V2 write paths are disabled. Writes from these" +
       " sources will fall back to the V1 sources.")
     .stringConf
-    .createWithDefault("csv,json,orc,text,parquet")
+    .createWithDefault("")
 
   val DISABLED_V2_STREAMING_WRITERS = buildConf("spark.sql.streaming.disabledV2Writers")
     .doc("A comma-separated list of fully qualified data source register class names for which" +

--- a/sql/core/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/sql/core/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,10 +1,10 @@
-org.apache.spark.sql.execution.datasources.v2.csv.CSVDataSourceV2
+org.apache.spark.sql.execution.datasources.v2.csv.CSVCatalog
 org.apache.spark.sql.execution.datasources.jdbc.JdbcRelationProvider
-org.apache.spark.sql.execution.datasources.v2.json.JsonDataSourceV2
+org.apache.spark.sql.execution.datasources.v2.json.JsonCatalog
 org.apache.spark.sql.execution.datasources.noop.NoopDataSource
-org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
-org.apache.spark.sql.execution.datasources.v2.parquet.ParquetDataSourceV2
-org.apache.spark.sql.execution.datasources.v2.text.TextDataSourceV2
+org.apache.spark.sql.execution.datasources.v2.orc.OrcCatalog
+org.apache.spark.sql.execution.datasources.v2.parquet.ParquetCatalog
+org.apache.spark.sql.execution.datasources.v2.text.TextCatalog
 org.apache.spark.sql.execution.streaming.ConsoleSinkProvider
 org.apache.spark.sql.execution.streaming.sources.RateStreamProvider
 org.apache.spark.sql.execution.streaming.sources.TextSocketSourceProvider

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -17,9 +17,7 @@
 
 package org.apache.spark.sql.execution.command
 
-import java.io.File
 import java.net.{URI, URISyntaxException}
-import java.nio.file.FileSystems
 
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Try
@@ -29,7 +27,7 @@ import org.apache.hadoop.fs.{FileContext, FsConstants, Path}
 
 import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.analysis.{NoSuchPartitionException, UnresolvedAttribute, UnresolvedRelation}
+import org.apache.spark.sql.catalyst.analysis.{NoSuchPartitionException, UnresolvedAttribute}
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.catalog.CatalogTableType._
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
@@ -40,10 +38,10 @@ import org.apache.spark.sql.execution.datasources.{DataSource, PartitioningUtils
 import org.apache.spark.sql.execution.datasources.csv.CSVFileFormat
 import org.apache.spark.sql.execution.datasources.json.JsonFileFormat
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
-import org.apache.spark.sql.execution.datasources.v2.csv.CSVDataSourceV2
-import org.apache.spark.sql.execution.datasources.v2.json.JsonDataSourceV2
-import org.apache.spark.sql.execution.datasources.v2.orc.OrcDataSourceV2
-import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetDataSourceV2
+import org.apache.spark.sql.execution.datasources.v2.csv.CSVCatalog
+import org.apache.spark.sql.execution.datasources.v2.json.JsonCatalog
+import org.apache.spark.sql.execution.datasources.v2.orc.OrcCatalog
+import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetCatalog
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.SchemaUtils
@@ -241,8 +239,7 @@ case class AlterTableAddColumnsCommand(
         // Hive type is already considered as hive serde table, so the logic will not
         // come in here.
         case _: CSVFileFormat | _: JsonFileFormat | _: ParquetFileFormat =>
-        case _: JsonDataSourceV2 | _: CSVDataSourceV2 |
-             _: OrcDataSourceV2 | _: ParquetDataSourceV2 =>
+        case _: JsonCatalog | _: CSVCatalog | _: OrcCatalog | _: ParquetCatalog =>
         case s if s.getClass.getCanonicalName.endsWith("OrcFileFormat") =>
         case s =>
           throw new AnalysisException(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -101,8 +101,8 @@ case class DataSource(
     // [[DataFrameReader]]/[[DataFrameWriter]], since they use method `lookupDataSource`
     // instead of `providingClass`.
     cls.newInstance() match {
-      case f: FileDataSourceV2 => f.fallbackFileFormat
-      case f: FileCatalog => f.getTableProvider.fallbackFileFormat
+      case f: FileCatalog =>
+        f.getTableProvider.fallbackFileFormat
       case _ => cls
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -40,8 +40,8 @@ import org.apache.spark.sql.execution.datasources.jdbc.JdbcRelationProvider
 import org.apache.spark.sql.execution.datasources.json.JsonFileFormat
 import org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
-import org.apache.spark.sql.execution.datasources.v2.FileDataSourceV2
-import org.apache.spark.sql.execution.datasources.v2.orc.OrcDataSourceV2
+import org.apache.spark.sql.execution.datasources.v2.{FileCatalog, FileDataSourceV2}
+import org.apache.spark.sql.execution.datasources.v2.orc.OrcCatalog
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.execution.streaming.sources.{RateStreamProvider, TextSocketSourceProvider}
 import org.apache.spark.sql.internal.SQLConf
@@ -102,6 +102,7 @@ case class DataSource(
     // instead of `providingClass`.
     cls.newInstance() match {
       case f: FileDataSourceV2 => f.fallbackFileFormat
+      case f: FileCatalog => f.getTableProvider.fallbackFileFormat
       case _ => cls
     }
   }
@@ -619,7 +620,7 @@ object DataSource extends Logging {
     val provider1 = backwardCompatibilityMap.getOrElse(provider, provider) match {
       case name if name.equalsIgnoreCase("orc") &&
           conf.getConf(SQLConf.ORC_IMPLEMENTATION) == "native" =>
-        classOf[OrcDataSourceV2].getCanonicalName
+        classOf[OrcCatalog].getCanonicalName
       case name if name.equalsIgnoreCase("orc") &&
           conf.getConf(SQLConf.ORC_IMPLEMENTATION) == "hive" =>
         "org.apache.spark.sql.hive.orc.OrcFileFormat"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
@@ -32,6 +32,15 @@ object DataSourceUtils {
   val PARTITIONING_COLUMNS_KEY = "__partition_columns"
 
   /**
+   * The key to use for storing output schema as options.
+   */
+  val OUTPUT_SCHEMA_KEY = "__output_schema"
+
+  /**
+   * The key to use for storing user-specified schema as options.
+   */
+  val USER_SPECIFIED_SCHEMA_KEY = "__user_specified_schema"
+  /**
    * Utility methods for converting partitionBy columns to options and back.
    */
   private implicit val formats = Serialization.formats(NoTypeHints)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Cast, Expres
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.command.DDLUtils
-import org.apache.spark.sql.execution.datasources.v2.FileDataSourceV2
+import org.apache.spark.sql.execution.datasources.v2.FileCatalog
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.InsertableRelation
 import org.apache.spark.sql.types.{AtomicType, StructType}
@@ -239,7 +239,7 @@ case class PreprocessTableCreation(sparkSession: SparkSession) extends Rule[Logi
   }
 
   private def fallBackV2ToV1(cls: Class[_]): Class[_] = cls.newInstance match {
-    case f: FileDataSourceV2 => f.fallbackFileFormat
+    case f: FileCatalog => f.getTableProvider.fallbackFileFormat
     case _ => cls
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileCatalog.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2
+
+import java.util
+
+import scala.collection.JavaConverters._
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalog.v2.{Identifier, PathCatalog, TableCatalog, TableChange}
+import org.apache.spark.sql.catalog.v2.expressions.Transform
+import org.apache.spark.sql.execution.datasources.DataSourceUtils
+import org.apache.spark.sql.sources.DataSourceRegister
+import org.apache.spark.sql.sources.v2.Table
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+trait FileCatalog extends PathCatalog with DataSourceRegister {
+  private var options: CaseInsensitiveStringMap = CaseInsensitiveStringMap.empty()
+  private var _name: String = shortName()
+
+  def getTableProvider: FileDataSourceV2
+
+  override def loadTable(ident: Identifier): Table = {
+    val tableProvider = getTableProvider
+    val tableOptions = DataSourceV2Utils.extractSessionConfigs(
+      tableProvider, SparkSession.active.sessionState.conf)
+    val extraOptions = options.asCaseSensitiveMap().asScala.toMap
+    val caseInsensitiveStringMap =
+      new CaseInsensitiveStringMap((tableOptions ++ extraOptions).asJava)
+    if (options.containsKey(DataSourceUtils.USER_SPECIFIED_SCHEMA_KEY)) {
+      val schemaString = options.get(DataSourceUtils.USER_SPECIFIED_SCHEMA_KEY)
+      val userSpecifiedSchema = StructType.fromString(schemaString)
+      tableProvider.getTable(caseInsensitiveStringMap, userSpecifiedSchema)
+    } else {
+      tableProvider.getTable(caseInsensitiveStringMap)
+    }
+  }
+
+  override def createTable(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): Table = {
+    val path = new Path(ident.name)
+    val fs = getFileSystem(path)
+    fs.mkdirs(path)
+    loadTable(ident)
+  }
+
+  override def dropTable(ident: Identifier): Boolean = {
+    val path = new Path(ident.name)
+    val fs = getFileSystem(path)
+    if (!fs.exists(path)) {
+      false
+    } else {
+      fs.delete(path, true)
+      true
+    }
+  }
+
+  override def listTables(namespace: Array[String]): Array[Identifier] =
+    throw new UnsupportedOperationException("")
+
+  override def alterTable(ident: Identifier, changes: TableChange*): Table =
+    throw new UnsupportedOperationException("")
+
+  override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
+    this._name = name
+    this.options = options
+  }
+
+  override def name(): String = _name
+
+  private def getFileSystem(path: Path): FileSystem = {
+    val sparkSession = SparkSession.active
+    val caseSensitiveMap = options.asCaseSensitiveMap.asScala.toMap
+    path.getFileSystem(sparkSession.sessionState.newHadoopConfWithOptions(caseSensitiveMap))
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileDataSourceV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileDataSourceV2.scala
@@ -29,7 +29,7 @@ import org.apache.spark.util.Utils
 /**
  * A base interface for data source v2 implementations of the built-in file-based data sources.
  */
-trait FileDataSourceV2 extends TableProvider with DataSourceRegister {
+trait FileDataSourceV2 extends TableProvider {
   /**
    * Returns a V1 [[FileFormat]] class of the same file data source.
    * This is a solution for the following cases:
@@ -51,7 +51,7 @@ trait FileDataSourceV2 extends TableProvider with DataSourceRegister {
   }
 
   protected def getTableName(paths: Seq[String]): String = {
-    val name = shortName() + " " + paths.map(qualifiedPathName).mkString(",")
+    val name = paths.map(qualifiedPathName).mkString(";")
     Utils.redact(sparkSession.sessionState.conf.stringRedactionPattern, name)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVCatalog.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2.csv
+
+import org.apache.spark.sql.execution.datasources.v2.{FileCatalog, FileDataSourceV2}
+
+class CSVCatalog extends FileCatalog {
+  override def getTableProvider: FileDataSourceV2 = new CSVDataSourceV2
+
+  override def shortName(): String = "csv"
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVDataSourceV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVDataSourceV2.scala
@@ -27,8 +27,6 @@ class CSVDataSourceV2 extends FileDataSourceV2 {
 
   override def fallbackFileFormat: Class[_ <: FileFormat] = classOf[CSVFileFormat]
 
-  override def shortName(): String = "csv"
-
   override def getTable(options: CaseInsensitiveStringMap): Table = {
     val paths = getPaths(options)
     val tableName = getTableName(paths)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonCatalog.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2.json
+
+import org.apache.spark.sql.execution.datasources.v2.{FileCatalog, FileDataSourceV2}
+
+class JsonCatalog extends FileCatalog {
+  override def getTableProvider: FileDataSourceV2 = new JsonDataSourceV2
+
+  override def shortName(): String = "json"
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonDataSourceV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonDataSourceV2.scala
@@ -27,8 +27,6 @@ class JsonDataSourceV2 extends FileDataSourceV2 {
 
   override def fallbackFileFormat: Class[_ <: FileFormat] = classOf[JsonFileFormat]
 
-  override def shortName(): String = "json"
-
   override def getTable(options: CaseInsensitiveStringMap): Table = {
     val paths = getPaths(options)
     val tableName = getTableName(paths)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcCatalog.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2.orc
+
+import org.apache.spark.sql.execution.datasources.v2.{FileCatalog, FileDataSourceV2}
+
+class OrcCatalog extends FileCatalog {
+  override def getTableProvider(): FileDataSourceV2 = new OrcDataSourceV2
+
+  override def shortName(): String = "orc"
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcDataSourceV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcDataSourceV2.scala
@@ -27,8 +27,6 @@ class OrcDataSourceV2 extends FileDataSourceV2 {
 
   override def fallbackFileFormat: Class[_ <: FileFormat] = classOf[OrcFileFormat]
 
-  override def shortName(): String = "orc"
-
   override def getTable(options: CaseInsensitiveStringMap): Table = {
     val paths = getPaths(options)
     val tableName = getTableName(paths)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetCatalog.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2.parquet
+
+import org.apache.spark.sql.execution.datasources.v2.{FileCatalog, FileDataSourceV2}
+
+class ParquetCatalog extends FileCatalog {
+  override def getTableProvider(): FileDataSourceV2 = new ParquetDataSourceV2
+
+  override def shortName(): String = "parquet"
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetDataSourceV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetDataSourceV2.scala
@@ -27,8 +27,6 @@ class ParquetDataSourceV2 extends FileDataSourceV2 {
 
   override def fallbackFileFormat: Class[_ <: FileFormat] = classOf[ParquetFileFormat]
 
-  override def shortName(): String = "parquet"
-
   override def getTable(options: CaseInsensitiveStringMap): Table = {
     val paths = getPaths(options)
     val tableName = getTableName(paths)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetWriteBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetWriteBuilder.scala
@@ -92,7 +92,7 @@ class ParquetWriteBuilder(
       conf.setEnum(ParquetOutputFormat.JOB_SUMMARY_LEVEL, JobSummaryLevel.NONE)
     }
 
-    if (ParquetOutputFormat.getJobSummaryLevel(conf) == JobSummaryLevel.NONE
+    if (ParquetOutputFormat.getJobSummaryLevel(conf) != JobSummaryLevel.NONE
       && !classOf[ParquetOutputCommitter].isAssignableFrom(committerClass)) {
       // output summary is requested, but the class is not a Parquet Committer
       logWarning(s"Committer $committerClass is not a ParquetOutputCommitter and cannot" +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/text/TextCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/text/TextCatalog.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2.text
+
+import org.apache.spark.sql.execution.datasources.v2.{FileCatalog, FileDataSourceV2}
+
+class TextCatalog extends FileCatalog {
+  override def getTableProvider: FileDataSourceV2 = new TextDataSourceV2
+
+  override def shortName(): String = "text"
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/text/TextDataSourceV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/text/TextDataSourceV2.scala
@@ -27,8 +27,6 @@ class TextDataSourceV2 extends FileDataSourceV2 {
 
   override def fallbackFileFormat: Class[_ <: FileFormat] = classOf[TextFileFormat]
 
-  override def shortName(): String = "text"
-
   override def getTable(options: CaseInsensitiveStringMap): Table = {
     val paths = getPaths(options)
     val tableName = getTableName(paths)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -975,7 +975,7 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
       createDF(0, 9)
         .write
         .mode(SaveMode.Append)
-        .format("org.apache.spark.sql.execution.datasources.v2.csv.CSVDataSourceV2")
+        .format("org.apache.spark.sql.execution.datasources.v2.csv.CSVCatalog")
         .saveAsTable("appendCSV")
       createDF(10, 19)
         .write
@@ -1014,7 +1014,7 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
       createDF(10, 19)
         .write
         .mode(SaveMode.Append)
-        .format("org.apache.spark.sql.execution.datasources.v2.csv.CSVDataSourceV2")
+        .format("org.apache.spark.sql.execution.datasources.v2.csv.CSVCatalog")
         .saveAsTable("appendCSV")
       checkAnswer(
         sql("SELECT p.c1, p.c2 FROM appendCSV p WHERE p.c1 > 5"),


### PR DESCRIPTION
**This is still in progress**
## What changes were proposed in this pull request?

Add PathCatalog for data source V2, so that:
1. We can convert SaveMode in DataFrameWriter into catalog table operations, instead of supporting SaveMode in file source V2.
2. Support create-table SQL statements like "CREATE TABLE orc.'path'"
## How was this patch tested?
Unit test
