### PR TITLE
[SPARK-28375][SQL] Prevent the PullupCorrelatedPredicates optimizer rule from removing predicates if run multiple times

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -275,13 +275,16 @@ object PullupCorrelatedPredicates extends Rule[LogicalPlan] with PredicateHelper
     plan transformExpressions {
       case ScalarSubquery(sub, children, exprId) if children.nonEmpty =>
         val (newPlan, newCond) = pullOutCorrelatedPredicates(sub, outerPlans)
-        ScalarSubquery(newPlan, newCond, exprId)
+        val conds = newCond ++ children.filter(_.isInstanceOf[Predicate])
+        ScalarSubquery(newPlan, conds, exprId)
       case Exists(sub, children, exprId) if children.nonEmpty =>
         val (newPlan, newCond) = pullOutCorrelatedPredicates(sub, outerPlans)
-        Exists(newPlan, newCond, exprId)
-      case ListQuery(sub, _, exprId, childOutputs) =>
+        val conds = newCond ++ children.filter(_.isInstanceOf[Predicate])
+        Exists(newPlan, conds, exprId)
+      case ListQuery(sub, children, exprId, childOutputs) =>
         val (newPlan, newCond) = pullOutCorrelatedPredicates(sub, outerPlans)
-        ListQuery(newPlan, newCond, exprId, childOutputs)
+        val conds = newCond ++ children.filter(_.isInstanceOf[Predicate])
+        ListQuery(newPlan, conds, exprId, childOutputs)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -275,16 +275,13 @@ object PullupCorrelatedPredicates extends Rule[LogicalPlan] with PredicateHelper
     plan transformExpressions {
       case ScalarSubquery(sub, children, exprId) if children.nonEmpty =>
         val (newPlan, newCond) = pullOutCorrelatedPredicates(sub, outerPlans)
-        val conds = newCond ++ children.filter(_.isInstanceOf[Predicate])
-        ScalarSubquery(newPlan, conds, exprId)
+        ScalarSubquery(newPlan, newCond, exprId)
       case Exists(sub, children, exprId) if children.nonEmpty =>
         val (newPlan, newCond) = pullOutCorrelatedPredicates(sub, outerPlans)
-        val conds = newCond ++ children.filter(_.isInstanceOf[Predicate])
-        Exists(newPlan, conds, exprId)
-      case ListQuery(sub, children, exprId, childOutputs) =>
+        Exists(newPlan, newCond, exprId)
+      case ListQuery(sub, children, exprId, childOutputs) if children.nonEmpty =>
         val (newPlan, newCond) = pullOutCorrelatedPredicates(sub, outerPlans)
-        val conds = newCond ++ children.filter(_.isInstanceOf[Predicate])
-        ListQuery(newPlan, conds, exprId, childOutputs)
+        ListQuery(newPlan, newCond, exprId, childOutputs)
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PullupCorrelatedPredicatesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PullupCorrelatedPredicatesSuite.scala
@@ -29,7 +29,8 @@ class PullupCorrelatedPredicatesSuite extends PlanTest {
   object Optimize extends RuleExecutor[LogicalPlan] {
     val batches =
       Batch("PullupCorrelatedPredicates", Once,
-        PullupCorrelatedPredicates) :: Nil
+        PullupCorrelatedPredicates,
+        RewritePredicateSubquery) :: Nil
   }
 
   val testRelation = LocalRelation('a.int, 'b.double)
@@ -64,8 +65,6 @@ class PullupCorrelatedPredicatesSuite extends PlanTest {
     val optimized = Optimize.execute(outerQuery)
     val doubleOptimized = Optimize.execute(optimized)
 
-    val listQuery = doubleOptimized.collect { case x: Filter => x }.head.condition
-      .asInstanceOf[InSubquery].query
-    assert(listQuery.children.nonEmpty)
+    comparePlans(optimized, doubleOptimized)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The original implementation of `PullupCorrelatedPredicates` can remove predicates in subqueries if the rule is run multiple times. This fix resolves this issue by appending new predicates to existing predicates from the last run.

## How was this patch tested?
A new UT.
