### PR TITLE
[SPARK-28411][PYTHON][SQL] InsertInto with overwrite is not honored

### DIFF
--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -765,8 +765,8 @@ class DataFrameWriter(OptionUtils):
 
         Optionally overwriting any existing data.
         """
-        if (overwrite):
-            self._jwrite.mode("overwrite")
+        if overwrite:
+            self.mode("overwrite")
         self._jwrite.insertInto(tableName)
 
     @since(1.4)

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -765,7 +765,9 @@ class DataFrameWriter(OptionUtils):
 
         Optionally overwriting any existing data.
         """
-        self._jwrite.mode("overwrite" if overwrite else "append").insertInto(tableName)
+        if (overwrite):
+            self._jwrite.mode("overwrite")
+        self._jwrite.insertInto(tableName)
 
     @since(1.4)
     def saveAsTable(self, name, format=None, mode=None, partitionBy=None, **options):

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -757,7 +757,7 @@ class DataFrameWriter(OptionUtils):
             self._jwrite.save(path)
 
     @since(1.4)
-    def insertInto(self, tableName, overwrite=False):
+    def insertInto(self, tableName, overwrite=None):
         """Inserts the content of the :class:`DataFrame` to the specified table.
 
         It requires that the schema of the class:`DataFrame` is the same as the
@@ -765,8 +765,8 @@ class DataFrameWriter(OptionUtils):
 
         Optionally overwriting any existing data.
         """
-        if overwrite:
-            self.mode("overwrite")
+        if overwrite is not None:
+            self.mode("overwrite" if overwrite else "append")
         self._jwrite.insertInto(tableName)
 
     @since(1.4)

--- a/python/pyspark/sql/tests/test_readwriter.py
+++ b/python/pyspark/sql/tests/test_readwriter.py
@@ -159,8 +159,6 @@ class ReadwriterTests(ReusedSQLTestCase):
             df.write.insertInto("test_table", False)
             self.assertEqual(4, self.spark.sql("select * from test_table").count())
 
-            # self.spark.sql("drop table test_table")
-
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/sql/tests/test_readwriter.py
+++ b/python/pyspark/sql/tests/test_readwriter.py
@@ -159,6 +159,9 @@ class ReadwriterTests(ReusedSQLTestCase):
             df.write.insertInto("test_table", False)
             self.assertEqual(4, self.spark.sql("select * from test_table").count())
 
+            df.write.mode("overwrite").insertInto("test_table", False)
+            self.assertEqual(6, self.spark.sql("select * from test_table").count())
+
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/sql/tests/test_readwriter.py
+++ b/python/pyspark/sql/tests/test_readwriter.py
@@ -143,22 +143,23 @@ class ReadwriterTests(ReusedSQLTestCase):
 
     def test_insert_into(self):
         df = self.spark.createDataFrame([("a", 1), ("b", 2)], ["C1", "C2"])
-        df.write.saveAsTable("test_table")
-        self.assertEqual(2, self.spark.sql("select * from test_table").count())
+        with self.table("test_table"):
+            df.write.saveAsTable("test_table")
+            self.assertEqual(2, self.spark.sql("select * from test_table").count())
 
-        df.write.insertInto("test_table")
-        self.assertEqual(4, self.spark.sql("select * from test_table").count())
+            df.write.insertInto("test_table")
+            self.assertEqual(4, self.spark.sql("select * from test_table").count())
 
-        df.write.mode("overwrite").insertInto("test_table")
-        self.assertEqual(2, self.spark.sql("select * from test_table").count())
+            df.write.mode("overwrite").insertInto("test_table")
+            self.assertEqual(2, self.spark.sql("select * from test_table").count())
 
-        df.write.insertInto("test_table", True)
-        self.assertEqual(2, self.spark.sql("select * from test_table").count())
+            df.write.insertInto("test_table", True)
+            self.assertEqual(2, self.spark.sql("select * from test_table").count())
 
-        df.write.insertInto("test_table", False)
-        self.assertEqual(4, self.spark.sql("select * from test_table").count())
+            df.write.insertInto("test_table", False)
+            self.assertEqual(4, self.spark.sql("select * from test_table").count())
 
-        self.spark.sql("drop table test_table")
+            # self.spark.sql("drop table test_table")
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/test_readwriter.py
+++ b/python/pyspark/sql/tests/test_readwriter.py
@@ -141,6 +141,25 @@ class ReadwriterTests(ReusedSQLTestCase):
                 .mode("overwrite").saveAsTable("pyspark_bucket"))
             self.assertSetEqual(set(data), set(self.spark.table("pyspark_bucket").collect()))
 
+    def test_insert_into(self):
+        df = self.spark.createDataFrame([("a", 1), ("b", 2)], ["C1", "C2"])
+        df.write.saveAsTable("test_table")
+        self.assertEqual(2, self.spark.sql("select * from test_table").count())
+
+        df.write.insertInto("test_table")
+        self.assertEqual(4, self.spark.sql("select * from test_table").count())
+
+        df.write.mode("overwrite").insertInto("test_table")
+        self.assertEqual(2, self.spark.sql("select * from test_table").count())
+
+        df.write.insertInto("test_table", True)
+        self.assertEqual(2, self.spark.sql("select * from test_table").count())
+
+        df.write.insertInto("test_table", False)
+        self.assertEqual(4, self.spark.sql("select * from test_table").count())
+
+        self.spark.sql("drop table test_table")
+
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
## What changes were proposed in this pull request?
In the following python code
```
df.write.mode("overwrite").insertInto("table") 
```
```insertInto``` ignores ```mode("overwrite")```  and appends by default.


## How was this patch tested?

Add Unit test.
