### PR TITLE
[SPARK-28419][SQL] A patch for SparkThriftServer to support multi-tenant authentication for spark-2.4.0

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -19,7 +19,7 @@ package org.apache.spark.rdd
 
 import java.util.Random
 
-import scala.collection.{Map, mutable}
+import scala.collection.{mutable, Map}
 import scala.collection.mutable.ArrayBuffer
 import scala.io.Codec
 import scala.language.implicitConversions

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1834,6 +1834,9 @@ class SQLConf extends Serializable with Logging {
   def hiveThriftServerSingleSession: Boolean =
     getConf(StaticSQLConf.HIVE_THRIFT_SERVER_SINGLESESSION)
 
+  def hiveThriftServerEnableDoAs: Boolean =
+    getConf(StaticSQLConf.HIVE_THRIFT_SERVER_ENABLE_DOAS)
+  
   def orderByOrdinal: Boolean = getConf(ORDER_BY_ORDINAL)
 
   def groupByOrdinal: Boolean = getConf(GROUP_BY_ORDINAL)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -90,6 +90,12 @@ object StaticSQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val HIVE_THRIFT_SERVER_ENABLE_DOAS =
+    buildStaticConf("spark.sql.hive.thriftServer.enable.doAs")
+      .doc("When set to true, Hive Thrift server will run with proxy client user.")
+      .booleanConf
+      .createWithDefault(false)
+
   val HIVE_THRIFT_SERVER_SINGLESESSION =
     buildStaticConf("spark.sql.hive.thriftServer.singleSession")
       .doc("When set to true, Hive Thrift server is running in a single session mode. " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -88,6 +88,10 @@ class SparkSession private(
     this(sc, None, None, new SparkSessionExtensions)
   }
 
+  private[sql] def this(sc:SparkContext, extensions: SparkSessionExtensions) {
+    this(sc, None, None, extensions)
+  }
+
   sparkContext.assertNotStopped()
 
   // If there is no active SparkSession, uses the default SQL conf. Otherwise, use the session's.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -184,7 +184,6 @@ object FileFormatWriter extends Logging {
         })
 
       val currentUser = SparkHadoopUtil.get.createSparkUser().getShortUserName
-      logInfo(s"SparkUser ${sparkSession.sparkContext.sparkUser}")
       UserGroupInformation
         .createProxyUser(sparkSession.sparkContext.sparkUser,
           UserGroupInformation.getLoginUser)
@@ -195,7 +194,6 @@ object FileFormatWriter extends Logging {
               fs.setOwner(path, owner, owner)
               fs.listStatus(path).map(_.getPath).foreach(changeOwnRecursive(fs, _, owner))
             } else {
-              logInfo(s"Change path[${path}] owner to current user ${owner}")
               fs.setOwner(path, owner, owner)
             }
           }

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/SessionManager.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/SessionManager.java
@@ -48,15 +48,15 @@ import org.apache.hive.service.server.ThreadFactoryWithGarbageCleanup;
  */
 public class SessionManager extends CompositeService {
 
-  private static final Log LOG = LogFactory.getLog(SessionManager.class);
+  protected static final Log LOG = LogFactory.getLog(SessionManager.class);
   public static final String HIVERCFILE = ".hiverc";
-  private HiveConf hiveConf;
-  private final Map<SessionHandle, HiveSession> handleToSession =
+  protected HiveConf hiveConf;
+  protected final Map<SessionHandle, HiveSession> handleToSession =
       new ConcurrentHashMap<SessionHandle, HiveSession>();
-  private final OperationManager operationManager = new OperationManager();
+  protected final OperationManager operationManager = new OperationManager();
   private ThreadPoolExecutor backgroundOperationPool;
-  private boolean isOperationLogEnabled;
-  private File operationLogRootDir;
+  protected boolean isOperationLogEnabled;
+  protected File operationLogRootDir;
 
   private long checkInterval;
   private long sessionTimeout;

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HadoopFSDelegationTokenProvider.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HadoopFSDelegationTokenProvider.scala
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.thriftserver
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.FileSystem
+import org.apache.hadoop.mapred.Master
+import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenIdentifier
+import org.apache.hadoop.security.{Credentials, UserGroupInformation}
+import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.PRINCIPAL
+import org.apache.spark.{SparkConf, SparkException}
+
+import scala.collection.JavaConverters._
+import scala.util.Try
+
+class HadoopFSDelegationTokenProvider(sparkConf: SparkConf, hadoopConf: Configuration)
+  extends Logging {
+
+  // This tokenRenewalInterval will be set in the first call to obtainDelegationTokens.
+  // If None, no token renewer is specified or no token can be renewed,
+  // so we cannot get the token renewal interval.
+  //  private var tokenRenewalInterval: Option[Long] = null
+
+  val serviceName: String = "hadoopfs"
+
+  def obtainDelegationTokens(creds: Credentials, renewer: String): Unit = {
+
+    val fsToGetTokens = ThriftServerHadoopUtil.hadoopFSsToAccess(sparkConf, hadoopConf)
+    fetchDelegationTokens(renewer, fsToGetTokens, creds)
+    //    val fetchCreds = fetchDelegationTokens(renewer, fsToGetTokens, creds)
+
+    // Get the token renewal interval if it is not set. It will only be called once.
+    //    if (tokenRenewalInterval == null) {
+    //      tokenRenewalInterval = getTokenRenewalInterval(hadoopConf, sparkConf, fsToGetTokens)
+    //    }
+    //
+    //    // Get the time of next renewal.
+    //    val nextRenewalDate = tokenRenewalInterval.flatMap { interval =>
+    //      val nextRenewalDates = fetchCreds.getAllTokens.asScala
+    //        .filter(_.decodeIdentifier().isInstanceOf[AbstractDelegationTokenIdentifier])
+    //        .map { token =>
+    //          val identifier = token
+    //            .decodeIdentifier()
+    //            .asInstanceOf[AbstractDelegationTokenIdentifier]
+    //          identifier.getIssueDate + interval
+    //        }
+    //      if (nextRenewalDates.isEmpty) None else Some(nextRenewalDates.min)
+    //    }
+    //
+    //    nextRenewalDate
+  }
+
+  def delegationTokensRequired(sparkConf: SparkConf,
+                               hadoopConf: Configuration): Boolean = {
+    UserGroupInformation.isSecurityEnabled
+  }
+
+  private def getTokenRenewer(hadoopConf: Configuration): String = {
+    val tokenRenewer = Master.getMasterPrincipal(hadoopConf)
+    logDebug("Delegation token renewer is: " + tokenRenewer)
+
+    if (tokenRenewer == null || tokenRenewer.length() == 0) {
+      val errorMessage = "Can't get Master Kerberos principal for use as renewer."
+      logError(errorMessage)
+      throw new SparkException(errorMessage)
+    }
+
+    tokenRenewer
+  }
+
+  private def fetchDelegationTokens(renewer: String,
+                                    filesystems: Set[FileSystem],
+                                    creds: Credentials): Credentials = {
+
+    filesystems.foreach { fs =>
+      logInfo("getting token for: " + fs)
+      fs.addDelegationTokens(renewer, creds)
+    }
+
+    creds
+  }
+
+  private def getTokenRenewalInterval(hadoopConf: Configuration,
+                                      sparkConf: SparkConf,
+                                      filesystems: Set[FileSystem]): Option[Long] = {
+    // We cannot use the tokens generated with renewer yarn. Trying to renew
+    // those will fail with an access control issue. So create new tokens with the logged in
+    // user as renewer.
+    sparkConf.get(PRINCIPAL).flatMap { renewer =>
+      val creds = new Credentials()
+      fetchDelegationTokens(renewer, filesystems, creds)
+
+      val renewIntervals = creds.getAllTokens.asScala.filter {
+        _.decodeIdentifier().isInstanceOf[AbstractDelegationTokenIdentifier]
+      }.flatMap { token =>
+        Try {
+          val newExpiration = token.renew(hadoopConf)
+          val identifier = token.decodeIdentifier().asInstanceOf[AbstractDelegationTokenIdentifier]
+          val interval = newExpiration - identifier.getIssueDate
+          logInfo(s"Renewal interval is $interval for token ${token.getKind.toString}")
+          interval
+        }.toOption
+      }
+      if (renewIntervals.isEmpty) None else Some(renewIntervals.min)
+    }
+  }
+}

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
@@ -21,7 +21,7 @@ import java.io.PrintStream
 
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{SparkSession, SQLContext}
+import org.apache.spark.sql.{SQLContext, SparkSession, SparkSessionExtensions}
 import org.apache.spark.sql.hive.{HiveExternalCatalog, HiveUtils}
 import org.apache.spark.util.Utils
 
@@ -31,6 +31,8 @@ private[hive] object SparkSQLEnv extends Logging {
 
   var sqlContext: SQLContext = _
   var sparkContext: SparkContext = _
+  var extension: SparkSessionExtensions = _
+
 
   def init() {
     if (sqlContext == null) {
@@ -48,6 +50,7 @@ private[hive] object SparkSQLEnv extends Logging {
       val sparkSession = SparkSession.builder.config(sparkConf).enableHiveSupport().getOrCreate()
       sparkContext = sparkSession.sparkContext
       sqlContext = sparkSession.sqlContext
+      extension = sparkSession.extensions
 
       val metadataHive = sparkSession
         .sharedState.externalCatalog.unwrapped.asInstanceOf[HiveExternalCatalog].client

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLSessionManager.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLSessionManager.scala
@@ -22,12 +22,12 @@ import java.util.concurrent.Executors
 import org.apache.commons.logging.Log
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars
-import org.apache.hive.service.cli.SessionHandle
-import org.apache.hive.service.cli.session.SessionManager
+import org.apache.hadoop.security.Credentials
+import org.apache.hive.service.cli.{HiveSQLException, SessionHandle}
+import org.apache.hive.service.cli.session._
 import org.apache.hive.service.cli.thrift.TProtocolVersion
 import org.apache.hive.service.server.HiveServer2
-
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.{SQLContext, SparkSession}
 import org.apache.spark.sql.hive.HiveUtils
 import org.apache.spark.sql.hive.thriftserver.ReflectionUtils._
 import org.apache.spark.sql.hive.thriftserver.server.SparkSQLOperationManager
@@ -38,6 +38,8 @@ private[hive] class SparkSQLSessionManager(hiveServer: HiveServer2, sqlContext: 
   with ReflectedCompositeService {
 
   private lazy val sparkSqlOperationManager = new SparkSQLOperationManager()
+  private lazy val sparkSessionManager = new SparkSessionManager()
+  private val hadoopTokenProvider = new HadoopFSDelegationTokenProvider(SparkSQLEnv.sparkContext.conf, SparkSQLEnv.sparkContext.hadoopConfiguration)
 
   override def init(hiveConf: HiveConf) {
     setSuperField(this, "operationManager", sparkSqlOperationManager)
@@ -52,22 +54,55 @@ private[hive] class SparkSQLSessionManager(hiveServer: HiveServer2, sqlContext: 
       sessionConf: java.util.Map[String, String],
       withImpersonation: Boolean,
       delegationToken: String): SessionHandle = {
-    val sessionHandle =
-      super.openSession(protocol, username, passwd, ipAddress, sessionConf, withImpersonation,
-          delegationToken)
-    val session = super.getSession(sessionHandle)
+    var session: HiveSession = null
+    var sparkSession: SparkSession = null
+    if (withImpersonation) {
+      val sessionWithUGI = new HiveSessionImplwithUGI(protocol, username, passwd, hiveConf, ipAddress, delegationToken)
+      val ugi = sessionWithUGI.getSessionUgi
+      val originalCreds = ugi.getCredentials
+      val creds = new Credentials()
+      ThriftServerHadoopUtil.doAs(ugi)(() => hadoopTokenProvider.obtainDelegationTokens(creds, username))
+      ugi.addCredentials(creds)
+      val existing = ugi.getCredentials()
+      existing.mergeAll(originalCreds)
+      ugi.addCredentials(existing)
+
+      session = HiveSessionProxy.getProxy(sessionWithUGI, sessionWithUGI.getSessionUgi)
+      sessionWithUGI.setProxySession(session)
+      sparkSession = sparkSessionManager.getOrCreteSparkSession(sessionWithUGI, withImpersonation)
+    }
+    else {
+      session = new HiveSessionImpl(protocol, username, passwd, hiveConf, ipAddress)
+      sparkSession = sparkSessionManager.getOrCreteSparkSession(session, withImpersonation)
+    }
+    val ctx = sparkSession.sqlContext
+    session.setSessionManager(this)
+    session.setOperationManager(operationManager)
+    try
+      session.open(sessionConf)
+    catch {
+      case e: Exception =>
+        try
+          session.close()
+        catch {
+          case t: Throwable =>
+            SessionManager.LOG.warn("Error closing session", t)
+        }
+        session = null
+        throw new HiveSQLException("Failed to open new session: " + e, e)
+    }
+    if (isOperationLogEnabled)
+      session.setOperationLogSessionDir(operationLogRootDir)
+    handleToSession.put(session.getSessionHandle, session)
+
+    val sessionHandle = session.getSessionHandle
     HiveThriftServer2.listener.onSessionCreated(
       session.getIpAddress, sessionHandle.getSessionId.toString, session.getUsername)
-    val ctx = if (sqlContext.conf.hiveThriftServerSingleSession) {
-      sqlContext
-    } else {
-      sqlContext.newSession()
-    }
-    ctx.setConf(HiveUtils.FAKE_HIVE_VERSION.key, HiveUtils.builtinHiveVersion)
+    sparkSession.sqlContext.setConf(HiveUtils.FAKE_HIVE_VERSION.key, HiveUtils.builtinHiveVersion)
     if (sessionConf != null && sessionConf.containsKey("use:database")) {
-      ctx.sql(s"use ${sessionConf.get("use:database")}")
+      sparkSession.sql(s"use ${sessionConf.get("use:database")}")
     }
-    sparkSqlOperationManager.sessionToContexts.put(sessionHandle, ctx)
+    sparkSqlOperationManager.sessionToContexts.put(sessionHandle, sparkSession.sqlContext)
     sessionHandle
   }
 

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSessionManager.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSessionManager.scala
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.thriftserver
+
+import java.io.{IOException, PrintStream}
+import java.security.PrivilegedExceptionAction
+import java.util.concurrent.ConcurrentHashMap
+
+import org.apache.hadoop.hive.conf.HiveConf
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars
+import org.apache.hadoop.hive.ql.metadata.{Hive, HiveException}
+import org.apache.hadoop.hive.shims.Utils
+import org.apache.hadoop.security.UserGroupInformation
+import org.apache.hive.service.auth.HiveAuthFactory
+import org.apache.hive.service.cli.HiveSQLException
+import org.apache.hive.service.cli.session.HiveSession
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.hive.thriftserver.SparkSQLEnv.sparkContext
+import org.apache.spark.sql.hive.{HiveExternalCatalog, HiveUtils}
+
+class SparkSessionManager extends Logging {
+  private val STS_TOKEN = "SparkThriftServer2ImpersonationToken"
+  private val LOCK = new Object()
+  private val cachedSession = new ConcurrentHashMap[String, SparkSession]()
+  private val hiveConf = new HiveConf()
+
+  def getDelegationToken(userName: String): String = {
+    if (userName != null &&
+      hiveConf.getVar(ConfVars.HIVE_SERVER2_AUTHENTICATION).equalsIgnoreCase(HiveAuthFactory.AuthTypes.KERBEROS.toString) &&
+      hiveConf.getBoolVar(HiveConf.ConfVars.METASTORE_USE_THRIFT_SASL) &&
+      hiveConf.getBoolVar(HiveConf.ConfVars.HIVE_SERVER2_ENABLE_DOAS)) {
+      try {
+        Hive.closeCurrent()
+        Hive.set(null)
+        Hive.get(hiveConf).getDelegationToken(userName, userName)
+      } catch {
+        case e: HiveException =>
+          if (e.getCause.isInstanceOf[UnsupportedOperationException]) throw e.getCause.asInstanceOf[UnsupportedOperationException]
+          else throw new HiveSQLException("Error connect metastore to setup impersonation", e)
+      }
+    } else {
+      null
+    }
+  }
+
+
+  def getOrCreteSparkSession(session: HiveSession, withImpersonation: Boolean): SparkSession = LOCK.synchronized {
+    if (cachedSession.containsKey(session.getUserName)) {
+      cachedSession.get(session.getUserName).newSession()
+    } else {
+      val ugi = if (withImpersonation) {
+        if (session.getUserName == null) throw new HiveSQLException("No username provided for impersonation")
+        if (UserGroupInformation.isSecurityEnabled) try
+          UserGroupInformation.createProxyUser(session.getUserName, UserGroupInformation.getLoginUser)
+        catch {
+          case e: IOException =>
+            throw new HiveSQLException("Couldn't setup proxy user", e)
+        }
+        else {
+          UserGroupInformation.createRemoteUser(session.getUserName)
+        }
+      } else {
+        UserGroupInformation.getLoginUser
+      }
+
+      logInfo(s"Current Username => ${session.getUserName}")
+      logInfo(s"Create SparkSession with UGI => ${ugi}")
+      sparkContext.conf.set("hive.metastore.token.signature", STS_TOKEN)
+      try {
+        val delegationToken = getDelegationToken(session.getUserName)
+        logInfo(s"Get DelegationToken => ${delegationToken}")
+        Utils.setTokenStr(ugi, delegationToken, STS_TOKEN)
+      } catch {
+        case e: IOException =>
+          throw new HiveSQLException("Couldn't setup delegation token in the ugi", e)
+      }
+
+      val sparkSession = ugi.doAs(new PrivilegedExceptionAction[SparkSession] {
+        override def run(): SparkSession = {
+          Hive.closeCurrent()
+          val sessionForSpecUser = new SparkSession(sparkContext, SparkSQLEnv.extension)
+          sessionForSpecUser.catalog
+          sessionForSpecUser.sessionState.catalog
+          val metadataHive = sessionForSpecUser
+            .sharedState.externalCatalog.unwrapped.asInstanceOf[HiveExternalCatalog].client
+          metadataHive.setOut(new PrintStream(System.out, true, "UTF-8"))
+          metadataHive.setInfo(new PrintStream(System.err, true, "UTF-8"))
+          metadataHive.setError(new PrintStream(System.err, true, "UTF-8"))
+          sessionForSpecUser.conf.set(HiveUtils.FAKE_HIVE_VERSION.key, HiveUtils.builtinHiveVersion)
+          sessionForSpecUser
+        }
+      })
+
+      cachedSession.put(session.getUserName, sparkSession)
+      sparkSession
+    }
+
+  }
+}

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSessionManager.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSessionManager.scala
@@ -79,12 +79,9 @@ class SparkSessionManager extends Logging {
         UserGroupInformation.getLoginUser
       }
 
-      logInfo(s"Current Username => ${session.getUserName}")
-      logInfo(s"Create SparkSession with UGI => ${ugi}")
       sparkContext.conf.set("hive.metastore.token.signature", STS_TOKEN)
       try {
         val delegationToken = getDelegationToken(session.getUserName)
-        logInfo(s"Get DelegationToken => ${delegationToken}")
         Utils.setTokenStr(ugi, delegationToken, STS_TOKEN)
       } catch {
         case e: IOException =>

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerHadoopUtil.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerHadoopUtil.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.thriftserver
+
+import java.security.PrivilegedExceptionAction
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.security.UserGroupInformation
+import org.apache.spark.SparkConf
+
+object ThriftServerHadoopUtil {
+  private val FILESYSTEMS_TO_ACCESS = "spark.yarn.access.hadoopFileSystems"
+
+  private val STAGING_DIR = "spark.yarn.stagingDir"
+
+  def hadoopFSsToAccess(sparkConf: SparkConf,
+                        hadoopConf: Configuration): Set[FileSystem] = {
+    val filesystemsToAccess = sparkConf.getOption(FILESYSTEMS_TO_ACCESS)
+    val requestAllDelegationTokens = filesystemsToAccess.isEmpty
+
+    val stagingFS = sparkConf.getOption(STAGING_DIR)
+      .map(new Path(_).getFileSystem(hadoopConf))
+      .getOrElse(FileSystem.get(hadoopConf))
+
+    // Add the list of available namenodes for all namespaces in HDFS federation.
+    // If ViewFS is enabled, this is skipped as ViewFS already handles delegation tokens for its
+    // namespaces.
+    val hadoopFilesystems = if (!requestAllDelegationTokens || stagingFS.getScheme == "viewfs") {
+      filesystemsToAccess.map(new Path(_).getFileSystem(hadoopConf)).toSet
+    } else {
+      val nameservices = hadoopConf.getTrimmedStrings("dfs.nameservices")
+      // Retrieving the filesystem for the nameservices where HA is not enabled
+      val filesystemsWithoutHA = nameservices.flatMap { ns =>
+        Option(hadoopConf.get(s"dfs.namenode.rpc-address.$ns")).map { nameNode =>
+          new Path(s"hdfs://$nameNode").getFileSystem(hadoopConf)
+        }
+      }
+      // Retrieving the filesystem for the nameservices where HA is enabled
+      val filesystemsWithHA = nameservices.flatMap { ns =>
+        Option(hadoopConf.get(s"dfs.ha.namenodes.$ns")).map { _ =>
+          new Path(s"hdfs://$ns").getFileSystem(hadoopConf)
+        }
+      }
+      (filesystemsWithoutHA ++ filesystemsWithHA).toSet
+    }
+
+    hadoopFilesystems + stagingFS
+  }
+
+  def doAs[T](ugi: UserGroupInformation)(f: () => T): T = {
+    ugi.doAs(new PrivilegedExceptionAction[T] {
+      override def run(): T = f()
+    })
+  }
+
+}
+


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is about a patch to improve spark-2.4.0 to support  multi-tenant authentication.

In this PR, hope to discuss with Spark SQL developers about how to enable SparkThriftServer proxy user. And accept suggestions about this method and improve code structure.(ps: there are some unsightly or crude code.)

## How was this patch tested?

I have test it in our enviorment, it can read and write with proxy user in Kerberos.
Hope some one can test it in different enviorment.
Need more  concurrency  test.