### PR TITLE
[SPARK-28423][SQL] Merge Scan and Batch/Stream

### DIFF
--- a/external/avro/src/main/scala/org/apache/spark/sql/v2/avro/AvroScanBuilder.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/v2/avro/AvroScanBuilder.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.v2.avro
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
 import org.apache.spark.sql.execution.datasources.v2.FileScanBuilder
-import org.apache.spark.sql.sources.v2.reader.Scan
+import org.apache.spark.sql.sources.v2.reader.BatchScan
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -30,7 +30,7 @@ class AvroScanBuilder (
     dataSchema: StructType,
     options: CaseInsensitiveStringMap)
   extends FileScanBuilder(sparkSession, fileIndex, dataSchema) {
-  override def build(): Scan = {
+  override def buildForBatch(): BatchScan = {
     AvroScan(sparkSession, fileIndex, dataSchema, readDataSchema(), readPartitionSchema(), options)
   }
 }

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaBatchScan.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaBatchScan.scala
@@ -22,21 +22,24 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.Network.NETWORK_TIMEOUT
-import org.apache.spark.sql.sources.v2.reader.{Batch, InputPartition, PartitionReaderFactory}
+import org.apache.spark.sql.sources.v2.reader.{BatchScan, InputPartition, PartitionReaderFactory}
+import org.apache.spark.sql.types.StructType
 
 
-private[kafka010] class KafkaBatch(
+private[kafka010] class KafkaBatchScan(
     strategy: ConsumerStrategy,
     sourceOptions: Map[String, String],
     specifiedKafkaParams: Map[String, String],
     failOnDataLoss: Boolean,
     startingOffsets: KafkaOffsetRangeLimit,
     endingOffsets: KafkaOffsetRangeLimit)
-  extends Batch with Logging {
+  extends BatchScan with Logging {
   assert(startingOffsets != LatestOffsetRangeLimit,
     "Starting offset not allowed to be set to latest offsets.")
   assert(endingOffsets != EarliestOffsetRangeLimit,
     "Ending offset not allowed to be set to earliest offsets.")
+
+  override def readSchema(): StructType = KafkaOffsetReader.kafkaSchema
 
   private val pollTimeoutMs = sourceOptions.getOrElse(
     KafkaSourceProvider.CONSUMER_POLL_TIMEOUT,

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaContinuousScan.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaContinuousScan.scala
@@ -30,10 +30,11 @@ import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.kafka010.KafkaSourceProvider.{INSTRUCTION_FOR_FAIL_ON_DATA_LOSS_FALSE, INSTRUCTION_FOR_FAIL_ON_DATA_LOSS_TRUE}
 import org.apache.spark.sql.sources.v2.reader._
 import org.apache.spark.sql.sources.v2.reader.streaming._
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
- * A [[ContinuousStream]] for data from kafka.
+ * A [[ContinuousScan]] for data from kafka.
  *
  * @param offsetReader  a reader used to get kafka offsets. Note that the actual data will be
  *                      read by per-task consumers generated later.
@@ -45,14 +46,16 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
  *                       scenarios, where some offsets after the specified initial ones can't be
  *                       properly read.
  */
-class KafkaContinuousStream(
+class KafkaContinuousScan(
     offsetReader: KafkaOffsetReader,
     kafkaParams: ju.Map[String, Object],
     options: CaseInsensitiveStringMap,
     metadataPath: String,
     initialOffsets: KafkaOffsetRangeLimit,
     failOnDataLoss: Boolean)
-  extends ContinuousStream with Logging {
+  extends ContinuousScan with Logging {
+
+  override def readSchema(): StructType = KafkaOffsetReader.kafkaSchema
 
   private val pollTimeoutMs =
     options.getLong(KafkaSourceProvider.CONSUMER_POLL_TIMEOUT, 512)

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaContinuousSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaContinuousSourceSuite.scala
@@ -213,8 +213,8 @@ class KafkaContinuousSourceTopicDeletionSuite extends KafkaContinuousTest {
           assert(
             query.lastExecution.executedPlan.collectFirst {
               case scan: ContinuousScanExec
-                if scan.stream.isInstanceOf[KafkaContinuousStream] =>
-                scan.stream.asInstanceOf[KafkaContinuousStream]
+                if scan.scan.isInstanceOf[KafkaContinuousScan] =>
+                scan.scan.asInstanceOf[KafkaContinuousScan]
             }.exists { stream =>
               // Ensure the new topic is present and the old topic is gone.
               stream.knownPartitions.exists(_.topic == topic2)

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaContinuousTest.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaContinuousTest.scala
@@ -47,8 +47,8 @@ trait KafkaContinuousTest extends KafkaSourceTest {
       assert(
         query.lastExecution.executedPlan.collectFirst {
           case scan: ContinuousScanExec
-              if scan.stream.isInstanceOf[KafkaContinuousStream] =>
-            scan.stream.asInstanceOf[KafkaContinuousStream]
+              if scan.scan.isInstanceOf[KafkaContinuousScan] =>
+            scan.scan.asInstanceOf[KafkaContinuousScan]
         }.exists(_.knownPartitions.size == newCount),
         s"query never reconfigured to $newCount partitions")
     }

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.execution.streaming.continuous.ContinuousExecution
 import org.apache.spark.sql.functions.{count, window}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.kafka010.KafkaSourceProvider._
-import org.apache.spark.sql.sources.v2.reader.streaming.SparkDataStream
+import org.apache.spark.sql.sources.v2.reader.streaming.StreamingScan
 import org.apache.spark.sql.streaming.{StreamTest, Trigger}
 import org.apache.spark.sql.streaming.util.StreamManualClock
 import org.apache.spark.sql.test.SharedSQLContext
@@ -95,7 +95,7 @@ abstract class KafkaSourceTest extends StreamTest with SharedSQLContext with Kaf
       message: String = "",
       topicAction: (String, Option[Int]) => Unit = (_, _) => {}) extends AddData {
 
-    override def addData(query: Option[StreamExecution]): (SparkDataStream, Offset) = {
+    override def addData(query: Option[StreamExecution]): (StreamingScan, Offset) = {
       query match {
         // Make sure no Spark job is running when deleting a topic
         case Some(m: MicroBatchExecution) => m.processAllAvailable()
@@ -115,12 +115,12 @@ abstract class KafkaSourceTest extends StreamTest with SharedSQLContext with Kaf
         query.nonEmpty,
         "Cannot add data when there is no query for finding the active kafka source")
 
-      val sources: Seq[SparkDataStream] = {
+      val sources: Seq[StreamingScan] = {
         query.get.logicalPlan.collect {
           case StreamingExecutionRelation(source: KafkaSource, _) => source
-          case r: StreamingDataSourceV2Relation if r.stream.isInstanceOf[KafkaMicroBatchStream] ||
-              r.stream.isInstanceOf[KafkaContinuousStream] =>
-            r.stream
+          case r: StreamingDataSourceV2Relation if r.scan.isInstanceOf[KafkaMicroBatchScan] ||
+              r.scan.isInstanceOf[KafkaContinuousScan] =>
+            r.scan
         }
       }.distinct
 
@@ -1111,7 +1111,7 @@ class KafkaMicroBatchV2SourceSuite extends KafkaMicroBatchSourceSuiteBase {
       makeSureGetOffsetCalled,
       AssertOnQuery { query =>
         query.logicalPlan.find {
-          case r: StreamingDataSourceV2Relation => r.stream.isInstanceOf[KafkaMicroBatchStream]
+          case r: StreamingDataSourceV2Relation => r.scan.isInstanceOf[KafkaMicroBatchScan]
           case _ => false
         }.isDefined
       }
@@ -1139,8 +1139,9 @@ class KafkaMicroBatchV2SourceSuite extends KafkaMicroBatchSourceSuiteBase {
         ) ++ Option(minPartitions).map { p => "minPartitions" -> p}
         val dsOptions = new CaseInsensitiveStringMap(options.asJava)
         val table = provider.getTable(dsOptions)
-        val stream = table.newScanBuilder(dsOptions).build().toMicroBatchStream(dir.getAbsolutePath)
-        val inputPartitions = stream.planInputPartitions(
+        val scan = table.newScanBuilder(dsOptions)
+          .buildForMicroBatchStreaming(dir.getAbsolutePath)
+        val inputPartitions = scan.planInputPartitions(
           KafkaSourceOffset(Map(tp -> 0L)),
           KafkaSourceOffset(Map(tp -> 100L))).map(_.asInstanceOf[KafkaBatchInputPartition])
         withClue(s"minPartitions = $minPartitions generated factories $inputPartitions\n\t") {

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
@@ -39,12 +39,12 @@ class KafkaSourceProviderSuite extends SparkFunSuite with PrivateMethodTester {
   }
 
   test("micro-batch mode - options should be handled as case-insensitive") {
-    def verifyFieldsInMicroBatchStream(
+    def verifyFieldsInMicroBatchScan(
         options: CaseInsensitiveStringMap,
         expectedPollTimeoutMs: Long,
         expectedMaxOffsetsPerTrigger: Option[Long]): Unit = {
-      // KafkaMicroBatchStream reads Spark conf from SparkEnv for default value
-      // hence we set mock SparkEnv here before creating KafkaMicroBatchStream
+      // KafkaMicroBatchScan reads Spark conf from SparkEnv for default value
+      // hence we set mock SparkEnv here before creating KafkaMicroBatchScan
       val sparkEnv = mock(classOf[SparkEnv])
       when(sparkEnv.conf).thenReturn(new SparkConf())
       SparkEnv.set(sparkEnv)
@@ -61,11 +61,11 @@ class KafkaSourceProviderSuite extends SparkFunSuite with PrivateMethodTester {
     buildCaseInsensitiveStringMapForUpperAndLowerKey(
       KafkaSourceProvider.CONSUMER_POLL_TIMEOUT -> expectedValue.toString,
       KafkaSourceProvider.MAX_OFFSET_PER_TRIGGER -> expectedValue.toString)
-      .foreach(verifyFieldsInMicroBatchStream(_, expectedValue, Some(expectedValue)))
+      .foreach(verifyFieldsInMicroBatchScan(_, expectedValue, Some(expectedValue)))
   }
 
   test("SPARK-28142 - continuous mode - options should be handled as case-insensitive") {
-    def verifyFieldsInContinuousStream(
+    def verifyFieldsInContinuousScan(
         options: CaseInsensitiveStringMap,
         expectedPollTimeoutMs: Long): Unit = {
       val builder = getKafkaDataSourceScanBuilder(options)
@@ -77,7 +77,7 @@ class KafkaSourceProviderSuite extends SparkFunSuite with PrivateMethodTester {
     val expectedValue = 1000
     buildCaseInsensitiveStringMapForUpperAndLowerKey(
       KafkaSourceProvider.CONSUMER_POLL_TIMEOUT -> expectedValue.toString)
-      .foreach(verifyFieldsInContinuousStream(_, expectedValue))
+      .foreach(verifyFieldsInContinuousScan(_, expectedValue))
   }
 
   private def buildCaseInsensitiveStringMapForUpperAndLowerKey(

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/sources/v2/reader/BatchScan.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/sources/v2/reader/BatchScan.java
@@ -17,26 +17,29 @@
 
 package org.apache.spark.sql.sources.v2.reader;
 
-import org.apache.spark.annotation.Evolving;
-
 /**
- * A physical representation of a data source scan for batch queries. This interface is used to
- * provide physical information, like how many partitions the scanned data has, and how to read
- * records from the partitions.
+ * An interface that defines how to scan the data from data source for batch processing.
+ *
+ * The scanning procedure is:
+ *   1. Create the input partitions of this scan by {@link #planInputPartitions()}. Launch a Spark
+ *      job and submit one task for each input partition to produce data.
+ *   2. Create a partition reader factory by {@link #createReaderFactory()}, serialize and send it
+ *      to each input partition.
+ *   3. For each partition, create the data reader from the reader factory, and scan the data from
+ *      the input partition with this reader.
  */
-@Evolving
-public interface Batch {
+public interface BatchScan extends Scan {
 
   /**
    * Returns a list of {@link InputPartition input partitions}. Each {@link InputPartition}
    * represents a data split that can be processed by one Spark task. The number of input
    * partitions returned here is the same as the number of RDD partitions this scan outputs.
    * <p>
-   * If the {@link Scan} supports filter pushdown, this Batch is likely configured with a filter
+   * If the data source supports filter pushdown, this scan is likely configured with a filter
    * and is responsible for creating splits for that filter, which is not a full scan.
    * </p>
    * <p>
-   * This method will be called only once during a data source scan, to launch one Spark job.
+   * This method will be called only once during a data source batch scan, to launch one Spark job.
    * </p>
    */
   InputPartition[] planInputPartitions();

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/sources/v2/reader/InputPartition.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/sources/v2/reader/InputPartition.java
@@ -23,7 +23,7 @@ import org.apache.spark.annotation.Evolving;
 
 /**
  * A serializable representation of an input partition returned by
- * {@link Batch#planInputPartitions()} and the corresponding ones in streaming .
+ * {@link BatchScan#planInputPartitions()} and the corresponding ones in streaming .
  *
  * Note that {@link InputPartition} will be serialized and sent to executors, then
  * {@link PartitionReader} will be created by

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/sources/v2/reader/Scan.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/sources/v2/reader/Scan.java
@@ -18,22 +18,10 @@
 package org.apache.spark.sql.sources.v2.reader;
 
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.sources.v2.reader.streaming.ContinuousStream;
-import org.apache.spark.sql.sources.v2.reader.streaming.MicroBatchStream;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.sql.sources.v2.Table;
-import org.apache.spark.sql.sources.v2.TableCapability;
 
 /**
- * A logical representation of a data source scan. This interface is used to provide logical
- * information, like what the actual read schema is.
- * <p>
- * This logical representation is shared between batch scan, micro-batch streaming scan and
- * continuous streaming scan. Data sources must implement the corresponding methods in this
- * interface, to match what the table promises to support. For example, {@link #toBatch()} must be
- * implemented, if the {@link Table} that creates this {@link Scan} returns
- * {@link TableCapability#BATCH_READ} support in its {@link Table#capabilities()}.
- * </p>
+ * An internal base interface for batch and streaming scan interfaces.
  */
 @Evolving
 public interface Scan {
@@ -55,49 +43,5 @@ public interface Scan {
    */
   default String description() {
     return this.getClass().toString();
-  }
-
-  /**
-   * Returns the physical representation of this scan for batch query. By default this method throws
-   * exception, data sources must overwrite this method to provide an implementation, if the
-   * {@link Table} that creates this scan returns {@link TableCapability#BATCH_READ} support in its
-   * {@link Table#capabilities()}.
-   *
-   * @throws UnsupportedOperationException
-   */
-  default Batch toBatch() {
-    throw new UnsupportedOperationException(description() + ": Batch scan are not supported");
-  }
-
-  /**
-   * Returns the physical representation of this scan for streaming query with micro-batch mode. By
-   * default this method throws exception, data sources must overwrite this method to provide an
-   * implementation, if the {@link Table} that creates this scan returns
-   * {@link TableCapability#MICRO_BATCH_READ} support in its {@link Table#capabilities()}.
-   *
-   * @param checkpointLocation a path to Hadoop FS scratch space that can be used for failure
-   *                           recovery. Data streams for the same logical source in the same query
-   *                           will be given the same checkpointLocation.
-   *
-   * @throws UnsupportedOperationException
-   */
-  default MicroBatchStream toMicroBatchStream(String checkpointLocation) {
-    throw new UnsupportedOperationException(description() + ": Micro-batch scan are not supported");
-  }
-
-  /**
-   * Returns the physical representation of this scan for streaming query with continuous mode. By
-   * default this method throws exception, data sources must overwrite this method to provide an
-   * implementation, if the {@link Table} that creates this scan returns
-   * {@link TableCapability#CONTINUOUS_READ} support in its {@link Table#capabilities()}.
-   *
-   * @param checkpointLocation a path to Hadoop FS scratch space that can be used for failure
-   *                           recovery. Data streams for the same logical source in the same query
-   *                           will be given the same checkpointLocation.
-   *
-   * @throws UnsupportedOperationException
-   */
-  default ContinuousStream toContinuousStream(String checkpointLocation) {
-    throw new UnsupportedOperationException(description() + ": Continuous scan are not supported");
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/sources/v2/reader/ScanBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/sources/v2/reader/ScanBuilder.java
@@ -18,13 +18,57 @@
 package org.apache.spark.sql.sources.v2.reader;
 
 import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.sources.v2.Table;
+import org.apache.spark.sql.sources.v2.TableCapability;
+import org.apache.spark.sql.sources.v2.reader.streaming.ContinuousScan;
+import org.apache.spark.sql.sources.v2.reader.streaming.MicroBatchScan;
 
 /**
- * An interface for building the {@link Scan}. Implementations can mixin SupportsPushDownXYZ
- * interfaces to do operator pushdown, and keep the operator pushdown result in the returned
- * {@link Scan}.
+ * An interface for building batch and streaming scans. Implementations can mixin
+ * SupportsPushDownXYZ interfaces to do operator pushdown, and keep the operator pushdown result in
+ * the returned scan.
  */
 @Evolving
 public interface ScanBuilder {
-  Scan build();
+
+  /**
+   * Returns a {@link BatchScan} to scan data from a batch source. By default this method throws
+   * exception, data sources must overwrite this method to provide an implementation, if the
+   * {@link Table} that creates this scan returns {@link TableCapability#BATCH_READ} support in
+   * its {@link Table#capabilities()}.
+   */
+  default BatchScan buildForBatch() {
+    throw new UnsupportedOperationException(getClass().getName() +
+      " does not support batch scan");
+  }
+
+  /**
+   * Returns a {@link MicroBatchScan} to scan data from a micro-batch streaming source. By default
+   * this method throws exception, data sources must overwrite this method to provide an
+   * implementation, if the {@link Table} that creates this scan returns
+   * {@link TableCapability#MICRO_BATCH_READ} support in its {@link Table#capabilities()}.
+   *
+   * @param checkpointLocation a path to Hadoop FS scratch space that can be used for failure
+   *                           recovery. Data streams for the same logical source in the same query
+   *                           will be given the same checkpointLocation.
+   */
+  default MicroBatchScan buildForMicroBatchStreaming(String checkpointLocation) {
+    throw new UnsupportedOperationException(getClass().getName() +
+      " does not support micro-batch streaming scan");
+  }
+
+  /**
+   * Returns a {@link ContinuousScan} to scan data from a continuous streaming source. By default
+   * this method throws exception, data sources must overwrite this method to provide an
+   * implementation, if the {@link Table} that creates this scan returns
+   * {@link TableCapability#CONTINUOUS_READ} support in its {@link Table#capabilities()}.
+   *
+   * @param checkpointLocation a path to Hadoop FS scratch space that can be used for failure
+   *                           recovery. Data streams for the same logical source in the same query
+   *                           will be given the same checkpointLocation.
+   */
+  default ContinuousScan buildForContinuousStreaming(String checkpointLocation) {
+    throw new UnsupportedOperationException(getClass().getName() +
+      " does not support continuous streaming scan");
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/sources/v2/reader/streaming/Offset.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/sources/v2/reader/streaming/Offset.java
@@ -20,8 +20,8 @@ package org.apache.spark.sql.sources.v2.reader.streaming;
 import org.apache.spark.annotation.Evolving;
 
 /**
- * An abstract representation of progress through a {@link MicroBatchStream} or
- * {@link ContinuousStream}.
+ * An abstract representation of progress through a {@link MicroBatchScan} or
+ * {@link ContinuousScan}.
  * During execution, offsets provided by the data source implementation will be logged and used as
  * restart checkpoints. Each source should provide an offset implementation which the source can use
  * to reconstruct a position in the stream up to which data has been seen/processed.

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/sources/v2/reader/streaming/StreamingScan.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/sources/v2/reader/streaming/StreamingScan.java
@@ -18,16 +18,13 @@
 package org.apache.spark.sql.sources.v2.reader.streaming;
 
 import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.sources.v2.reader.Scan;
 
 /**
- * The base interface representing a readable data stream in a Spark streaming query. It's
- * responsible to manage the offsets of the streaming source in the streaming query.
- *
- * Data sources should implement concrete data stream interfaces:
- * {@link MicroBatchStream} and {@link ContinuousStream}.
+ * An internal base interface for {@link MicroBatchScan} and {@link ContinuousScan}.
  */
 @Evolving
-public interface SparkDataStream {
+public interface StreamingScan extends Scan {
 
   /**
    * Returns the initial offset for a streaming query to start reading from. Note that the

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan, Stati
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.sources.v2._
 import org.apache.spark.sql.sources.v2.reader.{Statistics => V2Statistics, _}
-import org.apache.spark.sql.sources.v2.reader.streaming.{Offset, SparkDataStream}
+import org.apache.spark.sql.sources.v2.reader.streaming.{Offset, StreamingScan}
 import org.apache.spark.sql.sources.v2.writer._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -55,7 +55,7 @@ case class DataSourceV2Relation(
   }
 
   override def computeStats(): Statistics = {
-    val scan = newScanBuilder().build()
+    val scan = newScanBuilder().buildForBatch()
     scan match {
       case r: SupportsReportStatistics =>
         val statistics = r.estimateStatistics()
@@ -79,8 +79,7 @@ case class DataSourceV2Relation(
  */
 case class StreamingDataSourceV2Relation(
     output: Seq[Attribute],
-    scan: Scan,
-    stream: SparkDataStream,
+    scan: StreamingScan,
     startOffset: Option[Offset] = None,
     endOffset: Option[Offset] = None)
   extends LeafNode with MultiInstanceRelation {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
@@ -28,21 +28,19 @@ import org.apache.spark.sql.sources.v2.reader._
  */
 case class BatchScanExec(
     output: Seq[AttributeReference],
-    @transient scan: Scan) extends DataSourceV2ScanExecBase {
-
-  @transient lazy val batch = scan.toBatch
+    @transient scan: BatchScan) extends DataSourceV2ScanExecBase {
 
   // TODO: unify the equal/hashCode implementation for all data source v2 query plans.
   override def equals(other: Any): Boolean = other match {
-    case other: BatchScanExec => this.batch == other.batch
+    case other: BatchScanExec => this.scan == other.scan
     case _ => false
   }
 
-  override def hashCode(): Int = batch.hashCode()
+  override def hashCode(): Int = scan.hashCode()
 
-  override lazy val partitions: Seq[InputPartition] = batch.planInputPartitions()
+  override lazy val partitions: Seq[InputPartition] = scan.planInputPartitions()
 
-  override lazy val readerFactory: PartitionReaderFactory = batch.createReaderFactory()
+  override lazy val readerFactory: PartitionReaderFactory = scan.createReaderFactory()
 
   override lazy val inputRDD: RDD[InternalRow] = {
     new DataSourceRDD(sparkContext, partitions, readerFactory, supportsColumnar)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ContinuousScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ContinuousScanExec.scala
@@ -22,29 +22,28 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.streaming.continuous._
 import org.apache.spark.sql.sources.v2.reader._
-import org.apache.spark.sql.sources.v2.reader.streaming.{ContinuousPartitionReaderFactory, ContinuousStream, Offset}
+import org.apache.spark.sql.sources.v2.reader.streaming.{ContinuousPartitionReaderFactory, ContinuousScan, Offset}
 
 /**
  * Physical plan node for scanning data from a streaming data source with continuous mode.
  */
 case class ContinuousScanExec(
     output: Seq[Attribute],
-    @transient scan: Scan,
-    @transient stream: ContinuousStream,
+    @transient scan: ContinuousScan,
     @transient start: Offset) extends DataSourceV2ScanExecBase {
 
   // TODO: unify the equal/hashCode implementation for all data source v2 query plans.
   override def equals(other: Any): Boolean = other match {
-    case other: ContinuousScanExec => this.stream == other.stream
+    case other: ContinuousScanExec => this.scan == other.scan
     case _ => false
   }
 
-  override def hashCode(): Int = stream.hashCode()
+  override def hashCode(): Int = scan.hashCode()
 
-  override lazy val partitions: Seq[InputPartition] = stream.planInputPartitions(start)
+  override lazy val partitions: Seq[InputPartition] = scan.planInputPartitions(start)
 
   override lazy val readerFactory: ContinuousPartitionReaderFactory = {
-    stream.createContinuousReaderFactory()
+    scan.createContinuousReaderFactory()
   }
 
   override lazy val inputRDD: RDD[InternalRow] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
@@ -36,9 +36,7 @@ abstract class FileScan(
     sparkSession: SparkSession,
     fileIndex: PartitioningAwareFileIndex,
     readDataSchema: StructType,
-    readPartitionSchema: StructType)
-  extends Scan
-  with Batch with SupportsReportStatistics with Logging {
+    readPartitionSchema: StructType) extends BatchScan with SupportsReportStatistics with Logging {
   /**
    * Returns whether a file with `path` could be split or not.
    */
@@ -130,8 +128,6 @@ abstract class FileScan(
       override def numRows(): OptionalLong = OptionalLong.empty()
     }
   }
-
-  override def toBatch: Batch = this
 
   override def readSchema(): StructType =
     StructType(readDataSchema.fields ++ readPartitionSchema.fields)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVScanBuilder.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.datasources.v2.csv
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
 import org.apache.spark.sql.execution.datasources.v2.FileScanBuilder
-import org.apache.spark.sql.sources.v2.reader.Scan
+import org.apache.spark.sql.sources.v2.reader.BatchScan
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -32,7 +32,7 @@ case class CSVScanBuilder(
     options: CaseInsensitiveStringMap)
   extends FileScanBuilder(sparkSession, fileIndex, dataSchema) {
 
-  override def build(): Scan = {
+  override def buildForBatch(): BatchScan = {
     CSVScan(sparkSession, fileIndex, dataSchema, readDataSchema(), readPartitionSchema(), options)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonScanBuilder.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources.v2.json
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
 import org.apache.spark.sql.execution.datasources.v2.FileScanBuilder
-import org.apache.spark.sql.sources.v2.reader.Scan
+import org.apache.spark.sql.sources.v2.reader.BatchScan
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -30,7 +30,7 @@ class JsonScanBuilder (
     dataSchema: StructType,
     options: CaseInsensitiveStringMap)
   extends FileScanBuilder(sparkSession, fileIndex, dataSchema) {
-  override def build(): Scan = {
+  override def buildForBatch(): BatchScan = {
     JsonScan(sparkSession, fileIndex, dataSchema, readDataSchema(), readPartitionSchema(), options)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScanBuilder.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
 import org.apache.spark.sql.execution.datasources.orc.OrcFilters
 import org.apache.spark.sql.execution.datasources.v2.FileScanBuilder
 import org.apache.spark.sql.sources.Filter
-import org.apache.spark.sql.sources.v2.reader.{Scan, SupportsPushDownFilters}
+import org.apache.spark.sql.sources.v2.reader.{BatchScan, SupportsPushDownFilters}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -43,7 +43,7 @@ case class OrcScanBuilder(
     sparkSession.sessionState.newHadoopConfWithOptions(caseSensitiveMap)
   }
 
-  override def build(): Scan = {
+  override def buildForBatch(): BatchScan = {
     OrcScan(sparkSession, hadoopConf, fileIndex, dataSchema,
       readDataSchema(), readPartitionSchema(), options, pushedFilters())
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetScanBuilder.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFilters, SparkToParquetSchemaConverter}
 import org.apache.spark.sql.execution.datasources.v2.FileScanBuilder
 import org.apache.spark.sql.sources.Filter
-import org.apache.spark.sql.sources.v2.reader.{Scan, SupportsPushDownFilters}
+import org.apache.spark.sql.sources.v2.reader.{BatchScan, SupportsPushDownFilters}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -68,7 +68,7 @@ case class ParquetScanBuilder(
   // All filters that can be converted to Parquet are pushed down.
   override def pushedFilters(): Array[Filter] = pushedParquetFilters
 
-  override def build(): Scan = {
+  override def buildForBatch(): BatchScan = {
     ParquetScan(sparkSession, hadoopConf, fileIndex, dataSchema, readDataSchema(),
       readPartitionSchema(), pushedParquetFilters, options)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/text/TextScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/text/TextScanBuilder.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.datasources.v2.text
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
 import org.apache.spark.sql.execution.datasources.v2.FileScanBuilder
-import org.apache.spark.sql.sources.v2.reader.Scan
+import org.apache.spark.sql.sources.v2.reader.BatchScan
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -32,7 +32,7 @@ case class TextScanBuilder(
     options: CaseInsensitiveStringMap)
   extends FileScanBuilder(sparkSession, fileIndex, dataSchema) {
 
-  override def build(): Scan = {
+  override def buildForBatch(): BatchScan = {
     TextScan(sparkSession, fileIndex, readDataSchema(), readPartitionSchema(), options)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/OffsetSeq.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/OffsetSeq.scala
@@ -24,7 +24,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.RuntimeConfig
 import org.apache.spark.sql.execution.streaming.state.{FlatMapGroupsWithStateExecHelper, StreamingAggregationStateManager}
 import org.apache.spark.sql.internal.SQLConf.{FLATMAPGROUPSWITHSTATE_STATE_FORMAT_VERSION, _}
-import org.apache.spark.sql.sources.v2.reader.streaming.{Offset => OffsetV2, SparkDataStream}
+import org.apache.spark.sql.sources.v2.reader.streaming.{Offset => OffsetV2, StreamingScan}
 
 
 /**
@@ -41,7 +41,7 @@ case class OffsetSeq(offsets: Seq[Option[OffsetV2]], metadata: Option[OffsetSeqM
    * This method is typically used to associate a serialized offset with actual sources (which
    * cannot be serialized).
    */
-  def toStreamProgress(sources: Seq[SparkDataStream]): StreamProgress = {
+  def toStreamProgress(sources: Seq[StreamingScan]): StreamProgress = {
     assert(sources.size == offsets.size, s"There are [${offsets.size}] sources in the " +
       s"checkpoint offsets and now there are [${sources.size}] sources requested by the query. " +
       s"Cannot continue.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/Source.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/Source.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.streaming
 
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.sources.v2.reader.streaming.{Offset => OffsetV2}
-import org.apache.spark.sql.sources.v2.reader.streaming.SparkDataStream
+import org.apache.spark.sql.sources.v2.reader.streaming.StreamingScan
 import org.apache.spark.sql.types.StructType
 
 /**
@@ -30,7 +30,7 @@ import org.apache.spark.sql.types.StructType
  * Note that, we extends `SparkDataStream` here, to make the v1 streaming source API be compatible
  * with data source v2.
  */
-trait Source extends SparkDataStream {
+trait Source extends StreamingScan {
 
   /** Returns the schema of the data from this source */
   def schema: StructType
@@ -66,6 +66,8 @@ trait Source extends SparkDataStream {
    * equal to `end` and will only request offsets greater than `end` in the future.
    */
   def commit(end: Offset) : Unit = {}
+
+  override def readSchema(): StructType = schema
 
   override def initialOffset(): OffsetV2 = {
     throw new IllegalStateException("should not be called.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/Source.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/Source.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.types.StructType
  * monotonically increasing notion of progress that can be represented as an [[Offset]]. Spark
  * will regularly query each [[Source]] to see if any more data is available.
  *
- * Note that, we extends `SparkDataStream` here, to make the v1 streaming source API be compatible
+ * Note that, we extends [[StreamingScan]] here, to make the v1 streaming source API be compatible
  * with data source v2.
  */
 trait Source extends StreamingScan {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.execution.command.StreamingExplainCommand
 import org.apache.spark.sql.execution.datasources.v2.StreamWriterCommitProgress
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.v2.{SupportsWrite, Table}
-import org.apache.spark.sql.sources.v2.reader.streaming.{Offset => OffsetV2, SparkDataStream}
+import org.apache.spark.sql.sources.v2.reader.streaming.{Offset => OffsetV2, StreamingScan}
 import org.apache.spark.sql.sources.v2.writer.SupportsTruncate
 import org.apache.spark.sql.sources.v2.writer.streaming.StreamingWrite
 import org.apache.spark.sql.streaming._
@@ -206,7 +206,7 @@ abstract class StreamExecution(
   /**
    * A list of unique sources in the query plan. This will be set when generating logical plan.
    */
-  @volatile protected var uniqueSources: Seq[SparkDataStream] = Seq.empty
+  @volatile protected var uniqueSources: Seq[StreamingScan] = Seq.empty
 
   /** Defines the internal state of execution */
   protected val state = new AtomicReference[State](INITIALIZING)
@@ -215,7 +215,7 @@ abstract class StreamExecution(
   var lastExecution: IncrementalExecution = _
 
   /** Holds the most recent input data for each source. */
-  protected var newData: Map[SparkDataStream, LogicalPlan] = _
+  protected var newData: Map[StreamingScan, LogicalPlan] = _
 
   @volatile
   protected var streamDeathCause: StreamingQueryException = null

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamProgress.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamProgress.scala
@@ -19,35 +19,34 @@ package org.apache.spark.sql.execution.streaming
 
 import scala.collection.{immutable, GenTraversableOnce}
 
-import org.apache.spark.sql.sources.v2.reader.streaming.{Offset => OffsetV2, SparkDataStream}
-
+import org.apache.spark.sql.sources.v2.reader.streaming.{Offset => OffsetV2, StreamingScan}
 
 /**
  * A helper class that looks like a Map[Source, Offset].
  */
 class StreamProgress(
-    val baseMap: immutable.Map[SparkDataStream, OffsetV2] =
-        new immutable.HashMap[SparkDataStream, OffsetV2])
-  extends scala.collection.immutable.Map[SparkDataStream, OffsetV2] {
+    val baseMap: immutable.Map[StreamingScan, OffsetV2] =
+        new immutable.HashMap[StreamingScan, OffsetV2])
+  extends scala.collection.immutable.Map[StreamingScan, OffsetV2] {
 
-  def toOffsetSeq(source: Seq[SparkDataStream], metadata: OffsetSeqMetadata): OffsetSeq = {
+  def toOffsetSeq(source: Seq[StreamingScan], metadata: OffsetSeqMetadata): OffsetSeq = {
     OffsetSeq(source.map(get), Some(metadata))
   }
 
   override def toString: String =
     baseMap.map { case (k, v) => s"$k: $v"}.mkString("{", ",", "}")
 
-  override def +[B1 >: OffsetV2](kv: (SparkDataStream, B1)): Map[SparkDataStream, B1] = {
+  override def +[B1 >: OffsetV2](kv: (StreamingScan, B1)): Map[StreamingScan, B1] = {
     baseMap + kv
   }
 
-  override def get(key: SparkDataStream): Option[OffsetV2] = baseMap.get(key)
+  override def get(key: StreamingScan): Option[OffsetV2] = baseMap.get(key)
 
-  override def iterator: Iterator[(SparkDataStream, OffsetV2)] = baseMap.iterator
+  override def iterator: Iterator[(StreamingScan, OffsetV2)] = baseMap.iterator
 
-  override def -(key: SparkDataStream): Map[SparkDataStream, OffsetV2] = baseMap - key
+  override def -(key: StreamingScan): Map[StreamingScan, OffsetV2] = baseMap - key
 
-  def ++(updates: GenTraversableOnce[(SparkDataStream, OffsetV2)]): StreamProgress = {
+  def ++(updates: GenTraversableOnce[(StreamingScan, OffsetV2)]): StreamProgress = {
     new StreamProgress(baseMap ++ updates)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingRelation.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan, Stati
 import org.apache.spark.sql.execution.LeafExecNode
 import org.apache.spark.sql.execution.datasources.DataSource
 import org.apache.spark.sql.sources.v2.{Table, TableProvider}
-import org.apache.spark.sql.sources.v2.reader.streaming.SparkDataStream
+import org.apache.spark.sql.sources.v2.reader.streaming.StreamingScan
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 object StreamingRelation {
@@ -64,7 +64,7 @@ case class StreamingRelation(dataSource: DataSource, sourceName: String, output:
  * [[org.apache.spark.sql.catalyst.plans.logical.LogicalPlan]].
  */
 case class StreamingExecutionRelation(
-    source: SparkDataStream,
+    source: StreamingScan,
     output: Seq[Attribute])(session: SparkSession)
   extends LeafNode with MultiInstanceRelation {
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousRateStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousRateStreamSource.scala
@@ -23,14 +23,18 @@ import org.json4s.jackson.Serialization
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.streaming.{RateStreamOffset, ValueRunTimeMsPair}
+import org.apache.spark.sql.execution.streaming.sources.RateStreamProvider
 import org.apache.spark.sql.sources.v2.reader._
 import org.apache.spark.sql.sources.v2.reader.streaming._
+import org.apache.spark.sql.types.StructType
 
 case class RateStreamPartitionOffset(
    partition: Int, currentValue: Long, currentTimeMs: Long) extends PartitionOffset
 
-class RateStreamContinuousStream(rowsPerSecond: Long, numPartitions: Int) extends ContinuousStream {
+class RateStreamContinuousScan(rowsPerSecond: Long, numPartitions: Int) extends ContinuousScan {
   implicit val defaultFormats: DefaultFormats = DefaultFormats
+
+  override def readSchema(): StructType = RateStreamProvider.SCHEMA
 
   val creationTime = System.currentTimeMillis()
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousTextSocketSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousTextSocketSource.scala
@@ -43,7 +43,7 @@ import org.apache.spark.util.RpcUtils
 
 /**
  * A [[ContinuousScan]] that reads text lines through a TCP socket, designed only for tutorials
- * and debugging. This ContinuousStream will *not* work in production applications due to
+ * and debugging. This [[ContinuousScan]] will *not* work in production applications due to
  * multiple reasons, including no support for fault recovery.
  *
  * The driver maintains a socket connection to the host-port, keeps the received messages in

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousTextSocketSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousTextSocketSource.scala
@@ -36,21 +36,26 @@ import org.apache.spark.sql.execution.streaming.{Offset => _, _}
 import org.apache.spark.sql.execution.streaming.sources.TextSocketReader
 import org.apache.spark.sql.sources.v2.reader._
 import org.apache.spark.sql.sources.v2.reader.streaming._
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.RpcUtils
 
 
 /**
- * A [[ContinuousStream]] that reads text lines through a TCP socket, designed only for tutorials
+ * A [[ContinuousScan]] that reads text lines through a TCP socket, designed only for tutorials
  * and debugging. This ContinuousStream will *not* work in production applications due to
  * multiple reasons, including no support for fault recovery.
  *
  * The driver maintains a socket connection to the host-port, keeps the received messages in
  * buckets and serves the messages to the executors via a RPC endpoint.
  */
-class TextSocketContinuousStream(
-    host: String, port: Int, numPartitions: Int, options: CaseInsensitiveStringMap)
-  extends ContinuousStream with Logging {
+class TextSocketContinuousScan(
+    override val readSchema: StructType,
+    host: String,
+    port: Int,
+    numPartitions: Int,
+    options: CaseInsensitiveStringMap)
+  extends ContinuousScan with Logging {
 
   implicit val defaultFormats: DefaultFormats = DefaultFormats
 
@@ -176,7 +181,7 @@ class TextSocketContinuousStream(
               logWarning(s"Stream closed by $host:$port")
               return
             }
-            TextSocketContinuousStream.this.synchronized {
+            TextSocketContinuousScan.this.synchronized {
               currentOffset += 1
               val newData = (line,
                 Timestamp.valueOf(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/ContinuousMemoryStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/ContinuousMemoryStream.scala
@@ -43,7 +43,7 @@ import org.apache.spark.util.RpcUtils
  *    the specified offset within the list, or null if that offset doesn't yet have a record.
  */
 class ContinuousMemoryStream[A : Encoder](id: Int, sqlContext: SQLContext, numPartitions: Int = 2)
-  extends MemoryStreamBase[A](sqlContext) with ContinuousStream {
+  extends MemoryStreamBase[A](sqlContext) with ContinuousScan {
 
   private implicit val formats = Serialization.formats(NoTypeHints)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/RateControlMicroBatchScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/RateControlMicroBatchScan.scala
@@ -17,10 +17,10 @@
 
 package org.apache.spark.sql.execution.streaming.sources
 
-import org.apache.spark.sql.sources.v2.reader.streaming.{MicroBatchStream, Offset}
+import org.apache.spark.sql.sources.v2.reader.streaming.{MicroBatchScan, Offset}
 
-// A special `MicroBatchStream` that can get latestOffset with a start offset.
-trait RateControlMicroBatchStream extends MicroBatchStream {
+// A special `MicroBatchScan` that can get latestOffset with a start offset.
+trait RateControlMicroBatchScan extends MicroBatchScan {
 
   override def latestOffset(): Offset = {
     throw new IllegalAccessException(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/RateStreamMicroBatchScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/RateStreamMicroBatchScan.scala
@@ -29,19 +29,22 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.sources.v2.reader._
-import org.apache.spark.sql.sources.v2.reader.streaming.{MicroBatchStream, Offset}
+import org.apache.spark.sql.sources.v2.reader.streaming.{MicroBatchScan, Offset}
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.{ManualClock, SystemClock}
 
-class RateStreamMicroBatchStream(
+class RateStreamMicroBatchScan(
     rowsPerSecond: Long,
     // The default values here are used in tests.
     rampUpTimeSeconds: Long = 0,
     numPartitions: Int = 1,
     options: CaseInsensitiveStringMap,
     checkpointLocation: String)
-  extends MicroBatchStream with Logging {
+  extends MicroBatchScan with Logging {
   import RateStreamProvider._
+
+  override def readSchema(): StructType = RateStreamProvider.SCHEMA
 
   private[sources] val clock = {
     // The option to use a manual clock is provided only for unit testing purposes.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/TextSocketMicroBatchScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/TextSocketMicroBatchScan.scala
@@ -30,16 +30,18 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.streaming.LongOffset
 import org.apache.spark.sql.sources.v2.reader.{InputPartition, PartitionReader, PartitionReaderFactory}
-import org.apache.spark.sql.sources.v2.reader.streaming.{MicroBatchStream, Offset}
+import org.apache.spark.sql.sources.v2.reader.streaming.{MicroBatchScan, Offset}
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.unsafe.types.UTF8String
 
 /**
- * A MicroBatchReadSupport that reads text lines through a TCP socket, designed only for tutorials
+ * A [[MicroBatchScan]] that reads text lines through a TCP socket, designed only for tutorials
  * and debugging. This MicroBatchReadSupport will *not* work in production applications due to
  * multiple reasons, including no support for fault recovery.
  */
-class TextSocketMicroBatchStream(host: String, port: Int, numPartitions: Int)
-  extends MicroBatchStream with Logging {
+class TextSocketMicroBatchScan(
+    override val readSchema: StructType, host: String, port: Int, numPartitions: Int)
+  extends MicroBatchScan with Logging {
 
   @GuardedBy("this")
   private var socket: Socket = null
@@ -82,7 +84,7 @@ class TextSocketMicroBatchStream(host: String, port: Int, numPartitions: Int)
               logWarning(s"Stream closed by $host:$port")
               return
             }
-            TextSocketMicroBatchStream.this.synchronized {
+            TextSocketMicroBatchScan.this.synchronized {
               val newData = (
                 UTF8String.fromString(line),
                 DateTimeUtils.fromMillis(Calendar.getInstance().getTimeInMillis)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/TextSocketMicroBatchScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/TextSocketMicroBatchScan.scala
@@ -36,7 +36,7 @@ import org.apache.spark.unsafe.types.UTF8String
 
 /**
  * A [[MicroBatchScan]] that reads text lines through a TCP socket, designed only for tutorials
- * and debugging. This MicroBatchReadSupport will *not* work in production applications due to
+ * and debugging. This [[MicroBatchScan]] will *not* work in production applications due to
  * multiple reasons, including no support for fault recovery.
  */
 class TextSocketMicroBatchScan(

--- a/sql/core/src/test/java/test/org/apache/spark/sql/sources/v2/JavaAdvancedDataSourceV2.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/sources/v2/JavaAdvancedDataSourceV2.java
@@ -42,7 +42,7 @@ public class JavaAdvancedDataSourceV2 implements TableProvider {
     };
   }
 
-  static class AdvancedScanBuilder implements ScanBuilder, Scan,
+  static class AdvancedScanBuilder implements ScanBuilder,
     SupportsPushDownFilters, SupportsPushDownRequiredColumns {
 
     private StructType requiredSchema = new StructType().add("i", "int").add("j", "int");
@@ -51,11 +51,6 @@ public class JavaAdvancedDataSourceV2 implements TableProvider {
     @Override
     public void pruneColumns(StructType requiredSchema) {
       this.requiredSchema = requiredSchema;
-    }
-
-    @Override
-    public StructType readSchema() {
-      return requiredSchema;
     }
 
     @Override
@@ -88,24 +83,24 @@ public class JavaAdvancedDataSourceV2 implements TableProvider {
     }
 
     @Override
-    public Scan build() {
-      return this;
-    }
-
-    @Override
-    public Batch toBatch() {
-      return new AdvancedBatch(requiredSchema, filters);
+    public BatchScan buildForBatch() {
+      return new AdvancedBatchScan(requiredSchema, filters);
     }
   }
 
-  public static class AdvancedBatch implements Batch {
+  public static class AdvancedBatchScan implements BatchScan {
     // Exposed for testing.
     public StructType requiredSchema;
     public Filter[] filters;
 
-    AdvancedBatch(StructType requiredSchema, Filter[] filters) {
+    AdvancedBatchScan(StructType requiredSchema, Filter[] filters) {
       this.requiredSchema = requiredSchema;
       this.filters = filters;
+    }
+
+    @Override
+    public StructType readSchema() {
+      return requiredSchema;
     }
 
     @Override

--- a/sql/core/src/test/java/test/org/apache/spark/sql/sources/v2/JavaSimpleScanBuilder.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/sources/v2/JavaSimpleScanBuilder.java
@@ -17,21 +17,15 @@
 
 package test.org.apache.spark.sql.sources.v2;
 
-import org.apache.spark.sql.sources.v2.reader.Batch;
+import org.apache.spark.sql.sources.v2.reader.BatchScan;
 import org.apache.spark.sql.sources.v2.reader.PartitionReaderFactory;
-import org.apache.spark.sql.sources.v2.reader.Scan;
 import org.apache.spark.sql.sources.v2.reader.ScanBuilder;
 import org.apache.spark.sql.types.StructType;
 
-abstract class JavaSimpleScanBuilder implements ScanBuilder, Scan, Batch {
+abstract class JavaSimpleScanBuilder implements ScanBuilder, BatchScan {
 
   @Override
-  public Scan build() {
-    return this;
-  }
-
-  @Override
-  public Batch toBatch() {
+  public BatchScan buildForBatch() {
     return this;
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
@@ -42,7 +42,7 @@ import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.execution.streaming.continuous.{ContinuousExecution, EpochCoordinatorRef, IncrementAndGetEpoch}
 import org.apache.spark.sql.execution.streaming.sources.MemorySink
 import org.apache.spark.sql.execution.streaming.state.StateStore
-import org.apache.spark.sql.sources.v2.reader.streaming.{Offset => OffsetV2, SparkDataStream}
+import org.apache.spark.sql.sources.v2.reader.streaming.{Offset => OffsetV2, StreamingScan}
 import org.apache.spark.sql.streaming.StreamingQueryListener._
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.util.{Clock, SystemClock, Utils}
@@ -124,7 +124,7 @@ trait StreamTest extends QueryTest with SharedSQLContext with TimeLimits with Be
      * the active query, and then return the source object the data was added, as well as the
      * offset of added data.
      */
-    def addData(query: Option[StreamExecution]): (SparkDataStream, OffsetV2)
+    def addData(query: Option[StreamExecution]): (StreamingScan, OffsetV2)
   }
 
   /** A trait that can be extended when testing a source. */
@@ -135,7 +135,7 @@ trait StreamTest extends QueryTest with SharedSQLContext with TimeLimits with Be
   case class AddDataMemory[A](source: MemoryStreamBase[A], data: Seq[A]) extends AddData {
     override def toString: String = s"AddData to $source: ${data.mkString(",")}"
 
-    override def addData(query: Option[StreamExecution]): (SparkDataStream, OffsetV2) = {
+    override def addData(query: Option[StreamExecution]): (StreamingScan, OffsetV2) = {
       (source, source.addData(data))
     }
   }
@@ -682,7 +682,7 @@ trait StreamTest extends QueryTest with SharedSQLContext with TimeLimits with Be
                   // v1 source
                   case r: StreamingExecutionRelation => r.source
                   // v2 source
-                  case r: StreamingDataSourceV2Relation => r.stream
+                  case r: StreamingDataSourceV2Relation => r.scan
                   // We can add data to memory stream before starting it. Then the input plan has
                   // not been processed by the streaming engine and contains `StreamingRelationV2`.
                   case r: StreamingRelationV2 if r.sourceName == "memory" =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryManagerSuite.scala
@@ -308,7 +308,7 @@ class StreamingQueryManagerSuite extends StreamTest {
         logDebug(s"Terminating query ${queryToStop.name} with error")
         queryToStop.asInstanceOf[StreamingQueryWrapper].streamingQuery.logicalPlan.collect {
           case r: StreamingDataSourceV2Relation =>
-            r.stream.asInstanceOf[MemoryStream[Int]].addData(0)
+            r.scan.asInstanceOf[MemoryStream[Int]].addData(0)
         }
       } else {
         logDebug(s"Stopping query ${queryToStop.name}")

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousQueuedDataReaderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousQueuedDataReaderSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.rpc.RpcEndpointRef
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.execution.streaming.continuous._
-import org.apache.spark.sql.sources.v2.reader.streaming.{ContinuousPartitionReader, ContinuousStream, PartitionOffset}
+import org.apache.spark.sql.sources.v2.reader.streaming.{ContinuousPartitionReader, ContinuousScan, PartitionOffset}
 import org.apache.spark.sql.sources.v2.writer.streaming.StreamingWrite
 import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.types.{DataType, IntegerType, StructType}
@@ -44,7 +44,7 @@ class ContinuousQueuedDataReaderSuite extends StreamTest with MockitoSugar {
     super.beforeEach()
     epochEndpoint = EpochCoordinatorRef.create(
       mock[StreamingWrite],
-      mock[ContinuousStream],
+      mock[ContinuousScan],
       mock[ContinuousExecution],
       coordinatorId,
       startEpoch,

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/EpochCoordinatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/EpochCoordinatorSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.rpc.RpcEndpointRef
 import org.apache.spark.sql.LocalSparkSession
 import org.apache.spark.sql.execution.streaming.continuous._
 import org.apache.spark.sql.internal.SQLConf.CONTINUOUS_STREAMING_EPOCH_BACKLOG_QUEUE_SIZE
-import org.apache.spark.sql.sources.v2.reader.streaming.{ContinuousStream, PartitionOffset}
+import org.apache.spark.sql.sources.v2.reader.streaming.{ContinuousScan, PartitionOffset}
 import org.apache.spark.sql.sources.v2.writer.WriterCommitMessage
 import org.apache.spark.sql.sources.v2.writer.streaming.StreamingWrite
 import org.apache.spark.sql.test.TestSparkSession
@@ -47,7 +47,7 @@ class EpochCoordinatorSuite
   private val epochBacklogQueueSize = 10
 
   override def beforeEach(): Unit = {
-    val stream = mock[ContinuousStream]
+    val stream = mock[ContinuousScan]
     writeSupport = mock[StreamingWrite]
     query = mock[ContinuousExecution]
     orderVerifier = inOrder(writeSupport, query)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/sources/StreamingDataSourceV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/sources/StreamingDataSourceV2Suite.scala
@@ -38,7 +38,8 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.Utils
 
-class FakeDataStream extends MicroBatchStream with ContinuousStream {
+class FakeScanBuilder extends ScanBuilder with MicroBatchScan with ContinuousScan {
+  override def readSchema(): StructType = new StructType()
   override def deserializeOffset(json: String): Offset = RateStreamOffset(Map())
   override def commit(end: Offset): Unit = {}
   override def stop(): Unit = {}
@@ -57,13 +58,8 @@ class FakeDataStream extends MicroBatchStream with ContinuousStream {
   override def createContinuousReaderFactory(): ContinuousPartitionReaderFactory = {
     throw new IllegalStateException("fake source - cannot actually read")
   }
-}
-
-class FakeScanBuilder extends ScanBuilder with Scan {
-  override def build(): Scan = this
-  override def readSchema(): StructType = StructType(Seq())
-  override def toMicroBatchStream(checkpointLocation: String): MicroBatchStream = new FakeDataStream
-  override def toContinuousStream(checkpointLocation: String): ContinuousStream = new FakeDataStream
+  override def buildForMicroBatchStreaming(checkpointLocation: String): MicroBatchScan = this
+  override def buildForContinuousStreaming(checkpointLocation: String): ContinuousScan = this
 }
 
 class FakeWriteBuilder extends WriteBuilder with StreamingWrite {


### PR DESCRIPTION
## What changes were proposed in this pull request?

By design, `Scan` represents a logical data scan, `Batch`/`Stream` represents a physical data scan.

However, this doesn't match reality. The logical plan(`DataSourceV2Relation`) contains `Table` and the phyiscal plan(`BatchScanExec` and friends) contains `Scan`. The operator pushdown happens at planning time, so `Scan` and `Batch`/`Stream` are always created together in the planner rules. That said, `Table` is the actual logical data scan.

Since there is not much can be separated from `Scan` and `Batch`/`Stream`, almost all the existing DS v2 implementations either implement `Scan` and `Batch`/`Stream` together, or use anonymous class to implement `Scan`.

In addition, the write side API has no such separation either: it's just `WriterBuilder` -> `BatchWrite`/`StreamingWrite`.

This PR proposes to merge `Scan` and `Batch`/`Stream`, to match the write side API: `ScanBuilder` -> `BatchScan`/`MicroBatchScan`/`ContinuousScan`.

## How was this patch tested?

existing tests
