### PR TITLE
[SPARK-28431][SQL] Set maximum error message length in CSV datasource's parsing and writing

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -190,11 +190,6 @@ class CSVOptions(
   val emptyValueInWrite = emptyValue.getOrElse("\"\"")
 
   /**
-   * The max error content length in CSV parser/writer exception message.
-   */
-  val maxErrorContentLength = 1024
-
-  /**
    * A string between two consecutive JSON records.
    */
   val lineSeparator: Option[String] = parameters.get("lineSep").map { sep =>
@@ -225,7 +220,7 @@ class CSVOptions(
     writerSettings.setSkipEmptyLines(true)
     writerSettings.setQuoteAllFields(quoteAll)
     writerSettings.setQuoteEscapingEnabled(escapeQuotes)
-    writerSettings.setErrorContentLength(maxErrorContentLength)
+    writerSettings.setErrorContentLength(CSVOptions.maxErrorContentLength)
     writerSettings
   }
 
@@ -252,8 +247,16 @@ class CSVOptions(
     lineSeparatorInRead.foreach { _ =>
       settings.setNormalizeLineEndingsWithinQuotes(!multiLine)
     }
-    settings.setErrorContentLength(maxErrorContentLength)
+    settings.setErrorContentLength(CSVOptions.maxErrorContentLength)
 
     settings
   }
+}
+
+object CSVOptions {
+  /**
+   * The max error content length in CSV parser/writer exception message.
+   */
+  val maxErrorContentLength = 1024
+
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -190,7 +190,7 @@ class CSVOptions(
   val emptyValueInWrite = emptyValue.getOrElse("\"\"")
 
   /**
-   * The max error content in CSV parser/writer exception message.
+   * The max error content length in CSV parser/writer exception message.
    */
   val maxErrorContentLength = 1024
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -253,10 +253,10 @@ class CSVOptions(
   }
 }
 
-object CSVOptions {
+private[spark] object CSVOptions {
   /**
    * The max error content length in CSV parser/writer exception message.
    */
-  val maxErrorContentLength = 1024
+  val maxErrorContentLength = 1000
 
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -190,6 +190,11 @@ class CSVOptions(
   val emptyValueInWrite = emptyValue.getOrElse("\"\"")
 
   /**
+   * The max error content in CSV parser/writer exception message.
+   */
+  val maxErrorContentLength = 1024
+
+  /**
    * A string between two consecutive JSON records.
    */
   val lineSeparator: Option[String] = parameters.get("lineSep").map { sep =>
@@ -220,6 +225,7 @@ class CSVOptions(
     writerSettings.setSkipEmptyLines(true)
     writerSettings.setQuoteAllFields(quoteAll)
     writerSettings.setQuoteEscapingEnabled(escapeQuotes)
+    writerSettings.setErrorContentLength(maxErrorContentLength)
     writerSettings
   }
 
@@ -246,6 +252,7 @@ class CSVOptions(
     lineSeparatorInRead.foreach { _ =>
       settings.setNormalizeLineEndingsWithinQuotes(!multiLine)
     }
+    settings.setErrorContentLength(maxErrorContentLength)
 
     settings
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -163,6 +163,11 @@ class CSVOptions(
 
   val inputBufferSize = 128
 
+  /**
+   * The max error content length in CSV parser/writer exception message.
+   */
+  val maxErrorContentLength = 1000
+
   val isCommentSet = this.comment != '\u0000'
 
   val samplingRatio =
@@ -220,7 +225,7 @@ class CSVOptions(
     writerSettings.setSkipEmptyLines(true)
     writerSettings.setQuoteAllFields(quoteAll)
     writerSettings.setQuoteEscapingEnabled(escapeQuotes)
-    writerSettings.setErrorContentLength(CSVOptions.maxErrorContentLength)
+    writerSettings.setErrorContentLength(maxErrorContentLength)
     writerSettings
   }
 
@@ -247,16 +252,8 @@ class CSVOptions(
     lineSeparatorInRead.foreach { _ =>
       settings.setNormalizeLineEndingsWithinQuotes(!multiLine)
     }
-    settings.setErrorContentLength(CSVOptions.maxErrorContentLength)
+    settings.setErrorContentLength(maxErrorContentLength)
 
     settings
   }
-}
-
-private[spark] object CSVOptions {
-  /**
-   * The max error content length in CSV parser/writer exception message.
-   */
-  val maxErrorContentLength = 1000
-
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2108,7 +2108,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
       }.getMessage
 
       assert(errMsg.contains("..."),
-      s"expect the TextParsingException truncate the error content to be 1000 length.")
+        "expect the TextParsingException truncate the error content to be 1000 length.")
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2107,7 +2107,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
           .count()
       }.getMessage
 
-      assert(errMsg.contains("..." + "a" * CSVOptions.maxErrorContentLength),
+      assert(errMsg.endsWith("=..." + "a" * CSVOptions.maxErrorContentLength),
       s"expect the TextParsingException truncate the error content to be " +
         s"${CSVOptions.maxErrorContentLength} length.")
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2107,9 +2107,8 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
           .count()
       }.getMessage
 
-      assert(errMsg.endsWith("=..." + "a" * CSVOptions.maxErrorContentLength),
-      s"expect the TextParsingException truncate the error content to be " +
-        s"${CSVOptions.maxErrorContentLength} length.")
+      assert(errMsg.contains("..."),
+      s"expect the TextParsingException truncate the error content to be 1000 length.")
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix CSV datasource to throw `com.univocity.parsers.common.TextParsingException` with large size message, which will make log output consume large disk space.
This issue is troublesome when sometimes we need parse CSV with large size column.

This PR proposes to set CSV parser/writer settings by `setErrorContentLength(1000)` to limit the error message length.

## How was this patch tested?

Manually.

```
val s = "a" * 40 * 1000000
Seq(s).toDF.write.mode("overwrite").csv("/tmp/bogdan/es4196.csv")

spark.read .option("maxCharsPerColumn", 30000000) .csv("/tmp/bogdan/es4196.csv").count
```

**Before:**
The thrown message will include error content of about 30MB size (The column size exceed the max value 30MB, so the error content include the whole parsed content, so it is 30MB).

**After:**
The thrown message will include error content like "...aaa...aa" (the number of 'a' is 1024), i.e. limit the content size to be 1024.
