### PR TITLE
[SPARK-28434][MLlib] Decision Tree model isn't equal after save and load

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/mllib/tree/DecisionTreeSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/tree/DecisionTreeSuite.scala
@@ -625,8 +625,7 @@ object DecisionTreeSuite extends SparkFunSuite {
     assert(a.isLeaf === b.isLeaf)
     assert(a.split === b.split)
     (a.stats, b.stats) match {
-      // TODO: Check other fields besides the information gain.
-      case (Some(aStats), Some(bStats)) => assert(aStats.gain === bStats.gain)
+      case (Some(aStats), Some(bStats)) => assert(aStats == bStats)
       case (None, None) =>
       case _ => fail(s"Only one instance has stats defined. (a.stats: ${a.stats}, " +
         s"b.stats: ${b.stats})")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Check other `DecisionTreeModel`'s node's `stats` fields by using `InformationGainStats`'s overridden `equals` method.

The issue is that if we compare more fields of the `InformationGainStats` object, we'll see that they are different, unlike the only checked before `gain` field.

## How was this patch tested?

`build/mvn -e -Dtest=none -DwildcardSuites=org.apache.spark.mllib.tree.DecisionTreeSuite test` against `master` branch
