### PR TITLE
[SPARK-28436][SQL] Throw better exception when datasource's schema is not equal to user-specific schema

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -339,9 +339,9 @@ case class DataSource(
         val baseRelation =
           dataSource.createRelation(sparkSession.sqlContext, caseInsensitiveOptions)
         if (baseRelation.schema != schema) {
-          throw new AnalysisException(s"$className does not allow user-specified schemas, " +
-              s"user-specified schemas are not same as source schema: \n" +
-              s"${baseRelation.schema.treeString}")
+          throw new AnalysisException(s"$className does not allow user-specified schemas " +
+              s"because user-specified schema [${schema.catalogString}] was different from " +
+              s"its source schema [${baseRelation.schema.catalogString}]")
         }
         baseRelation
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -339,7 +339,8 @@ case class DataSource(
         val baseRelation =
           dataSource.createRelation(sparkSession.sqlContext, caseInsensitiveOptions)
         if (baseRelation.schema != schema) {
-          throw new AnalysisException(s"$className does not allow user-specified schemas.")
+          throw new AnalysisException(s"$className does not allow user-specified schemas, " +
+              s"source schema: ${baseRelation.schema}, user-specific schema: ${schema}")
         }
         baseRelation
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -340,7 +340,8 @@ case class DataSource(
           dataSource.createRelation(sparkSession.sqlContext, caseInsensitiveOptions)
         if (baseRelation.schema != schema) {
           throw new AnalysisException(s"$className does not allow user-specified schemas, " +
-              s"source schema: ${baseRelation.schema}, user-specific schema: ${schema}")
+              s"user-specified schemas are not same as source schema: \n" +
+              s"${baseRelation.schema.treeString}")
         }
         baseRelation
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/TableScanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/TableScanSuite.scala
@@ -361,7 +361,7 @@ class TableScanSuite extends DataSourceTest with SharedSQLContext {
       val schemaNotAllowed = intercept[Exception] {
         sql(
           s"""
-             |CREATE $tableType relationProvierWithSchema (i int)
+             |CREATE $tableType relationProviderWithSchema (i int)
              |USING org.apache.spark.sql.sources.SimpleScanSource
              |OPTIONS (
              |  From '1',
@@ -369,13 +369,15 @@ class TableScanSuite extends DataSourceTest with SharedSQLContext {
              |)
            """.stripMargin)
       }
+      val expectedSchema = StructType(StructField("i", IntegerType, nullable = false) :: Nil)
       assert(schemaNotAllowed.getMessage.contains("does not allow user-specified schemas, " +
-          "user-specified schemas are not same as source schema"))
+          "user-specified schemas are not same as source schema: \n" +
+          s"${expectedSchema.treeString}"))
 
       val schemaNeeded = intercept[Exception] {
         sql(
           s"""
-             |CREATE $tableType schemaRelationProvierWithoutSchema
+             |CREATE $tableType schemaRelationProviderWithoutSchema
              |USING org.apache.spark.sql.sources.AllDataTypesScanSource
              |OPTIONS (
              |  From '1',
@@ -389,7 +391,7 @@ class TableScanSuite extends DataSourceTest with SharedSQLContext {
 
   test("read the data source tables that do not extend SchemaRelationProvider") {
     Seq("TEMPORARY VIEW", "TABLE").foreach { tableType =>
-      val tableName = "relationProvierWithSchema"
+      val tableName = "relationProviderWithSchema"
       withTable (tableName) {
         sql(
           s"""

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/TableScanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/TableScanSuite.scala
@@ -369,10 +369,11 @@ class TableScanSuite extends DataSourceTest with SharedSQLContext {
              |)
            """.stripMargin)
       }
+      val inputSchema = StructType(StructField("i", IntegerType, nullable = true) :: Nil)
       val expectedSchema = StructType(StructField("i", IntegerType, nullable = false) :: Nil)
-      assert(schemaNotAllowed.getMessage.contains("does not allow user-specified schemas, " +
-          "user-specified schemas are not same as source schema: \n" +
-          s"${expectedSchema.treeString}"))
+      assert(schemaNotAllowed.getMessage.contains("does not allow user-specified schemas " +
+          s"because user-specified schema [${inputSchema.catalogString}] was different from " +
+          s"its source schema [${expectedSchema.catalogString}]"))
 
       val schemaNeeded = intercept[Exception] {
         sql(

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/TableScanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/TableScanSuite.scala
@@ -369,7 +369,8 @@ class TableScanSuite extends DataSourceTest with SharedSQLContext {
              |)
            """.stripMargin)
       }
-      assert(schemaNotAllowed.getMessage.contains("does not allow user-specified schemas"))
+      assert(schemaNotAllowed.getMessage.contains("does not allow user-specified schemas, " +
+          "user-specified schemas are not same as source schema"))
 
       val schemaNeeded = intercept[Exception] {
         sql(

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -434,8 +434,9 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSQLContext with Be
     val expectedSchema = StructType(StructField("i", IntegerType, nullable = false) :: Nil)
     val e = intercept[AnalysisException] { dfReader.schema(inputSchema).load() }
     assert(e.getMessage.contains(
-      "org.apache.spark.sql.sources.SimpleScanSource does not allow user-specified schemas, " +
-          s"user-specified schemas are not same as source schema: \n${expectedSchema.treeString}"))
+      "org.apache.spark.sql.sources.SimpleScanSource does not allow user-specified schemas " +
+          s"because user-specified schema [${inputSchema.catalogString}] was different from " +
+          s"its source schema [${expectedSchema.catalogString}]"))
   }
 
   test("read a data source that does not extend RelationProvider") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -431,10 +431,11 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSQLContext with Be
 
     // when users specify the schema
     val inputSchema = new StructType().add("s", IntegerType, nullable = false)
+    val expectedSchema = StructType(StructField("i", IntegerType, nullable = false) :: Nil)
     val e = intercept[AnalysisException] { dfReader.schema(inputSchema).load() }
     assert(e.getMessage.contains(
       "org.apache.spark.sql.sources.SimpleScanSource does not allow user-specified schemas, " +
-          "user-specified schemas are not same as source schema"))
+          s"user-specified schemas are not same as source schema: \n${expectedSchema.treeString}"))
   }
 
   test("read a data source that does not extend RelationProvider") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -433,7 +433,8 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSQLContext with Be
     val inputSchema = new StructType().add("s", IntegerType, nullable = false)
     val e = intercept[AnalysisException] { dfReader.schema(inputSchema).load() }
     assert(e.getMessage.contains(
-      "org.apache.spark.sql.sources.SimpleScanSource does not allow user-specified schemas"))
+      "org.apache.spark.sql.sources.SimpleScanSource does not allow user-specified schemas, " +
+          "user-specified schemas are not same as source schema"))
   }
 
   test("read a data source that does not extend RelationProvider") {


### PR DESCRIPTION
When this exception is thrown, users cannot find what's the difference between datasource's original schema and user-specific schema, and maybe very confused when meet the exception below.

```
org.apache.spark.sql.AnalysisException: org.apache.spark.odps.datasource does not allow user-specified schemas.
    at org.apache.spark.sql.execution.datasources.DataSource.resolveRelation(DataSource.scala:347)
    at org.apache.spark.sql.execution.command.CreateDataSourceTableCommand.run(createDataSourceTables.scala:78)
    at org.apache.spark.sql.execution.command.ExecutedCommandExec.sideEffectResult$lzycompute(commands.scala:70)
    at org.apache.spark.sql.execution.command.ExecutedCommandExec.sideEffectResult(commands.scala:68)
    at org.apache.spark.sql.execution.command.ExecutedCommandExec.executeCollect(commands.scala:79)
    at org.apache.spark.sql.Dataset$$anonfun$6.apply(Dataset.scala:190)
    at org.apache.spark.sql.Dataset$$anonfun$6.apply(Dataset.scala:190)
    at org.apache.spark.sql.Dataset$$anonfun$52.apply(Dataset.scala:3270)
    at org.apache.spark.sql.execution.SQLExecution$.withNewExecutionId(SQLExecution.scala:83)
    at org.apache.spark.sql.Dataset.withAction(Dataset.scala:3269)
    at org.apache.spark.sql.Dataset.<init>(Dataset.scala:190)
    at org.apache.spark.sql.Dataset$.ofRows(Dataset.scala:75)
    at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:653)
    at org.apache.spark.sql.SQLContext.sql(SQLContext.scala:714)
```