### PR TITLE
[SPARK-21067][SQL] Initialize the HdfsEncryptionShim and the underlying FileSystem(FS) e…

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -190,6 +190,13 @@ private[hive] class HiveClientImpl(
       Hive.set(clientLoader.cachedHive.asInstanceOf[Hive])
     }
     SessionState.start(state)
+    // SPARK-21067: Initialize the HdfsEncryptionShim and the underlying FileSystem(FS) eagerly.
+    // The underlying FS is cached and shared among sessions if the sessions request for FS with
+    // the same schema, authority and ugi. If we don't do this, the initialization of the FS will
+    // be delayed to when one session call `getHdfsEncryptionShim` explicitly. However the FS is
+    // auto-closable, which would be closed when the session is closed. The subsequent sessions use
+    // the same FS will throw "Filesystem closed Exception".
+    state.getHdfsEncryptionShim
     state.out = new PrintStream(outputBuffer, true, "UTF-8")
     state.err = new PrintStream(outputBuffer, true, "UTF-8")
     state


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr fix the "Filesystem Closed" exception that caused by the closing of a hive session in thriftserver.

A `sessionState` holds a `hdfsEncryptionShim`, which holds a `fileSystem`. When a session was closed, the fileSystem may be closed. While the fileSystem is cached, so the subsequent using of the same fileSystem may throw "Filesystem closed" exception if previous session closes the fileSystem.

We can move the "holding of the `fileSystem`" from session to thriftserver by triggering `SessionState#getHdfsEncryptionShim` eagerly at the starting phase of the thriftserver, see below,

```
HiveThriftServer2#main()
    hiveClientImpl
        val state = newState
            SessionState.start(state)
                SessionState.setCurrentSession(state)
        **state.getHdfsEncryptionShim**
```

In hive session, the new sessionState will reuse the `fileSystem` created by thriftserver,

```
CliService
    openSession
        HiveSessionImpl
            init
                sessionState = new SessionState
                SessionState.setCurrentSession(sessionState)
            executeStatementInternal
                SessionState.setCurrentSession(sessionState)
                operation.run()
                    hiveSession.getSessionManager().submitBackgroundOperation(operation)
                    **// If some code calls "state.getHdfsEncryptionShim", the cached `fileSystem` is reused.**
```

## How was this patch tested?

manual test

