### PR TITLE
[SPARK-28389][SQL][FOLLOW-UP] Use one example in 'add_months' behavior change at migration guide

### DIFF
--- a/docs/sql-migration-guide-upgrade.md
+++ b/docs/sql-migration-guide-upgrade.md
@@ -151,7 +151,7 @@ license: |
 
   - Since Spark 3.0, substitution order of nested WITH clauses is changed and an inner CTE definition takes precedence over an outer. In version 2.4 and earlier, `WITH t AS (SELECT 1), t2 AS (WITH t AS (SELECT 2) SELECT * FROM t) SELECT * FROM t2` returns `1` while in version 3.0 it returns `2`. The previous behaviour can be restored by setting `spark.sql.legacy.ctePrecedence.enabled` to `true`.
 
-  - Since Spark 3.0, the `add_months` function adjusts the resulting date to a last day of month only if it is invalid. For example, `select add_months(DATE'2019-01-31', 1)` results `2019-02-28`. In Spark version 2.4 and earlier, the resulting date is adjusted when it is invalid, or the original date is a last day of months. For example, adding a month to `2019-02-28` resultes in `2019-03-31`.
+  - Since Spark 3.0, the `add_months` function does not adjust the resulting date to a last day of month if the original date is a last day of months. For example, `select add_months(DATE'2019-02-28', 1)` results `2019-03-28`. In Spark version 2.4 and earlier, the resulting date is adjusted when the original date is a last day of months. For example, adding a month to `2019-02-28` resultes in `2019-03-31`.
 
 ## Upgrading from Spark SQL 2.4 to 2.4.1
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to add one example to describe 'add_months'  behaviour change by https://github.com/apache/spark/pull/25153.

**Spark 2.4:**

```sql
select add_months(DATE'2019-02-28', 1)
```

```
+--------------------------------+
|add_months(DATE '2019-02-28', 1)|
+--------------------------------+
|                      2019-03-31|
+--------------------------------+
```

**Current master:**

```sql
select add_months(DATE'2019-02-28', 1)
```

```
+--------------------------------+
|add_months(DATE '2019-02-28', 1)|
+--------------------------------+
|                      2019-03-28|
+--------------------------------+
```

## How was this patch tested?

Manually tested on Spark 2.4.1 and the current master.
