### PR TITLE
[SPARK-28441][SQL][Python] Fix error when non-foldable expression is used in correlated scalar subquery

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2698,7 +2698,7 @@ object EliminateUnions extends Rule[LogicalPlan] {
  * rule can't work for those parameters.
  */
 object CleanupAliases extends Rule[LogicalPlan] {
-  private def trimAliases(e: Expression): Expression = {
+  def trimAliases(e: Expression): Expression = {
     e.transformDown {
       case Alias(child, _) => child
       case MultiAlias(child, _) => child

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -650,7 +650,9 @@ object ColumnPruning extends Rule[LogicalPlan] {
    */
   private def removeProjectBeforeFilter(plan: LogicalPlan): LogicalPlan = plan transformUp {
     case p1 @ Project(_, f @ Filter(_, p2 @ Project(_, child)))
-      if p2.outputSet.subsetOf(child.outputSet) =>
+      if p2.outputSet.subsetOf(child.outputSet) &&
+        // We only remove attribute-only project.
+        p2.projectList.forall(_.isInstanceOf[AttributeReference]) =>
       p1.copy(child = f.copy(child = child))
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -331,8 +331,9 @@ object RewriteCorrelatedScalarSubquery extends Rule[LogicalPlan] {
           case None => Literal.default(NullType)
         }
     }
-    if (rewrittenExpr.find(_.isInstanceOf[PythonUDF]).isDefined) {
-      // SPARK-28441: `PythonUDF` can't be statically evaluated.
+    if (!rewrittenExpr.foldable) {
+      // SPARK-28441: Some expressions, like PythonUDF, can't be statically evaluated.
+      // Needs to evaluate them on query runtime.
       Some(rewrittenExpr)
     } else {
       val exprVal = rewrittenExpr.eval()

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -1600,5 +1600,6 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
                     |       )
                     |   ) = 2""".stripMargin)
     checkAnswer(df, df2)
+    checkAnswer(df, Nil)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -1425,7 +1425,8 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
     registerTestUDF(pythonTestUDF, spark)
 
     checkAnswer(
-      sql("""SELECT
+      sql("""
+            |SELECT
             |  l.a AS grp_a
             |FROM l GROUP BY l.a
             |HAVING
@@ -1443,7 +1444,8 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
     registerTestUDF(pythonTestUDF, spark)
 
     checkAnswer(
-      sql("""SELECT
+      sql("""
+            |SELECT
             |  l.a AS aval,
             |  sum(
             |    (
@@ -1470,7 +1472,8 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
       Row(2) :: Row(2) :: Row(3) :: Row(6) :: Nil)
     // Case 3: COUNT inside aggregate expression but no COUNT bug.
     checkAnswer(
-      sql("""SELECT
+      sql("""
+            |SELECT
             |  l.a
             |FROM l WHERE
             |  (
@@ -1487,7 +1490,8 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
     registerTestUDF(pythonTestUDF, spark)
 
     checkAnswer(
-      sql("""SELECT l.a FROM l
+      sql("""
+            |SELECT l.a FROM l
             |WHERE (
             |    SELECT cntPlusOne + 1 AS cntPlusTwo FROM (
             |        SELECT cnt + 1 AS cntPlusOne FROM (
@@ -1506,7 +1510,8 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
     registerTestUDF(pythonTestUDF, spark)
 
     checkAnswer(
-      sql("""SELECT
+      sql("""
+            |SELECT
             |  l.a
             |FROM l WHERE
             |  (
@@ -1559,7 +1564,8 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
 
   test("SPARK-28441: COUNT bug in nested subquery with non-foldable expr") {
     checkAnswer(
-      sql("""SELECT l.a FROM l
+      sql("""
+            |SELECT l.a FROM l
             |WHERE (
             |    SELECT cntPlusOne + 1 AS cntPlusTwo FROM (
             |        SELECT cnt + 1 AS cntPlusOne FROM (
@@ -1572,7 +1578,8 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
   }
 
   test("SPARK-28441: COUNT bug with non-foldable expression in Filter condition") {
-    val df = sql("""SELECT
+    val df = sql("""
+                   |SELECT
                    |  l.a
                    |  FROM l WHERE
                    |  (
@@ -1584,7 +1591,8 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
                    |      )
                    |    )
                    |  ) = 2""".stripMargin)
-    val df2 = sql("""SELECT
+    val df2 = sql("""
+                    |SELECT
                     |  l.a
                     |FROM l WHERE
                     |  (

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -1475,11 +1475,12 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
       sql("""
             |SELECT
             |  l.a
-            |FROM l WHERE
+            |FROM l
+            |WHERE
             |  (
-            |    SELECT udf(count(*)) + udf(sum(r.d)
-            |  )
-            |FROM r WHERE l.a = r.c) = 0""".stripMargin),
+            |    SELECT udf(count(*)) + udf(sum(r.d))
+            |    FROM r WHERE l.a = r.c
+            |  ) = 0""".stripMargin),
       Nil)
   }
 
@@ -1567,12 +1568,12 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
       sql("""
             |SELECT l.a FROM l
             |WHERE (
-            |    SELECT cntPlusOne + 1 AS cntPlusTwo FROM (
-            |        SELECT cnt + 1 AS cntPlusOne FROM (
-            |            SELECT sum(r.c) s, (count(*) + cast(rand() as int)) cnt FROM r
-            |                WHERE l.a = r.c HAVING cnt = 0
-            |        )
-            |    )
+            |  SELECT cntPlusOne + 1 AS cntPlusTwo FROM (
+            |    SELECT cnt + 1 AS cntPlusOne FROM (
+            |      SELECT sum(r.c) s, (count(*) + cast(rand() as int)) cnt FROM r
+            |        WHERE l.a = r.c HAVING cnt = 0
+            |      )
+            |  )
             |) = 2""".stripMargin),
       Row(1) :: Row(1) :: Row(null) :: Row(null) :: Nil)
   }
@@ -1581,7 +1582,7 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
     val df = sql("""
                    |SELECT
                    |  l.a
-                   |  FROM l WHERE
+                   |FROM l WHERE
                    |  (
                    |    SELECT cntPlusOne + 1 as cntPlusTwo FROM
                    |    (

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -1384,4 +1384,132 @@ class SubquerySuite extends QueryTest with SharedSQLContext {
     assert(subqueryExecs.forall(_.name.startsWith("scalar-subquery#")),
           "SubqueryExec name should start with scalar-subquery#")
   }
+
+  test("SPARK-28441: COUNT bug in WHERE clause (Filter) with PythonUDF") {
+    import IntegratedUDFTestUtils._
+
+    val pythonTestUDF = TestPythonUDF(name = "udf")
+    registerTestUDF(pythonTestUDF, spark)
+
+    // Case 1: Canonical example of the COUNT bug
+    checkAnswer(
+      sql("select l.a from l where (select udf(count(*)) from r where l.a = r.c) < l.a"),
+      Row(1) :: Row(1) :: Row(3) :: Row(6) :: Nil)
+    // Case 2: count(*) = 0; could be rewritten to NOT EXISTS but currently uses
+    // a rewrite that is vulnerable to the COUNT bug
+    checkAnswer(
+      sql("select l.a from l where (select udf(count(*)) from r where l.a = r.c) = 0"),
+      Row(1) :: Row(1) :: Row(null) :: Row(null) :: Nil)
+    // Case 3: COUNT bug without a COUNT aggregate
+    checkAnswer(
+      sql("select l.a from l where (select udf(sum(r.d)) is null from r where l.a = r.c)"),
+      Row(1) :: Row(1) ::Row(null) :: Row(null) :: Row(6) :: Nil)
+  }
+
+  test("SPARK-28441: COUNT bug in SELECT clause (Project) with PythonUDF") {
+    import IntegratedUDFTestUtils._
+
+    val pythonTestUDF = TestPythonUDF(name = "udf")
+    registerTestUDF(pythonTestUDF, spark)
+
+    checkAnswer(
+      sql("select a, (select udf(count(*)) from r where l.a = r.c) as cnt from l"),
+      Row(1, 0) :: Row(1, 0) :: Row(2, 2) :: Row(2, 2) :: Row(3, 1) :: Row(null, 0)
+        :: Row(null, 0) :: Row(6, 1) :: Nil)
+  }
+
+  test("SPARK-28441: COUNT bug in HAVING clause (Filter) with PythonUDF") {
+    import IntegratedUDFTestUtils._
+
+    val pythonTestUDF = TestPythonUDF(name = "udf")
+    registerTestUDF(pythonTestUDF, spark)
+
+    checkAnswer(
+      sql("select l.a as grp_a from l group by l.a " +
+        "having (select udf(count(*)) from r where grp_a = r.c) = 0 " +
+        "order by grp_a"),
+      Row(null) :: Row(1) :: Nil)
+  }
+
+  test("SPARK-28441: COUNT bug in Aggregate with PythonUDF") {
+    import IntegratedUDFTestUtils._
+
+    val pythonTestUDF = TestPythonUDF(name = "udf")
+    registerTestUDF(pythonTestUDF, spark)
+
+    checkAnswer(
+      sql("select l.a as aval, sum((select udf(count(*)) from r where l.a = r.c)) as cnt " +
+        "from l group by l.a order by aval"),
+      Row(null, 0) :: Row(1, 0) :: Row(2, 4) :: Row(3, 1) :: Row(6, 1)  :: Nil)
+  }
+
+  test("SPARK-28441: COUNT bug negative examples with PythonUDF") {
+    import IntegratedUDFTestUtils._
+
+    val pythonTestUDF = TestPythonUDF(name = "udf")
+    registerTestUDF(pythonTestUDF, spark)
+
+    // Case 1: Potential COUNT bug case that was working correctly prior to the fix
+    checkAnswer(
+      sql("select l.a from l where (select udf(sum(r.d)) from r where l.a = r.c) is null"),
+      Row(1) :: Row(1) :: Row(null) :: Row(null) :: Row(6) :: Nil)
+    // Case 2: COUNT aggregate but no COUNT bug due to > 0 test.
+    checkAnswer(
+      sql("select l.a from l where (select udf(count(*)) from r where l.a = r.c) > 0"),
+      Row(2) :: Row(2) :: Row(3) :: Row(6) :: Nil)
+    // Case 3: COUNT inside aggregate expression but no COUNT bug.
+    checkAnswer(
+      sql("select l.a from l where (select udf(count(*)) + udf(sum(r.d)) " +
+        "from r where l.a = r.c) = 0"),
+      Nil)
+  }
+
+  test("SPARK-28441: COUNT bug in subquery in subquery in subquery with PythonUDF") {
+    import IntegratedUDFTestUtils._
+
+    val pythonTestUDF = TestPythonUDF(name = "udf")
+    registerTestUDF(pythonTestUDF, spark)
+
+    checkAnswer(
+      sql("""select l.a from l
+            |where (
+            |    select cntPlusOne + 1 as cntPlusTwo from (
+            |        select cnt + 1 as cntPlusOne from (
+            |            select udf(sum(r.c)) s, udf(count(*)) cnt from r where l.a = r.c
+            |                   having cnt = 0
+            |        )
+            |    )
+            |) = 2""".stripMargin),
+      Row(1) :: Row(1) :: Row(null) :: Row(null) :: Nil)
+  }
+
+  test("SPARK-28441: COUNT bug with nasty predicate expr with PythonUDF") {
+    import IntegratedUDFTestUtils._
+
+    val pythonTestUDF = TestPythonUDF(name = "udf")
+    registerTestUDF(pythonTestUDF, spark)
+
+    checkAnswer(
+      sql("select l.a from l where " +
+        "(select case when udf(count(*)) = 1 then null else udf(count(*)) end as cnt " +
+        "from r where l.a = r.c) = 0"),
+      Row(1) :: Row(1) :: Row(null) :: Row(null) :: Nil)
+  }
+
+  test("SPARK-28441: COUNT bug with attribute ref in subquery input and output with PythonUDF") {
+    import IntegratedUDFTestUtils._
+
+    val pythonTestUDF = TestPythonUDF(name = "udf")
+    registerTestUDF(pythonTestUDF, spark)
+
+    checkAnswer(
+      sql(
+        """
+          |select l.b, (select (r.c + udf(count(*))) is null
+          |from r
+          |where l.a = r.c group by r.c) from l
+        """.stripMargin),
+      Row(1.0, false) :: Row(1.0, false) :: Row(2.0, true) :: Row(2.0, true) ::
+        Row(3.0, false) :: Row(5.0, true) :: Row(null, false) :: Row(null, true) :: Nil)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In SPARK-15370, We checked the expression at the root of the correlated subquery, in order to fix count bug. If a `PythonUDF` in in the checking path, evaluating it causes the failure as we can't statically evaluate `PythonUDF`. The Python UDF test added at SPARK-28277 shows this issue.

If we can statically evaluate the expression, we intercept NULL values coming from the outer join and replace them with the value that the subquery's expression like before, if it is not, we replace them with the `PythonUDF` expression, with statically evaluated parameters.

After this, the last query in `udf-except.sql` which throws `java.lang.UnsupportedOperationException` can be run:

```
SELECT t1.k
FROM   t1
WHERE  t1.v <= (SELECT   udf(max(udf(t2.v)))
                FROM     t2
                WHERE    udf(t2.k) = udf(t1.k))
MINUS
SELECT t1.k
FROM   t1
WHERE  udf(t1.v) >= (SELECT   min(udf(t2.v))
                FROM     t2
                WHERE    t2.k = t1.k)
-- !query 2 schema
struct<k:string>
-- !query 2 output
two
```

Note that this issue is also for other non-foldable expressions, like rand. As like PythonUDF, we can't call `eval` on this kind of expressions in optimization. The evaluation needs to defer to query runtime.

## How was this patch tested?

Added tests.