### PR TITLE
[SPARK-28265][SQL] Add renameTable to TableCatalog API

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalog/v2/TableCatalog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalog/v2/TableCatalog.java
@@ -134,4 +134,24 @@ public interface TableCatalog extends CatalogPlugin {
    * @return true if a table was deleted, false if no table exists for the identifier
    */
   boolean dropTable(Identifier ident);
+
+  /**
+   * Renames a table in the catalog.
+   * <p>
+   * If the catalog supports views and contains a view for the old identifier and not a table, this
+   * throws {@link NoSuchTableException}. Additionally, if the new identifier is a table or a view,
+   * this throws {@link TableAlreadyExistsException}.
+   * <p>
+   * If the catalog does not support table renames between namespaces, it throws
+   * {@link UnsupportedOperationException}.
+   *
+   * @param oldIdent the table identifier of the existing table to rename
+   * @param newIdent the new table identifier of the table
+   * @throws NoSuchTableException If the table to rename doesn't exist or is a view
+   * @throws TableAlreadyExistsException If the new table name already exists or is a view
+   * @throws UnsupportedOperationException If the namespaces of old and new identiers do not
+   *                                       match (optional)
+   */
+  void renameTable(Identifier oldIdent, Identifier newIdent)
+      throws NoSuchTableException, TableAlreadyExistsException;
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalog/v2/TestTableCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalog/v2/TestTableCatalog.scala
@@ -93,6 +93,19 @@ class TestTableCatalog extends TableCatalog with SupportsNamespaces {
 
   override def dropTable(ident: Identifier): Boolean = Option(tables.remove(ident)).isDefined
 
+  override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit = {
+    if (tables.containsKey(newIdent)) {
+      throw new TableAlreadyExistsException(newIdent)
+    }
+
+    Option(tables.remove(oldIdent)) match {
+      case Some(table) =>
+        tables.put(newIdent, InMemoryTable(table.name, table.schema, table.properties))
+      case _ =>
+        throw new NoSuchTableException(oldIdent)
+    }
+  }
+
   private def allNamespaces: Seq[Seq[String]] = {
     (tables.keySet.asScala.map(_.namespace.toSeq) ++ namespaces.keySet.asScala).toSeq.distinct
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
@@ -154,7 +154,11 @@ class V2SessionCatalog(sessionState: SessionState) extends TableCatalog {
   }
 
   override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit = {
-    if (Option(loadTable(newIdent)).isDefined) throw new TableAlreadyExistsException(newIdent)
+    try {
+      if (Option(loadTable(newIdent)).isDefined) throw new TableAlreadyExistsException(newIdent)
+    } catch {
+      case _: NoSuchTableException =>
+    }
 
     // Load table to make sure the table exists
     loadTable(oldIdent)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
@@ -154,10 +154,8 @@ class V2SessionCatalog(sessionState: SessionState) extends TableCatalog {
   }
 
   override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit = {
-    try {
-      if (Option(loadTable(newIdent)).isDefined) throw new TableAlreadyExistsException(newIdent)
-    } catch {
-      case _: NoSuchTableException =>
+    if (tableExists(newIdent)) {
+      throw new TableAlreadyExistsException(newIdent)
     }
 
     // Load table to make sure the table exists

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
@@ -153,6 +153,14 @@ class V2SessionCatalog(sessionState: SessionState) extends TableCatalog {
     }
   }
 
+  override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit = {
+    if (Option(loadTable(newIdent)).isDefined) throw new TableAlreadyExistsException(newIdent)
+
+    // Load table to make sure the table exists
+    loadTable(oldIdent)
+    catalog.renameTable(oldIdent.asTableIdentifier, newIdent.asTableIdentifier)
+  }
+
   implicit class TableIdentifierHelper(ident: Identifier) {
     def asTableIdentifier: TableIdentifier = {
       ident.namespace match {

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/v2/TestInMemoryTableCatalog.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/v2/TestInMemoryTableCatalog.scala
@@ -104,6 +104,20 @@ class TestInMemoryTableCatalog extends TableCatalog {
     Option(tables.remove(ident)).isDefined
   }
 
+  override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit = {
+    if (tables.containsKey(newIdent)) {
+      throw new TableAlreadyExistsException(newIdent)
+    }
+
+    Option(tables.remove(oldIdent)) match {
+      case Some(table) =>
+        tables.put(newIdent,
+          new InMemoryTable(table.name, table.schema, table.partitioning, table.properties))
+      case _ =>
+        throw new NoSuchTableException(oldIdent)
+    }
+  }
+
   def clearTables(): Unit = {
     tables.clear()
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds the `renameTable` call to the `TableCatalog` API, as described in the [Table Metadata API SPIP](https://docs.google.com/document/d/1zLFiA1VuaWeVxeTDXNg8bL6GP3BVoOZBkewFtEnjEoo/edit#heading=h.m45webtwxf2d).

This PR is related to: https://github.com/apache/spark/pull/24246

## How was this patch tested?

Added  unit tests and contract tests.
