### PR TITLE
[SPARK-28456][SQL] Add a public API `Encoder.makeCopy` to allow creating Encoder without touching Scala Reflection

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoder.scala
@@ -85,5 +85,5 @@ trait Encoder[T] extends Serializable {
    * Create a copied [[Encoder]]. The implementation may just copy internal reusable fields to speed
    * up the [[Encoder]] creation.
    */
-  def copyEncoder: Encoder[T]
+  def makeCopy: Encoder[T]
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoder.scala
@@ -80,4 +80,10 @@ trait Encoder[T] extends Serializable {
    * A ClassTag that can be used to construct an Array to contain a collection of `T`.
    */
   def clsTag: ClassTag[T]
+
+  /**
+   * Create a copied [[Encoder]]. The implementation may just copy internal reusable fields to speed
+   * up the [[Encoder]] creation.
+   */
+  def copyEncoder: Encoder[T]
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoder.scala
@@ -383,7 +383,7 @@ case class ExpressionEncoder[T](
 
   override def toString: String = s"class[$schemaString]"
 
-  override def copyEncoder: ExpressionEncoder[T] = copy()
+  override def makeCopy: ExpressionEncoder[T] = copy()
 }
 
 // A dummy logical plan that can hold expressions and go through optimizer rules.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoder.scala
@@ -382,6 +382,8 @@ case class ExpressionEncoder[T](
       .map { case(f, a) => s"${f.name}$a: ${f.dataType.simpleString}"}.mkString(", ")
 
   override def toString: String = s"class[$schemaString]"
+
+  override def copyEncoder: ExpressionEncoder[T] = copy()
 }
 
 // A dummy logical plan that can hold expressions and go through optimizer rules.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -427,6 +427,10 @@ class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTes
   testOverflowingBigNumeric(BigInt("9" * 100), "scala very large big int")
   testOverflowingBigNumeric(new BigInteger("9" * 100), "java very big int")
 
+  encodeDecodeTest("foo" -> 1L, "makeCopy") {
+    Encoders.product[(String, Long)].makeCopy.asInstanceOf[ExpressionEncoder[(String, Long)]]
+  }
+
   private def testOverflowingBigNumeric[T: TypeTag](bigNumeric: T, testName: String): Unit = {
     Seq(true, false).foreach { allowNullOnOverflow =>
       testAndVerifyNotLeakingReflectionObjects(
@@ -450,10 +454,6 @@ class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTes
         }
       }
     }
-  }
-
-  encodeDecodeTest("foo" -> 1L, "copied encoder") {
-    Encoders.product[(String, Long)].copyEncoder.asInstanceOf[ExpressionEncoder[(String, Long)]]
   }
 
   private def encodeDecodeTest[T : ExpressionEncoder](

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -452,6 +452,10 @@ class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTes
     }
   }
 
+  encodeDecodeTest("foo" -> 1L, "copied encoder") {
+    Encoders.product[(String, Long)].copyEncoder.asInstanceOf[ExpressionEncoder[(String, Long)]]
+  }
+
   private def encodeDecodeTest[T : ExpressionEncoder](
       input: T,
       testName: String): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Because `Encoder` is not thread safe, the user cannot reuse an `Encoder` in multiple `Dataset`s. However, creating an `Encoder` for a complicated class is slow due to Scala Reflection. To eliminate the cost of Scala Reflection, right now I usually use the private API `ExpressionEncoder.copy` as follows:

```scala
object FooEncoder {
  private lazy val _encoder: ExpressionEncoder[Foo] = ExpressionEncoder[Foo]()
  implicit def encoder: ExpressionEncoder[Foo] = _encoder.copy()
}
```

This PR proposes a new method `makeCopy` in `Encoder` so that the above codes can be rewritten using public APIs.

```scala
object FooEncoder {
  private lazy val _encoder: Encoder[Foo] = Encoders.product[Foo]()
  implicit def encoder: Encoder[Foo] = _encoder.makeCopy
}
```

The method name is consistent with `TreeNode.makeCopy`.

## How was this patch tested?

Jenkins