### PR TITLE
[WIP][SPARK-24907][SQL] DataSourceV2 based connector for JDBC

### DIFF
--- a/examples/src/main/python/sql/datasourcev2.py
+++ b/examples/src/main/python/sql/datasourcev2.py
@@ -1,0 +1,20 @@
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col
+
+spark = SparkSession\
+	.builder\
+        .appName("DV2Test")\
+	.getOrCreate()
+
+
+df = spark.read.format("csv").options(header='true').load("/home/shivsood/myspark_scripts/text.csv")
+df.show(5)
+
+#Read
+df_jdbc = spark.read.options(header='true').format("jdbcv2").load()
+df_jdbc.show(3)
+
+
+#Write
+#df.filter( col("rollnum") == "38" ).write.format("jdbcv2").save()
+

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
@@ -158,6 +158,16 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationSuite {
     df2.show()
   }
 
+  test("JDBCV2 read test") {
+    // Read table with JDBCV2
+    val df1 = spark.read.format("jdbc").option("url",jdbcUrl).option("dbtable","strings_numbers").load()
+    val numberOfRows = df1.count
+    val df2 = spark.read.format("jdbcv2").option("url",jdbcUrl).option("dbtable","strings_numbers").load()
+    df2.show(10)
+    df2.select("i").show(10)
+    assert(df2.count == numberOfRows)
+  }
+
   test("Basic test") {
     val df = spark.read.jdbc(jdbcUrl, "tbl", new Properties)
     val rows = df.collect()

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
@@ -130,7 +130,7 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationSuite {
     spark.createDataFrame(spark.sparkContext.parallelize(data),schema)
   }
 
-  test("JDBCV2 write test") {
+  test("JDBCV2 write append test") {
     // Read 1 row using JDBC. Write(append) this row using jdbcv2.
     val df1 = spark.read.format("jdbc").option("url",jdbcUrl).option("dbtable", "strings_numbers").load()
     df1.show(10)
@@ -147,6 +147,15 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationSuite {
     val df2_new = spark.read.format("jdbc").option("url",jdbcUrl).option("dbtable", "strings_numbers").load()
     df2_new.show(10)
     assert(df2_new.count == 4)
+  }
+
+  test("JDBCV2 write overwrite test") {
+    // Overwrite a existing table with a new schema and values.
+    val df1 = create_test_df()
+    // Overwrite test. Overwrite mode create a new table if it does not exist
+    df1.write.format("jdbcv2").mode("overwrite").option("url",jdbcUrl).option("dbtable","strings_numbers").save()
+    val df2 = spark.read.format("jdbc").option("url",jdbcUrl).option("dbtable","strings_numbers").load()
+    df2.show()
   }
 
   test("Basic test") {

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
@@ -99,6 +99,30 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationSuite {
         |'the', 'lazy',
         |'dog')
       """.stripMargin).executeUpdate()
+    conn.prepareStatement(
+      """
+        |CREATE TABLE strings_numbers (
+        |i NVarChar(10),
+        |j INT,
+        |k NVarChar(20))
+      """.stripMargin).executeUpdate()
+    conn.prepareStatement(
+      """
+        |INSERT INTO strings_numbers VALUES (
+        |'string',38,
+        |'big string')
+      """.stripMargin).executeUpdate()
+  }
+
+  test("JDBCV2 write test") {
+    // Read 1 row using JDBC. Write(append) this row using jdbcv2.
+    val df1 = spark.read.format("jdbc").option("url",jdbcUrl).option("dbtable", "strings_numbers").load()
+    df1.show(10)
+    assert(df1.count == 1)
+    df1.write.format("jdbcv2").mode("append").option("url",jdbcUrl).option("dbtable", "strings_numbers").save()
+    val df2 = spark.read.format("jdbc").option("url",jdbcUrl).option("dbtable", "strings_numbers").load()
+    df2.show(10)
+    assert(df2.count == 2)
   }
 
   test("Basic test") {

--- a/sql/core/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/sql/core/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -9,3 +9,4 @@ org.apache.spark.sql.execution.streaming.ConsoleSinkProvider
 org.apache.spark.sql.execution.streaming.sources.RateStreamProvider
 org.apache.spark.sql.execution.streaming.sources.TextSocketSourceProvider
 org.apache.spark.sql.execution.datasources.binaryfile.BinaryFileFormat
+org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCDataSourceV2

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBPartitionReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBPartitionReader.scala
@@ -26,14 +26,16 @@ import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.unsafe.types.UTF8String
 
 class DBPartitionReader(schema : StructType) extends PartitionReader[InternalRow] with Logging {
-
   var dummyRows = 0
+  /*
+   * Note : Read implementation is dummy as of now.
+   * It returns a hard coded schema and rows.
+   */
 
   @throws[IOException]
   def next(): Boolean = {
 
     logInfo("***dsv2-flows*** next() called")
-
     if(dummyRows <2) {
       dummyRows = dummyRows + 1
       true
@@ -47,7 +49,7 @@ class DBPartitionReader(schema : StructType) extends PartitionReader[InternalRow
     logInfo("***dsv2-flows*** get() called for row " + dummyRows)
 
     // Value for row1
-    var v_name = "shiv"
+    var v_name = "somename"
     var v_rollnum = "38"
     var v_occupation = "worker"
 
@@ -55,7 +57,7 @@ class DBPartitionReader(schema : StructType) extends PartitionReader[InternalRow
       // Values for row2
       v_name = "someone"
       v_rollnum = "39"
-      v_occupation = "dontknow"
+      v_occupation = "manager"
     }
 
     val values = schema.map(_.name).map {
@@ -64,13 +66,10 @@ class DBPartitionReader(schema : StructType) extends PartitionReader[InternalRow
       case "occupation" => UTF8String.fromString(v_occupation)
       case _ => UTF8String.fromString("anything")
     }
-
     InternalRow.fromSeq(values)
   }
 
   @throws[IOException]
   override def close(): Unit = {
-
   }
-
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBPartitionReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBPartitionReader.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.jdbc
+
+import java.io.IOException
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.sources.v2.reader.PartitionReader
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import org.apache.spark.unsafe.types.UTF8String
+
+class DBPartitionReader(schema : StructType) extends PartitionReader[InternalRow] with Logging {
+
+  var dummyRows = 0
+
+  @throws[IOException]
+  def next(): Boolean = {
+
+    logInfo("***dsv2-flows*** next() called")
+
+    if(dummyRows <2) {
+      dummyRows = dummyRows + 1
+      true
+    } else {
+      false
+    }
+  }
+
+  def get: InternalRow = {
+
+    logInfo("***dsv2-flows*** get() called for row " + dummyRows)
+
+    // Value for row1
+    var v_name = "shiv"
+    var v_rollnum = "38"
+    var v_occupation = "worker"
+
+    if(dummyRows == 2) {
+      // Values for row2
+      v_name = "someone"
+      v_rollnum = "39"
+      v_occupation = "dontknow"
+    }
+
+    val values = schema.map(_.name).map {
+      case "name" => UTF8String.fromString(v_name)
+      case "rollnum" => UTF8String.fromString(v_rollnum)
+      case "occupation" => UTF8String.fromString(v_occupation)
+      case _ => UTF8String.fromString("anything")
+    }
+
+    InternalRow.fromSeq(values)
+  }
+
+  @throws[IOException]
+  override def close(): Unit = {
+
+  }
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBPartitionReaderFactory.scala
@@ -19,12 +19,16 @@ package org.apache.spark.sql.execution.datasources.v2.jdbc
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
+import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.sources.v2.reader.{InputPartition, PartitionReader, PartitionReaderFactory}
 import org.apache.spark.sql.types.StructType
 
-class DBPartitionReaderFactory(schema : StructType) extends PartitionReaderFactory with Logging{
+class DBPartitionReaderFactory(options: JDBCOptions, schema : StructType,
+                               filters: Array[Filter], prunedCols: StructType)
+  extends PartitionReaderFactory with Logging{
   def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
     logInfo("***dsv2-flows*** createReader called")
-    new DBPartitionReader(schema)
+    new DBPartitionReader(options, schema, filters, prunedCols)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBPartitionReaderFactory.scala
@@ -23,7 +23,6 @@ import org.apache.spark.sql.sources.v2.reader.{InputPartition, PartitionReader, 
 import org.apache.spark.sql.types.StructType
 
 class DBPartitionReaderFactory(schema : StructType) extends PartitionReaderFactory with Logging{
-
   def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
     logInfo("***dsv2-flows*** createReader called")
     new DBPartitionReader(schema)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBPartitionReaderFactory.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.jdbc
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.sources.v2.reader.{InputPartition, PartitionReader, PartitionReaderFactory}
+import org.apache.spark.sql.types.StructType
+
+class DBPartitionReaderFactory(schema : StructType) extends PartitionReaderFactory with Logging{
+
+  def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
+    logInfo("***dsv2-flows*** createReader called")
+    new DBPartitionReader(schema)
+  }
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBPartitionReaderFactory.scala
@@ -28,5 +28,4 @@ class DBPartitionReaderFactory(schema : StructType) extends PartitionReaderFacto
     logInfo("***dsv2-flows*** createReader called")
     new DBPartitionReader(schema)
   }
-
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBTable.scala
@@ -72,7 +72,7 @@ case class DBTable (sparkSession: SparkSession,
 
   override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
     logInfo("***dsv2-flows*** newScanBuilder called")
-    new JDBCScanBuilder()
+    new JDBCScanBuilder(new JDBCOptions(options.asScala.toMap), userSchema)
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBTable.scala
@@ -58,8 +58,6 @@ case class DBTable (sparkSession: SparkSession,
 
   override def capabilities: java.util.Set[TableCapability] = DBTable.CAPABILITIES
 
-  def supportsDataType(dataType: DataType): Boolean = true
-
   override def newWriteBuilder(options: CaseInsensitiveStringMap): WriteBuilder = {
     logInfo("***dsv2-flows*** newWriteBuilder called")
     Utils.logSchema("Schema passed to DBTable", userSchema)
@@ -73,5 +71,5 @@ case class DBTable (sparkSession: SparkSession,
 }
 
 object DBTable {
-  private val CAPABILITIES = Set(BATCH_WRITE, BATCH_READ, TRUNCATE).asJava
+  private val CAPABILITIES = Set(BATCH_READ, BATCH_WRITE, TRUNCATE, OVERWRITE_BY_FILTER).asJava
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBTable.scala
@@ -71,7 +71,7 @@ case class DBTable (sparkSession: SparkSession,
   }
   override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
     logInfo("***dsv2-flows*** newScanBuilder called")
-    new JDBCScanBuilder()
+    new JDBCScanBuilder(new JDBCOptions(options.asScala.toMap), userSchema)
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBTable.scala
@@ -48,8 +48,10 @@ case class DBTable (sparkSession: SparkSession,
   }
 
   override def schema: StructType = {
-    // TODO - check why a schema request? What if no table exists and
-    // no userSpecifiedSchema
+    /* TODO - check why a schema request? Will this be called for every 'append'
+     *  request to get schema from DBTable. If so, schema check in append should
+     *  not be required.
+     */
     logInfo("***dsv2-flows*** schema called")
     val schemaInDB = JdbcUtils.getSchemaOption(conn, userOptions)
     Utils.logSchema("schema from DB", schemaInDB)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBTable.scala
@@ -48,9 +48,12 @@ case class DBTable (sparkSession: SparkSession,
   }
 
   override def schema: StructType = {
-    /* TODO - check why a schema request? Will this be called for every 'append'
-     *  request to get schema from DBTable. If so, schema check in append should
-     *  not be required.
+    /* TODO - check why a schema request?
+     *  1. Will this be called for every 'append' request to get schema from DBTable.
+     *  If so, schema check in append should not be required.
+     *  2. This is called in overwrite as well. What if the table does not exist. A empty
+     *     schema would be returned resulting in an exception. Should Overwrite semantics
+     *     not create a table.
      */
     logInfo("***dsv2-flows*** schema called")
     val schemaInDB = JdbcUtils.getSchemaOption(conn, userOptions)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBTable.scala
@@ -58,13 +58,14 @@ case class DBTable (sparkSession: SparkSession,
 
   override def capabilities: java.util.Set[TableCapability] = DBTable.CAPABILITIES
 
+  def supportsDataType(dataType: DataType): Boolean = true
+
   override def newWriteBuilder(options: CaseInsensitiveStringMap): WriteBuilder = {
     logInfo("***dsv2-flows*** newWriteBuilder called")
     Utils.logSchema("Schema passed to DBTable", userSchema)
     new JDBCWriteBuilder(
       new JdbcOptionsInWrite(options.asScala.toMap), userSchema)
   }
-
   override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
     logInfo("***dsv2-flows*** newScanBuilder called")
     new JDBCScanBuilder()
@@ -72,5 +73,5 @@ case class DBTable (sparkSession: SparkSession,
 }
 
 object DBTable {
-  private val CAPABILITIES = Set(BATCH_READ, BATCH_WRITE, TRUNCATE, OVERWRITE_BY_FILTER).asJava
+  private val CAPABILITIES = Set(BATCH_WRITE, BATCH_READ, TRUNCATE).asJava
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBTable.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.jdbc
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.execution.datasources.v2.FileTable
+import org.apache.spark.sql.execution.datasources.v2.csv.CSVWriteBuilder
+import org.apache.spark.sql.sources.v2.{SupportsRead, SupportsWrite, Table, TableCapability}
+import org.apache.spark.sql.sources.v2.TableCapability.{BATCH_READ, BATCH_WRITE, TRUNCATE}
+import org.apache.spark.sql.sources.v2.reader.ScanBuilder
+import org.apache.spark.sql.sources.v2.writer.WriteBuilder
+import org.apache.spark.sql.types.{DataType, IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+case class DBTable (sparkSession: SparkSession,
+                     options: CaseInsensitiveStringMap,
+                     userSpecifiedSchema: Option[StructType])
+  extends Table with SupportsWrite with SupportsRead with Logging{
+
+
+  override def name: String = {
+    // TODO - Should come from user options
+
+    logInfo("***dsv2-flows*** name called")
+
+    "mysqltable"
+  }
+
+  def schema: StructType = {
+    // TODO - Remove hardcoded schema
+    logInfo("***dsv2-flows*** schema called")
+    StructType(Seq(
+      StructField("name", StringType, true),
+      StructField("rollnum", StringType, true),
+      StructField("occupation", StringType, true)))
+  }
+
+  override def capabilities: java.util.Set[TableCapability] = DBTable.CAPABILITIES
+
+  def supportsDataType(dataType: DataType): Boolean = true
+
+  override def newWriteBuilder(options: CaseInsensitiveStringMap): WriteBuilder = {
+    logInfo("***dsv2-flows*** newWriteBuilder called")
+    new JDBCWriteBuilder()
+  }
+
+  override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
+    logInfo("***dsv2-flows*** newScanBuilder called")
+    new JDBCScanBuilder()
+  }
+
+}
+
+object DBTable {
+  private val CAPABILITIES = Set(BATCH_WRITE, BATCH_READ, TRUNCATE).asJava
+}
+
+
+

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBTable.scala
@@ -51,8 +51,8 @@ case class DBTable (sparkSession: SparkSession,
      *  1. Will this be called for every 'append' request to get schema from DBTable.
      *  If so, schema check in append should not be required.
      *  2. This is called in overwrite as well. What if the table does not exist. A empty
-     *     schema would be returned resulting in an exception. Should Overwrite semantics
-     *     not create a table.
+     *     schema would be returned resulting in an exception. Overwrite semantics
+     *     do not create a table. So returning a Nil would result in an error.
      */
     logInfo("***dsv2-flows*** schema called")
     val schemaInDB = JdbcUtils.getSchemaOption(conn, userOptions)
@@ -75,5 +75,5 @@ case class DBTable (sparkSession: SparkSession,
 }
 
 object DBTable {
-  private val CAPABILITIES = Set(BATCH_READ, BATCH_WRITE, TRUNCATE, OVERWRITE_BY_FILTER).asJava
+  private val CAPABILITIES = Set(BATCH_READ, BATCH_WRITE, TRUNCATE).asJava
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBTableScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBTableScan.scala
@@ -23,6 +23,11 @@ import org.apache.spark.sql.types.{StringType, StructField, StructType}
 
 class DBTableScan extends Scan with Batch with Logging {
 
+  /*
+   * Note : Read implementation is dummy as of now.
+   * It returns a hard coded schema and rows.
+   */
+
   val table_schema = StructType(Seq(
     StructField("name", StringType, true),
     StructField("rollnum", StringType, true),
@@ -43,14 +48,10 @@ class DBTableScan extends Scan with Batch with Logging {
   }
 
   def createReaderFactory: PartitionReaderFactory = {
-
     logInfo("***dsv2-flows*** createReaderFactory called")
     new DBPartitionReaderFactory(table_schema)
-
   }
-
 }
 
 object PartitionScheme extends InputPartition {
-
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBTableScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBTableScan.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.jdbc
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.sources.v2.reader.{Batch, InputPartition, PartitionReaderFactory, Scan}
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+
+class DBTableScan extends Scan with Batch with Logging {
+
+  val table_schema = StructType(Seq(
+    StructField("name", StringType, true),
+    StructField("rollnum", StringType, true),
+    StructField("occupation", StringType, true)))
+
+  def readSchema: StructType = {
+    logInfo("***dsv2-flows*** readSchema called")
+    table_schema
+
+  }
+
+  override def toBatch() : Batch = {
+    this
+  }
+
+  def planInputPartitions: Array[InputPartition] = {
+    Array(PartitionScheme)
+  }
+
+  def createReaderFactory: PartitionReaderFactory = {
+
+    logInfo("***dsv2-flows*** createReaderFactory called")
+    new DBPartitionReaderFactory(table_schema)
+
+  }
+
+}
+
+object PartitionScheme extends InputPartition {
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBTableScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DBTableScan.scala
@@ -32,7 +32,7 @@ class DBTableScan(options: JDBCOptions,
 
   def readSchema: StructType = {
     logInfo("***dsv2-flows*** readSchema called")
-    table_schema.getOrElse(StructType(Nil))
+    prunedCols
   }
 
   override def toBatch() : Batch = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCBatchWrite.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCBatchWrite.scala
@@ -18,25 +18,23 @@
 package org.apache.spark.sql.execution.datasources.v2.jdbc
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.datasources.jdbc.JdbcOptionsInWrite
 import org.apache.spark.sql.sources.v2.writer.{BatchWrite, DataWriterFactory, WriterCommitMessage}
+import org.apache.spark.sql.types.StructType
 
-class JDBCBatchWrite extends BatchWrite with Logging{
 
+class JDBCBatchWrite(options: JdbcOptionsInWrite, fwPassedSchema: StructType)
+  extends BatchWrite with Logging{
   def createBatchWriterFactory: DataWriterFactory = {
     logInfo("***dsv2-flows*** createBatchWriterFactory called" )
-    new JDBCDataWriterFactory()
+    new JDBCDataWriterFactory(options, fwPassedSchema)
   }
-
-
   def commit(messages: Array[WriterCommitMessage]): Unit = {
-
-    logInfo("***dsv2-flows*** commit called with message... " )
-
+    logInfo("***dsv2-flows*** commit called with $messages.length messages" +
+      s"with value as $messages.mkString(':')")
   }
 
   def abort(messages: Array[WriterCommitMessage]): Unit = {
     logInfo("***dsv2-flows*** abort called with message... " )
-
   }
-
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCBatchWrite.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCBatchWrite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.datasources.v2.jdbc
 
 import org.apache.spark.internal.Logging
+
 import org.apache.spark.sql.execution.datasources.jdbc.JdbcOptionsInWrite
 import org.apache.spark.sql.sources.v2.writer.{BatchWrite, DataWriterFactory, WriterCommitMessage}
 import org.apache.spark.sql.types.StructType

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCBatchWrite.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCBatchWrite.scala
@@ -23,7 +23,6 @@ import org.apache.spark.sql.execution.datasources.jdbc.JdbcOptionsInWrite
 import org.apache.spark.sql.sources.v2.writer.{BatchWrite, DataWriterFactory, WriterCommitMessage}
 import org.apache.spark.sql.types.StructType
 
-
 class JDBCBatchWrite(options: JdbcOptionsInWrite, fwPassedSchema: StructType)
   extends BatchWrite with Logging{
   def createBatchWriterFactory: DataWriterFactory = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCBatchWrite.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCBatchWrite.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.jdbc
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.sources.v2.writer.{BatchWrite, DataWriterFactory, WriterCommitMessage}
+
+class JDBCBatchWrite extends BatchWrite with Logging{
+
+  def createBatchWriterFactory: DataWriterFactory = {
+    logInfo("***dsv2-flows*** createBatchWriterFactory called" )
+    new JDBCDataWriterFactory()
+  }
+
+
+  def commit(messages: Array[WriterCommitMessage]): Unit = {
+
+    logInfo("***dsv2-flows*** commit called with message... " )
+
+  }
+
+  def abort(messages: Array[WriterCommitMessage]): Unit = {
+    logInfo("***dsv2-flows*** abort called with message... " )
+
+  }
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCBatchWrite.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCBatchWrite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.execution.datasources.v2.jdbc
 
 import org.apache.spark.internal.Logging
-
 import org.apache.spark.sql.execution.datasources.jdbc.JdbcOptionsInWrite
 import org.apache.spark.sql.sources.v2.writer.{BatchWrite, DataWriterFactory, WriterCommitMessage}
 import org.apache.spark.sql.types.StructType

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCDataSourceV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCDataSourceV2.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 class JDBCDataSourceV2 extends TableProvider with DataSourceRegister with Logging{
-
   override def shortName(): String = {
     logInfo("***dsv2-flows*** shortName - return connector name")
     "jdbcv2"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCDataSourceV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCDataSourceV2.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.jdbc
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.sources.DataSourceRegister
+import org.apache.spark.sql.sources.v2.{Table, TableProvider}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+class JDBCDataSourceV2 extends TableProvider with DataSourceRegister with Logging{
+
+  override def shortName(): String = {
+    logInfo("***dsv2-flows*** shortName - return connector name")
+    "jdbcv2"
+  }
+
+  override def getTable(options: CaseInsensitiveStringMap): Table = {
+    logInfo("***dsv2-flows*** getTable called")
+    DBTable(SparkSession.active, options, None)
+  }
+
+  override def getTable(options: CaseInsensitiveStringMap, schema: StructType): Table = {
+    logInfo("***dsv2-flows*** getTable called with schema")
+    DBTable(SparkSession.active, options, Some(schema))
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCDataWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCDataWriter.scala
@@ -48,6 +48,7 @@ class JDBCDataWriter(options: JdbcOptionsInWrite,
   def abort(): Unit = {
     logInfo("***dsv2-flows*** abort called " )
   }
+
 }
 
 object JDBCWriterCommitMessage extends WriterCommitMessage {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCDataWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCDataWriter.scala
@@ -48,7 +48,6 @@ class JDBCDataWriter(options: JdbcOptionsInWrite,
   def abort(): Unit = {
     logInfo("***dsv2-flows*** abort called " )
   }
-
 }
 
 object JDBCWriterCommitMessage extends WriterCommitMessage {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCDataWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCDataWriter.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.jdbc
+
+import java.io.IOException
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.sources.v2.writer.{DataWriter, WriterCommitMessage}
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+
+class JDBCDataWriter extends DataWriter[InternalRow] with Logging{
+
+  @throws[IOException]
+  def write(record: InternalRow): Unit = {
+    logInfo("***dsv2-flows*** write " )
+
+    val schema = StructType(Seq(
+      StructField("name", StringType, true),
+      StructField("rollnum", StringType, true),
+      StructField("occupation", StringType, true)))
+
+    val ret = record.toSeq(schema)
+    logInfo("***dsv2-flows*** write " + ret.mkString(":") )
+  }
+
+  @throws[IOException]
+  def commit: WriterCommitMessage = {
+    logInfo("***dsv2-flows*** commit called " )
+    JDBCWriterCommitMessage
+  }
+
+  @throws[IOException]
+  def abort(): Unit = {
+    logInfo("***dsv2-flows*** abort called " )
+  }
+}
+
+object JDBCWriterCommitMessage extends WriterCommitMessage {
+  val commitMessage: String = "committed"
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCDataWriterFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCDataWriterFactory.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.jdbc
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.sources.v2.writer.{DataWriter, DataWriterFactory}
+
+class JDBCDataWriterFactory extends DataWriterFactory with Logging{
+
+  def createWriter(partitionId: Int, taskId: Long): DataWriter[InternalRow] = {
+    logInfo("***dsv2-flows*** createWriter called " )
+
+    new JDBCDataWriter()
+  }
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCDataWriterFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCDataWriterFactory.scala
@@ -37,5 +37,4 @@ class JDBCDataWriterFactory(options: JdbcOptionsInWrite, schema: StructType) ext
     val conn: Connection = JdbcUtils.createConnectionFactory(options)()
     new JDBCDataWriter(options, conn, schema)
   }
-
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
@@ -29,7 +29,6 @@ class JDBCScanBuilder extends ScanBuilder with
 
   var specifiedFilters: Array[Filter] = Array.empty
 
-
   def build: Scan = {
     logInfo("***dsv2-flows*** Scan called")
   new DBTableScan()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.jdbc
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.sources.v2.SupportsRead
+import org.apache.spark.sql.sources.v2.reader._
+import org.apache.spark.sql.types.StructType
+
+class JDBCScanBuilder extends ScanBuilder with
+  SupportsPushDownFilters with SupportsPushDownRequiredColumns
+  with Logging {
+
+  var specifiedFilters: Array[Filter] = Array.empty
+
+
+  def build: Scan = {
+    logInfo("***dsv2-flows*** Scan called")
+  new DBTableScan()
+
+  }
+
+  def pushFilters(filters: Array[Filter]): Array[Filter] = {
+    logInfo("***dsv2-flows*** PushDown filters called")
+    specifiedFilters = filters
+    filters
+  }
+
+  def pruneColumns(requiredSchema: StructType): Unit = {
+    logInfo("***dsv2-flows*** pruneColumns called")
+
+  }
+
+  def pushedFilters: Array[Filter] = {
+    logInfo("***dsv2-flows*** pushedFilters called")
+    specifiedFilters
+  }
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
@@ -18,37 +18,36 @@
 package org.apache.spark.sql.execution.datasources.v2.jdbc
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 import org.apache.spark.sql.sources.Filter
-import org.apache.spark.sql.sources.v2.SupportsRead
 import org.apache.spark.sql.sources.v2.reader._
 import org.apache.spark.sql.types.StructType
 
-class JDBCScanBuilder extends ScanBuilder with
-  SupportsPushDownFilters with SupportsPushDownRequiredColumns
+class JDBCScanBuilder(options: JDBCOptions,
+                      userSchema: Option[StructType])
+  extends ScanBuilder with SupportsPushDownFilters with SupportsPushDownRequiredColumns
   with Logging {
-
   var specifiedFilters: Array[Filter] = Array.empty
+  var prunedCols: StructType = _
 
   def build: Scan = {
     logInfo("***dsv2-flows*** Scan called")
-  new DBTableScan()
-
+  new DBTableScan(options, specifiedFilters, prunedCols)
   }
 
   def pushFilters(filters: Array[Filter]): Array[Filter] = {
-    logInfo("***dsv2-flows*** PushDown filters called")
+    logInfo(s"***dsv2-flows*** PushDown filters called filters as $filters")
     specifiedFilters = filters
     filters
   }
 
   def pruneColumns(requiredSchema: StructType): Unit = {
-    logInfo("***dsv2-flows*** pruneColumns called")
-
+    logInfo(s"***dsv2-flows*** pruneColumns called with $requiredSchema")
+    prunedCols = requiredSchema
   }
 
   def pushedFilters: Array[Filter] = {
-    logInfo("***dsv2-flows*** pushedFilters called")
+    logInfo(s"***dsv2-flows*** pushedFilters called")
     specifiedFilters
   }
-
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCWriteBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCWriteBuilder.scala
@@ -17,24 +17,97 @@
 
 package org.apache.spark.sql.execution.datasources.v2.jdbc
 
+import java.sql.{Connection, DriverManager}
+
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.sources.v2.writer.{BatchWrite, WriteBuilder}
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.execution.datasources.jdbc.{JdbcOptionsInWrite, JdbcUtils}
+import org.apache.spark.sql.sources.{AlwaysTrue$, Filter}
+import org.apache.spark.sql.sources.v2.writer.{BatchWrite, SupportsOverwrite, WriteBuilder}
 import org.apache.spark.sql.types.StructType
 
-class JDBCWriteBuilder extends WriteBuilder with Logging{
+class JDBCWriteBuilder(options: JdbcOptionsInWrite,
+                       userSchema: Option[StructType])
+  extends SupportsOverwrite with Logging{
+  // TODO : Check, The default mode is assumed as Append. Refer physical plans to
+  // overwrite and append data i.e. OverwriteByExpressionExec and AppendDataExec
+  // respectively(Truncate and overwrite are called explicitly)
+  private var writeMode : SaveMode = SaveMode.Append
+  private var isTruncate : Boolean = false
+  private var fwPassedSchema : StructType = _
+  private val conn : Connection = JdbcUtils.createConnectionFactory(options)()
 
   override def withQueryId(queryId: String): WriteBuilder = {
     logInfo("***dsv2-flows*** withQueryId called with queryId" + queryId)
+    // TODO : Check, Possible for his object to handles multiple queries on same table.
     this
   }
 
   override def withInputDataSchema(schema: StructType): WriteBuilder = {
-    logInfo("***dsv2-flows*** withInputDataSchema called with schema" + schema.printTreeString())
+    logInfo("***dsv2-flows*** withInputDataSchema called with schema")
+    logInfo("***dsv2-flows*** schema is " + schema.printTreeString())
+    fwPassedSchema = schema
     this
   }
 
   override def buildForBatch : BatchWrite = {
-    logInfo("***dsv2-flows*** BatchWrite called")
-    new JDBCBatchWrite()
+    logInfo("***dsv2-flows*** buildForBatch called")
+    writeMode match {
+      case SaveMode.Overwrite =>
+        processOverwrite()
+      case SaveMode.Append =>
+        processAppend()
+    }
+    new JDBCBatchWrite(options, fwPassedSchema)
+  }
+
+  override def overwrite(filters: Array[Filter]): WriteBuilder = {
+    logInfo("***dsv2-flows*** overwrite called ")
+    writeMode = SaveMode.Overwrite
+    this
+  }
+
+  override def truncate(): WriteBuilder = {
+    logInfo("***dsv2-flows*** overwrite called ")
+    writeMode = SaveMode.Overwrite
+    isTruncate = true
+    this
+  }
+
+  def processOverwrite() : Boolean = {
+    /* Overwrite table logic
+        1. Check if table exists. If not create it here. Should create be done??
+        2. If table exists and isTruncate, then just truncate existing table
+        3. If table exists and !isTruncate, then recreate table with new schema
+        Post table creation, send requests to executors to insert data.
+
+        check filters.
+    */
+    logInfo("***dsv2-flows*** Overwrite table with new schema")
+    false
+  }
+
+  def processAppend() : Unit = {
+    /* Append table logic
+     * 1. Check is table exists. Create if not. Step4.
+     * 2. If table exists and schema does not match, raise exception.
+     * 3. If table exists and schema match. Step4
+     * 4. Send to executors for data insert
+     */
+    logInfo("***dsv2-flows*** Append to table")
+    // log schemas received.
+    Utils.logSchema("userSchema", userSchema)
+    Utils.logSchema("fwPassedSchema", Option(fwPassedSchema))
+
+    JdbcUtils.tableExists(conn, options) match {
+      case true =>
+        logInfo("***dsv2-flows*** Table exists" )
+        Utils.strictSchemaCheck(fwPassedSchema)
+        logInfo("***dsv2-flows*** schema check done. Good to go." )
+      case _ =>
+        logInfo("***dsv2-flows*** Table does not exists." )
+        // TODO : Check scemantics, Raise exception Or Create it.
+        Utils.createTable(fwPassedSchema)
+    }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCWriteBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCWriteBuilder.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.jdbc
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.sources.v2.writer.{BatchWrite, WriteBuilder}
+import org.apache.spark.sql.types.StructType
+
+class JDBCWriteBuilder extends WriteBuilder with Logging{
+
+  override def withQueryId(queryId: String): WriteBuilder = {
+    logInfo("***dsv2-flows*** withQueryId called with queryId" + queryId)
+    this
+  }
+
+  override def withInputDataSchema(schema: StructType): WriteBuilder = {
+    logInfo("***dsv2-flows*** withInputDataSchema called with schema" + schema.printTreeString())
+    this
+  }
+
+  override def buildForBatch : BatchWrite = {
+    logInfo("***dsv2-flows*** BatchWrite called")
+    new JDBCBatchWrite()
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCWriteBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCWriteBuilder.scala
@@ -88,26 +88,12 @@ class JDBCWriteBuilder(options: JdbcOptionsInWrite,
   }
 
   def processAppend() : Unit = {
-    /* Append table logic
-     * 1. Check is table exists. Create if not. Step4.
-     * 2. If table exists and schema does not match, raise exception.
-     * 3. If table exists and schema match. Step4
-     * 4. Send to executors for data insert
+    /* Append table logic : If we have reached this far, table exist and schema check is done.
+     * So processappend does nothing here. just sends request to executors for data insert
      */
     logInfo("***dsv2-flows*** Append to table")
     // log schemas received.
     Utils.logSchema("userSchema", userSchema)
     Utils.logSchema("fwPassedSchema", Option(fwPassedSchema))
-
-    JdbcUtils.tableExists(conn, options) match {
-      case true =>
-        logInfo("***dsv2-flows*** Table exists" )
-        Utils.strictSchemaCheck(fwPassedSchema)
-        logInfo("***dsv2-flows*** schema check done. Good to go." )
-      case _ =>
-        logInfo("***dsv2-flows*** Table does not exists." )
-        // TODO : Check scemantics, Raise exception Or Create it.
-        Utils.createTable(fwPassedSchema)
-    }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCWriteBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCWriteBuilder.scala
@@ -64,11 +64,12 @@ class JDBCWriteBuilder(options: JdbcOptionsInWrite,
   override def overwrite(filters: Array[Filter]): WriteBuilder = {
     logInfo("***dsv2-flows*** overwrite called ")
     writeMode = SaveMode.Overwrite
+    for(filter <- filters) logInfo(s"***dsv2-flows*** overwrite filter is $filter")
     this
   }
 
   override def truncate(): WriteBuilder = {
-    logInfo("***dsv2-flows*** overwrite called ")
+    logInfo("***dsv2-flows*** truncate called ")
     writeMode = SaveMode.Overwrite
     isTruncate = true
     this
@@ -83,7 +84,7 @@ class JDBCWriteBuilder(options: JdbcOptionsInWrite,
 
         check filters.
     */
-    logInfo("***dsv2-flows*** Overwrite table with new schema")
+    logInfo("***dsv2-flows*** processOverwrite called")
     false
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCWriteBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCWriteBuilder.scala
@@ -84,9 +84,9 @@ class JDBCWriteBuilder(options: JdbcOptionsInWrite,
 
       case false =>
         logInfo("***dsv2-flows*** Dropping Table")
-        // JdbcUtils.dropTable(conn, options.table, options)
+        JdbcUtils.dropTable(conn, options.table, options)
         logInfo("***dsv2-flows*** Recreating table with passed schema")
-        Utils.createTable(conn, fwPassedSchema)
+        JdbcUtils.createTable(conn, fwPassedSchema, options)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCWriteBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCWriteBuilder.scala
@@ -75,17 +75,19 @@ class JDBCWriteBuilder(options: JdbcOptionsInWrite,
     this
   }
 
-  def processOverwrite() : Boolean = {
-    /* Overwrite table logic
-        1. Check if table exists. If not create it here. Should create be done??
-        2. If table exists and isTruncate, then just truncate existing table
-        3. If table exists and !isTruncate, then recreate table with new schema
-        Post table creation, send requests to executors to insert data.
-
-        check filters.
-    */
+  def processOverwrite() : Unit = {
     logInfo("***dsv2-flows*** processOverwrite called")
-    false
+    isTruncate match {
+      case true =>
+        logInfo("***dsv2-flows*** truncating Table")
+        JdbcUtils.truncateTable(conn, options)
+
+      case false =>
+        logInfo("***dsv2-flows*** Dropping Table")
+        // JdbcUtils.dropTable(conn, options.table, options)
+        logInfo("***dsv2-flows*** Recreating table with passed schema")
+        Utils.createTable(conn, fwPassedSchema)
+    }
   }
 
   def processAppend() : Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/Readme.md
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/Readme.md
@@ -15,9 +15,20 @@ Status -> WIP ( Work in Progress), ReadyForReview, Done
 - Working branch is https://github.com/shivsood/spark-dsv2
 - Intrested in contribution? Add work item and your name against it and party on.
 
-## Major issues/mentions
+## Issues/Questions/Mentions
+- mode(overwrite) - what's the overwrite semantics in V2?
+  V1 overwrite will create a table if that does not exist. In V2 it seems that overwrite does not support
+  create semantics. overwrite with a non-existing table failed following tables:schema() which returned null
+  schema indicating no existing table. If not create scematics, then what's the diffrence between append
+  and overwrite without column filters.
+- mode(overwrite) - why overwrite results in call to truncate(). Was expecting call to overwrite() instead.
+- mode(append) - what's the append semantics in V2.
+  V1 append would throw an exception if the df col types are not same as table schema. Is that in v2
+  achieved by Table::schema? schema returns source schema (as in db) and framework checks if the source schema is
+  compatible with the dataframe type. Tested diffirence is number of cols and framework would raise an exception ,
+  but diffrence in data type did not raise any exception.
 - Lots of trivial logging. Draft implementation with API understanding as main goal
 
-Update date : 7/19
+Update date : 7/22
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/Readme.md
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/Readme.md
@@ -5,7 +5,7 @@
 |-----------------------------------------------| ----------- | ------ |
 | Batch write ( append, overwrite, truncate)    | shivsood    | WIP    |
 | Streaming write                               | TBD         |        |
-| Read path implementation                      | TBD         |        |
+| Read path implementation                      | shivsood    | WIP    |
 | Streaming read                                | TBD         |        |
 | ??                                            | TBD         |        |
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/Readme.md
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/Readme.md
@@ -1,0 +1,23 @@
+# Plan/Status of ongoing work on DataSource V2 JDBC connector
+
+## Plan
+| Work Item                                     | Who's on it | Status |
+|-----------------------------------------------| ----------- | ------ |
+| Batch write ( append, overwrite, truncate)    | shivsood    | WIP    |
+| Streaming write                               | TBD         |        |
+| Read path implementation                      | TBD         |        |
+| Streaming read                                | TBD         |        |
+| ??                                            | TBD         |        |
+
+Status -> WIP ( Work in Progress), ReadyForReview, Done
+
+## Others
+- Working branch is https://github.com/shivsood/spark-dsv2
+- Intrested in contribution? Add work item and your name against it and party on.
+
+## Major issues/mentions
+- Lots of trivial logging. Draft implementation with API understanding as main goal
+
+Update date : 7/19
+
+

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/Readme.md
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/Readme.md
@@ -3,25 +3,25 @@
 ## Plan
 | Work Item                                     | Who's on it | Status  | Notes  |
 |-----------------------------------------------| ----------- | ------  | -----  |
-| Batch write ( append)                         | shivsood    | WIP     | 1,6    |
-| Batch write ( overwrite w truncate)           | shivsood    | WIP     |        |
-| Batch write ( overwrite w/o truncate)         | shivsood    | WIP     | 2,3    |
+| Batch write ( append)                         | shivsood    | Done    | 1,6    |
+| Batch write ( overwrite w truncate)           | shivsood    | Done    |        |
+| Batch write ( overwrite w/o truncate)         | shivsood    | Issues  | 2,3    |
 | Read  implementation w/o column pruning       | shivsood    | Done    |        |
-| Read  w/o column pruning and filters          | shivsood    | ISSUES  | 4      |
+| Read  w/o column pruning and filters          | shivsood    | Issues  | 4      |
 | Columnar read                                 | TBD         |         |        |
 | Streaming write                               | TBD         |         |        |
 | Streaming read                                | TBD         |         |        |
-| Transactional write                           | shivsood    | ISSUES  | 5      |
+| Transactional write                           | shivsood    | Issues  | 5      |
 
 
 Status ->
 WIP ( Work in Progress),
 DONE ( implementation is done and tested),
-ISSUES (blocking issues)
+Issues (blocking issues)
 
 ## Others
 - Working branch is https://github.com/shivsood/spark-dsv2
-- Intrested in contribution? Add work item and your name against it and party on.
+- Interested in contribution? Add work item and your name against it and party on.
 
 ## Notes
 1. mode(append) - what's the append semantics in V2.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/Readme.md
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/Readme.md
@@ -8,16 +8,19 @@
 | Batch write ( overwrite w/o truncate)         | shivsood    | Issues  | 2,3    |
 | Read  implementation w/o column pruning       | shivsood    | Done    |        |
 | Read  w/o column pruning and filters          | shivsood    | Issues  | 4      |
+| Transactional write                           | shivsood    | Blocked | 5      |
+| Batch write with Filters                      | TBD         |         |        |
 | Columnar read                                 | TBD         |         |        |
 | Streaming write                               | TBD         |         |        |
 | Streaming read                                | TBD         |         |        |
-| Transactional write                           | shivsood    | Issues  | 5      |
+
 
 
 Status ->
 WIP ( Work in Progress),
 DONE ( implementation is done and tested),
-Issues (blocking issues)
+Issues (Problems that need resolution)
+Blocked ( B
 
 ## Others
 - Working branch is https://github.com/shivsood/spark-dsv2
@@ -42,6 +45,8 @@ Issues (blocking issues)
    //df2.select("i").show(10) after df.read.format("jdbc2") c.f test("JDBCV2 read test")
    in MsSqlServerIntegrationSuite
    Error seen as below
+   
+   ``
    19/07/31 15:20:55 INFO DBPartitionReader: ***dsv2-flows*** close called. number of rows retrieved is 0
    19/07/31 15:20:55 ERROR Executor: Exception in task 0.0 in stage 4.0 (TID 4)
    com.microsoft.sqlserver.jdbc.SQLServerException: The index 2 is out of range.
@@ -49,7 +54,8 @@ Issues (blocking issues)
    	at com.microsoft.sqlserver.jdbc.SQLServerResultSet.verifyValidColumnIndex(SQLServerResultSet.java:570)
    	at com.microsoft.sqlserver.jdbc.SQLServerResultSet.getterGetColumn(SQLServerResultSet.java:2012)
    	at com.microsoft.sqlserver.jdbc.SQLServerResultSet.getValue(SQLServerResultSet.java:2041)
-
+   ``
+   
 5. Transactional write - Does not seem feasible with the current FW. The FW suggest that executor send a commit message
    to Driver, and actual commit should only be done by the driver after receiving all commit confirmations. Dont see
    this feasible in JDBC as commit has to happen in JDBCConnection which is maintained by the TASKs and JDBCConnection

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/Readme.md
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/Readme.md
@@ -1,34 +1,71 @@
 # Plan/Status of ongoing work on DataSource V2 JDBC connector
 
 ## Plan
-| Work Item                                     | Who's on it | Status |
-|-----------------------------------------------| ----------- | ------ |
-| Batch write ( append, overwrite, truncate)    | shivsood    | WIP    |
-| Streaming write                               | TBD         |        |
-| Read path implementation                      | shivsood    | WIP    |
-| Streaming read                                | TBD         |        |
-| ??                                            | TBD         |        |
+| Work Item                                     | Who's on it | Status  | Notes  |
+|-----------------------------------------------| ----------- | ------  | -----  |
+| Batch write ( append)                         | shivsood    | WIP     | 1,6    |
+| Batch write ( overwrite w truncate)           | shivsood    | WIP     |        |
+| Batch write ( overwrite w/o truncate)         | shivsood    | WIP     | 2,3    |
+| Read  implementation w/o column pruning       | shivsood    | Done    |        |
+| Read  w/o column pruning and filters          | shivsood    | ISSUES  | 4      |
+| Columnar read                                 | TBD         |         |        |
+| Streaming write                               | TBD         |         |        |
+| Streaming read                                | TBD         |         |        |
+| Transactional write                           | shivsood    | ISSUES  | 5      |
 
-Status -> WIP ( Work in Progress), ReadyForReview, Done
+
+Status ->
+WIP ( Work in Progress),
+DONE ( implementation is done and tested),
+ISSUES (blocking issues)
 
 ## Others
 - Working branch is https://github.com/shivsood/spark-dsv2
 - Intrested in contribution? Add work item and your name against it and party on.
 
-## Issues/Questions/Mentions
-- mode(overwrite) - what's the overwrite semantics in V2?
+## Notes
+1. mode(append) - what's the append semantics in V2.
+  V1 append would throw an exception if the df col types are not same as table schema. Is that in v2
+  achieved by Table::schema? schema returns source schema (as in db) and framework checks if the source schema is
+  compatible with the dataframe type. Tested diff is number of cols and framework would raise an exception ,
+  but diff in data type did not raise any exception.
+2. mode(overwrite) - what's the overwrite semantics in V2?
   V1 overwrite will create a table if that does not exist. In V2 it seems that overwrite does not support
   create semantics. overwrite with a non-existing table failed following tables:schema() which returned null
   schema indicating no existing table. If not create scematics, then what's the diffrence between append
   and overwrite without column filters.
-- mode(overwrite) - why overwrite results in call to truncate(). Was expecting call to overwrite() instead.
-- mode(append) - what's the append semantics in V2.
-  V1 append would throw an exception if the df col types are not same as table schema. Is that in v2
-  achieved by Table::schema? schema returns source schema (as in db) and framework checks if the source schema is
-  compatible with the dataframe type. Tested diffirence is number of cols and framework would raise an exception ,
-  but diffrence in data type did not raise any exception.
+3. mode(overwrite) - why overwrite results in call to WriteBuilder::truncate(). Was expecting call to
+   overwrite() instead. Same issues even if option("truncate","false") is explicitly specified during df.write.
+   OverwriteByExpressionExec::execute() in WriteToDatasourceV2Exec.scala does overwrite only when
+   filters are present. No clear why.
+4. Read with column pruning fails with makeFromDriverError
+   //df2.select("i").show(10) after df.read.format("jdbc2") c.f test("JDBCV2 read test")
+   in MsSqlServerIntegrationSuite
+   Error seen as below
+   19/07/31 15:20:55 INFO DBPartitionReader: ***dsv2-flows*** close called. number of rows retrieved is 0
+   19/07/31 15:20:55 ERROR Executor: Exception in task 0.0 in stage 4.0 (TID 4)
+   com.microsoft.sqlserver.jdbc.SQLServerException: The index 2 is out of range.
+   	at com.microsoft.sqlserver.jdbc.SQLServerException.makeFromDriverError(SQLServerException.java:228)
+   	at com.microsoft.sqlserver.jdbc.SQLServerResultSet.verifyValidColumnIndex(SQLServerResultSet.java:570)
+   	at com.microsoft.sqlserver.jdbc.SQLServerResultSet.getterGetColumn(SQLServerResultSet.java:2012)
+   	at com.microsoft.sqlserver.jdbc.SQLServerResultSet.getValue(SQLServerResultSet.java:2041)
+
+5. Transactional write - Does not seem feasible with the current FW. The FW suggest that executor send a commit message
+   to Driver, and actual commit should only be done by the driver after receiving all commit confirmations. Dont see
+   this feasible in JDBC as commit has to happen in JDBCConnection which is maintained by the TASKs and JDBCConnection
+   is not serializable that it can be sent to the Driver.
+   A slightly better solution may be a 2-way commit. Executors send a 'ReadyToCommit' to Driver. Driver having received
+   all 'ReadyToCommit' messages from executors should then send "Commit" to all executors again and then executors
+   can commit.
+
+6. write flow - currently auto commits. This needs a fix ( set autocommit in JDBC connection to false and
+   then commit it batches)
+
+7. Bulk write - no provision for writing rows in bulk. Rows are provided one at a time.
+
+
 - Lots of trivial logging. Draft implementation with API understanding as main goal
 
-Update date : 7/22
+Update date : 7/31
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/Utils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/Utils.scala
@@ -50,9 +50,4 @@ object Utils extends Logging{
     // TODO : Raise exception if fwPassedSchema is not same as schemaInDB.
     schemaInSpark
   }
-
-
-
-
-
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/Utils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/Utils.scala
@@ -17,14 +17,16 @@
 
 package org.apache.spark.sql.execution.datasources.v2.jdbc
 
-import java.sql.{Connection, PreparedStatement}
+import java.sql.{Connection, PreparedStatement, ResultSet}
 
+import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.execution.datasources.jdbc.{JdbcOptionsInWrite, JdbcUtils}
+import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JdbcOptionsInWrite, JdbcUtils}
 import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils.{getCommonJDBCType, getJdbcType}
 import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcDialects, JdbcType}
+import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.{BooleanType, ByteType, DataType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, StructType}
 
 /* Misc utils
@@ -57,5 +59,53 @@ object Utils extends Logging{
       throw new AnalysisException(
         s"Schema does not match with that with the database table")
     }
+  }
+  def colList(cols: StructType): String = {
+    // TODO: column names in quotes
+    cols match {
+      case null =>
+        logInfo(s"***dsv2-flows*** prunedCols is NULL")
+        logInfo(s"***dsv2-flows*** returning * ")
+        "*"
+      case _ =>
+        logInfo(s"***dsv2-flows*** prunedCols is NULL")
+        val colArr = cols.names
+        colArr.length match {
+          case 0 =>
+            logInfo(s"***dsv2-flows*** returning *")
+            "*"
+          case _ => colArr.mkString(",")
+        }
+    }
+  }
+
+  def filterList(filters: Array[Filter]) : String = {
+    // TODO: Support for filters
+    ""
+  }
+
+  def createSelectStmt(prunedCols: StructType,
+                       filters: Array[Filter],
+                       table: String): String = {
+    val cols = colList(prunedCols)
+    val filtersToAdd = filterList(filters)
+    val selectStmt = s"SELECT $cols FROM $table $filtersToAdd"
+    logInfo(s"***dsv2-flows*** selectStmt is $selectStmt")
+    selectStmt
+  }
+
+  def executeSelect(options: JDBCOptions, prunedCols: StructType,
+                    filters: Array[Filter], schema : StructType): Iterator[InternalRow] = {
+    val stmtString = createSelectStmt(prunedCols, filters, options.tableOrQuery)
+    logInfo(s"***dsv2-flows*** executeStmt is $stmtString")
+    // TODO : Why we do need the inputMetric here.
+    val inputMetrics = TaskContext.get.taskMetrics().inputMetrics
+    val conn = JdbcUtils.createConnectionFactory(options)()
+    val stmt = conn.prepareStatement(stmtString,
+      ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)
+    stmt.setFetchSize(options.fetchSize)
+    stmt.setQueryTimeout(options.queryTimeout)
+    val rs = stmt.executeQuery()
+    JdbcUtils.resultSetToSparkInternalRows(rs, schema, inputMetrics)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/Utils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/Utils.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.datasources.v2.jdbc
 import java.sql.{Connection, PreparedStatement}
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.jdbc.{JdbcOptionsInWrite, JdbcUtils}
 import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils.{getCommonJDBCType, getJdbcType}
@@ -46,8 +47,15 @@ object Utils extends Logging{
      */
   }
 
-  def strictSchemaCheck(schemaInSpark: StructType) : StructType = {
+  def strictSchemaCheck(schemaInSpark: StructType, dbTableSchema: StructType) : Boolean = {
     // TODO : Raise exception if fwPassedSchema is not same as schemaInDB.
-    schemaInSpark
+    if (schemaInSpark == dbTableSchema) {
+      logInfo(s"***dsv2-flows*** strictSchemaCheck passed" )
+      true
+    } else {
+      logInfo(s"***dsv2-flows*** schema check failed" )
+      throw new AnalysisException(
+        s"Schema does not match with that with the database table")
+    }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/Utils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/Utils.scala
@@ -17,40 +17,42 @@
 
 package org.apache.spark.sql.execution.datasources.v2.jdbc
 
-import java.io.IOException
 import java.sql.{Connection, PreparedStatement}
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JdbcOptionsInWrite, JdbcUtils}
-import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils._
+import org.apache.spark.sql.execution.datasources.jdbc.{JdbcOptionsInWrite, JdbcUtils}
+import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils.{getCommonJDBCType, getJdbcType}
 import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcDialects, JdbcType}
-import org.apache.spark.sql.sources.v2.writer.{DataWriter, WriterCommitMessage}
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.{BooleanType, ByteType, DataType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, StructType}
 
-class JDBCDataWriter(options: JdbcOptionsInWrite,
-                     jdbcConn: Connection, schema: StructType)
-  extends DataWriter[InternalRow] with Logging{
-  @throws[IOException]
-  def write(record: InternalRow): Unit = {
-    logInfo("***dsv2-flows*** write " )
-    JdbcUtils.saveRow(jdbcConn, record, options, schema)
+/* Misc utils
+
+ */
+object Utils extends Logging{
+  def logSchema(prefix: String, schema: Option[StructType]) : Unit = {
+    schema match {
+      case Some(i) =>
+        val schemaString = i.printTreeString()
+        logInfo(s"***dsv2-flows*** $prefix schema exists" )
+        logInfo(s"***dsv2-flows*** $prefix schemaInDB schema is $schemaString")
+      case None =>
+        logInfo(s"***dsv2-flows*** $prefix schemaInDB schema is None" )
+    }
   }
 
-  @throws[IOException]
-  def commit: WriterCommitMessage = {
-    logInfo("***dsv2-flows*** commit called " )
-    JDBCWriterCommitMessage
+  def createTable(structType: StructType): Unit = {
+    /* Create table per passed schema. Raise exception on any failure.
+     */
   }
 
-  @throws[IOException]
-  def abort(): Unit = {
-    logInfo("***dsv2-flows*** abort called " )
+  def strictSchemaCheck(schemaInSpark: StructType) : StructType = {
+    // TODO : Raise exception if fwPassedSchema is not same as schemaInDB.
+    schemaInSpark
   }
 
-}
 
-object JDBCWriterCommitMessage extends WriterCommitMessage {
-  val commitMessage: String = "committed"
+
+
+
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/Utils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/Utils.scala
@@ -44,9 +44,10 @@ object Utils extends Logging{
     }
   }
 
-  def createTable(structType: StructType): Unit = {
+  def createTable(conn : Connection, structType: StructType): Unit = {
     /* Create table per passed schema. Raise exception on any failure.
      */
+    logInfo(s"***dsv2-flows*** Create Table is not implemented as yet!!" )
   }
 
   def strictSchemaCheck(schemaInSpark: StructType, dbTableSchema: StructType) : Boolean = {


### PR DESCRIPTION
## What changes were proposed in this pull request?
This is a Work in Progress PR for DataSourceV2 based connector for JDBC. The goal is a MVP for both read and write path based on latest data source V2 apis. As of now the PR is *not* complete, but provided here for visibility on this work and comments to set us in the right direction. 

Another PR on related work is https://github.com/apache/spark/pull/21861. That uses older V2 apis, but some of the work there may be still relevant. Have requested author to consider merge if possible. 
@tengpeng @xianyin as FYI as they volunteered for contribution to the work going forward.

Readme.md added for high level work items. Find it at org/apache/spark/sql/execution/datasources/v2/jdbc/Readme.md

(Please fill in changes proposed in this fix)
The current PR implements the following ( will keep this updated we make progress on this)
- Scaffolding for read/write paths.
- First draft implementation of dataframe write(append) flow. Connector name is "jdbcv2". df.write.format("jdbcv2").mode("append") appends to Table if table exists. Create table not supported as of now.
- E2E test cases added in MsSqlServerIntegrationSuite.scala
- JDBCUtils is reused as and when easiliy possible, but further scope of refactoring to make it work for both V1 and V2 flows.

## How was this patch tested?
- Validation with SQLServer 2017 only.
- No unit test cases added for now.

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
The path was mainly integration tested for write ( append) path.

Please review https://spark.apache.org/contributing.html before opening a pull request.
