### PR TITLE
[SPARK-28189][SQL][FOLLOW-UP] Remove the unnecessary test in DataFrameSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -585,14 +585,6 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
       checkAnswer(df2, testData.selectExpr("value"))
       assert(df2.schema.map(_.name) === Seq("value"))
     }
-
-    // With SQL config caseSensitive ON, AnalysisException should be thrown
-    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
-      val e = intercept[AnalysisException] {
-        testData("KEY")
-      }.getMessage
-      assert(e.contains("Cannot resolve column name"))
-    }
   }
 
   test("drop unknown column (no-op) with column reference") {


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr is to remove the unnecessary test  in DataFrameSuite.

## How was this patch tested?
N/A