### PR TITLE
[SPARK-28466][SQL] fix sts FileSystem closed error when to call Hive.moveFile

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -819,18 +819,6 @@ private[hive] class HiveClientImpl(
     }
   }
 
-  def checkFSClose(loadPath: String): Unit ={
-    try {
-      SessionState.get.getHdfsEncryptionShim.isPathEncrypted(new Path(loadPath))
-    } catch {
-      case e: Exception =>
-        logWarning("Origin FileSystem closed", e)
-        val field = SessionState.get().getClass.getDeclaredField("hdfsEncryptionShim")
-        field.setAccessible(true)
-        field.set(SessionState.get(), null)
-    }
-  }
-
   def loadPartition(
       loadPath: String,
       dbName: String,
@@ -840,7 +828,6 @@ private[hive] class HiveClientImpl(
       inheritTableSpecs: Boolean,
       isSrcLocal: Boolean): Unit = withHiveState {
     val hiveTable = client.getTable(dbName, tableName, true /* throw exception */)
-    checkFSClose(loadPath)
     shim.loadPartition(
       client,
       new Path(loadPath), // TODO: Use URI
@@ -857,7 +844,6 @@ private[hive] class HiveClientImpl(
       tableName: String,
       replace: Boolean,
       isSrcLocal: Boolean): Unit = withHiveState {
-    checkFSClose(loadPath)
     shim.loadTable(
       client,
       new Path(loadPath),
@@ -874,7 +860,6 @@ private[hive] class HiveClientImpl(
       replace: Boolean,
       numDP: Int): Unit = withHiveState {
     val hiveTable = client.getTable(dbName, tableName, true /* throw exception */)
-    checkFSClose(loadPath)
     shim.loadDynamicPartitions(
       client,
       new Path(loadPath),

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -167,7 +167,7 @@ private[client] sealed abstract class Shim {
     klass.getMethod(name, args: _*)
   }
 
-  protected def checkFSClose(loadPath: Path): Unit ={
+  protected def checkFSClose(loadPath: Path): Unit = {
     try {
       SessionState.get.getHdfsEncryptionShim.isPathEncrypted(loadPath)
     } catch {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When we close a session of STS, if this session has done some SQL about insert, then other session do CTAS/INSERT and trigger Hive.moveFile, DFSClient will do checkOpen and throw java.io.IOException: Filesystem closed.

**Root cause** :
When we first execut SQL like CTAS/INSERT,  it will call Hive.moveFile, during this method, it will initialize this field SessionState.hdfsEncryptionShim , when initialize this field, it will initialize a FS.
![image](https://user-images.githubusercontent.com/46485123/61587025-45802600-abb4-11e9-9926-6817f52490a3.png)

But this FS is under current HiveSessionImpleWithUgi.sessionUgi, so when we close this session, it will call `FileSystem.closeForUgi()`, above FileSystem will be closed, then during other session execute SQL like CTAS/INSERT,  such error will happen since FS has been close. 

Some one may be confused why HiveServer2 won't appear this problem : 

- In HiveServer2, each session has it's own SessionState, so close current session's FS is ok.
- In SparkThriftServer, all session interact with hive through one HiveClientImpl, it has only one SessionState, when we call method with HiveClientImpl, it will call **withHiveState** first to set HiveClientImpl's sessionState to current Thread.

## How was this patch tested?

manual tested 