### PR TITLE
[SPARK-28465][K8s] Fix integration tests which fail due to missing ceph-nano image

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DepsTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DepsTestsSuite.scala
@@ -41,7 +41,7 @@ private[spark] trait DepsTestsSuite { k8sSuite: KubernetesSuite =>
 
   private def getCephContainer(): Container = {
     val envVars = Map ( "NETWORK_AUTO_DETECT" -> "4",
-      "RGW_CIVETWEB_PORT" -> "8000",
+      "RGW_FRONTEND_PORT" -> "8000",
       "SREE_PORT" -> "5001",
       "CEPH_DEMO_UID" -> "nano",
       "CEPH_DAEMON" -> "demo",
@@ -63,7 +63,7 @@ private[spark] trait DepsTestsSuite { k8sSuite: KubernetesSuite =>
     ).asJava
 
     new ContainerBuilder()
-      .withImage("ceph/daemon:v4.0.0-stable-4.0-master-centos-7-x86_64")
+      .withImage("ceph/daemon:latest")
       .withImagePullPolicy("Always")
       .withName(cName)
       .withPorts(new ContainerPortBuilder()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes the tests. Follows instructions here: https://github.com/ceph/cn/issues/115#issuecomment-497384369
## How was this patch tested?

Manually by running the tests with minikube.