### PR TITLE
[SPARK-28467][CORE][TEST] Increase timeout to up executors for tests

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -761,7 +761,8 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
       sc = new SparkContext(conf)
 
       // Ensure all executors has started
-      TestUtils.waitUntilExecutorsUp(sc, 1, 10000)
+      // if the machine is busy, the executor can't up under 10000ms, increase to 30000ms
+      TestUtils.waitUntilExecutorsUp(sc, 1, 30000)
       assert(sc.resources.size === 1)
       assert(sc.resources.get(GPU).get.addresses === Array("5", "6"))
       assert(sc.resources.get(GPU).get.name === "gpu")
@@ -789,7 +790,8 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
       sc = new SparkContext(conf)
 
       // Ensure all executors has started
-      TestUtils.waitUntilExecutorsUp(sc, 1, 10000)
+      // if the machine is busy, the executor can't up under 10000ms, increase to 30000ms
+      TestUtils.waitUntilExecutorsUp(sc, 1, 30000)
       // driver gpu resources file should take precedence over the script
       assert(sc.resources.size === 1)
       assert(sc.resources.get(GPU).get.addresses === Array("0", "1", "8"))


### PR DESCRIPTION
[SPARK-28467][CORE] Increase timeout to up executors for tests

We use arm instance of vexxhost cloud to run the test, the flavor of the arm instance is 8C8G. And we ran the tests for several times(everytime the instance is new created) and the executor(2 required in test) can't up under 10000ms. The two tests mentioned in [SPARK-28467] is always failed due to timeout(now only these two tests failed due this reason):
test driver discovery under local-cluster mode *** FAILED ***
java.util.concurrent.TimeoutException: Can't find 1 executors before 10000 milliseconds elapsed
......
test gpu driver resource files and discovery under local-cluster mode *** FAILED ***
java.util.concurrent.TimeoutException: Can't find 1 executors before 10000 milliseconds elapsed
......

And the environment is: Linux ubuntu 4.15.0-46-generic #4916.04.1-Ubuntu SMP Tue Feb 12 17:45:52 UTC 2019 aarch64 aarch64 aarch64 GNU/Linux
The timeout doen't work well before, see [SPARK-7989] and [SPARK-10651]. I can't find the principle of the timeout setting, we set it to 20000, because we found the time is about 13000ms then the second executor(2 required in test) can up on our arm testing instances.

This fixes following the solution of [SPARK-7989] and [SPARK-10651].

