### PR TITLE
[SPARK-28472][SQL][TEST] Add test for thriftserver protocol versions

### DIFF
--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkThriftServerProtocolVersionsSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkThriftServerProtocolVersionsSuite.scala
@@ -68,7 +68,7 @@ class SparkThriftServerProtocolVersionsSuite extends HiveThriftServer2Test {
     }
   }
 
-  ThriftserverShimUtils.testedProtocalVersions.foreach { version =>
+  ThriftserverShimUtils.testedProtocolVersions.foreach { version =>
     test(s"$version get byte type") {
       testWithProtocolVersion(version, "SELECT cast(1 as byte)") { rs =>
         assert(rs.next())

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkThriftServerProtocolVersionsSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkThriftServerProtocolVersionsSuite.scala
@@ -53,6 +53,7 @@ class SparkThriftServerProtocolVersionsSuite extends HiveThriftServer2Test {
       val protocol = connection.getClass.getDeclaredField("protocol")
       protocol.setAccessible(true)
       protocol.set(connection, version)
+      assert(connection.getProtocol === version)
 
       rs = new HiveQueryResultSet.Builder(connection)
         .setClient(client)
@@ -111,13 +112,13 @@ class SparkThriftServerProtocolVersionsSuite extends HiveThriftServer2Test {
       }
     }
 
-    // TODO: active this test case after SPARK-28463 and SPARK-26969
-    // test(s"$version get decimal value") {
-    //   testWithProtocolVersion(version, "SELECT cast(1 as decimal(18, 2)) as c") { rs =>
-    //     assert(rs.next())
-    //     assert(rs.getBigDecimal(1) === new java.math.BigDecimal("1.00"))
-    //   }
-    // }
+    // TODO: enable this test case after SPARK-28463 and SPARK-26969
+    ignore(s"$version get decimal value") {
+      testWithProtocolVersion(version, "SELECT cast(1 as decimal(18, 2)) as c") { rs =>
+        assert(rs.next())
+        assert(rs.getBigDecimal(1) === new java.math.BigDecimal("1.00"))
+      }
+    }
 
     test(s"$version get string value") {
       testWithProtocolVersion(version, "SELECT 'str'") { rs =>
@@ -126,13 +127,13 @@ class SparkThriftServerProtocolVersionsSuite extends HiveThriftServer2Test {
       }
     }
 
-    // TODO: active this test case after SPARK-28474
-    // test(s"$version get binary value") {
-    //   testWithProtocolVersion(version, "SELECT cast('ABC' as binary)") { rs =>
-    //     assert(rs.next())
-    //     assert(rs.getObject(1) === "ABC".getBytes(StandardCharsets.UTF_8))
-    //   }
-    // }
+    // TODO: enable this test case after SPARK-28474
+    ignore(s"$version get binary value") {
+      testWithProtocolVersion(version, "SELECT cast('ABC' as binary)") { rs =>
+        assert(rs.next())
+        assert(rs.getString(1) === "ABC")
+      }
+    }
 
     test(s"$version get boolean value") {
       testWithProtocolVersion(version, "SELECT true") { rs =>
@@ -158,28 +159,28 @@ class SparkThriftServerProtocolVersionsSuite extends HiveThriftServer2Test {
     test(s"$version get void") {
       testWithProtocolVersion(version, "SELECT null") { rs =>
         assert(rs.next())
-        assert(rs.getObject(1) === null)
+        assert(rs.getString(1) === null)
       }
     }
 
-    test(s"$version get array") {
+    test(s"$version get array value") {
       testWithProtocolVersion(version, "SELECT array(1, 2)") { rs =>
         assert(rs.next())
-        assert(rs.getObject(1) === "[1,2]")
+        assert(rs.getString(1) === "[1,2]")
       }
     }
 
-    test(s"$version get map") {
+    test(s"$version get map value") {
       testWithProtocolVersion(version, "SELECT map(1, 2)") { rs =>
         assert(rs.next())
-        assert(rs.getObject(1) === "{1:2}")
+        assert(rs.getString(1) === "{1:2}")
       }
     }
 
-    test(s"$version get struct") {
+    test(s"$version get struct value") {
       testWithProtocolVersion(version, "SELECT struct('alpha' AS A, 'beta' AS B)") { rs =>
         assert(rs.next())
-        assert(rs.getObject(1) === """{"A":"alpha","B":"beta"}""")
+        assert(rs.getString(1) === """{"A":"alpha","B":"beta"}""")
       }
     }
   }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkThriftServerProtocolVersionsSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkThriftServerProtocolVersionsSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.hive.thriftserver
 
-import java.nio.charset.StandardCharsets
 import java.sql.{Date, Timestamp}
 import java.util.Properties
 
@@ -70,42 +69,42 @@ class SparkThriftServerProtocolVersionsSuite extends HiveThriftServer2Test {
   }
 
   ThriftserverShimUtils.testedProtocalVersions.foreach { version =>
-    test(s"$version get byte value") {
+    test(s"$version get byte type") {
       testWithProtocolVersion(version, "SELECT cast(1 as byte)") { rs =>
         assert(rs.next())
         assert(rs.getByte(1) === 1.toByte)
       }
     }
 
-    test(s"$version get short value") {
+    test(s"$version get short type") {
       testWithProtocolVersion(version, "SELECT cast(1 as short)") { rs =>
         assert(rs.next())
         assert(rs.getShort(1) === 1.toShort)
       }
     }
 
-    test(s"$version get int value") {
+    test(s"$version get int type") {
       testWithProtocolVersion(version, "SELECT 1") { rs =>
         assert(rs.next())
         assert(rs.getInt(1) === 1)
       }
     }
 
-    test(s"$version get bigint value") {
+    test(s"$version get bigint type") {
       testWithProtocolVersion(version, "SELECT cast(1 as bigint)") { rs =>
         assert(rs.next())
         assert(rs.getLong(1) === 1L)
       }
     }
 
-    test(s"$version get float value") {
+    test(s"$version get float type") {
       testWithProtocolVersion(version, "SELECT cast(1.2 as float)") { rs =>
         assert(rs.next())
         assert(rs.getFloat(1) === 1.2F)
       }
     }
 
-    test(s"$version get double value") {
+    test(s"$version get double type") {
       testWithProtocolVersion(version, "SELECT cast(1.2 as double)") { rs =>
         assert(rs.next())
         assert(rs.getDouble(1) === 1.2D)
@@ -113,71 +112,93 @@ class SparkThriftServerProtocolVersionsSuite extends HiveThriftServer2Test {
     }
 
     // TODO: enable this test case after SPARK-28463 and SPARK-26969
-    ignore(s"$version get decimal value") {
+    ignore(s"$version get decimal type") {
       testWithProtocolVersion(version, "SELECT cast(1 as decimal(18, 2)) as c") { rs =>
         assert(rs.next())
         assert(rs.getBigDecimal(1) === new java.math.BigDecimal("1.00"))
       }
     }
 
-    test(s"$version get string value") {
+    test(s"$version get string type") {
       testWithProtocolVersion(version, "SELECT 'str'") { rs =>
         assert(rs.next())
         assert(rs.getString(1) === "str")
       }
     }
 
+    test(s"$version get char type") {
+      testWithProtocolVersion(version, "SELECT cast('char-str' as char(10))") { rs =>
+        assert(rs.next())
+        assert(rs.getString(1) === "char-str")
+      }
+    }
+
+    test(s"$version get varchar type") {
+      testWithProtocolVersion(version, "SELECT cast('varchar-str' as varchar(10))") { rs =>
+        assert(rs.next())
+        assert(rs.getString(1) === "varchar-str")
+      }
+    }
+
     // TODO: enable this test case after SPARK-28474
-    ignore(s"$version get binary value") {
+    ignore(s"$version get binary type") {
       testWithProtocolVersion(version, "SELECT cast('ABC' as binary)") { rs =>
         assert(rs.next())
         assert(rs.getString(1) === "ABC")
       }
     }
 
-    test(s"$version get boolean value") {
+    test(s"$version get boolean type") {
       testWithProtocolVersion(version, "SELECT true") { rs =>
         assert(rs.next())
         assert(rs.getBoolean(1) === true)
       }
     }
 
-    test(s"$version get date value") {
+    test(s"$version get date type") {
       testWithProtocolVersion(version, "SELECT cast('2019-07-22' as date)") { rs =>
         assert(rs.next())
         assert(rs.getDate(1) === Date.valueOf("2019-07-22"))
       }
     }
 
-    test(s"$version get timestamp value") {
+    test(s"$version get timestamp type") {
       testWithProtocolVersion(version, "SELECT cast('2019-07-22 18:14:00' as timestamp)") { rs =>
         assert(rs.next())
         assert(rs.getTimestamp(1) === Timestamp.valueOf("2019-07-22 18:14:00"))
       }
     }
 
-    test(s"$version get void") {
+    // TODO: enable this test case after port HIVE-10646
+    ignore(s"$version get void") {
       testWithProtocolVersion(version, "SELECT null") { rs =>
         assert(rs.next())
         assert(rs.getString(1) === null)
       }
     }
 
-    test(s"$version get array value") {
+    // We do not fully support interval type
+    ignore(s"$version get interval type") {
+      testWithProtocolVersion(version, "SELECT interval '1' year '2' day") { rs =>
+        assert(rs.next())
+      }
+    }
+
+    test(s"$version get array type") {
       testWithProtocolVersion(version, "SELECT array(1, 2)") { rs =>
         assert(rs.next())
         assert(rs.getString(1) === "[1,2]")
       }
     }
 
-    test(s"$version get map value") {
+    test(s"$version get map type") {
       testWithProtocolVersion(version, "SELECT map(1, 2)") { rs =>
         assert(rs.next())
         assert(rs.getString(1) === "{1:2}")
       }
     }
 
-    test(s"$version get struct value") {
+    test(s"$version get struct type") {
       testWithProtocolVersion(version, "SELECT struct('alpha' AS A, 'beta' AS B)") { rs =>
         assert(rs.next())
         assert(rs.getString(1) === """{"A":"alpha","B":"beta"}""")

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkThriftServerProtocolVersionsSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkThriftServerProtocolVersionsSuite.scala
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.thriftserver
+
+import java.sql.{Date, Timestamp}
+import java.util.Properties
+
+import org.apache.hive.jdbc.{HiveConnection, HiveQueryResultSet}
+import org.apache.hive.service.auth.PlainSaslHelper
+import org.apache.hive.service.rpc.thrift.TExecuteStatementReq
+import org.apache.thrift.protocol.TBinaryProtocol
+import org.apache.thrift.transport.TSocket
+
+class SparkThriftServerProtocolVersionsSuite extends HiveThriftServer2Test {
+
+  override def mode: ServerMode.Value = ServerMode.binary
+
+  def testWithProtocolVersion(
+      version: ThriftserverShimUtils.TProtocolVersion,
+      sql: String)(f: HiveQueryResultSet => Unit): Unit = {
+    val rawTransport = new TSocket("localhost", serverPort)
+    val connection = new HiveConnection(s"jdbc:hive2://localhost:$serverPort", new Properties)
+    val user = System.getProperty("user.name")
+    val transport = PlainSaslHelper.getPlainTransport(user, "anonymous", rawTransport)
+    val client = new ThriftserverShimUtils.Client(new TBinaryProtocol(transport))
+    transport.open()
+    var rs: HiveQueryResultSet = null
+    try {
+      val clientProtocol = new ThriftserverShimUtils.TOpenSessionReq(version)
+      val openResp = client.OpenSession(clientProtocol)
+      val sessHandle = openResp.getSessionHandle
+      val execReq = new TExecuteStatementReq(sessHandle, sql)
+      val execResp = client.ExecuteStatement(execReq)
+      val stmtHandle = execResp.getOperationHandle
+
+      // Set the HiveConnection protocol to our testing protocol version.
+      // RowSetFactory uses this protocol version to construct different RowSet.
+      val protocol = connection.getClass.getDeclaredField("protocol")
+      protocol.setAccessible(true)
+      protocol.set(connection, version)
+
+      rs = new HiveQueryResultSet.Builder(connection)
+        .setClient(client)
+        .setSessionHandle(sessHandle)
+        .setStmtHandle(stmtHandle).setMaxRows(Int.MaxValue).setFetchSize(Int.MaxValue)
+        .build()
+      f(rs)
+    } finally {
+      rs.close()
+      connection.close()
+      transport.close()
+      rawTransport.close()
+    }
+  }
+
+  ThriftserverShimUtils.testedProtocalVersions.foreach { version =>
+    test(s"$version get int value") {
+      testWithProtocolVersion(version, "select 1") { rs =>
+        assert(rs.next())
+        assert(rs.getInt(1) === 1)
+      }
+    }
+
+    test(s"$version get float value") {
+      testWithProtocolVersion(version, "select cast(1.2 as float)") { rs =>
+        assert(rs.next())
+        assert(rs.getFloat(1) === 1.2F)
+      }
+    }
+
+    test(s"$version get double value") {
+      testWithProtocolVersion(version, "select cast(1.2 as double)") { rs =>
+        assert(rs.next())
+        assert(rs.getDouble(1) === 1.2D)
+      }
+    }
+
+    test(s"$version get string value") {
+      testWithProtocolVersion(version, "select 'str'") { rs =>
+        assert(rs.next())
+        assert(rs.getString(1) === "str")
+      }
+    }
+
+    // TODO: active this test case after SPARK-28463 and SPARK-26969
+    // test(s"$version get decimal value") {
+    //   testWithProtocolVersion(version, "select cast(1 as decimal(18, 2)) as c") { rs =>
+    //     assert(rs.next())
+    //     assert(rs.getBigDecimal(1) === new java.math.BigDecimal("1.00"))
+    //   }
+    // }
+
+    test(s"$version get date value") {
+      testWithProtocolVersion(version, "select cast('2019-07-22' as date)") { rs =>
+        assert(rs.next())
+        assert(rs.getDate(1) === Date.valueOf("2019-07-22"))
+      }
+    }
+
+    test(s"$version get timestamp value") {
+      testWithProtocolVersion(version, "select cast('2019-07-22 18:14:00' as timestamp)") { rs =>
+        assert(rs.next())
+        assert(rs.getTimestamp(1) === Timestamp.valueOf("2019-07-22 18:14:00"))
+      }
+    }
+  }
+}

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkThriftServerProtocolVersionsSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkThriftServerProtocolVersionsSuite.scala
@@ -18,18 +18,19 @@
 package org.apache.spark.sql.hive.thriftserver
 
 import java.sql.{Date, Timestamp}
-import java.util.Properties
+import java.util.{List => JList, Properties}
 
 import org.apache.hive.jdbc.{HiveConnection, HiveQueryResultSet}
 import org.apache.hive.service.auth.PlainSaslHelper
+import org.apache.hive.service.cli.GetInfoType
 import org.apache.thrift.protocol.TBinaryProtocol
 import org.apache.thrift.transport.TSocket
 
-class SparkThriftServerProtocolVersionsSuite extends HiveThriftServer2Test {
+class SparkThriftServerProtocolVersionsSuite extends HiveThriftJdbcTest {
 
   override def mode: ServerMode.Value = ServerMode.binary
 
-  def testWithProtocolVersion(
+  def testExecuteStatementWithProtocolVersion(
       version: ThriftserverShimUtils.TProtocolVersion,
       sql: String)(f: HiveQueryResultSet => Unit): Unit = {
     val rawTransport = new TSocket("localhost", serverPort)
@@ -68,44 +69,115 @@ class SparkThriftServerProtocolVersionsSuite extends HiveThriftServer2Test {
     }
   }
 
+  def testGetInfoWithProtocolVersion(version: ThriftserverShimUtils.TProtocolVersion): Unit = {
+    val rawTransport = new TSocket("localhost", serverPort)
+    val connection = new HiveConnection(s"jdbc:hive2://localhost:$serverPort", new Properties)
+    val transport = PlainSaslHelper.getPlainTransport(user, "anonymous", rawTransport)
+    val client = new ThriftserverShimUtils.Client(new TBinaryProtocol(transport))
+    transport.open()
+    try {
+      val clientProtocol = new ThriftserverShimUtils.TOpenSessionReq(version)
+      val openResp = client.OpenSession(clientProtocol)
+      val sessHandle = openResp.getSessionHandle
+
+      val dbVersionReq =
+        new ThriftserverShimUtils.TGetInfoReq(sessHandle, GetInfoType.CLI_DBMS_VER.toTGetInfoType)
+      val dbVersion = client.GetInfo(dbVersionReq).getInfoValue.getStringValue
+
+      val dbNameReq =
+        new ThriftserverShimUtils.TGetInfoReq(sessHandle, GetInfoType.CLI_DBMS_NAME.toTGetInfoType)
+      val dbName = client.GetInfo(dbNameReq).getInfoValue.getStringValue
+
+      assert(dbVersion === org.apache.spark.SPARK_VERSION)
+      assert(dbName === "Spark SQL")
+    } finally {
+      connection.close()
+      transport.close()
+      rawTransport.close()
+    }
+  }
+
+  def testGetTablesWithProtocolVersion(
+      version: ThriftserverShimUtils.TProtocolVersion,
+      schema: String,
+      tableNamePattern: String,
+      tableTypes: JList[String])(f: HiveQueryResultSet => Unit): Unit = {
+    val rawTransport = new TSocket("localhost", serverPort)
+    val connection = new HiveConnection(s"jdbc:hive2://localhost:$serverPort", new Properties)
+    val transport = PlainSaslHelper.getPlainTransport(user, "anonymous", rawTransport)
+    val client = new ThriftserverShimUtils.Client(new TBinaryProtocol(transport))
+    transport.open()
+    var rs: HiveQueryResultSet = null
+    try {
+      val clientProtocol = new ThriftserverShimUtils.TOpenSessionReq(version)
+      val openResp = client.OpenSession(clientProtocol)
+      val sessHandle = openResp.getSessionHandle
+      val getTableReq = new ThriftserverShimUtils.TGetTablesReq(sessHandle)
+      getTableReq.setSchemaName(schema)
+      getTableReq.setTableName(tableNamePattern)
+      getTableReq.setTableTypes(tableTypes)
+
+      val getTableResp = client.GetTables(getTableReq)
+
+      // Set the HiveConnection protocol to our testing protocol version.
+      // RowSetFactory uses this protocol version to construct different RowSet.
+      val protocol = connection.getClass.getDeclaredField("protocol")
+      protocol.setAccessible(true)
+      protocol.set(connection, version)
+      assert(connection.getProtocol === version)
+
+      rs = new HiveQueryResultSet.Builder(connection)
+        .setClient(client)
+        .setSessionHandle(sessHandle)
+        .setStmtHandle(getTableResp.getOperationHandle)
+        .build()
+      f(rs)
+    } finally {
+      rs.close()
+      connection.close()
+      transport.close()
+      rawTransport.close()
+    }
+  }
+
   ThriftserverShimUtils.testedProtocolVersions.foreach { version =>
     test(s"$version get byte type") {
-      testWithProtocolVersion(version, "SELECT cast(1 as byte)") { rs =>
+      testExecuteStatementWithProtocolVersion(version, "SELECT cast(1 as byte)") { rs =>
         assert(rs.next())
         assert(rs.getByte(1) === 1.toByte)
       }
     }
 
     test(s"$version get short type") {
-      testWithProtocolVersion(version, "SELECT cast(1 as short)") { rs =>
+      testExecuteStatementWithProtocolVersion(version, "SELECT cast(1 as short)") { rs =>
         assert(rs.next())
         assert(rs.getShort(1) === 1.toShort)
       }
     }
 
     test(s"$version get int type") {
-      testWithProtocolVersion(version, "SELECT 1") { rs =>
+      testExecuteStatementWithProtocolVersion(version, "SELECT 1") { rs =>
         assert(rs.next())
         assert(rs.getInt(1) === 1)
       }
     }
 
     test(s"$version get bigint type") {
-      testWithProtocolVersion(version, "SELECT cast(1 as bigint)") { rs =>
+      testExecuteStatementWithProtocolVersion(version, "SELECT cast(1 as bigint)") { rs =>
         assert(rs.next())
         assert(rs.getLong(1) === 1L)
       }
     }
 
     test(s"$version get float type") {
-      testWithProtocolVersion(version, "SELECT cast(1.2 as float)") { rs =>
+      testExecuteStatementWithProtocolVersion(version, "SELECT cast(1.2 as float)") { rs =>
         assert(rs.next())
         assert(rs.getFloat(1) === 1.2F)
       }
     }
 
     test(s"$version get double type") {
-      testWithProtocolVersion(version, "SELECT cast(1.2 as double)") { rs =>
+      testExecuteStatementWithProtocolVersion(version, "SELECT cast(1.2 as double)") { rs =>
         assert(rs.next())
         assert(rs.getDouble(1) === 1.2D)
       }
@@ -113,28 +185,31 @@ class SparkThriftServerProtocolVersionsSuite extends HiveThriftServer2Test {
 
     // TODO: enable this test case after SPARK-28463 and SPARK-26969
     ignore(s"$version get decimal type") {
-      testWithProtocolVersion(version, "SELECT cast(1 as decimal(18, 2)) as c") { rs =>
+      testExecuteStatementWithProtocolVersion(version,
+        "SELECT cast(1 as decimal(18, 2)) as c") { rs =>
         assert(rs.next())
         assert(rs.getBigDecimal(1) === new java.math.BigDecimal("1.00"))
       }
     }
 
     test(s"$version get string type") {
-      testWithProtocolVersion(version, "SELECT 'str'") { rs =>
+      testExecuteStatementWithProtocolVersion(version, "SELECT 'str'") { rs =>
         assert(rs.next())
         assert(rs.getString(1) === "str")
       }
     }
 
     test(s"$version get char type") {
-      testWithProtocolVersion(version, "SELECT cast('char-str' as char(10))") { rs =>
+      testExecuteStatementWithProtocolVersion(version,
+        "SELECT cast('char-str' as char(10))") { rs =>
         assert(rs.next())
         assert(rs.getString(1) === "char-str")
       }
     }
 
     test(s"$version get varchar type") {
-      testWithProtocolVersion(version, "SELECT cast('varchar-str' as varchar(10))") { rs =>
+      testExecuteStatementWithProtocolVersion(version,
+        "SELECT cast('varchar-str' as varchar(10))") { rs =>
         assert(rs.next())
         assert(rs.getString(1) === "varchar-str")
       }
@@ -142,28 +217,29 @@ class SparkThriftServerProtocolVersionsSuite extends HiveThriftServer2Test {
 
     // TODO: enable this test case after SPARK-28474
     ignore(s"$version get binary type") {
-      testWithProtocolVersion(version, "SELECT cast('ABC' as binary)") { rs =>
+      testExecuteStatementWithProtocolVersion(version, "SELECT cast('ABC' as binary)") { rs =>
         assert(rs.next())
         assert(rs.getString(1) === "ABC")
       }
     }
 
     test(s"$version get boolean type") {
-      testWithProtocolVersion(version, "SELECT true") { rs =>
+      testExecuteStatementWithProtocolVersion(version, "SELECT true") { rs =>
         assert(rs.next())
         assert(rs.getBoolean(1) === true)
       }
     }
 
     test(s"$version get date type") {
-      testWithProtocolVersion(version, "SELECT cast('2019-07-22' as date)") { rs =>
+      testExecuteStatementWithProtocolVersion(version, "SELECT cast('2019-07-22' as date)") { rs =>
         assert(rs.next())
         assert(rs.getDate(1) === Date.valueOf("2019-07-22"))
       }
     }
 
     test(s"$version get timestamp type") {
-      testWithProtocolVersion(version, "SELECT cast('2019-07-22 18:14:00' as timestamp)") { rs =>
+      testExecuteStatementWithProtocolVersion(version,
+        "SELECT cast('2019-07-22 18:14:00' as timestamp)") { rs =>
         assert(rs.next())
         assert(rs.getTimestamp(1) === Timestamp.valueOf("2019-07-22 18:14:00"))
       }
@@ -171,7 +247,7 @@ class SparkThriftServerProtocolVersionsSuite extends HiveThriftServer2Test {
 
     // TODO: enable this test case after port HIVE-10646
     ignore(s"$version get void") {
-      testWithProtocolVersion(version, "SELECT null") { rs =>
+      testExecuteStatementWithProtocolVersion(version, "SELECT null") { rs =>
         assert(rs.next())
         assert(rs.getString(1) === null)
       }
@@ -179,29 +255,61 @@ class SparkThriftServerProtocolVersionsSuite extends HiveThriftServer2Test {
 
     // We do not fully support interval type
     ignore(s"$version get interval type") {
-      testWithProtocolVersion(version, "SELECT interval '1' year '2' day") { rs =>
+      testExecuteStatementWithProtocolVersion(version, "SELECT interval '1' year '2' day") { rs =>
         assert(rs.next())
       }
     }
 
     test(s"$version get array type") {
-      testWithProtocolVersion(version, "SELECT array(1, 2)") { rs =>
+      testExecuteStatementWithProtocolVersion(version, "SELECT array(1, 2)") { rs =>
         assert(rs.next())
         assert(rs.getString(1) === "[1,2]")
       }
     }
 
     test(s"$version get map type") {
-      testWithProtocolVersion(version, "SELECT map(1, 2)") { rs =>
+      testExecuteStatementWithProtocolVersion(version, "SELECT map(1, 2)") { rs =>
         assert(rs.next())
         assert(rs.getString(1) === "{1:2}")
       }
     }
 
     test(s"$version get struct type") {
-      testWithProtocolVersion(version, "SELECT struct('alpha' AS A, 'beta' AS B)") { rs =>
+      testExecuteStatementWithProtocolVersion(version,
+        "SELECT struct('alpha' AS A, 'beta' AS B)") { rs =>
         assert(rs.next())
         assert(rs.getString(1) === """{"A":"alpha","B":"beta"}""")
+      }
+    }
+
+    test(s"$version get info") {
+      testGetInfoWithProtocolVersion(version)
+    }
+
+    test(s"$version get tables") {
+      def checkResult(tableNames: Seq[String], rs: HiveQueryResultSet): Unit = {
+        if (tableNames.nonEmpty) {
+          for (i <- tableNames.indices) {
+            assert(rs.next())
+            assert(rs.getString("TABLE_NAME") === tableNames(i))
+          }
+        } else {
+          assert(!rs.next())
+        }
+      }
+
+      withJdbcStatement("table1", "table2") { statement =>
+        Seq(
+          "CREATE TABLE table1(key INT, val STRING)",
+          "CREATE TABLE table2(key INT, val STRING)").foreach(statement.execute)
+
+        testGetTablesWithProtocolVersion(version, "%", "%", null) { rs =>
+          checkResult(Seq("table1", "table2"), rs)
+        }
+
+        testGetTablesWithProtocolVersion(version, "%", "table1", null) { rs =>
+          checkResult(Seq("table1"), rs)
+        }
       }
     }
   }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkThriftServerProtocolVersionsSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkThriftServerProtocolVersionsSuite.scala
@@ -22,7 +22,6 @@ import java.util.Properties
 
 import org.apache.hive.jdbc.{HiveConnection, HiveQueryResultSet}
 import org.apache.hive.service.auth.PlainSaslHelper
-import org.apache.hive.service.rpc.thrift.TExecuteStatementReq
 import org.apache.thrift.protocol.TBinaryProtocol
 import org.apache.thrift.transport.TSocket
 
@@ -44,7 +43,7 @@ class SparkThriftServerProtocolVersionsSuite extends HiveThriftServer2Test {
       val clientProtocol = new ThriftserverShimUtils.TOpenSessionReq(version)
       val openResp = client.OpenSession(clientProtocol)
       val sessHandle = openResp.getSessionHandle
-      val execReq = new TExecuteStatementReq(sessHandle, sql)
+      val execReq = new ThriftserverShimUtils.TExecuteStatementReq(sessHandle, sql)
       val execResp = client.ExecuteStatement(execReq)
       val stmtHandle = execResp.getOperationHandle
 

--- a/sql/hive-thriftserver/v1.2.1/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftserverShimUtils.scala
+++ b/sql/hive-thriftserver/v1.2.1/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftserverShimUtils.scala
@@ -49,9 +49,7 @@ private[thriftserver] object ThriftserverShimUtils {
 
   private[thriftserver] def toJavaSQLType(s: String): Int = Type.getType(s).toJavaSQLType
 
-  private[thriftserver] val testedProtocalVersions = Seq(
-    HIVE_CLI_SERVICE_PROTOCOL_V1,
-    HIVE_CLI_SERVICE_PROTOCOL_V2,
+  private[thriftserver] val testedProtocolVersions = Seq(
     HIVE_CLI_SERVICE_PROTOCOL_V3,
     HIVE_CLI_SERVICE_PROTOCOL_V4,
     HIVE_CLI_SERVICE_PROTOCOL_V5,

--- a/sql/hive-thriftserver/v1.2.1/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftserverShimUtils.scala
+++ b/sql/hive-thriftserver/v1.2.1/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftserverShimUtils.scala
@@ -33,6 +33,8 @@ private[thriftserver] object ThriftserverShimUtils {
   private[thriftserver] type TGetSchemasReq = org.apache.hive.service.cli.thrift.TGetSchemasReq
   private[thriftserver] type TGetTablesReq = org.apache.hive.service.cli.thrift.TGetTablesReq
   private[thriftserver] type TGetColumnsReq = org.apache.hive.service.cli.thrift.TGetColumnsReq
+  private[thriftserver] type TExecuteStatementReq =
+    org.apache.hive.service.cli.thrift.TExecuteStatementReq
 
   private[thriftserver] def getConsole: SessionState.LogHelper = {
     val LOG = LogFactory.getLog(classOf[SparkSQLCLIDriver])

--- a/sql/hive-thriftserver/v1.2.1/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftserverShimUtils.scala
+++ b/sql/hive-thriftserver/v1.2.1/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftserverShimUtils.scala
@@ -33,6 +33,7 @@ private[thriftserver] object ThriftserverShimUtils {
   private[thriftserver] type TGetSchemasReq = org.apache.hive.service.cli.thrift.TGetSchemasReq
   private[thriftserver] type TGetTablesReq = org.apache.hive.service.cli.thrift.TGetTablesReq
   private[thriftserver] type TGetColumnsReq = org.apache.hive.service.cli.thrift.TGetColumnsReq
+  private[thriftserver] type TGetInfoReq = org.apache.hive.service.cli.thrift.TGetInfoReq
   private[thriftserver] type TExecuteStatementReq =
     org.apache.hive.service.cli.thrift.TExecuteStatementReq
 
@@ -50,6 +51,8 @@ private[thriftserver] object ThriftserverShimUtils {
   private[thriftserver] def toJavaSQLType(s: String): Int = Type.getType(s).toJavaSQLType
 
   private[thriftserver] val testedProtocolVersions = Seq(
+    HIVE_CLI_SERVICE_PROTOCOL_V1,
+    HIVE_CLI_SERVICE_PROTOCOL_V2,
     HIVE_CLI_SERVICE_PROTOCOL_V3,
     HIVE_CLI_SERVICE_PROTOCOL_V4,
     HIVE_CLI_SERVICE_PROTOCOL_V5,

--- a/sql/hive-thriftserver/v1.2.1/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftserverShimUtils.scala
+++ b/sql/hive-thriftserver/v1.2.1/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftserverShimUtils.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.hive.thriftserver
 import org.apache.commons.logging.LogFactory
 import org.apache.hadoop.hive.ql.session.SessionState
 import org.apache.hive.service.cli.{RowSet, RowSetFactory, TableSchema, Type}
+import org.apache.hive.service.cli.thrift.TProtocolVersion._
 
 /**
  * Various utilities for hive-thriftserver used to upgrade the built-in Hive.
@@ -46,4 +47,11 @@ private[thriftserver] object ThriftserverShimUtils {
 
   private[thriftserver] def toJavaSQLType(s: String): Int = Type.getType(s).toJavaSQLType
 
+  private[thriftserver] val testedProtocalVersions = Seq(
+    HIVE_CLI_SERVICE_PROTOCOL_V3,
+    HIVE_CLI_SERVICE_PROTOCOL_V4,
+    HIVE_CLI_SERVICE_PROTOCOL_V5,
+    HIVE_CLI_SERVICE_PROTOCOL_V6,
+    HIVE_CLI_SERVICE_PROTOCOL_V7,
+    HIVE_CLI_SERVICE_PROTOCOL_V8)
 }

--- a/sql/hive-thriftserver/v1.2.1/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftserverShimUtils.scala
+++ b/sql/hive-thriftserver/v1.2.1/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftserverShimUtils.scala
@@ -50,6 +50,8 @@ private[thriftserver] object ThriftserverShimUtils {
   private[thriftserver] def toJavaSQLType(s: String): Int = Type.getType(s).toJavaSQLType
 
   private[thriftserver] val testedProtocalVersions = Seq(
+    HIVE_CLI_SERVICE_PROTOCOL_V1,
+    HIVE_CLI_SERVICE_PROTOCOL_V2,
     HIVE_CLI_SERVICE_PROTOCOL_V3,
     HIVE_CLI_SERVICE_PROTOCOL_V4,
     HIVE_CLI_SERVICE_PROTOCOL_V5,

--- a/sql/hive-thriftserver/v2.3.5/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftserverShimUtils.scala
+++ b/sql/hive-thriftserver/v2.3.5/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftserverShimUtils.scala
@@ -51,6 +51,8 @@ private[thriftserver] object ThriftserverShimUtils {
   private[thriftserver] def toJavaSQLType(s: String): Int = Type.getType(s).toJavaSQLType
 
   private[thriftserver] val testedProtocalVersions = Seq(
+    HIVE_CLI_SERVICE_PROTOCOL_V1,
+    HIVE_CLI_SERVICE_PROTOCOL_V2,
     HIVE_CLI_SERVICE_PROTOCOL_V3,
     HIVE_CLI_SERVICE_PROTOCOL_V4,
     HIVE_CLI_SERVICE_PROTOCOL_V5,

--- a/sql/hive-thriftserver/v2.3.5/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftserverShimUtils.scala
+++ b/sql/hive-thriftserver/v2.3.5/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftserverShimUtils.scala
@@ -34,6 +34,8 @@ private[thriftserver] object ThriftserverShimUtils {
   private[thriftserver] type TGetSchemasReq = org.apache.hive.service.rpc.thrift.TGetSchemasReq
   private[thriftserver] type TGetTablesReq = org.apache.hive.service.rpc.thrift.TGetTablesReq
   private[thriftserver] type TGetColumnsReq = org.apache.hive.service.rpc.thrift.TGetColumnsReq
+  private[thriftserver] type TExecuteStatementReq =
+    org.apache.hive.service.rpc.thrift.TExecuteStatementReq
 
   private[thriftserver] def getConsole: SessionState.LogHelper = {
     val LOG = LoggerFactory.getLogger(classOf[SparkSQLCLIDriver])

--- a/sql/hive-thriftserver/v2.3.5/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftserverShimUtils.scala
+++ b/sql/hive-thriftserver/v2.3.5/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftserverShimUtils.scala
@@ -50,9 +50,7 @@ private[thriftserver] object ThriftserverShimUtils {
 
   private[thriftserver] def toJavaSQLType(s: String): Int = Type.getType(s).toJavaSQLType
 
-  private[thriftserver] val testedProtocalVersions = Seq(
-    HIVE_CLI_SERVICE_PROTOCOL_V1,
-    HIVE_CLI_SERVICE_PROTOCOL_V2,
+  private[thriftserver] val testedProtocolVersions = Seq(
     HIVE_CLI_SERVICE_PROTOCOL_V3,
     HIVE_CLI_SERVICE_PROTOCOL_V4,
     HIVE_CLI_SERVICE_PROTOCOL_V5,

--- a/sql/hive-thriftserver/v2.3.5/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftserverShimUtils.scala
+++ b/sql/hive-thriftserver/v2.3.5/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftserverShimUtils.scala
@@ -61,5 +61,4 @@ private[thriftserver] object ThriftserverShimUtils {
     HIVE_CLI_SERVICE_PROTOCOL_V8,
     HIVE_CLI_SERVICE_PROTOCOL_V9,
     HIVE_CLI_SERVICE_PROTOCOL_V10)
-
 }

--- a/sql/hive-thriftserver/v2.3.5/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftserverShimUtils.scala
+++ b/sql/hive-thriftserver/v2.3.5/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftserverShimUtils.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.hive.thriftserver
 import org.apache.hadoop.hive.ql.session.SessionState
 import org.apache.hadoop.hive.serde2.thrift.Type
 import org.apache.hive.service.cli.{RowSet, RowSetFactory, TableSchema}
+import org.apache.hive.service.rpc.thrift.TProtocolVersion._
 import org.slf4j.LoggerFactory
 
 /**
@@ -46,5 +47,15 @@ private[thriftserver] object ThriftserverShimUtils {
   }
 
   private[thriftserver] def toJavaSQLType(s: String): Int = Type.getType(s).toJavaSQLType
+
+  private[thriftserver] val testedProtocalVersions = Seq(
+    HIVE_CLI_SERVICE_PROTOCOL_V3,
+    HIVE_CLI_SERVICE_PROTOCOL_V4,
+    HIVE_CLI_SERVICE_PROTOCOL_V5,
+    HIVE_CLI_SERVICE_PROTOCOL_V6,
+    HIVE_CLI_SERVICE_PROTOCOL_V7,
+    HIVE_CLI_SERVICE_PROTOCOL_V8,
+    HIVE_CLI_SERVICE_PROTOCOL_V9,
+    HIVE_CLI_SERVICE_PROTOCOL_V10)
 
 }

--- a/sql/hive-thriftserver/v2.3.5/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftserverShimUtils.scala
+++ b/sql/hive-thriftserver/v2.3.5/src/main/scala/org/apache/spark/sql/hive/thriftserver/ThriftserverShimUtils.scala
@@ -34,6 +34,7 @@ private[thriftserver] object ThriftserverShimUtils {
   private[thriftserver] type TGetSchemasReq = org.apache.hive.service.rpc.thrift.TGetSchemasReq
   private[thriftserver] type TGetTablesReq = org.apache.hive.service.rpc.thrift.TGetTablesReq
   private[thriftserver] type TGetColumnsReq = org.apache.hive.service.rpc.thrift.TGetColumnsReq
+  private[thriftserver] type TGetInfoReq = org.apache.hive.service.rpc.thrift.TGetInfoReq
   private[thriftserver] type TExecuteStatementReq =
     org.apache.hive.service.rpc.thrift.TExecuteStatementReq
 
@@ -51,6 +52,8 @@ private[thriftserver] object ThriftserverShimUtils {
   private[thriftserver] def toJavaSQLType(s: String): Int = Type.getType(s).toJavaSQLType
 
   private[thriftserver] val testedProtocolVersions = Seq(
+    HIVE_CLI_SERVICE_PROTOCOL_V1,
+    HIVE_CLI_SERVICE_PROTOCOL_V2,
     HIVE_CLI_SERVICE_PROTOCOL_V3,
     HIVE_CLI_SERVICE_PROTOCOL_V4,
     HIVE_CLI_SERVICE_PROTOCOL_V5,


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr adds a test(`SparkThriftServerProtocolVersionsSuite`) to test different versions of the thrift protocol because we use different logic to handle the `RowSet`:
https://github.com/apache/spark/blob/02c33694c8254f69cb36c71c0876194dccdbc014/sql/hive-thriftserver/v1.2.1/src/main/java/org/apache/hive/service/cli/RowSetFactory.java#L28-L40

When adding this test cases, found three bugs:
[SPARK-26969](https://issues.apache.org/jira/browse/SPARK-26969): Using ODBC not able to see the data in table when datatype is decimal
[SPARK-28463](https://issues.apache.org/jira/browse/SPARK-28463): Thriftserver throws BigDecimal incompatible with HiveDecimal
[SPARK-28474](https://issues.apache.org/jira/browse/SPARK-28474): Lower JDBC client version(Hive 0.12) cannot read binary type


## How was this patch tested?

N/A
