### PR TITLE
[SPARK-27900][K8s] Add jvm oom flag

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala
@@ -98,6 +98,28 @@ private[spark] trait BasicTestsSuite { k8sSuite: KubernetesSuite =>
       expectedJVMValue = Seq("(spark.test.foo,spark.test.bar)"))
   }
 
+  test("Run SparkPi without the default exit on OOM error flag", k8sTestTag) {
+    sparkAppConf
+      .set("spark.driver.extraJavaOptions", "-Dspark.test.foo=spark.test.bar")
+      .set("spark.kubernetes.driverEnv.DRIVER_VERBOSE", "true")
+      .set("spark.kubernetes.driverEnv.IGNORE_DEFAULT_DRIVER_JVM_OPTIONS", "true")
+
+    val output = Seq("Pi is roughly 3",
+      "(spark.driver.extraJavaOptions,-Dspark.test.foo=spark.test.bar)")
+
+    runSparkPiAndVerifyCompletion(expectedLogOnCompletion = output)
+  }
+
+  test("Run SparkPi with the default exit on OOM error flag set", k8sTestTag) {
+    sparkAppConf
+      .set("spark.driver.extraJavaOptions", "-Dspark.test.foo=spark.test.bar")
+      .set("spark.kubernetes.driverEnv.DRIVER_VERBOSE", "true")
+    val output = Seq("Pi is roughly 3",
+      "(spark.driver.extraJavaOptions,-XX:OnOutOfMemoryError=\"kill -9 %p\" " +
+        "-Dspark.test.foo=spark.test.bar)")
+    runSparkPiAndVerifyCompletion(expectedLogOnCompletion = output)
+  }
+
   test("Run SparkRemoteFileTest using a remote data file", k8sTestTag) {
     sparkAppConf
       .set("spark.files", REMOTE_PAGE_RANK_DATA_FILE)

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -161,13 +161,14 @@ class KubernetesSuite extends SparkFunSuite
       appResource: String = containerLocalSparkDistroExamplesJar,
       driverPodChecker: Pod => Unit = doBasicDriverPodCheck,
       executorPodChecker: Pod => Unit = doBasicExecutorPodCheck,
+      expectedLogOnCompletion: Seq[String] = Seq("Pi is roughly 3"),
       appArgs: Array[String] = Array.empty[String],
       appLocator: String = appLocator,
       isJVM: Boolean = true ): Unit = {
     runSparkApplicationAndVerifyCompletion(
       appResource,
       SPARK_PI_MAIN_CLASS,
-      Seq("Pi is roughly 3"),
+      expectedLogOnCompletion,
       appArgs,
       driverPodChecker,
       executorPodChecker,


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Adds a flag to make the driver exit in case of an oom error in the entrypoint script. 
- Adds integration tests for supporting de-activation of the flag if the user wishes.
- adds verbose flag support within the driver's container.
Note: This follows the discussion here: https://github.com/apache/spark/pull/24796. Without this pods on K8s will keep running although Spark has failed. In addition current behavior creates a problem to the Spark Operator and any other operator as it cannot detect failure at the K8s level.

## How was this patch tested?

Manually by launching SparkPi with a large number `100000000` which leads to an oom due to the large number of tasks allocated.
```
 $kubectl logs spark-pi-a59f4d6c44b525a9-driver -n spark

19/07/30 21:07:08 INFO BlockManagerMaster: Registered BlockManager BlockManagerId(driver, spark-pi-a59f4d6c44b525a9-driver-svc.spark.svc, 7079, None)
19/07/30 21:07:08 INFO BlockManager: Initialized BlockManager: BlockManagerId(driver, spark-pi-a59f4d6c44b525a9-driver-svc.spark.svc, 7079, None)
19/07/30 21:07:14 INFO KubernetesClusterSchedulerBackend$KubernetesDriverEndpoint: Registered executor NettyRpcEndpointRef(spark-client://Executor) (172.17.0.5:55032) with ID 1
19/07/30 21:07:14 INFO BlockManagerMasterEndpoint: Registering block manager 172.17.0.5:43067 with 413.9 MiB RAM, BlockManagerId(1, 172.17.0.5, 43067, None)
19/07/30 21:07:15 INFO KubernetesClusterSchedulerBackend$KubernetesDriverEndpoint: Registered executor NettyRpcEndpointRef(spark-client://Executor) (172.17.0.6:37344) with ID 2
19/07/30 21:07:15 INFO KubernetesClusterSchedulerBackend: SchedulerBackend is ready for scheduling beginning after reached minRegisteredResourcesRatio: 0.8
19/07/30 21:07:16 INFO BlockManagerMasterEndpoint: Registering block manager 172.17.0.6:46213 with 413.9 MiB RAM, BlockManagerId(2, 172.17.0.6, 46213, None)
#
# java.lang.OutOfMemoryError: Java heap space
# -XX:OnOutOfMemoryError="kill -9 %p"
#   Executing /bin/sh -c "kill -9 19"...
```
```
$ kubectl get pods spark-pi-8387506c19ad344d-driver  -n spark -o yaml
....
    state:
      terminated:
        containerID: docker://b3410c57d0e7424ec0af6cac4108669222210d80184d690ebeeb9494cf25e6f2
        exitCode: 137
        finishedAt: "2019-07-30T21:08:29Z"
        reason: Error
        startedAt: "2019-07-30T21:07:04Z"
```

