### PR TITLE
[SPARK-28054][SQL][followup] move the bug fix closer to where causes the issue

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/SaveAsHiveFile.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/SaveAsHiveFile.scala
@@ -83,16 +83,6 @@ private[hive] trait SaveAsHiveFile extends DataWritingCommand {
       jobId = java.util.UUID.randomUUID().toString,
       outputPath = outputLocation)
 
-    // SPARK-28054: Hive metastore is not case preserving and keeps partition columns
-    // with lower cased names, Hive will validate the column names in partition spec and
-    // the partition paths. Besides lowercasing the column names in the partition spec,
-    // we also need to lowercase the column names in written partition paths.
-    // scalastyle:off caselocale
-    val hiveCompatiblePartitionColumns = partitionAttributes.map { attr =>
-      attr.withName(attr.name.toLowerCase)
-    }
-    // scalastyle:on caselocale
-
     FileFormatWriter.write(
       sparkSession = sparkSession,
       plan = plan,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/SaveAsHiveFile.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/SaveAsHiveFile.scala
@@ -91,7 +91,7 @@ private[hive] trait SaveAsHiveFile extends DataWritingCommand {
       outputSpec =
         FileFormatWriter.OutputSpec(outputLocation, customPartitionLocations, outputColumns),
       hadoopConf = hadoopConf,
-      partitionColumns = hiveCompatiblePartitionColumns,
+      partitionColumns = partitionAttributes,
       bucketSpec = None,
       statsTrackers = Seq(basicWriteJobStatsTracker(hadoopConf)),
       options = Map.empty)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The bug fixed by https://github.com/apache/spark/pull/24886 is caused by Hive's `loadDynamicPartitions`. It's better to keep the fix surgical and put it right before we call `loadDynamicPartitions`.

This also makes the fix safer, instead of analyzing all the callers of `saveAsHiveFile` and proving that they are safe.

## How was this patch tested?

N/A