### PR TITLE
[SPARK-28499][ML] Optimize MinMaxScaler

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/MinMaxScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/MinMaxScaler.scala
@@ -183,18 +183,13 @@ class MinMaxScalerModel private[ml] (
     val minValue = $(min)
 
     // transformed value for constant cols
-    val constantOutput = 0.5 * scale + minValue
+    val constantOutput = ($(min) + $(max)) / 2
     val minArray = originalMin.toArray
 
-    val scaleArray = new Array[Double](numFeatures)
-    var i = 0
-    while (i < numFeatures) {
-      // scaleArray(i) == 0 iff i-th col is constant
+    val scaleArray = Array.tabulate(numFeatures) { i =>
       val range = originalMax(i) - originalMin(i)
-      if (range != 0) {
-        scaleArray(i) = scale / range
-      }
-      i += 1
+      // scaleArray(i) == 0 iff i-th col is constant (range == 0)
+      if (range != 0) scale / range else 0.0
     }
 
     val transformer = udf { vector: Vector =>

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/MinMaxScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/MinMaxScaler.scala
@@ -181,12 +181,15 @@ class MinMaxScalerModel private[ml] (
     val numFeatures = originalMax.size
     val scale = $(max) - $(min)
     val minValue = $(min)
-    val zeroRangeOutput = 0.5 * scale + minValue
+
+    // transformed value for constant cols
+    val constantOutput = 0.5 * scale + minValue
     val minArray = originalMin.toArray
 
     val scaleArray = new Array[Double](numFeatures)
     var i = 0
     while (i < numFeatures) {
+      // scaleArray(i) == 0 iff i-th col is constant
       val range = originalMax(i) - originalMin(i)
       if (range != 0) {
         scaleArray(i) = scale / range
@@ -205,7 +208,8 @@ class MinMaxScalerModel private[ml] (
           if (scaleArray(i) != 0) {
             values(i) = (values(i) - minArray(i)) * scaleArray(i) + minValue
           } else {
-            values(i) = zeroRangeOutput
+            // scaleArray(i) == 0 means i-th col is constant
+            values(i) = constantOutput
           }
         }
         i += 1


### PR DESCRIPTION
## What changes were proposed in this pull request?
1, avoid calling param getter in udf;
2, for constant dims, precompute the transformed result;
3, for usual dims, precompute `scale / originalRange(i)` to skip a division;


## How was this patch tested?
existing suites
