### PR TITLE
[SPARK-28507][ML][PYSPARK] Remove deprecated API context(self, sqlContext) from pyspark/ml/util.py

### DIFF
--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -78,14 +78,6 @@ class BaseReadWrite(object):
     def __init__(self):
         self._sparkSession = None
 
-    def context(self, sqlContext):
-        """
-        Sets the Spark SQLContext to use for saving/loading.
-
-        .. note:: Deprecated in 2.1 and will be removed in 3.0, use session instead.
-        """
-        raise NotImplementedError("Read/Write is not yet implemented for type: %s" % type(self))
-
     def session(self, sparkSession):
         """
         Sets the Spark Session to use for saving/loading.
@@ -191,18 +183,6 @@ class JavaMLWriter(MLWriter):
         self._jwrite.option(key, value)
         return self
 
-    def context(self, sqlContext):
-        """
-        Sets the SQL context to use for saving.
-
-        .. note:: Deprecated in 2.1 and will be removed in 3.0, use session instead.
-        """
-        warnings.warn(
-            "Deprecated in 2.1 and will be removed in 3.0, use session instead.",
-            DeprecationWarning)
-        self._jwrite.context(sqlContext._ssql_ctx)
-        return self
-
     def session(self, sparkSession):
         """Sets the Spark Session to use for saving."""
         self._jwrite.session(sparkSession._jsparkSession)
@@ -302,18 +282,6 @@ class JavaMLReader(MLReader):
             raise NotImplementedError("This Java ML type cannot be loaded into Python currently: %r"
                                       % self._clazz)
         return self._clazz._from_java(java_obj)
-
-    def context(self, sqlContext):
-        """
-        Sets the SQL context to use for loading.
-
-        .. note:: Deprecated in 2.1 and will be removed in 3.0, use session instead.
-        """
-        warnings.warn(
-            "Deprecated in 2.1 and will be removed in 3.0, use session instead.",
-            DeprecationWarning)
-        self._jread.context(sqlContext._ssql_ctx)
-        return self
 
     def session(self, sparkSession):
         """Sets the Spark Session to use for loading."""


### PR DESCRIPTION


## What changes were proposed in this pull request?

remove deprecated ```  def context(self, sqlContext)``` from ```pyspark/ml/util.py```

## How was this patch tested?
test with existing ml PySpark test suites
