### PR TITLE
[SPARK-28237][SQL] Enforce Idempotence for Once batches in RuleExecutor

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -49,7 +49,9 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
 
   override protected val blacklistedOnceBatches: Set[String] =
     Set("Pullup Correlated Expressions",
-        "Join Reorder"
+      "Join Reorder",
+      "Subquery",
+      "Extract Python UDFs"
     )
 
   protected def fixedPoint = FixedPoint(SQLConf.get.optimizerMaxIterations)
@@ -167,7 +169,7 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
       RemoveLiteralFromGroupExpressions,
       RemoveRepetitionFromGroupExpressions) :: Nil ++
     operatorOptimizationBatch) :+
-    Batch("Join Reorder", FixedPoint(1),
+    Batch("Join Reorder", Once,
       CostBasedJoinReorder) :+
     Batch("Remove Redundant Sorts", Once,
       RemoveRedundantSorts) :+

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -47,7 +47,10 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
       plan.find(PlanHelper.specialExpressionsInUnsupportedOperator(_).nonEmpty).isEmpty)
   }
 
-  override protected val blacklistedOnceBatches: Set[String] = Set("Pullup Correlated Expressions")
+  override protected val blacklistedOnceBatches: Set[String] =
+    Set("Pullup Correlated Expressions",
+        "Join Reorder"
+    )
 
   protected def fixedPoint = FixedPoint(SQLConf.get.optimizerMaxIterations)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -47,6 +47,8 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
       plan.find(PlanHelper.specialExpressionsInUnsupportedOperator(_).nonEmpty).isEmpty)
   }
 
+  override protected val blacklistedOnceBatches: Set[String] = Set("Pullup Correlated Expressions")
+
   protected def fixedPoint = FixedPoint(SQLConf.get.optimizerMaxIterations)
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -167,7 +167,7 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
       RemoveLiteralFromGroupExpressions,
       RemoveRepetitionFromGroupExpressions) :: Nil ++
     operatorOptimizationBatch) :+
-    Batch("Join Reorder", Once,
+    Batch("Join Reorder", FixedPoint(1),
       CostBasedJoinReorder) :+
     Batch("Remove Redundant Sorts", Once,
       RemoveRedundantSorts) :+

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
@@ -47,10 +47,13 @@ abstract class RuleExecutor[TreeType <: TreeNode[_]] extends Logging {
    */
   abstract class Strategy { def maxIterations: Int }
 
-  /** A strategy that only runs once. */
+  /** A strategy that is idempotent. */
   case object Once extends Strategy { val maxIterations = 1 }
 
-  /** A strategy that runs until fix point or maxIterations times, whichever comes first. */
+  /**
+   * A strategy that runs until fix point or maxIterations times, whichever comes first.
+   * Especially, a FixedPoint(1) batch is supposed to run only once.
+   */
   case class FixedPoint(maxIterations: Int) extends Strategy
 
   /** A batch of rules. */
@@ -59,6 +62,9 @@ abstract class RuleExecutor[TreeType <: TreeNode[_]] extends Logging {
   /** Defines a sequence of rule batches, to be overridden by the implementation. */
   protected def batches: Seq[Batch]
 
+  /** Once batches that are blacklisted in the idempotence checker */
+  protected val blacklistedOnceBatches: Set[String] = Set.empty
+
   /**
    * Defines a check function that checks for structural integrity of the plan after the execution
    * of each rule. For example, we can check whether a plan is still resolved after each rule in
@@ -66,6 +72,21 @@ abstract class RuleExecutor[TreeType <: TreeNode[_]] extends Logging {
    * `false` if the given plan doesn't pass the structural integrity check.
    */
   protected def isPlanIntegral(plan: TreeType): Boolean = true
+
+  /**
+   * Util method for checking whether a plan remains the same if re-optimized.
+   */
+  private def checkBatchIdempotence(batch: Batch, plan: TreeType): Unit = {
+    val reOptimized = batch.rules.foldLeft(plan) { case (p, rule) => rule(p) }
+    if (!plan.fastEquals(reOptimized)) {
+      val message =
+        s"""
+           |Once strategy's idempotence is broken for batch ${batch.name}
+           |${sideBySide(plan.treeString, reOptimized.treeString).mkString("\n")}
+          """.stripMargin
+      throw new TreeNodeException(reOptimized, message, null)
+    }
+  }
 
   /**
    * Executes the batches of rules defined by the subclass, and also tracks timing info for each
@@ -140,6 +161,11 @@ abstract class RuleExecutor[TreeType <: TreeNode[_]] extends Logging {
             } else {
               logWarning(message)
             }
+          }
+          // Check idempotence for Once batches.
+          if (batch.strategy == Once &&
+            Utils.isTesting && !blacklistedOnceBatches.contains(batch.name)) {
+            checkBatchIdempotence(batch, curPlan)
           }
           continue = false
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
@@ -47,7 +47,7 @@ abstract class RuleExecutor[TreeType <: TreeNode[_]] extends Logging {
    */
   abstract class Strategy { def maxIterations: Int }
 
-  /** A strategy that is idempotent. */
+  /** A strategy that is run once and idempotent. */
   case object Once extends Strategy { val maxIterations = 1 }
 
   /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PruneFiltersSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PruneFiltersSuite.scala
@@ -32,7 +32,7 @@ class PruneFiltersSuite extends PlanTest {
     val batches =
       Batch("Subqueries", Once,
         EliminateSubqueryAliases) ::
-      Batch("Filter Pushdown and Pruning", Once,
+      Batch("Filter Pushdown and Pruning", FixedPoint(1),
         CombineFilters,
         PruneFilters,
         PushPredicateThroughNonJoin,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PullupCorrelatedPredicatesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PullupCorrelatedPredicatesSuite.scala
@@ -27,6 +27,8 @@ import org.apache.spark.sql.catalyst.rules.RuleExecutor
 class PullupCorrelatedPredicatesSuite extends PlanTest {
 
   object Optimize extends RuleExecutor[LogicalPlan] {
+    override protected val blacklistedOnceBatches = Set("PullupCorrelatedPredicates")
+
     val batches =
       Batch("PullupCorrelatedPredicates", Once,
         PullupCorrelatedPredicates) :: Nil

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/StarJoinCostBasedReorderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/StarJoinCostBasedReorderSuite.scala
@@ -38,7 +38,7 @@ class StarJoinCostBasedReorderSuite extends PlanTest with StatsEstimationTestBas
         PushPredicateThroughJoin,
         ColumnPruning,
         CollapseProject) ::
-      Batch("Join Reorder", Once,
+      Batch("Join Reorder", FixedPoint(1),
         CostBasedJoinReorder) :: Nil
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/RuleExecutorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/RuleExecutorSuite.scala
@@ -30,9 +30,25 @@ class RuleExecutorSuite extends SparkFunSuite {
     }
   }
 
+  object SetToZero extends Rule[Expression] {
+    def apply(e: Expression): Expression = e transform {
+      case IntegerLiteral(_) => Literal(0)
+    }
+  }
+
+  test("idempotence") {
+    object ApplyIdempotent extends RuleExecutor[Expression] {
+      val batches = Batch("idempotent", Once, SetToZero) :: Nil
+    }
+
+    assert(ApplyIdempotent.execute(Literal(10)) === Literal(0))
+    assert(ApplyIdempotent.execute(ApplyIdempotent.execute(Literal(10))) ===
+      ApplyIdempotent.execute(Literal(10)))
+  }
+
   test("only once") {
     object ApplyOnce extends RuleExecutor[Expression] {
-      val batches = Batch("once", Once, DecrementLiterals) :: Nil
+      val batches = Batch("once", FixedPoint(1), DecrementLiterals) :: Nil
     }
 
     assert(ApplyOnce.execute(Literal(10)) === Literal(9))
@@ -63,7 +79,7 @@ class RuleExecutorSuite extends SparkFunSuite {
         case IntegerLiteral(_) => true
         case _ => false
       }
-      val batches = Batch("once", Once, DecrementLiterals) :: Nil
+      val batches = Batch("once", FixedPoint(1), DecrementLiterals) :: Nil
     }
 
     assert(WithSIChecker.execute(Literal(10)) === Literal(9))
@@ -81,7 +97,7 @@ class RuleExecutorSuite extends SparkFunSuite {
         case IntegerLiteral(i) if i > 0 => true
         case _ => false
       }
-      val batches = Batch("once", Once, DecrementLiterals) :: Nil
+      val batches = Batch("once", FixedPoint(1), DecrementLiterals) :: Nil
     }
 
     assert(WithSICheckerForPositiveLiteral.execute(Literal(2)) === Literal(1))


### PR DESCRIPTION
## What changes were proposed in this pull request?
In adaptive query processing (AQE), query plans are optimized on the fly during execution. However, a few `Once` rules can be problematic for such optimization since they can either generate wrong plan/unnecessary intermediate plan nodes.

This PR enforces idempotence for "Once" batches that are supposed to run once. This is a key enabler for AQE re-optimization and can improve robustness for existing optimizer rules.

Once batches that are currently not idempotent are marked in a blacklist. We will submit followup PRs to fix idempotence of these rules.

## How was this patch tested?
Existing UTs. Failing Once rules are temporarily blacklisted.
