### PR TITLE
[SPARK-28511][INFRA] Get REV from RELEASE_VERSION instead of VERSION

### DIFF
--- a/dev/create-release/release-util.sh
+++ b/dev/create-release/release-util.sh
@@ -102,7 +102,7 @@ function get_release_info {
   NEXT_VERSION="$VERSION"
   RELEASE_VERSION="${VERSION/-SNAPSHOT/}"
   SHORT_VERSION=$(echo "$VERSION" | cut -d . -f 1-2)
-  local REV=$(echo "$VERSION" | cut -d . -f 3)
+  local REV=$(echo "$RELEASE_VERSION" | cut -d . -f 3)
 
   # Find out what rc is being prepared.
   # - If the current version is "x.y.0", then this is rc1 of the "x.y.0" release.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Unlike the other versions, `x.x.0-SNAPSHOT` causes `x.x.-1`. Although this will not happen in the tags (there is no `SNAPSHOT` postfix), we had better fix this.
```
$ dev/create-release/do-release-docker.sh -d /tmp/spark-3.0.0 -n
Output directory already exists. Overwrite and continue? [y/n] y
Branch [branch-2.4]: master
Current branch version is 3.0.0-SNAPSHOT.
Release [3.0.-1]:
```

Since we already have `RELEASE_VERSION` by removing `SNAPSHOT`. This PR uses `RELEASE_VERSION` instead of `VERSION`.
```
$ dev/create-release/do-release-docker.sh -d /tmp/spark-3.0.0 -n
Branch [branch-2.4]: master
Current branch version is 3.0.0-SNAPSHOT.
Release [3.0.0]:
```

## How was this patch tested?

Manually do `dev/create-release/do-release-docker.sh -d /tmp/spark-3.0.0 -n` and see the default value of `Release`.