### PR TITLE
[SPARK-28518][SQL][TEST] Refer to ChecksumFileSystem#isChecksumFile to fix StatisticsCollectionTestBase#getDataSize

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionTestBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionTestBase.scala
@@ -295,8 +295,13 @@ abstract class StatisticsCollectionTestBase extends QueryTest with SQLTestUtils 
     }
   }
 
-  def getDataSize(file: File): Long =
-    file.listFiles.filter(!_.getName.endsWith(".crc")).map(_.length).sum
+  // Filter out the checksum file refer to ChecksumFileSystem#isChecksumFile.
+  def getDataSize(file: File): Long = {
+    file.listFiles.filter { f =>
+      val name = f.getName
+      !(name.startsWith(".") && name.endsWith(".crc"))
+    }.map(_.length).sum
+  }
 
   // This test will be run twice: with and without Hive support
   test("SPARK-18856: non-empty partitioned table should not report zero size") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -121,7 +121,7 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
     withTempDir { tempDir =>
       withTable("t1") {
         spark.range(5).write.mode(SaveMode.Overwrite).parquet(tempDir.getCanonicalPath)
-        val dataSize = getLocalDirSize(tempDir)
+        val dataSize = getDataSize(tempDir)
         spark.sql(
           s"""
              |CREATE EXTERNAL TABLE t1(id BIGINT)
@@ -1449,6 +1449,37 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
               assert(catalogTable.stats.isEmpty)
             }
           }
+        }
+      }
+    }
+  }
+
+  test("Fix StatisticsCollectionTestBase#getDataSize refer to ChecksumFileSystem#isChecksumFile") {
+    withTempDir { tempDir =>
+      withTable("t1") {
+        spark.range(5).write.mode(SaveMode.Overwrite).parquet(tempDir.getCanonicalPath)
+        Utils.tryWithResource(new PrintWriter(new File(tempDir + "/temp.crc"))) { writer =>
+          writer.write("1,2")
+        }
+
+        spark.sql(
+          s"""
+             |CREATE EXTERNAL TABLE t1(id BIGINT)
+             |STORED AS parquet
+             |LOCATION '${tempDir.getCanonicalPath}'
+             |TBLPROPERTIES (
+             |'rawDataSize'='-1', 'numFiles'='0', 'totalSize'='0',
+             |'COLUMN_STATS_ACCURATE'='false', 'numRows'='-1'
+             |)""".stripMargin)
+
+        spark.sql("REFRESH TABLE t1")
+        val relation1 = spark.table("t1").queryExecution.analyzed.children.head
+        assert(relation1.stats.sizeInBytes === spark.sessionState.conf.defaultSizeInBytes)
+
+        spark.sql("REFRESH TABLE t1")
+        withSQLConf(SQLConf.ENABLE_FALL_BACK_TO_HDFS_FOR_STATS.key -> "true") {
+          val relation2 = spark.table("t1").queryExecution.analyzed.children.head
+          assert(relation2.stats.sizeInBytes === getDataSize(tempDir))
         }
       }
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -1454,7 +1454,7 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
     }
   }
 
-  test("Fix StatisticsCollectionTestBase#getDataSize refer to ChecksumFileSystem#isChecksumFile") {
+  test("SPARK-28518 fix getDataSize refer to ChecksumFileSystem#isChecksumFile") {
     withTempDir { tempDir =>
       withTable("t1") {
         spark.range(5).write.mode(SaveMode.Overwrite).parquet(tempDir.getCanonicalPath)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fix [StatisticsCollectionTestBase.getDataSize](https://github.com/apache/spark/blob/8158d5e27fce8e4bc5877ed7bb4f7c3876007c13/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionTestBase.scala#L298-L304) refer to [ChecksumFileSystem.isChecksumFile](https://github.com/apache/hadoop/blob/release-2.7.4-RC0/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ChecksumFileSystem.java#L93-L97).

More details: https://github.com/apache/spark/pull/25014#discussion_r307050435

## How was this patch tested?

unit tests
