### PR TITLE
[SPARK-28520][SQL] WholeStageCodegen does not work property for LocalTableScanExec

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/LocalTableScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/LocalTableScanExec.scala
@@ -80,8 +80,7 @@ case class LocalTableScanExec(
   // Input is already UnsafeRows.
   override protected val createUnsafeProjection: Boolean = false
 
-  // Do not codegen when there is no parent - to support the fast driver-local collect/take paths.
-  override def supportCodegen: Boolean = (parent != null)
+  override def supportCodegen: Boolean = true
 
   override def inputRDD: RDD[InternalRow] = rdd
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/LocalTableScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/LocalTableScanExec.scala
@@ -80,7 +80,5 @@ case class LocalTableScanExec(
   // Input is already UnsafeRows.
   override protected val createUnsafeProjection: Boolean = false
 
-  override def supportCodegen: Boolean = true
-
   override def inputRDD: RDD[InternalRow] = rdd
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -895,6 +895,10 @@ case class CollapseCodegenStages(
       // domain object can not be written into unsafe row.
       case plan if plan.output.length == 1 && plan.output.head.dataType.isInstanceOf[ObjectType] =>
         plan.withNewChildren(plan.children.map(insertWholeStageCodegen(_, isColumnar)))
+      case plan: LocalTableScanExec =>
+        // Do not make LogicalTableScanExec the root of WholeStageCodegen
+        // to support the fast driver-local collect/take paths.
+        plan
       case plan: CodegenSupport if supportCodegen(plan) =>
         WholeStageCodegenExec(
           insertInputAdapter(plan, isColumnar))(codegenStageCounter.incrementAndGet())

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -331,63 +331,28 @@ class WholeStageCodegenSuite extends QueryTest with SharedSQLContext {
     // Case1: LocalTableScanExec is the root of a query plan tree.
     // In this case, WholeStageCodegenExec should not be inserted
     // as the direct parent of LocalTableScanExec.
-    val df1 = spark.createDataset(1 to 10).toDF
-    val rootOfExecutedPlan = df1.queryExecution.executedPlan
+    val df = Seq(1, 2, 3).toDF
+    val rootOfExecutedPlan = df.queryExecution.executedPlan
 
     // Ensure WholeStageCodegenExec is not inserted and
     // LocalTableScanExec is still the root.
-    assert(!rootOfExecutedPlan.isInstanceOf[WholeStageCodegenExec],
-      "WholeStageCodegenExec should not be inserted if LocalTableScanExec is the only plan.")
     assert(rootOfExecutedPlan.isInstanceOf[LocalTableScanExec],
       "LocalTableScanExec should be still the root.")
 
     // Case2: The parent of a LocalTableScanExec supports WholeStageCodegen.
     // In this case, the LocalTableScanExec should be within a WholeStageCodegen domain
     // and no more InputAdapter is inserted as the direct parent of the LocalTableScanExec.
-    val leftDF = spark.createDataset(1 to 10).toDF
-    val rightDF = spark.createDataset(1 to 10).toDF
+    val aggedDF = Seq(1, 2, 3).toDF.groupBy("value").sum()
+    val executedPlan = aggedDF.queryExecution.executedPlan
 
-    // Force BroadcastHasJoin enabled
-    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> Long.MaxValue.toString) {
-      val joinedDF = leftDF.join(rightDF, leftDF("value") === rightDF("value"))
-      val executedPlan = joinedDF.queryExecution.executedPlan
-
-      // BroadcastHashJoinExec supports WholeStageCodegen and it's the parent of
-      // LocalTableScanExec so LocalTableScanExec should be within a WholeStageCodegen domain.
-      assert(
-        executedPlan.find {
-          case WholeStageCodegenExec(
-            BroadcastHashJoinExec(_, _, _, _, _, _: LocalTableScanExec, _)) => true
-          case _ => false
-        }.isDefined,
-        "LocalTableScanExec is not within a WholeStageCodegen domain.")
-
-      // No more InputAdapter inserted between LocalTableScanExec and its parent.
-      assert(
-        executedPlan.find {
-          case InputAdapter(_: LocalTableScanExec, _) => true
-          case _ => false
-        }.isEmpty,
-        "InputAdapter should not be inserted.")
-    }
-
-    // Case3: The parent of a plan of LocalTableScanExec does not support WholeStageCodegen.
-    // In this case, the LocalTableScanExec should not be within a WholeStageCodegen domain
-    // and has a parent
-
-    // Force SortMergeJoin enabled
-    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0") {
-      val joinedDF = leftDF.join(rightDF, leftDF("value") === rightDF("value"))
-      val executedPlan = joinedDF.queryExecution.executedPlan
-      // The parent of LocalTableScanExec (ShuffleExchangeExec, in this case) does
-      // not support WholeStageCodegen so LocalTableScanExec should not be within a
-      // WholeStageCodegen domain and InputAdapter should be inserted.
-      assert(
-        executedPlan.find {
-          case InputAdapter(ShuffleExchangeExec(_, _: LocalTableScanExec, _), _) => true
-          case _ => false
-        }.isDefined,
-        "InputAdapter should be inserted as the grand parent of LocalTableScanExec.")
-    }
+    // HashAggregateExec supports WholeStageCodegen and it's the parent of
+    // LocalTableScanExec so LocalTableScanExec should be within a WholeStageCodegen domain.
+    assert(
+      executedPlan.find {
+        case WholeStageCodegenExec(
+          HashAggregateExec(_, _, _, _, _, _, _: LocalTableScanExec)) => true
+        case _ => false
+      }.isDefined,
+      "LocalTableScanExec should be within a WholeStageCodegen domain.")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -327,7 +327,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSQLContext {
     }
   }
 
-  test("WholeStageCodegen does not work properly for LocalTableScanExec") {
+  test("SPARK-28520: WholeStageCodegen does not work properly for LocalTableScanExec") {
     // Case1: LocalTableScanExec is the root of a query plan tree.
     // In this case, WholeStageCodegenExec should not be inserted
     // as the direct parent of LocalTableScanExec.


### PR DESCRIPTION
Code is not generated for LocalTableScanExec although proper situations.

If a LocalTableScanExec plan has the direct parent plan which supports WholeStageCodegen,
the LocalTableScanExec plan also should be within a WholeStageCodegen domain.
But code is not generated for LocalTableScanExec and InputAdapter is inserted for now.

```
val df1 = spark.createDataset(1 to 10).toDF
val df2 = spark.createDataset(1 to 10).toDF
val df3 = df1.join(df2, df1("value") === df2("value"))
df3.explain(true)

...

== Physical Plan ==
*(1) BroadcastHashJoin [value#1], [value#6], Inner, BuildRight
:- LocalTableScan [value#1]                                             // LocalTableScanExec is not within a WholeStageCodegen domain
+- BroadcastExchange HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)))
   +- LocalTableScan [value#6]
```

```
scala> df3.queryExecution.executedPlan.children.head.children.head.getClass
res4: Class[_ <: org.apache.spark.sql.execution.SparkPlan] = class org.apache.spark.sql.execution.InputAdapter
```

For the current implementation of LocalTableScanExec, codegen is enabled in case `parent` is not null
but `parent` is set in `consume`, which is called after `insertInputAdapter` so it doesn't work as intended.

After applying this cnahge, we can get following plan, which means LocalTableScanExec is within a WholeStageCodegen domain.

```
== Physical Plan ==
*(1) BroadcastHashJoin [value#63], [value#68], Inner, BuildRight
:- *(1) LocalTableScan [value#63]
+- BroadcastExchange HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)))
   +- LocalTableScan [value#68]

## How was this patch tested?

New test cases are added into WholeStageCodegenSuite.
