### PR TITLE
[SPARK-28532][SQL] Make optimizer batch "subquery" FixedPoint(1)

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -50,7 +50,6 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
   override protected val blacklistedOnceBatches: Set[String] =
     Set("Pullup Correlated Expressions",
       "Join Reorder",
-      "Subquery",
       "Extract Python UDFs"
     )
 
@@ -156,7 +155,7 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
       PropagateEmptyRelation) ::
     Batch("Pullup Correlated Expressions", Once,
       PullupCorrelatedPredicates) ::
-    Batch("Subquery", Once,
+    Batch("Subquery", FixedPoint(1),
       OptimizeSubqueries) ::
     Batch("Replace Operators", fixedPoint,
       RewriteExceptAll,


### PR DESCRIPTION
## What changes were proposed in this pull request?
In the Catalyst optimizer, the batch subquery actually calls the optimizer recursively. Therefore it makes no sense to enforce idempotence on it and we change this batch to `FixedPoint(1)`.

## How was this patch tested?
Existing UTs.