### PR TITLE
[SPARK-28375][SQL] Make pullupCorrelatedPredicate idempotent

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -48,9 +48,7 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
   }
 
   override protected val blacklistedOnceBatches: Set[String] =
-    Set("Pullup Correlated Expressions",
-      "Extract Python UDFs"
-    )
+    Set("Extract Python UDFs")
 
   protected def fixedPoint = FixedPoint(SQLConf.get.optimizerMaxIterations)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -273,6 +273,14 @@ object PullupCorrelatedPredicates extends Rule[LogicalPlan] with PredicateHelper
   }
 
   private def rewriteSubQueries(plan: LogicalPlan, outerPlans: Seq[LogicalPlan]): LogicalPlan = {
+    /**
+     * This function is used as a aid to enforce idempotency of pullUpCorrelatedPredicate rule.
+     * In the first call to rewriteSubqueries, all the outer references from the subplan are
+     * pulled up and join predicates are recorded as children of the enclosing subquery expression.
+     * The subsequent call to rewriteSubqueries would simply re-records the `children` which would
+     * contains the pulled up correlated predicates (from the previous call) in the enclosing
+     * subquery expression.
+     */
     def getJoinCondition(newCond: Seq[Expression], oldCond: Seq[Expression]): Seq[Expression] = {
       if (newCond.isEmpty) oldCond else newCond
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PullupCorrelatedPredicatesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PullupCorrelatedPredicatesSuite.scala
@@ -52,7 +52,7 @@ class PullupCorrelatedPredicatesSuite extends PlanTest {
     assert(optimized.resolved)
   }
 
-  test("SPARK-28375 PullupCorrelatedPredicates in correlated subquery idiompotency check") {
+  test("PullupCorrelatedPredicates in correlated subquery idiompotency check") {
     val subPlan =
       testRelation2
       .where('b < 'd)
@@ -68,7 +68,7 @@ class PullupCorrelatedPredicatesSuite extends PlanTest {
     comparePlans(optimized, doubleOptimized)
   }
 
-  test("SPARK-28375 PullupCorrelatedPredicates exists correlated subquery idiompotency check") {
+  test("PullupCorrelatedPredicates exists correlated subquery idiompotency check") {
     val subPlan =
       testRelation2
         .where('b === 'd && 'd === 1)
@@ -84,7 +84,7 @@ class PullupCorrelatedPredicatesSuite extends PlanTest {
     comparePlans(optimized, doubleOptimized)
   }
 
-  test("SPARK-28375 PullupCorrelatedPredicates scalar correlated subquery idiompotency check") {
+  test("PullupCorrelatedPredicates scalar correlated subquery idiompotency check") {
     val subPlan =
       testRelation2
         .where('b === 'd && 'd === 1)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PullupCorrelatedPredicatesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PullupCorrelatedPredicatesSuite.scala
@@ -52,7 +52,7 @@ class PullupCorrelatedPredicatesSuite extends PlanTest {
     assert(optimized.resolved)
   }
 
-  test("PullupCorrelatedPredicates in correlated subquery idiompotency check") {
+  test("PullupCorrelatedPredicates in correlated subquery idempotency check") {
     val subPlan =
       testRelation2
       .where('b < 'd)
@@ -68,7 +68,7 @@ class PullupCorrelatedPredicatesSuite extends PlanTest {
     comparePlans(optimized, doubleOptimized)
   }
 
-  test("PullupCorrelatedPredicates exists correlated subquery idiompotency check") {
+  test("PullupCorrelatedPredicates exists correlated subquery idempotency check") {
     val subPlan =
       testRelation2
         .where('b === 'd && 'd === 1)
@@ -84,7 +84,7 @@ class PullupCorrelatedPredicatesSuite extends PlanTest {
     comparePlans(optimized, doubleOptimized)
   }
 
-  test("PullupCorrelatedPredicates scalar correlated subquery idiompotency check") {
+  test("PullupCorrelatedPredicates scalar correlated subquery idempotency check") {
     val subPlan =
       testRelation2
         .where('b === 'd && 'd === 1)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR makes the optimizer rule PullupCorrelatedPredicates idempotent.
## How was this patch tested?

A new test PullupCorrelatedPredicatesSuite