### PR TITLE
[SPARK-28537][SQL] DebugExec cannot debug broadcast or columnar related queries.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
@@ -21,6 +21,7 @@ import java.util.Collections
 
 import scala.collection.JavaConverters._
 
+import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
@@ -33,6 +34,7 @@ import org.apache.spark.sql.catalyst.util.StringUtils.StringConcat
 import org.apache.spark.sql.execution.streaming.{StreamExecution, StreamingQueryWrapper}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.StreamingQuery
+import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.{AccumulatorV2, LongAccumulator}
 
 /**
@@ -254,6 +256,14 @@ package object debug {
 
     override def doConsume(ctx: CodegenContext, input: Seq[ExprCode], row: ExprCode): String = {
       consume(ctx, input)
+    }
+
+    override def doExecuteBroadcast[T](): Broadcast[T] = {
+      child.executeBroadcast()
+    }
+
+    override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+      child.executeColumnar()
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.debug
 
+import scala.util.{Failure, Success, Try}
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSQLContext
@@ -47,5 +49,26 @@ class DebuggingSuite extends SparkFunSuite with SharedSQLContext {
     assert(res.length == 2)
     assert(res.forall{ case (subtree, code) =>
       subtree.contains("Range") && code.contains("Object[]")})
+  }
+
+  test("debug() or broadcast and columnar") {
+    val rightDF = spark.range(10)
+    val leftDF = spark.range(10)
+    val joinedDF = leftDF.join(rightDF, leftDF("id") === rightDF("id"))
+    Try {
+      joinedDF.debug()
+    } match {
+      case Success(_) =>
+      case Failure(e) => fail(e)
+    }
+
+    val df = spark.range(5)
+    df.persist()
+    Try {
+      df.debug()
+    } match {
+      case Success(_) =>
+      case Failure(e) => fail(e)
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala
@@ -19,8 +19,6 @@ package org.apache.spark.sql.execution.debug
 
 import java.io.ByteArrayOutputStream
 
-import scala.util.control.NonFatal
-
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSQLContext

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala
@@ -66,14 +66,14 @@ class DebuggingSuite extends SparkFunSuite with SharedSQLContext {
     val output = captured.toString()
     assert(output.contains(
       """== BroadcastExchange HashedRelationBroadcastMode(List(input[0, bigint, false])) ==
-      |Tuples output: 0
-      | id LongType: {}
-      |== WholeStageCodegen ==
-      |Tuples output: 10
-      | id LongType: {java.lang.Long}
-      |== Range (0, 10, step=1, splits=2) ==
-      |Tuples output: 0
-      | id LongType: {}""".stripMargin))
+        |Tuples output: 0
+        | id LongType: {}
+        |== WholeStageCodegen ==
+        |Tuples output: 10
+        | id LongType: {java.lang.Long}
+        |== Range (0, 10, step=1, splits=2) ==
+        |Tuples output: 0
+        | id LongType: {}""".stripMargin))
   }
 
   test("SPARK-28537: DebugExec cannot debug columnar related queries") {
@@ -84,10 +84,11 @@ class DebuggingSuite extends SparkFunSuite with SharedSQLContext {
     Console.withOut(captured) {
       df.debug()
     }
+    df.unpersist()
 
-    val output = captured.toString()replaceAll ("#\\d+", "#x")
+    val output = captured.toString().replaceAll("#\\d+", "#x")
     assert(output.contains(
-      s"""== InMemoryTableScan [id#xL] ==
+      """== InMemoryTableScan [id#xL] ==
         |Tuples output: 0
         | id LongType: {}
         |""".stripMargin))


### PR DESCRIPTION
DebugExec does not implement doExecuteBroadcast and doExecuteColumnar so we can't debug broadcast or columnar related query.

One example for broadcast is here.
```
val df1 = Seq(1, 2, 3).toDF
val df2 = Seq(1, 2, 3).toDF
val joined = df1.join(df2, df1("value") === df2("value"))
joined.debug()

java.lang.UnsupportedOperationException: Debug does not implement doExecuteBroadcast
...
```

Another for columnar is here.
```
val df = Seq(1, 2, 3).toDF
df.persist
df.debug()

java.lang.IllegalStateException: Internal Error class org.apache.spark.sql.execution.debug.package$DebugExec has column support mismatch:
...
```

## How was this patch tested?

Additional test cases in DebuggingSuite.