### PR TITLE
[SPARK-28548][SQL] explain() shows wrong result for persisted DataFrames after some operations

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
@@ -149,8 +149,10 @@ package object debug {
    */
   implicit class DebugQuery(query: Dataset[_]) extends Logging {
     def debug(): Unit = {
+      val (_, _, _, _, executedPlan) = query.queryExecution.getOrCalculatePlans()
+
       val visited = new collection.mutable.HashSet[TreeNodeRef]()
-      val debugPlan = query.queryExecution.executedPlan transform {
+      val debugPlan = executedPlan transform {
         case s: SparkPlan if !visited.contains(new TreeNodeRef(s)) =>
           visited += new TreeNodeRef(s)
           DebugExec(s)
@@ -167,7 +169,8 @@ package object debug {
      * WholeStageCodegen subtree).
      */
     def debugCodegen(): Unit = {
-      debugPrint(codegenString(query.queryExecution.executedPlan))
+      val (_, _, _, _, executedPlan) = query.queryExecution.getOrCalculatePlans()
+      debugPrint(codegenString(executedPlan))
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
@@ -149,10 +149,10 @@ package object debug {
    */
   implicit class DebugQuery(query: Dataset[_]) extends Logging {
     def debug(): Unit = {
-      val (_, _, _, _, executedPlan) = query.queryExecution.getOrCalculatePlans()
+      val plans = query.queryExecution.getOrCalculatePlans()
 
       val visited = new collection.mutable.HashSet[TreeNodeRef]()
-      val debugPlan = executedPlan transform {
+      val debugPlan = plans.executedPlan transform {
         case s: SparkPlan if !visited.contains(new TreeNodeRef(s)) =>
           visited += new TreeNodeRef(s)
           DebugExec(s)
@@ -169,8 +169,8 @@ package object debug {
      * WholeStageCodegen subtree).
      */
     def debugCodegen(): Unit = {
-      val (_, _, _, _, executedPlan) = query.queryExecution.getOrCalculatePlans()
-      debugPrint(codegenString(executedPlan))
+      val plans = query.queryExecution.getOrCalculatePlans()
+      debugPrint(codegenString(plans.executedPlan))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -202,7 +202,7 @@ class ExplainSuite extends QueryTest with SharedSQLContext {
     }
   }
 
-  test("SPARK-28548: explain() shows wrong result for persisted DataFrames after some operations")
+  test("SPARK-28548: explain() shows wrong result for persisted DataFrames after some operations") {
     val df = spark.range(10).toDF
     val expected =
       s"""== Optimized Logical Plan ==


### PR DESCRIPTION
## What changes were proposed in this pull request?

After some operations against Datasets and then persist them, Dataset.explain shows wrong result.
One of those operations is explain() itself.
An example here.

```
val df = spark.range(10)
df.explain
df.persist
df.explain
```

Expected result is like as follows.
```
== Physical Plan ==
*(1) ColumnarToRow
+- InMemoryTableScan [id#7L]
      +- InMemoryRelation [id#7L], StorageLevel(disk, memory, deserialized, 1 replicas)
            +- *(1) Range (0, 10, step=1, splits=12)
```

But I got this.
```
== Physical Plan ==
*(1) Range (0, 10, step=1, splits=12)
```

This issue is caused by `withCachedData` in `QueryExecution` is materialized early when `explain()` or such methods are called so this patch prevents it.

## How was this patch tested?
Additional test cases in `ExplainSuite.scala`