### PR TITLE
 [SPARK-28036][SQL] Support negative length at LEFT/RIGHT SQL functions

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
@@ -850,4 +850,44 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(Sentences("Hi there! The price was $1,234.56.... But, not now.", "XXX", "YYY"),
       answer)
   }
+
+  test ("Left / Right") {
+    val nullString = Literal.create(null, StringType)
+    val row = create_row("example", "example".toArray.map(_.toByte))
+    val s = 'a.string.at(0)
+
+    // Check left function.
+    def leftExpr(str: Expression, len: Expression): Expression = {
+      val left = new Left(str, len)
+      left.child
+    }
+
+    checkEvaluation(leftExpr(s, Literal.create(null, IntegerType)), null, row)
+    checkEvaluation(leftExpr(s, Literal.create(0, IntegerType)), "", row)
+    checkEvaluation(leftExpr(s, Literal(1, IntegerType)), "e", row)
+    checkEvaluation(leftExpr(s, Literal(2, IntegerType)), "ex", row)
+    checkEvaluation(leftExpr(s, Literal(7, IntegerType)), "example", row)
+    checkEvaluation(leftExpr(s, Literal(8, IntegerType)), "example", row)
+    checkEvaluation(leftExpr(s, Literal(-1, IntegerType)), "exampl", row)
+    checkEvaluation(leftExpr(s, Literal(-2, IntegerType)), "examp", row)
+    checkEvaluation(leftExpr(s, Literal(-7, IntegerType)), "", row)
+    checkEvaluation(leftExpr(s, Literal(-8, IntegerType)), "", row)
+
+    // Check right function.
+    def rightExpr(str: Expression, len: Expression): Expression = {
+      val right = new Right(str, len)
+      right.child
+    }
+
+    checkEvaluation(rightExpr(s, Literal.create(null, IntegerType)), null, row)
+    checkEvaluation(rightExpr(s, Literal.create(0, IntegerType)), "", row)
+    checkEvaluation(rightExpr(s, Literal(1, IntegerType)), "e", row)
+    checkEvaluation(rightExpr(s, Literal(2, IntegerType)), "le", row)
+    checkEvaluation(rightExpr(s, Literal(7, IntegerType)), "example", row)
+    checkEvaluation(rightExpr(s, Literal(8, IntegerType)), "example", row)
+    checkEvaluation(rightExpr(s, Literal(-1, IntegerType)), "xample", row)
+    checkEvaluation(rightExpr(s, Literal(-2, IntegerType)), "ample", row)
+    checkEvaluation(rightExpr(s, Literal(-7, IntegerType)), "", row)
+    checkEvaluation(rightExpr(s, Literal(-8, IntegerType)), "", row)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
They are different when `n`/`len` is negative. So maybe need to change Spark to adapt  to Postgres's meaning.

In Postgres:
```
left(str text, n int): Return first n characters in the string. When n is negative, return all but last |n| characters;
right(str text, n int): Return last n characters in the string. When n is negative, return all but first |n| characters;
```

In Spark:
```
left(str, len) - Returns the leftmost `len`(`len` can be string type) characters from the string `str`,if `len` is less or equal than 0 the result is an empty string;
right(str, len) - Returns the rightmost `len`(`len` can be string type) characters from the string `str`,if `len` is less or equal than 0 the result is an empty string. 
```

This pr is to support  negative length at LEFT/RIGHT SQL functions.

## How was this patch tested?
Add `Left / Right` unittest in `org.apache.spark.sql.catalyst.expressions.StringExpressionsSuite`;

cc @wangyum .