### PR TITLE
[WIP][SPARK-28476][SQL] Support ALTER DATABASE SET LOCATION

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -89,6 +89,8 @@ statement
          (WITH DBPROPERTIES tablePropertyList))*                       #createDatabase
     | ALTER database db=errorCapturingIdentifier
         SET DBPROPERTIES tablePropertyList                             #setDatabaseProperties
+    | ALTER database db=errorCapturingIdentifier
+        SET locationSpec                                               #setDatabaseLocation
     | DROP database (IF EXISTS)? db=errorCapturingIdentifier
         (RESTRICT | CASCADE)?                                          #dropDatabase
     | SHOW DATABASES (LIKE? pattern=STRING)?                           #showDatabases

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -533,6 +533,22 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
   }
 
   /**
+   * Create an [[AlterDatabaseLocationCommand]] command.
+   *
+   * For example:
+   * {{{
+   *   ALTER (DATABASE|SCHEMA) database SET LOCATION path;
+   * }}}
+   */
+  override def visitSetDatabaseLocation(
+    ctx: SetDatabaseLocationContext): LogicalPlan = withOrigin(ctx) {
+      AlterDatabaseLocationCommand(
+        ctx.db.getText,
+        visitLocationSpec(ctx.locationSpec())
+      )
+  }
+
+  /**
    * Create a [[DropDatabaseCommand]] command.
    *
    * For example:

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -533,7 +533,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
   }
 
   /**
-   * Create an [[AlterDatabaseLocationCommand]] command.
+   * Create an [[AlterDatabaseSetLocationCommand]] command.
    *
    * For example:
    * {{{
@@ -542,9 +542,9 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
    */
   override def visitSetDatabaseLocation(
       ctx: SetDatabaseLocationContext): LogicalPlan = withOrigin(ctx) {
-    AlterDatabaseLocationCommand(
+    AlterDatabaseSetLocationCommand(
       ctx.db.getText,
-      visitLocationSpec(ctx.locationSpec())
+      visitLocationSpec(ctx.locationSpec)
     )
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -541,11 +541,11 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
    * }}}
    */
   override def visitSetDatabaseLocation(
-    ctx: SetDatabaseLocationContext): LogicalPlan = withOrigin(ctx) {
-      AlterDatabaseLocationCommand(
-        ctx.db.getText,
-        visitLocationSpec(ctx.locationSpec())
-      )
+      ctx: SetDatabaseLocationContext): LogicalPlan = withOrigin(ctx) {
+    AlterDatabaseLocationCommand(
+      ctx.db.getText,
+      visitLocationSpec(ctx.locationSpec())
+    )
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -133,6 +133,27 @@ case class AlterDatabasePropertiesCommand(
 }
 
 /**
+ * A command for users to set new location path for a database
+ * If the database does not exist, an error message will be issued to indicate the database
+ * does not exist.
+ * The syntax of using this command in SQL is:
+ * {{{
+ *    ALTER (DATABASE|SCHEMA) database_name SET LOCATION path
+ * }}}
+ */
+case class AlterDatabaseLocationCommand(databaseName: String, location: String)
+  extends RunnableCommand {
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val catalog = sparkSession.sessionState.catalog
+    val db: CatalogDatabase = catalog.getDatabaseMetadata(databaseName)
+    catalog.alterDatabase(db.copy(locationUri = CatalogUtils.stringToURI(location)))
+
+    Seq.empty[Row]
+  }
+}
+
+/**
  * A command for users to show the name of the database, its comment (if one has been set), and its
  * root location on the filesystem. When extended is true, it also shows the database's properties
  * If the database does not exist, an error message will be issued to indicate the database

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -141,7 +141,7 @@ case class AlterDatabasePropertiesCommand(
  *    ALTER (DATABASE|SCHEMA) database_name SET LOCATION path
  * }}}
  */
-case class AlterDatabaseLocationCommand(databaseName: String, location: String)
+case class AlterDatabaseSetLocationCommand(databaseName: String, location: String)
   extends RunnableCommand {
 
   override def run(sparkSession: SparkSession): Seq[Row] = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
@@ -184,6 +184,15 @@ class DDLParserSuite extends AnalysisTest with SharedSQLContext {
       containsThesePhrases = Seq("key_without_value"))
   }
 
+  test("alter database set location") {
+    // ALTER (DATABASE|SCHEMA) database_name SET LOCATION
+    val sql1 = "ALTER DATABASE database_name SET LOCATION '/home/user/db'"
+    val parsed1 = parser.parsePlan(sql1)
+
+    val expected1 = AlterDatabaseLocationCommand("database_name", "/home/user/db")
+    comparePlans(parsed1, expected1)
+  }
+
   test("describe database") {
     // DESCRIBE DATABASE [EXTENDED] db_name;
     val sql1 = "DESCRIBE DATABASE EXTENDED db_name"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
@@ -189,7 +189,7 @@ class DDLParserSuite extends AnalysisTest with SharedSQLContext {
     val sql1 = "ALTER DATABASE database_name SET LOCATION '/home/user/db'"
     val parsed1 = parser.parsePlan(sql1)
 
-    val expected1 = AlterDatabaseLocationCommand("database_name", "/home/user/db")
+    val expected1 = AlterDatabaseSetLocationCommand("database_name", "/home/user/db")
     comparePlans(parsed1, expected1)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -759,9 +759,12 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
             Row("Location", CatalogUtils.URIToString(location)) ::
             Row("Properties", "((a,a), (b,b), (c,c), (d,d))") :: Nil)
 
-        withTempDir { tmpDir =>
+        withTempDir { _tmpDir =>
+          val tmpDir = new File(_tmpDir, "db1.db")
           val path = tmpDir.getCanonicalPath
           val uri = tmpDir.toURI
+          logWarning(s"test change location: oldPath=${CatalogUtils.URIToString(location)}," +
+            s" newPath=${CatalogUtils.URIToString(uri)}")
           sql(s"ALTER DATABASE $dbName SET LOCATION '$uri'")
           val pathInCatalog = new Path(
             catalog.getDatabaseMetadata(dbNameWithoutBackTicks).locationUri).toUri

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -730,6 +730,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
       try {
         val dbNameWithoutBackTicks = cleanIdentifier(dbName)
         val location = getDBPath(dbNameWithoutBackTicks)
+        val location2 = getDBPath(dbNameWithoutBackTicks + "2")
 
         sql(s"CREATE DATABASE $dbName")
 
@@ -756,6 +757,15 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
           Row("Database Name", dbNameWithoutBackTicks) ::
             Row("Description", "") ::
             Row("Location", CatalogUtils.URIToString(location)) ::
+            Row("Properties", "((a,a), (b,b), (c,c), (d,d))") :: Nil)
+
+        sql(s"ALTER DATABASE $dbName SET LOCATION '$location2'")
+
+        checkAnswer(
+          sql(s"DESCRIBE DATABASE EXTENDED $dbName"),
+          Row("Database Name", dbNameWithoutBackTicks) ::
+            Row("Description", "") ::
+            Row("Location", CatalogUtils.URIToString(location2)) ::
             Row("Properties", "((a,a), (b,b), (c,c), (d,d))") :: Nil)
       } finally {
         catalog.reset()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -759,8 +759,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
             Row("Location", CatalogUtils.URIToString(location)) ::
             Row("Properties", "((a,a), (b,b), (c,c), (d,d))") :: Nil)
 
-        withTempDir { _tmpDir =>
-          val tmpDir = new File(_tmpDir, "db1.db")
+        withTempDir { tmpDir =>
           val path = tmpDir.getCanonicalPath
           val uri = tmpDir.toURI
           logWarning(s"test change location: oldPath=${CatalogUtils.URIToString(location)}," +

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -764,8 +764,8 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
           val dbNameWithoutBackTicks = cleanIdentifier(dbName)
           sql(s"ALTER DATABASE $dbName SET LOCATION '$path'")
           val dbPath = makeQualifiedPath(
-            catalog.getDatabaseMetadata(dbNameWithoutBackTicks).locationUri.toString)
-          val expPath = makeQualifiedPath(tmpDir.toString)
+            catalog.getDatabaseMetadata(dbNameWithoutBackTicks).locationUri.toString).getPath
+          val expPath = makeQualifiedPath(tmpDir.toString).getPath
           assert(dbPath === expPath)
         }
       } finally {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -205,12 +205,14 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
    */
   override def alterDatabase(dbDefinition: CatalogDatabase): Unit = withClient {
     val existingDb = getDatabase(dbDefinition.name)
-    if (existingDb.properties == dbDefinition.properties) {
+    if (existingDb.properties == dbDefinition.properties &&
+      existingDb.locationUri == dbDefinition.locationUri) {
       logWarning(s"Request to alter database ${dbDefinition.name} is a no-op because " +
         s"the provided database properties are the same as the old ones. Hive does not " +
-        s"currently support altering other database fields.")
+        s"currently support altering other database fields and database location.")
     }
     client.alterDatabase(dbDefinition)
+    client
   }
 
   override def getDatabase(db: String): CatalogDatabase = withClient {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -361,14 +361,14 @@ private[hive] class HiveClientImpl(
   }
 
   override def alterDatabase(database: CatalogDatabase): Unit = withHiveState {
-    val hiveDb = client.getDatabase(database.name)
+    val hiveDb = msClient.getDatabase(database.name)
     val oldPath = hiveDb.getLocationUri
     val newPath = CatalogUtils.URIToString(database.locationUri)
     hiveDb.setDescription(database.description)
     hiveDb.setLocationUri(CatalogUtils.URIToString(database.locationUri))
     hiveDb.setParameters(Option(database.properties).map(_.asJava).orNull)
-    client.alterDatabase(database.name, hiveDb)
-    val newPathInHive = client.getDatabase(database.name).getLocationUri
+    msClient.alterDatabase(database.name, hiveDb)
+    val newPathInHive = msClient.getDatabase(database.name).getLocationUri
     logWarning(s"Change database location, " +
       s"oldPath=${oldPath}, newPath=${newPath}, newPathInHive=${newPathInHive}")
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -362,10 +362,15 @@ private[hive] class HiveClientImpl(
 
   override def alterDatabase(database: CatalogDatabase): Unit = withHiveState {
     val hiveDb = client.getDatabase(database.name)
+    val oldPath = hiveDb.getLocationUri
+    val newPath = CatalogUtils.URIToString(database.locationUri)
     hiveDb.setDescription(database.description)
     hiveDb.setLocationUri(CatalogUtils.URIToString(database.locationUri))
     hiveDb.setParameters(Option(database.properties).map(_.asJava).orNull)
     client.alterDatabase(database.name, hiveDb)
+    val newPathInHive = client.getDatabase(database.name).getLocationUri
+    logWarning(s"Change database location, " +
+      s"oldPath=${oldPath}, newPath=${newPath}, newPathInHive=${newPathInHive}")
   }
 
   override def getDatabase(dbName: String): CatalogDatabase = withHiveState {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -361,16 +361,11 @@ private[hive] class HiveClientImpl(
   }
 
   override def alterDatabase(database: CatalogDatabase): Unit = withHiveState {
-    val location = CatalogUtils.URIToString(database.locationUri)
-    val dbName = database.name
-    client.alterDatabase(
-      dbName,
-      new HiveDatabase(
-        dbName,
-        database.description,
-        location,
-        Option(database.properties).map(_.asJava).orNull))
-    client.getDatabase(dbName).setLocationUri(location)
+    val hiveDb = client.getDatabase(database.name)
+    hiveDb.setDescription(database.description)
+    hiveDb.setLocationUri(CatalogUtils.URIToString(database.locationUri))
+    hiveDb.setParameters(Option(database.properties).map(_.asJava).orNull)
+    client.alterDatabase(database.name, hiveDb)
   }
 
   override def getDatabase(dbName: String): CatalogDatabase = withHiveState {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -361,13 +361,16 @@ private[hive] class HiveClientImpl(
   }
 
   override def alterDatabase(database: CatalogDatabase): Unit = withHiveState {
+    val location = CatalogUtils.URIToString(database.locationUri)
+    val dbName = database.name
     client.alterDatabase(
-      database.name,
+      dbName,
       new HiveDatabase(
-        database.name,
+        dbName,
         database.description,
-        CatalogUtils.URIToString(database.locationUri),
+        location,
         Option(database.properties).map(_.asJava).orNull))
+    client.getDatabase(dbName).setLocationUri(location)
   }
 
   override def getDatabase(dbName: String): CatalogDatabase = withHiveState {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
@@ -26,8 +26,8 @@ import org.apache.hadoop.hive.common.StatsSetupConst
 import org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
 import org.apache.hadoop.hive.serde2.`lazy`.LazySimpleSerDe
 import org.apache.hadoop.mapred.TextInputFormat
-import org.apache.spark.SparkFunSuite
 
+import org.apache.spark.SparkFunSuite
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support the syntax of ALTER (DATABASE|SCHEMA) database_name SET LOCATION path

Ref: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL

## How was this patch tested?

UT.

Please review https://spark.apache.org/contributing.html before opening a pull request.
