### PR TITLE
[MINOR][CORE][DOCS] Fix inconsistent description of showConsoleProgress

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1062,7 +1062,7 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.ui.showConsoleProgress</code></td>
-  <td>true</td>
+  <td>false</td>
   <td>
     Show the progress bar in the console. The progress bar shows the progress of stages
     that run for longer than 500ms. If multiple stages run at the same time, multiple

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1067,6 +1067,9 @@ Apart from these, the following properties are also available, and may be useful
     Show the progress bar in the console. The progress bar shows the progress of stages
     that run for longer than 500ms. If multiple stages run at the same time, multiple
     progress bars will be displayed on the same line.
+    <br/>
+    <em>Note:</em> In non-shell environment, the default value of spark.ui.showConsoleProgress is true or
+    specified by user.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1068,7 +1068,7 @@ Apart from these, the following properties are also available, and may be useful
     that run for longer than 500ms. If multiple stages run at the same time, multiple
     progress bars will be displayed on the same line.
     <br/>
-    <em>Note:</em> In non-shell environment, the default value of spark.ui.showConsoleProgress is true or
+    <em>Note:</em> In shell environment, the default value of spark.ui.showConsoleProgress is true or
     specified by user.
   </td>
 </tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1068,8 +1068,7 @@ Apart from these, the following properties are also available, and may be useful
     that run for longer than 500ms. If multiple stages run at the same time, multiple
     progress bars will be displayed on the same line.
     <br/>
-    <em>Note:</em> In shell environment, the default value of spark.ui.showConsoleProgress is true or
-    specified by user.
+    <em>Note:</em> In shell environment, the default value of spark.ui.showConsoleProgress is true.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The latest docs http://spark.apache.org/docs/latest/configuration.html contains some description as below:

spark.ui.showConsoleProgress | true | Show the progress bar in the console. The progress bar shows the progress of stages that run for longer than 500ms. If multiple stages run at the same time, multiple progress bars will be displayed on the same line.
-- | -- | --

But the class `org.apache.spark.internal.config.UI` define the config `spark.ui.showConsoleProgress` as below:
```
val UI_SHOW_CONSOLE_PROGRESS = ConfigBuilder("spark.ui.showConsoleProgress")
    .doc("When true, show the progress bar in the console.")
    .booleanConf
    .createWithDefault(false)
```
So I think there are exists some little mistake and lead to confuse reader.


## How was this patch tested?

No need UT.
