### PR TITLE
[BUILD] Exclude javax.validation:validation-api dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -729,6 +729,12 @@
         <groupId>org.glassfish.jersey.core</groupId>
         <artifactId>jersey-server</artifactId>
         <version>${jersey.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.core</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the classpath there is the following dependency transitive from jersey:

[...]
[INFO] +- org.glassfish.jersey.core:jersey-server:jar:2.22.2:compile
[INFO] |  \- javax.validation:validation-api:jar:1.1.0.Final:compile
[...]

It seams to be unused in spark: I did not found any direct use in the import and moreover there is not any implementation of the JSR 349 (i.e hibernate-validation)

This change enables to includelibraries that uses the more recent version of validation-api (2.0.1.Final)  in the classpath of the user code 

## How was this patch tested?

I have excluded the dependency and rerun the tests obtaining the same results of the master
