### PR TITLE
[SPARK-28503][SQL] Return null result on cast an out-of-range value to a integral type

### DIFF
--- a/docs/sql-migration-guide-hive-compatibility.md
+++ b/docs/sql-migration-guide-hive-compatibility.md
@@ -165,3 +165,12 @@ Below are the scenarios in which Hive and Spark generate different results:
 * `SQRT(n)` If n < 0, Hive returns null, Spark SQL returns NaN.
 * `ACOS(n)` If n < -1 or n > 1, Hive returns null, Spark SQL returns NaN.
 * `ASIN(n)` If n < -1 or n > 1, Hive returns null, Spark SQL returns NaN.
+
+### Incompatible data type conversion
+
+For type conversion, if the value is too big to fit in the target integral data type, Spark will return `null`,
+while Hive always returns lower-order bits. The related integral data types are:
+* Byte
+* Short
+* Int
+* Long

--- a/docs/sql-migration-guide-upgrade.md
+++ b/docs/sql-migration-guide-upgrade.md
@@ -23,6 +23,8 @@ license: |
 {:toc}
 
 ## Upgrading From Spark SQL 2.4 to 3.0
+  - Since Spark 3.0, for type conversion, if the value is too big to fit in the target `Long`/`Int`/`Short`/`Byte` data type, Spark will return `null`. In Spark version 2.4 and earlier, Spark always returns the lower-order bits of the out-of-range value. For example, the result of `Cast(257, ByteType)` will be `null`, instead of `1`.
+
   - Since Spark 3.0, we reversed argument order of the trim function from `TRIM(trimStr, str)` to `TRIM(str, trimStr)` to be compatible with other databases.
 
   - Since Spark 3.0, PySpark requires a Pandas version of 0.23.2 or higher to use Pandas related functionality, such as `toPandas`, `createDataFrame` from Pandas DataFrame, etc.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -433,9 +433,9 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
   }
 
   private[this] val maxLongValueAsDecimal = Decimal(Long.MaxValue)
-  private[this] val minongValueAsDecimal = Decimal(Long.MinValue)
+  private[this] val minLongValueAsDecimal = Decimal(Long.MinValue)
   private[this] def castDecimalToLong(d: Decimal): Any =
-    if (d <= maxLongValueAsDecimal && d >= minongValueAsDecimal) {
+    if (d <= maxLongValueAsDecimal && d >= minLongValueAsDecimal) {
       d.toLong
     } else {
       null

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -432,15 +432,6 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
       buildCast[UTF8String](_, s => CalendarInterval.fromString(s.toString))
   }
 
-  private[this] val maxLongValueAsDecimal = Decimal(Long.MaxValue)
-  private[this] val minLongValueAsDecimal = Decimal(Long.MinValue)
-  private[this] def castDecimalToLong(d: Decimal): Any =
-    if (d <= maxLongValueAsDecimal && d >= minLongValueAsDecimal) {
-      d.toLong
-    } else {
-      null
-    }
-
   // LongConverter
   private[this] def castToLong(from: DataType): Any => Any = from match {
     case StringType =>
@@ -458,10 +449,32 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
       b => b.asInstanceOf[Short].toLong
     case IntegerType =>
       b => b.asInstanceOf[Int].toLong
+    case FloatType =>
+      buildCast[Float](_, f =>
+        if (f <= Long.MaxValue && f >= Long.MinValue) {
+          f.toLong
+        } else {
+          null
+        }
+      )
+    case DoubleType =>
+      buildCast[Double](_, d =>
+        if (d <= Long.MaxValue && d >= Long.MinValue) {
+          d.toLong
+        } else {
+          null
+        }
+      )
     case _: DecimalType =>
-      b => castDecimalToLong(b.asInstanceOf[Decimal])
-    case x: NumericType =>
-      b => castDecimalToLong(Decimal(b.toString))
+      val longMaxValueAsDecimal = Decimal(Long.MaxValue)
+      val longMinValueAsDecimal = Decimal(Long.MinValue)
+      buildCast[Decimal](_, d =>
+        if (d <= longMaxValueAsDecimal && d >= longMinValueAsDecimal) {
+          d.toLong
+        } else {
+          null
+        }
+      )
   }
 
   // IntConverter
@@ -494,7 +507,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
           null
         }
       )
-    case x: FloatType =>
+    case FloatType =>
       buildCast[Float](_, f =>
         if (f <= Int.MaxValue && f >= Int.MinValue) {
           f.toInt
@@ -502,7 +515,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
           null
         }
       )
-    case x: DoubleType =>
+    case DoubleType =>
       buildCast[Double](_, d =>
         if (d <= Int.MaxValue && d >= Int.MinValue) {
           d.toInt
@@ -562,7 +575,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
           null
         }
       })
-    case x: FloatType =>
+    case FloatType =>
       buildCast[Float](_, f =>
         if (f <= Short.MaxValue && f >= Short.MinValue) {
           f.toShort
@@ -570,7 +583,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
           null
         }
       )
-    case x: DoubleType =>
+    case DoubleType =>
       buildCast[Double](_, d =>
         if (d <= Short.MaxValue && d >= Short.MinValue) {
           d.toShort
@@ -636,7 +649,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
           null
         }
       })
-    case x: FloatType =>
+    case FloatType =>
       buildCast[Float](_, f =>
         if (f <= Byte.MaxValue && f >= Byte.MinValue) {
           f.toByte
@@ -644,7 +657,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
           null
         }
       )
-    case x: DoubleType =>
+    case DoubleType =>
       buildCast[Double](_, d =>
         if (d <= Byte.MaxValue && d >= Byte.MinValue) {
           d.toByte

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -432,10 +432,10 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
       buildCast[UTF8String](_, s => CalendarInterval.fromString(s.toString))
   }
 
-  private[this] val longMaxValue = Decimal(Long.MaxValue)
-  private[this] val longMinValue = Decimal(Long.MinValue)
+  private[this] val maxLongValueAsDecimal = Decimal(Long.MaxValue)
+  private[this] val minongValueAsDecimal = Decimal(Long.MinValue)
   private[this] def castDecimalToLong(d: Decimal): Any =
-    if (d <= longMaxValue && d >= longMinValue) {
+    if (d <= maxLongValueAsDecimal && d >= minongValueAsDecimal) {
       d.toLong
     } else {
       null
@@ -1501,7 +1501,6 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
     case TimestampType =>
       (c, evPrim, evNull) => code"$evPrim = (long) ${timestampToIntegerCode(c)};"
     case DecimalType() =>
-      val bigIntValue = ctx.freshName("doubleValue")
       (c, evPrim, evNull) =>
         code"""
           try {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -516,18 +516,20 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
         }
       )
     case DoubleType =>
+      val upperBound = Int.MaxValue + 1L
+      val lowerBound = Int.MinValue - 1L
       buildCast[Double](_, d =>
-        if (d <= Int.MaxValue && d >= Int.MinValue) {
+        if (d < upperBound && d > lowerBound) {
           d.toInt
         } else {
           null
         }
       )
     case _: DecimalType =>
-      val intMaxValueAsDecimal = Decimal(Int.MaxValue)
-      val intMinValueAsDecimal = Decimal(Int.MinValue)
+      val upperBound = Decimal(Int.MaxValue + 1L)
+      val lowerBound = Decimal(Int.MinValue - 1L)
       buildCast[Decimal](_, d =>
-        if (d <= intMaxValueAsDecimal && d >= intMinValueAsDecimal) {
+        if (d < upperBound && d > lowerBound) {
           d.toInt
         } else {
           null
@@ -576,26 +578,30 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
         }
       })
     case FloatType =>
+      val upperBound = Short.MaxValue + 1
+      val lowerBound = Short.MinValue - 1
       buildCast[Float](_, f =>
-        if (f <= Short.MaxValue && f >= Short.MinValue) {
+        if (f < upperBound && f > lowerBound) {
           f.toShort
         } else {
           null
         }
       )
     case DoubleType =>
+      val upperBound = Short.MaxValue + 1
+      val lowerBound = Short.MinValue - 1
       buildCast[Double](_, d =>
-        if (d <= Short.MaxValue && d >= Short.MinValue) {
+        if (d < upperBound && d > lowerBound) {
           d.toShort
         } else {
           null
         }
       )
     case _: DecimalType =>
-      val shortMaxValueAsDecimal = Decimal(Short.MaxValue)
-      val shortMinValueAsDecimal = Decimal(Short.MinValue)
+      val upperBound = Decimal(Short.MaxValue + 1)
+      val lowerBound = Decimal(Short.MinValue - 1)
       buildCast[Decimal](_, d =>
-        if (d <= shortMaxValueAsDecimal && d >= shortMinValueAsDecimal) {
+        if (d < upperBound && d > lowerBound) {
           d.toShort
         } else {
           null
@@ -650,26 +656,30 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
         }
       })
     case FloatType =>
+      val upperBound = Byte.MaxValue + 1
+      val lowerBound = Byte.MinValue - 1
       buildCast[Float](_, f =>
-        if (f <= Byte.MaxValue && f >= Byte.MinValue) {
+        if (f < upperBound && f > lowerBound) {
           f.toByte
         } else {
           null
         }
       )
     case DoubleType =>
+      val upperBound = Byte.MaxValue + 1
+      val lowerBound = Byte.MinValue - 1
       buildCast[Double](_, d =>
-        if (d <= Byte.MaxValue && d >= Byte.MinValue) {
+        if (d < upperBound && d > lowerBound) {
           d.toByte
         } else {
           null
         }
       )
     case _: DecimalType =>
-      val byteMaxValueAsDecimal = Decimal(Byte.MaxValue)
-      val byteMinValueAsDecimal = Decimal(Byte.MinValue)
+      val upperBound = Decimal(Byte.MaxValue + 1)
+      val lowerBound = Decimal(Byte.MinValue - 1)
       buildCast[Decimal](_, d =>
-        if (d <= byteMaxValueAsDecimal && d >= byteMinValueAsDecimal) {
+        if (d < upperBound && d > lowerBound) {
           d.toByte
         } else {
           null
@@ -1343,7 +1353,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
       (c, evPrim, evNull) =>
         code"""
           float $floatValue = $c.toFloat();
-          if ($floatValue <= ${Byte.MaxValue} && $floatValue >= ${Byte.MinValue}) {
+          if ($floatValue < ${Byte.MaxValue + 1} && $floatValue > ${Byte.MinValue - 1}) {
             $evPrim = $c.toByte();
           } else {
             $evNull = true;
@@ -1361,7 +1371,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
     case _: FloatType | _: DoubleType =>
       (c, evPrim, evNull) =>
         code"""
-          if ($c >= ${Byte.MinValue} && $c <= ${Byte.MaxValue}) {
+          if ($c > ${Byte.MinValue + 1} && $c < ${Byte.MaxValue + 1}) {
             $evPrim = (byte) $c;
           } else {
             $evNull = true;
@@ -1404,7 +1414,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
       (c, evPrim, evNull) =>
         code"""
           float $floatValue = $c.toFloat();
-          if ($floatValue <= ${Short.MaxValue} && $floatValue >= ${Short.MinValue}) {
+          if ($floatValue < ${Short.MaxValue + 1} && $floatValue > ${Short.MinValue - 1}) {
             $evPrim = $c.toShort();
           } else {
             $evNull = true;
@@ -1424,7 +1434,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
     case _: FloatType | _: DoubleType =>
       (c, evPrim, evNull) =>
         code"""
-          if ($c >= ${Short.MinValue} && $c <= ${Short.MaxValue}) {
+          if ($c > ${Short.MinValue - 1} && $c < ${Short.MaxValue + 1}) {
             $evPrim = (short) $c;
           } else {
             $evNull = true;
@@ -1465,7 +1475,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
       (c, evPrim, evNull) =>
         code"""
           double $doubleValue = $c.toDouble();
-          if ($doubleValue <= ${Int.MaxValue} && $doubleValue >= ${Int.MinValue}) {
+          if ($doubleValue > ${Int.MinValue - 1L}L && $doubleValue < ${Int.MaxValue + 1L}L) {
             $evPrim = $c.toInt();
           } else {
             $evNull = true;
@@ -1482,10 +1492,19 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
             $evNull = true;
           }
         """
-    case _: FloatType | _: DoubleType =>
+    case _: FloatType =>
       (c, evPrim, evNull) =>
         code"""
           if ($c >= ${Int.MinValue} && $c <= ${Int.MaxValue}) {
+            $evPrim = (int) $c;
+          } else {
+            $evNull = true;
+          }
+        """
+    case _: DoubleType =>
+      (c, evPrim, evNull) =>
+        code"""
+          if ($c > ${Int.MinValue - 1L}L && $c < ${Int.MaxValue + 1L}L) {
             $evPrim = (int) $c;
           } else {
             $evNull = true;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1371,7 +1371,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
     case _: FloatType | _: DoubleType =>
       (c, evPrim, evNull) =>
         code"""
-          if ($c > ${Byte.MinValue + 1} && $c < ${Byte.MaxValue + 1}) {
+          if ($c > ${Byte.MinValue - 1} && $c < ${Byte.MaxValue + 1}) {
             $evPrim = (byte) $c;
           } else {
             $evNull = true;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/javaCode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/javaCode.scala
@@ -224,7 +224,8 @@ object Block {
       } else {
         args.foreach {
           case _: ExprValue | _: Inline | _: Block =>
-          case _: Boolean | _: Int | _: Long | _: Float | _: Double | _: String =>
+          case _: Boolean | _: Byte | _: Short| _: Int | _: Long | _: Float | _: Double |
+               _: String =>
           case other => throw new IllegalArgumentException(
             s"Can not interpolate ${other.getClass.getName} into code block.")
         }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveGroupingAnalyticsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveGroupingAnalyticsSuite.scala
@@ -285,7 +285,7 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
       GroupingSets(Seq(Seq(), Seq(unresolved_a), Seq(unresolved_a, unresolved_b)),
         Seq(unresolved_a, unresolved_b), r1, Seq(unresolved_a, unresolved_b)))
     val expected = Project(Seq(a, b), Sort(
-      Seq(SortOrder('aggOrder.byte.withNullability(false), Ascending)), true,
+      Seq(SortOrder('aggOrder.byte.withNullability(true), Ascending)), true,
       Aggregate(Seq(a, b, gid),
         Seq(a, b, grouping_a.as("aggOrder")),
         Expand(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -1101,6 +1101,10 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
       checkEvaluation(cast(Literal(value * MICROS_PER_SECOND, TimestampType), IntegerType), value)
       checkEvaluation(cast(Literal(value * 1.0, DoubleType), IntegerType), value)
     }
+    checkEvaluation(cast(2147483647.4f, IntegerType), 2147483647)
+    checkEvaluation(cast(-2147483648.4f, IntegerType), -2147483648)
+    checkEvaluation(cast(2147483647.4D, IntegerType), 2147483647)
+    checkEvaluation(cast(-2147483648.4D, IntegerType), -2147483648)
   }
 
   test("Cast to long") {
@@ -1113,5 +1117,9 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
       checkEvaluation(cast(Literal(value, TimestampType), LongType),
         Math.floorDiv(value, MICROS_PER_SECOND))
     }
+    checkEvaluation(cast(9223372036854775807.4f, LongType), 9223372036854775807L)
+    checkEvaluation(cast(-9223372036854775808.4f, LongType), -9223372036854775808L)
+    checkEvaluation(cast(9223372036854775807.4D, LongType), 9223372036854775807L)
+    checkEvaluation(cast(-9223372036854775808.4D, LongType), -9223372036854775808L)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -1023,4 +1023,95 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
       checkEvaluation(ret, InternalRow(null))
     }
   }
+
+  private def testIntMaxAndMin(dt: DataType): Unit = {
+    Seq(Int.MaxValue + 1L, Int.MinValue - 1L).foreach { value =>
+      checkEvaluation(cast(value, dt), null)
+      checkEvaluation(cast(value.toString, dt), null)
+      checkEvaluation(cast(Decimal(value.toString), dt), null)
+      checkEvaluation(cast(Literal(value * MICROS_PER_SECOND, TimestampType), dt), null)
+      checkEvaluation(cast(Literal(value * 2.0f, FloatType), dt), null)
+      checkEvaluation(cast(Literal(value * 1.0, DoubleType), dt), null)
+    }
+  }
+
+  private def testLongMaxAndMin(dt: DataType): Unit = {
+    Seq(Decimal(Long.MaxValue) + Decimal(1), Decimal(Long.MinValue) - Decimal(1)).foreach { value =>
+      checkEvaluation(cast(value.toString, dt), null)
+      checkEvaluation(cast(value, dt), null)
+      checkEvaluation(cast((value * Decimal(1.1)).toFloat, dt), null)
+      checkEvaluation(cast((value * Decimal(1.1)).toDouble, dt), null)
+    }
+  }
+
+  test("Cast to byte") {
+    testIntMaxAndMin(ByteType)
+    Seq(Byte.MaxValue + 1, Byte.MinValue - 1).foreach { value =>
+      checkEvaluation(cast(value, ByteType), null)
+      checkEvaluation(cast(value.toString, ByteType), null)
+      checkEvaluation(cast(Decimal(value.toString), ByteType), null)
+      checkEvaluation(cast(Literal(value * MICROS_PER_SECOND, TimestampType), ByteType), null)
+      checkEvaluation(cast(Literal(value, DateType), ByteType), null)
+      checkEvaluation(cast(Literal(value * 1.0f, FloatType), ByteType), null)
+      checkEvaluation(cast(Literal(value * 1.0, DoubleType), ByteType), null)
+    }
+
+    Seq(Byte.MaxValue, 0.toByte, Byte.MinValue).foreach { value =>
+      checkEvaluation(cast(value, ByteType), value)
+      checkEvaluation(cast(value.toString, ByteType), value)
+      checkEvaluation(cast(Decimal(value.toString), ByteType), value)
+      checkEvaluation(cast(Literal(value * MICROS_PER_SECOND, TimestampType), ByteType), value)
+      checkEvaluation(cast(Literal(value.toInt, DateType), ByteType), null)
+      checkEvaluation(cast(Literal(value * 1.0f, FloatType), ByteType), value)
+      checkEvaluation(cast(Literal(value * 1.0, DoubleType), ByteType), value)
+    }
+  }
+
+  test("Cast to short") {
+    testIntMaxAndMin(ShortType)
+    Seq(Short.MaxValue + 1, Short.MinValue - 1).foreach { value =>
+      checkEvaluation(cast(value, ShortType), null)
+      checkEvaluation(cast(value.toString, ShortType), null)
+      checkEvaluation(cast(Decimal(value.toString), ShortType), null)
+      checkEvaluation(cast(Literal(value * MICROS_PER_SECOND, TimestampType), ShortType), null)
+      checkEvaluation(cast(Literal(value, DateType), ShortType), null)
+      checkEvaluation(cast(Literal(value * 1.0f, FloatType), ShortType), null)
+      checkEvaluation(cast(Literal(value * 1.0, DoubleType), ShortType), null)
+    }
+
+    Seq(Short.MaxValue, 0.toShort, Short.MinValue).foreach { value =>
+      checkEvaluation(cast(value, ShortType), value)
+      checkEvaluation(cast(value.toString, ShortType), value)
+      checkEvaluation(cast(Decimal(value.toString), ShortType), value)
+      checkEvaluation(cast(Literal(value * MICROS_PER_SECOND, TimestampType), ShortType), value)
+      checkEvaluation(cast(Literal(value.toInt, DateType), ShortType), null)
+      checkEvaluation(cast(Literal(value * 1.0f, FloatType), ShortType), value)
+      checkEvaluation(cast(Literal(value * 1.0, DoubleType), ShortType), value)
+    }
+  }
+
+  test("Cast to int") {
+    testIntMaxAndMin(IntegerType)
+    testLongMaxAndMin(IntegerType)
+
+    Seq(Int.MaxValue, 0, Int.MinValue).foreach { value =>
+      checkEvaluation(cast(value, IntegerType), value)
+      checkEvaluation(cast(value.toString, IntegerType), value)
+      checkEvaluation(cast(Decimal(value.toString), IntegerType), value)
+      checkEvaluation(cast(Literal(value * MICROS_PER_SECOND, TimestampType), IntegerType), value)
+      checkEvaluation(cast(Literal(value * 1.0, DoubleType), IntegerType), value)
+    }
+  }
+
+  test("Cast to long") {
+    testLongMaxAndMin(LongType)
+
+    Seq(Long.MaxValue, 0, Long.MinValue).foreach { value =>
+      checkEvaluation(cast(value, LongType), value)
+      checkEvaluation(cast(value.toString, LongType), value)
+      checkEvaluation(cast(Decimal(value.toString), LongType), value)
+      checkEvaluation(cast(Literal(value, TimestampType), LongType),
+        Math.floorDiv(value, MICROS_PER_SECOND))
+    }
+  }
 }

--- a/sql/core/src/test/resources/sql-tests/results/pgSQL/float4.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pgSQL/float4.sql.out
@@ -336,7 +336,7 @@ SELECT int(float('-2147483900'))
 -- !query 37 schema
 struct<CAST(CAST(-2147483900 AS FLOAT) AS INT):int>
 -- !query 37 output
--2147483648
+NULL
 
 
 -- !query 38
@@ -368,7 +368,7 @@ SELECT bigint(float('-9223380000000000000'))
 -- !query 41 schema
 struct<CAST(CAST(-9223380000000000000 AS FLOAT) AS BIGINT):bigint>
 -- !query 41 output
--9223372036854775808
+NULL
 
 
 -- !query 42

--- a/sql/core/src/test/resources/sql-tests/results/pgSQL/float8.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pgSQL/float8.sql.out
@@ -828,7 +828,7 @@ SELECT bigint(double('-9223372036854780000'))
 -- !query 93 schema
 struct<CAST(CAST(-9223372036854780000 AS DOUBLE) AS BIGINT):bigint>
 -- !query 93 output
--9223372036854775808
+NULL
 
 
 -- !query 94

--- a/sql/core/src/test/resources/sql-tests/results/pgSQL/int8.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pgSQL/int8.sql.out
@@ -606,10 +606,10 @@ SELECT CAST(q1 AS int) FROM int8_tbl WHERE q2 <> 456
 -- !query 60 schema
 struct<q1:int>
 -- !query 60 output
--869367531
--869367531
--869367531
 123
+NULL
+NULL
+NULL
 
 
 -- !query 61
@@ -625,10 +625,10 @@ SELECT CAST(q1 AS smallint) FROM int8_tbl WHERE q2 <> 456
 -- !query 62 schema
 struct<q1:smallint>
 -- !query 62 output
--32491
--32491
--32491
 123
+NULL
+NULL
+NULL
 
 
 -- !query 63
@@ -664,7 +664,7 @@ SELECT CAST(double('922337203685477580700.0') AS bigint)
 -- !query 66 schema
 struct<CAST(CAST(922337203685477580700.0 AS DOUBLE) AS BIGINT):bigint>
 -- !query 66 output
-9223372036854775807
+NULL
 
 
 -- !query 67
@@ -730,7 +730,7 @@ SELECT string(int(shiftleft(bigint(-1), 63))+1)
 -- !query 72 schema
 struct<CAST((CAST(shiftleft(CAST(-1 AS BIGINT), 63) AS INT) + 1) AS STRING):string>
 -- !query 72 output
-1
+NULL
 
 
 -- !query 73

--- a/sql/hive/compatibility/src/test/scala/org/apache/spark/sql/hive/execution/HiveCompatibilitySuite.scala
+++ b/sql/hive/compatibility/src/test/scala/org/apache/spark/sql/hive/execution/HiveCompatibilitySuite.scala
@@ -246,6 +246,10 @@ class HiveCompatibilitySuite extends HiveQueryFileTest with BeforeAndAfter {
     // Limit clause without a ordering, which causes failure.
     "orc_predicate_pushdown",
 
+    // On casting a out-of-range value to a integral type, Hive returns the low-order bits, while
+    // Spark returns null.
+    "udf_to_byte",
+
     // Requires precision decimal support:
     "udf_when",
     "udf_case",
@@ -1086,7 +1090,6 @@ class HiveCompatibilitySuite extends HiveQueryFileTest with BeforeAndAfter {
     "udf_sum",
     "udf_tan",
     "udf_tinyint",
-    "udf_to_byte",
     "udf_to_date",
     "udf_to_double",
     "udf_to_float",


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, when we convert an out-of-range value to a numeric type, the value is unexpected
```
scala> spark.sql("select cast(1234567890 as short)").show()
+----------------------------+
|CAST(1234567890 AS SMALLINT)|
+----------------------------+
|                         722|
+----------------------------+
```
The result is actually `1234567890.toShort`  (1234567890 & 0xffff).
The issue exists in all the integral types: Byte/Short/Int/Long. In the current implementation of `Cast`, if the value is too big to fit in an integral type, only the low-order bits are returned.
For Float/Double type, the value is converted as `PositiveInfinity` or `NegativeInfinity` on overflow. We can keep the current behavior.

This PR is to convert out-of-range integral type castings to null results.


## How was this patch tested?

Unit test
