### PR TITLE
[SPARK-28573][SQL] Convert InsertIntoTable(HiveTableRelation) to DataSource inserting for partitioned table

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCDSQueryBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCDSQueryBenchmark.scala
@@ -75,7 +75,7 @@ object TPCDSQueryBenchmark extends Logging {
           queryRelations.add(alias.identifier)
         case LogicalRelation(_, _, Some(catalogTable), _) =>
           queryRelations.add(catalogTable.identifier.table)
-        case HiveTableRelation(tableMeta, _, _) =>
+        case HiveTableRelation(tableMeta, _, _, _) =>
           queryRelations.add(tableMeta.identifier.table)
         case _ =>
       }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -197,9 +197,7 @@ private[hive] class HiveMetastoreCatalog(sparkSession: SparkSession) extends Log
           Some(partitionSchema))
 
         val logicalRelation = cached.getOrElse {
-          val defaultSizeInBytes = sparkSession.sessionState.conf.defaultSizeInBytes
-          val sizeInBytes =
-            relation.tableMeta.stats.map(_.sizeInBytes.toLong).getOrElse(defaultSizeInBytes)
+          val sizeInBytes = relation.stats.sizeInBytes.toLong
           val fileIndex = {
             val index = new CatalogFileIndex(sparkSession, relation.tableMeta, sizeInBytes)
             if (lazyPruningEnabled) {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -196,7 +196,9 @@ case class RelationConversions(
     plan resolveOperators {
       // Write path
       case InsertIntoTable(r: HiveTableRelation, partition, query, overwrite, ifPartitionNotExists)
-          if query.resolved && DDLUtils.isHiveTable(r.tableMeta) && isConvertible(r) =>
+          if query.resolved && DDLUtils.isHiveTable(r.tableMeta) &&
+            (!r.isPartitioned || SQLConf.get.getConf(HiveUtils.CONVERT_INSERTING_PARTITIONED_TABLE))
+            && isConvertible(r) =>
         InsertIntoTable(metastoreCatalog.convert(r), partition,
           query, overwrite, ifPartitionNotExists)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning._
 import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoDir, InsertIntoTable, LogicalPlan,
-    ScriptTransformation}
+  ScriptTransformation, Statistics}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.command.{CreateTableCommand, DDLUtils}
@@ -134,8 +134,8 @@ class DetermineTableStats(session: SparkSession) extends Rule[LogicalPlan] {
       conf.defaultSizeInBytes
     }
 
-    val withStats = table.copy(stats = Some(CatalogStatistics(sizeInBytes = BigInt(sizeInBytes))))
-    relation.copy(tableMeta = withStats)
+    val stats = Some(Statistics(sizeInBytes = BigInt(sizeInBytes)))
+    relation.copy(tableStats = stats)
   }
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -196,9 +196,7 @@ case class RelationConversions(
     plan resolveOperators {
       // Write path
       case InsertIntoTable(r: HiveTableRelation, partition, query, overwrite, ifPartitionNotExists)
-        // Inserting into partitioned table is not supported in Parquet/Orc data source (yet).
-          if query.resolved && DDLUtils.isHiveTable(r.tableMeta) &&
-            !r.isPartitioned && isConvertible(r) =>
+          if query.resolved && DDLUtils.isHiveTable(r.tableMeta) && isConvertible(r) =>
         InsertIntoTable(metastoreCatalog.convert(r), partition,
           query, overwrite, ifPartitionNotExists)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -114,8 +114,8 @@ private[spark] object HiveUtils extends Logging {
 
   val CONVERT_INSERTING_PARTITIONED_TABLE =
     buildConf("spark.sql.hive.convertInsertingPartitionedTable")
-      .doc("When set to true, and \"spark.sql.hive.convertMetastoreParquet\" or " +
-        "\"spark.sql.hive.convertMetastoreOrc\" is true, the built-in ORC/Parquet writer is used" +
+      .doc("When set to true, and `spark.sql.hive.convertMetastoreParquet` or " +
+        "`spark.sql.hive.convertMetastoreOrc` is true, the built-in ORC/Parquet writer is used" +
         "to process inserting into partitioned ORC/Parquet tables created by using the HiveSQL " +
         "syntax.")
       .booleanConf

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -112,6 +112,15 @@ private[spark] object HiveUtils extends Logging {
     .booleanConf
     .createWithDefault(true)
 
+  val CONVERT_INSERTING_PARTITIONED_TABLE =
+    buildConf("spark.sql.hive.convertInsertingPartitionedTable")
+      .doc("When set to true, and \"spark.sql.hive.convertMetastoreParquet\" or " +
+        "\"spark.sql.hive.convertMetastoreOrc\" is true, the built-in ORC/Parquet writer is used" +
+        "to process inserting into partitioned ORC/Parquet tables created by using the HiveSQL " +
+        "syntax.")
+      .booleanConf
+      .createWithDefault(true)
+
   val CONVERT_METASTORE_CTAS = buildConf("spark.sql.hive.convertMetastoreCtas")
     .doc("When set to true,  Spark will try to use built-in data source writer " +
       "instead of Hive serde in CTAS. This flag is effective only if " +

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetMetastoreSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetMetastoreSuite.scala
@@ -512,16 +512,14 @@ class HiveParquetMetastoreSuite extends ParquetPartitioningTest {
         |PARTITION (`date`='2015-04-01')
         |select a, b from jt
       """.stripMargin)
-    // Right now, insert into a partitioned Parquet is not supported in data source Parquet.
-    // So, we expect it is not cached.
-    assert(getCachedDataSourceTable(tableIdentifier) === null)
+    checkCached(tableIdentifier)
     sql(
       """
         |INSERT INTO TABLE test_parquet_partitioned_cache_test
         |PARTITION (`date`='2015-04-02')
         |select a, b from jt
       """.stripMargin)
-    assert(getCachedDataSourceTable(tableIdentifier) === null)
+    checkCached(tableIdentifier)
 
     // Make sure we can cache the partitioned table.
     table("test_parquet_partitioned_cache_test")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -136,10 +136,9 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
              |)""".stripMargin)
 
         spark.sql("REFRESH TABLE t1")
-        // Before SPARK-19678, sizeInBytes should be equal to dataSize.
-        // After SPARK-19678, sizeInBytes should be equal to DEFAULT_SIZE_IN_BYTES.
+        // After SPARK-28573, sizeInBytes should be equal to dataSize.
         val relation1 = spark.table("t1").queryExecution.analyzed.children.head
-        assert(relation1.stats.sizeInBytes === spark.sessionState.conf.defaultSizeInBytes)
+        assert(relation1.stats.sizeInBytes === dataSize)
 
         spark.sql("REFRESH TABLE t1")
         // After SPARK-19678 and enable ENABLE_FALL_BACK_TO_HDFS_FOR_STATS,
@@ -1474,7 +1473,8 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
 
         spark.sql("REFRESH TABLE t1")
         val relation1 = spark.table("t1").queryExecution.analyzed.children.head
-        assert(relation1.stats.sizeInBytes === spark.sessionState.conf.defaultSizeInBytes)
+        // After SPARK-28573, sizeInBytes should be the actual size.
+        assert(relation1.stats.sizeInBytes === getDataSize(tempDir))
 
         spark.sql("REFRESH TABLE t1")
         withSQLConf(SQLConf.ENABLE_FALL_BACK_TO_HDFS_FOR_STATS.key -> "true") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
@@ -58,7 +58,11 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
         |TBLPROPERTIES('prop1Key'="prop1Val", '`prop2Key`'="prop2Val")
       """.stripMargin)
     sql("CREATE TABLE parquet_tab3(col1 int, `col 2` int)")
-    sql("CREATE TABLE parquet_tab4 (price int, qty int) partitioned by (year int, month int)")
+    sql(
+      """
+        |CREATE TABLE parquet_tab4 (price int, qty int) partitioned by (year int, month int)
+        |STORED AS PARQUET
+      """.stripMargin)
     sql("INSERT INTO parquet_tab4 PARTITION(year = 2015, month = 1) SELECT 1, 1")
     sql("INSERT INTO parquet_tab4 PARTITION(year = 2015, month = 2) SELECT 2, 2")
     sql("INSERT INTO parquet_tab4 PARTITION(year = 2016, month = 2) SELECT 3, 3")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
@@ -58,11 +58,7 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
         |TBLPROPERTIES('prop1Key'="prop1Val", '`prop2Key`'="prop2Val")
       """.stripMargin)
     sql("CREATE TABLE parquet_tab3(col1 int, `col 2` int)")
-    sql(
-      """
-        |CREATE TABLE parquet_tab4 (price int, qty int) partitioned by (year int, month int)
-        |STORED AS PARQUET
-      """.stripMargin)
+    sql("CREATE TABLE parquet_tab4 (price int, qty int) partitioned by (year int, month int)")
     sql("INSERT INTO parquet_tab4 PARTITION(year = 2015, month = 1) SELECT 1, 1")
     sql("INSERT INTO parquet_tab4 PARTITION(year = 2015, month = 2) SELECT 2, 2")
     sql("INSERT INTO parquet_tab4 PARTITION(year = 2016, month = 2) SELECT 3, 3")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcQuerySuite.scala
@@ -22,10 +22,11 @@ import java.io.File
 import com.google.common.io.Files
 
 import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.orc.OrcQueryTest
-import org.apache.spark.sql.hive.HiveUtils
+import org.apache.spark.sql.hive.{HiveSessionCatalog, HiveUtils}
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.internal.SQLConf
 
@@ -225,6 +226,66 @@ class HiveOrcQuerySuite extends OrcQueryTest with TestHiveSingleton {
       withTable("spark_26437") {
         sql("CREATE TABLE spark_26437 STORED AS ORCFILE AS SELECT 0.00 AS c1")
         checkAnswer(spark.table("spark_26437"), Seq(Row(0.00)))
+      }
+    }
+  }
+
+  private def getCachedDataSourceTable(table: TableIdentifier) = {
+    spark.sessionState.catalog.asInstanceOf[HiveSessionCatalog].metastoreCatalog
+      .getCachedDataSourceTable(table)
+  }
+
+  private def checkCached(tableIdentifier: TableIdentifier): Unit = {
+    getCachedDataSourceTable(tableIdentifier) match {
+      case null => fail(s"Converted ${tableIdentifier.table} should be cached in the cache.")
+      case LogicalRelation(_: HadoopFsRelation, _, _, _) => // OK
+      case other =>
+        fail(
+          s"The cached ${tableIdentifier.table} should be a HadoopFsRelation. " +
+            s"However, $other is returned form the cache.")
+    }
+  }
+
+  test("SPARK-28573 ORC conversation could be applied for partitioned table insertion") {
+    withTempView("single") {
+      val singleRowDF = Seq((0, "foo")).toDF("key", "value")
+      singleRowDF.createOrReplaceTempView("single")
+      Seq("true", "false").foreach { conversion =>
+        withSQLConf(HiveUtils.CONVERT_METASTORE_ORC.key -> "true",
+          HiveUtils.CONVERT_INSERTING_PARTITIONED_TABLE.key -> conversion) {
+          withTable("dummy_orc_partitioned") {
+            withTempPath { dir =>
+              spark.sessionState.refreshTable("dummy_orc_partitioned")
+              val path = dir.getCanonicalPath
+              spark.sql(
+                s"""
+                   |CREATE TABLE dummy_orc_partitioned(key INT, value STRING)
+                   |PARTITIONED by (`date` STRING)
+                   |STORED AS ORC
+                   |LOCATION '${dir.toURI}'
+                 """.stripMargin)
+
+              spark.sql(
+                s"""
+                   |INSERT INTO TABLE dummy_orc_partitioned
+                   |PARTITION (`date` = '2019-04-01')
+                   |SELECT key, value FROM single
+                 """.stripMargin)
+
+              val orcPartitionedTable = TableIdentifier("dummy_orc_partitioned", Some("default"))
+              if (conversion == "true") {
+                // if converted, it's cached as a datasource table.
+                checkCached(orcPartitionedTable)
+              } else {
+                // otherwise, not cached.
+                assert(getCachedDataSourceTable(orcPartitionedTable) === null)
+              }
+
+              val df = spark.sql("SELECT key, value FROM dummy_orc_partitioned WHERE key=0")
+              checkAnswer(df, singleRowDF)
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Datasource table now supports partition tables long ago. This commit adds the ability to translate
the InsertIntoTable(HiveTableRelation) to datasource table insertion.

## How was this patch tested?
Existing tests with some modification
