### PR TITLE
[SPARK-28574][CORE] Allow to config different sizes for event queues

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
@@ -46,8 +46,13 @@ private class AsyncEventQueue(
 
   // Cap the capacity of the queue so we get an explicit error (rather than an OOM exception) if
   // it's perpetually being added to more quickly than it's being drained.
-  private val eventQueue = new LinkedBlockingQueue[SparkListenerEvent](
-    conf.get(LISTENER_BUS_EVENT_QUEUE_CAPACITY))
+  // The capacity can be configured by spark.scheduler.listenerbus.eventqueue.${name}.capacity,
+  // if no such conf is specified, use the value specified in
+  // LISTENER_BUS_EVENT_QUEUE_CAPACITY
+  def capacity: Int = conf.getInt(
+    s"spark.scheduler.listenerbus.eventqueue.${name}.capacity",
+     conf.get(LISTENER_BUS_EVENT_QUEUE_CAPACITY))
+  private val eventQueue = new LinkedBlockingQueue[SparkListenerEvent](capacity)
 
   // Keep the event count separately, so that waitUntilEmpty() can be implemented properly;
   // this allows that method to return only when the events in the queue have been fully

--- a/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
@@ -52,7 +52,7 @@ private class AsyncEventQueue(
   private[scheduler] def capacity: Int = {
     val queuesize = conf.getInt(s"spark.scheduler.listenerbus.eventqueue.${name}.capacity",
                                 conf.get(LISTENER_BUS_EVENT_QUEUE_CAPACITY))
-    assert(queuesize > 0, s"capacity for event queue $name must be greater than 0," +
+    assert(queuesize > 0, s"capacity for event queue $name must be greater than 0, " +
       s"but $queuesize is configured.")
     queuesize
   }

--- a/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
@@ -49,9 +49,14 @@ private class AsyncEventQueue(
   // The capacity can be configured by spark.scheduler.listenerbus.eventqueue.${name}.capacity,
   // if no such conf is specified, use the value specified in
   // LISTENER_BUS_EVENT_QUEUE_CAPACITY
-  protected def capacity: Int = conf.getInt(
-    s"spark.scheduler.listenerbus.eventqueue.${name}.capacity",
-     conf.get(LISTENER_BUS_EVENT_QUEUE_CAPACITY))
+  private[scheduler] def capacity: Int = {
+    val queuesize = conf.getInt(s"spark.scheduler.listenerbus.eventqueue.${name}.capacity",
+                                conf.get(LISTENER_BUS_EVENT_QUEUE_CAPACITY))
+    assert(queuesize > 0, s"capacity for event queue $name must be greater than 0," +
+      s"but $queuesize is configured.")
+    queuesize
+  }
+
   private val eventQueue = new LinkedBlockingQueue[SparkListenerEvent](capacity)
 
   // Keep the event count separately, so that waitUntilEmpty() can be implemented properly;

--- a/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
@@ -49,7 +49,7 @@ private class AsyncEventQueue(
   // The capacity can be configured by spark.scheduler.listenerbus.eventqueue.${name}.capacity,
   // if no such conf is specified, use the value specified in
   // LISTENER_BUS_EVENT_QUEUE_CAPACITY
-  def capacity: Int = conf.getInt(
+  protected def capacity: Int = conf.getInt(
     s"spark.scheduler.listenerbus.eventqueue.${name}.capacity",
      conf.get(LISTENER_BUS_EVENT_QUEUE_CAPACITY))
   private val eventQueue = new LinkedBlockingQueue[SparkListenerEvent](capacity)

--- a/core/src/main/scala/org/apache/spark/scheduler/LiveListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/LiveListenerBus.scala
@@ -236,6 +236,13 @@ private[spark] class LiveListenerBus(conf: SparkConf) {
     queues.asScala.map(_.name).toSet
   }
 
+  // For testing only.
+  private[scheduler] def getQueueCapacity(name: String): Int = {
+    queues.asScala.find(_.name == name) match {
+      case Some(queue) => queue.capacity
+      case None => -1
+    }
+  }
 }
 
 private[spark] object LiveListenerBus {

--- a/core/src/main/scala/org/apache/spark/scheduler/LiveListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/LiveListenerBus.scala
@@ -238,10 +238,7 @@ private[spark] class LiveListenerBus(conf: SparkConf) {
 
   // For testing only.
   private[scheduler] def getQueueCapacity(name: String): Int = {
-    queues.asScala.find(_.name == name) match {
-      case Some(queue) => queue.capacity
-      case None => -1
-    }
+    queues.asScala.find(_.name == name).map(_.capacity).getOrElse(-1)
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/LiveListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/LiveListenerBus.scala
@@ -237,8 +237,8 @@ private[spark] class LiveListenerBus(conf: SparkConf) {
   }
 
   // For testing only.
-  private[scheduler] def getQueueCapacity(name: String): Int = {
-    queues.asScala.find(_.name == name).map(_.capacity).getOrElse(-1)
+  private[scheduler] def getQueueCapacity(name: String): Option[Int] = {
+    queues.asScala.find(_.name == name).map(_.capacity)
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -533,24 +533,30 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
   }
 
   test("event queue size can be configued through spark conf") {
+    // configure the shared queue size to be 1, event log queue size to be 2,
+    // and listner bus event queue size to be 5
     val conf = new SparkConf(false)
       .set(LISTENER_BUS_EVENT_QUEUE_CAPACITY, 5)
-      .set("spark.scheduler.listenerbus.eventqueue.shared.capacity", "1")
-      .set("spark.scheduler.listenerbus.eventqueue.eventLog.capacity", "2")
+      .set(s"spark.scheduler.listenerbus.eventqueue.${SHARED_QUEUE}.capacity", "1")
+      .set(s"spark.scheduler.listenerbus.eventqueue.${EVENT_LOG_QUEUE}.capacity", "2")
 
     val bus = new LiveListenerBus(conf)
     val counter1 = new BasicJobCounter()
     val counter2 = new BasicJobCounter()
     val counter3 = new BasicJobCounter()
 
+    // add a new shared, status and event queue
     bus.addToSharedQueue(counter1)
     bus.addToStatusQueue(counter2)
     bus.addToEventLogQueue(counter3)
 
     assert(bus.activeQueues() === Set(SHARED_QUEUE, APP_STATUS_QUEUE, EVENT_LOG_QUEUE))
-    // check the size of each queue
+    // check the size of shared queue is 1 as configured
     assert(bus.getQueueCapacity(SHARED_QUEUE) == 1)
+    // no specific size of status queue is configured,
+    // it shoud use the LISTENER_BUS_EVENT_QUEUE_CAPACITY
     assert(bus.getQueueCapacity(APP_STATUS_QUEUE) == 5)
+    // check the size of event log queue is 5 as configured
     assert(bus.getQueueCapacity(EVENT_LOG_QUEUE) == 2)
   }
 

--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -552,12 +552,15 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
 
     assert(bus.activeQueues() === Set(SHARED_QUEUE, APP_STATUS_QUEUE, EVENT_LOG_QUEUE))
     // check the size of shared queue is 1 as configured
-    assert(bus.getQueueCapacity(SHARED_QUEUE) == 1)
+    assert(bus.getQueueCapacity(SHARED_QUEUE).isDefined)
+    assert(bus.getQueueCapacity(SHARED_QUEUE).get == 1)
     // no specific size of status queue is configured,
     // it shoud use the LISTENER_BUS_EVENT_QUEUE_CAPACITY
-    assert(bus.getQueueCapacity(APP_STATUS_QUEUE) == 5)
+    assert(bus.getQueueCapacity(APP_STATUS_QUEUE).isDefined)
+    assert(bus.getQueueCapacity(APP_STATUS_QUEUE).get == 5)
     // check the size of event log queue is 5 as configured
-    assert(bus.getQueueCapacity(EVENT_LOG_QUEUE) == 2)
+    assert(bus.getQueueCapacity(EVENT_LOG_QUEUE).isDefined)
+    assert(bus.getQueueCapacity(EVENT_LOG_QUEUE).get == 2)
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -552,15 +552,12 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
 
     assert(bus.activeQueues() === Set(SHARED_QUEUE, APP_STATUS_QUEUE, EVENT_LOG_QUEUE))
     // check the size of shared queue is 1 as configured
-    assert(bus.getQueueCapacity(SHARED_QUEUE).isDefined)
-    assert(bus.getQueueCapacity(SHARED_QUEUE).get == 1)
+    assert(bus.getQueueCapacity(SHARED_QUEUE) == Some(1))
     // no specific size of status queue is configured,
     // it shoud use the LISTENER_BUS_EVENT_QUEUE_CAPACITY
-    assert(bus.getQueueCapacity(APP_STATUS_QUEUE).isDefined)
-    assert(bus.getQueueCapacity(APP_STATUS_QUEUE).get == 5)
+    assert(bus.getQueueCapacity(APP_STATUS_QUEUE) == Some(5))
     // check the size of event log queue is 5 as configured
-    assert(bus.getQueueCapacity(EVENT_LOG_QUEUE).isDefined)
-    assert(bus.getQueueCapacity(EVENT_LOG_QUEUE).get == 2)
+    assert(bus.getQueueCapacity(EVENT_LOG_QUEUE) == Some(2))
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add configuration spark.scheduler.listenerbus.eventqueue.${name}.capacity to allow configuration of different event queue size.

## How was this patch tested?
Unit test in core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
