### PR TITLE
[WIP][SPARK-28580][SQL] Support ANSI SQL Unique-Predicate syntax

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -661,6 +661,7 @@ expression
 booleanExpression
     : NOT booleanExpression                                        #logicalNot
     | EXISTS '(' query ')'                                         #exists
+    | UNIQUE '(' query ')'                                         #unique
     | valueExpression predicate?                                   #predicated
     | left=booleanExpression operator=AND right=booleanExpression  #logicalBinary
     | left=booleanExpression operator=OR right=booleanExpression   #logicalBinary


### PR DESCRIPTION
## What changes were proposed in this pull request?

The aim of this PR is to support ANSI SQL `Unique-Predicate` syntax.
The function of `Unique-Predicate` is specify a test for the absence of duplicate rows.
The definition in ANSI docs is below:
```
<unique predicate> ::=
UNIQUE <table subquery>
```
IMHO. I can't find any database supports this syntax. I lost some reference of other database.
The usage maybe looks like:
```
SELECT t.*
FROM course AS t
WHERE UNIQUE(
    SELECT r.course_id
    FROM section AS r
    WHERE t.course_id=r.course_id AND r.year = '2018'
);
```
I have referenced the implement of `Exists` in Spark SQL. The rule `RewritePredicateSubquery` replace the `Exists` with a semi join between inner table and outer table.
I have a basic idea use some rule replace `Unique-Predicate` with equivalent SQL.
Take the above SQL as an example, the replaced SQL likes below:
```
SELECT t.*
FROM course AS t
INNER JOIN(
   SELECT r.course_id AS course_id
   FROM section AS r
   WHERE r.year = '2018'
   GROUP BY r.course_id
   HAVING COUNT(r.course_id) = 1
) AS b
ON t.course_id = b.course_id;
```
But I don't know whether welcomed by everyone or not, I need some better thinking.
## How was this patch tested?

new UT
