### PR TITLE
[SPARK-28581][SQL] Replace _FUNC_ in UDF ExpressionInfo

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionInfo.java
@@ -37,7 +37,7 @@ public class ExpressionInfo {
     }
 
     public String getUsage() {
-        return usage;
+        return replaceFunctionName(usage);
     }
 
     public String getName() {
@@ -45,7 +45,7 @@ public class ExpressionInfo {
     }
 
     public String getExtended() {
-        return extended;
+        return replaceFunctionName(extended);
     }
 
     public String getSince() {
@@ -57,7 +57,7 @@ public class ExpressionInfo {
     }
 
     public String getExamples() {
-        return examples;
+        return replaceFunctionName(examples);
     }
 
     public String getNote() {
@@ -149,5 +149,13 @@ public class ExpressionInfo {
         // `arguments` and `examples` are concatenated for the extended description. So, here
         // simply pass the `extended` as `arguments` and an empty string for `examples`.
         this(className, db, name, usage, extended, "", "", "", "");
+    }
+
+    private String replaceFunctionName(String usage) {
+        if (usage == null) {
+            return "N/A.";
+        } else {
+            return usage.replaceAll("_FUNC_", name);
+        }
     }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
@@ -112,14 +112,6 @@ case class DescribeFunctionCommand(
     schema.toAttributes
   }
 
-  private def replaceFunctionName(usage: String, functionName: String): String = {
-    if (usage == null) {
-      "N/A."
-    } else {
-      usage.replaceAll("_FUNC_", functionName)
-    }
-  }
-
   override def run(sparkSession: SparkSession): Seq[Row] = {
     // Hard code "<>", "!=", "between", and "case" for now as there is no corresponding functions.
     functionName.funcName.toLowerCase(Locale.ROOT) match {
@@ -148,11 +140,11 @@ case class DescribeFunctionCommand(
           val result =
             Row(s"Function: $name") ::
               Row(s"Class: ${info.getClassName}") ::
-              Row(s"Usage: ${replaceFunctionName(info.getUsage, info.getName)}") :: Nil
+              Row(s"Usage: ${info.getUsage}") :: Nil
 
           if (isExtended) {
             result :+
-              Row(s"Extended Usage:${replaceFunctionName(info.getExtended, info.getName)}")
+              Row(s"Extended Usage:${info.getExtended}")
           } else {
             result
           }

--- a/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql
 import java.math.BigDecimal
 
 import org.apache.spark.sql.api.java._
+import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.plans.logical.Project
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.execution.columnar.InMemoryRelation
@@ -522,5 +523,16 @@ class UDFSuite extends QueryTest with SharedSQLContext {
       }, IntegerType).asNondeterministic()
 
     assert(spark.range(2).select(nonDeterministicJavaUDF()).distinct().count() == 2)
+  }
+
+  test("Replace _FUNC_ in UDF ExpressionInfo") {
+    val info = spark.sessionState.catalog.lookupFunctionInfo(FunctionIdentifier("upper"))
+    assert(info.getName === "upper")
+    assert(info.getClassName === "org.apache.spark.sql.catalyst.expressions.Upper")
+    assert(info.getUsage === "upper(str) - Returns `str` with all characters changed to uppercase.")
+    assert(info.getExamples.contains("> SELECT upper('SparkSql');"))
+    assert(info.getSince === "1.0.1")
+    assert(info.getNote === "")
+    assert(info.getExtended.contains("> SELECT upper('SparkSql');"))
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR moves `replaceFunctionName(usage: String, functionName: String)` 
from `DescribeFunctionCommand` to `ExpressionInfo` in order to make `ExpressionInfo` returns actual name instead of placeholder. We can get `ExpressionInfo`s directly through `SessionCatalog.lookupFunctionInfo` API and get the real names.

## How was this patch tested?

unit tests
