### PR TITLE
[SPARK-28582][PYSPARK] Fix flaky test DaemonTests.do_termination_test which fail on Python 3.7

### DIFF
--- a/python/pyspark/daemon.py
+++ b/python/pyspark/daemon.py
@@ -102,7 +102,7 @@ def manager():
         signal.signal(SIGTERM, SIG_DFL)
         # Send SIGHUP to notify workers of shutdown
         os.kill(0, SIGHUP)
-        os._exit(code)
+        sys.exit(code)
 
     def handle_sigterm(*args):
         shutdown(1)

--- a/python/pyspark/daemon.py
+++ b/python/pyspark/daemon.py
@@ -102,7 +102,7 @@ def manager():
         signal.signal(SIGTERM, SIG_DFL)
         # Send SIGHUP to notify workers of shutdown
         os.kill(0, SIGHUP)
-        sys.exit(code)
+        os._exit(code)
 
     def handle_sigterm(*args):
         shutdown(1)

--- a/python/pyspark/tests/test_daemon.py
+++ b/python/pyspark/tests/test_daemon.py
@@ -47,6 +47,9 @@ class DaemonTests(unittest.TestCase):
         # daemon should accept connections
         self.assertTrue(self.connect(port))
 
+        # wait worker process spawned from daemon exit.
+        time.sleep(1)
+
         # request shutdown
         terminator(daemon)
         time.sleep(1)

--- a/python/pyspark/tests/test_daemon.py
+++ b/python/pyspark/tests/test_daemon.py
@@ -52,7 +52,7 @@ class DaemonTests(unittest.TestCase):
 
         # request shutdown
         terminator(daemon)
-        time.sleep(1)
+        daemon.wait(5)
 
         # daemon should no longer accept connections
         try:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix flaky test DaemonTests.do_termination_test which fail on Python 3.7. I add a sleep after the test connection to daemon.

## How was this patch tested?

Run test
```
python/run-tests --python-executables=python3.7 --testname "pyspark.tests.test_daemon DaemonTests"
```
**Before**
Fail on test "test_termination_sigterm". And we can see daemon process do not exit.
**After**
Test passed