### PR TITLE
[SPARK-21481][ML][FOLLOWUP] HashingTF Cleanup

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
@@ -106,7 +106,7 @@ class HashingTF @Since("1.4.0") (@Since("1.4.0") override val uid: String)
     val hashUDF = udf { terms: Seq[_] =>
       val termFrequencies = mutable.HashMap.empty[Int, Double].withDefaultValue(0.0)
       terms.foreach { term =>
-        val i = Utils.nonNegativeMod(hashFunc(term), localNumFeatures)
+        val i = indexOf(term)
         if (localBinary) {
           termFrequencies(i) = 1.0
         } else {

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/HashingTF.scala
@@ -98,7 +98,7 @@ class HashingTF(val numFeatures: Int) extends Serializable {
     Vectors.sparse(numFeatures, seq)
   }
 
-  private[spark] def transformImpl(document: Iterable[_]): Seq[(Int, Double)] = {
+  private def transformImpl(document: Iterable[_]): Seq[(Int, Double)] = {
     val termFrequencies = mutable.HashMap.empty[Int, Double]
     val setTF = if (binary) (i: Int) => 1.0 else (i: Int) => termFrequencies.getOrElse(i, 0.0) + 1.0
     val hashFunc: Any => Int = getHashFunction

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/HashingTFSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/HashingTFSuite.scala
@@ -77,7 +77,6 @@ class HashingTFSuite extends MLTest with DefaultReadWriteTest {
   }
 
   test("indexOf method") {
-    val df = Seq((0, "a a b b c d".split(" ").toSeq)).toDF("id", "words")
     val n = 100
     val hashingTF = new HashingTF()
       .setInputCol("words")


### PR DESCRIPTION
## What changes were proposed in this pull request?
some cleanup and tiny optimization
1, since the `transformImpl` method in the .mllib side is no longer used in the .ml side, the scope should be limited;
2, in the `hashUDF`, val `numOfFeatures` is never used;
3, in the udf, it is inefficient to involve param getter (`$(numFeatures)`/`$(binary)`) directly or via method `indexOf` ((`$(numFeatures)`) . instead, the getter should be called outside of the udf;

## How was this patch tested?
existing suites