### PR TITLE
[SPARK-28590][PySpark][WIP] Add sort_stats Setter and Getter in Profiler

### DIFF
--- a/python/pyspark/profiler.py
+++ b/python/pyspark/profiler.py
@@ -110,6 +110,12 @@ class Profiler(object):
         """ Return the collected profiling stats (pstats.Stats)"""
         raise NotImplementedError
 
+    def set_sort_stats_sorters(self, sorter):
+        self._sort_stats_sorters = sorter
+
+    def get_sort_stats_sorters(self):
+        return self._sort_stats_sorters
+
     def show(self, id):
         """ Print the profile stats to stdout, id is the RDD id """
         stats = self.stats()
@@ -117,7 +123,9 @@ class Profiler(object):
             print("=" * 60)
             print("Profile of RDD<id=%d>" % id)
             print("=" * 60)
-            stats.sort_stats("time", "cumulative").print_stats()
+
+            sorter = self.get_sort_stats_sorters()
+            stats.sort_stats(*sorter).print_stats()
 
     def dump(self, id, path):
         """ Dump the profile into path, id is the RDD id """


### PR DESCRIPTION
## What changes were proposed in this pull request?

When I want to use _BasicProfiler_ with different sorters in **sort_stats**, I sometimes need to create a custom profiler and implement the **show()** method only to replace the following line: `stats.sort_stats("time", "cumulative").print_stats()`.

I think it'd be better if the users are able to specify the sorters without creating a custom profiler.

I implemented the changes in PySpark only.

To apply the **setter** and **getter** methods, one can use the following way:

```python
conf = SparkConf().set("spark.python.profile", "true")

# use BasicProfiler
sc = SparkContext('local', 'test', conf=conf)
sc.profiler_collector.profiler_cls.set_sort_stats_sorters(BasicProfiler, ['ncalls', 'tottime', 'name'])
```

## How was this patch tested?

plan to use unit test

Please review https://spark.apache.org/contributing.html before opening a pull request.
