### PR TITLE
[SPARK-28598][SQL] Few date time manipulation functions does not provide versions supporting Column as input through the Dataframe API

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2595,6 +2595,21 @@ object functions {
   }
 
   /**
+   * Returns the date that is `numMonths` after `startDate`.
+   *
+   * @param startDate A date, timestamp or string. If a string, the data must be in a format that
+   *                  can be cast to a date, such as `yyyy-MM-dd` or `yyyy-MM-dd HH:mm:ss.SSSS`
+   * @param numMonths A column of the number of months to add to `startDate`, can be negative to
+   *                  subtract months
+   * @return A date, or null if `startDate` was a string that could not be cast to a date
+   * @group datetime_funcs
+   * @since 3.0.0
+   */
+  def add_month(startDate: Column, numMonths: Column): Column = withExpr {
+    AddMonths(startDate.expr, numMonths.expr)
+  }
+
+  /**
    * Returns the current date as a date column.
    *
    * @group datetime_funcs
@@ -2643,6 +2658,18 @@ object functions {
   def date_add(start: Column, days: Int): Column = withExpr { DateAdd(start.expr, Literal(days)) }
 
   /**
+   * Returns the date that is `days` days after `start`
+   *
+   * @param start A date, timestamp or string. If a string, the data must be in a format that
+   *              can be cast to a date, such as `yyyy-MM-dd` or `yyyy-MM-dd HH:mm:ss.SSSS`
+   * @param days  A column of the number of days to add to `start`, can be negative to subtract days
+   * @return A date, or null if `start` was a string that could not be cast to a date
+   * @group datetime_funcs
+   * @since 3.0.0
+   */
+  def date_add(start: Column, days: Column): Column = withExpr { DateAdd(start.expr, days.expr) }
+
+  /**
    * Returns the date that is `days` days before `start`
    *
    * @param start A date, timestamp or string. If a string, the data must be in a format that
@@ -2653,6 +2680,19 @@ object functions {
    * @since 1.5.0
    */
   def date_sub(start: Column, days: Int): Column = withExpr { DateSub(start.expr, Literal(days)) }
+
+  /**
+   * Returns the date that is `days` days before `start`
+   *
+   * @param start A date, timestamp or string. If a string, the data must be in a format that
+   *              can be cast to a date, such as `yyyy-MM-dd` or `yyyy-MM-dd HH:mm:ss.SSSS`
+   * @param days  A column of the number of days to subtract from `start`, can be negative to add
+   *              days
+   * @return A date, or null if `start` was a string that could not be cast to a date
+   * @group datetime_funcs
+   * @since 3.0.0
+   */
+  def date_sub(start: Column, days: Column): Column = withExpr { DateSub(start.expr, days.expr) }
 
   /**
    * Returns the number of days from `start` to `end`.

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2590,9 +2590,7 @@ object functions {
    * @group datetime_funcs
    * @since 1.5.0
    */
-  def add_months(startDate: Column, numMonths: Int): Column = withExpr {
-    AddMonths(startDate.expr, Literal(numMonths))
-  }
+  def add_months(startDate: Column, numMonths: Int): Column = add_months(startDate, lit(numMonths))
 
   /**
    * Returns the date that is `numMonths` after `startDate`.
@@ -2605,7 +2603,7 @@ object functions {
    * @group datetime_funcs
    * @since 3.0.0
    */
-  def add_month(startDate: Column, numMonths: Column): Column = withExpr {
+  def add_months(startDate: Column, numMonths: Column): Column = withExpr {
     AddMonths(startDate.expr, numMonths.expr)
   }
 
@@ -2655,7 +2653,7 @@ object functions {
    * @group datetime_funcs
    * @since 1.5.0
    */
-  def date_add(start: Column, days: Int): Column = withExpr { DateAdd(start.expr, Literal(days)) }
+  def date_add(start: Column, days: Int): Column = date_add(start, lit(days))
 
   /**
    * Returns the date that is `days` days after `start`
@@ -2679,7 +2677,7 @@ object functions {
    * @group datetime_funcs
    * @since 1.5.0
    */
-  def date_sub(start: Column, days: Int): Column = withExpr { DateSub(start.expr, Literal(days)) }
+  def date_sub(start: Column, days: Int): Column = date_sub(start, lit(days))
 
   /**
    * Returns the date that is `days` days before `start`

--- a/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
@@ -239,6 +239,21 @@ class DateFunctionsSuite extends QueryTest with SharedSQLContext {
       df.select(date_add(col("ss"), 7)),
       Seq(Row(Date.valueOf("2015-06-08")), Row(Date.valueOf("2015-06-09"))))
 
+    val df2 = df.withColumn("x", lit(1))
+    checkAnswer(
+      df2.select(date_add(col("d"), col("x"))),
+      Seq(Row(Date.valueOf("2015-06-02")), Row(Date.valueOf("2015-06-03"))))
+    checkAnswer(
+      df2.select(date_add(col("t"), col("x") * 3)),
+      Seq(Row(Date.valueOf("2015-06-04")), Row(Date.valueOf("2015-06-05"))))
+    checkAnswer(
+      df2.select(date_add(col("s"), col("x") * 5)),
+      Seq(Row(Date.valueOf("2015-06-06")), Row(Date.valueOf("2015-06-07"))))
+    checkAnswer(
+      df2.select(date_add(col("ss"), col("x") * 7)),
+      Seq(Row(Date.valueOf("2015-06-08")), Row(Date.valueOf("2015-06-09"))))
+
+
     checkAnswer(df.selectExpr("DATE_ADD(null, 1)"), Seq(Row(null), Row(null)))
     checkAnswer(
       df.selectExpr("""DATE_ADD(d, 1)"""),
@@ -269,6 +284,22 @@ class DateFunctionsSuite extends QueryTest with SharedSQLContext {
       Seq(Row(Date.valueOf("2015-05-31")), Row(Date.valueOf("2015-06-01"))))
     checkAnswer(
       df.select(date_sub(lit(null), 1)).limit(1), Row(null))
+
+    val df2 = df.withColumn("x", lit(1))
+    checkAnswer(
+      df2.select(date_sub(col("d"), col("x"))),
+      Seq(Row(Date.valueOf("2015-05-31")), Row(Date.valueOf("2015-06-01"))))
+    checkAnswer(
+      df2.select(date_sub(col("t"), col("x"))),
+      Seq(Row(Date.valueOf("2015-05-31")), Row(Date.valueOf("2015-06-01"))))
+    checkAnswer(
+      df2.select(date_sub(col("s"), col("x"))),
+      Seq(Row(Date.valueOf("2015-05-31")), Row(Date.valueOf("2015-06-01"))))
+    checkAnswer(
+      df2.select(date_sub(col("ss"), col("x"))),
+      Seq(Row(Date.valueOf("2015-05-31")), Row(Date.valueOf("2015-06-01"))))
+    checkAnswer(
+      df2.select(date_sub(lit(null), col("x"))).limit(1), Row(null))
 
     checkAnswer(df.selectExpr("""DATE_SUB(d, null)"""), Seq(Row(null), Row(null)))
     checkAnswer(
@@ -318,6 +349,9 @@ class DateFunctionsSuite extends QueryTest with SharedSQLContext {
     checkAnswer(
       df.selectExpr("add_months(d, -1)"),
       Seq(Row(Date.valueOf("2015-07-31")), Row(Date.valueOf("2015-01-28"))))
+    checkAnswer(
+      df.withColumn("x", lit(1)).select(add_months(col("d"), col("x"))),
+      Seq(Row(Date.valueOf("2015-09-30")), Row(Date.valueOf("2015-03-28"))))
   }
 
   test("function months_between") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
@@ -239,20 +239,9 @@ class DateFunctionsSuite extends QueryTest with SharedSQLContext {
       df.select(date_add(col("ss"), 7)),
       Seq(Row(Date.valueOf("2015-06-08")), Row(Date.valueOf("2015-06-09"))))
 
-    val df2 = df.withColumn("x", lit(1))
     checkAnswer(
-      df2.select(date_add(col("d"), col("x"))),
+      df.withColumn("x", lit(1)).select(date_add(col("d"), col("x"))),
       Seq(Row(Date.valueOf("2015-06-02")), Row(Date.valueOf("2015-06-03"))))
-    checkAnswer(
-      df2.select(date_add(col("t"), col("x") * 3)),
-      Seq(Row(Date.valueOf("2015-06-04")), Row(Date.valueOf("2015-06-05"))))
-    checkAnswer(
-      df2.select(date_add(col("s"), col("x") * 5)),
-      Seq(Row(Date.valueOf("2015-06-06")), Row(Date.valueOf("2015-06-07"))))
-    checkAnswer(
-      df2.select(date_add(col("ss"), col("x") * 7)),
-      Seq(Row(Date.valueOf("2015-06-08")), Row(Date.valueOf("2015-06-09"))))
-
 
     checkAnswer(df.selectExpr("DATE_ADD(null, 1)"), Seq(Row(null), Row(null)))
     checkAnswer(
@@ -285,21 +274,9 @@ class DateFunctionsSuite extends QueryTest with SharedSQLContext {
     checkAnswer(
       df.select(date_sub(lit(null), 1)).limit(1), Row(null))
 
-    val df2 = df.withColumn("x", lit(1))
     checkAnswer(
-      df2.select(date_sub(col("d"), col("x"))),
+      df.withColumn("x", lit(1)).select(date_sub(col("d"), col("x"))),
       Seq(Row(Date.valueOf("2015-05-31")), Row(Date.valueOf("2015-06-01"))))
-    checkAnswer(
-      df2.select(date_sub(col("t"), col("x"))),
-      Seq(Row(Date.valueOf("2015-05-31")), Row(Date.valueOf("2015-06-01"))))
-    checkAnswer(
-      df2.select(date_sub(col("s"), col("x"))),
-      Seq(Row(Date.valueOf("2015-05-31")), Row(Date.valueOf("2015-06-01"))))
-    checkAnswer(
-      df2.select(date_sub(col("ss"), col("x"))),
-      Seq(Row(Date.valueOf("2015-05-31")), Row(Date.valueOf("2015-06-01"))))
-    checkAnswer(
-      df2.select(date_sub(lit(null), col("x"))).limit(1), Row(null))
 
     checkAnswer(df.selectExpr("""DATE_SUB(d, null)"""), Seq(Row(null), Row(null)))
     checkAnswer(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add following functions:
```
def add_months(startDate: Column, numMonths: Column): Column
def date_add(start: Column, days: Column): Column
def date_sub(start: Column, days: Column): Column
```

## How was this patch tested?

UT.

Please review https://spark.apache.org/contributing.html before opening a pull request.
