### PR TITLE
[SPARK-28601][CORE][SQL] Use StandardCharsets.UTF_8 instead of "UTF-8" string representation, and get rid of UnsupportedEncodingException

### DIFF
--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
@@ -621,13 +621,13 @@ public class UTF8StringSuite {
   public void writeToOutputStream() throws IOException {
     final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     EMPTY_UTF8.writeTo(outputStream);
-    assertEquals("", outputStream.toString("UTF-8"));
+    assertEquals("", outputStream.toString(StandardCharsets.UTF_8.name()));
     outputStream.reset();
 
     fromString("数据砖很重").writeTo(outputStream);
     assertEquals(
         "数据砖很重",
-        outputStream.toString("UTF-8"));
+        outputStream.toString(StandardCharsets.UTF_8.name()));
     outputStream.reset();
   }
 
@@ -651,7 +651,7 @@ public class UTF8StringSuite {
     final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     fromAddress(array, Platform.INT_ARRAY_OFFSET, length)
         .writeTo(outputStream);
-    assertEquals("大千世界", outputStream.toString("UTF-8"));
+    assertEquals("大千世界", outputStream.toString(StandardCharsets.UTF_8.name()));
   }
 
   @Test

--- a/core/src/main/scala/org/apache/spark/executor/ProcfsMetricsGetter.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ProcfsMetricsGetter.scala
@@ -19,7 +19,7 @@ package org.apache.spark.executor
 
 import java.io._
 import java.nio.charset.Charset
-import java.nio.charset.StandardCharsets
+import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{Files, Paths}
 import java.util.Locale
 
@@ -172,8 +172,7 @@ private[spark] class ProcfsMetricsGetter(procfsDir: String = "/proc/") extends L
       val pidDir = new File(procfsDir, pid.toString)
       def openReader(): BufferedReader = {
         val f = new File(new File(procfsDir, pid.toString), procfsStatFile)
-        new BufferedReader(new InputStreamReader(new FileInputStream(f),
-          StandardCharsets.UTF_8.name()))
+        new BufferedReader(new InputStreamReader(new FileInputStream(f), UTF_8))
       }
       Utils.tryWithResource(openReader) { in =>
         val procInfo = in.readLine

--- a/core/src/main/scala/org/apache/spark/executor/ProcfsMetricsGetter.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ProcfsMetricsGetter.scala
@@ -19,6 +19,7 @@ package org.apache.spark.executor
 
 import java.io._
 import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths}
 import java.util.Locale
 
@@ -171,7 +172,8 @@ private[spark] class ProcfsMetricsGetter(procfsDir: String = "/proc/") extends L
       val pidDir = new File(procfsDir, pid.toString)
       def openReader(): BufferedReader = {
         val f = new File(new File(procfsDir, pid.toString), procfsStatFile)
-        new BufferedReader(new InputStreamReader(new FileInputStream(f), Charset.forName("UTF-8")))
+        new BufferedReader(new InputStreamReader(new FileInputStream(f),
+          StandardCharsets.UTF_8.name()))
       }
       Utils.tryWithResource(openReader) { in =>
         val procInfo = in.readLine

--- a/core/src/main/scala/org/apache/spark/ui/PagedTable.scala
+++ b/core/src/main/scala/org/apache/spark/ui/PagedTable.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.ui
 
 import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 
 import scala.collection.JavaConverters._
 import scala.xml.{Node, Unparsed}
@@ -202,7 +203,7 @@ private[spark] trait PagedTable[T] {
           .asScala
           .filterKeys(_ != pageSizeFormField)
           .filterKeys(_ != pageNumberFormField)
-          .mapValues(URLDecoder.decode(_, "UTF-8"))
+          .mapValues(URLDecoder.decode(_, StandardCharsets.UTF_8.name()))
           .map { case (k, v) =>
             <input type="hidden" name={k} value={v} />
           }

--- a/core/src/main/scala/org/apache/spark/ui/PagedTable.scala
+++ b/core/src/main/scala/org/apache/spark/ui/PagedTable.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.ui
 
 import java.net.URLDecoder
-import java.nio.charset.StandardCharsets
+import java.nio.charset.StandardCharsets.UTF_8
 
 import scala.collection.JavaConverters._
 import scala.xml.{Node, Unparsed}
@@ -203,7 +203,7 @@ private[spark] trait PagedTable[T] {
           .asScala
           .filterKeys(_ != pageSizeFormField)
           .filterKeys(_ != pageNumberFormField)
-          .mapValues(URLDecoder.decode(_, StandardCharsets.UTF_8.name()))
+          .mapValues(URLDecoder.decode(_, UTF_8.name()))
           .map { case (k, v) =>
             <input type="hidden" name={k} value={v} />
           }

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.ui
 
 import java.net.URLDecoder
+import java.nio.charset.StandardCharsets.UTF_8
 import java.text.SimpleDateFormat
 import java.util.{Date, Locale, TimeZone}
 import javax.servlet.http.HttpServletRequest
@@ -523,10 +524,10 @@ private[spark] object UIUtils extends Logging {
    */
   def decodeURLParameter(urlParam: String): String = {
     var param = urlParam
-    var decodedParam = URLDecoder.decode(param, "UTF-8")
+    var decodedParam = URLDecoder.decode(param, UTF_8.name())
     while (param != decodedParam) {
       param = decodedParam
-      decodedParam = URLDecoder.decode(param, "UTF-8")
+      decodedParam = URLDecoder.decode(param, UTF_8.name())
     }
     param
   }

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.ui.jobs
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.UTF_8
 import java.util.Date
 import javax.servlet.http.HttpServletRequest
 
@@ -524,7 +525,7 @@ private[ui] class JobPagedTable(
     desc)
 
   override def pageLink(page: Int): String = {
-    val encodedSortColumn = URLEncoder.encode(sortColumn, "UTF-8")
+    val encodedSortColumn = URLEncoder.encode(sortColumn, UTF_8.name())
     parameterPath +
       s"&$pageNumberFormField=$page" +
       s"&$jobTag.sort=$encodedSortColumn" +
@@ -534,7 +535,7 @@ private[ui] class JobPagedTable(
   }
 
   override def goButtonFormPath: String = {
-    val encodedSortColumn = URLEncoder.encode(sortColumn, "UTF-8")
+    val encodedSortColumn = URLEncoder.encode(sortColumn, UTF_8.name())
     s"$parameterPath&$jobTag.sort=$encodedSortColumn&$jobTag.desc=$desc#$tableHeaderId"
   }
 
@@ -557,7 +558,7 @@ private[ui] class JobPagedTable(
         if (header == sortColumn) {
           val headerLink = Unparsed(
             parameterPath +
-              s"&$jobTag.sort=${URLEncoder.encode(header, "UTF-8")}" +
+              s"&$jobTag.sort=${URLEncoder.encode(header, UTF_8.name())}" +
               s"&$jobTag.desc=${!desc}" +
               s"&$jobTag.pageSize=$pageSize" +
               s"#$tableHeaderId")
@@ -574,7 +575,7 @@ private[ui] class JobPagedTable(
           if (sortable) {
             val headerLink = Unparsed(
               parameterPath +
-                s"&$jobTag.sort=${URLEncoder.encode(header, "UTF-8")}" +
+                s"&$jobTag.sort=${URLEncoder.encode(header, UTF_8.name())}" +
                 s"&$jobTag.pageSize=$pageSize" +
                 s"#$tableHeaderId")
 

--- a/core/src/main/scala/org/apache/spark/ui/jobs/PoolTable.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/PoolTable.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.ui.jobs
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import javax.servlet.http.HttpServletRequest
 
 import scala.xml.Node
@@ -48,7 +49,8 @@ private[ui] class PoolTable(pools: Map[Schedulable, PoolData], parent: StagesTab
   private def poolRow(request: HttpServletRequest, s: Schedulable, p: PoolData): Seq[Node] = {
     val activeStages = p.stageIds.size
     val href = "%s/stages/pool?poolname=%s"
-      .format(UIUtils.prependBaseUri(request, parent.basePath), URLEncoder.encode(p.name, "UTF-8"))
+      .format(UIUtils.prependBaseUri(request, parent.basePath),
+        URLEncoder.encode(p.name, StandardCharsets.UTF_8.name()))
     <tr>
       <td>
         <a href={href}>{p.name}</a>

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.ui.jobs
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.UTF_8
 import java.util.Date
 import java.util.concurrent.TimeUnit
 import javax.servlet.http.HttpServletRequest
@@ -506,7 +507,7 @@ private[ui] class TaskPagedTable(
     store)
 
   override def pageLink(page: Int): String = {
-    val encodedSortColumn = URLEncoder.encode(sortColumn, "UTF-8")
+    val encodedSortColumn = URLEncoder.encode(sortColumn, UTF_8.name())
     basePath +
       s"&$pageNumberFormField=$page" +
       s"&task.sort=$encodedSortColumn" +
@@ -515,7 +516,7 @@ private[ui] class TaskPagedTable(
   }
 
   override def goButtonFormPath: String = {
-    val encodedSortColumn = URLEncoder.encode(sortColumn, "UTF-8")
+    val encodedSortColumn = URLEncoder.encode(sortColumn, UTF_8.name())
     s"$basePath&task.sort=$encodedSortColumn&task.desc=$desc"
   }
 
@@ -563,7 +564,7 @@ private[ui] class TaskPagedTable(
         if (header == sortColumn) {
           val headerLink = Unparsed(
             basePath +
-              s"&task.sort=${URLEncoder.encode(header, "UTF-8")}" +
+              s"&task.sort=${URLEncoder.encode(header, UTF_8.name())}" +
               s"&task.desc=${!desc}" +
               s"&task.pageSize=$pageSize")
           val arrow = if (desc) "&#x25BE;" else "&#x25B4;" // UP or DOWN
@@ -576,7 +577,7 @@ private[ui] class TaskPagedTable(
         } else {
           val headerLink = Unparsed(
             basePath +
-              s"&task.sort=${URLEncoder.encode(header, "UTF-8")}" +
+              s"&task.sort=${URLEncoder.encode(header, UTF_8.name())}" +
               s"&task.pageSize=$pageSize")
           <th class={cssClass}>
             <a href={headerLink}>

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.ui.jobs
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.UTF_8
 import java.util.Date
 import javax.servlet.http.HttpServletRequest
 
@@ -160,7 +161,7 @@ private[ui] class StagePagedTable(
   )
 
   override def pageLink(page: Int): String = {
-    val encodedSortColumn = URLEncoder.encode(sortColumn, "UTF-8")
+    val encodedSortColumn = URLEncoder.encode(sortColumn, UTF_8.name())
     parameterPath +
       s"&$pageNumberFormField=$page" +
       s"&$stageTag.sort=$encodedSortColumn" +
@@ -170,7 +171,7 @@ private[ui] class StagePagedTable(
   }
 
   override def goButtonFormPath: String = {
-    val encodedSortColumn = URLEncoder.encode(sortColumn, "UTF-8")
+    val encodedSortColumn = URLEncoder.encode(sortColumn, UTF_8.name())
     s"$parameterPath&$stageTag.sort=$encodedSortColumn&$stageTag.desc=$desc#$tableHeaderId"
   }
 
@@ -217,7 +218,7 @@ private[ui] class StagePagedTable(
         if (header == sortColumn) {
           val headerLink = Unparsed(
             parameterPath +
-              s"&$stageTag.sort=${URLEncoder.encode(header, "UTF-8")}" +
+              s"&$stageTag.sort=${URLEncoder.encode(header, UTF_8.name())}" +
               s"&$stageTag.desc=${!desc}" +
               s"&$stageTag.pageSize=$pageSize") +
               s"#$tableHeaderId"
@@ -234,7 +235,7 @@ private[ui] class StagePagedTable(
           if (sortable) {
             val headerLink = Unparsed(
               parameterPath +
-                s"&$stageTag.sort=${URLEncoder.encode(header, "UTF-8")}" +
+                s"&$stageTag.sort=${URLEncoder.encode(header, UTF_8.name())}" +
                 s"&$stageTag.pageSize=$pageSize") +
                 s"#$tableHeaderId"
 

--- a/core/src/main/scala/org/apache/spark/ui/storage/RDDPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/RDDPage.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.ui.storage
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.UTF_8
 import javax.servlet.http.HttpServletRequest
 
 import scala.xml.{Node, Unparsed}
@@ -239,7 +240,7 @@ private[ui] class BlockPagedTable(
     executorSummaries.map { ex => (ex.id, ex.hostPort) }.toMap)
 
   override def pageLink(page: Int): String = {
-    val encodedSortColumn = URLEncoder.encode(sortColumn, "UTF-8")
+    val encodedSortColumn = URLEncoder.encode(sortColumn, UTF_8.name())
     basePath +
       s"&$pageNumberFormField=$page" +
       s"&block.sort=$encodedSortColumn" +
@@ -248,7 +249,7 @@ private[ui] class BlockPagedTable(
   }
 
   override def goButtonFormPath: String = {
-    val encodedSortColumn = URLEncoder.encode(sortColumn, "UTF-8")
+    val encodedSortColumn = URLEncoder.encode(sortColumn, UTF_8.name())
     s"$basePath&block.sort=$encodedSortColumn&block.desc=$desc"
   }
 
@@ -269,7 +270,7 @@ private[ui] class BlockPagedTable(
         if (header == sortColumn) {
           val headerLink = Unparsed(
             basePath +
-              s"&block.sort=${URLEncoder.encode(header, "UTF-8")}" +
+              s"&block.sort=${URLEncoder.encode(header, UTF_8.name())}" +
               s"&block.desc=${!desc}" +
               s"&block.pageSize=$pageSize")
           val arrow = if (desc) "&#x25BE;" else "&#x25B4;" // UP or DOWN
@@ -282,7 +283,7 @@ private[ui] class BlockPagedTable(
         } else {
           val headerLink = Unparsed(
             basePath +
-              s"&block.sort=${URLEncoder.encode(header, "UTF-8")}" +
+              s"&block.sort=${URLEncoder.encode(header, UTF_8.name())}" +
               s"&block.pageSize=$pageSize")
           <th>
             <a href={headerLink}>

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -23,7 +23,7 @@ import java.lang.{Double => JDouble, Float => JFloat}
 import java.lang.reflect.Field
 import java.net.{BindException, ServerSocket, URI}
 import java.nio.{ByteBuffer, ByteOrder}
-import java.nio.charset.StandardCharsets
+import java.nio.charset.StandardCharsets.UTF_8
 import java.text.DecimalFormatSymbols
 import java.util.Locale
 import java.util.concurrent.TimeUnit
@@ -351,7 +351,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     withTempDir { tmpDir2 =>
       val suffix = getSuffix(isCompressed)
       val f1Path = tmpDir2 + "/f1" + suffix
-      writeLogFile(f1Path, "1\n2\n3\n4\n5\n6\n7\n8\n9\n".getBytes(StandardCharsets.UTF_8))
+      writeLogFile(f1Path, "1\n2\n3\n4\n5\n6\n7\n8\n9\n".getBytes(UTF_8))
       val f1Length = Utils.getFileLength(new File(f1Path), workerConf)
 
       // Read first few bytes
@@ -387,10 +387,10 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
       val suffix = getSuffix(isCompressed)
       val files = (1 to 3).map(i =>
         new File(tmpDir, i.toString + suffix)) :+ new File(tmpDir, "4")
-      writeLogFile(files(0).getAbsolutePath, "0123456789".getBytes(StandardCharsets.UTF_8))
-      writeLogFile(files(1).getAbsolutePath, "abcdefghij".getBytes(StandardCharsets.UTF_8))
-      writeLogFile(files(2).getAbsolutePath, "ABCDEFGHIJ".getBytes(StandardCharsets.UTF_8))
-      writeLogFile(files(3).getAbsolutePath, "9876543210".getBytes(StandardCharsets.UTF_8))
+      writeLogFile(files(0).getAbsolutePath, "0123456789".getBytes(UTF_8))
+      writeLogFile(files(1).getAbsolutePath, "abcdefghij".getBytes(UTF_8))
+      writeLogFile(files(2).getAbsolutePath, "ABCDEFGHIJ".getBytes(UTF_8))
+      writeLogFile(files(3).getAbsolutePath, "9876543210".getBytes(UTF_8))
       val fileLengths = files.map(Utils.getFileLength(_, workerConf))
 
       // Read first few bytes in the 1st file
@@ -665,7 +665,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
       val outFile = File.createTempFile("test-load-spark-properties", "test", tmpDir)
       System.setProperty("spark.test.fileNameLoadB", "2")
       Files.write("spark.test.fileNameLoadA true\n" +
-        "spark.test.fileNameLoadB 1\n", outFile, StandardCharsets.UTF_8)
+        "spark.test.fileNameLoadB 1\n", outFile, UTF_8)
       val properties = Utils.getPropertiesFromFile(outFile.getAbsolutePath)
       properties
         .filter { case (k, v) => k.startsWith("spark.")}
@@ -694,7 +694,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
       val innerSourceDir = Utils.createTempDir(root = sourceDir.getPath)
       val sourceFile = File.createTempFile("someprefix", "somesuffix", innerSourceDir)
       val targetDir = new File(tempDir, "target-dir")
-      Files.write("some text", sourceFile, StandardCharsets.UTF_8)
+      Files.write("some text", sourceFile, UTF_8)
 
       val path =
         if (Utils.isWindows) {
@@ -823,14 +823,14 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
 
   test("circular buffer: if the buffer isn't full, print only the contents written") {
     val buffer = new CircularBuffer(10)
-    val stream = new PrintStream(buffer, true, "UTF-8")
+    val stream = new PrintStream(buffer, true, UTF_8.name())
     stream.print("test")
     assert(buffer.toString === "test")
   }
 
   test("circular buffer: data written == size of the buffer") {
     val buffer = new CircularBuffer(4)
-    val stream = new PrintStream(buffer, true, "UTF-8")
+    val stream = new PrintStream(buffer, true, UTF_8.name())
 
     // fill the buffer to its exact size so that it just hits overflow
     stream.print("test")
@@ -843,7 +843,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
 
   test("circular buffer: multiple overflow") {
     val buffer = new CircularBuffer(25)
-    val stream = new PrintStream(buffer, true, "UTF-8")
+    val stream = new PrintStream(buffer, true, UTF_8.name())
 
     stream.print("test circular test circular test circular test circular test circular")
     assert(buffer.toString === "st circular test circular")
@@ -987,7 +987,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
              |trap "" SIGTERM
              |sleep 10
            """.stripMargin
-        Files.write(cmd.getBytes(StandardCharsets.UTF_8), file)
+        Files.write(cmd.getBytes(UTF_8), file)
         file.getAbsoluteFile.setExecutable(true)
 
         val process = new ProcessBuilder(file.getAbsolutePath).start()

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -16,6 +16,7 @@
  */
 
 import java.io._
+import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
 import java.util.Locale
 
@@ -248,7 +249,7 @@ object SparkBuild extends PomBuild {
     javaVersion := SbtPomKeys.effectivePom.value.getProperties.get("java.version").asInstanceOf[String],
 
     javacOptions in Compile ++= Seq(
-      "-encoding", "UTF-8",
+      "-encoding", UTF_8.name(),
       "-source", javaVersion.value
     ),
     // This -target and Xlint:unchecked options cannot be set in the Compile configuration scope since

--- a/repl/src/main/scala/org/apache/spark/repl/ExecutorClassLoader.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/ExecutorClassLoader.scala
@@ -20,7 +20,7 @@ package org.apache.spark.repl
 import java.io.{ByteArrayOutputStream, FileNotFoundException, FilterInputStream, InputStream}
 import java.net.{URI, URL, URLEncoder}
 import java.nio.channels.Channels
-import java.nio.charset.StandardCharsets
+import java.nio.charset.StandardCharsets.UTF_8
 
 import scala.util.control.NonFatal
 
@@ -235,8 +235,7 @@ class ExecutorClassLoader(
    * URL-encode a string, preserving only slashes
    */
   def urlEncode(str: String): String = {
-    str.split('/').map(part => URLEncoder.encode(part, StandardCharsets.UTF_8.name()))
-      .mkString("/")
+    str.split('/').map(part => URLEncoder.encode(part, UTF_8.name())).mkString("/")
   }
 }
 

--- a/repl/src/main/scala/org/apache/spark/repl/ExecutorClassLoader.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/ExecutorClassLoader.scala
@@ -20,6 +20,7 @@ package org.apache.spark.repl
 import java.io.{ByteArrayOutputStream, FileNotFoundException, FilterInputStream, InputStream}
 import java.net.{URI, URL, URLEncoder}
 import java.nio.channels.Channels
+import java.nio.charset.StandardCharsets
 
 import scala.util.control.NonFatal
 
@@ -234,7 +235,8 @@ class ExecutorClassLoader(
    * URL-encode a string, preserving only slashes
    */
   def urlEncode(str: String): String = {
-    str.split('/').map(part => URLEncoder.encode(part, "UTF-8")).mkString("/")
+    str.split('/').map(part => URLEncoder.encode(part, StandardCharsets.UTF_8.name()))
+      .mkString("/")
   }
 }
 

--- a/repl/src/test/scala/org/apache/spark/repl/ExecutorClassLoaderSuite.scala
+++ b/repl/src/test/scala/org/apache/spark/repl/ExecutorClassLoaderSuite.scala
@@ -164,7 +164,7 @@ class ExecutorClassLoaderSuite
     val is = classLoader.getResourceAsStream(resourceName)
     assert(is != null, s"Resource $resourceName not found")
 
-    val bufferedSource = Source.fromInputStream(is, "UTF-8")
+    val bufferedSource = Source.fromInputStream(is, StandardCharsets.UTF_8.name())
     Utils.tryWithSafeFinally {
       val content = bufferedSource.getLines().next()
       assert(content.contains("resource"), "File doesn't contain 'resource'")

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/ProcessUtils.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/ProcessUtils.scala
@@ -19,6 +19,9 @@ package org.apache.spark.deploy.k8s.integrationtest
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeUnit
 
+import scala.collection.mutable.ArrayBuffer
+import scala.io.Source
+
 import org.apache.spark.internal.Logging
 
 object ProcessUtils extends Logging {

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/ProcessUtils.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/ProcessUtils.scala
@@ -16,10 +16,8 @@
  */
 package org.apache.spark.deploy.k8s.integrationtest
 
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeUnit
-
-import scala.collection.mutable.ArrayBuffer
-import scala.io.Source
 
 import org.apache.spark.internal.Logging
 
@@ -37,7 +35,7 @@ object ProcessUtils extends Logging {
     val proc = pb.start()
     val outputLines = new ArrayBuffer[String]
     Utils.tryWithResource(proc.getInputStream)(
-      Source.fromInputStream(_, "UTF-8").getLines().foreach { line =>
+      Source.fromInputStream(_, StandardCharsets.UTF_8.name()).getLines().foreach { line =>
         logInfo(line)
         outputLines += line
       })

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtilsSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtilsSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.scheduler.cluster.mesos
 
 import java.io.{File, FileNotFoundException}
+import java.nio.charset.StandardCharsets.UTF_8
 
 import scala.collection.JavaConverters._
 
@@ -253,7 +254,7 @@ class MesosSchedulerUtilsSuite extends SparkFunSuite with Matchers with MockitoS
   test("Principal specified via spark.mesos.principal.file") {
     val pFile = File.createTempFile("MesosSchedulerUtilsSuite", ".txt")
     pFile.deleteOnExit()
-    Files.write("test-principal".getBytes("UTF-8"), pFile)
+    Files.write("test-principal".getBytes(UTF_8), pFile)
     val conf = new SparkConf()
     conf.set(mesosConfig.CREDENTIAL_PRINCIPAL_FILE, pFile.getAbsolutePath())
 
@@ -282,7 +283,7 @@ class MesosSchedulerUtilsSuite extends SparkFunSuite with Matchers with MockitoS
   test("Principal specified via SPARK_MESOS_PRINCIPAL_FILE") {
     val pFile = File.createTempFile("MesosSchedulerUtilsSuite", ".txt")
     pFile.deleteOnExit()
-    Files.write("test-principal".getBytes("UTF-8"), pFile)
+    Files.write("test-principal".getBytes(UTF_8), pFile)
     val conf = new SparkConfWithEnv(Map("SPARK_MESOS_PRINCIPAL_FILE" -> pFile.getAbsolutePath()))
 
     val credBuilder = utils.buildCredentials(conf, FrameworkInfo.newBuilder())
@@ -313,7 +314,7 @@ class MesosSchedulerUtilsSuite extends SparkFunSuite with Matchers with MockitoS
   test("Principal specified via spark.mesos.secret.file") {
     val sFile = File.createTempFile("MesosSchedulerUtilsSuite", ".txt")
     sFile.deleteOnExit()
-    Files.write("my-secret".getBytes("UTF-8"), sFile)
+    Files.write("my-secret".getBytes(UTF_8), sFile)
     val conf = new SparkConf()
     conf.set(mesosConfig.CREDENTIAL_PRINCIPAL, "test-principal")
     conf.set(mesosConfig.CREDENTIAL_SECRET_FILE, sFile.getAbsolutePath())
@@ -350,7 +351,7 @@ class MesosSchedulerUtilsSuite extends SparkFunSuite with Matchers with MockitoS
   test("Principal specified via SPARK_MESOS_SECRET_FILE") {
     val sFile = File.createTempFile("MesosSchedulerUtilsSuite", ".txt")
     sFile.deleteOnExit()
-    Files.write("my-secret".getBytes("UTF-8"), sFile)
+    Files.write("my-secret".getBytes(UTF_8), sFile)
 
     val sFilePath = sFile.getAbsolutePath()
     val env = Map("SPARK_MESOS_SECRET_FILE" -> sFilePath)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/CreateJacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/CreateJacksonParser.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.json
 import java.io.{ByteArrayInputStream, InputStream, InputStreamReader}
 import java.nio.channels.Channels
 import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 
 import com.fasterxml.jackson.core.{JsonFactory, JsonParser}
 import org.apache.hadoop.io.Text
@@ -40,7 +41,7 @@ private[sql] object CreateJacksonParser extends Serializable {
     val bain = new ByteArrayInputStream(
       bb.array(), bb.arrayOffset() + bb.position(), bb.remaining())
 
-    jsonFactory.createParser(new InputStreamReader(bain, "UTF-8"))
+    jsonFactory.createParser(new InputStreamReader(bain, StandardCharsets.UTF_8))
   }
 
   def text(jsonFactory: JsonFactory, record: Text): JsonParser = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -17,7 +17,8 @@
 
 package org.apache.spark.sql.catalyst.json
 
-import java.nio.charset.{Charset, StandardCharsets}
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 import java.time.ZoneId
 import java.util.Locale
 
@@ -109,7 +110,7 @@ private[sql] class JSONOptions(
     .orElse(parameters.get("charset")).map(checkedEncoding)
 
   val lineSeparatorInRead: Option[Array[Byte]] = lineSeparator.map { lineSep =>
-    lineSep.getBytes(encoding.getOrElse("UTF-8"))
+    lineSep.getBytes(encoding.getOrElse(StandardCharsets.UTF_8.name()))
   }
   val lineSeparatorInWrite: String = lineSeparator.getOrElse("\n")
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -17,8 +17,7 @@
 
 package org.apache.spark.sql.catalyst.json
 
-import java.nio.charset.Charset
-import java.nio.charset.StandardCharsets
+import java.nio.charset.{Charset, StandardCharsets}
 import java.time.ZoneId
 import java.util.Locale
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst
 
 import java.io._
-import java.nio.charset.StandardCharsets
+import java.nio.charset.StandardCharsets.UTF_8
 import java.util.concurrent.atomic.AtomicBoolean
 
 import org.apache.spark.internal.Logging
@@ -45,7 +45,7 @@ package object util extends Logging {
     }
   }
 
-  def fileToString(file: File, encoding: String = "UTF-8"): String = {
+  def fileToString(file: File, encoding: String = UTF_8.name()): String = {
     val inStream = new FileInputStream(file)
     val outStream = new ByteArrayOutputStream
     try {
@@ -87,7 +87,7 @@ package object util extends Logging {
 
   def resourceToString(
       resource: String,
-      encoding: String = "UTF-8",
+      encoding: String = UTF_8.name(),
       classLoader: ClassLoader = Utils.getSparkClassLoader): String = {
     new String(resourceToBytes(resource, classLoader), encoding)
   }
@@ -119,7 +119,7 @@ package object util extends Logging {
       t.printStackTrace(writer)
       writer.flush()
     }
-    new String(out.toByteArray, StandardCharsets.UTF_8)
+    new String(out.toByteArray, UTF_8)
   }
 
   // Replaces attributes, string literals, complex type extractors with their pretty form so that

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst
 
 import java.io._
+import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -45,7 +46,7 @@ package object util extends Logging {
     }
   }
 
-  def fileToString(file: File, encoding: String = UTF_8.name()): String = {
+  def fileToString(file: File, encoding: Charset = UTF_8): String = {
     val inStream = new FileInputStream(file)
     val outStream = new ByteArrayOutputStream
     try {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/AllExecutionsPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/AllExecutionsPage.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.ui
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.UTF_8
 import javax.servlet.http.HttpServletRequest
 
 import scala.collection.JavaConverters._
@@ -249,7 +250,7 @@ private[ui] class ExecutionPagedTable(
       "table-head-clickable table-cell-width-limited"
 
   override def pageLink(page: Int): String = {
-    val encodedSortColumn = URLEncoder.encode(sortColumn, "UTF-8")
+    val encodedSortColumn = URLEncoder.encode(sortColumn, UTF_8.name())
     parameterPath +
       s"&$pageNumberFormField=$page" +
       s"&$executionTag.sort=$encodedSortColumn" +
@@ -263,7 +264,7 @@ private[ui] class ExecutionPagedTable(
   override def pageNumberFormField: String = s"$executionTag.page"
 
   override def goButtonFormPath: String = {
-    val encodedSortColumn = URLEncoder.encode(sortColumn, "UTF-8")
+    val encodedSortColumn = URLEncoder.encode(sortColumn, UTF_8.name())
     s"$parameterPath&$executionTag.sort=$encodedSortColumn&$executionTag.desc=$desc#$tableHeaderId"
   }
 
@@ -300,7 +301,7 @@ private[ui] class ExecutionPagedTable(
         if (header == sortColumn) {
           val headerLink = Unparsed(
             parameterPath +
-              s"&$executionTag.sort=${URLEncoder.encode(header, "UTF-8")}" +
+              s"&$executionTag.sort=${URLEncoder.encode(header, UTF_8.name())}" +
               s"&$executionTag.desc=${!desc}" +
               s"&$executionTag.pageSize=$pageSize" +
               s"#$tableHeaderId")
@@ -317,7 +318,7 @@ private[ui] class ExecutionPagedTable(
           if (sortable) {
             val headerLink = Unparsed(
               parameterPath +
-                s"&$executionTag.sort=${URLEncoder.encode(header, "UTF-8")}" +
+                s"&$executionTag.sort=${URLEncoder.encode(header, UTF_8.name())}" +
                 s"&$executionTag.pageSize=$pageSize" +
                 s"#$tableHeaderId")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -2199,7 +2199,7 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
     }
 
     val baos = new ByteArrayOutputStream()
-    val ps = new PrintStream(baos, true, "UTF-8")
+    val ps = new PrintStream(baos, true, StandardCharsets.UTF_8.name())
     exception.printStackTrace(ps)
     ps.flush()
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/TextSocketStreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/TextSocketStreamSuite.scala
@@ -417,7 +417,7 @@ class TextSocketStreamSuite extends StreamTest with SharedSQLContext with Before
 
         while (true) {
           val line = messageQueue.take() + "\n"
-          clientSocketChannel.write(ByteBuffer.wrap(line.getBytes(StandardCharsets.UTF_8.name())))
+          clientSocketChannel.write(ByteBuffer.wrap(line.getBytes(StandardCharsets.UTF_8)))
         }
       } catch {
         case e: InterruptedException =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/TextSocketStreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/TextSocketStreamSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.streaming.sources
 import java.net.{InetSocketAddress, SocketException}
 import java.nio.ByteBuffer
 import java.nio.channels.ServerSocketChannel
+import java.nio.charset.StandardCharsets
 import java.sql.Timestamp
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit._
@@ -416,7 +417,7 @@ class TextSocketStreamSuite extends StreamTest with SharedSQLContext with Before
 
         while (true) {
           val line = messageQueue.take() + "\n"
-          clientSocketChannel.write(ByteBuffer.wrap(line.getBytes("UTF-8")))
+          clientSocketChannel.write(ByteBuffer.wrap(line.getBytes(StandardCharsets.UTF_8.name())))
         }
       } catch {
         case e: InterruptedException =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.streaming
 
 import java.io.File
-import java.nio.charset.StandardCharsets
+import java.nio.charset.StandardCharsets.UTF_8
 import java.util.concurrent.CountDownLatch
 
 import scala.collection.mutable
@@ -959,11 +959,10 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
     // Ideally we should copy "_spark_metadata" directly like what the user is supposed to do to
     // migrate to new version. However, in our test, "tempDir" will be different in each run and
     // we need to fix the absolute path in the metadata to match "tempDir".
-    val sparkMetadata = FileUtils.readFileToString(new File(legacySparkMetadataDir, "0"),
-      StandardCharsets.UTF_8)
+    val sparkMetadata = FileUtils.readFileToString(new File(legacySparkMetadataDir, "0"), UTF_8)
     FileUtils.write(
       new File(legacySparkMetadataDir, "0"),
-      sparkMetadata.replaceAll("TEMPDIR", dir.getCanonicalPath), StandardCharsets.UTF_8)
+      sparkMetadata.replaceAll("TEMPDIR", dir.getCanonicalPath), UTF_8)
   }
 
   test("detect escaped path and report the migration guide") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.streaming
 
 import java.io.File
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.CountDownLatch
 
 import scala.collection.mutable
@@ -958,11 +959,11 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
     // Ideally we should copy "_spark_metadata" directly like what the user is supposed to do to
     // migrate to new version. However, in our test, "tempDir" will be different in each run and
     // we need to fix the absolute path in the metadata to match "tempDir".
-    val sparkMetadata = FileUtils.readFileToString(new File(legacySparkMetadataDir, "0"), "UTF-8")
+    val sparkMetadata = FileUtils.readFileToString(new File(legacySparkMetadataDir, "0"),
+      StandardCharsets.UTF_8)
     FileUtils.write(
       new File(legacySparkMetadataDir, "0"),
-      sparkMetadata.replaceAll("TEMPDIR", dir.getCanonicalPath),
-      "UTF-8")
+      sparkMetadata.replaceAll("TEMPDIR", dir.getCanonicalPath), StandardCharsets.UTF_8)
   }
 
   test("detect escaped path and report the migration guide") {

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -18,13 +18,10 @@
 package org.apache.spark.sql.hive.thriftserver
 
 import java.io._
+import java.nio.charset.StandardCharsets.UTF_8
 import java.util.{ArrayList => JArrayList, Locale}
 import java.util.concurrent.TimeUnit
 
-import scala.collection.JavaConverters._
-
-import jline.console.ConsoleReader
-import jline.console.history.FileHistory
 import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hive.cli.{CliDriver, CliSessionState, OptionsProcessor}
@@ -98,9 +95,9 @@ private[hive] object SparkSQLCLIDriver extends Logging {
 
     sessionState.in = System.in
     try {
-      sessionState.out = new PrintStream(System.out, true, "UTF-8")
-      sessionState.info = new PrintStream(System.err, true, "UTF-8")
-      sessionState.err = new PrintStream(System.err, true, "UTF-8")
+      sessionState.out = new PrintStream(System.out, true, UTF_8.name())
+      sessionState.info = new PrintStream(System.err, true, UTF_8.name())
+      sessionState.err = new PrintStream(System.err, true, UTF_8.name())
     } catch {
       case e: UnsupportedEncodingException => System.exit(3)
     }
@@ -168,9 +165,9 @@ private[hive] object SparkSQLCLIDriver extends Logging {
     // will set the output into an invalid buffer.
     sessionState.in = System.in
     try {
-      sessionState.out = new PrintStream(System.out, true, "UTF-8")
-      sessionState.info = new PrintStream(System.err, true, "UTF-8")
-      sessionState.err = new PrintStream(System.err, true, "UTF-8")
+      sessionState.out = new PrintStream(System.out, true, UTF_8.name())
+      sessionState.info = new PrintStream(System.err, true, UTF_8.name())
+      sessionState.err = new PrintStream(System.err, true, UTF_8.name())
     } catch {
       case e: UnsupportedEncodingException => System.exit(3)
     }

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -22,6 +22,10 @@ import java.nio.charset.StandardCharsets.UTF_8
 import java.util.{ArrayList => JArrayList, Locale}
 import java.util.concurrent.TimeUnit
 
+import scala.collection.JavaConverters._
+
+import jline.console.ConsoleReader
+import jline.console.history.FileHistory
 import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hive.cli.{CliDriver, CliSessionState, OptionsProcessor}

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.hive.thriftserver
 
 import java.io.PrintStream
+import java.nio.charset.StandardCharsets.UTF_8
 
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.internal.Logging
@@ -51,9 +52,9 @@ private[hive] object SparkSQLEnv extends Logging {
 
       val metadataHive = sparkSession
         .sharedState.externalCatalog.unwrapped.asInstanceOf[HiveExternalCatalog].client
-      metadataHive.setOut(new PrintStream(System.out, true, "UTF-8"))
-      metadataHive.setInfo(new PrintStream(System.err, true, "UTF-8"))
-      metadataHive.setError(new PrintStream(System.err, true, "UTF-8"))
+      metadataHive.setOut(new PrintStream(System.out, true, UTF_8.name()))
+      metadataHive.setInfo(new PrintStream(System.err, true, UTF_8.name()))
+      metadataHive.setError(new PrintStream(System.err, true, UTF_8.name()))
       sparkSession.conf.set(HiveUtils.FAKE_HIVE_VERSION.key, HiveUtils.builtinHiveVersion)
     }
   }

--- a/sql/hive-thriftserver/v1.2.1/src/main/java/org/apache/hive/service/cli/operation/HiveCommandOperation.java
+++ b/sql/hive-thriftserver/v1.2.1/src/main/java/org/apache/hive/service/cli/operation/HiveCommandOperation.java
@@ -26,10 +26,11 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import org.apache.hadoop.hive.metastore.api.Schema;
 import org.apache.hadoop.hive.ql.processors.CommandProcessor;
@@ -70,7 +71,7 @@ public class HiveCommandOperation extends ExecuteStatementOperation {
       LOG.info("Putting temp output to file " + sessionState.getTmpOutputFile().toString());
       sessionState.in = null; // hive server's session input stream is not used
       // open a per-session file in auto-flush mode for writing temp results
-      sessionState.out = new PrintStream(new FileOutputStream(sessionState.getTmpOutputFile()), true, StandardCharsets.UTF_8.name());
+      sessionState.out = new PrintStream(new FileOutputStream(sessionState.getTmpOutputFile()), true, UTF_8);
       // TODO: for hadoop jobs, progress is printed out to session.err,
       // we should find a way to feed back job progress to client
       sessionState.err = new PrintStream(System.err, true, StandardCharsets.UTF_8.name());

--- a/sql/hive-thriftserver/v1.2.1/src/main/java/org/apache/hive/service/cli/operation/HiveCommandOperation.java
+++ b/sql/hive-thriftserver/v1.2.1/src/main/java/org/apache/hive/service/cli/operation/HiveCommandOperation.java
@@ -26,6 +26,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -69,16 +70,16 @@ public class HiveCommandOperation extends ExecuteStatementOperation {
       LOG.info("Putting temp output to file " + sessionState.getTmpOutputFile().toString());
       sessionState.in = null; // hive server's session input stream is not used
       // open a per-session file in auto-flush mode for writing temp results
-      sessionState.out = new PrintStream(new FileOutputStream(sessionState.getTmpOutputFile()), true, UTF_8.name());
+      sessionState.out = new PrintStream(new FileOutputStream(sessionState.getTmpOutputFile()), true, StandardCharsets.UTF_8.name());
       // TODO: for hadoop jobs, progress is printed out to session.err,
       // we should find a way to feed back job progress to client
-      sessionState.err = new PrintStream(System.err, true, UTF_8.name());
+      sessionState.err = new PrintStream(System.err, true, StandardCharsets.UTF_8.name());
     } catch (IOException e) {
       LOG.error("Error in creating temp output file ", e);
       try {
         sessionState.in = null;
-        sessionState.out = new PrintStream(System.out, true, UTF_8.name());
-        sessionState.err = new PrintStream(System.err, true, UTF_8.name());
+        sessionState.out = new PrintStream(System.out, true, StandardCharsets.UTF_8.name());
+        sessionState.err = new PrintStream(System.err, true, StandardCharsets.UTF_8.name());
       } catch (UnsupportedEncodingException ee) {
         LOG.error("Error creating PrintStream", e);
         ee.printStackTrace();

--- a/sql/hive-thriftserver/v1.2.1/src/main/java/org/apache/hive/service/cli/operation/HiveCommandOperation.java
+++ b/sql/hive-thriftserver/v1.2.1/src/main/java/org/apache/hive/service/cli/operation/HiveCommandOperation.java
@@ -71,16 +71,16 @@ public class HiveCommandOperation extends ExecuteStatementOperation {
       LOG.info("Putting temp output to file " + sessionState.getTmpOutputFile().toString());
       sessionState.in = null; // hive server's session input stream is not used
       // open a per-session file in auto-flush mode for writing temp results
-      sessionState.out = new PrintStream(new FileOutputStream(sessionState.getTmpOutputFile()), true, UTF_8);
+      sessionState.out = new PrintStream(new FileOutputStream(sessionState.getTmpOutputFile()), true, UTF_8.name());
       // TODO: for hadoop jobs, progress is printed out to session.err,
       // we should find a way to feed back job progress to client
-      sessionState.err = new PrintStream(System.err, true, StandardCharsets.UTF_8.name());
+      sessionState.err = new PrintStream(System.err, true, UTF_8.name());
     } catch (IOException e) {
       LOG.error("Error in creating temp output file ", e);
       try {
         sessionState.in = null;
-        sessionState.out = new PrintStream(System.out, true, StandardCharsets.UTF_8.name());
-        sessionState.err = new PrintStream(System.err, true, StandardCharsets.UTF_8.name());
+        sessionState.out = new PrintStream(System.out, true, UTF_8.name());
+        sessionState.err = new PrintStream(System.err, true, UTF_8.name());
       } catch (UnsupportedEncodingException ee) {
         LOG.error("Error creating PrintStream", e);
         ee.printStackTrace();

--- a/sql/hive-thriftserver/v1.2.1/src/main/java/org/apache/hive/service/cli/operation/HiveCommandOperation.java
+++ b/sql/hive-thriftserver/v1.2.1/src/main/java/org/apache/hive/service/cli/operation/HiveCommandOperation.java
@@ -69,16 +69,16 @@ public class HiveCommandOperation extends ExecuteStatementOperation {
       LOG.info("Putting temp output to file " + sessionState.getTmpOutputFile().toString());
       sessionState.in = null; // hive server's session input stream is not used
       // open a per-session file in auto-flush mode for writing temp results
-      sessionState.out = new PrintStream(new FileOutputStream(sessionState.getTmpOutputFile()), true, "UTF-8");
+      sessionState.out = new PrintStream(new FileOutputStream(sessionState.getTmpOutputFile()), true, UTF_8.name());
       // TODO: for hadoop jobs, progress is printed out to session.err,
       // we should find a way to feed back job progress to client
-      sessionState.err = new PrintStream(System.err, true, "UTF-8");
+      sessionState.err = new PrintStream(System.err, true, UTF_8.name());
     } catch (IOException e) {
       LOG.error("Error in creating temp output file ", e);
       try {
         sessionState.in = null;
-        sessionState.out = new PrintStream(System.out, true, "UTF-8");
-        sessionState.err = new PrintStream(System.err, true, "UTF-8");
+        sessionState.out = new PrintStream(System.out, true, UTF_8.name());
+        sessionState.err = new PrintStream(System.err, true, UTF_8.name());
       } catch (UnsupportedEncodingException ee) {
         LOG.error("Error creating PrintStream", e);
         ee.printStackTrace();

--- a/sql/hive-thriftserver/v1.2.1/src/main/java/org/apache/hive/service/cli/operation/SQLOperation.java
+++ b/sql/hive-thriftserver/v1.2.1/src/main/java/org/apache/hive/service/cli/operation/SQLOperation.java
@@ -21,6 +21,7 @@ package org.apache.hive.service.cli.operation;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedExceptionAction;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -373,11 +374,7 @@ public class SQLOperation extends ExecuteStatementOperation {
 
     int protocol = getProtocolVersion().getValue();
     for (Object rowString : rows) {
-      try {
-        rowObj = serde.deserialize(new BytesWritable(((String)rowString).getBytes(StandardCharsets.UTF_8)));
-      } catch (UnsupportedEncodingException e) {
-        throw new SerDeException(e);
-      }
+      rowObj = serde.deserialize(new BytesWritable(((String)rowString).getBytes(StandardCharsets.UTF_8)));
       for (int i = 0; i < fieldRefs.size(); i++) {
         StructField fieldRef = fieldRefs.get(i);
         fieldOI = fieldRef.getFieldObjectInspector();

--- a/sql/hive-thriftserver/v1.2.1/src/main/java/org/apache/hive/service/cli/operation/SQLOperation.java
+++ b/sql/hive-thriftserver/v1.2.1/src/main/java/org/apache/hive/service/cli/operation/SQLOperation.java
@@ -374,7 +374,7 @@ public class SQLOperation extends ExecuteStatementOperation {
     int protocol = getProtocolVersion().getValue();
     for (Object rowString : rows) {
       try {
-        rowObj = serde.deserialize(new BytesWritable(((String)rowString).getBytes("UTF-8")));
+        rowObj = serde.deserialize(new BytesWritable(((String)rowString).getBytes(StandardCharsets.UTF_8)));
       } catch (UnsupportedEncodingException e) {
         throw new SerDeException(e);
       }

--- a/sql/hive-thriftserver/v2.3.5/src/main/java/org/apache/hive/service/cli/operation/HiveCommandOperation.java
+++ b/sql/hive-thriftserver/v2.3.5/src/main/java/org/apache/hive/service/cli/operation/HiveCommandOperation.java
@@ -69,16 +69,16 @@ public class HiveCommandOperation extends ExecuteStatementOperation {
       LOG.info("Putting temp output to file " + sessionState.getTmpOutputFile().toString());
       sessionState.in = null; // hive server's session input stream is not used
       // open a per-session file in auto-flush mode for writing temp results
-      sessionState.out = new PrintStream(new FileOutputStream(sessionState.getTmpOutputFile()), true, "UTF-8");
+      sessionState.out = new PrintStream(new FileOutputStream(sessionState.getTmpOutputFile()), true, UTF_8.name());
       // TODO: for hadoop jobs, progress is printed out to session.err,
       // we should find a way to feed back job progress to client
-      sessionState.err = new PrintStream(System.err, true, "UTF-8");
+      sessionState.err = new PrintStream(System.err, true, UTF_8.name());
     } catch (IOException e) {
       LOG.error("Error in creating temp output file ", e);
       try {
         sessionState.in = null;
-        sessionState.out = new PrintStream(System.out, true, "UTF-8");
-        sessionState.err = new PrintStream(System.err, true, "UTF-8");
+        sessionState.out = new PrintStream(System.out, true, UTF_8.name());
+        sessionState.err = new PrintStream(System.err, true, UTF_8.name());
       } catch (UnsupportedEncodingException ee) {
         LOG.error("Error creating PrintStream", e);
         ee.printStackTrace();

--- a/sql/hive-thriftserver/v2.3.5/src/main/java/org/apache/hive/service/cli/operation/HiveCommandOperation.java
+++ b/sql/hive-thriftserver/v2.3.5/src/main/java/org/apache/hive/service/cli/operation/HiveCommandOperation.java
@@ -30,6 +30,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import org.apache.hadoop.hive.metastore.api.Schema;
 import org.apache.hadoop.hive.ql.processors.CommandProcessor;
 import org.apache.hadoop.hive.ql.processors.CommandProcessorResponse;

--- a/sql/hive-thriftserver/v2.3.5/src/main/java/org/apache/hive/service/cli/operation/SQLOperation.java
+++ b/sql/hive-thriftserver/v2.3.5/src/main/java/org/apache/hive/service/cli/operation/SQLOperation.java
@@ -30,6 +30,8 @@ import java.util.Properties;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
@@ -372,11 +374,7 @@ public class SQLOperation extends ExecuteStatementOperation {
 
     int protocol = getProtocolVersion().getValue();
     for (Object rowString : rows) {
-      try {
-        rowObj = serde.deserialize(new BytesWritable(((String)rowString).getBytes(StandardCharsets.UTF_8)));
-      } catch (UnsupportedEncodingException e) {
-        throw new SerDeException(e);
-      }
+      rowObj = serde.deserialize(new BytesWritable(((String)rowString).getBytes(UTF_8)));
       for (int i = 0; i < fieldRefs.size(); i++) {
         StructField fieldRef = fieldRefs.get(i);
         fieldOI = fieldRef.getFieldObjectInspector();

--- a/sql/hive-thriftserver/v2.3.5/src/main/java/org/apache/hive/service/cli/operation/SQLOperation.java
+++ b/sql/hive-thriftserver/v2.3.5/src/main/java/org/apache/hive/service/cli/operation/SQLOperation.java
@@ -373,7 +373,7 @@ public class SQLOperation extends ExecuteStatementOperation {
     int protocol = getProtocolVersion().getValue();
     for (Object rowString : rows) {
       try {
-        rowObj = serde.deserialize(new BytesWritable(((String)rowString).getBytes("UTF-8")));
+        rowObj = serde.deserialize(new BytesWritable(((String)rowString).getBytes(StandardCharsets.UTF_8)));
       } catch (UnsupportedEncodingException e) {
         throw new SerDeException(e);
       }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.hive.client
 
 import java.io.{File, PrintStream}
 import java.lang.{Iterable => JIterable}
+import java.nio.charset.StandardCharsets.UTF_8
 import java.util.{Locale, Map => JMap}
 import java.util.concurrent.TimeUnit._
 
@@ -190,8 +191,8 @@ private[hive] class HiveClientImpl(
       Hive.set(clientLoader.cachedHive.asInstanceOf[Hive])
     }
     SessionState.start(state)
-    state.out = new PrintStream(outputBuffer, true, "UTF-8")
-    state.err = new PrintStream(outputBuffer, true, "UTF-8")
+    state.out = new PrintStream(outputBuffer, true, UTF_8.name())
+    state.err = new PrintStream(outputBuffer, true, UTF_8.name())
     state
   }
 

--- a/streaming/src/test/scala/org/apache/spark/streaming/util/RateLimitedOutputStreamSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/util/RateLimitedOutputStreamSuite.scala
@@ -40,6 +40,6 @@ class RateLimitedOutputStreamSuite extends SparkFunSuite {
     val seconds = SECONDS.convert(elapsedNs, NANOSECONDS)
     assert(seconds >= 4, s"Seconds value ($seconds) is less than 4.")
     assert(seconds <= 30, s"Took more than 30 seconds ($seconds) to write data.")
-    assert(underlying.toString("UTF-8") === data)
+    assert(underlying.toString(StandardCharsets.UTF_8.name()) === data)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch tries to keep consistency whenever UTF-8 charset is needed, as using `StandardCharsets.UTF_8` instead of using "UTF-8". If the String type is needed, `StandardCharsets.UTF_8.name()` is used.

This change also brings the benefit of getting rid of `UnsupportedEncodingException`, as we're providing `Charset` instead of `String` whenever possible.

This also changes some private Catalyst helper methods to operate on encodings as `Charset` objects rather than strings.

## How was this patch tested?

Existing unit tests.