### PR TITLE
[SPARK-28607][CORE][SHUFFLE] Don't store partition lengths twice.

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/api/ShuffleMapOutputWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShuffleMapOutputWriter.java
@@ -51,15 +51,19 @@ public interface ShuffleMapOutputWriter {
 
   /**
    * Commits the writes done by all partition writers returned by all calls to this object's
-   * {@link #getPartitionWriter(int)}.
+   * {@link #getPartitionWriter(int)}, and returns the number of bytes written for each
+   * partition.
    * <p>
    * This should ensure that the writes conducted by this module's partition writers are
    * available to downstream reduce tasks. If this method throws any exception, this module's
    * {@link #abort(Throwable)} method will be invoked before propagating the exception.
    * <p>
    * This can also close any resources and clean up temporary state if necessary.
+   * <p>
+   * The returned array should contain, for each partition from (0) to (numPartitions - 1), the
+   * number of bytes written by the partition writer for that partition id.
    */
-  void commitAllPartitions() throws IOException;
+  long[] commitAllPartitions() throws IOException;
 
   /**
    * Abort all of the writes done by any writers returned by {@link #getPartitionWriter(int)}.

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShufflePartitionWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShufflePartitionWriter.java
@@ -85,14 +85,4 @@ public interface ShufflePartitionWriter {
   default Optional<WritableByteChannelWrapper> openChannelWrapper() throws IOException {
     return Optional.empty();
   }
-
-  /**
-   * Returns the number of bytes written either by this writer's output stream opened by
-   * {@link #openStream()} or the byte channel opened by {@link #openChannelWrapper()}.
-   * <p>
-   * This can be different from the number of bytes given by the caller. For example, the
-   * stream might compress or encrypt the bytes before persisting the data to the backing
-   * data store.
-   */
-  long getNumBytesWritten();
 }

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShufflePartitionWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShufflePartitionWriter.java
@@ -85,4 +85,14 @@ public interface ShufflePartitionWriter {
   default Optional<WritableByteChannelWrapper> openChannelWrapper() throws IOException {
     return Optional.empty();
   }
+
+  /**
+   * Returns the number of bytes written either by this writer's output stream opened by
+   * {@link #openStream()} or the byte channel opened by {@link #openChannelWrapper()}.
+   * <p>
+   * This can be different from the number of bytes given by the caller. For example, the
+   * stream might compress or encrypt the bytes before persisting the data to the backing
+   * data store.
+   */
+  long getNumBytesWritten();
 }

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriter.java
@@ -178,6 +178,22 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
       }
       return Optional.of(partChannel);
     }
+
+    @Override
+    public long getNumBytesWritten() {
+      if (partChannel != null) {
+        try {
+          return partChannel.getCount();
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      } else if (partStream != null) {
+        return partStream.getCount();
+      } else {
+        // Assume an empty partition if stream and channel are never created
+        return 0;
+      }
+    }
   }
 
   private class PartitionWriterStream extends OutputStream {

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriter.java
@@ -96,10 +96,11 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
   }
 
   @Override
-  public void commitAllPartitions() throws IOException {
+  public long[] commitAllPartitions() throws IOException {
     cleanUp();
     File resolvedTmp = outputTempFile != null && outputTempFile.isFile() ? outputTempFile : null;
     blockResolver.writeIndexFileAndCommit(shuffleId, mapId, partitionLengths, resolvedTmp);
+    return partitionLengths;
   }
 
   @Override
@@ -176,22 +177,6 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
         partChannel = new PartitionWriterChannel(partitionId);
       }
       return Optional.of(partChannel);
-    }
-
-    @Override
-    public long getNumBytesWritten() {
-      if (partChannel != null) {
-        try {
-          return partChannel.getCount();
-        } catch (IOException e) {
-          throw new RuntimeException(e);
-        }
-      } else if (partStream != null) {
-        return partStream.getCount();
-      } else {
-        // Assume an empty partition if stream and channel are never created
-        return 0;
-      }
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriterSuite.scala
@@ -102,7 +102,6 @@ class LocalDiskShuffleMapOutputWriterSuite extends SparkFunSuite with BeforeAndA
       intercept[IllegalStateException] {
         stream.write(p)
       }
-      assert(writer.getNumBytesWritten === data(p).length)
     }
     verifyWrittenRecords()
   }
@@ -122,8 +121,6 @@ class LocalDiskShuffleMapOutputWriterSuite extends SparkFunSuite with BeforeAndA
             tempFileInput.getChannel, channelWrapper.channel(), 0L, data(p).length)
         }
       }
-      assert(writer.getNumBytesWritten === data(p).length,
-        s"Partition $p does not have the correct number of bytes.")
     }
     verifyWrittenRecords()
   }
@@ -139,8 +136,9 @@ class LocalDiskShuffleMapOutputWriterSuite extends SparkFunSuite with BeforeAndA
   }
 
   private def verifyWrittenRecords(): Unit = {
-    mapOutputWriter.commitAllPartitions()
+    val committedLengths = mapOutputWriter.commitAllPartitions()
     assert(partitionSizesInMergedFile === partitionLengths)
+    assert(committedLengths === partitionLengths)
     assert(mergedOutputFile.length() === partitionLengths.sum)
     assert(data === readRecordsFromFile())
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The shuffle writer API introduced in SPARK-28209 has a flaw that leads to a memory usage regression - we ended up tracking the partition lengths in two places. Here, we modify the API slightly to avoid redundant tracking. The implementation of the shuffle writer plugin is now responsible for tracking the lengths of partitions, and propagating this back up to the higher shuffle writer as part of the commitAllPartitions API.

## How was this patch tested?

Existing unit tests.
