### PR TITLE
[WIP][SPARK-28151][SQL] Mapped ByteType to TinyINT for MsSQLServerDialect

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -550,7 +550,7 @@ object JdbcUtils extends Logging {
 
     case ByteType =>
       (stmt: PreparedStatement, row: Row, pos: Int) =>
-        stmt.setInt(pos + 1, row.getByte(pos))
+        stmt.setByte(pos + 1, row.getByte(pos))
 
     case BooleanType =>
       (stmt: PreparedStatement, row: Row, pos: Int) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -33,6 +33,7 @@ private object MsSqlServerDialect extends JdbcDialect {
       sqlType match {
         case java.sql.Types.SMALLINT => Some(ShortType)
         case java.sql.Types.REAL => Some(FloatType)
+        case java.sql.Types.TINYINT => Some(ByteType)
         case _ => None
       }
     }
@@ -44,6 +45,7 @@ private object MsSqlServerDialect extends JdbcDialect {
     case BooleanType => Some(JdbcType("BIT", java.sql.Types.BIT))
     case BinaryType => Some(JdbcType("VARBINARY(MAX)", java.sql.Types.VARBINARY))
     case ShortType => Some(JdbcType("SMALLINT", java.sql.Types.SMALLINT))
+    case ByteType => Some(JdbcType("TINYINT", java.sql.Types.TINYINT))
     case _ => None
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change mapping of BYTETYPE from BYTE to TinyINT. 

### Why are the changes needed?

Writing dataframe with column type BYTETYPE fails when using JDBC connector for SQL Server. The problem is due to 
-  (Write path) Incorrect mapping of BYTETYPE in getCommonJDBCType() in jdbcutils.scala where BYTETYPE gets mapped to BYTE text. It should be mapped to TINYINT
    case ByteType => Option(JdbcType("BYTE", java.sql.Types.TINYINT))

In getCatalystType() ( JDBC to Catalyst type mapping) TINYINT is mapped to INTEGER, while it should be mapped to BYTETYPE. Mapping to integer is ok from the point of view of upcasting, but will lead to 4 byte allocation rather than 1 byte for BYTETYPE.

- (read path) Read path ends up calling makeGetter(dt: DataType, metadata: Metadata). The function sets the value in RDD row. The value is set per the data type. Here there is no mapping for BYTETYPE and thus results will result in an error when getCatalystType() is fixed.

Note : These issues were found when reading/writing with SQLServer. 

### Does this PR introduce any user-facing change?

No.

## How was this patch tested?

Path was tested with integration test by adding test case to MsSqlServerIntegrationSuite.scala. Test case passed on local tests.