### PR TITLE
[RFC][WIP][SPARK-25915][SQL] Replace grouping expressions with references in `aggregateExpressions` of logical `Aggregate`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressions.scala
@@ -127,3 +127,12 @@ class EquivalentExpressions {
     sb.toString()
   }
 }
+
+case class ExpressionEquals(e: Expression) {
+  override def equals(o: Any): Boolean = o match {
+    case other: ExpressionEquals => e.semanticEquals(other.e)
+    case _ => false
+  }
+
+  override def hashCode: Int = e.semanticHash()
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -211,7 +211,7 @@ object PhysicalAggregation {
     (Seq[NamedExpression], Seq[Expression], Seq[NamedExpression], LogicalPlan)
 
   def unapply(a: Any): Option[ReturnType] = a match {
-    case logical.Aggregate(groupingExpressions, resultExpressions, child) =>
+    case logical.RealAggregate(groupingExpressions, resultExpressions, child) =>
       // A single aggregate expression might appear multiple times in resultExpressions.
       // In order to avoid evaluating an individual aggregate function multiple times, we'll
       // build a set of semantically distinct aggregate expressions and re-write expressions so

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -63,7 +63,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]] extends TreeNode[PlanT
   /**
    * Attributes that are referenced by expressions but not provided by this node's children.
    */
-  final def missingInput: AttributeSet = references -- inputSet
+  def missingInput: AttributeSet = references -- inputSet
 
   /**
    * Runs [[transformExpressionsDown]] with `rule` on all expressions present

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/PlanHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/PlanHelper.scala
@@ -43,7 +43,8 @@ object PlanHelper {
         case e: WindowExpression
           if !plan.isInstanceOf[Window] => e
         case e: AggregateExpression
-          if !(plan.isInstanceOf[Aggregate] || plan.isInstanceOf[Window]) => e
+          if !(plan.isInstanceOf[Aggregate] || plan.isInstanceOf[Window] ||
+            plan.isInstanceOf[RealAggregate]) => e
         case e: Generator
           if !plan.isInstanceOf[Generate] => e
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
tl;dr The essential logic is in this [rule](https://github.com/apache/spark/pull/25346/files#diff-57b3d87be744b7d79a9beacf8e5e5eb2R222)

This PR tries to work on the long-existing issue on reference binding for Aggregate's grouping expression, which was discussed in more detail in https://issues.apache.org/jira/browse/SPARK-25914. The issue itself is more of a correctness issue.

Basically, it's a bad idea to put reference binding in the Analyzer's large resolution batch, since `Aggregate`'s content is not stable and resolution invariants are fragile and subtle (for example, `ResolveAggAliasInGroupBy` and `ResolveMissingReferences` are pretty tricky).

Therefore it's wiser put grouping expression binding at the end of the analysis phase, and after this binding, all `Aggregate`s are replaced with `RealAggregate` (ignore this silly name... I'll think about a better name). However, there are still a few rules in `finishAnalysis` that is relevant for generating a _correct_ analyzed plan, we still have to deal with those rules. The above scenario also applies to optimizer rules that are related to aggregates.

This PR has the following tentative roadmap:

- [ ] Implement reference binding for grouping expressions

- [ ] Make `CheckAnalysis` happy

- [ ] Modify relevant rules in `finishAnalysis` accordingly

- [ ] Modify all aggregation-related optimizer rules

## How was this patch tested?
Existing UTs.

New UTs such as
```
SELECT concat('x', concat(a, 's'))
FROM testData2
GROUP BY concat(a, 's')
```