### PR TITLE
[SPARK-28614][SQL][TEST] Do not remove leading write space in the golden result file

### DIFF
--- a/sql/core/src/test/resources/sql-tests/results/pgSQL/boolean.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pgSQL/boolean.sql.out
@@ -363,7 +363,7 @@ SELECT '' AS t_3, BOOLTBL1.* FROM BOOLTBL1
 -- !query 44 schema
 struct<t_3:string,f1:boolean>
 -- !query 44 output
-true
+	true
 	true
 	true
 
@@ -375,7 +375,7 @@ SELECT '' AS t_3, BOOLTBL1.*
 -- !query 45 schema
 struct<t_3:string,f1:boolean>
 -- !query 45 output
-true
+	true
 	true
 	true
 
@@ -387,7 +387,7 @@ SELECT '' AS t_3, BOOLTBL1.*
 -- !query 46 schema
 struct<t_3:string,f1:boolean>
 -- !query 46 output
-true
+	true
 	true
 	true
 
@@ -417,7 +417,7 @@ SELECT '' AS f_1, BOOLTBL1.*
 -- !query 49 schema
 struct<f_1:string,f1:boolean>
 -- !query 49 output
-false
+	false
 
 
 -- !query 50
@@ -474,7 +474,7 @@ SELECT '' AS f_4, BOOLTBL2.* FROM BOOLTBL2
 -- !query 56 schema
 struct<f_4:string,f1:boolean>
 -- !query 56 output
-NULL
+	NULL
 	false
 	false
 	false
@@ -488,7 +488,7 @@ SELECT '' AS tf_12, BOOLTBL1.*, BOOLTBL2.*
 -- !query 57 schema
 struct<tf_12:string,f1:boolean,f1:boolean>
 -- !query 57 output
-true	false
+	true	false
 	true	false
 	true	false
 	true	false
@@ -509,7 +509,7 @@ SELECT '' AS tf_12, BOOLTBL1.*, BOOLTBL2.*
 -- !query 58 schema
 struct<tf_12:string,f1:boolean,f1:boolean>
 -- !query 58 output
-true	false
+	true	false
 	true	false
 	true	false
 	true	false
@@ -530,7 +530,7 @@ SELECT '' AS ff_4, BOOLTBL1.*, BOOLTBL2.*
 -- !query 59 schema
 struct<ff_4:string,f1:boolean,f1:boolean>
 -- !query 59 output
-false	false
+	false	false
 	false	false
 	false	false
 	false	false
@@ -544,7 +544,7 @@ SELECT '' AS tf_12_ff_4, BOOLTBL1.*, BOOLTBL2.*
 -- !query 60 schema
 struct<tf_12_ff_4:string,f1:boolean,f1:boolean>
 -- !query 60 output
-false	false
+	false	false
 	false	false
 	false	false
 	false	false

--- a/sql/core/src/test/resources/sql-tests/results/pgSQL/case.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pgSQL/case.sql.out
@@ -217,7 +217,7 @@ SELECT '' AS `Five`,
 -- !query 22 schema
 struct<Five:string,>= 3 or Null:int>
 -- !query 22 output
-3
+	3
 	4
 	NULL
 	NULL
@@ -232,7 +232,7 @@ SELECT '' AS `Five`,
 -- !query 23 schema
 struct<Five:string,Simplest Math:int>
 -- !query 23 output
-1
+	1
 	2
 	6
 	8
@@ -250,7 +250,7 @@ SELECT '' AS `Five`, i AS `Value`,
 -- !query 24 schema
 struct<Five:string,Value:int,Category:string>
 -- !query 24 output
-1	one
+	1	one
 	2	two
 	3	big
 	4	big
@@ -268,7 +268,7 @@ SELECT '' AS `Five`,
 -- !query 25 schema
 struct<Five:string,Category:string>
 -- !query 25 output
-big
+	big
 	big
 	one
 	two
@@ -340,7 +340,7 @@ SELECT '' AS Five, NULLIF(a.i,b.i) AS `NULLIF(a.i,b.i)`,
 -- !query 30 schema
 struct<Five:string,NULLIF(a.i,b.i):int,NULLIF(b.i,4):int>
 -- !query 30 output
-1	2
+	1	2
 	1	2
 	1	3
 	1	NULL
@@ -373,7 +373,7 @@ SELECT '' AS `Two`, *
 -- !query 31 schema
 struct<Two:string,i:int,f:double,i:int,j:int>
 -- !query 31 output
-4	NULL	2	-2
+	4	NULL	2	-2
 	4	NULL	2	-4
 
 

--- a/sql/core/src/test/resources/sql-tests/results/pgSQL/float4.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pgSQL/float4.sql.out
@@ -151,7 +151,7 @@ SELECT '' AS five, * FROM FLOAT4_TBL
 -- !query 18 schema
 struct<five:string,f1:float>
 -- !query 18 output
--34.84
+	-34.84
 	0.0
 	1.2345679E-20
 	1.2345679E20
@@ -163,7 +163,7 @@ SELECT '' AS four, f.* FROM FLOAT4_TBL f WHERE f.f1 <> '1004.3'
 -- !query 19 schema
 struct<four:string,f1:float>
 -- !query 19 output
--34.84
+	-34.84
 	0.0
 	1.2345679E-20
 	1.2345679E20
@@ -174,7 +174,7 @@ SELECT '' AS one, f.* FROM FLOAT4_TBL f WHERE f.f1 = '1004.3'
 -- !query 20 schema
 struct<one:string,f1:float>
 -- !query 20 output
-1004.3
+	1004.3
 
 
 -- !query 21
@@ -182,7 +182,7 @@ SELECT '' AS three, f.* FROM FLOAT4_TBL f WHERE '1004.3' > f.f1
 -- !query 21 schema
 struct<three:string,f1:float>
 -- !query 21 output
--34.84
+	-34.84
 	0.0
 	1.2345679E-20
 
@@ -192,7 +192,7 @@ SELECT '' AS three, f.* FROM FLOAT4_TBL f WHERE  f.f1 < '1004.3'
 -- !query 22 schema
 struct<three:string,f1:float>
 -- !query 22 output
--34.84
+	-34.84
 	0.0
 	1.2345679E-20
 
@@ -202,7 +202,7 @@ SELECT '' AS four, f.* FROM FLOAT4_TBL f WHERE '1004.3' >= f.f1
 -- !query 23 schema
 struct<four:string,f1:float>
 -- !query 23 output
--34.84
+	-34.84
 	0.0
 	1.2345679E-20
 	1004.3
@@ -213,7 +213,7 @@ SELECT '' AS four, f.* FROM FLOAT4_TBL f WHERE  f.f1 <= '1004.3'
 -- !query 24 schema
 struct<four:string,f1:float>
 -- !query 24 output
--34.84
+	-34.84
 	0.0
 	1.2345679E-20
 	1004.3
@@ -225,7 +225,7 @@ SELECT '' AS three, f.f1, f.f1 * '-10' AS x FROM FLOAT4_TBL f
 -- !query 25 schema
 struct<three:string,f1:float,x:double>
 -- !query 25 output
-1.2345679E-20	-1.2345678720289608E-19
+	1.2345679E-20	-1.2345678720289608E-19
 	1.2345679E20	-1.2345678955701443E21
 	1004.3	-10042.999877929688
 
@@ -236,7 +236,7 @@ SELECT '' AS three, f.f1, f.f1 + '-10' AS x FROM FLOAT4_TBL f
 -- !query 26 schema
 struct<three:string,f1:float,x:double>
 -- !query 26 output
-1.2345679E-20	-10.0
+	1.2345679E-20	-10.0
 	1.2345679E20	1.2345678955701443E20
 	1004.3	994.2999877929688
 
@@ -247,7 +247,7 @@ SELECT '' AS three, f.f1, f.f1 / '-10' AS x FROM FLOAT4_TBL f
 -- !query 27 schema
 struct<three:string,f1:float,x:double>
 -- !query 27 output
-1.2345679E-20	-1.2345678720289608E-21
+	1.2345679E-20	-1.2345678720289608E-21
 	1.2345679E20	-1.2345678955701443E19
 	1004.3	-100.42999877929688
 
@@ -258,7 +258,7 @@ SELECT '' AS three, f.f1, f.f1 - '-10' AS x FROM FLOAT4_TBL f
 -- !query 28 schema
 struct<three:string,f1:float,x:double>
 -- !query 28 output
-1.2345679E-20	10.0
+	1.2345679E-20	10.0
 	1.2345679E20	1.2345678955701443E20
 	1004.3	1014.2999877929688
 
@@ -268,7 +268,7 @@ SELECT '' AS five, * FROM FLOAT4_TBL
 -- !query 29 schema
 struct<five:string,f1:float>
 -- !query 29 output
--34.84
+	-34.84
 	0.0
 	1.2345679E-20
 	1.2345679E20

--- a/sql/core/src/test/resources/sql-tests/results/pgSQL/float8.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pgSQL/float8.sql.out
@@ -183,7 +183,7 @@ SELECT '' AS five, * FROM FLOAT8_TBL
 -- !query 22 schema
 struct<five:string,f1:double>
 -- !query 22 output
--34.84
+	-34.84
 	0.0
 	1.2345678901234E-200
 	1.2345678901234E200
@@ -195,7 +195,7 @@ SELECT '' AS four, f.* FROM FLOAT8_TBL f WHERE f.f1 <> '1004.3'
 -- !query 23 schema
 struct<four:string,f1:double>
 -- !query 23 output
--34.84
+	-34.84
 	0.0
 	1.2345678901234E-200
 	1.2345678901234E200
@@ -206,7 +206,7 @@ SELECT '' AS one, f.* FROM FLOAT8_TBL f WHERE f.f1 = '1004.3'
 -- !query 24 schema
 struct<one:string,f1:double>
 -- !query 24 output
-1004.3
+	1004.3
 
 
 -- !query 25
@@ -214,7 +214,7 @@ SELECT '' AS three, f.* FROM FLOAT8_TBL f WHERE '1004.3' > f.f1
 -- !query 25 schema
 struct<three:string,f1:double>
 -- !query 25 output
--34.84
+	-34.84
 	0.0
 	1.2345678901234E-200
 
@@ -224,7 +224,7 @@ SELECT '' AS three, f.* FROM FLOAT8_TBL f WHERE  f.f1 < '1004.3'
 -- !query 26 schema
 struct<three:string,f1:double>
 -- !query 26 output
--34.84
+	-34.84
 	0.0
 	1.2345678901234E-200
 
@@ -234,7 +234,7 @@ SELECT '' AS four, f.* FROM FLOAT8_TBL f WHERE '1004.3' >= f.f1
 -- !query 27 schema
 struct<four:string,f1:double>
 -- !query 27 output
--34.84
+	-34.84
 	0.0
 	1.2345678901234E-200
 	1004.3
@@ -245,7 +245,7 @@ SELECT '' AS four, f.* FROM FLOAT8_TBL f WHERE  f.f1 <= '1004.3'
 -- !query 28 schema
 struct<four:string,f1:double>
 -- !query 28 output
--34.84
+	-34.84
 	0.0
 	1.2345678901234E-200
 	1004.3
@@ -258,7 +258,7 @@ SELECT '' AS three, f.f1, f.f1 * '-10' AS x
 -- !query 29 schema
 struct<three:string,f1:double,x:double>
 -- !query 29 output
-1.2345678901234E-200	-1.2345678901234E-199
+	1.2345678901234E-200	-1.2345678901234E-199
 	1.2345678901234E200	-1.2345678901234E201
 	1004.3	-10043.0
 
@@ -270,7 +270,7 @@ SELECT '' AS three, f.f1, f.f1 + '-10' AS x
 -- !query 30 schema
 struct<three:string,f1:double,x:double>
 -- !query 30 output
-1.2345678901234E-200	-10.0
+	1.2345678901234E-200	-10.0
 	1.2345678901234E200	1.2345678901234E200
 	1004.3	994.3
 
@@ -282,7 +282,7 @@ SELECT '' AS three, f.f1, f.f1 / '-10' AS x
 -- !query 31 schema
 struct<three:string,f1:double,x:double>
 -- !query 31 output
-1.2345678901234E-200	-1.2345678901234E-201
+	1.2345678901234E-200	-1.2345678901234E-201
 	1.2345678901234E200	-1.2345678901234E199
 	1004.3	-100.42999999999999
 
@@ -294,7 +294,7 @@ SELECT '' AS three, f.f1, f.f1 - '-10' AS x
 -- !query 32 schema
 struct<three:string,f1:double,x:double>
 -- !query 32 output
-1.2345678901234E-200	10.0
+	1.2345678901234E-200	10.0
 	1.2345678901234E200	1.2345678901234E200
 	1004.3	1014.3
 
@@ -305,7 +305,7 @@ SELECT '' AS five, f.f1, round(f.f1) AS round_f1
 -- !query 33 schema
 struct<five:string,f1:double,round_f1:double>
 -- !query 33 output
--34.84	-35.0
+	-34.84	-35.0
 	0.0	0.0
 	1.2345678901234E-200	0.0
 	1.2345678901234E200	1.2345678901234E200
@@ -431,7 +431,7 @@ SELECT '' AS three, f.f1, exp(ln(f.f1)) AS exp_ln_f1
 -- !query 46 schema
 struct<three:string,f1:double,exp_ln_f1:double>
 -- !query 46 output
-1.2345678901234E-200	1.2345678901233948E-200
+	1.2345678901234E-200	1.2345678901233948E-200
 	1.2345678901234E200	1.234567890123379E200
 	1004.3	1004.3000000000004
 
@@ -441,7 +441,7 @@ SELECT '' AS five, * FROM FLOAT8_TBL
 -- !query 47 schema
 struct<five:string,f1:double>
 -- !query 47 output
--34.84
+	-34.84
 	0.0
 	1.2345678901234E-200
 	1.2345678901234E200
@@ -464,7 +464,7 @@ SELECT '' AS bad, f.f1 * '1e200' from UPDATED_FLOAT8_TBL f
 -- !query 49 schema
 struct<bad:string,(f1 * CAST(1e200 AS DOUBLE)):double>
 -- !query 49 output
--1.0042999999999999E203
+	-1.0042999999999999E203
 	-1.2345678901234
 	-3.484E201
 	-Infinity
@@ -476,7 +476,7 @@ SELECT '' AS five, * FROM UPDATED_FLOAT8_TBL
 -- !query 50 schema
 struct<five:string,f1:double>
 -- !query 50 output
--1.2345678901234E-200
+	-1.2345678901234E-200
 	-1.2345678901234E200
 	-1004.3
 	-34.84
@@ -728,7 +728,7 @@ SELECT '' AS five, * FROM FLOAT8_TBL
 -- !query 81 schema
 struct<five:string,f1:double>
 -- !query 81 output
--1.2345678901234E-200
+	-1.2345678901234E-200
 	-1.2345678901234E200
 	-1004.3
 	-34.84

--- a/sql/core/src/test/resources/sql-tests/results/pgSQL/int2.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pgSQL/int2.sql.out
@@ -55,7 +55,7 @@ SELECT '' AS five, * FROM INT2_TBL
 -- !query 6 schema
 struct<five:string,f1:smallint>
 -- !query 6 output
--1234
+	-1234
 	-32767
 	0
 	1234
@@ -67,7 +67,7 @@ SELECT '' AS four, i.* FROM INT2_TBL i WHERE i.f1 <> smallint('0')
 -- !query 7 schema
 struct<four:string,f1:smallint>
 -- !query 7 output
--1234
+	-1234
 	-32767
 	1234
 	32767
@@ -78,7 +78,7 @@ SELECT '' AS four, i.* FROM INT2_TBL i WHERE i.f1 <> int('0')
 -- !query 8 schema
 struct<four:string,f1:smallint>
 -- !query 8 output
--1234
+	-1234
 	-32767
 	1234
 	32767
@@ -89,7 +89,7 @@ SELECT '' AS one, i.* FROM INT2_TBL i WHERE i.f1 = smallint('0')
 -- !query 9 schema
 struct<one:string,f1:smallint>
 -- !query 9 output
-0
+	0
 
 
 -- !query 10
@@ -97,7 +97,7 @@ SELECT '' AS one, i.* FROM INT2_TBL i WHERE i.f1 = int('0')
 -- !query 10 schema
 struct<one:string,f1:smallint>
 -- !query 10 output
-0
+	0
 
 
 -- !query 11
@@ -105,7 +105,7 @@ SELECT '' AS two, i.* FROM INT2_TBL i WHERE i.f1 < smallint('0')
 -- !query 11 schema
 struct<two:string,f1:smallint>
 -- !query 11 output
--1234
+	-1234
 	-32767
 
 
@@ -114,7 +114,7 @@ SELECT '' AS two, i.* FROM INT2_TBL i WHERE i.f1 < int('0')
 -- !query 12 schema
 struct<two:string,f1:smallint>
 -- !query 12 output
--1234
+	-1234
 	-32767
 
 
@@ -123,7 +123,7 @@ SELECT '' AS three, i.* FROM INT2_TBL i WHERE i.f1 <= smallint('0')
 -- !query 13 schema
 struct<three:string,f1:smallint>
 -- !query 13 output
--1234
+	-1234
 	-32767
 	0
 
@@ -133,7 +133,7 @@ SELECT '' AS three, i.* FROM INT2_TBL i WHERE i.f1 <= int('0')
 -- !query 14 schema
 struct<three:string,f1:smallint>
 -- !query 14 output
--1234
+	-1234
 	-32767
 	0
 
@@ -143,7 +143,7 @@ SELECT '' AS two, i.* FROM INT2_TBL i WHERE i.f1 > smallint('0')
 -- !query 15 schema
 struct<two:string,f1:smallint>
 -- !query 15 output
-1234
+	1234
 	32767
 
 
@@ -152,7 +152,7 @@ SELECT '' AS two, i.* FROM INT2_TBL i WHERE i.f1 > int('0')
 -- !query 16 schema
 struct<two:string,f1:smallint>
 -- !query 16 output
-1234
+	1234
 	32767
 
 
@@ -161,7 +161,7 @@ SELECT '' AS three, i.* FROM INT2_TBL i WHERE i.f1 >= smallint('0')
 -- !query 17 schema
 struct<three:string,f1:smallint>
 -- !query 17 output
-0
+	0
 	1234
 	32767
 
@@ -171,7 +171,7 @@ SELECT '' AS three, i.* FROM INT2_TBL i WHERE i.f1 >= int('0')
 -- !query 18 schema
 struct<three:string,f1:smallint>
 -- !query 18 output
-0
+	0
 	1234
 	32767
 
@@ -181,7 +181,7 @@ SELECT '' AS one, i.* FROM INT2_TBL i WHERE (i.f1 % smallint('2')) = smallint('1
 -- !query 19 schema
 struct<one:string,f1:smallint>
 -- !query 19 output
-32767
+	32767
 
 
 -- !query 20
@@ -189,7 +189,7 @@ SELECT '' AS three, i.* FROM INT2_TBL i WHERE (i.f1 % int('2')) = smallint('0')
 -- !query 20 schema
 struct<three:string,f1:smallint>
 -- !query 20 output
--1234
+	-1234
 	0
 	1234
 
@@ -200,7 +200,7 @@ WHERE abs(f1) < 16384
 -- !query 21 schema
 struct<five:string,f1:smallint,x:smallint>
 -- !query 21 output
--1234	-2468
+	-1234	-2468
 	0	0
 	1234	2468
 
@@ -210,7 +210,7 @@ SELECT '' AS five, i.f1, i.f1 * int('2') AS x FROM INT2_TBL i
 -- !query 22 schema
 struct<five:string,f1:smallint,x:int>
 -- !query 22 output
--1234	-2468
+	-1234	-2468
 	-32767	-65534
 	0	0
 	1234	2468
@@ -223,7 +223,7 @@ WHERE f1 < 32766
 -- !query 23 schema
 struct<five:string,f1:smallint,x:smallint>
 -- !query 23 output
--1234	-1232
+	-1234	-1232
 	-32767	-32765
 	0	2
 	1234	1236
@@ -234,7 +234,7 @@ SELECT '' AS five, i.f1, i.f1 + int('2') AS x FROM INT2_TBL i
 -- !query 24 schema
 struct<five:string,f1:smallint,x:int>
 -- !query 24 output
--1234	-1232
+	-1234	-1232
 	-32767	-32765
 	0	2
 	1234	1236
@@ -247,7 +247,7 @@ WHERE f1 > -32767
 -- !query 25 schema
 struct<five:string,f1:smallint,x:smallint>
 -- !query 25 output
--1234	-1236
+	-1234	-1236
 	0	-2
 	1234	1232
 	32767	32765
@@ -258,7 +258,7 @@ SELECT '' AS five, i.f1, i.f1 - int('2') AS x FROM INT2_TBL i
 -- !query 26 schema
 struct<five:string,f1:smallint,x:int>
 -- !query 26 output
--1234	-1236
+	-1234	-1236
 	-32767	-32769
 	0	-2
 	1234	1232
@@ -270,7 +270,7 @@ SELECT '' AS five, i.f1, i.f1 / smallint('2') AS x FROM INT2_TBL i
 -- !query 27 schema
 struct<five:string,f1:smallint,x:smallint>
 -- !query 27 output
--1234	-617
+	-1234	-617
 	-32767	-16383
 	0	0
 	1234	617
@@ -282,7 +282,7 @@ SELECT '' AS five, i.f1, i.f1 / int('2') AS x FROM INT2_TBL i
 -- !query 28 schema
 struct<five:string,f1:smallint,x:int>
 -- !query 28 output
--1234	-617
+	-1234	-617
 	-32767	-16383
 	0	0
 	1234	617

--- a/sql/core/src/test/resources/sql-tests/results/pgSQL/int4.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pgSQL/int4.sql.out
@@ -63,7 +63,7 @@ SELECT '' AS five, * FROM INT4_TBL
 -- !query 7 schema
 struct<five:string,f1:int>
 -- !query 7 output
--123456
+	-123456
 	-2147483647
 	0
 	123456
@@ -75,7 +75,7 @@ SELECT '' AS four, i.* FROM INT4_TBL i WHERE i.f1 <> smallint('0')
 -- !query 8 schema
 struct<four:string,f1:int>
 -- !query 8 output
--123456
+	-123456
 	-2147483647
 	123456
 	2147483647
@@ -86,7 +86,7 @@ SELECT '' AS four, i.* FROM INT4_TBL i WHERE i.f1 <> int('0')
 -- !query 9 schema
 struct<four:string,f1:int>
 -- !query 9 output
--123456
+	-123456
 	-2147483647
 	123456
 	2147483647
@@ -97,7 +97,7 @@ SELECT '' AS one, i.* FROM INT4_TBL i WHERE i.f1 = smallint('0')
 -- !query 10 schema
 struct<one:string,f1:int>
 -- !query 10 output
-0
+	0
 
 
 -- !query 11
@@ -105,7 +105,7 @@ SELECT '' AS one, i.* FROM INT4_TBL i WHERE i.f1 = int('0')
 -- !query 11 schema
 struct<one:string,f1:int>
 -- !query 11 output
-0
+	0
 
 
 -- !query 12
@@ -113,7 +113,7 @@ SELECT '' AS two, i.* FROM INT4_TBL i WHERE i.f1 < smallint('0')
 -- !query 12 schema
 struct<two:string,f1:int>
 -- !query 12 output
--123456
+	-123456
 	-2147483647
 
 
@@ -122,7 +122,7 @@ SELECT '' AS two, i.* FROM INT4_TBL i WHERE i.f1 < int('0')
 -- !query 13 schema
 struct<two:string,f1:int>
 -- !query 13 output
--123456
+	-123456
 	-2147483647
 
 
@@ -131,7 +131,7 @@ SELECT '' AS three, i.* FROM INT4_TBL i WHERE i.f1 <= smallint('0')
 -- !query 14 schema
 struct<three:string,f1:int>
 -- !query 14 output
--123456
+	-123456
 	-2147483647
 	0
 
@@ -141,7 +141,7 @@ SELECT '' AS three, i.* FROM INT4_TBL i WHERE i.f1 <= int('0')
 -- !query 15 schema
 struct<three:string,f1:int>
 -- !query 15 output
--123456
+	-123456
 	-2147483647
 	0
 
@@ -151,7 +151,7 @@ SELECT '' AS two, i.* FROM INT4_TBL i WHERE i.f1 > smallint('0')
 -- !query 16 schema
 struct<two:string,f1:int>
 -- !query 16 output
-123456
+	123456
 	2147483647
 
 
@@ -160,7 +160,7 @@ SELECT '' AS two, i.* FROM INT4_TBL i WHERE i.f1 > int('0')
 -- !query 17 schema
 struct<two:string,f1:int>
 -- !query 17 output
-123456
+	123456
 	2147483647
 
 
@@ -169,7 +169,7 @@ SELECT '' AS three, i.* FROM INT4_TBL i WHERE i.f1 >= smallint('0')
 -- !query 18 schema
 struct<three:string,f1:int>
 -- !query 18 output
-0
+	0
 	123456
 	2147483647
 
@@ -179,7 +179,7 @@ SELECT '' AS three, i.* FROM INT4_TBL i WHERE i.f1 >= int('0')
 -- !query 19 schema
 struct<three:string,f1:int>
 -- !query 19 output
-0
+	0
 	123456
 	2147483647
 
@@ -189,7 +189,7 @@ SELECT '' AS one, i.* FROM INT4_TBL i WHERE (i.f1 % smallint('2')) = smallint('1
 -- !query 20 schema
 struct<one:string,f1:int>
 -- !query 20 output
-2147483647
+	2147483647
 
 
 -- !query 21
@@ -197,7 +197,7 @@ SELECT '' AS three, i.* FROM INT4_TBL i WHERE (i.f1 % int('2')) = smallint('0')
 -- !query 21 schema
 struct<three:string,f1:int>
 -- !query 21 output
--123456
+	-123456
 	0
 	123456
 
@@ -207,7 +207,7 @@ SELECT '' AS five, i.f1, i.f1 * smallint('2') AS x FROM INT4_TBL i
 -- !query 22 schema
 struct<five:string,f1:int,x:int>
 -- !query 22 output
--123456	-246912
+	-123456	-246912
 	-2147483647	2
 	0	0
 	123456	246912
@@ -220,7 +220,7 @@ WHERE abs(f1) < 1073741824
 -- !query 23 schema
 struct<five:string,f1:int,x:int>
 -- !query 23 output
--123456	-246912
+	-123456	-246912
 	0	0
 	123456	246912
 
@@ -230,7 +230,7 @@ SELECT '' AS five, i.f1, i.f1 * int('2') AS x FROM INT4_TBL i
 -- !query 24 schema
 struct<five:string,f1:int,x:int>
 -- !query 24 output
--123456	-246912
+	-123456	-246912
 	-2147483647	2
 	0	0
 	123456	246912
@@ -243,7 +243,7 @@ WHERE abs(f1) < 1073741824
 -- !query 25 schema
 struct<five:string,f1:int,x:int>
 -- !query 25 output
--123456	-246912
+	-123456	-246912
 	0	0
 	123456	246912
 
@@ -253,7 +253,7 @@ SELECT '' AS five, i.f1, i.f1 + smallint('2') AS x FROM INT4_TBL i
 -- !query 26 schema
 struct<five:string,f1:int,x:int>
 -- !query 26 output
--123456	-123454
+	-123456	-123454
 	-2147483647	-2147483645
 	0	2
 	123456	123458
@@ -266,7 +266,7 @@ WHERE f1 < 2147483646
 -- !query 27 schema
 struct<five:string,f1:int,x:int>
 -- !query 27 output
--123456	-123454
+	-123456	-123454
 	-2147483647	-2147483645
 	0	2
 	123456	123458
@@ -277,7 +277,7 @@ SELECT '' AS five, i.f1, i.f1 + int('2') AS x FROM INT4_TBL i
 -- !query 28 schema
 struct<five:string,f1:int,x:int>
 -- !query 28 output
--123456	-123454
+	-123456	-123454
 	-2147483647	-2147483645
 	0	2
 	123456	123458
@@ -290,7 +290,7 @@ WHERE f1 < 2147483646
 -- !query 29 schema
 struct<five:string,f1:int,x:int>
 -- !query 29 output
--123456	-123454
+	-123456	-123454
 	-2147483647	-2147483645
 	0	2
 	123456	123458
@@ -301,7 +301,7 @@ SELECT '' AS five, i.f1, i.f1 - smallint('2') AS x FROM INT4_TBL i
 -- !query 30 schema
 struct<five:string,f1:int,x:int>
 -- !query 30 output
--123456	-123458
+	-123456	-123458
 	-2147483647	2147483647
 	0	-2
 	123456	123454
@@ -314,7 +314,7 @@ WHERE f1 > -2147483647
 -- !query 31 schema
 struct<five:string,f1:int,x:int>
 -- !query 31 output
--123456	-123458
+	-123456	-123458
 	0	-2
 	123456	123454
 	2147483647	2147483645
@@ -325,7 +325,7 @@ SELECT '' AS five, i.f1, i.f1 - int('2') AS x FROM INT4_TBL i
 -- !query 32 schema
 struct<five:string,f1:int,x:int>
 -- !query 32 output
--123456	-123458
+	-123456	-123458
 	-2147483647	2147483647
 	0	-2
 	123456	123454
@@ -338,7 +338,7 @@ WHERE f1 > -2147483647
 -- !query 33 schema
 struct<five:string,f1:int,x:int>
 -- !query 33 output
--123456	-123458
+	-123456	-123458
 	0	-2
 	123456	123454
 	2147483647	2147483645
@@ -349,7 +349,7 @@ SELECT '' AS five, i.f1, i.f1 / smallint('2') AS x FROM INT4_TBL i
 -- !query 34 schema
 struct<five:string,f1:int,x:int>
 -- !query 34 output
--123456	-61728
+	-123456	-61728
 	-2147483647	-1073741823
 	0	0
 	123456	61728
@@ -361,7 +361,7 @@ SELECT '' AS five, i.f1, i.f1 / int('2') AS x FROM INT4_TBL i
 -- !query 35 schema
 struct<five:string,f1:int,x:int>
 -- !query 35 output
--123456	-61728
+	-123456	-61728
 	-2147483647	-1073741823
 	0	0
 	123456	61728

--- a/sql/core/src/test/resources/sql-tests/results/pgSQL/int8.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pgSQL/int8.sql.out
@@ -355,7 +355,7 @@ SELECT '' AS five, q1 AS plus, -q1 AS `minus` FROM INT8_TBL
 -- !query 37 schema
 struct<five:string,plus:bigint,minus:bigint>
 -- !query 37 output
-123	-123
+	123	-123
 	123	-123
 	4567890123456789	-4567890123456789
 	4567890123456789	-4567890123456789
@@ -367,7 +367,7 @@ SELECT '' AS five, q1, q2, q1 + q2 AS plus FROM INT8_TBL
 -- !query 38 schema
 struct<five:string,q1:bigint,q2:bigint,plus:bigint>
 -- !query 38 output
-123	456	579
+	123	456	579
 	123	4567890123456789	4567890123456912
 	4567890123456789	-4567890123456789	0
 	4567890123456789	123	4567890123456912
@@ -379,7 +379,7 @@ SELECT '' AS five, q1, q2, q1 - q2 AS `minus` FROM INT8_TBL
 -- !query 39 schema
 struct<five:string,q1:bigint,q2:bigint,minus:bigint>
 -- !query 39 output
-123	456	-333
+	123	456	-333
 	123	4567890123456789	-4567890123456666
 	4567890123456789	-4567890123456789	9135780246913578
 	4567890123456789	123	4567890123456666
@@ -391,7 +391,7 @@ SELECT '' AS three, q1, q2, q1 * q2 AS multiply FROM INT8_TBL
 -- !query 40 schema
 struct<three:string,q1:bigint,q2:bigint,multiply:bigint>
 -- !query 40 output
-123	456	56088
+	123	456	56088
 	123	4567890123456789	561850485185185047
 	4567890123456789	-4567890123456789	-4868582358072306617
 	4567890123456789	123	561850485185185047
@@ -404,7 +404,7 @@ SELECT '' AS three, q1, q2, q1 * q2 AS multiply FROM INT8_TBL
 -- !query 41 schema
 struct<three:string,q1:bigint,q2:bigint,multiply:bigint>
 -- !query 41 output
-123	456	56088
+	123	456	56088
 	123	4567890123456789	561850485185185047
 	4567890123456789	123	561850485185185047
 
@@ -414,7 +414,7 @@ SELECT '' AS five, q1, q2, q1 / q2 AS divide, q1 % q2 AS mod FROM INT8_TBL
 -- !query 42 schema
 struct<five:string,q1:bigint,q2:bigint,divide:bigint,mod:bigint>
 -- !query 42 output
-123	456	0	123
+	123	456	0	123
 	123	4567890123456789	0	123
 	4567890123456789	-4567890123456789	-1	0
 	4567890123456789	123	37137318076884	57
@@ -426,7 +426,7 @@ SELECT '' AS five, q1, double(q1) FROM INT8_TBL
 -- !query 43 schema
 struct<five:string,q1:bigint,q1:double>
 -- !query 43 output
-123	123.0
+	123	123.0
 	123	123.0
 	4567890123456789	4.567890123456789E15
 	4567890123456789	4.567890123456789E15
@@ -438,7 +438,7 @@ SELECT '' AS five, q2, double(q2) FROM INT8_TBL
 -- !query 44 schema
 struct<five:string,q2:bigint,q2:double>
 -- !query 44 output
--4567890123456789	-4.567890123456789E15
+	-4567890123456789	-4.567890123456789E15
 	123	123.0
 	456	456.0
 	4567890123456789	4.567890123456789E15
@@ -474,7 +474,7 @@ SELECT '' AS five, 2 * q1 AS `twice int4` FROM INT8_TBL
 -- !query 47 schema
 struct<five:string,twice int4:bigint>
 -- !query 47 output
-246
+	246
 	246
 	9135780246913578
 	9135780246913578
@@ -486,7 +486,7 @@ SELECT '' AS five, q1 * 2 AS `twice int4` FROM INT8_TBL
 -- !query 48 schema
 struct<five:string,twice int4:bigint>
 -- !query 48 output
-246
+	246
 	246
 	9135780246913578
 	9135780246913578

--- a/sql/core/src/test/resources/sql-tests/results/pgSQL/join.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pgSQL/join.sql.out
@@ -245,7 +245,7 @@ SELECT '' AS `xxx`, *
 -- !query 27 schema
 struct<xxx:string,i:int,j:int,t:string>
 -- !query 27 output
-0	NULL	zero
+	0	NULL	zero
 	1	4	one
 	2	3	two
 	3	2	three
@@ -264,7 +264,7 @@ SELECT '' AS `xxx`, *
 -- !query 28 schema
 struct<xxx:string,i:int,j:int,t:string>
 -- !query 28 output
-0	NULL	zero
+	0	NULL	zero
 	1	4	one
 	2	3	two
 	3	2	three
@@ -283,7 +283,7 @@ SELECT '' AS `xxx`, *
 -- !query 29 schema
 struct<xxx:string,a:int,b:int,c:string>
 -- !query 29 output
-0	NULL	zero
+	0	NULL	zero
 	1	4	one
 	2	3	two
 	3	2	three
@@ -302,7 +302,7 @@ SELECT '' AS `xxx`, *
 -- !query 30 schema
 struct<xxx:string,a:int,b:int,c:string>
 -- !query 30 output
-0	NULL	zero
+	0	NULL	zero
 	1	4	one
 	2	3	two
 	3	2	three
@@ -321,7 +321,7 @@ SELECT '' AS `xxx`, *
 -- !query 31 schema
 struct<xxx:string,a:int,b:int,c:string,d:int,e:int>
 -- !query 31 output
-0	NULL	zero	0	NULL
+	0	NULL	zero	0	NULL
 	0	NULL	zero	1	-1
 	0	NULL	zero	2	2
 	0	NULL	zero	2	4
@@ -428,7 +428,7 @@ SELECT '' AS `xxx`, *
 -- !query 32 schema
 struct<xxx:string,i:int,j:int,t:string,i:int,k:int>
 -- !query 32 output
-0	NULL	zero	0	NULL
+	0	NULL	zero	0	NULL
 	0	NULL	zero	1	-1
 	0	NULL	zero	2	2
 	0	NULL	zero	2	4
@@ -545,7 +545,7 @@ SELECT '' AS `xxx`, t1.i, k, t
 -- !query 34 schema
 struct<xxx:string,i:int,k:int,t:string>
 -- !query 34 output
-0	-1	zero
+	0	-1	zero
 	0	-3	zero
 	0	-5	zero
 	0	-5	zero
@@ -653,7 +653,7 @@ SELECT '' AS `xxx`, ii, tt, kk
 -- !query 35 schema
 struct<xxx:string,ii:int,tt:string,kk:int>
 -- !query 35 output
-0	zero	-1
+	0	zero	-1
 	0	zero	-3
 	0	zero	-5
 	0	zero	-5
@@ -760,7 +760,7 @@ SELECT '' AS `xxx`, *
 -- !query 36 schema
 struct<xxx:string,i:int,j:int,t:string,i:int,k:int,i:int,k:int>
 -- !query 36 output
-0	NULL	zero	0	NULL	0	NULL
+	0	NULL	zero	0	NULL	0	NULL
 	0	NULL	zero	0	NULL	1	-1
 	0	NULL	zero	0	NULL	2	2
 	0	NULL	zero	0	NULL	2	4
@@ -1659,7 +1659,7 @@ SELECT '' AS `xxx`, *
 -- !query 37 schema
 struct<xxx:string,i:int,j:int,t:string,k:int>
 -- !query 37 output
-0	NULL	zero	NULL
+	0	NULL	zero	NULL
 	1	4	one	-1
 	2	3	two	2
 	2	3	two	4
@@ -1674,7 +1674,7 @@ SELECT '' AS `xxx`, *
 -- !query 38 schema
 struct<xxx:string,i:int,j:int,t:string,k:int>
 -- !query 38 output
-0	NULL	zero	NULL
+	0	NULL	zero	NULL
 	1	4	one	-1
 	2	3	two	2
 	2	3	two	4
@@ -1690,7 +1690,7 @@ SELECT '' AS `xxx`, *
 -- !query 39 schema
 struct<xxx:string,a:int,b:int,c:string,d:int>
 -- !query 39 output
-0	NULL	zero	NULL
+	0	NULL	zero	NULL
 	1	4	one	-1
 	2	3	two	2
 	2	3	two	4
@@ -1705,7 +1705,7 @@ SELECT '' AS `xxx`, *
 -- !query 40 schema
 struct<xxx:string,i:int,j:int,t:string,k:int>
 -- !query 40 output
-0	NULL	zero	NULL
+	0	NULL	zero	NULL
 	1	4	one	-1
 	2	3	two	2
 	2	3	two	4
@@ -1720,7 +1720,7 @@ SELECT '' AS `xxx`, *
 -- !query 41 schema
 struct<xxx:string,a:int,b:int,c:string,d:int>
 -- !query 41 output
-0	NULL	zero	NULL
+	0	NULL	zero	NULL
 	1	4	one	-1
 	2	3	two	2
 	2	3	two	4
@@ -1735,7 +1735,7 @@ SELECT '' AS `xxx`, *
 -- !query 42 schema
 struct<xxx:string,a:int,b:int,c:string,d:int>
 -- !query 42 output
-0	NULL	zero	NULL
+	0	NULL	zero	NULL
 	2	3	two	2
 	4	1	four	2
 
@@ -1746,7 +1746,7 @@ SELECT '' AS `xxx`, *
 -- !query 43 schema
 struct<xxx:string,i:int,j:int,t:string,i:int,k:int>
 -- !query 43 output
-0	NULL	zero	0	NULL
+	0	NULL	zero	0	NULL
 	1	4	one	1	-1
 	2	3	two	2	2
 	2	3	two	2	4
@@ -1761,7 +1761,7 @@ SELECT '' AS `xxx`, *
 -- !query 44 schema
 struct<xxx:string,i:int,j:int,t:string,i:int,k:int>
 -- !query 44 output
-0	NULL	zero	NULL	0
+	0	NULL	zero	NULL	0
 	2	3	two	2	2
 	4	1	four	2	4
 
@@ -1772,7 +1772,7 @@ SELECT '' AS `xxx`, *
 -- !query 45 schema
 struct<xxx:string,i:int,j:int,t:string,i:int,k:int>
 -- !query 45 output
-0	NULL	zero	2	2
+	0	NULL	zero	2	2
 	0	NULL	zero	2	4
 	0	NULL	zero	NULL	0
 	1	4	one	2	2
@@ -1790,7 +1790,7 @@ SELECT '' AS `xxx`, *
 -- !query 46 schema
 struct<xxx:string,i:int,j:int,t:string,k:int>
 -- !query 46 output
-NULL	NULL	null	NULL
+	NULL	NULL	null	NULL
 	NULL	0	zero	NULL
 	0	NULL	zero	NULL
 	1	4	one	-1
@@ -1812,7 +1812,7 @@ SELECT '' AS `xxx`, *
 -- !query 47 schema
 struct<xxx:string,i:int,j:int,t:string,k:int>
 -- !query 47 output
-NULL	NULL	null	NULL
+	NULL	NULL	null	NULL
 	NULL	0	zero	NULL
 	0	NULL	zero	NULL
 	1	4	one	-1
@@ -1833,7 +1833,7 @@ SELECT '' AS `xxx`, *
 -- !query 48 schema
 struct<xxx:string,i:int,j:int,t:string,k:int>
 -- !query 48 output
-0	NULL	zero	NULL
+	0	NULL	zero	NULL
 	1	4	one	-1
 	2	3	two	2
 	2	3	two	4
@@ -1850,7 +1850,7 @@ SELECT '' AS `xxx`, *
 -- !query 49 schema
 struct<xxx:string,i:int,j:int,t:string,k:int>
 -- !query 49 output
-0	NULL	zero	NULL
+	0	NULL	zero	NULL
 	1	4	one	-1
 	2	3	two	2
 	2	3	two	4
@@ -1868,7 +1868,7 @@ SELECT '' AS `xxx`, *
 -- !query 50 schema
 struct<xxx:string,i:int,j:int,t:string,k:int>
 -- !query 50 output
-NULL	NULL	NULL	NULL
+	NULL	NULL	NULL	NULL
 	NULL	NULL	null	NULL
 	NULL	0	zero	NULL
 	NULL	NULL	NULL	0
@@ -1892,7 +1892,7 @@ SELECT '' AS `xxx`, *
 -- !query 51 schema
 struct<xxx:string,i:int,j:int,t:string,k:int>
 -- !query 51 output
-NULL	NULL	NULL	NULL
+	NULL	NULL	NULL	NULL
 	NULL	NULL	null	NULL
 	NULL	0	zero	NULL
 	NULL	NULL	NULL	0
@@ -1924,7 +1924,7 @@ SELECT '' AS `xxx`, *
 -- !query 53 schema
 struct<xxx:string,i:int,j:int,t:string,k:int>
 -- !query 53 output
-1	4	one	-1
+	1	4	one	-1
 
 
 -- !query 54

--- a/sql/core/src/test/resources/sql-tests/results/pgSQL/strings.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pgSQL/strings.sql.out
@@ -563,7 +563,7 @@ SELECT lpad('hi', 5)
 -- !query 68 schema
 struct<lpad(hi, 5,  ):string>
 -- !query 68 output
-hi
+   hi
 
 
 -- !query 69
@@ -683,7 +683,7 @@ SELECT chr(0)
 -- !query 83 schema
 struct<chr(CAST(0 AS BIGINT)):string>
 -- !query 83 output
-
+ 
 
 
 -- !query 84

--- a/sql/core/src/test/resources/sql-tests/results/pgSQL/text.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pgSQL/text.sql.out
@@ -47,7 +47,7 @@ SELECT '' AS two, * FROM TEXT_TBL
 -- !query 5 schema
 struct<two:string,f1:string>
 -- !query 5 output
-doh!
+	doh!
 	hi de ho neighbor
 
 

--- a/sql/core/src/test/resources/sql-tests/results/pgSQL/timestamp.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pgSQL/timestamp.sql.out
@@ -47,7 +47,7 @@ SELECT '' AS `64`, d1 FROM TIMESTAMP_TBL
 -- !query 5 schema
 struct<64:string,d1:timestamp>
 -- !query 5 output
-1997-01-02 00:00:00
+	1997-01-02 00:00:00
 	1997-01-02 03:04:05
 	1997-02-10 17:32:01
 	2001-09-22 18:19:20
@@ -59,7 +59,7 @@ SELECT '' AS `48`, d1 FROM TIMESTAMP_TBL
 -- !query 6 schema
 struct<48:string,d1:timestamp>
 -- !query 6 output
-1997-01-02 03:04:05
+	1997-01-02 03:04:05
 	1997-02-10 17:32:01
 	2001-09-22 18:19:20
 
@@ -79,7 +79,7 @@ SELECT '' AS one, d1 FROM TIMESTAMP_TBL
 -- !query 8 schema
 struct<one:string,d1:timestamp>
 -- !query 8 output
-1997-01-02 00:00:00
+	1997-01-02 00:00:00
 
 
 -- !query 9
@@ -88,7 +88,7 @@ SELECT '' AS `63`, d1 FROM TIMESTAMP_TBL
 -- !query 9 schema
 struct<63:string,d1:timestamp>
 -- !query 9 output
-1997-01-02 03:04:05
+	1997-01-02 03:04:05
 	1997-02-10 17:32:01
 	2001-09-22 18:19:20
 
@@ -99,7 +99,7 @@ SELECT '' AS `16`, d1 FROM TIMESTAMP_TBL
 -- !query 10 schema
 struct<16:string,d1:timestamp>
 -- !query 10 output
-1997-01-02 00:00:00
+	1997-01-02 00:00:00
 
 
 -- !query 11
@@ -108,7 +108,7 @@ SELECT '' AS `49`, d1 FROM TIMESTAMP_TBL
 -- !query 11 schema
 struct<49:string,d1:timestamp>
 -- !query 11 output
-1997-01-02 00:00:00
+	1997-01-02 00:00:00
 	1997-01-02 03:04:05
 	1997-02-10 17:32:01
 	2001-09-22 18:19:20
@@ -119,7 +119,7 @@ SELECT '' AS date_trunc_week, date_trunc( 'week', timestamp '2004-02-29 15:44:17
 -- !query 12 schema
 struct<date_trunc_week:string,week_trunc:timestamp>
 -- !query 12 output
-2004-02-23 00:00:00
+	2004-02-23 00:00:00
 
 
 -- !query 13

--- a/sql/core/src/test/resources/sql-tests/results/show-tables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/show-tables.sql.out
@@ -124,7 +124,7 @@ SHOW TABLE EXTENDED LIKE 'show_t*'
 -- !query 12 schema
 struct<database:string,tableName:string,isTemporary:boolean,information:string>
 -- !query 12 output
-show_t3	true	Table: show_t3
+	show_t3	true	Table: show_t3
 Created Time [not included in comparison]
 Last Access [not included in comparison]
 Created By [not included in comparison]

--- a/sql/core/src/test/resources/sql-tests/results/udf/pgSQL/udf-case.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/pgSQL/udf-case.sql.out
@@ -217,7 +217,7 @@ SELECT '' AS `Five`,
 -- !query 22 schema
 struct<Five:string,>= 3 or Null:int>
 -- !query 22 output
-3
+	3
 	4
 	NULL
 	NULL
@@ -232,7 +232,7 @@ SELECT '' AS `Five`,
 -- !query 23 schema
 struct<Five:string,Simplest Math:int>
 -- !query 23 output
-1
+	1
 	2
 	6
 	8
@@ -250,7 +250,7 @@ SELECT '' AS `Five`, i AS `Value`,
 -- !query 24 schema
 struct<Five:string,Value:int,Category:string>
 -- !query 24 output
-1	one
+	1	one
 	2	two
 	3	big
 	4	big
@@ -268,7 +268,7 @@ SELECT '' AS `Five`,
 -- !query 25 schema
 struct<Five:string,Category:string>
 -- !query 25 output
-big
+	big
 	big
 	one
 	two
@@ -340,7 +340,7 @@ SELECT udf('') AS Five, NULLIF(a.i,b.i) AS `NULLIF(a.i,b.i)`,
 -- !query 30 schema
 struct<Five:string,NULLIF(a.i,b.i):int,NULLIF(b.i,4):int>
 -- !query 30 output
-1	2
+	1	2
 	1	2
 	1	3
 	1	NULL
@@ -373,7 +373,7 @@ SELECT '' AS `Two`, *
 -- !query 31 schema
 struct<Two:string,i:int,f:double,i:int,j:int>
 -- !query 31 output
-4	NULL	2	-2
+	4	NULL	2	-2
 	4	NULL	2	-4
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -314,7 +314,7 @@ class SQLQueryTestSuite extends QueryTest with SharedSQLContext {
       QueryOutput(
         sql = sql,
         schema = schema.catalogString,
-        output = output.mkString("\n").trim)
+        output = output.mkString("\n").replaceAll("\\s+$", ""))
     }
 
     if (regenerateGoldenFiles) {
@@ -345,7 +345,7 @@ class SQLQueryTestSuite extends QueryTest with SharedSQLContext {
         QueryOutput(
           sql = segments(i * 3 + 1).trim,
           schema = segments(i * 3 + 2).trim,
-          output = segments(i * 3 + 3).trim
+          output = segments(i * 3 + 3).replaceAll("\\s+$", "")
         )
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

It's hard to know if the query needs to be sorted like [`SQLQueryTestSuite.isSorted`](https://github.com/apache/spark/blob/2ecc39c8d346437811fa991dc6471dc6862eb1f2/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala#L375-L380) when building a test framework for Thriftserver. So we  can sort both  the `outputs` and  the `expectedOutputs. However, we removed leading write space in the golden result file. This can lead to inconsistent results.
This PR makes it does not remove leading write space in the golden result file. Trailing write space still needs to be removed.


## How was this patch tested?

N/A
