### PR TITLE
[SPARK-28615][SQL][DOCS] Add a guide line for dataframe functions to say column signature function is by default

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -55,6 +55,9 @@ import org.apache.spark.util.Utils
  * `regr_count` is an example of a function that is built-in but not defined here, because it is
  * less commonly used. To invoke it, use `expr("regr_count(yCol, xCol)")`.
  *
+ * We add these functions with `Column` type arguments by default. All the other variants are there
+ * for historic reasons.
+ *
  * @groupname udf_funcs UDF functions
  * @groupname agg_funcs Aggregate functions
  * @groupname datetime_funcs Date time functions

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -55,8 +55,9 @@ import org.apache.spark.util.Utils
  * `regr_count` is an example of a function that is built-in but not defined here, because it is
  * less commonly used. To invoke it, use `expr("regr_count(yCol, xCol)")`.
  *
- * We add these functions with `Column` type arguments by default. All the other variants are there
- * for historic reasons.
+ * This function APIs usually have methods with Column signature only because it can support not
+ * only Column but also other types such as a native string. The other variants currently exist
+ * for historical reasons.
  *
  * @groupname udf_funcs UDF functions
  * @groupname agg_funcs Aggregate functions

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -55,8 +55,8 @@ import org.apache.spark.util.Utils
  * `regr_count` is an example of a function that is built-in but not defined here, because it is
  * less commonly used. To invoke it, use `expr("regr_count(yCol, xCol)")`.
  *
- * This function APIs usually have methods with Column signature only because it can support not
- * only Column but also other types such as a native string. The other variants currently exist
+ * This function APIs usually have methods with `Column` signature only because it can support not
+ * only `Column` but also other types such as a native string. The other variants currently exist
  * for historical reasons.
  *
  * @groupname udf_funcs UDF functions


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a guide line for dataframe functions, say:
```
This function APIs usually have methods with Column signature only because it can support not only Column but also other types such as a native string. The other variants currently exist for historical reasons.
```

## How was this patch tested?

N/A
