### PR TITLE
[WIP][SPARK-28621][SQL] Fix CheckCartesianProducts mismatch actual physical plan

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression,
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, RangePartitioning, RoundRobinPartitioning}
 import org.apache.spark.sql.catalyst.util.truncatedString
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.util.random.RandomSampler
 
@@ -379,6 +380,12 @@ case class Join(
     (!e.isInstanceOf[JoinHint]
       || e.asInstanceOf[JoinHint].leftHint.isDefined
       || e.asInstanceOf[JoinHint].rightHint.isDefined)
+  }
+}
+
+object Join {
+  def canBroadcast(plan: LogicalPlan, conf: SQLConf): Boolean = {
+    plan.stats.sizeInBytes >= 0 && plan.stats.sizeInBytes <= conf.autoBroadcastJoinThreshold
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -141,7 +141,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
      * Matches a plan whose output should be small enough to be used in broadcast join.
      */
     private def canBroadcast(plan: LogicalPlan): Boolean = {
-      plan.stats.sizeInBytes >= 0 && plan.stats.sizeInBytes <= conf.autoBroadcastJoinThreshold
+      Join.canBroadcast(plan, conf)
     }
 
     /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix `CheckCartesianProducts.isCartesianProduct` so that
1) when left or right side table can broadcast, then do not raise `Detected implicit cartesian product...` exception. (because we will use broadcast nested loop join)
2) when left or right side table both cannot broadcast and join conditions do not include equi-condition, then raise `Detected implicit cartesian product...` exception.

## How was this patch tested?

Unit test added.

Manual test by:

Providing
```
spark.range(2).createOrReplaceTempView("sm1") // can be broadcast
spark.range(50000000).createOrReplaceTempView("bg1") // cannot be broadcast
spark.range(60000000).createOrReplaceTempView("bg2") // cannot be broadcast
```
and suppose `spark.sql.crossJoin.enabled=false`

### Test1
Run
```
spark.sql("select sm1.id, bg1.id from bg1 join sm1 where sm1.id < bg1.id").explain
```
**Before**:
`Detected implicit cartesian product...` exception raised.
**After**:
Print correct sql plan like:
```
== Physical Plan ==
*(3) Project [id#10L, id#0L]
+- BroadcastNestedLoopJoin BuildRight, Inner, (id#10L < id#0L)
   :- *(1) Range (0, 50000000, step=1, splits=1)
   +- BroadcastExchange IdentityBroadcastMode
      +- *(2) Range (0, 2, step=1, splits=1)
```

### Test2
Run
```
spark.sql("select bg2.id, bg1.id from bg1 join bg2 where bg2.id < bg1.id").explain
```
**Before**
Print planner include Cartesian join (BUT we expect a `Detected implicit cartesian product...` exception raised):
```
== Physical Plan ==
*(3) Project [id#0L, id#2L]
+- CartesianProduct (id#0L < id#2L)
   :- *(1) Range (0, 50000000, step=1, splits=1)
   +- *(2) Range (0, 60000000, step=1, splits=1)
```
**After**:
`Detected implicit cartesian product...` exception raised.

Please review https://spark.apache.org/contributing.html before opening a pull request.
