### PR TITLE
[SPARK-28628][SQL] Implement SupportsNamespaces in V2SessionCatalog

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalogSuite.scala
@@ -22,41 +22,55 @@ import java.util.Collections
 
 import scala.collection.JavaConverters._
 
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalog.v2.{Catalogs, Identifier, TableCatalog, TableChange}
-import org.apache.spark.sql.catalyst.analysis.{NoSuchTableException, TableAlreadyExistsException}
+import org.apache.spark.sql.catalog.v2.{Catalogs, Identifier, NamespaceChange, TableChange}
+import org.apache.spark.sql.catalyst.analysis.{NamespaceAlreadyExistsException, NoSuchNamespaceException, NoSuchTableException, TableAlreadyExistsException}
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{DoubleType, IntegerType, LongType, StringType, StructField, StructType, TimestampType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
-class V2SessionCatalogSuite
-    extends SparkFunSuite with SharedSparkSession with BeforeAndAfter {
-  import org.apache.spark.sql.catalog.v2.CatalogV2Implicits._
+class V2SessionCatalogSuite extends SparkFunSuite with SharedSparkSession with BeforeAndAfter {
 
-  private val emptyProps: util.Map[String, String] = Collections.emptyMap[String, String]
-  private val schema: StructType = new StructType()
+  val emptyProps: util.Map[String, String] = Collections.emptyMap[String, String]
+  val schema: StructType = new StructType()
       .add("id", IntegerType)
       .add("data", StringType)
 
+  val testNs: Array[String] = Array("db")
+  val defaultNs: Array[String] = Array("default")
+  val testIdent: Identifier = Identifier.of(testNs, "test_table")
+
+  def newCatalog(): V2SessionCatalog = {
+    val newCatalog = new V2SessionCatalog(spark.sessionState)
+    newCatalog.initialize("test", CaseInsensitiveStringMap.empty())
+    newCatalog
+  }
+}
+
+class V2SessionCatalogTableSuite extends V2SessionCatalogSuite {
+
+  import org.apache.spark.sql.catalog.v2.CatalogV2Implicits._
+
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-    spark.sql("""CREATE DATABASE IF NOT EXISTS db""")
-    spark.sql("""CREATE DATABASE IF NOT EXISTS db2""")
-    spark.sql("""CREATE DATABASE IF NOT EXISTS ns""")
-    spark.sql("""CREATE DATABASE IF NOT EXISTS ns2""")
+    val catalog = newCatalog()
+    catalog.createNamespace(Array("db"), emptyProps)
+    catalog.createNamespace(Array("db2"), emptyProps)
+    catalog.createNamespace(Array("ns"), emptyProps)
+    catalog.createNamespace(Array("ns2"), emptyProps)
   }
 
   override protected def afterAll(): Unit = {
-    spark.sql("""DROP TABLE IF EXISTS db.test_table""")
-    spark.sql("""DROP DATABASE IF EXISTS db""")
-    spark.sql("""DROP DATABASE IF EXISTS db2""")
-    spark.sql("""DROP DATABASE IF EXISTS ns""")
-    spark.sql("""DROP DATABASE IF EXISTS ns2""")
+    val catalog = newCatalog()
+    catalog.dropNamespace(Array("db"))
+    catalog.dropNamespace(Array("db2"))
+    catalog.dropNamespace(Array("ns"))
+    catalog.dropNamespace(Array("ns2"))
     super.afterAll()
   }
 
@@ -65,14 +79,6 @@ class V2SessionCatalogSuite
     newCatalog().dropTable(testIdentNew)
   }
 
-  private def newCatalog(): TableCatalog = {
-    val newCatalog = new V2SessionCatalog(spark.sessionState)
-    newCatalog.initialize("test", CaseInsensitiveStringMap.empty())
-    newCatalog
-  }
-
-  private val testNs = Array("db")
-  private val testIdent = Identifier.of(testNs, "test_table")
   private val testIdentNew = Identifier.of(testNs, "test_table_new")
 
   test("Catalogs can load the catalog") {
@@ -751,5 +757,200 @@ class V2SessionCatalogSuite
     assert(exc.message.contains(testIdent.namespace.quoted))
     assert(exc.message.contains(testIdentNewOtherDb.namespace.quoted))
     assert(exc.message.contains("RENAME TABLE source and destination databases do not match"))
+  }
+}
+
+class V2SessionCatalogNamespaceSuite extends V2SessionCatalogSuite {
+
+  import org.apache.spark.sql.catalog.v2.CatalogV2Implicits._
+
+  def checkMetadata(
+      expected: scala.collection.Map[String, String],
+      actual: scala.collection.Map[String, String]): Unit = {
+    // remove location and comment that are automatically added by HMS unless they are expected
+    val toRemove = Seq("location", "comment").filter(expected.contains)
+    assert(expected -- toRemove === actual)
+  }
+
+  test("listNamespaces: basic behavior") {
+    val catalog = newCatalog()
+    catalog.createNamespace(testNs, Map("property" -> "value").asJava)
+
+    assert(catalog.listNamespaces() === Array(testNs, defaultNs))
+    assert(catalog.listNamespaces(Array()) === Array(testNs, defaultNs))
+    assert(catalog.listNamespaces(testNs) === Array())
+
+    catalog.dropNamespace(testNs)
+  }
+
+  test("listNamespaces: fail if missing namespace") {
+    val catalog = newCatalog()
+
+    assert(catalog.namespaceExists(testNs) === false)
+
+    val exc = intercept[NoSuchNamespaceException] {
+      assert(catalog.listNamespaces(testNs) === Array())
+    }
+
+    assert(exc.getMessage.contains(testNs.quoted))
+    assert(catalog.namespaceExists(testNs) === false)
+  }
+
+  test("loadNamespaceMetadata: fail missing namespace") {
+    val catalog = newCatalog()
+
+    val exc = intercept[NoSuchNamespaceException] {
+      catalog.loadNamespaceMetadata(testNs)
+    }
+
+    assert(exc.getMessage.contains(testNs.quoted))
+  }
+
+  test("loadNamespaceMetadata: non-empty metadata") {
+    val catalog = newCatalog()
+
+    assert(catalog.namespaceExists(testNs) === false)
+
+    catalog.createNamespace(testNs, Map("property" -> "value").asJava)
+
+    val metadata = catalog.loadNamespaceMetadata(testNs)
+
+    assert(catalog.namespaceExists(testNs) === true)
+    checkMetadata(metadata.asScala, Map("property" -> "value"))
+
+    catalog.dropNamespace(testNs)
+  }
+
+  test("loadNamespaceMetadata: empty metadata") {
+    val catalog = newCatalog()
+
+    assert(catalog.namespaceExists(testNs) === false)
+
+    catalog.createNamespace(testNs, emptyProps)
+
+    val metadata = catalog.loadNamespaceMetadata(testNs)
+
+    assert(catalog.namespaceExists(testNs) === true)
+    checkMetadata(metadata.asScala, emptyProps.asScala)
+
+    catalog.dropNamespace(testNs)
+  }
+
+  test("createNamespace: basic behavior") {
+    val catalog = newCatalog()
+
+    catalog.createNamespace(testNs, Map("property" -> "value").asJava)
+
+    assert(catalog.namespaceExists(testNs) === true)
+    checkMetadata(catalog.loadNamespaceMetadata(testNs).asScala, Map("property" -> "value"))
+
+    catalog.dropNamespace(testNs)
+  }
+
+  test("createNamespace: fail if namespace already exists") {
+    val catalog = newCatalog()
+
+    catalog.createNamespace(testNs, Map("property" -> "value").asJava)
+
+    val exc = intercept[NamespaceAlreadyExistsException] {
+      catalog.createNamespace(testNs, Map("property" -> "value2").asJava)
+    }
+
+    assert(exc.getMessage.contains(testNs.quoted))
+    assert(catalog.namespaceExists(testNs) === true)
+    checkMetadata(catalog.loadNamespaceMetadata(testNs).asScala, Map("property" -> "value"))
+
+    catalog.dropNamespace(testNs)
+  }
+
+  test("createTable: fail if namespace does not exist") {
+    val catalog = newCatalog()
+
+    assert(catalog.namespaceExists(testNs) === false)
+
+    val exc = intercept[NoSuchNamespaceException] {
+      catalog.createTable(testIdent, schema, Array.empty, emptyProps)
+    }
+
+    assert(exc.getMessage.contains(testNs.quoted))
+    assert(catalog.namespaceExists(testNs) === false)
+  }
+
+  test("dropNamespace: drop missing namespace") {
+    val catalog = newCatalog()
+
+    assert(catalog.namespaceExists(testNs) === false)
+
+    val ret = catalog.dropNamespace(testNs)
+
+    assert(ret === false)
+  }
+
+  test("dropNamespace: drop empty namespace") {
+    val catalog = newCatalog()
+
+    catalog.createNamespace(testNs, emptyProps)
+
+    assert(catalog.namespaceExists(testNs) === true)
+
+    val ret = catalog.dropNamespace(testNs)
+
+    assert(ret === true)
+    assert(catalog.namespaceExists(testNs) === false)
+  }
+
+  test("dropNamespace: fail if not empty") {
+    val catalog = newCatalog()
+
+    catalog.createNamespace(testNs, Map("property" -> "value").asJava)
+    catalog.createTable(testIdent, schema, Array.empty, emptyProps)
+
+    val exc = intercept[IllegalStateException] {
+      catalog.dropNamespace(testNs)
+    }
+
+    assert(exc.getMessage.contains(testNs.quoted))
+    assert(catalog.namespaceExists(testNs) === true)
+    checkMetadata(catalog.loadNamespaceMetadata(testNs).asScala, Map("property" -> "value"))
+
+    catalog.dropTable(testIdent)
+    catalog.dropNamespace(testNs)
+  }
+
+  test("alterNamespace: basic behavior") {
+    val catalog = newCatalog()
+
+    catalog.createNamespace(testNs, Map("property" -> "value").asJava)
+
+    catalog.alterNamespace(testNs, NamespaceChange.setProperty("property2", "value2"))
+    checkMetadata(
+      catalog.loadNamespaceMetadata(testNs).asScala,
+      Map("property" -> "value", "property2" -> "value2"))
+
+    catalog.alterNamespace(testNs,
+      NamespaceChange.removeProperty("property2"),
+      NamespaceChange.setProperty("property3", "value3"))
+    checkMetadata(
+      catalog.loadNamespaceMetadata(testNs).asScala,
+      Map("property" -> "value", "property3" -> "value3"))
+
+    catalog.alterNamespace(testNs, NamespaceChange.removeProperty("property3"))
+    checkMetadata(
+      catalog.loadNamespaceMetadata(testNs).asScala,
+      Map("property" -> "value"))
+
+    catalog.dropNamespace(testNs)
+  }
+
+  test("alterNamespace: fail if namespace doesn't exist") {
+    val catalog = newCatalog()
+
+    assert(catalog.namespaceExists(testNs) === false)
+
+    val exc = intercept[NoSuchNamespaceException] {
+      catalog.alterNamespace(testNs, NamespaceChange.setProperty("property", "value"))
+    }
+
+    assert(exc.getMessage.contains(testNs.quoted))
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This adds namespace support to V2SessionCatalog.

## How was this patch tested?

WIP: will add tests for v2 session catalog namespace methods.