### PR TITLE
[SPARK-21067][DOC] Fix Thrift Server - CTAS fail with Unable to move source

### DIFF
--- a/docs/sql-distributed-sql-engine.md
+++ b/docs/sql-distributed-sql-engine.md
@@ -85,6 +85,8 @@ To test, use beeline to connect to the JDBC/ODBC server in http mode with:
 
     beeline> !connect jdbc:hive2://<host>:<port>/<database>?hive.server2.transport.mode=http;hive.server2.thrift.http.path=<http_endpoint>
 
+If you closed a session and do CTAS, you must set `fs.%s.impl.disable.cache` to true in `hive-site.xml`.
+See more details in [[SPARK-21067]](https://issues.apache.org/jira/browse/SPARK-21067).
 
 ## Running the Spark SQL CLI
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to fix CTAS fails after we closed a session of ThriftServer.

- sql-distributed-sql-engine.md
![image](https://user-images.githubusercontent.com/25916266/62509628-6f854980-b83e-11e9-9bea-daaf76c8f724.png)

It seems the simplest way to fix [[SPARK-21067]](https://issues.apache.org/jira/browse/SPARK-21067).

For example :
If we use HDFS, we can set the following property in hive-site.xml.
`<property>`
`  <name>fs.hdfs.impl.disable.cache</name>`
`  <value>true</value>`
`</property>`

## How was this patch tested

Manual.
