### PR TITLE
[SPARK-28640][SQL] Do not show stack trace when default or session catalog is misconfigured

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalog/v2/Catalogs.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalog/v2/Catalogs.java
@@ -46,7 +46,8 @@ public class Catalogs {
    * @param name a String catalog name
    * @param conf a SQLConf
    * @return an initialized CatalogPlugin
-   * @throws CatalogNotFoundException if the plugin class cannot be found
+   * @throws CatalogNotFoundException if the plugin cannot be found
+   * @throws CatalogClassNotFoundException if the plugin class cannot be found
    * @throws SparkException if the plugin class cannot be instantiated
    */
   public static CatalogPlugin load(String name, SQLConf conf)
@@ -78,8 +79,8 @@ public class Catalogs {
       return plugin;
 
     } catch (ClassNotFoundException e) {
-      throw new SparkException(String.format(
-          "Cannot find catalog plugin class for catalog '%s': %s", name, pluginClassName));
+      throw new CatalogClassNotFoundException(String.format(
+          "Catalog '%s' plugin class '%s' not found", name, pluginClassName), e);
 
     } catch (NoSuchMethodException e) {
       throw new SparkException(String.format(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalog/v2/CatalogClassNotFoundException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalog/v2/CatalogClassNotFoundException.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalog.v2
+
+import org.apache.spark.SparkException
+import org.apache.spark.annotation.Experimental
+
+@Experimental
+class CatalogClassNotFoundException(message: String, cause: Throwable)
+  extends SparkException(message, cause) {
+
+  def this(message: String) = this(message, null)
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalog/v2/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalog/v2/CatalogManager.scala
@@ -40,6 +40,9 @@ class CatalogManager(conf: SQLConf) extends Logging {
       try {
         Some(catalog(catalogName))
       } catch {
+        case e @ (_: CatalogClassNotFoundException | _: CatalogNotFoundException) =>
+          logWarning(e.getMessage)
+          None
         case NonFatal(e) =>
           logError(s"Cannot load default v2 catalog: $catalogName", e)
           None
@@ -51,6 +54,9 @@ class CatalogManager(conf: SQLConf) extends Logging {
     try {
       Some(catalog(CatalogManager.SESSION_CATALOG_NAME))
     } catch {
+      case e @ (_: CatalogClassNotFoundException | _: CatalogNotFoundException) =>
+        logWarning(e.getMessage)
+        None
       case NonFatal(e) =>
         logError("Cannot load v2 session catalog", e)
         None

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalog/v2/CatalogLoadingSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalog/v2/CatalogLoadingSuite.java
@@ -81,10 +81,12 @@ public class CatalogLoadingSuite {
     SQLConf conf = new SQLConf();
     conf.setConfString("spark.sql.catalog.missing", "com.example.NoSuchCatalogPlugin");
 
-    SparkException exc = intercept(SparkException.class, () -> Catalogs.load("missing", conf));
+    SparkException exc =
+        intercept(CatalogClassNotFoundException.class, () -> Catalogs.load("missing", conf));
 
     Assert.assertTrue("Should complain that the class is not found",
-        exc.getMessage().contains("Cannot find catalog plugin class"));
+        exc.getMessage().contains(
+            "Catalog 'missing' plugin class 'com.example.NoSuchCatalogPlugin' not found"));
     Assert.assertTrue("Should identify the catalog by name",
         exc.getMessage().contains("missing"));
     Assert.assertTrue("Should identify the missing class",


### PR DESCRIPTION
## What changes were proposed in this pull request?

LookupCatalog's `sessionCatalog` and `defaultCatalog` logs an error message and the exception stack upon any nonfatal exception. When either catalog is misconfigured, this may clutter the console and alarm the user unnecessarily. It should be enough to print a warning and return None.

## How was this patch tested?

Manual test cases

Start Spark shell with either of these configurations:
- spark.sql.catalog.session=noclass
- spark.sql.default.catalog=def
- spark.sql.default.catalog=def and spark.sql.catalog.def=noclass

Enter `spark.sessionState.analyzer.defaultCatalog` or `spark.sessionState.analyzer.sessionCatalog` at the prompt, expect a warning and no stack trace.