### PR TITLE
[SPARK-28649][INFRA] Add Python .eggs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ project/plugins/project/build.properties
 project/plugins/src_managed/
 project/plugins/target/
 python/lib/pyspark.zip
+python/.eggs/
 python/deps
 python/test_coverage/coverage_data
 python/test_coverage/htmlcov


### PR DESCRIPTION
## What changes were proposed in this pull request?

If you build Spark distributions you potentially end up with a `python/.eggs` directory in your working copy which is not currently ignored by Spark's `.gitignore` file.  Since these are transient build artifacts there is no reason to ever commit these to Git so this should be placed in the `.gitignore` list

## How was this patch tested?

Verified the offending artifacts were no longer reported as untracked content by Git