### PR TITLE
[SPARK-28531][SQL] Improve Extract Python UDFs optimizer rule to enforce idempotence

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -47,8 +47,7 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
       plan.find(PlanHelper.specialExpressionsInUnsupportedOperator(_).nonEmpty).isEmpty)
   }
 
-  override protected val blacklistedOnceBatches: Set[String] =
-    Set("Extract Python UDFs")
+  override protected val blacklistedOnceBatches: Set[String] = Set.empty
 
   protected def fixedPoint = FixedPoint(SQLConf.get.optimizerMaxIterations)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
@@ -39,7 +39,8 @@ class SparkOptimizer(
       ExtractPythonUDFFromAggregate,
       // This must be executed after `ExtractPythonUDFFromAggregate` and before `ExtractPythonUDFs`.
       ExtractGroupingPythonUDFFromAggregate,
-      ExtractPythonUDFs,
+      ExtractPythonUDFs) :+
+    Batch("Post Extract Python UDFs Optimization", fixedPoint,
       // The eval-python node may be between Project/Filter and the scan node, which breaks
       // column pruning and filter push-down. Here we rerun the related optimizer rules.
       ColumnPruning,


### PR DESCRIPTION
## What changes were proposed in this pull request?
Since the action of extract python UDFs should be considered idempotent, in this PR we separate "extract Python UDFs" and "post python UDF extraction optimization" into two different batches, therefore enable the idempotence checker for "extract Python UDFs".

## How was this patch tested?

Existing UTs.
