### PR TITLE
[SPARK-13677][ML] Implement Tree-Based Feature Transformation for ML

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -26,7 +26,7 @@ import org.apache.spark.ml.feature.{Instance, LabeledPoint}
 import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.tree._
-import org.apache.spark.ml.tree.{DecisionTreeModel, Node, TreeClassifierParams}
+import org.apache.spark.ml.tree.{DecisionTreeModel, HasClassificationImpurity, Node}
 import org.apache.spark.ml.tree.DecisionTreeModelReadWrite._
 import org.apache.spark.ml.tree.impl.RandomForest
 import org.apache.spark.ml.util._
@@ -179,7 +179,7 @@ class DecisionTreeClassifier @Since("1.4.0") (
 object DecisionTreeClassifier extends DefaultParamsReadable[DecisionTreeClassifier] {
   /** Accessor for supported impurities: entropy, gini */
   @Since("1.4.0")
-  final val supportedImpurities: Array[String] = TreeClassifierParams.supportedImpurities
+  final val supportedImpurities: Array[String] = HasClassificationImpurity.supportedImpurities
 
   @Since("2.0.0")
   override def load(path: String): DecisionTreeClassifier = super.load(path)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -222,6 +222,7 @@ class DecisionTreeClassificationModel private[ml] (
   def predictLeaf(features: Vector): Double = predictLeafImpl(features)
 
   override def transform(dataset: Dataset[_]): DataFrame = {
+    transformSchema(dataset.schema, logging = true)
     if ($(leafCol).isEmpty) {
       super.transform(dataset)
     } else {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -26,7 +26,7 @@ import org.apache.spark.ml.feature.{Instance, LabeledPoint}
 import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.tree._
-import org.apache.spark.ml.tree.{DecisionTreeModel, HasClassificationImpurity, Node}
+import org.apache.spark.ml.tree.{DecisionTreeModel, Node, TreeClassifierParams}
 import org.apache.spark.ml.tree.DecisionTreeModelReadWrite._
 import org.apache.spark.ml.tree.impl.RandomForest
 import org.apache.spark.ml.util._
@@ -179,7 +179,7 @@ class DecisionTreeClassifier @Since("1.4.0") (
 object DecisionTreeClassifier extends DefaultParamsReadable[DecisionTreeClassifier] {
   /** Accessor for supported impurities: entropy, gini */
   @Since("1.4.0")
-  final val supportedImpurities: Array[String] = HasClassificationImpurity.supportedImpurities
+  final val supportedImpurities: Array[String] = TreeClassifierParams.supportedImpurities
 
   @Since("2.0.0")
   override def load(path: String): DecisionTreeClassifier = super.load(path)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -223,6 +223,7 @@ class DecisionTreeClassificationModel private[ml] (
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
+
     if ($(leafCol).nonEmpty) {
       val leafUDF = udf { vector: Vector => predictLeaf(vector) }
       super.transform(dataset)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -223,12 +223,12 @@ class DecisionTreeClassificationModel private[ml] (
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
-    if ($(leafCol).isEmpty) {
-      super.transform(dataset)
-    } else {
+    if ($(leafCol).nonEmpty) {
       val leafUDF = udf { vector: Vector => predictLeaf(vector) }
       super.transform(dataset)
         .withColumn($(leafCol), leafUDF(col($(featuresCol))))
+    } else {
+      super.transform(dataset)
     }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -218,14 +218,11 @@ class DecisionTreeClassificationModel private[ml] (
   @Since("3.0.0")
   def setLeafCol(value: String): this.type = set(leafCol, value)
 
-  @Since("3.0.0")
-  def predictLeaf(features: Vector): Double = predictLeafImpl(features)
-
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
 
     if ($(leafCol).nonEmpty) {
-      val leafUDF = udf { vector: Vector => predictLeaf(vector) }
+      val leafUDF = udf { features: Vector => predictLeaf(features) }
       super.transform(dataset)
         .withColumn($(leafCol), leafUDF(col($(featuresCol))))
     } else {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -140,8 +140,8 @@ class DecisionTreeClassifier @Since("1.4.0") (
     val strategy = getOldStrategy(categoricalFeatures, numClasses)
     instr.logNumClasses(numClasses)
     instr.logParams(this, labelCol, featuresCol, predictionCol, rawPredictionCol,
-      probabilityCol, maxDepth, maxBins, minInstancesPerNode, minInfoGain, maxMemoryInMB,
-      cacheNodeIds, checkpointInterval, impurity, seed)
+      probabilityCol, leafCol, maxDepth, maxBins, minInstancesPerNode, minInfoGain,
+      maxMemoryInMB, cacheNodeIds, checkpointInterval, impurity, seed)
 
     val trees = RandomForest.run(instances, strategy, numTrees = 1, featureSubsetStrategy = "all",
       seed = $(seed), instr = Some(instr), parentUID = Some(uid))
@@ -219,9 +219,7 @@ class DecisionTreeClassificationModel private[ml] (
   def setLeafCol(value: String): this.type = set(leafCol, value)
 
   @Since("3.0.0")
-  def predictLeaf(features: Vector): Double = {
-    predictLeafImpl(features)
-  }
+  def predictLeaf(features: Vector): Double = predictLeafImpl(features)
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     if ($(leafCol).isEmpty) {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -56,10 +56,6 @@ class DecisionTreeClassifier @Since("1.4.0") (
   // Override parameter setters from parent trait for Java API compatibility.
 
   /** @group setParam */
-  @Since("3.0.0")
-  def setLeafCol(value: String): this.type = set(leafCol, value)
-
-  /** @group setParam */
   @Since("1.4.0")
   def setMaxDepth(value: Int): this.type = set(maxDepth, value)
 
@@ -214,19 +210,15 @@ class DecisionTreeClassificationModel private[ml] (
     rootNode.predictImpl(features).prediction
   }
 
-  /** @group setParam */
-  @Since("3.0.0")
-  def setLeafCol(value: String): this.type = set(leafCol, value)
-
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
 
+    val outputData = super.transform(dataset)
     if ($(leafCol).nonEmpty) {
       val leafUDF = udf { features: Vector => predictLeaf(features) }
-      super.transform(dataset)
-        .withColumn($(leafCol), leafUDF(col($(featuresCol))))
+      outputData.withColumn($(leafCol), leafUDF(col($(featuresCol))))
     } else {
-      super.transform(dataset)
+      outputData
     }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -294,14 +294,11 @@ class GBTClassificationModel private[ml](
   @Since("3.0.0")
   def setLeafCol(value: String): this.type = set(leafCol, value)
 
-  @Since("3.0.0")
-  def predictLeaf(features: Vector): Vector = predictLeafImpl(features)
-
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
 
     if ($(leafCol).nonEmpty) {
-      val leafUDF = udf { vector: Vector => predictLeaf(vector) }
+      val leafUDF = udf { features: Vector => predictLeaf(features) }
       super.transform(dataset)
         .withColumn($(leafCol), leafUDF(col($(featuresCol))))
     } else {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -299,6 +299,7 @@ class GBTClassificationModel private[ml](
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
+
     if ($(leafCol).nonEmpty) {
       val leafUDF = udf { vector: Vector => predictLeaf(vector) }
       super.transform(dataset)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -299,27 +299,12 @@ class GBTClassificationModel private[ml](
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
-    var predictionColNames = Seq.empty[String]
-    var predictionColumns = Seq.empty[Column]
-
-    if ($(predictionCol).nonEmpty) {
-      val predictUDF = udf { features: Vector => predict(features) }
-      predictionColNames :+= $(predictionCol)
-      predictionColumns :+= predictUDF(col($(featuresCol)))
-    }
-
-    if ($(leafCol).nonEmpty) {
-      val leafUDF = udf { features: Vector => predictLeaf(features) }
-      predictionColNames :+= $(leafCol)
-      predictionColumns :+= leafUDF(col($(featuresCol)))
-    }
-
-    if (predictionColNames.nonEmpty) {
-      dataset.withColumns(predictionColNames, predictionColumns)
+    if ($(leafCol).isEmpty) {
+      super.transform(dataset)
     } else {
-      this.logWarning(s"$uid: GBTClassificationModel.transform() does nothing" +
-        " because no output columns were set.")
-      dataset.toDF()
+      val leafUDF = udf { vector: Vector => predictLeaf(vector) }
+      super.transform(dataset)
+        .withColumn($(leafCol), leafUDF(col($(featuresCol))))
     }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -34,7 +34,7 @@ import org.apache.spark.ml.util.DefaultParamsReader.Metadata
 import org.apache.spark.ml.util.Instrumentation.instrumented
 import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
 import org.apache.spark.mllib.tree.model.{GradientBoostedTreesModel => OldGBTModel}
-import org.apache.spark.sql.{Column, DataFrame, Dataset, Row}
+import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.apache.spark.sql.functions._
 
 /**
@@ -299,12 +299,12 @@ class GBTClassificationModel private[ml](
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
-    if ($(leafCol).isEmpty) {
-      super.transform(dataset)
-    } else {
+    if ($(leafCol).nonEmpty) {
       val leafUDF = udf { vector: Vector => predictLeaf(vector) }
       super.transform(dataset)
         .withColumn($(leafCol), leafUDF(col($(featuresCol))))
+    } else {
+      super.transform(dataset)
     }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -68,10 +68,6 @@ class GBTClassifier @Since("1.4.0") (
   // Parameters from TreeClassifierParams:
 
   /** @group setParam */
-  @Since("3.0.0")
-  def setLeafCol(value: String): this.type = set(leafCol, value)
-
-  /** @group setParam */
   @Since("1.4.0")
   def setMaxDepth(value: Int): this.type = set(maxDepth, value)
 
@@ -290,19 +286,15 @@ class GBTClassificationModel private[ml](
   @Since("1.4.0")
   override def treeWeights: Array[Double] = _treeWeights
 
-  /** @group setParam */
-  @Since("3.0.0")
-  def setLeafCol(value: String): this.type = set(leafCol, value)
-
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
 
+    val outputData = super.transform(dataset)
     if ($(leafCol).nonEmpty) {
       val leafUDF = udf { features: Vector => predictLeaf(features) }
-      super.transform(dataset)
-        .withColumn($(leafCol), leafUDF(col($(featuresCol))))
+      outputData.withColumn($(leafCol), leafUDF(col($(featuresCol))))
     } else {
-      super.transform(dataset)
+      outputData
     }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.types.{DataType, StructType}
 /**
  * (private[classification])  Params for probabilistic classification.
  */
-private[classification] trait ProbabilisticClassifierParams
+private[ml] trait ProbabilisticClassifierParams
   extends ClassifierParams with HasProbabilityCol with HasThresholds {
   override protected def validateAndTransformSchema(
       schema: StructType,

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
@@ -222,6 +222,7 @@ class RandomForestClassificationModel private[ml] (
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
+
     if ($(leafCol).nonEmpty) {
       val leafUDF = udf { vector: Vector => predictLeaf(vector) }
       super.transform(dataset)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
@@ -34,7 +34,7 @@ import org.apache.spark.ml.util.Instrumentation.instrumented
 import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
 import org.apache.spark.mllib.tree.model.{RandomForestModel => OldRandomForestModel}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{Column, DataFrame, Dataset}
+import org.apache.spark.sql.{DataFrame, Dataset}
 import org.apache.spark.sql.functions.{col, udf}
 
 /**
@@ -222,12 +222,12 @@ class RandomForestClassificationModel private[ml] (
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
-    if ($(leafCol).isEmpty) {
-      super.transform(dataset)
-    } else {
+    if ($(leafCol).nonEmpty) {
       val leafUDF = udf { vector: Vector => predictLeaf(vector) }
       super.transform(dataset)
         .withColumn($(leafCol), leafUDF(col($(featuresCol))))
+    } else {
+      super.transform(dataset)
     }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
@@ -25,7 +25,7 @@ import org.apache.spark.ml.feature.Instance
 import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.tree._
-import org.apache.spark.ml.tree.{HasClassificationImpurity, TreeEnsembleModel}
+import org.apache.spark.ml.tree.{TreeClassifierParams, TreeEnsembleModel}
 import org.apache.spark.ml.tree.impl.RandomForest
 import org.apache.spark.ml.util._
 import org.apache.spark.ml.util.{Identifiable, MetadataUtils}
@@ -162,7 +162,7 @@ class RandomForestClassifier @Since("1.4.0") (
 object RandomForestClassifier extends DefaultParamsReadable[RandomForestClassifier] {
   /** Accessor for supported impurity settings: entropy, gini */
   @Since("1.4.0")
-  final val supportedImpurities: Array[String] = HasClassificationImpurity.supportedImpurities
+  final val supportedImpurities: Array[String] = TreeClassifierParams.supportedImpurities
 
   /** Accessor for supported featureSubsetStrategy settings: auto, all, onethird, sqrt, log2 */
   @Since("1.4.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
@@ -217,14 +217,11 @@ class RandomForestClassificationModel private[ml] (
   @Since("3.0.0")
   def setLeafCol(value: String): this.type = set(leafCol, value)
 
-  @Since("3.0.0")
-  def predictLeaf(features: Vector): Vector = predictLeafImpl(features)
-
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
 
     if ($(leafCol).nonEmpty) {
-      val leafUDF = udf { vector: Vector => predictLeaf(vector) }
+      val leafUDF = udf { features: Vector => predictLeaf(features) }
       super.transform(dataset)
         .withColumn($(leafCol), leafUDF(col($(featuresCol))))
     } else {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
@@ -25,7 +25,7 @@ import org.apache.spark.ml.feature.Instance
 import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.tree._
-import org.apache.spark.ml.tree.{TreeClassifierParams, TreeEnsembleModel}
+import org.apache.spark.ml.tree.{HasClassificationImpurity, TreeEnsembleModel}
 import org.apache.spark.ml.tree.impl.RandomForest
 import org.apache.spark.ml.util._
 import org.apache.spark.ml.util.{Identifiable, MetadataUtils}
@@ -162,7 +162,7 @@ class RandomForestClassifier @Since("1.4.0") (
 object RandomForestClassifier extends DefaultParamsReadable[RandomForestClassifier] {
   /** Accessor for supported impurity settings: entropy, gini */
   @Since("1.4.0")
-  final val supportedImpurities: Array[String] = TreeClassifierParams.supportedImpurities
+  final val supportedImpurities: Array[String] = HasClassificationImpurity.supportedImpurities
 
   /** Accessor for supported featureSubsetStrategy settings: auto, all, onethird, sqrt, log2 */
   @Since("1.4.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
@@ -57,10 +57,6 @@ class RandomForestClassifier @Since("1.4.0") (
   // Parameters from TreeClassifierParams:
 
   /** @group setParam */
-  @Since("3.0.0")
-  def setLeafCol(value: String): this.type = set(leafCol, value)
-
-  /** @group setParam */
   @Since("1.4.0")
   def setMaxDepth(value: Int): this.type = set(maxDepth, value)
 
@@ -213,19 +209,15 @@ class RandomForestClassificationModel private[ml] (
   @Since("1.4.0")
   override def treeWeights: Array[Double] = _treeWeights
 
-  /** @group setParam */
-  @Since("3.0.0")
-  def setLeafCol(value: String): this.type = set(leafCol, value)
-
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
 
+    val outputData = super.transform(dataset)
     if ($(leafCol).nonEmpty) {
       val leafUDF = udf { features: Vector => predictLeaf(features) }
-      super.transform(dataset)
-        .withColumn($(leafCol), leafUDF(col($(featuresCol))))
+      outputData.withColumn($(leafCol), leafUDF(col($(featuresCol))))
     } else {
-      super.transform(dataset)
+      outputData
     }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
@@ -165,7 +165,7 @@ class DecisionTreeRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: S
 @Since("1.4.0")
 object DecisionTreeRegressor extends DefaultParamsReadable[DecisionTreeRegressor] {
   /** Accessor for supported impurities: variance */
-  final val supportedImpurities: Array[String] = HasRegressionImpurity.supportedImpurities
+  final val supportedImpurities: Array[String] = HasVarianceImpurity.supportedImpurities
 
   @Since("2.0.0")
   override def load(path: String): DecisionTreeRegressor = super.load(path)

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
@@ -213,33 +213,27 @@ class DecisionTreeRegressionModel private[ml] (
   @Since("3.0.0")
   def setLeafCol(value: String): this.type = set(leafCol, value)
 
-  @Since("3.0.0")
-  def predictLeaf(features: Vector): Double = predictLeafImpl(features)
-
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
-    transformImpl(dataset)
-  }
 
-  override protected def transformImpl(dataset: Dataset[_]): DataFrame = {
     var predictionColNames = Seq.empty[String]
     var predictionColumns = Seq.empty[Column]
 
     if ($(predictionCol).nonEmpty) {
-      val predictUDF = udf { vector: Vector => predict(vector) }
+      val predictUDF = udf { features: Vector => predict(features) }
       predictionColNames :+= $(predictionCol)
       predictionColumns :+= predictUDF(col($(featuresCol)))
     }
 
     if (isDefined(varianceCol) && $(varianceCol).nonEmpty) {
-      val predictVarianceUDF = udf { vector: Vector => predictVariance(vector) }
+      val predictVarianceUDF = udf { features: Vector => predictVariance(features) }
       predictionColNames :+= $(varianceCol)
       predictionColumns :+= predictVarianceUDF(col($(featuresCol)))
     }
 
     if ($(leafCol).nonEmpty) {
-      val leafUDF = udf { vector: Vector => predictLeaf(vector) }
+      val leafUDF = udf { features: Vector => predictLeaf(features) }
       predictionColNames :+= $(leafCol)
       predictionColumns :+= leafUDF(col($(featuresCol)))
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
@@ -227,19 +227,19 @@ class DecisionTreeRegressionModel private[ml] (
     var predictionColumns = Seq.empty[Column]
 
     if ($(predictionCol).nonEmpty) {
-      val predictUDF = udf { features: Vector => predict(features) }
+      val predictUDF = udf { vector: Vector => predict(vector) }
       predictionColNames :+= $(predictionCol)
       predictionColumns :+= predictUDF(col($(featuresCol)))
     }
 
     if (isDefined(varianceCol) && $(varianceCol).nonEmpty) {
-      val predictVarianceUDF = udf { features: Vector => predictVariance(features) }
+      val predictVarianceUDF = udf { vector: Vector => predictVariance(vector) }
       predictionColNames :+= $(varianceCol)
       predictionColumns :+= predictVarianceUDF(col($(featuresCol)))
     }
 
     if ($(leafCol).nonEmpty) {
-      val leafUDF = udf { features: Vector => predictLeaf(features) }
+      val leafUDF = udf { vector: Vector => predictLeaf(vector) }
       predictionColNames :+= $(leafCol)
       predictionColumns :+= leafUDF(col($(featuresCol)))
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
@@ -165,7 +165,7 @@ class DecisionTreeRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: S
 @Since("1.4.0")
 object DecisionTreeRegressor extends DefaultParamsReadable[DecisionTreeRegressor] {
   /** Accessor for supported impurities: variance */
-  final val supportedImpurities: Array[String] = HasVarianceImpurity.supportedImpurities
+  final val supportedImpurities: Array[String] = HasRegressionImpurity.supportedImpurities
 
   @Since("2.0.0")
   override def load(path: String): DecisionTreeRegressor = super.load(path)

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
@@ -100,6 +100,10 @@ class DecisionTreeRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: S
   @Since("1.6.0")
   def setSeed(value: Long): this.type = set(seed, value)
 
+  /** @group setParam */
+  @Since("2.0.0")
+  def setVarianceCol(value: String): this.type = set(varianceCol, value)
+
   /**
    * Sets the value of param [[weightCol]].
    * If this is not set or empty, we treat all instance weights as 1.0.
@@ -181,6 +185,9 @@ class DecisionTreeRegressionModel private[ml] (
     override val numFeatures: Int)
   extends PredictionModel[Vector, DecisionTreeRegressionModel]
   with DecisionTreeModel with DecisionTreeRegressorParams with MLWritable with Serializable {
+
+  /** @group setParam */
+  def setVarianceCol(value: String): this.type = set(varianceCol, value)
 
   require(rootNode != null,
     "DecisionTreeRegressionModel given null rootNode, but it requires a non-null rootNode.")

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
@@ -100,10 +100,6 @@ class DecisionTreeRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: S
   @Since("1.6.0")
   def setSeed(value: Long): this.type = set(seed, value)
 
-  /** @group setParam */
-  @Since("2.0.0")
-  def setVarianceCol(value: String): this.type = set(varianceCol, value)
-
   /**
    * Sets the value of param [[weightCol]].
    * If this is not set or empty, we treat all instance weights as 1.0.
@@ -186,9 +182,6 @@ class DecisionTreeRegressionModel private[ml] (
   extends PredictionModel[Vector, DecisionTreeRegressionModel]
   with DecisionTreeModel with DecisionTreeRegressorParams with MLWritable with Serializable {
 
-  /** @group setParam */
-  def setVarianceCol(value: String): this.type = set(varianceCol, value)
-
   require(rootNode != null,
     "DecisionTreeRegressionModel given null rootNode, but it requires a non-null rootNode.")
 
@@ -208,10 +201,6 @@ class DecisionTreeRegressionModel private[ml] (
   protected def predictVariance(features: Vector): Double = {
     rootNode.predictImpl(features).impurityStats.calculate()
   }
-
-  /** @group setParam */
-  @Since("3.0.0")
-  def setLeafCol(value: String): this.type = set(leafCol, value)
 
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -34,7 +34,7 @@ import org.apache.spark.ml.util.DefaultParamsReader.Metadata
 import org.apache.spark.ml.util.Instrumentation.instrumented
 import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
 import org.apache.spark.mllib.tree.model.{GradientBoostedTreesModel => OldGBTModel}
-import org.apache.spark.sql.{DataFrame, Dataset, Row}
+import org.apache.spark.sql.{Column, DataFrame, Dataset, Row}
 import org.apache.spark.sql.functions._
 
 /**
@@ -258,12 +258,30 @@ class GBTRegressionModel private[ml](
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
+
+    var predictionColNames = Seq.empty[String]
+    var predictionColumns = Seq.empty[Column]
+
+    val bcastModel = dataset.sparkSession.sparkContext.broadcast(this)
+
+    if ($(predictionCol).nonEmpty) {
+      val predictUDF = udf { (vector: Vector) => bcastModel.value.predict(vector) }
+      predictionColNames :+= $(predictionCol)
+      predictionColumns :+= predictUDF(col($(featuresCol)))
+    }
+
     if ($(leafCol).nonEmpty) {
-      val leafUDF = udf { vector: Vector => predictLeaf(vector) }
-      super.transform(dataset)
-        .withColumn($(leafCol), leafUDF(col($(featuresCol))))
+      val leafUDF = udf { vector: Vector => bcastModel.value.predictLeaf(vector) }
+      predictionColNames :+= $(leafCol)
+      predictionColumns :+= leafUDF(col($(featuresCol)))
+    }
+
+    if (predictionColNames.nonEmpty) {
+      dataset.withColumns(predictionColNames, predictionColumns)
     } else {
-      super.transform(dataset)
+      this.logWarning(s"$uid: GBTRegressionModel.transform() does nothing" +
+        " because no output columns were set.")
+      dataset.toDF()
     }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -265,7 +265,7 @@ class GBTRegressionModel private[ml](
     val bcastModel = dataset.sparkSession.sparkContext.broadcast(this)
 
     if ($(predictionCol).nonEmpty) {
-      val predictUDF = udf { (vector: Vector) => bcastModel.value.predict(vector) }
+      val predictUDF = udf { vector: Vector => bcastModel.value.predict(vector) }
       predictionColNames :+= $(predictionCol)
       predictionColumns :+= predictUDF(col($(featuresCol)))
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -34,7 +34,7 @@ import org.apache.spark.ml.util.DefaultParamsReader.Metadata
 import org.apache.spark.ml.util.Instrumentation.instrumented
 import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
 import org.apache.spark.mllib.tree.model.{GradientBoostedTreesModel => OldGBTModel}
-import org.apache.spark.sql.{DataFrame, Dataset, Row}
+import org.apache.spark.sql.{Column, DataFrame, Dataset, Row}
 import org.apache.spark.sql.functions._
 
 /**
@@ -65,6 +65,10 @@ class GBTRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: String)
   // Override parameter setters from parent trait for Java API compatibility.
 
   // Parameters from TreeRegressorParams:
+
+  /** @group setParam */
+  @Since("3.0.0")
+  def setLeafCol(value: String): this.type = set(leafCol, value)
 
   /** @group setParam */
   @Since("1.4.0")
@@ -169,7 +173,7 @@ class GBTRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: String)
 
     instr.logPipelineStage(this)
     instr.logDataset(dataset)
-    instr.logParams(this, labelCol, featuresCol, predictionCol, impurity, lossType,
+    instr.logParams(this, labelCol, featuresCol, predictionCol, leafCol, impurity, lossType,
       maxDepth, maxBins, maxIter, maxMemoryInMB, minInfoGain, minInstancesPerNode,
       seed, stepSize, subsamplingRate, cacheNodeIds, checkpointInterval, featureSubsetStrategy,
       validationIndicatorCol, validationTol)
@@ -245,12 +249,37 @@ class GBTRegressionModel private[ml](
   @Since("1.4.0")
   override def treeWeights: Array[Double] = _treeWeights
 
-  override protected def transformImpl(dataset: Dataset[_]): DataFrame = {
-    val bcastModel = dataset.sparkSession.sparkContext.broadcast(this)
-    val predictUDF = udf { (features: Any) =>
-      bcastModel.value.predict(features.asInstanceOf[Vector])
+  /** @group setParam */
+  @Since("3.0.0")
+  def setLeafCol(value: String): this.type = set(leafCol, value)
+
+  @Since("3.0.0")
+  def predictLeaf(features: Vector): Vector = predictLeafImpl(features)
+
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    transformSchema(dataset.schema, logging = true)
+    var predictionColNames = Seq.empty[String]
+    var predictionColumns = Seq.empty[Column]
+
+    if ($(predictionCol).nonEmpty) {
+      val predictUDF = udf { features: Vector => predict(features) }
+      predictionColNames :+= $(predictionCol)
+      predictionColumns :+= predictUDF(col($(featuresCol)))
     }
-    dataset.withColumn($(predictionCol), predictUDF(col($(featuresCol))))
+
+    if ($(leafCol).nonEmpty) {
+      val leafUDF = udf { features: Vector => predictLeaf(features) }
+      predictionColNames :+= $(leafCol)
+      predictionColumns :+= leafUDF(col($(featuresCol)))
+    }
+
+    if (predictionColNames.nonEmpty) {
+      dataset.withColumns(predictionColNames, predictionColumns)
+    } else {
+      this.logWarning(s"$uid: GBTRegressionModel.transform() does nothing" +
+        " because no output columns were set.")
+      dataset.toDF()
+    }
   }
 
   override def predict(features: Vector): Double = {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -253,9 +253,6 @@ class GBTRegressionModel private[ml](
   @Since("3.0.0")
   def setLeafCol(value: String): this.type = set(leafCol, value)
 
-  @Since("3.0.0")
-  def predictLeaf(features: Vector): Vector = predictLeafImpl(features)
-
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
 
@@ -265,13 +262,13 @@ class GBTRegressionModel private[ml](
     val bcastModel = dataset.sparkSession.sparkContext.broadcast(this)
 
     if ($(predictionCol).nonEmpty) {
-      val predictUDF = udf { vector: Vector => bcastModel.value.predict(vector) }
+      val predictUDF = udf { features: Vector => bcastModel.value.predict(features) }
       predictionColNames :+= $(predictionCol)
       predictionColumns :+= predictUDF(col($(featuresCol)))
     }
 
     if ($(leafCol).nonEmpty) {
-      val leafUDF = udf { vector: Vector => bcastModel.value.predictLeaf(vector) }
+      val leafUDF = udf { features: Vector => bcastModel.value.predictLeaf(features) }
       predictionColNames :+= $(leafCol)
       predictionColumns :+= leafUDF(col($(featuresCol)))
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -67,10 +67,6 @@ class GBTRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: String)
   // Parameters from TreeRegressorParams:
 
   /** @group setParam */
-  @Since("3.0.0")
-  def setLeafCol(value: String): this.type = set(leafCol, value)
-
-  /** @group setParam */
   @Since("1.4.0")
   def setMaxDepth(value: Int): this.type = set(maxDepth, value)
 
@@ -248,10 +244,6 @@ class GBTRegressionModel private[ml](
 
   @Since("1.4.0")
   override def treeWeights: Array[Double] = _treeWeights
-
-  /** @group setParam */
-  @Since("3.0.0")
-  def setLeafCol(value: String): this.type = set(leafCol, value)
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -211,7 +211,7 @@ class RandomForestRegressionModel private[ml] (
     val bcastModel = dataset.sparkSession.sparkContext.broadcast(this)
 
     if ($(predictionCol).nonEmpty) {
-      val predictUDF = udf { (vector: Vector) => bcastModel.value.predict(vector) }
+      val predictUDF = udf { vector: Vector => bcastModel.value.predict(vector) }
       predictionColNames :+= $(predictionCol)
       predictionColumns :+= predictUDF(col($(featuresCol)))
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -148,7 +148,7 @@ class RandomForestRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: S
 object RandomForestRegressor extends DefaultParamsReadable[RandomForestRegressor]{
   /** Accessor for supported impurity settings: variance */
   @Since("1.4.0")
-  final val supportedImpurities: Array[String] = HasVarianceImpurity.supportedImpurities
+  final val supportedImpurities: Array[String] = HasRegressionImpurity.supportedImpurities
 
   /** Accessor for supported featureSubsetStrategy settings: auto, all, onethird, sqrt, log2 */
   @Since("1.4.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -199,9 +199,6 @@ class RandomForestRegressionModel private[ml] (
   @Since("3.0.0")
   def setLeafCol(value: String): this.type = set(leafCol, value)
 
-  @Since("3.0.0")
-  def predictLeaf(features: Vector): Vector = predictLeafImpl(features)
-
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
 
@@ -211,13 +208,13 @@ class RandomForestRegressionModel private[ml] (
     val bcastModel = dataset.sparkSession.sparkContext.broadcast(this)
 
     if ($(predictionCol).nonEmpty) {
-      val predictUDF = udf { vector: Vector => bcastModel.value.predict(vector) }
+      val predictUDF = udf { features: Vector => bcastModel.value.predict(features) }
       predictionColNames :+= $(predictionCol)
       predictionColumns :+= predictUDF(col($(featuresCol)))
     }
 
     if ($(leafCol).nonEmpty) {
-      val leafUDF = udf { vector: Vector => bcastModel.value.predictLeaf(vector) }
+      val leafUDF = udf { features: Vector => bcastModel.value.predictLeaf(features) }
       predictionColNames :+= $(leafCol)
       predictionColumns :+= leafUDF(col($(featuresCol)))
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -31,7 +31,7 @@ import org.apache.spark.ml.util.DefaultParamsReader.Metadata
 import org.apache.spark.ml.util.Instrumentation.instrumented
 import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
 import org.apache.spark.mllib.tree.model.{RandomForestModel => OldRandomForestModel}
-import org.apache.spark.sql.{Column, DataFrame, Dataset}
+import org.apache.spark.sql.{DataFrame, Dataset}
 import org.apache.spark.sql.functions.{col, udf}
 
 /**
@@ -204,27 +204,12 @@ class RandomForestRegressionModel private[ml] (
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
-    var predictionColNames = Seq.empty[String]
-    var predictionColumns = Seq.empty[Column]
-
-    if ($(predictionCol).nonEmpty) {
-      val predictUDF = udf { features: Vector => predict(features) }
-      predictionColNames :+= $(predictionCol)
-      predictionColumns :+= predictUDF(col($(featuresCol)))
-    }
-
     if ($(leafCol).nonEmpty) {
-      val leafUDF = udf { features: Vector => predictLeaf(features) }
-      predictionColNames :+= $(leafCol)
-      predictionColumns :+= leafUDF(col($(featuresCol)))
-    }
-
-    if (predictionColNames.nonEmpty) {
-      dataset.withColumns(predictionColNames, predictionColumns)
+      val leafUDF = udf { vector: Vector => predictLeaf(vector) }
+      super.transform(dataset)
+        .withColumn($(leafCol), leafUDF(col($(featuresCol))))
     } else {
-      this.logWarning(s"$uid: RandomForestRegressionModel.transform() does nothing" +
-        " because no output columns were set.")
-      dataset.toDF()
+      super.transform(dataset)
     }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -31,7 +31,7 @@ import org.apache.spark.ml.util.DefaultParamsReader.Metadata
 import org.apache.spark.ml.util.Instrumentation.instrumented
 import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
 import org.apache.spark.mllib.tree.model.{RandomForestModel => OldRandomForestModel}
-import org.apache.spark.sql.{DataFrame, Dataset}
+import org.apache.spark.sql.{Column, DataFrame, Dataset}
 import org.apache.spark.sql.functions.{col, udf}
 
 /**
@@ -50,6 +50,10 @@ class RandomForestRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: S
   // Override parameter setters from parent trait for Java API compatibility.
 
   // Parameters from TreeRegressorParams:
+
+  /** @group setParam */
+  @Since("3.0.0")
+  def setLeafCol(value: String): this.type = set(leafCol, value)
 
   /** @group setParam */
   @Since("1.4.0")
@@ -123,7 +127,7 @@ class RandomForestRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: S
 
     instr.logPipelineStage(this)
     instr.logDataset(instances)
-    instr.logParams(this, labelCol, featuresCol, predictionCol, impurity, numTrees,
+    instr.logParams(this, labelCol, featuresCol, predictionCol, leafCol, impurity, numTrees,
       featureSubsetStrategy, maxDepth, maxBins, maxMemoryInMB, minInfoGain,
       minInstancesPerNode, seed, subsamplingRate, cacheNodeIds, checkpointInterval)
 
@@ -191,12 +195,37 @@ class RandomForestRegressionModel private[ml] (
   @Since("1.4.0")
   override def treeWeights: Array[Double] = _treeWeights
 
-  override protected def transformImpl(dataset: Dataset[_]): DataFrame = {
-    val bcastModel = dataset.sparkSession.sparkContext.broadcast(this)
-    val predictUDF = udf { (features: Any) =>
-      bcastModel.value.predict(features.asInstanceOf[Vector])
+  /** @group setParam */
+  @Since("3.0.0")
+  def setLeafCol(value: String): this.type = set(leafCol, value)
+
+  @Since("3.0.0")
+  def predictLeaf(features: Vector): Vector = predictLeafImpl(features)
+
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    transformSchema(dataset.schema, logging = true)
+    var predictionColNames = Seq.empty[String]
+    var predictionColumns = Seq.empty[Column]
+
+    if ($(predictionCol).nonEmpty) {
+      val predictUDF = udf { features: Vector => predict(features) }
+      predictionColNames :+= $(predictionCol)
+      predictionColumns :+= predictUDF(col($(featuresCol)))
     }
-    dataset.withColumn($(predictionCol), predictUDF(col($(featuresCol))))
+
+    if ($(leafCol).nonEmpty) {
+      val leafUDF = udf { features: Vector => predictLeaf(features) }
+      predictionColNames :+= $(leafCol)
+      predictionColumns :+= leafUDF(col($(featuresCol)))
+    }
+
+    if (predictionColNames.nonEmpty) {
+      dataset.withColumns(predictionColNames, predictionColumns)
+    } else {
+      this.logWarning(s"$uid: RandomForestRegressionModel.transform() does nothing" +
+        " because no output columns were set.")
+      dataset.toDF()
+    }
   }
 
   override def predict(features: Vector): Double = {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -148,7 +148,7 @@ class RandomForestRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: S
 object RandomForestRegressor extends DefaultParamsReadable[RandomForestRegressor]{
   /** Accessor for supported impurity settings: variance */
   @Since("1.4.0")
-  final val supportedImpurities: Array[String] = HasRegressionImpurity.supportedImpurities
+  final val supportedImpurities: Array[String] = HasVarianceImpurity.supportedImpurities
 
   /** Accessor for supported featureSubsetStrategy settings: auto, all, onethird, sqrt, log2 */
   @Since("1.4.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -52,10 +52,6 @@ class RandomForestRegressor @Since("1.4.0") (@Since("1.4.0") override val uid: S
   // Parameters from TreeRegressorParams:
 
   /** @group setParam */
-  @Since("3.0.0")
-  def setLeafCol(value: String): this.type = set(leafCol, value)
-
-  /** @group setParam */
   @Since("1.4.0")
   def setMaxDepth(value: Int): this.type = set(maxDepth, value)
 
@@ -194,10 +190,6 @@ class RandomForestRegressionModel private[ml] (
 
   @Since("1.4.0")
   override def treeWeights: Array[Double] = _treeWeights
-
-  /** @group setParam */
-  @Since("3.0.0")
-  def setLeafCol(value: String): this.type = set(leafCol, value)
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
@@ -36,8 +36,6 @@ import org.apache.spark.util.collection.OpenHashMap
 
 /**
  * Abstraction for Decision Tree models.
- *
- * TODO: Add support for predicting probabilities and raw predictions  SPARK-3727
  */
 private[spark] trait DecisionTreeModel {
 
@@ -79,8 +77,9 @@ private[spark] trait DecisionTreeModel {
   /** Convert to spark.mllib DecisionTreeModel (losing some information) */
   private[spark] def toOld: OldDecisionTreeModel
 
-  /** Returns an iterator that traverses (DFS, left to right) the leaves
-   *  in the subtree of this node.
+  /**
+   * @return an iterator that traverses (DFS, left to right) the leaves
+   *         in the subtree of this node.
    */
   private def leafIterator(node: Node): Iterator[LeafNode] = {
     node match {
@@ -94,8 +93,9 @@ private[spark] trait DecisionTreeModel {
     leafIterator(rootNode).zipWithIndex.toMap
   }
 
-  /** Returns the index of leaf given a input vector.
-   *  The leave are indexed from zero by pre-order.
+  /**
+   * @return the index of leaf given a input vector.
+   *         The leave are indexed from zero by pre-order.
    */
   def predictLeaf(features: Vector): Double = {
     leafIndices(rootNode.predictImpl(features)).toDouble
@@ -104,9 +104,6 @@ private[spark] trait DecisionTreeModel {
 
 /**
  * Abstraction for models which are ensembles of decision trees
- *
- * TODO: Add support for predicting probabilities and raw predictions  SPARK-3727
- *
  * @tparam M  Type of tree model in this ensemble
  */
 private[ml] trait TreeEnsembleModel[M <: DecisionTreeModel] {

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
@@ -90,11 +90,13 @@ private[spark] trait DecisionTreeModel {
     }
   }
 
-  @transient private lazy val leafIndices: Map[LeafNode, Int] =
+  @transient private lazy val leafIndices: Map[LeafNode, Int] = {
     leafIterator(rootNode).zipWithIndex.toMap
+  }
 
-  private[ml] def predictLeafImpl(features: Vector): Double =
+  def predictLeaf(features: Vector): Double = {
     leafIndices(rootNode.predictImpl(features)).toDouble
+  }
 }
 
 /**
@@ -136,8 +138,8 @@ private[ml] trait TreeEnsembleModel[M <: DecisionTreeModel] {
   /** Total number of nodes, summed over all trees in the ensemble. */
   lazy val totalNumNodes: Int = trees.map(_.numNodes).sum
 
-  private[ml] def predictLeafImpl(features: Vector): Vector = {
-    val indices = trees.map(_.predictLeafImpl(features))
+  def predictLeaf(features: Vector): Vector = {
+    val indices = trees.map(_.predictLeaf(features))
     Vectors.dense(indices)
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
@@ -93,7 +93,7 @@ private[spark] trait DecisionTreeModel {
   @transient private[ml] lazy val leafIndices: Map[LeafNode, Int] =
     leafIterator(rootNode).zipWithIndex.toMap
 
-  private[ml] def predictLeafIndexImpl(features: Vector): Double = {
+  private[ml] def predictLeafImpl(features: Vector): Double = {
     leafIndices(rootNode.predictImpl(features)).toDouble
   }
 }
@@ -137,8 +137,8 @@ private[ml] trait TreeEnsembleModel[M <: DecisionTreeModel] {
   /** Total number of nodes, summed over all trees in the ensemble. */
   lazy val totalNumNodes: Int = trees.map(_.numNodes).sum
 
-  private[ml] def predictLeafIndicesImpl(features: Vector): Vector =
-    Vectors.dense(trees.map(_.predictLeafIndexImpl(features)))
+  private[ml] def predictLeafImpl(features: Vector): Vector =
+    Vectors.dense(trees.map(_.predictLeafImpl(features)))
 }
 
 private[ml] object TreeEnsembleModel {

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
@@ -137,8 +137,10 @@ private[ml] trait TreeEnsembleModel[M <: DecisionTreeModel] {
   /** Total number of nodes, summed over all trees in the ensemble. */
   lazy val totalNumNodes: Int = trees.map(_.numNodes).sum
 
-  private[ml] def predictLeafImpl(features: Vector): Vector =
-    Vectors.dense(trees.map(_.predictLeafImpl(features)))
+  private[ml] def predictLeafImpl(features: Vector): Vector = {
+    val indices = trees.map(_.predictLeafImpl(features))
+    Vectors.dense(indices)
+  }
 }
 
 private[ml] object TreeEnsembleModel {

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
@@ -138,8 +138,9 @@ private[ml] trait TreeEnsembleModel[M <: DecisionTreeModel] {
   /** Total number of nodes, summed over all trees in the ensemble. */
   lazy val totalNumNodes: Int = trees.map(_.numNodes).sum
 
-  /** Returns the indices of leave of all trees given a input vector.
-   *  The leave are indexed from zero by pre-order in each tree.
+  /**
+   * @return the indices of leave of all trees given a input vector.
+   *         The leave are indexed from zero by pre-order in each tree.
    */
   def predictLeaf(features: Vector): Vector = {
     val indices = trees.map(_.predictLeaf(features))

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
@@ -90,12 +90,11 @@ private[spark] trait DecisionTreeModel {
     }
   }
 
-  @transient private[ml] lazy val leafIndices: Map[LeafNode, Int] =
+  @transient private lazy val leafIndices: Map[LeafNode, Int] =
     leafIterator(rootNode).zipWithIndex.toMap
 
-  private[ml] def predictLeafImpl(features: Vector): Double = {
+  private[ml] def predictLeafImpl(features: Vector): Double =
     leafIndices(rootNode.predictImpl(features)).toDouble
-  }
 }
 
 /**

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
@@ -94,6 +94,9 @@ private[spark] trait DecisionTreeModel {
     leafIterator(rootNode).zipWithIndex.toMap
   }
 
+  /** Returns the index of leaf given a input vector.
+   *  The leave are indexed from zero by pre-order.
+   */
   def predictLeaf(features: Vector): Double = {
     leafIndices(rootNode.predictImpl(features)).toDouble
   }
@@ -138,6 +141,9 @@ private[ml] trait TreeEnsembleModel[M <: DecisionTreeModel] {
   /** Total number of nodes, summed over all trees in the ensemble. */
   lazy val totalNumNodes: Int = trees.map(_.numNodes).sum
 
+  /** Returns the indices of leave of all trees given a input vector.
+   *  The leave are indexed from zero by pre-order in each tree.
+   */
   def predictLeaf(features: Vector): Vector = {
     val indices = trees.map(_.predictLeaf(features))
     Vectors.dense(indices)

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
@@ -94,8 +94,8 @@ private[spark] trait DecisionTreeModel {
   }
 
   /**
-   * @return the index of leaf given a input vector.
-   *         The leave are indexed from zero by pre-order.
+   * @return The index of the leaf corresponding to the feature vector.
+   *         Leaves are indexed in pre-order from 0.
    */
   def predictLeaf(features: Vector): Double = {
     leafIndices(rootNode.predictImpl(features)).toDouble
@@ -139,8 +139,8 @@ private[ml] trait TreeEnsembleModel[M <: DecisionTreeModel] {
   lazy val totalNumNodes: Int = trees.map(_.numNodes).sum
 
   /**
-   * @return the indices of leave of all trees given a input vector.
-   *         The leave are indexed from zero by pre-order in each tree.
+   * @return The indices of the leaves corresponding to the feature vector.
+   *         Leaves are indexed in pre-order from 0.
    */
   def predictLeaf(features: Vector): Vector = {
     val indices = trees.map(_.predictLeaf(features))

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -189,19 +189,20 @@ private[ml] trait DecisionTreeParams extends PredictorParams
 /**
  * Parameters for Decision Tree-based classification algorithms.
  */
-private[ml] trait TreeClassifierParams extends Params {
+private[ml] trait HasClassificationImpurity extends Params {
 
   /**
    * Criterion used for information gain calculation (case-insensitive).
+   * This impurity type is used in DecisionTreeClassifier and RandomForestClassifier,
    * Supported: "entropy" and "gini".
    * (default = gini)
    * @group param
    */
   final val impurity: Param[String] = new Param[String](this, "impurity", "Criterion used for" +
     " information gain calculation (case-insensitive). Supported options:" +
-    s" ${TreeClassifierParams.supportedImpurities.mkString(", ")}",
+    s" ${HasClassificationImpurity.supportedImpurities.mkString(", ")}",
     (value: String) =>
-      TreeClassifierParams.supportedImpurities.contains(value.toLowerCase(Locale.ROOT)))
+      HasClassificationImpurity.supportedImpurities.contains(value.toLowerCase(Locale.ROOT)))
 
   setDefault(impurity -> "gini")
 
@@ -221,14 +222,14 @@ private[ml] trait TreeClassifierParams extends Params {
   }
 }
 
-private[ml] object TreeClassifierParams {
+private[ml] object HasClassificationImpurity {
   // These options should be lowercase.
   final val supportedImpurities: Array[String] =
     Array("entropy", "gini").map(_.toLowerCase(Locale.ROOT))
 }
 
 private[ml] trait DecisionTreeClassifierParams
-  extends DecisionTreeParams with TreeClassifierParams with ProbabilisticClassifierParams {
+  extends DecisionTreeParams with HasClassificationImpurity with ProbabilisticClassifierParams {
 
   override protected def validateAndTransformSchema(
       schema: StructType,
@@ -242,18 +243,21 @@ private[ml] trait DecisionTreeClassifierParams
   }
 }
 
-private[ml] trait HasVarianceImpurity extends Params {
+private[ml] trait HasRegressionImpurity extends Params {
   /**
    * Criterion used for information gain calculation (case-insensitive).
+   * This impurity type is used in DecisionTreeRegressor, RandomForestRegressor, GBTRegressor
+   * and GBTClassifier (since GBTClassificationModel is internally composed of
+   * DecisionTreeRegressionModels).
    * Supported: "variance".
    * (default = variance)
    * @group param
    */
   final val impurity: Param[String] = new Param[String](this, "impurity", "Criterion used for" +
     " information gain calculation (case-insensitive). Supported options:" +
-    s" ${HasVarianceImpurity.supportedImpurities.mkString(", ")}",
+    s" ${HasRegressionImpurity.supportedImpurities.mkString(", ")}",
     (value: String) =>
-      HasVarianceImpurity.supportedImpurities.contains(value.toLowerCase(Locale.ROOT)))
+      HasRegressionImpurity.supportedImpurities.contains(value.toLowerCase(Locale.ROOT)))
 
   setDefault(impurity -> "variance")
 
@@ -272,7 +276,7 @@ private[ml] trait HasVarianceImpurity extends Params {
   }
 }
 
-private[ml] object HasVarianceImpurity {
+private[ml] object HasRegressionImpurity {
   // These options should be lowercase.
   final val supportedImpurities: Array[String] =
     Array("variance").map(_.toLowerCase(Locale.ROOT))
@@ -281,7 +285,7 @@ private[ml] object HasVarianceImpurity {
 /**
  * Parameters for Decision Tree-based regression algorithms.
  */
-private[ml] trait TreeRegressorParams extends HasVarianceImpurity
+private[ml] trait TreeRegressorParams extends HasRegressionImpurity
 
 private[ml] trait DecisionTreeRegressorParams extends DecisionTreeParams
   with TreeRegressorParams with HasVarianceCol {
@@ -445,7 +449,7 @@ private[ml] trait RandomForestParams extends TreeEnsembleParams {
 }
 
 private[ml] trait RandomForestClassifierParams
-  extends RandomForestParams with TreeEnsembleClassifierParams with TreeClassifierParams
+  extends RandomForestParams with TreeEnsembleClassifierParams with HasClassificationImpurity
 
 private[ml] trait RandomForestRegressorParams
   extends RandomForestParams with TreeEnsembleRegressorParams with TreeRegressorParams
@@ -519,7 +523,7 @@ private[ml] object GBTClassifierParams {
 }
 
 private[ml] trait GBTClassifierParams
-  extends GBTParams with TreeEnsembleClassifierParams with HasVarianceImpurity {
+  extends GBTParams with TreeEnsembleClassifierParams with HasRegressionImpurity {
 
   /**
    * Loss function which GBT tries to minimize. (case-insensitive)

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -40,6 +40,16 @@ private[ml] trait DecisionTreeParams extends PredictorParams
   with HasCheckpointInterval with HasSeed with HasWeightCol {
 
   /**
+   * Leaf indices column name.
+   * Predicted leaf index of each instance in each tree by preorder.
+   * (default = "")
+   * @group param
+   */
+  final val leafCol: Param[String] =
+    new Param[String](this, "leafCol", "Leaf indices column name. " +
+      "Predicted leaf index of each instance in each tree by preorder")
+
+  /**
    * Maximum depth of the tree (nonnegative).
    * E.g., depth 0 means 1 leaf node; depth 1 means 1 internal node + 2 leaf nodes.
    * (default = 5)
@@ -122,9 +132,12 @@ private[ml] trait DecisionTreeParams extends PredictorParams
     " algorithm will cache node IDs for each instance. Caching can speed up training of deeper" +
     " trees.")
 
-  setDefault(maxDepth -> 5, maxBins -> 32, minInstancesPerNode -> 1,
+  setDefault(leafCol -> "", maxDepth -> 5, maxBins -> 32, minInstancesPerNode -> 1,
     minWeightFractionPerNode -> 0.0, minInfoGain -> 0.0, maxMemoryInMB -> 256,
     cacheNodeIds -> false, checkpointInterval -> 10)
+
+  /** @group getParam */
+  final def getLeafCol: String = $(leafCol)
 
   /** @group getParam */
   final def getMaxDepth: Int = $(maxDepth)
@@ -213,7 +226,7 @@ private[ml] object TreeClassifierParams {
 }
 
 private[ml] trait DecisionTreeClassifierParams
-  extends DecisionTreeParams with TreeClassifierParams
+  extends DecisionTreeParams with TreeClassifierParams with ProbabilisticClassifierParams
 
 private[ml] trait HasVarianceImpurity extends Params {
   /**

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -189,7 +189,7 @@ private[ml] trait DecisionTreeParams extends PredictorParams
 /**
  * Parameters for Decision Tree-based classification algorithms.
  */
-private[ml] trait HasClassificationImpurity extends Params {
+private[ml] trait TreeClassifierParams extends Params {
 
   /**
    * Criterion used for information gain calculation (case-insensitive).
@@ -200,9 +200,9 @@ private[ml] trait HasClassificationImpurity extends Params {
    */
   final val impurity: Param[String] = new Param[String](this, "impurity", "Criterion used for" +
     " information gain calculation (case-insensitive). Supported options:" +
-    s" ${HasClassificationImpurity.supportedImpurities.mkString(", ")}",
+    s" ${TreeClassifierParams.supportedImpurities.mkString(", ")}",
     (value: String) =>
-      HasClassificationImpurity.supportedImpurities.contains(value.toLowerCase(Locale.ROOT)))
+      TreeClassifierParams.supportedImpurities.contains(value.toLowerCase(Locale.ROOT)))
 
   setDefault(impurity -> "gini")
 
@@ -222,14 +222,14 @@ private[ml] trait HasClassificationImpurity extends Params {
   }
 }
 
-private[ml] object HasClassificationImpurity {
+private[ml] object TreeClassifierParams {
   // These options should be lowercase.
   final val supportedImpurities: Array[String] =
     Array("entropy", "gini").map(_.toLowerCase(Locale.ROOT))
 }
 
 private[ml] trait DecisionTreeClassifierParams
-  extends DecisionTreeParams with HasClassificationImpurity with ProbabilisticClassifierParams {
+  extends DecisionTreeParams with TreeClassifierParams with ProbabilisticClassifierParams {
 
   override protected def validateAndTransformSchema(
       schema: StructType,
@@ -243,7 +243,7 @@ private[ml] trait DecisionTreeClassifierParams
   }
 }
 
-private[ml] trait HasRegressionImpurity extends Params {
+private[ml] trait HasVarianceImpurity extends Params {
   /**
    * Criterion used for information gain calculation (case-insensitive).
    * This impurity type is used in DecisionTreeRegressor, RandomForestRegressor, GBTRegressor
@@ -255,9 +255,9 @@ private[ml] trait HasRegressionImpurity extends Params {
    */
   final val impurity: Param[String] = new Param[String](this, "impurity", "Criterion used for" +
     " information gain calculation (case-insensitive). Supported options:" +
-    s" ${HasRegressionImpurity.supportedImpurities.mkString(", ")}",
+    s" ${HasVarianceImpurity.supportedImpurities.mkString(", ")}",
     (value: String) =>
-      HasRegressionImpurity.supportedImpurities.contains(value.toLowerCase(Locale.ROOT)))
+      HasVarianceImpurity.supportedImpurities.contains(value.toLowerCase(Locale.ROOT)))
 
   setDefault(impurity -> "variance")
 
@@ -276,7 +276,7 @@ private[ml] trait HasRegressionImpurity extends Params {
   }
 }
 
-private[ml] object HasRegressionImpurity {
+private[ml] object HasVarianceImpurity {
   // These options should be lowercase.
   final val supportedImpurities: Array[String] =
     Array("variance").map(_.toLowerCase(Locale.ROOT))
@@ -285,7 +285,7 @@ private[ml] object HasRegressionImpurity {
 /**
  * Parameters for Decision Tree-based regression algorithms.
  */
-private[ml] trait TreeRegressorParams extends HasRegressionImpurity
+private[ml] trait TreeRegressorParams extends HasVarianceImpurity
 
 private[ml] trait DecisionTreeRegressorParams extends DecisionTreeParams
   with TreeRegressorParams with HasVarianceCol {
@@ -449,7 +449,7 @@ private[ml] trait RandomForestParams extends TreeEnsembleParams {
 }
 
 private[ml] trait RandomForestClassifierParams
-  extends RandomForestParams with TreeEnsembleClassifierParams with HasClassificationImpurity
+  extends RandomForestParams with TreeEnsembleClassifierParams with TreeClassifierParams
 
 private[ml] trait RandomForestRegressorParams
   extends RandomForestParams with TreeEnsembleRegressorParams with TreeRegressorParams
@@ -523,7 +523,7 @@ private[ml] object GBTClassifierParams {
 }
 
 private[ml] trait GBTClassifierParams
-  extends GBTParams with TreeEnsembleClassifierParams with HasRegressionImpurity {
+  extends GBTParams with TreeEnsembleClassifierParams with HasVarianceImpurity {
 
   /**
    * Loss function which GBT tries to minimize. (case-insensitive)

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -234,11 +234,11 @@ private[ml] trait DecisionTreeClassifierParams
       schema: StructType,
       fitting: Boolean,
       featuresDataType: DataType): StructType = {
-    var schema = super.validateAndTransformSchema(schema, fitting, featuresDataType)
+    var outputSchema = super.validateAndTransformSchema(schema, fitting, featuresDataType)
     if ($(leafCol).nonEmpty) {
-      schema = SchemaUtils.appendColumn(schema, $(leafCol), DoubleType)
+      outputSchema = SchemaUtils.appendColumn(outputSchema, $(leafCol), DoubleType)
     }
-    schema
+    outputSchema
   }
 }
 
@@ -290,14 +290,14 @@ private[ml] trait DecisionTreeRegressorParams extends DecisionTreeParams
       schema: StructType,
       fitting: Boolean,
       featuresDataType: DataType): StructType = {
-    var schema = super.validateAndTransformSchema(schema, fitting, featuresDataType)
+    var outputSchema = super.validateAndTransformSchema(schema, fitting, featuresDataType)
     if (isDefined(varianceCol) && $(varianceCol).nonEmpty) {
-      schema = SchemaUtils.appendColumn(schema, $(varianceCol), DoubleType)
+      outputSchema = SchemaUtils.appendColumn(outputSchema, $(varianceCol), DoubleType)
     }
     if ($(leafCol).nonEmpty) {
-      schema = SchemaUtils.appendColumn(schema, $(leafCol), DoubleType)
+      outputSchema = SchemaUtils.appendColumn(outputSchema, $(leafCol), DoubleType)
     }
-    schema
+    outputSchema
   }
 }
 
@@ -417,11 +417,11 @@ private[ml] trait RandomForestClassifierParams
       schema: StructType,
       fitting: Boolean,
       featuresDataType: DataType): StructType = {
-    var schema = super.validateAndTransformSchema(schema, fitting, featuresDataType)
+    var outputSchema = super.validateAndTransformSchema(schema, fitting, featuresDataType)
     if ($(leafCol).nonEmpty) {
-      schema = SchemaUtils.appendColumn(schema, $(leafCol), new VectorUDT)
+      outputSchema = SchemaUtils.appendColumn(outputSchema, $(leafCol), new VectorUDT)
     }
-    schema
+    outputSchema
   }
 }
 
@@ -432,11 +432,11 @@ private[ml] trait RandomForestRegressorParams
       schema: StructType,
       fitting: Boolean,
       featuresDataType: DataType): StructType = {
-    var schema = super.validateAndTransformSchema(schema, fitting, featuresDataType)
+    var outputSchema = super.validateAndTransformSchema(schema, fitting, featuresDataType)
     if ($(leafCol).nonEmpty) {
-      schema = SchemaUtils.appendColumn(schema, $(leafCol), new VectorUDT)
+      outputSchema = SchemaUtils.appendColumn(outputSchema, $(leafCol), new VectorUDT)
     }
-    schema
+    outputSchema
   }
 }
 
@@ -515,11 +515,11 @@ private[ml] trait GBTClassifierParams extends GBTParams with HasVarianceImpurity
       schema: StructType,
       fitting: Boolean,
       featuresDataType: DataType): StructType = {
-    var schema = super.validateAndTransformSchema(schema, fitting, featuresDataType)
+    var outputSchema = super.validateAndTransformSchema(schema, fitting, featuresDataType)
     if ($(leafCol).nonEmpty) {
-      schema = SchemaUtils.appendColumn(schema, $(leafCol), new VectorUDT)
+      outputSchema = SchemaUtils.appendColumn(outputSchema, $(leafCol), new VectorUDT)
     }
-    schema
+    outputSchema
   }
 
   /**
@@ -563,11 +563,11 @@ private[ml] trait GBTRegressorParams extends GBTParams with TreeRegressorParams 
       schema: StructType,
       fitting: Boolean,
       featuresDataType: DataType): StructType = {
-    var schema = super.validateAndTransformSchema(schema, fitting, featuresDataType)
+    var outputSchema = super.validateAndTransformSchema(schema, fitting, featuresDataType)
     if ($(leafCol).nonEmpty) {
-      schema = SchemaUtils.appendColumn(schema, $(leafCol), new VectorUDT)
+      outputSchema = SchemaUtils.appendColumn(outputSchema, $(leafCol), new VectorUDT)
     }
-    schema
+    outputSchema
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -382,7 +382,41 @@ private[ml] trait TreeEnsembleParams extends DecisionTreeParams {
   final def getFeatureSubsetStrategy: String = $(featureSubsetStrategy).toLowerCase(Locale.ROOT)
 }
 
+/**
+ * Parameters for Decision Tree-based ensemble classification algorithms.
+ */
+private[ml] trait TreeEnsembleClassifierParams
+  extends TreeEnsembleParams with ProbabilisticClassifierParams {
 
+  override protected def validateAndTransformSchema(
+      schema: StructType,
+      fitting: Boolean,
+      featuresDataType: DataType): StructType = {
+    var outputSchema = super.validateAndTransformSchema(schema, fitting, featuresDataType)
+    if ($(leafCol).nonEmpty) {
+      outputSchema = SchemaUtils.appendColumn(outputSchema, $(leafCol), new VectorUDT)
+    }
+    outputSchema
+  }
+}
+
+/**
+ * Parameters for Decision Tree-based ensemble regression algorithms.
+ */
+private[ml] trait TreeEnsembleRegressorParams
+  extends TreeEnsembleParams {
+
+  override protected def validateAndTransformSchema(
+      schema: StructType,
+      fitting: Boolean,
+      featuresDataType: DataType): StructType = {
+    var outputSchema = super.validateAndTransformSchema(schema, fitting, featuresDataType)
+    if ($(leafCol).nonEmpty) {
+      outputSchema = SchemaUtils.appendColumn(outputSchema, $(leafCol), new VectorUDT)
+    }
+    outputSchema
+  }
+}
 
 /**
  * Parameters for Random Forest algorithms.
@@ -411,34 +445,10 @@ private[ml] trait RandomForestParams extends TreeEnsembleParams {
 }
 
 private[ml] trait RandomForestClassifierParams
-  extends RandomForestParams with TreeClassifierParams with ProbabilisticClassifierParams {
-
-  override protected def validateAndTransformSchema(
-      schema: StructType,
-      fitting: Boolean,
-      featuresDataType: DataType): StructType = {
-    var outputSchema = super.validateAndTransformSchema(schema, fitting, featuresDataType)
-    if ($(leafCol).nonEmpty) {
-      outputSchema = SchemaUtils.appendColumn(outputSchema, $(leafCol), new VectorUDT)
-    }
-    outputSchema
-  }
-}
+  extends RandomForestParams with TreeEnsembleClassifierParams with TreeClassifierParams
 
 private[ml] trait RandomForestRegressorParams
-  extends RandomForestParams with TreeRegressorParams {
-
-  override protected def validateAndTransformSchema(
-      schema: StructType,
-      fitting: Boolean,
-      featuresDataType: DataType): StructType = {
-    var outputSchema = super.validateAndTransformSchema(schema, fitting, featuresDataType)
-    if ($(leafCol).nonEmpty) {
-      outputSchema = SchemaUtils.appendColumn(outputSchema, $(leafCol), new VectorUDT)
-    }
-    outputSchema
-  }
-}
+  extends RandomForestParams with TreeEnsembleRegressorParams with TreeRegressorParams
 
 /**
  * Parameters for Gradient-Boosted Tree algorithms.
@@ -508,19 +518,8 @@ private[ml] object GBTClassifierParams {
     Array("logistic").map(_.toLowerCase(Locale.ROOT))
 }
 
-private[ml] trait GBTClassifierParams extends GBTParams with HasVarianceImpurity
-  with ProbabilisticClassifierParams {
-
-  override protected def validateAndTransformSchema(
-      schema: StructType,
-      fitting: Boolean,
-      featuresDataType: DataType): StructType = {
-    var outputSchema = super.validateAndTransformSchema(schema, fitting, featuresDataType)
-    if ($(leafCol).nonEmpty) {
-      outputSchema = SchemaUtils.appendColumn(outputSchema, $(leafCol), new VectorUDT)
-    }
-    outputSchema
-  }
+private[ml] trait GBTClassifierParams
+  extends GBTParams with TreeEnsembleClassifierParams with HasVarianceImpurity {
 
   /**
    * Loss function which GBT tries to minimize. (case-insensitive)
@@ -557,18 +556,8 @@ private[ml] object GBTRegressorParams {
     Array("squared", "absolute").map(_.toLowerCase(Locale.ROOT))
 }
 
-private[ml] trait GBTRegressorParams extends GBTParams with TreeRegressorParams {
-
-  override protected def validateAndTransformSchema(
-      schema: StructType,
-      fitting: Boolean,
-      featuresDataType: DataType): StructType = {
-    var outputSchema = super.validateAndTransformSchema(schema, fitting, featuresDataType)
-    if ($(leafCol).nonEmpty) {
-      outputSchema = SchemaUtils.appendColumn(outputSchema, $(leafCol), new VectorUDT)
-    }
-    outputSchema
-  }
+private[ml] trait GBTRegressorParams
+  extends GBTParams with TreeEnsembleRegressorParams with TreeRegressorParams {
 
   /**
    * Loss function which GBT tries to minimize. (case-insensitive)

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -293,9 +293,6 @@ private[ml] trait TreeRegressorParams extends HasVarianceImpurity
 private[ml] trait DecisionTreeRegressorParams extends DecisionTreeParams
   with TreeRegressorParams with HasVarianceCol {
 
-  /** @group setParam */
-  final def setVarianceCol(value: String): this.type = set(varianceCol, value)
-
   override protected def validateAndTransformSchema(
       schema: StructType,
       fitting: Boolean,

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -138,6 +138,9 @@ private[ml] trait DecisionTreeParams extends PredictorParams
     minWeightFractionPerNode -> 0.0, minInfoGain -> 0.0, maxMemoryInMB -> 256,
     cacheNodeIds -> false, checkpointInterval -> 10)
 
+  /** @group setParam */
+  final def setLeafCol(value: String): this.type = set(leafCol, value)
+
   /** @group getParam */
   final def getLeafCol: String = $(leafCol)
 
@@ -289,6 +292,9 @@ private[ml] trait TreeRegressorParams extends HasVarianceImpurity
 
 private[ml] trait DecisionTreeRegressorParams extends DecisionTreeParams
   with TreeRegressorParams with HasVarianceCol {
+
+  /** @group setParam */
+  final def setVarianceCol(value: String): this.type = set(varianceCol, value)
 
   override protected def validateAndTransformSchema(
       schema: StructType,

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -316,36 +316,13 @@ class DecisionTreeClassifierSuite extends MLTest with DefaultReadWriteTest {
   }
 
   test("model support predict leaf index") {
-    val leaf0 = new LeafNode(0.0, Double.NaN, null)
-    val leaf1 = new LeafNode(1.0, Double.NaN, null)
-    val leaf2 = new LeafNode(0.0, Double.NaN, null)
-    val node1 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf0, leaf1,
-      new ContinuousSplit(0, 0.0), null)
-    val node0 = new InternalNode(0.0, Double.NaN, Double.NaN, node1, leaf2,
-      new CategoricalSplit(1, Array(0.0, 2.0), 3), null)
-
-    /**
-     *                       root=node0
-     *                      /         \
-     *             x1 in [0, 2]   otherwise
-     *                    /            \
-     *               node1           leaf2
-     *               /    \
-     *          x0 <= 0  x0 > 0
-     *             /       \
-     *          leaf0      leaf1
-     */
-    val model = new DecisionTreeClassificationModel("dtc", node0, 3, 2)
+    val model = new DecisionTreeClassificationModel("dtc", TreeTests.root0, 3, 2)
     model.setLeafCol("predictedLeafId")
       .setRawPredictionCol("")
       .setPredictionCol("")
       .setProbabilityCol("")
 
-    val data = Array((2.0, Vectors.dense(0, 1, 3)),
-      (0.0, Vectors.dense(-1, 2, 1)),
-      (1.0, Vectors.dense(1, 0, 2)),
-      (2.0, Vectors.dense(2, 1, 9)),
-      (0.0, Vectors.dense(0, 2, 6)))
+    val data = TreeTests.getSingleTreeLeafData
 
     data.foreach { case (leafId, vec) =>
       assert(leafId === model.predictLeaf(vec))

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -323,10 +323,7 @@ class DecisionTreeClassifierSuite extends MLTest with DefaultReadWriteTest {
       .setProbabilityCol("")
 
     val data = TreeTests.getSingleTreeLeafData
-
-    data.foreach { case (leafId, vec) =>
-      assert(leafId === model.predictLeaf(vec))
-    }
+    data.foreach { case (leafId, vec) => assert(leafId === model.predictLeaf(vec)) }
 
     val df = sc.parallelize(data, 1).toDF("leafId", "features")
     model.transform(df).select("leafId", "predictedLeafId")

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -327,8 +327,8 @@ class DecisionTreeClassifierSuite extends MLTest with DefaultReadWriteTest {
 
     val df = sc.parallelize(data, 1).toDF("leafId", "features")
     model.transform(df).select("leafId", "predictedLeafId")
-      .collect().foreach {
-      case Row(leafId: Double, predictedLeafId: Double) =>
+      .collect()
+      .foreach { case Row(leafId: Double, predictedLeafId: Double) =>
         assert(leafId === predictedLeafId)
     }
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.ml.feature.LabeledPoint
 import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.ml.param.ParamsSuite
 import org.apache.spark.ml.regression.DecisionTreeRegressionModel
-import org.apache.spark.ml.tree.LeafNode
+import org.apache.spark.ml.tree._
 import org.apache.spark.ml.tree.impl.{GradientBoostedTrees, TreeTests}
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest, MLTestingUtils}
 import org.apache.spark.ml.util.TestingUtils._
@@ -250,6 +250,61 @@ class GBTClassifierSuite extends MLTest with DefaultReadWriteTest {
 
     sc.checkpointDir = None
     Utils.deleteRecursively(tempDir)
+  }
+
+  test("model support predict leaf index") {
+    val leaf0_0 = new LeafNode(0.0, Double.NaN, null)
+    val leaf1_0 = new LeafNode(1.0, Double.NaN, null)
+    val leaf2_0 = new LeafNode(0.0, Double.NaN, null)
+    val node1_0 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf0_0, leaf1_0,
+      new ContinuousSplit(0, 0.0), null)
+    val node0_0 = new InternalNode(0.0, Double.NaN, Double.NaN, node1_0, leaf2_0,
+      new CategoricalSplit(1, Array(0.0, 2.0), 3), null)
+
+    val leaf0_1 = new LeafNode(0.0, Double.NaN, null)
+    val leaf1_1 = new LeafNode(1.0, Double.NaN, null)
+    val leaf2_1 = new LeafNode(0.0, Double.NaN, null)
+    val node1_1 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf1_1, leaf2_1,
+      new CategoricalSplit(1, Array(0.0, 1.0), 3), null)
+    val node0_1 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf0_1, node1_1,
+      new ContinuousSplit(2, 1.0), null)
+
+    /**
+     *                          tree_0                            tree_1
+     *                       root=node0_0                    root=node0_1
+     *                      /         \                       /         \
+     *             x1 in [0, 2]   otherwise               x3 <= 1      x3 > 1
+     *                    /            \                    /            \
+     *               node1_0         leaf2_0           leaf_0_1        node1_1
+     *               /    \                                             /    \
+     *          x0 <= 0  x0 > 0                               x1 in [0, 1]   otherwise
+     *             /       \                                          /       \
+     *         leaf0_0   leaf1_0                                  leaf1_1   leaf2_1
+     */
+    val model0 = new DecisionTreeRegressionModel("dtc", node0_0, 3)
+    val model1 = new DecisionTreeRegressionModel("dtc", node0_1, 3)
+    val model = new GBTClassificationModel("gbtc", Array(model0, model1), Array(1.0, 1.0), 3, 2)
+    model.setLeafCol("predictedLeafId")
+      .setRawPredictionCol("")
+      .setPredictionCol("")
+      .setProbabilityCol("")
+
+    val data = Array((Vectors.dense(2, 1), Vectors.dense(0, 1, 3)),
+      (Vectors.dense(0, 0), Vectors.dense(-1, 2, 1)),
+      (Vectors.dense(1, 1), Vectors.dense(1, 0, 2)),
+      (Vectors.dense(2, 1), Vectors.dense(2, 1, 9)),
+      (Vectors.dense(0, 2), Vectors.dense(0, 2, 6)))
+
+    data.foreach { case (leafId, vec) =>
+      assert(leafId === model.predictLeaf(vec))
+    }
+
+    val df = sc.parallelize(data, 1).toDF("leafId", "features")
+    model.transform(df).select("leafId", "predictedLeafId")
+      .collect().foreach {
+      case Row(leafId: Vector, predictedLeafId: Vector) =>
+        assert(leafId === predictedLeafId)
+    }
   }
 
   test("should support all NumericType labels and not support other types") {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
@@ -259,10 +259,7 @@ class GBTClassifierSuite extends MLTest with DefaultReadWriteTest {
       .setProbabilityCol("")
 
     val data = TreeTests.getTwoTreesLeafData
-
-    data.foreach { case (leafId, vec) =>
-      assert(leafId === model.predictLeaf(vec))
-    }
+    data.foreach { case (leafId, vec) => assert(leafId === model.predictLeaf(vec)) }
 
     val df = sc.parallelize(data, 1).toDF("leafId", "features")
     model.transform(df).select("leafId", "predictedLeafId")

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
@@ -263,8 +263,8 @@ class GBTClassifierSuite extends MLTest with DefaultReadWriteTest {
 
     val df = sc.parallelize(data, 1).toDF("leafId", "features")
     model.transform(df).select("leafId", "predictedLeafId")
-      .collect().foreach {
-      case Row(leafId: Vector, predictedLeafId: Vector) =>
+      .collect()
+      .foreach { case Row(leafId: Vector, predictedLeafId: Vector) =>
         assert(leafId === predictedLeafId)
     }
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
@@ -203,47 +203,15 @@ class RandomForestClassifierSuite extends MLTest with DefaultReadWriteTest {
   }
 
   test("model support predict leaf index") {
-    val leaf0_0 = new LeafNode(0.0, Double.NaN, null)
-    val leaf1_0 = new LeafNode(1.0, Double.NaN, null)
-    val leaf2_0 = new LeafNode(0.0, Double.NaN, null)
-    val node1_0 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf0_0, leaf1_0,
-      new ContinuousSplit(0, 0.0), null)
-    val node0_0 = new InternalNode(0.0, Double.NaN, Double.NaN, node1_0, leaf2_0,
-      new CategoricalSplit(1, Array(0.0, 2.0), 3), null)
-
-    val leaf0_1 = new LeafNode(0.0, Double.NaN, null)
-    val leaf1_1 = new LeafNode(1.0, Double.NaN, null)
-    val leaf2_1 = new LeafNode(0.0, Double.NaN, null)
-    val node1_1 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf1_1, leaf2_1,
-      new CategoricalSplit(1, Array(0.0, 1.0), 3), null)
-    val node0_1 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf0_1, node1_1,
-      new ContinuousSplit(2, 1.0), null)
-
-    /**
-     *                          tree_0                            tree_1
-     *                       root=node0_0                    root=node0_1
-     *                      /         \                       /         \
-     *             x1 in [0, 2]   otherwise               x3 <= 1      x3 > 1
-     *                    /            \                    /            \
-     *               node1_0         leaf2_0           leaf_0_1        node1_1
-     *               /    \                                             /    \
-     *          x0 <= 0  x0 > 0                               x1 in [0, 1]   otherwise
-     *             /       \                                          /       \
-     *         leaf0_0   leaf1_0                                  leaf1_1   leaf2_1
-     */
-    val model0 = new DecisionTreeClassificationModel("dtc", node0_0, 3, 2)
-    val model1 = new DecisionTreeClassificationModel("dtc", node0_1, 3, 2)
+    val model0 = new DecisionTreeClassificationModel("dtc", TreeTests.root0, 3, 2)
+    val model1 = new DecisionTreeClassificationModel("dtc", TreeTests.root1, 3, 2)
     val model = new RandomForestClassificationModel("rfc", Array(model0, model1), 3, 2)
     model.setLeafCol("predictedLeafId")
       .setRawPredictionCol("")
       .setPredictionCol("")
       .setProbabilityCol("")
 
-    val data = Array((Vectors.dense(2, 1), Vectors.dense(0, 1, 3)),
-      (Vectors.dense(0, 0), Vectors.dense(-1, 2, 1)),
-      (Vectors.dense(1, 1), Vectors.dense(1, 0, 2)),
-      (Vectors.dense(2, 1), Vectors.dense(2, 1, 9)),
-      (Vectors.dense(0, 2), Vectors.dense(0, 2, 6)))
+    val data = TreeTests.getTwoTreesLeafData
 
     data.foreach { case (leafId, vec) =>
       assert(leafId === model.predictLeaf(vec))

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
@@ -212,10 +212,7 @@ class RandomForestClassifierSuite extends MLTest with DefaultReadWriteTest {
       .setProbabilityCol("")
 
     val data = TreeTests.getTwoTreesLeafData
-
-    data.foreach { case (leafId, vec) =>
-      assert(leafId === model.predictLeaf(vec))
-    }
+    data.foreach { case (leafId, vec) => assert(leafId === model.predictLeaf(vec)) }
 
     val df = sc.parallelize(data, 1).toDF("leafId", "features")
     model.transform(df).select("leafId", "predictedLeafId")

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
@@ -18,10 +18,10 @@
 package org.apache.spark.ml.classification
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.ml.feature.{Instance, LabeledPoint}
+import org.apache.spark.ml.feature.LabeledPoint
 import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.ml.param.ParamsSuite
-import org.apache.spark.ml.tree.LeafNode
+import org.apache.spark.ml.tree._
 import org.apache.spark.ml.tree.impl.TreeTests
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest, MLTestingUtils}
 import org.apache.spark.mllib.regression.{LabeledPoint => OldLabeledPoint}
@@ -200,6 +200,61 @@ class RandomForestClassifierSuite extends MLTest with DefaultReadWriteTest {
     assert(mostImportantFeature === 1)
     assert(importances.toArray.sum === 1.0)
     assert(importances.toArray.forall(_ >= 0.0))
+  }
+
+  test("model support predict leaf index") {
+    val leaf0_0 = new LeafNode(0.0, Double.NaN, null)
+    val leaf1_0 = new LeafNode(1.0, Double.NaN, null)
+    val leaf2_0 = new LeafNode(0.0, Double.NaN, null)
+    val node1_0 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf0_0, leaf1_0,
+      new ContinuousSplit(0, 0.0), null)
+    val node0_0 = new InternalNode(0.0, Double.NaN, Double.NaN, node1_0, leaf2_0,
+      new CategoricalSplit(1, Array(0.0, 2.0), 3), null)
+
+    val leaf0_1 = new LeafNode(0.0, Double.NaN, null)
+    val leaf1_1 = new LeafNode(1.0, Double.NaN, null)
+    val leaf2_1 = new LeafNode(0.0, Double.NaN, null)
+    val node1_1 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf1_1, leaf2_1,
+      new CategoricalSplit(1, Array(0.0, 1.0), 3), null)
+    val node0_1 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf0_1, node1_1,
+      new ContinuousSplit(2, 1.0), null)
+
+    /**
+     *                          tree_0                            tree_1
+     *                       root=node0_0                    root=node0_1
+     *                      /         \                       /         \
+     *             x1 in [0, 2]   otherwise               x3 <= 1      x3 > 1
+     *                    /            \                    /            \
+     *               node1_0         leaf2_0           leaf_0_1        node1_1
+     *               /    \                                             /    \
+     *          x0 <= 0  x0 > 0                               x1 in [0, 1]   otherwise
+     *             /       \                                          /       \
+     *         leaf0_0   leaf1_0                                  leaf1_1   leaf2_1
+     */
+    val model0 = new DecisionTreeClassificationModel("dtc", node0_0, 3, 2)
+    val model1 = new DecisionTreeClassificationModel("dtc", node0_1, 3, 2)
+    val model = new RandomForestClassificationModel("rfc", Array(model0, model1), 3, 2)
+    model.setLeafCol("predictedLeafId")
+      .setRawPredictionCol("")
+      .setPredictionCol("")
+      .setProbabilityCol("")
+
+    val data = Array((Vectors.dense(2, 1), Vectors.dense(0, 1, 3)),
+      (Vectors.dense(0, 0), Vectors.dense(-1, 2, 1)),
+      (Vectors.dense(1, 1), Vectors.dense(1, 0, 2)),
+      (Vectors.dense(2, 1), Vectors.dense(2, 1, 9)),
+      (Vectors.dense(0, 2), Vectors.dense(0, 2, 6)))
+
+    data.foreach { case (leafId, vec) =>
+      assert(leafId === model.predictLeaf(vec))
+    }
+
+    val df = sc.parallelize(data, 1).toDF("leafId", "features")
+    model.transform(df).select("leafId", "predictedLeafId")
+      .collect().foreach {
+      case Row(leafId: Vector, predictedLeafId: Vector) =>
+        assert(leafId === predictedLeafId)
+    }
   }
 
   test("should support all NumericType labels and not support other types") {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
@@ -216,8 +216,8 @@ class RandomForestClassifierSuite extends MLTest with DefaultReadWriteTest {
 
     val df = sc.parallelize(data, 1).toDF("leafId", "features")
     model.transform(df).select("leafId", "predictedLeafId")
-      .collect().foreach {
-      case Row(leafId: Vector, predictedLeafId: Vector) =>
+      .collect()
+      .foreach { case Row(leafId: Vector, predictedLeafId: Vector) =>
         assert(leafId === predictedLeafId)
     }
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -19,8 +19,7 @@ package org.apache.spark.ml.regression
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.feature.LabeledPoint
-import org.apache.spark.ml.linalg.{Vector, Vectors}
-import org.apache.spark.ml.tree._
+import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.ml.tree.impl.TreeTests
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest, MLTestingUtils}
 import org.apache.spark.ml.util.TestingUtils._
@@ -160,34 +159,11 @@ class DecisionTreeRegressorSuite extends MLTest with DefaultReadWriteTest {
   }
 
   test("model support predict leaf index") {
-    val leaf0 = new LeafNode(0.0, Double.NaN, null)
-    val leaf1 = new LeafNode(1.0, Double.NaN, null)
-    val leaf2 = new LeafNode(0.0, Double.NaN, null)
-    val node1 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf0, leaf1,
-      new ContinuousSplit(0, 0.0), null)
-    val node0 = new InternalNode(0.0, Double.NaN, Double.NaN, node1, leaf2,
-      new CategoricalSplit(1, Array(0.0, 2.0), 3), null)
-
-    /**
-     *                       root=node0
-     *                      /         \
-     *             x1 in [0, 2]   otherwise
-     *                    /            \
-     *               node1           leaf2
-     *               /    \
-     *          x0 <= 0  x0 > 0
-     *             /       \
-     *          leaf0      leaf1
-     */
-    val model = new DecisionTreeRegressionModel("dtr", node0, 3)
+    val model = new DecisionTreeRegressionModel("dtr", TreeTests.root0, 3)
     model.setLeafCol("predictedLeafId")
       .setPredictionCol("")
 
-    val data = Array((2.0, Vectors.dense(0, 1, 3)),
-      (0.0, Vectors.dense(-1, 2, 1)),
-      (1.0, Vectors.dense(1, 0, 2)),
-      (2.0, Vectors.dense(2, 1, 9)),
-      (0.0, Vectors.dense(0, 2, 6)))
+    val data = TreeTests.getSingleTreeLeafData
 
     data.foreach { case (leafId, vec) =>
       assert(leafId === model.predictLeaf(vec))

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -18,8 +18,9 @@
 package org.apache.spark.ml.regression
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.ml.feature.{Instance, LabeledPoint}
-import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.ml.feature.LabeledPoint
+import org.apache.spark.ml.linalg.{Vector, Vectors}
+import org.apache.spark.ml.tree._
 import org.apache.spark.ml.tree.impl.TreeTests
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest, MLTestingUtils}
 import org.apache.spark.ml.util.TestingUtils._
@@ -156,6 +157,48 @@ class DecisionTreeRegressorSuite extends MLTest with DefaultReadWriteTest {
 
     val model = dt.fit(df)
     testPredictionModelSinglePrediction(model, df)
+  }
+
+  test("model support predict leaf index") {
+    val leaf0 = new LeafNode(0.0, Double.NaN, null)
+    val leaf1 = new LeafNode(1.0, Double.NaN, null)
+    val leaf2 = new LeafNode(0.0, Double.NaN, null)
+    val node1 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf0, leaf1,
+      new ContinuousSplit(0, 0.0), null)
+    val node0 = new InternalNode(0.0, Double.NaN, Double.NaN, node1, leaf2,
+      new CategoricalSplit(1, Array(0.0, 2.0), 3), null)
+
+    /**
+     *                       root=node0
+     *                      /         \
+     *             x1 in [0, 2]   otherwise
+     *                    /            \
+     *               node1           leaf2
+     *               /    \
+     *          x0 <= 0  x0 > 0
+     *             /       \
+     *          leaf0      leaf1
+     */
+    val model = new DecisionTreeRegressionModel("dtr", node0, 3)
+    model.setLeafCol("predictedLeafId")
+      .setPredictionCol("")
+
+    val data = Array((2.0, Vectors.dense(0, 1, 3)),
+      (0.0, Vectors.dense(-1, 2, 1)),
+      (1.0, Vectors.dense(1, 0, 2)),
+      (2.0, Vectors.dense(2, 1, 9)),
+      (0.0, Vectors.dense(0, 2, 6)))
+
+    data.foreach { case (leafId, vec) =>
+      assert(leafId === model.predictLeaf(vec))
+    }
+
+    val df = sc.parallelize(data, 1).toDF("leafId", "features")
+    model.transform(df).select("leafId", "predictedLeafId")
+      .collect().foreach {
+      case Row(leafId: Double, predictedLeafId: Double) =>
+        assert(leafId === predictedLeafId)
+    }
   }
 
   test("should support all NumericType labels and not support other types") {

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -164,10 +164,7 @@ class DecisionTreeRegressorSuite extends MLTest with DefaultReadWriteTest {
       .setPredictionCol("")
 
     val data = TreeTests.getSingleTreeLeafData
-
-    data.foreach { case (leafId, vec) =>
-      assert(leafId === model.predictLeaf(vec))
-    }
+    data.foreach { case (leafId, vec) => assert(leafId === model.predictLeaf(vec)) }
 
     val df = sc.parallelize(data, 1).toDF("leafId", "features")
     model.transform(df).select("leafId", "predictedLeafId")

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -168,8 +168,8 @@ class DecisionTreeRegressorSuite extends MLTest with DefaultReadWriteTest {
 
     val df = sc.parallelize(data, 1).toDF("leafId", "features")
     model.transform(df).select("leafId", "predictedLeafId")
-      .collect().foreach {
-      case Row(leafId: Double, predictedLeafId: Double) =>
+      .collect()
+      .foreach { case Row(leafId: Double, predictedLeafId: Double) =>
         assert(leafId === predictedLeafId)
     }
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GBTRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GBTRegressorSuite.scala
@@ -135,10 +135,7 @@ class GBTRegressorSuite extends MLTest with DefaultReadWriteTest {
       .setPredictionCol("")
 
     val data = TreeTests.getTwoTreesLeafData
-
-    data.foreach { case (leafId, vec) =>
-      assert(leafId === model.predictLeaf(vec))
-    }
+    data.foreach { case (leafId, vec) => assert(leafId === model.predictLeaf(vec)) }
 
     val df = sc.parallelize(data, 1).toDF("leafId", "features")
     model.transform(df).select("leafId", "predictedLeafId")

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GBTRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GBTRegressorSuite.scala
@@ -20,7 +20,6 @@ package org.apache.spark.ml.regression
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.feature.LabeledPoint
 import org.apache.spark.ml.linalg.{Vector, Vectors}
-import org.apache.spark.ml.tree._
 import org.apache.spark.ml.tree.impl.{GradientBoostedTrees, TreeTests}
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest, MLTestingUtils}
 import org.apache.spark.ml.util.TestingUtils._
@@ -129,45 +128,13 @@ class GBTRegressorSuite extends MLTest with DefaultReadWriteTest {
   }
 
   test("model support predict leaf index") {
-    val leaf0_0 = new LeafNode(0.0, Double.NaN, null)
-    val leaf1_0 = new LeafNode(1.0, Double.NaN, null)
-    val leaf2_0 = new LeafNode(0.0, Double.NaN, null)
-    val node1_0 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf0_0, leaf1_0,
-      new ContinuousSplit(0, 0.0), null)
-    val node0_0 = new InternalNode(0.0, Double.NaN, Double.NaN, node1_0, leaf2_0,
-      new CategoricalSplit(1, Array(0.0, 2.0), 3), null)
-
-    val leaf0_1 = new LeafNode(0.0, Double.NaN, null)
-    val leaf1_1 = new LeafNode(1.0, Double.NaN, null)
-    val leaf2_1 = new LeafNode(0.0, Double.NaN, null)
-    val node1_1 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf1_1, leaf2_1,
-      new CategoricalSplit(1, Array(0.0, 1.0), 3), null)
-    val node0_1 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf0_1, node1_1,
-      new ContinuousSplit(2, 1.0), null)
-
-    /**
-     *                          tree_0                            tree_1
-     *                       root=node0_0                    root=node0_1
-     *                      /         \                       /         \
-     *             x1 in [0, 2]   otherwise               x3 <= 1      x3 > 1
-     *                    /            \                    /            \
-     *               node1_0         leaf2_0           leaf_0_1        node1_1
-     *               /    \                                             /    \
-     *          x0 <= 0  x0 > 0                               x1 in [0, 1]   otherwise
-     *             /       \                                          /       \
-     *         leaf0_0   leaf1_0                                  leaf1_1   leaf2_1
-     */
-    val model0 = new DecisionTreeRegressionModel("dtc", node0_0, 3)
-    val model1 = new DecisionTreeRegressionModel("dtc", node0_1, 3)
+    val model0 = new DecisionTreeRegressionModel("dtc", TreeTests.root0, 3)
+    val model1 = new DecisionTreeRegressionModel("dtc", TreeTests.root1, 3)
     val model = new GBTRegressionModel("gbtr", Array(model0, model1), Array(1.0, 1.0), 3)
     model.setLeafCol("predictedLeafId")
       .setPredictionCol("")
 
-    val data = Array((Vectors.dense(2, 1), Vectors.dense(0, 1, 3)),
-      (Vectors.dense(0, 0), Vectors.dense(-1, 2, 1)),
-      (Vectors.dense(1, 1), Vectors.dense(1, 0, 2)),
-      (Vectors.dense(2, 1), Vectors.dense(2, 1, 9)),
-      (Vectors.dense(0, 2), Vectors.dense(0, 2, 6)))
+    val data = TreeTests.getTwoTreesLeafData
 
     data.foreach { case (leafId, vec) =>
       assert(leafId === model.predictLeaf(vec))

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GBTRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GBTRegressorSuite.scala
@@ -139,8 +139,8 @@ class GBTRegressorSuite extends MLTest with DefaultReadWriteTest {
 
     val df = sc.parallelize(data, 1).toDF("leafId", "features")
     model.transform(df).select("leafId", "predictedLeafId")
-      .collect().foreach {
-      case Row(leafId: Vector, predictedLeafId: Vector) =>
+      .collect()
+      .foreach { case Row(leafId: Vector, predictedLeafId: Vector) =>
         assert(leafId === predictedLeafId)
     }
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
@@ -19,8 +19,7 @@ package org.apache.spark.ml.regression
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.feature.LabeledPoint
-import org.apache.spark.ml.linalg.{Vector, Vectors}
-import org.apache.spark.ml.tree._
+import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.ml.tree.impl.TreeTests
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest, MLTestingUtils}
 import org.apache.spark.mllib.regression.{LabeledPoint => OldLabeledPoint}
@@ -115,45 +114,13 @@ class RandomForestRegressorSuite extends MLTest with DefaultReadWriteTest{
   }
 
   test("model support predict leaf index") {
-    val leaf0_0 = new LeafNode(0.0, Double.NaN, null)
-    val leaf1_0 = new LeafNode(1.0, Double.NaN, null)
-    val leaf2_0 = new LeafNode(0.0, Double.NaN, null)
-    val node1_0 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf0_0, leaf1_0,
-      new ContinuousSplit(0, 0.0), null)
-    val node0_0 = new InternalNode(0.0, Double.NaN, Double.NaN, node1_0, leaf2_0,
-      new CategoricalSplit(1, Array(0.0, 2.0), 3), null)
-
-    val leaf0_1 = new LeafNode(0.0, Double.NaN, null)
-    val leaf1_1 = new LeafNode(1.0, Double.NaN, null)
-    val leaf2_1 = new LeafNode(0.0, Double.NaN, null)
-    val node1_1 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf1_1, leaf2_1,
-      new CategoricalSplit(1, Array(0.0, 1.0), 3), null)
-    val node0_1 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf0_1, node1_1,
-      new ContinuousSplit(2, 1.0), null)
-
-    /**
-     *                          tree_0                            tree_1
-     *                       root=node0_0                    root=node0_1
-     *                      /         \                       /         \
-     *             x1 in [0, 2]   otherwise               x3 <= 1      x3 > 1
-     *                    /            \                    /            \
-     *               node1_0         leaf2_0           leaf_0_1        node1_1
-     *               /    \                                             /    \
-     *          x0 <= 0  x0 > 0                               x1 in [0, 1]   otherwise
-     *             /       \                                          /       \
-     *         leaf0_0   leaf1_0                                  leaf1_1   leaf2_1
-     */
-    val model0 = new DecisionTreeRegressionModel("dtc", node0_0, 3)
-    val model1 = new DecisionTreeRegressionModel("dtc", node0_1, 3)
+    val model0 = new DecisionTreeRegressionModel("dtc", TreeTests.root0, 3)
+    val model1 = new DecisionTreeRegressionModel("dtc", TreeTests.root1, 3)
     val model = new RandomForestRegressionModel("rfr", Array(model0, model1), 3)
     model.setLeafCol("predictedLeafId")
       .setPredictionCol("")
 
-    val data = Array((Vectors.dense(2, 1), Vectors.dense(0, 1, 3)),
-      (Vectors.dense(0, 0), Vectors.dense(-1, 2, 1)),
-      (Vectors.dense(1, 1), Vectors.dense(1, 0, 2)),
-      (Vectors.dense(2, 1), Vectors.dense(2, 1, 9)),
-      (Vectors.dense(0, 2), Vectors.dense(0, 2, 6)))
+    val data = TreeTests.getTwoTreesLeafData
 
     data.foreach { case (leafId, vec) =>
       assert(leafId === model.predictLeaf(vec))

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
@@ -19,7 +19,8 @@ package org.apache.spark.ml.regression
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.feature.LabeledPoint
-import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.ml.linalg.{Vector, Vectors}
+import org.apache.spark.ml.tree._
 import org.apache.spark.ml.tree.impl.TreeTests
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest, MLTestingUtils}
 import org.apache.spark.mllib.regression.{LabeledPoint => OldLabeledPoint}
@@ -111,6 +112,59 @@ class RandomForestRegressorSuite extends MLTest with DefaultReadWriteTest{
     assert(mostImportantFeature === 1)
     assert(importances.toArray.sum === 1.0)
     assert(importances.toArray.forall(_ >= 0.0))
+  }
+
+  test("model support predict leaf index") {
+    val leaf0_0 = new LeafNode(0.0, Double.NaN, null)
+    val leaf1_0 = new LeafNode(1.0, Double.NaN, null)
+    val leaf2_0 = new LeafNode(0.0, Double.NaN, null)
+    val node1_0 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf0_0, leaf1_0,
+      new ContinuousSplit(0, 0.0), null)
+    val node0_0 = new InternalNode(0.0, Double.NaN, Double.NaN, node1_0, leaf2_0,
+      new CategoricalSplit(1, Array(0.0, 2.0), 3), null)
+
+    val leaf0_1 = new LeafNode(0.0, Double.NaN, null)
+    val leaf1_1 = new LeafNode(1.0, Double.NaN, null)
+    val leaf2_1 = new LeafNode(0.0, Double.NaN, null)
+    val node1_1 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf1_1, leaf2_1,
+      new CategoricalSplit(1, Array(0.0, 1.0), 3), null)
+    val node0_1 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf0_1, node1_1,
+      new ContinuousSplit(2, 1.0), null)
+
+    /**
+     *                          tree_0                            tree_1
+     *                       root=node0_0                    root=node0_1
+     *                      /         \                       /         \
+     *             x1 in [0, 2]   otherwise               x3 <= 1      x3 > 1
+     *                    /            \                    /            \
+     *               node1_0         leaf2_0           leaf_0_1        node1_1
+     *               /    \                                             /    \
+     *          x0 <= 0  x0 > 0                               x1 in [0, 1]   otherwise
+     *             /       \                                          /       \
+     *         leaf0_0   leaf1_0                                  leaf1_1   leaf2_1
+     */
+    val model0 = new DecisionTreeRegressionModel("dtc", node0_0, 3)
+    val model1 = new DecisionTreeRegressionModel("dtc", node0_1, 3)
+    val model = new RandomForestRegressionModel("rfr", Array(model0, model1), 3)
+    model.setLeafCol("predictedLeafId")
+      .setPredictionCol("")
+
+    val data = Array((Vectors.dense(2, 1), Vectors.dense(0, 1, 3)),
+      (Vectors.dense(0, 0), Vectors.dense(-1, 2, 1)),
+      (Vectors.dense(1, 1), Vectors.dense(1, 0, 2)),
+      (Vectors.dense(2, 1), Vectors.dense(2, 1, 9)),
+      (Vectors.dense(0, 2), Vectors.dense(0, 2, 6)))
+
+    data.foreach { case (leafId, vec) =>
+      assert(leafId === model.predictLeaf(vec))
+    }
+
+    val df = sc.parallelize(data, 1).toDF("leafId", "features")
+    model.transform(df).select("leafId", "predictedLeafId")
+      .collect().foreach {
+      case Row(leafId: Vector, predictedLeafId: Vector) =>
+        assert(leafId === predictedLeafId)
+    }
   }
 
   test("should support all NumericType labels and not support other types") {

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
@@ -121,10 +121,7 @@ class RandomForestRegressorSuite extends MLTest with DefaultReadWriteTest{
       .setPredictionCol("")
 
     val data = TreeTests.getTwoTreesLeafData
-
-    data.foreach { case (leafId, vec) =>
-      assert(leafId === model.predictLeaf(vec))
-    }
+    data.foreach { case (leafId, vec) => assert(leafId === model.predictLeaf(vec)) }
 
     val df = sc.parallelize(data, 1).toDF("leafId", "features")
     model.transform(df).select("leafId", "predictedLeafId")

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
@@ -125,8 +125,8 @@ class RandomForestRegressorSuite extends MLTest with DefaultReadWriteTest{
 
     val df = sc.parallelize(data, 1).toDF("leafId", "features")
     model.transform(df).select("leafId", "predictedLeafId")
-      .collect().foreach {
-      case Row(leafId: Vector, predictedLeafId: Vector) =>
+      .collect()
+      .foreach { case Row(leafId: Vector, predictedLeafId: Vector) =>
         assert(leafId === predictedLeafId)
     }
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreeTests.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreeTests.scala
@@ -246,20 +246,20 @@ private[ml] object TreeTests extends SparkFunSuite {
     Vectors.dense(2, 1, 9),
     Vectors.dense(0, 2, 6))
 
-  /**
-   * A tree structure used in tree-based transformation.
-   *
-   *                         root
-   *                      /         \
-   *             x1 in [0, 2]   otherwise
-   *                    /            \
-   *               node1           leaf2
-   *               /    \
-   *          x0 <= 0  x0 > 0
-   *             /       \
-   *          leaf0      leaf1
-   */
   val root0 = {
+    /**
+     * A tree structure used in tree-based transformation.
+     *
+     *                         root
+     *                      /         \
+     *             x1 in [0, 2]   otherwise
+     *                    /            \
+     *               node1           leaf2
+     *               /    \
+     *          x0 <= 0  x0 > 0
+     *             /       \
+     *          leaf0      leaf1
+     */
     val leaf0 = new LeafNode(0.0, Double.NaN, null)
     val leaf1 = new LeafNode(1.0, Double.NaN, null)
     val leaf2 = new LeafNode(0.0, Double.NaN, null)
@@ -274,20 +274,20 @@ private[ml] object TreeTests extends SparkFunSuite {
    */
   val leafIndices0 = Array(2.0, 0.0, 1.0, 2.0, 0.0)
 
-  /**
-   * A tree structure used in tree-based transformation.
-   *
-   *                          root
-   *                      /         \
-   *                 x2 <= 1      x2 > 1
-   *                    /            \
-   *                 leaf0          node1
-   *                               /    \
-   *                    x1 in [0, 1]   otherwise
-   *                             /       \
-   *                         leaf1     leaf2
-   */
   val root1 = {
+    /**
+     * A tree structure used in tree-based transformation.
+     *
+     *                          root
+     *                      /         \
+     *                 x2 <= 1      x2 > 1
+     *                    /            \
+     *                 leaf0          node1
+     *                               /    \
+     *                    x1 in [0, 1]   otherwise
+     *                             /       \
+     *                         leaf1     leaf2
+     */
     val leaf0 = new LeafNode(0.0, Double.NaN, null)
     val leaf1 = new LeafNode(1.0, Double.NaN, null)
     val leaf2 = new LeafNode(0.0, Double.NaN, null)

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreeTests.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreeTests.scala
@@ -271,7 +271,7 @@ private[ml] object TreeTests extends SparkFunSuite {
   }
 
   /**
-   * The leaf indices of vectors after transformation by root0 in leafData.
+   * The leaf indices of vectors after transformation by root0.
    */
   val leafIndices0 = Array(2.0, 0.0, 1.0, 2.0, 0.0)
 
@@ -299,7 +299,7 @@ private[ml] object TreeTests extends SparkFunSuite {
   }
 
   /**
-   * The leaf indices of vectors after transformation by root1 in leafData.
+   * The leaf indices of vectors after transformation by root1.
    */
   val leafIndices1 = Array(1.0, 0.0, 1.0, 1.0, 2.0)
 

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreeTests.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreeTests.scala
@@ -18,12 +18,12 @@
 package org.apache.spark.ml.tree.impl
 
 import scala.collection.JavaConverters._
-import scala.util.Random
 
 import org.apache.spark.{SparkContext, SparkFunSuite}
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.ml.attribute.{AttributeGroup, NominalAttribute, NumericAttribute}
 import org.apache.spark.ml.feature.{Instance, LabeledPoint}
+import org.apache.spark.ml.linalg
 import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.ml.tree._
 import org.apache.spark.mllib.util.TestingUtils._
@@ -236,4 +236,77 @@ private[ml] object TreeTests extends SparkFunSuite {
       LabeledPoint(1.0, Vectors.dense(1.0, 2.0)))
     sc.parallelize(arr)
   }
+
+  /**
+   * Feature vectors used in tree-based transformation.
+   */
+  val leafVectors = Array(
+    Vectors.dense(0, 1, 3),
+    Vectors.dense(-1, 2, 1),
+    Vectors.dense(1, 0, 2),
+    Vectors.dense(2, 1, 9),
+    Vectors.dense(0, 2, 6))
+
+  /**
+   * A tree structure used in tree-based transformation.
+   *
+   *                         root
+   *                      /         \
+   *             x1 in [0, 2]   otherwise
+   *                    /            \
+   *               node1           leaf2
+   *               /    \
+   *          x0 <= 0  x0 > 0
+   *             /       \
+   *          leaf0      leaf1
+   */
+  val root0 = {
+    val leaf0 = new LeafNode(0.0, Double.NaN, null)
+    val leaf1 = new LeafNode(1.0, Double.NaN, null)
+    val leaf2 = new LeafNode(0.0, Double.NaN, null)
+    val node1 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf0, leaf1,
+      new ContinuousSplit(0, 0.0), null)
+    new InternalNode(0.0, Double.NaN, Double.NaN, node1, leaf2,
+      new CategoricalSplit(1, Array(0.0, 2.0), 3), null)
+  }
+
+  /**
+   * The leaf indices of vectors after transformation by root0 in leafData.
+   */
+  val leafIndices0 = Array(2.0, 0.0, 1.0, 2.0, 0.0)
+
+  /**
+   * A tree structure used in tree-based transformation.
+   *
+   *                          root
+   *                      /         \
+   *                 x2 <= 1      x2 > 1
+   *                    /            \
+   *                 leaf0          node1
+   *                               /    \
+   *                    x1 in [0, 1]   otherwise
+   *                             /       \
+   *                         leaf1     leaf2
+   */
+  val root1 = {
+    val leaf0 = new LeafNode(0.0, Double.NaN, null)
+    val leaf1 = new LeafNode(1.0, Double.NaN, null)
+    val leaf2 = new LeafNode(0.0, Double.NaN, null)
+    val node1 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf1, leaf2,
+      new CategoricalSplit(1, Array(0.0, 1.0), 3), null)
+    new InternalNode(0.0, Double.NaN, Double.NaN, leaf0, node1,
+      new ContinuousSplit(2, 1.0), null)
+  }
+
+  /**
+   * The leaf indices of vectors after transformation by root1 in leafData.
+   */
+  val leafIndices1 = Array(1.0, 0.0, 1.0, 1.0, 2.0)
+
+  def getSingleTreeLeafData: Array[(Double, linalg.Vector)] =
+    leafIndices0.zip(leafVectors)
+
+  def getTwoTreesLeafData: Array[(linalg.Vector, linalg.Vector)] =
+    leafIndices0.zip(leafIndices1).zip(leafVectors)
+      .map { case ((i0, i1), vec) => (Vectors.dense(i0, i1), vec) }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreeTests.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreeTests.scala
@@ -23,8 +23,7 @@ import org.apache.spark.{SparkContext, SparkFunSuite}
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.ml.attribute.{AttributeGroup, NominalAttribute, NumericAttribute}
 import org.apache.spark.ml.feature.{Instance, LabeledPoint}
-import org.apache.spark.ml.linalg
-import org.apache.spark.ml.linalg.Vectors
+import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.ml.tree._
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.rdd.RDD
@@ -303,10 +302,10 @@ private[ml] object TreeTests extends SparkFunSuite {
    */
   val leafIndices1 = Array(1.0, 0.0, 1.0, 1.0, 2.0)
 
-  def getSingleTreeLeafData: Array[(Double, linalg.Vector)] =
+  def getSingleTreeLeafData: Array[(Double, Vector)] =
     leafIndices0.zip(leafVectors)
 
-  def getTwoTreesLeafData: Array[(linalg.Vector, linalg.Vector)] =
+  def getTwoTreesLeafData: Array[(Vector, Vector)] =
     leafIndices0.zip(leafIndices1).zip(leafVectors)
       .map { case ((i0, i1), vec) => (Vectors.dense(i0, i1), vec) }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Tree-based feature transformation is a widely used feature and already implemented in many famous libraries, like sklearn/xgboost/lightgbm/catboost. But is still missing in ML.
The previous discussions and design doc can be found in [SPARK-13677](https://issues.apache.org/jira/browse/SPARK-13677), which is the only left subtask in 'GBT improvement umbrella' [SPARK-14047](https://issues.apache.org/jira/browse/SPARK-14047).

This pr is to add tree-based feature transformation.

## How was this patch tested?
existing and added suites