### PR TITLE
[SPARK-28655] Support to cut the event log, and solve the history server was too slow when event log is too large.

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -65,6 +65,13 @@ package object config {
       .booleanConf
       .createWithDefault(false)
 
+  private[spark] val EVENT_LOG_CUTTYPE =
+    ConfigBuilder("spark.eventLog.cuttype")
+      .doc("Event log cut type none month day hour.")
+      .internal()
+      .stringConf
+      .createWithDefault("none")
+
   private[spark] val EVENT_LOG_OUTPUT_BUFFER_SIZE = ConfigBuilder("spark.eventLog.buffer.kb")
     .doc("Buffer size to use when writing to output streams, in KiB unless otherwise specified.")
     .bytesConf(ByteUnit.KiB)

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -154,7 +154,7 @@ private[spark] class EventLoggingListener(
     }
   }
 
-  /** cut the event log file **/
+  /** cut the event log file, reload the new log writer and stop the old writer**/
   private def logReload(): Unit = {
     val tlogPath = getLogPath(logBaseDir, appId, appAttemptId, compressionCodecName, cutType)
     // is the logPath is not change, then exit

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -170,7 +170,7 @@ case class SparkListenerExecutorMetricsUpdate(
 @DeveloperApi
 case class SparkListenerApplicationStart(
     appName: String,
-    appId: Option[String],
+    var appId: Option[String],
     time: Long,
     sparkUser: String,
     appAttemptId: Option[String],


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support to cut the event log, and solve the history server was too slow when event log is too large.

## How was this patch tested?

manual tests

![image](https://user-images.githubusercontent.com/16531687/62685138-a1d8a780-b9f4-11e9-9387-c2c2a1940af3.png)

![image](https://user-images.githubusercontent.com/16531687/62685157-ae5d0000-b9f4-11e9-9b28-1a51fc5cd782.png)

Please review https://spark.apache.org/contributing.html before opening a pull request.
