### PR TITLE
[SPARK-28659][SQL] Use data source if convertible in insert overwrite directory

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -1405,7 +1405,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
       val lowerCaseSerde = x.toLowerCase(Locale.ROOT)
       if (lowerCaseSerde.contains("parquet")) "parquet"
       else if (lowerCaseSerde.contains("orc")) "orc"
-      else  DDLUtils.HIVE_PROVIDER
-    }).getOrElse( DDLUtils.HIVE_PROVIDER)
+      else DDLUtils.HIVE_PROVIDER
+    }).getOrElse(DDLUtils.HIVE_PROVIDER)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -1401,12 +1401,11 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
   }
 
   private def extractFileFormat(serde: Option[String]): String = {
-    if (serde.toString.contains("parquet")) {
-      "parquet"
-    } else if (serde.toString.contains("orc")) {
-      "orc"
-    } else {
-      DDLUtils.HIVE_PROVIDER
-    }
+    serde.map({ x =>
+      val lowerCaseSerde = x.toLowerCase(Locale.ROOT)
+      if (lowerCaseSerde.contains("parquet")) "parquet"
+      else if (lowerCaseSerde.contains("orc")) "orc"
+      else  DDLUtils.HIVE_PROVIDER
+    }).getOrElse( DDLUtils.HIVE_PROVIDER)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -1396,6 +1396,17 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
       compressed = false,
       properties = rowStorage.properties ++ fileStorage.properties)
 
-    (ctx.LOCAL != null, storage, Some(DDLUtils.HIVE_PROVIDER))
+    val fileFormat = extractFileFormat(fileStorage.serde)
+    (ctx.LOCAL != null, storage, Some(fileFormat))
+  }
+
+  private def extractFileFormat(serde: Option[String]): String = {
+    if (serde.toString.contains("parquet")) {
+      "parquet"
+    } else if (serde.toString.contains("orc")) {
+      "orc"
+    } else {
+      DDLUtils.HIVE_PROVIDER
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -441,7 +441,6 @@ class InsertSuite extends DataSourceTest with SharedSQLContext {
         sql(
           s"""
              |INSERT OVERWRITE LOCAL DIRECTORY '$path'
-             |STORED AS orc
              |SELECT 1, 2
            """.stripMargin)
       }.getMessage

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -434,7 +434,7 @@ class InsertSuite extends DataSourceTest with SharedSQLContext {
     }
   }
 
-  test("Insert overwrite directory using Hive serde without turning on Hive support") {
+  test("Insert overwrite directory in hive table without turning on Hive support") {
     withTempDir { dir =>
       val path = dir.toURI.getPath
       val e = intercept[AnalysisException] {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -2520,21 +2520,17 @@ class HiveDDLSuite
   test("SPARK-28659: hive insert overwrite directory should use data source " +
     "if it is convertible") {
     Seq("orc", "parquet").foreach { format =>
-
       withTable("t1") {
         sql(s"CREATE TABLE t1 (id int)")
         sql(s"INSERT INTO t1 SELECT * FROM range(1, 100, 1, 10)")
-
         withTempDir { dir =>
           val pathUri = dir.toURI
-
           sql(
             s"""
                |INSERT OVERWRITE DIRECTORY '${pathUri}'
                |STORED AS $format
                |SELECT * FROM t1
            """.stripMargin)
-
           val snappyFile = dir.listFiles().find(_.getName.startsWith("part"))
           assertCompression(snappyFile, format, "SNAPPY")
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In insert overwrite directory while using `STORED AS file_format`,  files are not compressed.
In this PR it is converted to `datasource`  if it is convertible, to make it inline with`CTAS` behavior which is fixed in this  [PR](https://github.com/apache/spark/pull/22514)

### Why are the changes needed?
To make the behavior inline with `CTAS` while using `STORED AS file_format`

### Does this PR introduce any user-facing change?
Yes, After the fix of this PR now `STORED AS file_format` will be converted to `datasource` if it is convertible 
**Before**
![before](https://user-images.githubusercontent.com/44489863/66637198-28a03f80-ec45-11e9-9eb1-69bc21643138.png)


**After**
![after](https://user-images.githubusercontent.com/44489863/66637058-eb3bb200-ec44-11e9-88a0-2b2ab242f88f.PNG)

### How was this patch tested?
New testcase is added