### PR TITLE
[SPARK-28679][YARN] changes to setResourceInformation to handle empty resources and reflection error handling

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ResourceRequestHelper.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ResourceRequestHelper.scala
@@ -153,11 +153,13 @@ private object ResourceRequestHelper extends Logging {
 
     val resInfoClass = Utils.classForName(RESOURCE_INFO_CLASS)
     val setResourceInformationMethod =
-      try { 
+      try {
         resource.getClass.getMethod("setResourceInformation", classOf[String], resInfoClass)
       } catch {
-        case e: NoSuchMethodException => 
-          logError(s"Cannot find $RESOURCE_INFO_CLASS.setResourceInformation. This is likely due to a jar conflict between different yarn versions. Unable to set resources.")
+        case e: NoSuchMethodException =>
+          logError(s"""Cannot find $RESOURCE_INFO_CLASS.setResourceInformation.
+                    |This is likely due to a jar conflict between different yarn versions.
+                    |Unable to set resources.""").stripMargin().replace("\n", " ")
           return
       }
 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ResourceRequestHelper.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ResourceRequestHelper.scala
@@ -162,7 +162,7 @@ private object ResourceRequestHelper extends Logging {
         case e: NoSuchMethodException =>
           throw new SparkException(
             s"Cannot find setResourceInformation in ${resource.getClass}. " +
-              "This is likely due to a jar conflict between different YARN versions.", e)
+              "This is likely due to a JAR conflict between different YARN versions.", e)
       }
 
     resources.foreach { case (name, rawAmount) =>

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ResourceRequestHelper.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ResourceRequestHelper.scala
@@ -161,8 +161,8 @@ private object ResourceRequestHelper extends Logging {
       } catch {
         case e: NoSuchMethodException =>
           throw new SparkException(
-            s"Cannot find $RESOURCE_INFO_CLASS.setResourceInformation. " +
-              "This is likely due to a jar conflict between different yarn versions.", e)
+            s"Cannot find setResourceInformation in ${resource.getClass}. " +
+              "This is likely due to a jar conflict between different YARN versions.", e)
       }
 
     resources.foreach { case (name, rawAmount) =>

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ResourceRequestHelper.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ResourceRequestHelper.scala
@@ -159,7 +159,7 @@ private object ResourceRequestHelper extends Logging {
         case e: NoSuchMethodException =>
           logError(s"""Cannot find $RESOURCE_INFO_CLASS.setResourceInformation.
                     |This is likely due to a jar conflict between different yarn versions.
-                    |Unable to set resources.""".stripMargin().replace("\n", " "))
+                    |Unable to set resources.""".stripMargin.replace("\n", " "))
           return
       }
 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ResourceRequestHelper.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ResourceRequestHelper.scala
@@ -159,7 +159,7 @@ private object ResourceRequestHelper extends Logging {
         case e: NoSuchMethodException =>
           logError(s"""Cannot find $RESOURCE_INFO_CLASS.setResourceInformation.
                     |This is likely due to a jar conflict between different yarn versions.
-                    |Unable to set resources.""").stripMargin().replace("\n", " ")
+                    |Unable to set resources.""".stripMargin().replace("\n", " "))
           return
       }
 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ResourceRequestHelper.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ResourceRequestHelper.scala
@@ -160,7 +160,7 @@ private object ResourceRequestHelper extends Logging {
         resource.getClass.getMethod("setResourceInformation", classOf[String], resInfoClass)
       } catch {
         case e: NoSuchMethodException =>
-          new SparkException(
+          throw new SparkException(
             s"""Cannot find $RESOURCE_INFO_CLASS.setResourceInformation.
                 |This is likely due to a jar conflict between different yarn versions."""
                 .stripMargin.replace("\n", " "), e)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ResourceRequestHelper.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ResourceRequestHelper.scala
@@ -161,9 +161,8 @@ private object ResourceRequestHelper extends Logging {
       } catch {
         case e: NoSuchMethodException =>
           throw new SparkException(
-            s"""Cannot find $RESOURCE_INFO_CLASS.setResourceInformation.
-                |This is likely due to a jar conflict between different yarn versions."""
-                .stripMargin.replace("\n", " "), e)
+            s"Cannot find $RESOURCE_INFO_CLASS.setResourceInformation. " +
+              "This is likely due to a jar conflict between different yarn versions.", e)
       }
 
     resources.foreach { case (name, rawAmount) =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This fixes issues that can arise when the jars for different hadoop versions mix, and short-circuits the case where we are running with a spark that was not built for yarn 3 (resource support).

## How was this patch tested?

I tested it manually.