### PR TITLE
[SPARK-28650][SS][DOC] Correct explanation of guarantee for ForeachWriter

### DIFF
--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -2251,13 +2251,13 @@ When the streaming query is started, Spark calls the function or the object’s 
 
 - The close() method (if it exists) is called if an open() method exists and returns successfully (irrespective of the return value), except if the JVM or Python process crashes in the middle.
 
-- **Note:** Spark doesn't guarantee same output for (partitionId, epochId) on failure, so deduplication
+- **Note:** Spark does not guarantee same output for (partitionId, epochId) on failure, so deduplication
   cannot be achieved with (partitionId, epochId). e.g. source provides different number of
-  partitions for some reason, Spark optimization changes number of partitions, etc.
-  Refer SPARK-28650 for more details. `epochId` can still be used for deduplication, but there's less
-  benefit to leverage this, as the chance for Spark to successfully write all partitions and fail to checkpoint
-  the batch is small. You also need to care about whether epoch is fully written, via ensuring all
-  partitions for the epochId are written successfully.
+  partitions for some reasons, Spark optimization changes number of partitions, etc.
+  See [SPARK-28650](https://issues.apache.org/jira/browse/SPARK-28650) for more details. `epochId` can still be used
+  for deduplication, but there's less benefit to leverage this, as the chance for Spark to successfully write all
+  partitions and fail to checkpoint the batch is small. You also need to care about whether epoch is fully written,
+  via ensuring all partitions for the epochId are written successfully.
 
 #### Triggers
 The trigger settings of a streaming query define the timing of streaming data processing, whether

--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -1843,7 +1843,7 @@ Here are the details of all the sinks in Spark.
     <td><b>Foreach Sink</b></td>
     <td>Append, Update, Complete</td>
     <td>None</td>
-    <td>Depends on ForeachWriter implementation</td>
+    <td>Yes (at-least-once)</td>
     <td>More details in the <a href="#using-foreach-and-foreachbatch">next section</a></td>
   </tr>
   <tr>
@@ -2251,10 +2251,11 @@ When the streaming query is started, Spark calls the function or the object’s 
 
 - The close() method (if it exists) is called if an open() method exists and returns successfully (irrespective of the return value), except if the JVM or Python process crashes in the middle.
 
-- **Note:** Spark does not guarantee same output for (partitionId, epochId) on failure, so deduplication
+- **Note:** Spark does not guarantee same output for (partitionId, epochId), so deduplication
   cannot be achieved with (partitionId, epochId). e.g. source provides different number of
   partitions for some reasons, Spark optimization changes number of partitions, etc.
   See [SPARK-28650](https://issues.apache.org/jira/browse/SPARK-28650) for more details.
+  If you need deduplication on output, try out `foreachBatch` instead.
 
 #### Triggers
 The trigger settings of a streaming query define the timing of streaming data processing, whether

--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -2254,10 +2254,7 @@ When the streaming query is started, Spark calls the function or the object’s 
 - **Note:** Spark does not guarantee same output for (partitionId, epochId) on failure, so deduplication
   cannot be achieved with (partitionId, epochId). e.g. source provides different number of
   partitions for some reasons, Spark optimization changes number of partitions, etc.
-  See [SPARK-28650](https://issues.apache.org/jira/browse/SPARK-28650) for more details. `epochId` can still be used
-  for deduplication, but there's less benefit to leverage this, as the chance for Spark to successfully write all
-  partitions and fail to checkpoint the batch is small. You also need to care about whether epoch is fully written,
-  via ensuring all partitions for the epochId are written successfully.
+  See [SPARK-28650](https://issues.apache.org/jira/browse/SPARK-28650) for more details.
 
 #### Triggers
 The trigger settings of a streaming query define the timing of streaming data processing, whether

--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -2251,13 +2251,13 @@ When the streaming query is started, Spark calls the function or the object’s 
 
 - The close() method (if it exists) is called if an open() method exists and returns successfully (irrespective of the return value), except if the JVM or Python process crashes in the middle.
 
-- **Note:** The partitionId and epochId in the open() method can be used to deduplicate generated data 
-  when failures cause reprocessing of some input data. This depends on the execution mode of the query. 
-  If the streaming query is being executed in the micro-batch mode, then every partition represented 
-  by a unique tuple (partition_id, epoch_id) is guaranteed to have the same data. 
-  Hence, (partition_id, epoch_id) can be used to deduplicate and/or transactionally commit 
-  data and achieve exactly-once guarantees. However, if the streaming query is being executed 
-  in the continuous mode, then this guarantee does not hold and therefore should not be used for deduplication.
+- **Note:** Spark doesn't guarantee same output for (partitionId, epochId) on failure, so deduplication
+  cannot be achieved with (partitionId, epochId). e.g. source provides different number of
+  partitions for some reason, Spark optimization changes number of partitions, etc.
+  Refer SPARK-28650 for more details. `epochId` can still be used for deduplication, but there's less
+  benefit to leverage this, as the chance for Spark to successfully write all partitions and fail to checkpoint
+  the batch is small. You also need to care about whether epoch is fully written, via ensuring all
+  partitions for the epochId are written successfully.
 
 #### Triggers
 The trigger settings of a streaming query define the timing of streaming data processing, whether

--- a/sql/core/src/main/scala/org/apache/spark/sql/ForeachWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/ForeachWriter.scala
@@ -55,11 +55,6 @@ import org.apache.spark.annotation.Evolving
  *     partitions for some reason, Spark optimization changes number of partitions, etc.
  *     Refer SPARK-28650 for more details.
  *
- *     `epochId` can still be used for deduplication, but there's less benefit to leverage this,
- *     as the chance for Spark to successfully write all partitions and fail to checkpoint the
- *     batch is small. You also need to care about whether epoch is fully written, via ensuring all
- *     partitions for the epochId are written successfully.
- *
  * <li>The `close()` method will be called if `open()` method returns successfully (irrespective
  *     of the return value), except if the JVM crashes in the middle.
  * </ul>

--- a/sql/core/src/main/scala/org/apache/spark/sql/ForeachWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/ForeachWriter.scala
@@ -50,10 +50,11 @@ import org.apache.spark.annotation.Evolving
  *
  * Important points to note:
  * <ul>
- * <li>Spark doesn't guarantee same output for (partitionId, epochId) on failure, so deduplication
+ * <li>Spark doesn't guarantee same output for (partitionId, epochId), so deduplication
  *     cannot be achieved with (partitionId, epochId). e.g. source provides different number of
  *     partitions for some reason, Spark optimization changes number of partitions, etc.
- *     Refer SPARK-28650 for more details.
+ *     Refer SPARK-28650 for more details. If you need deduplication on output, try out
+ *     `foreachBatch` instead.
  *
  * <li>The `close()` method will be called if `open()` method returns successfully (irrespective
  *     of the return value), except if the JVM crashes in the middle.

--- a/sql/core/src/main/scala/org/apache/spark/sql/ForeachWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/ForeachWriter.scala
@@ -51,9 +51,11 @@ import org.apache.spark.annotation.Evolving
  * Important points to note:
  * <ul>
  * <li>Spark doesn't guarantee same output for (partitionId, epochId) on failure, so deduplication
- *     cannot be achieved with (partitionId, epochId). Refer SPARK-28650 for more details.
+ *     cannot be achieved with (partitionId, epochId). e.g. source provides different number of
+ *     partitions for some reason, Spark optimization changes number of partitions, etc.
+ *     Refer SPARK-28650 for more details.
  *
- *     You can still apply deduplication on `epochId`, but there's less benefit to leverage this,
+ *     `epochId` can still be used for deduplication, but there's less benefit to leverage this,
  *     as the chance for Spark to successfully write all partitions and fail to checkpoint the
  *     batch is small. You also need to care about whether epoch is fully written, via ensuring all
  *     partitions for the epochId are written successfully.

--- a/sql/core/src/main/scala/org/apache/spark/sql/ForeachWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/ForeachWriter.scala
@@ -50,14 +50,13 @@ import org.apache.spark.annotation.Evolving
  *
  * Important points to note:
  * <ul>
- * <li>The `partitionId` and `epochId` can be used to deduplicate generated data when failures
- *     cause reprocessing of some input data. This depends on the execution mode of the query. If
- *     the streaming query is being executed in the micro-batch mode, then every partition
- *     represented by a unique tuple (partitionId, epochId) is guaranteed to have the same data.
- *     Hence, (partitionId, epochId) can be used to deduplicate and/or transactionally commit data
- *     and achieve exactly-once guarantees. However, if the streaming query is being executed in the
- *     continuous mode, then this guarantee does not hold and therefore should not be used for
- *     deduplication.
+ * <li>Spark doesn't guarantee same output for (partitionId, epochId) on failure, so deduplication
+ *     cannot be achieved with (partitionId, epochId). Refer SPARK-28650 for more details.
+ *
+ *     You can still apply deduplication on `epochId`, but there's less benefit to leverage this,
+ *     as the chance for Spark to successfully write all partitions and fail to checkpoint the
+ *     batch is small. You also need to care about whether epoch is fully written, via ensuring all
+ *     partitions for the epochId are written successfully.
  *
  * <li>The `close()` method will be called if `open()` method returns successfully (irrespective
  *     of the return value), except if the JVM crashes in the middle.


### PR DESCRIPTION
#  What changes were proposed in this pull request?

This patch modifies the explanation of guarantee for ForeachWriter as it doesn't guarantee same output for `(partitionId, epochId)`. Refer the description of [SPARK-28650](https://issues.apache.org/jira/browse/SPARK-28650) for more details.

Spark itself still guarantees same output for same epochId (batch) if the preconditions are met, 1) source is always providing the same input records for same offset request. 2) the query is idempotent in overall (indeterministic calculation like now(), random() can break this). 

Assuming breaking preconditions as an exceptional case (the preconditions are implicitly required even before), we still can describe the guarantee with `epochId`, though it will be  harder to leverage the guarantee: 1) ForeachWriter should implement a feature to track whether all the partitions are written successfully for given `epochId` 2) There's pretty less chance to leverage the fact, as the chance for Spark to successfully write all partitions and fail to checkpoint the batch is small.

Credit to @zsxwing on discovering the broken guarantee.

## How was this patch tested?

This is just a documentation change, both on javadoc and guide doc.