### PR TITLE
[SPARK-28652][TESTS][K8S] Add python version check for executor

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/PythonTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/PythonTestsSuite.scala
@@ -44,7 +44,8 @@ private[spark] trait PythonTestsSuite { k8sSuite: KubernetesSuite =>
       mainClass = "",
       expectedLogOnCompletion = Seq(
         "Python runtime version check is: True",
-        "Python environment version check is: True"),
+        "Python environment version check is: True",
+        "Python runtime version check for executor is: True"),
       appArgs = Array("python"),
       driverPodChecker = doBasicDriverPyPodCheck,
       executorPodChecker = doBasicExecutorPyPodCheck,
@@ -62,7 +63,8 @@ private[spark] trait PythonTestsSuite { k8sSuite: KubernetesSuite =>
       mainClass = "",
       expectedLogOnCompletion = Seq(
         "Python runtime version check is: True",
-        "Python environment version check is: True"),
+        "Python environment version check is: True",
+        "Python runtime version check for executor is: True"),
       appArgs = Array("python3"),
       driverPodChecker = doBasicDriverPyPodCheck,
       executorPodChecker = doBasicExecutorPyPodCheck,

--- a/resource-managers/kubernetes/integration-tests/tests/pyfiles.py
+++ b/resource-managers/kubernetes/integration-tests/tests/pyfiles.py
@@ -37,8 +37,8 @@ if __name__ == "__main__":
     version_check(sys.argv[1], 2 if sys.argv[1] == "python" else 3)
 
     # Check python executable at executors
-    spark.catalog.registerFunction("getSysVer", \
-        lambda: "%d.%d" % sys.version_info[:2], StringType())
+    spark.catalog.registerFunction("getSysVer",
+                                   lambda: "%d.%d" % sys.version_info[:2], StringType())
     [row] = spark.sql("SELECT getSysVer()").collect()
     driverVersion = "%d.%d" % sys.version_info[:2]
     print("Python runtime version check for executor is: " + str(row[0] == driverVersion))

--- a/resource-managers/kubernetes/integration-tests/tests/pyfiles.py
+++ b/resource-managers/kubernetes/integration-tests/tests/pyfiles.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 import sys
 
 from pyspark.sql import SparkSession
+from pyspark.sql.types import StringType
 
 
 if __name__ == "__main__":
@@ -34,5 +35,12 @@ if __name__ == "__main__":
     from py_container_checks import version_check
     # Begin of Python container checks
     version_check(sys.argv[1], 2 if sys.argv[1] == "python" else 3)
+
+    # Check python executable at executors
+    spark.catalog.registerFunction("getSysVer", \
+        lambda: "%d.%d" % sys.version_info[:2], StringType())
+    [row] = spark.sql("SELECT getSysVer()").collect()
+    driverVersion = "%d.%d" % sys.version_info[:2]
+    print("Python runtime version check for executor is: " + str(row[0] == driverVersion))
 
     spark.stop()

--- a/resource-managers/kubernetes/integration-tests/tests/pyfiles.py
+++ b/resource-managers/kubernetes/integration-tests/tests/pyfiles.py
@@ -37,10 +37,10 @@ if __name__ == "__main__":
     version_check(sys.argv[1], 2 if sys.argv[1] == "python" else 3)
 
     # Check python executable at executors
-    spark.catalog.registerFunction("getSysVer",
-                                   lambda: "%d.%d" % sys.version_info[:2], StringType())
-    [row] = spark.sql("SELECT getSysVer()").collect()
-    driverVersion = "%d.%d" % sys.version_info[:2]
-    print("Python runtime version check for executor is: " + str(row[0] == driverVersion))
+    spark.udf.register("get_sys_ver",
+                       lambda: "%d.%d" % sys.version_info[:2], StringType())
+    [row] = spark.sql("SELECT get_sys_ver()").collect()
+    driver_version = "%d.%d" % sys.version_info[:2]
+    print("Python runtime version check for executor is: " + str(row[0] == driver_version))
 
     spark.stop()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Current two PySpark version tests in PythonTestsSuite, just test against Python version at driver side. Because the test script doesn't run any spark job requiring python worker, it doesn't actually do version check at worker side. This patch adds pieces of code to the test script, to run a simple job to verify Python version.

## How was this patch tested?

Unit test. Locally manual test.