### PR TITLE
[SPARK-28390][SQL][PYTHON][TESTS] [FOLLOW-UP] Update the TODO with  actual blocking JIRA IDs

### DIFF
--- a/sql/core/src/test/resources/sql-tests/inputs/udf/pgSQL/udf-select_having.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/udf/pgSQL/udf-select_having.sql
@@ -6,7 +6,7 @@
 -- https://github.com/postgres/postgres/blob/REL_12_BETA2/src/test/regress/sql/select_having.sql
 --
 -- This test file was converted from inputs/pgSQL/select_having.sql
--- TODO: We should add UDFs in GROUP BY clause when [SPARK-28445] is resolved.
+-- TODO: We should add UDFs in GROUP BY clause when [SPARK-28386] and [SPARK-26741] is resolved.
 
 -- load test data
 CREATE TABLE test_having (a int, b int, c string, d string) USING parquet;


### PR DESCRIPTION
## What changes were proposed in this pull request?
 only todo message updated. Need to add udf() for GroupBy Tests, after resolving following jira
[SPARK-28386] and [SPARK-26741]

## How was this patch tested?
NA, only TODO message updated.

