### PR TITLE
[SPARK-28706][SQL] Allow cast null type to any types

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -134,7 +134,7 @@ object Cast {
     case (DateType, TimestampType) => true
     case (_: AtomicType, StringType) => true
     case (_: CalendarIntervalType, StringType) => true
-    case (NullType, StringType) => true
+    case (NullType, _) => true
 
     // Spark supports casting between long and timestamp, please see `longToTimestamp` and
     // `timestampToLong` for details.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -134,6 +134,7 @@ object Cast {
     case (DateType, TimestampType) => true
     case (_: AtomicType, StringType) => true
     case (_: CalendarIntervalType, StringType) => true
+    case (NullType, StringType) => true
 
     // Spark supports casting between long and timestamp, please see `longToTimestamp` and
     // `timestampToLong` for details.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -1008,6 +1008,8 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
         assert(!Cast.canUpCast(complexType, StringType))
       }
     }
+
+    assert(Cast.canUpCast(NullType, StringType))
   }
 
   test("SPARK-27671: cast from nested null type in struct") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -974,7 +974,7 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
       )
     }
 
-    import DataTypeTestUtils.numericTypes
+    import DataTypeTestUtils._
     numericTypes.foreach { from =>
       val (safeTargetTypes, unsafeTargetTypes) = numericTypes.partition(to => isCastSafe(from, to))
 
@@ -1009,7 +1009,9 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
       }
     }
 
-    assert(Cast.canUpCast(NullType, StringType))
+    atomicTypes.foreach { atomicType =>
+      assert(Cast.canUpCast(NullType, atomicType))
+    }
   }
 
   test("SPARK-27671: cast from nested null type in struct") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

#25242 proposed to disallow upcasting complex data types to string type, however, upcasting from null type to any types should still be safe.

## How was this patch tested?

Add corresponding case in `CastSuite`.