### PR TITLE
[SPARK-28705][SQL][TEST] Drop tables after being used in AnalysisExternalCatalogSuite

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisExternalCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisExternalCatalogSuite.scala
@@ -57,6 +57,7 @@ class AnalysisExternalCatalogSuite extends AnalysisTest with Matchers {
     val plan = Project(Seq(func), testRelation)
     analyzer.execute(plan)
     verifyZeroInteractions(catalog)
+    catalog.dropTable("default", "t1", true, false)
   }
 
   test("check the existence of builtin functions don't call the external catalog") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

drop the table after the test `query builtin functions don't call the external catalog`  executed

This is required for [SPARK-25464](https://github.com/apache/spark/pull/22466)

## How was this patch tested?

existing UT
