### PR TITLE
[SPARK-11215][ML][FollowUp] update the examples and suites using new api

### DIFF
--- a/examples/src/main/java/org/apache/spark/examples/ml/JavaDecisionTreeClassificationExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/ml/JavaDecisionTreeClassificationExample.java
@@ -71,7 +71,7 @@ public class JavaDecisionTreeClassificationExample {
     IndexToString labelConverter = new IndexToString()
       .setInputCol("prediction")
       .setOutputCol("predictedLabel")
-      .setLabels(labelIndexer.labels());
+      .setLabels(labelIndexer.labelsArray()[0]);
 
     // Chain indexers and tree in a Pipeline.
     Pipeline pipeline = new Pipeline()

--- a/examples/src/main/java/org/apache/spark/examples/ml/JavaGradientBoostedTreeClassifierExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/ml/JavaGradientBoostedTreeClassifierExample.java
@@ -73,7 +73,7 @@ public class JavaGradientBoostedTreeClassifierExample {
     IndexToString labelConverter = new IndexToString()
       .setInputCol("prediction")
       .setOutputCol("predictedLabel")
-      .setLabels(labelIndexer.labels());
+      .setLabels(labelIndexer.labelsArray()[0]);
 
     // Chain indexers and GBT in a Pipeline.
     Pipeline pipeline = new Pipeline()

--- a/examples/src/main/java/org/apache/spark/examples/ml/JavaRandomForestClassifierExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/ml/JavaRandomForestClassifierExample.java
@@ -69,7 +69,7 @@ public class JavaRandomForestClassifierExample {
     IndexToString labelConverter = new IndexToString()
       .setInputCol("prediction")
       .setOutputCol("predictedLabel")
-      .setLabels(labelIndexer.labels());
+      .setLabels(labelIndexer.labelsArray()[0]);
 
     // Chain indexers and forest in a Pipeline
     Pipeline pipeline = new Pipeline()

--- a/examples/src/main/scala/org/apache/spark/examples/ml/DecisionTreeClassificationExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/DecisionTreeClassificationExample.scala
@@ -62,7 +62,7 @@ object DecisionTreeClassificationExample {
     val labelConverter = new IndexToString()
       .setInputCol("prediction")
       .setOutputCol("predictedLabel")
-      .setLabels(labelIndexer.labels)
+      .setLabels(labelIndexer.labelsArray(0))
 
     // Chain indexers and tree in a Pipeline.
     val pipeline = new Pipeline()

--- a/examples/src/main/scala/org/apache/spark/examples/ml/GradientBoostedTreeClassifierExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/GradientBoostedTreeClassifierExample.scala
@@ -65,7 +65,7 @@ object GradientBoostedTreeClassifierExample {
     val labelConverter = new IndexToString()
       .setInputCol("prediction")
       .setOutputCol("predictedLabel")
-      .setLabels(labelIndexer.labels)
+      .setLabels(labelIndexer.labelsArray(0))
 
     // Chain indexers and GBT in a Pipeline.
     val pipeline = new Pipeline()

--- a/examples/src/main/scala/org/apache/spark/examples/ml/RandomForestClassifierExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/RandomForestClassifierExample.scala
@@ -64,7 +64,7 @@ object RandomForestClassifierExample {
     val labelConverter = new IndexToString()
       .setInputCol("prediction")
       .setOutputCol("predictedLabel")
-      .setLabels(labelIndexer.labels)
+      .setLabels(labelIndexer.labelsArray(0))
 
     // Chain indexers and forest in a Pipeline.
     val pipeline = new Pipeline()

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
@@ -246,7 +246,7 @@ class StringIndexerSuite extends MLTest with DefaultReadWriteTest {
       .setOutputCol("myOutputCol")
       .setHandleInvalid("skip")
     val newInstance = testDefaultReadWrite(instance)
-    assert(newInstance.labels === instance.labels)
+    assert(newInstance.labelsArray(0) === instance.labelsArray(0))
   }
 
   test("IndexToString params") {
@@ -292,7 +292,7 @@ class StringIndexerSuite extends MLTest with DefaultReadWriteTest {
     val idx2str = new IndexToString()
       .setInputCol("labelIndex")
       .setOutputCol("sameLabel")
-      .setLabels(indexer.labels)
+      .setLabels(indexer.labelsArray(0))
 
     testTransformer[(Int, String, Double)](transformed, idx2str, "sameLabel", "label") {
       case Row(sameLabel, label) =>


### PR DESCRIPTION
## What changes were proposed in this pull request?
since method `labels` is already deprecated, we should update the examples and suites to turn off warings when compiling spark:
```
[warn] /Users/zrf/Dev/OpenSource/spark/examples/src/main/scala/org/apache/spark/examples/ml/DecisionTreeClassificationExample.scala:65: method labels in class StringIndexerModel is deprecated (since 3.0.0): `labels` is deprecated and will be removed in 3.1.0. Use `labelsArray` instead.
[warn]       .setLabels(labelIndexer.labels)
[warn]                               ^
[warn] /Users/zrf/Dev/OpenSource/spark/examples/src/main/scala/org/apache/spark/examples/ml/GradientBoostedTreeClassifierExample.scala:68: method labels in class StringIndexerModel is deprecated (since 3.0.0): `labels` is deprecated and will be removed in 3.1.0. Use `labelsArray` instead.
[warn]       .setLabels(labelIndexer.labels)
[warn]                               ^
```

## How was this patch tested?
existing suites