### PR TITLE
[SPARK-28711][DOCS] Update migration guide to add note about Hive upgrade

### DIFF
--- a/docs/sql-migration-guide-upgrade.md
+++ b/docs/sql-migration-guide-upgrade.md
@@ -23,6 +23,9 @@ license: |
 {:toc}
 
 ## Upgrading From Spark SQL 2.4 to 3.0
+  - Since Spark 3.0, hive is upgraded to 2.3.x, so it is required to update the Hive
+  `SCHEMA_VERSION` in the database to at least 2.3.0. 
+  
   - Since Spark 3.0, we reversed argument order of the trim function from `TRIM(trimStr, str)` to `TRIM(str, trimStr)` to be compatible with other databases.
 
   - Since Spark 3.0, PySpark requires a Pandas version of 0.23.2 or higher to use Pandas related functionality, such as `toPandas`, `createDataFrame` from Pandas DataFrame, etc.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add note about updating `SCHEMA_VERSION` of Hive in the database

After upgrading to SPARK 3.0 Thrift Server is failed to start as there is a mismatch in the schema version.

Hive throws MetaException

Caused by: MetaException(message:Hive Schema version 2.3.0 does not match metastore's schema version 1.3.0 Metastore is not upgraded or corrupt)

So need to help the users for the smooth upgrade by documenting it.

## How was this patch tested?

Manually