### PR TITLE
[SPARK-28720][BUILD][R] Update AppVeyor R version to 3.6.1

### DIFF
--- a/dev/appveyor-install-dependencies.ps1
+++ b/dev/appveyor-install-dependencies.ps1
@@ -115,7 +115,7 @@ $env:Path += ";$env:HADOOP_HOME\bin"
 Pop-Location
 
 # ========================== R
-$rVer = "3.6.0"
+$rVer = "3.6.1"
 $rToolsVer = "3.5.1"
 
 InstallR


### PR DESCRIPTION
## What changes were proposed in this pull request?

R version 3.6.1 (Action of the Toes) was released on 2019-07-05. This PR aims to upgrade R installation for AppVeyor CI environment.

## How was this patch tested?

Pass the AppVeyor CI.