### PR TITLE
[SPARK-28697][SQL] Invalidate Database/Table names starting with underscore

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -102,7 +102,7 @@ class SessionCatalog(
   @GuardedBy("this")
   protected var currentDb: String = formatDatabaseName(DEFAULT_DATABASE)
 
-  private val validNameFormat = "([a-zA-Z0-9]+[\\w]+)".r
+  private val validNameFormat = "([a-zA-Z0-9]+[\\w]*)".r
 
   /**
    * Checks if the given name conforms the Hive standard ("[a-zA-Z_0-9]+"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -114,7 +114,7 @@ class SessionCatalog(
   private def validateName(name: String): Unit = {
     if (!validNameFormat.pattern.matcher(name).matches()) {
       throw new AnalysisException(s"`$name` is not a valid name for tables/databases. " +
-        "Valid names only contain alphabet characters, numbers and _ and do not start with _")
+        "Valid names only contain alphabet characters, numbers and _ and do not start with _.")
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -102,7 +102,7 @@ class SessionCatalog(
   @GuardedBy("this")
   protected var currentDb: String = formatDatabaseName(DEFAULT_DATABASE)
 
-  private val validNameFormat = "([\\w_]+)".r
+  private val validNameFormat = "([a-zA-Z0-9]+[\\w]+)".r
 
   /**
    * Checks if the given name conforms the Hive standard ("[a-zA-Z_0-9]+"),
@@ -114,7 +114,7 @@ class SessionCatalog(
   private def validateName(name: String): Unit = {
     if (!validNameFormat.pattern.matcher(name).matches()) {
       throw new AnalysisException(s"`$name` is not a valid name for tables/databases. " +
-        "Valid names only contain alphabet characters, numbers and _.")
+        "Valid names only contain alphabet characters, numbers and _ and do not start with _")
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -90,12 +90,14 @@ abstract class SessionCatalogSuite extends AnalysisTest {
   def testInvalidName(func: (String) => Unit) {
     // scalastyle:off
     // non ascii characters are not allowed in the source code, so we disable the scalastyle.
-    val name = "砖"
+    val names = Array("砖" , "_hello")
     // scalastyle:on
-    val e = intercept[AnalysisException] {
-      func(name)
-    }.getMessage
-    assert(e.contains(s"`$name` is not a valid name for tables/databases."))
+    names.foreach { name =>
+      val e = intercept[AnalysisException] {
+        func(name)
+      }.getMessage
+      assert(e.contains(s"`$name` is not a valid name for tables/databases."))
+    }
   }
 
   test("create databases using invalid names") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MultiDatabaseSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MultiDatabaseSuite.scala
@@ -294,7 +294,7 @@ class MultiDatabaseSuite extends QueryTest with SQLTestUtils with TestHiveSingle
             """.stripMargin)
         }.getMessage
         assert(message.contains("`t:a` is not a valid name for tables/databases. " +
-          "Valid names only contain alphabet characters, numbers and _."))
+          "Valid names only contain alphabet characters, numbers and _ and do not start with _."))
       }
 
       {


### PR DESCRIPTION
## What changes were proposed in this pull request?

I think we should disallow if a identifier starts with _ for create database and create table
Partially we can see its effect in SPARK-28697 where as the table name starts with _ (like _sampleTable) , the FileFormat assumes it to be a hidden folder and do not list it which causes unusual behavior

## How was this patch tested?

Avoiding creating tables and databases with names starting from underscore. Added test case for same