### PR TITLE
[SPARK-28710][SQL]to fix replace function, spark should call drop and create function

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
@@ -22,7 +22,7 @@ import java.util.Locale
 import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.{FunctionRegistry, NoSuchFunctionException}
-import org.apache.spark.sql.catalyst.catalog.{CatalogFunction, FunctionResource}
+import org.apache.spark.sql.catalyst.catalog.{CatalogFunction, FunctionResource, SessionCatalog}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, ExpressionInfo}
 import org.apache.spark.sql.catalyst.util.StringUtils
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
@@ -73,6 +73,17 @@ case class CreateFunctionCommand(
       s"is not allowed: '${databaseName.get}'")
   }
 
+  def isResourceChanged(catalog: SessionCatalog, changedFuntion: CatalogFunction): Boolean = {
+    val oldFunction = catalog.getFunctionMetadata(changedFuntion.identifier)
+    if (oldFunction.resources.size != changedFuntion.resources.size) {
+      return true
+    }
+    val changedResources = changedFuntion.resources.filter(
+      newResource => !oldFunction.resources.contains(newResource))
+    changedResources.nonEmpty
+  }
+
+
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
     val func = CatalogFunction(FunctionIdentifier(functionName, databaseName), className, resources)
@@ -83,8 +94,14 @@ case class CreateFunctionCommand(
     } else {
       // Handles `CREATE OR REPLACE FUNCTION AS ... USING ...`
       if (replace && catalog.functionExists(func.identifier)) {
-        // alter the function in the metastore
-        catalog.alterFunction(func)
+        isResourceChanged(catalog, func) match {
+          // as of now Hive only alter name, owner, class name, type but not resource URI
+          // So in order to replace function spark needs to delete and create the function
+          case true => catalog.dropFunction(func.identifier, ignoreIfExists)
+            catalog.createFunction(func, ignoreIfExists)
+          // replace the function in the metastore if there is no change in the resource
+          case _ => catalog.alterFunction(func)
+        }
       } else {
         // For a permanent, we will store the metadata into underlying external catalog.
         // This function will be loaded into the FunctionRegistry when a query uses it.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -1286,7 +1286,8 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     isResourceChanged(db, newDefinition) match {
       // as of now Hive only alter name, owner, class name, type but not resource URI
       // So in order to replace function with resource spark needs to delete and create the function
-      case true => client.dropFunction(db, functionName)
+      case true =>
+        client.dropFunction(db, functionName)
         client.createFunction(db, newDefinition)
       // replace the function in the metastore if there is no change in the resource
       case _ =>
@@ -1318,7 +1319,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     client.listFunctions(db, pattern)
   }
 
-  def isResourceChanged(db: String, newFunction: CatalogFunction): Boolean = {
+  private def isResourceChanged(db: String, newFunction: CatalogFunction): Boolean = {
     val oldFunction = getFunction(db, newFunction.identifier.funcName)
     if (oldFunction.resources.size != newFunction.resources.size) {
       return true


### PR DESCRIPTION
## What changes were proposed in this pull request?

create or replace function **X as 'Y' using jar Z**;  does not work if the X is already present and is created with some other jar lets say xyz.

As per current implementation spark calls alter Function API of Hive, as of now Hive only alter name, owner, class name, type but not resource URI. After calling alter function only  **X and Y**  are updated **but not Z.**

So when the select is performed on X UDF it throws class not found exception.

Observation 1: Temporary function does not have this problem as it is handled by spark logic 

Observation 2: For permanent function Spark calls the Hive to alter function , as of now Hive only alter name, owner, class name, type but not resource URI.

[SparkCode]
![image](https://user-images.githubusercontent.com/35216143/76546139-fd01d980-64b0-11ea-8a8a-9ee39609fe88.png)


[Hive Code]
![image](https://user-images.githubusercontent.com/35216143/76546060-d9d72a00-64b0-11ea-9543-b4ae0f113cdf.png)


 As per [Hive Documentation](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-Create/Drop/ReloadFunction) it does not supports create or replace command for function

## How was this patch tested?

Added UT and also manually tested

Before Fix:
![image](https://user-images.githubusercontent.com/35216143/63011564-308e6e00-bea6-11e9-8b1d-271847a96018.png)

After Fix:
![image](https://user-images.githubusercontent.com/35216143/63011970-fa9db980-bea6-11e9-8d7f-1aece951ca84.png)



