### PR TITLE
[MINOR][DOCS] Remove Note on Parquet Nullability Behaviour

### DIFF
--- a/docs/sql-data-sources-parquet.md
+++ b/docs/sql-data-sources-parquet.md
@@ -24,8 +24,7 @@ license: |
 
 [Parquet](http://parquet.io) is a columnar format that is supported by many other data processing systems.
 Spark SQL provides support for both reading and writing Parquet files that automatically preserves the schema
-of the original data. When reading Parquet files, all columns are automatically converted to be nullable for
-compatibility reasons.
+of the original data.
 
 ### Loading Data Programmatically
 


### PR DESCRIPTION
## Changes Proposed

The documentation on [Parquet Files](https://spark.apache.org/docs/latest/sql-data-sources-parquet.html) states that,
> When writing Parquet files, all columns are automatically converted to be nullable for compatibility reasons.

This behaviour has changed since 2.0.0 and was reported as a regression in [SPARK-17725](https://issues.apache.org/jira/browse/SPARK-17725). Since it was decided to not address this change in behaviour for now, it makes sense to remove the above statement from the documentation.