### PR TITLE
[SPARK-25474][SQL][FOLLOW-UP] fallback to hdfs when relation table stats is not available

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelation.scala
@@ -73,7 +73,7 @@ case class HadoopFsRelation(
     val defaultSize = (location.sizeInBytes * compressionFactor).toLong
     location match {
       case cfi: CatalogFileIndex if sparkSession.sessionState.conf.fallBackToHdfsForStatsEnabled &&
-          defaultSize == sqlContext.conf.defaultSizeInBytes =>
+          location.sizeInBytes == sqlContext.conf.defaultSizeInBytes =>
         CommandUtils.getSizeInBytesFallBackToHdfs(sparkSession, new Path(cfi.table.location),
           defaultSize)
       case _ => defaultSize

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelation.scala
@@ -72,7 +72,8 @@ case class HadoopFsRelation(
     val compressionFactor = sqlContext.conf.fileCompressionFactor
     val defaultSize = (location.sizeInBytes * compressionFactor).toLong
     location match {
-      case cfi: CatalogFileIndex if sparkSession.sessionState.conf.fallBackToHdfsForStatsEnabled =>
+      case cfi: CatalogFileIndex if sparkSession.sessionState.conf.fallBackToHdfsForStatsEnabled
+        && defaultSize == sqlContext.conf.defaultSizeInBytes =>
         CommandUtils.getSizeInBytesFallBackToHdfs(sparkSession, new Path(cfi.table.location),
           defaultSize)
       case _ => defaultSize

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelation.scala
@@ -72,8 +72,8 @@ case class HadoopFsRelation(
     val compressionFactor = sqlContext.conf.fileCompressionFactor
     val defaultSize = (location.sizeInBytes * compressionFactor).toLong
     location match {
-      case cfi: CatalogFileIndex if sparkSession.sessionState.conf.fallBackToHdfsForStatsEnabled
-        && defaultSize == sqlContext.conf.defaultSizeInBytes =>
+      case cfi: CatalogFileIndex if sparkSession.sessionState.conf.fallBackToHdfsForStatsEnabled &&
+        defaultSize == sqlContext.conf.defaultSizeInBytes =>
         CommandUtils.getSizeInBytesFallBackToHdfs(sparkSession, new Path(cfi.table.location),
           defaultSize)
       case _ => defaultSize

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelation.scala
@@ -73,7 +73,7 @@ case class HadoopFsRelation(
     val defaultSize = (location.sizeInBytes * compressionFactor).toLong
     location match {
       case cfi: CatalogFileIndex if sparkSession.sessionState.conf.fallBackToHdfsForStatsEnabled &&
-        defaultSize == sqlContext.conf.defaultSizeInBytes =>
+          defaultSize == sqlContext.conf.defaultSizeInBytes =>
         CommandUtils.getSizeInBytesFallBackToHdfs(sparkSession, new Path(cfi.table.location),
           defaultSize)
       case _ => defaultSize


### PR DESCRIPTION
## What changes were proposed in this pull request?
When the table relation stats are not empty, do not fall back to HDFS for size estimation.

## How was this patch tested?

Existing tests