### PR TITLE
[SPARK-28741][SQL]Optional mode: throw exceptions when casting to integers causes overflow

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1252,7 +1252,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
     }
   }
 
-  private[this] def castDecimalToIntegerCode(
+  private[this] def castDecimalToIntegralTypeCode(
       ctx: CodegenContext,
       integralType: String): CastFunction = {
     (c, evPrim, evNull) => code"$evPrim = $c.to${integralType.capitalize}($failOnIntegerOverflow);"
@@ -1284,7 +1284,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
     (min.toString + typeIndicator, max.toString + typeIndicator)
   }
 
-  private[this] def castFractionToIntegerExactCode(
+  private[this] def castFractionToIntegralTypeCode(
       fractionType: String,
       integralType: String): CastFunction = {
     assert(failOnIntegerOverflow)
@@ -1323,13 +1323,13 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
     case DateType =>
       (c, evPrim, evNull) => code"$evNull = true;"
     case TimestampType => castTimestampToIntegralTypeCode(ctx, "byte")
-    case DecimalType() => castDecimalToIntegerCode(ctx, "byte")
+    case DecimalType() => castDecimalToIntegralTypeCode(ctx, "byte")
     case _: ShortType | _: IntegerType | _: LongType if failOnIntegerOverflow =>
       castIntegerToIntegerExactCode("byte")
     case _: FloatType if failOnIntegerOverflow =>
-      castFractionToIntegerExactCode("float", "byte")
+      castFractionToIntegralTypeCode("float", "byte")
     case _: DoubleType if failOnIntegerOverflow =>
-      castFractionToIntegerExactCode("double", "byte")
+      castFractionToIntegralTypeCode("double", "byte")
     case x: NumericType =>
       (c, evPrim, evNull) => code"$evPrim = (byte) $c;"
   }
@@ -1354,13 +1354,13 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
     case DateType =>
       (c, evPrim, evNull) => code"$evNull = true;"
     case TimestampType => castTimestampToIntegralTypeCode(ctx, "short")
-    case DecimalType() => castDecimalToIntegerCode(ctx, "short")
+    case DecimalType() => castDecimalToIntegralTypeCode(ctx, "short")
     case _: IntegerType | _: LongType if failOnIntegerOverflow =>
       castIntegerToIntegerExactCode("short")
     case _: FloatType if failOnIntegerOverflow =>
-      castFractionToIntegerExactCode("float", "short")
+      castFractionToIntegralTypeCode("float", "short")
     case _: DoubleType if failOnIntegerOverflow =>
-      castFractionToIntegerExactCode("double", "short")
+      castFractionToIntegralTypeCode("double", "short")
     case x: NumericType =>
       (c, evPrim, evNull) => code"$evPrim = (short) $c;"
   }
@@ -1383,12 +1383,12 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
     case DateType =>
       (c, evPrim, evNull) => code"$evNull = true;"
     case TimestampType => castTimestampToIntegralTypeCode(ctx, "int")
-    case DecimalType() => castDecimalToIntegerCode(ctx, "int")
+    case DecimalType() => castDecimalToIntegralTypeCode(ctx, "int")
     case _: LongType if failOnIntegerOverflow => castIntegerToIntegerExactCode("int")
     case _: FloatType if failOnIntegerOverflow =>
-      castFractionToIntegerExactCode("float", "int")
+      castFractionToIntegralTypeCode("float", "int")
     case _: DoubleType if failOnIntegerOverflow =>
-      castFractionToIntegerExactCode("double", "int")
+      castFractionToIntegralTypeCode("double", "int")
     case x: NumericType =>
       (c, evPrim, evNull) => code"$evPrim = (int) $c;"
   }
@@ -1413,11 +1413,11 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
       (c, evPrim, evNull) => code"$evNull = true;"
     case TimestampType =>
       (c, evPrim, evNull) => code"$evPrim = (long) ${timestampToLongCode(c)};"
-    case DecimalType() => castDecimalToIntegerCode(ctx, "long")
+    case DecimalType() => castDecimalToIntegralTypeCode(ctx, "long")
     case _: FloatType if failOnIntegerOverflow =>
-      castFractionToIntegerExactCode("float", "long")
+      castFractionToIntegralTypeCode("float", "long")
     case _: DoubleType if failOnIntegerOverflow =>
-      castFractionToIntegerExactCode("double", "long")
+      castFractionToIntegralTypeCode("double", "long")
     case x: NumericType =>
       (c, evPrim, evNull) => code"$evPrim = (long) $c;"
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -183,14 +183,14 @@ object Cast {
 
     case (FloatType | DoubleType, TimestampType) => true
     case (TimestampType, DateType) => false
-    case (TimestampType, _: IntegralType) if to != LongType => true
+
     case (_, DateType) => true
     case (DateType, TimestampType) => false
     case (DateType, _) => true
     case (_, CalendarIntervalType) => true
 
     case (_, to: DecimalType) if !canNullSafeCastToDecimal(from, to) => true
-    case (_: NumericType, _: IntegralType) if !legalNumericPrecedence(from, to) => true
+    case (_: FractionalType, _: IntegralType) => true  // NaN, infinity
     case _ => false
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1278,7 +1278,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
     val typeIndicator = fractionType.charAt(0)
     val (min, max) = integralType.toLowerCase(Locale.ROOT) match {
       case "long" => (Long.MinValue, Long.MaxValue)
-      case "int" => (Int.MinValue, Int.MaxValue.toLong)
+      case "int" => (Int.MinValue, Int.MaxValue)
       case "short" => (Short.MinValue, Short.MaxValue)
       case "byte" => (Byte.MinValue, Byte.MaxValue)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1263,12 +1263,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
   private[this] def castDecimalToIntegerCode(
       ctx: CodegenContext,
       integralType: String): CastFunction = {
-    val capitalizedIntegralType = integralType.capitalize
-    if (failOnIntegerOverflow) {
-      (c, evPrim, evNull) => code"$evPrim = $c.roundTo$capitalizedIntegralType();"
-    } else {
-      (c, evPrim, evNull) => code"$evPrim = $c.to$capitalizedIntegralType();"
-    }
+    (c, evPrim, evNull) => code"$evPrim = $c.to${integralType.capitalize}($failOnIntegerOverflow);"
   }
 
   private[this] def castIntegerToIntegerExactCode(integralType: String): CastFunction = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -478,9 +478,9 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
     case DateType =>
       buildCast[Int](_, d => null)
     case TimestampType if failOnIntegerOverflow =>
-        buildCast[Long](_, t => LongExactNumeric.toInt(timestampToLong(t)))
+      buildCast[Long](_, t => LongExactNumeric.toInt(timestampToLong(t)))
     case TimestampType =>
-        buildCast[Long](_, t => timestampToLong(t).toInt)
+      buildCast[Long](_, t => timestampToLong(t).toInt)
     case x: NumericType if failOnIntegerOverflow =>
       b => x.exactNumeric.asInstanceOf[Numeric[Any]].toInt(b)
     case x: NumericType =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1233,7 +1233,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
       (c, evPrim, evNull) => code"$evPrim = $c != 0;"
   }
 
-  private[this] def castTimestampToIntegerCode(
+  private[this] def castTimestampToIntegralTypeCode(
       ctx: CodegenContext,
       integralType: String): CastFunction = {
     if (failOnIntegerOverflow) {
@@ -1322,7 +1322,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
       (c, evPrim, evNull) => code"$evPrim = $c ? (byte) 1 : (byte) 0;"
     case DateType =>
       (c, evPrim, evNull) => code"$evNull = true;"
-    case TimestampType => castTimestampToIntegerCode(ctx, "byte")
+    case TimestampType => castTimestampToIntegralTypeCode(ctx, "byte")
     case DecimalType() => castDecimalToIntegerCode(ctx, "byte")
     case _: ShortType | _: IntegerType | _: LongType if failOnIntegerOverflow =>
       castIntegerToIntegerExactCode("byte")
@@ -1353,7 +1353,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
       (c, evPrim, evNull) => code"$evPrim = $c ? (short) 1 : (short) 0;"
     case DateType =>
       (c, evPrim, evNull) => code"$evNull = true;"
-    case TimestampType => castTimestampToIntegerCode(ctx, "short")
+    case TimestampType => castTimestampToIntegralTypeCode(ctx, "short")
     case DecimalType() => castDecimalToIntegerCode(ctx, "short")
     case _: IntegerType | _: LongType if failOnIntegerOverflow =>
       castIntegerToIntegerExactCode("short")
@@ -1382,7 +1382,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
       (c, evPrim, evNull) => code"$evPrim = $c ? 1 : 0;"
     case DateType =>
       (c, evPrim, evNull) => code"$evNull = true;"
-    case TimestampType => castTimestampToIntegerCode(ctx, "int")
+    case TimestampType => castTimestampToIntegralTypeCode(ctx, "int")
     case DecimalType() => castDecimalToIntegerCode(ctx, "int")
     case _: LongType if failOnIntegerOverflow => castIntegerToIntegerExactCode("int")
     case _: FloatType if failOnIntegerOverflow =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -258,7 +258,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
 
   private lazy val dateFormatter = DateFormatter()
   private lazy val timestampFormatter = TimestampFormatter.getFractionFormatter(zoneId)
-  private val failOnIntegerOverflow = SQLConf.get.failOnIntegerOverflow
+  private val failOnIntegerOverflow = SQLConf.get.failOnIntegralTypeOverflow
 
   // UDFToString
   private[this] def castToString(from: DataType): Any => Any = from match {
@@ -1258,7 +1258,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
     (c, evPrim, evNull) => code"$evPrim = $c.to${integralType.capitalize}($failOnIntegerOverflow);"
   }
 
-  private[this] def castIntegerToIntegerExactCode(integralType: String): CastFunction = {
+  private[this] def castIntegralTypeToIntegralTypeExactCode(integralType: String): CastFunction = {
     assert(failOnIntegerOverflow)
     (c, evPrim, evNull) =>
       code"""
@@ -1325,7 +1325,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
     case TimestampType => castTimestampToIntegralTypeCode(ctx, "byte")
     case DecimalType() => castDecimalToIntegralTypeCode(ctx, "byte")
     case _: ShortType | _: IntegerType | _: LongType if failOnIntegerOverflow =>
-      castIntegerToIntegerExactCode("byte")
+      castIntegralTypeToIntegralTypeExactCode("byte")
     case _: FloatType if failOnIntegerOverflow =>
       castFractionToIntegralTypeCode("float", "byte")
     case _: DoubleType if failOnIntegerOverflow =>
@@ -1356,7 +1356,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
     case TimestampType => castTimestampToIntegralTypeCode(ctx, "short")
     case DecimalType() => castDecimalToIntegralTypeCode(ctx, "short")
     case _: IntegerType | _: LongType if failOnIntegerOverflow =>
-      castIntegerToIntegerExactCode("short")
+      castIntegralTypeToIntegralTypeExactCode("short")
     case _: FloatType if failOnIntegerOverflow =>
       castFractionToIntegralTypeCode("float", "short")
     case _: DoubleType if failOnIntegerOverflow =>
@@ -1384,7 +1384,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
       (c, evPrim, evNull) => code"$evNull = true;"
     case TimestampType => castTimestampToIntegralTypeCode(ctx, "int")
     case DecimalType() => castDecimalToIntegralTypeCode(ctx, "int")
-    case _: LongType if failOnIntegerOverflow => castIntegerToIntegerExactCode("int")
+    case _: LongType if failOnIntegerOverflow => castIntegralTypeToIntegralTypeExactCode("int")
     case _: FloatType if failOnIntegerOverflow =>
       castFractionToIntegralTypeCode("float", "int")
     case _: DoubleType if failOnIntegerOverflow =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -183,7 +183,6 @@ object Cast {
 
     case (FloatType | DoubleType, TimestampType) => true
     case (TimestampType, DateType) => false
-
     case (_, DateType) => true
     case (DateType, TimestampType) => false
     case (DateType, _) => true
@@ -1283,7 +1282,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
     }
   }
 
-  private[this] def castIntegerToIntegerCode(intType: String): CastFunction = {
+  private[this] def castIntegerToIntegerExactCode(intType: String): CastFunction = {
     assert(failOnIntegerOverflow)
     (c, evPrim, evNull) =>
       code"""
@@ -1328,7 +1327,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
     case TimestampType => castTimestampToIntegerCode(ctx, "byte")
     case DecimalType() => castDecimalToIntegerCode(ctx, "byte")
     case _: ShortType | _: IntegerType | _: LongType if failOnIntegerOverflow =>
-      castIntegerToIntegerCode("byte")
+      castIntegerToIntegerExactCode("byte")
     case _: FloatType | _: DoubleType if failOnIntegerOverflow =>
       castFractionToIntegerExactCode("byte")
     case x: NumericType =>
@@ -1357,7 +1356,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
     case TimestampType => castTimestampToIntegerCode(ctx, "short")
     case DecimalType() => castDecimalToIntegerCode(ctx, "short")
     case _: IntegerType | _: LongType if failOnIntegerOverflow =>
-      castIntegerToIntegerCode("short")
+      castIntegerToIntegerExactCode("short")
     case _: FloatType | _: DoubleType if failOnIntegerOverflow =>
       castFractionToIntegerExactCode("short")
     case x: NumericType =>
@@ -1383,7 +1382,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
       (c, evPrim, evNull) => code"$evNull = true;"
     case TimestampType => castTimestampToIntegerCode(ctx, "int")
     case DecimalType() => castDecimalToIntegerCode(ctx, "int")
-    case _: LongType if failOnIntegerOverflow => castIntegerToIntegerCode("int")
+    case _: LongType if failOnIntegerOverflow => castIntegerToIntegerExactCode("int")
     case _: FloatType | _: DoubleType if failOnIntegerOverflow =>
       castFractionToIntegerExactCode("int")
     case x: NumericType =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1252,7 +1252,7 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
       (c, evPrim, evNull) => code"$evPrim = $c ? (byte) 1 : (byte) 0;"
     case DateType =>
       (c, evPrim, evNull) => code"$evNull = true;"
-    case TimestampType =>
+    case TimestampType if failOnIntegerOverflow =>
       val longValue = ctx.freshName("longValue")
       (c, evPrim, evNull) =>
         code"""

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1255,8 +1255,11 @@ case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String
   private[this] def castDecimalToIntegralTypeCode(
       ctx: CodegenContext,
       integralType: String): CastFunction = {
-    (c, evPrim, evNull) =>
-      code"$evPrim = $c.to${integralType.capitalize}($failOnIntegralTypeOverflow);"
+    if (failOnIntegralTypeOverflow) {
+      (c, evPrim, evNull) => code"$evPrim = $c.roundTo${integralType.capitalize}();"
+    } else {
+      (c, evPrim, evNull) => code"$evPrim = $c.to${integralType.capitalize}();"
+    }
   }
 
   private[this] def castIntegralTypeToIntegralTypeExactCode(integralType: String): CastFunction = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -35,7 +35,7 @@ import org.apache.spark.unsafe.types.CalendarInterval
   """)
 case class UnaryMinus(child: Expression) extends UnaryExpression
     with ExpectsInputTypes with NullIntolerant {
-  private val checkOverflow = SQLConf.get.arithmeticOperationsFailOnOverflow
+  private val checkOverflow = SQLConf.get.failOnIntegerOverflow
 
   override def inputTypes: Seq[AbstractDataType] = Seq(TypeCollection.NumericAndInterval)
 
@@ -136,7 +136,7 @@ case class Abs(child: Expression)
 
 abstract class BinaryArithmetic extends BinaryOperator with NullIntolerant {
 
-  protected val checkOverflow = SQLConf.get.arithmeticOperationsFailOnOverflow
+  protected val checkOverflow = SQLConf.get.failOnIntegerOverflow
 
   override def dataType: DataType = left.dataType
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -35,7 +35,7 @@ import org.apache.spark.unsafe.types.CalendarInterval
   """)
 case class UnaryMinus(child: Expression) extends UnaryExpression
     with ExpectsInputTypes with NullIntolerant {
-  private val checkOverflow = SQLConf.get.failOnIntegerOverflow
+  private val checkOverflow = SQLConf.get.failOnIntegralTypeOverflow
 
   override def inputTypes: Seq[AbstractDataType] = Seq(TypeCollection.NumericAndInterval)
 
@@ -136,7 +136,7 @@ case class Abs(child: Expression)
 
 abstract class BinaryArithmetic extends BinaryOperator with NullIntolerant {
 
-  protected val checkOverflow = SQLConf.get.failOnIntegerOverflow
+  protected val checkOverflow = SQLConf.get.failOnIntegralTypeOverflow
 
   override def dataType: DataType = left.dataType
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/javaCode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/javaCode.scala
@@ -224,8 +224,7 @@ object Block {
       } else {
         args.foreach {
           case _: ExprValue | _: Inline | _: Block =>
-          case _: Boolean | _: Byte | _: Short| _: Int | _: Long | _: Float | _: Double |
-               _: String =>
+          case _: Boolean | _: Int | _: Long | _: Float | _: Double | _: String =>
           case other => throw new IllegalArgumentException(
             s"Can not interpolate ${other.getClass.getName} into code block.")
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/javaCode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/javaCode.scala
@@ -224,7 +224,8 @@ object Block {
       } else {
         args.foreach {
           case _: ExprValue | _: Inline | _: Block =>
-          case _: Boolean | _: Int | _: Long | _: Float | _: Double | _: String =>
+          case _: Boolean | _: Byte | _: Short| _: Int | _: Long | _: Float | _: Double |
+               _: String =>
           case other => throw new IllegalArgumentException(
             s"Can not interpolate ${other.getClass.getName} into code block.")
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1805,9 +1805,9 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
-  val ARITHMETIC_OPERATIONS_FAIL_ON_OVERFLOW =
-    buildConf("spark.sql.arithmeticOperations.failOnOverFlow")
-      .doc("If it is set to true, all arithmetic operations on non-decimal fields throw an " +
+  val FAIL_ON_INTEGER_OVERFLOW =
+    buildConf("spark.sql.failOnIntegerOverFlow")
+      .doc("If it is set to true, all operations on integral fields throw an " +
         "exception if an overflow occurs. If it is false (default), in case of overflow a wrong " +
         "result is returned.")
       .internal()
@@ -2321,7 +2321,7 @@ class SQLConf extends Serializable with Logging {
 
   def decimalOperationsNullOnOverflow: Boolean = getConf(DECIMAL_OPERATIONS_NULL_ON_OVERFLOW)
 
-  def arithmeticOperationsFailOnOverflow: Boolean = getConf(ARITHMETIC_OPERATIONS_FAIL_ON_OVERFLOW)
+  def failOnIntegerOverflow: Boolean = getConf(FAIL_ON_INTEGER_OVERFLOW)
 
   def literalPickMinimumPrecision: Boolean = getConf(LITERAL_PICK_MINIMUM_PRECISION)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1805,8 +1805,8 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
-  val FAIL_ON_INTEGER_OVERFLOW =
-    buildConf("spark.sql.failOnIntegerOverFlow")
+  val FAIL_ON_INTEGRAL_TYPE_OVERFLOW =
+    buildConf("spark.sql.failOnIntegralTypeOverflow")
       .doc("If it is set to true, all operations on integral fields throw an " +
         "exception if an overflow occurs. If it is false (default), in case of overflow a wrong " +
         "result is returned.")
@@ -2321,7 +2321,7 @@ class SQLConf extends Serializable with Logging {
 
   def decimalOperationsNullOnOverflow: Boolean = getConf(DECIMAL_OPERATIONS_NULL_ON_OVERFLOW)
 
-  def failOnIntegerOverflow: Boolean = getConf(FAIL_ON_INTEGER_OVERFLOW)
+  def failOnIntegralTypeOverflow: Boolean = getConf(FAIL_ON_INTEGRAL_TYPE_OVERFLOW)
 
   def literalPickMinimumPrecision: Boolean = getConf(LITERAL_PICK_MINIMUM_PRECISION)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -238,6 +238,91 @@ final class Decimal extends Ordered[Decimal] with Serializable {
 
   def toByte: Byte = toLong.toByte
 
+  private def overflowException(dataType: String) =
+    throw new ArithmeticException(s"Casting $this to $dataType causes overflow.")
+
+  /**
+   * @return the Byte value that is equal to the rounded decimal.
+   * @throws ArithmeticException if the decimal can't fit into Byte type.
+   */
+  def roundToByte(): Byte = {
+    if (decimalVal.eq(null)) {
+      val actualLongVal = longVal / POW_10(_scale)
+      if (actualLongVal == actualLongVal.toByte) {
+        actualLongVal.toByte
+      } else {
+        overflowException("byte")
+      }
+    } else {
+      val doubleVal = decimalVal.toDouble
+      if (Math.floor(doubleVal) <= Byte.MaxValue && Math.ceil(doubleVal) >= Byte.MinValue) {
+        doubleVal.toByte
+      } else {
+        overflowException("byte")
+      }
+    }
+  }
+
+  /**
+   * @return the Short value that is equal to the rounded decimal.
+   * @throws ArithmeticException if the decimal can't fit into Short type.
+   */
+  def roundToShort(): Short = {
+    if (decimalVal.eq(null)) {
+      val actualLongVal = longVal / POW_10(_scale)
+      if (actualLongVal == actualLongVal.toShort) {
+        actualLongVal.toShort
+      } else {
+        overflowException("short")
+      }
+    } else {
+      val doubleVal = decimalVal.toDouble
+      if (Math.floor(doubleVal) <= Short.MaxValue && Math.ceil(doubleVal) >= Short.MinValue) {
+        doubleVal.toShort
+      } else {
+        overflowException("short")
+      }
+    }
+  }
+
+  /**
+   * @return the Int value that is equal to the rounded decimal.
+   * @throws ArithmeticException if the decimal can't fit into Int type.
+   */
+  def roundToInt(): Int = {
+    if (decimalVal.eq(null)) {
+      val actualLongVal = longVal / POW_10(_scale)
+      if (actualLongVal == actualLongVal.toInt) {
+        actualLongVal.toInt
+      } else {
+        overflowException("int")
+      }
+    } else {
+      val doubleVal = decimalVal.toDouble
+      if (Math.floor(doubleVal) <= Int.MaxValue && Math.ceil(doubleVal) >= Int.MinValue) {
+        doubleVal.toInt
+      } else {
+        overflowException("int")
+      }
+    }
+  }
+
+  /**
+   * @return the Long value that is equal to the rounded decimal.
+   * @throws ArithmeticException if the decimal can't fit into Long type.
+   */
+  def roundToLong(): Long = {
+    if (decimalVal.eq(null)) {
+      longVal / POW_10(_scale)
+    } else {
+      try {
+        decimalVal.bigDecimal.toBigInteger.longValueExact()
+      } catch {
+        case _: ArithmeticException => overflowException("long")
+      }
+    }
+  }
+
   /**
    * Update precision and scale while keeping our value the same, and return true if successful.
    *

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -243,7 +243,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
 
   /**
    * @return the Byte value that is equal to the rounded decimal.
-   * @throws ArithmeticException if the decimal can't fit into Byte type.
+   * @throws ArithmeticException if the decimal is too big to fit in Byte type.
    */
   def roundToByte(): Byte = {
     if (decimalVal.eq(null)) {
@@ -265,7 +265,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
 
   /**
    * @return the Short value that is equal to the rounded decimal.
-   * @throws ArithmeticException if the decimal can't fit into Short type.
+   * @throws ArithmeticException if the decimal is too big to fit in Short type.
    */
   def roundToShort(): Short = {
     if (decimalVal.eq(null)) {
@@ -287,7 +287,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
 
   /**
    * @return the Int value that is equal to the rounded decimal.
-   * @throws ArithmeticException if the decimal can't fit into Int type.
+   * @throws ArithmeticException if the decimal too big to fit in Int type.
    */
   def roundToInt(): Int = {
     if (decimalVal.eq(null)) {
@@ -309,7 +309,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
 
   /**
    * @return the Long value that is equal to the rounded decimal.
-   * @throws ArithmeticException if the decimal can't fit into Long type.
+   * @throws ArithmeticException if the decimal too big to fit in Long type.
    */
   def roundToLong(): Long = {
     if (decimalVal.eq(null)) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -232,63 +232,11 @@ final class Decimal extends Ordered[Decimal] with Serializable {
     }
   }
 
-  /**
-   * @return the Long value that is equal to the rounded decimal.
-   * @throws ArithmeticException if checkOverflow is true and
-   *                             the decimal too big to fit in Long type.
-   */
-  def toLong(checkOverflow: Boolean): Long = {
-    if (!checkOverflow) {
-      toLong
-    } else {
-      roundToLong()
-    }
-  }
-
   def toInt: Int = toLong.toInt
-
-  /**
-   * @return the Int value that is equal to the rounded decimal.
-   * @throws ArithmeticException if checkOverflow is true and
-   *                             the decimal too big to fit in Int type.
-   */
-  def toInt(checkOverflow: Boolean): Int = {
-    if (!checkOverflow) {
-      toInt
-    } else {
-      roundToInt()
-    }
-  }
 
   def toShort: Short = toLong.toShort
 
-  /**
-   * @return the Short value that is equal to the rounded decimal.
-   * @throws ArithmeticException if checkOverflow is true and
-   *                             the decimal is too big to fit in Short type.
-   */
-  def toShort(checkOverflow: Boolean): Short = {
-    if (!checkOverflow) {
-      toShort
-    } else {
-      roundToShort()
-    }
-  }
-
   def toByte: Byte = toLong.toByte
-
-  /**
-   * @return the Byte value that is equal to the rounded decimal.
-   * @throws ArithmeticException if checkOverflow is true and
-   *                             the decimal is too big to fit in Byte type.
-   */
-  def toByte(checkOverflow: Boolean): Byte = {
-    if (!checkOverflow) {
-      toByte
-    } else {
-      roundToByte()
-    }
-  }
 
   private def overflowException(dataType: String) =
     throw new ArithmeticException(s"Casting $this to $dataType causes overflow.")
@@ -297,7 +245,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
    * @return the Byte value that is equal to the rounded decimal.
    * @throws ArithmeticException if the decimal is too big to fit in Byte type.
    */
-  private def roundToByte(): Byte = {
+  private[sql] def roundToByte(): Byte = {
     if (decimalVal.eq(null)) {
       val actualLongVal = longVal / POW_10(_scale)
       if (actualLongVal == actualLongVal.toByte) {
@@ -319,7 +267,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
    * @return the Short value that is equal to the rounded decimal.
    * @throws ArithmeticException if the decimal is too big to fit in Short type.
    */
-  private def roundToShort(): Short = {
+  private[sql] def roundToShort(): Short = {
     if (decimalVal.eq(null)) {
       val actualLongVal = longVal / POW_10(_scale)
       if (actualLongVal == actualLongVal.toShort) {
@@ -341,7 +289,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
    * @return the Int value that is equal to the rounded decimal.
    * @throws ArithmeticException if the decimal too big to fit in Int type.
    */
-  private def roundToInt(): Int = {
+  private[sql] def roundToInt(): Int = {
     if (decimalVal.eq(null)) {
       val actualLongVal = longVal / POW_10(_scale)
       if (actualLongVal == actualLongVal.toInt) {
@@ -363,12 +311,12 @@ final class Decimal extends Ordered[Decimal] with Serializable {
    * @return the Long value that is equal to the rounded decimal.
    * @throws ArithmeticException if the decimal too big to fit in Long type.
    */
-  private def roundToLong(): Long = {
+  private[sql] def roundToLong(): Long = {
     if (decimalVal.eq(null)) {
       longVal / POW_10(_scale)
     } else {
       try {
-        // We cannot store Long.MAX_VALUE as a double without losing precision.
+        // We cannot store Long.MAX_VALUE as a Double without losing precision.
         // Simply converting the decimal to `BigInteger` and using the method `longValueExact` can
         // guarantee the precision of the range check.
         decimalVal.bigDecimal.toBigInteger.longValueExact()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -368,6 +368,9 @@ final class Decimal extends Ordered[Decimal] with Serializable {
       longVal / POW_10(_scale)
     } else {
       try {
+        // We cannot store Long.MAX_VALUE as a double without losing precision.
+        // Simply converting the decimal to `BigInteger` and using the method `longValueExact` can
+        // guarantee the precision of the range check.
         decimalVal.bigDecimal.toBigInteger.longValueExact()
       } catch {
         case _: ArithmeticException => overflowException("long")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -317,8 +317,8 @@ final class Decimal extends Ordered[Decimal] with Serializable {
     } else {
       try {
         // We cannot store Long.MAX_VALUE as a Double without losing precision.
-        // Simply converting the decimal to `BigInteger` and using the method `longValueExact` can
-        // guarantee the precision of the range check.
+        // Here we simply convert the decimal to `BigInteger` and use the method
+        // `longValueExact` to make sure the range check is accurate.
         decimalVal.bigDecimal.toBigInteger.longValueExact()
       } catch {
         case _: ArithmeticException => overflowException("long")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -232,11 +232,63 @@ final class Decimal extends Ordered[Decimal] with Serializable {
     }
   }
 
+  /**
+   * @return the Long value that is equal to the rounded decimal.
+   * @throws ArithmeticException if checkOverflow is true and
+   *                             the decimal too big to fit in Long type.
+   */
+  def toLong(checkOverflow: Boolean): Long = {
+    if (!checkOverflow) {
+      toLong
+    } else {
+      roundToLong()
+    }
+  }
+
   def toInt: Int = toLong.toInt
+
+  /**
+   * @return the Int value that is equal to the rounded decimal.
+   * @throws ArithmeticException if checkOverflow is true and
+   *                             the decimal too big to fit in Int type.
+   */
+  def toInt(checkOverflow: Boolean): Int = {
+    if (!checkOverflow) {
+      toInt
+    } else {
+      roundToInt()
+    }
+  }
 
   def toShort: Short = toLong.toShort
 
+  /**
+   * @return the Short value that is equal to the rounded decimal.
+   * @throws ArithmeticException if checkOverflow is true and
+   *                             the decimal is too big to fit in Short type.
+   */
+  def toShort(checkOverflow: Boolean): Short = {
+    if (!checkOverflow) {
+      toShort
+    } else {
+      roundToShort()
+    }
+  }
+
   def toByte: Byte = toLong.toByte
+
+  /**
+   * @return the Byte value that is equal to the rounded decimal.
+   * @throws ArithmeticException if checkOverflow is true and
+   *                             the decimal is too big to fit in Byte type.
+   */
+  def toByte(checkOverflow: Boolean): Byte = {
+    if (!checkOverflow) {
+      toByte
+    } else {
+      roundToByte()
+    }
+  }
 
   private def overflowException(dataType: String) =
     throw new ArithmeticException(s"Casting $this to $dataType causes overflow.")
@@ -245,7 +297,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
    * @return the Byte value that is equal to the rounded decimal.
    * @throws ArithmeticException if the decimal is too big to fit in Byte type.
    */
-  def roundToByte(): Byte = {
+  private def roundToByte(): Byte = {
     if (decimalVal.eq(null)) {
       val actualLongVal = longVal / POW_10(_scale)
       if (actualLongVal == actualLongVal.toByte) {
@@ -267,7 +319,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
    * @return the Short value that is equal to the rounded decimal.
    * @throws ArithmeticException if the decimal is too big to fit in Short type.
    */
-  def roundToShort(): Short = {
+  private def roundToShort(): Short = {
     if (decimalVal.eq(null)) {
       val actualLongVal = longVal / POW_10(_scale)
       if (actualLongVal == actualLongVal.toShort) {
@@ -289,7 +341,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
    * @return the Int value that is equal to the rounded decimal.
    * @throws ArithmeticException if the decimal too big to fit in Int type.
    */
-  def roundToInt(): Int = {
+  private def roundToInt(): Int = {
     if (decimalVal.eq(null)) {
       val actualLongVal = longVal / POW_10(_scale)
       if (actualLongVal == actualLongVal.toInt) {
@@ -311,7 +363,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
    * @return the Long value that is equal to the rounded decimal.
    * @throws ArithmeticException if the decimal too big to fit in Long type.
    */
-  def roundToLong(): Long = {
+  private def roundToLong(): Long = {
     if (decimalVal.eq(null)) {
       longVal / POW_10(_scale)
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalType.scala
@@ -62,6 +62,8 @@ case class DecimalType(precision: Int, scale: Int) extends FractionalType {
   private[sql] val ordering = Decimal.DecimalIsFractional
   private[sql] val asIntegral = Decimal.DecimalAsIfIntegral
 
+  override private[sql] def exactNumeric = DecimalExactNumeric
+
   override def typeName: String = s"decimal($precision,$scale)"
 
   override def toString: String = s"DecimalType($precision,$scale)"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DoubleType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DoubleType.scala
@@ -42,6 +42,8 @@ class DoubleType private() extends FractionalType {
     (x: Double, y: Double) => Utils.nanSafeCompareDoubles(x, y)
   private[sql] val asIntegral = DoubleAsIfIntegral
 
+  override private[sql] def exactNumeric = DoubleExactNumeric
+
   /**
    * The default size of a value of the DoubleType is 8 bytes.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/FloatType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/FloatType.scala
@@ -43,6 +43,7 @@ class FloatType private() extends FractionalType {
   private[sql] val asIntegral = FloatAsIfIntegral
 
   override private[sql] def exactNumeric = FloatExactNumeric
+
   /**
    * The default size of a value of the FloatType is 4 bytes.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/FloatType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/FloatType.scala
@@ -42,6 +42,7 @@ class FloatType private() extends FractionalType {
     (x: Float, y: Float) => Utils.nanSafeCompareFloats(x, y)
   private[sql] val asIntegral = FloatAsIfIntegral
 
+  override private[sql] def exactNumeric = FloatExactNumeric
   /**
    * The default size of a value of the FloatType is 4 bytes.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
@@ -124,6 +124,16 @@ object FloatExactNumeric extends FloatIsFractional with Ordering.FloatOrdering {
 
   private val intUpperBound = Int.MaxValue + 1L
   private val intLowerBound = Int.MinValue - 1L
+  // We cannot compare `Long.MAX_VALUE` to a float without losing precision.
+  // In fact, the difference between `Math.nextUp(Long.MAX_VALUE.toFloat)` and
+  // `Long.MAX_VALUE.toFloat` is 1.09951163E12.
+  // To make it simple, we compare the input value with `Long.MaxValue.toFloat` directly.
+  private val longUpperBound = Long.MaxValue.toFloat
+  // We cannot compare `Long.MIN_VALUE` to a float without losing precision.
+  // In fact, the difference between `Math.nextDown(Long.MIN_VALUE.toFloat)` and
+  // `Long.MIN_VALUE.toFloat` is -1.09951163E12.
+  // To make it simple, we compare the input value with `Long.MIN_VALUE.toFloat` directly.
+  private val longLowerBound = Long.MinValue.toFloat
 
   override def toInt(x: Float): Int = {
     if (x < intUpperBound && x > intLowerBound) {
@@ -134,7 +144,7 @@ object FloatExactNumeric extends FloatIsFractional with Ordering.FloatOrdering {
   }
 
   override def toLong(x: Float): Long = {
-    if (x <= Long.MaxValue && x >= Long.MinValue) {
+    if (x <= longUpperBound && x >= longLowerBound) {
       x.toLong
     } else {
       throwException(x, "int")
@@ -148,6 +158,16 @@ object DoubleExactNumeric extends DoubleIsFractional with Ordering.DoubleOrderin
 
   private val intUpperBound = Int.MaxValue + 1L
   private val intLowerBound = Int.MinValue - 1L
+  // We cannot compare `Long.MAX_VALUE` to a double without losing precision.
+  // In fact, the difference between `Math.nextUp(Long.MAX_VALUE.toDouble)` and
+  // `Long.MAX_VALUE.toDouble` is 2048.
+  // To make it simple, we compare the input value with `Long.MaxValue.toDouble` directly.
+  private val longUpperBound = Long.MaxValue.toDouble
+  // We cannot compare `Long.MIN_VALUE` to a double without losing precision.
+  // In fact, the difference between `Math.nextDown(Long.MIN_VALUE.toDouble)` and
+  // `Long.MIN_VALUE.toDouble` is -2048.
+  // To make it simple, we compare the input value with `Long.MIN_VALUE.toDouble` directly.
+  private val longLowerBound = Long.MinValue.toDouble
 
   override def toInt(x: Double): Int = {
     if (x < intUpperBound && x > intLowerBound) {
@@ -158,7 +178,7 @@ object DoubleExactNumeric extends DoubleIsFractional with Ordering.DoubleOrderin
   }
 
   override def toLong(x: Double): Long = {
-    if (x <= Long.MaxValue && x >= Long.MinValue) {
+    if (x <= longUpperBound && x >= longLowerBound) {
       x.toLong
     } else {
       throw new ArithmeticException(throwException(x, "long"))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
@@ -119,7 +119,7 @@ object LongExactNumeric extends LongIsIntegral with Ordering.LongOrdering {
 }
 
 object FloatExactNumeric extends FloatIsFractional with Ordering.FloatOrdering {
-  private def throwException(x: Float, dataType: String) =
+  private def overflowException(x: Float, dataType: String) =
     throw new ArithmeticException(s"Casting $x to $dataType causes overflow.")
 
   private val intUpperBound = Int.MaxValue + 1L
@@ -139,7 +139,7 @@ object FloatExactNumeric extends FloatIsFractional with Ordering.FloatOrdering {
     if (x < intUpperBound && x > intLowerBound) {
       x.toInt
     } else {
-      throwException(x, "int")
+      overflowException(x, "int")
     }
   }
 
@@ -147,14 +147,14 @@ object FloatExactNumeric extends FloatIsFractional with Ordering.FloatOrdering {
     if (x <= longUpperBound && x >= longLowerBound) {
       x.toLong
     } else {
-      throwException(x, "int")
+      overflowException(x, "int")
     }
   }
 }
 
 object DoubleExactNumeric extends DoubleIsFractional with Ordering.DoubleOrdering {
-  private def throwException(x: Double, dataType: String): String =
-    s"Casting $x to $dataType causes overflow."
+  private def overflowException(x: Double, dataType: String) =
+    throw new ArithmeticException(s"Casting $x to $dataType causes overflow.")
 
   private val intUpperBound = Int.MaxValue + 1L
   private val intLowerBound = Int.MinValue - 1L
@@ -173,7 +173,7 @@ object DoubleExactNumeric extends DoubleIsFractional with Ordering.DoubleOrderin
     if (x < intUpperBound && x > intLowerBound) {
       x.toInt
     } else {
-      throw new ArithmeticException(throwException(x, "int"))
+      overflowException(x, "int")
     }
   }
 
@@ -181,7 +181,7 @@ object DoubleExactNumeric extends DoubleIsFractional with Ordering.DoubleOrderin
     if (x <= longUpperBound && x >= longLowerBound) {
       x.toLong
     } else {
-      throw new ArithmeticException(throwException(x, "long"))
+      overflowException(x, "long")
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
@@ -187,7 +187,7 @@ object DoubleExactNumeric extends DoubleIsFractional with Ordering.DoubleOrderin
 }
 
 object DecimalExactNumeric extends DecimalIsConflicted {
-  override def toInt(x: Decimal): Int = x.roundToInt()
+  override def toInt(x: Decimal): Int = x.toInt(checkOverflow = true)
 
-  override def toLong(x: Decimal): Long = x.roundToLong()
+  override def toLong(x: Decimal): Long = x.toLong(checkOverflow = true)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
@@ -177,7 +177,7 @@ object DoubleExactNumeric extends DoubleIsFractional with Ordering.DoubleOrderin
 }
 
 object DecimalExactNumeric extends DecimalIsConflicted {
-  override def toInt(x: Decimal): Int = x.toInt(checkOverflow = true)
+  override def toInt(x: Decimal): Int = x.roundToInt()
 
-  override def toLong(x: Decimal): Long = x.toLong(checkOverflow = true)
+  override def toLong(x: Decimal): Long = x.roundToLong()
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
@@ -122,8 +122,11 @@ object FloatExactNumeric extends FloatIsFractional with Ordering.FloatOrdering {
   private def exceptionMessage(x: Float, dataType: String): String =
     s"Casting $x to $dataType causes overflow."
 
+  private val intUpperBound = Int.MaxValue + 1L
+  private val intLowerBound = Int.MinValue - 1L
+
   override def toInt(x: Float): Int = {
-    if (x <= Int.MaxValue && x >= Int.MinValue) {
+    if (x < intUpperBound && x > intLowerBound) {
       x.toInt
     } else {
       throw new ArithmeticException(exceptionMessage(x, "Int"))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
@@ -187,27 +187,7 @@ object DoubleExactNumeric extends DoubleIsFractional with Ordering.DoubleOrderin
 }
 
 object DecimalExactNumeric extends DecimalIsConflicted {
-  private def exceptionMessage(x: Decimal, dataType: String): String =
-    s"Casting $x to $dataType causes overflow."
+  override def toInt(x: Decimal): Int = x.roundToInt()
 
-  private val intUpperBound = Decimal(Int.MaxValue + 1L)
-  private val intLowerBound = Decimal(Int.MinValue - 1L)
-  private val longUpperBound = Decimal(Long.MaxValue) + Decimal(1L)
-  private val longLowerBound = Decimal(Long.MinValue) - Decimal(1L)
-
-  override def toInt(x: Decimal): Int = {
-    if (x < intUpperBound && x > intLowerBound) {
-      x.toInt
-    } else {
-      throw new ArithmeticException(exceptionMessage(x, "int"))
-    }
-  }
-
-  override def toLong(x: Decimal): Long = {
-    if (x < longUpperBound && x > longLowerBound) {
-      x.toLong
-    } else {
-      throw new ArithmeticException(exceptionMessage(x, "long"))
-    }
-  }
+  override def toLong(x: Decimal): Long = x.roundToLong()
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
@@ -122,21 +122,19 @@ object FloatExactNumeric extends FloatIsFractional with Ordering.FloatOrdering {
   private def overflowException(x: Float, dataType: String) =
     throw new ArithmeticException(s"Casting $x to $dataType causes overflow.")
 
-  private val intUpperBound = Int.MaxValue + 1L
-  private val intLowerBound = Int.MinValue - 1L
-  // We cannot compare `Long.MAX_VALUE` to a float without losing precision.
-  // In fact, the difference between `Math.nextUp(Long.MAX_VALUE.toFloat)` and
-  // `Long.MAX_VALUE.toFloat` is 1.09951163E12.
-  // To make it simple, we compare the input value with `Long.MaxValue.toFloat` directly.
+  private val intUpperBound = Int.MaxValue.toFloat
+  private val intLowerBound = Int.MinValue.toFloat
   private val longUpperBound = Long.MaxValue.toFloat
-  // We cannot compare `Long.MIN_VALUE` to a float without losing precision.
-  // In fact, the difference between `Math.nextDown(Long.MIN_VALUE.toFloat)` and
-  // `Long.MIN_VALUE.toFloat` is -1.09951163E12.
-  // To make it simple, we compare the input value with `Long.MIN_VALUE.toFloat` directly.
   private val longLowerBound = Long.MinValue.toFloat
 
   override def toInt(x: Float): Int = {
-    if (x < intUpperBound && x > intLowerBound) {
+    // When casting floating values to integral types, Spark uses the method `Numeric.toInt`
+    // Or `Numeric.toLong` directly. For positive floating values, it is equivalent to `Math.floor`;
+    // for negative floating values, it is equivalent to `Math.ceil`.
+    // So, we can use the condition `Math.floor(x) <= upperBound && Math.ceil(x) >= lowerBound`
+    // to check if the floating value x is in the range of an integral type after rounding.
+    // This condition applies to converting Float/Double value to any integral types.
+    if (Math.floor(x) <= intUpperBound && Math.ceil(x) >= intLowerBound) {
       x.toInt
     } else {
       overflowException(x, "int")
@@ -144,7 +142,7 @@ object FloatExactNumeric extends FloatIsFractional with Ordering.FloatOrdering {
   }
 
   override def toLong(x: Float): Long = {
-    if (x <= longUpperBound && x >= longLowerBound) {
+    if (Math.floor(x) <= longUpperBound && Math.ceil(x) >= longLowerBound) {
       x.toLong
     } else {
       overflowException(x, "int")
@@ -156,21 +154,13 @@ object DoubleExactNumeric extends DoubleIsFractional with Ordering.DoubleOrderin
   private def overflowException(x: Double, dataType: String) =
     throw new ArithmeticException(s"Casting $x to $dataType causes overflow.")
 
-  private val intUpperBound = Int.MaxValue + 1L
-  private val intLowerBound = Int.MinValue - 1L
-  // We cannot compare `Long.MAX_VALUE` to a double without losing precision.
-  // In fact, the difference between `Math.nextUp(Long.MAX_VALUE.toDouble)` and
-  // `Long.MAX_VALUE.toDouble` is 2048.
-  // To make it simple, we compare the input value with `Long.MaxValue.toDouble` directly.
+  private val intUpperBound = Int.MaxValue.toDouble
+  private val intLowerBound = Int.MinValue.toDouble
   private val longUpperBound = Long.MaxValue.toDouble
-  // We cannot compare `Long.MIN_VALUE` to a double without losing precision.
-  // In fact, the difference between `Math.nextDown(Long.MIN_VALUE.toDouble)` and
-  // `Long.MIN_VALUE.toDouble` is -2048.
-  // To make it simple, we compare the input value with `Long.MIN_VALUE.toDouble` directly.
   private val longLowerBound = Long.MinValue.toDouble
 
   override def toInt(x: Double): Int = {
-    if (x < intUpperBound && x > intLowerBound) {
+    if (Math.floor(x) <= intUpperBound && Math.ceil(x) >= intLowerBound) {
       x.toInt
     } else {
       overflowException(x, "int")
@@ -178,7 +168,7 @@ object DoubleExactNumeric extends DoubleIsFractional with Ordering.DoubleOrderin
   }
 
   override def toLong(x: Double): Long = {
-    if (x <= longUpperBound && x >= longLowerBound) {
+    if (Math.floor(x) <= longUpperBound && Math.ceil(x) >= longLowerBound) {
       x.toLong
     } else {
       overflowException(x, "long")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
@@ -119,8 +119,8 @@ object LongExactNumeric extends LongIsIntegral with Ordering.LongOrdering {
 }
 
 object FloatExactNumeric extends FloatIsFractional with Ordering.FloatOrdering {
-  private def exceptionMessage(x: Float, dataType: String): String =
-    s"Casting $x to $dataType causes overflow."
+  private def throwException(x: Float, dataType: String) =
+    throw new ArithmeticException(s"Casting $x to $dataType causes overflow.")
 
   private val intUpperBound = Int.MaxValue + 1L
   private val intLowerBound = Int.MinValue - 1L
@@ -129,7 +129,7 @@ object FloatExactNumeric extends FloatIsFractional with Ordering.FloatOrdering {
     if (x < intUpperBound && x > intLowerBound) {
       x.toInt
     } else {
-      throw new ArithmeticException(exceptionMessage(x, "int"))
+      throwException(x, "int")
     }
   }
 
@@ -137,13 +137,13 @@ object FloatExactNumeric extends FloatIsFractional with Ordering.FloatOrdering {
     if (x <= Long.MaxValue && x >= Long.MinValue) {
       x.toLong
     } else {
-      throw new ArithmeticException(exceptionMessage(x, "long"))
+      throwException(x, "int")
     }
   }
 }
 
 object DoubleExactNumeric extends DoubleIsFractional with Ordering.DoubleOrdering {
-  private def exceptionMessage(x: Double, dataType: String): String =
+  private def throwException(x: Double, dataType: String): String =
     s"Casting $x to $dataType causes overflow."
 
   private val intUpperBound = Int.MaxValue + 1L
@@ -153,7 +153,7 @@ object DoubleExactNumeric extends DoubleIsFractional with Ordering.DoubleOrderin
     if (x < intUpperBound && x > intLowerBound) {
       x.toInt
     } else {
-      throw new ArithmeticException(exceptionMessage(x, "int"))
+      throw new ArithmeticException(throwException(x, "int"))
     }
   }
 
@@ -161,7 +161,7 @@ object DoubleExactNumeric extends DoubleIsFractional with Ordering.DoubleOrderin
     if (x <= Long.MaxValue && x >= Long.MinValue) {
       x.toLong
     } else {
-      throw new ArithmeticException(exceptionMessage(x, "long"))
+      throw new ArithmeticException(throwException(x, "long"))
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
@@ -114,7 +114,7 @@ object LongExactNumeric extends LongIsIntegral with Ordering.LongOrdering {
     if (x == x.toInt) {
       x.toInt
     } else {
-      throw new ArithmeticException(s"Casting $x to Int causes overflow.")
+      throw new ArithmeticException(s"Casting $x to int causes overflow.")
     }
 }
 
@@ -129,7 +129,7 @@ object FloatExactNumeric extends FloatIsFractional with Ordering.FloatOrdering {
     if (x < intUpperBound && x > intLowerBound) {
       x.toInt
     } else {
-      throw new ArithmeticException(exceptionMessage(x, "Int"))
+      throw new ArithmeticException(exceptionMessage(x, "int"))
     }
   }
 
@@ -137,7 +137,7 @@ object FloatExactNumeric extends FloatIsFractional with Ordering.FloatOrdering {
     if (x <= Long.MaxValue && x >= Long.MinValue) {
       x.toLong
     } else {
-      throw new ArithmeticException(exceptionMessage(x, "Long"))
+      throw new ArithmeticException(exceptionMessage(x, "long"))
     }
   }
 }
@@ -153,7 +153,7 @@ object DoubleExactNumeric extends DoubleIsFractional with Ordering.DoubleOrderin
     if (x < intUpperBound && x > intLowerBound) {
       x.toInt
     } else {
-      throw new ArithmeticException(exceptionMessage(x, "Int"))
+      throw new ArithmeticException(exceptionMessage(x, "int"))
     }
   }
 
@@ -161,7 +161,7 @@ object DoubleExactNumeric extends DoubleIsFractional with Ordering.DoubleOrderin
     if (x <= Long.MaxValue && x >= Long.MinValue) {
       x.toLong
     } else {
-      throw new ArithmeticException(exceptionMessage(x, "Long"))
+      throw new ArithmeticException(exceptionMessage(x, "long"))
     }
   }
 }
@@ -179,7 +179,7 @@ object DecimalExactNumeric extends DecimalIsConflicted {
     if (x < intUpperBound && x > intLowerBound) {
       x.toInt
     } else {
-      throw new ArithmeticException(exceptionMessage(x, "Int"))
+      throw new ArithmeticException(exceptionMessage(x, "int"))
     }
   }
 
@@ -187,7 +187,7 @@ object DecimalExactNumeric extends DecimalIsConflicted {
     if (x < longUpperBound && x > longLowerBound) {
       x.toLong
     } else {
-      throw new ArithmeticException(exceptionMessage(x, "Long"))
+      throw new ArithmeticException(exceptionMessage(x, "long"))
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
@@ -60,7 +60,7 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     checkEvaluation(Add(positiveLongLit, negativeLongLit), -1L)
 
     Seq("true", "false").foreach { checkOverflow =>
-      withSQLConf(SQLConf.ARITHMETIC_OPERATIONS_FAIL_ON_OVERFLOW.key -> checkOverflow) {
+      withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> checkOverflow) {
         DataTypeTestUtils.numericAndInterval.foreach { tpe =>
           checkConsistencyBetweenInterpretedAndCodegenAllowingException(Add, tpe, tpe)
         }
@@ -79,7 +79,7 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     checkEvaluation(UnaryMinus(Literal(Int.MinValue)), Int.MinValue)
     checkEvaluation(UnaryMinus(Literal(Short.MinValue)), Short.MinValue)
     checkEvaluation(UnaryMinus(Literal(Byte.MinValue)), Byte.MinValue)
-    withSQLConf(SQLConf.ARITHMETIC_OPERATIONS_FAIL_ON_OVERFLOW.key -> "true") {
+    withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> "true") {
       checkExceptionInExpression[ArithmeticException](
         UnaryMinus(Literal(Long.MinValue)), "overflow")
       checkExceptionInExpression[ArithmeticException](
@@ -121,7 +121,7 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     checkEvaluation(Subtract(positiveLongLit, negativeLongLit), positiveLong - negativeLong)
 
     Seq("true", "false").foreach { checkOverflow =>
-      withSQLConf(SQLConf.ARITHMETIC_OPERATIONS_FAIL_ON_OVERFLOW.key -> checkOverflow) {
+      withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> checkOverflow) {
         DataTypeTestUtils.numericAndInterval.foreach { tpe =>
           checkConsistencyBetweenInterpretedAndCodegenAllowingException(Subtract, tpe, tpe)
         }
@@ -143,7 +143,7 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     checkEvaluation(Multiply(positiveLongLit, negativeLongLit), positiveLong * negativeLong)
 
     Seq("true", "false").foreach { checkOverflow =>
-      withSQLConf(SQLConf.ARITHMETIC_OPERATIONS_FAIL_ON_OVERFLOW.key -> checkOverflow) {
+      withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> checkOverflow) {
         DataTypeTestUtils.numericTypeWithoutDecimal.foreach { tpe =>
           checkConsistencyBetweenInterpretedAndCodegenAllowingException(Multiply, tpe, tpe)
         }
@@ -414,12 +414,12 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     val e4 = Add(minLongLiteral, minLongLiteral)
     val e5 = Subtract(minLongLiteral, maxLongLiteral)
     val e6 = Multiply(minLongLiteral, minLongLiteral)
-    withSQLConf(SQLConf.ARITHMETIC_OPERATIONS_FAIL_ON_OVERFLOW.key -> "true") {
+    withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> "true") {
       Seq(e1, e2, e3, e4, e5, e6).foreach { e =>
         checkExceptionInExpression[ArithmeticException](e, "overflow")
       }
     }
-    withSQLConf(SQLConf.ARITHMETIC_OPERATIONS_FAIL_ON_OVERFLOW.key -> "false") {
+    withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> "false") {
       checkEvaluation(e1, Long.MinValue)
       checkEvaluation(e2, Long.MinValue)
       checkEvaluation(e3, -2L)
@@ -438,12 +438,12 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     val e4 = Add(minIntLiteral, minIntLiteral)
     val e5 = Subtract(minIntLiteral, maxIntLiteral)
     val e6 = Multiply(minIntLiteral, minIntLiteral)
-    withSQLConf(SQLConf.ARITHMETIC_OPERATIONS_FAIL_ON_OVERFLOW.key -> "true") {
+    withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> "true") {
       Seq(e1, e2, e3, e4, e5, e6).foreach { e =>
         checkExceptionInExpression[ArithmeticException](e, "overflow")
       }
     }
-    withSQLConf(SQLConf.ARITHMETIC_OPERATIONS_FAIL_ON_OVERFLOW.key -> "false") {
+    withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> "false") {
       checkEvaluation(e1, Int.MinValue)
       checkEvaluation(e2, Int.MinValue)
       checkEvaluation(e3, -2)
@@ -462,12 +462,12 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     val e4 = Add(minShortLiteral, minShortLiteral)
     val e5 = Subtract(minShortLiteral, maxShortLiteral)
     val e6 = Multiply(minShortLiteral, minShortLiteral)
-    withSQLConf(SQLConf.ARITHMETIC_OPERATIONS_FAIL_ON_OVERFLOW.key -> "true") {
+    withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> "true") {
       Seq(e1, e2, e3, e4, e5, e6).foreach { e =>
         checkExceptionInExpression[ArithmeticException](e, "overflow")
       }
     }
-    withSQLConf(SQLConf.ARITHMETIC_OPERATIONS_FAIL_ON_OVERFLOW.key -> "false") {
+    withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> "false") {
       checkEvaluation(e1, Short.MinValue)
       checkEvaluation(e2, Short.MinValue)
       checkEvaluation(e3, (-2).toShort)
@@ -486,12 +486,12 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     val e4 = Add(minByteLiteral, minByteLiteral)
     val e5 = Subtract(minByteLiteral, maxByteLiteral)
     val e6 = Multiply(minByteLiteral, minByteLiteral)
-    withSQLConf(SQLConf.ARITHMETIC_OPERATIONS_FAIL_ON_OVERFLOW.key -> "true") {
+    withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> "true") {
       Seq(e1, e2, e3, e4, e5, e6).foreach { e =>
         checkExceptionInExpression[ArithmeticException](e, "overflow")
       }
     }
-    withSQLConf(SQLConf.ARITHMETIC_OPERATIONS_FAIL_ON_OVERFLOW.key -> "false") {
+    withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> "false") {
       checkEvaluation(e1, Byte.MinValue)
       checkEvaluation(e2, Byte.MinValue)
       checkEvaluation(e3, (-2).toByte)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
@@ -60,7 +60,7 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     checkEvaluation(Add(positiveLongLit, negativeLongLit), -1L)
 
     Seq("true", "false").foreach { checkOverflow =>
-      withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> checkOverflow) {
+      withSQLConf(SQLConf.FAIL_ON_INTEGRAL_TYPE_OVERFLOW.key -> checkOverflow) {
         DataTypeTestUtils.numericAndInterval.foreach { tpe =>
           checkConsistencyBetweenInterpretedAndCodegenAllowingException(Add, tpe, tpe)
         }
@@ -79,7 +79,7 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     checkEvaluation(UnaryMinus(Literal(Int.MinValue)), Int.MinValue)
     checkEvaluation(UnaryMinus(Literal(Short.MinValue)), Short.MinValue)
     checkEvaluation(UnaryMinus(Literal(Byte.MinValue)), Byte.MinValue)
-    withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> "true") {
+    withSQLConf(SQLConf.FAIL_ON_INTEGRAL_TYPE_OVERFLOW.key -> "true") {
       checkExceptionInExpression[ArithmeticException](
         UnaryMinus(Literal(Long.MinValue)), "overflow")
       checkExceptionInExpression[ArithmeticException](
@@ -121,7 +121,7 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     checkEvaluation(Subtract(positiveLongLit, negativeLongLit), positiveLong - negativeLong)
 
     Seq("true", "false").foreach { checkOverflow =>
-      withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> checkOverflow) {
+      withSQLConf(SQLConf.FAIL_ON_INTEGRAL_TYPE_OVERFLOW.key -> checkOverflow) {
         DataTypeTestUtils.numericAndInterval.foreach { tpe =>
           checkConsistencyBetweenInterpretedAndCodegenAllowingException(Subtract, tpe, tpe)
         }
@@ -143,7 +143,7 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     checkEvaluation(Multiply(positiveLongLit, negativeLongLit), positiveLong * negativeLong)
 
     Seq("true", "false").foreach { checkOverflow =>
-      withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> checkOverflow) {
+      withSQLConf(SQLConf.FAIL_ON_INTEGRAL_TYPE_OVERFLOW.key -> checkOverflow) {
         DataTypeTestUtils.numericTypeWithoutDecimal.foreach { tpe =>
           checkConsistencyBetweenInterpretedAndCodegenAllowingException(Multiply, tpe, tpe)
         }
@@ -414,12 +414,12 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     val e4 = Add(minLongLiteral, minLongLiteral)
     val e5 = Subtract(minLongLiteral, maxLongLiteral)
     val e6 = Multiply(minLongLiteral, minLongLiteral)
-    withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> "true") {
+    withSQLConf(SQLConf.FAIL_ON_INTEGRAL_TYPE_OVERFLOW.key -> "true") {
       Seq(e1, e2, e3, e4, e5, e6).foreach { e =>
         checkExceptionInExpression[ArithmeticException](e, "overflow")
       }
     }
-    withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> "false") {
+    withSQLConf(SQLConf.FAIL_ON_INTEGRAL_TYPE_OVERFLOW.key -> "false") {
       checkEvaluation(e1, Long.MinValue)
       checkEvaluation(e2, Long.MinValue)
       checkEvaluation(e3, -2L)
@@ -438,12 +438,12 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     val e4 = Add(minIntLiteral, minIntLiteral)
     val e5 = Subtract(minIntLiteral, maxIntLiteral)
     val e6 = Multiply(minIntLiteral, minIntLiteral)
-    withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> "true") {
+    withSQLConf(SQLConf.FAIL_ON_INTEGRAL_TYPE_OVERFLOW.key -> "true") {
       Seq(e1, e2, e3, e4, e5, e6).foreach { e =>
         checkExceptionInExpression[ArithmeticException](e, "overflow")
       }
     }
-    withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> "false") {
+    withSQLConf(SQLConf.FAIL_ON_INTEGRAL_TYPE_OVERFLOW.key -> "false") {
       checkEvaluation(e1, Int.MinValue)
       checkEvaluation(e2, Int.MinValue)
       checkEvaluation(e3, -2)
@@ -462,12 +462,12 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     val e4 = Add(minShortLiteral, minShortLiteral)
     val e5 = Subtract(minShortLiteral, maxShortLiteral)
     val e6 = Multiply(minShortLiteral, minShortLiteral)
-    withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> "true") {
+    withSQLConf(SQLConf.FAIL_ON_INTEGRAL_TYPE_OVERFLOW.key -> "true") {
       Seq(e1, e2, e3, e4, e5, e6).foreach { e =>
         checkExceptionInExpression[ArithmeticException](e, "overflow")
       }
     }
-    withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> "false") {
+    withSQLConf(SQLConf.FAIL_ON_INTEGRAL_TYPE_OVERFLOW.key -> "false") {
       checkEvaluation(e1, Short.MinValue)
       checkEvaluation(e2, Short.MinValue)
       checkEvaluation(e3, (-2).toShort)
@@ -486,12 +486,12 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     val e4 = Add(minByteLiteral, minByteLiteral)
     val e5 = Subtract(minByteLiteral, maxByteLiteral)
     val e6 = Multiply(minByteLiteral, minByteLiteral)
-    withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> "true") {
+    withSQLConf(SQLConf.FAIL_ON_INTEGRAL_TYPE_OVERFLOW.key -> "true") {
       Seq(e1, e2, e3, e4, e5, e6).foreach { e =>
         checkExceptionInExpression[ArithmeticException](e, "overflow")
       }
     }
-    withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> "false") {
+    withSQLConf(SQLConf.FAIL_ON_INTEGRAL_TYPE_OVERFLOW.key -> "false") {
       checkEvaluation(e1, Byte.MinValue)
       checkEvaluation(e2, Byte.MinValue)
       checkEvaluation(e3, (-2).toByte)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -1103,7 +1103,7 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("Cast to byte with option FAIL_ON_INTEGER_OVERFLOW enabled") {
-    withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> "true") {
+    withSQLConf(SQLConf.FAIL_ON_INTEGRAL_TYPE_OVERFLOW.key -> "true") {
       testIntMaxAndMin(ByteType)
       Seq(Byte.MaxValue + 1, Byte.MinValue - 1).foreach { value =>
         checkExceptionInExpression[ArithmeticException](cast(value, ByteType), "overflow")
@@ -1128,7 +1128,7 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("Cast to short with option FAIL_ON_INTEGER_OVERFLOW enabled") {
-    withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> "true") {
+    withSQLConf(SQLConf.FAIL_ON_INTEGRAL_TYPE_OVERFLOW.key -> "true") {
       testIntMaxAndMin(ShortType)
       Seq(Short.MaxValue + 1, Short.MinValue - 1).foreach { value =>
         checkExceptionInExpression[ArithmeticException](cast(value, ShortType), "overflow")
@@ -1153,7 +1153,7 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("Cast to int with option FAIL_ON_INTEGER_OVERFLOW enabled") {
-    withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> "true") {
+    withSQLConf(SQLConf.FAIL_ON_INTEGRAL_TYPE_OVERFLOW.key -> "true") {
       testIntMaxAndMin(IntegerType)
       testLongMaxAndMin(IntegerType)
 
@@ -1170,7 +1170,7 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("Cast to long with option FAIL_ON_INTEGER_OVERFLOW enabled") {
-    withSQLConf(SQLConf.FAIL_ON_INTEGER_OVERFLOW.key -> "true") {
+    withSQLConf(SQLConf.FAIL_ON_INTEGRAL_TYPE_OVERFLOW.key -> "true") {
       testLongMaxAndMin(LongType)
 
       Seq(Long.MaxValue, 0, Long.MinValue).foreach { value =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -1077,6 +1077,7 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   private def testIntMaxAndMin(dt: DataType): Unit = {
+    assert(Seq(IntegerType, ShortType, ByteType).contains(dt))
     Seq(Int.MaxValue + 1L, Int.MinValue - 1L).foreach { value =>
       checkExceptionInExpression[ArithmeticException](cast(value, dt), "overflow")
       checkExceptionInExpression[ArithmeticException](cast(Decimal(value.toString), dt), "overflow")
@@ -1090,6 +1091,7 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   private def testLongMaxAndMin(dt: DataType): Unit = {
+    assert(Seq(LongType, IntegerType).contains(dt))
     Seq(Decimal(Long.MaxValue) + Decimal(1), Decimal(Long.MinValue) - Decimal(1)).foreach { value =>
       checkExceptionInExpression[ArithmeticException](
         cast(value, dt), "overflow")
@@ -1162,8 +1164,8 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
         checkEvaluation(cast(Literal(value * MICROS_PER_SECOND, TimestampType), IntegerType), value)
         checkEvaluation(cast(Literal(value * 1.0, DoubleType), IntegerType), value)
       }
-      checkEvaluation(cast(2147483647.9D, IntegerType), 2147483647)
-      checkEvaluation(cast(-2147483648.9D, IntegerType), -2147483648)
+      checkEvaluation(cast(Int.MaxValue + 0.9D, IntegerType), Int.MaxValue)
+      checkEvaluation(cast(Int.MinValue - 0.9D, IntegerType), Int.MinValue)
     }
   }
 
@@ -1178,10 +1180,10 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
         checkEvaluation(cast(Literal(value, TimestampType), LongType),
           Math.floorDiv(value, MICROS_PER_SECOND))
       }
-      checkEvaluation(cast(9223372036854775807.9f, LongType), 9223372036854775807L)
-      checkEvaluation(cast(-9223372036854775808.9f, LongType), -9223372036854775808L)
-      checkEvaluation(cast(9223372036854775807.9D, LongType), 9223372036854775807L)
-      checkEvaluation(cast(-9223372036854775808.9D, LongType), -9223372036854775808L)
+      checkEvaluation(cast(Long.MaxValue + 0.9F, LongType), Long.MaxValue)
+      checkEvaluation(cast(Long.MinValue - 0.9F, LongType), Long.MinValue)
+      checkEvaluation(cast(Long.MaxValue + 0.9D, LongType), Long.MaxValue)
+      checkEvaluation(cast(Long.MinValue - 0.9D, LongType), Long.MinValue)
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

To follow ANSI SQL, we should support a configurable mode that throws exceptions when casting to integers causes overflow.
The behavior is similar to https://issues.apache.org/jira/browse/SPARK-26218, which throws exceptions on arithmetical operation overflow.
To unify it, the configuration is renamed from "spark.sql.arithmeticOperations.failOnOverFlow" to "spark.sql.failOnIntegerOverFlow"
## How was this patch tested?

Unit test
