### PR TITLE
[SPARK-28745][SQL][TEST] Add benchmarks for `extract()`

### DIFF
--- a/sql/core/benchmarks/ExtractBenchmark-results.txt
+++ b/sql/core/benchmarks/ExtractBenchmark-results.txt
@@ -2,144 +2,144 @@
 Extract
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
-Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_222-b10 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    291            308          24         34.4          29.1       1.0X
-cast to timestamp wholestage on                     250            286          32         40.0          25.0       1.2X
+cast to timestamp wholestage off                    407            432          36         24.6          40.7       1.0X
+cast to timestamp wholestage on                     348            396          80         28.7          34.8       1.2X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
-Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_222-b10 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 MILLENNIUM of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-MILLENNIUM of timestamp wholestage off             1141           1142           1          8.8         114.1       1.0X
-MILLENNIUM of timestamp wholestage on              1064           1076           9          9.4         106.4       1.1X
+MILLENNIUM of timestamp wholestage off             1407           1408           2          7.1         140.7       1.0X
+MILLENNIUM of timestamp wholestage on              1334           1380          81          7.5         133.4       1.1X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
-Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_222-b10 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 CENTURY of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-CENTURY of timestamp wholestage off                1137           1140           5          8.8         113.7       1.0X
-CENTURY of timestamp wholestage on                 1113           1122           9          9.0         111.3       1.0X
+CENTURY of timestamp wholestage off                1362           1364           3          7.3         136.2       1.0X
+CENTURY of timestamp wholestage on                 1334           1342           8          7.5         133.4       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
-Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_222-b10 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 DECADE of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-DECADE of timestamp wholestage off                 1017           1020           3          9.8         101.7       1.0X
-DECADE of timestamp wholestage on                  1005           1016          12         10.0         100.5       1.0X
+DECADE of timestamp wholestage off                 1226           1229           4          8.2         122.6       1.0X
+DECADE of timestamp wholestage on                  1218           1225           8          8.2         121.8       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
-Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_222-b10 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 YEAR of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-YEAR of timestamp wholestage off                    991           1010          28         10.1          99.1       1.0X
-YEAR of timestamp wholestage on                    1006           1021          13          9.9         100.6       1.0X
+YEAR of timestamp wholestage off                   1207           1210           4          8.3         120.7       1.0X
+YEAR of timestamp wholestage on                    1201           1216          17          8.3         120.1       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
-Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_222-b10 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 ISOYEAR of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ISOYEAR of timestamp wholestage off                1165           1174          12          8.6         116.5       1.0X
-ISOYEAR of timestamp wholestage on                 1111           1134          18          9.0         111.1       1.0X
+ISOYEAR of timestamp wholestage off                1442           1446           6          6.9         144.2       1.0X
+ISOYEAR of timestamp wholestage on                 1315           1336          18          7.6         131.5       1.1X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
-Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_222-b10 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 QUARTER of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-QUARTER of timestamp wholestage off                1135           1141           9          8.8         113.5       1.0X
-QUARTER of timestamp wholestage on                 1158           1166           5          8.6         115.8       1.0X
+QUARTER of timestamp wholestage off                1443           1454          16          6.9         144.3       1.0X
+QUARTER of timestamp wholestage on                 1429           1442           9          7.0         142.9       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
-Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_222-b10 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 MONTH of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-MONTH of timestamp wholestage off                   997            998           1         10.0          99.7       1.0X
-MONTH of timestamp wholestage on                    992           1003           9         10.1          99.2       1.0X
+MONTH of timestamp wholestage off                  1196           1200           5          8.4         119.6       1.0X
+MONTH of timestamp wholestage on                   1192           1204          10          8.4         119.2       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
-Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_222-b10 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 WEEK of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-WEEK of timestamp wholestage off                   1799           1804           7          5.6         179.9       1.0X
-WEEK of timestamp wholestage on                    1378           1384           7          7.3         137.8       1.3X
+WEEK of timestamp wholestage off                   2103           2104           2          4.8         210.3       1.0X
+WEEK of timestamp wholestage on                    1798           1804           8          5.6         179.8       1.2X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
-Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_222-b10 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 DAY of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-DAY of timestamp wholestage off                    1030           1031           2          9.7         103.0       1.0X
-DAY of timestamp wholestage on                     1008           1019           8          9.9         100.8       1.0X
+DAY of timestamp wholestage off                    1211           1228          23          8.3         121.1       1.0X
+DAY of timestamp wholestage on                     1204           1212           6          8.3         120.4       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
-Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_222-b10 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 DAYOFWEEK of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-DAYOFWEEK of timestamp wholestage off              1123           1128           8          8.9         112.3       1.0X
-DAYOFWEEK of timestamp wholestage on               1116           1134          21          9.0         111.6       1.0X
+DAYOFWEEK of timestamp wholestage off              1387           1389           3          7.2         138.7       1.0X
+DAYOFWEEK of timestamp wholestage on               1353           1360           8          7.4         135.3       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
-Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_222-b10 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 DOW of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-DOW of timestamp wholestage off                    1132           1147          22          8.8         113.2       1.0X
-DOW of timestamp wholestage on                     1107           1111           4          9.0         110.7       1.0X
+DOW of timestamp wholestage off                    1373           1373           0          7.3         137.3       1.0X
+DOW of timestamp wholestage on                     1361           1372          15          7.3         136.1       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
-Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_222-b10 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 ISODOW of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ISODOW of timestamp wholestage off                 1081           1082           2          9.2         108.1       1.0X
-ISODOW of timestamp wholestage on                  1074           1090          19          9.3         107.4       1.0X
+ISODOW of timestamp wholestage off                 1311           1366          77          7.6         131.1       1.0X
+ISODOW of timestamp wholestage on                  1307           1314           6          7.7         130.7       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
-Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_222-b10 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 DOY of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-DOY of timestamp wholestage off                    1046           1073          37          9.6         104.6       1.0X
-DOY of timestamp wholestage on                     1026           1039          10          9.7         102.6       1.0X
+DOY of timestamp wholestage off                    1241           1243           2          8.1         124.1       1.0X
+DOY of timestamp wholestage on                     1229           1239           9          8.1         122.9       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
-Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_222-b10 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 HOUR of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-HOUR of timestamp wholestage off                    406            406           1         24.6          40.6       1.0X
-HOUR of timestamp wholestage on                     399            407           9         25.1          39.9       1.0X
+HOUR of timestamp wholestage off                    353            358           8         28.3          35.3       1.0X
+HOUR of timestamp wholestage on                     358            365           5         27.9          35.8       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
-Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_222-b10 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 MINUTE of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-MINUTE of timestamp wholestage off                  404            405           0         24.7          40.4       1.0X
-MINUTE of timestamp wholestage on                   400            406           6         25.0          40.0       1.0X
+MINUTE of timestamp wholestage off                  353            354           2         28.3          35.3       1.0X
+MINUTE of timestamp wholestage on                   362            368           9         27.6          36.2       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
-Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_222-b10 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 SECOND of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SECOND of timestamp wholestage off                  408            424          22         24.5          40.8       1.0X
-SECOND of timestamp wholestage on                   401            405           3         24.9          40.1       1.0X
+SECOND of timestamp wholestage off                  341            350          13         29.3          34.1       1.0X
+SECOND of timestamp wholestage on                   362            368           7         27.6          36.2       0.9X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
-Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_222-b10 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 MILLISECONDS of timestamp:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-MILLISECONDS of timestamp wholestage off          29329          30007         960          0.3        2932.9       1.0X
-MILLISECONDS of timestamp wholestage on           29611          29742          80          0.3        2961.1       1.0X
+MILLISECONDS of timestamp wholestage off          36785          36808          32          0.3        3678.5       1.0X
+MILLISECONDS of timestamp wholestage on           36644          36760          72          0.3        3664.4       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
-Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_222-b10 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 MICROSECONDS of timestamp:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-MICROSECONDS of timestamp wholestage off            493            497           5         20.3          49.3       1.0X
-MICROSECONDS of timestamp wholestage on             495            508          12         20.2          49.5       1.0X
+MICROSECONDS of timestamp wholestage off            446            447           0         22.4          44.6       1.0X
+MICROSECONDS of timestamp wholestage on             458            463           4         21.8          45.8       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
-Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_222-b10 on Linux 3.10.0-862.3.2.el7.x86_64
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 EPOCH of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-EPOCH of timestamp wholestage off                 24148          24174          36          0.4        2414.8       1.0X
-EPOCH of timestamp wholestage on                  23748          23978         167          0.4        2374.8       1.0X
+EPOCH of timestamp wholestage off                 29807          29811           5          0.3        2980.7       1.0X
+EPOCH of timestamp wholestage on                  29843          29930          64          0.3        2984.3       1.0X
 
 

--- a/sql/core/benchmarks/ExtractBenchmark-results.txt
+++ b/sql/core/benchmarks/ExtractBenchmark-results.txt
@@ -1,0 +1,145 @@
+================================================================================================
+Extract
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+cast to timestamp wholestage off                    291            308          24         34.4          29.1       1.0X
+cast to timestamp wholestage on                     250            286          32         40.0          25.0       1.2X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+MILLENNIUM of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+MILLENNIUM of timestamp wholestage off             1141           1142           1          8.8         114.1       1.0X
+MILLENNIUM of timestamp wholestage on              1064           1076           9          9.4         106.4       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+CENTURY of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+CENTURY of timestamp wholestage off                1137           1140           5          8.8         113.7       1.0X
+CENTURY of timestamp wholestage on                 1113           1122           9          9.0         111.3       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+DECADE of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+DECADE of timestamp wholestage off                 1017           1020           3          9.8         101.7       1.0X
+DECADE of timestamp wholestage on                  1005           1016          12         10.0         100.5       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+YEAR of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+YEAR of timestamp wholestage off                    991           1010          28         10.1          99.1       1.0X
+YEAR of timestamp wholestage on                    1006           1021          13          9.9         100.6       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+ISOYEAR of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+ISOYEAR of timestamp wholestage off                1165           1174          12          8.6         116.5       1.0X
+ISOYEAR of timestamp wholestage on                 1111           1134          18          9.0         111.1       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+QUARTER of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+QUARTER of timestamp wholestage off                1135           1141           9          8.8         113.5       1.0X
+QUARTER of timestamp wholestage on                 1158           1166           5          8.6         115.8       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+MONTH of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+MONTH of timestamp wholestage off                   997            998           1         10.0          99.7       1.0X
+MONTH of timestamp wholestage on                    992           1003           9         10.1          99.2       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+WEEK of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+WEEK of timestamp wholestage off                   1799           1804           7          5.6         179.9       1.0X
+WEEK of timestamp wholestage on                    1378           1384           7          7.3         137.8       1.3X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+DAY of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+DAY of timestamp wholestage off                    1030           1031           2          9.7         103.0       1.0X
+DAY of timestamp wholestage on                     1008           1019           8          9.9         100.8       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+DAYOFWEEK of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+DAYOFWEEK of timestamp wholestage off              1123           1128           8          8.9         112.3       1.0X
+DAYOFWEEK of timestamp wholestage on               1116           1134          21          9.0         111.6       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+DOW of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+DOW of timestamp wholestage off                    1132           1147          22          8.8         113.2       1.0X
+DOW of timestamp wholestage on                     1107           1111           4          9.0         110.7       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+ISODOW of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+ISODOW of timestamp wholestage off                 1081           1082           2          9.2         108.1       1.0X
+ISODOW of timestamp wholestage on                  1074           1090          19          9.3         107.4       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+DOY of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+DOY of timestamp wholestage off                    1046           1073          37          9.6         104.6       1.0X
+DOY of timestamp wholestage on                     1026           1039          10          9.7         102.6       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+HOUR of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+HOUR of timestamp wholestage off                    406            406           1         24.6          40.6       1.0X
+HOUR of timestamp wholestage on                     399            407           9         25.1          39.9       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+MINUTE of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+MINUTE of timestamp wholestage off                  404            405           0         24.7          40.4       1.0X
+MINUTE of timestamp wholestage on                   400            406           6         25.0          40.0       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+SECOND of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+SECOND of timestamp wholestage off                  408            424          22         24.5          40.8       1.0X
+SECOND of timestamp wholestage on                   401            405           3         24.9          40.1       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+MILLISECONDS of timestamp:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+MILLISECONDS of timestamp wholestage off          29329          30007         960          0.3        2932.9       1.0X
+MILLISECONDS of timestamp wholestage on           29611          29742          80          0.3        2961.1       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+MICROSECONDS of timestamp:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+MICROSECONDS of timestamp wholestage off            493            497           5         20.3          49.3       1.0X
+MICROSECONDS of timestamp wholestage on             495            508          12         20.2          49.5       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+EPOCH of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+EPOCH of timestamp wholestage off                 24148          24174          36          0.4        2414.8       1.0X
+EPOCH of timestamp wholestage on                  23748          23978         167          0.4        2374.8       1.0X
+
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ExtractBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ExtractBenchmark.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.benchmark
+
+import java.time.Instant
+
+/**
+ * Synthetic benchmark for the extract function.
+ * To run this benchmark:
+ * {{{
+ *   1. without sbt:
+ *      bin/spark-submit --class <this class> --jars <spark core test jar> <sql core test jar>
+ *   2. build/sbt "sql/test:runMain <this class>"
+ *   3. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain <this class>"
+ *      Results will be written to "benchmarks/ExtractBenchmark-results.txt".
+ * }}}
+ */
+object ExtractBenchmark extends SqlBasedBenchmark {
+  private def doBenchmark(cardinality: Long, exprs: String*): Unit = {
+    val sinceSecond = Instant.parse("2010-01-01T00:00:00Z").getEpochSecond
+    spark
+      .range(sinceSecond, sinceSecond + cardinality, 1, 1)
+      .selectExpr(exprs: _*)
+      .write.format("noop").save()
+  }
+
+  private def run(cardinality: Long, name: String, exprs: String*): Unit = {
+    codegenBenchmark(name, cardinality) {
+      doBenchmark(cardinality, exprs: _*)
+    }
+  }
+
+  private def run(cardinality: Int, field: String): Unit = {
+    codegenBenchmark(s"$field of timestamp", cardinality) {
+      doBenchmark(cardinality, s"EXTRACT($field FROM (cast(id as timestamp)))")
+    }
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    val N = 10000000L
+    runBenchmark("Extract") {
+      run(N, "cast to timestamp", "cast(id as timestamp)")
+      run(N, "MILLENNIUM")
+      run(N, "CENTURY")
+      run(N, "DECADE")
+      run(N, "YEAR")
+      run(N, "ISOYEAR")
+      run(N, "QUARTER")
+      run(N, "MONTH")
+      run(N, "WEEK")
+      run(N, "DAY")
+      run(N, "DAYOFWEEK")
+      run(N, "DOW")
+      run(N, "ISODOW")
+      run(N, "DOY")
+      run(N, "HOUR")
+      run(N, "MINUTE")
+      run(N, "SECOND")
+      run(N, "MILLISECONDS")
+      run(N, "MICROSECONDS")
+      run(N, "EPOCH")
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ExtractBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ExtractBenchmark.scala
@@ -37,7 +37,9 @@ object ExtractBenchmark extends SqlBasedBenchmark {
     spark
       .range(sinceSecond, sinceSecond + cardinality, 1, 1)
       .selectExpr(exprs: _*)
-      .write.format("noop").save()
+      .write
+      .format("noop")
+      .save()
   }
 
   private def run(cardinality: Long, name: String, exprs: String*): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ExtractBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ExtractBenchmark.scala
@@ -48,7 +48,7 @@ object ExtractBenchmark extends SqlBasedBenchmark {
     }
   }
 
-  private def run(cardinality: Int, field: String): Unit = {
+  private def run(cardinality: Long, field: String): Unit = {
     codegenBenchmark(s"$field of timestamp", cardinality) {
       doBenchmark(cardinality, s"EXTRACT($field FROM (cast(id as timestamp)))")
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added new benchmark `ExtractBenchmark` for the `EXTRACT(field FROM source)` function. It was executed on all currently supported values of the `field` argument:  `MILLENNIUM`, `CENTURY`, `DECADE`, `YEAR`, `ISOYEAR`, `QUARTER`, `MONTH`, `WEEK`, `DAY`, `DAYOFWEEK`, `HOUR`, `MINUTE`, `SECOND`, `MILLISECONDS`, `MICROSECONDS`, `EPOCH`. The `cast(id as timestamp)` was taken as the `source` argument.

## How was this patch tested?

By running the benchmark via:
```
$ SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain org.apache.spark.sql.execution.benchmark.ExtractBenchmark"
```