### PR TITLE
[SPARK-27637][Shuffle][FOLLOW-UP]For nettyBlockTransferService, if IOException occurred while create client, check whether relative executor is alive before retry #24533

### DIFF
--- a/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
@@ -117,8 +117,8 @@ private[spark] class NettyBlockTransferService(
     try {
       val blockFetchStarter = new RetryingBlockFetcher.BlockFetchStarter {
         override def createAndStart(blockIds: Array[String], listener: BlockFetchingListener) {
-          val client = clientFactory.createClient(host, port)
           try {
+            val client = clientFactory.createClient(host, port)
             new OneForOneBlockFetcher(client, appId, execId, blockIds, listener,
               transportConf, tempFileManager).start()
           } catch {


### PR DESCRIPTION
### What changes were proposed in this pull request?

In pr #[24533](https://github.com/apache/spark/pull/24533/files) , it prevent retry to a removed Executor. 
In my test, I can't catch exceptions from 
` new OneForOneBlockFetcher(client, appId, execId, blockIds, listener,
              transportConf, tempFileManager).start()`
And I check the code carefully， method **start()** will handle exception of IOException in it's retry logical, won't throw it out. until it meet maxRetry times or meet exception that is not  IOException. 

And if we meet the situation that when we fetch block , the executor is dead, when we rerun 
`RetryingBlockFetcher.BlockFetchStarter.createAndStart()`
we may failed when we create a transport client to dead executor. it will throw a IOException. 
We should catch this IOException.

### Why are the changes needed?
Old solution not comprehensive. Didn't cover more case.


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Existed Unit Test