### PR TITLE
[SPARK-28751][Core][WIP] Improve java serializer deserialization performance

### DIFF
--- a/core/benchmarks/JavaSerializerBenchmark-results.txt
+++ b/core/benchmarks/JavaSerializerBenchmark-results.txt
@@ -1,0 +1,22 @@
+================================================================================================
+Benchmark Java Serializer Deserialization use vs not use Class Resolve Cache
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_111-b14 on Linux 4.15.0-55-generic
+Intel(R) Core(TM) i7-6950X CPU @ 3.00GHz
+Benchmark Java Serializer Deserialization use vs not use Class Resolve Cache:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Int with cache:true                                 173            200          58          0.6        1733.9       1.0X
+Long with cache:true                                161            163           2          0.6        1614.3       1.1X
+Float with cache:true                               161            179          45          0.6        1612.0       1.1X
+Double with cache:true                              162            164           2          0.6        1624.3       1.1X
+String(10) with cache:true                           41             42           2          2.4         410.3       4.2X
+Person(String(10), Int) with cache:true             185            186           3          0.5        1850.5       0.9X
+Student(Person, String(10)) with cache:true            390            392           3          0.3        3900.8       0.4X
+Int with cache:false                                241            248          13          0.4        2414.2       0.7X
+Long with cache:false                               234            235           2          0.4        2335.6       0.7X
+Float with cache:false                              238            242           6          0.4        2381.0       0.7X
+Double with cache:false                             239            240           1          0.4        2390.4       0.7X
+String(10) with cache:false                          41             43           1          2.4         414.7       4.2X
+Person(String(10), Int) with cache:false            244            245           1          0.4        2437.4       0.7X
+Student(Person, String(10)) with cache:false            509            511           1          0.2        5086.7       0.3X

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1333,6 +1333,11 @@ package object config {
     .booleanConf
     .createWithDefault(true)
 
+  private[spark] val JAVA_SERIALIZER_CACHE_RESOLVED_CLASSES =
+    ConfigBuilder("spark.serializer.JavaSerializer.cache.resolvedClasses")
+      .booleanConf
+      .createWithDefault(true)
+
   private[spark] val JARS = ConfigBuilder("spark.jars")
     .stringConf
     .toSequence

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1334,7 +1334,8 @@ package object config {
     .createWithDefault(true)
 
   private[spark] val JAVA_SERIALIZER_CACHE_RESOLVED_CLASSES =
-    ConfigBuilder("spark.serializer.JavaSerializer.cache.resolvedClasses")
+    ConfigBuilder("spark.serializer.javaSerializer.cache.resolvedClasses")
+      .doc("Whether to cache the resolved class when deserialize object with JavaSerializer")
       .booleanConf
       .createWithDefault(true)
 

--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
@@ -272,13 +272,13 @@ private[netty] class NettyRpcEnv(
    * Returns [[SerializationStream]] that forwards the serialized bytes to `out`.
    */
   private[netty] def serializeStream(out: OutputStream): SerializationStream = {
-    serializer.get.serializeStream(out)
+    serializer.get().serializeStream(out)
   }
 
   private[netty] def deserialize[T: ClassTag](client: TransportClient, bytes: ByteBuffer): T = {
     NettyRpcEnv.currentClient.withValue(client) {
       deserialize { () =>
-        serializer.get.deserialize[T](bytes)
+        serializer.get().deserialize[T](bytes)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/serializer/JavaSerializerBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/JavaSerializerBenchmark.scala
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.serializer
+
+import java.nio.ByteBuffer
+
+import scala.reflect.ClassTag
+import scala.util.Random
+
+import org.apache.spark.SparkConf
+import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
+import org.apache.spark.internal.config._
+
+/**
+ * Benchmark for Java Serializer Deserialization use vs not use Class Resolve Cache.
+ * To run this benchmark:
+ * {{{
+ *   1. without sbt:
+ *      bin/spark-submit --class <this class> --jars <spark core test jar>
+ *   2. build/sbt "core/test:runMain <this class>"
+ *   3. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "core/test:runMain <this class>"
+ *      Results will be written to "benchmarks/JavaSerializerBenchmark-results.txt".
+ * }}}
+ */
+object JavaSerializerBenchmark extends BenchmarkBase {
+
+  val N = 100000
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    val name = "Benchmark Java Serializer Deserialization use vs not use Class Resolve Cache"
+    runBenchmark(name) {
+      val benchmark = new Benchmark(name, N, 10, output = output)
+      Seq(true, false).foreach(useUnsafe => run(useUnsafe, benchmark))
+      benchmark.run()
+    }
+  }
+
+  private def run(useCache: Boolean, benchmark: Benchmark): Unit = {
+    // Benchmark Primitives
+    def createCase[T: ClassTag](name: String, size: Int, gen: () => T): Unit = {
+      lazy val ser = createSerializer(useCache)
+      val data: Array[ByteBuffer] = Array.fill(size)(ser.serialize(gen()))
+
+      benchmark.addCase(s"$name with cache:$useCache") { _ =>
+        var i = 0
+        var s: ByteBuffer = null
+        while (i < size) {
+          s = data(i)
+          s.rewind()
+          ser.deserialize(s)
+          i += 1
+        }
+      }
+    }
+    createCase("Int", N, () => Random.nextInt())
+    createCase("Long", N, () => Random.nextLong())
+    createCase("Float", N, () => Random.nextFloat())
+    createCase("Double", N, () => Random.nextDouble())
+    createCase("String(10)", N, () => Random.nextString(10))
+
+    val personNameLen = 10
+    createCase("Person(String(10), Int)", N,
+      () => Person(Random.nextString(personNameLen), Random.nextInt()))
+
+    val schoolLen = 10
+    createCase("Student(Person, String(10))", N, () =>
+      Student(Person(Random.nextString(personNameLen), Random.nextInt()),
+        Random.nextString(schoolLen)))
+  }
+
+  def createSerializer(cache: Boolean): SerializerInstance = {
+    val conf = new SparkConf()
+    conf.set(JAVA_SERIALIZER_CACHE_RESOLVED_CLASSES, cache)
+
+    new JavaSerializer(conf).newInstance()
+  }
+}
+
+case class Person(name: String, id: Int)
+case class Student(person: Person, school: String)

--- a/core/src/test/scala/org/apache/spark/serializer/JavaSerializerBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/JavaSerializerBenchmark.scala
@@ -51,7 +51,6 @@ object JavaSerializerBenchmark extends BenchmarkBase {
   }
 
   private def run(useCache: Boolean, benchmark: Benchmark): Unit = {
-    // Benchmark Primitives
     def createCase[T: ClassTag](name: String, size: Int, gen: () => T): Unit = {
       lazy val ser = createSerializer(useCache)
       val data: Array[ByteBuffer] = Array.fill(size)(ser.serialize(gen()))

--- a/core/src/test/scala/org/apache/spark/serializer/JavaSerializerBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/JavaSerializerBenchmark.scala
@@ -45,7 +45,7 @@ object JavaSerializerBenchmark extends BenchmarkBase {
     val name = "Benchmark Java Serializer Deserialization use vs not use Class Resolve Cache"
     runBenchmark(name) {
       val benchmark = new Benchmark(name, N, 10, output = output)
-      Seq(true, false).foreach(useUnsafe => run(useUnsafe, benchmark))
+      Seq(true, false).foreach(userCache => run(userCache, benchmark))
       benchmark.run()
     }
   }

--- a/core/src/test/scala/org/apache/spark/serializer/JavaSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/JavaSerializerSuite.scala
@@ -18,25 +18,113 @@
 package org.apache.spark.serializer
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.internal.config.JAVA_SERIALIZER_CACHE_RESOLVED_CLASSES
 
 class JavaSerializerSuite extends SparkFunSuite {
-  test("JavaSerializer instances are serializable") {
-    val serializer = new JavaSerializer(new SparkConf())
+  test("JavaSerializer(without resolve class cache) instances are serializable") {
+    val serializer = getSerializer(false)
     val instance = serializer.newInstance()
     val obj = instance.deserialize[JavaSerializer](instance.serialize(serializer))
     // enforce class cast
     obj.getClass
   }
 
-  test("Deserialize object containing a primitive Class as attribute") {
-    val serializer = new JavaSerializer(new SparkConf())
+  test("JavaSerializer(with resolve class cache) instances are serializable") {
+    val serializer = getSerializer(true)
+    val instance = serializer.newInstance()
+    val obj = instance.deserialize[JavaSerializer](instance.serialize(serializer))
+    // enforce class cast
+    obj.getClass
+  }
+
+  test("Deserialize(without resolve class cache) object containing a primitive " +
+    "Class as attribute") {
+    val serializer = getSerializer(false)
     val instance = serializer.newInstance()
     val obj = instance.deserialize[ContainsPrimitiveClass](instance.serialize(
       new ContainsPrimitiveClass()))
     // enforce class cast
     obj.getClass
   }
+
+  test("Deserialize(with resolve class cache) object containing a primitive " +
+    "Class as attribute") {
+    val serializer = getSerializer(true)
+    val instance = serializer.newInstance()
+    val obj = instance.deserialize[ContainsPrimitiveClass](instance.serialize(
+      new ContainsPrimitiveClass()))
+    // enforce class cast
+    obj.getClass
+  }
+
+  test ("Deserialize(without resolve class cache) object with provider ClassLoader") {
+    val serializer = getSerializer(false)
+    val instance = serializer.newInstance()
+    deserializeWithClassLoader(instance)
+    deserializeWithClassLoader(instance)
+  }
+
+  test ("Deserialize(with resolve class cache) object with provider ClassLoader") {
+    val serializer = getSerializer(true)
+    val instance = serializer.newInstance()
+    deserializeWithClassLoader(instance)
+    deserializeWithClassLoader(instance)
+  }
+
+  private def deserializeWithClassLoader(instance: SerializerInstance): Unit = {
+    val myClass1Instance1 = new MyClass1
+    val myClass2Instance1 = new MyClass2
+    val bytes1 = instance.serialize(myClass1Instance1)
+    val bytes2 = instance.serialize(myClass2Instance1)
+    val deserialized1 = instance.deserialize[MyClass1](bytes1, loader1)
+    val deserialized2 = instance.deserialize[MyClass2](bytes2, loader2)
+    deserialized1.getClass
+    deserialized2.getClass
+
+    bytes1.rewind()
+    bytes2.rewind()
+
+    val thrown1 = intercept[ClassNotFoundException] {
+      instance.deserialize(bytes1, loader2)
+    }
+    assert(thrown1.getMessage.contains("ClassLoader2 can't load class"))
+
+    val thrown2 = intercept[ClassNotFoundException] {
+      instance.deserialize(bytes2, loader1)
+    }
+    assert(thrown2.getMessage.contains("ClassLoader1 can't load class"))
+  }
+
+  def getSerializer(cache: Boolean): JavaSerializer = {
+    val conf = new SparkConf()
+    conf.set(JAVA_SERIALIZER_CACHE_RESOLVED_CLASSES, cache)
+
+    new JavaSerializer(conf)
+  }
+
+  lazy val loader1 = new ClassLoader(null) {
+    override def loadClass(name: String): Class[_] = {
+      if (classOf[MyClass1].getName == name) {
+        classOf[MyClass1]
+      } else {
+        throw new ClassNotFoundException(s"ClassLoader1 can't load class :${name}")
+      }
+    }
+  }
+
+  lazy val loader2 = new ClassLoader(null) {
+    override def loadClass(name: String): Class[_] = {
+      if (classOf[MyClass2].getName == name) {
+        classOf[MyClass2]
+      } else {
+        throw new ClassNotFoundException(s"ClassLoader2 can't load class :${name}")
+      }
+    }
+  }
 }
+
+class MyClass1 extends Serializable
+class MyClass2 extends Serializable
 
 private class ContainsPrimitiveClass extends Serializable {
   val intClass = classOf[Int]


### PR DESCRIPTION
### What changes were proposed in this pull request?

Improve the performance of java serializer deserialization by caching the resolved class. Java serializer is used in many places: closure, RPC and others. This change could improve the performance of deserialization 1.3X ~ 1.5X.  Especially for java primitive instances. 

And also, add new UT tests and benchmarks case.

### Why are the changes needed?

This change could improve the performance of deserialization 1.3X ~ 1.5X.  Especially for java primitive instances. 


### Does this PR introduce any user-facing change?

Add new config to enable disable this feature, default is true. This shouldn't influence the existed code.


### How was this patch tested?
New UT tests.
