### PR TITLE
[SPARK-28756][R] Fix checkJavaVersion to accept JDK8+

### DIFF
--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -13,7 +13,7 @@ Authors@R: c(person("Shivaram", "Venkataraman", role = c("aut", "cre"),
 License: Apache License (== 2.0)
 URL: https://www.apache.org/ https://spark.apache.org/
 BugReports: https://spark.apache.org/contributing.html
-SystemRequirements: Java (== 8)
+SystemRequirements: Java (>= 8)
 Depends:
     R (>= 3.1),
     methods

--- a/R/pkg/R/client.R
+++ b/R/pkg/R/client.R
@@ -100,7 +100,8 @@ checkJavaVersion <- function() {
     javaVersionNum <- as.integer(versions[1])
   }
   if (javaVersionNum < sparkJavaVersion) {
-    stop(paste("Java version", sparkJavaVersion, ", or greater, is required for this package; found version:",
+    stop(paste("Java version", sparkJavaVersion,
+               ", or greater, is required for this package; found version:",
                javaVersionStr))
   }
   return(javaVersionNum)

--- a/R/pkg/R/client.R
+++ b/R/pkg/R/client.R
@@ -95,12 +95,12 @@ checkJavaVersion <- function() {
   # We are using 8, 9, 10, 11 for sparkJavaVersion.
   versions = strsplit(javaVersionStr, "[.]")[[1L]]
   if ("1" == versions[1]) {
-      javaVersionNum <- as.integer(versions[2])
+    javaVersionNum <- as.integer(versions[2])
   } else {
-      javaVersionNum <- as.integer(versions[1])
+    javaVersionNum <- as.integer(versions[1])
   }
   if (javaVersionNum < sparkJavaVersion) {
-    stop(paste("Java version", sparkJavaVersion, "is required for this package; found version:",
+    stop(paste("Java version", sparkJavaVersion, ", or greater, is required for this package; found version:",
                javaVersionStr))
   }
   return(javaVersionNum)

--- a/R/pkg/R/client.R
+++ b/R/pkg/R/client.R
@@ -93,7 +93,7 @@ checkJavaVersion <- function() {
   javaVersionStr <- strsplit(javaVersionFilter[[1]], "[\"]")[[1L]][2]
   # javaVersionStr is of the form 1.8.0_92/9.0.x/11.0.x.
   # We are using 8, 9, 10, 11 for sparkJavaVersion.
-  versions = strsplit(javaVersionStr, "[.]")[[1L]]
+  versions <- strsplit(javaVersionStr, "[.]")[[1L]]
   if ("1" == versions[1]) {
     javaVersionNum <- as.integer(versions[2])
   } else {

--- a/R/pkg/R/client.R
+++ b/R/pkg/R/client.R
@@ -91,10 +91,15 @@ checkJavaVersion <- function() {
       }, javaVersionOut)
 
   javaVersionStr <- strsplit(javaVersionFilter[[1]], "[\"]")[[1L]][2]
-  # javaVersionStr is of the form 1.8.0_92.
-  # Extract 8 from it to compare to sparkJavaVersion
-  javaVersionNum <- as.integer(strsplit(javaVersionStr, "[.]")[[1L]][2])
-  if (javaVersionNum != sparkJavaVersion) {
+  # javaVersionStr is of the form 1.8.0_92/9.0.x/11.0.x.
+  # We are using 8, 9, 10, 11 for sparkJavaVersion.
+  versions = strsplit(javaVersionStr, "[.]")[[1L]]
+  if ("1" == versions[1]) {
+      javaVersionNum <- as.integer(versions[2])
+  } else {
+      javaVersionNum <- as.integer(versions[1])
+  }
+  if (javaVersionNum < sparkJavaVersion) {
     stop(paste("Java version", sparkJavaVersion, "is required for this package; found version:",
                javaVersionStr))
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, `checkJavaVersion` only accepts JDK8 because it compares with the number in `SystemRequirements`. This PR changes it to accept the higher version, too.

### Why are the changes needed?
Without this, two test suites are skipped on JDK11 environment due to this check.

**BEFORE**
```
$ build/mvn -Phadoop-3.2 -Psparkr -DskipTests package
$ R/install-dev.sh
$ R/run-tests.sh
...
basic tests for CRAN: SS

Skipped ------------------------------------------------------------------------
1. create DataFrame from list or data.frame (@test_basic.R#21) - error on Java check
2. spark.glm and predict (@test_basic.R#57) - error on Java check
DONE ===========================================================================
```

**AFTER**
```
basic tests for CRAN: .............

DONE ===========================================================================
```

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?

Manually, build and test on JDK11.