### PR TITLE
[SPARK-28758][BUILD][SQL] Upgrade Janino to 3.0.15

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -30,7 +30,7 @@ commons-beanutils-1.9.3.jar
 commons-cli-1.2.jar
 commons-codec-1.10.jar
 commons-collections-3.2.2.jar
-commons-compiler-3.0.13.jar
+commons-compiler-3.0.15.jar
 commons-compress-1.8.1.jar
 commons-configuration-1.6.jar
 commons-crypto-1.0.0.jar
@@ -96,7 +96,7 @@ jackson-module-paranamer-2.9.9.jar
 jackson-module-scala_2.12-2.9.9.jar
 jackson-xc-1.9.13.jar
 jakarta.xml.bind-api-2.3.2.jar
-janino-3.0.13.jar
+janino-3.0.15.jar
 javassist-3.18.1-GA.jar
 javax.annotation-api-1.2.jar
 javax.inject-1.jar

--- a/dev/deps/spark-deps-hadoop-3.2
+++ b/dev/deps/spark-deps-hadoop-3.2
@@ -28,7 +28,7 @@ commons-beanutils-1.9.3.jar
 commons-cli-1.2.jar
 commons-codec-1.10.jar
 commons-collections-3.2.2.jar
-commons-compiler-3.0.13.jar
+commons-compiler-3.0.15.jar
 commons-compress-1.8.1.jar
 commons-configuration2-2.1.1.jar
 commons-crypto-1.0.0.jar
@@ -97,7 +97,7 @@ jackson-module-jaxb-annotations-2.9.9.jar
 jackson-module-paranamer-2.9.9.jar
 jackson-module-scala_2.12-2.9.9.jar
 jakarta.xml.bind-api-2.3.2.jar
-janino-3.0.13.jar
+janino-3.0.15.jar
 javassist-3.18.1-GA.jar
 javax.annotation-api-1.2.jar
 javax.inject-1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
     <!-- org.apache.commons/commons-lang3/-->
     <commons-lang3.version>3.8.1</commons-lang3.version>
     <datanucleus-core.version>3.2.10</datanucleus-core.version>
-    <janino.version>3.0.13</janino.version>
+    <janino.version>3.0.15</janino.version>
     <jersey.version>2.22.2</jersey.version>
     <joda.version>2.9.3</joda.version>
     <jodd.version>3.5.2</jodd.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `Janino` from `3.0.13` to `3.0.15` in order to bring the bug fixes. Please note that `3.1.0` is a major refactoring instead of bug fixes. We had better use `3.0.15` and wait for the stabler 3.1.x.

### Why are the changes needed?

This brings the following bug fixes.

**3.0.15 (2019-07-28)**

- Fix overloaded single static method import

**3.0.14 (2019-07-05)**

- Conflict in sbt-assembly
- Overloaded static on-demand imported methods cause a CompileException: Ambiguous static method import
- Handle overloaded static on-demand imports
- Major refactoring of the Java 8 and Java 9 retrofit mechanism
- Added tests for "JLS8 8.6 Instance Initializers" and "JLS8 8.7 Static Initializers"
- Local variables in instance initializers don't work
- Provide an option to keep generated code files
- Added compile error handler and warning handler to ICompiler

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Pass the Jenkins with the existing tests.