### PR TITLE
[SPARK-28759][BUILD] Upgrade scala-maven-plugin to 4.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2254,7 +2254,7 @@
         <plugin>
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
-          <version>3.4.4</version>
+          <version>4.1.1</version>
           <executions>
             <execution>
               <id>eclipse-add-source</id>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `scala-maven-plugin` to 4.1.1 to bring the improvement (including Scala 2.13.0 support, Zinc update) and bug fixes in the plugin.


### Why are the changes needed?

`4.1.1` uses the latest dependent plugins.

### Does this PR introduce any user-facing change?

No.


### How was this patch tested?

Pass the Jenkins.