### PR TITLE
[SPARK-28763][SQL][TEST] Flaky Tests: SparkThriftServerProtocolVersionsSuite.HIVE_CLI_SERVICE_PROTOCOL_V1 get binary type

### DIFF
--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkThriftServerProtocolVersionsSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkThriftServerProtocolVersionsSuite.scala
@@ -222,10 +222,11 @@ class SparkThriftServerProtocolVersionsSuite extends HiveThriftJdbcTest {
         assert(rs.next())
         assert(rs.getString(1) === "ABC")
       }
-      testExecuteStatementWithProtocolVersion(version,
-        "SELECT cast(cast(49960 as int) as binary)") { rs =>
+      testExecuteStatementWithProtocolVersion(version, "SELECT cast(49960 as binary)") { rs =>
         assert(rs.next())
-        assert(rs.getString(1) === UTF8String.fromBytes(NumberConverter.toBinary(49960)).toString)
+        assertResult(Array(0, 0, 65533, 40).map(_.toChar)) {
+          rs.getString(1).toCharArray
+        }
       }
       testExecuteStatementWithProtocolVersion(version, "SELECT cast(null as binary)") { rs =>
         assert(rs.next())

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkThriftServerProtocolVersionsSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkThriftServerProtocolVersionsSuite.scala
@@ -222,7 +222,8 @@ class SparkThriftServerProtocolVersionsSuite extends HiveThriftJdbcTest {
         assert(rs.next())
         assert(rs.getString(1) === "ABC")
       }
-      testExecuteStatementWithProtocolVersion(version, "SELECT cast(49960 as binary)") { rs =>
+      testExecuteStatementWithProtocolVersion(version,
+        "SELECT cast(cast(49960 as int) as binary)") { rs =>
         assert(rs.next())
         assert(rs.getString(1) === UTF8String.fromBytes(NumberConverter.toBinary(49960)).toString)
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr try to fix flaky tests:
```
org.scalatest.exceptions.TestFailedException: "[?](" did not equal "[�]("
```

```
org.apache.spark.sql.hive.thriftserver.SparkThriftServerProtocolVersionsSuite.HIVE_CLI_SERVICE_PROTOCOL_V1 get binary type | 0.48 秒 | 2
-- | -- | --
org.apache.spark.sql.hive.thriftserver.SparkThriftServerProtocolVersionsSuite.HIVE_CLI_SERVICE_PROTOCOL_V2 get binary type | 0.34 秒 | 2
org.apache.spark.sql.hive.thriftserver.SparkThriftServerProtocolVersionsSuite.HIVE_CLI_SERVICE_PROTOCOL_V3 get binary type | 0.36 秒 | 2
org.apache.spark.sql.hive.thriftserver.SparkThriftServerProtocolVersionsSuite.HIVE_CLI_SERVICE_PROTOCOL_V4 get binary type | 0.3 秒 | 2
org.apache.spark.sql.hive.thriftserver.SparkThriftServerProtocolVersionsSuite.HIVE_CLI_SERVICE_PROTOCOL_V5 get binary type | 0.36 秒 | 2
```

https://amplab.cs.berkeley.edu/jenkins/job/NewSparkPullRequestBuilder/4832/testReport/

### How was this patch tested?
N/A
