### PR TITLE
[SPARK-28749][TEST][BRANCH-2.4] Fix PySpark tests not to require kafka-0-8

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -252,6 +252,9 @@ streaming_kinesis_asl = Module(
 )
 
 
+# kafka-0-8 support is deprecated as of Spark 2.3 and removed in Spark 3.x.
+# Since Spark 2.4 supports Scala-2.12, and kafka-0-8 does not, we have made
+# streaming-kafka-0-8 optional for pyspark testing in 2.4.
 streaming_kafka = Module(
     name="streaming-kafka-0-8",
     dependencies=[streaming],

--- a/python/pyspark/streaming/tests.py
+++ b/python/pyspark/streaming/tests.py
@@ -1519,11 +1519,7 @@ def search_kafka_assembly_jar():
     kafka_assembly_dir = os.path.join(SPARK_HOME, "external/kafka-0-8-assembly")
     jars = search_jar(kafka_assembly_dir, "spark-streaming-kafka-0-8-assembly")
     if not jars:
-        raise Exception(
-            ("Failed to find Spark Streaming kafka assembly jar in %s. " % kafka_assembly_dir) +
-            "You need to build Spark with "
-            "'build/sbt -Pkafka-0-8 assembly/package streaming-kafka-0-8-assembly/assembly' or "
-            "'build/mvn -DskipTests -Pkafka-0-8 package' before running this test.")
+        return None
     elif len(jars) > 1:
         raise Exception(("Found multiple Spark Streaming Kafka assembly JARs: %s; please "
                          "remove all but one") % (", ".join(jars)))
@@ -1579,13 +1575,11 @@ if __name__ == "__main__":
     kafka_assembly_jar = search_kafka_assembly_jar()
     flume_assembly_jar = search_flume_assembly_jar()
     kinesis_asl_assembly_jar = search_kinesis_asl_assembly_jar()
+    jars_list = [j for j in (kafka_assembly_jar, flume_assembly_jar, kinesis_asl_assembly_jar) if j]
+    jars = ",".join(jars_list)
 
-    if kinesis_asl_assembly_jar is None:
-        kinesis_jar_present = False
-        jars = "%s,%s" % (kafka_assembly_jar, flume_assembly_jar)
-    else:
-        kinesis_jar_present = True
-        jars = "%s,%s,%s" % (kafka_assembly_jar, flume_assembly_jar, kinesis_asl_assembly_jar)
+    kinesis_jar_present = kinesis_asl_assembly_jar in jars_list
+    kafka08_jar_present = kafka_assembly_jar in jars_list
 
     existing_args = os.environ.get("PYSPARK_SUBMIT_ARGS", "pyspark-shell")
     jars_args = "--jars %s" % jars
@@ -1601,12 +1595,15 @@ if __name__ == "__main__":
             "Skipped test_flume_stream (enable by setting environment variable %s=1"
             % flume_test_environ_var)
 
-    if are_kafka_tests_enabled:
+    if kafka08_jar_present:
         testcases.append(KafkaStreamTests)
     else:
-        sys.stderr.write(
-            "Skipped test_kafka_stream (enable by setting environment variable %s=1"
-            % kafka_test_environ_var)
+        sys.stderr.write("Skipping kafka-0-8 tests as the optional kafka-0-8 profile was "
+                         "not compiled into a JAR. To run these tests, "
+                         "you need to build Spark with "
+                         "'build/sbt -Pkafka-0-8 assembly/package streaming-kafka-0-8-assembly/assembly' or "
+                         "'build/mvn -DskipTests -Pkafka-0-8 package' before running this test. "
+                         "Note that kafka-0-8 is not compatible with Scala version 2.12 and higher.")
 
     if kinesis_jar_present is True:
         testcases.append(KinesisStreamTests)

--- a/python/pyspark/streaming/tests.py
+++ b/python/pyspark/streaming/tests.py
@@ -1600,10 +1600,11 @@ if __name__ == "__main__":
     else:
         sys.stderr.write("Skipping kafka-0-8 tests as the optional kafka-0-8 profile was "
                          "not compiled into a JAR. To run these tests, "
-                         "you need to build Spark with "
-                         "'build/sbt -Pkafka-0-8 assembly/package streaming-kafka-0-8-assembly/assembly' or "
+                         "you need to build Spark with 'build/sbt -Pkafka-0-8 assembly/package "
+                         "streaming-kafka-0-8-assembly/assembly' or "
                          "'build/mvn -DskipTests -Pkafka-0-8 package' before running this test. "
-                         "Note that kafka-0-8 is not compatible with Scala version 2.12 and higher.")
+                         "Note that kafka-0-8 is not compatible with Scala version 2.12 and "
+                         "higher.")
 
     if kinesis_jar_present is True:
         testcases.append(KinesisStreamTests)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Simple fix of https://issues.apache.org/jira/browse/SPARK-28749

### Why are the changes needed?
As discussed in the referenced Jira, currently, the PySpark tests invoked by `python/run-tests` demand the presence of kafka-0-8 libraries. If not present, a failure message will be generated regardless of whether the tests are enabled by env variables. Since Kafka-0-8 libraries are not compatible with Scala-2.12, this means we can’t successfully run pyspark tests on a Scala-2.12 build.  These proposed changes fix the problem. 

### Does this PR introduce any user-facing change?
No. It only changes a test behavior. 

### How was this patch tested?
This is a fix of a test bug. The current behavior is demonstrably wrong under Scala-2.12, as stated above. The corrected behavior allows the tests to run to completion, with results that are consistent with the expected results, similar to the successful Scala-2.11 results.

We performed the following:
- Full mvn build under Scala-2.11, with kafka-0-8 profile
- Full mvn build under Scala-2.12, without kafka-0-8 profile
- Full maven Unit Test of both, with no change (as expected)
- PySpark tests via `python/run-tests` with both.  Both complete successfully.

Former behavior before this patch was that the last step would post a Failure on the Scala-2.12 build.

### Notes for reviewers
There are of course many ways to fix the problem. I chose to follow the pattern established by the Kinesis testing routines that were right “next to” the Kafka-0-8 test routines in the same file. They showed a presumably acceptable way of dealing with missing jars. 

I ignored the env variable, because the presence or absence of the jar seemed a sufficient and more important determinant. But if you want me to use the env variable exactly the same way as the Kinesis testing code, I’ll be happy to do so. 