### PR TITLE
[SPARK-28766][R][DOC] Fix CRAN incoming feasibility warning on invalid URL

### DIFF
--- a/R/pkg/R/context.R
+++ b/R/pkg/R/context.R
@@ -325,7 +325,8 @@ setCheckpointDirSC <- function(sc, dirName) {
 #'
 #' A directory can be given if the recursive option is set to true.
 #' Currently directories are only supported for Hadoop-supported filesystems.
-#' Refer Hadoop-supported filesystems at \url{https://cwiki.apache.org/confluence/display/HADOOP2/HCFS}.
+#' Refer Hadoop-supported filesystems at
+#' \url{https://cwiki.apache.org/confluence/display/HADOOP2/HCFS}.
 #'
 #' Note: A path can be added only once. Subsequent additions of the same path are ignored.
 #'

--- a/R/pkg/R/context.R
+++ b/R/pkg/R/context.R
@@ -325,7 +325,7 @@ setCheckpointDirSC <- function(sc, dirName) {
 #'
 #' A directory can be given if the recursive option is set to true.
 #' Currently directories are only supported for Hadoop-supported filesystems.
-#' Refer Hadoop-supported filesystems at \url{https://wiki.apache.org/hadoop/HCFS}.
+#' Refer Hadoop-supported filesystems at \url{https://cwiki.apache.org/confluence/display/HADOOP2/HCFS}.
 #'
 #' Note: A path can be added only once. Subsequent additions of the same path are ignored.
 #'


### PR DESCRIPTION
### What changes were proposed in this pull request?

This updates an URL in R doc to fix `Had CRAN check errors; see logs`.

### Why are the changes needed?
Currently, this invalid link causes a warning during CRAN incoming feasibility. We had better fix this before submitting `3.0.0/2.4.4/2.3.4`.

**BEFORE**
```
* checking CRAN incoming feasibility ... NOTE
Maintainer: ‘Shivaram Venkataraman <shivaram@cs.berkeley.edu>’

Found the following (possibly) invalid URLs:
  URL: https://wiki.apache.org/hadoop/HCFS (moved to https://cwiki.apache.org/confluence/display/hadoop/HCFS)
    From: man/spark.addFile.Rd
    Status: 404
    Message: Not Found
```

**AFTER**
```
* checking CRAN incoming feasibility ... Note_to_CRAN_maintainers
Maintainer: ‘Shivaram Venkataraman <shivaram@cs.berkeley.edu>’
```

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Check the warning message during R testing.
```
$ R/install-dev.sh
$ R/run-tests.sh
```