### PR TITLE
[SPARK-28699][SQL] Disable using radix sort for ShuffleExchangeExec in repartition case

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -29,7 +29,7 @@ import org.apache.spark.shuffle.sort.SortShuffleManager
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.errors._
 import org.apache.spark.sql.catalyst.expressions.{Attribute, BoundReference, UnsafeProjection, UnsafeRow}
-import org.apache.spark.sql.catalyst.expressions.codegen.{GenerateOrdering, LazilyGeneratedOrdering}
+import org.apache.spark.sql.catalyst.expressions.codegen.LazilyGeneratedOrdering
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics, SQLShuffleReadMetricsReporter, SQLShuffleWriteMetricsReporter}
@@ -237,57 +237,36 @@ object ShuffleExchangeExec {
       // that case all output rows go to the same partition.
       val newRdd = if (isRoundRobin && SQLConf.get.sortBeforeRepartition) {
         rdd.mapPartitionsInternal { iter =>
-          val schema = StructType.fromAttributes(outputAttributes)
-          val canUseRadixSort = SQLConf.get.enableRadixSort && schema.length == 1 &&
-            SortPrefixUtils.canSortFullyWithPrefix(schema.head)
+          val recordComparatorSupplier = new Supplier[RecordComparator] {
+            override def get: RecordComparator = new RecordBinaryComparator()
+          }
+          // The comparator for comparing row hashcode, which should always be Integer.
+          val prefixComparator = PrefixComparators.LONG
+
+          // The prefix computer generates row hashcode as the prefix, so we may decrease the
+          // probability that the prefixes are equal when input rows choose column values from a
+          // limited range.
+          val prefixComputer = new UnsafeExternalRowSorter.PrefixComputer {
+            private val result = new UnsafeExternalRowSorter.PrefixComputer.Prefix
+            override def computePrefix(row: InternalRow):
+            UnsafeExternalRowSorter.PrefixComputer.Prefix = {
+              // The hashcode generated from the binary form of a [[UnsafeRow]] should not be null.
+              result.isNull = false
+              result.value = row.hashCode()
+              result
+            }
+          }
           val pageSize = SparkEnv.get.memoryManager.pageSizeBytes
 
-          val sorter = if (canUseRadixSort) {
-            // For better performance, enable radix sort if possible.
-            val prefixComputer = SortPrefixUtils.createPrefixGenerator(schema)
-            val prefixComparator = SortPrefixUtils.getPrefixComparator(schema)
-            val ordering = GenerateOrdering.create(schema)
-
-            UnsafeExternalRowSorter.create(
-              schema,
-              ordering,
-              prefixComparator,
-              prefixComputer,
-              pageSize,
-              true)
-          } else {
-            val recordComparatorSupplier = new Supplier[RecordComparator] {
-              override def get: RecordComparator = new RecordBinaryComparator()
-            }
-            // The comparator for comparing row hashcode, which should always be Integer.
-            val prefixComparator = PrefixComparators.LONG
-
-            // The prefix computer generates row hashcode as the prefix, so we may decrease the
-            // probability that the prefixes are equal when input rows choose column values from a
-            // limited range.
-            val prefixComputer = new UnsafeExternalRowSorter.PrefixComputer {
-              private val result = new UnsafeExternalRowSorter.PrefixComputer.Prefix
-              override def computePrefix(row: InternalRow):
-              UnsafeExternalRowSorter.PrefixComputer.Prefix = {
-                // The hashcode generated from the binary form of a [[UnsafeRow]] should not
-                // be null.
-                result.isNull = false
-                result.value = row.hashCode()
-                result
-              }
-            }
-
-            UnsafeExternalRowSorter.createWithRecordComparator(
-              schema,
-              recordComparatorSupplier,
-              prefixComparator,
-              prefixComputer,
-              pageSize,
-              // We are comparing binary here, which does not support radix sort.
-              // See more details in SPARK-28699.
-              false)
-          }
-
+          val sorter = UnsafeExternalRowSorter.createWithRecordComparator(
+            StructType.fromAttributes(outputAttributes),
+            recordComparatorSupplier,
+            prefixComparator,
+            prefixComputer,
+            pageSize,
+            // We are comparing binary here, which does not support radix sort.
+            // See more details in SPARK-28699.
+            false)
           sorter.sort(iter.asInstanceOf[Iterator[UnsafeRow]])
         }
       } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -264,6 +264,10 @@ object ShuffleExchangeExec {
             prefixComparator,
             prefixComputer,
             pageSize,
+            // As we need to compare the binary of UnsafeRow here, we can't make sure whether all
+            // the fields can sort fully with prefix like SortExec. So we disable radix sort here
+            // to avoid getting unstable sort, and result to a correctness bug.
+            // See more details in SPARK-28699.
             false /* canUseRadixSort */)
           sorter.sort(iter.asInstanceOf[Iterator[UnsafeRow]])
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -268,7 +268,7 @@ object ShuffleExchangeExec {
             // the fields can sort fully with prefix like SortExec. So we disable radix sort here
             // to avoid getting unstable sort, and result to a correctness bug.
             // See more details in SPARK-28699.
-            false /* canUseRadixSort */)
+            false)
           sorter.sort(iter.asInstanceOf[Iterator[UnsafeRow]])
         }
       } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -264,9 +264,7 @@ object ShuffleExchangeExec {
             prefixComparator,
             prefixComputer,
             pageSize,
-            // As we need to compare the binary of UnsafeRow here, we can't make sure whether all
-            // the fields can sort fully with prefix like SortExec. So we disable radix sort here
-            // to avoid getting unstable sort, and result to a correctness bug.
+            // We are comparing binary here, which does not support radix sort.
             // See more details in SPARK-28699.
             false)
           sorter.sort(iter.asInstanceOf[Iterator[UnsafeRow]])

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -242,7 +242,7 @@ object ShuffleExchangeExec {
           }
           // The comparator for comparing row hashcode, which should always be Integer.
           val prefixComparator = PrefixComparators.LONG
-          val canUseRadixSort = SQLConf.get.enableRadixSort
+
           // The prefix computer generates row hashcode as the prefix, so we may decrease the
           // probability that the prefixes are equal when input rows choose column values from a
           // limited range.
@@ -264,7 +264,7 @@ object ShuffleExchangeExec {
             prefixComparator,
             prefixComputer,
             pageSize,
-            canUseRadixSort)
+            false /* canUseRadixSort */)
           sorter.sort(iter.asInstanceOf[Iterator[UnsafeRow]])
         }
       } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Disable using radix sort in ShuffleExchangeExec when we do repartition.
In #20393, we fixed the indeterministic result in the shuffle repartition case by performing a local sort before repartitioning.
But for the newly added sort operation, we use radix sort which is wrong because binary data can't be compared by only the prefix. This makes the sort unstable and fails to solve the indeterminate shuffle output problem.

### Why are the changes needed?
Fix the correctness bug caused by repartition after a shuffle.

### Does this PR introduce any user-facing change?
Yes, user will get the right result in the case of repartition stage rerun.

## How was this patch tested?

Test with `local-cluster[5, 2, 5120]`, use the integrated test below, it can return a right answer 100000000.
```
import scala.sys.process._
import org.apache.spark.TaskContext

val res = spark.range(0, 10000 * 10000, 1).map{ x => (x % 1000, x)}
// kill an executor in the stage that performs repartition(239)
val df = res.repartition(113).map{ x => (x._1 + 1, x._2)}.repartition(239).map { x =>
  if (TaskContext.get.attemptNumber == 0 && TaskContext.get.partitionId < 1 && TaskContext.get.stageAttemptNumber == 0) {
    throw new Exception("pkill -f -n java".!!)
  }
  x
}
val r2 = df.distinct.count()
```