### PR TITLE
[SPARK-28655] [patch] Support to cut the event log, and solve the history server was too slow when event log is too large.

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -65,6 +65,13 @@ package object config {
       .booleanConf
       .createWithDefault(false)
 
+  private[spark] val EVENT_LOG_CUTTYPE =
+    ConfigBuilder("spark.eventLog.cuttype")
+      .doc("Event log cut type none month day hour.")
+      .internal()
+      .stringConf
+      .createWithDefault("none")
+
   private[spark] val EVENT_LOG_OUTPUT_BUFFER_SIZE = ConfigBuilder("spark.eventLog.buffer.kb")
     .doc("Buffer size to use when writing to output streams, in KiB unless otherwise specified.")
     .bytesConf(ByteUnit.KiB)

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -170,7 +170,7 @@ case class SparkListenerExecutorMetricsUpdate(
 @DeveloperApi
 case class SparkListenerApplicationStart(
     appName: String,
-    appId: Option[String],
+    var appId: Option[String],
     time: Long,
     sparkUser: String,
     appAttemptId: Option[String],


### PR DESCRIPTION
…slow when open the application and event log is too large, and add event log split with the config spark.eventLog.cuttype

### What changes were proposed in this pull request?
Support to cut the event log, and solve the history server was too slow when event log is too large. When the cuttype is configed, the EventLoggingListener will check the logpath, if the logpath is changed, the eventlog writer will be created when all jobs are end. And there is a write/read lock to ensure the multiprocess safe.


### Why are the changes needed?
When the eventlog is very large, the history server will be oom.



### How was this patch tested?
manual tests

![image](https://user-images.githubusercontent.com/16531687/63254513-784a3680-c2a6-11e9-9e20-d5760c4d347d.png)
![image](https://user-images.githubusercontent.com/16531687/63254615-9f086d00-c2a6-11e9-94c8-35244e827814.png)
