### PR TITLE
[PYTHON][SQL][WIP] repr(schema) and schema.toString produce runnable code

### DIFF
--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -536,6 +536,26 @@ class TypesTests(ReusedSQLTestCase):
         self.assertEqual(_infer_type(2**61), LongType())
         self.assertEqual(_infer_type(2**71), LongType())
 
+    def test_repr(self):
+        schema_expected = StructType([
+            StructField("string", StringType(), False),
+            StructField("long", LongType(), True),
+            StructField("decimal", DecimalType(10,2), True),
+            StructField("timestamp", TimestampType(), False),
+            StructField("array1", ArrayType(StructType([
+                StructField("item1", LongType(), True),
+                StructField("array2", ArrayType(StructType([
+                    StructField("item2", LongType(), False),
+                    StructField("array2", ArrayType(StructType([
+                        StructField("item3", LongType(), True),
+                        StructField("item4", StringType(), False),
+                    ]), True), False),
+                ]), True), True),
+            ]), False), True)
+        ])
+        schema_actual = eval(repr(schema_expected))
+        self.assertEqual(schema_expected, schema_actual)
+
     def test_merge_type(self):
         self.assertEqual(_merge_type(LongType(), NullType()), LongType())
         self.assertEqual(_merge_type(NullType(), LongType()), LongType())

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -46,7 +46,7 @@ class DataType(object):
     """Base class for data types."""
 
     def __repr__(self):
-        return self.__class__.__name__
+        return self.__class__.__name__ + '()'
 
     def __hash__(self):
         return hash(str(self))
@@ -298,8 +298,8 @@ class ArrayType(DataType):
         return 'array<%s>' % self.elementType.simpleString()
 
     def __repr__(self):
-        return "ArrayType(%s,%s)" % (self.elementType,
-                                     str(self.containsNull).lower())
+        return "ArrayType(%r,containsNull=%r)" % (self.elementType,
+                                                  self.containsNull)
 
     def jsonValue(self):
         return {"type": self.typeName(),
@@ -356,8 +356,9 @@ class MapType(DataType):
         return 'map<%s,%s>' % (self.keyType.simpleString(), self.valueType.simpleString())
 
     def __repr__(self):
-        return "MapType(%s,%s,%s)" % (self.keyType, self.valueType,
-                                      str(self.valueContainsNull).lower())
+        return "MapType(%r,%r,valueContainsNull=%r)" % (self.keyType,
+                                                        self.valueType,
+                                                        self.valueContainsNull)
 
     def jsonValue(self):
         return {"type": self.typeName(),
@@ -419,8 +420,8 @@ class StructField(DataType):
         return '%s:%s' % (self.name, self.dataType.simpleString())
 
     def __repr__(self):
-        return "StructField(%s,%s,%s)" % (self.name, self.dataType,
-                                          str(self.nullable).lower())
+        return "StructField(%r,%r,nullable=%r)" % (self.name, self.dataType,
+                                                   self.nullable)
 
     def jsonValue(self):
         return {"name": self.name,
@@ -565,8 +566,7 @@ class StructType(DataType):
         return 'struct<%s>' % (','.join(f.simpleString() for f in self))
 
     def __repr__(self):
-        return ("StructType(List(%s))" %
-                ",".join(str(field) for field in self))
+        return "StructType([%s])" % ",".join(repr(field) for field in self)
 
     def jsonValue(self):
         return {"type": self.typeName(),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructField.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructField.scala
@@ -49,7 +49,7 @@ case class StructField(
   }
 
   // override the default toString to be compatible with legacy parquet files.
-  override def toString: String = s"StructField($name,$dataType,$nullable)"
+  override def toString: String = s"""StructField("$name",$dataType,$nullable)"""
 
   private[sql] def jsonValue: JValue = {
     ("name" -> name) ~


### PR DESCRIPTION
# What changes were proposed in this pull request?
repr(schema) produces runnable python code
schema.toString produce runnable scala code

### Why are the changes needed?
Previously, schema.toString produced scala code that wasn't runnable because field-names weren't quoted.  Even worse, repr(schema) in python produced the same non-runnable scala code.  This resolves both issues, so that runnable Scala and Python are available.

### Does this PR introduce any user-facing change?
Yes, see above.

### How was this patch tested?
pyspark/sql/tests/test_types.py now has test_repr()
