### PR TITLE
 [PYTHON][WIP] pyspark schema.toDDL() and DataType.fromDDL(ddl)

### DIFF
--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -713,6 +713,27 @@ class TypesTests(ReusedSQLTestCase):
                 a = array.array(t)
                 self.spark.createDataFrame([Row(myarray=a)]).collect()
 
+    def test_to_ddl(self):
+        schemaExpected=StructType([
+            StructField("string",StringType(),True),
+            StructField("long",LongType(),True),
+            StructField("decimal",DecimalType(10,2),True),
+            StructField("timestamp",TimestampType(),True),
+            StructField("array1",ArrayType(StructType([
+                StructField("item1",LongType(),True),
+                StructField("array2",ArrayType(StructType([
+                    StructField("item2",LongType(),True),
+                    StructField("array2",ArrayType(StructType([
+                        StructField("item3",LongType(),True),
+                        StructField("item4",StringType(),True),
+                    ]),True),True),
+                ]),True),True),
+            ]),True),True)
+        ])
+        ddl=schemaExpected.toDDL()
+        schemaActual=_parse_datatype_string(ddl)
+        self.assertEqual(schemaExpected, schemaActual)
+
 
 class DataTypeTests(unittest.TestCase):
     # regression test for SPARK-6055

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -102,6 +102,13 @@ class DataType(object):
         json = self.json()
         return dt.fromJson(json).toDDL()
 
+    @Since(3.0)
+    @static_method
+    def fromDDL(self, ddl):
+        """
+        Returns a StructType containing the schema matching the DDL.
+        """
+        return _parse_datatype_string(ddl)
 
 # This singleton pattern does not work with pickle, you will get
 # another object after pickle and unpickle
@@ -828,6 +835,9 @@ def _parse_datatype_string(s):
                 return from_ddl_datatype("struct<%s>" % s.strip())
             except:
                 raise e
+
+
+DataType.fromDDL.__doc__ = _parse_datatype_string.__doc__
 
 
 def _parse_datatype_json_string(json_string):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -33,7 +33,7 @@ if sys.version >= "3":
 from py4j.protocol import register_input_converter
 from py4j.java_gateway import JavaClass
 
-from pyspark import SparkContext
+from pyspark import SparkContext, since
 from pyspark.serializers import CloudPickleSerializer
 
 __all__ = [
@@ -91,6 +91,16 @@ class DataType(object):
         Converts an internal SQL object into a native Python object.
         """
         return obj
+
+    @Since(3.0)
+    def toDDL(self):
+        """
+        Returns a string containing a schema in DDL format.
+        """
+        sc = SparkContext._active_spark_context
+        dt = sc._jvm.__getattr__("org.apache.spark.sql.types.DataType$").__getattr__("MODULE$")
+        json = self.json()
+        return dt.fromJson(json).toDDL()
 
 
 # This singleton pattern does not work with pickle, you will get


### PR DESCRIPTION
# What changes were proposed in this pull request?
Add a pyspark equivalent to schema.toDDL

### Why are the changes needed?
Spark in Scala has a schema.toDDL method, but pyspark lacks an analog.

### Does this PR introduce any user-facing change?
Yes.  This change adds DataType.toDDL and DataType.fromDDL to pyspark, matching
the equivalent methods in core Spark.

### How was this patch tested?
pyspark/sql/tests/test_types.py now has test_to_ddl()
