### PR TITLE
[SPARK-28774] [SQL] Fix exchange reuse for columnar data

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{LeafExecNode, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
  * Base class for operators that exchange data among multiple threads or processes.
@@ -49,11 +50,17 @@ abstract class Exchange extends UnaryExecNode {
 case class ReusedExchangeExec(override val output: Seq[Attribute], child: Exchange)
   extends LeafExecNode {
 
+  override def supportsColumnar: Boolean = child.supportsColumnar
+
   // Ignore this wrapper for canonicalizing.
   override def doCanonicalize(): SparkPlan = child.canonicalized
 
   def doExecute(): RDD[InternalRow] = {
     child.execute()
+  }
+
+  override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+    child.executeColumnar()
   }
 
   override protected[sql] def doExecuteBroadcast[T](): broadcast.Broadcast[T] = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeSuite.scala
@@ -22,8 +22,8 @@ import scala.util.Random
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Dataset, Row}
 import org.apache.spark.sql.catalyst.expressions.{Alias, Literal}
-import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, IdentityBroadcastMode, SinglePartition}
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, IdentityBroadcastMode, SinglePartition}
 import org.apache.spark.sql.execution.exchange._
 import org.apache.spark.sql.execution.joins.HashedRelationBroadcastMode
 import org.apache.spark.sql.internal.SQLConf
@@ -35,7 +35,7 @@ class RanRowBased extends RuntimeException
 
 case class ColumnarExchange(child: SparkPlan) extends Exchange {
 
-  override def supportsColumnar = true
+  override def supportsColumnar: Boolean = true
 
   override protected def doExecute(): RDD[InternalRow] = throw new RanRowBased
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeSuite.scala
@@ -19,13 +19,28 @@ package org.apache.spark.sql.execution
 
 import scala.util.Random
 
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Dataset, Row}
 import org.apache.spark.sql.catalyst.expressions.{Alias, Literal}
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, IdentityBroadcastMode, SinglePartition}
-import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ReusedExchangeExec, ShuffleExchangeExec}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.exchange._
 import org.apache.spark.sql.execution.joins.HashedRelationBroadcastMode
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+class RanColumnar extends RuntimeException
+class RanRowBased extends RuntimeException
+
+case class ColumnarExchange(child: SparkPlan) extends Exchange {
+
+  override def supportsColumnar = true
+
+  override protected def doExecute(): RDD[InternalRow] = throw new RanRowBased
+
+  override protected def doExecuteColumnar(): RDD[ColumnarBatch] = throw new RanColumnar
+}
 
 class ExchangeSuite extends SparkPlanTest with SharedSparkSession {
   import testImplicits._
@@ -103,6 +118,17 @@ class ExchangeSuite extends SparkPlanTest with SharedSparkSession {
     assert(!exchange3.sameResult(exchange4))
     assert(exchange4.sameResult(exchange5))
     assert(exchange5 sameResult exchange4)
+  }
+
+  test ("Columnar exchange works") {
+    val df = spark.range(10)
+    val plan = df.queryExecution.executedPlan
+    assert(plan sameResult plan)
+
+    val exchange = ColumnarExchange(plan)
+    val reused = ReusedExchangeExec(plan.output, exchange)
+
+    assertThrows[RanColumnar](reused.executeColumnar())
   }
 
   test("SPARK-23207: Make repartition() generate consistent output") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeSuite.scala
@@ -21,8 +21,8 @@ import scala.util.Random
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Dataset, Row}
-import org.apache.spark.sql.catalyst.expressions.{Alias, Literal}
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Alias, Literal}
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, IdentityBroadcastMode, SinglePartition}
 import org.apache.spark.sql.execution.exchange._
 import org.apache.spark.sql.execution.joins.HashedRelationBroadcastMode

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeSuite.scala
@@ -120,11 +120,9 @@ class ExchangeSuite extends SparkPlanTest with SharedSparkSession {
     assert(exchange5 sameResult exchange4)
   }
 
-  test ("Columnar exchange works") {
+  test("Columnar exchange works") {
     val df = spark.range(10)
     val plan = df.queryExecution.executedPlan
-    assert(plan sameResult plan)
-
     val exchange = ColumnarExchange(plan)
     val reused = ReusedExchangeExec(plan.output, exchange)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The rule ReuseExchange optimization rule will look for instances of Exchange that have the same plan and convert dedupe them to them to a ReuseExchangeExec instance. In the current Spark codebase all Exchange instances are row based, but if we use the spark.sql.extensions config to put in our own columnar based exchange implementation reuse will throw an exception saying that there was a columnar mismatch.

### Why are the changes needed?
Without it Reused Columnar Exchanges throw an exception

### Does this PR introduce any user-facing change?
No

### How was this patch tested?

I tested this patch by running it against a query that was showing this exact issue and it fixed it.

I also added a very simple unit test that shows the issue.