### PR TITLE
[SPARK-27905][SQL][FOLLOW-UP] Add prettyNames.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
@@ -445,6 +445,8 @@ case class ArrayExists(
       false
     }
   }
+
+  override def prettyName: String = "exists"
 }
 
 /**
@@ -512,6 +514,8 @@ case class ArrayForAll(
       forall
     }
   }
+
+  override def prettyName: String = "forall"
 }
 
 /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #24761 which added a higher-order function `ArrayForAll`.
The PR mistakenly removed the `prettyName` from `ArrayExists` and forgot to add it to `ArrayForAll`.

### Why are the changes needed?

This reverts the `prettyName` back to `ArrayExists` not to affect explained plans, and adds it to `ArrayForAll` to clarify the `prettyName` as the same as the expressions around.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Existing tests.
