### PR TITLE
[SPARK-28780][ML] Delete the incorrect setWeightCol method in LinearSVCModel

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LinearSVC.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LinearSVC.scala
@@ -312,9 +312,6 @@ class LinearSVCModel private[classification] (
   def setThreshold(value: Double): this.type = set(threshold, value)
   setDefault(threshold, 0.0)
 
-  @Since("2.2.0")
-  def setWeightCol(value: Double): this.type = set(threshold, value)
-
   private val margin: Vector => Double = (features) => {
     BLAS.dot(features, coefficients) + intercept
   }

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -190,6 +190,9 @@ object MimaExcludes {
     ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.mllib.regression.LabeledPointBeanInfo"),
     ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.ml.feature.LabeledPointBeanInfo"),
 
+    // [SPARK-28780][ML] Delete the incorrect setWeightCol method in LinearSVCModel
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.ml.classification.LinearSVCModel.setWeightCol"),
+
     // [SPARK-25959] GBTClassifier picks wrong impurity stats on loading
     ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("org.apache.spark.ml.tree.HasVarianceImpurity.org$apache$spark$ml$tree$HasVarianceImpurity$_setter_$impurity_="),
     ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("org.apache.spark.ml.tree.HasVarianceImpurity.org$apache$spark$ml$tree$HasVarianceImpurity$_setter_$impurity_="),


### PR DESCRIPTION

### What changes were proposed in this pull request?
Delete the incorrect method `def setWeightCol(value: Double): this.type = set(threshold, value)` in `LinearSVCModel`


### Why are the changes needed?
`LinearSVCModel` should not provide this setter, moreover, this method is wrongly defined.

### Does this PR introduce any user-facing change?
yes, a public method is removed

### How was this patch tested?
existing suites