### PR TITLE
[SPARK-28782][SQL] Generator support in aggregate expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2028,11 +2028,9 @@ class Analyzer(
         throw new AnalysisException("Only one generator allowed per aggregate clause but found " +
           generators.size + ": " + generators.map(toPrettySQL).mkString(", "))
 
-      case agg @ Aggregate(groupList, aggList, child) if aggList.forall {
-        case AliasedGenerator(generator, _, _) => generator.childrenResolved
-        case other => other.resolved
-      } =>
-        // Holds the resolved generator, if one exists in the project list.
+      case agg @ Aggregate(groupList, aggList, child)
+        if aggList.forall(_.resolved) && aggList.exists(hasGenerator) =>
+        // If generator in the aggregate list was visited, set the boolean flag true.
         var generatorVisited = false
 
         val projectExprs = Array.ofDim[NamedExpression](aggList.length)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2029,7 +2029,7 @@ class Analyzer(
           generators.size + ": " + generators.map(toPrettySQL).mkString(", "))
 
       case agg @ Aggregate(groupList, aggList, child) if aggList.forall {
-          case AliasedGenerator(generator, _, _) => generator.resolved
+          case AliasedGenerator(_, _, _) => true
           case other => other.resolved
         } && aggList.exists(hasGenerator) =>
         // If generator in the aggregate list was visited, set the boolean flag true.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2028,8 +2028,10 @@ class Analyzer(
         throw new AnalysisException("Only one generator allowed per aggregate clause but found " +
           generators.size + ": " + generators.map(toPrettySQL).mkString(", "))
 
-      case agg @ Aggregate(groupList, aggList, child)
-        if aggList.forall(_.resolved) && aggList.exists(hasGenerator) =>
+      case agg @ Aggregate(groupList, aggList, child) if aggList.forall {
+          case AliasedGenerator(generator, _, _) => generator.childrenResolved
+          case other => other.resolved
+        } =>
         // If generator in the aggregate list was visited, set the boolean flag true.
         var generatorVisited = false
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2029,9 +2029,9 @@ class Analyzer(
           generators.size + ": " + generators.map(toPrettySQL).mkString(", "))
 
       case agg @ Aggregate(groupList, aggList, child) if aggList.forall {
-          case AliasedGenerator(generator, _, _) => generator.childrenResolved
+          case AliasedGenerator(generator, _, _) => generator.resolved
           case other => other.resolved
-        } =>
+        } && aggList.exists(hasGenerator) =>
         // If generator in the aggregate list was visited, set the boolean flag true.
         var generatorVisited = false
 
@@ -2067,12 +2067,8 @@ class Analyzer(
               other :: Nil
           }
 
-        if (generatorVisited) {
-          val newAgg = Aggregate(groupList, newAggList, child)
-          Project(projectExprs.toList, newAgg)
-        } else {
-          agg
-        }
+        val newAgg = Aggregate(groupList, newAggList, child)
+        Project(projectExprs.toList, newAgg)
 
       case p @ Project(projectList, child) =>
         // Holds the resolved generator, if one exists in the project list.

--- a/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
@@ -310,20 +310,22 @@ class GeneratorFunctionSuite extends QueryTest with SharedSQLContext {
   }
 
   test("generator in aggregate expression") {
-    Seq((1, 1), (1, 2), (2, 3)).toDF("c1", "c2").createOrReplaceTempView("t1")
-    checkAnswer(
-      sql("select explode(array(min(c2), max(c2))) from t1"),
-      Row(1) :: Row(3) :: Nil
-    )
-    checkAnswer(
-      sql("select posexplode(array(min(c2), max(c2))) from t1 group by c1"),
-      Row(0, 1) :: Row(1, 2) :: Row(0, 3) :: Row(1, 3) :: Nil
-    )
-    // test generator "stack" which require foldable argument
-    checkAnswer(
-      sql("select stack(2, min(c1), max(c1), min(c2), max(c2)) from t1"),
-      Row(1, 2) :: Row(1, 3) :: Nil
-    )
+    withTempView("t1") {
+      Seq((1, 1), (1, 2), (2, 3)).toDF("c1", "c2").createTempView("t1")
+      checkAnswer(
+        sql("select explode(array(min(c2), max(c2))) from t1"),
+        Row(1) :: Row(3) :: Nil
+      )
+      checkAnswer(
+        sql("select posexplode(array(min(c2), max(c2))) from t1 group by c1"),
+        Row(0, 1) :: Row(1, 2) :: Row(0, 3) :: Row(1, 3) :: Nil
+      )
+      // test generator "stack" which require foldable argument
+      checkAnswer(
+        sql("select stack(2, min(c1), max(c1), min(c2), max(c2)) from t1"),
+        Row(1, 2) :: Row(1, 3) :: Nil
+      )
+    }
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
@@ -310,7 +310,7 @@ class GeneratorFunctionSuite extends QueryTest with SharedSQLContext {
   }
 
   test("generator in aggregate expression") {
-    Seq((1, 1), (1, 2), (2, 3)).toDF("c1", "c2").createOrReplaceGlobalTempView("t1")
+    Seq((1, 1), (1, 2), (2, 3)).toDF("c1", "c2").createOrReplaceTempView("t1")
     checkAnswer(
       sql("select explode(array(min(c2), max(c2))) from t1"),
       Row(1) :: Row(3) :: Nil

--- a/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
@@ -308,6 +308,23 @@ class GeneratorFunctionSuite extends QueryTest with SharedSQLContext {
       sql("select * from values 1, 2 lateral view outer empty_gen() a as b"),
       Row(1, null) :: Row(2, null) :: Nil)
   }
+
+  test("generator in aggregate expression") {
+    Seq((1, 1), (1, 2), (2, 3)).toDF("c1", "c2").createOrReplaceGlobalTempView("t1")
+    checkAnswer(
+      sql("select explode(array(min(c2), max(c2))) from t1"),
+      Row(1) :: Row(3) :: Nil
+    )
+    checkAnswer(
+      sql("select posexplode(array(min(c2), max(c2))) from t1 group by c1"),
+      Row(0, 1) :: Row(1, 2) :: Row(0, 3) :: Row(1, 3) :: Nil
+    )
+    // test generator "stack" which require foldable argument
+    checkAnswer(
+      sql("select stack(2, min(c1), max(c1), min(c2), max(c2)) from t1"),
+      Row(1, 2) :: Row(1, 3) :: Nil
+    )
+  }
 }
 
 case class EmptyGenerator() extends Generator {

--- a/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
@@ -325,6 +325,21 @@ class GeneratorFunctionSuite extends QueryTest with SharedSQLContext {
         sql("select stack(2, min(c1), max(c1), min(c2), max(c2)) from t1"),
         Row(1, 2) :: Row(1, 3) :: Nil
       )
+
+      val msg1 = intercept[AnalysisException] {
+        sql("select 1 + explode(array(min(c2), max(c2))) from t1 group by c1")
+      }.getMessage
+      assert(msg1.contains("Generators are not supported when it's nested in expressions"))
+
+      val msg2 = intercept[AnalysisException] {
+        sql(
+          """select
+            |  explode(array(min(c2), max(c2))),
+            |  posexplode(array(min(c2), max(c2)))
+            |from t1 group by c1
+          """.stripMargin)
+      }.getMessage
+      assert(msg2.contains("Only one generator allowed per aggregate clause"))
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support generator in aggregate expressions.

In this PR, I check the aggregate logical plan, if its aggregateExpressions include generator, then convert this agg plan into "normal agg plan + generator plan + projection plan". I.e:
```
aggregate(with generator)
 |--child_plan
```
===>
```
project
  |--generator(resolved)
         |--aggregate
               |--child_plan
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
We should support sql like:
```
select explode(array(min(a), max(a))) from t
```

### Does this PR introduce any user-facing change?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test added.