### PR TITLE
[SPARK-26046][SS] Add StreamingQueryManager.listListeners()

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
@@ -199,6 +199,15 @@ class StreamingQueryManager private[sql] (sparkSession: SparkSession) extends Lo
     listenerBus.removeListener(listener)
   }
 
+  /**
+   * Deregister all [[StreamingQueryListener]]s attached to this [[StreamingQueryManager]].
+   *
+   * @since 3.0.0
+   */
+  def removeAllListeners(): Unit = {
+    listenerBus.removeAllListeners()
+  }
+
   /** Post a listener event */
   private[sql] def postListenerEvent(event: StreamingQueryListener.Event): Unit = {
     listenerBus.post(event)

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
@@ -21,6 +21,7 @@ import java.util.UUID
 import java.util.concurrent.TimeUnit
 import javax.annotation.concurrent.GuardedBy
 
+import scala.collection.JavaConverters._
 import scala.collection.mutable
 
 import org.apache.hadoop.fs.Path
@@ -200,12 +201,12 @@ class StreamingQueryManager private[sql] (sparkSession: SparkSession) extends Lo
   }
 
   /**
-   * Deregister all [[StreamingQueryListener]]s attached to this [[StreamingQueryManager]].
+   * List all [[StreamingQueryListener]]s attached to this [[StreamingQueryManager]].
    *
    * @since 3.0.0
    */
-  def removeAllListeners(): Unit = {
-    listenerBus.removeAllListeners()
+  def listListeners(): Array[StreamingQueryListener] = {
+    listenerBus.listeners.asScala.toArray
   }
 
   /** Post a listener event */

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
@@ -223,7 +223,36 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
       assert(isListenerActive(listener1) === false)
       assert(isListenerActive(listener2))
     } finally {
-      addedListeners().foreach(spark.streams.removeListener)
+      spark.streams.removeAllListeners()
+    }
+  }
+
+  test("removing all listeners") {
+    def isListenerActive(listener: EventCollector): Boolean = {
+      listener.reset()
+      testStream(MemoryStream[Int].toDS)(
+        StartStream(),
+        StopStream
+      )
+      listener.startEvent != null
+    }
+
+    try {
+      val listener1 = new EventCollector
+      val listener2 = new EventCollector
+
+      spark.streams.addListener(listener1)
+      assert(isListenerActive(listener1))
+      assert(isListenerActive(listener2) === false)
+      spark.streams.addListener(listener2)
+      assert(isListenerActive(listener1))
+      assert(isListenerActive(listener2))
+      spark.streams.removeAllListeners()
+      assert(isListenerActive(listener1) === false)
+      assert(isListenerActive(listener2) === false)
+      assert(addedListeners().isEmpty)
+    } finally {
+      spark.streams.removeAllListeners()
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a listListeners() method to StreamingQueryManager that lists all StreamingQueryListeners that have been added to that manager.

### Why are the changes needed?

While it's best practice to keep handles on all listeners added, it's still nice to have an API to be able to list what listeners have been added to a StreamingQueryManager.

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

Modified existing unit tests to use the new API instead of using reflection.
