### PR TITLE
[SPARK-28635][SQL][followup] CatalogManager should reflect the changes of default catalog

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/CatalogManagerSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/CatalogManagerSuite.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.catalog
+
+import java.util
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalog.v2.{CatalogManager, NamespaceChange, SupportsNamespaces}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+class CatalogManagerSuite extends SparkFunSuite {
+
+  test("CatalogManager should reflect the changes of default catalog") {
+    val conf = new SQLConf
+    val catalogManager = new CatalogManager(conf)
+    assert(catalogManager.currentCatalog.isEmpty)
+    assert(catalogManager.currentNamespace.sameElements(Array("default")))
+
+    conf.setConfString("spark.sql.catalog.dummy", classOf[DummyCatalog].getName)
+    conf.setConfString(SQLConf.DEFAULT_V2_CATALOG.key, "dummy")
+
+    // The current catalog should be changed if the default catalog is set.
+    assert(catalogManager.currentCatalog == Some("dummy"))
+    assert(catalogManager.currentNamespace.sameElements(Array("a", "b")))
+  }
+
+  test("CatalogManager should keep the current catalog once set") {
+    val conf = new SQLConf
+    val catalogManager = new CatalogManager(conf)
+    assert(catalogManager.currentCatalog.isEmpty)
+    conf.setConfString("spark.sql.catalog.dummy", classOf[DummyCatalog].getName)
+    catalogManager.setCurrentCatalog("dummy")
+    assert(catalogManager.currentCatalog == Some("dummy"))
+    assert(catalogManager.currentNamespace.sameElements(Array("a", "b")))
+
+    conf.setConfString("spark.sql.catalog.dummy2", classOf[DummyCatalog].getName)
+    conf.setConfString(SQLConf.DEFAULT_V2_CATALOG.key, "dummy2")
+    // The current catalog shouldn't be changed if it's set before.
+    assert(catalogManager.currentCatalog == Some("dummy"))
+  }
+
+  test("current namespace should be updated when switching current catalog") {
+    val conf = new SQLConf
+    val catalogManager = new CatalogManager(conf)
+    catalogManager.setCurrentNamespace(Array("abc"))
+    assert(catalogManager.currentNamespace.sameElements(Array("abc")))
+
+    conf.setConfString("spark.sql.catalog.dummy", classOf[DummyCatalog].getName)
+    catalogManager.setCurrentCatalog("dummy")
+    assert(catalogManager.currentNamespace.sameElements(Array("a", "b")))
+  }
+}
+
+class DummyCatalog extends SupportsNamespaces {
+  override def defaultNamespace(): Array[String] = Array("a", "b")
+
+  override def listNamespaces(): Array[Array[String]] = {
+    throw new UnsupportedOperationException
+  }
+  override def listNamespaces(namespace: Array[String]): Array[Array[String]] = {
+    throw new UnsupportedOperationException
+  }
+  override def loadNamespaceMetadata(namespace: Array[String]): util.Map[String, String] = {
+    throw new UnsupportedOperationException
+  }
+  override def createNamespace(
+      namespace: Array[String], metadata: util.Map[String, String]): Unit = {
+    throw new UnsupportedOperationException
+  }
+  override def alterNamespace(namespace: Array[String], changes: NamespaceChange*): Unit = {
+    throw new UnsupportedOperationException
+  }
+  override def dropNamespace(namespace: Array[String]): Boolean = {
+    throw new UnsupportedOperationException
+  }
+  override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {}
+  override def name(): String = "dummy"
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
The current namespace/catalog should be set to None at the beginning, so that we can read the new configs when reporting currennt namespace/catalog later.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix a bug in CatalogManager, to reflect the change of default catalog config when reporting current catalog.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No. The current namespace/catalog stuff is still internal right now.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
a new test suite