### PR TITLE
[SPARK-28787][DOC][SQL]Document LOAD DATA statement in SQL Reference

### DIFF
--- a/docs/sql-ref-syntax-dml-load.md
+++ b/docs/sql-ref-syntax-dml-load.md
@@ -1,7 +1,7 @@
 ---
 layout: global
-title: LOAD
-displayTitle: LOAD
+title: LOAD DATA
+displayTitle: LOAD DATA
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -19,4 +19,37 @@ license: |
   limitations under the License.
 ---
 
-**This page is under construction**
+### Description
+The LOAD DATA statement can be used to load data from a file into a table or a partition in the table. The target table must not be temporary. A partition spec must be provided if and only if the target table is partitioned. The LOAD DATA statement is only supported for tables created using the Hive format.
+
+### Syntax
+{% highlight sql %}
+LOAD DATA [LOCAL] INPATH path [OVERWRITE] INTO TABLE [db_name.]table_name
+  [PARTITION partition_spec]
+
+partition_spec:
+    : (part_col_name1=val1, part_col_name2=val2, ...)
+{% endhighlight %}
+
+### Example
+{% highlight sql %}
+LOAD DATA LOCAL INPATH 'data/files/f1.txt'
+  OVERWRITE INTO TABLE testDB.testTable PARTITION (p1 = 3, p2 = 4)
+{% endhighlight %}
+
+### Parameters
+
+#### ***path***:
+Path of the file system.
+
+#### ***table_name***:
+The name of an existing table.
+
+#### ***partition_spec***:
+One or more partition column name and value pairs.
+
+##### ***LOCAL***:
+If specified, local file system is used. Otherwise, the default file system is used.
+
+##### ***OVERWRITE***:
+If specified, existing data in the table is overwritten. Otherwise, new data is appended to the table.

--- a/docs/sql-ref-syntax-dml-load.md
+++ b/docs/sql-ref-syntax-dml-load.md
@@ -20,7 +20,7 @@ license: |
 ---
 
 ### Description
-The `LOAD DATA` statement can be used to load data from a file into a table, or into a partition in the table. The target table must not be temporary. A partition spec must be provided if and only if the target table is partitioned. The LOAD DATA statement is only supported for tables created using the Hive format.
+The `LOAD DATA` statement can be used to load data from a file into a table, or into a partition in the table. The target table must not be temporary. A partition spec must be provided if and only if the target table is partitioned. The `LOAD DATA` statement is only supported for tables created using the Hive format.
 
 ### Syntax
 {% highlight sql %}

--- a/docs/sql-ref-syntax-dml-load.md
+++ b/docs/sql-ref-syntax-dml-load.md
@@ -20,7 +20,7 @@ license: |
 ---
 
 ### Description
-The LOAD DATA statement can be used to load data from a file into a table or a partition in the table. The target table must not be temporary. A partition spec must be provided if and only if the target table is partitioned. The LOAD DATA statement is only supported for tables created using the Hive format.
+The `LOAD DATA` statement can be used to load data from a file into a table, or into a partition in the table. The target table must not be temporary. A partition spec must be provided if and only if the target table is partitioned. The LOAD DATA statement is only supported for tables created using the Hive format.
 
 ### Syntax
 {% highlight sql %}
@@ -49,7 +49,7 @@ The name of an existing table.
 One or more partition column name and value pairs.
 
 ##### ***LOCAL***:
-If specified, local file system is used. Otherwise, the default file system is used.
+If specified, it causes the `INPATH` to be resolved against the local file system, instead of the default file system, which is typically distributed storage.
 
 ##### ***OVERWRITE***:
 If specified, existing data in the table is overwritten. Otherwise, new data is appended to the table.

--- a/docs/sql-ref-syntax-dml-load.md
+++ b/docs/sql-ref-syntax-dml-load.md
@@ -20,18 +20,18 @@ license: |
 ---
 
 ### Description
-`LOAD DATA` loads data from a directoy or a file into a table or into a partition in the table. A partition spec should be specified whenever the target table is partitioned. The `LOAD DATA` statement can only be used with tables created using the Hive format.
+`LOAD DATA` statement loads the data into a table from the user specified directory or file. If a directory is specified then all the files from the directory are loaded. If a file is specified then only the single file is loaded. Additionally the `LOAD DATA` statement takes an optional partition specification. When a partition is specified, the data files ( when input source is a directory ) or the single file ( when input source is a file ) are loaded into the partition of the target table.
 
 ### Syntax
 {% highlight sql %}
 LOAD DATA [ LOCAL ] INPATH path [ OVERWRITE ] INTO TABLE table_name
-  [ PARTITION ( partition_col_name [ = partition_col_val ] [ , ... ] ) ]
+  [ PARTITION ( partition_col_name = partition_col_val [ , ... ] ) ]
 {% endhighlight %}
 
 ### Parameters
 <dl>
   <dt><code><em>path</em></code></dt>
-  <dd>Path of the file system.</dd>
+  <dd>Path of the file system. It can be either an absolute or a relative path.</dd>
 </dl>
 
 <dl>
@@ -40,8 +40,8 @@ LOAD DATA [ LOCAL ] INPATH path [ OVERWRITE ] INTO TABLE table_name
 </dl>
 
 <dl>
-  <dt><code><em>PARTITION ( partition_col_name [ = partition_col_val ] [ , ... ] )</em></code></dt>
-  <dd>Specifies one or more partition column and value pairs. The partition value is optional.</dd>
+  <dt><code><em>PARTITION ( partition_col_name = partition_col_val [ , ... ] )</em></code></dt>
+  <dd>Specifies one or more partition column and value pairs.</dd>
 </dl>
 
 <dl>
@@ -56,6 +56,7 @@ LOAD DATA [ LOCAL ] INPATH path [ OVERWRITE ] INTO TABLE table_name
 
 ### Examples
 {% highlight sql %}
+ -- Example without partition specification.
  -- Assuming the students table has already been created and populated.
  SELECT * FROM students;
 
@@ -65,7 +66,7 @@ LOAD DATA [ LOCAL ] INPATH path [ OVERWRITE ] INTO TABLE table_name
      | Amy Smith      | 123 Park Ave, San Jose         | 111111         |
      + -------------- + ------------------------------ + -------------- +
 
- CREATE TABLE test_load (name VARCHAR(64), address VARCHAR(64), student_id INT) USING HIVE;
+ CREATE TABLE test_load (name VARCHAR(64), address VARCHAR(64), student_id INT);
 
  -- Assuming the students table is in '/user/hive/warehouse/'
  LOAD DATA LOCAL INPATH '/user/hive/warehouse/students' OVERWRITE INTO TABLE test_load;
@@ -77,5 +78,42 @@ LOAD DATA [ LOCAL ] INPATH path [ OVERWRITE ] INTO TABLE table_name
      + -------------- + ------------------------------ + -------------- +
      | Amy Smith      | 123 Park Ave, San Jose         | 111111         |
      + -------------- + ------------------------------ + -------------- +
+
+ -- Example with partition specification.
+ CREATE TABLE test_partition (c1 INT, c2 INT, c3 INT) USING HIVE PARTITIONED BY (c2, c3);
+
+ INSERT INTO test_partition PARTITION (c2 = 2, c3 = 3) VALUES (1);
+
+ INSERT INTO test_partition PARTITION (c2 = 5, c3 = 6) VALUES (4);
+
+ INSERT INTO test_partition PARTITION (c2 = 8, c3 = 9) VALUES (7);
+
+ SELECT * FROM test_partition;
+
+      + ------- + ------- + ----- +
+      | c1      | c2      | c3    |
+      + ------- + --------------- +
+      | 1       | 2       | 3     |
+      + ------- + ------- + ----- +
+      | 4       | 5       | 6     |
+      + ------- + ------- + ----- +
+      | 7       | 8       | 9     |
+      + ------- + ------- + ----- +
+
+ CREATE TABLE test_load_partition (c1 INT, c2 INT, c3 INT) USING HIVE PARTITIONED BY (c2, c3);
+
+ -- Assuming the test_partition table is in '/user/hive/warehouse/'
+ LOAD DATA LOCAL INPATH '/user/hive/warehouse/test_partition/c2=2/c3=3'
+     OVERWRITE INTO TABLE test_load_partition PARTITION (c2=2, c3=3);
+
+ SELECT * FROM test_load_partition;
+
+      + ------- + ------- + ----- +
+      | c1      | c2      | c3    |
+      + ------- + --------------- +
+      | 1       | 2       | 3     |
+      + ------- + ------- + ----- +
+
+
 {% endhighlight %}
 

--- a/docs/sql-ref-syntax-dml-load.md
+++ b/docs/sql-ref-syntax-dml-load.md
@@ -20,7 +20,7 @@ license: |
 ---
 
 ### Description
-The `LOAD DATA` statement can be used to load data from a file into a table, or into a partition in the table. The target table must not be temporary. A partition spec must be provided if and only if the target table is partitioned. The `LOAD DATA` statement is only supported for tables created using the Hive format.
+`LOAD DATA` loads data from a file into a non-temporary table, or into a partition therein. A partition spec should be specified whenever the target table is partitioned. The `LOAD DATA` statement can only be used with tables created using the Hive format.
 
 ### Syntax
 {% highlight sql %}
@@ -52,4 +52,4 @@ One or more partition column name and value pairs.
 If specified, it causes the `INPATH` to be resolved against the local file system, instead of the default file system, which is typically distributed storage.
 
 ##### ***OVERWRITE***:
-If specified, existing data in the table is overwritten. Otherwise, new data is appended to the table.
+By default, new data is appended to the table. If `OVERWRITE` is used, the table is instead overwritten with new data.

--- a/docs/sql-ref-syntax-dml-load.md
+++ b/docs/sql-ref-syntax-dml-load.md
@@ -20,36 +20,62 @@ license: |
 ---
 
 ### Description
-`LOAD DATA` loads data from a file into a non-temporary table, or into a partition therein. A partition spec should be specified whenever the target table is partitioned. The `LOAD DATA` statement can only be used with tables created using the Hive format.
+`LOAD DATA` loads data from a directoy or a file into a table or into a partition in the table. A partition spec should be specified whenever the target table is partitioned. The `LOAD DATA` statement can only be used with tables created using the Hive format.
 
 ### Syntax
 {% highlight sql %}
-LOAD DATA [LOCAL] INPATH path [OVERWRITE] INTO TABLE [db_name.]table_name
-  [PARTITION partition_spec]
-
-partition_spec:
-    : (part_col_name1=val1, part_col_name2=val2, ...)
-{% endhighlight %}
-
-### Example
-{% highlight sql %}
-LOAD DATA LOCAL INPATH 'data/files/f1.txt'
-  OVERWRITE INTO TABLE testDB.testTable PARTITION (p1 = 3, p2 = 4)
+LOAD DATA [ LOCAL ] INPATH path [ OVERWRITE ] INTO TABLE table_name
+  [ PARTITION ( partition_col_name [ = partition_col_val ] [ , ... ] ) ]
 {% endhighlight %}
 
 ### Parameters
+<dl>
+  <dt><code><em>path</em></code></dt>
+  <dd>Path of the file system.</dd>
+</dl>
 
-#### ***path***:
-Path of the file system.
+<dl>
+  <dt><code><em>table_name</em></code></dt>
+  <dd>The name of an existing table.</dd>
+</dl>
 
-#### ***table_name***:
-The name of an existing table.
+<dl>
+  <dt><code><em>PARTITION ( partition_col_name [ = partition_col_val ] [ , ... ] )</em></code></dt>
+  <dd>Specifies one or more partition column and value pairs. The partition value is optional.</dd>
+</dl>
 
-#### ***partition_spec***:
-One or more partition column name and value pairs.
+<dl>
+  <dt><code><em>LOCAL</em></code></dt>
+  <dd>If specified, it causes the <code>INPATH</code> to be resolved against the local file system, instead of the default file system, which is typically a distributed storage.</dd>
+</dl>
 
-##### ***LOCAL***:
-If specified, it causes the `INPATH` to be resolved against the local file system, instead of the default file system, which is typically distributed storage.
+<dl>
+  <dt><code><em>OVERWRITE</em></code></dt>
+  <dd>By default, new data is appended to the table. If <code>OVERWRITE</code> is used, the table is instead overwritten with new data.</dd>
+</dl>
 
-##### ***OVERWRITE***:
-By default, new data is appended to the table. If `OVERWRITE` is used, the table is instead overwritten with new data.
+### Examples
+{% highlight sql %}
+ -- Assuming the students table has already been created and populated.
+ SELECT * FROM students;
+
+     + -------------- + ------------------------------ + -------------- +
+     | name           | address                        | student_id     |
+     + -------------- + ------------------------------ + -------------- +
+     | Amy Smith      | 123 Park Ave, San Jose         | 111111         |
+     + -------------- + ------------------------------ + -------------- +
+
+ CREATE TABLE test_load (name VARCHAR(64), address VARCHAR(64), student_id INT) USING HIVE;
+
+ -- Assuming the students table is in '/user/hive/warehouse/'
+ LOAD DATA LOCAL INPATH '/user/hive/warehouse/students' OVERWRITE INTO TABLE test_load;
+
+ SELECT * FROM test_load;
+
+     + -------------- + ------------------------------ + -------------- +
+     | name           | address                        | student_id     |
+     + -------------- + ------------------------------ + -------------- +
+     | Amy Smith      | 123 Park Ave, San Jose         | 111111         |
+     + -------------- + ------------------------------ + -------------- +
+{% endhighlight %}
+

--- a/docs/sql-ref-syntax-dml-load.md
+++ b/docs/sql-ref-syntax-dml-load.md
@@ -20,7 +20,7 @@ license: |
 ---
 
 ### Description
-`LOAD DATA` statement loads the data into a table from the user specified directory or file. If a directory is specified then all the files from the directory are loaded. If a file is specified then only the single file is loaded. Additionally the `LOAD DATA` statement takes an optional partition specification. When a partition is specified, the data files ( when input source is a directory ) or the single file ( when input source is a file ) are loaded into the partition of the target table.
+`LOAD DATA` statement loads the data into a table from the user specified directory or file. If a directory is specified then all the files from the directory are loaded. If a file is specified then only the single file is loaded. Additionally the `LOAD DATA` statement takes an optional partition specification. When a partition is specified, the data files (when input source is a directory) or the single file (when input source is a file) are loaded into the partition of the target table.
 
 ### Syntax
 {% highlight sql %}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Document LOAD DATA statement in SQL Reference



### Why are the changes needed?
To complete the SQL Reference


### Does this PR introduce any user-facing change?
Yes


### How was this patch tested?
Tested using jykyll build --serve

Here are the screen shots:

![image](https://user-images.githubusercontent.com/13592258/64073167-e7cd0800-cc4e-11e9-9fcc-92fe4cb5a942.png)

![image](https://user-images.githubusercontent.com/13592258/64073169-ee5b7f80-cc4e-11e9-9a36-cc023bcd32b1.png)

![image](https://user-images.githubusercontent.com/13592258/64073170-f4516080-cc4e-11e9-9101-2609a01fe6fe.png)





