### PR TITLE
[SPARK-28789][DOCS][SQL] Document ALTER DATABASE command

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -82,16 +82,18 @@ code {
 }
 
 dt code {
-        white-space: nowrap;
-        max-width: 100%;
-        border: solid 1px #e1e4e5;
-        font-size: .8rem;
-        padding: 0 5px;
-        font-family: Consolas,"Andale Mono WT","Andale Mono","Lucida Console","Lucida Sans Typewriter","DejaVu Sans Mono","Bitstream Vera Sans Mono","Liberation Mono","Nimbus Mono L",Monaco,"Courier New",Courier,monospace;
-        overflow-x: auto;
-    }
+  white-space: nowrap;
+  max-width: 100%;
+  border: solid 1px #e1e4e5;
+  font-size: .8rem;
+  padding: 0 5px;
+  font-family: "Menlo", "Lucida Console", monospace;
+  overflow-x: auto;
+}
 
-dd { margin: 0 1.5em 1.5em; }
+dd { 
+  margin: 0 1.5em 1.5em;
+}
 
 div .highlight pre {
   font-size: 12px;

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -81,6 +81,18 @@ code {
   color: #444444;
 }
 
+dt code {
+        white-space: nowrap;
+        max-width: 100%;
+        border: solid 1px #e1e4e5;
+        font-size: .8rem;
+        padding: 0 5px;
+        font-family: Consolas,"Andale Mono WT","Andale Mono","Lucida Console","Lucida Sans Typewriter","DejaVu Sans Mono","Bitstream Vera Sans Mono","Liberation Mono","Nimbus Mono L",Monaco,"Courier New",Courier,monospace;
+        overflow-x: auto;
+    }
+
+dd { margin: 0 1.5em 1.5em; }
+
 div .highlight pre {
   font-size: 12px;
 }

--- a/docs/sql-ref-syntax-ddl-alter-database.md
+++ b/docs/sql-ref-syntax-ddl-alter-database.md
@@ -19,22 +19,45 @@ license: |
   limitations under the License.
 ---
 ### Description
-You can author metadata associated with a database by setting `DBPROPERTIES`. Using this command 
-you can set key-value pairs in the `DBPROPERTIES`. The specified property values override any existing
-value with the same property name. Please note that the usage of `SCHEMA` and `DATABASE` are interchangable 
-and mean the same thing. An error message is issued if the database does not exist in the system. This
-command is mostly used to record the metadata for a database and can be used for auditing purposes.
+You can author metadata associated with a database by setting `DBPROPERTIES`.  The specified property
+values override any existing value with the same property name. Please note that the usage of 
+`SCHEMA` and `DATABASE` are interchangable and one can be used in place of the other. An error message
+is issued if the database is not found in the system. This command is mostly used to record the metadata
+for a database and may be used for auditing purposes.
 
 ### Syntax
 {% highlight sql %}
-ALTER {DATABASE | SCHEMA} database_name SET DBPROPERTIES (propery_name=property_value, ...)
+ALTER {DATABASE | SCHEMA} database_name SET DBPROPERTIES (propery_name=property_value, ...);
 {% endhighlight %}
 
-### Example
+### Parameters
+<dl>
+  <dt><code><em>database_name</em></code></dt>
+  <dd>
+    Specifies the name of the database to be altered.
+  </dd>
+</dl>
+
+### Examples
 {% highlight sql %}
-ALTER DATABASE inventory SET DBPROPERTIES ('Edited-by' = 'John', 'Edit-date' = '01/01/2001')
+-- Creates a database named `inventory`.
+CREATE DATABASE inventory;
+
+-- Alters the database to set properties `Edited-by` and `Edit-date`.
+ALTER DATABASE inventory SET DBPROPERTIES ('Edited-by' = 'John', 'Edit-date' = '01/01/2001');
+
+-- Verify that properties are set.
+DESCRIBE DATABASE EXTENDED inventory;
+
+   +-------------------------+--------------------------------------------+
+   |database_description_item|database_description_value                  |
+   +-------------------------+--------------------------------------------+
+   |Database Name            |inventory                                   |
+   |Description              |                                            |
+   |Location                 |file:/temp/spark-warehouse/inventory.db     |
+   |Properties               |((Edit-date,01/01/2001), (Edited-by,John))  |
+   +-------------------------+--------------------------------------------+
 {% endhighlight %}
 
-You can use [describe-database](sql-ref-syntax-aux-describe-database.html) command to verify the setting
-of properties.
-
+### Related Statements
+- [DESCRIBE DATABASE](sql-ref-syntax-aux-describe-database.html)

--- a/docs/sql-ref-syntax-ddl-alter-database.md
+++ b/docs/sql-ref-syntax-ddl-alter-database.md
@@ -19,7 +19,7 @@ license: |
   limitations under the License.
 ---
 ### Description
-You can author metadata associated with a database by setting `DBPROPERTIES`.  The specified property
+You can alter metadata associated with a database by setting `DBPROPERTIES`.  The specified property
 values override any existing value with the same property name. Please note that the usage of 
 `SCHEMA` and `DATABASE` are interchangable and one can be used in place of the other. An error message
 is issued if the database is not found in the system. This command is mostly used to record the metadata

--- a/docs/sql-ref-syntax-ddl-alter-database.md
+++ b/docs/sql-ref-syntax-ddl-alter-database.md
@@ -19,9 +19,9 @@ license: |
   limitations under the License.
 ---
 ### Description
-You can author metadata associated with a database by setting the `DBPROPERTIES`. Using this command 
+You can author metadata associated with a database by setting `DBPROPERTIES`. Using this command 
 you can set key-value pairs in the `DBPROPERTIES`. The specified property values override any existing
-value with the same property name. Please note that the usage of SCHEMA and DATABASE are interchangable 
+value with the same property name. Please note that the usage of `SCHEMA` and `DATABASE` are interchangable 
 and mean the same thing. An error message is issued if the database does not exist in the system. This
 command is mostly used to record the metadata for a database and can be used for auditing purposes.
 

--- a/docs/sql-ref-syntax-ddl-alter-database.md
+++ b/docs/sql-ref-syntax-ddl-alter-database.md
@@ -18,5 +18,23 @@ license: |
   See the License for the specific language governing permissions and
   limitations under the License.
 ---
+### Description
+You can author metadata associated with a database by setting the `DBPROPERTIES`. Using this command 
+you can set key-value pairs in the `DBPROPERTIES`. The specified property values override any existing
+value with the same property name. Please note that the usage of SCHEMA and DATABASE are interchangable 
+and mean the same thing. An error message is issued if the database does not exist in the system. This
+command is mostly used to record the metadata for a database and can be used for auditing purposes.
 
-**This page is under construction**
+### Syntax
+{% highlight sql %}
+ALTER {DATABASE | SCHEMA} database_name SET DBPROPERTIES (propery_name=property_value, ...)
+{% endhighlight %}
+
+### Example
+{% highlight sql %}
+ALTER DATABASE inventory SET DBPROPERTIES ('Edited-by' = 'John', 'Edit-date' = '01/01/2001')
+{% endhighlight %}
+
+You can use [describe-database](sql-ref-syntax-aux-describe-database.html) command to verify the setting
+of properties.
+

--- a/docs/sql-ref-syntax-ddl-alter-database.md
+++ b/docs/sql-ref-syntax-ddl-alter-database.md
@@ -33,9 +33,7 @@ ALTER {DATABASE | SCHEMA} database_name SET DBPROPERTIES (propery_name=property_
 ### Parameters
 <dl>
   <dt><code><em>database_name</em></code></dt>
-  <dd>
-    Specifies the name of the database to be altered.
-  </dd>
+  <dd>Specifies the name of the database to be altered.</dd>
 </dl>
 
 ### Examples


### PR DESCRIPTION
### What changes were proposed in this pull request?
Document ALTER DATABSE statement in SQL Reference Guide. 

### Why are the changes needed?
Currently Spark lacks documentation on the supported SQL constructs causing
confusion among users who sometimes have to look at the code to understand the
usage. This is aimed at addressing this issue.

### Does this PR introduce any user-facing change?
Yes. 

**Before:**
There was no documentation for this.

**After.**
<img width="1234" alt="Screen Shot 2019-08-28 at 1 51 13 PM" src="https://user-images.githubusercontent.com/14225158/63891854-fc817580-c99a-11e9-918e-6b305edf92e6.png">
<img width="1234" alt="Screen Shot 2019-08-28 at 1 51 27 PM" src="https://user-images.githubusercontent.com/14225158/63891869-0acf9180-c99b-11e9-91a4-04d870474a40.png">

### How was this patch tested?
Tested using jykyll build --serve
