### PR TITLE
[SPARK-28807][DOCS][SQL] Document SHOW DATABASES in SQL Reference

### DIFF
--- a/docs/sql-ref-syntax-aux-show-databases.md
+++ b/docs/sql-ref-syntax-aux-show-databases.md
@@ -1,7 +1,7 @@
 ---
 layout: global
-title: SHOW DATABASE
-displayTitle: SHOW DATABASE
+title: SHOW DATABASES
+displayTitle: SHOW DATABASES
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -19,4 +19,61 @@ license: |
   limitations under the License.
 ---
 
-**This page is under construction**
+### Description
+Lists the databases that match an optionally supplied string pattern. If no
+pattern is supplied then the command lists all the databases in the system.
+Please note that the usage of `SCHEMAS` and `DATABASES` are interchangable
+and mean the same thing.
+
+### Syntax
+{% highlight sql %}
+SHOW {DATABASES|SCHEMAS} [LIKE string_pattern]
+{% endhighlight %}
+
+### Parameters
+<dl>
+  <dt><code><em>LIKE string_pattern</em></code></dt>
+  <dd>
+    Specifies a string pattern that is used to match the databases in the system. In 
+    the specified string pattern <code>'*'</code> matches any number of characters.
+  </dd>
+</dl>
+
+### Examples
+{% highlight sql %}
+-- Create database. Assumes a database named `default` already exists in
+-- the system. 
+CREATE DATABASE payroll_db;
+CREATE DATABASE payments_db;
+
+-- Lists all the databases. 
+SHOW DATABASES;
+  +------------+
+  |databaseName|
+  +------------+
+  |     default|
+  | payments_db|
+  |  payroll_db|
+  +------------+
+-- Lists databases with name starting with string pattern `pay`
+SHOW DATABASES LIKE 'pay*';
+  +------------+
+  |databaseName|
+  +------------+
+  | payments_db|
+  |  payroll_db|
+  +------------+
+-- Lists all databases. Keywords SCHEMAS and DATABASES are interchangeable. 
+SHOW SCHEMAS;
+  +------------+
+  |databaseName|
+  +------------+
+  |     default|
+  | payments_db|
+  |  payroll_db|
+  +------------+
+{% endhighlight %}
+### Related Statements
+- [DESCRIBE DATABASE](sql-ref-syntax-aux-describe-databases.html)
+- [CREATE DATABASE](sql-ref-syntax-ddl-create-database.html)
+- [ALTER DATABASE](sql-ref-syntax-ddl-alter-database.html)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Document SHOW DATABASES statement in SQL Reference Guide. 

### Why are the changes needed?
Currently Spark lacks documentation on the supported SQL constructs causing
confusion among users who sometimes have to look at the code to understand the
usage. This is aimed at addressing this issue.

### Does this PR introduce any user-facing change?
Yes. 

**Before:**
There was no documentation for this.

**After.**
<img width="1234" alt="Screen Shot 2019-08-28 at 11 43 36 PM" src="https://user-images.githubusercontent.com/14225158/63916727-dd600380-c9ed-11e9-8372-789110c9d2dc.png">
<img width="1234" alt="Screen Shot 2019-08-28 at 11 43 57 PM" src="https://user-images.githubusercontent.com/14225158/63916734-e0f38a80-c9ed-11e9-8ad4-d854febeaab8.png">
<img width="1234" alt="Screen Shot 2019-08-28 at 11 44 13 PM" src="https://user-images.githubusercontent.com/14225158/63916740-e4871180-c9ed-11e9-9cfc-199cd8a64852.png">

### How was this patch tested?
Tested using jykyll build --serve
