### PR TITLE
[SPARK-28805][DOCS][SQL] Document DESCRIBE FUNCTION in SQL Reference

### DIFF
--- a/docs/sql-ref-syntax-aux-describe-function.md
+++ b/docs/sql-ref-syntax-aux-describe-function.md
@@ -18,5 +18,40 @@ license: |
   See the License for the specific language governing permissions and
   limitations under the License.
 ---
+### Description
 
-**This page is under construction**
+Return the metadata such as qualified function name, implementing class and usage of an existing function.
+Input parameter function name may be optionally qualified. If the function is not qualified then the function is
+resolved from the current database. If EXTENDED option is specified then additionally extended usage information
+including usage examples are returned. 
+
+### Syntax
+{% highlight sql %}
+{DESC | DESCRIBE} FUNCTION [EXTENDED] [db_name.]function_name
+{% endhighlight %}
+
+### Examples
+{% highlight sql %}
+-- Describe a builtin scalar function.
+-- Returns function name, implementing class and usage
+DESC FUNCTION Trim;
+-- Describe a builtin scalar function.
+-- Returns function name, implementing class and usage and examples.
+DESC FUNCTION EXTENDED trim;
+-- Describe a builtin aggregate function
+DESC FUNCTION Max;
+-- Describe a builtin user defined aggregate function
+-- Returns function name, implementing class and usage and examples.
+DESC FUNCTION EXTENDED Explode
+-- Create a UDF
+CREATE FUNCTION myFunc
+AS 'com.mycompany.functions.myFunc'
+USING JAR 'jar-file-uri'
+-- describe the user defined function
+DESC FUNCTION myFunc
+{% endhighlight %}
+
+### Related Statements
+- [DESCRIBE DATABASE](sql-ref-syntax-aux-describe-database.html)
+- [DESCRIBE TABLE](sql-ref-syntax-aux-describe-table.html)
+- [DESCRIBE QUERY](sql-ref-syntax-aux-describe-query.html)

--- a/docs/sql-ref-syntax-aux-describe-function.md
+++ b/docs/sql-ref-syntax-aux-describe-function.md
@@ -21,8 +21,8 @@ license: |
 ### Description
 
 Return the metadata such as qualified function name, implementing class and usage of an existing function.
-Input parameter function name may be optionally qualified. If the function is not qualified then the function is
-resolved from the current database. If EXTENDED option is specified then additionally extended usage information
+Input parameter `function_name` may be optionally qualified. If the function is not qualified then the function is
+resolved from the current database. If the `EXTENDED` option is specified then additionally extended usage information
 including usage examples are returned. 
 
 ### Syntax

--- a/docs/sql-ref-syntax-aux-describe-function.md
+++ b/docs/sql-ref-syntax-aux-describe-function.md
@@ -20,10 +20,10 @@ license: |
 ---
 ### Description
 
-`DESCRIBE FUNCTION` statement returns the basic metadata information of a
-existing function. The metadata information includes function name, implementing
-class and the usage details.  If the optional `EXTENDED` option is specified then basic
-metadata information is returned along with extended usage information.
+`DESCRIBE FUNCTION` statement returns the basic metadata information of an
+existing function. The metadata information includes the function name, implementing
+class and the usage details.  If the optional `EXTENDED` option is specified, the basic
+metadata information is returned along with the extended usage information.
 
 ### Syntax
 {% highlight sql %}

--- a/docs/sql-ref-syntax-aux-describe-function.md
+++ b/docs/sql-ref-syntax-aux-describe-function.md
@@ -23,7 +23,7 @@ license: |
 `DESCRIBE FUNCTION` statement returns the basic metadata information of a
 existing function. The metadata information includes function name, implementing
 class and the usage details.  If the optional `EXTENDED` option is specified then basic
-metadata augmented with extended usage information are returned.
+metadata information is returned along with extended usage information.
 
 ### Syntax
 {% highlight sql %}
@@ -36,7 +36,7 @@ metadata augmented with extended usage information are returned.
   <dd>
     Specifies a name of an existing function in the syetem. The function name may be
     optionally qualified with a database name. If `function_name` is qualified with
-    a database then the function is resolved from the qualified database, otherwise
+    a database then the function is resolved from the user specified database, otherwise
     it is resolved from the current database.<br><br>
     <b>Syntax:</b>
       <code>
@@ -49,21 +49,61 @@ metadata augmented with extended usage information are returned.
 {% highlight sql %}
 -- Describe a builtin scalar function.
 -- Returns function name, implementing class and usage
-DESC FUNCTION Trim;
+DESC FUNCTION abs;
+  +-------------------------------------------------------------------+
+  |function_desc                                                      |
+  +-------------------------------------------------------------------+
+  |Function: abs                                                      |
+  |Class: org.apache.spark.sql.catalyst.expressions.Abs               |
+  |Usage: abs(expr) - Returns the absolute value of the numeric value.|
+  +-------------------------------------------------------------------+
+
 -- Describe a builtin scalar function.
 -- Returns function name, implementing class and usage and examples.
-DESC FUNCTION EXTENDED trim;
+DESC FUNCTION EXTENDED abs;
+  +-------------------------------------------------------------------+
+  |function_desc                                                      |
+  +-------------------------------------------------------------------+
+  |Function: abs                                                      |
+  |Class: org.apache.spark.sql.catalyst.expressions.Abs               |
+  |Usage: abs(expr) - Returns the absolute value of the numeric value.|
+  |Extended Usage:                                                    |
+  |    Examples:                                                      |
+  |      > SELECT abs(-1);                                            |
+  |       1                                                           |
+  |                                                                   |
+  +-------------------------------------------------------------------+
+
 -- Describe a builtin aggregate function
-DESC FUNCTION Max;
+DESC FUNCTION max;
+  +--------------------------------------------------------------+
+  |function_desc                                                 |
+  +--------------------------------------------------------------+
+  |Function: max                                                 |
+  |Class: org.apache.spark.sql.catalyst.expressions.aggregate.Max|
+  |Usage: max(expr) - Returns the maximum value of `expr`.       |
+  +--------------------------------------------------------------+
+
 -- Describe a builtin user defined aggregate function
 -- Returns function name, implementing class and usage and examples.
-DESC FUNCTION EXTENDED Explode
--- Create a UDF
-CREATE FUNCTION myFunc
-AS 'com.mycompany.functions.myFunc'
-USING JAR 'jar-file-uri'
--- describe the user defined function
-DESC FUNCTION myFunc
+DESC FUNCTION EXTENDED explode
+  +---------------------------------------------------------------+
+  |function_desc                                                  |
+  +---------------------------------------------------------------+
+  |Function: explode                                              |
+  |Class: org.apache.spark.sql.catalyst.expressions.Explode       | 
+  |Usage: explode(expr) - Separates the elements of array `expr`  |
+  | into multiple rows, or the elements of map `expr` into        |
+  | multiple rows and columns. Unless specified otherwise, uses   |
+  | the default column name `col` for elements of the array or    |
+  | `key` and `value` for the elements of the map.                |
+  |Extended Usage:                                                |
+  |    Examples:                                                  |
+  |      > SELECT explode(array(10, 20));                         |
+  |       10                                                      |
+  |       20                                                      |
+  +---------------------------------------------------------------+
+
 {% endhighlight %}
 
 ### Related Statements

--- a/docs/sql-ref-syntax-aux-describe-function.md
+++ b/docs/sql-ref-syntax-aux-describe-function.md
@@ -20,15 +20,30 @@ license: |
 ---
 ### Description
 
-Return the metadata such as qualified function name, implementing class and usage of an existing function.
-Input parameter `function_name` may be optionally qualified. If the function is not qualified then the function is
-resolved from the current database. If the `EXTENDED` option is specified then additionally extended usage information
-including usage examples are returned. 
+`DESCRIBE FUNCTION` statement returns the basic metadata information of a
+existing function. The metadata information includes function name, implementing
+class and the usage details.  If the optional `EXTENDED` option is specified then basic
+metadata augmented with extended usage information are returned.
 
 ### Syntax
 {% highlight sql %}
-{DESC | DESCRIBE} FUNCTION [EXTENDED] [db_name.]function_name
+{DESC | DESCRIBE} FUNCTION [EXTENDED] function_name
 {% endhighlight %}
+
+### Parameters
+<dl>
+  <dt><code><em>function_name</em></code></dt>
+  <dd>
+    Specifies a name of an existing function in the syetem. The function name may be
+    optionally qualified with a database name. If `function_name` is qualified with
+    a database then the function is resolved from the qualified database, otherwise
+    it is resolved from the current database.<br><br>
+    <b>Syntax:</b>
+      <code>
+        [database_name.]function_name
+      </code>
+  </dd>
+</dl>
 
 ### Examples
 {% highlight sql %}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Document DESCRIBE FUNCTION statement in SQL Reference Guide. 

### Why are the changes needed?
Currently Spark lacks documentation on the supported SQL constructs causing
confusion among users who sometimes have to look at the code to understand the
usage. This is aimed at addressing this issue.

### Does this PR introduce any user-facing change?
Yes. 

**Before:**
There was no documentation for this.

**After.**
<img width="1234" alt="Screen Shot 2019-09-02 at 11 14 09 PM" src="https://user-images.githubusercontent.com/14225158/64148193-85534380-cdd7-11e9-9c07-5956b5e8276e.png">
<img width="1234" alt="Screen Shot 2019-09-02 at 11 14 29 PM" src="https://user-images.githubusercontent.com/14225158/64148201-8a17f780-cdd7-11e9-93d8-10ad9932977c.png">
<img width="1234" alt="Screen Shot 2019-09-02 at 11 14 42 PM" src="https://user-images.githubusercontent.com/14225158/64148208-8dab7e80-cdd7-11e9-97c5-3a4ce12cac7a.png">


### How was this patch tested?
Tested using jykyll build --serve
