### PR TITLE
[SPARK-28806][DOCS][SQL] Document SHOW COLUMNS in SQL Reference

### DIFF
--- a/docs/sql-ref-syntax-aux-show-columns.md
+++ b/docs/sql-ref-syntax-aux-show-columns.md
@@ -27,7 +27,7 @@ SHOW COLUMNS {IN | FROM} [db.]table {IN | FROM} database
 {% endhighlight %}
 **Note**
 - You can list the columns of a table in a database other than current database in one of following
-ways
+ways:
   - By qualifying the table name with a database name other than current database.
   - By specifying the database name in the database parameter.
 - Keywords IN and FROM are interchangeable.

--- a/docs/sql-ref-syntax-aux-show-columns.md
+++ b/docs/sql-ref-syntax-aux-show-columns.md
@@ -30,7 +30,7 @@ SHOW COLUMNS {IN | FROM} [db.]table {IN | FROM} database
 ways:
   - By qualifying the table name with a database name other than current database.
   - By specifying the database name in the database parameter.
-- Keywords IN and FROM are interchangeable.
+- Keywords `IN` and `FROM` are interchangeable.
 
 ### Examples
 {% highlight sql %}

--- a/docs/sql-ref-syntax-aux-show-columns.md
+++ b/docs/sql-ref-syntax-aux-show-columns.md
@@ -18,5 +18,26 @@ license: |
   See the License for the specific language governing permissions and
   limitations under the License.
 ---
+### Description
+Return the list of columns in a table. If the table does not exist, an exception is thrown.
 
-**This page is under construction**
+### Syntax
+{% highlight sql %}
+SHOW COLUMNS {IN | FROM} [db.]table {IN | FROM} database
+{% endhighlight %}
+**Note**
+- You can list the columns of a table in a database other than current database in one of following
+ways
+  - By qualifying the table name with a database name other than current database.
+  - By specifying the database name in the database parameter.
+- Keywords IN and FROM are interchangeable.
+
+### Examples
+{% highlight sql %}
+-- List the columns of table employee in current database.
+SHOW COLUMNS IN employee
+-- List the columns of table employee in salesdb database.
+SHOW COLUMNS IN salesdb.employee
+-- List the columns of table employee in salesdb database
+SHOW COLUMNS IN employee IN salesdb
+{% endhighlight %}

--- a/docs/sql-ref-syntax-aux-show-columns.md
+++ b/docs/sql-ref-syntax-aux-show-columns.md
@@ -91,3 +91,7 @@ SHOW COLUMNS IN customer IN salesdb;
   |cust_addr|
   +---------+
 {% endhighlight %}
+
+### Related Statements
+- [DESCRIBE TABLE](sql-ref-syntax-aux-describe-table.html)
+- [SHOW TABLE](sql-ref-syntax-aux-show-table.html)

--- a/docs/sql-ref-syntax-aux-show-columns.md
+++ b/docs/sql-ref-syntax-aux-show-columns.md
@@ -23,21 +23,71 @@ Return the list of columns in a table. If the table does not exist, an exception
 
 ### Syntax
 {% highlight sql %}
-SHOW COLUMNS {IN | FROM} [db.]table {IN | FROM} database
+SHOW COLUMNS table [ database ]
 {% endhighlight %}
-**Note**
-- You can list the columns of a table in a database other than current database in one of following
-ways:
-  - By qualifying the table name with a database name other than current database.
-  - By specifying the database name in the database parameter.
-- Keywords `IN` and `FROM` are interchangeable.
+
+### Parameters
+<dl>
+  <dt><code><em>table</em></code></dt>
+  <dd>
+    Specifies the table name of an existing table. The table may be optionally qualified
+    with a database name.<br><br>
+    <b>Syntax:</b>
+      <code>
+        { IN | FROM } [database_name.]table_name
+      </code><br><br>
+    <b>Note:</b>
+    Keywords <code>IN</code> and <code>FROM</code> are interchangeable.
+  </dd>
+  <dt><code><em>database</em></code></dt>
+  <dd>
+    Specifies a optional database name. The table is resolved from this database when it
+    is specified. Please note that when this parameter is specified then table
+    name should not be qualified with a different database name. <br><br>
+    <b>Syntax:</b>
+      <code>
+        { IN | FROM } database_name
+      </code><br><br>
+    <b>Note:</b>
+    Keywords <code>IN</code> and <code>FROM</code> are interchangeable.
+  </dd>
+</dl>
 
 ### Examples
 {% highlight sql %}
--- List the columns of table employee in current database.
-SHOW COLUMNS IN employee
--- List the columns of table employee in salesdb database.
-SHOW COLUMNS IN salesdb.employee
--- List the columns of table employee in salesdb database
-SHOW COLUMNS IN employee IN salesdb
+-- Create `customer` table in `salesdb` database;
+USE salesdb;
+CREATE TABLE customer(cust_cd INT,
+  name VARCHAR(100),
+  cust_addr STRING);
+
+-- List the columns of `customer` table in current database.
+SHOW COLUMNS IN customer;
+  +---------+
+  |col_name |
+  +---------+
+  |cust_cd  |
+  |name     |
+  |cust_addr|
+  +---------+
+
+-- List the columns of `customer` table in `salesdb` database.
+SHOW COLUMNS IN salesdb.customer;
+  +---------+
+  |col_name |
+  +---------+
+  |cust_cd  |
+  |name     |
+  |cust_addr|
+  +---------+
+
+-- List the columns of `customer` table in `salesdb` database
+SHOW COLUMNS IN customer IN salesdb;
+  +---------+
+  |col_name |
+  +---------+
+  |cust_cd  |
+  |name     |
+  |cust_addr|
+  +---------+
 {% endhighlight %}

--- a/docs/sql-ref-syntax-aux-show-columns.md
+++ b/docs/sql-ref-syntax-aux-show-columns.md
@@ -41,7 +41,7 @@ SHOW COLUMNS table [ database ]
   </dd>
   <dt><code><em>database</em></code></dt>
   <dd>
-    Specifies a optional database name. The table is resolved from this database when it
+    Specifies an optional database name. The table is resolved from this database when it
     is specified. Please note that when this parameter is specified then table
     name should not be qualified with a different database name. <br><br>
     <b>Syntax:</b>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Document SHOW COLUMNS statement in SQL Reference Guide. 

### Why are the changes needed?
Currently Spark lacks documentation on the supported SQL constructs causing
confusion among users who sometimes have to look at the code to understand the
usage. This is aimed at addressing this issue.

### Does this PR introduce any user-facing change?
Yes. 

**Before:**
There was no documentation for this.

**After.**
<img width="1234" alt="Screen Shot 2019-09-02 at 11 07 48 PM" src="https://user-images.githubusercontent.com/14225158/64148033-0fe77300-cdd7-11e9-93ee-e5951c7ed33c.png">
<img width="1234" alt="Screen Shot 2019-09-02 at 11 08 08 PM" src="https://user-images.githubusercontent.com/14225158/64148039-137afa00-cdd7-11e9-8bec-634ea9d2594c.png">
<img width="1234" alt="Screen Shot 2019-09-02 at 11 11 45 PM" src="https://user-images.githubusercontent.com/14225158/64148046-17a71780-cdd7-11e9-91c3-95a9c97e7a77.png">

### How was this patch tested?
Tested using jykyll build --serve
