### PR TITLE
[SPARK-28831][DOC][SQL]Document CLEAR CACHE statement in SQL Reference

### DIFF
--- a/docs/sql-ref-syntax-aux-cache-clear-cache.md
+++ b/docs/sql-ref-syntax-aux-cache-clear-cache.md
@@ -20,7 +20,7 @@ license: |
 ---
 
 ### Description
-Clear the RDD cache associated with a SQLContext.
+Clears all cached RDDs and DataFrames associated with a `SparkSession`.
 
 ### Syntax
 {% highlight sql %}

--- a/docs/sql-ref-syntax-aux-cache-clear-cache.md
+++ b/docs/sql-ref-syntax-aux-cache-clear-cache.md
@@ -19,4 +19,16 @@ license: |
   limitations under the License.
 ---
 
-**This page is under construction**
+### Description
+Clear the RDD cache associated with a SQLContext.
+
+### Syntax
+{% highlight sql %}
+CLEAR CACHE
+{% endhighlight %}
+
+### Example
+{% highlight sql %}
+CLEAR CACHE
+{% endhighlight %}
+

--- a/docs/sql-ref-syntax-aux-cache-clear-cache.md
+++ b/docs/sql-ref-syntax-aux-cache-clear-cache.md
@@ -20,7 +20,7 @@ license: |
 ---
 
 ### Description
-`CLEAR CACHE` removes the entries and associated data from the in-memory and/or on-disk cache for all cached tables  and views.
+`CLEAR CACHE` removes the entries and associated data from the in-memory and/or on-disk cache for all cached tables and views.
 
 ### Syntax
 {% highlight sql %}

--- a/docs/sql-ref-syntax-aux-cache-clear-cache.md
+++ b/docs/sql-ref-syntax-aux-cache-clear-cache.md
@@ -20,15 +20,19 @@ license: |
 ---
 
 ### Description
-Clears all cached RDDs and DataFrames associated with a `SparkSession`.
+`CLEAR CACHE` removes the entries and associated data from the in-memory and/or on-disk cache for all cached tables  and views.
 
 ### Syntax
 {% highlight sql %}
 CLEAR CACHE
 {% endhighlight %}
 
-### Example
+### Examples
 {% highlight sql %}
-CLEAR CACHE
+CLEAR CACHE;
 {% endhighlight %}
+
+### Related Statements
+ * [CACHE TABLE](sql-ref-syntax-aux-cache-cache-table.html)
+ * [UNCACHE TABLE](sql-ref-syntax-aux-cache-uncache-table.html)
 

--- a/docs/sql-ref-syntax-aux-cache-uncache-table.md
+++ b/docs/sql-ref-syntax-aux-cache-uncache-table.md
@@ -20,7 +20,7 @@ license: |
 ---
 
 ### Description
-`UNCACHE TABLE` removes the entries and associated data from the in-memory and/or on-disk cache for a given table. The
+`UNCACHE TABLE` removes the entries and associated data from the in-memory and/or on-disk cache for a given table or view. The
 underlying entries should already have been brought to cache by previous `CACHE TABLE` operation. `UNCACHE TABLE` on a non-existent table throws Exception if `IF EXISTS` is not specified.
 ### Syntax
 {% highlight sql %}
@@ -29,7 +29,7 @@ UNCACHE TABLE [ IF EXISTS ] table_name
 ### Parameters
 <dl>
  <dt><code><em>table_name</em></code></dt>
- <dd>The name of the table to be uncached.</dd>
+ <dd>The name of the table or view to be uncached.</dd>
 </dl>
 ### Examples
 {% highlight sql %}

--- a/docs/sql-ref-syntax-aux-cache.md
+++ b/docs/sql-ref-syntax-aux-cache.md
@@ -1,7 +1,7 @@
 ---
 layout: global
-title: Reference
-displayTitle: Reference
+title: Cache
+displayTitle: Cache
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -9,9 +9,9 @@ license: |
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
- 
+
      http://www.apache.org/licenses/LICENSE-2.0
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ license: |
   limitations under the License.
 ---
 
-Spark SQL is a Apache Spark's module for working with structured data.
-This guide is a reference for Structured Query Language (SQL) for Apache 
-Spark. This document describes the SQL constructs supported by Spark in detail
-along with usage examples when applicable.
+* [CACHE TABLE statement](sql-ref-syntax-aux-cache-cache-table.html)
+* [UNCACHE TABLE statement](sql-ref-syntax-aux-cache-uncache-table.html)
+* [CLEAR CACHE statement](sql-ref-syntax-aux-cache-clear-cache.html)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Document CLEAR CACHE statement in SQL Reference


### Why are the changes needed?
To complete SQL Reference


### Does this PR introduce any user-facing change?
Yes

After change:
![image](https://user-images.githubusercontent.com/13592258/64565512-caf89a80-d308-11e9-99ea-88e966d1b1a1.png)



### How was this patch tested?
Tested using jykyll build --serve
