### PR TITLE
[SPARK-28780][ML][2.4] deprecate LinearSVCModel.setWeightCol

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LinearSVC.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LinearSVC.scala
@@ -313,7 +313,8 @@ class LinearSVCModel private[classification] (
   setDefault(threshold, 0.0)
 
   @Since("2.2.0")
-  def setWeightCol(value: Double): this.type = set(threshold, value)
+  @deprecated("This method is deprecated and will be removed in the future.", "2.4.4")
+  def setWeightCol(value: Double): this.type = this
 
   private val margin: Vector => Double = (features) => {
     BLAS.dot(features, coefficients) + intercept

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LinearSVC.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LinearSVC.scala
@@ -313,7 +313,7 @@ class LinearSVCModel private[classification] (
   setDefault(threshold, 0.0)
 
   @Since("2.2.0")
-  @deprecated("This method is deprecated and will be removed in the future.", "2.4.4")
+  @deprecated("This method is deprecated and will be removed in 3.0.0.", "2.4.4")
   def setWeightCol(value: Double): this.type = this
 
   private val margin: Vector => Double = (features) => {


### PR DESCRIPTION
### What changes were proposed in this pull request?
deprecate `LinearSVCModel.setWeightCol`, and make it a no-op


### Why are the changes needed?
`LinearSVCModel` should not provide this setter, moreover, this method is wrongly defined.

### Does this PR introduce any user-facing change?
no, this method is only deprecated

### How was this patch tested?
existing suites