### PR TITLE
[SPARK-28849][CORE] Add a number to control transferTo calls to avoid infinite loop in some occasional cases

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
@@ -80,6 +80,7 @@ final class BypassMergeSortShuffleWriter<K, V> extends ShuffleWriter<K, V> {
 
   private final int fileBufferSize;
   private final boolean transferToEnabled;
+  private final int transferToNumCalls;
   private final int numPartitions;
   private final BlockManager blockManager;
   private final Partitioner partitioner;
@@ -114,6 +115,7 @@ final class BypassMergeSortShuffleWriter<K, V> extends ShuffleWriter<K, V> {
     // Use getSizeAsKb (not bytes) to maintain backwards compatibility if no units are provided
     this.fileBufferSize = (int) (long) conf.get(package$.MODULE$.SHUFFLE_FILE_BUFFER_SIZE()) * 1024;
     this.transferToEnabled = conf.getBoolean("spark.file.transferTo", true);
+    this.transferToNumCalls = conf.getInt("spark.file.transferToNumCalls", Integer.MAX_VALUE);
     this.blockManager = blockManager;
     final ShuffleDependency<K, V, V> dep = handle.dependency();
     this.mapId = mapId;
@@ -238,8 +240,11 @@ final class BypassMergeSortShuffleWriter<K, V> extends ShuffleWriter<K, V> {
     try {
       FileInputStream in = new FileInputStream(file);
       try (FileChannel inputChannel = in.getChannel()) {
-        Utils.copyFileStreamNIO(
-            inputChannel, outputChannel.channel(), 0L, inputChannel.size());
+        Utils.copyFileStreamNIO(inputChannel,
+          outputChannel.channel(),
+          0L,
+          inputChannel.size(),
+          transferToNumCalls);
         copyThrewException = false;
       } finally {
         Closeables.close(in, copyThrewException);
@@ -257,7 +262,7 @@ final class BypassMergeSortShuffleWriter<K, V> extends ShuffleWriter<K, V> {
     try {
       outputStream = writer.openStream();
       try {
-        Utils.copyStream(in, outputStream, false, false);
+        Utils.copyStream(in, outputStream, false, false, Integer.MAX_VALUE);
         copyThrewException = false;
       } finally {
         Closeables.close(outputStream, copyThrewException);

--- a/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
@@ -80,7 +80,7 @@ final class BypassMergeSortShuffleWriter<K, V> extends ShuffleWriter<K, V> {
 
   private final int fileBufferSize;
   private final boolean transferToEnabled;
-  private final int transferToNumCalls;
+  private final int transferToZeroReturns;
   private final int numPartitions;
   private final BlockManager blockManager;
   private final Partitioner partitioner;
@@ -115,7 +115,7 @@ final class BypassMergeSortShuffleWriter<K, V> extends ShuffleWriter<K, V> {
     // Use getSizeAsKb (not bytes) to maintain backwards compatibility if no units are provided
     this.fileBufferSize = (int) (long) conf.get(package$.MODULE$.SHUFFLE_FILE_BUFFER_SIZE()) * 1024;
     this.transferToEnabled = conf.getBoolean("spark.file.transferTo", true);
-    this.transferToNumCalls = conf.getInt("spark.file.transferToNumCalls", Integer.MAX_VALUE);
+    this.transferToZeroReturns = conf.getInt("spark.file.transferToZeroReturns", Integer.MAX_VALUE);
     this.blockManager = blockManager;
     final ShuffleDependency<K, V, V> dep = handle.dependency();
     this.mapId = mapId;
@@ -244,7 +244,7 @@ final class BypassMergeSortShuffleWriter<K, V> extends ShuffleWriter<K, V> {
           outputChannel.channel(),
           0L,
           inputChannel.size(),
-          transferToNumCalls);
+          transferToZeroReturns);
         copyThrewException = false;
       } finally {
         Closeables.close(in, copyThrewException);

--- a/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
@@ -459,7 +459,8 @@ public class UnsafeShuffleWriter<K, V> extends ShuffleWriter<K, V> {
             spillInputChannel,
             mergedFileOutputChannel,
             spillInputChannelPositions[i],
-            partitionLengthInSpill);
+            partitionLengthInSpill,
+            sparkConf.getInt("spark.file.transferToNumCalls", Integer.MAX_VALUE));
           spillInputChannelPositions[i] += partitionLengthInSpill;
           writeMetrics.incWriteTime(System.nanoTime() - writeStartTime);
           bytesWrittenToMergedFile += partitionLengthInSpill;

--- a/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
@@ -460,7 +460,7 @@ public class UnsafeShuffleWriter<K, V> extends ShuffleWriter<K, V> {
             mergedFileOutputChannel,
             spillInputChannelPositions[i],
             partitionLengthInSpill,
-            sparkConf.getInt("spark.file.transferToNumCalls", Integer.MAX_VALUE));
+            sparkConf.getInt("spark.file.transferToZeroReturns", Integer.MAX_VALUE));
           spillInputChannelPositions[i] += partitionLengthInSpill;
           writeMetrics.incWriteTime(System.nanoTime() - writeStartTime);
           bytesWrittenToMergedFile += partitionLengthInSpill;

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1408,10 +1408,12 @@ package object config {
     .createOptional
 
   private[spark] val TRANSFERTO_NUM_CALLS =
-    ConfigBuilder("spark.file.transferToNumCalls")
-      .doc("Number to control the calls Java NIO's transferTo. In some occasional case, Spark's " +
-        "copyFileStreamNIO will run into infinite loop, we should control the calls and jump out " +
-        "of loop int time. This is an internal configuration, user shouldn't configure it normally")
+    ConfigBuilder("spark.file.transferToZeroReturns")
+      .doc("To track the numbers of 0 return value of Java NIO's transferTo. " +
+        "In some occasional case, Spark's copyFileStreamNIO will always return zero and " +
+        "run into infinite loop, this configuration is used to track the number of return 0 and " +
+        "jump out of loop in time. This is an internal configuration, " +
+        "user shouldn't configure it normally")
       .intConf
       .createWithDefault(Int.MaxValue)
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1407,4 +1407,11 @@ package object config {
     .bytesConf(ByteUnit.BYTE)
     .createOptional
 
+  private[spark] val TRANSFERTO_NUM_CALLS =
+    ConfigBuilder("spark.file.transferToNumCalls")
+      .doc("Number to control the calls Java NIO's transferTo. In some occasional case, Spark's " +
+        "copyFileStreamNIO will run into infinite loop, we should control the calls and jump out " +
+        "of loop int time. This is an internal configuration, user shouldn't configure it normally")
+      .intConf
+      .createWithDefault(Int.MaxValue)
 }

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriterSuite.scala
@@ -119,7 +119,7 @@ class LocalDiskShuffleMapOutputWriterSuite extends SparkFunSuite with BeforeAndA
           assert(channelWrapper.channel().isInstanceOf[FileChannel],
             "Underlying channel should be a file channel")
           Utils.copyFileStreamNIO(
-            tempFileInput.getChannel, channelWrapper.channel(), 0L, data(p).length)
+            tempFileInput.getChannel, channelWrapper.channel(), 0L, data(p).length, Int.MaxValue)
         }
       }
       assert(writer.getNumBytesWritten === data(p).length,


### PR DESCRIPTION
This patch propose a way to detect the infinite loop issue in `transferTo` and make it fail fast. The detailed issue is shown in https://issues.apache.org/jira/browse/SPARK-28849. 

Here propose a new undocumented configuration and a way to track the number of `transferTo` calls, if the number is larger than the specified value, it will jump out of the loop and throw an exception. 

Typically this will not be happened, and user don't need to set this configuration explicitly, in our environment it happens occasionally and cause the task hung infinitely.
