### PR TITLE
[SPARK-28797][DOC] Document DROP FUNCTION statement in SQL Reference.

### DIFF
--- a/docs/sql-ref-syntax-ddl-drop-function.md
+++ b/docs/sql-ref-syntax-ddl-drop-function.md
@@ -20,8 +20,8 @@ license: |
 ---
 
 ### Description
-`DROP FUNCTION` statement drops a temporary or user defined function(UDF). An exception will be thrown if the function does not exist
- in the system. 
+The `DROP FUNCTION` statement drops a temporary or user defined function (UDF). An exception will
+ be thrown if the function does not exists. 
 
 ### Syntax
 {% highlight sql %}

--- a/docs/sql-ref-syntax-ddl-drop-function.md
+++ b/docs/sql-ref-syntax-ddl-drop-function.md
@@ -21,7 +21,7 @@ license: |
 
 ### Description
 The `DROP FUNCTION` statement drops a temporary or user defined function (UDF). An exception will
- be thrown if the function does not exists. 
+ be thrown if the function does not exist. 
 
 ### Syntax
 {% highlight sql %}

--- a/docs/sql-ref-syntax-ddl-drop-function.md
+++ b/docs/sql-ref-syntax-ddl-drop-function.md
@@ -89,11 +89,11 @@ SHOW USER FUNCTIONS;
   +-----------+
   | function  |
   +-----------+
-  | temp_avg  |
+  | test_avg  |
   +-----------+
   
 -- Drop Temporary function
-DROP TEMPORARY FUNCTION IF EXISTS temp_avg;
+DROP TEMPORARY FUNCTION IF EXISTS test_avg;
   +---------+
   | Result  |
   +---------+

--- a/docs/sql-ref-syntax-ddl-drop-function.md
+++ b/docs/sql-ref-syntax-ddl-drop-function.md
@@ -59,6 +59,18 @@ SHOW USER FUNCTIONS;
   | default.test_avg  |
   +-------------------+
 
+-- Create Temporary function `temp_avg`
+CREATE TEMPORARY FUNCTION temp_avg as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDAFAverage';
+
+-- List user functions
+SHOW USER FUNCTIONS;
+  +-------------------+
+  |     function      |
+  +-------------------+
+  | default.test_avg  |
+  | temp_avg          |
+  +-------------------+
+
 -- Drop Permanent function
 DROP FUNCTION test_avg;
   +---------+
@@ -72,9 +84,14 @@ DROP FUNCTION test_avg;
   org.apache.spark.sql.catalyst.analysis.NoSuchPermanentFunctionException:
   Function 'default.test_avg' not found in database 'default'; (state=,code=0)
 
--- Create Temporary function `temp_avg`
-CREATE TEMPORARY FUNCTION temp_avg as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDAFAverage';
-
+-- List the functions after dropping, it should list only temporary function
+SHOW USER FUNCTIONS;
+  +-----------+
+  | function  |
+  +-----------+
+  | temp_avg  |
+  +-----------+
+  
 -- Drop Temporary function
 DROP TEMPORARY FUNCTION IF EXISTS temp_avg;
   +---------+

--- a/docs/sql-ref-syntax-ddl-drop-function.md
+++ b/docs/sql-ref-syntax-ddl-drop-function.md
@@ -42,8 +42,8 @@ The name of an existing function.
 
 ### **TEMPORARY**
 
-If specified, the function created will be local to session. On close of session it will be removed.
+Should be used to delete the `temporary` function.
 
 ### **IF EXISTS**
 
-If specified will not throw any exception if no function exists.
+If specified, no exception is thrown when the function does not exist.

--- a/docs/sql-ref-syntax-ddl-drop-function.md
+++ b/docs/sql-ref-syntax-ddl-drop-function.md
@@ -59,8 +59,8 @@ SHOW USER FUNCTIONS;
   | default.test_avg  |
   +-------------------+
 
--- Create Temporary function `temp_avg`
-CREATE TEMPORARY FUNCTION temp_avg as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDAFAverage';
+-- Create Temporary function `test_avg`
+CREATE TEMPORARY FUNCTION test_avg as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDAFAverage';
 
 -- List user functions
 SHOW USER FUNCTIONS;
@@ -68,7 +68,7 @@ SHOW USER FUNCTIONS;
   |     function      |
   +-------------------+
   | default.test_avg  |
-  | temp_avg          |
+  | test_avg          |
   +-------------------+
 
 -- Drop Permanent function

--- a/docs/sql-ref-syntax-ddl-drop-function.md
+++ b/docs/sql-ref-syntax-ddl-drop-function.md
@@ -19,4 +19,31 @@ license: |
   limitations under the License.
 ---
 
-**This page is under construction**
+### Description
+Dropping a user-defined function(UDF). An exception will be thrown if the function does not exist
+ in the system. 
+
+### Syntax
+{% highlight sql %}
+DROP [TEMPORARY] FUNCTION [IF EXISTS] [db_name.]function_name;
+{% endhighlight %}
+
+### Example
+{% highlight sql %}
+DROP TEMPORARY FUNCTION tempfunction;
+DROP FUNCTION testdb.permfunction;
+{% endhighlight %}
+
+### Parameters
+
+### **function_name**
+
+The name of an existing function.
+
+### **TEMPORARY**
+
+If specified, the function created will be local to session. On close of session it will be removed.
+
+### **IF EXISTS**
+
+If specified will not throw any exception if no function exists.

--- a/docs/sql-ref-syntax-ddl-drop-function.md
+++ b/docs/sql-ref-syntax-ddl-drop-function.md
@@ -53,7 +53,6 @@ CREATE FUNCTION test_avg as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDAFAv
 
 -- List user functions
 SHOW user functions;
-
   +-------------------+
   |     function      |
   +-------------------+

--- a/docs/sql-ref-syntax-ddl-drop-function.md
+++ b/docs/sql-ref-syntax-ddl-drop-function.md
@@ -28,22 +28,61 @@ Dropping a user-defined function(UDF). An exception will be thrown if the functi
 DROP [TEMPORARY] FUNCTION [IF EXISTS] [db_name.]function_name;
 {% endhighlight %}
 
-### Example
-{% highlight sql %}
-DROP TEMPORARY FUNCTION tempfunction;
-DROP FUNCTION testdb.permfunction;
-{% endhighlight %}
 
 ### Parameters
 
-### **function_name**
+<dl>
+  <dt><code><em>function_name</em></code></dt>
+  <dd>The name of an existing function.</dd>
+</dl>
 
-The name of an existing function.
+<dl>
+  <dt><code><em>TEMPORARY</em></code></dt>
+  <dd>Should be used to delete the `temporary` function.</dd>
+</dl>
 
-### **TEMPORARY**
+<dl>
+  <dt><code><em>IF EXISTS</em></code></dt>
+  <dd>If specified, no exception is thrown when the function does not exist.</dd>
+</dl>
 
-Should be used to delete the `temporary` function.
+### Example
+{% highlight sql %}
+-- Create a permanent function `test_avg`
 
-### **IF EXISTS**
+CREATE FUNCTION test_avg as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDAFAverage';
 
-If specified, no exception is thrown when the function does not exist.
+-- List user functions 
+
+SHOW user functions;
+
++-------------------+
+|     function      |
++-------------------+
+| default.test_avg  |
++-------------------+
+
+-- Drop Permanent function
+
+DROP FUNCTION test_avg;
++---------+
+| Result  |
++---------+
++---------+
+
+-- Creaet Temporary function `temp_avg`
+CREATE TEMPORARY FUNCTION temp_avg as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDAFAverage';
+
+-- Drop Temporary function
+
+DROP TEMPORARY FUNCTION IF EXISTS temp_avg;
++---------+
+| Result  |
++---------+
++---------+
+
+{% endhighlight %}
+### Related statements
+- [CREATE FUNCTION](sql-ref-syntax-ddl-create-function.html)
+- [DESCRIBE FUNCTION](sql-ref-syntax-aux-describe-function.html)
+- [SHOW FUNCTION](sql-ref-syntax-aux-show-functions.html)

--- a/docs/sql-ref-syntax-ddl-drop-function.md
+++ b/docs/sql-ref-syntax-ddl-drop-function.md
@@ -20,7 +20,7 @@ license: |
 ---
 
 ### Description
-Dropping a user-defined function(UDF). An exception will be thrown if the function does not exist
+`DROP FUNCTION` statement drops a temporary or user defined function(UDF). An exception will be thrown if the function does not exist
  in the system. 
 
 ### Syntax
@@ -49,38 +49,33 @@ DROP [TEMPORARY] FUNCTION [IF EXISTS] [db_name.]function_name;
 ### Example
 {% highlight sql %}
 -- Create a permanent function `test_avg`
-
 CREATE FUNCTION test_avg as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDAFAverage';
 
--- List user functions 
-
+-- List user functions
 SHOW user functions;
 
-+-------------------+
-|     function      |
-+-------------------+
-| default.test_avg  |
-+-------------------+
+  +-------------------+
+  |     function      |
+  +-------------------+
+  | default.test_avg  |
+  +-------------------+
 
 -- Drop Permanent function
-
 DROP FUNCTION test_avg;
-+---------+
-| Result  |
-+---------+
-+---------+
+  +---------+
+  | Result  |
+  +---------+
+  +---------+
 
--- Creaet Temporary function `temp_avg`
+-- Create Temporary function `temp_avg`
 CREATE TEMPORARY FUNCTION temp_avg as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDAFAverage';
 
 -- Drop Temporary function
-
 DROP TEMPORARY FUNCTION IF EXISTS temp_avg;
-+---------+
-| Result  |
-+---------+
-+---------+
-
+  +---------+
+  | Result  |
+  +---------+
+  +---------+
 {% endhighlight %}
 ### Related statements
 - [CREATE FUNCTION](sql-ref-syntax-ddl-create-function.html)

--- a/docs/sql-ref-syntax-ddl-drop-function.md
+++ b/docs/sql-ref-syntax-ddl-drop-function.md
@@ -52,7 +52,7 @@ DROP [TEMPORARY] FUNCTION [IF EXISTS] [db_name.]function_name;
 CREATE FUNCTION test_avg as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDAFAverage';
 
 -- List user functions
-SHOW user functions;
+SHOW USER FUNCTIONS;
   +-------------------+
   |     function      |
   +-------------------+
@@ -65,6 +65,12 @@ DROP FUNCTION test_avg;
   | Result  |
   +---------+
   +---------+
+
+-- Try to drop Permanent function which is not present
+DROP FUNCTION test_avg;
+  Error: Error running query:
+  org.apache.spark.sql.catalyst.analysis.NoSuchPermanentFunctionException:
+  Function 'default.test_avg' not found in database 'default'; (state=,code=0)
 
 -- Create Temporary function `temp_avg`
 CREATE TEMPORARY FUNCTION temp_avg as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDAFAverage';


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add DROP FUNCTION sql description in SQL reference


### Why are the changes needed?
Currently from spark there is no complete sql guide is present, so it is better to document all the sql commands, this jira is sub part of this task.

### Does this PR introduce any user-facing change?
Yes before user cannot find any reference for drop function command in the spark docs.

After Fix:
![image](https://user-images.githubusercontent.com/35216143/66134570-240cd300-e616-11e9-9c78-259c0d355378.png)

![image](https://user-images.githubusercontent.com/35216143/65397825-d059e880-ddd0-11e9-8bd3-a65ccae56063.png)

![image](https://user-images.githubusercontent.com/35216143/66404731-9f032e80-ea06-11e9-8fef-1e266efa4c66.png)








### How was this patch tested?
tested with jekyll build 
