### PR TITLE
[SPARK-28796][DOC]Document DROP DATABASE statement in SQL Reference

### DIFF
--- a/docs/sql-ref-syntax-ddl-drop-database.md
+++ b/docs/sql-ref-syntax-ddl-drop-database.md
@@ -31,25 +31,50 @@ DROP (DATABASE|SCHEMA) [IF EXISTS] dbname [RESTRICT|CASCADE];
 {% endhighlight %}
 
 
-### Example
-{% highlight sql %}
-DROP DATABASE inventorydb CASCADE;
-{% endhighlight %}
-
 ### Parameters
 
-### **DATABASE** and **SCHEMA**
+<dl>
+  <dt><code><em>DATABASE|SCHEMA</em></code></dt>
+  <dd>`DATABASE` and `SCHEMA` mean the same thing, either of them can be used.</dd>
+</dl>
 
-`DATABASE` and `SCHEMA` mean the same thing, either of them can be used.
+<dl>
+  <dt><code><em>IF EXISTS</em></code></dt>
+  <dd>If specified, no exception is thrown when the database does not exist.</dd>
+</dl>
 
-### **IF EXISTS**
+<dl>
+  <dt><code><em>RESTRICT</em></code></dt>
+  <dd>If specified, will restrict dropping a non-empty database and is enabled by default.</dd>
+</dl>
 
-If specified, no exception is thrown when the database does not exist.
- 
-###  **RESTRICT**
+<dl>
+  <dt><code><em>CASCADE</em></code></dt>
+  <dd>If specified, will drop all the associated tables and functions.</dd>
+</dl>
 
-If specified, will restrict dropping a non-empty database and is enabled by default.
+### Example
+{% highlight sql %}
+-- Create `inventory_db` Database
+CREATE DATABASE inventory_db COMMENT 'This database is used to maintain Inventory';
 
-### **CASCADE**
+-- Drop the database and it's tables
+DROP DATABASE inventory_db CASCADE;
++---------+
+| Result  |
++---------+
++---------+
 
-If specified, will drop all the associated tables and functions.
+-- Drop the database using IF EXISTS
+DROP DATABASE IF EXISTS inventory_db CASCADE;
++---------+
+| Result  |
++---------+
++---------+
+
+{% endhighlight %}
+
+### Related statements
+- [CREATE DATABASE](sql-ref-syntax-ddl-create-database.html)
+- [DESCRIBE DATABASE](sql-ref-syntax-aux-describe-database.html)
+- [SHOW DATABASE](sql-ref-syntax-aux-show-databases.html)

--- a/docs/sql-ref-syntax-ddl-drop-database.md
+++ b/docs/sql-ref-syntax-ddl-drop-database.md
@@ -77,4 +77,4 @@ DROP DATABASE IF EXISTS inventory_db CASCADE;
 ### Related statements
 - [CREATE DATABASE](sql-ref-syntax-ddl-create-database.html)
 - [DESCRIBE DATABASE](sql-ref-syntax-aux-describe-database.html)
-- [SHOW DATABASE](sql-ref-syntax-aux-show-databases.html)
+- [SHOW DATABASES](sql-ref-syntax-aux-show-databases.html)

--- a/docs/sql-ref-syntax-ddl-drop-database.md
+++ b/docs/sql-ref-syntax-ddl-drop-database.md
@@ -19,4 +19,37 @@ license: |
   limitations under the License.
 ---
 
-**This page is under construction**
+### Description
+
+Drop a database and delete the directory associated with the database from the file system. An 
+exception will be thrown if the database does not exist in the system. 
+
+### Syntax
+
+{% highlight sql %}
+DROP (DATABASE|SCHEMA) [IF EXISTS] dbname [RESTRICT|CASCADE];
+{% endhighlight %}
+
+
+### Example
+{% highlight sql %}
+DROP DATABASE inventorydb CASCADE;
+{% endhighlight %}
+
+### Parameters
+
+### **DATABASE** and **SCHEMA**
+
+`DATABASE` and `SCHEMA` mean the same thing, either of them can be used.
+
+### **IF EXISTS**
+
+If specified will not throw any exception if no database exists.
+ 
+###  **RESTRICT**
+
+If specified will restrict dropping a non-empty database and is enabled by default.
+
+### **CASCADE**
+
+If specified will drop all the associated tables and functions.

--- a/docs/sql-ref-syntax-ddl-drop-database.md
+++ b/docs/sql-ref-syntax-ddl-drop-database.md
@@ -44,12 +44,12 @@ DROP DATABASE inventorydb CASCADE;
 
 ### **IF EXISTS**
 
-If specified will not throw any exception if no database exists.
+If specified, no exception is thrown when the database does not exist.
  
 ###  **RESTRICT**
 
-If specified will restrict dropping a non-empty database and is enabled by default.
+If specified, will restrict dropping a non-empty database and is enabled by default.
 
 ### **CASCADE**
 
-If specified will drop all the associated tables and functions.
+If specified, will drop all the associated tables and functions.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Document DROP DATABASE statement in SQL Reference

### Why are the changes needed?
Currently from spark there is no complete sql guide is present, so it is better to document all the sql commands, this jira is sub part of this task.

### Does this PR introduce any user-facing change?
Yes, Before there was no documentation about drop database syntax

After Fix
![image](https://user-images.githubusercontent.com/35216143/64787097-977a7200-d58d-11e9-911c-d2ff6f3ccff5.png)
![image](https://user-images.githubusercontent.com/35216143/64787122-a6612480-d58d-11e9-978c-9455baff007f.png)


### How was this patch tested?
tested with jenkyll build
