### PR TITLE
[SPARK-27330][SS][2.4] support task abort in foreach writer

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/ForeachWriterProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/ForeachWriterProvider.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.streaming.sources
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.{ForeachWriter, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
@@ -112,6 +113,8 @@ class ForeachDataWriter[T](
 
   // If open returns false, we should skip writing rows.
   private val opened = writer.open(partitionId, epochId)
+  private var closeCalled: Boolean = false
+
 
   override def write(record: InternalRow): Unit = {
     if (!opened) return
@@ -120,17 +123,26 @@ class ForeachDataWriter[T](
       writer.process(rowConverter(record))
     } catch {
       case t: Throwable =>
-        writer.close(t)
+        closeWriter(t)
         throw t
     }
   }
 
   override def commit(): WriterCommitMessage = {
-    writer.close(null)
+    closeWriter(null)
     ForeachWriterCommitMessage
   }
 
-  override def abort(): Unit = {}
+  override def abort(): Unit = {
+    closeWriter(new SparkException("Foreach writer has been aborted due to a task failure"))
+  }
+
+  private def closeWriter(errorOrNull: Throwable): Unit = {
+    if (!closeCalled) {
+      closeCalled = true
+      writer.close(errorOrNull)
+    }
+  }
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/ForeachWriterProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/ForeachWriterProvider.scala
@@ -115,7 +115,6 @@ class ForeachDataWriter[T](
   private val opened = writer.open(partitionId, epochId)
   private var closeCalled: Boolean = false
 
-
   override def write(record: InternalRow): Unit = {
     if (!opened) return
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/ForeachWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/ForeachWriterSuite.scala
@@ -154,7 +154,6 @@ class ForeachWriterSuite extends StreamTest with SharedSQLContext with BeforeAnd
       val errorEvent = allEvents(0)(2).asInstanceOf[ForeachWriterSuite.Close]
       assert(errorEvent.error.get.isInstanceOf[RuntimeException])
       assert(errorEvent.error.get.getMessage === "ForeachSinkSuite error")
-
       // 'close' shouldn't be called with abort message if close with error has been called
       assert(allEvents(0).size == 3)
     }
@@ -261,7 +260,6 @@ class ForeachWriterSuite extends StreamTest with SharedSQLContext with BeforeAnd
       query.stop()
     }
   }
-
 
   testQuietly("foreach with error not caused by ForeachWriter") {
     withTempDir { checkpointDir =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/ForeachWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/ForeachWriterSuite.scala
@@ -154,6 +154,9 @@ class ForeachWriterSuite extends StreamTest with SharedSQLContext with BeforeAnd
       val errorEvent = allEvents(0)(2).asInstanceOf[ForeachWriterSuite.Close]
       assert(errorEvent.error.get.isInstanceOf[RuntimeException])
       assert(errorEvent.error.get.getMessage === "ForeachSinkSuite error")
+
+      // 'close' shouldn't be called with abort message if close with error has been called
+      assert(allEvents(0).size == 3)
     }
   }
 
@@ -256,6 +259,35 @@ class ForeachWriterSuite extends StreamTest with SharedSQLContext with BeforeAnd
         s"recentProgress[${query.recentProgress.toList}] doesn't contain correct metrics")
     } finally {
       query.stop()
+    }
+  }
+
+
+  testQuietly("foreach with error not caused by ForeachWriter") {
+    withTempDir { checkpointDir =>
+      val input = MemoryStream[Int]
+      val query = input.toDS().repartition(1).map(_ / 0).writeStream
+        .option("checkpointLocation", checkpointDir.getCanonicalPath)
+        .foreach(new TestForeachWriter)
+        .start()
+      input.addData(1, 2, 3, 4)
+
+      val e = intercept[StreamingQueryException] {
+        query.processAllAvailable()
+      }
+
+      assert(e.getCause.isInstanceOf[SparkException])
+      assert(e.getCause.getCause.getCause.getMessage === "/ by zero")
+      assert(query.isActive === false)
+
+      val allEvents = ForeachWriterSuite.allEvents()
+      assert(allEvents.size === 1)
+      assert(allEvents(0)(0) === ForeachWriterSuite.Open(partition = 0, version = 0))
+      // `close` should be called with the error
+      val errorEvent = allEvents(0)(1).asInstanceOf[ForeachWriterSuite.Close]
+      assert(errorEvent.error.get.isInstanceOf[SparkException])
+      assert(errorEvent.error.get.getMessage ===
+        "Foreach writer has been aborted due to a task failure")
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
in order to address cases where foreach writer task is failing without calling the close() method, (for example when a task is interrupted) abort() method will be called when the task is aborted. the abort will call writer.close()


### How was this patch tested?
update existing unit tests.
