### PR TITLE
[SPARK-28238][SQL][FOLLOW-UP] Clean up attributes for Datasource v2 DESCRIBE TABLE

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/sql/DescribeColumnStatement.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/sql/DescribeColumnStatement.scala
@@ -17,19 +17,7 @@
 
 package org.apache.spark.sql.catalyst.plans.logical.sql
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
-import org.apache.spark.sql.types.{MetadataBuilder, StringType}
-
 case class DescribeColumnStatement(
     tableName: Seq[String],
     colNameParts: Seq[String],
-    isExtended: Boolean) extends ParsedStatement {
-  override def output: Seq[Attribute] = {
-    Seq(
-      AttributeReference("info_name", StringType, nullable = false,
-        new MetadataBuilder().putString("comment", "name of the column info").build())(),
-      AttributeReference("info_value", StringType, nullable = false,
-        new MetadataBuilder().putString("comment", "value of the column info").build())()
-    )
-  }
-}
+    isExtended: Boolean) extends ParsedStatement

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/sql/DescribeTableStatement.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/sql/DescribeTableStatement.scala
@@ -18,12 +18,8 @@
 package org.apache.spark.sql.catalyst.plans.logical.sql
 
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
-import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.plans.DescribeTableSchema
 
 case class DescribeTableStatement(
     tableName: Seq[String],
     partitionSpec: TablePartitionSpec,
-    isExtended: Boolean) extends ParsedStatement {
-  override def output: Seq[Attribute] = DescribeTableSchema.describeTableAttributes()
-}
+    isExtended: Boolean) extends ParsedStatement

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -260,9 +260,8 @@ object DataSourceV2Strategy extends Strategy with PredicateHelper {
         Nil
       }
 
-    case r: DescribeTable if r.table.isInstanceOf[DataSourceV2Relation] =>
-      val datasource = r.table.asInstanceOf[DataSourceV2Relation]
-      DescribeTableExec(r.output, datasource.table, r.isExtended) :: Nil
+    case r @ DescribeTable(datasource: DataSourceV2Relation, isExtended) =>
+      DescribeTableExec(r.output, datasource.table, isExtended) :: Nil
 
     case DropTable(catalog, ident, ifExists) =>
       DropTableExec(catalog, ident, ifExists) :: Nil

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -260,8 +260,9 @@ object DataSourceV2Strategy extends Strategy with PredicateHelper {
         Nil
       }
 
-    case DescribeTable(r: DataSourceV2Relation, isExtended) =>
-      DescribeTableExec(r.table, isExtended) :: Nil
+    case r: DescribeTable if r.table.isInstanceOf[DataSourceV2Relation] =>
+      val datasource = r.table.asInstanceOf[DataSourceV2Relation]
+      DescribeTableExec(r.output, datasource.table, r.isExtended) :: Nil
 
     case DropTable(catalog, ident, ifExists) =>
       DropTableExec(catalog, ident, ifExists) :: Nil
@@ -269,7 +270,7 @@ object DataSourceV2Strategy extends Strategy with PredicateHelper {
     case AlterTable(catalog, ident, _, changes) =>
       AlterTableExec(catalog, ident, changes) :: Nil
 
-    case r : ShowTables =>
+    case r: ShowTables =>
       ShowTablesExec(r.output, r.catalog, r.namespace, r.pattern) :: Nil
 
     case _ => Nil

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -260,8 +260,8 @@ object DataSourceV2Strategy extends Strategy with PredicateHelper {
         Nil
       }
 
-    case r @ DescribeTable(datasource: DataSourceV2Relation, isExtended) =>
-      DescribeTableExec(r.output, datasource.table, isExtended) :: Nil
+    case desc @ DescribeTable(datasource: DataSourceV2Relation, isExtended) =>
+      DescribeTableExec(desc.output, datasource.table, isExtended) :: Nil
 
     case DropTable(catalog, ident, ifExists) =>
       DropTableExec(catalog, ident, ifExists) :: Nil
@@ -269,7 +269,7 @@ object DataSourceV2Strategy extends Strategy with PredicateHelper {
     case AlterTable(catalog, ident, _, changes) =>
       AlterTableExec(catalog, ident, changes) :: Nil
 
-    case r: ShowTables =>
+    case r : ShowTables =>
       ShowTablesExec(r.output, r.catalog, r.namespace, r.pattern) :: Nil
 
     case _ => Nil

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -260,8 +260,8 @@ object DataSourceV2Strategy extends Strategy with PredicateHelper {
         Nil
       }
 
-    case desc @ DescribeTable(datasource: DataSourceV2Relation, isExtended) =>
-      DescribeTableExec(desc.output, datasource.table, isExtended) :: Nil
+    case desc @ DescribeTable(r: DataSourceV2Relation, isExtended) =>
+      DescribeTableExec(desc.output, r.table, isExtended) :: Nil
 
     case DropTable(catalog, ident, ifExists) =>
       DropTableExec(catalog, ident, ifExists) :: Nil

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
@@ -23,16 +23,15 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, GenericRowWithSchema}
-import org.apache.spark.sql.catalyst.plans.DescribeTableSchema
+import org.apache.spark.sql.catalyst.expressions.{Attribute, GenericRowWithSchema}
 import org.apache.spark.sql.execution.LeafExecNode
 import org.apache.spark.sql.sources.v2.Table
 import org.apache.spark.sql.types.StructType
 
-case class DescribeTableExec(table: Table, isExtended: Boolean) extends LeafExecNode {
-
-  override val output: Seq[AttributeReference] =
-    DescribeTableSchema.describeTableAttributes()
+case class DescribeTableExec(
+    output: Seq[Attribute],
+    table: Table,
+    isExtended: Boolean) extends LeafExecNode {
 
   private val encoder = RowEncoder(StructType.fromAttributes(output)).resolveAndBind()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Fix the physical plan (`DescribeTableExec`) to have the same output attributes as the corresponding logical plan.
2. Remove `output` in statements since they are unresolved plans.

### Why are the changes needed?
Correctness of how output attributes should work.

### Does this PR introduce any user-facing change?
NO

### How was this patch tested?
Existing tests
