### PR TITLE
[SPARK-28811][DOCS][SQL] Document SHOW TBLPROPERTIES in SQL Reference

### DIFF
--- a/docs/sql-ref-syntax-aux-show-tblproperties.md
+++ b/docs/sql-ref-syntax-aux-show-tblproperties.md
@@ -19,4 +19,40 @@ license: |
   limitations under the License.
 ---
 
-**This page is under construction**
+### Description
+This statement returns the value of a table property given an optional value for
+a property key. If no key is specified then all the proerties are returned. 
+
+### Syntax
+{% highlight sql %}
+SHOW TBLPROPERTIES tableIdentifier [(tablePropertyKey)]
+
+tableIdentifier:= [db_name.]table_name
+tablePropertyKey:= (unquoted_property_key | property_key_as_string_literal)
+unquoted_property_key:= [key_part1][.key_part2][...]
+{% endhighlight %}
+
+**Note**
+- Property value returned by this statement exludes some properties 
+  that are internal to spark and hive. The excluded properties are :
+  - All the properties that start with prefix `spark.sql`
+  - Propery keys such as:  `EXTERNAL`, `comment`
+  - All the properties generated intenally by hive to store statistics. Some of these
+    properties are: `numFiles`, `numPartitions`, `numRows`.
+
+### Examples
+{% highlight sql %}
+-- show all the user specified properties for table `customer`
+SHOW TBLPROPERTIES customer;
+-- show all the user specified properties for a qualified table `customer`
+-- in database `salesdb`
+SHOW TBLPROPERTIES salesdb.customer;
+-- show value for unquoted propery key `show.me.the.value`
+SHOW TBLPROPERTIES customer (show.me.the.value)
+-- show value for property `show.me.the.value` specified as string literal
+SHOW TBLPROPERTIES customer ('show.me.the.value')
+{% endhighlight %}
+
+### Related Statements
+- [ALTER TABLE SET TBLPROPERTIES](sql-ref-syntax-ddl-alter-table.html)
+- [SHOW TABLE](sql-ref-syntax-aux-show-table.html)

--- a/docs/sql-ref-syntax-aux-show-tblproperties.md
+++ b/docs/sql-ref-syntax-aux-show-tblproperties.md
@@ -25,12 +25,35 @@ a property key. If no key is specified then all the proerties are returned.
 
 ### Syntax
 {% highlight sql %}
-SHOW TBLPROPERTIES tableIdentifier [(tablePropertyKey)]
-
-tableIdentifier:= [db_name.]table_name
-tablePropertyKey:= (unquoted_property_key | property_key_as_string_literal)
-unquoted_property_key:= [key_part1][.key_part2][...]
+SHOW TBLPROPERTIES table_identifier 
+   [ ( unquoted_property_key | property_key_as_string_literal ) ]
 {% endhighlight %}
+
+### Parameters
+<dl>
+  <dt><code><em>table_identifier</em></code></dt>
+  <dd>
+    Specifies the table name of an existing table. The table may be optionally qualified
+    with a database name.<br><br>
+    <b>Syntax:</b>
+      <code>
+        [database_name.]table_name
+      </code>
+  </dd>
+  <dt><code><em>unquoted_property_key</em></code></dt>
+  <dd>
+    Specifies the property key in unquoted form. The key may consists of multiple
+    parts separated by dot.<br><br>
+    <b>Syntax:</b>
+      <code>
+        [key_part1][.key_part2][...]
+      </code>
+  </dd>   
+  <dt><code><em>property_key_as_string_literal</em></code></dt>
+  <dd>
+    Specifies a property key value as a string literal.
+  </dd>
+</dl>
 
 **Note**
 - Property value returned by this statement exludes some properties 
@@ -42,17 +65,50 @@ unquoted_property_key:= [key_part1][.key_part2][...]
 
 ### Examples
 {% highlight sql %}
+-- create a table `customer` in database `salesdb`
+USE salesdb;
+CREATE TABLE customer(cust_code INT, name VARCHAR(100), cust_addr STRING)
+  TBLPROPERTIES ('created.by.user' = 'John', 'created.date' = '01-01-2001');
+
 -- show all the user specified properties for table `customer`
 SHOW TBLPROPERTIES customer;
+  +---------------------+----------+
+  |key                  |value     |
+  +---------------------+----------+
+  |created.by.user      |John      |
+  |created.date         |01-01-2001|
+  |transient_lastDdlTime|1567554931|
+  +---------------------+----------+
+
 -- show all the user specified properties for a qualified table `customer`
 -- in database `salesdb`
 SHOW TBLPROPERTIES salesdb.customer;
--- show value for unquoted propery key `show.me.the.value`
-SHOW TBLPROPERTIES customer (show.me.the.value)
--- show value for property `show.me.the.value` specified as string literal
-SHOW TBLPROPERTIES customer ('show.me.the.value')
+  +---------------------+----------+
+  |key                  |value     |
+  +---------------------+----------+
+  |created.by.user      |John      |
+  |created.date         |01-01-2001|
+  |transient_lastDdlTime|1567554931|
+  +---------------------+----------+
+
+-- show value for unquoted property key `created.by.user`
+SHOW TBLPROPERTIES customer (created.by.user);
+  +-----+
+  |value|
+  +-----+
+  |John |
+  +-----+
+
+-- show value for property `created.date`` specified as string literal
+SHOW TBLPROPERTIES customer ('created.date');
+  +----------+
+  |value     |
+  +----------+
+  |01-01-2001|
+  +----------+
 {% endhighlight %}
 
 ### Related Statements
+- [CREATE TABLE](sql-ref-syntax-ddl-create-table.html)
 - [ALTER TABLE SET TBLPROPERTIES](sql-ref-syntax-ddl-alter-table.html)
 - [SHOW TABLE](sql-ref-syntax-aux-show-table.html)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Document SHOW TBLPROPERTIES statement in SQL Reference Guide. 

### Why are the changes needed?
Currently Spark lacks documentation on the supported SQL constructs causing
confusion among users who sometimes have to look at the code to understand the
usage. This is aimed at addressing this issue.

### Does this PR introduce any user-facing change?
Yes. 

**Before:**
There was no documentation for this.

**After.**
![image](https://user-images.githubusercontent.com/11567269/64281442-fdb92200-cf07-11e9-90ba-4699b6e93e23.png)
![Screen Shot 2019-09-04 at 11 32 11 AM](https://user-images.githubusercontent.com/11567269/64281484-188b9680-cf08-11e9-8e42-f130751ca495.png)


### How was this patch tested?
Tested using jykyll build --serve
