### PR TITLE
[WIP][CORE][SPARK-28867] InMemoryStore checkpoint to speed up replay log file in HistoryServer

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/ArrayWrappers.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/ArrayWrappers.java
@@ -17,6 +17,7 @@
 
 package org.apache.spark.util.kvstore;
 
+import java.io.Serializable;
 import java.util.Arrays;
 
 import com.google.common.base.Preconditions;
@@ -34,7 +35,7 @@ import com.google.common.base.Preconditions;
  * This class is not efficient and is mostly meant to compare really small arrays, like those
  * generally used as indices and keys in a KVStore.
  */
-class ArrayWrappers {
+class ArrayWrappers implements Serializable {
 
   @SuppressWarnings("unchecked")
   public static Comparable<Object> forArray(Object a) {
@@ -53,7 +54,7 @@ class ArrayWrappers {
     return (Comparable<Object>) ret;
   }
 
-  private static class ComparableIntArray implements Comparable<ComparableIntArray> {
+  private static class ComparableIntArray implements Comparable<ComparableIntArray>, Serializable {
 
     private final int[] array;
 
@@ -92,7 +93,8 @@ class ArrayWrappers {
     }
   }
 
-  private static class ComparableLongArray implements Comparable<ComparableLongArray> {
+  private static class ComparableLongArray
+    implements Comparable<ComparableLongArray>, Serializable {
 
     private final long[] array;
 
@@ -131,7 +133,8 @@ class ArrayWrappers {
     }
   }
 
-  private static class ComparableByteArray implements Comparable<ComparableByteArray> {
+  private static class ComparableByteArray
+    implements Comparable<ComparableByteArray>, Serializable {
 
     private final byte[] array;
 
@@ -170,7 +173,8 @@ class ArrayWrappers {
     }
   }
 
-  private static class ComparableObjectArray implements Comparable<ComparableObjectArray> {
+  private static class ComparableObjectArray
+    implements Comparable<ComparableObjectArray>, Serializable {
 
     private final Object[] array;
 

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
@@ -17,6 +17,7 @@
 
 package org.apache.spark.util.kvstore;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
@@ -18,13 +18,7 @@
 package org.apache.spark.util.kvstore;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.NoSuchElementException;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiConsumer;
@@ -43,7 +37,7 @@ import org.apache.spark.annotation.Private;
  * according to the index. This saves memory but makes iteration more expensive.
  */
 @Private
-public class InMemoryStore implements KVStore {
+public class InMemoryStore implements KVStore, Serializable {
 
   private Object metadata;
   private InMemoryLists inMemoryLists = new InMemoryLists();
@@ -144,7 +138,7 @@ public class InMemoryStore implements KVStore {
    * Encapsulates ConcurrentHashMap so that the typing in and out of the map strictly maps a
    * class of type T to an InstanceList of type T.
    */
-  private static class InMemoryLists {
+  private static class InMemoryLists implements Serializable {
     private final ConcurrentMap<Class<?>, InstanceList<?>> data = new ConcurrentHashMap<>();
 
     @SuppressWarnings("unchecked")
@@ -164,7 +158,7 @@ public class InMemoryStore implements KVStore {
     }
   }
 
-  private static class InstanceList<T> {
+  private static class InstanceList<T> implements Serializable {
 
     /**
      * A BiConsumer to control multi-entity removal.  We use this in a forEach rather than an

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -445,8 +445,8 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
             // reading a garbage file is safe, but we would log an error which can be scary to
             // the end-user.
             !entry.getPath().getName().startsWith(".") &&
-            !entry.getPath().getName().endsWith(".ckp") &&
-            !entry.getPath().getName().endsWith(".ckp.tmp") &&
+            !entry.getPath().getName().endsWith(EventLoggingListener.CHECKPOINT) &&
+            !entry.getPath().getName().endsWith(s"${EventLoggingListener.CHECKPOINT}.tmp") &&
             !isBlacklisted(entry.getPath)
         }
         .filter { entry =>
@@ -1105,7 +1105,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
   private def getOrCreateInMemoryStoreSnapshot(attempt: AttemptInfoWrapper)
     : InMemoryStoreSnapshot = {
     if (conf.get(IMS_CHECKPOINT_ENABLED)) {
-      val ckpPath = new Path(logDir, attempt.logPath + ".ckp")
+      val ckpPath = new Path(logDir, attempt.logPath + EventLoggingListener.CHECKPOINT)
       if (fs.exists(ckpPath)) {
         try {
           logInfo(s"Loading InMemoryStore checkpoint file: $ckpPath")

--- a/core/src/main/scala/org/apache/spark/internal/config/Status.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Status.scala
@@ -24,7 +24,7 @@ import org.apache.spark.network.util.ByteUnit
 private[spark] object Status {
 
   val IMS_CHECKPOINT_ENABLED =
-    ConfigBuilder("spark.appStateStore.ims.checkpoint.enabled")
+    ConfigBuilder("spark.appStateStore.checkpoint.enabled")
       .doc("Whether to checkpoint InMemoryStore in a live AppStatusListener, in order to " +
         "accelerate the startup speed of History Server.")
       .booleanConf

--- a/core/src/main/scala/org/apache/spark/internal/config/Status.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Status.scala
@@ -21,6 +21,19 @@ import java.util.concurrent.TimeUnit
 
 private[spark] object Status {
 
+  val IMS_CHECKPOINT_ENABLED =
+    ConfigBuilder("spark.appStateStore.ims.checkpoint.enabled")
+      .doc("Whether to checkpoint InMemoryStore in a live AppStatusListener, in order to " +
+        "accelerate the startup speed of History Server.")
+      .booleanConf
+      .createWithDefault(true)
+
+  val IMS_CHECKPOINT_BATCH_SIZE =
+    ConfigBuilder("spark.appStateStore.ims.checkpoint.batchSize")
+      .doc("The minimal batch size to trigger a checkpoint for InMemoryStore.")
+      .intConf
+      .createWithDefault(1000)
+
   val ASYNC_TRACKING_ENABLED = ConfigBuilder("spark.appStateStore.asyncTracking.enable")
     .booleanConf
     .createWithDefault(true)

--- a/core/src/main/scala/org/apache/spark/internal/config/Status.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Status.scala
@@ -19,6 +19,8 @@ package org.apache.spark.internal.config
 
 import java.util.concurrent.TimeUnit
 
+import org.apache.spark.network.util.ByteUnit
+
 private[spark] object Status {
 
   val IMS_CHECKPOINT_ENABLED =
@@ -26,13 +28,20 @@ private[spark] object Status {
       .doc("Whether to checkpoint InMemoryStore in a live AppStatusListener, in order to " +
         "accelerate the startup speed of History Server.")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   val IMS_CHECKPOINT_BATCH_SIZE =
     ConfigBuilder("spark.appStateStore.ims.checkpoint.batchSize")
-      .doc("The minimal batch size to trigger a checkpoint for InMemoryStore.")
+      .doc("The minimal batch size to trigger the checkpoint for InMemoryStore.")
       .intConf
-      .createWithDefault(1000)
+      .createWithDefault(5000)
+
+  val IMS_CHECKPOINT_BUFFER_SIZE =
+    ConfigBuilder("spark.appStateStore.ims.checkpoint.bufferSize")
+      .doc("Buffer size to use when checkpoint InMemoryStore to output streams, " +
+        "in KiB unless otherwise specified.")
+      .bytesConf(ByteUnit.KiB)
+      .createWithDefaultString("100k")
 
   val ASYNC_TRACKING_ENABLED = ConfigBuilder("spark.appStateStore.asyncTracking.enable")
     .booleanConf

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -345,6 +345,7 @@ private[spark] class EventLoggingListener(
 }
 
 private[spark] object EventLoggingListener extends Logging {
+  val CKP = ".ckp"
   // Suffix applied to the names of files still being written by applications.
   val IN_PROGRESS = ".inprogress"
   val DEFAULT_LOG_DIR = "/tmp/spark-events"
@@ -430,7 +431,7 @@ private[spark] object EventLoggingListener extends Logging {
   def codecName(log: Path): Option[String] = {
     // Compression codec is encoded as an extension, e.g. app_123.lzf
     // Since we sanitize the app ID to not include periods, it is safe to split on it
-    val logName = log.getName.stripSuffix(IN_PROGRESS)
+    val logName = log.getName.stripSuffix(CKP).stripSuffix(IN_PROGRESS)
     logName.split("\\.").tail.lastOption
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -345,7 +345,7 @@ private[spark] class EventLoggingListener(
 }
 
 private[spark] object EventLoggingListener extends Logging {
-  val CKP = ".ckp"
+  val CHECKPOINT = ".checkpoint"
   // Suffix applied to the names of files still being written by applications.
   val IN_PROGRESS = ".inprogress"
   val DEFAULT_LOG_DIR = "/tmp/spark-events"
@@ -431,7 +431,7 @@ private[spark] object EventLoggingListener extends Logging {
   def codecName(log: Path): Option[String] = {
     // Compression codec is encoded as an extension, e.g. app_123.lzf
     // Since we sanitize the app ID to not include periods, it is safe to split on it
-    val logName = log.getName.stripSuffix(CKP).stripSuffix(IN_PROGRESS)
+    val logName = log.getName.stripSuffix(CHECKPOINT).stripSuffix(IN_PROGRESS)
     logName.split("\\.").tail.lastOption
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
@@ -76,8 +76,7 @@ private[spark] class ReplayListenerBus(eventSkipNum: Int = 0)
     try {
       val lineEntries = lines
         .zipWithIndex
-        .filter { case (_, index) => index >= eventSkipNum}
-        .filter { case (line, _) => eventsFilter(line) }
+        .filter { case (line, index) => index >= eventSkipNum && eventsFilter(line) }
 
       while (lineEntries.hasNext) {
         try {

--- a/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
@@ -32,7 +32,8 @@ import org.apache.spark.util.JsonProtocol
 /**
  * A SparkListenerBus that can be used to replay events from serialized event data.
  */
-private[spark] class ReplayListenerBus extends SparkListenerBus with Logging {
+private[spark] class ReplayListenerBus(eventSkipNum: Int = 0)
+  extends SparkListenerBus with Logging {
 
   /**
    * Replay each event in the order maintained in the given stream. The stream is expected to
@@ -75,6 +76,7 @@ private[spark] class ReplayListenerBus extends SparkListenerBus with Logging {
     try {
       val lineEntries = lines
         .zipWithIndex
+        .filter { case (_, index) => index >= eventSkipNum}
         .filter { case (line, _) => eventsFilter(line) }
 
       while (lineEntries.hasNext) {

--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -1289,6 +1289,8 @@ private[spark] class AppStatusListener(
   }
 
   private def cleanupTasks(stage: LiveStage): Unit = {
+    if (imsCheckpoint.isDefined && !imsCheckpoint.get.isDone) return
+
     val countToDelete = calculateNumberToRemove(stage.savedTasks.get(), maxTasksPerStage).toInt
     if (countToDelete > 0) {
       val stageKey = Array(stage.info.stageId, stage.info.attemptNumber)

--- a/core/src/main/scala/org/apache/spark/status/ElementTrackingStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/ElementTrackingStore.scala
@@ -48,7 +48,7 @@ import org.apache.spark.util.kvstore._
  * The configured triggers are run on a separate thread by default; they can be forced to run on
  * the calling thread by setting the `ASYNC_TRACKING_ENABLED` configuration to `false`.
  */
-private[spark] class ElementTrackingStore(store: KVStore, conf: SparkConf) extends KVStore {
+private[spark] class ElementTrackingStore(val store: KVStore, conf: SparkConf) extends KVStore {
 
   private class LatchedTriggers(val triggers: Seq[Trigger[_]]) {
     private val pending = new AtomicBoolean(false)

--- a/core/src/main/scala/org/apache/spark/status/InMemoryStoreCheckpoint.scala
+++ b/core/src/main/scala/org/apache/spark/status/InMemoryStoreCheckpoint.scala
@@ -104,7 +104,8 @@ private[spark] class InMemoryStoreCheckpoint(
         assert(appInfo != null, "appInfo is null")
         val uri = new Path(ckpPath).toUri
         val ckpFile = new Path(uri.getPath +
-          (if (!finished) EventLoggingListener.IN_PROGRESS else "") + EventLoggingListener.CKP)
+          (if (!finished) EventLoggingListener.IN_PROGRESS else "") +
+          EventLoggingListener.CHECKPOINT)
         val tmpFile = new Path(ckpFile + ".tmp")
         val fileOut = fileSystem.create(tmpFile)
         val bufferOut = new BufferedOutputStream(fileOut, bufferSize)
@@ -116,7 +117,7 @@ private[spark] class InMemoryStoreCheckpoint(
         FileUtil.copy(fileSystem, tmpFile, fileSystem, ckpFile, true, hadoopConf)
         if (finished) {
           val inProgressCkpFile = new Path(uri.getPath + EventLoggingListener.IN_PROGRESS +
-            EventLoggingListener.CKP)
+            EventLoggingListener.CHECKPOINT)
           if (!fileSystem.delete(inProgressCkpFile, true)) {
             logWarning(s"Failed to delete $inProgressCkpFile")
           }

--- a/core/src/main/scala/org/apache/spark/status/InMemoryStoreCheckpoint.scala
+++ b/core/src/main/scala/org/apache/spark/status/InMemoryStoreCheckpoint.scala
@@ -77,8 +77,8 @@ private[spark] class InMemoryStoreCheckpoint(
 
   def eventInc(finish: Boolean = false): Unit = {
     processedEventsNum += 1
-    val shouldCheckpoint = !finished && (processedEventsNum - lastRecordEventsNum >=
-      batchSize || finish)
+    val shouldCheckpoint = isDone && (finish || processedEventsNum - lastRecordEventsNum >=
+      batchSize)
     if (shouldCheckpoint) {
       // flush to make sure that all processed events' related data have write into InMemoryStore
       listener.flush(listener.update(_, System.nanoTime()))

--- a/core/src/main/scala/org/apache/spark/status/InMemoryStoreCheckpoint.scala
+++ b/core/src/main/scala/org/apache/spark/status/InMemoryStoreCheckpoint.scala
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.status
+
+import java.io.BufferedOutputStream
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+import org.apache.hadoop.fs.{FileUtil, Path}
+
+import org.apache.spark.SparkConf
+import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config._
+import org.apache.spark.internal.config.Status._
+import org.apache.spark.scheduler.EventLoggingListener
+import org.apache.spark.serializer.JavaSerializer
+import org.apache.spark.status.api.v1
+import org.apache.spark.util.{ThreadUtils, Utils}
+import org.apache.spark.util.kvstore.InMemoryStore
+
+case class InMemoryStoreSnapshot(
+    store: InMemoryStore,
+    eventsNum: Int,
+    finished: Boolean) extends Serializable
+
+
+private[spark] class InMemoryStoreCheckpoint(
+    store: InMemoryStore,
+    conf: SparkConf,
+    listener: AppStatusListener) extends Logging {
+  var lastRecordEventsNum: Int = 0
+  var finished: Boolean = false
+
+  // used to count the number of processed events in a live AppStatusListener
+  private var processedEventsNum = 0
+  private val batchSize = conf.get(IMS_CHECKPOINT_BATCH_SIZE)
+  private val bufferSize = conf.get(IMS_CHECKPOINT_BUFFER_SIZE).toInt
+  private var latch = new CountDownLatch(0)
+  @volatile var isDone = true
+  // a JavaSerializer used to serialize InMemoryStoreSnapshot
+  private val serializer = new JavaSerializer(conf).newInstance()
+  private val logBaseDir = Utils.resolveURI(conf.get(EVENT_LOG_DIR).stripSuffix("/"))
+  private lazy val ckpPath = getCheckpointPath
+  private val hadoopConf = SparkHadoopUtil.get.newConfiguration(conf)
+  private val fileSystem = Utils.getHadoopFileSystem(logBaseDir, hadoopConf)
+  private val executor = ThreadUtils.newDaemonSingleThreadExecutor(
+    "inmemorystore-checkpoint-thread")
+  // should be inited before the first time checkpoint
+  var appInfo: v1.ApplicationInfo = _
+
+  private val checkpointTask = new Runnable {
+    override def run(): Unit = Utils.tryLogNonFatalError(doCheckpoint())
+  }
+
+  private def getCheckpointPath: String = {
+    val appId = appInfo.id
+    val appAttemptId = appInfo.attempts.head.attemptId
+    EventLoggingListener.getLogPath(logBaseDir, appId, appAttemptId, None)
+  }
+
+  def await(): Unit = latch.await()
+
+  def eventInc(finish: Boolean = false): Unit = {
+    processedEventsNum += 1
+    val shouldCheckpoint = !finished && (processedEventsNum - lastRecordEventsNum >=
+      batchSize || finish)
+    if (shouldCheckpoint) {
+      // flush to make sure that all processed events' related data have write into InMemoryStore
+      listener.flush(listener.update(_, System.nanoTime()))
+      latch = new CountDownLatch(1)
+      lastRecordEventsNum = processedEventsNum
+      if (finish) {
+        finished = true
+        doCheckpoint()
+        executor.shutdown()
+      } else {
+        executor.submit(checkpointTask)
+      }
+    }
+  }
+
+  private def doCheckpoint(): Unit = {
+    try {
+      isDone = false
+      if (appInfo == null) {
+        logWarning("Haven't received event SparkListenerApplicationStart, skip checkpoint")
+      } else {
+        logInfo(s"Checkpoint InMemoryStore started, eventsNum=$processedEventsNum")
+        assert(appInfo != null, "appInfo is null")
+        val uri = new Path(ckpPath).toUri
+        val ckpFile = new Path(uri.getPath +
+          (if (!finished) EventLoggingListener.IN_PROGRESS else "") + EventLoggingListener.CKP)
+        val tmpFile = new Path(ckpFile + ".tmp")
+        val fileOut = fileSystem.create(tmpFile)
+        val bufferOut = new BufferedOutputStream(fileOut, bufferSize)
+        val objOut = serializer.serializeStream(bufferOut)
+        val startNs = System.nanoTime()
+        objOut.writeObject(InMemoryStoreSnapshot(store, lastRecordEventsNum, finished))
+        fileOut.flush()
+        objOut.close()
+        FileUtil.copy(fileSystem, tmpFile, fileSystem, ckpFile, true, hadoopConf)
+        if (finished) {
+          val inProgressCkpFile = new Path(uri.getPath + EventLoggingListener.IN_PROGRESS +
+            EventLoggingListener.CKP)
+          if (!fileSystem.delete(inProgressCkpFile, true)) {
+            logWarning(s"Failed to delete $inProgressCkpFile")
+          }
+          if (fileSystem.exists(tmpFile) && !fileSystem.delete(tmpFile, true)) {
+            logWarning(s"Failed to delete $tmpFile")
+          }
+        }
+        val finishedNs = System.nanoTime()
+        val duration = TimeUnit.NANOSECONDS.toMillis(finishedNs - startNs)
+        logInfo(s"Checkpoint InMemoryStore finished, took $duration ms")
+      }
+    } finally {
+      latch.countDown()
+      isDone = true
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/storage/StorageLevel.scala
+++ b/core/src/main/scala/org/apache/spark/storage/StorageLevel.scala
@@ -163,6 +163,21 @@ object StorageLevel {
   val MEMORY_AND_DISK_SER_2 = new StorageLevel(true, true, false, false, 2)
   val OFF_HEAP = new StorageLevel(true, true, true, false, 1)
 
+
+  /**
+   * :: DeveloperApi ::
+   * Return the StorageLevel object with the specified description.
+   */
+  @DeveloperApi
+  def fromDescription(desc: String): StorageLevel = {
+    val (useDisk_, useMemory_, useOffHeap_, deserialized_) = {
+      (desc.contains("Disk"), desc.contains("Memory"),
+        desc.contains("off heap"), desc.contains("Deserialized"))
+    }
+    val replication_ = desc.split(" ").takeRight(2)(0).dropRight(1).toInt
+    new StorageLevel(useDisk_, useMemory_, useOffHeap_, deserialized_, replication_)
+  }
+
   /**
    * :: DeveloperApi ::
    * Return the StorageLevel object with the specified name.

--- a/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
+++ b/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
@@ -47,13 +47,13 @@ private[spark] case class RDDOperationNode(
     name: String,
     cached: Boolean,
     barrier: Boolean,
-    callsite: String)
+    callsite: String) extends Serializable
 
 /**
  * A directed edge connecting two nodes in an RDDOperationGraph.
  * This represents an RDD dependency.
  */
-private[spark] case class RDDOperationEdge(fromId: Int, toId: Int)
+private[spark] case class RDDOperationEdge(fromId: Int, toId: Int) extends Serializable
 
 /**
  * A cluster that groups nodes together in an RDDOperationGraph.
@@ -64,7 +64,7 @@ private[spark] case class RDDOperationEdge(fromId: Int, toId: Int)
 private[spark] class RDDOperationCluster(
     val id: String,
     val barrier: Boolean,
-    private var _name: String) {
+    private var _name: String) extends Serializable {
   private val _childNodes = new ListBuffer[RDDOperationNode]
   private val _childClusters = new ListBuffer[RDDOperationCluster]
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR aims to improve the replay performance in HistoryServer by periodically checkpoint InMemoryStore in an in-completed application and achieve incremental replay.The main idea
is, for an in-completed application, we periodically (normally every N events num) checkpoint InMemoryStore with processed events num(X) into event log dir. And in HistoryServer, it reconstructs InMemoryStore from checkpoint file and gets X. Then, we could skip X events while replaying the log file basing on the partial InMemoryStore. Note that we should also recover those live entities from the the partial InMemoryStore in AppStatusListener to perform incremental replay. For a completed application, HistoryServer could just reconstructs InMemoryStore and no need to do replay.

And in this PR, we only focus on handling InMemoryStore in HistoryServer, while LevelDB is planed to be handled in similar way in following PR.

Basic experiment on a completed application of 20055 events shows the improvement of this optimization:

without optimization  | with optimization(including deserialization time)
 :-: | :-: | 
4343 | 78(70)
4512 | 92(85)
4475 | 74(68)
4254 | 93(78)
4126 | 81(71)

Work TODO

- [ ] compression support when checkpoint InMemoryStore
- [ ] More accurate conversion from wrapper data to live entity
- [ ] checkpoint file cleaning in HistoryServer
- [ ] overcome frequently StackOverError in deserialization
- [ ] SparkListenerStageExecutorMetrics synchronization between EventLoggingListener and AppStatusListener when log stage executor metrics is enabled
- [ ] unit tests

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Change is needed because HistoryServer now could be very slow to replay a large log file at the first time and it always re-replay an in-progress log file after it changes which leads to low efficiency. 

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

Yes, if user wants to use this optimization by several new configurations.  

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Only tested manually yet, still work in process.