### PR TITLE
[SPARK-28642][SQL][TEST][FOLLOW-UP] Test spark.sql.redaction.options.regex with and without default values

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -1031,8 +1031,10 @@ class JDBCSuite extends QueryTest
   }
 
   test("Hide credentials in show create table") {
+    val userName = "testUser"
     val password = "testPass"
     val tableName = "tab1"
+    val dbTable = "TEST.PEOPLE"
     withTable(tableName) {
       sql(
         s"""
@@ -1040,18 +1042,30 @@ class JDBCSuite extends QueryTest
            |USING org.apache.spark.sql.jdbc
            |OPTIONS (
            | url '$urlWithUserAndPass',
-           | dbtable 'TEST.PEOPLE',
-           | user 'testUser',
+           | dbtable '$dbTable',
+           | user '$userName',
            | password '$password')
          """.stripMargin)
 
       val show = ShowCreateTableCommand(TableIdentifier(tableName))
       spark.sessionState.executePlan(show).executedPlan.executeCollect().foreach { r =>
         assert(!r.toString.contains(password))
+        assert(r.toString.contains(dbTable))
+        assert(r.toString.contains(userName))
       }
 
       sql(s"SHOW CREATE TABLE $tableName").collect().foreach { r =>
-        assert(!r.toString().contains(password))
+        assert(!r.toString.contains(password))
+        assert(r.toString.contains(dbTable))
+        assert(r.toString.contains(userName))
+      }
+
+      withSQLConf(SQLConf.SQL_OPTIONS_REDACTION_PATTERN.key -> "(?i)dbtable|user") {
+        spark.sessionState.executePlan(show).executedPlan.executeCollect().foreach { r =>
+          assert(!r.toString.contains(password))
+          assert(!r.toString.contains(dbTable))
+          assert(!r.toString.contains(userName))
+        }
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Test `spark.sql.redaction.options.regex` with and without  default values.


### Why are the changes needed?

Normally, we do not rely on the default value of `spark.sql.redaction.options.regex`.


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
N/A
