### PR TITLE
[SPARK-28495][SQL] Introduce ANSI store assignment policy for table insertion

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TableOutputResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TableOutputResolver.scala
@@ -108,10 +108,11 @@ object TableOutputResolver {
       case StoreAssignmentPolicy.LEGACY =>
         outputField
 
-      case StoreAssignmentPolicy.STRICT =>
+      case StoreAssignmentPolicy.STRICT | StoreAssignmentPolicy.ANSI =>
         // run the type check first to ensure type errors are present
         val canWrite = DataType.canWrite(
-          queryExpr.dataType, tableAttr.dataType, byName, conf.resolver, tableAttr.name, addError)
+          queryExpr.dataType, tableAttr.dataType, byName, conf.resolver, tableAttr.name,
+          storeAssignmentPolicy, addError)
         if (queryExpr.nullable && !tableAttr.nullable) {
           addError(s"Cannot write nullable values to non-null column '${tableAttr.name}'")
           None

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -158,6 +158,35 @@ object Cast {
     case _ => false
   }
 
+  def canANSIStoreAssign(from: DataType, to: DataType): Boolean = (from, to) match {
+    case _ if from == to => true
+    case (_: NumericType, _: NumericType) => true
+    case (_, StringType) => true
+    case (DateType, TimestampType) => true
+    case (TimestampType, DateType) => true
+    // Spark supports casting between long and timestamp, please see `longToTimestamp` and
+    // `timestampToLong` for details.
+    case (TimestampType, LongType) => true
+    case (LongType, TimestampType) => true
+
+    case (ArrayType(fromType, fn), ArrayType(toType, tn)) =>
+      resolvableNullability(fn, tn) && canANSIStoreAssign(fromType, toType)
+
+    case (MapType(fromKey, fromValue, fn), MapType(toKey, toValue, tn)) =>
+      resolvableNullability(fn, tn) && canANSIStoreAssign(fromKey, toKey) &&
+        canANSIStoreAssign(fromValue, toValue)
+
+    case (StructType(fromFields), StructType(toFields)) =>
+      fromFields.length == toFields.length &&
+        fromFields.zip(toFields).forall {
+          case (f1, f2) =>
+            resolvableNullability(f1.nullable, f2.nullable) &&
+              canANSIStoreAssign(f1.dataType, f2.dataType)
+        }
+
+    case _ => false
+  }
+
   private def legalNumericPrecedence(from: DataType, to: DataType): Boolean = {
     val fromPrecedence = TypeCoercion.numericPrecedence.indexOf(from)
     val toPrecedence = TypeCoercion.numericPrecedence.indexOf(to)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -161,7 +161,8 @@ object Cast {
   def canANSIStoreAssign(from: DataType, to: DataType): Boolean = (from, to) match {
     case _ if from == to => true
     case (_: NumericType, _: NumericType) => true
-    case (_, StringType) => true
+    case (_: AtomicType, StringType) => true
+    case (_: CalendarIntervalType, StringType) => true
     case (DateType, TimestampType) => true
     case (TimestampType, DateType) => true
     // Spark supports casting between long and timestamp, please see `longToTimestamp` and

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1644,14 +1644,15 @@ object SQLConf {
       .createWithDefault(PartitionOverwriteMode.STATIC.toString)
 
   object StoreAssignmentPolicy extends Enumeration {
-    val LEGACY, STRICT = Value
+    val ANSI, LEGACY, STRICT = Value
   }
 
   val STORE_ASSIGNMENT_POLICY =
     buildConf("spark.sql.storeAssignmentPolicy")
       .doc("When inserting a value into a column with different data type, Spark will perform " +
-        "type coercion. Currently we support 2 policies for the type coercion rules: legacy and " +
-        "strict. With legacy policy, Spark allows casting any value to any data type. " +
+        "type coercion. Currently we support 3 policies for the type coercion rules: ansi, " +
+        "legacy and strict. With ansi policy, Spark performs the type coercion as per ANSI SQL. " +
+        "With legacy policy, Spark allows casting any value to any data type. " +
         "The legacy policy is the only behavior in Spark 2.x and it is compatible with Hive. " +
         "With strict policy, Spark doesn't allow any possible precision loss or data truncation " +
         "in type coercion, e.g. `int` to `long` and `float` to `double` are not allowed."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -31,6 +31,8 @@ import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.expressions.{Cast, Expression}
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.SQLConf.StoreAssignmentPolicy
+import org.apache.spark.sql.internal.SQLConf.StoreAssignmentPolicy.{ANSI, STRICT}
 import org.apache.spark.util.Utils
 
 /**
@@ -371,12 +373,14 @@ object DataType {
       byName: Boolean,
       resolver: Resolver,
       context: String,
+      storeAssignmentPolicy: StoreAssignmentPolicy.Value,
       addError: String => Unit): Boolean = {
     (write, read) match {
       case (wArr: ArrayType, rArr: ArrayType) =>
         // run compatibility check first to produce all error messages
         val typesCompatible = canWrite(
-          wArr.elementType, rArr.elementType, byName, resolver, context + ".element", addError)
+          wArr.elementType, rArr.elementType, byName, resolver, context + ".element",
+          storeAssignmentPolicy, addError)
 
         if (wArr.containsNull && !rArr.containsNull) {
           addError(s"Cannot write nullable elements to array of non-nulls: '$context'")
@@ -391,9 +395,11 @@ object DataType {
 
         // run compatibility check first to produce all error messages
         val keyCompatible = canWrite(
-          wMap.keyType, rMap.keyType, byName, resolver, context + ".key", addError)
+          wMap.keyType, rMap.keyType, byName, resolver, context + ".key",
+          storeAssignmentPolicy, addError)
         val valueCompatible = canWrite(
-          wMap.valueType, rMap.valueType, byName, resolver, context + ".value", addError)
+          wMap.valueType, rMap.valueType, byName, resolver, context + ".value",
+          storeAssignmentPolicy, addError)
 
         if (wMap.valueContainsNull && !rMap.valueContainsNull) {
           addError(s"Cannot write nullable values to map of non-nulls: '$context'")
@@ -409,7 +415,8 @@ object DataType {
             val nameMatch = resolver(wField.name, rField.name) || isSparkGeneratedName(wField.name)
             val fieldContext = s"$context.${rField.name}"
             val typesCompatible = canWrite(
-              wField.dataType, rField.dataType, byName, resolver, fieldContext, addError)
+              wField.dataType, rField.dataType, byName, resolver, fieldContext,
+              storeAssignmentPolicy, addError)
 
             if (byName && !nameMatch) {
               addError(s"Struct '$context' $i-th field name does not match " +
@@ -441,9 +448,17 @@ object DataType {
 
         fieldCompatible
 
-      case (w: AtomicType, r: AtomicType) =>
+      case (w: AtomicType, r: AtomicType) if storeAssignmentPolicy == STRICT =>
         if (!Cast.canUpCast(w, r)) {
           addError(s"Cannot safely cast '$context': $w to $r")
+          false
+        } else {
+          true
+        }
+
+      case (w: AtomicType, r: AtomicType) if storeAssignmentPolicy == ANSI =>
+        if (!Cast.canANSIStoreAssign(w, r)) {
+          addError(s"Cannot cast '$context': $w to $r")
           false
         } else {
           true

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -458,7 +458,7 @@ object DataType {
 
       case (w: AtomicType, r: AtomicType) if storeAssignmentPolicy == ANSI =>
         if (!Cast.canANSIStoreAssign(w, r)) {
-          addError(s"Cannot cast '$context': $w to $r")
+          addError(s"Cannot safely cast '$context': $w to $r")
           false
         } else {
           true

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeWriteCompatibilitySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeWriteCompatibilitySuite.scala
@@ -22,21 +22,277 @@ import scala.collection.mutable
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.analysis
 import org.apache.spark.sql.catalyst.expressions.Cast
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.StoreAssignmentPolicy
 
-class DataTypeWriteCompatibilitySuite extends SparkFunSuite {
-  private val atomicTypes = Seq(BooleanType, ByteType, ShortType, IntegerType, LongType, FloatType,
-    DoubleType, DateType, TimestampType, StringType, BinaryType)
+class StrictDataTypeWriteCompatibilitySuite extends DataTypeWriteCompatibilityBaseSuite {
+  override protected def storeAssignmentPolicy: SQLConf.StoreAssignmentPolicy.Value =
+    StoreAssignmentPolicy.STRICT
 
-  private val point2 = StructType(Seq(
+  test("Check atomic types: write allowed only when casting is safe") {
+    atomicTypes.foreach { w =>
+      atomicTypes.foreach { r =>
+        if (Cast.canUpCast(w, r)) {
+          assertAllowed(w, r, "t", s"Should allow writing $w to $r because cast is safe")
+
+        } else {
+          assertSingleError(w, r, "t",
+            s"Should not allow writing $w to $r because cast is not safe") { err =>
+            assert(err.contains("'t'"), "Should include the field name context")
+            assert(err.contains("Cannot safely cast"), "Should identify unsafe cast")
+            assert(err.contains(s"$w"), "Should include write type")
+            assert(err.contains(s"$r"), "Should include read type")
+          }
+        }
+      }
+    }
+  }
+
+  test("Check struct types: unsafe casts are not allowed") {
+    assertNumErrors(widerPoint2, point2, "t",
+      "Should fail because types require unsafe casts", 2) { errs =>
+
+      assert(errs(0).contains("'t.x'"), "Should include the nested field name context")
+      assert(errs(0).contains("Cannot safely cast"))
+
+      assert(errs(1).contains("'t.y'"), "Should include the nested field name context")
+      assert(errs(1).contains("Cannot safely cast"))
+    }
+  }
+
+  test("Check array types: unsafe casts are not allowed") {
+    val arrayOfLong = ArrayType(LongType)
+    val arrayOfInt = ArrayType(IntegerType)
+
+    assertSingleError(arrayOfLong, arrayOfInt, "arr",
+      "Should not allow array of longs to array of ints") { err =>
+      assert(err.contains("'arr.element'"),
+        "Should identify problem with named array's element type")
+      assert(err.contains("Cannot safely cast"))
+    }
+  }
+
+  test("Check map value types: casting Long to Integer is not allowed") {
+    val mapOfLong = MapType(StringType, LongType)
+    val mapOfInt = MapType(StringType, IntegerType)
+
+    assertSingleError(mapOfLong, mapOfInt, "m",
+      "Should not allow map of longs to map of ints") { err =>
+      assert(err.contains("'m.value'"), "Should identify problem with named map's value type")
+      assert(err.contains("Cannot safely cast"))
+    }
+  }
+
+  test("Check map key types: unsafe casts are not allowed") {
+    val mapKeyLong = MapType(LongType, StringType)
+    val mapKeyInt = MapType(IntegerType, StringType)
+
+    assertSingleError(mapKeyLong, mapKeyInt, "m",
+      "Should not allow map of long keys to map of int keys") { err =>
+      assert(err.contains("'m.key'"), "Should identify problem with named map's key type")
+      assert(err.contains("Cannot safely cast"))
+    }
+  }
+
+  test("Check types with multiple errors") {
+    val readType = StructType(Seq(
+      StructField("a", ArrayType(DoubleType, containsNull = false)),
+      StructField("arr_of_structs", ArrayType(point2, containsNull = false)),
+      StructField("bad_nested_type", ArrayType(StringType)),
+      StructField("m", MapType(LongType, FloatType, valueContainsNull = false)),
+      StructField("map_of_structs", MapType(StringType, point3, valueContainsNull = false)),
+      StructField("x", IntegerType, nullable = false),
+      StructField("missing1", StringType, nullable = false),
+      StructField("missing2", StringType)
+    ))
+
+    val missingMiddleField = StructType(Seq(
+      StructField("x", FloatType, nullable = false),
+      StructField("z", FloatType, nullable = false)))
+
+    val writeType = StructType(Seq(
+      StructField("a", ArrayType(StringType)),
+      StructField("arr_of_structs", ArrayType(point3)),
+      StructField("bad_nested_type", point3),
+      StructField("m", MapType(DoubleType, DoubleType)),
+      StructField("map_of_structs", MapType(StringType, missingMiddleField)),
+      StructField("y", LongType)
+    ))
+
+    assertNumErrors(writeType, readType, "top", "Should catch 14 errors", 14) { errs =>
+      assert(errs(0).contains("'top.a.element'"), "Should identify bad type")
+      assert(errs(0).contains("Cannot safely cast"))
+      assert(errs(0).contains("StringType to DoubleType"))
+
+      assert(errs(1).contains("'top.a'"), "Should identify bad type")
+      assert(errs(1).contains("Cannot write nullable elements to array of non-nulls"))
+
+      assert(errs(2).contains("'top.arr_of_structs.element'"), "Should identify bad type")
+      assert(errs(2).contains("'z'"), "Should identify bad field")
+      assert(errs(2).contains("Cannot write extra fields to struct"))
+
+      assert(errs(3).contains("'top.arr_of_structs'"), "Should identify bad type")
+      assert(errs(3).contains("Cannot write nullable elements to array of non-nulls"))
+
+      assert(errs(4).contains("'top.bad_nested_type'"), "Should identify bad type")
+      assert(errs(4).contains("is incompatible with"))
+
+      assert(errs(5).contains("'top.m.key'"), "Should identify bad type")
+      assert(errs(5).contains("Cannot safely cast"))
+      assert(errs(5).contains("DoubleType to LongType"))
+
+      assert(errs(6).contains("'top.m.value'"), "Should identify bad type")
+      assert(errs(6).contains("Cannot safely cast"))
+      assert(errs(6).contains("DoubleType to FloatType"))
+
+      assert(errs(7).contains("'top.m'"), "Should identify bad type")
+      assert(errs(7).contains("Cannot write nullable values to map of non-nulls"))
+
+      assert(errs(8).contains("'top.map_of_structs.value'"), "Should identify bad type")
+      assert(errs(8).contains("expected 'y', found 'z'"), "Should detect name mismatch")
+      assert(errs(8).contains("field name does not match"), "Should identify name problem")
+
+      assert(errs(9).contains("'top.map_of_structs.value'"), "Should identify bad type")
+      assert(errs(9).contains("'z'"), "Should identify missing field")
+      assert(errs(9).contains("missing fields"), "Should detect missing field")
+
+      assert(errs(10).contains("'top.map_of_structs'"), "Should identify bad type")
+      assert(errs(10).contains("Cannot write nullable values to map of non-nulls"))
+
+      assert(errs(11).contains("'top.x'"), "Should identify bad type")
+      assert(errs(11).contains("Cannot safely cast"))
+      assert(errs(11).contains("LongType to IntegerType"))
+
+      assert(errs(12).contains("'top'"), "Should identify bad type")
+      assert(errs(12).contains("expected 'x', found 'y'"), "Should detect name mismatch")
+      assert(errs(12).contains("field name does not match"), "Should identify name problem")
+
+      assert(errs(13).contains("'top'"), "Should identify bad type")
+      assert(errs(13).contains("'missing1'"), "Should identify missing field")
+      assert(errs(13).contains("missing fields"), "Should detect missing field")
+    }
+  }
+}
+
+class ANSIDataTypeWriteCompatibilitySuite extends DataTypeWriteCompatibilityBaseSuite {
+  override protected def storeAssignmentPolicy: SQLConf.StoreAssignmentPolicy.Value =
+    StoreAssignmentPolicy.ANSI
+
+  test("Check map value types: unsafe casts are not allowed") {
+    val mapOfString = MapType(StringType, StringType)
+    val mapOfInt = MapType(StringType, IntegerType)
+
+    assertSingleError(mapOfString, mapOfInt, "m",
+      "Should not allow map of strings to map of ints") { err =>
+      assert(err.contains("'m.value'"), "Should identify problem with named map's value type")
+      assert(err.contains("Cannot cast"))
+    }
+  }
+
+  test("Check map key types: unsafe casts are not allowed") {
+    val mapKeyString = MapType(StringType, StringType)
+    val mapKeyInt = MapType(IntegerType, StringType)
+
+    assertSingleError(mapKeyString, mapKeyInt, "m",
+      "Should not allow map of string keys to map of int keys") { err =>
+      assert(err.contains("'m.key'"), "Should identify problem with named map's key type")
+      assert(err.contains("Cannot cast"))
+    }
+  }
+
+  test("Check types with multiple errors") {
+    val readType = StructType(Seq(
+      StructField("a", ArrayType(DoubleType, containsNull = false)),
+      StructField("arr_of_structs", ArrayType(point2, containsNull = false)),
+      StructField("bad_nested_type", ArrayType(StringType)),
+      StructField("m", MapType(LongType, FloatType, valueContainsNull = false)),
+      StructField("map_of_structs", MapType(StringType, point3, valueContainsNull = false)),
+      StructField("x", IntegerType, nullable = false),
+      StructField("missing1", StringType, nullable = false),
+      StructField("missing2", StringType)
+    ))
+
+    val missingMiddleField = StructType(Seq(
+      StructField("x", FloatType, nullable = false),
+      StructField("z", FloatType, nullable = false)))
+
+    val writeType = StructType(Seq(
+      StructField("a", ArrayType(StringType)),
+      StructField("arr_of_structs", ArrayType(point3)),
+      StructField("bad_nested_type", point3),
+      StructField("m", MapType(StringType, BooleanType)),
+      StructField("map_of_structs", MapType(StringType, missingMiddleField)),
+      StructField("y", StringType)
+    ))
+
+    assertNumErrors(writeType, readType, "top", "Should catch 14 errors", 14) { errs =>
+      assert(errs(0).contains("'top.a.element'"), "Should identify bad type")
+      assert(errs(0).contains("Cannot cast"))
+      assert(errs(0).contains("StringType to DoubleType"))
+
+      assert(errs(1).contains("'top.a'"), "Should identify bad type")
+      assert(errs(1).contains("Cannot write nullable elements to array of non-nulls"))
+
+      assert(errs(2).contains("'top.arr_of_structs.element'"), "Should identify bad type")
+      assert(errs(2).contains("'z'"), "Should identify bad field")
+      assert(errs(2).contains("Cannot write extra fields to struct"))
+
+      assert(errs(3).contains("'top.arr_of_structs'"), "Should identify bad type")
+      assert(errs(3).contains("Cannot write nullable elements to array of non-nulls"))
+
+      assert(errs(4).contains("'top.bad_nested_type'"), "Should identify bad type")
+      assert(errs(4).contains("is incompatible with"))
+
+      assert(errs(5).contains("'top.m.key'"), "Should identify bad type")
+      assert(errs(5).contains("Cannot cast"))
+      assert(errs(5).contains("StringType to LongType"))
+
+      assert(errs(6).contains("'top.m.value'"), "Should identify bad type")
+      assert(errs(6).contains("Cannot cast"))
+      assert(errs(6).contains("BooleanType to FloatType"))
+
+      assert(errs(7).contains("'top.m'"), "Should identify bad type")
+      assert(errs(7).contains("Cannot write nullable values to map of non-nulls"))
+
+      assert(errs(8).contains("'top.map_of_structs.value'"), "Should identify bad type")
+      assert(errs(8).contains("expected 'y', found 'z'"), "Should detect name mismatch")
+      assert(errs(8).contains("field name does not match"), "Should identify name problem")
+
+      assert(errs(9).contains("'top.map_of_structs.value'"), "Should identify bad type")
+      assert(errs(9).contains("'z'"), "Should identify missing field")
+      assert(errs(9).contains("missing fields"), "Should detect missing field")
+
+      assert(errs(10).contains("'top.map_of_structs'"), "Should identify bad type")
+      assert(errs(10).contains("Cannot write nullable values to map of non-nulls"))
+
+      assert(errs(11).contains("'top.x'"), "Should identify bad type")
+      assert(errs(11).contains("Cannot cast"))
+      assert(errs(11).contains("StringType to IntegerType"))
+
+      assert(errs(12).contains("'top'"), "Should identify bad type")
+      assert(errs(12).contains("expected 'x', found 'y'"), "Should detect name mismatch")
+      assert(errs(12).contains("field name does not match"), "Should identify name problem")
+
+      assert(errs(13).contains("'top'"), "Should identify bad type")
+      assert(errs(13).contains("'missing1'"), "Should identify missing field")
+      assert(errs(13).contains("missing fields"), "Should detect missing field")
+    }
+  }
+}
+
+abstract class DataTypeWriteCompatibilityBaseSuite extends SparkFunSuite {
+  protected val atomicTypes = Seq(BooleanType, ByteType, ShortType, IntegerType, LongType,
+    FloatType, DoubleType, DateType, TimestampType, StringType, BinaryType)
+
+  protected val point2 = StructType(Seq(
     StructField("x", FloatType, nullable = false),
     StructField("y", FloatType, nullable = false)))
 
-  private val widerPoint2 = StructType(Seq(
+  protected val widerPoint2 = StructType(Seq(
     StructField("x", DoubleType, nullable = false),
     StructField("y", DoubleType, nullable = false)))
 
-  private val point3 = StructType(Seq(
+  protected val point3 = StructType(Seq(
     StructField("x", FloatType, nullable = false),
     StructField("y", FloatType, nullable = false),
     StructField("z", FloatType)))
@@ -62,25 +318,6 @@ class DataTypeWriteCompatibilitySuite extends SparkFunSuite {
   test("Check each type with itself") {
     allNonNullTypes.foreach { t =>
       assertAllowed(t, t, "t", s"Should allow writing type to itself $t")
-    }
-  }
-
-  test("Check atomic types: write allowed only when casting is safe") {
-    atomicTypes.foreach { w =>
-      atomicTypes.foreach { r =>
-        if (Cast.canUpCast(w, r)) {
-          assertAllowed(w, r, "t", s"Should allow writing $w to $r because cast is safe")
-
-        } else {
-          assertSingleError(w, r, "t",
-            s"Should not allow writing $w to $r because cast is not safe") { err =>
-            assert(err.contains("'t'"), "Should include the field name context")
-            assert(err.contains("Cannot safely cast"), "Should identify unsafe cast")
-            assert(err.contains(s"$w"), "Should include write type")
-            assert(err.contains(s"$r"), "Should include read type")
-          }
-        }
-      }
     }
   }
 
@@ -173,18 +410,6 @@ class DataTypeWriteCompatibilitySuite extends SparkFunSuite {
     }
   }
 
-  test("Check struct types: unsafe casts are not allowed") {
-    assertNumErrors(widerPoint2, point2, "t",
-      "Should fail because types require unsafe casts", 2) { errs =>
-
-      assert(errs(0).contains("'t.x'"), "Should include the nested field name context")
-      assert(errs(0).contains("Cannot safely cast"))
-
-      assert(errs(1).contains("'t.y'"), "Should include the nested field name context")
-      assert(errs(1).contains("Cannot safely cast"))
-    }
-  }
-
   test("Check struct types: type promotion is allowed") {
     assertAllowed(point2, widerPoint2, "t",
       "Should allow widening float fields x and y to double")
@@ -202,18 +427,6 @@ class DataTypeWriteCompatibilitySuite extends SparkFunSuite {
     // built-in data sources do not yet support missing fields when optional
     assertAllowed(point2, point3, "t",
       "Should allow writing point (x,y) to point(x,y,z=null)")
-  }
-
-  test("Check array types: unsafe casts are not allowed") {
-    val arrayOfLong = ArrayType(LongType)
-    val arrayOfInt = ArrayType(IntegerType)
-
-    assertSingleError(arrayOfLong, arrayOfInt, "arr",
-      "Should not allow array of longs to array of ints") { err =>
-      assert(err.contains("'arr.element'"),
-        "Should identify problem with named array's element type")
-      assert(err.contains("Cannot safely cast"))
-    }
   }
 
   test("Check array types: type promotion is allowed") {
@@ -242,17 +455,6 @@ class DataTypeWriteCompatibilitySuite extends SparkFunSuite {
       "Should allow array of required elements to array of optional elements")
   }
 
-  test("Check map value types: unsafe casts are not allowed") {
-    val mapOfLong = MapType(StringType, LongType)
-    val mapOfInt = MapType(StringType, IntegerType)
-
-    assertSingleError(mapOfLong, mapOfInt, "m",
-      "Should not allow map of longs to map of ints") { err =>
-      assert(err.contains("'m.value'"), "Should identify problem with named map's value type")
-      assert(err.contains("Cannot safely cast"))
-    }
-  }
-
   test("Check map value types: type promotion is allowed") {
     val mapOfLong = MapType(StringType, LongType)
     val mapOfInt = MapType(StringType, IntegerType)
@@ -279,17 +481,6 @@ class DataTypeWriteCompatibilitySuite extends SparkFunSuite {
       "Should allow map of required elements to map of optional elements")
   }
 
-  test("Check map key types: unsafe casts are not allowed") {
-    val mapKeyLong = MapType(LongType, StringType)
-    val mapKeyInt = MapType(IntegerType, StringType)
-
-    assertSingleError(mapKeyLong, mapKeyInt, "m",
-      "Should not allow map of long keys to map of int keys") { err =>
-      assert(err.contains("'m.key'"), "Should identify problem with named map's key type")
-      assert(err.contains("Cannot safely cast"))
-    }
-  }
-
   test("Check map key types: type promotion is allowed") {
     val mapKeyLong = MapType(LongType, StringType)
     val mapKeyInt = MapType(IntegerType, StringType)
@@ -298,86 +489,9 @@ class DataTypeWriteCompatibilitySuite extends SparkFunSuite {
       "Should allow map of int written to map of long column")
   }
 
-  test("Check types with multiple errors") {
-    val readType = StructType(Seq(
-      StructField("a", ArrayType(DoubleType, containsNull = false)),
-      StructField("arr_of_structs", ArrayType(point2, containsNull = false)),
-      StructField("bad_nested_type", ArrayType(StringType)),
-      StructField("m", MapType(LongType, FloatType, valueContainsNull = false)),
-      StructField("map_of_structs", MapType(StringType, point3, valueContainsNull = false)),
-      StructField("x", IntegerType, nullable = false),
-      StructField("missing1", StringType, nullable = false),
-      StructField("missing2", StringType)
-    ))
-
-    val missingMiddleField = StructType(Seq(
-      StructField("x", FloatType, nullable = false),
-      StructField("z", FloatType, nullable = false)))
-
-    val writeType = StructType(Seq(
-      StructField("a", ArrayType(StringType)),
-      StructField("arr_of_structs", ArrayType(point3)),
-      StructField("bad_nested_type", point3),
-      StructField("m", MapType(DoubleType, DoubleType)),
-      StructField("map_of_structs", MapType(StringType, missingMiddleField)),
-      StructField("y", LongType)
-    ))
-
-    assertNumErrors(writeType, readType, "top", "Should catch 14 errors", 14) { errs =>
-      assert(errs(0).contains("'top.a.element'"), "Should identify bad type")
-      assert(errs(0).contains("Cannot safely cast"))
-      assert(errs(0).contains("StringType to DoubleType"))
-
-      assert(errs(1).contains("'top.a'"), "Should identify bad type")
-      assert(errs(1).contains("Cannot write nullable elements to array of non-nulls"))
-
-      assert(errs(2).contains("'top.arr_of_structs.element'"), "Should identify bad type")
-      assert(errs(2).contains("'z'"), "Should identify bad field")
-      assert(errs(2).contains("Cannot write extra fields to struct"))
-
-      assert(errs(3).contains("'top.arr_of_structs'"), "Should identify bad type")
-      assert(errs(3).contains("Cannot write nullable elements to array of non-nulls"))
-
-      assert(errs(4).contains("'top.bad_nested_type'"), "Should identify bad type")
-      assert(errs(4).contains("is incompatible with"))
-
-      assert(errs(5).contains("'top.m.key'"), "Should identify bad type")
-      assert(errs(5).contains("Cannot safely cast"))
-      assert(errs(5).contains("DoubleType to LongType"))
-
-      assert(errs(6).contains("'top.m.value'"), "Should identify bad type")
-      assert(errs(6).contains("Cannot safely cast"))
-      assert(errs(6).contains("DoubleType to FloatType"))
-
-      assert(errs(7).contains("'top.m'"), "Should identify bad type")
-      assert(errs(7).contains("Cannot write nullable values to map of non-nulls"))
-
-      assert(errs(8).contains("'top.map_of_structs.value'"), "Should identify bad type")
-      assert(errs(8).contains("expected 'y', found 'z'"), "Should detect name mismatch")
-      assert(errs(8).contains("field name does not match"), "Should identify name problem")
-
-      assert(errs(9).contains("'top.map_of_structs.value'"), "Should identify bad type")
-      assert(errs(9).contains("'z'"), "Should identify missing field")
-      assert(errs(9).contains("missing fields"), "Should detect missing field")
-
-      assert(errs(10).contains("'top.map_of_structs'"), "Should identify bad type")
-      assert(errs(10).contains("Cannot write nullable values to map of non-nulls"))
-
-      assert(errs(11).contains("'top.x'"), "Should identify bad type")
-      assert(errs(11).contains("Cannot safely cast"))
-      assert(errs(11).contains("LongType to IntegerType"))
-
-      assert(errs(12).contains("'top'"), "Should identify bad type")
-      assert(errs(12).contains("expected 'x', found 'y'"), "Should detect name mismatch")
-      assert(errs(12).contains("field name does not match"), "Should identify name problem")
-
-      assert(errs(13).contains("'top'"), "Should identify bad type")
-      assert(errs(13).contains("'missing1'"), "Should identify missing field")
-      assert(errs(13).contains("missing fields"), "Should detect missing field")
-    }
-  }
-
   // Helper functions
+
+  protected def storeAssignmentPolicy: StoreAssignmentPolicy.Value
 
   def assertAllowed(
       writeType: DataType,
@@ -387,7 +501,7 @@ class DataTypeWriteCompatibilitySuite extends SparkFunSuite {
       byName: Boolean = true): Unit = {
     assert(
       DataType.canWrite(writeType, readType, byName, analysis.caseSensitiveResolution, name,
-        StoreAssignmentPolicy.STRICT,
+        storeAssignmentPolicy,
         errMsg => fail(s"Should not produce errors but was called with: $errMsg")), desc)
   }
 
@@ -413,7 +527,7 @@ class DataTypeWriteCompatibilitySuite extends SparkFunSuite {
     val errs = new mutable.ArrayBuffer[String]()
     assert(
       DataType.canWrite(writeType, readType, byName, analysis.caseSensitiveResolution, name,
-        StoreAssignmentPolicy.STRICT, errMsg => errs += errMsg) === false, desc)
+        storeAssignmentPolicy, errMsg => errs += errMsg) === false, desc)
     assert(errs.size === numErrs, s"Should produce $numErrs error messages")
     checkErrors(errs)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeWriteCompatibilitySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeWriteCompatibilitySuite.scala
@@ -26,27 +26,10 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.StoreAssignmentPolicy
 
 class StrictDataTypeWriteCompatibilitySuite extends DataTypeWriteCompatibilityBaseSuite {
-  override protected def storeAssignmentPolicy: SQLConf.StoreAssignmentPolicy.Value =
+  override def storeAssignmentPolicy: SQLConf.StoreAssignmentPolicy.Value =
     StoreAssignmentPolicy.STRICT
 
-  test("Check atomic types: write allowed only when casting is safe") {
-    atomicTypes.foreach { w =>
-      atomicTypes.foreach { r =>
-        if (Cast.canUpCast(w, r)) {
-          assertAllowed(w, r, "t", s"Should allow writing $w to $r because cast is safe")
-
-        } else {
-          assertSingleError(w, r, "t",
-            s"Should not allow writing $w to $r because cast is not safe") { err =>
-            assert(err.contains("'t'"), "Should include the field name context")
-            assert(err.contains("Cannot safely cast"), "Should identify unsafe cast")
-            assert(err.contains(s"$w"), "Should include write type")
-            assert(err.contains(s"$r"), "Should include read type")
-          }
-        }
-      }
-    }
-  }
+  override def canCast: (DataType, DataType) => Boolean = Cast.canUpCast
 
   test("Check struct types: unsafe casts are not allowed") {
     assertNumErrors(widerPoint2, point2, "t",
@@ -178,24 +161,7 @@ class ANSIDataTypeWriteCompatibilitySuite extends DataTypeWriteCompatibilityBase
   override protected def storeAssignmentPolicy: SQLConf.StoreAssignmentPolicy.Value =
     StoreAssignmentPolicy.ANSI
 
-  test("Check atomic types: write allowed only when casting is safe") {
-    atomicTypes.foreach { w =>
-      atomicTypes.foreach { r =>
-        if ((w.isInstanceOf[NumericType] && r.isInstanceOf[NumericType]) ||
-          Cast.canANSIStoreAssign(w, r)) {
-          assertAllowed(w, r, "t", s"Should allow writing $w to $r because cast is safe")
-        } else {
-          assertSingleError(w, r, "t",
-            s"Should not allow writing $w to $r because cast is not safe") { err =>
-            assert(err.contains("'t'"), "Should include the field name context")
-            assert(err.contains("Cannot cast"), "Should identify unsafe cast")
-            assert(err.contains(s"$w"), "Should include write type")
-            assert(err.contains(s"$r"), "Should include read type")
-          }
-        }
-      }
-    }
-  }
+  override def canCast: (DataType, DataType) => Boolean = Cast.canANSIStoreAssign
 
   test("Check map value types: unsafe casts are not allowed") {
     val mapOfString = MapType(StringType, StringType)
@@ -204,7 +170,35 @@ class ANSIDataTypeWriteCompatibilitySuite extends DataTypeWriteCompatibilityBase
     assertSingleError(mapOfString, mapOfInt, "m",
       "Should not allow map of strings to map of ints") { err =>
       assert(err.contains("'m.value'"), "Should identify problem with named map's value type")
-      assert(err.contains("Cannot cast"))
+      assert(err.contains("Cannot safely cast"))
+    }
+  }
+
+  private val stringPoint2 = StructType(Seq(
+    StructField("x", StringType, nullable = false),
+    StructField("y", StringType, nullable = false)))
+
+  test("Check struct types: unsafe casts are not allowed") {
+    assertNumErrors(stringPoint2, point2, "t",
+      "Should fail because types require unsafe casts", 2) { errs =>
+
+      assert(errs(0).contains("'t.x'"), "Should include the nested field name context")
+      assert(errs(0).contains("Cannot safely cast"))
+
+      assert(errs(1).contains("'t.y'"), "Should include the nested field name context")
+      assert(errs(1).contains("Cannot safely cast"))
+    }
+  }
+
+  test("Check array types: unsafe casts are not allowed") {
+    val arrayOfString = ArrayType(StringType)
+    val arrayOfInt = ArrayType(IntegerType)
+
+    assertSingleError(arrayOfString, arrayOfInt, "arr",
+      "Should not allow array of strings to array of ints") { err =>
+      assert(err.contains("'arr.element'"),
+        "Should identify problem with named array's element type")
+      assert(err.contains("Cannot safely cast"))
     }
   }
 
@@ -215,7 +209,7 @@ class ANSIDataTypeWriteCompatibilitySuite extends DataTypeWriteCompatibilityBase
     assertSingleError(mapKeyString, mapKeyInt, "m",
       "Should not allow map of string keys to map of int keys") { err =>
       assert(err.contains("'m.key'"), "Should identify problem with named map's key type")
-      assert(err.contains("Cannot cast"))
+      assert(err.contains("Cannot safely cast"))
     }
   }
 
@@ -246,7 +240,7 @@ class ANSIDataTypeWriteCompatibilitySuite extends DataTypeWriteCompatibilityBase
 
     assertNumErrors(writeType, readType, "top", "Should catch 14 errors", 14) { errs =>
       assert(errs(0).contains("'top.a.element'"), "Should identify bad type")
-      assert(errs(0).contains("Cannot cast"))
+      assert(errs(0).contains("Cannot safely cast"))
       assert(errs(0).contains("StringType to DoubleType"))
 
       assert(errs(1).contains("'top.a'"), "Should identify bad type")
@@ -263,11 +257,11 @@ class ANSIDataTypeWriteCompatibilitySuite extends DataTypeWriteCompatibilityBase
       assert(errs(4).contains("is incompatible with"))
 
       assert(errs(5).contains("'top.m.key'"), "Should identify bad type")
-      assert(errs(5).contains("Cannot cast"))
+      assert(errs(5).contains("Cannot safely cast"))
       assert(errs(5).contains("StringType to LongType"))
 
       assert(errs(6).contains("'top.m.value'"), "Should identify bad type")
-      assert(errs(6).contains("Cannot cast"))
+      assert(errs(6).contains("Cannot safely cast"))
       assert(errs(6).contains("BooleanType to FloatType"))
 
       assert(errs(7).contains("'top.m'"), "Should identify bad type")
@@ -285,7 +279,7 @@ class ANSIDataTypeWriteCompatibilitySuite extends DataTypeWriteCompatibilityBase
       assert(errs(10).contains("Cannot write nullable values to map of non-nulls"))
 
       assert(errs(11).contains("'top.x'"), "Should identify bad type")
-      assert(errs(11).contains("Cannot cast"))
+      assert(errs(11).contains("Cannot safely cast"))
       assert(errs(11).contains("StringType to IntegerType"))
 
       assert(errs(12).contains("'top'"), "Should identify bad type")
@@ -300,6 +294,10 @@ class ANSIDataTypeWriteCompatibilitySuite extends DataTypeWriteCompatibilityBase
 }
 
 abstract class DataTypeWriteCompatibilityBaseSuite extends SparkFunSuite {
+  protected def storeAssignmentPolicy: StoreAssignmentPolicy.Value
+
+  protected def canCast: (DataType, DataType) => Boolean
+
   protected val atomicTypes = Seq(BooleanType, ByteType, ShortType, IntegerType, LongType,
     FloatType, DoubleType, DateType, TimestampType, StringType, BinaryType)
 
@@ -337,6 +335,25 @@ abstract class DataTypeWriteCompatibilityBaseSuite extends SparkFunSuite {
   test("Check each type with itself") {
     allNonNullTypes.foreach { t =>
       assertAllowed(t, t, "t", s"Should allow writing type to itself $t")
+    }
+  }
+
+  test("Check atomic types: write allowed only when casting is safe") {
+    atomicTypes.foreach { w =>
+      atomicTypes.foreach { r =>
+        if (canCast(w, r)) {
+          assertAllowed(w, r, "t", s"Should allow writing $w to $r because cast is safe")
+
+        } else {
+          assertSingleError(w, r, "t",
+            s"Should not allow writing $w to $r because cast is not safe") { err =>
+            assert(err.contains("'t'"), "Should include the field name context")
+            assert(err.contains("Cannot safely cast"), "Should identify unsafe cast")
+            assert(err.contains(s"$w"), "Should include write type")
+            assert(err.contains(s"$r"), "Should include read type")
+          }
+        }
+      }
     }
   }
 
@@ -509,8 +526,6 @@ abstract class DataTypeWriteCompatibilityBaseSuite extends SparkFunSuite {
   }
 
   // Helper functions
-
-  protected def storeAssignmentPolicy: StoreAssignmentPolicy.Value
 
   def assertAllowed(
       writeType: DataType,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeWriteCompatibilitySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeWriteCompatibilitySuite.scala
@@ -22,6 +22,7 @@ import scala.collection.mutable
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.analysis
 import org.apache.spark.sql.catalyst.expressions.Cast
+import org.apache.spark.sql.internal.SQLConf.StoreAssignmentPolicy
 
 class DataTypeWriteCompatibilitySuite extends SparkFunSuite {
   private val atomicTypes = Seq(BooleanType, ByteType, ShortType, IntegerType, LongType, FloatType,
@@ -386,6 +387,7 @@ class DataTypeWriteCompatibilitySuite extends SparkFunSuite {
       byName: Boolean = true): Unit = {
     assert(
       DataType.canWrite(writeType, readType, byName, analysis.caseSensitiveResolution, name,
+        StoreAssignmentPolicy.STRICT,
         errMsg => fail(s"Should not produce errors but was called with: $errMsg")), desc)
   }
 
@@ -411,7 +413,7 @@ class DataTypeWriteCompatibilitySuite extends SparkFunSuite {
     val errs = new mutable.ArrayBuffer[String]()
     assert(
       DataType.canWrite(writeType, readType, byName, analysis.caseSensitiveResolution, name,
-        errMsg => errs += errMsg) === false, desc)
+        StoreAssignmentPolicy.STRICT, errMsg => errs += errMsg) === false, desc)
     assert(errs.size === numErrs, s"Should produce $numErrs error messages")
     checkErrors(errs)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeWriteCompatibilitySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeWriteCompatibilitySuite.scala
@@ -76,85 +76,6 @@ class StrictDataTypeWriteCompatibilitySuite extends DataTypeWriteCompatibilityBa
       assert(err.contains("Cannot safely cast"))
     }
   }
-
-  test("Check types with multiple errors") {
-    val readType = StructType(Seq(
-      StructField("a", ArrayType(DoubleType, containsNull = false)),
-      StructField("arr_of_structs", ArrayType(point2, containsNull = false)),
-      StructField("bad_nested_type", ArrayType(StringType)),
-      StructField("m", MapType(LongType, FloatType, valueContainsNull = false)),
-      StructField("map_of_structs", MapType(StringType, point3, valueContainsNull = false)),
-      StructField("x", IntegerType, nullable = false),
-      StructField("missing1", StringType, nullable = false),
-      StructField("missing2", StringType)
-    ))
-
-    val missingMiddleField = StructType(Seq(
-      StructField("x", FloatType, nullable = false),
-      StructField("z", FloatType, nullable = false)))
-
-    val writeType = StructType(Seq(
-      StructField("a", ArrayType(StringType)),
-      StructField("arr_of_structs", ArrayType(point3)),
-      StructField("bad_nested_type", point3),
-      StructField("m", MapType(DoubleType, DoubleType)),
-      StructField("map_of_structs", MapType(StringType, missingMiddleField)),
-      StructField("y", LongType)
-    ))
-
-    assertNumErrors(writeType, readType, "top", "Should catch 14 errors", 14) { errs =>
-      assert(errs(0).contains("'top.a.element'"), "Should identify bad type")
-      assert(errs(0).contains("Cannot safely cast"))
-      assert(errs(0).contains("StringType to DoubleType"))
-
-      assert(errs(1).contains("'top.a'"), "Should identify bad type")
-      assert(errs(1).contains("Cannot write nullable elements to array of non-nulls"))
-
-      assert(errs(2).contains("'top.arr_of_structs.element'"), "Should identify bad type")
-      assert(errs(2).contains("'z'"), "Should identify bad field")
-      assert(errs(2).contains("Cannot write extra fields to struct"))
-
-      assert(errs(3).contains("'top.arr_of_structs'"), "Should identify bad type")
-      assert(errs(3).contains("Cannot write nullable elements to array of non-nulls"))
-
-      assert(errs(4).contains("'top.bad_nested_type'"), "Should identify bad type")
-      assert(errs(4).contains("is incompatible with"))
-
-      assert(errs(5).contains("'top.m.key'"), "Should identify bad type")
-      assert(errs(5).contains("Cannot safely cast"))
-      assert(errs(5).contains("DoubleType to LongType"))
-
-      assert(errs(6).contains("'top.m.value'"), "Should identify bad type")
-      assert(errs(6).contains("Cannot safely cast"))
-      assert(errs(6).contains("DoubleType to FloatType"))
-
-      assert(errs(7).contains("'top.m'"), "Should identify bad type")
-      assert(errs(7).contains("Cannot write nullable values to map of non-nulls"))
-
-      assert(errs(8).contains("'top.map_of_structs.value'"), "Should identify bad type")
-      assert(errs(8).contains("expected 'y', found 'z'"), "Should detect name mismatch")
-      assert(errs(8).contains("field name does not match"), "Should identify name problem")
-
-      assert(errs(9).contains("'top.map_of_structs.value'"), "Should identify bad type")
-      assert(errs(9).contains("'z'"), "Should identify missing field")
-      assert(errs(9).contains("missing fields"), "Should detect missing field")
-
-      assert(errs(10).contains("'top.map_of_structs'"), "Should identify bad type")
-      assert(errs(10).contains("Cannot write nullable values to map of non-nulls"))
-
-      assert(errs(11).contains("'top.x'"), "Should identify bad type")
-      assert(errs(11).contains("Cannot safely cast"))
-      assert(errs(11).contains("LongType to IntegerType"))
-
-      assert(errs(12).contains("'top'"), "Should identify bad type")
-      assert(errs(12).contains("expected 'x', found 'y'"), "Should detect name mismatch")
-      assert(errs(12).contains("field name does not match"), "Should identify name problem")
-
-      assert(errs(13).contains("'top'"), "Should identify bad type")
-      assert(errs(13).contains("'missing1'"), "Should identify missing field")
-      assert(errs(13).contains("missing fields"), "Should detect missing field")
-    }
-  }
 }
 
 class ANSIDataTypeWriteCompatibilitySuite extends DataTypeWriteCompatibilityBaseSuite {
@@ -210,85 +131,6 @@ class ANSIDataTypeWriteCompatibilitySuite extends DataTypeWriteCompatibilityBase
       "Should not allow map of string keys to map of int keys") { err =>
       assert(err.contains("'m.key'"), "Should identify problem with named map's key type")
       assert(err.contains("Cannot safely cast"))
-    }
-  }
-
-  test("Check types with multiple errors") {
-    val readType = StructType(Seq(
-      StructField("a", ArrayType(DoubleType, containsNull = false)),
-      StructField("arr_of_structs", ArrayType(point2, containsNull = false)),
-      StructField("bad_nested_type", ArrayType(StringType)),
-      StructField("m", MapType(LongType, FloatType, valueContainsNull = false)),
-      StructField("map_of_structs", MapType(StringType, point3, valueContainsNull = false)),
-      StructField("x", IntegerType, nullable = false),
-      StructField("missing1", StringType, nullable = false),
-      StructField("missing2", StringType)
-    ))
-
-    val missingMiddleField = StructType(Seq(
-      StructField("x", FloatType, nullable = false),
-      StructField("z", FloatType, nullable = false)))
-
-    val writeType = StructType(Seq(
-      StructField("a", ArrayType(StringType)),
-      StructField("arr_of_structs", ArrayType(point3)),
-      StructField("bad_nested_type", point3),
-      StructField("m", MapType(StringType, BooleanType)),
-      StructField("map_of_structs", MapType(StringType, missingMiddleField)),
-      StructField("y", StringType)
-    ))
-
-    assertNumErrors(writeType, readType, "top", "Should catch 14 errors", 14) { errs =>
-      assert(errs(0).contains("'top.a.element'"), "Should identify bad type")
-      assert(errs(0).contains("Cannot safely cast"))
-      assert(errs(0).contains("StringType to DoubleType"))
-
-      assert(errs(1).contains("'top.a'"), "Should identify bad type")
-      assert(errs(1).contains("Cannot write nullable elements to array of non-nulls"))
-
-      assert(errs(2).contains("'top.arr_of_structs.element'"), "Should identify bad type")
-      assert(errs(2).contains("'z'"), "Should identify bad field")
-      assert(errs(2).contains("Cannot write extra fields to struct"))
-
-      assert(errs(3).contains("'top.arr_of_structs'"), "Should identify bad type")
-      assert(errs(3).contains("Cannot write nullable elements to array of non-nulls"))
-
-      assert(errs(4).contains("'top.bad_nested_type'"), "Should identify bad type")
-      assert(errs(4).contains("is incompatible with"))
-
-      assert(errs(5).contains("'top.m.key'"), "Should identify bad type")
-      assert(errs(5).contains("Cannot safely cast"))
-      assert(errs(5).contains("StringType to LongType"))
-
-      assert(errs(6).contains("'top.m.value'"), "Should identify bad type")
-      assert(errs(6).contains("Cannot safely cast"))
-      assert(errs(6).contains("BooleanType to FloatType"))
-
-      assert(errs(7).contains("'top.m'"), "Should identify bad type")
-      assert(errs(7).contains("Cannot write nullable values to map of non-nulls"))
-
-      assert(errs(8).contains("'top.map_of_structs.value'"), "Should identify bad type")
-      assert(errs(8).contains("expected 'y', found 'z'"), "Should detect name mismatch")
-      assert(errs(8).contains("field name does not match"), "Should identify name problem")
-
-      assert(errs(9).contains("'top.map_of_structs.value'"), "Should identify bad type")
-      assert(errs(9).contains("'z'"), "Should identify missing field")
-      assert(errs(9).contains("missing fields"), "Should detect missing field")
-
-      assert(errs(10).contains("'top.map_of_structs'"), "Should identify bad type")
-      assert(errs(10).contains("Cannot write nullable values to map of non-nulls"))
-
-      assert(errs(11).contains("'top.x'"), "Should identify bad type")
-      assert(errs(11).contains("Cannot safely cast"))
-      assert(errs(11).contains("StringType to IntegerType"))
-
-      assert(errs(12).contains("'top'"), "Should identify bad type")
-      assert(errs(12).contains("expected 'x', found 'y'"), "Should detect name mismatch")
-      assert(errs(12).contains("field name does not match"), "Should identify name problem")
-
-      assert(errs(13).contains("'top'"), "Should identify bad type")
-      assert(errs(13).contains("'missing1'"), "Should identify missing field")
-      assert(errs(13).contains("missing fields"), "Should detect missing field")
     }
   }
 }
@@ -523,6 +365,85 @@ abstract class DataTypeWriteCompatibilityBaseSuite extends SparkFunSuite {
 
     assertAllowed(mapKeyInt, mapKeyLong, "m",
       "Should allow map of int written to map of long column")
+  }
+
+  test("Check types with multiple errors") {
+    val readType = StructType(Seq(
+      StructField("a", ArrayType(DoubleType, containsNull = false)),
+      StructField("arr_of_structs", ArrayType(point2, containsNull = false)),
+      StructField("bad_nested_type", ArrayType(StringType)),
+      StructField("m", MapType(LongType, FloatType, valueContainsNull = false)),
+      StructField("map_of_structs", MapType(StringType, point3, valueContainsNull = false)),
+      StructField("x", IntegerType, nullable = false),
+      StructField("missing1", StringType, nullable = false),
+      StructField("missing2", StringType)
+    ))
+
+    val missingMiddleField = StructType(Seq(
+      StructField("x", FloatType, nullable = false),
+      StructField("z", FloatType, nullable = false)))
+
+    val writeType = StructType(Seq(
+      StructField("a", ArrayType(StringType)),
+      StructField("arr_of_structs", ArrayType(point3)),
+      StructField("bad_nested_type", point3),
+      StructField("m", MapType(StringType, BooleanType)),
+      StructField("map_of_structs", MapType(StringType, missingMiddleField)),
+      StructField("y", StringType)
+    ))
+
+    assertNumErrors(writeType, readType, "top", "Should catch 14 errors", 14) { errs =>
+      assert(errs(0).contains("'top.a.element'"), "Should identify bad type")
+      assert(errs(0).contains("Cannot safely cast"))
+      assert(errs(0).contains("StringType to DoubleType"))
+
+      assert(errs(1).contains("'top.a'"), "Should identify bad type")
+      assert(errs(1).contains("Cannot write nullable elements to array of non-nulls"))
+
+      assert(errs(2).contains("'top.arr_of_structs.element'"), "Should identify bad type")
+      assert(errs(2).contains("'z'"), "Should identify bad field")
+      assert(errs(2).contains("Cannot write extra fields to struct"))
+
+      assert(errs(3).contains("'top.arr_of_structs'"), "Should identify bad type")
+      assert(errs(3).contains("Cannot write nullable elements to array of non-nulls"))
+
+      assert(errs(4).contains("'top.bad_nested_type'"), "Should identify bad type")
+      assert(errs(4).contains("is incompatible with"))
+
+      assert(errs(5).contains("'top.m.key'"), "Should identify bad type")
+      assert(errs(5).contains("Cannot safely cast"))
+      assert(errs(5).contains("StringType to LongType"))
+
+      assert(errs(6).contains("'top.m.value'"), "Should identify bad type")
+      assert(errs(6).contains("Cannot safely cast"))
+      assert(errs(6).contains("BooleanType to FloatType"))
+
+      assert(errs(7).contains("'top.m'"), "Should identify bad type")
+      assert(errs(7).contains("Cannot write nullable values to map of non-nulls"))
+
+      assert(errs(8).contains("'top.map_of_structs.value'"), "Should identify bad type")
+      assert(errs(8).contains("expected 'y', found 'z'"), "Should detect name mismatch")
+      assert(errs(8).contains("field name does not match"), "Should identify name problem")
+
+      assert(errs(9).contains("'top.map_of_structs.value'"), "Should identify bad type")
+      assert(errs(9).contains("'z'"), "Should identify missing field")
+      assert(errs(9).contains("missing fields"), "Should detect missing field")
+
+      assert(errs(10).contains("'top.map_of_structs'"), "Should identify bad type")
+      assert(errs(10).contains("Cannot write nullable values to map of non-nulls"))
+
+      assert(errs(11).contains("'top.x'"), "Should identify bad type")
+      assert(errs(11).contains("Cannot safely cast"))
+      assert(errs(11).contains("StringType to IntegerType"))
+
+      assert(errs(12).contains("'top'"), "Should identify bad type")
+      assert(errs(12).contains("expected 'x', found 'y'"), "Should detect name mismatch")
+      assert(errs(12).contains("field name does not match"), "Should identify name problem")
+
+      assert(errs(13).contains("'top'"), "Should identify bad type")
+      assert(errs(13).contains("'missing1'"), "Should identify missing field")
+      assert(errs(13).contains("missing fields"), "Should detect missing field")
+    }
   }
 
   // Helper functions

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -598,6 +598,11 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
         }.getMessage
         assert(msg.contains("Cannot cast 'i': TimestampType to IntegerType") &&
           msg.contains("Cannot cast 'd': TimestampType to DoubleType"))
+        msg = intercept[AnalysisException] {
+          sql("insert into t values(true, false)")
+        }.getMessage
+        assert(msg.contains("Cannot cast 'i': BooleanType to IntegerType") &&
+          msg.contains("Cannot cast 'd': BooleanType to DoubleType"))
       }
     }
   }
@@ -609,7 +614,9 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
       withTable("t") {
         sql("create table t(i int, d float) using parquet")
         sql("insert into t values(1L, 2.0)")
-        checkAnswer(sql("select * from t"), Row(1, 2.0F))
+        sql("insert into t values(3.0, 4)")
+        sql("insert into t values(5.0, 6L)")
+        checkAnswer(sql("select * from t"), Seq(Row(1, 2.0F), Row(3, 4.0F), Row(5, 6.0F)))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -339,6 +339,12 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSparkSession with 
         }.getMessage
         assert(msg.contains("Cannot cast 'i': StringType to IntegerType") &&
           msg.contains("Cannot cast 'd': StringType to DoubleType"))
+
+        msg = intercept[AnalysisException] {
+          Seq((true, false)).toDF("i", "d").write.mode("append").saveAsTable("t")
+        }.getMessage
+        assert(msg.contains("Cannot cast 'i': BooleanType to IntegerType") &&
+          msg.contains("Cannot cast 'd': BooleanType to DoubleType"))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -330,7 +330,7 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSparkSession with 
   test("Throw exception on unsafe cast with ANSI casting policy") {
     withSQLConf(
       SQLConf.USE_V1_SOURCE_WRITER_LIST.key -> "parquet",
-      SQLConf.STORE_ASSIGNMENT_POLICY.key -> SQLConf.StoreAssignmentPolicy.STRICT.toString) {
+      SQLConf.STORE_ASSIGNMENT_POLICY.key -> SQLConf.StoreAssignmentPolicy.ANSI.toString) {
       withTable("t") {
         sql("create table t(i int, d double) using parquet")
         // Calling `saveAsTable` to an existing table with append mode results in table insertion.
@@ -339,6 +339,7 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSparkSession with 
         }.getMessage
         assert(msg.contains("Cannot cast 'i': StringType to IntegerType") &&
           msg.contains("Cannot cast 'd': StringType to DoubleType"))
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -337,14 +337,14 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSparkSession with 
         var msg = intercept[AnalysisException] {
           Seq(("a", "b")).toDF("i", "d").write.mode("append").saveAsTable("t")
         }.getMessage
-        assert(msg.contains("Cannot cast 'i': StringType to IntegerType") &&
-          msg.contains("Cannot cast 'd': StringType to DoubleType"))
+        assert(msg.contains("Cannot safely cast 'i': StringType to IntegerType") &&
+          msg.contains("Cannot safely cast 'd': StringType to DoubleType"))
 
         msg = intercept[AnalysisException] {
           Seq((true, false)).toDF("i", "d").write.mode("append").saveAsTable("t")
         }.getMessage
-        assert(msg.contains("Cannot cast 'i': BooleanType to IntegerType") &&
-          msg.contains("Cannot cast 'd': BooleanType to DoubleType"))
+        assert(msg.contains("Cannot safely cast 'i': BooleanType to IntegerType") &&
+          msg.contains("Cannot safely cast 'd': BooleanType to DoubleType"))
       }
     }
   }


### PR DESCRIPTION

### What changes were proposed in this pull request?
 Introduce ANSI store assignment policy for table insertion. 
With ANSI policy, Spark performs the type coercion of table insertion as per ANSI SQL.

### Why are the changes needed?
In Spark version 2.4 and earlier, when inserting into a table, Spark will cast the data type of input query to the data type of target table by coercion. This can be super confusing, e.g. users make a mistake and write string values to an int column.

In data source V2, by default, only upcasting is allowed when inserting data into a table. E.g. int -> long and int -> string are allowed, while decimal -> double or long -> int are not allowed. The rules of UpCast was originally created for Dataset type coercion. They are quite strict and different from the behavior of all existing popular DBMS. This is breaking change. It is possible that existing queries are broken after 3.0 releases.

Following ANSI SQL standard makes Spark consistent with the table insertion behaviors of popular DBMS like PostgreSQL/Oracle/Mysql.


### Does this PR introduce any user-facing change?
A new optional mode for table insertion.


### How was this patch tested?
Unit test
