### PR TITLE
[SPARK-28876][SQL] fallBackToHdfs should not support Hive partitioned table

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -114,10 +114,10 @@ class ResolveHiveSerdeTable(session: SparkSession) extends Rule[LogicalPlan] {
 
 class DetermineTableStats(session: SparkSession) extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
-    case relation: HiveTableRelation
-        if DDLUtils.isHiveTable(relation.tableMeta) && relation.tableMeta.stats.isEmpty =>
-      val table = relation.tableMeta
-      val sizeInBytes = if (session.sessionState.conf.fallBackToHdfsForStatsEnabled) {
+    case relation @ HiveTableRelation(table, _, partitionCols)
+      if DDLUtils.isHiveTable(table) && table.stats.isEmpty =>
+      val conf = session.sessionState.conf
+      val sizeInBytes = if (conf.fallBackToHdfsForStatsEnabled && partitionCols.isEmpty) {
         try {
           val hadoopConf = session.sessionState.newHadoopConf()
           val tablePath = new Path(table.location)
@@ -125,11 +125,11 @@ class DetermineTableStats(session: SparkSession) extends Rule[LogicalPlan] {
           fs.getContentSummary(tablePath).getLength
         } catch {
           case e: IOException =>
-            logWarning("Failed to get table size from hdfs.", e)
-            session.sessionState.conf.defaultSizeInBytes
+            logWarning("Failed to get table size from HDFS.", e)
+            conf.defaultSizeInBytes
         }
       } else {
-        session.sessionState.conf.defaultSizeInBytes
+        conf.defaultSizeInBytes
       }
 
       val withStats = table.copy(stats = Some(CatalogStatistics(sizeInBytes = BigInt(sizeInBytes))))

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -117,6 +117,8 @@ class DetermineTableStats(session: SparkSession) extends Rule[LogicalPlan] {
     case relation @ HiveTableRelation(table, _, partitionCols)
       if DDLUtils.isHiveTable(table) && table.stats.isEmpty =>
       val conf = session.sessionState.conf
+      // For partitioned tables, the partition directory may be outside of the table directory.
+      // Which is expensive to get table size. Please see how we implemented it in the AnalyzeTable.
       val sizeInBytes = if (conf.fallBackToHdfsForStatsEnabled && partitionCols.isEmpty) {
         try {
           val hadoopConf = session.sessionState.newHadoopConf()

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -1484,4 +1484,27 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
       }
     }
   }
+
+  test("fallBackToHdfs should not support Hive partitioned table") {
+    Seq(true, false).foreach { fallBackToHdfs =>
+      withSQLConf(SQLConf.ENABLE_FALL_BACK_TO_HDFS_FOR_STATS.key -> s"$fallBackToHdfs",
+        HiveUtils.CONVERT_METASTORE_PARQUET.key -> "false") {
+        withTempDir { tempDir =>
+          withTable("spark_28876") {
+            sql(s"""
+               |CREATE EXTERNAL TABLE spark_28876(id bigint)
+               |PARTITIONED BY (ds STRING)
+               |STORED AS PARQUET
+               |LOCATION '${tempDir.toURI}'
+             """.stripMargin)
+            sql("INSERT INTO TABLE spark_28876 PARTITION (ds='p1') SELECT 1")
+            assert(getCatalogTable("spark_28876").stats.isEmpty)
+            val sizeInBytes = spark.table("spark_28876").queryExecution.analyzed.children.head
+              .asInstanceOf[HiveTableRelation].stats.sizeInBytes
+            assert(sizeInBytes === conf.defaultSizeInBytes)
+          }
+        }
+      }
+    }
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -1489,19 +1489,33 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
     Seq(true, false).foreach { fallBackToHdfs =>
       withSQLConf(SQLConf.ENABLE_FALL_BACK_TO_HDFS_FOR_STATS.key -> s"$fallBackToHdfs",
         HiveUtils.CONVERT_METASTORE_PARQUET.key -> "false") {
-        withTempDir { tempDir =>
+        withTempDir { tableDir =>
           withTable("spark_28876") {
-            sql(s"""
-               |CREATE EXTERNAL TABLE spark_28876(id bigint)
-               |PARTITIONED BY (ds STRING)
-               |STORED AS PARQUET
-               |LOCATION '${tempDir.toURI}'
+            sql(
+              s"""
+                 |CREATE TABLE spark_28876(id bigint)
+                 |PARTITIONED BY (ds STRING)
+                 |STORED AS PARQUET
+                 |LOCATION '${tableDir.toURI}'
              """.stripMargin)
-            sql("INSERT INTO TABLE spark_28876 PARTITION (ds='p1') SELECT 1")
-            assert(getCatalogTable("spark_28876").stats.isEmpty)
-            val sizeInBytes = spark.table("spark_28876").queryExecution.analyzed.children.head
-              .asInstanceOf[HiveTableRelation].stats.sizeInBytes
-            assert(sizeInBytes === conf.defaultSizeInBytes)
+            withTempDir { partitionDir =>
+              spark.range(5).write.mode(SaveMode.Overwrite).parquet(partitionDir.getCanonicalPath)
+              sql(s"ALTER TABLE spark_28876 ADD PARTITION (ds='p1') LOCATION '$partitionDir'")
+
+              val table = getCatalogTable("spark_28876")
+              assert(table.stats.isEmpty)
+              val partitions = spark.sessionState.catalog.listPartitions(table.identifier)
+              assert(partitions.size === 1)
+              partitions.foreach { p =>
+                // Partition directory is outside of the table directory
+                assert(!p.storage.locationUri.get.toString.stripSuffix("/")
+                  .startsWith(table.location.toString.stripSuffix("/")))
+              }
+
+              val sizeInBytes = spark.table("spark_28876").queryExecution.analyzed.children.head
+                .asInstanceOf[HiveTableRelation].stats.sizeInBytes
+              assert(sizeInBytes === conf.defaultSizeInBytes)
+            }
           }
         }
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes `spark.sql.statistics.fallBackToHdfs` not support Hive partitioned tables.


### Why are the changes needed?

The current implementation is incorrect for external partitions and it is expensive to support partitioned table with external partitions.


### Does this PR introduce any user-facing change?
Yes.  But I think it will not change the join strategy because partitioned table usually very large.


### How was this patch tested?
unit test
