### PR TITLE
[SPARK-28701][INFRA][FOLLOWUP] Fix the key error when looking in os.environ

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -405,10 +405,11 @@ def run_scala_tests(build_tool, hadoop_version, test_modules, excluded_tags):
         test_profiles += ['-Dtest.exclude.tags=' + ",".join(excluded_tags)]
 
     # set up java11 env if this is a pull request build with 'test-java11' in the title
-    if "test-java11" in os.environ["ghprbPullTitle"].lower():
-        os.environ["JAVA_HOME"] = "/usr/java/jdk-11.0.1"
-        os.environ["PATH"] = "%s/bin:%s" % (os.environ["JAVA_HOME"], os.environ["PATH"])
-        test_profiles += ['-Djava.version=11']
+    if "ghprbPullTitle" in os.environ:
+        if "test-java11" in os.environ["ghprbPullTitle"].lower():
+            os.environ["JAVA_HOME"] = "/usr/java/jdk-11.0.1"
+            os.environ["PATH"] = "%s/bin:%s" % (os.environ["JAVA_HOME"], os.environ["PATH"])
+            test_profiles += ['-Djava.version=11']
 
     if build_tool == "maven":
         run_scala_tests_maven(test_profiles)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

i broke run-tests.py for non-PRB builds in this PR:
https://github.com/apache/spark/pull/25423

### Why are the changes needed?

to fix what i broke


### Does this PR introduce any user-facing change?
no

### How was this patch tested?
the build system will test this
