### PR TITLE
[SPARK-28792][SQL][DOC] Document CREATE DATABASE statement in SQL Reference.

### DIFF
--- a/docs/sql-ref-syntax-ddl-create-database.md
+++ b/docs/sql-ref-syntax-ddl-create-database.md
@@ -39,7 +39,7 @@ CREATE {DATABASE | SCHEMA} [ IF NOT EXISTS ] database_name
     <dd>Creates a database with the given name if it doesn't exists. If a database with the same name already exists, nothing will happen.</dd>
 
     <dt><code><em>database_directory</em></code></dt>
-    <dd>Path of the file system in which database to be created. If the specified path does not exist in the underlying file system, this command creates a directory with the path. If location is not specified, database will be created in default warehouse directory.</dd>
+    <dd>Path of the file system in which the specified database is to be created. If the specified path does not exist in the underlying file system, this command creates a directory with the path. If location is not specified, database will be created in default warehouse directory.</dd>
 
     <dt><code><em>database_comment</em></code></dt>
     <dd>Specifies the description for the database.</dd>

--- a/docs/sql-ref-syntax-ddl-create-database.md
+++ b/docs/sql-ref-syntax-ddl-create-database.md
@@ -19,4 +19,39 @@ license: |
   limitations under the License.
 ---
 
-**This page is under construction**
+### Description
+Creates a database with the given name. If database with the same name exists an exception will be thrown.
+
+### Syntax
+{% highlight sql %}
+CREATE (DATABASE|SCHEMA) [IF NOT EXISTS] database_name
+  [COMMENT database_comment]
+  [LOCATION database_directory]
+  [WITH DBPROPERTIES (property_name=property_value, ...)]
+
+{% endhighlight %}
+
+### Parameters
+- ##### ***IF NOT EXISTS***:
+Creates a database with the given name if it doesn't exists. If a database with the same name already exists, nothing will happen.
+- ##### ***LOCATION***:
+Path of the file system in which database to be created. If the specified path does not exist in the underlying file system, this command creates a directory with the path.
+- ##### ***COMMENT***:
+Description for the Database.
+- ##### ***WITH DBPROPERTIES***:
+Properties for the database in key-value pair.
+
+### Examples
+{% highlight sql %}
+-- Create database `customer_db`. This throws exception if database with name customer_db already exists.
+CREATE DATABASE customer_db;
+-- Create database `customer_db` only if database with same name doesn't exist.
+CREATE DATABASE IF NOT EXISTS customer_db;
+-- Create database `customer_db` only if database with same name doesn't exist with `Comments`, `Specific Location` and `Database properties`.
+CREATE DATABASE IF NOT EXISTS customer_db COMMENT 'This is customer database' LOCATION '/user' WITH DBPROPERTIES (ID=001, Name='John');
+{% endhighlight %}
+
+
+### Related statements.
+- [DESCRIBE DATABASE](sql-ref-syntax-aux-describe-database.html)
+

--- a/docs/sql-ref-syntax-ddl-create-database.md
+++ b/docs/sql-ref-syntax-ddl-create-database.md
@@ -42,22 +42,25 @@ CREATE {DATABASE | SCHEMA} [ IF NOT EXISTS ] database_name
     <dd>Path of the file system in which database to be created. If the specified path does not exist in the underlying file system, this command creates a directory with the path. If location is not specified, database will be created in default warehouse directory.</dd>
 
     <dt><code><em>database_comment</em></code></dt>
-    <dd>Description for the database.</dd>
+    <dd>Specifies the description for the database.</dd>
 
     <dt><code><em>WITH DBPROPERTIES (property_name=property_value [ , ...])</em></code></dt>
-    <dd>Properties for the database in key-value pair.</dd>
+    <dd>Specifies the properties for the database in key-value pair.</dd>
 </dl>
 
 ### Examples
 {% highlight sql %}
--- Create database `customer_db`. This throws exception if database with name customer_db already exists.
+-- Create database `customer_db`. This throws exception if database with name customer_db
+-- already exists.
 CREATE DATABASE customer_db;
 
 -- Create database `customer_db` only if database with same name doesn't exist.
 CREATE DATABASE IF NOT EXISTS customer_db;
 
--- Create database `customer_db` only if database with same name doesn't exist with `Comments`,`Specific Location` and `Database properties`.
-CREATE DATABASE IF NOT EXISTS customer_db COMMENT 'This is customer database' LOCATION '/user' WITH DBPROPERTIES (ID=001, Name='John');
+-- Create database `customer_db` only if database with same name doesn't exist with 
+-- `Comments`,`Specific Location` and `Database properties`.
+CREATE DATABASE IF NOT EXISTS customer_db COMMENT 'This is customer database' LOCATION '/user'
+ WITH DBPROPERTIES (ID=001, Name='John');
 
 -- Verify that properties are set.
 DESCRIBE DATABASE EXTENDED customer_db;
@@ -73,4 +76,4 @@ DESCRIBE DATABASE EXTENDED customer_db;
 
 ### Related Statements
 - [DESCRIBE DATABASE](sql-ref-syntax-aux-describe-database.html)
-
+- [DROP DATABASE](sql-ref-syntax-ddl-drop-database.html)

--- a/docs/sql-ref-syntax-ddl-create-database.md
+++ b/docs/sql-ref-syntax-ddl-create-database.md
@@ -39,13 +39,13 @@ CREATE {DATABASE | SCHEMA} [ IF NOT EXISTS ] database_name
     <dd>Creates a database with the given name if it doesn't exists. If a database with the same name already exists, nothing will happen.</dd>
 
     <dt><code><em>database_directory</em></code></dt>
-    <dd>Path of the file system in which the specified database is to be created. If the specified path does not exist in the underlying file system, this command creates a directory with the path. If location is not specified, database will be created in default warehouse directory.</dd>
+    <dd>Path of the file system in which the specified database is to be created. If the specified path does not exist in the underlying file system, this command creates a directory with the path. If the location is not specified, the database will be created in the default warehouse directory, whose path is configured by the static configuration spark.sql.warehouse.dir.</dd>
 
     <dt><code><em>database_comment</em></code></dt>
     <dd>Specifies the description for the database.</dd>
 
     <dt><code><em>WITH DBPROPERTIES (property_name=property_value [ , ...])</em></code></dt>
-    <dd>Specifies the properties for the database in key-value pair.</dd>
+    <dd>Specifies the properties for the database in key-value pairs.</dd>
 </dl>
 
 ### Examples

--- a/docs/sql-ref-syntax-ddl-create-database.md
+++ b/docs/sql-ref-syntax-ddl-create-database.md
@@ -20,38 +20,57 @@ license: |
 ---
 
 ### Description
-Creates a database with the given name. If database with the same name exists an exception will be thrown.
+Creates a database with the specified name. If database with the same name already exists, an exception will be thrown.
 
 ### Syntax
 {% highlight sql %}
-CREATE (DATABASE|SCHEMA) [IF NOT EXISTS] database_name
-  [COMMENT database_comment]
-  [LOCATION database_directory]
-  [WITH DBPROPERTIES (property_name=property_value, ...)]
-
+CREATE {DATABASE | SCHEMA} [ IF NOT EXISTS ] database_name
+  [ COMMENT database_comment ]
+  [ LOCATION database_directory ]
+  [ WITH DBPROPERTIES (property_name=property_value [ , ...]) ]
 {% endhighlight %}
 
 ### Parameters
-- ##### ***IF NOT EXISTS***:
-Creates a database with the given name if it doesn't exists. If a database with the same name already exists, nothing will happen.
-- ##### ***LOCATION***:
-Path of the file system in which database to be created. If the specified path does not exist in the underlying file system, this command creates a directory with the path.
-- ##### ***COMMENT***:
-Description for the Database.
-- ##### ***WITH DBPROPERTIES***:
-Properties for the database in key-value pair.
+<dl>
+    <dt><code><em>database_name</em></code></dt>
+    <dd>Specifies the name of the database to be created.</dd>
+
+    <dt><code><em>IF NOT EXISTS</em></code></dt>
+    <dd>Creates a database with the given name if it doesn't exists. If a database with the same name already exists, nothing will happen.</dd>
+
+    <dt><code><em>database_directory</em></code></dt>
+    <dd>Path of the file system in which database to be created. If the specified path does not exist in the underlying file system, this command creates a directory with the path. If location is not specified, database will be created in default warehouse directory.</dd>
+
+    <dt><code><em>database_comment</em></code></dt>
+    <dd>Description for the database.</dd>
+
+    <dt><code><em>WITH DBPROPERTIES (property_name=property_value [ , ...])</em></code></dt>
+    <dd>Properties for the database in key-value pair.</dd>
+</dl>
 
 ### Examples
 {% highlight sql %}
 -- Create database `customer_db`. This throws exception if database with name customer_db already exists.
 CREATE DATABASE customer_db;
+
 -- Create database `customer_db` only if database with same name doesn't exist.
 CREATE DATABASE IF NOT EXISTS customer_db;
--- Create database `customer_db` only if database with same name doesn't exist with `Comments`, `Specific Location` and `Database properties`.
+
+-- Create database `customer_db` only if database with same name doesn't exist with `Comments`,`Specific Location` and `Database properties`.
 CREATE DATABASE IF NOT EXISTS customer_db COMMENT 'This is customer database' LOCATION '/user' WITH DBPROPERTIES (ID=001, Name='John');
+
+-- Verify that properties are set.
+DESCRIBE DATABASE EXTENDED customer_db;
+   +----------------------------+-----------------------------+
+   | database_description_item  | database_description_value  |
+   +----------------------------+-----------------------------+
+   | Database Name              | customer_db                 |
+   | Description                | This is customer database   |
+   | Location                   | hdfs://hacluster/user       |
+   | Properties                 | ((ID,001), (Name,John))     |
+   +----------------------------+-----------------------------+
 {% endhighlight %}
 
-
-### Related statements.
+### Related Statements
 - [DESCRIBE DATABASE](sql-ref-syntax-aux-describe-database.html)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Document CREATE DATABASE statement in SQL Reference Guide.

### Why are the changes needed?
Currently Spark lacks documentation on the supported SQL constructs causing
confusion among users who sometimes have to look at the code to understand the
usage. This is aimed at addressing this issue.

### Does this PR introduce any user-facing change?
Yes.

### Before:
There was no documentation for this.
### After:
![image](https://user-images.githubusercontent.com/29914590/65037831-290e2900-d96c-11e9-8563-92e5379c3ad1.png)
![image](https://user-images.githubusercontent.com/29914590/64858915-55f9cd80-d646-11e9-91a9-16c52b1daa56.png)



### How was this patch tested?
Manual Review and Tested using jykyll build --serve
