### PR TITLE
[SPARK-28613][SQL] Add config option for limiting uncompressed result size in SQL

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -164,7 +164,7 @@ of the most common options to set are:
   </td>
 </tr>
 <tr>
-  <td><code>spark.sql.driver.maxUncompressedResultSize</code></td>
+  <td><code>spark.sql.driver.maxCollectSize</code></td>
   <td>None</td>
   <td>
     Similar to spark.driver.maxResultSize but enforces a limit on the the total size of the 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -164,11 +164,11 @@ of the most common options to set are:
   </td>
 </tr>
 <tr>
-  <td><code>spark.sql.driver.limitUncompressedResultSize</code></td>
-  <td>false</td>
+  <td><code>spark.sql.driver.maxUncompressedResultSize</code></td>
+  <td>None</td>
   <td>
-    If set to true then the value of spark.driver.maxResultSize will also be used for limiting the
-    the total size of the uncompressed results that are produced by actions on sql dataframes. 
+    Similar to spark.driver.maxResultSize but enforces a limit on the the total size of the 
+    uncompressed results that are produced by actions on sql dataframes. 
     This can further help protect the driver from out-of-memory errors because the compressed,
     serialized size can be much smaller than the uncompressed size.
   </td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -164,6 +164,16 @@ of the most common options to set are:
   </td>
 </tr>
 <tr>
+  <td><code>spark.sql.driver.limitUncompressedResultSize</code></td>
+  <td>false</td>
+  <td>
+    If set to true then the value of spark.driver.maxResultSize will also be used for limiting the
+    the total size of the uncompressed results that are produced by actions on sql dataframes. 
+    This can further help protect the driver from out-of-memory errors because the compressed,
+    serialized size can be much smaller than the uncompressed size.
+  </td>
+</tr>
+<tr>
   <td><code>spark.driver.memory</code></td>
   <td>1g</td>
   <td>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1862,7 +1862,7 @@ object SQLConf {
       "(nonnegative and shorter than the maximum size).")
     .createWithDefault(ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH)
 
-  val MAX_UNCOMPRESSED_RESULT_SIZE = buildConf("spark.sql.driver.maxUncompressedResultSize")
+  val MAX_COLLECT_SIZE = buildConf("spark.sql.driver.maxCollectSize")
     .doc("If specified then its value will be used for limiting the total size of " +
       "uncompressed results of all partitions for each Spark action (e.g. collect). " +
       "This is similar to spark.driver.maxResultSize but it enforces the limit on the " +
@@ -2411,7 +2411,7 @@ class SQLConf extends Serializable with Logging {
 
   def maxPlanStringLength: Int = getConf(SQLConf.MAX_PLAN_STRING_LENGTH).toInt
 
-  def maxUncompressedResultSize: Option[Long] = getConf(SQLConf.MAX_UNCOMPRESSED_RESULT_SIZE)
+  def maxCollectSize: Option[Long] = getConf(SQLConf.MAX_COLLECT_SIZE)
 
   def setCommandRejectsSparkCoreConfs: Boolean =
     getConf(SQLConf.SET_COMMAND_REJECTS_SPARK_CORE_CONFS)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1862,6 +1862,13 @@ object SQLConf {
       "(nonnegative and shorter than the maximum size).")
     .createWithDefault(ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH)
 
+  val LIMIT_UNCOMPRESSED_RESULT_SIZE = buildConf("spark.sql.driver.limitUncompressedResultSize")
+    .doc("If set to true then the value of spark.driver.maxResultSize, will be used for limiting the " +
+      "total size of uncompressed results of all partitions for each Spark action (e.g. collect)." +
+      "This can help protect the driver from out-of-memory errors.")
+    .booleanConf
+    .createWithDefault(false)
+
   val SET_COMMAND_REJECTS_SPARK_CORE_CONFS =
     buildConf("spark.sql.legacy.setCommandRejectsSparkCoreConfs")
       .internal()
@@ -2402,6 +2409,8 @@ class SQLConf extends Serializable with Logging {
   def maxToStringFields: Int = getConf(SQLConf.MAX_TO_STRING_FIELDS)
 
   def maxPlanStringLength: Int = getConf(SQLConf.MAX_PLAN_STRING_LENGTH).toInt
+
+  def limitUncompressedResultSize: Boolean = getConf(SQLConf.LIMIT_UNCOMPRESSED_RESULT_SIZE)
 
   def setCommandRejectsSparkCoreConfs: Boolean =
     getConf(SQLConf.SET_COMMAND_REJECTS_SPARK_CORE_CONFS)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1862,12 +1862,13 @@ object SQLConf {
       "(nonnegative and shorter than the maximum size).")
     .createWithDefault(ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH)
 
-  val LIMIT_UNCOMPRESSED_RESULT_SIZE = buildConf("spark.sql.driver.limitUncompressedResultSize")
-    .doc("If set to true then the value of spark.driver.maxResultSize will be used for " +
-      "limiting the total size of uncompressed results of all partitions for each Spark " +
-      "action (e.g. collect). This can help protect the driver from out-of-memory errors.")
-    .booleanConf
-    .createWithDefault(false)
+  val MAX_UNCOMPRESSED_RESULT_SIZE = buildConf("spark.sql.driver.maxUncompressedResultSize")
+    .doc("If specified then its value will be used for limiting the total size of " +
+      "uncompressed results of all partitions for each Spark action (e.g. collect). " +
+      "This is similar to spark.driver.maxResultSize but it enforces the limit on the " +
+      "uncompressed result. Specifying this can help protect the driver from out-of-memory errors.")
+    .bytesConf(ByteUnit.BYTE)
+    .createOptional
 
   val SET_COMMAND_REJECTS_SPARK_CORE_CONFS =
     buildConf("spark.sql.legacy.setCommandRejectsSparkCoreConfs")
@@ -2410,7 +2411,7 @@ class SQLConf extends Serializable with Logging {
 
   def maxPlanStringLength: Int = getConf(SQLConf.MAX_PLAN_STRING_LENGTH).toInt
 
-  def limitUncompressedResultSize: Boolean = getConf(SQLConf.LIMIT_UNCOMPRESSED_RESULT_SIZE)
+  def maxUncompressedResultSize: Option[Long] = getConf(SQLConf.MAX_UNCOMPRESSED_RESULT_SIZE)
 
   def setCommandRejectsSparkCoreConfs: Boolean =
     getConf(SQLConf.SET_COMMAND_REJECTS_SPARK_CORE_CONFS)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1863,9 +1863,9 @@ object SQLConf {
     .createWithDefault(ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH)
 
   val LIMIT_UNCOMPRESSED_RESULT_SIZE = buildConf("spark.sql.driver.limitUncompressedResultSize")
-    .doc("If set to true then the value of spark.driver.maxResultSize, will be used for limiting the " +
-      "total size of uncompressed results of all partitions for each Spark action (e.g. collect)." +
-      "This can help protect the driver from out-of-memory errors.")
+    .doc("If set to true then the value of spark.driver.maxResultSize will be used for " +
+      "limiting the total size of uncompressed results of all partitions for each Spark " +
+      "action (e.g. collect). This can help protect the driver from out-of-memory errors.")
     .booleanConf
     .createWithDefault(false)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SizeLimitingByteArrayDecoder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SizeLimitingByteArrayDecoder.scala
@@ -37,7 +37,7 @@ private[spark] class SizeLimitingByteArrayDecoder(
      nFields: Int,
      sqlConf: SQLConf) extends Logging {
   private var totalUncompressedResultSize = 0L
-  private val maxUncompressedResultSize = sqlConf.maxUncompressedResultSize
+  private val maxCollectSize = sqlConf.maxCollectSize
 
   /**
    * Decodes the byte arrays back to UnsafeRows and puts them into buffer.
@@ -66,7 +66,7 @@ private[spark] class SizeLimitingByteArrayDecoder(
 
   private def ensureCanFetchMoreResults(sizeOfNextRow: Int): Unit = {
     totalUncompressedResultSize += sizeOfNextRow
-    maxUncompressedResultSize match {
+    maxCollectSize match {
       case Some(maxSize) => if (totalUncompressedResultSize > maxSize) {
         val msg = s"Total size of uncompressed results " +
           s"(${Utils.bytesToString(totalUncompressedResultSize)}) " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SizeLimitingByteArrayDecoder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SizeLimitingByteArrayDecoder.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import java.io.{ByteArrayInputStream, DataInputStream}
+
+import org.apache.spark.{SparkConf, SparkEnv, SparkException}
+import org.apache.spark.internal.{config, Logging}
+import org.apache.spark.io.CompressionCodec
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.util.Utils
+
+private[spark] class SizeLimitingByteArrayDecoder(
+     nFields: Int,
+     conf: SparkConf,
+     sqlConf: SQLConf) extends Logging {
+  private var totalUncompressedResultSize = 0L
+  private val maxResultSize = conf.get(config.MAX_RESULT_SIZE)
+  private val limitUncompressedMaxResultSize = sqlConf.limitUncompressedResultSize
+
+  /**
+   * Decodes the byte arrays back to UnsafeRows and put them into buffer.
+   * Fails if size limiting is enabled and the size is bigger than the maximum allowed size.
+   */
+  def decodeUnsafeRows(bytes: Array[Byte]): Iterator[InternalRow] = {
+    val codec = CompressionCodec.createCodec(SparkEnv.get.conf)
+    val bis = new ByteArrayInputStream(bytes)
+    val ins = new DataInputStream(codec.compressedInputStream(bis))
+
+    new Iterator[InternalRow] {
+      private var sizeOfNextRow = ins.readInt()
+
+      override def hasNext: Boolean = sizeOfNextRow >= 0
+
+      override def next(): InternalRow = {
+        ensureCanFetchMoreResults(sizeOfNextRow)
+        val bs = new Array[Byte](sizeOfNextRow)
+        ins.readFully(bs)
+        val row = new UnsafeRow(nFields)
+        row.pointTo(bs, sizeOfNextRow)
+        sizeOfNextRow = ins.readInt()
+        row
+      }
+    }
+  }
+
+  private def ensureCanFetchMoreResults(sizeOfNextRow: Int): Unit = {
+    totalUncompressedResultSize += sizeOfNextRow
+    if (limitUncompressedMaxResultSize && totalUncompressedResultSize > maxResultSize) {
+      val msg = s"Total size of uncompressed results " +
+        s"(${Utils.bytesToString(totalUncompressedResultSize)}) " +
+        s"is bigger than ${config.MAX_RESULT_SIZE.key} (${Utils.bytesToString(maxResultSize)})"
+      logError(msg)
+      throw new SparkException(msg)
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SizeLimitingByteArrayDecoder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SizeLimitingByteArrayDecoder.scala
@@ -42,7 +42,7 @@ private[spark] class SizeLimitingByteArrayDecoder(
   private val limitUncompressedMaxResultSize = sqlConf.limitUncompressedResultSize
 
   /**
-   * Decodes the byte arrays back to UnsafeRows and put them into buffer.
+   * Decodes the byte arrays back to UnsafeRows and puts them into buffer.
    */
   def decodeUnsafeRows(bytes: Array[Byte]): Iterator[InternalRow] = {
     val codec = CompressionCodec.createCodec(SparkEnv.get.conf)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SizeLimitingByteArrayDecoder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SizeLimitingByteArrayDecoder.scala
@@ -27,6 +27,12 @@ import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.Utils
 
+/**
+ * Provides methods for converting compressed byte arrays back to UnsafeRows.
+ * Additionally, can enforce a limit on the total, decoded size of all decoded UnsafeRows.
+ * Enforcing the limit is controlled via a sql config and if it is turned on the encoder will
+ * throw a SparkException when the limit is reached.
+ */
 private[spark] class SizeLimitingByteArrayDecoder(
      nFields: Int,
      conf: SparkConf,
@@ -37,7 +43,6 @@ private[spark] class SizeLimitingByteArrayDecoder(
 
   /**
    * Decodes the byte arrays back to UnsafeRows and put them into buffer.
-   * Fails if size limiting is enabled and the size is bigger than the maximum allowed size.
    */
   def decodeUnsafeRows(bytes: Array[Byte]): Iterator[InternalRow] = {
     val codec = CompressionCodec.createCodec(SparkEnv.get.conf)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SizeLimitingByteArrayUnsafeRowsConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SizeLimitingByteArrayUnsafeRowsConverter.scala
@@ -28,12 +28,12 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.Utils
 
 /**
- * Provides methods for converting compressed byte arrays back to UnsafeRows.
+ * Provides methods for converting compressed byte arrays to UnsafeRows and vice versa.
  * Additionally, can enforce a limit on the total, decoded size of all decoded UnsafeRows.
  * Enforcing the limit is controlled via a sql config and if it is turned on the encoder will
  * throw a SparkException when the limit is reached.
  */
-private[spark] class SizeLimitingByteArrayDecoder(
+private[spark] class SizeLimitingByteArrayUnsafeRowsConverter(
      nFields: Int,
      sqlConf: SQLConf) extends Logging {
   private var totalUncompressedResultSize = 0L

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -324,7 +324,7 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
    */
   private def getByteArrayRdd(n: Int = -1): RDD[(Long, Array[Byte])] = {
     execute().mapPartitionsInternal { iter =>
-      new SizeLimitingByteArrayDecoder(schema.length, sqlContext.conf)
+      new SizeLimitingByteArrayUnsafeRowsConverter(schema.length, sqlContext.conf)
         .encodeUnsafeRows(n, iter)
     }
   }
@@ -336,7 +336,7 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
     val byteArrayRdd = getByteArrayRdd()
 
     val results = ArrayBuffer[InternalRow]()
-    val decoder = new SizeLimitingByteArrayDecoder(schema.length, sqlContext.conf)
+    val decoder = new SizeLimitingByteArrayUnsafeRowsConverter(schema.length, sqlContext.conf)
     byteArrayRdd.collect().foreach { countAndBytes =>
       decoder.decodeUnsafeRows(countAndBytes._2).foreach(results.+=)
     }
@@ -346,7 +346,7 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
   private[spark] def executeCollectIterator(): (Long, Iterator[InternalRow]) = {
     val countsAndBytes = getByteArrayRdd().collect()
     val total = countsAndBytes.map(_._1).sum
-    val decoder = new SizeLimitingByteArrayDecoder(schema.length, sqlContext.conf)
+    val decoder = new SizeLimitingByteArrayUnsafeRowsConverter(schema.length, sqlContext.conf)
     val rows = countsAndBytes.iterator
       .flatMap(countAndBytes => decoder.decodeUnsafeRows(countAndBytes._2))
     (total, rows)
@@ -358,7 +358,7 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
    * @note Triggers multiple jobs (one for each partition).
    */
   def executeToIterator(): Iterator[InternalRow] = {
-    val decoder = new SizeLimitingByteArrayDecoder(schema.length, sqlContext.conf)
+    val decoder = new SizeLimitingByteArrayUnsafeRowsConverter(schema.length, sqlContext.conf)
     getByteArrayRdd().map(_._2).toLocalIterator.flatMap(decoder.decodeUnsafeRows)
   }
 
@@ -385,7 +385,7 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
     val buf = new ArrayBuffer[InternalRow]
     val totalParts = childRDD.partitions.length
     var partsScanned = 0
-    val decoder = new SizeLimitingByteArrayDecoder(schema.length, sqlContext.conf)
+    val decoder = new SizeLimitingByteArrayUnsafeRowsConverter(schema.length, sqlContext.conf)
     while (buf.length < n && partsScanned < totalParts) {
       // The number of partitions to try in this iteration. It is ok for this number to be
       // greater than totalParts because we actually cap it at totalParts in runJob.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -353,8 +353,7 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
     val byteArrayRdd = getByteArrayRdd()
 
     val results = ArrayBuffer[InternalRow]()
-    val decoder = new SizeLimitingByteArrayDecoder(
-      schema.fields.length, sparkContext.getConf, sqlContext.conf)
+    val decoder = new SizeLimitingByteArrayDecoder(schema.fields.length, sqlContext.conf)
     byteArrayRdd.collect().foreach { countAndBytes =>
       decoder.decodeUnsafeRows(countAndBytes._2).foreach(results.+=)
     }
@@ -364,8 +363,7 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
   private[spark] def executeCollectIterator(): (Long, Iterator[InternalRow]) = {
     val countsAndBytes = getByteArrayRdd().collect()
     val total = countsAndBytes.map(_._1).sum
-    val decoder = new SizeLimitingByteArrayDecoder(
-      schema.fields.length, sparkContext.getConf, sqlContext.conf)
+    val decoder = new SizeLimitingByteArrayDecoder(schema.fields.length, sqlContext.conf)
     val rows = countsAndBytes.iterator
       .flatMap(countAndBytes => decoder.decodeUnsafeRows(countAndBytes._2))
     (total, rows)
@@ -377,8 +375,7 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
    * @note Triggers multiple jobs (one for each partition).
    */
   def executeToIterator(): Iterator[InternalRow] = {
-    val decoder = new SizeLimitingByteArrayDecoder(
-      schema.fields.length, sparkContext.getConf, sqlContext.conf)
+    val decoder = new SizeLimitingByteArrayDecoder(schema.fields.length, sqlContext.conf)
     getByteArrayRdd().map(_._2).toLocalIterator.flatMap(decoder.decodeUnsafeRows)
   }
 
@@ -405,8 +402,7 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
     val buf = new ArrayBuffer[InternalRow]
     val totalParts = childRDD.partitions.length
     var partsScanned = 0
-    val decoder = new SizeLimitingByteArrayDecoder(
-      schema.fields.length, sparkContext.getConf, sqlContext.conf)
+    val decoder = new SizeLimitingByteArrayDecoder(schema.fields.length, sqlContext.conf)
     while (buf.length < n && partsScanned < totalParts) {
       // The number of partitions to try in this iteration. It is ok for this number to be
       // greater than totalParts because we actually cap it at totalParts in runJob.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
@@ -89,7 +89,7 @@ class SparkPlanSuite extends QueryTest with SharedSparkSession {
     val plan = spark.range(10000).queryExecution.executedPlan
     assert(plan.executeCollect().length == 10000)
     // When setting a low limit it fails
-    withSQLConf(SQLConf.MAX_UNCOMPRESSED_RESULT_SIZE.key -> "1KB") {
+    withSQLConf(SQLConf.MAX_COLLECT_SIZE.key -> "1KB") {
       val plan = spark.range(10000).queryExecution.executedPlan
       assertThrows[SparkException] { plan.executeCollect() }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds a new config option `spark.sql.driver.maxUncompressedResultSize` (defaulting to empty which preserves the same behavior as before this PR).
If this config option is present then the size of the uncompressed, decoded result of SQL actions (e.g., collect) will be limited to its value.

### Why are the changes needed?
The main problem with the existing `spark.driver.maxResultSize` is that it only enforces the size of the compressed data (of the compressed byte rdd). The actual uncompressed size can be much larger. Thus, `spark.driver.maxResultSize` is no good mechanism for protecting the driver against OOMs when using spark sql.

Adding this new config option provides an additional, better way for protecting the driver against OOMs during collects.

### Does this PR introduce any user-facing change?
No. 


### How was this patch tested?
I added a new unit test in `SparkPlanSuite.scala`
