### PR TITLE
[SPARK-28908][SS]Implement Kafka EOS sink for Structured Streaming

### DIFF
--- a/external/kafka-0-10-sql/src/main/java/org/apache/spark/sql/kafka010/InternalKafkaProducer.java
+++ b/external/kafka-0-10-sql/src/main/java/org/apache/spark/sql/kafka010/InternalKafkaProducer.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.kafka010;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+import com.google.common.base.Preconditions;
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.requests.FindCoordinatorRequest;
+
+import org.apache.spark.annotation.Evolving;
+
+/**
+ * Wrapper around KafkaProducer that allows to resume transactions when restart
+ *  in case of application fail between {@link #flush()} and {@link #commitTransaction()}
+ */
+@Evolving
+public class InternalKafkaProducer<K, V> implements Producer<K, V> {
+  private static final Logger LOG = LoggerFactory.getLogger(InternalKafkaProducer.class);
+
+  protected final KafkaProducer<K, V> kafkaProducer;
+
+  @Nullable
+  protected final String transactionalId;
+
+  public InternalKafkaProducer(Map<String, Object> configs) {
+    if (configs.containsKey(ProducerConfig.TRANSACTIONAL_ID_CONFIG)) {
+      transactionalId = configs.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG).toString();
+    } else {
+      transactionalId = null;
+    }
+    kafkaProducer = new KafkaProducer<>(configs);
+  }
+
+  @Override
+  public void initTransactions() {
+    kafkaProducer.initTransactions();
+  }
+
+  @Override
+  public void beginTransaction() throws ProducerFencedException {
+    kafkaProducer.beginTransaction();
+  }
+
+  @Override
+  public void commitTransaction() throws ProducerFencedException {
+    kafkaProducer.commitTransaction();
+  }
+
+  @Override
+  public void abortTransaction() throws ProducerFencedException {
+    kafkaProducer.abortTransaction();
+  }
+
+  @Override
+  public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
+                                       String consumerGroupId) throws ProducerFencedException {
+    kafkaProducer.sendOffsetsToTransaction(offsets, consumerGroupId);
+  }
+
+  @Override
+  public Future<RecordMetadata> send(ProducerRecord<K, V> record) {
+    return kafkaProducer.send(record);
+  }
+
+  @Override
+  public Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback) {
+    return kafkaProducer.send(record, callback);
+  }
+
+  @Override
+  public List<PartitionInfo> partitionsFor(String topic) {
+    return kafkaProducer.partitionsFor(topic);
+  }
+
+  @Override
+  public Map<MetricName, ? extends Metric> metrics() {
+    return kafkaProducer.metrics();
+  }
+
+  @Override
+  public void close() {
+    kafkaProducer.close();
+  }
+
+  @Override
+  public void close(long timeout, TimeUnit unit) {
+    kafkaProducer.close(timeout, unit);
+  }
+
+  @Override
+  public void close(Duration duration) {
+    kafkaProducer.close(duration);
+  }
+
+  @Override
+  public void flush() {
+    kafkaProducer.flush();
+  }
+
+  /**
+   * Instead of obtaining producerId and epoch from the transaction coordinator, re-use previously
+   * obtained ones, so that we can resume transaction after a restart. Implementation of
+   * this method is based on {@link KafkaProducer#initTransactions}.
+   * https://github.com/apache/kafka/commit/5d2422258cb975a137a42a4e08f03573c49a387e#diff-f4ef1afd8792cd2a2e9069cd7ddea630
+   */
+  public void resumeTransaction(long producerId, short epoch) {
+    Preconditions.checkState(producerId >= 0 && epoch >= 0,
+        "Incorrect values for producerId %s and epoch %s", producerId, epoch);
+    LOG.info("Attempting to resume transaction {} with producerId {} and epoch {}",
+        transactionalId, producerId, epoch);
+
+    Object transactionManager = getValue(kafkaProducer, "transactionManager");
+    synchronized (transactionManager) {
+      invoke(transactionManager, "transitionTo", getEnum(
+          "org.apache.kafka.clients.producer.internals.TransactionManager$State.INITIALIZING"));
+
+      Object producerIdAndEpoch = getValue(transactionManager, "producerIdAndEpoch");
+      setValue(producerIdAndEpoch, "producerId", producerId);
+      setValue(producerIdAndEpoch, "epoch", epoch);
+
+      invoke(transactionManager, "transitionTo", getEnum(
+          "org.apache.kafka.clients.producer.internals.TransactionManager$State.READY"));
+
+      invoke(transactionManager, "transitionTo", getEnum(
+          "org.apache.kafka.clients.producer.internals.TransactionManager$State.IN_TRANSACTION"));
+      setValue(transactionManager, "transactionStarted", true);
+    }
+  }
+
+  public String getTransactionalId() {
+    return transactionalId;
+  }
+
+  public long getProducerId() {
+    Object transactionManager = getValue(kafkaProducer, "transactionManager");
+    Object producerIdAndEpoch = getValue(transactionManager, "producerIdAndEpoch");
+    return (long) getValue(producerIdAndEpoch, "producerId");
+  }
+
+  public short getEpoch() {
+    Object transactionManager = getValue(kafkaProducer, "transactionManager");
+    Object producerIdAndEpoch = getValue(transactionManager, "producerIdAndEpoch");
+    return (short) getValue(producerIdAndEpoch, "epoch");
+  }
+
+  @VisibleForTesting
+  public int getTransactionCoordinatorId() {
+    Object transactionManager = getValue(kafkaProducer, "transactionManager");
+    Node node = (Node) invoke(transactionManager, "coordinator",
+        FindCoordinatorRequest.CoordinatorType.TRANSACTION);
+    return node.id();
+  }
+
+  protected static Enum<?> getEnum(String enumFullName) {
+    String[] x = enumFullName.split("\\.(?=[^\\.]+$)");
+    if (x.length == 2) {
+      String enumClassName = x[0];
+      String enumName = x[1];
+      try {
+        Class<Enum> cl = (Class<Enum>) Class.forName(enumClassName);
+        return Enum.valueOf(cl, enumName);
+      } catch (ClassNotFoundException e) {
+        throw new RuntimeException("Incompatible KafkaProducer version", e);
+      }
+    }
+    return null;
+  }
+
+  protected static Object invoke(Object object, String methodName, Object... args) {
+    Class<?>[] argTypes = new Class[args.length];
+    for (int i = 0; i < args.length; i++) {
+      argTypes[i] = args[i].getClass();
+    }
+    return invoke(object, methodName, argTypes, args);
+  }
+
+  private static Object invoke(Object object, String methodName, Class<?>[] argTypes, Object[] args) {
+    try {
+      Method method = object.getClass().getDeclaredMethod(methodName, argTypes);
+      method.setAccessible(true);
+      return method.invoke(object, args);
+    } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+      throw new RuntimeException("Incompatible KafkaProducer version", e);
+    }
+  }
+
+  protected static Object getValue(Object object, String fieldName) {
+    return getValue(object, object.getClass(), fieldName);
+  }
+
+  private static Object getValue(Object object, Class<?> clazz, String fieldName) {
+    try {
+      Field field = clazz.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return field.get(object);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new RuntimeException("Incompatible KafkaProducer version", e);
+    }
+  }
+
+  protected static void setValue(Object object, String fieldName, Object value) {
+    try {
+      Field field = object.getClass().getDeclaredField(fieldName);
+      field.setAccessible(true);
+      field.set(object, value);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new RuntimeException("Incompatible KafkaProducer version", e);
+    }
+  }
+}

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/CachedKafkaProducer.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/CachedKafkaProducer.scala
@@ -20,11 +20,11 @@ package org.apache.spark.sql.kafka010
 import java.{util => ju}
 import java.util.concurrent.{ConcurrentMap, ExecutionException, TimeUnit}
 
-import com.google.common.cache._
-import com.google.common.util.concurrent.{ExecutionError, UncheckedExecutionException}
-import org.apache.kafka.clients.producer.KafkaProducer
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
+
+import com.google.common.cache._
+import com.google.common.util.concurrent.{ExecutionError, UncheckedExecutionException}
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
@@ -32,7 +32,7 @@ import org.apache.spark.kafka010.{KafkaConfigUpdater, KafkaRedactionUtil}
 
 private[kafka010] object CachedKafkaProducer extends Logging {
 
-  private type Producer = KafkaProducer[Array[Byte], Array[Byte]]
+  private type Producer = InternalKafkaProducer[Array[Byte], Array[Byte]]
 
   private val defaultCacheExpireTimeout = TimeUnit.MINUTES.toMillis(10)
 

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaDataWriter.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaDataWriter.scala
@@ -18,16 +18,160 @@
 package org.apache.spark.sql.kafka010
 
 import java.{util => ju}
+import java.util.concurrent.atomic.AtomicInteger
+
+import com.google.common.cache._
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.sources.v2.writer._
+import org.apache.spark.util.Utils
 
 /**
- * Dummy commit message. The DataSourceV2 framework requires a commit message implementation but we
- * don't need to really send one.
+ * A [[WriterCommitMessage]] for Kafka commit message.
+ * @param transactionalId Unique transactionalId for each producer.
+ * @param epoch Transactional epoch.
+ * @param producerId Transactional producerId for producer, got when init transaction.
  */
-private case object KafkaDataWriterCommitMessage extends WriterCommitMessage
+private[kafka010] case class ProducerTransactionMetaData(
+    transactionalId: String,
+    epoch: Short,
+    producerId: Long)
+  extends WriterCommitMessage
+
+/**
+ * Emtpy commit message for resume transaction.
+ */
+private case object EmptyCommitMessage extends WriterCommitMessage
+
+private[kafka010] case object ProducerTransactionMetaData {
+  val VERSION = 1
+
+  def toTransactionId(
+      executorId: String,
+      taskIndex: String,
+      transactionalIdSuffix: String): String = {
+    toTransactionId(toProducerIdentity(executorId, taskIndex), transactionalIdSuffix)
+  }
+
+  def toTransactionId(producerIdentity: String, transactionalIdSuffix: String): String = {
+    s"$producerIdentity||$transactionalIdSuffix"
+  }
+
+  def toTransactionalIdSuffix(transactionalId: String): String = {
+    transactionalId.split("\\|\\|", 2)(1)
+  }
+
+  def toProducerIdentity(transactionalId: String): String = {
+    transactionalId.split("\\|\\|", 2)(0)
+  }
+
+  def toExecutorId(transactionalId: String): String = {
+    val producerIdentity = toProducerIdentity(transactionalId)
+    producerIdentity.split("-", 2)(0)
+  }
+
+  def toTaskIndex(transactionalId: String): String = {
+    val producerIdentity = toProducerIdentity(transactionalId)
+    producerIdentity.split("-", 2)(1)
+  }
+
+  def toProducerIdentity(executorId: String, taskIndex: String): String = {
+    s"$executorId-$taskIndex"
+  }
+}
+
+/**
+ * A [[DataWriter]] for Kafka transactional writing. One data writer will be created
+ * in each partition to process incoming rows.
+ *
+ * @param targetTopic The topic that this data writer is targeting. If None, topic will be inferred
+ *                    from a `topic` field in the incoming data.
+ * @param producerParams Parameters to use for the Kafka producer.
+ * @param inputSchema The attributes in the input data.
+ */
+private[kafka010] class KafkaTransactionDataWriter(
+    targetTopic: Option[String],
+    producerParams: ju.Map[String, Object],
+    inputSchema: Seq[Attribute])
+  extends KafkaRowWriter(inputSchema, targetTopic) with DataWriter[InternalRow] {
+
+  private lazy val producer = {
+    val kafkaProducer = CachedKafkaProducer.getOrCreate(producerParams)
+    if (kafkaProducer.getProducerId == -1) {
+      kafkaProducer.initTransactions()
+    }
+    kafkaProducer.beginTransaction()
+    kafkaProducer
+  }
+
+  def write(row: InternalRow): Unit = {
+    checkForErrors()
+    sendRow(row, producer)
+  }
+
+  def commit(): WriterCommitMessage = {
+    // Send is asynchronous, but we can't commit until all rows are actually in Kafka.
+    // This requires flushing and then checking that no callbacks produced errors.
+    // We also check for errors before to fail as soon as possible - the check is cheap.
+    checkForErrors()
+    producer.flush()
+    checkForErrors()
+    ProducerTransactionMetaData(producer.getTransactionalId, producer.getEpoch,
+      producer.getProducerId)
+  }
+
+  def abort(): Unit = {
+    if (producer.getProducerId != -1) {
+      Utils.tryWithSafeFinallyAndFailureCallbacks(block = {
+        producer.abortTransaction()
+      })(catchBlock = {
+        CachedKafkaProducer.close(producerParams)
+      })
+    }
+  }
+
+  def close(): Unit = {
+    checkForErrors()
+    if (producer != null) {
+      producer.flush()
+      checkForErrors()
+      CachedKafkaProducer.close(producerParams)
+    }
+  }
+}
+
+/**
+ * A [[DataWriter]] for resume Kafka transaction.
+ *
+ * @param producerParams Parameters to use for the Kafka producer.
+ */
+private[kafka010] class KafkaTransactionResumeDataWriter(
+    targetTopic: Option[String],
+    producerParams: ju.Map[String, Object],
+    inputSchema: Seq[Attribute],
+    metaData: ProducerTransactionMetaData)
+  extends KafkaRowWriter(inputSchema, targetTopic) with DataWriter[InternalRow] {
+
+  private val producer = CachedKafkaProducer.getOrCreate(producerParams)
+
+  def write(row: InternalRow): Unit = {}
+
+  def commit(): WriterCommitMessage = {
+    producer.resumeTransaction(metaData.producerId, metaData.epoch)
+    producer.commitTransaction()
+
+    EmptyCommitMessage
+  }
+
+  def abort(): Unit = {}
+
+  def close(): Unit = {
+    if (producer != null) {
+      CachedKafkaProducer.close(producerParams)
+    }
+  }
+}
 
 /**
  * A [[DataWriter]] for Kafka writing. One data writer will be created in each partition to
@@ -58,7 +202,7 @@ private[kafka010] class KafkaDataWriter(
     checkForErrors()
     producer.flush()
     checkForErrors()
-    KafkaDataWriterCommitMessage
+    EmptyCommitMessage
   }
 
   def abort(): Unit = {}
@@ -70,5 +214,24 @@ private[kafka010] class KafkaDataWriter(
       checkForErrors()
       CachedKafkaProducer.close(producerParams)
     }
+  }
+}
+
+
+private object TaskIndexGenerator {
+  private val generator = CacheBuilder.newBuilder().build[String, AtomicInteger](
+    new CacheLoader[String, AtomicInteger] {
+      override def load(key: String): AtomicInteger = {
+        new AtomicInteger(0)
+      }
+    }
+  )
+
+  def getTaskIndex(transactionIdSuffix: String): String = {
+    generator.get(transactionIdSuffix).getAndIncrement().toString
+  }
+
+  def resetTaskIndex(transactionIdSuffix: String): Unit = {
+    generator.get(transactionIdSuffix).set(0)
   }
 }

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaStreamingWrite.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaStreamingWrite.scala
@@ -18,12 +18,179 @@
 package org.apache.spark.sql.kafka010
 
 import java.{util => ju}
+import java.time.Duration
 
+import org.apache.hadoop.fs.Path
+import org.apache.kafka.clients.producer.ProducerConfig
+
+import org.apache.spark.SparkEnv
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.streaming.OffsetSeqLog
 import org.apache.spark.sql.kafka010.KafkaWriter.validateQuery
 import org.apache.spark.sql.sources.v2.writer._
 import org.apache.spark.sql.sources.v2.writer.streaming.{StreamingDataWriterFactory, StreamingWrite}
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.storage.BlockManagerId
+
+/**
+ * A [[StreamingWrite]] for Kafka transactional writing. Responsible for generating
+ * the transactional writer factory.
+ *
+ * @param topic The topic this writer is responsible for. If None, topic will be inferred from
+ *              a `topic` field in the incoming data.
+ * @param producerParams Parameters for Kafka producers in each task.
+ * @param schema The schema of the input data.
+ */
+private[kafka010] class KafkaTransactionStreamingWrite(
+    topic: Option[String],
+    producerParams: ju.Map[String, Object],
+    schema: StructType)
+  extends StreamingWrite with Logging {
+  private var initialized = false
+  private lazy val transactionalIdSuffix: String =
+    KafkaTransactionStreamingWrite.generateTransactionIdSuffix(producerParams)
+  private lazy val metaDataLog = {
+    val sparkSession = SparkSession.getActiveSession.get
+    KafkaTransactionStreamingWrite.getTransactionMetaDataLog(producerParams,
+      sparkSession)
+  }
+
+  validateQuery(schema.toAttributes, producerParams, topic)
+  updateProducerParams()
+
+  override def createStreamingWriterFactory(): StreamingDataWriterFactory = {
+    if (initialized) {
+      KafkaTransactionStreamWriterFactory(topic, producerParams, schema, transactionalIdSuffix)
+    } else {
+      val writerFactory = {
+        val sparkSession = SparkSession.getActiveSession.get
+        val batchId = KafkaTransactionStreamingWrite.getCurrentBatchId(producerParams, sparkSession)
+        val metaData = metaDataLog.get(batchId)
+
+        if (batchId == 0 || metaData.isEmpty) {
+          KafkaTransactionStreamWriterFactory(topic, producerParams, schema,
+            transactionalIdSuffix)
+        } else {
+
+          // restart and commit transaction since fail to commit transaction
+          val resumedTransId = metaData.get.head.transactionalId
+          val resumedTranslIdSuffix =
+            ProducerTransactionMetaData.toTransactionalIdSuffix(resumedTransId)
+          KafkaStreamTransactionResumeWriterFactory(topic, producerParams, schema,
+            resumedTranslIdSuffix, metaData.get)
+        }
+      }
+      initialize()
+      writerFactory
+    }
+  }
+
+  override def commit(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {
+    val needCommit = messages.nonEmpty && messages.head.isInstanceOf[ProducerTransactionMetaData]
+    if (needCommit) {
+      val metaDatas = messages.map(_.asInstanceOf[ProducerTransactionMetaData])
+      metaDataLog.add(epochId, metaDatas)
+
+      val config = new ju.HashMap[String, Object]()
+      config.putAll(producerParams)
+      val sparkSession = SparkSession.getActiveSession.get
+      val aliveExecutors = KafkaTransactionStreamingWrite.getExecutors(sparkSession)
+      val executorNum = if (aliveExecutors.nonEmpty) aliveExecutors.size else 1
+      val executorMetaData = metaDatas.groupBy(
+        metaData => ProducerTransactionMetaData.toExecutorId(metaData.transactionalId))
+      val transactionSuffix =
+        ProducerTransactionMetaData.toTransactionalIdSuffix(metaDatas.head.transactionalId)
+      val successExecutors = sparkSession.sparkContext
+        .parallelize( 0 until executorNum, executorNum)
+        .map(_ => {
+          val executorId = SparkEnv.get.executorId
+          if (executorMetaData.contains(executorId)) {
+            executorMetaData(executorId).foreach(metaData => {
+              config.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, metaData.transactionalId)
+              val producer = CachedKafkaProducer.getOrCreate(config)
+              producer.commitTransaction()
+            })
+
+            TaskIndexGenerator.resetTaskIndex(transactionSuffix)
+          }
+          executorId
+        }).collect()
+
+      val failedExecutors = executorMetaData.keys.toList.diff(successExecutors)
+      if (failedExecutors.nonEmpty) {
+        throw new Exception("Fail to commit the writing job, " +
+          s"since kafka producer failed to commit transaction in " +
+          s"executor[${failedExecutors.mkString(",")}].")
+      }
+    }
+  }
+
+  override def abort(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {
+    val sparkSession = SparkSession.getActiveSession.get
+    val batchId = KafkaTransactionStreamingWrite.getCurrentBatchId(producerParams, sparkSession)
+    val metaData = metaDataLog.get(batchId)
+    val needAbort = messages.nonEmpty && messages.head.isInstanceOf[ProducerTransactionMetaData] &&
+      metaData.isEmpty
+    if (needAbort) {
+      val metaDatas = messages.map(_.asInstanceOf[ProducerTransactionMetaData])
+      val config = new ju.HashMap[String, Object]()
+      config.putAll(producerParams)
+      val aliveExecutors = KafkaTransactionStreamingWrite.getExecutors(sparkSession)
+      val executorNum = if (aliveExecutors.nonEmpty) aliveExecutors.size else 1
+      val executorMetaData = metaDatas.groupBy(
+        metaData => ProducerTransactionMetaData.toExecutorId(metaData.transactionalId))
+      sparkSession.sparkContext
+        .parallelize( 0 until executorNum, executorNum)
+        .foreach(_ => {
+          val executorId = SparkEnv.get.executorId
+          if (executorMetaData.contains(executorId)) {
+            executorMetaData(executorId).foreach(metaData => {
+              config.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, metaData.transactionalId)
+              val producer = CachedKafkaProducer.getOrCreate(config)
+              try {
+                producer.abortTransaction()
+              } finally {
+                producer.close(Duration.ofSeconds(0))
+              }
+            })
+          }
+        })
+    }
+  }
+
+  override def getOptionalPartitionNum: Integer = {
+    if (producerParams.containsKey(KafkaTransactionStreamingWrite.PRODUCER_CREATE_FACTOR_CONFIG)) {
+      producerParams.get(
+        KafkaTransactionStreamingWrite.PRODUCER_CREATE_FACTOR_CONFIG).toString.toInt
+    } else {
+      KafkaTransactionStreamingWrite.DEFAULT_PRODUCER_CREATE_FACTOR
+    }
+  }
+
+  private def initialize(): Unit = {
+    initialized = true
+  }
+
+  private def updateProducerParams(): Unit = {
+    if (!producerParams.containsKey(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG)) {
+      producerParams.put(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG,
+        KafkaTransactionStreamingWrite.DEFAULT_KAFKA_BROKER_TRANSACTION_MAX_TIMEOUT_MS)
+    } else {
+      val timeout = producerParams.get(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG).toString.toLong
+      val recommendTimeout =
+        KafkaTransactionStreamingWrite.DEFAULT_KAFKA_BROKER_TRANSACTION_MAX_TIMEOUT_MS.toLong
+      if (timeout < recommendTimeout) {
+        logWarning(s"Value of config ${ProducerConfig.TRANSACTION_TIMEOUT_CONFIG} is $timeout, " +
+          s"less than recommend value: " +
+          s"${KafkaTransactionStreamingWrite.DEFAULT_KAFKA_BROKER_TRANSACTION_MAX_TIMEOUT_MS}," +
+          s" recover from failure when restart application will fail and lost data " +
+          s"if exceed $timeout.")
+      }
+    }
+  }
+}
 
 /**
  * A [[StreamingWrite]] for Kafka writing. Responsible for generating the writer factory.
@@ -49,6 +216,60 @@ private[kafka010] class KafkaStreamingWrite(
 }
 
 /**
+ * A [[StreamingDataWriterFactory]] for Kafka transactional writing. Will be serialized
+ * and sent to executors to generate the per-task transactional data writers.
+ * @param topic The topic that should be written to. If None, topic will be inferred from
+ *              a `topic` field in the incoming data.
+ * @param producerParams Parameters for Kafka producers in each task.
+ * @param schema The schema of the input data.
+ */
+private case class KafkaTransactionStreamWriterFactory(
+    topic: Option[String],
+    producerParams: ju.Map[String, Object],
+    schema: StructType,
+    transactionSuffix: String)
+  extends StreamingDataWriterFactory {
+
+  override def createWriter(
+      partitionId: Int,
+      taskId: Long,
+      epochId: Long): DataWriter[InternalRow] = {
+    val executorId = SparkEnv.get.executorId
+    val taskIndex = TaskIndexGenerator.getTaskIndex(transactionSuffix)
+    val transactionalId = ProducerTransactionMetaData.toTransactionId(executorId, taskIndex,
+      transactionSuffix)
+    producerParams.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId)
+    new KafkaTransactionDataWriter(topic, producerParams, schema.toAttributes)
+  }
+}
+
+/**
+ * A [[StreamingDataWriterFactory]] for resuming Kafka transaction. Will be serialized and sent to
+ * executors to resume transaction.
+ * @param topic The topic that should be written to. If None, topic will be inferred from
+ *              a `topic` field in the incoming data.
+ * @param producerParams Parameters for Kafka producers in each task.
+ * @param schema The schema of the input data.
+ */
+private case class KafkaStreamTransactionResumeWriterFactory(
+    topic: Option[String],
+    producerParams: ju.Map[String, Object],
+    schema: StructType,
+    transactionSuffix: String,
+    metaDatas: Array[ProducerTransactionMetaData])
+  extends StreamingDataWriterFactory {
+
+  override def createWriter(
+      partitionId: Int,
+      taskId: Long,
+      epochId: Long): DataWriter[InternalRow] = {
+    val metaData: ProducerTransactionMetaData = metaDatas(taskId.toInt)
+    producerParams.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, metaData.transactionalId)
+    new KafkaTransactionResumeDataWriter(topic, producerParams, schema.toAttributes, metaData)
+  }
+}
+
+/**
  * A [[StreamingDataWriterFactory]] for Kafka writing. Will be serialized and sent to executors to
  * generate the per-task data writers.
  * @param topic The topic that should be written to. If None, topic will be inferred from
@@ -67,5 +288,40 @@ private case class KafkaStreamWriterFactory(
       taskId: Long,
       epochId: Long): DataWriter[InternalRow] = {
     new KafkaDataWriter(topic, producerParams, schema.toAttributes)
+  }
+}
+
+private[kafka010] object KafkaTransactionStreamingWrite {
+  private val METADATA_DIR = "_kafka_producer_transaction_metadata"
+  private val PRODUCER_CREATE_FACTOR_CONFIG = "producerCreateFactor"
+  private val DEFAULT_PRODUCER_CREATE_FACTOR = 10
+
+  // equals to the default value of config transaction.max.timeout.ms in Kafka broker
+  private val DEFAULT_KAFKA_BROKER_TRANSACTION_MAX_TIMEOUT_MS = "900000"
+
+  def getTransactionMetaDataLog(
+      params: ju.Map[String, Object],
+      sparkSession: SparkSession): ProducerTransactionMetaDataLog = {
+    val checkpointLoc = params.get("checkpointLocation")
+    val basePath = s"$checkpointLoc/sinks"
+    val logPath = new Path(basePath, METADATA_DIR)
+    new ProducerTransactionMetaDataLog(sparkSession, logPath.toUri.toString, params)
+  }
+
+  def getCurrentBatchId(params: ju.Map[String, Object], sparkSession: SparkSession): Long = {
+    val checkpointLoc = params.get("checkpointLocation").toString
+    val logPath = new Path(checkpointLoc, "offsets")
+    val offsetLog = new OffsetSeqLog(sparkSession, logPath.toUri.toString)
+    offsetLog.getLatest().get._1
+  }
+
+  def generateTransactionIdSuffix(params: ju.Map[String, Object]): String = {
+      val userDefinedTransId = params.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG)
+      userDefinedTransId + ju.UUID.randomUUID().toString
+  }
+
+  def getExecutors(sparkSession: SparkSession): Seq[BlockManagerId] = {
+    val blockManager = sparkSession.sparkContext.env.blockManager
+    blockManager.master.getPeers(blockManager.blockManagerId)
   }
 }

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaWriteTask.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaWriteTask.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.kafka010
 
 import java.{util => ju}
 
-import org.apache.kafka.clients.producer.{Callback, KafkaProducer, ProducerRecord, RecordMetadata}
+import org.apache.kafka.clients.producer.{Callback, ProducerRecord, RecordMetadata}
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Literal, UnsafeProjection}
@@ -35,7 +35,7 @@ private[kafka010] class KafkaWriteTask(
     inputSchema: Seq[Attribute],
     topic: Option[String]) extends KafkaRowWriter(inputSchema, topic) {
   // used to synchronize with Kafka callbacks
-  private var producer: KafkaProducer[Array[Byte], Array[Byte]] = _
+  private var producer: InternalKafkaProducer[Array[Byte], Array[Byte]] = _
 
   /**
    * Writes key value data out to topics.
@@ -79,7 +79,7 @@ private[kafka010] abstract class KafkaRowWriter(
    * assuming the row is in Kafka.
    */
   protected def sendRow(
-      row: InternalRow, producer: KafkaProducer[Array[Byte], Array[Byte]]): Unit = {
+      row: InternalRow, producer: InternalKafkaProducer[Array[Byte], Array[Byte]]): Unit = {
     val projectedRow = projection(row)
     val topic = projectedRow.getUTF8String(0)
     val key = projectedRow.getBinary(1)

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/ProducerTransactionMetaDataLog.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/ProducerTransactionMetaDataLog.scala
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.kafka010
+
+import java.{util => ju}
+import java.io.{InputStream, OutputStream}
+import java.nio.charset.StandardCharsets.UTF_8
+
+import scala.io.{Source => IOSource}
+import scala.reflect.ClassTag
+
+import org.json4s.NoTypeHints
+import org.json4s.jackson.Serialization
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.execution.streaming.HDFSMetadataLog
+
+private[kafka010] class ProducerTransactionMetaDataLog(
+    sparkSession: SparkSession,
+    path: String,
+    params: ju.Map[String, Object])
+  extends HDFSMetadataLog[Array[ProducerTransactionMetaData]](sparkSession, path) {
+  private val BATCHES_PURGE_INTERVAL_KEY = "batchesPurgeInterval"
+  private val DEFAULT_BATCHES_PURGE_INTERVAL = 10
+
+  private implicit val formats = Serialization.formats(NoTypeHints)
+
+  /** Needed to serialize type T into JSON when using Jackson */
+  private implicit val manifest = Manifest.classType[ProducerTransactionMetaData](
+    implicitly[ClassTag[ProducerTransactionMetaData]].runtimeClass)
+
+  private val minBatchesToRetain = sparkSession.sessionState.conf.minBatchesToRetain
+  private val purgeInterval = if (params.containsKey(BATCHES_PURGE_INTERVAL_KEY)) {
+    val interval = params.get(BATCHES_PURGE_INTERVAL_KEY).toString.toInt
+    assert(interval > 0, s"Kafka sink option '$BATCHES_PURGE_INTERVAL_KEY' should greater than 0.")
+    interval
+  } else {
+    DEFAULT_BATCHES_PURGE_INTERVAL
+  }
+
+  override def serialize(logData: Array[ProducerTransactionMetaData], out: OutputStream): Unit = {
+    out.write(("v" + ProducerTransactionMetaData.VERSION).getBytes(UTF_8))
+    logData.foreach { data =>
+      out.write('\n')
+      out.write(Serialization.write(data).getBytes(UTF_8))
+    }
+  }
+
+  override def deserialize(in: InputStream): Array[ProducerTransactionMetaData] = {
+    val lines = IOSource.fromInputStream(in, UTF_8.name()).getLines()
+    if (!lines.hasNext) {
+      throw new IllegalStateException("Invalid log file, find no line.")
+    }
+    validateVersion(lines.next(), ProducerTransactionMetaData.VERSION)
+    lines.map(Serialization.read[ProducerTransactionMetaData]).toArray
+  }
+
+  /**
+   * Store the metadata for the specified batchId and purge stored metadata with
+   * `batchesPurgeInterval` if exceed minBatchesToRetain. Return `true` if successful.
+   * If the batchId's metadata has already been stored, this method will return `false`.
+   */
+  override def add(batchId: Long, metadata: Array[ProducerTransactionMetaData]): Boolean = {
+    val ret = super.add(batchId, metadata)
+    if (ret &&
+      batchId > minBatchesToRetain && (batchId - minBatchesToRetain) % purgeInterval == 0) {
+      val threshold = batchId - minBatchesToRetain
+      purge(threshold)
+    }
+    ret
+  }
+}

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/CachedKafkaProducerSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/CachedKafkaProducerSuite.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.kafka010
 import java.{util => ju}
 import java.util.concurrent.ConcurrentMap
 
-import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.common.serialization.ByteArraySerializer
 import org.scalatest.PrivateMethodTester
 
@@ -28,7 +27,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 
 class CachedKafkaProducerSuite extends SharedSparkSession with PrivateMethodTester with KafkaTest {
 
-  type KP = KafkaProducer[Array[Byte], Array[Byte]]
+  type KP = InternalKafkaProducer[Array[Byte], Array[Byte]]
 
   protected override def beforeEach(): Unit = {
     super.beforeEach()

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaContinuousSinkSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaContinuousSinkSuite.scala
@@ -364,7 +364,7 @@ class KafkaContinuousSinkSuite extends KafkaContinuousTest {
     options.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer].getName)
     val inputSchema = Seq(AttributeReference("value", BinaryType)())
     val data = new Array[Byte](15000) // large value
-    val writeTask = new KafkaDataWriter(Some(topic), options, inputSchema)
+    val writeTask = new KafkaTransactionDataWriter(Some(topic), options, inputSchema)
     try {
       val fieldTypes: Array[DataType] = Array(BinaryType)
       val converter = UnsafeProjection.create(fieldTypes)

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaContinuousSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaContinuousSourceSuite.scala
@@ -33,7 +33,7 @@ class KafkaContinuousSourceSuite extends KafkaSourceSuiteBase with KafkaContinuo
     withTable(table) {
       val topic = newTopic()
       testUtils.createTopic(topic)
-      testUtils.withTranscationalProducer { producer =>
+      testUtils.withTransactionalProducer { producer =>
         val df = spark
           .readStream
           .format("kafka")
@@ -99,7 +99,7 @@ class KafkaContinuousSourceSuite extends KafkaSourceSuiteBase with KafkaContinuo
     withTable(table) {
       val topic = newTopic()
       testUtils.createTopic(topic)
-      testUtils.withTranscationalProducer { producer =>
+      testUtils.withTransactionalProducer { producer =>
         val df = spark
           .readStream
           .format("kafka")

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -807,7 +807,7 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
 
     val topicPartition = new TopicPartition(topic, 0)
     // The message values are the same as their offsets to make the test easy to follow
-    testUtils.withTranscationalProducer { producer =>
+    testUtils.withTransactionalProducer { producer =>
       testStream(mapped)(
         StartStream(Trigger.ProcessingTime(100), clock),
         waitUntilBatchProcessed,
@@ -930,7 +930,7 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
 
     val topicPartition = new TopicPartition(topic, 0)
     // The message values are the same as their offsets to make the test easy to follow
-    testUtils.withTranscationalProducer { producer =>
+    testUtils.withTransactionalProducer { producer =>
       testStream(mapped)(
         StartStream(Trigger.ProcessingTime(100), clock),
         waitUntilBatchProcessed,
@@ -1021,7 +1021,7 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
       .load()
       .select($"value".as[String])
 
-    testUtils.withTranscationalProducer { producer =>
+    testUtils.withTransactionalProducer { producer =>
       producer.beginTransaction()
       (0 to 3).foreach { i =>
         producer.send(new ProducerRecord[String, String](topic, i.toString)).get()
@@ -1037,7 +1037,7 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
         // this case, if we forget to reset `FetchedData._nextOffsetInFetchedData` or
         // `FetchedData._offsetAfterPoll` (See SPARK-25495), the next batch will see incorrect
         // values and return wrong results hence fail the test.
-        testUtils.withTranscationalProducer { producer =>
+        testUtils.withTransactionalProducer { producer =>
           producer.beginTransaction()
           (4 to 7).foreach { i =>
             producer.send(new ProducerRecord[String, String](topic, i.toString)).get()
@@ -1539,7 +1539,7 @@ abstract class KafkaSourceSuiteBase extends KafkaSourceTest {
     withTable(table) {
       val topic = newTopic()
       testUtils.createTopic(topic)
-      testUtils.withTranscationalProducer { producer =>
+      testUtils.withTransactionalProducer { producer =>
         val df = spark
           .readStream
           .format("kafka")

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRelationSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRelationSuite.scala
@@ -31,7 +31,6 @@ import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
 
@@ -284,7 +283,7 @@ abstract class KafkaRelationSuiteBase extends QueryTest with SharedSparkSession 
   test("read Kafka transactional messages: read_committed") {
     val topic = newTopic()
     testUtils.createTopic(topic)
-    testUtils.withTranscationalProducer { producer =>
+    testUtils.withTransactionalProducer { producer =>
       val df = spark
         .read
         .format("kafka")
@@ -333,7 +332,7 @@ abstract class KafkaRelationSuiteBase extends QueryTest with SharedSparkSession 
   test("read Kafka transactional messages: read_uncommitted") {
     val topic = newTopic()
     testUtils.createTopic(topic)
-    testUtils.withTranscationalProducer { producer =>
+    testUtils.withTransactionalProducer { producer =>
       val df = spark
         .read
         .format("kafka")

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/sources/v2/writer/BatchWrite.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/sources/v2/writer/BatchWrite.java
@@ -98,4 +98,8 @@ public interface BatchWrite {
    * clean up the data left by data writers.
    */
   void abort(WriterCommitMessage[] messages);
+
+  default Integer getOptionalPartitionNum() {
+    return null;
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/sources/v2/writer/WriteBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/sources/v2/writer/WriteBuilder.java
@@ -71,8 +71,9 @@ public interface WriteBuilder {
    * throws exception, data sources must overwrite this method to provide an implementation, if the
    * {@link Table} that creates this write returns {@link TableCapability#STREAMING_WRITE} support
    * in its {@link Table#capabilities()}.
+   * @param isContinuous true if in continuous mode
    */
-  default StreamingWrite buildForStreaming() {
+  default StreamingWrite buildForStreaming(boolean isContinuous) {
     throw new UnsupportedOperationException(getClass().getName() +
       " does not support streaming write");
   }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/sources/v2/writer/streaming/StreamingWrite.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/sources/v2/writer/streaming/StreamingWrite.java
@@ -81,4 +81,8 @@ public interface StreamingWrite {
    * clean up the data left by data writers.
    */
   void abort(long epochId, WriterCommitMessage[] messages);
+
+  default Integer getOptionalPartitionNum() {
+    return null;
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/noop/NoopDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/noop/NoopDataSource.scala
@@ -54,7 +54,8 @@ private[noop] object NoopTable extends Table with SupportsWrite {
 private[noop] object NoopWriteBuilder extends WriteBuilder with SupportsTruncate {
   override def truncate(): WriteBuilder = this
   override def buildForBatch(): BatchWrite = NoopBatchWrite
-  override def buildForStreaming(): StreamingWrite = NoopStreamingWrite
+  override def buildForStreaming(isContinuous: Boolean): StreamingWrite =
+    NoopStreamingWrite
 }
 
 private[noop] object NoopBatchWrite extends BatchWrite {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
@@ -127,7 +127,8 @@ class MicroBatchExecution(
     // TODO (SPARK-27484): we should add the writing node before the plan is analyzed.
     sink match {
       case s: SupportsWrite =>
-        val streamingWrite = createStreamingWrite(s, extraOptions, _logicalPlan)
+        val streamingWrite =
+          createWriteBuilder(s, extraOptions, _logicalPlan).buildForStreaming(false)
         WriteToMicroBatchDataSource(streamingWrite, _logicalPlan)
 
       case _ => _logicalPlan

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/console.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/console.scala
@@ -83,7 +83,7 @@ object ConsoleTable extends Table with SupportsWrite {
       // Do nothing for truncate. Console sink is special that it just prints all the records.
       override def truncate(): WriteBuilder = this
 
-      override def buildForStreaming(): StreamingWrite = {
+      override def buildForStreaming(isContinuous: Boolean): StreamingWrite = {
         assert(inputSchema != null)
         new ConsoleWrite(inputSchema, options)
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
@@ -89,7 +89,8 @@ class ContinuousExecution(
 
     // TODO (SPARK-27484): we should add the writing node before the plan is analyzed.
     WriteToContinuousDataSource(
-      createStreamingWrite(sink, extraOptions, _logicalPlan), _logicalPlan)
+      createWriteBuilder(sink, extraOptions, _logicalPlan).buildForStreaming(true),
+      _logicalPlan)
   }
 
   private val triggerExecutor = trigger match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/ForeachWriterTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/ForeachWriterTable.scala
@@ -67,7 +67,7 @@ case class ForeachWriterTable[T](
       // ForeachWriter.
       override def truncate(): WriteBuilder = this
 
-      override def buildForStreaming(): StreamingWrite = {
+      override def buildForStreaming(isContinuous: Boolean): StreamingWrite = {
         new StreamingWrite {
           override def commit(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {}
           override def abort(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/MicroBatchWrite.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/MicroBatchWrite.scala
@@ -39,6 +39,10 @@ class MicroBatchWrite(eppchId: Long, val writeSupport: StreamingWrite) extends B
   override def createBatchWriterFactory(): DataWriterFactory = {
     new MicroBatchWriterFactory(eppchId, writeSupport.createStreamingWriterFactory())
   }
+
+  override def getOptionalPartitionNum(): Integer = {
+    writeSupport.getOptionalPartitionNum()
+  }
 }
 
 class MicroBatchWriterFactory(epochId: Long, streamingWriterFactory: StreamingDataWriterFactory)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/memory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/memory.scala
@@ -68,7 +68,7 @@ class MemorySink extends Table with SupportsWrite with Logging {
         this
       }
 
-      override def buildForStreaming(): StreamingWrite = {
+      override def buildForStreaming(isContinuous: Boolean): StreamingWrite = {
         new MemoryStreamingWrite(MemorySink.this, inputSchema, needTruncate)
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/v2/writer/V1WriteBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/v2/writer/V1WriteBuilder.scala
@@ -50,5 +50,6 @@ trait V1WriteBuilder extends WriteBuilder {
   // an Unsupported OperationException
   override final def buildForBatch(): BatchWrite = super.buildForBatch()
 
-  override final def buildForStreaming(): StreamingWrite = super.buildForStreaming()
+  override final def buildForStreaming(isContinuous: Boolean): StreamingWrite =
+    super.buildForStreaming(isContinuous: Boolean)
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/sources/StreamingDataSourceV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/sources/StreamingDataSourceV2Suite.scala
@@ -67,7 +67,7 @@ class FakeScanBuilder extends ScanBuilder with Scan {
 }
 
 class FakeWriteBuilder extends WriteBuilder with StreamingWrite {
-  override def buildForStreaming(): StreamingWrite = this
+  override def buildForStreaming(isContinuous: Boolean): StreamingWrite = this
   override def createStreamingWriterFactory(): StreamingDataWriterFactory = {
     throw new IllegalStateException("fake sink - cannot actually write")
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Implement Kafka sink exactly-once semantics with transaction Kafka producer.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
1. Added UT

- write to transaction kafka
- restart from failed send, resend data
- recover from failed commit, resume producer and commit
- recover from other task failed commit, resume producer and recommit

2. Failover Test

situation | result
-- | --
task retry when sending data to Kafka | no data loss
application failed after successfully sending data to Kafka | no data loss when job attempt or application restart
job failed after store producer meta-info to HDFS | no data loss when job attempt or application restart
task retry when commit transaction | job failed and no data loss when job attempt or application restart and resume transaction
executor crash down | job failed and no data loss when job attempt or application restart

