### PR TITLE
[SPARK-28923][SQL] Deduplicate the codes 'multipartIdentifier' and 'identifierSeq'

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -122,7 +122,7 @@ statement
         (TBLPROPERTIES tableProps=tablePropertyList))*
         (AS? query)?                                                   #replaceTable
     | ANALYZE TABLE tableIdentifier partitionSpec? COMPUTE STATISTICS
-        (identifier | FOR COLUMNS identifierSeq | FOR ALL COLUMNS)?    #analyze
+        (identifier | FOR COLUMNS multipartIdentifier | FOR ALL COLUMNS)?   #analyze
     | ALTER TABLE multipartIdentifier
         ADD (COLUMN | COLUMNS)
         columns=qualifiedColTypeWithPositionList                       #addTableColumns
@@ -198,7 +198,7 @@ statement
     | (DESC | DESCRIBE) FUNCTION EXTENDED? describeFuncName            #describeFunction
     | (DESC | DESCRIBE) database EXTENDED? db=errorCapturingIdentifier #describeDatabase
     | (DESC | DESCRIBE) TABLE? option=(EXTENDED | FORMATTED)?
-        multipartIdentifier partitionSpec? describeColName?                #describeTable
+        multipartIdentifier partitionSpec? describeColName?            #describeTable
     | (DESC | DESCRIBE) QUERY? query                                   #describeQuery
     | REFRESH TABLE tableIdentifier                                    #refreshTable
     | REFRESH (STRING | .*?)                                           #refreshResource
@@ -465,7 +465,7 @@ transformClause
       inRowFormat=rowFormat?
       (RECORDWRITER recordWriter=STRING)?
       USING script=STRING
-      (AS (identifierSeq | colTypeList | ('(' (identifierSeq | colTypeList) ')')))?
+      (AS (multipartIdentifier | colTypeList | ('(' (multipartIdentifier | colTypeList) ')')))?
       outRowFormat=rowFormat?
       (RECORDREADER recordReader=STRING)?
     ;
@@ -567,11 +567,7 @@ sampleMethod
     ;
 
 identifierList
-    : '(' identifierSeq ')'
-    ;
-
-identifierSeq
-    : ident+=errorCapturingIdentifier (',' ident+=errorCapturingIdentifier)*
+    : '(' multipartIdentifier ')'
     ;
 
 orderedIdentifierList

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -524,9 +524,9 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
     val (attributes, schemaLess) = if (transformClause.colTypeList != null) {
       // Typed return columns.
       (createSchema(transformClause.colTypeList).toAttributes, false)
-    } else if (transformClause.identifierSeq != null) {
+    } else if (transformClause.multipartIdentifier != null) {
       // Untyped return columns.
-      val attrs = visitIdentifierSeq(transformClause.identifierSeq).map { name =>
+      val attrs = visitMultipartIdentifier(transformClause.multipartIdentifier).map { name =>
         AttributeReference(name, StringType, nullable = true)()
       }
       (attrs, false)
@@ -1048,14 +1048,7 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
    * Create a Sequence of Strings for a parenthesis enclosed alias list.
    */
   override def visitIdentifierList(ctx: IdentifierListContext): Seq[String] = withOrigin(ctx) {
-    visitIdentifierSeq(ctx.identifierSeq)
-  }
-
-  /**
-   * Create a Sequence of Strings for an identifier list.
-   */
-  override def visitIdentifierSeq(ctx: IdentifierSeqContext): Seq[String] = withOrigin(ctx) {
-    ctx.ident.asScala.map(_.getText)
+    visitMultipartIdentifier(ctx.multipartIdentifier)
   }
 
   /* ********************************************************************************************

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -124,7 +124,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
     if (ctx.ALL() != null) {
       checkPartitionSpec()
       AnalyzeColumnCommand(table, None, allColumns = true)
-    } else if (ctx.identifierSeq() == null) {
+    } else if (ctx.multipartIdentifier() == null) {
       if (ctx.partitionSpec != null) {
         AnalyzePartitionCommand(table, visitPartitionSpec(ctx.partitionSpec),
           noscan = ctx.identifier != null)
@@ -134,7 +134,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
     } else {
       checkPartitionSpec()
       AnalyzeColumnCommand(table,
-        Option(visitIdentifierSeq(ctx.identifierSeq())), allColumns = false)
+        Option(visitMultipartIdentifier(ctx.multipartIdentifier())), allColumns = false)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `sqlbase.g4`, `multipartIdentifier` and `identifierSeq` have the same functionality. We'd better deduplicate them.

### Why are the changes needed?
Deduplicate the codes which have the same function.

### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Existing tests.
