### PR TITLE
SPARK-28921: Use latest kubernetes client for 2.3 branch

### DIFF
--- a/resource-managers/kubernetes/core/pom.xml
+++ b/resource-managers/kubernetes/core/pom.xml
@@ -29,7 +29,7 @@
   <name>Spark Project Kubernetes</name>
   <properties>
     <sbt.project.name>kubernetes</sbt.project.name>
-    <kubernetes.client.version>3.0.0</kubernetes.client.version>
+    <kubernetes.client.version>4.4.2</kubernetes.client.version>
   </properties>
 
   <dependencies>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/LoggingPodStatusWatcher.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/LoggingPodStatusWatcher.scala
@@ -20,7 +20,7 @@ import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 import scala.collection.JavaConverters._
 
-import io.fabric8.kubernetes.api.model.{ContainerStateRunning, ContainerStateTerminated, ContainerStateWaiting, ContainerStatus, Pod, Time}
+import io.fabric8.kubernetes.api.model.{ContainerStateRunning, ContainerStateTerminated, ContainerStateWaiting, ContainerStatus, Pod}
 import io.fabric8.kubernetes.client.{KubernetesClientException, Watcher}
 import io.fabric8.kubernetes.client.Watcher.Action
 
@@ -174,7 +174,7 @@ private[k8s] class LoggingPodStatusWatcherImpl(
         }.getOrElse(Seq(("Container state", "N/A")))
   }
 
-  private def formatTime(time: Time): String = {
-    if (time != null) time.getTime else "N/A"
+  private def formatTime(time: String): String = {
+    if (time != null) time else "N/A"
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade the version of kubernets-client JAR

### Why are the changes needed?
It is no longer possible to run Spark 2.3 jobs on certain EKS versions since AWS patched some CVEs in the past couple days

### Does this PR introduce any user-facing change?
No


### How was this patch tested?
I manually verified that this works, by using spark-submit to deploy to EKS.
