### PR TITLE
[SPARK-28951][INFRA] Add release announce template

### DIFF
--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -113,6 +113,7 @@ spark-warehouse
 structured-streaming/*
 kafka-source-initial-offset-version-2.1.0.bin
 kafka-source-initial-offset-future-version.bin
+announce.tmpl
 vote.tmpl
 SessionManager.java
 SessionHandler.java

--- a/dev/create-release/announce.tmpl
+++ b/dev/create-release/announce.tmpl
@@ -1,0 +1,16 @@
+We are happy to announce the availability of Spark {version}!
+
+Spark {version} is a maintenance release containing stability fixes. This
+release is based on the {branch} maintenance branch of Spark. We strongly
+recommend all {short_version} users to upgrade to this stable release.
+
+To download Spark {version}, head over to the download page:
+https://spark.apache.org/downloads.html
+
+To view the release notes:
+https://spark.apache.org/releases/spark-release-{hyphened_version}.html
+
+We would like to acknowledge all community members for contributing to this
+release. This release would not have been possible without you.
+
+{release_manager_name}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a release announce template.

### Why are the changes needed?

- We want to use a formal template including HTTPS in the future release.
- The future release managers don't need to search mailing list to find this form.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

N/A.