### PR TITLE
[SPARK-28962][SQL] Provide index argument to filter lambda functions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
@@ -345,9 +345,12 @@ case class MapFilter(
       > SELECT _FUNC_(array(1, 2, 3), x -> x % 2 == 1);
        [1,3]
       > SELECT _FUNC_(array(0, 2, 3), (x, i) -> x > i);
-       [2, 3]
+       [2,3]
   """,
-  since = "2.4.0")
+  since = "2.4.0",
+  note = """
+    The inner function may use the index argument since 3.0.0.
+  """)
 case class ArrayFilter(
     argument: Expression,
     function: Expression)
@@ -369,11 +372,7 @@ case class ArrayFilter(
 
   @transient lazy val (elementVar, indexVar) = {
     val LambdaFunction(_, (elementVar: NamedLambdaVariable) +: tail, _) = function
-    val indexVar = if (tail.nonEmpty) {
-      Some(tail.head.asInstanceOf[NamedLambdaVariable])
-    } else {
-      None
-    }
+    val indexVar = tail.headOption.map(_.asInstanceOf[NamedLambdaVariable])
     (elementVar, indexVar)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -2199,9 +2199,9 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
     ).toDF("s", "i")
 
     val ex1 = intercept[AnalysisException] {
-      df.selectExpr("filter(s, (x, y) -> x + y)")
+      df.selectExpr("filter(s, (x, y, z) -> x + y)")
     }
-    assert(ex1.getMessage.contains("The number of lambda function arguments '2' does not match"))
+    assert(ex1.getMessage.contains("The number of lambda function arguments '3' does not match"))
 
     val ex2 = intercept[AnalysisException] {
       df.selectExpr("filter(i, x -> x)")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Lambda functions to array `filter` can now take as input the index as well as the element. This behavior matches array `transform`.


### Why are the changes needed?
See JIRA. It's generally useful, and particularly so if you're working with fixed length arrays.


### Does this PR introduce any user-facing change?
Previously filter lambdas had to look like
`filter(arr, el -> whatever)`

Now, lambdas can take an index argument as well
`filter(array, (el, idx) -> whatever)`


### How was this patch tested?
I added unit tests to `HigherOrderFunctionsSuite`.