### PR TITLE
[SPARK-28963][BUILD] Fall back to archive.apache.org in build/mvn for older releases

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -80,6 +80,17 @@ install_mvn() {
   fi
   if [ $(version $MVN_DETECTED_VERSION) -lt $(version $MVN_VERSION) ]; then
     local APACHE_MIRROR=${APACHE_MIRROR:-'https://www.apache.org/dyn/closer.lua?action=download&filename='}
+        
+    if [ $(command -v curl) ]; then
+      local TEST_MIRROR_URL="${APACHE_MIRROR}/maven/maven-3/${MVN_VERSION}/binaries/apache-maven-${MVN_VERSION}-bin.tar.gz"
+      if curl -L --output /dev/null --silent --head --fail "$TEST_MIRROR_URL" ; then
+        echo "Found Maven at $TEST_MIRROR_URL"
+      else
+        # Fall back to archive.apache.org for older Maven
+        echo "Falling back to archive.apache.org to download Maven"
+        APACHE_MIRROR="https://archive.apache.org/dist"
+      fi
+    fi
 
     install_app \
       "${APACHE_MIRROR}/maven/maven-3/${MVN_VERSION}/binaries" \

--- a/build/mvn
+++ b/build/mvn
@@ -83,9 +83,7 @@ install_mvn() {
         
     if [ $(command -v curl) ]; then
       local TEST_MIRROR_URL="${APACHE_MIRROR}/maven/maven-3/${MVN_VERSION}/binaries/apache-maven-${MVN_VERSION}-bin.tar.gz"
-      if curl -L --output /dev/null --silent --head --fail "$TEST_MIRROR_URL" ; then
-        echo "Found Maven at $TEST_MIRROR_URL"
-      else
+      if ! curl -L --output /dev/null --silent --head --fail "$TEST_MIRROR_URL" ; then
         # Fall back to archive.apache.org for older Maven
         echo "Falling back to archive.apache.org to download Maven"
         APACHE_MIRROR="https://archive.apache.org/dist"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fall back to archive.apache.org in `build/mvn` to download Maven, in case the ASF mirrors no longer have an older release.

### Why are the changes needed?

If an older release's specified Maven doesn't exist in the mirrors, {{build/mvn}} will fail.

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

Manually tested different paths and failures by commenting in/out parts of the script and modifying it directly.