### PR TITLE
[SPARK-28884][Core] Default number of core for yarn mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2714,7 +2714,7 @@ object SparkContext extends Logging {
       case SparkMasterRegex.LOCAL_N_FAILURES_REGEX(threads, _) => convertToInt(threads)
       case "yarn" =>
         if (conf != null && conf.get(SUBMIT_DEPLOY_MODE) == "cluster") {
-          conf.getInt(DRIVER_CORES.key, 0)
+          conf.getInt(DRIVER_CORES.key, 1)
         } else {
           0
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Launch spark in local and yarn mode. 

- local mode: the number of driver cores is 1.
- yarn mode:  the number of driver cores is 0.

Expectation: It should display 1 by default
