### PR TITLE
[SPARK-28964] Add the provider information to the table properties in saveAsTable

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -535,7 +535,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
           ident,
           partitionTransforms,
           df.queryExecution.analyzed,
-          Map.empty,            // properties can't be specified through this API
+          Map("provider" -> source),            // properties can't be specified through this API
           extraOptions.toMap,
           orCreate = true)      // Create the table if it doesn't exist
 
@@ -548,7 +548,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
           ident,
           partitionTransforms,
           df.queryExecution.analyzed,
-          Map.empty,
+          Map("provider" -> source),
           extraOptions.toMap,
           ignoreIfExists = other == SaveMode.Ignore)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, NoSuchT
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, CreateTableAsSelect, InsertIntoTable, LogicalPlan, OverwriteByExpression, OverwritePartitionsDynamic, ReplaceTableAsSelect}
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.command.DDLUtils
 import org.apache.spark.sql.execution.datasources.{CreateTable, DataSource, DataSourceUtils, LogicalRelation}
@@ -523,8 +524,8 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
     }
 
     def getLocationIfExists: Option[(String, String)] = {
-      val storage = DataSource.buildStorageFormatFromOptions(extraOptions.toMap)
-      storage.locationUri.map(uri => "location" -> CatalogUtils.URIToString(uri))
+      val opts = CaseInsensitiveMap(extraOptions.toMap)
+      opts.get("path").map("location" -> _)
     }
 
     val command = (mode, tableOpt) match {

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/v2/DataSourceV2DataFrameSessionCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/v2/DataSourceV2DataFrameSessionCatalogSuite.scala
@@ -109,8 +109,6 @@ class InMemoryTableSessionCatalog extends TestV2SessionCatalogBase[InMemoryTable
       schema: StructType,
       partitions: Array[Transform],
       properties: util.Map[String, String]): InMemoryTable = {
-    assert(properties.get("provider") == classOf[InMemoryTableProvider].getName,
-      "Did not get the correct provider information")
     new InMemoryTable(name, schema, partitions, properties)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/v2/DataSourceV2DataFrameSessionCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/v2/DataSourceV2DataFrameSessionCatalogSuite.scala
@@ -98,6 +98,8 @@ class InMemoryTableSessionCatalog extends TestV2SessionCatalogBase[InMemoryTable
       schema: StructType,
       partitions: Array[Transform],
       properties: util.Map[String, String]): InMemoryTable = {
+    assert(properties.get("provider") == classOf[InMemoryTableProvider].getName,
+      "Did not get the correct provider information")
     new InMemoryTable(name, schema, partitions, properties)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds the provider information to the table properties in saveAsTable.

### Why are the changes needed?

Otherwise, catalog implementations don't know what kind of Table definition to create.

### Does this PR introduce any user-facing change?

nope

### How was this patch tested?

Existing unit tests check the existence of the provider now.