### PR TITLE
[SPARK-28981][K8S] Missing library for reading/writing Snappy-compressed files

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -29,7 +29,7 @@ ARG spark_uid=185
 RUN set -ex && \
     apk upgrade --no-cache && \
     ln -s /lib /lib64 && \
-    apk add --no-cache bash tini libc6-compat linux-pam krb5 krb5-libs nss && \
+    apk add --no-cache bash tini libc6-compat linux-pam krb5 krb5-libs nss gcompat && \
     mkdir -p /opt/spark && \
     mkdir -p /opt/spark/examples && \
     mkdir -p /opt/spark/work-dir && \


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adding `gcompat` library to Dockerfile for Spark on Kubernetes

### Why are the changes needed?
Current Dockerfile throws an error when trying to read/write snappy-compressed files. As Snappy is one of the default Spark compression codecs, it should be supported out-of-the-box.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
Built Spark container image and testing reading / writing Snappy files.