### PR TITLE
[SPARK-28901][SQL][FLLOW-UP] SparkThriftServer's Cancel SQL Operation show it in JDBC Tab UI 

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -186,6 +186,7 @@ object HiveThriftServer2 extends Logging {
     def isExecutionActive(execInfo: ExecutionInfo): Boolean = {
       !(execInfo.state == ExecutionState.FAILED ||
         execInfo.state == ExecutionState.CANCELED ||
+        execInfo.state == ExecutionState.FINISHED ||
         execInfo.state == ExecutionState.CLOSED)
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
For last pr https://github.com/apache/spark/pull/25611/, seems I forgot one case when 
getTotalRunning SQL numbers, I miss end status of FINISHED


### Why are the changes needed?
Fix bug


### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Existed UT