### PR TITLE
[SPARK-28992][K8S] Support update dependencies from hdfs when task run on executor pods

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
@@ -90,6 +90,7 @@ private[spark] object Constants {
   val KRB_FILE_VOLUME = "krb5-file"
   val HADOOP_CONF_DIR_PATH = "/opt/hadoop/conf"
   val KRB_FILE_DIR_PATH = "/etc"
+  val KRB_FILE_NAME = "krb5.conf"
   val ENV_HADOOP_CONF_DIR = "HADOOP_CONF_DIR"
   val HADOOP_CONFIG_MAP_NAME =
     "spark.kubernetes.executor.hadoopConfigMapName"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
@@ -89,8 +89,8 @@ private[spark] object Constants {
   val HADOOP_CONF_VOLUME = "hadoop-properties"
   val KRB_FILE_VOLUME = "krb5-file"
   val HADOOP_CONF_DIR_PATH = "/opt/hadoop/conf"
-  val KRB_FILE_DIR_PATH = "/etc"
   val KRB_FILE_NAME = "krb5.conf"
+  val KRB_FILE_FULL_NAME = s"/etc/$KRB_FILE_NAME"
   val ENV_HADOOP_CONF_DIR = "HADOOP_CONF_DIR"
   val HADOOP_CONFIG_MAP_NAME =
     "spark.kubernetes.executor.hadoopConfigMapName"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/HadoopConfExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/HadoopConfExecutorFeatureStep.scala
@@ -2,7 +2,7 @@
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- *  The ASF licenses this file to You under the Apache License, Version 2.0
+ * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.spark.deploy.k8s.features
 
 import java.io.File

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/HadoopConfExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/HadoopConfExecutorFeatureStep.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.k8s.features
+
+import java.io.File
+
+import scala.collection.JavaConverters._
+
+import io.fabric8.kubernetes.api.model.{ContainerBuilder, KeyToPathBuilder, PodBuilder, VolumeBuilder}
+
+import org.apache.spark.deploy.k8s.{KubernetesExecutorConf, SparkPod}
+import org.apache.spark.deploy.k8s.Constants._
+
+/**
+ * Mounts the Hadoop configuration for executor pods iff the driver pod is mounted.
+ */
+class HadoopConfExecutorFeatureStep(conf: KubernetesExecutorConf)
+  extends KubernetesFeatureConfigStep {
+
+  private val confFiles: Seq[File] = Option(conf.sparkConf.getenv(ENV_HADOOP_CONF_DIR)) match {
+    case Some(dir) =>
+      val file = new File(dir)
+      if (file.isDirectory) file.listFiles().filter(_.isFile).toSeq else Nil
+    case _ => Nil
+  }
+
+  override def configurePod(original: SparkPod): SparkPod = {
+    original.transform { case pod if confFiles.nonEmpty =>
+      val keyPaths = confFiles.map { file =>
+        new KeyToPathBuilder().withKey(file.getName).withPath(file.getName).build()
+      }.asJava
+
+      val confVolume = new VolumeBuilder()
+        .withName(HADOOP_CONF_VOLUME)
+        .withNewConfigMap()
+          .withName(conf.resourceNamePrefix + "-hadoop-config")
+          .withItems(keyPaths)
+          .endConfigMap()
+        .build()
+
+      val podWithConf = new PodBuilder(pod.pod)
+        .editSpec()
+          .addNewVolumeLike(confVolume)
+          .endVolume()
+        .endSpec()
+        .build()
+
+      val containerWithMount = new ContainerBuilder(pod.container)
+        .addNewVolumeMount()
+        .withName(HADOOP_CONF_VOLUME)
+        .withMountPath(HADOOP_CONF_DIR_PATH)
+        .endVolumeMount()
+        .addNewEnv()
+        .withName(ENV_HADOOP_CONF_DIR)
+        .withValue(HADOOP_CONF_DIR_PATH)
+        .endEnv()
+        .build()
+
+      SparkPod(podWithConf, containerWithMount)
+    }
+  }
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStep.scala
@@ -149,8 +149,8 @@ private[spark] class KerberosConfDriverFeatureStep(kubernetesConf: KubernetesDri
       val containerWithMount = new ContainerBuilder(pod.container)
         .addNewVolumeMount()
           .withName(KRB_FILE_VOLUME)
-          .withMountPath(KRB_FILE_DIR_PATH + "/krb5.conf")
-          .withSubPath("krb5.conf")
+          .withMountPath(s"$KRB_FILE_DIR_PATH/$KRB_FILE_NAME")
+          .withSubPath(KRB_FILE_NAME)
           .endVolumeMount()
         .build()
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KerberosConfExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KerberosConfExecutorFeatureStep.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.k8s.features
+
+import java.io.File
+
+import io.fabric8.kubernetes.api.model.{ContainerBuilder, KeyToPathBuilder, PodBuilder, VolumeBuilder}
+
+import org.apache.spark.deploy.k8s.{KubernetesExecutorConf, SparkPod}
+import org.apache.spark.deploy.k8s.Constants._
+
+/**
+ * Forward kerberos conf file to executor pods iff it has been mounted on driver pod.
+ */
+class KerberosConfExecutorFeatureStep(kubernetesConf: KubernetesExecutorConf)
+  extends KubernetesFeatureConfigStep {
+
+  private val krb5File = new File(s"$KRB_FILE_DIR_PATH/$KRB_FILE_NAME")
+
+  override def configurePod(original: SparkPod): SparkPod = {
+    original.transform { case pod if krb5File.exists() =>
+      val krb5Volume = new VolumeBuilder()
+        .withName(KRB_FILE_VOLUME)
+        .withNewConfigMap()
+        .withName(s"${kubernetesConf.resourceNamePrefix}-krb5-file")
+        .withItems(new KeyToPathBuilder()
+          .withKey(krb5File.getName)
+          .withPath(krb5File.getName)
+          .build())
+        .endConfigMap()
+        .build()
+
+      val podWithVolume = new PodBuilder(pod.pod)
+        .editSpec()
+        .addNewVolumeLike(krb5Volume)
+          .endVolume()
+          .endSpec()
+        .build()
+
+      val containerWithMount = new ContainerBuilder(pod.container)
+        .addNewVolumeMount()
+          .withName(KRB_FILE_VOLUME)
+          .withMountPath(krb5File.getAbsolutePath)
+          .withSubPath(KRB_FILE_NAME)
+          .endVolumeMount()
+        .build()
+      SparkPod(podWithVolume, containerWithMount)
+    }
+  }
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KerberosConfExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KerberosConfExecutorFeatureStep.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.deploy.k8s.features
 
+import java.io.File
+
 import io.fabric8.kubernetes.api.model.{ContainerBuilder, KeyToPathBuilder, PodBuilder, VolumeBuilder}
 
 import org.apache.spark.deploy.k8s.{KubernetesExecutorConf, SparkPod}
@@ -33,13 +35,14 @@ private[spark] class KerberosConfExecutorFeatureStep(kubernetesConf: KubernetesE
 
   override def configurePod(original: SparkPod): SparkPod = {
     original.transform { case pod if krb5File.isDefined =>
+      val krb5Conf = new File(krb5File.get)
       val krb5Volume = new VolumeBuilder()
         .withName(KRB_FILE_VOLUME)
         .withNewConfigMap()
           .withName(s"${kubernetesConf.resourceNamePrefix}-krb5-file")
           .withItems(new KeyToPathBuilder()
-            .withKey(krb5File.get)
-            .withPath(krb5File.get)
+            .withKey(krb5Conf.getName)
+            .withPath(krb5Conf.getName)
             .build())
           .endConfigMap()
         .build()

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KerberosConfExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KerberosConfExecutorFeatureStep.scala
@@ -23,12 +23,13 @@ import io.fabric8.kubernetes.api.model.{ContainerBuilder, KeyToPathBuilder, PodB
 
 import org.apache.spark.deploy.k8s.{KubernetesExecutorConf, SparkPod}
 import org.apache.spark.deploy.k8s.Constants._
+import org.apache.spark.internal.Logging
 
 /**
  * Forward kerberos conf file to executor pods iff it has been mounted on driver pod.
  */
-class KerberosConfExecutorFeatureStep(kubernetesConf: KubernetesExecutorConf)
-  extends KubernetesFeatureConfigStep {
+private[spark] class KerberosConfExecutorFeatureStep(kubernetesConf: KubernetesExecutorConf)
+  extends KubernetesFeatureConfigStep with Logging {
 
   private val krb5File = new File(s"$KRB_FILE_DIR_PATH/$KRB_FILE_NAME")
 
@@ -37,12 +38,12 @@ class KerberosConfExecutorFeatureStep(kubernetesConf: KubernetesExecutorConf)
       val krb5Volume = new VolumeBuilder()
         .withName(KRB_FILE_VOLUME)
         .withNewConfigMap()
-        .withName(s"${kubernetesConf.resourceNamePrefix}-krb5-file")
-        .withItems(new KeyToPathBuilder()
-          .withKey(krb5File.getName)
-          .withPath(krb5File.getName)
-          .build())
-        .endConfigMap()
+          .withName(s"${kubernetesConf.resourceNamePrefix}-krb5-file")
+          .withItems(new KeyToPathBuilder()
+            .withKey(krb5File.getName)
+            .withPath(krb5File.getName)
+            .build())
+          .endConfigMap()
         .build()
 
       val podWithVolume = new PodBuilder(pod.pod)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KerberosConfExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KerberosConfExecutorFeatureStep.scala
@@ -2,7 +2,7 @@
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- *  The ASF licenses this file to You under the Apache License, Version 2.0
+ * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
@@ -14,10 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.spark.deploy.k8s.features
-
-import java.io.File
 
 import io.fabric8.kubernetes.api.model.{ContainerBuilder, KeyToPathBuilder, PodBuilder, VolumeBuilder}
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
@@ -45,7 +45,8 @@ private[spark] class KubernetesExecutorBuilder {
       new MountSecretsFeatureStep(conf),
       new EnvSecretsFeatureStep(conf),
       new MountVolumesFeatureStep(conf),
-      new LocalDirsFeatureStep(conf))
+      new LocalDirsFeatureStep(conf),
+      new HadoopConfExecutorFeatureStep(conf))
 
     features.foldLeft(initialPod) { case (pod, feature) => feature.configurePod(pod) }
   }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
@@ -46,7 +46,8 @@ private[spark] class KubernetesExecutorBuilder {
       new EnvSecretsFeatureStep(conf),
       new MountVolumesFeatureStep(conf),
       new LocalDirsFeatureStep(conf),
-      new HadoopConfExecutorFeatureStep(conf))
+      new HadoopConfExecutorFeatureStep(conf),
+      new KerberosConfExecutorFeatureStep(conf))
 
     features.foldLeft(initialPod) { case (pod, feature) => feature.configurePod(pod) }
   }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/HadoopConfExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/HadoopConfExecutorFeatureStepSuite.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.k8s.features
+
+import java.io.File
+import java.nio.charset.StandardCharsets.UTF_8
+
+import com.google.common.io.Files
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.deploy.k8s.{KubernetesTestConf, SparkPod}
+import org.apache.spark.deploy.k8s.Constants._
+import org.apache.spark.deploy.k8s.SecretVolumeUtils.{containerHasVolume, podHasVolume}
+import org.apache.spark.deploy.k8s.features.KubernetesFeaturesTestUtils.containerHasEnvVar
+import org.apache.spark.util.{SparkConfWithEnv, Utils}
+
+class HadoopConfExecutorFeatureStepSuite extends SparkFunSuite {
+
+  test("populate hadoop conf for executor pods if driver pod has") {
+    val confDir = Utils.createTempDir()
+    val confFiles = Set("core-site.xml", "hdfs-site.xml")
+
+    confFiles.foreach { f =>
+      Files.write("some data", new File(confDir, f), UTF_8)
+    }
+    val sparkConf = new SparkConfWithEnv(Map(ENV_HADOOP_CONF_DIR -> confDir.getAbsolutePath))
+    val conf = KubernetesTestConf.createExecutorConf(sparkConf = sparkConf)
+
+    val step = new HadoopConfExecutorFeatureStep(conf)
+    val pod = step.configurePod(SparkPod.initialPod())
+    assert(podHasVolume(pod.pod, HADOOP_CONF_VOLUME))
+    assert(containerHasVolume(pod.container, HADOOP_CONF_VOLUME, HADOOP_CONF_DIR_PATH))
+    assert(containerHasEnvVar(pod.container, ENV_HADOOP_CONF_DIR))
+  }
+}

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStepSuite.scala
@@ -149,7 +149,7 @@ class KerberosConfDriverFeatureStepSuite extends SparkFunSuite {
   private def checkPodForKrbConf(pod: SparkPod, confMapName: String): Unit = {
     val podVolume = pod.pod.getSpec().getVolumes().asScala.find(_.getName() == KRB_FILE_VOLUME)
     assert(podVolume.isDefined)
-    assert(containerHasVolume(pod.container, KRB_FILE_VOLUME, KRB_FILE_DIR_PATH + "/krb5.conf"))
+    assert(containerHasVolume(pod.container, KRB_FILE_VOLUME, KRB_FILE_FULL_NAME))
     assert(podVolume.get.getConfigMap().getName() === confMapName)
   }
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStepSuite.scala
@@ -50,7 +50,7 @@ class KerberosConfDriverFeatureStepSuite extends SparkFunSuite {
       new SparkConf(false).set(KUBERNETES_KERBEROS_KRB5_CONFIG_MAP, configMap))
 
     checkPodForKrbConf(step.configurePod(SparkPod.initialPod()), configMap)
-    assert(step.getAdditionalPodSystemProperties().isEmpty)
+    assert(step.getAdditionalPodSystemProperties().contains(KUBERNETES_KERBEROS_KRB5_FILE.key))
     assert(filter[ConfigMap](step.getAdditionalKubernetesResources()).isEmpty)
   }
 
@@ -66,7 +66,7 @@ class KerberosConfDriverFeatureStepSuite extends SparkFunSuite {
     assert(confMap.getData().keySet().asScala === Set(krbConf.getName()))
 
     checkPodForKrbConf(step.configurePod(SparkPod.initialPod()), confMap.getMetadata().getName())
-    assert(step.getAdditionalPodSystemProperties().isEmpty)
+    assert(step.getAdditionalPodSystemProperties().contains(KUBERNETES_KERBEROS_KRB5_FILE.key))
   }
 
   test("create keytab secret if client keytab file used") {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/KerberosConfExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/KerberosConfExecutorFeatureStepSuite.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.k8s.features
+
+import java.io.File
+import java.nio.charset.StandardCharsets.UTF_8
+
+import com.google.common.io.Files
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.deploy.k8s.{KubernetesTestConf, SparkPod}
+import org.apache.spark.deploy.k8s.Config.KUBERNETES_KERBEROS_KRB5_FILE
+import org.apache.spark.deploy.k8s.Constants._
+import org.apache.spark.deploy.k8s.SecretVolumeUtils._
+import org.apache.spark.util.Utils
+
+class KerberosConfExecutorFeatureStepSuite extends SparkFunSuite {
+
+  test("executor pod should mount with krb5 if driver pod is configured") {
+    val tmpDir = Utils.createTempDir()
+    val krbConf = File.createTempFile("krb5", ".conf", tmpDir)
+    Files.write("some data", krbConf, UTF_8)
+    val conf = new SparkConf().set(KUBERNETES_KERBEROS_KRB5_FILE, krbConf.getAbsolutePath)
+    val executorConf = KubernetesTestConf.createExecutorConf(conf)
+    val step = new KerberosConfExecutorFeatureStep(executorConf)
+    val pod = SparkPod.initialPod()
+    val newPod = step.configurePod(pod)
+    assert(podHasVolume(newPod.pod, KRB_FILE_VOLUME))
+    assert(containerHasVolume(newPod.container, KRB_FILE_VOLUME, KRB_FILE_FULL_NAME))
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?


Here is a case: 

```shell
bin/spark-submit  --class com.github.ehiggs.spark.terasort.TeraSort hdfs://hz-cluster10/user/kyuubi/udf/spark-terasort-1.1-SNAPSHOT-jar-with-dependencies.jar hdfs://hz-cluster10/user/kyuubi/terasort/1000g hdfs://hz-cluster10/user/kyuubi/terasort/1000g-out1
```
Spark supports add jar logic and application-jar from hdfs - -  http://spark.apache.org/docs/latest/submitting-applications.html#launching-applications-with-spark-submit

Take spark on yarn for example, it creates a _spark_hadoop_conf_.xml file and upload the hadoop distribute cache, the executor processes can use this to identify where their dependencies located.

But on k8s, i tried and failed to update dependencies.
```scala
19/09/04 08:08:52 INFO scheduler.DAGScheduler: ShuffleMapStage 0 (newAPIHadoopFile at TeraSort.scala:60) failed in 1.058 s due to Job aborted due to stage failure: Task 0 in stage 0.0 failed 4 times, most recent failure: Lost task 0.3 in stage 0.0 (TID 9, 100.66.0.75, executor 2): java.lang.IllegalArgumentException: java.net.UnknownHostException: hz-cluster10
	at org.apache.hadoop.security.SecurityUtil.buildTokenService(SecurityUtil.java:378)
	at org.apache.hadoop.hdfs.NameNodeProxies.createNonHAProxy(NameNodeProxies.java:310)
	at org.apache.hadoop.hdfs.NameNodeProxies.createProxy(NameNodeProxies.java:176)
	at org.apache.hadoop.hdfs.DFSClient.<init>(DFSClient.java:678)
	at org.apache.hadoop.hdfs.DFSClient.<init>(DFSClient.java:619)
	at org.apache.hadoop.hdfs.DistributedFileSystem.initialize(DistributedFileSystem.java:149)
	at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:2669)
	at org.apache.hadoop.fs.FileSystem.access$200(FileSystem.java:94)
	at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:2703)
	at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:2685)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:373)
	at org.apache.spark.util.Utils$.getHadoopFileSystem(Utils.scala:1881)
	at org.apache.spark.util.Utils$.doFetchFile(Utils.scala:737)
	at org.apache.spark.util.Utils$.fetchFile(Utils.scala:522)
	at org.apache.spark.executor.Executor.$anonfun$updateDependencies$7(Executor.scala:869)
	at org.apache.spark.executor.Executor.$anonfun$updateDependencies$7$adapted(Executor.scala:860)
	at scala.collection.TraversableLike$WithFilter.$anonfun$foreach$1(TraversableLike.scala:792)
	at scala.collection.mutable.HashMap.$anonfun$foreach$1(HashMap.scala:149)
	at scala.collection.mutable.HashTable.foreachEntry(HashTable.scala:237)
	at scala.collection.mutable.HashTable.foreachEntry$(HashTable.scala:230)
	at scala.collection.mutable.HashMap.foreachEntry(HashMap.scala:44)
	at scala.collection.mutable.HashMap.foreach(HashMap.scala:149)
	at scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:791)
	at org.apache.spark.executor.Executor.org$apache$spark$executor$Executor$$updateDependencies(Executor.scala:860)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:409)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We need to update dependencies for task, some of them could located on hdfs

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

manually test & add uts
