### PR TITLE
[SPARK-29001][CORE] Print events that take too long time to process

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -608,7 +608,7 @@ package object config {
 
   private[spark] val LISTENER_BUS_LOG_SLOW_EVENT_ENABLED =
     ConfigBuilder("spark.scheduler.listenerbus.logSlowEvent.enabled")
-      .doc("When enabled, log the event name that takes too much time to process. This helps us " +
+      .doc("When enabled, log the event that takes too much time to process. This helps us " +
         "discover the event types that cause performance bottlenecks. The time threshold is " +
         "controlled by spark.scheduler.listenerbus.logSlowEvent.threshold.")
       .booleanConf
@@ -617,7 +617,7 @@ package object config {
   private[spark] val LISTENER_BUS_LOG_SLOW_EVENT_TIME_THRESHOLD =
     ConfigBuilder("spark.scheduler.listenerbus.logSlowEvent.threshold")
       .doc("The time threshold of whether a event is considered to be taking too much time to " +
-        "process. Log the event type if spark.scheduler.listenerbus.logSlowEvent.enabled is true.")
+        "process. Log the event if spark.scheduler.listenerbus.logSlowEvent.enabled is true.")
       .timeConf(TimeUnit.NANOSECONDS)
       .createWithDefaultString("1s")
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -608,6 +608,7 @@ package object config {
 
   private[spark] val LISTENER_BUS_LOG_SLOW_EVENT_ENABLED =
     ConfigBuilder("spark.scheduler.listenerbus.logSlowEvent.enabled")
+      .internal()
       .doc("When enabled, log the event that takes too much time to process. This helps us " +
         "discover the event types that cause performance bottlenecks. The time threshold is " +
         "controlled by spark.scheduler.listenerbus.logSlowEvent.threshold.")
@@ -616,6 +617,7 @@ package object config {
 
   private[spark] val LISTENER_BUS_LOG_SLOW_EVENT_TIME_THRESHOLD =
     ConfigBuilder("spark.scheduler.listenerbus.logSlowEvent.threshold")
+      .internal()
       .doc("The time threshold of whether a event is considered to be taking too much time to " +
         "process. Log the event if spark.scheduler.listenerbus.logSlowEvent.enabled is true.")
       .timeConf(TimeUnit.NANOSECONDS)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -606,6 +606,21 @@ package object config {
       .intConf
       .createWithDefault(128)
 
+  private[spark] val LISTENER_BUS_LOG_SLOW_EVENT_ENABLED =
+    ConfigBuilder("spark.scheduler.listenerbus.logSlowEvent.enabled")
+      .doc("When enabled, log the event name that takes too much time to process. This helps us " +
+        "discover the event types that cause performance bottlenecks. The time threshold is " +
+        "controlled by spark.scheduler.listenerbus.logSlowEvent.threshold.")
+      .booleanConf
+      .createWithDefault(true)
+
+  private[spark] val LISTENER_BUS_LOG_SLOW_EVENT_TIME_THRESHOLD =
+    ConfigBuilder("spark.scheduler.listenerbus.logSlowEvent.threshold")
+      .doc("The time threshold of whether a event is considered to be taking too much time to " +
+        "process. Log the event type if spark.scheduler.listenerbus.logSlowEvent.enabled is true.")
+      .timeConf(TimeUnit.NANOSECONDS)
+      .createWithDefaultString("1s")
+
   // This property sets the root namespace for metrics reporting
   private[spark] val METRICS_NAMESPACE = ConfigBuilder("spark.metrics.namespace")
     .stringConf

--- a/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
@@ -164,6 +164,7 @@ private class AsyncEventQueue(
       logError(s"Dropping event from queue $name. " +
         "This likely means one of the listeners is too slow and cannot keep up with " +
         "the rate at which tasks are being started by the scheduler.")
+      logError("Current stack trace: \n" + dispatchThread.getStackTrace.mkString("\n"))
     }
     logTrace(s"Dropping event $event")
 
@@ -181,6 +182,7 @@ private class AsyncEventQueue(
           val previous = new java.util.Date(prevLastReportTimestamp)
           logWarning(s"Dropped $droppedCount events from $name since " +
             s"${if (prevLastReportTimestamp == 0) "the application started" else s"$previous"}.")
+          logWarning("Current stack trace: \n" + dispatchThread.getStackTrace.mkString("\n"))
         }
       }
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
@@ -164,7 +164,6 @@ private class AsyncEventQueue(
       logError(s"Dropping event from queue $name. " +
         "This likely means one of the listeners is too slow and cannot keep up with " +
         "the rate at which tasks are being started by the scheduler.")
-      logError("Current stack trace: \n" + dispatchThread.getStackTrace.mkString("\n"))
     }
     logTrace(s"Dropping event $event")
 
@@ -182,7 +181,6 @@ private class AsyncEventQueue(
           val previous = new java.util.Date(prevLastReportTimestamp)
           logWarning(s"Dropped $droppedCount events from $name since " +
             s"${if (prevLastReportTimestamp == 0) "the application started" else s"$previous"}.")
-          logWarning("Current stack trace: \n" + dispatchThread.getStackTrace.mkString("\n"))
         }
       }
     }

--- a/core/src/main/scala/org/apache/spark/util/ListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/util/ListenerBus.scala
@@ -110,6 +110,7 @@ private[spark] trait ListenerBus[L <: AnyRef, E] extends Logging {
       } else {
         null
       }
+      lazy val listenerName = Utils.getFormattedClassName(listener)
       try {
         doPostEvent(listener, event)
         if (Thread.interrupted()) {
@@ -119,16 +120,16 @@ private[spark] trait ListenerBus[L <: AnyRef, E] extends Logging {
         }
       } catch {
         case ie: InterruptedException =>
-          logError(s"Interrupted while posting to ${Utils.getFormattedClassName(listener)}.  " +
-            s"Removing that listener.", ie)
+          logError(s"Interrupted while posting to ${listenerName}. Removing that listener.", ie)
           removeListenerOnError(listener)
         case NonFatal(e) if !isIgnorableException(e) =>
-          logError(s"Listener ${Utils.getFormattedClassName(listener)} threw an exception", e)
+          logError(s"Listener ${listenerName} threw an exception", e)
       } finally {
         if (maybeTimerContext != null) {
           val elapsed = maybeTimerContext.stop()
           if (logSlowEventEnabled && elapsed > logSlowEventThreshold) {
-            logError(s"Process of event ${event} took ${elapsed / 1000000000d}s.")
+            logError(s"Process of event ${event} by listener ${listenerName} took " +
+              s"${elapsed / 1000000000d}s.")
           }
         }
       }

--- a/core/src/main/scala/org/apache/spark/util/ListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/util/ListenerBus.scala
@@ -38,11 +38,19 @@ private[spark] trait ListenerBus[L <: AnyRef, E] extends Logging {
   // Marked `private[spark]` for access in tests.
   private[spark] def listeners = listenersPlusTimers.asScala.map(_._1).asJava
 
-  private lazy val logSlowEventEnabled =
-    SparkEnv.get.conf.get(config.LISTENER_BUS_LOG_SLOW_EVENT_ENABLED)
+  private lazy val env = SparkEnv.get
 
-  private lazy val logSlowEventThreshold =
-    SparkEnv.get.conf.get(config.LISTENER_BUS_LOG_SLOW_EVENT_TIME_THRESHOLD)
+  private lazy val logSlowEventEnabled = if (env != null) {
+    env.conf.get(config.LISTENER_BUS_LOG_SLOW_EVENT_ENABLED)
+  } else {
+    false
+  }
+
+  private lazy val logSlowEventThreshold = if (env != null) {
+    env.conf.get(config.LISTENER_BUS_LOG_SLOW_EVENT_TIME_THRESHOLD)
+  } else {
+    Long.MaxValue
+  }
 
   /**
    * Returns a CodaHale metrics Timer for measuring the listener's event processing time.

--- a/core/src/main/scala/org/apache/spark/util/ListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/util/ListenerBus.scala
@@ -128,7 +128,7 @@ private[spark] trait ListenerBus[L <: AnyRef, E] extends Logging {
         if (maybeTimerContext != null) {
           val elapsed = maybeTimerContext.stop()
           if (logSlowEventEnabled && elapsed > logSlowEventThreshold) {
-            logError(s"Process of event ${event} by listener ${listenerName} took " +
+            logInfo(s"Process of event ${event} by listener ${listenerName} took " +
               s"${elapsed / 1000000000d}s.")
           }
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Print events that take too long time to process, to help find out what type of events is slow.
Introduce two extra configs:
* **spark.scheduler.listenerbus.logSlowEvent.enabled** Whether to enable log the events that are slow
* **spark.scheduler.listenerbus.logSlowEvent.threshold** The time threshold of whether an event is considered to be slow.

### How was this patch tested?
N/A