### PR TITLE
[SPARK-28587][SQL] Explicitly cast JDBC partition string literals to timestamp/date

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
@@ -195,15 +195,15 @@ private[sql] object JDBCRelation extends Logging {
       value: Long,
       columnType: DataType,
       timeZoneId: String): String = {
-    def dateTimeToString(): String = {
-      val dateTimeStr = columnType match {
-        case DateType => DateFormatter().format(value.toInt)
-        case TimestampType =>
-          val timestampFormatter = TimestampFormatter.getFractionFormatter(
-            DateTimeUtils.getZoneId(timeZoneId))
-          DateTimeUtils.timestampToString(timestampFormatter, value)
-      }
-      s"'$dateTimeStr'"
+    def dateTimeToString(): String = columnType match {
+      case DateType =>
+        val dateStr = DateFormatter().format(value.toInt)
+        s"CAST('$dateStr' AS DATE)"
+      case TimestampType =>
+        val timestampFormatter = TimestampFormatter.getFractionFormatter(
+          DateTimeUtils.getZoneId(timeZoneId))
+        val timestampStr = DateTimeUtils.timestampToString(timestampFormatter, value)
+        s"CAST('$timestampStr' AS TIMESTAMP)"
     }
     columnType match {
       case _: NumericType => value.toString

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -1547,9 +1547,9 @@ class JDBCSuite extends QueryTest
       case LogicalRelation(JDBCRelation(_, parts, _), _, _, _) =>
         val whereClauses = parts.map(_.asInstanceOf[JDBCPartition].whereClause).toSet
         assert(whereClauses === Set(
-          """"D" < '2018-07-10' or "D" is null""",
-          """"D" >= '2018-07-10' AND "D" < '2018-07-14'""",
-          """"D" >= '2018-07-14'"""))
+          """"D" < CAST('2018-07-10' AS DATE) or "D" is null""",
+          """"D" >= CAST('2018-07-10' AS DATE) AND "D" < CAST('2018-07-14' AS DATE)""",
+          """"D" >= CAST('2018-07-14' AS DATE)"""))
     }
     checkAnswer(df1, expectedResult)
 
@@ -1567,8 +1567,8 @@ class JDBCSuite extends QueryTest
       case LogicalRelation(JDBCRelation(_, parts, _), _, _, _) =>
         val whereClauses = parts.map(_.asInstanceOf[JDBCPartition].whereClause).toSet
         assert(whereClauses === Set(
-          """"T" < '2018-07-15 20:50:32.5' or "T" is null""",
-          """"T" >= '2018-07-15 20:50:32.5'"""))
+          """"T" < CAST('2018-07-15 20:50:32.5' AS TIMESTAMP) or "T" is null""",
+          """"T" >= CAST('2018-07-15 20:50:32.5' AS TIMESTAMP)"""))
     }
     checkAnswer(df2, expectedResult)
   }
@@ -1651,8 +1651,8 @@ class JDBCSuite extends QueryTest
               val jdbcRelation = lr.relation.asInstanceOf[JDBCRelation]
               val whereClauses = jdbcRelation.parts.map(_.asInstanceOf[JDBCPartition].whereClause)
               assert(whereClauses.toSet === Set(
-                s""""T" < '$middle' or "T" is null""",
-                s""""T" >= '$middle'"""))
+                s""""T" < CAST('$middle' AS TIMESTAMP) or "T" is null""",
+                s""""T" >= CAST('$middle' AS TIMESTAMP)"""))
           }
         }
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This pr proposes to add explicit casts for generated JDBC partition string literals. In the current master, that logic depends on implicit casts of datasource DBMSs. For example;
```
// This assumes we have a relation testdb(t timestamp) in PostgreSQL
scala> val df = spark.read.format("jdbc")
  .option("url", "jdbc:postgresql...")
  .option("dbtable", "testdb")
  .option("partitionColumn", "t")
  .option("lowerBound", "1972-07-04 03:30:00")
  .option("upperBound", "1972-07-27 14:11:05")
  .option("numPartitions", 2)
  .load()
```
The query above generates  `"t" < '1972-07-15 20:50:32.5' or "t" is null"` and `"t" >= '1972-07-15 20:50:32.5'` internally for where clauses. Since `t` is timestamp, the clauses depend on implicit casts of PostgreSQL. The current one looks ok in most databases, but I believe explicit casts are more reasonable.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To support JDBC partitioning broadly.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing tests.