### PR TITLE
[WIP][SQL] Resolve the time zone before inline tables

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -196,10 +196,10 @@ class Analyzer(
       GlobalAggregates ::
       ResolveAggregateFunctions ::
       TimeWindowing ::
+      ResolveTimeZone(conf) ::
       ResolveInlineTables(conf) ::
       ResolveHigherOrderFunctions(catalog) ::
       ResolveLambdaVariables(conf) ::
-      ResolveTimeZone(conf) ::
       ResolveRandomSeed ::
       TypeCoercion.typeCoercionRules(conf) ++
       extendedResolutionRules : _*),


### PR DESCRIPTION
### What changes were proposed in this pull request?

In the PR, I propose to resolve the time zone before inlining tables in the Analyzer. The former rules uses `Cast` there: https://github.com/apache/spark/blob/e6e9031d7b7458c9d88205d06cdcdd95a98b9537/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveInlineTables.scala#L101-L103
which can require the time zone in some cases.

For example, `SQLQueryTestSuite`/`window.sql` failed here https://github.com/apache/spark/pull/25708#issuecomment-528818439 because of the reason with the error:
```
Error in query: failed to evaluate expression CAST('2017-08-01' AS DATE): None.get; line 1 pos 59
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->


### How was this patch tested?

Tested in the PR https://github.com/apache/spark/pull/25708 on the query:
```sql
spark-sql> CREATE OR REPLACE TEMPORARY VIEW testData AS SELECT * FROM VALUES 
         > (null, 1L, 1.0D, date("2017-08-01"), timestamp(1501545600), "a")
         > AS testData(val, val_long, val_double, val_date, val_timestamp, cate);
```