### PR TITLE
[SPARK-29011][BUILD] Update netty-all from 4.1.30-Final to 4.1.39-Final.

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -150,7 +150,7 @@ metrics-graphite-3.1.5.jar
 metrics-json-3.1.5.jar
 metrics-jvm-3.1.5.jar
 minlog-1.3.0.jar
-netty-all-4.1.30.Final.jar
+netty-all-4.1.39.Final.jar
 objenesis-2.5.1.jar
 okapi-shade-0.4.2.jar
 okhttp-3.8.1.jar

--- a/dev/deps/spark-deps-hadoop-3.2
+++ b/dev/deps/spark-deps-hadoop-3.2
@@ -167,7 +167,7 @@ metrics-json-3.1.5.jar
 metrics-jvm-3.1.5.jar
 minlog-1.3.0.jar
 mssql-jdbc-6.2.1.jre7.jar
-netty-all-4.1.30.Final.jar
+netty-all-4.1.39.Final.jar
 nimbus-jose-jwt-4.41.1.jar
 objenesis-2.5.1.jar
 okapi-shade-0.4.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -658,7 +658,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.30.Final</version>
+        <version>4.1.39.Final</version>
       </dependency>
       <dependency>
         <groupId>org.apache.derby</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade netty-all to latest in the 4.1.x line which is 4.1.39-Final.


### Why are the changes needed?
Currency of dependencies.


### Does this PR introduce any user-facing change?
No.


### How was this patch tested?
Existing unit-tests against master branch.
