### PR TITLE
[SPARK-29010][SQL] Cast decimal to float type may lost precision when don't allow loss

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3180,6 +3180,18 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession {
     }
 
   }
+
+  test("SPARK-29010: cast decimal to float type may lost precision when don't allow loss") {
+    withSQLConf("spark.sql.decimalOperations.allowPrecisionLoss" -> "false") {
+      val df1 = sql("select case when 1=2 then 1 else 0.123456789012345678901234 end * " +
+        "cast(1 as double)")
+      checkAnswer(df1, Array(Row(new java.math.BigDecimal("0.123456789012345678901234"))))
+
+      val df2 = sql("select cast(1 as double) * case when 1=2 then 1 else " +
+        "0.123456789012345678901234 end")
+      checkAnswer(df2, Array(Row(new java.math.BigDecimal("0.123456789012345678901234"))))
+    }
+  }
 }
 
 case class Foo(bar: Option[String])


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Let us check the nondecimalAndDecimal method in DecimalPrecision class.
When there is a BinaryOperator with a nondecimal and decimal, it will process left and right expressions.
When the two expressions are float/double and decimal, it will cast decimal to double type.
However, this operation may lost decimal precision, even when we set spark.sql.decimalOperations.allowPrecisionLoss=false.
For example:
![image](https://user-images.githubusercontent.com/6757692/64435215-a75d0680-d0f4-11e9-9367-6c6efe7ab8d2.png)

In this PR, I will check whether allow decimal precision loss, if precision loss is not allowed, I will cast the float/double to decimal.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Decimal may lost precision when user don't allow decimal precision loss
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce any user-facing change?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->


### How was this patch tested?
Added Unit test.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
