### PR TITLE
[SPARK-29026][SQL] Improve error message in `schemaFor` in trait without companion object constructor

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -910,7 +910,7 @@ trait ScalaReflection extends Logging {
       case NoSymbol =>
         throw new UnsupportedOperationException(s"Unable to find constructor for $tpe. " +
           s"This could happen if $tpe is an interface, or a trait without companion object " +
-          s"constructor.")
+          "constructor.")
       case sym => sym.asTerm.typeSignature.member(universe.TermName("apply"))
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -916,7 +916,7 @@ trait ScalaReflection extends Logging {
     }
     val params = if (constructorSymbol.isMethod) {
       constructorSymbol.asMethod.paramLists
-    } else {
+    } else if (constructorSymbol.isTerm) {
       // Find the primary constructor, and use its parameter ordering.
       val primaryConstructorSymbol: Option[Symbol] = constructorSymbol.asTerm.alternatives.find(
         s => s.isMethod && s.asMethod.isPrimaryConstructor)
@@ -925,6 +925,9 @@ trait ScalaReflection extends Logging {
       } else {
         primaryConstructorSymbol.get.asMethod.paramLists
       }
+    } else {
+      throw new UnsupportedOperationException(s"Unable to find constructor for ${tpe}. " +
+        s"This could happen if ${tpe} is a trait / interface.")
     }
     params.flatten
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -906,12 +906,18 @@ trait ScalaReflection extends Logging {
    * only defines a constructor via `apply` method.
    */
   private def getCompanionConstructor(tpe: Type): Symbol = {
-    tpe.typeSymbol.asClass.companion match {
-      case NoSymbol =>
-        throw new UnsupportedOperationException(s"Unable to find constructor for $tpe. " +
-          s"This could happen if $tpe is an interface, or a trait without companion object " +
-          "constructor.")
-      case sym => sym.asTerm.typeSignature.member(universe.TermName("apply"))
+    def throwUnsupportedOperation = {
+      throw new UnsupportedOperationException(s"Unable to find constructor for $tpe. " +
+        s"This could happen if $tpe is an interface, or a trait without companion object " +
+        "constructor.")
+    }
+    val companionType = tpe.typeSymbol.asClass.companion match {
+      case NoSymbol => throwUnsupportedOperation
+      case sym => sym
+    }
+    companionType.asTerm.typeSignature.member(universe.TermName("apply")) match {
+      case NoSymbol => throwUnsupportedOperation
+      case sym => sym
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -911,13 +911,13 @@ trait ScalaReflection extends Logging {
         s"This could happen if $tpe is an interface, or a trait without companion object " +
         "constructor.")
     }
-    val companionType = tpe.typeSymbol.asClass.companion match {
+    val companionSym = tpe.typeSymbol.asClass.companion match {
       case NoSymbol => throwUnsupportedOperation
       case sym => sym
     }
-    companionType.asTerm.typeSignature.member(universe.TermName("apply")) match {
+    companionSym.asTerm.typeSignature.member(universe.TermName("apply")) match {
       case NoSymbol => throwUnsupportedOperation
-      case sym => sym
+      case constructorSym => constructorSym
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -911,13 +911,12 @@ trait ScalaReflection extends Logging {
         s"This could happen if $tpe is an interface, or a trait without companion object " +
         "constructor.")
     }
-    val companionSym = tpe.typeSymbol.asClass.companion match {
+    tpe.typeSymbol.asClass.companion match {
       case NoSymbol => throwUnsupportedOperation
-      case sym => sym
-    }
-    companionSym.asTerm.typeSignature.member(universe.TermName("apply")) match {
-      case NoSymbol => throwUnsupportedOperation
-      case constructorSym => constructorSym
+      case sym => sym.asTerm.typeSignature.member(universe.TermName("apply")) match {
+        case NoSymbol => throwUnsupportedOperation
+        case constructorSym => constructorSym
+      }
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -926,8 +926,8 @@ trait ScalaReflection extends Logging {
         primaryConstructorSymbol.get.asMethod.paramLists
       }
     } else {
-      throw new UnsupportedOperationException(s"Unable to find constructor for ${tpe}. " +
-        s"This could happen if ${tpe} is a trait / interface.")
+      throw new UnsupportedOperationException(s"Unable to find constructor for $tpe. " +
+        s"This could happen if $tpe is a trait / interface.")
     }
     params.flatten
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -138,7 +138,7 @@ trait ScroogeLikeExample extends Product1[Int] with Serializable {
   override def hashCode: Int = x
 }
 
-/** Counter-example to [[ScroogeLikeExample]] where getting schema should fail  */
+/** Counter-example to [[ScroogeLikeExample]] as a trait without a companion object constructor */
 trait TraitProductWithoutCompanion extends Product1[Int] {}
 
 class ScalaReflectionSuite extends SparkFunSuite {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -417,14 +417,14 @@ class ScalaReflectionSuite extends SparkFunSuite {
     val e = intercept[UnsupportedOperationException] {
       schemaFor[TraitProductWithoutCompanion]
     }
-    e.getMessage.contains("Unable to find constructor")
+    assert(e.getMessage.contains("Unable to find constructor"))
   }
 
   test("SPARK-29026: schemaFor for trait with no-constructor companion throws exception ") {
     val e = intercept[UnsupportedOperationException] {
       schemaFor[TraitProductWithNoConstructorCompanion]
     }
-    e.getMessage.contains("Unable to find constructor")
+    assert(e.getMessage.contains("Unable to find constructor"))
   }
 
   test("SPARK-27625: annotated data types") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -138,6 +138,9 @@ trait ScroogeLikeExample extends Product1[Int] with Serializable {
   override def hashCode: Int = x
 }
 
+/** Counter-example to [[ScroogeLikeExample]] where getting schema should fail  */
+trait TraitProductWithoutCompanion extends Product1[Int] {}
+
 class ScalaReflectionSuite extends SparkFunSuite {
   import org.apache.spark.sql.catalyst.ScalaReflection._
 
@@ -402,6 +405,13 @@ class ScalaReflectionSuite extends SparkFunSuite {
     assert(schema === Schema(
       StructType(Seq(
         StructField("x", IntegerType, nullable = false))), nullable = true))
+  }
+
+  test("SPARK-29026: schemaFor for trait without companion constructor throws exception ") {
+    val e = intercept[UnsupportedOperationException] {
+      schemaFor[TraitProductWithoutCompanion]
+    }
+    e.getMessage.contains("Unable to find constructor")
   }
 
   test("SPARK-27625: annotated data types") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -413,7 +413,7 @@ class ScalaReflectionSuite extends SparkFunSuite {
         StructField("x", IntegerType, nullable = false))), nullable = true))
   }
 
-  test("SPARK-29026: schemaFor for trait without companion constructor throws exception ") {
+  test("SPARK-29026: schemaFor for trait without companion object throws exception ") {
     val e = intercept[UnsupportedOperationException] {
       schemaFor[TraitProductWithoutCompanion]
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -146,7 +146,6 @@ object TraitProductWithNoConstructorCompanion {}
 
 trait TraitProductWithNoConstructorCompanion extends Product1[Int] {}
 
-
 class ScalaReflectionSuite extends SparkFunSuite {
   import org.apache.spark.sql.catalyst.ScalaReflection._
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -138,8 +138,14 @@ trait ScroogeLikeExample extends Product1[Int] with Serializable {
   override def hashCode: Int = x
 }
 
-/** Counter-example to [[ScroogeLikeExample]] as a trait without a companion object constructor */
+/** Counter-examples to [[ScroogeLikeExample]] as a trait without a companion object constructor */
 trait TraitProductWithoutCompanion extends Product1[Int] {}
+
+/** Counter-examples to [[ScroogeLikeExample]] as a trait with no-constructor companion object */
+object TraitProductWithNoConstructorCompanion {}
+
+trait TraitProductWithNoConstructorCompanion extends Product1[Int] {}
+
 
 class ScalaReflectionSuite extends SparkFunSuite {
   import org.apache.spark.sql.catalyst.ScalaReflection._
@@ -410,6 +416,13 @@ class ScalaReflectionSuite extends SparkFunSuite {
   test("SPARK-29026: schemaFor for trait without companion constructor throws exception ") {
     val e = intercept[UnsupportedOperationException] {
       schemaFor[TraitProductWithoutCompanion]
+    }
+    e.getMessage.contains("Unable to find constructor")
+  }
+
+  test("SPARK-29026: schemaFor for trait with no-constructor companion throws exception ") {
+    val e = intercept[UnsupportedOperationException] {
+      schemaFor[TraitProductWithNoConstructorCompanion]
     }
     e.getMessage.contains("Unable to find constructor")
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -311,15 +311,6 @@ class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTes
 
   productTest(("UDT", new ExamplePoint(0.1, 0.2)))
 
-  trait NoConstructorProductTrait extends scala.Product {}
-
-  test("No constructor product") {
-    val e = intercept[UnsupportedOperationException] {
-      implicitly[ExpressionEncoder[NoConstructorProductTrait]]
-    }
-    e.getMessage.contains("Unable to find constructor")
-  }
-
   test("nullable of encoder schema") {
     def checkNullable[T: ExpressionEncoder](nullable: Boolean*): Unit = {
       assert(implicitly[ExpressionEncoder[T]].schema.map(_.nullable) === nullable.toSeq)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -311,6 +311,15 @@ class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTes
 
   productTest(("UDT", new ExamplePoint(0.1, 0.2)))
 
+  trait NoConstructorProductTrait extends scala.Product {}
+
+  test("No constructor product") {
+    val e = intercept[UnsupportedOperationException] {
+      implicitly[ExpressionEncoder[NoConstructorProductTrait]]
+    }
+    e.getMessage.contains("Unable to find constructor")
+  }
+
   test("nullable of encoder schema") {
     def checkNullable[T: ExpressionEncoder](nullable: Boolean*): Unit = {
       assert(implicitly[ExpressionEncoder[T]].schema.map(_.nullable) === nullable.toSeq)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

- For trait without companion object constructor, currently the method to get constructor parameters `constructParams` in `ScalaReflection` will throw exception.
```
scala.ScalaReflectionException: <none> is not a term
	at scala.reflect.api.Symbols$SymbolApi.asTerm(Symbols.scala:211)
	at scala.reflect.api.Symbols$SymbolApi.asTerm$(Symbols.scala:211)
	at scala.reflect.internal.Symbols$SymbolContextApiImpl.asTerm(Symbols.scala:106)
	at org.apache.spark.sql.catalyst.ScalaReflection.getCompanionConstructor(ScalaReflection.scala:909)
	at org.apache.spark.sql.catalyst.ScalaReflection.constructParams(ScalaReflection.scala:914)
	at org.apache.spark.sql.catalyst.ScalaReflection.constructParams$(ScalaReflection.scala:912)
	at org.apache.spark.sql.catalyst.ScalaReflection$.constructParams(ScalaReflection.scala:47)
	at org.apache.spark.sql.catalyst.ScalaReflection.getConstructorParameters(ScalaReflection.scala:890)
	at org.apache.spark.sql.catalyst.ScalaReflection.getConstructorParameters$(ScalaReflection.scala:886)
	at org.apache.spark.sql.catalyst.ScalaReflection$.getConstructorParameters(ScalaReflection.scala:47)
```
- Instead this PR would throw exception:
```
Unable to find constructor for type [XXX]. This could happen if [XXX] is an interface or a trait without companion object constructor
UnsupportedOperationException:
```

In the normal usage of ExpressionEncoder, this can happen if the type is interface extending `scala.Product`. Also, since this is a protected method, this could have been other arbitrary types without constructor.

### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

- The error message `<none> is not a term` isn't helpful for users to understand the problem.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
- The exception would be thrown instead of runtime exception from the `scala.ScalaReflectionException`.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

- Added a unit test to illustrate the `type` where expression encoder will fail and trigger the proposed error message.

