### PR TITLE
[SPARK-28939][SQL][FOLLOWUP] Fix JDK11 compilation due to ambiguous reference

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecutionRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecutionRDD.scala
@@ -39,7 +39,7 @@ class SQLExecutionRDD(
   private val sqlConfigs = conf.getAllConfs
   private lazy val sqlConfExecutorSide = {
     val props = new Properties()
-    props.putAll(sqlConfigs.asJava)
+    sqlConfigs.foreach { case (k, v) => props.setProperty(k, v) }
     val newConf = new SQLConf()
     newConf.setConf(props)
     newConf


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to recover the JDK11 compilation with a workaround.
For now, the master branch is broken like the following due to a [Scala bug](https://github.com/scala/bug/issues/10418) which is fixed in `2.13.0-RC2`.
```
[ERROR] [Error] /spark/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecutionRDD.scala:42: ambiguous reference to overloaded definition,
both method putAll in class Properties of type (x$1: java.util.Map[_, _])Unit
and  method putAll in class Hashtable of type (x$1: java.util.Map[_ <: Object, _ <: Object])Unit
match argument types (java.util.Map[String,String])
```

- https://github.com/apache/spark/actions (JDK11 build monitoring)

### Why are the changes needed?

This workaround recovers JDK11 compilation.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Manual build with JDK11 because this is JDK11 compilation fix.
- Jenkins builds with JDK8 and tests with JDK11.
- GitHub action will verify this after merging.