### PR TITLE
[WIP][SPARK-28945][CORE][SQL] Support concurrent dynamic partition writes to different partitions in the same table

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SQLHadoopMapReduceCommitProtocol.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SQLHadoopMapReduceCommitProtocol.scala
@@ -55,7 +55,8 @@ class SQLHadoopMapReduceCommitProtocol(
         // The specified output committer is a FileOutputCommitter.
         // So, we will use the FileOutputCommitter-specified constructor.
         val ctor = clazz.getDeclaredConstructor(classOf[Path], classOf[TaskAttemptContext])
-        committer = ctor.newInstance(new Path(path), context)
+        val outputPath = getOutputPath(context)
+        committer = ctor.newInstance(outputPath, context)
       } else {
         // The specified output committer is just an OutputCommitter.
         // So, we will use the no-argument constructor.

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
@@ -19,10 +19,13 @@ package org.apache.spark.sql.sources
 
 import java.io.File
 import java.sql.Timestamp
+import java.util.concurrent.Semaphore
 
-import org.apache.hadoop.mapreduce.TaskAttemptContext
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapreduce.{OutputCommitter, TaskAttemptContext}
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat
 
-import org.apache.spark.TestUtils
+import org.apache.spark.{SparkContext, TestUtils}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils
@@ -30,7 +33,8 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.datasources.SQLHadoopMapReduceCommitProtocol
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.internal.SQLConf.PartitionOverwriteMode
+import org.apache.spark.sql.test.{SharedSparkSession, TestSparkSession}
 import org.apache.spark.util.Utils
 
 private class OnlyDetectCustomPathFileCommitProtocol(jobId: String, path: String)
@@ -43,8 +47,33 @@ private class OnlyDetectCustomPathFileCommitProtocol(jobId: String, path: String
   }
 }
 
+private class DetectCorrectOutputPathFileCommitProtocol(
+    jobId: String, path: String, dynamicPartitionOverwrite: Boolean)
+  extends SQLHadoopMapReduceCommitProtocol(jobId, path, dynamicPartitionOverwrite)
+    with Serializable with Logging {
+
+  override def setupCommitter(context: TaskAttemptContext): OutputCommitter = {
+    val committer = super.setupCommitter(context)
+
+    val newOutputPath = context.getConfiguration.get(FileOutputFormat.OUTDIR, "")
+    if (dynamicPartitionOverwrite) {
+      assert(new Path(newOutputPath).getName.startsWith(".spark-staging"))
+    } else {
+      assert(newOutputPath == path)
+    }
+    committer
+  }
+}
+
 class PartitionedWriteSuite extends QueryTest with SharedSparkSession {
   import testImplicits._
+
+  // create sparkSession with 4 cores to support concurrent write.
+  override protected def createSparkSession = new TestSparkSession(
+    new SparkContext(
+      "local[4]",
+      "test-partitioned-write-context",
+      sparkConf.set("spark.sql.testkey", "true")))
 
   test("write many partitions") {
     val path = Utils.createTempDir()
@@ -155,5 +184,66 @@ class PartitionedWriteSuite extends QueryTest with SharedSparkSession {
         checkPartitionValues(files.head, "2016-12-01 08:00:00")
       }
     }
+  }
+
+  test("Output path should be staging dir when dynamicPartitionOverwrite is enabled") {
+    withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key -> PartitionOverwriteMode.DYNAMIC.toString) {
+      withTable("t") {
+        withSQLConf(SQLConf.FILE_COMMIT_PROTOCOL_CLASS.key ->
+          classOf[DetectCorrectOutputPathFileCommitProtocol].getName) {
+          Seq((1, 2)).toDF("a", "b")
+            .write
+            .partitionBy("b")
+            .mode("overwrite")
+            .saveAsTable("t")
+        }
+      }
+    }
+  }
+
+  test("Concurrent write to the same table with different partitions should be possible") {
+    withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key -> PartitionOverwriteMode.DYNAMIC.toString) {
+      withTable("t") {
+        val sem = new Semaphore(0)
+        Seq((1, 2)).toDF("a", "b")
+          .write
+          .partitionBy("b")
+          .mode("overwrite")
+          .saveAsTable("t")
+
+        val df1 = spark.range(0, 10).map(x => (x, 1)).toDF("a", "b")
+        val df2 = spark.range(0, 10).map(x => (x, 2)).toDF("a", "b")
+        val dfs = Seq(df1, df2)
+
+        var throwable: Option[Throwable] = None
+        for (i <- 0 until 2) {
+          new Thread {
+            override def run(): Unit = {
+              try {
+                dfs(i)
+                  .write
+                  .mode("overwrite")
+                  .insertInto("t")
+              } catch {
+                case t: Throwable =>
+                  throwable = Some(t)
+              } finally {
+                sem.release()
+              }
+            }
+          }.start()
+        }
+        // make sure writing table in two threads are executed.
+        sem.acquire(2)
+        throwable.foreach { t => throw improveStackTrace(t) }
+        checkAnswer(spark.sql("select a, b from t where b = 1"), df1)
+        checkAnswer(spark.sql("select a, b from t where b = 2"), df2)
+      }
+    }
+  }
+
+  private def improveStackTrace(t: Throwable): Throwable = {
+    t.setStackTrace(t.getStackTrace ++ Thread.currentThread.getStackTrace)
+    t
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This commit enables concurrent writes to different partitions in the same table with dynamicPartitionOverwrite enabled.  Currently Spark uses table's location as output when writing to the table, which would conflict each other(multiple `OutputCommitter`s operating on the same output dir) when writing to the same table concurrently.  In this commit, we set OutputCommitter's output to stagingDir to avoid collision when dynamicPartitionOverwrite is enabled.


### Why are the changes needed?
This is an improvement of user case.

### Does this PR introduce any user-facing change?
Yes, users can expect success concurrent write to the same table

### How was this patch tested?
Added two tests and existing tests for regression.