### PR TITLE
[SPARK-29037] Make staging dir identified with applicationId.

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
@@ -29,6 +29,7 @@ import org.apache.hadoop.mapreduce._
 import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
 
+import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 import org.apache.spark.mapred.SparkHadoopMapRedUtil
 
@@ -85,11 +86,13 @@ class HadoopMapReduceCommitProtocol(
    */
   @transient private var partitionPaths: mutable.Set[String] = null
 
+  private val appId = SparkEnv.get.conf.getAppId
+
   /**
    * The staging directory of this write job. Spark uses it to deal with files with absolute output
    * path, or writing data into partitioned directory with dynamicPartitionOverwrite=true.
    */
-  private def stagingDir = new Path(path, ".spark-staging-" + jobId)
+  private def stagingDir = new Path(path, s".spark-staging-${appId}-${jobId}")
 
   protected def setupCommitter(context: TaskAttemptContext): OutputCommitter = {
     val format = context.getOutputFormatClass.getConstructor().newInstance()


### PR DESCRIPTION
### What changes were proposed in this pull request?
When we insert overwrite a partition of hive table with dynamic partition mode.
For a stage, whose tasks commit output, a task saves output to a staging dir firstly, when all tasks of this stage success, all task output under staging dir will be moved to destination dir.

However, when we kill an application, which  is committing tasks' output,  parts of tasks' results  will  be kept in staging dir, which would not be cleared gracefully.

Then we rerun this application and the new application will reuse this staging dir.

And when the task commit stage of new application success, all task output under this staging dir, which contains parts of old application's task output, would be moved to destination dir and the result is duplicated.


In this PR, I make the  staging dir identified with applicationId.


### Why are the changes needed?
Spark may give duplicated result without this PR.


### Does this PR introduce any user-facing change?
No.


### How was this patch tested?
Existing UT.
