### PR TITLE
[SPARK-29073][INFRA][2.4] Add GitHub Action to branch-2.4 for `Scala-2.11/2.12` build

### DIFF
--- a/.github/workflows/branch-2.4.yml
+++ b/.github/workflows/branch-2.4.yml
@@ -1,0 +1,30 @@
+name: branch-2.4
+
+on:
+  push:
+    branches:
+    - branch-2.4
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        scala: [ '2.11', '2.12' ]
+    name: Build Spark with Scala ${{ matrix.scala }}
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up JDK 8
+      uses: actions/setup-java@v1
+      with:
+        version: '1.8'
+    - name: Change to Scala ${{ matrix.scala }}
+      run: |
+        dev/change-scala-version.sh ${{ matrix.scala }}
+    - name: Build with Maven
+      run: |
+        export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
+        export MAVEN_CLI_OPTS="--no-transfer-progress"
+        ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pmesos -Pkubernetes -Phive -Phive-thriftserver -Pscala-${{ matrix.scala }} package


### PR DESCRIPTION
### What changes were proposed in this pull request?

Apache Spark community is using GitHub action to monitor `JDK8/JDK11` build on `master` branch. It's very helpful. This PR aims to monitor both `Scala-2.11/2.12` build on `branch-2.4` by using GitHub Action.

### Why are the changes needed?

Currently, Apache Spark Jenkins servers only test `Scala-2.11` on `branch-2.4`.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Manual. (This can be tested in the repositories which received GitHub Action invitation)

- https://github.com/dongjoon-hyun/action/commit/61a77a04854987dde3d5eff873edbf2625907f83/checks