### PR TITLE
[SPARK-29074][SQL] Optimize `date_format` for foldable `fmt`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -596,17 +596,14 @@ case class DateFormatClass(
   override def withTimeZone(timeZoneId: String): TimeZoneAwareExpression = {
     val tf = if (formatter.isEmpty && right.foldable) {
       val format = right.eval().toString
-      Some(TimestampFormatter(
-        format,
-        DateTimeUtils.getZoneId(timeZoneId),
-        Locale.US))
+      Some(TimestampFormatter(format, DateTimeUtils.getZoneId(timeZoneId)))
     } else None
     copy(formatter = tf, timeZoneId = Option(timeZoneId))
   }
 
   override protected def nullSafeEval(timestamp: Any, format: Any): Any = {
     val tf = if (formatter.isEmpty) {
-      TimestampFormatter(format.toString, zoneId, Locale.US)
+      TimestampFormatter(format.toString, zoneId)
     } else {
       formatter.get
     }
@@ -622,9 +619,8 @@ case class DateFormatClass(
     }.getOrElse {
       val tf = TimestampFormatter.getClass.getName.stripSuffix("$")
       val zid = ctx.addReferenceObj("zoneId", zoneId, classOf[ZoneId].getName)
-      val locale = ctx.addReferenceObj("locale", Locale.US)
       defineCodeGen(ctx, ev, (timestamp, format) => {
-        s"""UTF8String.fromString($tf$$.MODULE$$.apply($format.toString(), $zid, $locale)
+        s"""UTF8String.fromString($tf$$.MODULE$$.apply($format.toString(), $zid)
           .format($timestamp))"""
       })
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -596,7 +596,7 @@ case class DateFormatClass(
   override def withTimeZone(timeZoneId: String): TimeZoneAwareExpression = {
     val tf = if (formatter.isEmpty && right.foldable) {
       val format = right.eval().toString
-      Some(TimestampFormatter(format, DateTimeUtils.getZoneId(timeZoneId)))
+      Some(TimestampFormatter(format, getZoneId(timeZoneId)))
     } else None
     copy(formatter = tf, timeZoneId = Option(timeZoneId))
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -594,8 +594,7 @@ case class DateFormatClass(left: Expression, right: Expression, timeZoneId: Opti
 
   @transient private lazy val formatter: Option[TimestampFormatter] = {
     if (right.foldable) {
-      val format = right.eval().toString
-      Some(TimestampFormatter(format, zoneId))
+      Option(right.eval()).map(format => TimestampFormatter(format.toString, zoneId))
     } else None
   }
 

--- a/sql/core/benchmarks/DateTimeBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-results.txt
@@ -168,8 +168,8 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.3
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 format date:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-format date wholestage off                    7180 / 7181          1.4         718.0       1.0X
-format date wholestage on                     7051 / 7194          1.4         705.1       1.0X
+format date wholestage off                    6642 / 6666          1.4         664.2       1.0X
+format date wholestage on                     6556 / 6565          1.5         655.6       1.0X
 
 
 ================================================================================================

--- a/sql/core/benchmarks/DateTimeBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-results.txt
@@ -168,8 +168,8 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.3
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 format date:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------
-format date wholestage off                    6642 / 6666          1.4         664.2       1.0X
-format date wholestage on                     6556 / 6565          1.5         655.6       1.0X
+format date wholestage off                    4787 / 4839          2.1         478.7       1.0X
+format date wholestage on                     4736 / 4802          2.1         473.6       1.0X
 
 
 ================================================================================================


### PR DESCRIPTION
### What changes were proposed in this pull request?

In the PR, I propose to create an instance of `TimestampFormatter` only once at the initialization, and reuse it inside of `nullSafeEval()` and `doGenCode()` in the case when the `fmt` parameter is foldable.

### Why are the changes needed?

The changes improve performance of the `date_format()` function.

Before:
```
format date:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------
format date wholestage off                    7180 / 7181          1.4         718.0       1.0X
format date wholestage on                     7051 / 7194          1.4         705.1       1.0X
```

After:
```
format date:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------
format date wholestage off                    4787 / 4839          2.1         478.7       1.0X
format date wholestage on                     4736 / 4802          2.1         473.6       1.0X
```

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?

By existing test suites `DateExpressionsSuite` and `DateFunctionsSuite`.
