### PR TITLE
[SPARK-28927][ML] Rethrow block mismatch exception in ALS when input data is nondeterministic

### DIFF
--- a/R/pkg/R/mllib_recommendation.R
+++ b/R/pkg/R/mllib_recommendation.R
@@ -82,9 +82,10 @@ setClass("ALSModel", representation(jobj = "jobj"))
 #' statsS <- summary(modelS)
 #' }
 #' @note spark.als since 2.1.0
-#' @note the input rating dataframe to the ALS implementation must be deterministic. If the training
-#'       data is prepared using some indeterminate operations, like \code{randomSplit} or
-#'       \code{sample}, please checkpoint the training data before fitting.
+#' @note the input rating dataframe to the ALS implementation should not be indeterminate.
+#'       Indeterminate data can probably cause failure during fitting ALS model. If the
+#'       training data is prepared using some indeterminate operations, like \code{randomSplit}
+#'       or \code{sample}, please checkpoint the training data before fitting.
 setMethod("spark.als", signature(data = "SparkDataFrame"),
           function(data, ratingCol = "rating", userCol = "user", itemCol = "item",
                    rank = 10, regParam = 0.1, maxIter = 10, nonnegative = FALSE,

--- a/R/pkg/R/mllib_recommendation.R
+++ b/R/pkg/R/mllib_recommendation.R
@@ -82,10 +82,12 @@ setClass("ALSModel", representation(jobj = "jobj"))
 #' statsS <- summary(modelS)
 #' }
 #' @note spark.als since 2.1.0
-#' @note the input rating dataframe to the ALS implementation should not be indeterminate.
-#'       Indeterminate data can probably cause failure during fitting ALS model. If the
-#'       training data is prepared using some indeterminate operations, like \code{randomSplit}
-#'       or \code{sample}, please checkpoint the training data before fitting.
+#' @note the input rating dataframe to the ALS implementation should not be nondeterministic.
+#'       Nondeterministic data can probably cause failure during fitting ALS model. For example,
+#'       an order-sensitive operation like sampling after a repartition makes dataframe output
+#'       nondeterministic, like \code{sample(repartition(df, 2L), FALSE, 0.5, 1618L)}.
+#'       Checkpointing sampled dataframe or adding a sort before sampling can help make the
+#'       dataframe deterministic.
 setMethod("spark.als", signature(data = "SparkDataFrame"),
           function(data, ratingCol = "rating", userCol = "user", itemCol = "item",
                    rank = 10, regParam = 0.1, maxIter = 10, nonnegative = FALSE,

--- a/R/pkg/R/mllib_recommendation.R
+++ b/R/pkg/R/mllib_recommendation.R
@@ -82,6 +82,9 @@ setClass("ALSModel", representation(jobj = "jobj"))
 #' statsS <- summary(modelS)
 #' }
 #' @note spark.als since 2.1.0
+#' @note the input rating dataframe to the ALS implementation must be determinate. If the training
+#'       data is prepared using some indeterminate operations, like \code{randomSplit} or
+#'       \code{sample}, please checkpoint the training data before fitting.
 setMethod("spark.als", signature(data = "SparkDataFrame"),
           function(data, ratingCol = "rating", userCol = "user", itemCol = "item",
                    rank = 10, regParam = 0.1, maxIter = 10, nonnegative = FALSE,

--- a/R/pkg/R/mllib_recommendation.R
+++ b/R/pkg/R/mllib_recommendation.R
@@ -82,7 +82,7 @@ setClass("ALSModel", representation(jobj = "jobj"))
 #' statsS <- summary(modelS)
 #' }
 #' @note spark.als since 2.1.0
-#' @note the input rating dataframe to the ALS implementation must be determinate. If the training
+#' @note the input rating dataframe to the ALS implementation must be deterministic. If the training
 #'       data is prepared using some indeterminate operations, like \code{randomSplit} or
 #'       \code{sample}, please checkpoint the training data before fitting.
 setMethod("spark.als", signature(data = "SparkDataFrame"),

--- a/R/pkg/R/mllib_recommendation.R
+++ b/R/pkg/R/mllib_recommendation.R
@@ -82,8 +82,8 @@ setClass("ALSModel", representation(jobj = "jobj"))
 #' statsS <- summary(modelS)
 #' }
 #' @note spark.als since 2.1.0
-#' @note the input rating dataframe to the ALS implementation should not be nondeterministic.
-#'       Nondeterministic data can probably cause failure during fitting ALS model. For example,
+#' @note the input rating dataframe to the ALS implementation should be deterministic.
+#'       Nondeterministic data can cause failure during fitting ALS model. For example,
 #'       an order-sensitive operation like sampling after a repartition makes dataframe output
 #'       nondeterministic, like \code{sample(repartition(df, 2L), FALSE, 0.5, 1618L)}.
 #'       Checkpointing sampled dataframe or adding a sort before sampling can help make the

--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
@@ -927,9 +927,11 @@ object ALS extends DefaultParamsReadable[ALS] with Logging {
     // Indeterminate rating RDD causes inconsistent in/out blocks in case of rerun.
     // It can cause runtime error when matching in/out user/item blocks.
     if (ratings.outputDeterministicLevel == DeterministicLevel.INDETERMINATE) {
-      throw new IllegalArgumentException("The output of rating RDD can not be indeterminate. " +
-        "If your training data has indeterminate RDD computations, like `randomSplit` or `sample`" +
-        ", please checkpoint the training data before running ALS.")
+      logWarning("The output of rating RDD should not be indeterminate. " +
+        "If indeterminate RDD needs to be rerun during fitting ALS model, it could " +
+        "cause failures. If your training data has indeterminate RDD computations, " +
+        "like `randomSplit` or `sample`, please checkpoint the training data before " +
+        "running ALS.")
     }
 
     val sc = ratings.sparkContext

--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
@@ -565,9 +565,10 @@ object ALSModel extends MLReadable[ALSModel] {
  * values related to strength of indicated user
  * preferences rather than explicit ratings given to items.
  *
- * Note: the input rating dataset to the ALS implementation must be deterministic. If the training
- * data is prepared using some indeterminate operations, like `randomSplit` or `sample`, please
- * checkpoint the training data before fitting.
+ * Note: the input rating dataset to the ALS implementation should not be indeterminate.
+ * Indeterminate data can probably cause failure during fitting ALS model. If the
+ * training data is prepared using some indeterminate operations, like `randomSplit`
+ * or `sample`, please checkpoint the training data before fitting.
  */
 @Since("1.3.0")
 class ALS(@Since("1.4.0") override val uid: String) extends Estimator[ALSModel] with ALSParams

--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
@@ -565,10 +565,12 @@ object ALSModel extends MLReadable[ALSModel] {
  * values related to strength of indicated user
  * preferences rather than explicit ratings given to items.
  *
- * Note: the input rating dataset to the ALS implementation should not be indeterminate.
- * Indeterminate data can probably cause failure during fitting ALS model. If the
- * training data is prepared using some indeterminate operations, like `randomSplit`
- * or `sample`, please checkpoint the training data before fitting.
+ * Note: the input rating dataset to the ALS implementation should not be nondeterministic.
+ * Nondeterministic data can probably cause failure during fitting ALS model.
+ * For example, an order-sensitive operation like sampling after a repartition makes dataset
+ * output nondeterministic, like `dataset.repartition(2).sample(false, 0.5, 1618)`.
+ * Checkpointing sampled dataset or adding a sort before sampling can help make the dataset
+ * deterministic.
  */
 @Since("1.3.0")
 class ALS(@Since("1.4.0") override val uid: String) extends Estimator[ALSModel] with ALSParams

--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
@@ -565,7 +565,7 @@ object ALSModel extends MLReadable[ALSModel] {
  * values related to strength of indicated user
  * preferences rather than explicit ratings given to items.
  *
- * Note: the input rating dataset to the ALS implementation must be determinate. If the training
+ * Note: the input rating dataset to the ALS implementation must be deterministic. If the training
  * data is prepared using some indeterminate operations, like `randomSplit` or `sample`, please
  * checkpoint the training data before fitting.
  */

--- a/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala
@@ -565,8 +565,8 @@ object ALSModel extends MLReadable[ALSModel] {
  * values related to strength of indicated user
  * preferences rather than explicit ratings given to items.
  *
- * Note: the input rating dataset to the ALS implementation should not be nondeterministic.
- * Nondeterministic data can probably cause failure during fitting ALS model.
+ * Note: the input rating dataset to the ALS implementation should be deterministic.
+ * Nondeterministic data can cause failure during fitting ALS model.
  * For example, an order-sensitive operation like sampling after a repartition makes dataset
  * output nondeterministic, like `dataset.repartition(2).sample(false, 0.5, 1618)`.
  * Checkpointing sampled dataset or adding a sort before sampling can help make the dataset

--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
@@ -63,10 +63,12 @@ case class Rating @Since("0.8.0") (
  * indicated user
  * preferences rather than explicit ratings given to items.
  *
- * Note: the input rating RDD to the ALS implementation should not be indeterminate.
- * Indeterminate data can probably cause failure during fitting ALS model. If the
- * training data is prepared using some indeterminate operations, like `randomSplit`
- * or `sample`, please checkpoint the training data before fitting.
+ * Note: the input rating RDD to the ALS implementation should not be nondeterministic.
+ * Nondeterministic data can probably cause failure during fitting ALS model.
+ * For example, an order-sensitive operation like sampling after a repartition makes RDD
+ * output nondeterministic, like `rdd.repartition(2).sample(false, 0.5, 1618)`.
+ * Checkpointing sampled RDD or adding a sort before sampling can help make the RDD
+ * deterministic.
  */
 @Since("0.8.0")
 class ALS private (

--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
@@ -62,6 +62,10 @@ case class Rating @Since("0.8.0") (
  * r &gt; 0 and 0 if r &lt;= 0. The ratings then act as 'confidence' values related to strength of
  * indicated user
  * preferences rather than explicit ratings given to items.
+ *
+ * Note: the input rating RDD to the ALS implementation must be determinate. If the training data
+ * is prepared using some indeterminate RDD operations, like `randomSplit` or `sample`, please
+ * checkpoint the training data before fitting.
  */
 @Since("0.8.0")
 class ALS private (

--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
@@ -63,9 +63,10 @@ case class Rating @Since("0.8.0") (
  * indicated user
  * preferences rather than explicit ratings given to items.
  *
- * Note: the input rating RDD to the ALS implementation must be deterministic. If the training data
- * is prepared using some indeterminate RDD operations, like `randomSplit` or `sample`, please
- * checkpoint the training data before fitting.
+ * Note: the input rating RDD to the ALS implementation should not be indeterminate.
+ * Indeterminate data can probably cause failure during fitting ALS model. If the
+ * training data is prepared using some indeterminate operations, like `randomSplit`
+ * or `sample`, please checkpoint the training data before fitting.
  */
 @Since("0.8.0")
 class ALS private (

--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
@@ -63,8 +63,8 @@ case class Rating @Since("0.8.0") (
  * indicated user
  * preferences rather than explicit ratings given to items.
  *
- * Note: the input rating RDD to the ALS implementation should not be nondeterministic.
- * Nondeterministic data can probably cause failure during fitting ALS model.
+ * Note: the input rating RDD to the ALS implementation should be deterministic.
+ * Nondeterministic data can cause failure during fitting ALS model.
  * For example, an order-sensitive operation like sampling after a repartition makes RDD
  * output nondeterministic, like `rdd.repartition(2).sample(false, 0.5, 1618)`.
  * Checkpointing sampled RDD or adding a sort before sampling can help make the RDD

--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
@@ -63,7 +63,7 @@ case class Rating @Since("0.8.0") (
  * indicated user
  * preferences rather than explicit ratings given to items.
  *
- * Note: the input rating RDD to the ALS implementation must be determinate. If the training data
+ * Note: the input rating RDD to the ALS implementation must be deterministic. If the training data
  * is prepared using some indeterminate RDD operations, like `randomSplit` or `sample`, please
  * checkpoint the training data before fitting.
  */

--- a/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
@@ -36,10 +36,10 @@ import org.apache.spark.ml.recommendation.ALS._
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest, MLTestingUtils}
 import org.apache.spark.ml.util.TestingUtils._
 import org.apache.spark.mllib.util.MLlibTestSparkContext
-import org.apache.spark.rdd.{DeterministicLevel, RDD}
+import org.apache.spark.rdd.RDD
 import org.apache.spark.scheduler.{SparkListener, SparkListenerStageCompleted}
 import org.apache.spark.sql.{DataFrame, Encoder, Row, SparkSession}
-import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.streaming.StreamingQueryException
 import org.apache.spark.sql.types._
@@ -948,30 +948,6 @@ class ALSSuite extends MLTest with DefaultReadWriteTest with Logging {
     }
     assert(shuffledUserFactors.size == 0)
     assert(shuffledItemFactors.size == 0)
-  }
-
-  test("The input data to ALS must be determinate") {
-    // Explicitly disable this config, so the input dataset is indeterminate.
-    withSQLConf("spark.sql.execution.sortBeforeRepartition" -> "false") {
-      val spark = this.spark
-      import spark.implicits._
-
-      val (ratings, _) = genExplicitTestData(numUsers = 2, numItems = 2, rank = 1)
-      val data = ratings.toDF
-      implicit val rowEncoder = RowEncoder(data.schema)
-
-      val input = data.repartition(10).map(x => x).repartition(20).map(x => x)
-      assert(input.rdd.outputDeterministicLevel == DeterministicLevel.INDETERMINATE)
-
-      val err = intercept[IllegalArgumentException] {
-        new ALS()
-          .setMaxIter(2)
-          .setImplicitPrefs(true)
-          .setCheckpointInterval(-1)
-          .fit(input)
-      }
-      assert(err.getMessage.contains("The output of rating RDD can not be indeterminate."))
-    }
   }
 
   private def checkRecommendations(

--- a/python/pyspark/ml/recommendation.py
+++ b/python/pyspark/ml/recommendation.py
@@ -67,7 +67,8 @@ class ALS(JavaEstimator, HasCheckpointInterval, HasMaxIter, HasPredictionCol, Ha
     indicated user preferences rather than explicit ratings given to
     items.
 
-    .. note:: the input rating dataframe to the ALS implementation must be deterministic. If the
+    .. note:: the input rating dataframe to the ALS implementation should not be indeterminate.
+              Indeterminate data can probably cause failure during fitting ALS model. If the
               training data is prepared using some indeterminate operations, like `randomSplit`
               or `sample`, please checkpoint the training data before fitting.
 

--- a/python/pyspark/ml/recommendation.py
+++ b/python/pyspark/ml/recommendation.py
@@ -67,7 +67,7 @@ class ALS(JavaEstimator, HasCheckpointInterval, HasMaxIter, HasPredictionCol, Ha
     indicated user preferences rather than explicit ratings given to
     items.
 
-    .. note:: the input rating dataframe to the ALS implementation must be determinate. If the
+    .. note:: the input rating dataframe to the ALS implementation must be deterministic. If the
               training data is prepared using some indeterminate operations, like `randomSplit`
               or `sample`, please checkpoint the training data before fitting.
 

--- a/python/pyspark/ml/recommendation.py
+++ b/python/pyspark/ml/recommendation.py
@@ -67,6 +67,10 @@ class ALS(JavaEstimator, HasCheckpointInterval, HasMaxIter, HasPredictionCol, Ha
     indicated user preferences rather than explicit ratings given to
     items.
 
+    .. note:: the input rating dataframe to the ALS implementation must be determinate. If the
+              training data is prepared using some indeterminate operations, like `randomSplit`
+              or `sample`, please checkpoint the training data before fitting.
+
     >>> df = spark.createDataFrame(
     ...     [(0, 0, 4.0), (0, 1, 2.0), (1, 1, 3.0), (1, 2, 4.0), (2, 1, 1.0), (2, 2, 5.0)],
     ...     ["user", "item", "rating"])

--- a/python/pyspark/ml/recommendation.py
+++ b/python/pyspark/ml/recommendation.py
@@ -67,8 +67,8 @@ class ALS(JavaEstimator, HasCheckpointInterval, HasMaxIter, HasPredictionCol, Ha
     indicated user preferences rather than explicit ratings given to
     items.
 
-    .. note:: the input rating dataframe to the ALS implementation should not be nondeterministic.
-              Nondeterministic data can probably cause failure during fitting ALS model.
+    .. note:: the input rating dataframe to the ALS implementation should be deterministic.
+              Nondeterministic data can cause failure during fitting ALS model.
               For example, an order-sensitive operation like sampling after a repartition makes
               dataframe output nondeterministic, like `df.repartition(2).sample(False, 0.5, 1618)`.
               Checkpointing sampled dataframe or adding a sort before sampling can help make the

--- a/python/pyspark/ml/recommendation.py
+++ b/python/pyspark/ml/recommendation.py
@@ -67,10 +67,12 @@ class ALS(JavaEstimator, HasCheckpointInterval, HasMaxIter, HasPredictionCol, Ha
     indicated user preferences rather than explicit ratings given to
     items.
 
-    .. note:: the input rating dataframe to the ALS implementation should not be indeterminate.
-              Indeterminate data can probably cause failure during fitting ALS model. If the
-              training data is prepared using some indeterminate operations, like `randomSplit`
-              or `sample`, please checkpoint the training data before fitting.
+    .. note:: the input rating dataframe to the ALS implementation should not be nondeterministic.
+              Nondeterministic data can probably cause failure during fitting ALS model.
+              For example, an order-sensitive operation like sampling after a repartition makes
+              dataframe output nondeterministic, like `df.repartition(2).sample(False, 0.5, 1618)`.
+              Checkpointing sampled dataframe or adding a sort before sampling can help make the
+              dataframe deterministic.
 
     >>> df = spark.createDataFrame(
     ...     [(0, 0, 4.0), (0, 1, 2.0), (1, 1, 3.0), (1, 2, 4.0), (2, 1, 1.0), (2, 2, 5.0)],


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Fitting ALS model can be failed due to nondeterministic input data. Currently the failure is thrown by an ArrayIndexOutOfBoundsException which is not explainable for end users what is wrong in fitting.

This patch catches this exception and rethrows a more explainable one, when the input data is nondeterministic.

Because we may not exactly know the output deterministic level of RDDs produced by user code, this patch also adds a note to Scala/Python/R ALS document about the training data deterministic level.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

ArrayIndexOutOfBoundsException was observed during fitting ALS model. It was caused by mismatching between in/out user/item blocks during computing ratings.

If the training RDD output is nondeterministic, when fetch failure is happened, rerun part of training RDD can produce inconsistent user/item blocks.

This patch is needed to notify users ALS fitting on nondeterministic input.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

Yes. When fitting ALS model on nondeterministic input data, previously if rerun happens, users would see ArrayIndexOutOfBoundsException caused by mismatch between In/Out user/item blocks.

After this patch, a SparkException with more clear message will be thrown, and original ArrayIndexOutOfBoundsException is wrapped.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Tested on development cluster.