### PR TITLE
[WIP][SPARK-29037][Core] Spark gives duplicate result when an application was killed

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkException.scala
+++ b/core/src/main/scala/org/apache/spark/SparkException.scala
@@ -43,3 +43,9 @@ private[spark] case class SparkUserAppException(exitCode: Int)
  */
 private[spark] case class ExecutorDeadException(message: String)
   extends SparkException(message)
+
+/**
+ * Exception thrown when several InsertDataSource operations are conflicted.
+ */
+private[spark] case class InsertDataSourceConflictException(message: String)
+  extends SparkException(message)

--- a/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
@@ -160,6 +160,8 @@ class HadoopMapReduceCommitProtocol(
 
     val taskAttemptContext = new TaskAttemptContextImpl(jobContext.getConfiguration, taskAttemptId)
     committer = setupCommitter(taskAttemptContext)
+    // For dynamic partition overwrite, it has specific job attempt path, so we don't need
+    // committer.setupJob here. Same with the commitJob and abortJob operations below.
     if (!dynamicPartitionOverwrite) {
       committer.setupJob(jobContext)
     }

--- a/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
@@ -161,7 +161,7 @@ class HadoopMapReduceCommitProtocol(
     val taskAttemptContext = new TaskAttemptContextImpl(jobContext.getConfiguration, taskAttemptId)
     committer = setupCommitter(taskAttemptContext)
     if (!dynamicPartitionOverwrite) {
-      committer.setupJob(jobContext)
+      committer.setupJob(jobContext )
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
@@ -161,7 +161,7 @@ class HadoopMapReduceCommitProtocol(
     val taskAttemptContext = new TaskAttemptContextImpl(jobContext.getConfiguration, taskAttemptId)
     committer = setupCommitter(taskAttemptContext)
     if (!dynamicPartitionOverwrite) {
-      committer.setupJob(jobContext )
+      committer.setupJob(jobContext)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
@@ -29,6 +29,7 @@ import org.apache.hadoop.mapreduce._
 import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
 
+import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 import org.apache.spark.mapred.SparkHadoopMapRedUtil
 
@@ -85,11 +86,13 @@ class HadoopMapReduceCommitProtocol(
    */
   @transient private var partitionPaths: mutable.Set[String] = null
 
+  private val appId = SparkEnv.get.conf.getAppId
+
   /**
    * The staging directory of this write job. Spark uses it to deal with files with absolute output
    * path, or writing data into partitioned directory with dynamicPartitionOverwrite=true.
    */
-  private def stagingDir = new Path(path, ".spark-staging-" + jobId)
+  private def stagingDir = new Path(path, s".spark-staging-${appId}-${jobId}")
 
   protected def setupCommitter(context: TaskAttemptContext): OutputCommitter = {
     val format = context.getOutputFormatClass.getConstructor().newInstance()

--- a/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
@@ -29,7 +29,6 @@ import org.apache.hadoop.mapreduce._
 import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
 
-import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 import org.apache.spark.mapred.SparkHadoopMapRedUtil
 
@@ -86,13 +85,11 @@ class HadoopMapReduceCommitProtocol(
    */
   @transient private var partitionPaths: mutable.Set[String] = null
 
-  private val appId = SparkEnv.get.conf.getAppId
-
   /**
    * The staging directory of this write job. Spark uses it to deal with files with absolute output
    * path, or writing data into partitioned directory with dynamicPartitionOverwrite=true.
    */
-  private def stagingDir = new Path(path, s".spark-staging-${appId}-${jobId}")
+  private def stagingDir = new Path(path, ".spark-staging-" + jobId)
 
   protected def setupCommitter(context: TaskAttemptContext): OutputCommitter = {
     val format = context.getOutputFormatClass.getConstructor().newInstance()
@@ -167,7 +164,9 @@ class HadoopMapReduceCommitProtocol(
   }
 
   override def commitJob(jobContext: JobContext, taskCommits: Seq[TaskCommitMessage]): Unit = {
-    committer.commitJob(jobContext)
+    if (!dynamicPartitionOverwrite) {
+      committer.commitJob(jobContext)
+    }
 
     if (hasValidPath) {
       val (allAbsPathFiles, allPartitionPaths) =

--- a/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
@@ -160,7 +160,9 @@ class HadoopMapReduceCommitProtocol(
 
     val taskAttemptContext = new TaskAttemptContextImpl(jobContext.getConfiguration, taskAttemptId)
     committer = setupCommitter(taskAttemptContext)
-    committer.setupJob(jobContext)
+    if (!dynamicPartitionOverwrite) {
+      committer.setupJob(jobContext)
+    }
   }
 
   override def commitJob(jobContext: JobContext, taskCommits: Seq[TaskCommitMessage]): Unit = {
@@ -217,7 +219,9 @@ class HadoopMapReduceCommitProtocol(
    */
   override def abortJob(jobContext: JobContext): Unit = {
     try {
-      committer.abortJob(jobContext, JobStatus.State.FAILED)
+      if (!dynamicPartitionOverwrite) {
+        committer.abortJob(jobContext, JobStatus.State.FAILED)
+      }
     } catch {
       case e: IOException =>
         logWarning(s"Exception while aborting ${jobContext.getJobID}", e)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3205,7 +3205,8 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession {
         checkAnswer(df, Array(Row(1)))
 
         val warehouse = SQLConf.get.warehousePath.split(":").last
-        val tblPath = Array(warehouse, "test").mkString(File.separator)
+        val tblPath = Array(warehouse, "org.apache.spark.sql.SQLQuerySuite", "test")
+          .mkString(File.separator)
         val taskAttemptPath = Array(tblPath, "_temporary", "0", "task_20190914232019_0000_m_000000",
           "p1=1", "p2=3").mkString(File.separator)
         new File(taskAttemptPath).mkdirs()

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -24,7 +24,6 @@ import java.util.{Locale, TimeZone}
 
 import scala.util.Try
 
-import com.google.common.io.Files
 import org.apache.commons.lang3.{JavaVersion, SystemUtils}
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars
 import org.scalatest.BeforeAndAfter
@@ -39,7 +38,6 @@ import org.apache.spark.sql.hive._
 import org.apache.spark.sql.hive.test.{HiveTestUtils, TestHive}
 import org.apache.spark.sql.hive.test.TestHive._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.SQLConf.{PARTITION_OVERWRITE_MODE, PartitionOverwriteMode}
 import org.apache.spark.sql.test.SQLTestUtils
 
 case class TestData(a: Int, b: String)
@@ -1223,34 +1221,6 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
 
       assertResult(Array(Row(2.4999991485811655))) {
         sql("select radians(143.2394) FROM src tablesample (1 rows)").collect()
-      }
-    }
-  }
-
-  test("SPARK-29037: Spark gives duplicate result when an application was killed") {
-    withSQLConf(PARTITION_OVERWRITE_MODE.key -> PartitionOverwriteMode.DYNAMIC.toString) {
-      withTable("test") {
-        sql("create table test(id int, p1 int, p2 int) using parquet partitioned by (p1, p2)")
-        sql("insert overwrite table test partition(p1=1,p2) select 1,3")
-        val df = sql("select id from test where p1=1 and p2=3").collect()
-        assertResult(Array(Row(1)))(df)
-
-        val warehouse = SQLConf.get.warehousePath
-        val tblPath = Array(warehouse, "test").mkString(File.separator)
-        val taskAttemptPath = Array(tblPath, "_temporary", "0", "task_20190914232019_0000_m_000000",
-          "p1=1", "p2=3").mkString(File.separator)
-        new File(taskAttemptPath).mkdirs()
-
-        val tblResult = new File(Array(tblPath, "p1=1", "p2=3").mkString(File.separator))
-        val tFile = tblResult.list((_: File, name: String) => !name.startsWith(".")).apply(0)
-        val from = new File(tblResult.getAbsolutePath + File.separator + tFile)
-        val to = new File(taskAttemptPath + File.separator + tFile)
-        Files.copy(from, to)
-
-        sql("insert overwrite table test partition(p1=1,p2) select 2, 3")
-        assert(tblResult.list((_: File, name: String) => !name.startsWith(".")).size === 1)
-        val df2 = sql("select id from test where p1=1 and p2=3").collect()
-        assertResult(Array(Row(2)))(df2)
       }
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -22,10 +22,9 @@ import java.net.URI
 import java.sql.Timestamp
 import java.util.{Locale, TimeZone}
 
-import com.google.common.io.Files
-
 import scala.util.Try
 
+import com.google.common.io.Files
 import org.apache.commons.lang3.{JavaVersion, SystemUtils}
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars
 import org.scalatest.BeforeAndAfter


### PR DESCRIPTION
### What changes were proposed in this pull request?

Case:
Application **appA** insert overwrite table **table_a** with static partition overwrite.
But it was killed when committing tasks,  because one task is hang.
And parts of its committed tasks output is kept under `/path/table_a/_temporary/0/`.

Then we run application **appB** insert overwrite table **table_a** with dynamic partition overwrite.
It executes successfully.
But it also commit the data under `/path/table_a/_temporary/0/` to destination dir.

In this PR, we skip the FileOutputCommitter.{setupJob, commitJob, abortJob} operations when dynamicPartitionOverwrite.

### Why are the changes needed?
Data may corrupt without this PR.

### Does this PR introduce any user-facing change?
No.


### How was this patch tested?
Existing Unit Test.
