### PR TITLE
[SPARK-29908][SQL] Support partitioning and bucketing through DataFrameWriter.save for V2 Tables

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsCreateTable.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsCreateTable.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.catalog;
+
+import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+import java.util.Map;
+
+/**
+ * An interface that can be extended by DataSources that implement the {@link TableProvider}
+ * that can create new tables for the given options. These tables are not stored in any catalog,
+ * but have a mechanism to check whether a table can be created for the specified data source
+ * options.
+ */
+@Evolving
+public interface SupportsCreateTable extends TableProvider {
+
+  /**
+   * Check whether a new table can be created for the given options.
+   *
+   * @param options The options that should be sufficient to define and access a table
+   * @return true if the table exists, false otherwise
+   */
+  boolean canCreateTable(CaseInsensitiveStringMap options);
+
+  /**
+   * Create a table with the given options. It is the data source's responsibility to check if
+   * the provided schema and the transformations are acceptable in case a table already exists
+   * for the given options.
+   *
+   * @param options The data source options that define how to access the table. This can contain
+   *                the path for file based tables, kafka broker addresses to connect to Kafka or
+   *                the JDBC URL to connect to a JDBC data source.
+   * @param schema The schema of the new table, as a struct type
+   * @param partitions Transforms to use for partitioning data in the table
+   * @param properties A string map of table properties
+   * @return Metadata for the new table. The table creation can be followed up by a write
+   * @throws IllegalArgumentException If a table already exists for these options with a
+   *                                  non-conforming schema or different partitioning specification.
+   * @throws UnsupportedOperationException If a requested partition transform is not supported or
+   *                                       table properties are not supported
+   */
+  Table buildTable(
+    CaseInsensitiveStringMap options,
+    StructType schema,
+    Transform[] partitions,
+    Map<String, String> properties);
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -26,12 +26,12 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, NoSuchTableException, UnresolvedRelation}
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.expressions.Literal
-import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.plans.logical.{AppendData, CreateTableAsSelect, LogicalPlan, OverwriteByExpression, OverwritePartitionsDynamic, ReplaceTableAsSelect}
 import org.apache.spark.sql.catalyst.plans.logical.sql.InsertIntoStatement
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
-import org.apache.spark.sql.connector.catalog._
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, Identifier, SupportsCreateTable, SupportsWrite, TableCatalog, TableProvider, V1Table}
 import org.apache.spark.sql.connector.catalog.TableCapability._
-import org.apache.spark.sql.connector.expressions._
+import org.apache.spark.sql.connector.expressions.{BucketTransform, FieldReference, IdentityTransform, LiteralValue, Transform}
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.command.DDLUtils
 import org.apache.spark.sql.execution.datasources.{CreateTable, DataSource, DataSourceUtils, LogicalRelation}

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
@@ -17,7 +17,9 @@
 
 package org.apache.spark.sql.connector
 
-import org.apache.spark.sql.{DataFrame, Row, SaveMode}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SaveMode}
+import org.apache.spark.sql.connector.expressions.{BucketTransform, FieldReference, IdentityTransform, LiteralValue}
+import org.apache.spark.sql.types.IntegerType
 
 class DataSourceV2DataFrameSuite
   extends InsertIntoTests(supportsDynamicOverwrite = true, includeSQLOnlyTests = false) {
@@ -26,11 +28,13 @@ class DataSourceV2DataFrameSuite
   before {
     spark.conf.set("spark.sql.catalog.testcat", classOf[InMemoryTableCatalog].getName)
     spark.conf.set("spark.sql.catalog.testcat2", classOf[InMemoryTableCatalog].getName)
+    InMemoryV1Provider.clear()
   }
 
   after {
     spark.sessionState.catalogManager.reset()
     spark.sessionState.conf.clear()
+    InMemoryV1Provider.clear()
   }
 
   override protected val catalogAndNamespace: String = "testcat.ns1.ns2.tbls"
@@ -121,5 +125,69 @@ class DataSourceV2DataFrameSuite
       df.write.mode("ignore").saveAsTable(t1)
       checkAnswer(spark.table(t1), Seq(Row("c", "d")))
     }
+  }
+
+  SaveMode.values().foreach { mode =>
+    test(s"save: new table creations with partitioning for table - mode: $mode") {
+      val format = classOf[InMemoryV1Provider].getName
+      val df = Seq((1, "x"), (2, "y"), (3, "z")).toDF("a", "b")
+      df.write.mode(mode).option("name", "t1").format(format).partitionBy("a").save()
+
+      checkAnswer(InMemoryV1Provider.getTableData(spark, "t1"), df)
+      assert(InMemoryV1Provider.tables("t1").schema === df.schema.asNullable)
+      assert(InMemoryV1Provider.tables("t1").partitioning.sameElements(
+        Array(IdentityTransform(FieldReference(Seq("a"))))))
+    }
+
+    test(s"save: new table creations with bucketing for table - mode: $mode") {
+      val format = classOf[InMemoryV1Provider].getName
+      val df = Seq((1, "x"), (2, "y"), (3, "z")).toDF("a", "b")
+      df.write.mode(mode).option("name", "t1").format(format).bucketBy(2, "a").save()
+
+      checkAnswer(InMemoryV1Provider.getTableData(spark, "t1"), df)
+      assert(InMemoryV1Provider.tables("t1").schema === df.schema.asNullable)
+      assert(InMemoryV1Provider.tables("t1").partitioning.sameElements(
+        Array(BucketTransform(LiteralValue(2, IntegerType), Seq(FieldReference(Seq("a")))))))
+    }
+  }
+
+  test("save: default mode is ErrorIfExists") {
+    val format = classOf[InMemoryV1Provider].getName
+    val df = Seq((1, "x"), (2, "y"), (3, "z")).toDF("a", "b")
+
+    df.write.option("name", "t1").format(format).partitionBy("a").save()
+    // default is ErrorIfExists, and since a table already exists we throw an exception
+    val e = intercept[AnalysisException] {
+      df.write.option("name", "t1").format(format).partitionBy("a").save()
+    }
+    assert(e.getMessage.contains("already exists"))
+  }
+
+  test("save: Ignore mode") {
+    val format = classOf[InMemoryV1Provider].getName
+    val df = Seq((1, "x"), (2, "y"), (3, "z")).toDF("a", "b")
+
+    df.write.option("name", "t1").format(format).partitionBy("a").save()
+    // no-op
+    df.write.option("name", "t1").format(format).mode("ignore").partitionBy("a").save()
+
+    checkAnswer(InMemoryV1Provider.getTableData(spark, "t1"), df)
+  }
+
+  test("save: tables can perform schema and partitioning checks if they already exist") {
+    val format = classOf[InMemoryV1Provider].getName
+    val df = Seq((1, "x"), (2, "y"), (3, "z")).toDF("a", "b")
+
+    df.write.option("name", "t1").format(format).partitionBy("a").save()
+    val e2 = intercept[IllegalArgumentException] {
+      df.write.mode("append").option("name", "t1").format(format).partitionBy("b").save()
+    }
+    assert(e2.getMessage.contains("partitioning"))
+
+    val e3 = intercept[IllegalArgumentException] {
+      Seq((1, "x")).toDF("c", "d").write.mode("append").option("name", "t1").format(format)
+        .save()
+    }
+    assert(e3.getMessage.contains("schema"))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/V1WriteFallbackSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/V1WriteFallbackSuite.scala
@@ -26,7 +26,7 @@ import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.sql.{DataFrame, QueryTest, Row, SaveMode, SparkSession}
 import org.apache.spark.sql.connector.catalog._
-import org.apache.spark.sql.connector.expressions.{FieldReference, IdentityTransform, Transform}
+import org.apache.spark.sql.connector.expressions.{BucketTransform, FieldReference, IdentityTransform, Transform}
 import org.apache.spark.sql.connector.write.{SupportsOverwrite, SupportsTruncate, V1WriteBuilder, WriteBuilder}
 import org.apache.spark.sql.sources.{DataSourceRegister, Filter, InsertableRelation}
 import org.apache.spark.sql.test.SharedSparkSession
@@ -162,8 +162,8 @@ class InMemoryTableWithV1Fallback(
     override val properties: util.Map[String, String]) extends Table with SupportsWrite {
 
   partitioning.foreach { t =>
-    if (!t.isInstanceOf[IdentityTransform]) {
-      throw new IllegalArgumentException(s"Transform $t must be IdentityTransform")
+    if (!t.isInstanceOf[IdentityTransform] && !t.isInstanceOf[BucketTransform]) {
+      throw new IllegalArgumentException(s"Transform $t must be IdentityTransform or Bucketing")
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

We add a new interface `SupportsCreateTable` to support the passing of partitioning transforms and table properties for tables that can be created without the existence of a catalog. Traditionally, data sources were passed all necessary information to define a table through the options in DataFrameWriter in conjunction with `save`.

Through this new interface, we can continue to perform the necessary checks for SaveMode.ErrorIfExists and SaveMode.Ignore through `save` for V2 tables. For example, a file based data source such as parquet can check if the target directory is empty or not as part of the `SupportsCreateTable.canCreateTable` to support these save modes. In addition, if metadata is available for a table (e.g. the schema of a jdbc data source would be available), the data source can check if the correct schema and partitioning transforms have been provided as part of the `SupportsCreateTable.buildTable` if a table already exists for the given options. The `buildTable` method also takes in table properties. While this isn't available for save, they can be provided through the DataFrameWriterV2 API.

Thoughts about DataFrameWriterV2:
I'm also thinking that there could be a separate API that can potentially go from and to `options <-> Identifier`. This can make sure that these data sources can also leverage the DFWriterV2 API without requiring a catalog.

### Why are the changes needed?

Currently partitioning and bucketing information cannot be passed through for DataSources that migrate to DataSource V2 through the DataFrameWriter.save method which is one of the most commonly used methods used in Apache Spark.

### Does this PR introduce any user-facing change?

This adds a new interface `SupportsCreateTable` which DataSource developers can implement as part of their `TableProvider` interface to support the creation of tables when a catalog is not available.

### How was this patch tested?

Tests in DataSourceV2DataFrameSuite