### PR TITLE
[SPARK-29128][SQL] Split predicate code in OR expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -625,7 +625,7 @@ case class HiveTableRelation(
       storage = CatalogStorageFormat.empty,
       createTime = -1
     ),
-    dataCols = dataCols.zipWithIndex.map {
+    dataCols = dataCols.zipWithIndex.map sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala{
       case (attr, index) => attr.withExprId(ExprId(index))
     },
     partitionCols = partitionCols.zipWithIndex.map {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -625,7 +625,7 @@ case class HiveTableRelation(
       storage = CatalogStorageFormat.empty,
       createTime = -1
     ),
-    dataCols = dataCols.zipWithIndex.map sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala{
+    dataCols = dataCols.zipWithIndex.map {
       case (attr, index) => attr.withExprId(ExprId(index))
     },
     partitionCols = partitionCols.zipWithIndex.map {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -156,6 +156,12 @@ abstract class Expression extends TreeNode[Expression] {
 
   private def reduceCodeSize(ctx: CodegenContext, eval: ExprCode): Unit = {
     // TODO: support whole stage codegen too
+    //
+    // NOTE: We could use `CodeGenerator.defineIndependentFunction` here for the code path
+    // of the whole stage codegen. But, we don't do so now because the performance changes that
+    // we don't expect might occur in many queries. Therefore, we currently apply
+    // this split function to specific performance-sensitive places only,
+    // e.g., common subexpression elimination for the whole stage codegen and OR expressions.
     val splitThreshold = SQLConf.get.methodSplitThreshold
     if (eval.code.length > splitThreshold && ctx.INPUT_ROW != null && ctx.currentVars == null) {
       val setIsNull = if (!eval.isNull.isInstanceOf[LiteralValue]) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -157,7 +157,7 @@ abstract class Expression extends TreeNode[Expression] {
   private def reduceCodeSize(ctx: CodegenContext, eval: ExprCode): Unit = {
     // TODO: support whole stage codegen too
     //
-    // NOTE: We could use `CodeGenerator.defineIndependentFunction` here for the code path
+    // NOTE: We could use `CodeGenerator.defineSingleSplitFunction` here for the code path
     // of the whole stage codegen. But, we don't do so now because the performance changes that
     // we don't expect might occur in many queries. Therefore, we currently apply
     // this split function to specific performance-sensitive places only,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1023,7 +1023,7 @@ class CodegenContext extends Logging {
   }
 
   /**
-   * Defines an independent function for a given expression and returns a caller-side code
+   * Defines an individual function for a given expression and returns a caller-side code
    * for the function as `ExprCode`.
    */
   def defineSingleSplitFunction(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1026,7 +1026,7 @@ class CodegenContext extends Logging {
    * Defines an independent function for a given expression and returns a caller-side code
    * for the function as `ExprCode`.
    */
-  def defineIndependentFunction(
+  def defineSingleSplitFunction(
       expr: Expression,
       ev: ExprCode,
       funcNameOption: Option[String] = None,
@@ -1096,7 +1096,7 @@ class CodegenContext extends Logging {
       }
       if (inputVarsForAllFuncs.map(calculateParamLengthFromExprValues).forall(isValidParamLength)) {
         commonExprs.zipWithIndex.map { case (exprs, i) =>
-          val funcEval = defineIndependentFunction(
+          val funcEval = defineSingleSplitFunction(
             expr = exprs.head,
             ev = commonExprVals(i),
             funcNameOption = Some("subExprValue"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -633,7 +633,7 @@ case class Or(left: Expression, right: Expression) extends BinaryOperator with P
   private def genSplitCode(ctx: CodegenContext, expr: Expression): ExprCode = {
     val eval = expr.genCode(ctx)
     if (eval.code.length > SQLConf.get.methodSplitThreshold) {
-      ctx.defineIndependentFunction(this, eval)
+      ctx.defineSingleSplitFunction(this, eval)
     } else {
       eval
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQuerySuite.scala
@@ -82,11 +82,6 @@ class TPCDSQuerySuite extends BenchmarkQueryTest with TPCDSSchema {
     "q3", "q7", "q10", "q19", "q27", "q34", "q42", "q43", "q46", "q52", "q53", "q55", "q59",
     "q63", "q65", "q68", "q73", "q79", "q89", "q98", "ss_max")
 
-  // List up the known queries having too large code in a generated function.
-  // A JIRA file for `modified-q3` is as follows;
-  // [SPARK-29128] Split predicate code in OR expressions
-  val blackListForMethodCodeSizeCheck = Set("modified-q3")
-
   modifiedTPCDSQueries.foreach { name =>
     val queryString = resourceToString(s"tpcds-modifiedQueries/$name.sql",
       classLoader = Thread.currentThread().getContextClassLoader)
@@ -94,7 +89,7 @@ class TPCDSQuerySuite extends BenchmarkQueryTest with TPCDSSchema {
     test(testName) {
       // check the plans can be properly generated
       val plan = sql(queryString).queryExecution.executedPlan
-      checkGeneratedCode(plan, !blackListForMethodCodeSizeCheck.contains(testName))
+      checkGeneratedCode(plan)
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This pr is to split predicate code in OR expressions. When I checked if method bytecode size in `BenchmarkQueryTest` went over the OpenJDK default limit (8000) or not in #25788, I found [TPCDSQuerySuite.modified-q3](https://github.com/apache/spark/blob/master/sql/core/src/test/resources/tpcds-modifiedQueries/q3.sql) had too big functions. That's because too long OR chains in the query generate too long code in a single function;

`modified-q3` generates [the code](https://gist.github.com/maropu/9bfdcf9f8b694ad68ad6b3dc67fddb7c#file-non-split-case-in-spark-xxxxx-tpcdsquerysuite-modified-q3) below in the master 
```
== Subtree 2 / 4 (maxMethodCodeSize:12497; maxConstantPoolSize:732(1.12% used); numInnerClasses:1) ==
                                    ^^^^^^
*(3) HashAggregate(keys=[d_year#9, i_brand#62, i_brand_id#61], functions=[partial_sum(UnscaledValue(ss_net_profit#53))], output=[d_year#9, i_brand#62, i_brand_id#61, sum#85L])
+- *(3) Project [d_year#9, ss_net_profit#53, i_brand_id#61, i_brand#62]
....
/* 365 */   private void agg_doAggregateWithKeys_0() throws java.io.IOException {
/* 366 */     if (columnartorow_mutableStateArray_1[0] == null) {
/* 367 */       columnartorow_nextBatch_0();
/* 368 */     }
/* 369 */     while ( columnartorow_mutableStateArray_1[0] != null) {
/* 370 */       int columnartorow_numRows_0 = columnartorow_mutableStateArray_1[0].numRows();
/* 371 */       int columnartorow_localEnd_0 = columnartorow_numRows_0 - columnartorow_batchIdx_0;
/* 372 */       for (int columnartorow_localIdx_0 = 0; columnartorow_localIdx_0 < columnartorow_localEnd_0; columnartorow_localIdx_0++) {
/* 373 */         int columnartorow_rowIdx_0 = columnartorow_batchIdx_0 + columnartorow_localIdx_0;
/* 374 */         do {
/* 375 */           boolean columnartorow_isNull_0 = columnartorow_mutableStateArray_2[0].isNullAt(columnartorow_rowIdx_0);
/* 376 */           int columnartorow_value_0 = columnartorow_isNull_0 ? -1 : (columnartorow_mutableStateArray_2[0].getInt(columnartorow_rowIdx_0));
/* 377 */
/* 378 */           boolean filter_value_2 = !columnartorow_isNull_0;
/* 379 */           if (!filter_value_2) continue;
/* 380 */
/* 381 */           boolean filter_value_12 = false;
/* 382 */           filter_value_12 = columnartorow_value_0 >= 2415355;
/* 383 */           boolean filter_value_11 = false;
/* 384 */
.....
too long code
```

This pr split the predicate code into [small functions](https://gist.github.com/maropu/f2f8dba8fe74b50fc0b8ba73ecfbb5d2) below;
```
== Subtree 2 / 4 (maxMethodCodeSize:688; maxConstantPoolSize:949(1.45% used); numInnerClasses:1) ==
                                    ^^^^
*(3) HashAggregate(keys=[d_year#9, i_brand#62, i_brand_id#61], functions=[partial_sum(UnscaledValue(ss_net_profit#53))], output=[d_year#9, i_brand#62, i_brand_id#61, sum#85L])
+- *(3) Project [d_year#9, ss_net_profit#53, i_brand_id#61, i_brand#62]
...
/* 3285 */   private void agg_doAggregateWithKeys_0() throws java.io.IOException {
/* 3286 */     if (columnartorow_mutableStateArray_1[0] == null) {
/* 3287 */       columnartorow_nextBatch_0();
/* 3288 */     }
/* 3289 */     while ( columnartorow_mutableStateArray_1[0] != null) {
/* 3290 */       int columnartorow_numRows_0 = columnartorow_mutableStateArray_1[0].numRows();
/* 3291 */       int columnartorow_localEnd_0 = columnartorow_numRows_0 - columnartorow_batchIdx_0;
/* 3292 */       for (int columnartorow_localIdx_0 = 0; columnartorow_localIdx_0 < columnartorow_localEnd_0; columnartorow_localIdx_0++) {
/* 3293 */         int columnartorow_rowIdx_0 = columnartorow_batchIdx_0 + columnartorow_localIdx_0;
/* 3294 */         do {
/* 3295 */           boolean columnartorow_isNull_0 = columnartorow_mutableStateArray_2[0].isNullAt(columnartorow_rowIdx_0);
/* 3296 */           int columnartorow_value_0 = columnartorow_isNull_0 ? -1 : (columnartorow_mutableStateArray_2[0].getInt(columnartorow_rowIdx_0));
/* 3297 */
/* 3298 */           boolean filter_value_2 = !columnartorow_isNull_0;
/* 3299 */           if (!filter_value_2) continue;
/* 3300 */
/* 3301 */           boolean filter_value_213 = filter_or_8(columnartorow_value_0, columnartorow_isNull_0);
/* 3302 */           boolean filter_value_5 = true;
/* 3303 */
/* 3304 */           if (!filter_value_213) {
/* 3305 */             boolean filter_value_421 = filter_or_17(columnartorow_value_0, columnartorow_isNull_0);
/* 3306 */             filter_value_5 = filter_value_421;
/* 3307 */           }
/* 3308 */           boolean filter_value_4 = true;
/* 3309 */
/* 3310 */           if (!filter_value_5) {
/* 3311 */             boolean filter_value_630 = filter_or_26(columnartorow_value_0, columnartorow_isNull_0);
/* 3312 */             boolean filter_value_422 = true;
/* 3313 */
/* 3314 */             if (!filter_value_630) {
/* 3315 */               boolean filter_value_838 = filter_or_35(columnartorow_value_0, columnartorow_isNull_0);
/* 3316 */               filter_value_422 = filter_value_838;
/* 3317 */             }
/* 3318 */             filter_value_4 = filter_value_422;
/* 3319 */           }
/* 3320 */           boolean filter_value_3 = true;
/* 3321 */
/* 3322 */           if (!filter_value_4) {
/* 3323 */             boolean filter_value_1048 = filter_or_44(columnartorow_value_0, columnartorow_isNull_0);
/* 3324 */             boolean filter_value_840 = true;
/* 3325 */
/* 3326 */             if (!filter_value_1048) {
/* 3327 */               boolean filter_value_1256 = filter_or_53(columnartorow_value_0, columnartorow_isNull_0);
/* 3328 */               filter_value_840 = filter_value_1256;
/* 3329 */             }
/* 3330 */             boolean filter_value_839 = true;
/* 3331 */
/* 3332 */             if (!filter_value_840) {
/* 3333 */               boolean filter_value_1465 = filter_or_62(columnartorow_value_0, columnartorow_isNull_0);
/* 3334 */               boolean filter_value_1257 = true;
/* 3335 */
/* 3336 */               if (!filter_value_1465) {
/* 3337 */                 boolean filter_value_1673 = filter_or_71(columnartorow_value_0, columnartorow_isNull_0);
/* 3338 */                 filter_value_1257 = filter_value_1673;
/* 3339 */               }
/* 3340 */               filter_value_839 = filter_value_1257;
/* 3341 */             }
/* 3342 */             filter_value_3 = filter_value_839;
/* 3343 */           }
/* 3344 */           if (!filter_value_3) continue;
/* 3345 */
/* 3346 */           boolean columnartorow_isNull_1 = columnartorow_mutableStateArray_2[1].isNullAt(columnartorow_rowIdx_0);
/* 3347 */           int columnartorow_value_1 = columnartorow_isNull_1 ? -1 : (columnartorow_mutableStateArray_2[1].getInt(columnartorow_rowIdx_0));
/* 3348 */
/* 3349 */           boolean filter_value_1676 = !columnartorow_isNull_1;
/* 3350 */           if (!filter_value_1676) continue;
/* 3351 */
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
For better generated code.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing unit tests.