### PR TITLE
[SPARK-29144][ML] Binarizer handle sparse vectors incorrectly with negative threshold

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/feature/BinarizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/BinarizerSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.ml.feature
 
+import org.apache.spark.SparkException
 import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.ml.param.ParamsSuite
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest}
@@ -101,6 +102,19 @@ class BinarizerSuite extends MLTest with DefaultReadWriteTest {
     }
   }
 
+  test("Binarizer should not support sparse vector with negative threshold") {
+    val threshold = -0.5
+    val data = Seq((0, Vectors.sparse(3, Array(1), Array(0.5))),
+      (1, Vectors.dense(Array(0.0, 0.5, 0.0))))
+    val df = data.toDF("id", "feature")
+    val binarizer = new Binarizer()
+      .setInputCol("feature")
+      .setOutputCol("binarized_feature")
+      .setThreshold(-0.5)
+    intercept[SparkException] {
+      binarizer.transform(df).count()
+    }
+  }
 
   test("read/write") {
     val t = new Binarizer()

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/BinarizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/BinarizerSuite.scala
@@ -103,7 +103,6 @@ class BinarizerSuite extends MLTest with DefaultReadWriteTest {
   }
 
   test("Binarizer should not support sparse vector with negative threshold") {
-    val threshold = -0.5
     val data = Seq((0, Vectors.sparse(3, Array(1), Array(0.5))),
       (1, Vectors.dense(Array(0.0, 0.5, 0.0))))
     val df = data.toDF("id", "feature")


### PR DESCRIPTION
### What changes were proposed in this pull request?
if threshold<0, convert implict 0 to 1, althought this will break sparsity

### Why are the changes needed?
if `threshold<0`, current impl deal with sparse vector incorrectly.
See JIRA [SPARK-29144](https://issues.apache.org/jira/browse/SPARK-29144) and [Scikit-Learn's Binarizer](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.Binarizer.html) ('Threshold may not be less than 0 for operations on sparse matrices.') for details.


### Does this PR introduce any user-facing change?
no


### How was this patch tested?
added testsuite