### PR TITLE
[SPARK-29158][SQL] Expose SerializableConfiguration for DataSource V2 developers

### DIFF
--- a/core/src/main/java/org/apache/spark/util/SerializableConfigurationSuite.java
+++ b/core/src/main/java/org/apache/spark/util/SerializableConfigurationSuite.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.util;
+
+/**
+ * This test ensures that the API we've exposed for SerializableConfiguration is usable
+ * from Java. It does not test any of the serialization it's self.
+ */
+class SerializableConfigurationSuite {
+  public SerializableConfiguration compileTest() {
+    SerializableConfiguration scs = new SerializableConfiguration(null);
+    return scs;
+  }
+}

--- a/core/src/main/scala/org/apache/spark/util/SerializableConfiguration.scala
+++ b/core/src/main/scala/org/apache/spark/util/SerializableConfiguration.scala
@@ -23,8 +23,8 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.spark.annotation.DeveloperApi
 
 /**
- * Helper wrapper to serialize a Hadoop configuration. Intended for use when implementing DataSourceV2
- * readers & writers which depend on the Hadoop configuration from the driver node.
+ * Helper wrapper to serialize a Hadoop configuration. Intended for use when implementing
+ * DataSourceV2 readers & writers which depend on the Hadoop configuration from the driver node.
  */
 @DeveloperApi
 class SerializableConfiguration(@transient var value: Configuration) extends Serializable {

--- a/core/src/main/scala/org/apache/spark/util/SerializableConfiguration.scala
+++ b/core/src/main/scala/org/apache/spark/util/SerializableConfiguration.scala
@@ -20,13 +20,13 @@ import java.io.{ObjectInputStream, ObjectOutputStream}
 
 import org.apache.hadoop.conf.Configuration
 
-import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.annotation.{DeveloperApi, Unstable}
 
 /**
  * Helper wrapper to serialize a Hadoop configuration. Intended for use when implementing
  * DataSourceV2 readers & writers which depend on the Hadoop configuration from the driver node.
  */
-@DeveloperApi
+@DeveloperApi @Unstable
 class SerializableConfiguration(@transient var value: Configuration) extends Serializable {
   private def writeObject(out: ObjectOutputStream): Unit = Utils.tryOrIOException {
     out.defaultWriteObject()

--- a/core/src/main/scala/org/apache/spark/util/SerializableConfiguration.scala
+++ b/core/src/main/scala/org/apache/spark/util/SerializableConfiguration.scala
@@ -20,7 +20,13 @@ import java.io.{ObjectInputStream, ObjectOutputStream}
 
 import org.apache.hadoop.conf.Configuration
 
-private[spark]
+import org.apache.spark.annotation.DeveloperApi
+
+/**
+ * Helper wrapper to serialize a Hadoop configuration. Intended for use when implementing DataSourceV2
+ * readers & writers which depend on the Hadoop configuration from the driver node.
+ */
+@DeveloperApi
 class SerializableConfiguration(@transient var value: Configuration) extends Serializable {
   private def writeObject(out: ObjectOutputStream): Unit = Utils.tryOrIOException {
     out.defaultWriteObject()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently the SerializableConfiguration, which makes the Hadoop configuration serializable is private. This makes it public, with a developer annotation.

### Why are the changes needed?

Many data source depend on the Hadoop configuration which may have specific components on the driver. Inside of Spark's own DataSourceV2 implementations this is frequently used (Parquet, Json, Orc, etc.)

### Does this PR introduce any user-facing change?

This provides a new developer API.

### How was this patch tested?

No new tests are added as this only exposes a previously developed & thoroughly used + tested component.