### PR TITLE
[SPARK-29168][WebUI] Use a unique color on selected item on timeline view

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/timeline-view.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/timeline-view.css
@@ -223,8 +223,8 @@ rect.getting-result-time-proportion {
 }
 
 .vis-timeline .vis-item.executor.vis-selected {
-  background-color: #A2FCC0;
-  border-color: #36F572;
+  background-color: #A0DFFF;
+  border-color: #3EC0FF;
   z-index: 2;
 }
 

--- a/core/src/main/resources/org/apache/spark/ui/static/timeline-view.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/timeline-view.css
@@ -222,12 +222,6 @@ rect.getting-result-time-proportion {
   stroke: #FF4D6D;
 }
 
-.vis-timeline .vis-item.executor.vis-selected {
-  background-color: #A0DFFF;
-  border-color: #3EC0FF;
-  z-index: 2;
-}
-
 tr.corresponding-item-hover > td, tr.corresponding-item-hover > th {
   background-color: #D6FFE4 !important;
 }

--- a/core/src/main/resources/org/apache/spark/ui/static/timeline-view.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/timeline-view.css
@@ -223,10 +223,11 @@ rect.getting-result-time-proportion {
 }
 
 .vis-timeline .vis-item.executor.vis-selected {
-    background-color: #00aaff;
-    border-color: #184c66;
-    z-index: 2;
+  background-color: #00AAFF;
+  border-color: #184C66;
+  z-index: 2;
 }
+
 tr.corresponding-item-hover > td, tr.corresponding-item-hover > th {
   background-color: #D6FFE4 !important;
 }

--- a/core/src/main/resources/org/apache/spark/ui/static/timeline-view.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/timeline-view.css
@@ -222,6 +222,11 @@ rect.getting-result-time-proportion {
   stroke: #FF4D6D;
 }
 
+.vis-timeline .vis-item.executor.vis-selected {
+    background-color: #00aaff;
+    border-color: #184c66;
+    z-index: 2;
+}
 tr.corresponding-item-hover > td, tr.corresponding-item-hover > th {
   background-color: #D6FFE4 !important;
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Changed color settings in .vis-timeline .vis-item.executor.vis-selected (timeline-view.css)

### Why are the changes needed?

In WebUI, executor bar's color changes blue to green when you click it. It might be confused user because of the color. 

[ Before ]
![before](https://user-images.githubusercontent.com/55128575/65487629-40a45f00-dee2-11e9-8974-dc7027824b52.png)

[ After ]
![after](https://user-images.githubusercontent.com/55128575/65487674-5580f280-dee2-11e9-8e70-28f4ddcf56c3.png)

### Does this PR introduce any user-facing change?

Yes.

### How was this patch tested?

Manually test.
