### PR TITLE
[SPARK-21045][PYTHON] Allow non-ascii string as an exception message from python execution in Python 2

### DIFF
--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -18,6 +18,9 @@
 import py4j
 import sys
 
+if sys.version_info.major >= 3:
+    unicode = str
+
 
 class CapturedException(Exception):
     def __init__(self, desc, stackTrace, cause=None):

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -18,6 +18,7 @@ import glob
 import os
 import struct
 import sys
+import threading
 import unittest
 
 from pyspark import SparkContext, SparkConf
@@ -127,3 +128,18 @@ def search_jar(project_relative_path, sbt_jar_name_prefix, mvn_jar_name_prefix):
         raise Exception("Found multiple JARs: %s; please remove all but one" % (", ".join(jars)))
     else:
         return jars[0]
+
+
+class ExecThread(threading.Thread):
+    """ A wrapper thread which stores exception info if any occurred.
+    """
+    def __init__(self, target):
+        self.target = target
+        self.exception = None
+        threading.Thread.__init__(self)
+
+    def run(self):
+        try:
+            self.target()
+        except Exception as e:  # captures any exceptions
+            self.exception = e

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -128,18 +128,3 @@ def search_jar(project_relative_path, sbt_jar_name_prefix, mvn_jar_name_prefix):
         raise Exception("Found multiple JARs: %s; please remove all but one" % (", ".join(jars)))
     else:
         return jars[0]
-
-
-class ExecThread(threading.Thread):
-    """ A wrapper thread which stores exception info if any occurred.
-    """
-    def __init__(self, target):
-        self.target = target
-        self.exception = None
-        threading.Thread.__init__(self)
-
-    def run(self):
-        try:
-            self.target()
-        except Exception as e:  # captures any exceptions
-            self.exception = e

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -18,7 +18,6 @@ import glob
 import os
 import struct
 import sys
-import threading
 import unittest
 
 from pyspark import SparkContext, SparkConf

--- a/python/pyspark/tests/test_worker.py
+++ b/python/pyspark/tests/test_worker.py
@@ -29,7 +29,7 @@ except ImportError:
 
 from py4j.protocol import Py4JJavaError
 
-from pyspark.testing.utils import ExecThread, ReusedPySparkTestCase, PySparkTestCase, QuietTest
+from pyspark.testing.utils import ReusedPySparkTestCase, PySparkTestCase, QuietTest
 
 if sys.version_info[0] >= 3:
     xrange = range
@@ -152,26 +152,18 @@ class WorkerTests(ReusedPySparkTestCase):
             self.sc.pythonVer = version
 
     def test_python_exception_non_hanging(self):
-        """
-        SPARK-21045: exceptions with no ascii encoding shall not hanging PySpark.
-        """
-        def f():
-            raise Exception("exception with 中 and \xd6\xd0")
+        # SPARK-21045: exceptions with no ascii encoding shall not hanging PySpark.
+        try:
+            def f():
+                raise Exception("exception with 中 and \xd6\xd0")
 
-        def run():
             self.sc.parallelize([1]).map(lambda x: f()).count()
-
-        t = ExecThread(target=run)
-        t.daemon = True
-        t.start()
-        t.join(10)
-        self.assertFalse(t.isAlive(), "Spark should not be blocked")
-        self.assertIsInstance(t.exception, Py4JJavaError)
-        if sys.version_info.major < 3:
-            # we have to use unicode here to avoid UnicodeDecodeError
-            self.assertRegexpMatches(unicode(t.exception).encode("utf-8"), "exception with 中")
-        else:
-            self.assertRegexpMatches(str(t.exception), "exception with 中")
+        except Py4JJavaError as e:
+            if sys.version_info.major < 3:
+                # we have to use unicode here to avoid UnicodeDecodeError
+                self.assertRegexpMatches(unicode(e).encode("utf-8"), "exception with 中")
+            else:
+                self.assertRegexpMatches(str(e), "exception with 中")
 
 
 class WorkerReuseTest(PySparkTestCase):

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -46,7 +46,6 @@ from pyspark import shuffle
 
 if sys.version >= '3':
     basestring = str
-    unicode = str
 else:
     from itertools import imap as map  # use iterator map by default
 
@@ -600,13 +599,10 @@ def main(infile, outfile):
     except Exception:
         try:
             exc_info = traceback.format_exc()
-            if sys.version_info.major < 3:
-                if isinstance(exc_info, unicode):
-                    exc_info = exc_info.encode("utf-8")
-                else:
-                    # exc_info may contains other encoding bytes, replace the invalid byte and
-                    # convert it back to utf-8 again
-                    exc_info = exc_info.decode("utf-8", "replace").encode("utf-8")
+            if isinstance(exc_info, bytes):
+                # exc_info may contains other encoding bytes, replace the invalid bytes and convert
+                # it back to utf-8 again
+                exc_info = exc_info.decode("utf-8", "replace").encode("utf-8")
             else:
                 exc_info = exc_info.encode("utf-8")
             write_int(SpecialLengths.PYTHON_EXCEPTION_THROWN, outfile)

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -44,7 +44,7 @@ from pyspark.sql.types import to_arrow_type, StructType
 from pyspark.util import _get_argspec, fail_on_stopiteration
 from pyspark import shuffle
 
-if sys.version >= '3':
+if sys.version_info.major >= 3:
     basestring = str
 else:
     from itertools import imap as map  # use iterator map by default
@@ -598,8 +598,18 @@ def main(infile, outfile):
             process()
     except Exception:
         try:
+            exc_info = traceback.format_exc()
+            if sys.version_info.major < 3:
+                if isinstance(exc_info, unicode):
+                    exc_info = exc_info.encode("utf-8")
+                else:
+                    # exc_info may contains other encoding bytes, replace the invalid byte and
+                    # convert it back to utf-8 again
+                    exc_info = exc_info.decode("utf-8", "replace").encode("utf-8")
+            else:
+                exc_info = exc_info.encode("utf-8")
             write_int(SpecialLengths.PYTHON_EXCEPTION_THROWN, outfile)
-            write_with_length(traceback.format_exc().encode("utf-8"), outfile)
+            write_with_length(exc_info, outfile)
         except IOError:
             # JVM close the socket
             pass

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -46,6 +46,7 @@ from pyspark import shuffle
 
 if sys.version >= '3':
     basestring = str
+    unicode = str
 else:
     from itertools import imap as map  # use iterator map by default
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -44,7 +44,7 @@ from pyspark.sql.types import to_arrow_type, StructType
 from pyspark.util import _get_argspec, fail_on_stopiteration
 from pyspark import shuffle
 
-if sys.version_info.major >= 3:
+if sys.version >= '3':
     basestring = str
 else:
     from itertools import imap as map  # use iterator map by default


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR allows non-ascii string as an exception message in Python 2 by explicitly en/decoding in case of `str` in Python 2.

### Why are the changes needed?

Previously PySpark will hang when the `UnicodeDecodeError` occurs and the real exception cannot be passed to the JVM side.

See the reproducer as below:

```python
def f():
    raise Exception("中")
spark = SparkSession.builder.master('local').getOrCreate()
spark.sparkContext.parallelize([1]).map(lambda x: f()).count()
```

### Does this PR introduce any user-facing change?

User may not observe hanging for the similar cases.

### How was this patch tested?

Added a new test and manually checking.

This pr is based on #18324, credits should also go to @dataknocker. 
To make lint-python happy for python3, it also includes a followup fix for #25814