### PR TITLE
[MINOR][INFRA] Use java-version instead of version for GitHub Action

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v1
       with:
-        version: ${{ matrix.java }}
+        java-version: ${{ matrix.java }}
     - name: Build with Maven
       run: |
         export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=1g -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR use `java-version` instead of `version` for GitHub Action. More details:
https://github.com/actions/setup-java/commit/204b974cf476e9709b6fab0c59007578676321c5
https://github.com/actions/setup-java/commit/ac25aeee3a8ad80e5e24d12610e451338577534f


### Why are the changes needed?

The `version` property will not be supported after October 1, 2019.

### Does this PR introduce any user-facing change?
No


### How was this patch tested?
N/A
