### PR TITLE
[SPARK-29189][SQL] Add an option to ignore block locations when listing file

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -834,9 +834,11 @@ object SQLConf {
 
   val IGNORE_DATA_LOCALITY =
     buildConf("spark.sql.sources.ignore.datalocality")
-      .doc("If it is set to true, Spark will not fetch the block locations for each file on " +
-        "listing files, which will boost listing file operation, at the cost of loss of " +
-        "data locality.")
+      .doc("If true, Spark will not fetch the block locations for each file on " +
+        "listing files. This speeds up file listing, but the scheduler cannot " +
+        "schedule tasks to take advantage of data locality. It can be particularly " +
+        "useful if data is read from a remote cluster so the scheduler could never " +
+        "take advantage of locality anyway.")
       .internal()
       .booleanConf
       .createWithDefault(false)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -832,6 +832,14 @@ object SQLConf {
       .intConf
       .createWithDefault(10000)
 
+  val IGNORE_DATA_LOCALITY =
+    buildConf("spark.sql.sources.ignore.datalocality")
+      .doc("If it is set to true, Spark will not fetch the block locations for each file on " +
+        "listing files, which will greatly accelerate the list file operation, while loss " +
+        "data locality.")
+      .booleanConf
+      .createWithDefault(false)
+
   // Whether to automatically resolve ambiguity in join conditions for self-joins.
   // See SPARK-6231.
   val DATAFRAME_SELF_JOIN_AUTO_RESOLVE_AMBIGUITY =
@@ -1979,14 +1987,6 @@ object SQLConf {
       .doc("When true, the ArrayExists will follow the three-valued boolean logic.")
       .booleanConf
       .createWithDefault(true)
-
-  val IGNORE_DATA_LOCALITY =
-    buildConf("spark.sql.ignore.datalocality")
-      .doc("If it is set to true, Spark won't fetch the block locations for each file on " +
-        "listing files, which will greatly accelerate the list file operation, while loss " +
-        "data locality.")
-      .booleanConf
-      .createWithDefault(false)
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1979,6 +1979,14 @@ object SQLConf {
       .doc("When true, the ArrayExists will follow the three-valued boolean logic.")
       .booleanConf
       .createWithDefault(true)
+
+  val IGNORE_DATA_LOCALITY =
+    buildConf("spark.sql.ignore.datalocality")
+      .doc("If it is set to true, Spark won't fetch the block locations for each file on " +
+        "listing files, which will greatly accelerate the list file operation, while loss " +
+        "data locality.")
+      .booleanConf
+      .createWithDefault(false)
 }
 
 /**
@@ -2474,6 +2482,8 @@ class SQLConf extends Serializable with Logging {
   def castDatetimeToString: Boolean = getConf(SQLConf.LEGACY_CAST_DATETIME_TO_STRING)
 
   def defaultV2Catalog: Option[String] = getConf(DEFAULT_V2_CATALOG)
+
+  def ignoreDataLocality: Boolean = getConf(SQLConf.IGNORE_DATA_LOCALITY)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -835,8 +835,9 @@ object SQLConf {
   val IGNORE_DATA_LOCALITY =
     buildConf("spark.sql.sources.ignore.datalocality")
       .doc("If it is set to true, Spark will not fetch the block locations for each file on " +
-        "listing files, which will greatly accelerate the list file operation, while loss " +
+        "listing files, which will boost listing file operation, at the cost of loss of " +
         "data locality.")
+      .internal()
       .booleanConf
       .createWithDefault(false)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -31,6 +31,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.metrics.source.HiveCatalogMetrics
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.streaming.FileStreamSink
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
@@ -290,7 +291,7 @@ object InMemoryFileIndex extends Logging {
       isRootPath: Boolean): Seq[FileStatus] = {
     logTrace(s"Listing $path")
     val fs = path.getFileSystem(hadoopConf)
-    val ignoreLocality = sessionOpt.map(_.sqlContext.conf.ignoreDataLocality).getOrElse(false)
+    val ignoreLocality = hadoopConf.getBoolean(SQLConf.IGNORE_DATA_LOCALITY.key, false)
 
     // Note that statuses only include FileStatus for the files and dirs directly under path,
     // and does not include anything else recursively.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -31,7 +31,6 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.metrics.source.HiveCatalogMetrics
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.streaming.FileStreamSink
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -172,6 +172,7 @@ object InMemoryFileIndex extends Logging {
       areRootPaths: Boolean): Seq[(Path, Seq[FileStatus])] = {
 
     val ignoreMissingFiles = sparkSession.sessionState.conf.ignoreMissingFiles
+    val ignoreLocality = sparkSession.sessionState.conf.ignoreDataLocality
 
     // Short-circuits parallel listing when serial listing is likely to be faster.
     if (paths.size <= sparkSession.sessionState.conf.parallelPartitionDiscoveryThreshold) {
@@ -182,6 +183,7 @@ object InMemoryFileIndex extends Logging {
           filter,
           Some(sparkSession),
           ignoreMissingFiles = ignoreMissingFiles,
+          ignoreLocality = ignoreLocality,
           isRootPath = areRootPaths)
         (path, leafFiles)
       }
@@ -222,6 +224,7 @@ object InMemoryFileIndex extends Logging {
               filter,
               None,
               ignoreMissingFiles = ignoreMissingFiles,
+              ignoreLocality = ignoreLocality,
               isRootPath = areRootPaths)
             (path, leafFiles)
           }.iterator
@@ -288,10 +291,10 @@ object InMemoryFileIndex extends Logging {
       filter: PathFilter,
       sessionOpt: Option[SparkSession],
       ignoreMissingFiles: Boolean,
+      ignoreLocality: Boolean,
       isRootPath: Boolean): Seq[FileStatus] = {
     logTrace(s"Listing $path")
     val fs = path.getFileSystem(hadoopConf)
-    val ignoreLocality = hadoopConf.getBoolean(SQLConf.IGNORE_DATA_LOCALITY.key, false)
 
     // Note that statuses only include FileStatus for the files and dirs directly under path,
     // and does not include anything else recursively.
@@ -355,6 +358,7 @@ object InMemoryFileIndex extends Logging {
               filter,
               sessionOpt,
               ignoreMissingFiles = ignoreMissingFiles,
+              ignoreLocality = ignoreLocality,
               isRootPath = false)
           }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -433,7 +433,7 @@ class FileIndexSuite extends SharedSparkSession {
           listLeafFiles(Seq(new Path(partitionDirectory.getPath)))
 
         withSQLConf(SQLConf.IGNORE_DATA_LOCALITY.key -> "true",
-                     "fs.file.impl" -> classOf[SpecialBlockLocationFileSystem].getName) {
+           "fs.file.impl" -> classOf[SpecialBlockLocationFileSystem].getName) {
           val fileIndex = new InMemoryFileIndex(spark, Seq(path), Map.empty, None)
           val withoutBlockLocations = fileIndex.
             listLeafFiles(Seq(new Path(partitionDirectory.getPath)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -425,16 +425,13 @@ class FileIndexSuite extends SharedSparkSession {
         stringToFile(file, "text")
       }
       val path = new Path(dir.getCanonicalPath)
-
+      val fileIndex = new InMemoryFileIndex(spark, Seq(path), Map.empty, None)
       withSQLConf(SQLConf.IGNORE_DATA_LOCALITY.key -> "false",
          "fs.file.impl" -> classOf[SpecialBlockLocationFileSystem].getName) {
-        val fileIndex = new InMemoryFileIndex(spark, Seq(path), Map.empty, None)
         val withBlockLocations = fileIndex.
           listLeafFiles(Seq(new Path(partitionDirectory.getPath)))
 
-        withSQLConf(SQLConf.IGNORE_DATA_LOCALITY.key -> "true",
-           "fs.file.impl" -> classOf[SpecialBlockLocationFileSystem].getName) {
-          val fileIndex = new InMemoryFileIndex(spark, Seq(path), Map.empty, None)
+        withSQLConf(SQLConf.IGNORE_DATA_LOCALITY.key -> "true") {
           val withoutBlockLocations = fileIndex.
             listLeafFiles(Seq(new Path(partitionDirectory.getPath)))
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -442,8 +442,8 @@ class FileIndexSuite extends SharedSparkSession {
       assert(withBlockLocations.size == withoutBlockLocations.size)
       assert(withBlockLocations.forall(b => b.isInstanceOf[LocatedFileStatus] &&
         b.asInstanceOf[LocatedFileStatus].getBlockLocations.nonEmpty))
-      assert(withBlockLocations.forall(b => b.isInstanceOf[LocatedFileStatus] &&
-        b.asInstanceOf[LocatedFileStatus].getBlockLocations.isEmpty))
+      assert(withoutBlockLocations.forall(b => b.isInstanceOf[FileStatus] &&
+        !b.isInstanceOf[LocatedFileStatus]))
       assert(withoutBlockLocations.forall(withBlockLocations.contains))
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In our PROD env, we have a pure Spark cluster, I think this is also pretty common, where computation is separated from storage layer. In such deploy mode, data locality is never reachable.
And there are some configurations in Spark scheduler to reduce waiting time for data locality(e.g. "spark.locality.wait"). While, problem is that, in listing file phase, the location informations of all the files, with all the blocks inside each file, are all fetched from the distributed file system. Actually, in a PROD environment, a table can be so huge that even fetching all these location informations need take tens of seconds.
To improve such scenario, Spark need provide an option, where data locality can be totally ignored, all we need in the listing file phase are the files locations, without any block location informations.


### Why are the changes needed?
And we made a benchmark in our PROD env, after ignore the block locations, we got a pretty huge improvement. 

Table Size | Total File Number | Total Block Number | List File Duration(With Block Location) | List File Duration(Without Block Location)
-- | -- | -- | -- | --
22.6T | 30000 | 120000 | 16.841s | 1.730s
28.8 T | 42001 | 148964 | 10.099s | 2.858s
3.4 T | 20000 | 20000 | 5.833s | 4.881s


### Does this PR introduce any user-facing change?
No.


### How was this patch tested?
Via ut.
