### PR TITLE
[NO-NOT-MERGE][test-maven] Verify timeout for maven SparkPullRequestBuilder

### DIFF
--- a/dev/run-tests-jenkins.py
+++ b/dev/run-tests-jenkins.py
@@ -196,7 +196,7 @@ def main():
     # format: http://linux.die.net/man/1/timeout
     # must be less than the timeout configured on Jenkins. Usually Jenkins's timeout is higher
     # then this. Please consult with the build manager or a committer when it should be increased.
-    tests_timeout = "400m"
+    tests_timeout = "450m"
 
     # Array to capture all test names to run on the pull request. These tests are represented
     # by their file equivalents in the dev/tests/ directory.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR verify timeout for maven SparkPullRequestBuilder:
```
Test build #111076 has finished for PR 25690 at commit 274ade7.

This patch fails from timeout after a configured wait of 400m.
This patch merges cleanly.
This patch adds no public classes.
```
