### PR TITLE
[SPARK-29201][INFRA][2.4] Add Hadoop 2.6 combination to GitHub Action

### DIFF
--- a/.github/workflows/branch-2.4.yml
+++ b/.github/workflows/branch-2.4.yml
@@ -15,7 +15,8 @@ jobs:
     strategy:
       matrix:
         scala: [ '2.11', '2.12' ]
-    name: Build Spark with Scala ${{ matrix.scala }}
+        hadoop: [ 'hadoop-2.6', 'hadoop-2.7' ]
+    name: Build Spark with Scala ${{ matrix.scala }} / Hadoop ${{ matrix.hadoop }}
 
     steps:
     - uses: actions/checkout@master
@@ -30,7 +31,7 @@ jobs:
       run: |
         export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
         export MAVEN_CLI_OPTS="--no-transfer-progress"
-        ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pmesos -Pkubernetes -Phive -Phive-thriftserver -Pscala-${{ matrix.scala }} package
+        ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pmesos -Pkubernetes -Phive -Phive-thriftserver -Pscala-${{ matrix.scala }} -P${{ matrix.hadoop }} -Phadoop-cloud package
 
 
   lint:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Hadoop 2.6` combination to `branch-2.4` GitHub Action.

### Why are the changes needed?

This will help `branch-2.4` maintenance to prevent Hadoop-2.6 related issue at PR stages.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

This PR's GitHub Action should show both Hadoop 2.6/2.7.
