### PR TITLE
[WIP][SPARK-29164][SQL] Rewrite coalesce(expression, BooleanLiteral) make it more suitable for filter pushdown

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -90,6 +90,7 @@ abstract class Optimizer(sessionCatalog: SessionCatalog)
         ConstantFolding,
         ReorderAssociativeOperator,
         LikeSimplification,
+        RewriteCoalesceWithBooleanExpr,
         BooleanSimplification,
         SimplifyConditionals,
         RemoveDispensableExpressions,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Coalesce is not eligible for DataSource / Parquet filter pushdown.
Rewrite  `coalesce(expression, BooleanLiteral) ` to  boolean make it more suitable for filter pushdown.




### Why are the changes needed?
Better for some special case when filter push down.

### Does this PR introduce any user-facing change?
no


### How was this patch tested?
ADD UT
