### PR TITLE
[SPARK-21492] [SQL] Fix memory leak issue in SMJ

### DIFF
--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillMerger.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillMerger.java
@@ -60,7 +60,7 @@ final class UnsafeSorterSpillMerger {
     }
   }
 
-  public UnsafeSorterIterator getSortedIterator() throws IOException {
+  public UnsafeSorterIterator getSortedIterator(UnsafeExternalSorter sorter) throws IOException {
     return new UnsafeSorterIterator() {
 
       private UnsafeSorterIterator spillReader;
@@ -72,7 +72,8 @@ final class UnsafeSorterSpillMerger {
 
       @Override
       public boolean hasNext() {
-        return !priorityQueue.isEmpty() || (spillReader != null && spillReader.hasNext());
+        return !sorter.isResourceCleand()
+            && (!priorityQueue.isEmpty() || (spillReader != null && spillReader.hasNext()));
       }
 
       @Override

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowIterator.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowIterator.java
@@ -27,7 +27,8 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.Platform;
 import org.apache.spark.util.collection.unsafe.sort.UnsafeSorterIterator;
 
-public abstract class UnsafeExternalRowIterator extends AbstractIterator<UnsafeRow> implements Closeable {
+public abstract class UnsafeExternalRowIterator extends AbstractIterator<UnsafeRow>
+    implements Closeable {
 
   private final UnsafeSorterIterator sortedIterator;
   private UnsafeRow row;

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowIterator.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowIterator.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import scala.collection.AbstractIterator;
+
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.Platform;
+import org.apache.spark.util.collection.unsafe.sort.UnsafeSorterIterator;
+
+public abstract class UnsafeExternalRowIterator extends AbstractIterator<UnsafeRow> implements Closeable {
+
+  private final UnsafeSorterIterator sortedIterator;
+  private UnsafeRow row;
+
+  UnsafeExternalRowIterator(StructType schema, UnsafeSorterIterator iterator) {
+    row = new UnsafeRow(schema.length());
+    sortedIterator = iterator;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return sortedIterator.hasNext();
+  }
+
+  @Override
+  public UnsafeRow next() {
+    try {
+      sortedIterator.loadNext();
+      row.pointTo(
+          sortedIterator.getBaseObject(),
+          sortedIterator.getBaseOffset(),
+          sortedIterator.getRecordLength());
+      if (!hasNext()) {
+        UnsafeRow copy = row.copy(); // so that we don't have dangling pointers to freed page
+        row = null; // so that we don't keep references to the base object
+        close();
+        return copy;
+      } else {
+        return row;
+      }
+    } catch (IOException e) {
+      close();
+      // Scala iterators don't declare any checked exceptions, so we need to use this hack
+      // to re-throw the exception:
+      Platform.throwException(e);
+    }
+    throw new RuntimeException("Exception should have been re-thrown in next()");
+  }
+
+  /**
+   * Implementation should clean up resources used by this iterator, to prevent memory leaks
+   */
+  @Override
+  public abstract void close();
+}

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/BufferedRowIterator.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/BufferedRowIterator.java
@@ -95,4 +95,10 @@ public abstract class BufferedRowIterator {
    * After it's called, if currentRow is still null, it means no more rows left.
    */
   protected abstract void processNext() throws IOException;
+
+  /**
+   * This enables the generate class to implement a method in order to properly release the resources
+   * if the iterator is not fully consumed. See SPARK-21492 for more details.
+   */
+  public void close() {}
 }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/BufferedRowIterator.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/BufferedRowIterator.java
@@ -97,8 +97,8 @@ public abstract class BufferedRowIterator {
   protected abstract void processNext() throws IOException;
 
   /**
-   * This enables the generate class to implement a method in order to properly release the resources
-   * if the iterator is not fully consumed. See SPARK-21492 for more details.
+   * This enables the generate class to implement a method in order to properly release the
+   * resources if the iterator is not fully consumed. See SPARK-21492 for more details.
    */
   public void close() {}
 }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowSorter.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowSorter.java
@@ -31,7 +31,6 @@ import org.apache.spark.internal.config.package$;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.unsafe.Platform;
 import org.apache.spark.util.collection.unsafe.sort.PrefixComparator;
 import org.apache.spark.util.collection.unsafe.sort.RecordComparator;
 import org.apache.spark.util.collection.unsafe.sort.UnsafeExternalSorter;

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
@@ -149,6 +149,16 @@ case class SortExec(
         |   ${child.asInstanceOf[CodegenSupport].produce(ctx, this)}
         | }
       """.stripMargin.trim)
+    // Override the close method in BufferedRowIterator to release resources if the sortedIterator
+    // is not fully consumed
+    ctx.addNewFunction("close",
+      s"""
+         | public void close() {
+         |   if ($sortedIterator != null) {
+         |     ((org.apache.spark.sql.execution.UnsafeExternalRowIterator)$sortedIterator).close();
+         |   }
+         | }
+       """.stripMargin, true)
 
     val outputRow = ctx.freshName("outputRow")
     val peakMemory = metricTerm(ctx, "peakMemory")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/SMJMemoryLeakTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/SMJMemoryLeakTestSuite.scala
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.joins
+
+import org.apache.spark.sql.execution.SparkPlanTest
+import org.apache.spark.sql.functions.{col, rand}
+import org.apache.spark.sql.test.SharedSQLContext
+
+/**
+ * This test suite permutates three sample test data, different join strategies,
+ * and enable/disable spilling during UnsafeExternalSort, generates more than 400
+ * test cases, in order to discover potential memory leaks, that could happen in a corner
+ * combination of possibilities.
+ */
+
+class SMJMemoryLeakTestSuite extends SparkPlanTest with SharedSQLContext {
+
+  /**
+   * Calculates all permutations taking n elements of the input List,
+   * with repetitions.
+   * Precondition: input.length > 0 && n > 0
+   */
+  def permutationsWithRepetitions[T](input : List[T], n : Int) : List[List[T]] = {
+    require(input.length > 0 && n > 0)
+    n match {
+      case 1 => for (el <- input) yield List(el)
+      case _ => for (el <- input; perm <- permutationsWithRepetitions(input, n - 1)) yield el :: perm
+    }
+  }
+
+  private lazy val df0 = spark.range(1, 1001).select(col("id"))
+    .withColumn("value", rand()).coalesce(1)
+
+  private lazy val df1 = spark.range(1000, 2001).select(col("id"))
+    .withColumn("value", rand()).coalesce(1)
+
+  private lazy val df2 = spark.range(1, 2001).select(col("id"))
+    .withColumn("value", rand()).coalesce(1)
+
+  private val SMJwithSortSpillingConf = Seq(
+    ("spark.sql.join.preferSortMergeJoin", "true"),
+    ("spark.sql.autoBroadcastJoinThreshold", "-1"),
+    ("spark.sql.shuffle.partitions", "200"),
+    ("spark.sql.sortMergeJoinExec.buffer.spill.threshold", "1"),
+    ("spark.sql.sortMergeJoinExec.buffer.in.memory.threshold", "0")
+  )
+
+  private val SMJwithoutSortSpillingConf = Seq(
+    ("spark.sql.join.preferSortMergeJoin", "true"),
+    ("spark.sql.autoBroadcastJoinThreshold", "-1"),
+    ("spark.sql.shuffle.partitions", "200"),
+    ("spark.sql.sortMergeJoinExec.buffer.spill.threshold", "2000"),
+    ("spark.sql.sortMergeJoinExec.buffer.in.memory.threshold", "2000")
+  )
+
+  {
+    val list = List(0, 1, 2)
+    val joinTypes = List("inner", "leftsemi")
+
+    // Permutate data with duplicates and job strategies
+    for (dataPerm <- permutationsWithRepetitions(list, 3);
+         joinPerm <- permutationsWithRepetitions(joinTypes, 2)) {
+
+      val leftIndex = dataPerm(0)
+      val midIndex = dataPerm(1)
+      val rightIndex = dataPerm(2)
+
+      // Enable spilling during SMJ
+      val testNameEnableSpilling = s"df$leftIndex, df$midIndex, and df$rightIndex. " +
+        s"jointype1: ${joinPerm(0)} and jointype2: ${joinPerm(1)} " +
+        s"spilling enabled "
+      joinUtility(testNameEnableSpilling, leftIndex, midIndex, rightIndex,
+        joinPerm(0), joinPerm(1), SMJwithSortSpillingConf: _*)
+
+      // Disable spilling during SMJ
+      val testNameDisableSpilling = s"df$leftIndex, df$midIndex, and df$rightIndex. " +
+        s"jointype1: ${joinPerm(0)} and jointype2: ${joinPerm(1)} " +
+        s"spilling disabled "
+      joinUtility(testNameDisableSpilling, leftIndex, midIndex, rightIndex,
+        joinPerm(0), joinPerm(1), SMJwithoutSortSpillingConf: _*)
+    }
+  }
+
+  private def joinUtility( testName: String,
+                           leftIndex : Int,
+                           midIndex : Int,
+                           rightIndex: Int,
+                           joinType1: String,
+                           joinType2: String,
+                           sqlConf: (String, String)*) {
+
+    // One nested SMJ when inner SMJ occurring in the right side.
+    //        SMJ
+    //       /   \
+    //      SMJ  DF
+    //     /   \
+    //    DF   DF
+    test(testName + " left sub tree") {
+      withSQLConf(sqlConf: _*) {
+        val list = Seq(df0, df1, df2)
+        val joined = list(leftIndex).join(list(midIndex), Seq("id"), joinType1).coalesce(1)
+        val joined2 = joined.join(list(rightIndex), Seq("id"), joinType2).coalesce(1)
+
+        val cacheJoined = joined2.cache()
+        cacheJoined.explain()
+        cacheJoined.count()
+      }
+    }
+
+    // One nested SMJ when inner SMJ occurring in the left side.
+    //        SMJ
+    //       /   \
+    //      DF   SMJ
+    //          /   \
+    //         DF   DF
+    test(testName + "right sub tree") {
+      withSQLConf(sqlConf: _*) {
+        val list = Seq(df0, df1, df2)
+        val joined = list(midIndex).join(list(rightIndex), Seq("id"), joinType2).coalesce(1)
+        val joined2 = joined.join(list(leftIndex), Seq("id"), joinType1).coalesce(1)
+
+        val cacheJoined = joined2.cache()
+        cacheJoined.explain()
+        cacheJoined.count()
+      }
+    }
+  }
+
+  test("SPARK-21492 memory leak reproduction") {
+    spark.conf.set("spark.sql.join.preferSortMergeJoin", "true")
+    spark.conf.set("spark.sql.autoBroadcastJoinThreshold", -1)
+    spark.conf.set("spark.sql.shuffle.partitions", 200)
+    spark.conf.set("spark.sql.codegen.wholeStage", false)
+
+    var r1 = spark.range(1, 1001).select(col("id").alias("timestamp1"))
+    r1 = r1.withColumn("value", rand())
+    var r2 = spark.range(1000, 2001).select(col("id").alias("timestamp2"))
+    r2 = r2.withColumn("value2", rand())
+    var joined = r1.join(r2, col("timestamp1") === col("timestamp2"), "inner")
+    joined = joined.coalesce(1)
+    joined.explain()
+    joined.count()
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/SMJMemoryLeakTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/SMJMemoryLeakTestSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.joins
 
 import org.apache.spark.sql.execution.SparkPlanTest
 import org.apache.spark.sql.functions.{col, rand}
-import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.sql.test.SharedSparkSession
 
 /**
  * This test suite permutates three sample test data, different join strategies,
@@ -28,7 +28,7 @@ import org.apache.spark.sql.test.SharedSQLContext
  * combination of possibilities.
  */
 
-class SMJMemoryLeakTestSuite extends SparkPlanTest with SharedSQLContext {
+class SMJMemoryLeakTestSuite extends SparkPlanTest with SharedSparkSession {
 
   /**
    * Calculates all permutations taking n elements of the input List,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/SMJMemoryLeakTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/SMJMemoryLeakTestSuite.scala
@@ -39,7 +39,8 @@ class SMJMemoryLeakTestSuite extends SparkPlanTest with SharedSQLContext {
     require(input.length > 0 && n > 0)
     n match {
       case 1 => for (el <- input) yield List(el)
-      case _ => for (el <- input; perm <- permutationsWithRepetitions(input, n - 1)) yield el :: perm
+      case _ =>
+        for (el <- input; perm <- permutationsWithRepetitions(input, n - 1)) yield el :: perm
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch builds on top of #23762 to resolve the memory leak issue with SMJ. Specifically, when the underlying iterator from UnsafeExternalRowSorter is not fully consumed by SortMergeJoinExec, the requested memory by UnsafeExternalSorter will not be released, which leads to OOM, spill, and task failures. On top of the change introduced in #23762, this patch fixes the issue for when whole-stage codegen is enabled.

### How was this patch tested?
Manually tested against the example provided in SPARK-21492 to verify both inner join and non-inner join work when whole-stage codegen is either enabled or disabled. 