### PR TITLE
[SPARK-28599][WEBUI][2.4] Support sorting `Execution Time` and `Duration` columns for ThriftServerSessionPage

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerSessionPage.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerSessionPage.scala
@@ -100,7 +100,8 @@ private[ui] class ThriftServerSessionPage(parent: ThriftServerTab)
           <td>{info.groupId}</td>
           <td>{formatDate(info.startTimestamp)}</td>
           <td>{formatDate(info.finishTimestamp)}</td>
-          <td>{formatDurationOption(Some(info.totalTime))}</td>
+          <td sorttable_customkey={info.totalTime.toString}>
+            {formatDurationOption(Some(info.totalTime))}</td>
           <td>{info.statement}</td>
           <td>{info.state}</td>
           {errorMessageCell(detail)}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR add support for sorting `Duration` column for `ThriftServerSessionPage`.


### Why are the changes needed?
Sorting on duration columns consider time as a string after converting into readable form which is the reason for wrong sort results as mentioned in [SPARK_28599](https://issues.apache.org/jira/browse/SPARK-28599).


### Does this PR introduce any user-facing change?
No.


### How was this patch tested?
Tested manually.
Back-port of https://github.com/apache/spark/pull/25892
