### PR TITLE
[SPARK-29206][SHUFFLE] Make number of shuffle server threads a multiple of number of chunk fetch handler threads.

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -122,14 +122,18 @@ public class TransportConf {
 
   /**
    * Number of threads used in the server thread pool. Default to 0, which is 2x#cores.
-   * If spark.shuffle.server.chunkFetchHandlerThreadsRatio is configured, the actual
-   * # of server threads will round up to the nearest int that is a multiple of the
-   * configured ratio.
+   * If spark.shuffle.server.chunkFetchHandlerThreadsRatio is configured, and the Netty server
+   * is for shuffle, then the actual # of server threads will round up to the nearest int that
+   * is a multiple of the configured ratio.
    */
   public int serverThreads() {
-    int chunkFetchHandlerThreadsRatio = getChunkFetchHandlerThreadsRatio();
     int configuredServerThreads = conf.getInt(SPARK_NETWORK_IO_SERVERTHREADS_KEY, 0);
-    return (int) Math.ceil(configuredServerThreads / (chunkFetchHandlerThreadsRatio * 1.0));
+    if (this.getModuleName().equalsIgnoreCase("shuffle")) {
+      int chunkFetchHandlerThreadsRatio = getChunkFetchHandlerThreadsRatio();
+      return (int) Math.ceil(configuredServerThreads / (chunkFetchHandlerThreadsRatio * 1.0));
+    } else {
+      return configuredServerThreads;
+    }
   }
 
   /** Number of threads used in the client thread pool. Default to 0, which is 2x#cores. */


### PR DESCRIPTION
### What changes were proposed in this pull request?
We propose to change the configuration of Netty server threads and chunk fetch handler threads to make sure the former is always a multiple of the latter. This change is necessary to make sure the RPC timeout issues can be fully resolved with the dedicated chunk fetch handler EventLoopGroup. SPARK-29206 has more details on the explanations behind this change.

### How was this patch tested?
Verified that after configuring the number of threads for both thread pools appropriately, we no longer see the RPC timeout issues when shuffle service gets really busy.
A custom Spark shuffle service stress testing suite was used for this purpose.