### PR TITLE
[SPARK-29223][SQL][SS] Enable global timestamp per topic while specifying offset by timestamp in Kafka source

### DIFF
--- a/docs/structured-streaming-kafka-integration.md
+++ b/docs/structured-streaming-kafka-integration.md
@@ -365,15 +365,16 @@ The following configurations are optional:
 <tr>
   <td>startingOffsetsByTimestamp</td>
   <td>json string
-  """ {"topicA":{"0": 1000, "1": 1000}, "topicB": {"0": 2000, "1": 2000}} """
+  """ {"topicA":{"0": 1000, "1": 1000}, "topicB": {"0": 2000, "1": 2000}} """ or """ {"topicA":{"-1": 1000}, "topicB": {"-1": 2000}} """
   </td>
-  <td>none (the value of <code>startingOffsets<code/> will apply)</td>
+  <td>none (the value of <code>startingOffsets</code> will apply)</td>
   <td>streaming and batch</td>
   <td>The start point of timestamp when a query is started, a json string specifying a starting timestamp for
   each TopicPartition. The returned offset for each partition is the earliest offset whose timestamp is greater than or
   equal to the given timestamp in the corresponding partition. If the matched offset doesn't exist,
   the query will fail immediately to prevent unintended read from such partition. (This is a kind of limitation as of now, and will be addressed in near future.)<p/>
-  <p/>
+  You can specify global timestamp per topic which applies to all partitions in topic, via setting partition to "-1".
+  Note that the option is mutually exclusive, you can't specify timestamp for both global and specific partition(s).<p/>
   Spark simply passes the timestamp information to <code>KafkaConsumer.offsetsForTimes</code>, and doesn't interpret or reason about the value. <p/>
   For more details on <code>KafkaConsumer.offsetsForTimes</code>, please refer <a href="https://kafka.apache.org/21/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#offsetsForTimes-java.util.Map-">javadoc</a> for details.<p/>
   Also the meaning of <code>timestamp</code> here can be vary according to Kafka configuration (<code>log.message.timestamp.type</code>): please refer <a href="https://kafka.apache.org/documentation/">Kafka documentation</a> for further details.<p/>
@@ -401,15 +402,16 @@ The following configurations are optional:
 <tr>
   <td>endingOffsetsByTimestamp</td>
   <td>json string
-  """ {"topicA":{"0": 1000, "1": 1000}, "topicB": {"0": 2000, "1": 2000}} """
+  """ {"topicA":{"0": 1000, "1": 1000}, "topicB": {"0": 2000, "1": 2000}} """ or """ {"topicA":{"-1": 1000}, "topicB": {"-1": 2000} """
   </td>
-  <td>latest</td>
+  <td>the value of <code>endingOffsets</code> will apply</td>
   <td>batch query</td>
-  <td>The end point when a batch query is ended, a json string specifying an ending timesamp for each TopicPartition.
+  <td>The end point when a batch query is ended, a json string specifying an ending timestamp for each TopicPartition.
   The returned offset for each partition is the earliest offset whose timestamp is greater than or equal to
   the given timestamp in the corresponding partition. If the matched offset doesn't exist, the offset will
   be set to latest.<p/>
-  <p/>
+  You can specify global timestamp per topic which applies to all partitions in topic, via setting partition to "-1".
+  Note that the option is mutually exclusive, you can't specify timestamp for both global and specific partition(s).<p/>
   Spark simply passes the timestamp information to <code>KafkaConsumer.offsetsForTimes</code>, and doesn't interpret or reason about the value. <p/>
   For more details on <code>KafkaConsumer.offsetsForTimes</code>, please refer <a href="https://kafka.apache.org/21/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#offsetsForTimes-java.util.Map-">javadoc</a> for details.<p/>
   Also the meaning of <code>timestamp</code> here can be vary according to Kafka configuration (<code>log.message.timestamp.type</code>): please refer <a href="https://kafka.apache.org/documentation/">Kafka documentation</a> for further details.<p/>

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReader.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReader.scala
@@ -21,7 +21,7 @@ import java.{util => ju}
 import java.util.concurrent.Executors
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
@@ -347,7 +347,7 @@ private[kafka010] class KafkaOffsetReader(
          * latest offset (offset in `knownOffsets` is great than the one in `partitionOffsets`).
          */
         def findIncorrectOffsets(): Seq[(TopicPartition, Long, Long)] = {
-          var incorrectOffsets = mutable.ArrayBuffer[(TopicPartition, Long, Long)]()
+          var incorrectOffsets = ArrayBuffer[(TopicPartition, Long, Long)]()
           partitionOffsets.foreach { case (tp, offset) =>
             knownOffsets.foreach(_.get(tp).foreach { knownOffset =>
               if (knownOffset > offset) {

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -1288,6 +1288,16 @@ abstract class KafkaSourceSuiteBase extends KafkaSourceTest {
         "failOnDataLoss" -> failOnDataLoss.toString)
     }
 
+    test(s"assign from global timestamp per topic (failOnDataLoss: $failOnDataLoss)") {
+      val topic = newTopic()
+      testFromGlobalTimestamp(
+        topic,
+        failOnDataLoss = failOnDataLoss,
+        addPartitions = false,
+        "assign" -> assignString(topic, 0 to 4),
+        "failOnDataLoss" -> failOnDataLoss.toString)
+    }
+
     test(s"subscribing topic by name from latest offsets (failOnDataLoss: $failOnDataLoss)") {
       val topic = newTopic()
       testFromLatestOffsets(
@@ -1314,6 +1324,13 @@ abstract class KafkaSourceSuiteBase extends KafkaSourceTest {
     test(s"subscribing topic by name from specific timestamps (failOnDataLoss: $failOnDataLoss)") {
       val topic = newTopic()
       testFromSpecificTimestamps(topic, failOnDataLoss = failOnDataLoss, addPartitions = true,
+        "subscribe" -> topic)
+    }
+
+    test(s"subscribing topic by name from global timestamp per topic" +
+      s" (failOnDataLoss: $failOnDataLoss)") {
+      val topic = newTopic()
+      testFromGlobalTimestamp(topic, failOnDataLoss = failOnDataLoss, addPartitions = true,
         "subscribe" -> topic)
     }
 
@@ -1351,6 +1368,17 @@ abstract class KafkaSourceSuiteBase extends KafkaSourceTest {
       val topicPrefix = newTopic()
       val topic = topicPrefix + "-suffix"
       testFromSpecificTimestamps(
+        topic,
+        failOnDataLoss = failOnDataLoss,
+        addPartitions = true,
+        "subscribePattern" -> s"$topicPrefix-.*")
+    }
+
+    test(s"subscribing topic by pattern from global timestamp per topic " +
+      s"(failOnDataLoss: $failOnDataLoss)") {
+      val topicPrefix = newTopic()
+      val topic = topicPrefix + "-suffix"
+      testFromGlobalTimestamp(
         topic,
         failOnDataLoss = failOnDataLoss,
         addPartitions = true,
@@ -1505,28 +1533,11 @@ abstract class KafkaSourceSuiteBase extends KafkaSourceTest {
       failOnDataLoss: Boolean,
       addPartitions: Boolean,
       options: (String, String)*): Unit = {
-    def sendMessages(topic: String, msgs: Seq[String], part: Int, ts: Long): Unit = {
-      val records = msgs.map { msg =>
-        new RecordBuilder(topic, msg).partition(part).timestamp(ts).build()
-      }
-      testUtils.sendMessages(records)
-    }
-
     testUtils.createTopic(topic, partitions = 5)
 
     val firstTimestamp = System.currentTimeMillis() - 5000
-    sendMessages(topic, Array(-20).map(_.toString), 0, firstTimestamp)
-    sendMessages(topic, Array(-10).map(_.toString), 1, firstTimestamp)
-    sendMessages(topic, Array(0, 1).map(_.toString), 2, firstTimestamp)
-    sendMessages(topic, Array(10, 11).map(_.toString), 3, firstTimestamp)
-    sendMessages(topic, Array(20, 21, 22).map(_.toString), 4, firstTimestamp)
-
     val secondTimestamp = firstTimestamp + 1000
-    sendMessages(topic, Array(-21, -22).map(_.toString), 0, secondTimestamp)
-    sendMessages(topic, Array(-11, -12).map(_.toString), 1, secondTimestamp)
-    sendMessages(topic, Array(2).map(_.toString), 2, secondTimestamp)
-    sendMessages(topic, Array(12).map(_.toString), 3, secondTimestamp)
-    // no data after second timestamp for partition 4
+    setupTestMessagesForTestOnTimestampOffsets(topic, firstTimestamp, secondTimestamp)
 
     require(testUtils.getLatestOffsets(Set(topic)).size === 5)
 
@@ -1537,19 +1548,8 @@ abstract class KafkaSourceSuiteBase extends KafkaSourceTest {
     ) ++ Map(new TopicPartition(topic, 4) -> firstTimestamp)
     val startingTimestamps = JsonUtils.partitionTimestamps(startPartitionTimestamps)
 
-    val reader = spark
-      .readStream
-      .format("kafka")
-      .option("startingOffsetsByTimestamp", startingTimestamps)
-      .option("kafka.bootstrap.servers", testUtils.brokerAddress)
-      .option("kafka.metadata.max.age.ms", "1")
-      .option("failOnDataLoss", failOnDataLoss.toString)
-    options.foreach { case (k, v) => reader.option(k, v) }
-    val kafka = reader.load()
-      .selectExpr("CAST(key AS STRING)", "CAST(value AS STRING)")
-      .as[(String, String)]
-    val mapped: org.apache.spark.sql.Dataset[_] = kafka.map(kv => kv._2.toInt)
-
+    val mapped = setupDataFrameForTestOnTimestampOffsets(startingTimestamps, failOnDataLoss,
+      options: _*)
     testStream(mapped)(
       makeSureGetOffsetCalled,
       Execute { q =>
@@ -1574,6 +1574,108 @@ abstract class KafkaSourceSuiteBase extends KafkaSourceTest {
       CheckAnswer(-21, -22, -11, -12, 2, 12, 20, 21, 22, 30, 31, 32, 40, 41, 42, 43, 44),
       StopStream
     )
+  }
+
+  private def testFromGlobalTimestamp(
+      topic: String,
+      failOnDataLoss: Boolean,
+      addPartitions: Boolean,
+      options: (String, String)*): Unit = {
+    testUtils.createTopic(topic, partitions = 5)
+
+    val firstTimestamp = System.currentTimeMillis() - 5000
+    val secondTimestamp = firstTimestamp + 1000
+    setupTestMessagesForTestOnTimestampOffsets(topic, firstTimestamp, secondTimestamp)
+    // here we should add records in partition 4 which match with second timestamp
+    // as the query will break if there's no matching records
+    sendMessagesWithTimestamp(topic, Array(23, 24).map(_.toString), 4, secondTimestamp)
+
+    require(testUtils.getLatestOffsets(Set(topic)).size === 5)
+
+    // we intentionally starts from second timestamp for all partitions
+    // via setting global partition
+    val startPartitionTimestamps: Map[TopicPartition, Long] = Map(
+      new TopicPartition(topic, KafkaOffsetReader.GLOBAL_PARTITION_NUM) -> secondTimestamp)
+    val startingTimestamps = JsonUtils.partitionTimestamps(startPartitionTimestamps)
+
+    val mapped = setupDataFrameForTestOnTimestampOffsets(startingTimestamps, failOnDataLoss,
+      options: _*)
+    testStream(mapped)(
+      makeSureGetOffsetCalled,
+      Execute { q =>
+        // wait to reach the last offset in every partition
+        val partAndOffsets = (0 to 4).map(new TopicPartition(topic, _)).map { tp =>
+          if (tp.partition() < 4) {
+            tp -> 3L
+          } else {
+            tp -> 5L // we added 2 more records to partition 4
+          }
+        }.toMap
+        q.awaitOffset(0, KafkaSourceOffset(partAndOffsets), streamingTimeout.toMillis)
+      },
+      CheckAnswer(-21, -22, -11, -12, 2, 12, 23, 24),
+      StopStream,
+      StartStream(),
+      CheckAnswer(-21, -22, -11, -12, 2, 12, 23, 24), // Should get the data back on recovery
+      StopStream,
+      AddKafkaData(Set(topic), 30, 31, 32), // Add data when stream is stopped
+      StartStream(),
+      CheckAnswer(-21, -22, -11, -12, 2, 12, 23, 24, 30, 31, 32), // Should get the added data
+      AssertOnQuery("Add partitions") { query: StreamExecution =>
+        if (addPartitions) setTopicPartitions(topic, 10, query)
+        true
+      },
+      AddKafkaData(Set(topic), 40, 41, 42, 43, 44)(ensureDataInMultiplePartition = true),
+      CheckAnswer(-21, -22, -11, -12, 2, 12, 23, 24, 30, 31, 32, 40, 41, 42, 43, 44),
+      StopStream
+    )
+  }
+
+  private def sendMessagesWithTimestamp(
+      topic: String,
+      msgs: Seq[String],
+      part: Int,
+      ts: Long): Unit = {
+    val records = msgs.map { msg =>
+      new RecordBuilder(topic, msg).partition(part).timestamp(ts).build()
+    }
+    testUtils.sendMessages(records)
+  }
+
+  private def setupTestMessagesForTestOnTimestampOffsets(
+      topic: String,
+      firstTimestamp: Long,
+      secondTimestamp: Long): Unit = {
+    sendMessagesWithTimestamp(topic, Array(-20).map(_.toString), 0, firstTimestamp)
+    sendMessagesWithTimestamp(topic, Array(-10).map(_.toString), 1, firstTimestamp)
+    sendMessagesWithTimestamp(topic, Array(0, 1).map(_.toString), 2, firstTimestamp)
+    sendMessagesWithTimestamp(topic, Array(10, 11).map(_.toString), 3, firstTimestamp)
+    sendMessagesWithTimestamp(topic, Array(20, 21, 22).map(_.toString), 4, firstTimestamp)
+
+    sendMessagesWithTimestamp(topic, Array(-21, -22).map(_.toString), 0, secondTimestamp)
+    sendMessagesWithTimestamp(topic, Array(-11, -12).map(_.toString), 1, secondTimestamp)
+    sendMessagesWithTimestamp(topic, Array(2).map(_.toString), 2, secondTimestamp)
+    sendMessagesWithTimestamp(topic, Array(12).map(_.toString), 3, secondTimestamp)
+    // no data after second timestamp for partition 4
+  }
+
+  private def setupDataFrameForTestOnTimestampOffsets(
+      startingTimestamps: String,
+      failOnDataLoss: Boolean,
+      options: (String, String)*): Dataset[_] = {
+    val reader = spark
+      .readStream
+      .format("kafka")
+      .option("startingOffsetsByTimestamp", startingTimestamps)
+      .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+      .option("kafka.metadata.max.age.ms", "1")
+      .option("failOnDataLoss", failOnDataLoss.toString)
+    options.foreach { case (k, v) => reader.option(k, v) }
+    val kafka = reader.load()
+      .selectExpr("CAST(key AS STRING)", "CAST(value AS STRING)")
+      .as[(String, String)]
+    val mapped: org.apache.spark.sql.Dataset[_] = kafka.map(kv => kv._2.toInt)
+    mapped
   }
 
   test("Kafka column types") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This patch is a follow-up of SPARK-26848 (#23747).  In SPARK-26848, we decided to open possibility to let end users set individual timestamp per partition. But in many cases, specifying timestamp represents the intention that we would want to go back to specific timestamp and reprocess records, which should be applied to all topics and partitions.

This patch proposes to provide a way to set a global timestamp across partitions for a topic, so that end users can set all offsets by specific timestamp easily. 

The patch doesn't provide a way to set global timestamp across topics, as it would require modification of format of `startingOffsetsByTimestamp`/`endingOffsetsByTimestamp`, which may not be intuitive to understand.

### Why are the changes needed?

This would helps end users to set timestamp for reprocessing from specific point of time much easier. It also remedies the requirement of knowing number of partitions to set offsets.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Added UTs to verify the new feature.