### PR TITLE
[SPARK-29225][SQL] Change Spark SQL `DESC FORMATTED` format same with Hive

### DIFF
--- a/sql/core/src/test/resources/sql-tests/results/describe-part-after-analyze.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/describe-part-after-analyze.sql.out
@@ -43,13 +43,15 @@ DESC EXTENDED t PARTITION (ds='2017-08-01', hr=10)
 -- !query 4 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 4 output
-key                 	string              	                    
+# col_name          	data_type           	comment
+
+key                 	string
 value               	string              	                    
-ds                  	string              	                    
-hr                  	int                 	                    
-# Partition Information	                    	                    
+
+# Partition Information
 # col_name          	data_type           	comment             
-ds                  	string              	                    
+
+ds                  	string
 hr                  	int                 	                    
                     	                    	                    
 # Detailed Partition Information	                    	                    
@@ -77,13 +79,15 @@ DESC EXTENDED t PARTITION (ds='2017-08-01', hr=10)
 -- !query 6 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 6 output
-key                 	string              	                    
+# col_name          	data_type           	comment
+
+key                 	string
 value               	string              	                    
-ds                  	string              	                    
-hr                  	int                 	                    
-# Partition Information	                    	                    
+
+# Partition Information
 # col_name          	data_type           	comment             
-ds                  	string              	                    
+
+ds                  	string
 hr                  	int                 	                    
                     	                    	                    
 # Detailed Partition Information	                    	                    
@@ -112,13 +116,15 @@ DESC EXTENDED t PARTITION (ds='2017-08-01', hr=10)
 -- !query 8 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 8 output
-key                 	string              	                    
+# col_name          	data_type           	comment
+
+key                 	string
 value               	string              	                    
-ds                  	string              	                    
-hr                  	int                 	                    
-# Partition Information	                    	                    
+
+# Partition Information
 # col_name          	data_type           	comment             
-ds                  	string              	                    
+
+ds                  	string
 hr                  	int                 	                    
                     	                    	                    
 # Detailed Partition Information	                    	                    
@@ -139,13 +145,15 @@ DESC EXTENDED t PARTITION (ds='2017-08-01', hr=11)
 -- !query 9 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 9 output
-key                 	string              	                    
+# col_name          	data_type           	comment
+
+key                 	string
 value               	string              	                    
-ds                  	string              	                    
-hr                  	int                 	                    
-# Partition Information	                    	                    
+
+# Partition Information
 # col_name          	data_type           	comment             
-ds                  	string              	                    
+
+ds                  	string
 hr                  	int                 	                    
                     	                    	                    
 # Detailed Partition Information	                    	                    
@@ -174,13 +182,15 @@ DESC EXTENDED t PARTITION (ds='2017-08-01', hr=10)
 -- !query 11 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 11 output
-key                 	string              	                    
+# col_name          	data_type           	comment
+
+key                 	string
 value               	string              	                    
-ds                  	string              	                    
-hr                  	int                 	                    
-# Partition Information	                    	                    
+
+# Partition Information
 # col_name          	data_type           	comment             
-ds                  	string              	                    
+
+ds                  	string
 hr                  	int                 	                    
                     	                    	                    
 # Detailed Partition Information	                    	                    
@@ -201,13 +211,15 @@ DESC EXTENDED t PARTITION (ds='2017-08-01', hr=11)
 -- !query 12 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 12 output
-key                 	string              	                    
+# col_name          	data_type           	comment
+
+key                 	string
 value               	string              	                    
-ds                  	string              	                    
-hr                  	int                 	                    
-# Partition Information	                    	                    
+
+# Partition Information
 # col_name          	data_type           	comment             
-ds                  	string              	                    
+
+ds                  	string
 hr                  	int                 	                    
                     	                    	                    
 # Detailed Partition Information	                    	                    
@@ -228,13 +240,15 @@ DESC EXTENDED t PARTITION (ds='2017-09-01', hr=5)
 -- !query 13 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 13 output
-key                 	string              	                    
+# col_name          	data_type           	comment
+
+key                 	string
 value               	string              	                    
-ds                  	string              	                    
-hr                  	int                 	                    
-# Partition Information	                    	                    
+
+# Partition Information
 # col_name          	data_type           	comment             
-ds                  	string              	                    
+
+ds                  	string
 hr                  	int                 	                    
                     	                    	                    
 # Detailed Partition Information	                    	                    

--- a/sql/core/src/test/resources/sql-tests/results/describe-part-after-analyze.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/describe-part-after-analyze.sql.out
@@ -43,15 +43,15 @@ DESC EXTENDED t PARTITION (ds='2017-08-01', hr=10)
 -- !query 4 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 4 output
-# col_name          	data_type           	comment
-
-key                 	string
-value               	string              	                    
-
-# Partition Information
 # col_name          	data_type           	comment             
-
-ds                  	string
+                    	                    	                    
+key                 	string              	                    
+value               	string              	                    
+                    	                    	                    
+# Partition Information	                    	                    
+# col_name          	data_type           	comment             
+                    	                    	                    
+ds                  	string              	                    
 hr                  	int                 	                    
                     	                    	                    
 # Detailed Partition Information	                    	                    
@@ -79,15 +79,15 @@ DESC EXTENDED t PARTITION (ds='2017-08-01', hr=10)
 -- !query 6 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 6 output
-# col_name          	data_type           	comment
-
-key                 	string
-value               	string              	                    
-
-# Partition Information
 # col_name          	data_type           	comment             
-
-ds                  	string
+                    	                    	                    
+key                 	string              	                    
+value               	string              	                    
+                    	                    	                    
+# Partition Information	                    	                    
+# col_name          	data_type           	comment             
+                    	                    	                    
+ds                  	string              	                    
 hr                  	int                 	                    
                     	                    	                    
 # Detailed Partition Information	                    	                    
@@ -116,15 +116,15 @@ DESC EXTENDED t PARTITION (ds='2017-08-01', hr=10)
 -- !query 8 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 8 output
-# col_name          	data_type           	comment
-
-key                 	string
-value               	string              	                    
-
-# Partition Information
 # col_name          	data_type           	comment             
-
-ds                  	string
+                    	                    	                    
+key                 	string              	                    
+value               	string              	                    
+                    	                    	                    
+# Partition Information	                    	                    
+# col_name          	data_type           	comment             
+                    	                    	                    
+ds                  	string              	                    
 hr                  	int                 	                    
                     	                    	                    
 # Detailed Partition Information	                    	                    
@@ -145,15 +145,15 @@ DESC EXTENDED t PARTITION (ds='2017-08-01', hr=11)
 -- !query 9 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 9 output
-# col_name          	data_type           	comment
-
-key                 	string
-value               	string              	                    
-
-# Partition Information
 # col_name          	data_type           	comment             
-
-ds                  	string
+                    	                    	                    
+key                 	string              	                    
+value               	string              	                    
+                    	                    	                    
+# Partition Information	                    	                    
+# col_name          	data_type           	comment             
+                    	                    	                    
+ds                  	string              	                    
 hr                  	int                 	                    
                     	                    	                    
 # Detailed Partition Information	                    	                    
@@ -182,15 +182,15 @@ DESC EXTENDED t PARTITION (ds='2017-08-01', hr=10)
 -- !query 11 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 11 output
-# col_name          	data_type           	comment
-
-key                 	string
-value               	string              	                    
-
-# Partition Information
 # col_name          	data_type           	comment             
-
-ds                  	string
+                    	                    	                    
+key                 	string              	                    
+value               	string              	                    
+                    	                    	                    
+# Partition Information	                    	                    
+# col_name          	data_type           	comment             
+                    	                    	                    
+ds                  	string              	                    
 hr                  	int                 	                    
                     	                    	                    
 # Detailed Partition Information	                    	                    
@@ -211,15 +211,15 @@ DESC EXTENDED t PARTITION (ds='2017-08-01', hr=11)
 -- !query 12 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 12 output
-# col_name          	data_type           	comment
-
-key                 	string
-value               	string              	                    
-
-# Partition Information
 # col_name          	data_type           	comment             
-
-ds                  	string
+                    	                    	                    
+key                 	string              	                    
+value               	string              	                    
+                    	                    	                    
+# Partition Information	                    	                    
+# col_name          	data_type           	comment             
+                    	                    	                    
+ds                  	string              	                    
 hr                  	int                 	                    
                     	                    	                    
 # Detailed Partition Information	                    	                    
@@ -240,15 +240,15 @@ DESC EXTENDED t PARTITION (ds='2017-09-01', hr=5)
 -- !query 13 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 13 output
-# col_name          	data_type           	comment
-
-key                 	string
-value               	string              	                    
-
-# Partition Information
 # col_name          	data_type           	comment             
-
-ds                  	string
+                    	                    	                    
+key                 	string              	                    
+value               	string              	                    
+                    	                    	                    
+# Partition Information	                    	                    
+# col_name          	data_type           	comment             
+                    	                    	                    
+ds                  	string              	                    
 hr                  	int                 	                    
                     	                    	                    
 # Detailed Partition Information	                    	                    

--- a/sql/core/src/test/resources/sql-tests/results/describe-table-after-alter-table.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/describe-table-after-alter-table.sql.out
@@ -15,6 +15,8 @@ DESC FORMATTED table_with_comment
 -- !query 1 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 1 output
+# col_name          	data_type           	comment             
+                    	                    	                    
 a                   	string              	                    
 b                   	int                 	                    
 c                   	string              	                    
@@ -45,6 +47,8 @@ DESC FORMATTED table_with_comment
 -- !query 3 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 3 output
+# col_name          	data_type           	comment             
+                    	                    	                    
 a                   	string              	                    
 b                   	int                 	                    
 c                   	string              	                    
@@ -84,6 +88,8 @@ DESC FORMATTED table_comment
 -- !query 6 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 6 output
+# col_name          	data_type           	comment             
+                    	                    	                    
 a                   	string              	                    
 b                   	int                 	                    
                     	                    	                    
@@ -111,6 +117,8 @@ DESC formatted table_comment
 -- !query 8 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 8 output
+# col_name          	data_type           	comment             
+                    	                    	                    
 a                   	string              	                    
 b                   	int                 	                    
                     	                    	                    
@@ -139,6 +147,8 @@ DESC FORMATTED table_comment
 -- !query 10 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 10 output
+# col_name          	data_type           	comment             
+                    	                    	                    
 a                   	string              	                    
 b                   	int                 	                    
                     	                    	                    

--- a/sql/core/src/test/resources/sql-tests/results/describe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/describe.sql.out
@@ -64,12 +64,12 @@ DESCRIBE t
 -- !query 6 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 6 output
-a                   	string              	                    
+a                   	string
 b                   	int                 	                    
-c                   	string              	                    
-d                   	string              	                    
-# Partition Information	                    	                    
-# col_name          	data_type           	comment             
+
+# Partition Information
+# col_name          	data_type           	comment
+
 c                   	string              	                    
 d                   	string
 
@@ -81,11 +81,11 @@ struct<col_name:string,data_type:string,comment:string>
 -- !query 7 output
 a                   	string              	                    
 b                   	int                 	                    
-c                   	string              	                    
-d                   	string              	                    
-# Partition Information	                    	                    
+
+# Partition Information
 # col_name          	data_type           	comment             
-c                   	string              	                    
+
+c                   	string
 d                   	string
 
 
@@ -96,11 +96,11 @@ struct<col_name:string,data_type:string,comment:string>
 -- !query 8 output
 a                   	string              	                    
 b                   	int                 	                    
-c                   	string              	                    
-d                   	string              	                    
-# Partition Information	                    	                    
+
+# Partition Information
 # col_name          	data_type           	comment             
-c                   	string              	                    
+
+c                   	string
 d                   	string
 
 
@@ -109,13 +109,15 @@ DESC FORMATTED t
 -- !query 9 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 9 output
-a                   	string              	                    
+# col_name          	data_type           	comment
+
+a                   	string
 b                   	int                 	                    
-c                   	string              	                    
-d                   	string              	                    
-# Partition Information	                    	                    
+
+# Partition Information
 # col_name          	data_type           	comment             
-c                   	string              	                    
+
+c                   	string
 d                   	string              	                    
                     	                    	                    
 # Detailed Table Information	                    	                    
@@ -141,13 +143,15 @@ DESC EXTENDED t
 -- !query 10 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 10 output
-a                   	string              	                    
+# col_name          	data_type           	comment
+
+a                   	string
 b                   	int                 	                    
-c                   	string              	                    
-d                   	string              	                    
-# Partition Information	                    	                    
+
+# Partition Information
 # col_name          	data_type           	comment             
-c                   	string              	                    
+
+c                   	string
 d                   	string              	                    
                     	                    	                    
 # Detailed Table Information	                    	                    
@@ -181,13 +185,15 @@ DESC EXTENDED t
 -- !query 12 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 12 output
-a                   	string              	                    
+# col_name          	data_type           	comment
+
+a                   	string
 b                   	int                 	                    
-c                   	string              	                    
-d                   	string              	                    
-# Partition Information	                    	                    
+
+# Partition Information
 # col_name          	data_type           	comment             
-c                   	string              	                    
+
+c                   	string
 d                   	string              	                    
                     	                    	                    
 # Detailed Table Information	                    	                    
@@ -221,13 +227,15 @@ DESC EXTENDED t
 -- !query 14 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 14 output
-a                   	string              	                    
+# col_name          	data_type           	comment
+
+a                   	string
 b                   	int                 	                    
-c                   	string              	                    
-d                   	string              	                    
-# Partition Information	                    	                    
+
+# Partition Information
 # col_name          	data_type           	comment             
-c                   	string              	                    
+
+c                   	string
 d                   	string              	                    
                     	                    	                    
 # Detailed Table Information	                    	                    
@@ -254,11 +262,11 @@ struct<col_name:string,data_type:string,comment:string>
 -- !query 15 output
 a                   	string              	                    
 b                   	int                 	                    
-c                   	string              	                    
-d                   	string              	                    
-# Partition Information	                    	                    
+
+# Partition Information
 # col_name          	data_type           	comment             
-c                   	string              	                    
+
+c                   	string
 d                   	string
 
 
@@ -267,13 +275,15 @@ DESC EXTENDED t PARTITION (c='Us', d=1)
 -- !query 16 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 16 output
-a                   	string              	                    
+# col_name          	data_type           	comment
+
+a                   	string
 b                   	int                 	                    
-c                   	string              	                    
-d                   	string              	                    
-# Partition Information	                    	                    
+
+# Partition Information
 # col_name          	data_type           	comment             
-c                   	string              	                    
+
+c                   	string
 d                   	string              	                    
                     	                    	                    
 # Detailed Partition Information	                    	                    
@@ -298,13 +308,15 @@ DESC FORMATTED t PARTITION (c='Us', d=1)
 -- !query 17 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 17 output
-a                   	string              	                    
+# col_name          	data_type           	comment
+
+a                   	string
 b                   	int                 	                    
-c                   	string              	                    
-d                   	string              	                    
-# Partition Information	                    	                    
+
+# Partition Information
 # col_name          	data_type           	comment             
-c                   	string              	                    
+
+c                   	string
 d                   	string              	                    
                     	                    	                    
 # Detailed Partition Information	                    	                    
@@ -385,7 +397,9 @@ DESC FORMATTED temp_v
 -- !query 23 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 23 output
-a                   	string              	                    
+# col_name          	data_type           	comment
+
+a                   	string
 b                   	int                 	                    
 c                   	string              	                    
 d                   	string
@@ -396,7 +410,9 @@ DESC EXTENDED temp_v
 -- !query 24 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 24 output
-a                   	string              	                    
+# col_name          	data_type           	comment
+
+a                   	string
 b                   	int                 	                    
 c                   	string              	                    
 d                   	string
@@ -407,7 +423,9 @@ DESC temp_Data_Source_View
 -- !query 25 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 25 output
-intType             	int                 	test comment test1  
+# col_name          	data_type           	comment
+
+intType             	int                 	test comment test1
 stringType          	string              	                    
 dateType            	date                	                    
 timestampType       	timestamp           	                    
@@ -461,7 +479,9 @@ DESC FORMATTED v
 -- !query 29 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 29 output
-a                   	string              	                    
+# col_name          	data_type           	comment
+
+a                   	string
 b                   	int                 	                    
 c                   	string              	                    
 d                   	string              	                    
@@ -485,7 +505,9 @@ DESC EXTENDED v
 -- !query 30 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 30 output
-a                   	string              	                    
+# col_name          	data_type           	comment
+
+a                   	string
 b                   	int                 	                    
 c                   	string              	                    
 d                   	string              	                    

--- a/sql/core/src/test/resources/sql-tests/results/describe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/describe.sql.out
@@ -64,12 +64,12 @@ DESCRIBE t
 -- !query 6 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 6 output
-a                   	string
+a                   	string              	                    
 b                   	int                 	                    
-
-# Partition Information
-# col_name          	data_type           	comment
-
+                    	                    	                    
+# Partition Information	                    	                    
+# col_name          	data_type           	comment             
+                    	                    	                    
 c                   	string              	                    
 d                   	string
 
@@ -81,11 +81,11 @@ struct<col_name:string,data_type:string,comment:string>
 -- !query 7 output
 a                   	string              	                    
 b                   	int                 	                    
-
-# Partition Information
+                    	                    	                    
+# Partition Information	                    	                    
 # col_name          	data_type           	comment             
-
-c                   	string
+                    	                    	                    
+c                   	string              	                    
 d                   	string
 
 
@@ -96,11 +96,11 @@ struct<col_name:string,data_type:string,comment:string>
 -- !query 8 output
 a                   	string              	                    
 b                   	int                 	                    
-
-# Partition Information
+                    	                    	                    
+# Partition Information	                    	                    
 # col_name          	data_type           	comment             
-
-c                   	string
+                    	                    	                    
+c                   	string              	                    
 d                   	string
 
 
@@ -109,15 +109,15 @@ DESC FORMATTED t
 -- !query 9 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 9 output
-# col_name          	data_type           	comment
-
-a                   	string
-b                   	int                 	                    
-
-# Partition Information
 # col_name          	data_type           	comment             
-
-c                   	string
+                    	                    	                    
+a                   	string              	                    
+b                   	int                 	                    
+                    	                    	                    
+# Partition Information	                    	                    
+# col_name          	data_type           	comment             
+                    	                    	                    
+c                   	string              	                    
 d                   	string              	                    
                     	                    	                    
 # Detailed Table Information	                    	                    
@@ -143,15 +143,15 @@ DESC EXTENDED t
 -- !query 10 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 10 output
-# col_name          	data_type           	comment
-
-a                   	string
-b                   	int                 	                    
-
-# Partition Information
 # col_name          	data_type           	comment             
-
-c                   	string
+                    	                    	                    
+a                   	string              	                    
+b                   	int                 	                    
+                    	                    	                    
+# Partition Information	                    	                    
+# col_name          	data_type           	comment             
+                    	                    	                    
+c                   	string              	                    
 d                   	string              	                    
                     	                    	                    
 # Detailed Table Information	                    	                    
@@ -185,15 +185,15 @@ DESC EXTENDED t
 -- !query 12 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 12 output
-# col_name          	data_type           	comment
-
-a                   	string
-b                   	int                 	                    
-
-# Partition Information
 # col_name          	data_type           	comment             
-
-c                   	string
+                    	                    	                    
+a                   	string              	                    
+b                   	int                 	                    
+                    	                    	                    
+# Partition Information	                    	                    
+# col_name          	data_type           	comment             
+                    	                    	                    
+c                   	string              	                    
 d                   	string              	                    
                     	                    	                    
 # Detailed Table Information	                    	                    
@@ -227,15 +227,15 @@ DESC EXTENDED t
 -- !query 14 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 14 output
-# col_name          	data_type           	comment
-
-a                   	string
-b                   	int                 	                    
-
-# Partition Information
 # col_name          	data_type           	comment             
-
-c                   	string
+                    	                    	                    
+a                   	string              	                    
+b                   	int                 	                    
+                    	                    	                    
+# Partition Information	                    	                    
+# col_name          	data_type           	comment             
+                    	                    	                    
+c                   	string              	                    
 d                   	string              	                    
                     	                    	                    
 # Detailed Table Information	                    	                    
@@ -262,11 +262,11 @@ struct<col_name:string,data_type:string,comment:string>
 -- !query 15 output
 a                   	string              	                    
 b                   	int                 	                    
-
-# Partition Information
+                    	                    	                    
+# Partition Information	                    	                    
 # col_name          	data_type           	comment             
-
-c                   	string
+                    	                    	                    
+c                   	string              	                    
 d                   	string
 
 
@@ -275,15 +275,15 @@ DESC EXTENDED t PARTITION (c='Us', d=1)
 -- !query 16 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 16 output
-# col_name          	data_type           	comment
-
-a                   	string
-b                   	int                 	                    
-
-# Partition Information
 # col_name          	data_type           	comment             
-
-c                   	string
+                    	                    	                    
+a                   	string              	                    
+b                   	int                 	                    
+                    	                    	                    
+# Partition Information	                    	                    
+# col_name          	data_type           	comment             
+                    	                    	                    
+c                   	string              	                    
 d                   	string              	                    
                     	                    	                    
 # Detailed Partition Information	                    	                    
@@ -308,15 +308,15 @@ DESC FORMATTED t PARTITION (c='Us', d=1)
 -- !query 17 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 17 output
-# col_name          	data_type           	comment
-
-a                   	string
-b                   	int                 	                    
-
-# Partition Information
 # col_name          	data_type           	comment             
-
-c                   	string
+                    	                    	                    
+a                   	string              	                    
+b                   	int                 	                    
+                    	                    	                    
+# Partition Information	                    	                    
+# col_name          	data_type           	comment             
+                    	                    	                    
+c                   	string              	                    
 d                   	string              	                    
                     	                    	                    
 # Detailed Partition Information	                    	                    
@@ -397,9 +397,9 @@ DESC FORMATTED temp_v
 -- !query 23 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 23 output
-# col_name          	data_type           	comment
-
-a                   	string
+# col_name          	data_type           	comment             
+                    	                    	                    
+a                   	string              	                    
 b                   	int                 	                    
 c                   	string              	                    
 d                   	string
@@ -410,9 +410,9 @@ DESC EXTENDED temp_v
 -- !query 24 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 24 output
-# col_name          	data_type           	comment
-
-a                   	string
+# col_name          	data_type           	comment             
+                    	                    	                    
+a                   	string              	                    
 b                   	int                 	                    
 c                   	string              	                    
 d                   	string
@@ -423,9 +423,7 @@ DESC temp_Data_Source_View
 -- !query 25 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 25 output
-# col_name          	data_type           	comment
-
-intType             	int                 	test comment test1
+intType             	int                 	test comment test1  
 stringType          	string              	                    
 dateType            	date                	                    
 timestampType       	timestamp           	                    
@@ -479,9 +477,9 @@ DESC FORMATTED v
 -- !query 29 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 29 output
-# col_name          	data_type           	comment
-
-a                   	string
+# col_name          	data_type           	comment             
+                    	                    	                    
+a                   	string              	                    
 b                   	int                 	                    
 c                   	string              	                    
 d                   	string              	                    
@@ -505,9 +503,9 @@ DESC EXTENDED v
 -- !query 30 schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query 30 output
-# col_name          	data_type           	comment
-
-a                   	string
+# col_name          	data_type           	comment             
+                    	                    	                    
+a                   	string              	                    
 b                   	int                 	                    
 c                   	string              	                    
 d                   	string              	                    

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -1043,9 +1043,10 @@ class HiveDDLSuite
       assert(sql("DESC tbl").collect().containsSlice(
         Seq(
           Row("a", "int", null),
-          Row("b", "int", null),
+          Row("", "", ""),
           Row("# Partition Information", "", ""),
           Row("# col_name", "data_type", "comment"),
+          Row("", "", ""),
           Row("b", "int", null)
         )
       ))


### PR DESCRIPTION
### What changes were proposed in this pull request?
As I have mentioned in [SPARK-29225](https://issues.apache.org/jira/browse/SPARK-29225)
Spark SQL `DESC FORMATTED table_name` format have so many different point form hive's format.
Since some JDBC query interaction platform like `HUE` use  Hive format to parse information form the query result.
Such as column information: 
Hue use `DESC FORMATTED table` query to get result and parse column information by it's result format.  
Spark SQL show different format, it cause problem when show result. 



### Why are the changes needed?
For better interaction with JDBC query platform like Hue. 



### Does this PR introduce any user-facing change?
Create table like below:
```
create table order_partition(
    id string,
    name string,
    num int,
    order_number string, 
   event_time string)
PARTITIONED BY(event_month string)
```

Then call `DESC FORMATTED order_partition` .

Origin Format:
![image](https://user-images.githubusercontent.com/46485123/65567346-77cd4b80-df88-11e9-805f-d2ec05c6272c.png)

Current format:
![image](https://user-images.githubusercontent.com/46485123/65567359-84ea3a80-df88-11e9-966d-46254af14707.png)

**Changes**
When call `DESC FORMATTED table_name`

1. Add header before no-partition columns
2. Add empty line between header and columns
3. Add empty line between normal column and `#Partition information`
4. Remove partition columns in normal column information, only show below `#Partition information`

### How was this patch tested?
MT