### PR TITLE
[SPARK-29116][PYTHON][ML] Refactor py classes related to DecisionTree

### DIFF
--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -22,9 +22,9 @@ from multiprocessing.pool import ThreadPool
 from pyspark import since, keyword_only
 from pyspark.ml import Estimator, Model
 from pyspark.ml.param.shared import *
-from pyspark.ml.tree import DecisionTreeModel, DecisionTreeParams, \
-    TreeEnsembleModel, RandomForestParams, GBTParams, \
-    HasVarianceImpurity, TreeClassifierParams, TreeEnsembleParams
+from pyspark.ml.tree import _DecisionTreeModel, _DecisionTreeParams, \
+    _TreeEnsembleModel, _RandomForestParams, _GBTParams, \
+    _HasVarianceImpurity, _TreeClassifierParams, _TreeEnsembleParams
 from pyspark.ml.regression import DecisionTreeRegressionModel
 from pyspark.ml.util import *
 from pyspark.ml.wrapper import JavaEstimator, JavaModel, JavaParams, \
@@ -941,7 +941,7 @@ class BinaryLogisticRegressionTrainingSummary(BinaryLogisticRegressionSummary,
 
 
 @inherit_doc
-class _DecisionTreeClassifierParams(DecisionTreeParams, TreeClassifierParams):
+class _DecisionTreeClassifierParams(_DecisionTreeParams, _TreeClassifierParams):
     """
     Params for :py:class:`DecisionTreeClassifier` and :py:class:`DecisionTreeClassificationModel`.
     """
@@ -1120,7 +1120,7 @@ class DecisionTreeClassifier(JavaProbabilisticClassifier, _DecisionTreeClassifie
 
 
 @inherit_doc
-class DecisionTreeClassificationModel(DecisionTreeModel, JavaProbabilisticClassificationModel,
+class DecisionTreeClassificationModel(_DecisionTreeModel, JavaProbabilisticClassificationModel,
                                       _DecisionTreeClassifierParams, JavaMLWritable,
                                       JavaMLReadable):
     """
@@ -1152,7 +1152,7 @@ class DecisionTreeClassificationModel(DecisionTreeModel, JavaProbabilisticClassi
 
 
 @inherit_doc
-class _RandomForestClassifierParams(RandomForestParams, TreeClassifierParams):
+class _RandomForestClassifierParams(_RandomForestParams, _TreeClassifierParams):
     """
     Params for :py:class:`RandomForestClassifier` and :py:class:`RandomForestClassificationModel`.
     """
@@ -1337,7 +1337,7 @@ class RandomForestClassifier(JavaProbabilisticClassifier, _RandomForestClassifie
         return self._set(featureSubsetStrategy=value)
 
 
-class RandomForestClassificationModel(TreeEnsembleModel, JavaProbabilisticClassificationModel,
+class RandomForestClassificationModel(_TreeEnsembleModel, JavaProbabilisticClassificationModel,
                                       _RandomForestClassifierParams, JavaMLWritable,
                                       JavaMLReadable):
     """
@@ -1368,7 +1368,7 @@ class RandomForestClassificationModel(TreeEnsembleModel, JavaProbabilisticClassi
         return [DecisionTreeClassificationModel(m) for m in list(self._call_java("trees"))]
 
 
-class GBTClassifierParams(GBTParams, HasVarianceImpurity):
+class GBTClassifierParams(_GBTParams, _HasVarianceImpurity):
     """
     Private class to track supported GBTClassifier params.
 
@@ -1601,7 +1601,7 @@ class GBTClassifier(JavaProbabilisticClassifier, GBTClassifierParams,
         return self._set(validationIndicatorCol=value)
 
 
-class GBTClassificationModel(TreeEnsembleModel, JavaProbabilisticClassificationModel,
+class GBTClassificationModel(_TreeEnsembleModel, JavaProbabilisticClassificationModel,
                              GBTClassifierParams, JavaMLWritable, JavaMLReadable):
     """
     Model fitted by GBTClassifier.

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -943,7 +943,7 @@ class BinaryLogisticRegressionTrainingSummary(BinaryLogisticRegressionSummary,
 @inherit_doc
 class _DecisionTreeClassifierParams(DecisionTreeParams, TreeClassifierParams):
     """
-    Params for :py:attr:`DecisionTreeClassifier` and :py:attr:`DecisionTreeClassificationModel`.
+    Params for :py:class:`DecisionTreeClassifier` and :py:class:`DecisionTreeClassificationModel`.
     """
     pass
 
@@ -1154,7 +1154,7 @@ class DecisionTreeClassificationModel(DecisionTreeModel, JavaProbabilisticClassi
 @inherit_doc
 class _RandomForestClassifierParams(RandomForestParams, TreeClassifierParams):
     """
-    Params for :py:attr:`RandomForestClassifier` and :py:attr:`RandomForestClassificationModel`.
+    Params for :py:class:`RandomForestClassifier` and :py:class:`RandomForestClassificationModel`.
     """
     pass
 

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -941,8 +941,7 @@ class BinaryLogisticRegressionTrainingSummary(BinaryLogisticRegressionSummary,
 
 
 @inherit_doc
-class DecisionTreeClassifierParams(DecisionTreeParams, TreeClassifierParams,
-                                   JavaProbabilisticClassifierParams):
+class DecisionTreeClassifierParams(DecisionTreeParams, TreeClassifierParams):
     """
     (Private) Params for DecisionTree Classifier.
     """

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -941,15 +941,15 @@ class BinaryLogisticRegressionTrainingSummary(BinaryLogisticRegressionSummary,
 
 
 @inherit_doc
-class DecisionTreeClassifierParams(DecisionTreeParams, TreeClassifierParams):
+class _DecisionTreeClassifierParams(DecisionTreeParams, TreeClassifierParams):
     """
-    (Private) Params for DecisionTree Classifier.
+    Params for :py:attr:`DecisionTreeClassifier` and :py:attr:`DecisionTreeClassificationModel`.
     """
     pass
 
 
 @inherit_doc
-class DecisionTreeClassifier(JavaProbabilisticClassifier, DecisionTreeClassifierParams,
+class DecisionTreeClassifier(JavaProbabilisticClassifier, _DecisionTreeClassifierParams,
                              JavaMLWritable, JavaMLReadable):
     """
     `Decision tree <http://en.wikipedia.org/wiki/Decision_tree_learning>`_
@@ -1121,7 +1121,7 @@ class DecisionTreeClassifier(JavaProbabilisticClassifier, DecisionTreeClassifier
 
 @inherit_doc
 class DecisionTreeClassificationModel(DecisionTreeModel, JavaProbabilisticClassificationModel,
-                                      DecisionTreeClassifierParams, JavaMLWritable,
+                                      _DecisionTreeClassifierParams, JavaMLWritable,
                                       JavaMLReadable):
     """
     Model fitted by DecisionTreeClassifier.
@@ -1152,15 +1152,15 @@ class DecisionTreeClassificationModel(DecisionTreeModel, JavaProbabilisticClassi
 
 
 @inherit_doc
-class RandomForestClassifierParams(RandomForestParams, TreeClassifierParams):
+class _RandomForestClassifierParams(RandomForestParams, TreeClassifierParams):
     """
-    (Private) Params for RandomForest Classifier.
+    Params for :py:attr:`RandomForestClassifier` and :py:attr:`RandomForestClassificationModel`.
     """
     pass
 
 
 @inherit_doc
-class RandomForestClassifier(JavaProbabilisticClassifier, RandomForestClassifierParams,
+class RandomForestClassifier(JavaProbabilisticClassifier, _RandomForestClassifierParams,
                              JavaMLWritable, JavaMLReadable):
     """
     `Random Forest <http://en.wikipedia.org/wiki/Random_forest>`_
@@ -1338,7 +1338,7 @@ class RandomForestClassifier(JavaProbabilisticClassifier, RandomForestClassifier
 
 
 class RandomForestClassificationModel(TreeEnsembleModel, JavaProbabilisticClassificationModel,
-                                      RandomForestClassifierParams, JavaMLWritable,
+                                      _RandomForestClassifierParams, JavaMLWritable,
                                       JavaMLReadable):
     """
     Model fitted by RandomForestClassifier.

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -19,9 +19,9 @@ import sys
 
 from pyspark import since, keyword_only
 from pyspark.ml.param.shared import *
-from pyspark.ml.tree import DecisionTreeModel, DecisionTreeParams, \
-    TreeEnsembleModel, TreeEnsembleParams, RandomForestParams, GBTParams, \
-    HasVarianceImpurity, TreeRegressorParams
+from pyspark.ml.tree import _DecisionTreeModel, _DecisionTreeParams, \
+    _TreeEnsembleModel, _TreeEnsembleParams, _RandomForestParams, _GBTParams, \
+    _HasVarianceImpurity, _TreeRegressorParams
 from pyspark.ml.util import *
 from pyspark.ml.wrapper import JavaEstimator, JavaModel, JavaParams, \
     JavaPredictor, JavaPredictionModel, JavaWrapper
@@ -594,7 +594,7 @@ class IsotonicRegressionModel(JavaPredictionModel, JavaMLWritable, JavaMLReadabl
         return self._call_java("predictions")
 
 
-class _DecisionTreeRegressorParams(DecisionTreeParams, TreeRegressorParams, HasVarianceCol):
+class _DecisionTreeRegressorParams(_DecisionTreeParams, _TreeRegressorParams, HasVarianceCol):
     """
     Params for :py:class:`DecisionTreeRegressor` and :py:class:`DecisionTreeRegressionModel`.
 
@@ -765,7 +765,7 @@ class DecisionTreeRegressor(JavaPredictor, _DecisionTreeRegressorParams, JavaMLW
 
 
 @inherit_doc
-class DecisionTreeRegressionModel(DecisionTreeModel, _DecisionTreeRegressorParams,
+class DecisionTreeRegressionModel(_DecisionTreeModel, _DecisionTreeRegressorParams,
                                   JavaMLWritable, JavaMLReadable):
     """
     Model fitted by :class:`DecisionTreeRegressor`.
@@ -795,7 +795,7 @@ class DecisionTreeRegressionModel(DecisionTreeModel, _DecisionTreeRegressorParam
         return self._call_java("featureImportances")
 
 
-class _RandomForestRegressorParams(RandomForestParams, TreeRegressorParams):
+class _RandomForestRegressorParams(_RandomForestParams, _TreeRegressorParams):
     """
     Params for :py:class:`RandomForestRegressor` and :py:class:`RandomForestRegressionModel`.
 
@@ -969,7 +969,7 @@ class RandomForestRegressor(JavaPredictor, _RandomForestRegressorParams, JavaMLW
         return self._set(featureSubsetStrategy=value)
 
 
-class RandomForestRegressionModel(TreeEnsembleModel, _RandomForestRegressorParams,
+class RandomForestRegressionModel(_TreeEnsembleModel, _RandomForestRegressorParams,
                                   JavaMLWritable, JavaMLReadable):
     """
     Model fitted by :class:`RandomForestRegressor`.
@@ -999,9 +999,10 @@ class RandomForestRegressionModel(TreeEnsembleModel, _RandomForestRegressorParam
         return self._call_java("featureImportances")
 
 
-class GBTRegressorParams(GBTParams, TreeRegressorParams):
+class _GBTRegressorParams(_GBTParams, _TreeRegressorParams):
     """
-    (Private) class to track supported GBTRegressor params.
+    Params for :py:class:`GBTRegressor` and :py:class:`GBTRegressorModel`.
+
     .. versionadded:: 3.0.0
     """
 
@@ -1021,7 +1022,7 @@ class GBTRegressorParams(GBTParams, TreeRegressorParams):
 
 
 @inherit_doc
-class GBTRegressor(JavaPredictor, GBTRegressorParams, JavaMLWritable, JavaMLReadable):
+class GBTRegressor(JavaPredictor, _GBTRegressorParams, JavaMLWritable, JavaMLReadable):
     """
     `Gradient-Boosted Trees (GBTs) <http://en.wikipedia.org/wiki/Gradient_boosting>`_
     learning algorithm for regression.
@@ -1204,8 +1205,7 @@ class GBTRegressor(JavaPredictor, GBTRegressorParams, JavaMLWritable, JavaMLRead
         return self._set(validationIndicatorCol=value)
 
 
-class GBTRegressionModel(TreeEnsembleModel, GBTRegressorParams,
-                         JavaMLWritable, JavaMLReadable):
+class GBTRegressionModel(_TreeEnsembleModel, _GBTRegressorParams, JavaMLWritable, JavaMLReadable):
     """
     Model fitted by :class:`GBTRegressor`.
 

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -596,7 +596,7 @@ class IsotonicRegressionModel(JavaPredictionModel, JavaMLWritable, JavaMLReadabl
 
 class _DecisionTreeRegressorParams(DecisionTreeParams, TreeRegressorParams, HasVarianceCol):
     """
-    Params for :py:attr:`DecisionTreeRegressor` and :py:attr:`DecisionTreeRegressionModel`.
+    Params for :py:class:`DecisionTreeRegressor` and :py:class:`DecisionTreeRegressionModel`.
 
     .. versionadded:: 3.0.0
     """
@@ -797,7 +797,7 @@ class DecisionTreeRegressionModel(DecisionTreeModel, _DecisionTreeRegressorParam
 
 class _RandomForestRegressorParams(RandomForestParams, TreeRegressorParams):
     """
-    Params for :py:attr:`RandomForestRegressor` and :py:attr:`RandomForestRegressionModel`.
+    Params for :py:class:`RandomForestRegressor` and :py:class:`RandomForestRegressionModel`.
     .. versionadded:: 3.0.0
     """
     pass

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -798,6 +798,7 @@ class DecisionTreeRegressionModel(DecisionTreeModel, _DecisionTreeRegressorParam
 class _RandomForestRegressorParams(RandomForestParams, TreeRegressorParams):
     """
     Params for :py:class:`RandomForestRegressor` and :py:class:`RandomForestRegressionModel`.
+
     .. versionadded:: 3.0.0
     """
     pass

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -594,9 +594,9 @@ class IsotonicRegressionModel(JavaPredictionModel, JavaMLWritable, JavaMLReadabl
         return self._call_java("predictions")
 
 
-class DecisionTreeRegressorParams(DecisionTreeParams, TreeRegressorParams, HasVarianceCol):
+class _DecisionTreeRegressorParams(DecisionTreeParams, TreeRegressorParams, HasVarianceCol):
     """
-    (Private) Params for DecisionTree Regressor.
+    Params for :py:attr:`DecisionTreeRegressor` and :py:attr:`DecisionTreeRegressionModel`.
 
     .. versionadded:: 3.0.0
     """
@@ -605,7 +605,7 @@ class DecisionTreeRegressorParams(DecisionTreeParams, TreeRegressorParams, HasVa
 
 
 @inherit_doc
-class DecisionTreeRegressor(JavaPredictor, DecisionTreeRegressorParams, JavaMLWritable,
+class DecisionTreeRegressor(JavaPredictor, _DecisionTreeRegressorParams, JavaMLWritable,
                             JavaMLReadable):
     """
     `Decision tree <http://en.wikipedia.org/wiki/Decision_tree_learning>`_
@@ -765,7 +765,7 @@ class DecisionTreeRegressor(JavaPredictor, DecisionTreeRegressorParams, JavaMLWr
 
 
 @inherit_doc
-class DecisionTreeRegressionModel(DecisionTreeModel, DecisionTreeRegressorParams,
+class DecisionTreeRegressionModel(DecisionTreeModel, _DecisionTreeRegressorParams,
                                   JavaMLWritable, JavaMLReadable):
     """
     Model fitted by :class:`DecisionTreeRegressor`.
@@ -795,16 +795,16 @@ class DecisionTreeRegressionModel(DecisionTreeModel, DecisionTreeRegressorParams
         return self._call_java("featureImportances")
 
 
-class RandomForestRegressorParams(RandomForestParams, TreeRegressorParams):
+class _RandomForestRegressorParams(RandomForestParams, TreeRegressorParams):
     """
-    (Private) Params for RandomForest Regressor.
+    Params for :py:attr:`RandomForestRegressor` and :py:attr:`RandomForestRegressionModel`.
     .. versionadded:: 3.0.0
     """
     pass
 
 
 @inherit_doc
-class RandomForestRegressor(JavaPredictor, RandomForestRegressorParams, JavaMLWritable,
+class RandomForestRegressor(JavaPredictor, _RandomForestRegressorParams, JavaMLWritable,
                             JavaMLReadable):
     """
     `Random Forest <http://en.wikipedia.org/wiki/Random_forest>`_
@@ -968,7 +968,7 @@ class RandomForestRegressor(JavaPredictor, RandomForestRegressorParams, JavaMLWr
         return self._set(featureSubsetStrategy=value)
 
 
-class RandomForestRegressionModel(TreeEnsembleModel, RandomForestRegressorParams,
+class RandomForestRegressionModel(TreeEnsembleModel, _RandomForestRegressorParams,
                                   JavaMLWritable, JavaMLReadable):
     """
     Model fitted by :class:`RandomForestRegressor`.

--- a/python/pyspark/ml/tree.py
+++ b/python/pyspark/ml/tree.py
@@ -24,9 +24,10 @@ from pyspark.ml.common import inherit_doc, _java2py, _py2java
 
 
 @inherit_doc
-class DecisionTreeModel(JavaPredictionModel):
+class _DecisionTreeModel(JavaPredictionModel):
     """
     Abstraction for Decision Tree models.
+
     .. versionadded:: 1.5.0
     """
 
@@ -59,7 +60,7 @@ class DecisionTreeModel(JavaPredictionModel):
         return self._call_java("toString")
 
 
-class DecisionTreeParams(HasCheckpointInterval, HasSeed, HasWeightCol):
+class _DecisionTreeParams(HasCheckpointInterval, HasSeed, HasWeightCol):
     """
     Mixin for Decision Tree parameters.
     """
@@ -106,7 +107,7 @@ class DecisionTreeParams(HasCheckpointInterval, HasSeed, HasWeightCol):
                          typeConverter=TypeConverters.toBoolean)
 
     def __init__(self):
-        super(DecisionTreeParams, self).__init__()
+        super(_DecisionTreeParams, self).__init__()
 
     def setLeafCol(self, value):
         """
@@ -164,7 +165,7 @@ class DecisionTreeParams(HasCheckpointInterval, HasSeed, HasWeightCol):
 
 
 @inherit_doc
-class TreeEnsembleModel(JavaPredictionModel):
+class _TreeEnsembleModel(JavaPredictionModel):
     """
     (private abstraction)
     Represents a tree ensemble model.
@@ -174,7 +175,7 @@ class TreeEnsembleModel(JavaPredictionModel):
     @since("2.0.0")
     def trees(self):
         """Trees in this ensemble. Warning: These have null parent Estimators."""
-        return [DecisionTreeModel(m) for m in list(self._call_java("trees"))]
+        return [_DecisionTreeModel(m) for m in list(self._call_java("trees"))]
 
     @property
     @since("2.0.0")
@@ -211,7 +212,7 @@ class TreeEnsembleModel(JavaPredictionModel):
         return self._call_java("toString")
 
 
-class TreeEnsembleParams(DecisionTreeParams):
+class _TreeEnsembleParams(_DecisionTreeParams):
     """
     Mixin for Decision Tree-based ensemble algorithms parameters.
     """
@@ -234,7 +235,7 @@ class TreeEnsembleParams(DecisionTreeParams):
               " n features). default = 'auto'", typeConverter=TypeConverters.toString)
 
     def __init__(self):
-        super(TreeEnsembleParams, self).__init__()
+        super(_TreeEnsembleParams, self).__init__()
 
     @since("1.4.0")
     def getSubsamplingRate(self):
@@ -251,7 +252,7 @@ class TreeEnsembleParams(DecisionTreeParams):
         return self.getOrDefault(self.featureSubsetStrategy)
 
 
-class RandomForestParams(TreeEnsembleParams):
+class _RandomForestParams(_TreeEnsembleParams):
     """
     Private class to track supported random forest parameters.
     """
@@ -260,7 +261,7 @@ class RandomForestParams(TreeEnsembleParams):
                      typeConverter=TypeConverters.toInt)
 
     def __init__(self):
-        super(RandomForestParams, self).__init__()
+        super(_RandomForestParams, self).__init__()
 
     @since("1.4.0")
     def getNumTrees(self):
@@ -270,7 +271,7 @@ class RandomForestParams(TreeEnsembleParams):
         return self.getOrDefault(self.numTrees)
 
 
-class GBTParams(TreeEnsembleParams, HasMaxIter, HasStepSize, HasValidationIndicatorCol):
+class _GBTParams(_TreeEnsembleParams, HasMaxIter, HasStepSize, HasValidationIndicatorCol):
     """
     Private class to track supported GBT params.
     """
@@ -295,7 +296,7 @@ class GBTParams(TreeEnsembleParams, HasMaxIter, HasStepSize, HasValidationIndica
         return self.getOrDefault(self.validationTol)
 
 
-class HasVarianceImpurity(Params):
+class _HasVarianceImpurity(Params):
     """
     Private class to track supported impurity measures.
     """
@@ -308,7 +309,7 @@ class HasVarianceImpurity(Params):
                      ", ".join(supportedImpurities), typeConverter=TypeConverters.toString)
 
     def __init__(self):
-        super(HasVarianceImpurity, self).__init__()
+        super(_HasVarianceImpurity, self).__init__()
 
     @since("1.4.0")
     def getImpurity(self):
@@ -318,11 +319,13 @@ class HasVarianceImpurity(Params):
         return self.getOrDefault(self.impurity)
 
 
-class TreeClassifierParams(object):
+class _TreeClassifierParams(object):
     """
     Private class to track supported impurity measures.
+
     .. versionadded:: 1.4.0
     """
+
     supportedImpurities = ["entropy", "gini"]
 
     impurity = Param(Params._dummy(), "impurity",
@@ -331,7 +334,7 @@ class TreeClassifierParams(object):
                      ", ".join(supportedImpurities), typeConverter=TypeConverters.toString)
 
     def __init__(self):
-        super(TreeClassifierParams, self).__init__()
+        super(_TreeClassifierParams, self).__init__()
 
     @since("1.6.0")
     def getImpurity(self):
@@ -341,7 +344,7 @@ class TreeClassifierParams(object):
         return self.getOrDefault(self.impurity)
 
 
-class TreeRegressorParams(HasVarianceImpurity):
+class _TreeRegressorParams(_HasVarianceImpurity):
     """
     Private class to track supported impurity measures.
     """

--- a/python/pyspark/ml/tree.py
+++ b/python/pyspark/ml/tree.py
@@ -1,0 +1,348 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark import since, keyword_only
+from pyspark.ml.param.shared import *
+from pyspark.ml.util import *
+from pyspark.ml.wrapper import JavaEstimator, JavaModel, JavaParams, \
+    JavaPredictor, JavaPredictionModel
+from pyspark.ml.common import inherit_doc, _java2py, _py2java
+
+
+@inherit_doc
+class DecisionTreeModel(JavaPredictionModel):
+    """
+    Abstraction for Decision Tree models.
+    .. versionadded:: 1.5.0
+    """
+
+    @property
+    @since("1.5.0")
+    def numNodes(self):
+        """Return number of nodes of the decision tree."""
+        return self._call_java("numNodes")
+
+    @property
+    @since("1.5.0")
+    def depth(self):
+        """Return depth of the decision tree."""
+        return self._call_java("depth")
+
+    @property
+    @since("2.0.0")
+    def toDebugString(self):
+        """Full description of model."""
+        return self._call_java("toDebugString")
+
+    @since("3.0.0")
+    def predictLeaf(self, value):
+        """
+        Predict the indices of the leaves corresponding to the feature vector.
+        """
+        return self._call_java("predictLeaf", value)
+
+    def __repr__(self):
+        return self._call_java("toString")
+
+
+class DecisionTreeParams(HasCheckpointInterval, HasSeed, HasWeightCol):
+    """
+    Mixin for Decision Tree parameters.
+    """
+
+    leafCol = Param(Params._dummy(), "leafCol", "Leaf indices column name. Predicted leaf " +
+                    "index of each instance in each tree by preorder.",
+                    typeConverter=TypeConverters.toString)
+
+    maxDepth = Param(Params._dummy(), "maxDepth", "Maximum depth of the tree. (>= 0) E.g., " +
+                     "depth 0 means 1 leaf node; depth 1 means 1 internal node + 2 leaf nodes.",
+                     typeConverter=TypeConverters.toInt)
+
+    maxBins = Param(Params._dummy(), "maxBins", "Max number of bins for discretizing continuous " +
+                    "features.  Must be >=2 and >= number of categories for any categorical " +
+                    "feature.", typeConverter=TypeConverters.toInt)
+
+    minInstancesPerNode = Param(Params._dummy(), "minInstancesPerNode", "Minimum number of " +
+                                "instances each child must have after split. If a split causes " +
+                                "the left or right child to have fewer than " +
+                                "minInstancesPerNode, the split will be discarded as invalid. " +
+                                "Should be >= 1.", typeConverter=TypeConverters.toInt)
+
+    minWeightFractionPerNode = Param(Params._dummy(), "minWeightFractionPerNode", "Minimum "
+                                     "fraction of the weighted sample count that each child "
+                                     "must have after split. If a split causes the fraction "
+                                     "of the total weight in the left or right child to be "
+                                     "less than minWeightFractionPerNode, the split will be "
+                                     "discarded as invalid. Should be in interval [0.0, 0.5).",
+                                     typeConverter=TypeConverters.toFloat)
+
+    minInfoGain = Param(Params._dummy(), "minInfoGain", "Minimum information gain for a split " +
+                        "to be considered at a tree node.", typeConverter=TypeConverters.toFloat)
+
+    maxMemoryInMB = Param(Params._dummy(), "maxMemoryInMB", "Maximum memory in MB allocated to " +
+                          "histogram aggregation. If too small, then 1 node will be split per " +
+                          "iteration, and its aggregates may exceed this size.",
+                          typeConverter=TypeConverters.toInt)
+
+    cacheNodeIds = Param(Params._dummy(), "cacheNodeIds", "If false, the algorithm will pass " +
+                         "trees to executors to match instances with nodes. If true, the " +
+                         "algorithm will cache node IDs for each instance. Caching can speed " +
+                         "up training of deeper trees. Users can set how often should the cache " +
+                         "be checkpointed or disable it by setting checkpointInterval.",
+                         typeConverter=TypeConverters.toBoolean)
+
+    def __init__(self):
+        super(DecisionTreeParams, self).__init__()
+
+    def setLeafCol(self, value):
+        """
+        Sets the value of :py:attr:`leafCol`.
+        """
+        return self._set(leafCol=value)
+
+    def getLeafCol(self):
+        """
+        Gets the value of leafCol or its default value.
+        """
+        return self.getOrDefault(self.leafCol)
+
+    def getMaxDepth(self):
+        """
+        Gets the value of maxDepth or its default value.
+        """
+        return self.getOrDefault(self.maxDepth)
+
+    def getMaxBins(self):
+        """
+        Gets the value of maxBins or its default value.
+        """
+        return self.getOrDefault(self.maxBins)
+
+    def getMinInstancesPerNode(self):
+        """
+        Gets the value of minInstancesPerNode or its default value.
+        """
+        return self.getOrDefault(self.minInstancesPerNode)
+
+    def getMinWeightFractionPerNode(self):
+        """
+        Gets the value of minWeightFractionPerNode or its default value.
+        """
+        return self.getOrDefault(self.minWeightFractionPerNode)
+
+    def getMinInfoGain(self):
+        """
+        Gets the value of minInfoGain or its default value.
+        """
+        return self.getOrDefault(self.minInfoGain)
+
+    def getMaxMemoryInMB(self):
+        """
+        Gets the value of maxMemoryInMB or its default value.
+        """
+        return self.getOrDefault(self.maxMemoryInMB)
+
+    def getCacheNodeIds(self):
+        """
+        Gets the value of cacheNodeIds or its default value.
+        """
+        return self.getOrDefault(self.cacheNodeIds)
+
+
+@inherit_doc
+class TreeEnsembleModel(JavaPredictionModel):
+    """
+    (private abstraction)
+    Represents a tree ensemble model.
+    """
+
+    @property
+    @since("2.0.0")
+    def trees(self):
+        """Trees in this ensemble. Warning: These have null parent Estimators."""
+        return [DecisionTreeModel(m) for m in list(self._call_java("trees"))]
+
+    @property
+    @since("2.0.0")
+    def getNumTrees(self):
+        """Number of trees in ensemble."""
+        return self._call_java("getNumTrees")
+
+    @property
+    @since("1.5.0")
+    def treeWeights(self):
+        """Return the weights for each tree"""
+        return list(self._call_java("javaTreeWeights"))
+
+    @property
+    @since("2.0.0")
+    def totalNumNodes(self):
+        """Total number of nodes, summed over all trees in the ensemble."""
+        return self._call_java("totalNumNodes")
+
+    @property
+    @since("2.0.0")
+    def toDebugString(self):
+        """Full description of model."""
+        return self._call_java("toDebugString")
+
+    @since("3.0.0")
+    def predictLeaf(self, value):
+        """
+        Predict the indices of the leaves corresponding to the feature vector.
+        """
+        return self._call_java("predictLeaf", value)
+
+    def __repr__(self):
+        return self._call_java("toString")
+
+
+class TreeEnsembleParams(DecisionTreeParams):
+    """
+    Mixin for Decision Tree-based ensemble algorithms parameters.
+    """
+
+    subsamplingRate = Param(Params._dummy(), "subsamplingRate", "Fraction of the training data " +
+                            "used for learning each decision tree, in range (0, 1].",
+                            typeConverter=TypeConverters.toFloat)
+
+    supportedFeatureSubsetStrategies = ["auto", "all", "onethird", "sqrt", "log2"]
+
+    featureSubsetStrategy = \
+        Param(Params._dummy(), "featureSubsetStrategy",
+              "The number of features to consider for splits at each tree node. Supported " +
+              "options: 'auto' (choose automatically for task: If numTrees == 1, set to " +
+              "'all'. If numTrees > 1 (forest), set to 'sqrt' for classification and to " +
+              "'onethird' for regression), 'all' (use all features), 'onethird' (use " +
+              "1/3 of the features), 'sqrt' (use sqrt(number of features)), 'log2' (use " +
+              "log2(number of features)), 'n' (when n is in the range (0, 1.0], use " +
+              "n * number of features. When n is in the range (1, number of features), use" +
+              " n features). default = 'auto'", typeConverter=TypeConverters.toString)
+
+    def __init__(self):
+        super(TreeEnsembleParams, self).__init__()
+
+    @since("1.4.0")
+    def getSubsamplingRate(self):
+        """
+        Gets the value of subsamplingRate or its default value.
+        """
+        return self.getOrDefault(self.subsamplingRate)
+
+    @since("1.4.0")
+    def getFeatureSubsetStrategy(self):
+        """
+        Gets the value of featureSubsetStrategy or its default value.
+        """
+        return self.getOrDefault(self.featureSubsetStrategy)
+
+
+class RandomForestParams(TreeEnsembleParams):
+    """
+    Private class to track supported random forest parameters.
+    """
+
+    numTrees = Param(Params._dummy(), "numTrees", "Number of trees to train (>= 1).",
+                     typeConverter=TypeConverters.toInt)
+
+    def __init__(self):
+        super(RandomForestParams, self).__init__()
+
+    @since("1.4.0")
+    def getNumTrees(self):
+        """
+        Gets the value of numTrees or its default value.
+        """
+        return self.getOrDefault(self.numTrees)
+
+
+class GBTParams(TreeEnsembleParams, HasMaxIter, HasStepSize, HasValidationIndicatorCol):
+    """
+    Private class to track supported GBT params.
+    """
+
+    stepSize = Param(Params._dummy(), "stepSize",
+                     "Step size (a.k.a. learning rate) in interval (0, 1] for shrinking " +
+                     "the contribution of each estimator.",
+                     typeConverter=TypeConverters.toFloat)
+
+    validationTol = Param(Params._dummy(), "validationTol",
+                          "Threshold for stopping early when fit with validation is used. " +
+                          "If the error rate on the validation input changes by less than the " +
+                          "validationTol, then learning will stop early (before `maxIter`). " +
+                          "This parameter is ignored when fit without validation is used.",
+                          typeConverter=TypeConverters.toFloat)
+
+    @since("3.0.0")
+    def getValidationTol(self):
+        """
+        Gets the value of validationTol or its default value.
+        """
+        return self.getOrDefault(self.validationTol)
+
+
+class HasVarianceImpurity(Params):
+    """
+    Private class to track supported impurity measures.
+    """
+
+    supportedImpurities = ["variance"]
+
+    impurity = Param(Params._dummy(), "impurity",
+                     "Criterion used for information gain calculation (case-insensitive). " +
+                     "Supported options: " +
+                     ", ".join(supportedImpurities), typeConverter=TypeConverters.toString)
+
+    def __init__(self):
+        super(HasVarianceImpurity, self).__init__()
+
+    @since("1.4.0")
+    def getImpurity(self):
+        """
+        Gets the value of impurity or its default value.
+        """
+        return self.getOrDefault(self.impurity)
+
+
+class TreeClassifierParams(object):
+    """
+    Private class to track supported impurity measures.
+    .. versionadded:: 1.4.0
+    """
+    supportedImpurities = ["entropy", "gini"]
+
+    impurity = Param(Params._dummy(), "impurity",
+                     "Criterion used for information gain calculation (case-insensitive). " +
+                     "Supported options: " +
+                     ", ".join(supportedImpurities), typeConverter=TypeConverters.toString)
+
+    def __init__(self):
+        super(TreeClassifierParams, self).__init__()
+
+    @since("1.6.0")
+    def getImpurity(self):
+        """
+        Gets the value of impurity or its default value.
+        """
+        return self.getOrDefault(self.impurity)
+
+
+class TreeRegressorParams(HasVarianceImpurity):
+    """
+    Private class to track supported impurity measures.
+    """
+    pass


### PR DESCRIPTION


### What changes were proposed in this pull request?

- Move tree related classes to a separate file ```tree.py```
- add method ```predictLeaf``` in ```DecisionTreeModel```& ```TreeEnsembleModel```


### Why are the changes needed?

- keep parity between scala and python
- easy code maintenance


### Does this PR introduce any user-facing change?
Yes
add method ```predictLeaf``` in ```DecisionTreeModel```& ```TreeEnsembleModel```
add ```setMinWeightFractionPerNode```  in ```DecisionTreeClassifier``` and ```DecisionTreeRegressor```

### How was this patch tested?
add some doc tests
