### PR TITLE
[SPARK-29249][SQL] V2 writer: Don't allow tableProperty for existing tables

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriterV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriterV2.scala
@@ -89,7 +89,7 @@ final class DataFrameWriterV2[T] private[sql](table: String, ds: Dataset[T])
     this
   }
 
-  override def tableProperty(property: String, value: String): DataFrameWriterV2[T] = {
+  override def tableProperty(property: String, value: String): CreateTableWriter[T] = {
     this.properties.put(property, value)
     this
   }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameWriterV2Suite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameWriterV2Suite.java
@@ -57,21 +57,18 @@ public class JavaDataFrameWriterV2Suite {
   public void testAppendAPI() throws NoSuchTableException {
     df().writeTo("testcat.t").append();
     df().writeTo("testcat.t").option("property", "value").append();
-    df().writeTo("testcat.t").tableProperty("property", "value").append();
   }
 
   @Test
   public void testOverwritePartitionsAPI() throws NoSuchTableException {
     df().writeTo("testcat.t").overwritePartitions();
     df().writeTo("testcat.t").option("property", "value").overwritePartitions();
-    df().writeTo("testcat.t").tableProperty("property", "value").overwritePartitions();
   }
 
   @Test
   public void testOverwriteAPI() throws NoSuchTableException {
     df().writeTo("testcat.t").overwrite(lit(true));
     df().writeTo("testcat.t").option("property", "value").overwrite(lit(true));
-    df().writeTo("testcat.t").tableProperty("property", "value").overwrite(lit(true));
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Don't allow calling append, overwrite, or overwritePartitions after tableProperty is used in DataFrameWriterV2 because table properties are not set as part of operations on existing tables. Only tables that are created or replaced can set table properties.

### Why are the changes needed?

The properties are discarded otherwise, so this avoids confusing behavior.

### Does this PR introduce any user-facing change?

Yes, but to a new API, DataFrameWriterV2.

### How was this patch tested?

Removed test cases that used this method and the append, etc. methods because they no longer compile.