### PR TITLE
[SPARK-29252][BUILD] Upgrade zookeeper to 3.4.14 and fix vulnerabilities.

### DIFF
--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -1365,3 +1365,9 @@ Copyright (C) 2000-2007 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+Apache Yetus - Audience Annotations
+Copyright 2015-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -193,7 +193,6 @@ spire-macros_2.12-0.17.0-M1.jar
 spire-platform_2.12-0.17.0-M1.jar
 spire-util_2.12-0.17.0-M1.jar
 spire_2.12-0.17.0-M1.jar
-spotbugs-annotations-3.1.9.jar
 stax-api-1.0-2.jar
 stax-api-1.0.1.jar
 stream-2.9.6.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -20,6 +20,7 @@ arpack_combined_all-0.1.jar
 arrow-format-0.12.0.jar
 arrow-memory-0.12.0.jar
 arrow-vector-0.12.0.jar
+audience-annotations-0.5.0.jar
 automaton-1.11-8.jar
 avro-1.8.2.jar
 avro-ipc-1.8.2.jar
@@ -192,6 +193,7 @@ spire-macros_2.12-0.17.0-M1.jar
 spire-platform_2.12-0.17.0-M1.jar
 spire-util_2.12-0.17.0-M1.jar
 spire_2.12-0.17.0-M1.jar
+spotbugs-annotations-3.1.9.jar
 stax-api-1.0-2.jar
 stax-api-1.0.1.jar
 stream-2.9.6.jar
@@ -204,5 +206,5 @@ xercesImpl-2.9.1.jar
 xmlenc-0.52.jar
 xz-1.5.jar
 zjsonpatch-0.3.0.jar
-zookeeper-3.4.6.jar
+zookeeper-3.4.14.jar
 zstd-jni-1.4.2-1.jar

--- a/dev/deps/spark-deps-hadoop-3.2
+++ b/dev/deps/spark-deps-hadoop-3.2
@@ -211,6 +211,7 @@ spire-macros_2.12-0.17.0-M1.jar
 spire-platform_2.12-0.17.0-M1.jar
 spire-util_2.12-0.17.0-M1.jar
 spire_2.12-0.17.0-M1.jar
+spotbugs-annotations-3.1.9.jar
 stax-api-1.0.1.jar
 stax2-api-3.1.4.jar
 stream-2.9.6.jar
@@ -223,5 +224,5 @@ woodstox-core-5.0.3.jar
 xbean-asm7-shaded-4.14.jar
 xz-1.5.jar
 zjsonpatch-0.3.0.jar
-zookeeper-3.4.13.jar
+zookeeper-3.4.14.jar
 zstd-jni-1.4.2-1.jar

--- a/dev/deps/spark-deps-hadoop-3.2
+++ b/dev/deps/spark-deps-hadoop-3.2
@@ -211,7 +211,6 @@ spire-macros_2.12-0.17.0-M1.jar
 spire-platform_2.12-0.17.0-M1.jar
 spire-util_2.12-0.17.0-M1.jar
 spire_2.12-0.17.0-M1.jar
-spotbugs-annotations-3.1.9.jar
 stax-api-1.0.1.jar
 stax2-api-3.1.4.jar
 stream-2.9.6.jar

--- a/pom.xml
+++ b/pom.xml
@@ -1339,8 +1339,8 @@
           </exclusion>
           <exclusion>
             <groupId>com.github.spotbugs</groupId>
-	    <artifactId>spotbugs-annotations</artifactId>
-	  </exclusion>
+            <artifactId>spotbugs-annotations</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <hadoop.version>2.7.4</hadoop.version>
     <protobuf.version>2.5.0</protobuf.version>
     <yarn.version>${hadoop.version}</yarn.version>
-    <zookeeper.version>3.4.6</zookeeper.version>
+    <zookeeper.version>3.4.14</zookeeper.version>
     <curator.version>2.7.1</curator.version>
     <okapi.version>0.4.2</okapi.version>
     <hive.group>org.spark-project.hive</hive.group>
@@ -2979,7 +2979,7 @@
       <properties>
         <hadoop.version>3.2.0</hadoop.version>
         <curator.version>2.13.0</curator.version>
-        <zookeeper.version>3.4.13</zookeeper.version>
+        <zookeeper.version>3.4.14</zookeeper.version>
         <hive.group>org.apache.hive</hive.group>
         <hive.classifier>core</hive.classifier>
         <hive.version>${hive23.version}</hive.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1337,6 +1337,10 @@
             <groupId>io.netty</groupId>
             <artifactId>netty</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.github.spotbugs</groupId>
+	    <artifactId>spotbugs-annotations</artifactId>
+	  </exclusion>
         </exclusions>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2983,7 +2983,6 @@
       <properties>
         <hadoop.version>3.2.0</hadoop.version>
         <curator.version>2.13.0</curator.version>
-        <zookeeper.version>3.4.14</zookeeper.version>
         <hive.group>org.apache.hive</hive.group>
         <hive.classifier>core</hive.classifier>
         <hive.version>${hive23.version}</hive.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The current code uses org.apache.zookeeper:zookeeper:jar:3.4.6 and it will cause a security vulnerabilities. We could get some security info from https://www.tenable.com/cve/CVE-2019-0201

This reference remind to upgrate the version of `zookeeper` to 3.4.14 or later.


### Why are the changes needed?
This PR fix the security vulnerabilities.


### Does this PR introduce any user-facing change?
No.


### How was this patch tested?
Exists UT.
