### PR TITLE
[SPARK-29253][SQL] Add agg(String, String*) to Dataset

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1842,6 +1842,19 @@ class Dataset[T] private[sql](
   def agg(expr: Column, exprs: Column*): DataFrame = groupBy().agg(expr, exprs : _*)
 
   /**
+   * Aggregates on the entire Dataset without groups.
+   * {{{
+   *   // ds.agg(...) is a shorthand for ds.groupBy().agg(...)
+   *   ds.agg("colA", "colB")
+   *   ds.agg($"colA", $"colB")
+   * }}}
+   *
+   * @group untypedrel
+   * @since 3.0.0
+   */
+  def agg(col: String, cols: String*): DataFrame = agg(Column(col), cols.map(Column(_)) : _*)
+
+  /**
    * Returns a new Dataset by taking the first `n` rows. The difference between this function
    * and `head` is that `head` is an action and returns an array (by triggering query execution)
    * while `limit` returns a new Dataset.

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1852,7 +1852,11 @@ class Dataset[T] private[sql](
    * @group untypedrel
    * @since 3.0.0
    */
-  def agg(col: String, cols: String*): DataFrame = agg(Column(col), cols.map(Column(_)) : _*)
+  def agg(expr: String, exprs: String*): DataFrame = {
+    agg(
+      Column(sparkSession.sessionState.sqlParser.parseExpression(expr)),
+      exprs.map(expr => Column(sparkSession.sessionState.sqlParser.parseExpression(expr))) : _*)
+  }
 
   /**
    * Returns a new Dataset by taking the first `n` rows. The difference between this function

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -228,6 +228,12 @@ class RelationalGroupedDataset protected[sql](
     })
   }
 
+  def agg(expr: String, exprs: String*): DataFrame = {
+    agg(
+      Column(df.sparkSession.sessionState.sqlParser.parseExpression(expr)),
+      exprs.map(expr => Column(df.sparkSession.sessionState.sqlParser.parseExpression(expr))) : _*)
+  }
+
   /**
    * Count the number of rows for each group.
    * The resulting `DataFrame` will also contain the grouping columns.

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -389,7 +389,17 @@ class DataFrameAggregateSuite extends QueryTest with SharedSparkSession {
     )
 
     checkAnswer(
+      df1.agg("countDistinct(key1, key2, key3)"),
+      Row(3)
+    )
+
+    checkAnswer(
       df1.groupBy('key1).agg(countDistinct('key2, 'key3)),
+      Seq(Row("a", 2), Row("x", 1))
+    )
+
+    checkAnswer(
+      df1.groupBy('key1).agg("countDistinct(key2, key3)"),
       Seq(Row("a", 2), Row("x", 1))
     )
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->Add agg(String, String*) and its test.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->Other API (filter, select...etc) can use both of Column and String on argument, butagg() was not able to use String on argument.
I think agg() should be able to use Column on argument, too.

Ex.)
[ Before ] We can use String in groupBy(), but we should use Column in agg().
`df.groupBy("_1").agg($"_2")`

[ After ] We can use String both of in groupBy() and agg().
`df.groupBy("_1").agg("_2")`


### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->Yes.
Users can use agg(String, String*).

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->Added test case to DataFrameAggregateSuite.scala .
