### PR TITLE
[SPARK-29275][SQL][DOC] Describe special date/timestamp values in the SQL migration guide

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -203,16 +203,16 @@ license: |
 
   - Since Spark 3.0, special values are supported in conversion from strings to dates and timestamps. Those values are simply notational shorthands that will be converted to ordinary date or timestamp values when read. The following string values are supported for dates:
     - `epoch [zoneId]` - 1970-01-01
-    - `today [zoneId]` - the current date in the time zone specified by `spark.sql.session.timeZone`.
+    - `today [zoneId]` - the current date in the time zone specified by `spark.sql.session.timeZone`
     - `yesterday [zoneId]` - the current date - 1
     - `tomorrow [zoneId]` - the current date + 1
-    - `now` - the date of running the current query. It has the same notion as today.
+    - `now` - the date of running the current query. It has the same notion as today
   For example `SELECT date 'tomorrow' - date 'yesterday';` should output `2`. Here are special timestamp values:
     - `epoch [zoneId]` - 1970-01-01 00:00:00+00 (Unix system time zero)
-    - `today [zoneId]` - midnight today.
+    - `today [zoneId]` - midnight today
     - `yesterday [zoneId]` - midnight yesterday
     - `tomorrow [zoneId]` - midnight tomorrow
-    - `now` - current query start time.
+    - `now` - current query start time
   For example `SELECT timestamp 'tomorrow';`. 
 
 ## Upgrading from Spark SQL 2.4 to 2.4.1

--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -201,6 +201,20 @@ license: |
         </tr>
     </table>
 
+  - Since Spark 3.0, special values are supported in conversion from strings to dates and timestamps. Those values are simply notational shorthands that will be converted to ordinary date or timestamp values when read. The following string values are supported for dates:
+    - `epoch [zoneId]` - 1970-01-01
+    - `today [zoneId]` - the current date in the time zone specified by `spark.sql.session.timeZone`.
+    - `yesterday [zoneId]` - the current date - 1
+    - `tomorrow [zoneId]` - the current date + 1
+    - `now` - the date of running the current query. It has the same notion as today.
+  For example `SELECT date 'tomorrow' - date 'yesterday';` should output `2`. Here are special timestamp values:
+    - `epoch [zoneId]` - 1970-01-01 00:00:00+00 (Unix system time zero)
+    - `today [zoneId]` - midnight today.
+    - `yesterday [zoneId]` - midnight yesterday
+    - `tomorrow [zoneId]` - midnight tomorrow
+    - `now` - current query start time.
+  For example `SELECT timestamp 'tomorrow';`. 
+
 ## Upgrading from Spark SQL 2.4 to 2.4.1
 
   - The value of `spark.executor.heartbeatInterval`, when specified without units like "30" rather than "30s", was


### PR DESCRIPTION
### What changes were proposed in this pull request?

Updated the SQL migration guide regarding to recently supported special date and timestamp values, see https://github.com/apache/spark/pull/25716 and https://github.com/apache/spark/pull/25708.

Closes #25834

### Why are the changes needed?
To let users know about new feature in Spark 3.0.

### Does this PR introduce any user-facing change?
No

