### PR TITLE
[SPARK-29263][CORE][TEST][FOLLOWUP][2.4] Fix build failure of `TaskSchedulerImplSuite`

### DIFF
--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -1398,7 +1398,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     assert(taskSetManager1.isZombie)
     assert(taskSetManager1.runningTasks === 9)
 
-    val taskSet2 = FakeTask.createTaskSet(10, stageAttemptId = 1)
+    val taskSet2 = FakeTask.createTaskSet(10, stageId = 0, stageAttemptId = 1)
     sched.submitTasks(taskSet2)
     sched.resourceOffers(
       (11 until 20).map { idx => WorkerOffer(s"exec-$idx", s"host-$idx", 1) })


### PR DESCRIPTION
### What changes were proposed in this pull request?

https://github.com/apache/spark/pull/25946 Fixed a bug and modified the `TaskSchedulerImplSuite`, when backported to 2.4 it breaks the build. This PR is to fix the broken test build.

### How was this patch tested?

Passed locally.
