### PR TITLE
[SPARK-29244][Core] Prevent freed page in BytesToBytesMap free again

### DIFF
--- a/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
+++ b/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
@@ -742,11 +742,7 @@ public final class BytesToBytesMap extends MemoryConsumer {
         isDefined = true;
 
         if (numKeys >= growthThreshold && longArray.size() < MAX_CAPACITY) {
-          try {
-            growAndRehash();
-          } catch (SparkOutOfMemoryError oom) {
-            canGrowArray = false;
-          }
+          growAndRehash();
         }
       }
       return true;
@@ -787,8 +783,16 @@ public final class BytesToBytesMap extends MemoryConsumer {
     assert (capacity >= 0);
     capacity = Math.max((int) Math.min(MAX_CAPACITY, ByteArrayMethods.nextPowerOf2(capacity)), 64);
     assert (capacity <= MAX_CAPACITY);
-    longArray = allocateArray(capacity * 2L);
-    longArray.zeroOut();
+    try {
+      longArray = allocateArray(capacity * 2L);
+      longArray.zeroOut();
+    } catch (SparkOutOfMemoryError e) {
+      // When OOM, allocated page was already freed by `TaskMemoryManager`.
+      // We should not keep it in `longArray`. Otherwise it might be freed again in task
+      // complete listeners and cause unnecessary error.
+      longArray = null;
+      throw e;
+    }
 
     this.growthThreshold = (int) (capacity * loadFactor);
     this.mask = capacity - 1;
@@ -907,25 +911,32 @@ public final class BytesToBytesMap extends MemoryConsumer {
     final LongArray oldLongArray = longArray;
     final int oldCapacity = (int) oldLongArray.size() / 2;
 
-    // Allocate the new data structures
-    allocate(Math.min(growthStrategy.nextCapacity(oldCapacity), MAX_CAPACITY));
-
-    // Re-mask (we don't recompute the hashcode because we stored all 32 bits of it)
-    for (int i = 0; i < oldLongArray.size(); i += 2) {
-      final long keyPointer = oldLongArray.get(i);
-      if (keyPointer == 0) {
-        continue;
-      }
-      final int hashcode = (int) oldLongArray.get(i + 1);
-      int newPos = hashcode & mask;
-      int step = 1;
-      while (longArray.get(newPos * 2) != 0) {
-        newPos = (newPos + step) & mask;
-        step++;
-      }
-      longArray.set(newPos * 2, keyPointer);
-      longArray.set(newPos * 2 + 1, hashcode);
+    try {
+      // Allocate the new data structures
+      allocate(Math.min(growthStrategy.nextCapacity(oldCapacity), MAX_CAPACITY));
+    } catch (SparkOutOfMemoryError oom) {
+      canGrowArray = false;
+      longArray = oldLongArray;
     }
-    freeArray(oldLongArray);
+
+    if (canGrowArray) {
+      // Re-mask (we don't recompute the hashcode because we stored all 32 bits of it)
+      for (int i = 0; i < oldLongArray.size(); i += 2) {
+        final long keyPointer = oldLongArray.get(i);
+        if (keyPointer == 0) {
+          continue;
+        }
+        final int hashcode = (int) oldLongArray.get(i + 1);
+        int newPos = hashcode & mask;
+        int step = 1;
+        while (longArray.get(newPos * 2) != 0) {
+          newPos = (newPos + step) & mask;
+          step++;
+        }
+        longArray.set(newPos * 2, keyPointer);
+        longArray.set(newPos * 2 + 1, hashcode);
+      }
+      freeArray(oldLongArray);
+    }
   }
 }

--- a/core/src/test/java/org/apache/spark/unsafe/map/AbstractBytesToBytesMapSuite.java
+++ b/core/src/test/java/org/apache/spark/unsafe/map/AbstractBytesToBytesMapSuite.java
@@ -729,9 +729,10 @@ public abstract class AbstractBytesToBytesMapSuite {
 
   @Test
   public void freeAfterFailedReset() {
+    // SPARK-29244: BytesToBytesMap.free after a OOM reset operation should not cause failure.
     memoryManager.limit(5000);
     BytesToBytesMap map =
-            new BytesToBytesMap(taskMemoryManager, blockManager, serializerManager, 256, 0.5, 4000);
+      new BytesToBytesMap(taskMemoryManager, blockManager, serializerManager, 256, 0.5, 4000);
     // Force OOM on next memory allocation.
     memoryManager.markExecutionAsOutOfMemoryOnce();
     try {

--- a/core/src/test/java/org/apache/spark/unsafe/map/AbstractBytesToBytesMapSuite.java
+++ b/core/src/test/java/org/apache/spark/unsafe/map/AbstractBytesToBytesMapSuite.java
@@ -34,6 +34,7 @@ import org.mockito.MockitoAnnotations;
 import org.apache.spark.SparkConf;
 import org.apache.spark.executor.ShuffleWriteMetrics;
 import org.apache.spark.memory.MemoryMode;
+import org.apache.spark.memory.SparkOutOfMemoryError;
 import org.apache.spark.memory.TestMemoryConsumer;
 import org.apache.spark.memory.TaskMemoryManager;
 import org.apache.spark.memory.TestMemoryManager;
@@ -723,6 +724,23 @@ public abstract class AbstractBytesToBytesMapSuite {
         assertFalse("Spill file " + spillFile.getPath() + " was not cleaned up",
           spillFile.exists());
       }
+    }
+  }
+
+  @Test
+  public void freeAfterFailedReset() {
+    memoryManager.limit(5000);
+    BytesToBytesMap map =
+            new BytesToBytesMap(taskMemoryManager, blockManager, serializerManager, 256, 0.5, 4000);
+    // Force OOM on next memory allocation.
+    memoryManager.markExecutionAsOutOfMemoryOnce();
+    try {
+      map.reset();
+      Assert.fail("Expected SparkOutOfMemoryError to be thrown");
+    } catch (SparkOutOfMemoryError e) {
+      // Expected exception; do nothing.
+    } finally {
+      map.free();
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMapSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMapSuite.scala
@@ -28,7 +28,7 @@ import org.scalatest.Matchers
 
 import org.apache.spark.{SparkConf, SparkFunSuite, TaskContext, TaskContextImpl}
 import org.apache.spark.internal.config.MEMORY_OFFHEAP_ENABLED
-import org.apache.spark.memory.{SparkOutOfMemoryError, TaskMemoryManager, TestMemoryConsumer, TestMemoryManager}
+import org.apache.spark.memory.{TaskMemoryManager, TestMemoryManager}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.test.SharedSparkSession
@@ -380,52 +380,6 @@ class UnsafeFixedWidthAggregationMapSuite
       if (sorter != null) {
         sorter.cleanupResources()
       }
-    }
-  }
-
-  testWithMemoryLeakDetection("SPARK-29244: freed page should not be freed again") {
-    memoryManager.limit(8000)
-
-    val pageSize = 4096
-    val map = new UnsafeFixedWidthAggregationMap(
-      emptyAggregationBuffer,
-      aggBufferSchema,
-      groupKeySchema,
-      TaskContext.get(), // We want to run completion listener.
-      256, // initial capacity
-      pageSize
-    )
-
-    val rand = new Random(42)
-    val str = rand.nextString(1024)
-    val buf = map.getAggregationBuffer(InternalRow(UTF8String.fromString(str)))
-    buf.setInt(0, str.length)
-
-    var stopThread = false
-    val thread = new Thread {
-      override def run {
-        val testConsumer = new TestMemoryConsumer(taskMemoryManager)
-        while (!stopThread) {
-          try {
-            testConsumer.allocateArray(4000)
-          } catch {
-            case _: SparkOutOfMemoryError =>
-          }
-        }
-      }
-    }
-    thread.start()
-
-    try {
-      map.destructAndCreateExternalSorter()
-    } catch {
-      // In some chance, the `BytesToBytesMap` inside `UnsafeFixedWidthAggregationMap` cannot
-      // allocate enough memory when calling `reset`. It will throw OOM exception.
-      case s: SparkOutOfMemoryError =>
-        TaskContext.get().markTaskCompleted(Some(s))
-    } finally {
-      stopThread = true
-      thread.join()
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMapSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMapSuite.scala
@@ -423,7 +423,9 @@ class UnsafeFixedWidthAggregationMapSuite
       // allocate enough memory when calling `reset`. It will throw OOM exception.
       case s: SparkOutOfMemoryError =>
         TaskContext.get().markTaskCompleted(Some(s))
+    } finally {
+      stopThread = true
+      thread.join()
     }
-    stopThread = true
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

When BytesToBytesMap cannot allocate a page, allocated page was freed by TaskMemoryManager. In this case, we should not keep it in longArray field of BytesToBytesMap. Otherwise it might be freed again in task completion listener of UnsafeFixedWidthAggregationMap and cause confusing error.

Note that because we catch Throwable when invoking completion listeners, this error should not affect other listeners, except for the current listener. In the completion listener of UnsafeFixedWidthAggregationMap, it only performs BytesToBytesMap.free().

BytesToBytesMap.free() does two things: freeing allocated pages and deleting spilled files. When it tries to free a freed page, this error hits and skips remaining pages (Executor.cleanUpAllAllocatedMemory will guard memory leak) and spilled files.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

By chance, it is possibly that we free an already freed page in BytesToBytesMap. Because we have some guards when freeing a page, a confusing error would be hit:

```
16:07:33.550 ERROR org.apache.spark.TaskContextImpl: Error in TaskCompletionListener
java.lang.AssertionError: Called freePage() on a memory block that has already been freed
        at org.apache.spark.memory.TaskMemoryManager.freePage(TaskMemoryManager.java:332)                                                                                             
        at org.apache.spark.memory.MemoryConsumer.freePage(MemoryConsumer.java:129)  
        at org.apache.spark.memory.MemoryConsumer.freeArray(MemoryConsumer.java:107)
        at org.apache.spark.unsafe.map.BytesToBytesMap.free(BytesToBytesMap.java:806)                                                                                                 
        at org.apache.spark.sql.execution.UnsafeFixedWidthAggregationMap.free(UnsafeFixedWidthAggregationMap.java:226)
        at org.apache.spark.sql.execution.UnsafeFixedWidthAggregationMap.lambda$new$0(UnsafeFixedWidthAggregationMap.java:112)
        at org.apache.spark.TaskContextImpl.$anonfun$markTaskCompleted$1(TaskContextImpl.scala:119)
        at org.apache.spark.TaskContextImpl.$anonfun$markTaskCompleted$1$adapted(TaskContextImpl.scala:119)
        at org.apache.spark.TaskContextImpl.$anonfun$invokeListeners$1(TaskContextImpl.scala:132)                                                                                     
        at org.apache.spark.TaskContextImpl.$anonfun$invokeListeners$1$adapted(TaskContextImpl.scala:130)
        at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)       
        at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)      
        at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
        at org.apache.spark.TaskContextImpl.invokeListeners(TaskContextImpl.scala:130)                                                                                                
        at org.apache.spark.TaskContextImpl.markTaskCompleted(TaskContextImpl.scala:119)                                                                                              
        at org.apache.spark.sql.execution.UnsafeFixedWidthAggregationMapSuite.$anonfun$new$19(UnsafeFixedWidthAggregationMapSuite.scala:425)
        at org.apache.spark.sql.execution.UnsafeFixedWidthAggregationMapSuite.$anonfun$testWithMemoryLeakDetection$1(UnsafeFixedWidthAggregationMapSuite.scala:87)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
        at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)                                                                                                                      
        at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)                                                                                                                     
        at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)                         
        at org.scalatest.Transformer.apply(Transformer.scala:22)                                                                                                                      
        at org.scalatest.Transformer.apply(Transformer.scala:20)                                                                                                                      
        at org.scalatest.FunSuiteLike$$anon$1.apply(FunSuiteLike.scala:186)                                                                                                           
        at org.apache.spark.SparkFunSuite.withFixture(SparkFunSuite.scala:149)                                                                                                        
        at org.scalatest.FunSuiteLike.invokeWithFixture$1(FunSuiteLike.scala:184) 
        at org.scalatest.FunSuiteLike.$anonfun$runTest$1(FunSuiteLike.scala:196)
        at org.scalatest.SuperEngine.runTestImpl(Engine.scala:289)
        at org.scalatest.FunSuiteLike.runTest(FunSuiteLike.scala:196)
        at org.scalatest.FunSuiteLike.runTest$(FunSuiteLike.scala:178)
        at org.apache.spark.SparkFunSuite.org$scalatest$BeforeAndAfterEach$$super$runTest(SparkFunSuite.scala:56)
        at org.scalatest.BeforeAndAfterEach.runTest(BeforeAndAfterEach.scala:221)
        at org.scalatest.BeforeAndAfterEach.runTest$(BeforeAndAfterEach.scala:214)
        at org.apache.spark.SparkFunSuite.runTest(SparkFunSuite.scala:56)         
        at org.scalatest.FunSuiteLike.$anonfun$runTests$1(FunSuiteLike.scala:229)
        at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:396)
        at scala.collection.immutable.List.foreach(List.scala:392)    
        at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:384)                  
        at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:379)                                                                                                               
        at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:461)               
        at org.scalatest.FunSuiteLike.runTests(FunSuiteLike.scala:229)             
        at org.scalatest.FunSuiteLike.runTests$(FunSuiteLike.scala:228)   
        at org.scalatest.FunSuite.runTests(FunSuite.scala:1560)                   
        at org.scalatest.Suite.run(Suite.scala:1147)                               
        at org.scalatest.Suite.run$(Suite.scala:1129)                                    
        at org.scalatest.FunSuite.org$scalatest$FunSuiteLike$$super$run(FunSuite.scala:1560)                                                                                          
        at org.scalatest.FunSuiteLike.$anonfun$run$1(FunSuiteLike.scala:233)               
        at org.scalatest.SuperEngine.runImpl(Engine.scala:521)                             
        at org.scalatest.FunSuiteLike.run(FunSuiteLike.scala:233)                   
        at org.scalatest.FunSuiteLike.run$(FunSuiteLike.scala:232)                       
        at org.apache.spark.SparkFunSuite.org$scalatest$BeforeAndAfterAll$$super$run(SparkFunSuite.scala:56)                                                                          
        at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
        at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)         
        at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)                                                                                                          
        at org.apache.spark.SparkFunSuite.run(SparkFunSuite.scala:56)                                                                                                                 
        at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:314)                         
        at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:507)                                                                                                   
        at sbt.ForkMain$Run$2.call(ForkMain.java:296)                                                                                                                                 
        at sbt.ForkMain$Run$2.call(ForkMain.java:286)                                                                                                                                 
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)                                                                                                                   
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)                             
[info] - SPARK-29244 *** FAILED *** (16 milliseconds)                                                                                                                                 
[info]   org.apache.spark.util.TaskCompletionListenerException: Called freePage() on a memory block that has already been freed                                                       
[info]                                                                                                                                                                                
[info] Previous exception in task: Unable to acquire 4096 bytes of memory, got 0                                                                                                      
[info]  org.apache.spark.memory.MemoryConsumer.throwOom(MemoryConsumer.java:157) 
[info]  org.apache.spark.memory.MemoryConsumer.allocateArray(MemoryConsumer.java:97)                                                                                                  
[info]  org.apache.spark.unsafe.map.BytesToBytesMap.allocate(BytesToBytesMap.java:790)                                                                                                
[info]  org.apache.spark.unsafe.map.BytesToBytesMap.reset(BytesToBytesMap.java:893)        
[info]  org.apache.spark.sql.execution.UnsafeKVExternalSorter.<init>(UnsafeKVExternalSorter.java:170)                                                                                 
[info]  org.apache.spark.sql.execution.UnsafeFixedWidthAggregationMap.destructAndCreateExternalSorter(UnsafeFixedWidthAggregationMap.java:249)                                        
[info]  org.apache.spark.sql.execution.UnsafeFixedWidthAggregationMapSuite.$anonfun$new$19(UnsafeFixedWidthAggregationMapSuite.scala:421)                                             
[info]  org.apache.spark.sql.execution.UnsafeFixedWidthAggregationMapSuite.$anonfun$testWithMemoryLeakDetection$1(UnsafeFixedWidthAggregationMapSuite.scala:87) 
```


### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added unit test.
