### PR TITLE
[SPARK-28137][SQL] Add Postgresql function to_number.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -331,6 +331,7 @@ object FunctionRegistry {
     expression[Encode]("encode"),
     expression[FindInSet]("find_in_set"),
     expression[FormatNumber]("format_number"),
+    expression[ToNumber]("to_number"),
     expression[FormatString]("format_string"),
     expression[GetJsonObject]("get_json_object"),
     expression[InitCap]("initcap"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -2268,7 +2268,7 @@ case class FormatNumber(x: Expression, d: Expression)
 }
 
 /**
- * A function that convert string to numeric.
+ * A function that converts string to numeric.
  */
 // scalastyle:off line.size.limit
 @ExpressionDescription(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -2287,13 +2287,13 @@ case class FormatNumber(x: Expression, d: Expression)
   examples = """
     Examples:
       > SELECT _FUNC_('4540', '999');
-       '454'
+       454
       > SELECT _FUNC_('454.00', '000D00');
-       '454'
+       454
       > SELECT _FUNC_('12,454.8-', '99G999D9S');
-       '-12454.8'
+       -12454.8
       > SELECT _FUNC_('CNY234234.4350', 'L999999.0000');
-       '-234234.435'
+       234234.435
   """)
 // scalastyle:on line.size.limit
 case class ToNumber(strExpr: Expression, patternExpr: Expression)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -2373,7 +2373,6 @@ case class ToNumber(strExpr: Expression, patternExpr: Expression)
         }
         indexOfString += 1
       }
-      
     }
 
     var result = if (integerLen == -1 && wholeLen == -1) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -2301,7 +2301,9 @@ case class FormatNumber(x: Expression, d: Expression)
 case class ToNumber(strExpr: Expression, patternExpr: Expression)
   extends BinaryExpression with ImplicitCastInputTypes {
 
-  private lazy val pattern = patternExpr.eval().asInstanceOf[UTF8String].toString
+  // scalastyle:off caselocale
+  private lazy val patternStr = patternExpr.eval().asInstanceOf[UTF8String].toUpperCase.toString
+  // scalastyle:on caselocale
 
   override def left: Expression = strExpr
   override def right: Expression = patternExpr
@@ -2315,7 +2317,7 @@ case class ToNumber(strExpr: Expression, patternExpr: Expression)
 
     val inputTypeCheck = super.checkInputDataTypes()
     if(inputTypeCheck.isSuccess) {
-      if (pattern.count(checkDecimalPointNum(_)) > 1) {
+      if (patternStr.count(checkDecimalPointNum(_)) > 1) {
         TypeCheckResult.TypeCheckFailure(s"Multiple decimal points in $patternExpr")
       } else {
         inputTypeCheck
@@ -2328,7 +2330,7 @@ case class ToNumber(strExpr: Expression, patternExpr: Expression)
   override def nullSafeEval(string: Any, pattern: Any): Any = {
     val str = string.asInstanceOf[UTF8String]
     val chars = str.toString().toCharArray()
-    val patternChars = pattern.asInstanceOf[UTF8String].toUpperCase.toString.toIterator
+    val patternChars = patternStr.toIterator
     val builder = new UTF8StringBuilder
     var indexOfString = 0
     var hasSign = false
@@ -2363,7 +2365,7 @@ case class ToNumber(strExpr: Expression, patternExpr: Expression)
           case 'S' if currentChar.equals('-') =>
             hasSign = true
           case 'L' =>
-            while(Character.isLetter(chars(indexOfString))) {
+            while (Character.isLetter(chars(indexOfString))) {
               indexOfString += 1
             }
             indexOfString -= 1
@@ -2376,7 +2378,7 @@ case class ToNumber(strExpr: Expression, patternExpr: Expression)
 
     var result = if (integerLen == -1 && wholeLen == -1) {
       builder.build
-    } else if (wholeLen == -1 || wholeLen == integerLen + 1){
+    } else if (wholeLen == -1 || wholeLen == integerLen + 1) {
       builder.build.substringSQL(1, integerLen)
     } else {
       builder.build.substringSQL(1, wholeLen)
@@ -2441,11 +2443,11 @@ case class ToNumber(strExpr: Expression, patternExpr: Expression)
                    $hasPoint = true;
                    $integerLen = $sb.length();
                    $sb.append($chars[$indexOfString]);
-		 } 
+                 }
                  break;
                case ',':
                case 'G':
-		 break;
+                 break;
                case 'S':
                  if ('-' == $chars[$indexOfString]) {
                    $hasSign = true;
@@ -2454,7 +2456,7 @@ case class ToNumber(strExpr: Expression, patternExpr: Expression)
                case 'L':
                  while(Character.isLetter($chars[$indexOfString])) {
                    $indexOfString++;
-		 }
+                 }
                  $indexOfString--;
                  break;
                default :

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -2268,6 +2268,216 @@ case class FormatNumber(x: Expression, d: Expression)
 }
 
 /**
+ * A function that convert string to numeric.
+ */
+// scalastyle:off line.size.limit
+@ExpressionDescription(
+  usage = """
+    _FUNC_(strExpr, patternExpr) - Convert a string to a number based on the pattern.
+    The pattern can consist of the following characters:
+      '9': digit position (can be dropped if insignificant)
+      '0': digit position (will not be dropped, even if insignificant)
+      '.': decimal point (only allowed once)
+      ',': group (thousands) separator
+      'S': sign anchored to number (uses locale)
+      'L': currency symbol (uses locale)
+      'D': decimal point (uses locale)
+      'G': group separator (uses locale)
+  """,
+  examples = """
+    Examples:
+      > SELECT _FUNC_('454', '');
+       ''
+      > SELECT _FUNC_('4540', '999');
+       '454'
+      > SELECT _FUNC_('454.00', '000D00');
+       '454'
+      > SELECT _FUNC_('12,454.8-', '99G999D9S');
+       '-12454.8'
+      > SELECT _FUNC_('CNY234234.4350', 'L999999.0000');
+       '-234234.435'
+  """)
+// scalastyle:on line.size.limit
+case class ToNumber(strExpr: Expression, patternExpr: Expression)
+  extends BinaryExpression with ImplicitCastInputTypes {
+
+  private lazy val pattern = patternExpr.eval().asInstanceOf[UTF8String].toString
+
+  override def left: Expression = strExpr
+  override def right: Expression = patternExpr
+  override def dataType: DataType = StringType
+  override def inputTypes: Seq[DataType] = Seq(StringType, StringType)
+
+  override def checkInputDataTypes(): TypeCheckResult = {
+    def checkDecimalPointNum(c: Char): Boolean = {
+      c == '.' || c.toUpper == 'D'
+    }
+
+    val inputTypeCheck = super.checkInputDataTypes()
+    if(inputTypeCheck.isSuccess) {
+      if (pattern.count(checkDecimalPointNum(_)) > 1) {
+        TypeCheckResult.TypeCheckFailure(s"Multiple decimal points in $patternExpr")
+      } else {
+        inputTypeCheck
+      }
+    } else {
+      inputTypeCheck
+    }
+  }
+
+  override def nullSafeEval(string: Any, pattern: Any): Any = {
+    val str = string.asInstanceOf[UTF8String]
+    val chars = str.toString().toCharArray()
+    val patternChars = pattern.asInstanceOf[UTF8String].toUpperCase.toString.toIterator
+    val builder = new UTF8StringBuilder
+    var indexOfString = 0
+    var hasSign = false
+    var hasPoint = false
+    var integerLen = -1
+    var wholeLen = -1
+    patternChars.foreach { c =>
+      val indexOfUTFString = indexOfString + 1
+      if (str.numChars >= indexOfUTFString) {
+        val currentChar = chars(indexOfString)
+        c match {
+          case '9' | '0' if Character.isDigit(currentChar) =>
+            if (!currentChar.equals('0')) {
+              builder.append(str.substringSQL(indexOfUTFString, 1))
+              if (hasPoint) {
+                integerLen = -1
+                wholeLen = -1
+              }
+            } else if (hasPoint) {
+              if (wholeLen == -1) {
+                wholeLen = builder.build.numChars
+              }
+              builder.append(str.substringSQL(indexOfUTFString, 1))
+            } else if (builder.build().numChars > 0) {
+              builder.append(str.substringSQL(indexOfUTFString, 1))
+            }
+          case '.' | 'D' if currentChar.equals('.') =>
+            hasPoint = true
+            integerLen = builder.build.numChars
+            builder.append(str.substringSQL(indexOfUTFString, 1))
+          case ',' | 'G' if currentChar.equals(',') =>
+          case 'S' if currentChar.equals('-') =>
+            hasSign = true
+          case 'L' =>
+            while(Character.isLetter(chars(indexOfString))) {
+              indexOfString += 1
+            }
+            indexOfString -= 1
+          case _ =>
+        }
+        indexOfString += 1
+      }
+      
+    }
+
+    var result = if (integerLen == -1 && wholeLen == -1) {
+      builder.build
+    } else if (wholeLen == -1 || wholeLen == integerLen + 1){
+      builder.build.substringSQL(1, integerLen)
+    } else {
+      builder.build.substringSQL(1, wholeLen)
+    }
+    if (hasSign) {
+      val newBuilder = new UTF8StringBuilder
+      newBuilder.append("-")
+      newBuilder.append(result)
+      newBuilder.build
+    } else {
+      result
+    }
+  }
+
+  override def prettyName: String = "to_number"
+
+  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    nullSafeCodeGen(ctx, ev, (l, r) => {
+      val chars = ctx.freshName("chars")
+      val patternChars = ctx.freshName("patternChars")
+      val sb = ctx.freshName("sb")
+      val stringBuffer = classOf[StringBuffer].getName
+      val indexOfString = ctx.freshName("indexOfString")
+      val hasSign = ctx.freshName("hasSign")
+      val hasPoint = ctx.freshName("hasPoint")
+      val integerLen = ctx.freshName("integerLen")
+      val wholeLen = ctx.freshName("wholeLen")
+      s"""
+        char[] $chars = $l.toString().toCharArray();
+        char[] $patternChars = $r.toUpperCase().toString().toCharArray();
+        $stringBuffer $sb = new $stringBuffer();
+        int $indexOfString = 0;
+        boolean $hasSign = false;
+        boolean $hasPoint = false;
+        int $integerLen = -1;
+        int $wholeLen = -1;
+          for (char c: $patternChars) {
+            if ($chars.length > $indexOfString) {
+              switch (c) {
+                case '9':
+                case '0':
+                  if (Character.isDigit($chars[$indexOfString])) {
+                    if ('0' != $chars[$indexOfString]) {
+                      $sb.append($chars[$indexOfString]);
+                      if ($hasPoint) {
+                        $integerLen = -1;
+                        $wholeLen = -1;
+                      }
+                    } else if ($hasPoint) {
+                      if ($wholeLen == -1) {
+                        $wholeLen = $sb.length();
+                      }
+                      $sb.append($chars[$indexOfString]);
+                    } else if ($sb.length() > 0) {
+                      $sb.append($chars[$indexOfString]);
+                    }
+                  }
+                  break;
+               case '.':
+               case 'D':
+                 if ('.' == $chars[$indexOfString]) {
+                   $hasPoint = true;
+                   $integerLen = $sb.length();
+                   $sb.append($chars[$indexOfString]);
+		 } 
+                 break;
+               case ',':
+               case 'G':
+		 break;
+               case 'S':
+                 if ('-' == $chars[$indexOfString]) {
+                   $hasSign = true;
+                 }
+                 break;
+               case 'L':
+                 while(Character.isLetter($chars[$indexOfString])) {
+                   $indexOfString++;
+		 }
+                 $indexOfString--;
+                 break;
+               default :
+             }
+             $indexOfString++;
+           }
+         }
+
+         if ($wholeLen != -1 && $wholeLen > $integerLen + 1) {
+           $sb = new StringBuffer($sb.toString().substring(0, $wholeLen));
+         } else if ($integerLen != -1) {
+           $sb = new StringBuffer($sb.toString().substring(0, $integerLen));
+         }
+         if ($hasSign) {
+           ${ev.value} = UTF8String.fromString("-" + $sb.toString());
+         } else {
+           ${ev.value} = UTF8String.fromString($sb.toString());
+         }
+        """})
+  }
+}
+
+/**
  * Splits a string into arrays of sentences, where each sentence is an array of words.
  * The 'lang' and 'country' arguments are optional, and if omitted, the default locale is used.
  */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -2286,8 +2286,6 @@ case class FormatNumber(x: Expression, d: Expression)
   """,
   examples = """
     Examples:
-      > SELECT _FUNC_('454', '');
-       ''
       > SELECT _FUNC_('4540', '999');
        '454'
       > SELECT _FUNC_('454.00', '000D00');

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
@@ -886,14 +886,53 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(ToNumber(Literal("1-2,454.8"), Literal("9S9,999D9")), "-12454.8")
     checkEvaluation(ToNumber(Literal("00,454.8-"), Literal("99G999.9S")), "-454.8")
     // Test 'L'
-    checkEvaluation(ToNumber(Literal("CNY234234.4350"), Literal("L999999.0000")), "234234.435")
+    checkEvaluation(ToNumber(Literal("CNY234234.4350"), Literal("L999999.0000")),
+      "234234.435")
     checkEvaluation(ToNumber(Literal("RMB34234.4350"), Literal("L99999.0000")), "34234.435")
     checkEvaluation(ToNumber(Literal("RY34234.4350"), Literal("L99999.0000")), "34234.435")
     checkEvaluation(ToNumber(Literal("R34234.4350"), Literal("L99999.0000")), "34234.435")
 
+    checkEvaluation(ToNumber(Literal("-34,338,492"), Literal("99G999G999")), "-34338492")
+    checkEvaluation(ToNumber(Literal("-34,338,492.654,878"), Literal("99G999G999D999G999")),
+      "-34338492.654878")
+    checkEvaluation(ToNumber(Literal("<564646.654564>"), Literal("999999.999999PR")),
+      "-564646.654564")
+    checkEvaluation(ToNumber(Literal("0.00001-"), Literal("9.999999S")), "-0.00001")
+    checkEvaluation(ToNumber(Literal("5.01-"), Literal("FM9.999999S")), "-5.01")
+    checkEvaluation(ToNumber(Literal("5.01-"), Literal("FM9.999999MI")), "-5.01")
+    checkEvaluation(ToNumber(Literal("5 4 4 4 4 8 . 7 8"), Literal("9 9 9 9 9 9 . 9 9")),
+      "544448.78")
+    checkEvaluation(ToNumber(Literal(".01"), Literal("FM9.99")), "0.01")
+    checkEvaluation(ToNumber(Literal(".0"), Literal("99999999.99999999")), "0")
+    checkEvaluation(ToNumber(Literal("0"), Literal("99.99")), "0")
+    checkEvaluation(ToNumber(Literal(".-01"), Literal("S99.99")), "-0.01")
+    checkEvaluation(ToNumber(Literal(".01-"), Literal("99.99S")), "-0.01")
+    checkEvaluation(ToNumber(Literal(" . 0 1-"), Literal(" 9 9 . 9 9 S")), "-0.01")
+    checkEvaluation(ToNumber(Literal("34,50"), Literal("999,99")), "3450")
+    checkEvaluation(ToNumber(Literal("123,000"), Literal("999G")), "123")
+    checkEvaluation(ToNumber(Literal("123456"), Literal("999G999")), "123456")
+    checkEvaluation(ToNumber(Literal("$1234.56"), Literal("L9,999.99")), "1234.56")
+    checkEvaluation(ToNumber(Literal("$1234.56"), Literal("L99,999.99")), "1234.56")
+    checkEvaluation(ToNumber(Literal("$1,234.56"), Literal("L99,999.99")), "1234.56")
+    checkEvaluation(ToNumber(Literal("1234.56"), Literal("L99,999.99")), "1234.56")
+    checkEvaluation(ToNumber(Literal("1,234.56"), Literal("L99,999.99")), "1234.56")
+    checkEvaluation(ToNumber(Literal("42nd"), Literal("99th")), "42")
+
     ToNumber(Literal("454.3.2"), Literal("999D9D9")).checkInputDataTypes() match {
       case TypeCheckResult.TypeCheckFailure(msg) =>
         assert(msg.contains("Multiple decimal points in"))
+    }
+    ToNumber(Literal("4543.2-"), Literal("9999D9SS")).checkInputDataTypes() match {
+      case TypeCheckResult.TypeCheckFailure(msg) =>
+        assert(msg.contains("Cannot use 'S' twice."))
+    }
+    ToNumber(Literal("4543.2-"), Literal("9999D9SPR")).checkInputDataTypes() match {
+      case TypeCheckResult.TypeCheckFailure(msg) =>
+        assert(msg.contains("Cannot use 'S' and 'PR' together."))
+    }
+    ToNumber(Literal("4543.2-"), Literal("9999D9SMI")).checkInputDataTypes() match {
+      case TypeCheckResult.TypeCheckFailure(msg) =>
+        assert(msg.contains("Cannot use 'S' and 'MI' together."))
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2259,26 +2259,6 @@ object functions {
   }
 
   /**
-   * Convert a string to a number based on the pattern.
-   *
-   * The pattern can consist of the following characters:
-   *   '9': digit position (can be dropped if insignificant)
-   *   '0': digit position (will not be dropped, even if insignificant)
-   *   '.': decimal point (only allowed once)
-   *   ',': group (thousands) separator
-   *   'S': sign anchored to number (uses locale)
-   *   'L': currency symbol (uses locale)
-   *   'D': decimal point (uses locale)
-   *   'G': group separator (uses locale)
-   *
-   * @group string_funcs
-   * @since 3.0.0
-   */
-  def to_number(x: Column, format: String): Column = withExpr {
-    ToNumber(x.expr, lit(format).expr)
-  }
-
-  /**
    * Formats the arguments in printf-style and returns the result as a string column.
    *
    * @group string_funcs

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2259,6 +2259,26 @@ object functions {
   }
 
   /**
+   * Convert a string to a number based on the pattern.
+   *
+   * The pattern can consist of the following characters:
+   *   '9': digit position (can be dropped if insignificant)
+   *   '0': digit position (will not be dropped, even if insignificant)
+   *   '.': decimal point (only allowed once)
+   *   ',': group (thousands) separator
+   *   'S': sign anchored to number (uses locale)
+   *   'L': currency symbol (uses locale)
+   *   'D': decimal point (uses locale)
+   *   'G': group separator (uses locale)
+   *
+   * @group string_funcs
+   * @since 3.0.0
+   */
+  def to_number(x: Column, format: String): Column = withExpr {
+    ToNumber(x.expr, lit(format).expr)
+  }
+
+  /**
    * Formats the arguments in printf-style and returns the result as a string column.
    *
    * @group string_funcs


### PR DESCRIPTION
### What changes were proposed in this pull request?
`Postgresql` and `Oracle` have the function `to_number` to convert a string to number. 
The implement and support syntax has many different between `Postgresql` and `Oracle`. So, this PR mainly follows the implement of `to_number` in `Postgresql`.

There are some mainstream database support the syntax.
**PostgreSQL:**
https://www.postgresql.org/docs/12/functions-formatting.html

**Oracle:**
https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/TO_NUMBER.html#GUID-D4807212-AFD7-48A7-9AED-BEC3E8809866

**Vertica**
https://www.vertica.com/docs/10.0.x/HTML/Content/Authoring/SQLReferenceManual/Functions/Formatting/TO_NUMBER.htm?tocpath=SQL%20Reference%20Manual%7CSQL%20Functions%7CFormatting%20Functions%7C_____7

**Redshift**
https://docs.aws.amazon.com/redshift/latest/dg/r_TO_NUMBER.html

**DB2**
https://www.ibm.com/support/knowledgecenter/SSGU8G_14.1.0/com.ibm.sqls.doc/ids_sqs_1544.htm

**Teradata**
https://docs.teradata.com/r/kmuOwjp1zEYg98JsB8fu_A/TH2cDXBn6tala29S536nqg

**Snowflake:**
https://docs.snowflake.net/manuals/sql-reference/functions/to_decimal.html

**Exasol**
https://docs.exasol.com/sql_references/functions/alphabeticallistfunctions/to_number.htm#TO_NUMBER

**Singlestore**
https://docs.singlestore.com/v7.3/reference/sql-reference/numeric-functions/to-number/

**Intersystems**
https://docs.intersystems.com/latest/csp/docbook/DocBook.UI.Page.cls?KEY=RSQL_TONUMBER

The syntax like:
> select to_number('12,454.8-', '99G999D9S');
-12454.8

### Why are the changes needed?
This PR adds a new function.


### Does this PR introduce any user-facing change?
No.


### How was this patch tested?
New UT.
