### PR TITLE
[SPARK-29288][SQL] Spark SQL ADD JAR support HTTP path. 

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
@@ -177,20 +177,26 @@ class SessionResourceLoader(session: SparkSession) extends FunctionResourceLoade
   }
 
   def resolveAndDownLoad(path: String): String = {
-    val uri = new URI(path)
-    if (uri.getScheme == null) {
-      path
-    } else {
-      uri.getScheme.toLowerCase(Locale.ROOT) match {
-        case "ftp" | "http" | "https" =>
-          Utils.doFetchFile(path,
-            new File(SparkFiles.getRootDirectory()),
-            Utils.decodeFileNameInURI(uri),
-            session.sparkContext.getConf,
-            session.sparkContext.env.securityManager,
-            session.sparkContext.hadoopConfiguration).getPath
-        case _ => path
+    try {
+      val uri = new URI(path)
+      if (uri.getScheme == null) {
+        path
+      } else {
+        uri.getScheme.toLowerCase(Locale.ROOT) match {
+          case "ftp" | "http" | "https" =>
+            Utils.doFetchFile(path,
+              new File(SparkFiles.getRootDirectory()),
+              Utils.decodeFileNameInURI(uri),
+              session.sparkContext.getConf,
+              session.sparkContext.env.securityManager,
+              session.sparkContext.hadoopConfiguration).getPath
+          case _ => path
+        }
       }
+    } catch {
+      case e: Exception =>
+        e.printStackTrace()
+        path
     }
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
@@ -534,6 +534,52 @@ class HiveThriftBinaryServerSuite extends HiveThriftJdbcTest {
     )
   }
 
+  test("SPARK-29288: test add remote uri jar") {
+    withMultipleConnectionJdbcStatement("smallKV", "addJar")(
+      {
+        statement =>
+          val jarFile = HiveTestJars.getRemoteHiveHcatalogCoreJarUri()
+
+          statement.executeQuery(s"ADD JAR $jarFile")
+      },
+
+      {
+        statement =>
+          val queries = Seq(
+            "CREATE TABLE smallKV(key INT, val STRING)",
+            s"LOAD DATA LOCAL INPATH '${TestData.smallKv}' OVERWRITE INTO TABLE smallKV",
+            """CREATE TABLE addJar(key string)
+              |ROW FORMAT SERDE 'org.apache.hive.hcatalog.data.JsonSerDe'
+            """.stripMargin)
+
+          queries.foreach(statement.execute)
+
+          statement.executeQuery(
+            """
+              |INSERT INTO TABLE addJar SELECT 'k1' as key FROM smallKV limit 1
+            """.stripMargin)
+
+          val actualResult =
+            statement.executeQuery("SELECT key FROM addJar")
+          val actualResultBuffer = new collection.mutable.ArrayBuffer[String]()
+          while (actualResult.next()) {
+            actualResultBuffer += actualResult.getString(1)
+          }
+          actualResult.close()
+
+          val expectedResult =
+            statement.executeQuery("SELECT 'k1'")
+          val expectedResultBuffer = new collection.mutable.ArrayBuffer[String]()
+          while (expectedResult.next()) {
+            expectedResultBuffer += expectedResult.getString(1)
+          }
+          expectedResult.close()
+
+          assert(expectedResultBuffer === actualResultBuffer)
+      }
+    )
+  }
+
   test("Checks Hive version via SET -v") {
     withJdbcStatement() { statement =>
       val resultSet = statement.executeQuery("SET -v")

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
@@ -114,7 +114,8 @@ class HiveSessionResourceLoader(
   extends SessionResourceLoader(session) {
   private lazy val client = clientBuilder()
   override def addJar(path: String): Unit = {
-    client.addJar(path)
-    super.addJar(path)
+    val resolvedPath: String = resolveAndDownLoad(path)
+    client.addJar(resolvedPath)
+    super.addJar(resolvedPath)
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -655,6 +655,7 @@ private[hive] object HiveTestJars {
   def getHiveContribJar(version: String = HiveUtils.builtinHiveVersion): File =
     getJarFromUrl(s"${repository}org/apache/hive/hive-contrib/" +
       s"$version/hive-contrib-$version.jar")
+
   def getHiveHcatalogCoreJar(version: String = HiveUtils.builtinHiveVersion): File =
     getJarFromUrl(s"${repository}org/apache/hive/hcatalog/hive-hcatalog-core/" +
       s"$version/hive-hcatalog-core-$version.jar")
@@ -667,4 +668,12 @@ private[hive] object HiveTestJars {
     }
     targetFile
   }
+
+  def getRemoteHiveContribJarUri(version: String = HiveUtils.builtinHiveVersion): String =
+    s"${repository}org/apache/hive/hive-contrib/$version/hive-contrib-$version.jar"
+
+  def getRemoteHiveHcatalogCoreJarUri(version: String = HiveUtils.builtinHiveVersion): String =
+    s"${repository}org/apache/hive/hcatalog/hive-hcatalog-core/" +
+      s"$version/hive-hcatalog-core-$version.jar"
+
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support Spark SQL add jar with http/https/ftp path.

### Why are the changes needed?
Hive 2.3 support add jar with http path, Spark SQL add this feature too.

### Does this PR introduce any user-facing change?
User can use SPARK SQL `ADD JAR` with http/https/ftp path such as :

```
0: jdbc:hive2://localhost:10000/default> add jar https://maven-central.storage-download.googleapis.com/repos/central/data/org/apache/hive/hcatalog/hive-hcatalog-core/2.3.5/hive-hcatalog-core-2.3.5.jar;
INFO  : Added [/private/var/folders/4l/7_c5c97s1_gb0d9_d6shygx00000gn/T/spark-504057ea-5b3b-4cac-ae3f-ecd368c55923/userFiles-deedcbb7-d3dc-45a5-8f04-246882f87b1b/hive-hcatalog-core-2.3.5.jar] to class path
INFO  : Added resources: [/private/var/folders/4l/7_c5c97s1_gb0d9_d6shygx00000gn/T/spark-504057ea-5b3b-4cac-ae3f-ecd368c55923/userFiles-deedcbb7-d3dc-45a5-8f04-246882f87b1b/hive-hcatalog-core-2.3.5.jar]
+---------+
| result  |
+---------+
+---------+
No rows selected (0.785 seconds)
0: jdbc:hive2://localhost:10000/default> CREATE TABLE addJar(key string) ROW FORMAT SERDE 'org.apache.hive.hcatalog.data.JsonSerDe';
+---------+
| Result  |
+---------+
+---------+
No rows selected (0.743 seconds)
0: jdbc:hive2://localhost:10000/default> insert into table addJar select 1;
+---------+
| Result  |
+---------+
+---------+
No rows selected (2.656 seconds)
0: jdbc:hive2://localhost:10000/default> select * from addJar;
+------+
| key  |
+------+
| 1    |
+------+
1 row selected (0.521 seconds)
0: jdbc:hive2://localhost:10000/default>
```


### How was this patch tested?
UT + MT