### PR TITLE
[SPARK-29268][SQL]isolationOn value is wrong in case of spark.sql.hive.metastore.jars != builtin

### DIFF
--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -383,5 +383,9 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
       "DROP TABLE sourceTableForWithSQL;"
         -> ""
     )
+    }
+  test("SPARK-29268 test spark sql with spark.sql.hive.metastore.jars") {
+    runCliWithin(2.minute, Seq("--conf", "spark.sql.hive.metastore.jars=maven"))(
+      "SET conf1;" -> "conftest")
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -383,8 +383,9 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
       "DROP TABLE sourceTableForWithSQL;"
         -> ""
     )
-    }
-  test("SPARK-29268 test spark sql with spark.sql.hive.metastore.jars") {
+  }
+
+  test("SPARK-29268 test spark sql with spark.sql.hive.metastore.jars != builtin") {
     runCliWithin(2.minute, Seq("--conf", "spark.sql.hive.metastore.jars=maven"))(
       "SET conf1;" -> "conftest")
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -385,7 +385,8 @@ private[spark] object HiveUtils extends Logging {
         hadoopConf = hadoopConf,
         config = configurations,
         barrierPrefixes = hiveMetastoreBarrierPrefixes,
-        sharedPrefixes = hiveMetastoreSharedPrefixes)
+        sharedPrefixes = hiveMetastoreSharedPrefixes,
+        isolationOn = !isCliSessionState)
     } else {
       // Convert to files and expand any directories.
       val jars =
@@ -414,7 +415,7 @@ private[spark] object HiveUtils extends Logging {
         hadoopConf = hadoopConf,
         execJars = jars.toSeq,
         config = configurations,
-        isolationOn = true,
+        isolationOn = !isCliSessionState(),
         barrierPrefixes = hiveMetastoreBarrierPrefixes,
         sharedPrefixes = hiveMetastoreSharedPrefixes)
     }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
@@ -53,7 +53,8 @@ private[hive] object IsolatedClientLoader extends Logging {
       ivyPath: Option[String] = None,
       sharedPrefixes: Seq[String] = Seq.empty,
       barrierPrefixes: Seq[String] = Seq.empty,
-      sharesHadoopClasses: Boolean = true): IsolatedClientLoader = synchronized {
+      sharesHadoopClasses: Boolean = true,
+      isolationOn: Boolean = true): IsolatedClientLoader = synchronized {
     val resolvedVersion = hiveVersion(hiveMetastoreVersion)
     // We will first try to share Hadoop classes. If we cannot resolve the Hadoop artifact
     // with the given version, we will use Hadoop 2.7 and then will not share Hadoop classes.
@@ -89,6 +90,7 @@ private[hive] object IsolatedClientLoader extends Logging {
       execJars = files,
       hadoopConf = hadoopConf,
       config = config,
+      isolationOn = isolationOn,
       sharesHadoopClasses = _sharesHadoopClasses,
       sharedPrefixes = sharedPrefixes,
       barrierPrefixes = barrierPrefixes)


### PR DESCRIPTION

### What changes were proposed in this pull request?
Failed to start **spark-sql** when using **Derby metastore**   and **isolatedLoader** is enabled
i.e. spark.sql.hive.metastore.jars=maven or spark.sql.hive.metastore.jars=classpath

when `spark.sql.hive.metastore.jars != builtin`  `isolationOn` value is true, it should be taken from the `isCliSessionState`


### Why are the changes needed?

`isolationOn`  flag is made same as case when `spark.sql.hive.metastore.jars == builtin` case logic


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Added UT and also tested manually
**case 1 :  spark.sql.hive.metastore.jars = classpath**
![usingClassPath](https://user-images.githubusercontent.com/35216143/65888973-11985c80-e3be-11e9-9d2a-99aaa6981c52.png)

**case 2:  spark.sql.hive.metastore.jars = maven**
![UsingMaven_1](https://user-images.githubusercontent.com/35216143/65889132-558b6180-e3be-11e9-8575-4711918bce1b.png)
![UsingMaven_2](https://user-images.githubusercontent.com/35216143/65889141-591ee880-e3be-11e9-996f-0f72f29042aa.png)

