### PR TITLE
[SPARK-29327][MLLIB]Support specifying features via multiple columns

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/param/shared/sharedParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/shared/sharedParams.scala
@@ -78,6 +78,28 @@ trait HasFeaturesCol extends Params {
 }
 
 /**
+ * Trait for shared param featuresCols. (default: Array.empty[String]) This trait may be changed or
+ * removed between minor versions.
+ *
+ * This is to support multiple columns for features.
+ */
+@DeveloperApi
+trait HasFeaturesCols extends Params {
+
+  /**
+   * Param for features columns names.
+   * @group param
+   */
+  final val featuresCols: StringArrayParam = new StringArrayParam(this, "featuresCols",
+    "names of the multiple columns for features")
+
+  setDefault(featuresCols, Array.empty[String])
+
+  /** @group getParam */
+  final def getFeaturesCols: Array[String] = $(featuresCols)
+}
+
+/**
  * Trait for shared param labelCol (default: "label"). This trait may be changed or
  * removed between minor versions.
  */

--- a/mllib/src/test/scala/org/apache/spark/ml/PredictorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/PredictorSuite.scala
@@ -85,7 +85,10 @@ class PredictorSuite extends SparkFunSuite with MLlibTestSparkContext {
       predictor.setFeaturesCol(Array("feature1", "feature2", "feature3")).fit(df2)
     }
 
-    // Should fail due to wrong type in schema for single column of features
+    // Should fail due to wrong type in schema for single column of features.
+    // "features", being equal to the single column name, are provided in "df2" schema
+    // but not specified as multi-columns, so treat it as single column and should be
+    // "Vector", but actually "Int".
     intercept[IllegalArgumentException] {
       predictor.setFeaturesCol(Array("feature2", "feature3")).fit(df2)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR will mainly introduce two new APIs in both “Predictor” and “PredictionModel”, and a new parameter named “featuresCols” in “sharedParams”.
**APIs:**
`def setFeaturesCol(value: Array[String]): M = ...`
`protected def isSupportMultiColumnsForFeatures: Boolean = false`
**Parameter:**
`final val featuresCols: StringArrayParam = new StringArrayParam(this, "featuresCols",   ...)`

### Why are the changes needed?
There are always more features than one in a classification/regression task, however the current API to specify features columns in Predictor of Spark MLLib only supports one single column, which requires users to assemble the multiple features columns into a "org.apache.spark.ml.linalg.Vector" before fitting to Spark ML pipeline. So users have to spend some extra time to search and learn other transformers that can do this vectorization thing, then pick one in their applications. It looks like somewhat complicated.

With this PR, things become much more simple to run a machine learning task. Users no longer need the vectorization step for features columns, just specify these features columns by our new API, then fit the loaded the dataset directly to Spark ML Pipeline. It not only makes the ML application code more concise, but also saves a lot of time to learn other transformers for vectorization to run a classification/regression task , especially for novices at Spark ML.

### Does this PR introduce any user-facing change?
Yes, it is adding a new API `setFeaturesCol(value: Array[String]` for users to specify multiple columns for features directly, without assembling them into a vector.

### How was this patch tested?
Added unit test, and tested implementation on XGBoost-Spark.
