### PR TITLE
[SPARK-29311][SQL] Return seconds with fraction from `date_part()` and `extract`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -2065,6 +2065,8 @@ object DatePart {
        33
       > SELECT _FUNC_('doy', DATE'2019-08-12');
        224
+      > SELECT _FUNC_('SECONDS', timestamp'2019-10-01 00:00:01.000001');
+       1.000001
   """,
   since = "3.0.0")
 case class DatePart(field: Expression, source: Expression, child: Expression)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -298,6 +298,30 @@ case class Second(child: Expression, timeZoneId: Option[String] = None)
   }
 }
 
+case class SecondWithFraction(child: Expression, timeZoneId: Option[String] = None)
+  extends UnaryExpression with TimeZoneAwareExpression with ImplicitCastInputTypes {
+
+  def this(child: Expression) = this(child, None)
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(TimestampType)
+
+  // 2 digits for seconds, and 6 digits for the fractional part with microsecond precision.
+  override def dataType: DataType = DecimalType(8, 6)
+
+  override def withTimeZone(timeZoneId: String): TimeZoneAwareExpression =
+    copy(timeZoneId = Option(timeZoneId))
+
+  override protected def nullSafeEval(timestamp: Any): Any = {
+    DateTimeUtils.getSecondsWithFraction(timestamp.asInstanceOf[Long], timeZone)
+  }
+
+  override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    val tz = ctx.addReferenceObj("timeZone", timeZone)
+    val dtu = DateTimeUtils.getClass.getName.stripSuffix("$")
+    defineCodeGen(ctx, ev, c => s"$dtu.getSecondsWithFraction($c, $tz)")
+  }
+}
+
 case class Milliseconds(child: Expression, timeZoneId: Option[String] = None)
   extends UnaryExpression with ImplicitCastInputTypes with TimeZoneAwareExpression {
 
@@ -1997,7 +2021,7 @@ object DatePart {
     case "DOY" => DayOfYear(source)
     case "HOUR" | "H" | "HOURS" | "HR" | "HRS" => Hour(source)
     case "MINUTE" | "M" | "MIN" | "MINS" | "MINUTES" => Minute(source)
-    case "SECOND" | "S" | "SEC" | "SECONDS" | "SECS" => Second(source)
+    case "SECOND" | "S" | "SEC" | "SECONDS" | "SECS" => SecondWithFraction(source)
     case "MILLISECONDS" | "MSEC" | "MSECS" | "MILLISECON" | "MSECONDS" | "MS" =>
       Milliseconds(source)
     case "MICROSECONDS" | "USEC" | "USECS" | "USECONDS" | "MICROSECON" | "US" =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -462,6 +462,14 @@ object DateTimeUtils {
   }
 
   /**
+   * Returns the seconds part and its fractional part with microseconds.
+   */
+  def getSecondsWithFraction(microsec: SQLTimestamp, timeZone: TimeZone): Decimal = {
+    val secFrac = localTimestamp(microsec, timeZone) % (MILLIS_PER_MINUTE * MICROS_PER_MILLIS)
+    Decimal(secFrac, 8, 6)
+  }
+
+  /**
    * Returns seconds, including fractional parts, multiplied by 1000. The timestamp
    * is expressed in microseconds since the epoch.
    */

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
@@ -1053,4 +1053,20 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(IsoYear(MakeDate(Literal(2006), Literal(1), Literal(1))), 2005)
     checkEvaluation(IsoYear(MakeDate(Literal(2006), Literal(1), Literal(2))), 2006)
   }
+
+  test("extract the seconds part with fraction from timestamps") {
+    outstandingTimezonesIds.foreach { timezone =>
+      val timestamp = MakeTimestamp(Literal(2019), Literal(8), Literal(10),
+        Literal(0), Literal(0), Literal(Decimal(10.123456, 8, 6)),
+        Some(Literal(timezone)))
+
+      checkEvaluation(SecondWithFraction(timestamp), Decimal(10.123456, 8, 6))
+      checkEvaluation(
+        SecondWithFraction(timestamp.copy(sec = Literal(Decimal(59000001, 8, 6)))),
+        Decimal(59000001, 8, 6))
+      checkEvaluation(
+        SecondWithFraction(timestamp.copy(sec = Literal(Decimal(1, 8, 6)))),
+        Decimal(0.000001, 8, 6))
+    }
+  }
 }

--- a/sql/core/benchmarks/ExtractBenchmark-results.txt
+++ b/sql/core/benchmarks/ExtractBenchmark-results.txt
@@ -2,99 +2,99 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 Invoke extract for timestamp:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   254            275          35         39.4          25.4       1.0X
-MILLENNIUM of timestamp                            1149           1159           9          8.7         114.9       0.2X
-CENTURY of timestamp                               1102           1115          16          9.1         110.2       0.2X
-DECADE of timestamp                                1024           1036          11          9.8         102.4       0.2X
-YEAR of timestamp                                  1000           1004           5         10.0         100.0       0.3X
-ISOYEAR of timestamp                               1090           1101          11          9.2         109.0       0.2X
-QUARTER of timestamp                               1169           1178           7          8.6         116.9       0.2X
-MONTH of timestamp                                  981            984           4         10.2          98.1       0.3X
-WEEK of timestamp                                  1372           1388          14          7.3         137.2       0.2X
-DAY of timestamp                                    994           1000           7         10.1          99.4       0.3X
-DAYOFWEEK of timestamp                             1102           1108           6          9.1         110.2       0.2X
-DOW of timestamp                                   1102           1105           3          9.1         110.2       0.2X
-ISODOW of timestamp                                1063           1078          18          9.4         106.3       0.2X
-DOY of timestamp                                   1015           1021           5          9.9         101.5       0.2X
-HOUR of timestamp                                   385            390           5         26.0          38.5       0.7X
-MINUTE of timestamp                                 387            391           7         25.8          38.7       0.7X
-SECOND of timestamp                                 381            382           1         26.2          38.1       0.7X
-MILLISECONDS of timestamp                           584            588           4         17.1          58.4       0.4X
-MICROSECONDS of timestamp                           482            500          16         20.8          48.2       0.5X
-EPOCH of timestamp                                  957            961           6         10.4          95.7       0.3X
+cast to timestamp                                   255            307          48         39.2          25.5       1.0X
+MILLENNIUM of timestamp                            1269           1316          64          7.9         126.9       0.2X
+CENTURY of timestamp                               1157           1188          33          8.6         115.7       0.2X
+DECADE of timestamp                                1067           1122          52          9.4         106.7       0.2X
+YEAR of timestamp                                  1099           1163          76          9.1         109.9       0.2X
+ISOYEAR of timestamp                               1133           1181          43          8.8         113.3       0.2X
+QUARTER of timestamp                               1192           1222          28          8.4         119.2       0.2X
+MONTH of timestamp                                 1035           1057          38          9.7         103.5       0.2X
+WEEK of timestamp                                  1519           1570          61          6.6         151.9       0.2X
+DAY of timestamp                                   1020           1046          37          9.8         102.0       0.3X
+DAYOFWEEK of timestamp                             1159           1194          41          8.6         115.9       0.2X
+DOW of timestamp                                   1151           1163          17          8.7         115.1       0.2X
+ISODOW of timestamp                                1099           1117          26          9.1         109.9       0.2X
+DOY of timestamp                                   1050           1067          27          9.5         105.0       0.2X
+HOUR of timestamp                                   442            449           6         22.6          44.2       0.6X
+MINUTE of timestamp                                 434            437           4         23.1          43.4       0.6X
+SECOND of timestamp                                 606            612           5         16.5          60.6       0.4X
+MILLISECONDS of timestamp                           627            629           3         15.9          62.7       0.4X
+MICROSECONDS of timestamp                           528            530           2         18.9          52.8       0.5X
+EPOCH of timestamp                                  998           1001           3         10.0          99.8       0.3X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 Invoke extract for date:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        834            842          12         12.0          83.4       1.0X
-MILLENNIUM of date                                 1078           1088          16          9.3         107.8       0.8X
-CENTURY of date                                    1063           1067           4          9.4         106.3       0.8X
-DECADE of date                                      989            992           3         10.1          98.9       0.8X
-YEAR of date                                        975            976           1         10.3          97.5       0.9X
-ISOYEAR of date                                    1177           1186           9          8.5         117.7       0.7X
-QUARTER of date                                    1219           1222           4          8.2         121.9       0.7X
-MONTH of date                                       982            992          10         10.2          98.2       0.8X
-WEEK of date                                       1360           1364           6          7.4         136.0       0.6X
-DAY of date                                         973            980           7         10.3          97.3       0.9X
-DAYOFWEEK of date                                  1100           1104           7          9.1         110.0       0.8X
-DOW of date                                        1091           1096           4          9.2         109.1       0.8X
-ISODOW of date                                     1053           1057           6          9.5         105.3       0.8X
-DOY of date                                        1006           1012           4          9.9         100.6       0.8X
-HOUR of date                                       1683           1688           6          5.9         168.3       0.5X
-MINUTE of date                                     1686           1691           5          5.9         168.6       0.5X
-SECOND of date                                     1706           1714           7          5.9         170.6       0.5X
-MILLISECONDS of date                               1881           1887           6          5.3         188.1       0.4X
-MICROSECONDS of date                               1767           1778          16          5.7         176.7       0.5X
-EPOCH of date                                      2274           2281           7          4.4         227.4       0.4X
+cast to date                                        859            862           3         11.6          85.9       1.0X
+MILLENNIUM of date                                 1097           1097           1          9.1         109.7       0.8X
+CENTURY of date                                    1100           1105           6          9.1         110.0       0.8X
+DECADE of date                                     1030           1032           1          9.7         103.0       0.8X
+YEAR of date                                       1011           1014           3          9.9         101.1       0.8X
+ISOYEAR of date                                    1228           1242          20          8.1         122.8       0.7X
+QUARTER of date                                    1241           1259          17          8.1         124.1       0.7X
+MONTH of date                                      1016           1018           2          9.8         101.6       0.8X
+WEEK of date                                       1485           1496           9          6.7         148.5       0.6X
+DAY of date                                        1019           1027          11          9.8         101.9       0.8X
+DAYOFWEEK of date                                  1131           1142          10          8.8         113.1       0.8X
+DOW of date                                        1125           1132           7          8.9         112.5       0.8X
+ISODOW of date                                     1087           1089           2          9.2         108.7       0.8X
+DOY of date                                        1053           1057           3          9.5         105.3       0.8X
+HOUR of date                                       1768           1773           5          5.7         176.8       0.5X
+MINUTE of date                                     1764           1771           9          5.7         176.4       0.5X
+SECOND of date                                     1960           1964           4          5.1         196.0       0.4X
+MILLISECONDS of date                               1967           1971           4          5.1         196.7       0.4X
+MICROSECONDS of date                               1852           1859           6          5.4         185.2       0.5X
+EPOCH of date                                      2387           2390           4          4.2         238.7       0.4X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 Invoke date_part for timestamp:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   212            214           3         47.2          21.2       1.0X
-MILLENNIUM of timestamp                            1082           1092          10          9.2         108.2       0.2X
-CENTURY of timestamp                               1087           1089           2          9.2         108.7       0.2X
-DECADE of timestamp                                 986           1001          21         10.1          98.6       0.2X
-YEAR of timestamp                                   983            985           2         10.2          98.3       0.2X
-ISOYEAR of timestamp                               1160           1168          12          8.6         116.0       0.2X
-QUARTER of timestamp                               1219           1228           9          8.2         121.9       0.2X
-MONTH of timestamp                                  973            979           5         10.3          97.3       0.2X
-WEEK of timestamp                                  1348           1357           8          7.4         134.8       0.2X
-DAY of timestamp                                    969            974           5         10.3          96.9       0.2X
-DAYOFWEEK of timestamp                             1093           1096           3          9.1         109.3       0.2X
-DOW of timestamp                                   1089           1096           7          9.2         108.9       0.2X
-ISODOW of timestamp                                1048           1056           7          9.5         104.8       0.2X
-DOY of timestamp                                   1007           1011           5          9.9         100.7       0.2X
-HOUR of timestamp                                   385            387           3         26.0          38.5       0.6X
-MINUTE of timestamp                                 382            384           2         26.2          38.2       0.6X
-SECOND of timestamp                                 377            378           1         26.5          37.7       0.6X
-MILLISECONDS of timestamp                           572            574           2         17.5          57.2       0.4X
-MICROSECONDS of timestamp                           473            490          18         21.1          47.3       0.4X
-EPOCH of timestamp                                  937            947          11         10.7          93.7       0.2X
+cast to timestamp                                   242            248          10         41.3          24.2       1.0X
+MILLENNIUM of timestamp                            1121           1128           9          8.9         112.1       0.2X
+CENTURY of timestamp                               1104           1109           7          9.1         110.4       0.2X
+DECADE of timestamp                                1023           1026           3          9.8         102.3       0.2X
+YEAR of timestamp                                  1009           1011           2          9.9         100.9       0.2X
+ISOYEAR of timestamp                               1225           1228           4          8.2         122.5       0.2X
+QUARTER of timestamp                               1222           1226           3          8.2         122.2       0.2X
+MONTH of timestamp                                 1017           1018           1          9.8         101.7       0.2X
+WEEK of timestamp                                  1480           1485           5          6.8         148.0       0.2X
+DAY of timestamp                                   1010           1012           2          9.9         101.0       0.2X
+DAYOFWEEK of timestamp                             1124           1128           3          8.9         112.4       0.2X
+DOW of timestamp                                   1119           1121           3          8.9         111.9       0.2X
+ISODOW of timestamp                                1085           1087           4          9.2         108.5       0.2X
+DOY of timestamp                                   1040           1054          12          9.6         104.0       0.2X
+HOUR of timestamp                                   433            435           2         23.1          43.3       0.6X
+MINUTE of timestamp                                 430            431           2         23.3          43.0       0.6X
+SECOND of timestamp                                 600            603           3         16.7          60.0       0.4X
+MILLISECONDS of timestamp                           618            623           5         16.2          61.8       0.4X
+MICROSECONDS of timestamp                           521            524           3         19.2          52.1       0.5X
+EPOCH of timestamp                                  987            989           2         10.1          98.7       0.2X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.14.6
 Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
 Invoke date_part for date:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        835            836           1         12.0          83.5       1.0X
-MILLENNIUM of date                                 1062           1070          10          9.4         106.2       0.8X
-CENTURY of date                                    1060           1068          12          9.4         106.0       0.8X
-DECADE of date                                      984            992           8         10.2          98.4       0.8X
-YEAR of date                                        971            973           3         10.3          97.1       0.9X
-ISOYEAR of date                                    1158           1175          22          8.6         115.8       0.7X
-QUARTER of date                                    1239           1239           0          8.1         123.9       0.7X
-MONTH of date                                       972            987          23         10.3          97.2       0.9X
-WEEK of date                                       1346           1350           5          7.4         134.6       0.6X
-DAY of date                                         970            971           1         10.3          97.0       0.9X
-DAYOFWEEK of date                                  1099           1107          10          9.1         109.9       0.8X
-DOW of date                                        1089           1091           2          9.2         108.9       0.8X
-ISODOW of date                                     1053           1062          13          9.5         105.3       0.8X
-DOY of date                                        1008           1010           4          9.9         100.8       0.8X
-HOUR of date                                       1697           1703           7          5.9         169.7       0.5X
-MINUTE of date                                     1697           1699           3          5.9         169.7       0.5X
-SECOND of date                                     1682           1692           8          5.9         168.2       0.5X
-MILLISECONDS of date                               1884           1890           7          5.3         188.4       0.4X
-MICROSECONDS of date                               1765           1770           7          5.7         176.5       0.5X
-EPOCH of date                                      2273           2282           8          4.4         227.3       0.4X
+cast to date                                        856            865           8         11.7          85.6       1.0X
+MILLENNIUM of date                                 1096           1098           3          9.1         109.6       0.8X
+CENTURY of date                                    1095           1099           4          9.1         109.5       0.8X
+DECADE of date                                     1023           1028           6          9.8         102.3       0.8X
+YEAR of date                                       1006           1011           5          9.9         100.6       0.9X
+ISOYEAR of date                                    1201           1212          14          8.3         120.1       0.7X
+QUARTER of date                                    1224           1228           4          8.2         122.4       0.7X
+MONTH of date                                      1009           1011           2          9.9         100.9       0.8X
+WEEK of date                                       1478           1485           7          6.8         147.8       0.6X
+DAY of date                                        1006           1008           3          9.9         100.6       0.9X
+DAYOFWEEK of date                                  1131           1133           2          8.8         113.1       0.8X
+DOW of date                                        1119           1121           2          8.9         111.9       0.8X
+ISODOW of date                                     1083           1085           3          9.2         108.3       0.8X
+DOY of date                                        1035           1051          25          9.7         103.5       0.8X
+HOUR of date                                       1764           1779          22          5.7         176.4       0.5X
+MINUTE of date                                     1763           1766           2          5.7         176.3       0.5X
+SECOND of date                                     1957           1965          10          5.1         195.7       0.4X
+MILLISECONDS of date                               1960           1961           2          5.1         196.0       0.4X
+MICROSECONDS of date                               1852           1854           2          5.4         185.2       0.5X
+EPOCH of date                                      2381           2383           3          4.2         238.1       0.4X
 

--- a/sql/core/src/test/resources/sql-tests/results/date_part.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/date_part.sql.out
@@ -357,41 +357,41 @@ struct<date_part('minutes', t.`c`):int>
 -- !query 44
 select date_part('second', c) from t
 -- !query 44 schema
-struct<date_part('second', t.`c`):int>
+struct<date_part('second', t.`c`):decimal(8,6)>
 -- !query 44 output
-9
+9.123456
 
 
 -- !query 45
 select date_part('s', c) from t
 -- !query 45 schema
-struct<date_part('s', t.`c`):int>
+struct<date_part('s', t.`c`):decimal(8,6)>
 -- !query 45 output
-9
+9.123456
 
 
 -- !query 46
 select date_part('sec', c) from t
 -- !query 46 schema
-struct<date_part('sec', t.`c`):int>
+struct<date_part('sec', t.`c`):decimal(8,6)>
 -- !query 46 output
-9
+9.123456
 
 
 -- !query 47
 select date_part('seconds', c) from t
 -- !query 47 schema
-struct<date_part('seconds', t.`c`):int>
+struct<date_part('seconds', t.`c`):decimal(8,6)>
 -- !query 47 output
-9
+9.123456
 
 
 -- !query 48
 select date_part('secs', c) from t
 -- !query 48 schema
-struct<date_part('secs', t.`c`):int>
+struct<date_part('secs', t.`c`):decimal(8,6)>
 -- !query 48 output
-9
+9.123456
 
 
 -- !query 49

--- a/sql/core/src/test/resources/sql-tests/results/extract.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/extract.sql.out
@@ -365,41 +365,41 @@ struct<date_part('minutes', `c`):int>
 -- !query 45
 select extract(second from c) from t
 -- !query 45 schema
-struct<date_part('second', `c`):int>
+struct<date_part('second', `c`):decimal(8,6)>
 -- !query 45 output
-9
+9.123456
 
 
 -- !query 46
 select extract(s from c) from t
 -- !query 46 schema
-struct<date_part('s', `c`):int>
+struct<date_part('s', `c`):decimal(8,6)>
 -- !query 46 output
-9
+9.123456
 
 
 -- !query 47
 select extract(sec from c) from t
 -- !query 47 schema
-struct<date_part('sec', `c`):int>
+struct<date_part('sec', `c`):decimal(8,6)>
 -- !query 47 output
-9
+9.123456
 
 
 -- !query 48
 select extract(seconds from c) from t
 -- !query 48 schema
-struct<date_part('seconds', `c`):int>
+struct<date_part('seconds', `c`):decimal(8,6)>
 -- !query 48 output
-9
+9.123456
 
 
 -- !query 49
 select extract(secs from c) from t
 -- !query 49 schema
-struct<date_part('secs', `c`):int>
+struct<date_part('secs', `c`):decimal(8,6)>
 -- !query 49 output
-9
+9.123456
 
 
 -- !query 50

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/timestamp.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/timestamp.sql.out
@@ -228,7 +228,7 @@ SELECT '' AS `54`, d1 as `timestamp`,
     date_part( 'minute', d1) AS `minute`, date_part( 'second', d1) AS `second`
     FROM TIMESTAMP_TBL WHERE d1 BETWEEN '1902-01-01' AND '2038-01-01'
 -- !query 25 schema
-struct<54:string,timestamp:timestamp,year:int,month:int,day:int,hour:int,minute:int,second:int>
+struct<54:string,timestamp:timestamp,year:int,month:int,day:int,hour:int,minute:int,second:decimal(8,6)>
 -- !query 25 output
 	1969-12-31 16:00:00	1969	12	31	16	0	0
 	1997-01-02 00:00:00	1997	1	2	0	0	0


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added new expression `SecondWithFraction` which produces the `seconds` part of timestamps/dates with fractional part containing microseconds. This expression is used only in the `DatePart` expression. As the result, `date_part()` and `extract` return seconds and microseconds as the fractional part of the seconds part when `field` is `SECOND` (or synonyms).

### Why are the changes needed?

The `date_part()` and `extract` were added to maintain feature parity with PostgreSQL which has different behavior for the `SECOND` value of the `field` parameter. The fix is needed to behave in the same way. Here is PostgreSQL's output:
```sql
# SELECT date_part('SECONDS', timestamp'2019-10-01 00:00:01.000001');
 date_part 
-----------
  1.000001
(1 row)
```

### Does this PR introduce any user-facing change?
Yes, type of `date_part('SECOND', ...)` is changed from `INT` to `DECIMAL(8, 6)`.
Before:
```sql
spark-sql> SELECT date_part('SECONDS', '2019-10-01 00:00:01.000001');
1
```
After:
```sql
spark-sql> SELECT date_part('SECONDS', '2019-10-01 00:00:01.000001');
1.000001
```


### How was this patch tested?
- Added new tests to `DateExpressionSuite` for the `SecondWithFraction` expression
- Regenerated results of `date_part.sql`, `extract.sql` and `timestamp.sql`
- Updated results of `ExtractBenchmark`
