### PR TITLE
[SPARK-29323][WEBUI] Add tooltip for The Executors Tab's column names in the Spark history server Page

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/executorspage-template.html
+++ b/core/src/main/resources/org/apache/spark/ui/static/executorspage-template.html
@@ -37,8 +37,8 @@ limitations under the License.
         </th>
         <th>Disk Used</th>
         <th>Cores</th>
-        <th><span data-toggle="tooltip" data-placement="top" title="Active Tasks show in shaded blue. % of color opacity range from 0 to maxTasks.">Active Tasks</span></th>
-        <th><span data-toggle="tooltip" data-placement="top" title="Failed Tasks show in shaded red. Color opacity reach max at 10% of Total Tasks.">Failed Tasks</span></th>
+        <th><span data-toggle="tooltip" data-placement="top" title="Number of tasks currently executing. Darker shading highlights executors with more active tasks.">Active Tasks</span></th>
+        <th><span data-toggle="tooltip" data-placement="top" title="Number of tasks that have failed on this executor. Darker shading highlights executors with a high proportion of failed tasks.">Failed Tasks</span></th>
         <th>Complete Tasks</th>
         <th>Total Tasks</th>
         <th><span data-toggle="tooltip"
@@ -93,8 +93,8 @@ limitations under the License.
           <th><span data-toggle="tooltip" data-placement="top" title="Disk Used">Disk Used</span></th>
           <th><span data-toggle="tooltip" data-placement="top" title="Cores">Cores</span></th>
           <th><span data-toggle="tooltip" data-placement="top" title="Resources">Resources</span></th>
-          <th><span data-toggle="tooltip" data-placement="top" title="Active Tasks show in shaded blue. % of color opacity range from 0 to maxTasks.">Active Tasks</span></th>
-          <th><span data-toggle="tooltip" data-placement="top" title="Failed Tasks show in shaded red. Color opacity reach max at 10% of Total Tasks.">Failed Tasks</span></th>
+          <th><span data-toggle="tooltip" data-placement="top" title="Number of tasks currently executing. Darker shading highlights executors with more active tasks.">Active Tasks</span></th>
+          <th><span data-toggle="tooltip" data-placement="top" title="Number of tasks that have failed on this executor. Darker shading highlights executors with a high proportion of failed tasks.">Failed Tasks</span></th>
           <th><span data-toggle="tooltip" data-placement="top" title="Complete Tasks">Complete Tasks</span></th>
           <th><span data-toggle="tooltip" data-placement="top" title="Total Tasks">Total Tasks</span></th>
           <th>

--- a/core/src/main/resources/org/apache/spark/ui/static/executorspage-template.html
+++ b/core/src/main/resources/org/apache/spark/ui/static/executorspage-template.html
@@ -23,7 +23,7 @@ limitations under the License.
       <table id="summary-execs-table" class="table table-striped compact cell-border">
         <thead>
         <th></th>
-        <th><span data-toggle="tooltip" data-placement="top" title="RDD Blocks">RDD Blocks</span></th>
+        <th>RDD Blocks</th>
         <th><span data-toggle="tooltip"
                   title="Memory used / total available memory for storage of data like RDD partitions cached in memory.">Storage Memory</span>
         </th>
@@ -35,12 +35,12 @@ limitations under the License.
           <span data-toggle="tooltip"
                 title="Memory used / total available memory for off heap storage of data like RDD partitions cached in memory.">Off Heap Storage Memory</span>
         </th>
-        <th><span data-toggle="tooltip" data-placement="top" title="Disk Used">Disk Used</span></th>
-        <th><span data-toggle="tooltip" data-placement="top" title="Cores">Cores</span></th>
-        <th><span data-toggle="tooltip" data-placement="top" title="Active Tasks">Active Tasks</span></th>
-        <th><span data-toggle="tooltip" data-placement="top" title="Failed Tasks">Failed Tasks</span></th>
-        <th><span data-toggle="tooltip" data-placement="top" title="Complete Tasks">Complete Tasks</span></th>
-        <th><span data-toggle="tooltip" data-placement="top" title="Total Tasks">Total Tasks</span></th>
+        <th>Disk Used</th>
+        <th>Cores</th>
+        <th><span data-toggle="tooltip" data-placement="top" title="Active Tasks show in shaded blue. % of color opacity range from 0 to maxTasks.">Active Tasks</span></th>
+        <th><span data-toggle="tooltip" data-placement="top" title="Failed Tasks show in shaded red. Color opacity reach max at 10% of Total Tasks.">Failed Tasks</span></th>
+        <th>Complete Tasks</th>
+        <th>Total Tasks</th>
         <th><span data-toggle="tooltip"
                   title="Shaded red when garbage collection (GC) time is over 10% of task time">
           Task Time (GC Time)</span></th>
@@ -93,8 +93,8 @@ limitations under the License.
           <th><span data-toggle="tooltip" data-placement="top" title="Disk Used">Disk Used</span></th>
           <th><span data-toggle="tooltip" data-placement="top" title="Cores">Cores</span></th>
           <th><span data-toggle="tooltip" data-placement="top" title="Resources">Resources</span></th>
-          <th><span data-toggle="tooltip" data-placement="top" title="Active Tasks">Active Tasks</span></th>
-          <th><span data-toggle="tooltip" data-placement="top" title="Failed Tasks">Failed Tasks</span></th>
+          <th><span data-toggle="tooltip" data-placement="top" title="Active Tasks show in shaded blue. % of color opacity range from 0 to maxTasks.">Active Tasks</span></th>
+          <th><span data-toggle="tooltip" data-placement="top" title="Failed Tasks show in shaded red. Color opacity reach max at 10% of Total Tasks.">Failed Tasks</span></th>
           <th><span data-toggle="tooltip" data-placement="top" title="Complete Tasks">Complete Tasks</span></th>
           <th><span data-toggle="tooltip" data-placement="top" title="Total Tasks">Total Tasks</span></th>
           <th>

--- a/core/src/main/resources/org/apache/spark/ui/static/executorspage-template.html
+++ b/core/src/main/resources/org/apache/spark/ui/static/executorspage-template.html
@@ -23,7 +23,7 @@ limitations under the License.
       <table id="summary-execs-table" class="table table-striped compact cell-border">
         <thead>
         <th></th>
-        <th>RDD Blocks</th>
+        <th><span data-toggle="tooltip" data-placement="top" title="RDD Blocks">RDD Blocks</span></th>
         <th><span data-toggle="tooltip"
                   title="Memory used / total available memory for storage of data like RDD partitions cached in memory.">Storage Memory</span>
         </th>
@@ -35,12 +35,12 @@ limitations under the License.
           <span data-toggle="tooltip"
                 title="Memory used / total available memory for off heap storage of data like RDD partitions cached in memory.">Off Heap Storage Memory</span>
         </th>
-        <th>Disk Used</th>
-        <th>Cores</th>
-        <th>Active Tasks</th>
-        <th>Failed Tasks</th>
-        <th>Complete Tasks</th>
-        <th>Total Tasks</th>
+        <th><span data-toggle="tooltip" data-placement="top" title="Disk Used">Disk Used</span></th>
+        <th><span data-toggle="tooltip" data-placement="top" title="Cores">Cores</span></th>
+        <th><span data-toggle="tooltip" data-placement="top" title="Active Tasks">Active Tasks</span></th>
+        <th><span data-toggle="tooltip" data-placement="top" title="Failed Tasks">Failed Tasks</span></th>
+        <th><span data-toggle="tooltip" data-placement="top" title="Complete Tasks">Complete Tasks</span></th>
+        <th><span data-toggle="tooltip" data-placement="top" title="Total Tasks">Total Tasks</span></th>
         <th><span data-toggle="tooltip"
                   title="Shaded red when garbage collection (GC) time is over 10% of task time">
           Task Time (GC Time)</span></th>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is Adding tooltip for The Executors Tab's column names include RDD Blocks, Disk Used,Cores, Activity Tasks, Failed Tasks , Complete Tasks, Total Tasks in the history server Page.
https://issues.apache.org/jira/browse/SPARK-29323

![image](https://user-images.githubusercontent.com/28332082/66017759-b6c24a80-e50e-11e9-807b-5b076f701d2f.png)

I have modify the following code in executorspage-template.html
Before:
<th>RDD Blocks</th>
<th>Disk Used</th>
<th>Cores</th>
<th>Active Tasks</th>
<th>Failed Tasks</th>
<th>Complete Tasks</th>
<th>Total Tasks</th>

![image](https://user-images.githubusercontent.com/28332082/66018111-4ddbd200-e510-11e9-9cfc-19f3eae81e76.png)

After:

<th><span data-toggle="tooltip" data-placement="top" title="RDD Blocks">RDD Blocks</span></th>
<th><span data-toggle="tooltip" data-placement="top" title="Disk Used">Disk Used</span></th>
<th><span data-toggle="tooltip" data-placement="top" title="Cores">Cores</span></th>
<th><span data-toggle="tooltip" data-placement="top" title="Active Tasks">Active Tasks</span></th>
<th><span data-toggle="tooltip" data-placement="top" title="Failed Tasks">Failed Tasks</span></th>
<th><span data-toggle="tooltip" data-placement="top" title="Complete Tasks">Complete Tasks</span></th>
<th><span data-toggle="tooltip" data-placement="top" title="Total Tasks">Total Tasks</span></th>
   

![image](https://user-images.githubusercontent.com/28332082/66018157-79f75300-e510-11e9-96ba-6230aa0940c7.png)
    

### Why are the changes needed?

the spark Executors of history Tab page, the Summary part shows the line in the list of title, but format is irregular.
Some column names have tooltip, such as Storage Memory, Task Time(GC Time), Input, Shuffle Read,
Shuffle Write and Blacklisted, but there are still some list names that have not tooltip. They are RDD Blocks, Disk Used,Cores, Activity Tasks, Failed Tasks , Complete Tasks and Total Tasks. oddly, Executors section below,All the column names Contains the column names above have tooltip .
It's important for open source projects to have consistent style and user-friendly UI, and I'm working on keeping it consistent And more user-friendly.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Manual tests for Chrome, Firefox and Safari


Authored-by: liucht-inspur <liucht@inspur.com>
Signed-off-by: liucht-inspur <liucht@inspur.com>