### PR TITLE
[SPARK-29346][SQL] Add Aggregating Accumulator

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
@@ -546,7 +546,7 @@ abstract class TypedImperativeAggregate[T] extends ImperativeAggregate {
 
   private[this] val anyObjectType = ObjectType(classOf[AnyRef])
   private def getBufferObject(bufferRow: InternalRow): T = {
-    bufferRow.get(mutableAggBufferOffset, anyObjectType).asInstanceOf[T]
+    getBufferObject(bufferRow, mutableAggBufferOffset)
   }
 
   final override lazy val aggBufferAttributes: Seq[AttributeReference] = {
@@ -569,5 +569,22 @@ abstract class TypedImperativeAggregate[T] extends ImperativeAggregate {
    */
   final def serializeAggregateBufferInPlace(buffer: InternalRow): Unit = {
     buffer(mutableAggBufferOffset) = serialize(getBufferObject(buffer))
+  }
+
+  /**
+   * Merge an input buffer into the aggregation buffer, where both buffers contain the deserialized
+   * java object. This function is used by aggregating accumulators.
+   *
+   * @param buffer the aggregation buffer that is updated.
+   * @param inputBuffer the buffer that is merged into the aggregation buffer.
+   */
+  final def mergeBuffersObjects(buffer: InternalRow, inputBuffer: InternalRow): Unit = {
+    val bufferObject = getBufferObject(buffer)
+    val inputObject = getBufferObject(inputBuffer, inputAggBufferOffset)
+    buffer(mutableAggBufferOffset) = merge(bufferObject, inputObject)
+  }
+
+  private def getBufferObject(buffer: InternalRow, offset: Int): T = {
+    buffer.get(offset, anyObjectType).asInstanceOf[T]
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -89,11 +89,16 @@ object SQLConf {
   }
 
   def withExistingConf[T](conf: SQLConf)(f: => T): T = {
+    val old = existingConf.get()
     existingConf.set(conf)
     try {
       f
     } finally {
-      existingConf.remove()
+      if (old != null) {
+        existingConf.set(old)
+      } else {
+        existingConf.remove()
+      }
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/AggregatingAccumulator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/AggregatingAccumulator.scala
@@ -172,7 +172,7 @@ class AggregatingAccumulator private(
 
   override def value: InternalRow = withSQLConf(InternalRow.empty) {
     // Either use the existing buffer or create a temporary one.
-    val input = if (buffer != null) {
+    val input = if (!isZero) {
       buffer
     } else {
       // Create a temporary buffer because we want to avoid changing the state of the accumulator

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/AggregatingAccumulator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/AggregatingAccumulator.scala
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution
+
+import scala.collection.mutable
+
+import org.apache.spark.TaskContext
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSeq, BindReferences, Expression, InterpretedMutableProjection, InterpretedUnsafeProjection, JoinedRow, MutableProjection, NamedExpression, Projection, SpecificInternalRow, UnsafeProjection}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, DeclarativeAggregate, ImperativeAggregate, NoOp, TypedImperativeAggregate}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{DataType, StructField, StructType}
+import org.apache.spark.util.AccumulatorV2
+
+/**
+ * Accumulator that computes a global aggregate.
+ */
+class AggregatingAccumulator private(
+    bufferSchema: Seq[DataType],
+    initialValues: Seq[Expression],
+    updateExpressions: Seq[Expression],
+    @transient private var mergeExpressions: Seq[Expression],
+    @transient private var resultExpressions: Seq[Expression],
+    imperatives: Array[ImperativeAggregate],
+    typedImperatives: Array[TypedImperativeAggregate[_]],
+    @transient private var conf: SQLConf)
+  extends AccumulatorV2[InternalRow, InternalRow] {
+  assert(bufferSchema.size == initialValues.size)
+  assert(bufferSchema.size == updateExpressions.size)
+  assert(bufferSchema.size == mergeExpressions.size)
+
+  private[this] var joinedRow: JoinedRow = _
+
+  private var buffer: SpecificInternalRow = _
+
+  private def createBuffer(): SpecificInternalRow = {
+    val buffer = new SpecificInternalRow(bufferSchema)
+
+    // Initialize the buffer. Note that we do not use a code generated projection here because
+    // generating and compiling a projection is probably more expensive than using an interpreted
+    // projection.
+    InterpretedMutableProjection.createProjection(initialValues)
+      .target(buffer)
+      .apply(InternalRow.empty)
+    imperatives.foreach(_.initialize(buffer))
+    typedImperatives.foreach(_.initialize(buffer))
+    buffer
+  }
+
+  private def getOrCreateBuffer(): SpecificInternalRow = {
+    if (buffer == null) {
+      buffer = createBuffer()
+
+      // Create the joined row and set the buffer as its 'left' row.
+      joinedRow = new JoinedRow()
+      joinedRow.withLeft(buffer)
+    }
+    buffer
+  }
+
+  private def initializeProjection[T <: Projection](projection: T): T = {
+    projection.initialize(TaskContext.getPartitionId())
+    projection
+  }
+
+  @transient
+  private[this] lazy val updateProjection = initializeProjection {
+    MutableProjection.create(updateExpressions)
+  }
+
+  @transient
+  private[this] lazy val mergeProjection = SQLConf.withExistingConf(conf) {
+    initializeProjection {
+      InterpretedMutableProjection.createProjection(mergeExpressions)
+    }
+  }
+
+  @transient
+  private[this] lazy val resultProjection = SQLConf.withExistingConf(conf) {
+    initializeProjection {
+      InterpretedUnsafeProjection.createProjection(resultExpressions)
+    }
+  }
+
+  override def reset(): Unit = {
+    buffer = null
+    joinedRow = null
+  }
+
+  override def isZero: Boolean = buffer == null
+
+  override def copyAndReset(): AggregatingAccumulator = {
+    new AggregatingAccumulator(
+      bufferSchema,
+      initialValues,
+      updateExpressions,
+      mergeExpressions,
+      resultExpressions,
+      imperatives,
+      typedImperatives,
+      conf)
+  }
+
+  override def copy(): AggregatingAccumulator = {
+    val copy = copyAndReset()
+    copy.merge(this)
+    copy
+  }
+
+  override def add(v: InternalRow): Unit = {
+    val buffer = getOrCreateBuffer()
+    updateProjection.target(buffer)(joinedRow.withRight(v))
+    var i = 0
+    while (i < imperatives.length) {
+      imperatives(i).update(buffer, v)
+      i += 1
+    }
+    i = 0
+    while (i < typedImperatives.length) {
+      typedImperatives(i).update(buffer, v)
+      i += 1
+    }
+  }
+
+  override def merge(other: AccumulatorV2[InternalRow, InternalRow]): Unit = {
+    SQLConf.withExistingConf(conf) {
+      if (!other.isZero) {
+        other match {
+          case agg: AggregatingAccumulator =>
+            val buffer = getOrCreateBuffer()
+            val otherBuffer = agg.buffer
+            mergeProjection.target(buffer)(joinedRow.withRight(otherBuffer))
+            var i = 0
+            while (i < imperatives.length) {
+              imperatives(i).merge(buffer, otherBuffer)
+              i += 1
+            }
+            i = 0
+            while (i < typedImperatives.length) {
+              typedImperatives(i).mergeBuffersObjects(buffer, otherBuffer)
+              i += 1
+            }
+          case _ =>
+            throw new UnsupportedOperationException(
+              s"Cannot merge ${this.getClass.getName} with ${other.getClass.getName}")
+        }
+      }
+    }
+  }
+
+  override def value: InternalRow = SQLConf.withExistingConf(conf) {
+    // Either use the existing buffer or create a temporary one.
+    val input = if (buffer != null) {
+      buffer
+    } else {
+      // Create a temporary buffer because we want to avoid changing the state of the accumulator
+      // here, which would happen if we called getOrCreateBuffer(). This is relatively expensive to
+      // do but it should be no problem since this method is supposed to be called rarely (once per
+      // query execution).
+      createBuffer()
+    }
+    resultProjection(input)
+  }
+
+
+  /**
+   * Get the output schema of the aggregating accumulator.
+   */
+  lazy val schema: StructType = {
+    StructType(resultExpressions.zipWithIndex.map {
+      case (e: NamedExpression, _) => StructField(e.name, e.dataType, e.nullable, e.metadata)
+      case (e, i) => StructField(s"c_$i", e.dataType, e.nullable)
+    })
+  }
+}
+
+object AggregatingAccumulator {
+  /**
+   * Create an aggregating accumulator for the given functions and input schema.
+   */
+  def apply(functions: Seq[Expression], inputAttributes: Seq[Attribute]): AggregatingAccumulator = {
+    // There are a couple of things happening here:
+    // - Collect the schema's of the aggregate and input aggregate buffers. These are needed to bind
+    //   the expressions which will be done when we create the accumulator.
+    // - Collect the initialValues, update and merge expressions for declarative aggregate
+    //   functions.
+    // - Bind and Collect the imperative aggregate functions. Note that we insert NoOps into the
+    //   (declarative) initialValues, update and merge expression buffers to keep these aligned with
+    //   the aggregate buffer.
+    // - Build the result expressions.
+    val aggBufferAttributes = mutable.Buffer.empty[AttributeReference]
+    val inputAggBufferAttributes = mutable.Buffer.empty[AttributeReference]
+    val initialValues = mutable.Buffer.empty[Expression]
+    val updateExpressions = mutable.Buffer.empty[Expression]
+    val mergeExpressions = mutable.Buffer.empty[Expression]
+    val imperatives = mutable.Buffer.empty[ImperativeAggregate]
+    val typedImperatives = mutable.Buffer.empty[TypedImperativeAggregate[_]]
+    val inputAttributeSeq: AttributeSeq = inputAttributes
+    val resultExpressions = functions.map(_.transform {
+      case AggregateExpression(agg: DeclarativeAggregate, _, _, _) =>
+        aggBufferAttributes ++= agg.aggBufferAttributes
+        inputAggBufferAttributes ++= agg.inputAggBufferAttributes
+        initialValues ++= agg.initialValues
+        updateExpressions ++= agg.updateExpressions
+        mergeExpressions ++= agg.mergeExpressions
+        agg.evaluateExpression
+      case AggregateExpression(agg: ImperativeAggregate, _, _, _) =>
+        val imperative = BindReferences.bindReference(agg
+          .withNewMutableAggBufferOffset(aggBufferAttributes.size)
+          .withNewInputAggBufferOffset(inputAggBufferAttributes.size),
+          inputAttributeSeq)
+        imperative match {
+          case typedImperative: TypedImperativeAggregate[_] =>
+            typedImperatives += typedImperative
+          case _ =>
+            imperatives += imperative
+        }
+        aggBufferAttributes ++= imperative.aggBufferAttributes
+        inputAggBufferAttributes ++= agg.inputAggBufferAttributes
+        val noOps = Seq.fill(imperative.aggBufferAttributes.size)(NoOp)
+        initialValues ++= noOps
+        updateExpressions ++= noOps
+        mergeExpressions ++= noOps
+        imperative
+    })
+
+    val updateAttrSeq: AttributeSeq = aggBufferAttributes ++ inputAttributes
+    val mergeAttrSeq: AttributeSeq = aggBufferAttributes ++ inputAggBufferAttributes
+    val aggBufferAttributesSeq: AttributeSeq = aggBufferAttributes
+
+    // Create the accumulator.
+    new AggregatingAccumulator(
+      aggBufferAttributes.map(_.dataType),
+      initialValues,
+      updateExpressions.map(BindReferences.bindReference(_, updateAttrSeq)),
+      mergeExpressions.map(BindReferences.bindReference(_, mergeAttrSeq)),
+      resultExpressions.map(BindReferences.bindReference(_, aggBufferAttributesSeq)),
+      imperatives.toArray,
+      typedImperatives.toArray,
+      SQLConf.get)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/AggregatingAccumulatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/AggregatingAccumulatorSuite.scala
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution
+
+import java.util.Properties
+
+import org.apache.spark.{SparkFunSuite, TaskContext, TaskContextImpl}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.expressions.{ExpressionEvalHelper, If, SortArray, SparkPartitionID, SpecificInternalRow}
+import org.apache.spark.sql.catalyst.expressions.aggregate.CollectSet
+import org.apache.spark.sql.catalyst.util.GenericArrayData
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{LongType, StringType, StructType}
+import org.apache.spark.unsafe.types.UTF8String
+
+/**
+ * Test suite for [[AggregatingAccumulator]].
+ */
+class AggregatingAccumulatorSuite
+  extends SparkFunSuite
+  with SharedSparkSession
+  with ExpressionEvalHelper {
+  private val a = 'a.long
+  private val b = 'b.string
+  private val c = 'c.double
+  private val inputAttributes = Seq(a, b, c)
+  private def str(s: String): UTF8String = UTF8String.fromString(s)
+
+  test("empty aggregation") {
+    val acc1 = AggregatingAccumulator(
+      Seq(sum(a) + 1L as "sum_a", max(b) as "max_b", approxCountDistinct(c) as "acntd_c"),
+      inputAttributes)
+    val expectedSchema = new StructType()
+      .add("sum_a", "long")
+      .add("max_b", "string")
+      .add("acntd_c", "long", nullable = false)
+    assert(acc1.schema === expectedSchema)
+
+    val accEmpty = acc1.copy()
+    val acc2 = acc1.copy()
+
+    // Merge empty
+    acc1.merge(accEmpty)
+    assert(acc1.isZero)
+
+    // No updates
+    assert(acc1.isZero)
+    checkResult(acc1.value, InternalRow(null, null, 0), expectedSchema, false)
+    assert(acc1.isZero)
+
+    // A few updates
+    acc1.add(InternalRow(4L, str("foo"), 4.9d))
+    acc1.add(InternalRow(98L, str("bar"), -323.9d))
+    acc1.add(InternalRow(-30L, str("baz"), 4129.8d))
+    assert(!acc1.isZero)
+    checkResult(acc1.value, InternalRow(73L, str("baz"), 3L), expectedSchema, false)
+
+    // Idempotency of result
+    checkResult(acc1.value, InternalRow(73L, str("baz"), 3L), expectedSchema, false)
+
+    // A few updates to the copied accumulator
+    acc2.add(InternalRow(-2L, str("qwerty"), -6773.9d))
+    acc2.add(InternalRow(-35L, str("zzz-top"), -323.9d))
+    checkResult(acc2.value, InternalRow(-36L, str("zzz-top"), 2L), expectedSchema, false)
+
+    // Merge accumulators
+    acc1.merge(acc2)
+    acc1.merge(acc2)
+    acc1.merge(accEmpty)
+    acc1.merge(accEmpty)
+    checkResult(acc1.value, InternalRow(1L, str("zzz-top"), 5L), expectedSchema, false)
+
+    // Reset
+    acc1.reset()
+    assert(acc1.isZero)
+  }
+
+  test("non-deterministic expressions") {
+    val acc_driver = AggregatingAccumulator(
+      Seq(
+        min(SparkPartitionID()) as "min_pid",
+        max(SparkPartitionID()) as "max_pid",
+        SparkPartitionID()),
+      Nil)
+    checkResult(acc_driver.value, InternalRow(null, null, 0), acc_driver.schema, false)
+
+    def inPartition(id: Int)(f: => Unit): Unit = {
+      val ctx = new TaskContextImpl(0, 0, 1, 0, 0, null, new Properties, null)
+      TaskContext.setTaskContext(ctx)
+      try {
+        f
+      } finally {
+        TaskContext.unset()
+      }
+    }
+
+    val acc1 = acc_driver.copy()
+    inPartition(3) {
+      acc1.add(InternalRow.empty)
+    }
+    val acc2 = acc_driver.copy()
+    inPartition(42) {
+      acc2.add(InternalRow.empty)
+    }
+    val acc3 = acc_driver.copy()
+    inPartition(96) {
+      acc3.add(InternalRow.empty)
+    }
+
+    acc_driver.merge(acc1)
+    acc_driver.merge(acc2)
+    acc_driver.merge(acc3)
+    assert(!acc_driver.isZero)
+    checkResult(acc_driver.value, InternalRow(3, 96, 0), acc_driver.schema, false)
+  }
+
+  test("collect agg metrics on job") {
+    val acc = AggregatingAccumulator(
+      Seq(
+        avg(a) + 1.0d as "avg_a",
+        sum(a + 10L) as "sum_a",
+        min(b) as "min_b",
+        max(b) as "max_b",
+        approxCountDistinct(b) as "acntd_b",
+        SortArray(CollectSet(If(a < 1000L, a % 3L, a % 6L)).toAggregateExpression(), true)
+          as "item_set",
+        min(SparkPartitionID()) as "min_pid",
+        max(SparkPartitionID()) as "max_pid",
+        SparkPartitionID()),
+      Seq(a, b))
+    sparkContext.register(acc)
+    def consume(ids: Iterator[Long]): Unit = {
+      val row = new SpecificInternalRow(Seq(LongType, StringType))
+      ids.foreach { id =>
+        // Create the new row values.
+        row.setLong(0, id)
+        row.update(1, UTF8String.fromString(f"val_$id%06d"))
+
+        // Update the accumulator
+        acc.add(row)
+      }
+    }
+
+    // Run job 1
+    spark.sparkContext
+      .range(0, 1000, 1, 8)
+      .foreachPartition(consume)
+    assert(checkResult(
+      acc.value,
+      InternalRow(
+        500.5d,
+        509500L,
+        str("val_000000"),
+        str("val_000999"),
+        1057L,
+        new GenericArrayData(Seq(0L, 1L, 2L)),
+        0,
+        7,
+        0),
+      acc.schema,
+      false))
+
+    // Run job 2
+    spark.sparkContext
+      .range(1000, 1200, 1, 8)
+      .foreachPartition(consume)
+    assert(checkResult(
+      acc.value,
+      InternalRow(
+        600.5d,
+        731400L,
+        str("val_000000"),
+        str("val_001199"),
+        1280L,
+        new GenericArrayData(Seq(0L, 1L, 2L, 3L, 4L, 5L)),
+        0,
+        7,
+        0),
+      acc.schema,
+      false))
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds an accumulator that computes a global aggregate over a number of rows. A user can define an arbitrary number of aggregate functions which can be computed at the same time.

The accumulator uses the standard technique for implementing (interpreted) aggregation in Spark. It uses projections and manual updates for each of the aggregation steps (initialize buffer, update buffer with new input row, merge two buffers and compute the final result on the buffer). Note that two of the steps (update and merge) use the aggregation buffer both as input and output.

Accumulators do not have an explicit point at which they get serialized. A somewhat surprising side effect is that the buffers of a `TypedImperativeAggregate` go over the wire as-is instead of serializing them. The merging logic for `TypedImperativeAggregate` assumes that the input buffer contains serialized buffers, this is violated by the accumulator's implicit serialization. In order to get around this I have added `mergeBuffersObjects` method that merges two unserialized buffers to `TypedImperativeAggregate`.

### Why are the changes needed?
This is the mechanism we are going to use to implement observable metrics.

### Does this PR introduce any user-facing change?
No, not yet.

### How was this patch tested?
Added `AggregatingAccumulator` test suite.
