### PR TITLE
[SPARK-24914][SQL] Calculated table statistic to improve data size estimate for ORC which manually settable for other columnar formats

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -25,8 +25,6 @@ import java.util.Date
 import scala.collection.mutable
 import scala.util.control.NonFatal
 
-import com.google.common.math.DoubleMath.roundToBigInteger
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, InternalRow, TableIdentifier}
@@ -447,7 +445,7 @@ case class CatalogStatistics(
       // When plan statistics are disabled or the table doesn't have other statistics,
       // we apply the size-only estimation strategy and only propagate sizeInBytes in statistics.
       val size = deserFactor.map { factor =>
-        BigInt(roundToBigInteger(sizeInBytes.doubleValue * deserFactorDistortion * factor, UP))
+        BigDecimal(Math.ceil(sizeInBytes.doubleValue * deserFactorDistortion * factor)).toBigInt()
       }.getOrElse(sizeInBytes)
       Statistics(sizeInBytes = size)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1589,6 +1589,29 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val DESERIALIZATION_FACTOR_CALC_ENABLED =
+    buildConf("spark.sql.statistics.deserFactor.calc.enabled")
+      .doc("Enables the calculation of the deserialization factor as a table statistic. " +
+        "This factor is intended to be calculated for columnar storage formats as a ratio of " +
+        "actual data size to raw file size but currently Spark calculates this only for the ORC " +
+        "format. Spark uses this ratio is to scale up the estimated size, which leads to " +
+        "better estimate of in-memory data size and improves the query optimization (i.e., join " +
+        "strategy). In case of partitioned table the maximum of these factors is taken. " +
+        "Spark stores this factor in the meta store and reuses it so the table " +
+        "can grow without having to recompute this statistic. " +
+        "The stored factor can be removed only by a TRUNCATE or a DROP table so even a " +
+        "subsequent ANALYZE TABLE where the calculation is disabled keeps the old value.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val DESERIALIZATION_FACTOR_EXTRA_DISTORTION =
+    buildConf("spark.sql.statistics.deserFactor.distortion")
+      .doc("Distortion value used as an extra multiplier at the application of the " +
+        "deserialization factor making one capable to modify the computed table size even after " +
+        "the deserialization factor is calculated and stored in the meta store.")
+      .doubleConf
+      .createWithDefault(1.0)
+
   val CBO_ENABLED =
     buildConf("spark.sql.cbo.enabled")
       .doc("Enables CBO for estimation of plan statistics when set true.")
@@ -2884,6 +2907,10 @@ class SQLConf extends Serializable with Logging {
   def planStatsEnabled: Boolean = getConf(SQLConf.PLAN_STATS_ENABLED)
 
   def autoSizeUpdateEnabled: Boolean = getConf(SQLConf.AUTO_SIZE_UPDATE_ENABLED)
+
+  def deserFactorStatCalcEnabled: Boolean = getConf(SQLConf.DESERIALIZATION_FACTOR_CALC_ENABLED)
+
+  def deserFactorDistortion: Double = getConf(SQLConf.DESERIALIZATION_FACTOR_EXTRA_DISTORTION)
 
   def joinReorderEnabled: Boolean = getConf(SQLConf.JOIN_REORDER_ENABLED)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzeColumnCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzeColumnCommand.scala
@@ -111,7 +111,7 @@ case class AnalyzeColumnCommand(
         throw new AnalysisException("ANALYZE TABLE is not supported on views.")
       }
     } else {
-      val sizeInBytes = CommandUtils.calculateTotalSize(sparkSession, tableMeta)
+      val sizeWithDeserFactor = CommandUtils.calculateTotalSize(sparkSession, tableMeta)
       val relation = sparkSession.table(tableIdent).logicalPlan
       val columnsToAnalyze = getColumnsToAnalyze(tableIdent, relation, columnNames, allColumns)
 
@@ -126,7 +126,8 @@ case class AnalyzeColumnCommand(
 
       // We also update table-level stats in order to keep them consistent with column-level stats.
       val statistics = CatalogStatistics(
-        sizeInBytes = sizeInBytes,
+        sizeInBytes = sizeWithDeserFactor.sizeInBytes,
+        deserFactor = sizeWithDeserFactor.deserFactor,
         rowCount = Some(rowCount),
         // Newly computed column stats should override the existing ones.
         colStats = tableMeta.stats.map(_.colStats).getOrElse(Map.empty) ++ newColCatalogStats)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzePartitionCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzePartitionCommand.scala
@@ -108,7 +108,7 @@ case class AnalyzePartitionCommand(
     // recorded in the metastore.
 
     val sizes = CommandUtils.calculateMultipleLocationSizes(sparkSession, tableMeta.identifier,
-      partitions.map(_.storage.locationUri))
+      partitions.map(_.storage.locationUri), tableMeta.storage.serde)
     val newPartitions = partitions.zipWithIndex.flatMap { case (p, idx) =>
       val newRowCount = rowCounts.get(p.spec)
       val newStats = CommandUtils.compareAndGetNewStats(p.stats, sizes(idx), newRowCount)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
@@ -120,7 +120,7 @@ object CommandUtils extends Logging {
     assert(fStatus.isFile)
     val factor = if (calcDeserFact) {
       val isOrc = serde.contains(orcSerDeCanonicalClass) || fStatus.getPath.getName.endsWith(".orc")
-      val rawSize = if (isOrc) Some(OrcUtils.rawSize(hadoopConf, fStatus.getPath)) else None
+      val rawSize = if (isOrc) OrcUtils.rawSize(hadoopConf, fStatus.getPath) else None
       rawSize.map { rawSize =>
         // deserialization factor is a ratio of the data size in memory to file size rounded up
         // to the next integer number

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
@@ -104,9 +104,9 @@ object CommandUtils extends Logging {
     totalSize
   }
 
-   def sumSizeWithMaxDeserializationFactor(sizesWithFactors: Seq[SizeInBytesWithDeserFactor])
-    : SizeInBytesWithDeserFactor = {
-    val definedFactors = sizesWithFactors.filter(_.deserFactor.isDefined).map(_.deserFactor.get)
+  def sumSizeWithMaxDeserializationFactor(
+      sizesWithFactors: Seq[SizeInBytesWithDeserFactor]): SizeInBytesWithDeserFactor = {
+    val definedFactors = sizesWithFactors.flatMap(_.deserFactor)
     SizeInBytesWithDeserFactor(
       sizesWithFactors.map(_.sizeInBytes).sum,
       if (definedFactors.isEmpty) None else Some(definedFactors.max))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
@@ -152,7 +152,7 @@ object CommandUtils extends Logging {
     val stagingDir = sessionState.conf.getConfString("hive.exec.stagingdir", ".hive-staging")
     val hadoopConf = sessionState.newHadoopConf()
 
-    val calcDeserFactEnabled = sessionState.conf.deserFactorStatCalcEnabled
+    val deserFactCalcEnabled = sessionState.conf.deserFactorStatCalcEnabled
     def getSumSizeInBytesWithDeserFactor(fs: FileSystem, path: Path): SizeInBytesWithDeserFactor = {
       val fileStatus = fs.getFileStatus(path)
       if (fileStatus.isDirectory) {
@@ -165,7 +165,7 @@ object CommandUtils extends Logging {
         }
         sumSizeWithMaxDeserializationFactor(fileSizesWithDeserFactor)
       } else {
-        sizeInBytesWithDeserFactor(calcDeserFactEnabled, hadoopConf, fileStatus, serde)
+        sizeInBytesWithDeserFactor(deserFactCalcEnabled, hadoopConf, fileStatus, serde)
       }
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -484,12 +484,22 @@ case class AlterTableAddPartitionCommand(
       catalog.createPartitions(table.identifier, batch, ignoreIfExists = ifNotExists)
     }
 
-    if (table.stats.nonEmpty) {
+    table.stats.foreach { stats =>
       if (sparkSession.sessionState.conf.autoSizeUpdateEnabled) {
-        val addedSize = CommandUtils.calculateMultipleLocationSizes(sparkSession, table.identifier,
-          parts.map(_.storage.locationUri)).sum
+        val sizesWithFactors =
+          CommandUtils.calculateMultipleLocationSizes(sparkSession, table.identifier,
+            parts.map(_.storage.locationUri))
+        val newPartsTotalSizeAndDeserializationFactor =
+          CommandUtils.sumSizeWithMaxDeserializationFactor(sizesWithFactors)
+        val addedSize = newPartsTotalSizeAndDeserializationFactor.sizeInBytes
+        // if the calculation of the deserialization factor is disabled now then take the old factor
+        // otherwise take the largest factor
+        val newFactor = newPartsTotalSizeAndDeserializationFactor
+          .deserFactor
+          .map(Math.max(_, stats.deserFactor.getOrElse(0)))
+          .orElse(stats.deserFactor)
         if (addedSize > 0) {
-          val newStats = CatalogStatistics(sizeInBytes = table.stats.get.sizeInBytes + addedSize)
+          val newStats = CatalogStatistics(sizeInBytes = stats.sizeInBytes + addedSize, newFactor)
           catalog.alterTableStats(table.identifier, Some(newStats))
         }
       } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -487,8 +487,11 @@ case class AlterTableAddPartitionCommand(
     table.stats.foreach { stats =>
       if (sparkSession.sessionState.conf.autoSizeUpdateEnabled) {
         val sizesWithFactors =
-          CommandUtils.calculateMultipleLocationSizes(sparkSession, table.identifier,
-            parts.map(_.storage.locationUri))
+          CommandUtils.calculateMultipleLocationSizes(
+            sparkSession,
+            table.identifier,
+            parts.map(_.storage.locationUri),
+            table.storage.serde)
         val newPartsTotalSizeAndDeserializationFactor =
           CommandUtils.sumSizeWithMaxDeserializationFactor(sizesWithFactors)
         val addedSize = newPartsTotalSizeAndDeserializationFactor.sizeInBytes

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -586,7 +586,9 @@ case class TruncateTableCommand(
 
     if (table.stats.nonEmpty) {
       // empty table after truncation
-      val newStats = CatalogStatistics(sizeInBytes = 0, rowCount = Some(0))
+      val newStats = CatalogStatistics(sizeInBytes = 0,
+        deserFactor = None,
+        rowCount = Some(0))
       catalog.alterTableStats(tableName, Some(newStats))
     }
     Seq.empty[Row]

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/LogicalRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/LogicalRelation.scala
@@ -40,8 +40,9 @@ case class LogicalRelation(
     catalogTable = None)
 
   override def computeStats(): Statistics = {
+    val planStatsEnabled = conf.cboEnabled || conf.planStatsEnabled
     catalogTable
-      .flatMap(_.stats.map(_.toPlanStats(output, conf.cboEnabled || conf.planStatsEnabled)))
+      .flatMap(_.stats.map(_.toPlanStats(output, planStatsEnabled, conf.deserFactorDistortion)))
       .getOrElse(Statistics(sizeInBytes = relation.sizeInBytes))
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -94,8 +94,12 @@ private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
         val prunedFsRelation =
           fsRelation.copy(location = prunedFileIndex)(fsRelation.sparkSession)
         // Change table stats based on the sizeInBytes of pruned files
-        val withStats = logicalRelation.catalogTable.map(_.copy(
-          stats = Some(CatalogStatistics(sizeInBytes = BigInt(prunedFileIndex.sizeInBytes)))))
+        val withStats = logicalRelation.catalogTable.map { catalogTable =>
+          catalogTable.copy(
+            stats = Some(CatalogStatistics(
+              sizeInBytes = BigInt(prunedFileIndex.sizeInBytes),
+              deserFactor = catalogTable.stats.flatMap(_.deserFactor))))
+        }
         val prunedLogicalRelation = logicalRelation.copy(
           relation = prunedFsRelation, catalogTable = withStats)
         // Keep partition-pruning predicates so that they are visible in physical planning

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.orc
 
+import java.io.IOException
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.Locale
 
@@ -45,6 +46,17 @@ object OrcUtils extends Logging {
     "SNAPPY" -> ".snappy",
     "ZLIB" -> ".zlib",
     "LZO" -> ".lzo")
+
+  def rawSize(hadoopConf: Configuration, filePath: Path): BigInt = {
+    val fs = filePath.getFileSystem(hadoopConf)
+    val readerOptions = OrcFile.readerOptions(hadoopConf).filesystem(fs)
+    try {
+      val reader = OrcFile.createReader(filePath, readerOptions)
+      reader.getRawDataSize
+    } catch {
+      case _: IOException => BigInt(0)
+    }
+  }
 
   def listOrcFiles(pathStr: String, conf: Configuration): Seq[Path] = {
     val origPath = new Path(pathStr)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -51,8 +51,7 @@ object OrcUtils extends Logging {
     val fs = filePath.getFileSystem(hadoopConf)
     val readerOptions = OrcFile.readerOptions(hadoopConf).filesystem(fs)
     try {
-      val reader = OrcFile.createReader(filePath, readerOptions)
-      reader.getRawDataSize
+      Utils.tryWithResource(OrcFile.createReader(filePath, readerOptions))(_.getRawDataSize)
     } catch {
       case _: IOException => BigInt(0)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -47,13 +47,15 @@ object OrcUtils extends Logging {
     "ZLIB" -> ".zlib",
     "LZO" -> ".lzo")
 
-  def rawSize(hadoopConf: Configuration, filePath: Path): BigInt = {
+  def rawSize(hadoopConf: Configuration, filePath: Path): Option[BigInt] = {
     val fs = filePath.getFileSystem(hadoopConf)
     val readerOptions = OrcFile.readerOptions(hadoopConf).filesystem(fs)
     try {
-      Utils.tryWithResource(OrcFile.createReader(filePath, readerOptions))(_.getRawDataSize)
+      Utils.tryWithResource(OrcFile.createReader(filePath, readerOptions)) { r =>
+        Some(r.getRawDataSize)
+      }
     } catch {
-      case _: IOException => BigInt(0)
+      case _: IOException => None
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionTestBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionTestBase.scala
@@ -31,6 +31,8 @@ import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, Histogram, Histo
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.execution.exchange.EnsureRequirements
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, SortMergeJoinExec}
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.test.SQLTestUtils
 
@@ -393,5 +395,15 @@ abstract class StatisticsCollectionTestBase extends QueryTest with SQLTestUtils 
       assert(relation.stats.rowCount.isEmpty)
       assert(relation.stats.attributeStats.isEmpty)
     }
+  }
+
+  def checkNumBroadcastHashJoins(df: DataFrame, expectedNumBhj: Int, clue: String): Unit = {
+    val plan = EnsureRequirements(spark.sessionState.conf).apply(df.queryExecution.sparkPlan)
+    assert(plan.collect { case p: BroadcastHashJoinExec => p }.size === expectedNumBhj, clue)
+  }
+
+  def checkNumSortMergeJoins(df: DataFrame, expectedNumSmj: Int, clue: String): Unit = {
+    val plan = EnsureRequirements(spark.sessionState.conf).apply(df.queryExecution.sparkPlan)
+    assert(plan.collect { case p: SortMergeJoinExec => p }.size === expectedNumSmj, clue)
   }
 }

--- a/sql/hive/benchmarks/OrcReadBenchmark-results.txt
+++ b/sql/hive/benchmarks/OrcReadBenchmark-results.txt
@@ -2,155 +2,193 @@
 SQL Single Numeric Column Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_232-8u232-b09-0ubuntu1~18.04.1-b09 on Linux 4.15.0-1044-aws
+OpenJDK 64-Bit Server VM 1.8.0_242-b07 on Linux 4.15.0-1021-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 SQL Single TINYINT Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      1844           1851          10          8.5         117.2       1.0X
-Native ORC Vectorized                               284            312          36         55.5          18.0       6.5X
-Hive built-in ORC                                  2380           2380           1          6.6         151.3       0.8X
+Native ORC MR                                      1860           1891          44          8.5         118.2       1.0X
+Native ORC Vectorized                               303            362          62         51.9          19.3       6.1X
+Hive built-in ORC                                  2428           2454          37          6.5         154.4       0.8X
 
-OpenJDK 64-Bit Server VM 1.8.0_232-8u232-b09-0ubuntu1~18.04.1-b09 on Linux 4.15.0-1044-aws
+OpenJDK 64-Bit Server VM 1.8.0_242-b07 on Linux 4.15.0-1021-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 SQL Single SMALLINT Column Scan:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      1999           2031          45          7.9         127.1       1.0X
-Native ORC Vectorized                               252            264          15         62.5          16.0       7.9X
-Hive built-in ORC                                  2483           2509          37          6.3         157.9       0.8X
+Native ORC MR                                      2076           2087          16          7.6         132.0       1.0X
+Native ORC Vectorized                               266            278          12         59.1          16.9       7.8X
+Hive built-in ORC                                  2538           2570          46          6.2         161.3       0.8X
 
-OpenJDK 64-Bit Server VM 1.8.0_232-8u232-b09-0ubuntu1~18.04.1-b09 on Linux 4.15.0-1044-aws
+OpenJDK 64-Bit Server VM 1.8.0_242-b07 on Linux 4.15.0-1021-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 SQL Single INT Column Scan:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      2134           2135           2          7.4         135.7       1.0X
-Native ORC Vectorized                               329            351          34         47.8          20.9       6.5X
-Hive built-in ORC                                  2672           2716          61          5.9         169.9       0.8X
+Native ORC MR                                      2024           2137         160          7.8         128.7       1.0X
+Native ORC Vectorized                               347            363          21         45.4          22.0       5.8X
+Hive built-in ORC                                  2808           2828          29          5.6         178.5       0.7X
 
-OpenJDK 64-Bit Server VM 1.8.0_232-8u232-b09-0ubuntu1~18.04.1-b09 on Linux 4.15.0-1044-aws
+OpenJDK 64-Bit Server VM 1.8.0_242-b07 on Linux 4.15.0-1021-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 SQL Single BIGINT Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      2172           2247         105          7.2         138.1       1.0X
-Native ORC Vectorized                               407            427          23         38.7          25.9       5.3X
-Hive built-in ORC                                  2806           2822          22          5.6         178.4       0.8X
+Native ORC MR                                      2197           2237          57          7.2         139.7       1.0X
+Native ORC Vectorized                               430            454          23         36.6          27.4       5.1X
+Hive built-in ORC                                  2882           2925          61          5.5         183.2       0.8X
 
-OpenJDK 64-Bit Server VM 1.8.0_232-8u232-b09-0ubuntu1~18.04.1-b09 on Linux 4.15.0-1044-aws
+OpenJDK 64-Bit Server VM 1.8.0_242-b07 on Linux 4.15.0-1021-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 SQL Single FLOAT Column Scan:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      2187           2200          19          7.2         139.0       1.0X
-Native ORC Vectorized                               451            457           5         34.9          28.7       4.8X
-Hive built-in ORC                                  2886           2938          73          5.4         183.5       0.8X
+Native ORC MR                                      2254           2259           7          7.0         143.3       1.0X
+Native ORC Vectorized                               472            483          15         33.3          30.0       4.8X
+Hive built-in ORC                                  2906           2956          71          5.4         184.8       0.8X
 
-OpenJDK 64-Bit Server VM 1.8.0_232-8u232-b09-0ubuntu1~18.04.1-b09 on Linux 4.15.0-1044-aws
+OpenJDK 64-Bit Server VM 1.8.0_242-b07 on Linux 4.15.0-1021-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 SQL Single DOUBLE Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      2313           2319           9          6.8         147.1       1.0X
-Native ORC Vectorized                               554            562           7         28.4          35.2       4.2X
-Hive built-in ORC                                  2927           2933           8          5.4         186.1       0.8X
+Native ORC MR                                      2314           2331          25          6.8         147.1       1.0X
+Native ORC Vectorized                               581            593          18         27.1          36.9       4.0X
+Hive built-in ORC                                  3115           3167          74          5.0         198.0       0.7X
 
 
 ================================================================================================
 Int and String Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_232-8u232-b09-0ubuntu1~18.04.1-b09 on Linux 4.15.0-1044-aws
+OpenJDK 64-Bit Server VM 1.8.0_242-b07 on Linux 4.15.0-1021-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Int and String Scan:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      4162           4294         186          2.5         397.0       1.0X
-Native ORC Vectorized                              2236           2258          32          4.7         213.2       1.9X
-Hive built-in ORC                                  5054           5135         114          2.1         482.0       0.8X
+Native ORC MR                                      4243           4336         132          2.5         404.6       1.0X
+Native ORC Vectorized                              2310           2347          53          4.5         220.3       1.8X
+Hive built-in ORC                                  5925           6015         128          1.8         565.0       0.7X
 
 
 ================================================================================================
 Partitioned Table Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_232-8u232-b09-0ubuntu1~18.04.1-b09 on Linux 4.15.0-1044-aws
+OpenJDK 64-Bit Server VM 1.8.0_242-b07 on Linux 4.15.0-1021-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Partitioned Table:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Data column - Native ORC MR                        2436           2447          16          6.5         154.8       1.0X
-Data column - Native ORC Vectorized                 421            443          35         37.4          26.8       5.8X
-Data column - Hive built-in ORC                    3007           3026          27          5.2         191.2       0.8X
-Partition column - Native ORC MR                   1603           1630          39          9.8         101.9       1.5X
-Partition column - Native ORC Vectorized             84             96          15        186.7           5.4      28.9X
-Partition column - Hive built-in ORC               2174           2187          18          7.2         138.2       1.1X
-Both columns - Native ORC MR                       2609           2645          51          6.0         165.9       0.9X
-Both columns - Native ORC Vectorized                460            470           9         34.2          29.3       5.3X
-Both columns - Hive built-in ORC                   3094           3099           8          5.1         196.7       0.8X
+Data column - Native ORC MR                        2483           2517          49          6.3         157.8       1.0X
+Data column - Native ORC Vectorized                 443            467          30         35.5          28.2       5.6X
+Data column - Hive built-in ORC                    3138           3149          16          5.0         199.5       0.8X
+Partition column - Native ORC MR                   1620           1630          13          9.7         103.0       1.5X
+Partition column - Native ORC Vectorized             95            111          16        165.8           6.0      26.2X
+Partition column - Hive built-in ORC               2213           2245          45          7.1         140.7       1.1X
+Both columns - Native ORC MR                       2646           2674          40          5.9         168.2       0.9X
+Both columns - Native ORC Vectorized                482            507          26         32.6          30.6       5.2X
+Both columns - Hive built-in ORC                   3178           3201          33          4.9         202.0       0.8X
 
 
 ================================================================================================
 Repeated String Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_232-8u232-b09-0ubuntu1~18.04.1-b09 on Linux 4.15.0-1044-aws
+OpenJDK 64-Bit Server VM 1.8.0_242-b07 on Linux 4.15.0-1021-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Repeated String:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      2036           2046          13          5.1         194.2       1.0X
-Native ORC Vectorized                               366            386          18         28.6          34.9       5.6X
-Hive built-in ORC                                  2683           2686           4          3.9         255.9       0.8X
+Native ORC MR                                      2019           2062          62          5.2         192.5       1.0X
+Native ORC Vectorized                               384            397          10         27.3          36.7       5.3X
+Hive built-in ORC                                  2731           2733           2          3.8         260.5       0.7X
 
 
 ================================================================================================
 String with Nulls Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_232-8u232-b09-0ubuntu1~18.04.1-b09 on Linux 4.15.0-1044-aws
+OpenJDK 64-Bit Server VM 1.8.0_242-b07 on Linux 4.15.0-1021-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 String with Nulls Scan (0.0%):            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      3614           3643          40          2.9         344.7       1.0X
-Native ORC Vectorized                              1072           1087          22          9.8         102.2       3.4X
-Hive built-in ORC                                  4625           4636          15          2.3         441.1       0.8X
+Native ORC MR                                      3613           3642          42          2.9         344.5       1.0X
+Native ORC Vectorized                              1107           1131          34          9.5         105.6       3.3X
+Hive built-in ORC                                  4794           4819          35          2.2         457.2       0.8X
 
-OpenJDK 64-Bit Server VM 1.8.0_232-8u232-b09-0ubuntu1~18.04.1-b09 on Linux 4.15.0-1044-aws
+OpenJDK 64-Bit Server VM 1.8.0_242-b07 on Linux 4.15.0-1021-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 String with Nulls Scan (50.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      3347           3376          42          3.1         319.2       1.0X
-Native ORC Vectorized                              1220           1225           7          8.6         116.3       2.7X
-Hive built-in ORC                                  4168           4184          23          2.5         397.5       0.8X
+Native ORC MR                                      3375           3381           8          3.1         321.9       1.0X
+Native ORC Vectorized                              1226           1227           2          8.6         116.9       2.8X
+Hive built-in ORC                                  4304           4317          19          2.4         410.5       0.8X
 
-OpenJDK 64-Bit Server VM 1.8.0_232-8u232-b09-0ubuntu1~18.04.1-b09 on Linux 4.15.0-1044-aws
+OpenJDK 64-Bit Server VM 1.8.0_242-b07 on Linux 4.15.0-1021-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 String with Nulls Scan (95.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      1851           1862          16          5.7         176.5       1.0X
-Native ORC Vectorized                               466            471           7         22.5          44.4       4.0X
-Hive built-in ORC                                  2523           2529           8          4.2         240.6       0.7X
+Native ORC MR                                      1860           1874          20          5.6         177.4       1.0X
+Native ORC Vectorized                               474            486          12         22.1          45.2       3.9X
+Hive built-in ORC                                  2603           2632          41          4.0         248.3       0.7X
 
 
 ================================================================================================
 Single Column Scan From Wide Columns
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_232-8u232-b09-0ubuntu1~18.04.1-b09 on Linux 4.15.0-1044-aws
+OpenJDK 64-Bit Server VM 1.8.0_242-b07 on Linux 4.15.0-1021-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Single Column Scan from 100 columns:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       250            264          15          4.2         238.1       1.0X
-Native ORC Vectorized                               121            138          24          8.7         115.5       2.1X
-Hive built-in ORC                                  1761           1792          43          0.6        1679.3       0.1X
+Native ORC MR                                       274            304          35          3.8         260.9       1.0X
+Native ORC Vectorized                               131            150          22          8.0         124.9       2.1X
+Hive built-in ORC                                  1839           1862          32          0.6        1754.2       0.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_232-8u232-b09-0ubuntu1~18.04.1-b09 on Linux 4.15.0-1044-aws
+OpenJDK 64-Bit Server VM 1.8.0_242-b07 on Linux 4.15.0-1021-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Single Column Scan from 200 columns:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       319            341          17          3.3         304.5       1.0X
-Native ORC Vectorized                               188            222          50          5.6         178.8       1.7X
-Hive built-in ORC                                  3492           3508          24          0.3        3329.8       0.1X
+Native ORC MR                                       334            344          16          3.1         318.3       1.0X
+Native ORC Vectorized                               201            222          24          5.2         191.6       1.7X
+Hive built-in ORC                                  3587           3622          49          0.3        3421.1       0.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_232-8u232-b09-0ubuntu1~18.04.1-b09 on Linux 4.15.0-1044-aws
+OpenJDK 64-Bit Server VM 1.8.0_242-b07 on Linux 4.15.0-1021-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Single Column Scan from 300 columns:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       443            456          12          2.4         422.9       1.0X
-Native ORC Vectorized                               306            321          23          3.4         292.0       1.4X
-Hive built-in ORC                                  5295           5312          24          0.2        5049.9       0.1X
+Native ORC MR                                       458            470           8          2.3         436.7       1.0X
+Native ORC Vectorized                               319            326          10          3.3         304.4       1.4X
+Hive built-in ORC                                  5474           5556         117          0.2        5220.2       0.1X
+
+
+================================================================================================
+Deser Factor Calculation From Wide Columns
+================================================================================================
+
+OpenJDK 64-Bit Server VM 1.8.0_242-b07 on Linux 4.15.0-1021-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+DeserFactor calculation with 100 columns:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Native ORC (no deserFactor calc)                    747            842         127         14.0          71.3       1.0X
+Native ORC (with deserFactor calc)                  763            779          14         13.7          72.7       1.0X
+
+OpenJDK 64-Bit Server VM 1.8.0_242-b07 on Linux 4.15.0-1021-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+DeserFactor calculation with 200 columns:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Native ORC (no deserFactor calc)                   3895           3928          47          2.7         371.5       1.0X
+Native ORC (with deserFactor calc)                 3904           3907           4          2.7         372.3       1.0X
+
+OpenJDK 64-Bit Server VM 1.8.0_242-b07 on Linux 4.15.0-1021-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+DeserFactor calculation with 300 columns:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Native ORC (no deserFactor calc)                  11564          11687         173          0.9        1102.9       1.0X
+Native ORC (with deserFactor calc)                11489          11493           5          0.9        1095.7       1.0X
+
+
+================================================================================================
+Deser Factor with Repeated String Scan
+================================================================================================
+
+OpenJDK 64-Bit Server VM 1.8.0_242-b07 on Linux 4.15.0-1021-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+DeserFactor calculation with Repeated String:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Native ORC (no deserFactor calc)                     62             70          10        168.1           5.9       1.0X
+Native ORC (with deserFactor calc)                   64             70          11        164.5           6.1       1.0X
 
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -632,7 +632,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       // to retain the spark specific format if it is.
       val propsFromOldTable = oldTableDef.properties.filter { case (k, v) =>
         k.startsWith(DATASOURCE_PREFIX) || k.startsWith(STATISTICS_PREFIX) ||
-          k.startsWith(CREATED_SPARK_VERSION)
+          k.startsWith(CREATED_SPARK_VERSION) || k == DESER_FACTOR
       }
       val newTableProps = propsFromOldTable ++ tableDefinition.properties + partitionProviderProp
 
@@ -702,7 +702,9 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
         new mutable.HashMap[String, String]()
       }
 
-    val oldTableNonStatsProps = rawTable.properties.filterNot(_._1.startsWith(STATISTICS_PREFIX))
+    val oldTableNonStatsProps = rawTable.properties.filterNot { prop =>
+      prop._1.startsWith(STATISTICS_PREFIX) || prop._1 == DESER_FACTOR
+    }
     val updatedTable = rawTable.copy(properties = oldTableNonStatsProps ++ statsProperties)
     client.alterTable(updatedTable)
   }
@@ -1084,7 +1086,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       statsProperties += STATISTICS_NUM_ROWS -> stats.rowCount.get.toString()
     }
     if (stats.deserFactor.isDefined) {
-      statsProperties += STATISTICS_DESER_FACTOR -> stats.deserFactor.get.toString()
+      statsProperties += DESER_FACTOR -> stats.deserFactor.get.toString()
     }
 
     stats.colStats.foreach { case (colName, colStat) =>
@@ -1127,7 +1129,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
 
       Some(CatalogStatistics(
         sizeInBytes = BigInt(statsProps(STATISTICS_TOTAL_SIZE)),
-        deserFactor = statsProps.get(STATISTICS_DESER_FACTOR).map(_.toInt),
+        deserFactor = properties.get(DESER_FACTOR).map(_.toInt),
         rowCount = statsProps.get(STATISTICS_NUM_ROWS).map(BigInt(_)),
         colStats = colStats.toMap))
     }
@@ -1338,7 +1340,11 @@ object HiveExternalCatalog {
 
   val STATISTICS_PREFIX = SPARK_SQL_PREFIX + "statistics."
   val STATISTICS_TOTAL_SIZE = STATISTICS_PREFIX + "totalSize"
-  val STATISTICS_DESER_FACTOR = STATISTICS_PREFIX + "deserFactor"
+
+  // The deserialization factor is special statistics which is calculated by analyze table (when its
+  // calculation is enabled by a config) but to make the factor modifiable as table property
+  // it does not start with the SPARK_SQL_PREFIX.
+  val DESER_FACTOR = "spark.deserFactor"
   val STATISTICS_NUM_ROWS = STATISTICS_PREFIX + "numRows"
   val STATISTICS_COL_STATS_PREFIX = STATISTICS_PREFIX + "colStats."
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -1083,6 +1083,9 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     if (stats.rowCount.isDefined) {
       statsProperties += STATISTICS_NUM_ROWS -> stats.rowCount.get.toString()
     }
+    if (stats.deserFactor.isDefined) {
+      statsProperties += STATISTICS_DESER_FACTOR -> stats.deserFactor.get.toString()
+    }
 
     stats.colStats.foreach { case (colName, colStat) =>
       colStat.toMap(colName).foreach { case (k, v) =>
@@ -1124,6 +1127,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
 
       Some(CatalogStatistics(
         sizeInBytes = BigInt(statsProps(STATISTICS_TOTAL_SIZE)),
+        deserFactor = statsProps.get(STATISTICS_DESER_FACTOR).map(_.toInt),
         rowCount = statsProps.get(STATISTICS_NUM_ROWS).map(BigInt(_)),
         colStats = colStats.toMap))
     }
@@ -1334,6 +1338,7 @@ object HiveExternalCatalog {
 
   val STATISTICS_PREFIX = SPARK_SQL_PREFIX + "statistics."
   val STATISTICS_TOTAL_SIZE = STATISTICS_PREFIX + "totalSize"
+  val STATISTICS_DESER_FACTOR = STATISTICS_PREFIX + "deserFactor"
   val STATISTICS_NUM_ROWS = STATISTICS_PREFIX + "numRows"
   val STATISTICS_COL_STATS_PREFIX = STATISTICS_PREFIX + "colStats."
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -56,7 +56,7 @@ import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException}
 import org.apache.spark.sql.connector.catalog.SupportsNamespaces._
 import org.apache.spark.sql.execution.QueryExecutionException
 import org.apache.spark.sql.hive.HiveExternalCatalog
-import org.apache.spark.sql.hive.HiveExternalCatalog.{DATASOURCE_SCHEMA, DATASOURCE_SCHEMA_NUMPARTS, DATASOURCE_SCHEMA_PART_PREFIX, STATISTICS_DESER_FACTOR}
+import org.apache.spark.sql.hive.HiveExternalCatalog.{DATASOURCE_SCHEMA, DATASOURCE_SCHEMA_NUMPARTS, DATASOURCE_SCHEMA_PART_PREFIX, DESER_FACTOR}
 import org.apache.spark.sql.hive.HiveUtils
 import org.apache.spark.sql.hive.client.HiveClientImpl._
 import org.apache.spark.sql.internal.SQLConf
@@ -1213,7 +1213,7 @@ private[hive] object HiveClientImpl {
     // return None.
     // In Hive, when statistics gathering is disabled, `rawDataSize` and `numRows` is always
     // zero after INSERT command. So they are used here only if they are larger than zero.
-    val deserFactor = properties.get(STATISTICS_DESER_FACTOR).map(_.toInt)
+    val deserFactor = properties.get(DESER_FACTOR).map(_.toInt)
     if (totalSize.isDefined && totalSize.get > 0L) {
       Some(CatalogStatistics(
         sizeInBytes = totalSize.get,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -1222,7 +1222,7 @@ private[hive] object HiveClientImpl {
     } else if (rawDataSize.isDefined && rawDataSize.get > 0) {
       Some(CatalogStatistics(
         sizeInBytes = rawDataSize.get,
-        deserFactor = deserFactor,
+        deserFactor = None,
         rowCount = rowCount.filter(_ > 0)))
     } else {
       // TODO: still fill the rowCount even if sizeInBytes is empty. Might break anything?

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -56,7 +56,7 @@ import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException}
 import org.apache.spark.sql.connector.catalog.SupportsNamespaces._
 import org.apache.spark.sql.execution.QueryExecutionException
 import org.apache.spark.sql.hive.HiveExternalCatalog
-import org.apache.spark.sql.hive.HiveExternalCatalog.{DATASOURCE_SCHEMA, DATASOURCE_SCHEMA_NUMPARTS, DATASOURCE_SCHEMA_PART_PREFIX}
+import org.apache.spark.sql.hive.HiveExternalCatalog.{DATASOURCE_SCHEMA, DATASOURCE_SCHEMA_NUMPARTS, DATASOURCE_SCHEMA_PART_PREFIX, STATISTICS_DESER_FACTOR}
 import org.apache.spark.sql.hive.HiveUtils
 import org.apache.spark.sql.hive.client.HiveClientImpl._
 import org.apache.spark.sql.internal.SQLConf
@@ -1213,10 +1213,17 @@ private[hive] object HiveClientImpl {
     // return None.
     // In Hive, when statistics gathering is disabled, `rawDataSize` and `numRows` is always
     // zero after INSERT command. So they are used here only if they are larger than zero.
+    val deserFactor = properties.get(STATISTICS_DESER_FACTOR).map(_.toInt)
     if (totalSize.isDefined && totalSize.get > 0L) {
-      Some(CatalogStatistics(sizeInBytes = totalSize.get, rowCount = rowCount.filter(_ > 0)))
+      Some(CatalogStatistics(
+        sizeInBytes = totalSize.get,
+        deserFactor = deserFactor,
+        rowCount = rowCount.filter(_ > 0)))
     } else if (rawDataSize.isDefined && rawDataSize.get > 0) {
-      Some(CatalogStatistics(sizeInBytes = rawDataSize.get, rowCount = rowCount.filter(_ > 0)))
+      Some(CatalogStatistics(
+        sizeInBytes = rawDataSize.get,
+        deserFactor = deserFactor,
+        rowCount = rowCount.filter(_ > 0)))
     } else {
       // TODO: still fill the rowCount even if sizeInBytes is empty. Might break anything?
       None


### PR DESCRIPTION
### Why are the changes needed?

Before this change Spark estimated the table size as the sum of all the file sizes. This estimate can be way too low at columnar file formats where huge data can be compressed into a very small file because of serialization (like dictionary encoding) and compression. 

This PR introduces a new statistic called `deserFactor` which is calculated for columnar file formats as a ratio of actual data size (raw data size) to file size which is used for scaling up the file size to improve the estimate of in-memory data size and having a better query optimization (i.e., join strategy decision). This way the OOM error which is the result of a wrongly chosen broadcast join strategy can be avoided.

In case of partitioned table the factors are calculated for each files and the maximum of these factors is taken. Spark stores this factor in the meta store and reuses it so the table can grow without having to recompute this statistic. The stored factor can be removed only by a `TRUNCATE` or a `DROP` table so even a subsequent `ANALYZE TABLE` where the calculation is disabled keeps the old value.

Although this intended to be a generic solution for each columnar file formats this PR currently only focusing on the ORC file format.

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

The StatisticsSuite is extended with a new test: `SPARK-24914 - test deserialization factor (ORC)` which checks:
- the factor calculation and application 
- keeping and using the old factor when the calculation is switched off
- calculating it for multiple partitions
- removing the factor at `TRUNCATE`