### PR TITLE
[SPARK-29361][SQL] Enable DataFrame with streaming source support on DSv1

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -23,7 +23,7 @@ import scala.collection.immutable
 import scala.reflect.runtime.universe.TypeTag
 
 import org.apache.spark.{SparkConf, SparkContext}
-import org.apache.spark.annotation.{DeveloperApi, Experimental, Stable, Unstable}
+import org.apache.spark.annotation.{DeveloperApi, Evolving, Experimental, Stable, Unstable}
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.ConfigEntry
@@ -310,6 +310,21 @@ class SQLContext private[sql](val sparkSession: SparkSession)
   @DeveloperApi
   def createDataFrame(rowRDD: RDD[Row], schema: StructType): DataFrame = {
     sparkSession.createDataFrame(rowRDD, schema)
+  }
+
+  /**
+   * :: DeveloperApi ::
+   * Creates a `DataFrame` from an `RDD` containing [[Row]]s using the given schema.
+   * Set `isStreaming` to true if you're creating DataFrame for streaming source.
+   * It is important to make sure that the structure of every [[Row]] of the provided RDD matches
+   * the provided schema. Otherwise, there will be runtime exception.
+   *
+   * @group dataframes
+   * @since 3.0.0
+   */
+  @DeveloperApi
+  def createDataFrame(rowRDD: RDD[Row], schema: StructType, isStreaming: Boolean): DataFrame = {
+    sparkSession.createDataFrame(rowRDD, schema, isStreaming)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -344,11 +344,25 @@ class SparkSession private(
    */
   @DeveloperApi
   def createDataFrame(rowRDD: RDD[Row], schema: StructType): DataFrame = {
+    createDataFrame(rowRDD, schema, isStreaming = false)
+  }
+
+  /**
+   * :: DeveloperApi ::
+   * Creates a `DataFrame` from an `RDD` containing [[Row]]s using the given schema.
+   * Set `isStreaming` to true if you're creating DataFrame for streaming source.
+   * It is important to make sure that the structure of every [[Row]] of the provided RDD matches
+   * the provided schema. Otherwise, there will be runtime exception.
+   *
+   * @since 3.0.0
+   */
+  @DeveloperApi
+  def createDataFrame(rowRDD: RDD[Row], schema: StructType, isStreaming: Boolean): DataFrame = {
     // TODO: use MutableProjection when rowRDD is another DataFrame and the applied
     // schema differs from the existing schema on any field data type.
     val encoder = RowEncoder(schema)
     val catalystRows = rowRDD.map(encoder.toRow)
-    internalCreateDataFrame(catalystRows.setName(rowRDD.name), schema)
+    internalCreateDataFrame(catalystRows.setName(rowRDD.name), schema, isStreaming)
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

This patch provides a new API on creating streaming DataFrame from RDD, which helps to create custom streaming data source in DSv1. This will be the one of interim solutions until new DSv2 has been stabilized and widely adopted.

JavaRDD is not addressed since `Source` and its relevant interfaces are not Java-friendly.

### Why are the changes needed?

The new API this patch proposes would help developers to choose DSv1 for streaming source: for now they're stuck between choosing old DSv2 (and have to work for Spark 3.0 again) and new DSv2 (wait for new API to be available - Spark 3.0 - and overcome huge learning curve).

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

New UT.