### PR TITLE
[SPARK-29364][SQL] Return an interval from `datediff()` in the ANSI mode and Spark dialect

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -1673,19 +1673,28 @@ case class TruncTimestamp(
 }
 
 /**
- * Returns the number of days from startDate to endDate.
+ * Returns the number of days from startDate to endDate or an interval between the dates.
  */
+// scalastyle:off line.size.limit line.contains.tab
 @ExpressionDescription(
-  usage = "_FUNC_(endDate, startDate) - Returns the number of days from `startDate` to `endDate`.",
+  usage = "_FUNC_(endDate, startDate) - Returns the number of days from `startDate` to `endDate`." +
+    "When `spark.sql.ansi.enabled` is set to `true` and `spark.sql.dialect` is `Spark`, it returns " +
+    "an interval between `startDate` (inclusive) and `endDate` (exclusive).",
   examples = """
     Examples:
       > SELECT _FUNC_('2009-07-31', '2009-07-30');
        1
-
       > SELECT _FUNC_('2009-07-30', '2009-07-31');
        -1
+      > SET spark.sql.ansi.enabled=true;
+      spark.sql.ansi.enabled	true
+      > SET spark.sql.dialect=Spark;
+      spark.sql.dialect	Spark
+      > select _FUNC_(date'tomorrow', date'yesterday');
+      interval 2 days
   """,
   since = "1.5.0")
+// scalastyle:on line.size.limit line.contains.tab
 case class DateDiff(endDate: Expression, startDate: Expression)
   extends BinaryExpression with ImplicitCastInputTypes {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -1702,7 +1702,7 @@ case class DateDiff(endDate: Expression, startDate: Expression)
     val startDate = start.asInstanceOf[Int]
     val endDate = end.asInstanceOf[Int]
     if (returnInterval) {
-      dateDiff(startDate, endDate)
+      dateDiff(endDate, startDate)
     } else {
       endDate - startDate
     }
@@ -1712,7 +1712,7 @@ case class DateDiff(endDate: Expression, startDate: Expression)
     defineCodeGen(ctx, ev, (end, start) => {
       if (returnInterval) {
         val dtu = DateTimeUtils.getClass.getName.stripSuffix("$")
-        s"$dtu.dateDiff($start, $end)"
+        s"$dtu.dateDiff($end, $start)"
       } else {
         s"$end - $start"
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -953,12 +953,12 @@ object DateTimeUtils {
 
   /**
    * Gets difference between two dates.
-   * @param startDate - the start date, inclusive
    * @param endDate - the end date, exclusive
+   * @param startDate - the start date, inclusive
    * @return an interval between two dates. The interval can be negative
    *         if the end date is before the start date.
    */
-  def dateDiff(startDate: SQLDate, endDate: SQLDate): CalendarInterval = {
+  def dateDiff(endDate: SQLDate, startDate: SQLDate): CalendarInterval = {
     val period = Period.between(
       LocalDate.ofEpochDay(startDate),
       LocalDate.ofEpochDay(endDate))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit._
 import scala.util.control.NonFatal
 
 import org.apache.spark.sql.types.Decimal
-import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
 /**
  * Helper functions for converting between internal and external date and time representations.
@@ -949,5 +949,21 @@ object DateTimeUtils {
     } else {
       None
     }
+  }
+
+  /**
+   * Gets difference between two dates.
+   * @param startDate - the start date, inclusive
+   * @param endDate - the end date, exclusive
+   * @return an interval between two dates. The interval can be negative
+   *         if the end date is before the start date.
+   */
+  def dateDiff(startDate: SQLDate, endDate: SQLDate): CalendarInterval = {
+    val period = Period.between(
+      LocalDate.ofEpochDay(startDate),
+      LocalDate.ofEpochDay(endDate))
+    val months = period.getMonths + 12 * period.getYears
+    val microseconds = period.getDays * MICROS_PER_DAY
+    new CalendarInterval(months, microseconds)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
@@ -837,17 +837,28 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("datediff returns an integer") {
-    checkEvaluation(
-      DateDiff(Literal(Date.valueOf("2015-07-24")), Literal(Date.valueOf("2015-07-21"))), 3)
-    checkEvaluation(
-      DateDiff(Literal(Date.valueOf("2015-07-21")), Literal(Date.valueOf("2015-07-24"))), -3)
-    checkEvaluation(DateDiff(Literal.create(null, DateType), Literal(Date.valueOf("2015-07-24"))),
-      null)
-    checkEvaluation(DateDiff(Literal(Date.valueOf("2015-07-24")), Literal.create(null, DateType)),
-      null)
-    checkEvaluation(
-      DateDiff(Literal.create(null, DateType), Literal.create(null, DateType)),
-      null)
+    Seq(
+      (true, "PostgreSQL"),
+      (false, "PostgreSQL"),
+      (false, "Spark")).foreach { case (ansi, dialect) =>
+      withSQLConf(
+        SQLConf.ANSI_ENABLED.key -> ansi.toString,
+        SQLConf.DIALECT.key -> dialect.toString) {
+        checkEvaluation(
+          DateDiff(Literal(Date.valueOf("2015-07-24")), Literal(Date.valueOf("2015-07-21"))), 3)
+        checkEvaluation(
+          DateDiff(Literal(Date.valueOf("2015-07-21")), Literal(Date.valueOf("2015-07-24"))), -3)
+        checkEvaluation(
+          DateDiff(Literal.create(null, DateType), Literal(Date.valueOf("2015-07-24"))),
+          null)
+        checkEvaluation(
+          DateDiff(Literal(Date.valueOf("2015-07-24")), Literal.create(null, DateType)),
+          null)
+        checkEvaluation(
+          DateDiff(Literal.create(null, DateType), Literal.create(null, DateType)),
+          null)
+      }
+    }
   }
 
   test("datediff returns an interval") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Modified the `DateDiff` expression to return `CalendarIntervalType` according to the SQL standard , see [4.5.3  Operations involving datetimes and intervals](http://www.contrib.andrew.cmu.edu/~shadow/sql/sql1992.txt). This affects the `datediff` function and dates subtraction. By default, the expression return an integer which is the number of days between dates but when `spark.sql.ansi.enabled` is set to `true` and `spark.sql.dialect` is `Spark`, result type is the `INTERVAL` type. For example:
```sql
> select date'tomorrow' - date'yesterday';
interval 2 days
```
_Note: I haven't found any DBMS that return an interval for date subtract for now._

### Why are the changes needed?
- To conform the SQL standard which states the result type of `date operand 1` - `date operand 2` must be the interval type.
- Improve Spark SQL UX and allow mixing date and timestamp in subtractions. For example: `select timestamp'now' + (date'2019-10-01' - date'2019-09-15')`

### Does this PR introduce any user-facing change?
Yes, when SQL ANSI is enabled in the Spark dialect.
Before the query below returns number of days:
```sql
spark-sql> SET spark.sql.ansi.enabled=true;
spark.sql.ansi.enabled	true
spark-sql> SET spark.sql.dialect=Spark;
spark.sql.dialect	Spark
spark-sql> select date'2019-10-05' - date'2018-09-01';
399
```
After it returns an interval:
```sql
spark-sql> SET spark.sql.ansi.enabled=true;
spark.sql.ansi.enabled	true
spark-sql> SET spark.sql.dialect=Spark;
spark.sql.dialect	Spark
spark-sql> select date'2019-10-05' - date'2018-09-01';
interval 1 years 1 months 4 days
```


### How was this patch tested?
- by new tests in `DateExpressionsSuite`.
- by examples for `DateDiff` that are checked due to https://github.com/apache/spark/pull/25942 
