### PR TITLE
[SPARK-29092][SQL] Report additional information about DataSourceScanExec in EXPLAIN FORMATTED

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -68,7 +68,7 @@ trait DataSourceScanExec extends LeafExecNode {
   override def verboseStringWithOperatorId(): String = {
     val metadataStr = metadata.toSeq.sorted.filterNot {
       case (_, value) if (value.isEmpty || value.equals("[]")) => true
-      case (key, _) if (key.equals("DataFilters")) => true
+      case (key, _) if (key.equals("DataFilters") || key.equals("Format")) => true
       case (_, _) => false
     }.map {
       case (key, value) if (key.equals("Location")) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -68,7 +68,8 @@ trait DataSourceScanExec extends LeafExecNode {
   override def verboseStringWithOperatorId(): String = {
      val metadataStr = metadata.toSeq.sorted.map {
        case (_, value) if (value.isEmpty || value.equals("[]")) => ""
-       case (key, value) if (key.equalsIgnoreCase("location")) =>
+       case (key, _) if (key.equals("DataFilters")) => ""
+       case (key, value) if (key.equals("Location")) =>
          val abbreviatedLoaction = StringUtils.abbreviate(redact(value), 100)
          s"$key: $abbreviatedLoaction"
        case (key, value) => s"$key: ${redact(value)}"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -66,14 +66,16 @@ trait DataSourceScanExec extends LeafExecNode {
   }
 
   override def verboseStringWithOperatorId(): String = {
-     val metadataStr = metadata.toSeq.sorted.map {
-       case (_, value) if (value.isEmpty || value.equals("[]")) => ""
-       case (key, _) if (key.equals("DataFilters")) => ""
-       case (key, value) if (key.equals("Location")) =>
-         val abbreviatedLoaction = StringUtils.abbreviate(redact(value), 100)
-         s"$key: $abbreviatedLoaction"
-       case (key, value) => s"$key: ${redact(value)}"
-    }.filter(_.nonEmpty)
+    val metadataStr = metadata.toSeq.sorted.filterNot {
+      case (_, value) if (value.isEmpty || value.equals("[]")) => true
+      case (key, _) if (key.equals("DataFilters")) => true
+      case (_, _) => false
+    }.map {
+      case (key, value) if (key.equals("Location")) =>
+        val abbreviatedLoaction = StringUtils.abbreviate(redact(value), 100)
+        s"$key: $abbreviatedLoaction"
+      case (key, value) => s"$key: ${redact(value)}"
+    }
 
     s"""
        |(${ExplainUtils.getOpId(this)}) $nodeName ${ExplainUtils.getCodegenId(this)}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
@@ -193,7 +193,7 @@ case class PlanSubqueries(sparkSession: SparkSession) extends Rule[SparkPlan] {
           )
         }
         val executedPlan = new QueryExecution(sparkSession, query).executedPlan
-        InSubqueryExec(expr, SubqueryExec(s"subquery${exprId.id}", executedPlan), exprId)
+        InSubqueryExec(expr, SubqueryExec(s"subquery#${exprId.id}", executedPlan), exprId)
     }
   }
 }

--- a/sql/core/src/test/resources/sql-tests/results/describe-part-after-analyze.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/describe-part-after-analyze.sql.out
@@ -56,12 +56,12 @@ hr                  	int
 Database            	default             	                    
 Table               	t                   	                    
 Partition Values    	[ds=2017-08-01, hr=10]	                    
-Location [not included in comparison]sql/core/spark-warehouse/t/ds=2017-08-01/hr=10	                    
+Location [not included in comparison]/{warehouse_dir}/t/ds=2017-08-01/hr=10	                    
 Created Time [not included in comparison]
 Last Access [not included in comparison]
                     	                    	                    
 # Storage Information	                    	                    
-Location [not included in comparison]sql/core/spark-warehouse/t
+Location [not included in comparison]/{warehouse_dir}/t
 
 
 -- !query 5
@@ -90,13 +90,13 @@ hr                  	int
 Database            	default             	                    
 Table               	t                   	                    
 Partition Values    	[ds=2017-08-01, hr=10]	                    
-Location [not included in comparison]sql/core/spark-warehouse/t/ds=2017-08-01/hr=10	                    
+Location [not included in comparison]/{warehouse_dir}/t/ds=2017-08-01/hr=10	                    
 Created Time [not included in comparison]
 Last Access [not included in comparison]
 Partition Statistics	[not included in comparison] bytes, 3 rows  	                    
                     	                    	                    
 # Storage Information	                    	                    
-Location [not included in comparison]sql/core/spark-warehouse/t
+Location [not included in comparison]/{warehouse_dir}/t
 
 
 -- !query 7
@@ -125,13 +125,13 @@ hr                  	int
 Database            	default             	                    
 Table               	t                   	                    
 Partition Values    	[ds=2017-08-01, hr=10]	                    
-Location [not included in comparison]sql/core/spark-warehouse/t/ds=2017-08-01/hr=10	                    
+Location [not included in comparison]/{warehouse_dir}/t/ds=2017-08-01/hr=10	                    
 Created Time [not included in comparison]
 Last Access [not included in comparison]
 Partition Statistics	[not included in comparison] bytes, 3 rows  	                    
                     	                    	                    
 # Storage Information	                    	                    
-Location [not included in comparison]sql/core/spark-warehouse/t
+Location [not included in comparison]/{warehouse_dir}/t
 
 
 -- !query 9
@@ -152,13 +152,13 @@ hr                  	int
 Database            	default             	                    
 Table               	t                   	                    
 Partition Values    	[ds=2017-08-01, hr=11]	                    
-Location [not included in comparison]sql/core/spark-warehouse/t/ds=2017-08-01/hr=11	                    
+Location [not included in comparison]/{warehouse_dir}/t/ds=2017-08-01/hr=11	                    
 Created Time [not included in comparison]
 Last Access [not included in comparison]
 Partition Statistics	[not included in comparison] bytes, 4 rows  	                    
                     	                    	                    
 # Storage Information	                    	                    
-Location [not included in comparison]sql/core/spark-warehouse/t
+Location [not included in comparison]/{warehouse_dir}/t
 
 
 -- !query 10
@@ -187,13 +187,13 @@ hr                  	int
 Database            	default             	                    
 Table               	t                   	                    
 Partition Values    	[ds=2017-08-01, hr=10]	                    
-Location [not included in comparison]sql/core/spark-warehouse/t/ds=2017-08-01/hr=10	                    
+Location [not included in comparison]/{warehouse_dir}/t/ds=2017-08-01/hr=10	                    
 Created Time [not included in comparison]
 Last Access [not included in comparison]
 Partition Statistics	[not included in comparison] bytes, 3 rows  	                    
                     	                    	                    
 # Storage Information	                    	                    
-Location [not included in comparison]sql/core/spark-warehouse/t
+Location [not included in comparison]/{warehouse_dir}/t
 
 
 -- !query 12
@@ -214,13 +214,13 @@ hr                  	int
 Database            	default             	                    
 Table               	t                   	                    
 Partition Values    	[ds=2017-08-01, hr=11]	                    
-Location [not included in comparison]sql/core/spark-warehouse/t/ds=2017-08-01/hr=11	                    
+Location [not included in comparison]/{warehouse_dir}/t/ds=2017-08-01/hr=11	                    
 Created Time [not included in comparison]
 Last Access [not included in comparison]
 Partition Statistics	[not included in comparison] bytes, 4 rows  	                    
                     	                    	                    
 # Storage Information	                    	                    
-Location [not included in comparison]sql/core/spark-warehouse/t
+Location [not included in comparison]/{warehouse_dir}/t
 
 
 -- !query 13
@@ -241,13 +241,13 @@ hr                  	int
 Database            	default             	                    
 Table               	t                   	                    
 Partition Values    	[ds=2017-09-01, hr=5]	                    
-Location [not included in comparison]sql/core/spark-warehouse/t/ds=2017-09-01/hr=5	                    
+Location [not included in comparison]/{warehouse_dir}/t/ds=2017-09-01/hr=5	                    
 Created Time [not included in comparison]
 Last Access [not included in comparison]
 Partition Statistics	[not included in comparison] bytes, 2 rows  	                    
                     	                    	                    
 # Storage Information	                    	                    
-Location [not included in comparison]sql/core/spark-warehouse/t
+Location [not included in comparison]/{warehouse_dir}/t
 
 
 -- !query 14

--- a/sql/core/src/test/resources/sql-tests/results/describe-table-after-alter-table.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/describe-table-after-alter-table.sql.out
@@ -29,7 +29,7 @@ Created By [not included in comparison]
 Type                	MANAGED             	                    
 Provider            	parquet             	                    
 Comment             	added               	                    
-Location [not included in comparison]sql/core/spark-warehouse/table_with_comment
+Location [not included in comparison]/{warehouse_dir}/table_with_comment
 
 
 -- !query 2
@@ -60,7 +60,7 @@ Type                	MANAGED
 Provider            	parquet             	                    
 Comment             	modified comment    	                    
 Table Properties    	[type=parquet]      	                    
-Location [not included in comparison]sql/core/spark-warehouse/table_with_comment
+Location [not included in comparison]/{warehouse_dir}/table_with_comment
 
 
 -- !query 4
@@ -95,7 +95,7 @@ Last Access [not included in comparison]
 Created By [not included in comparison]
 Type                	MANAGED             	                    
 Provider            	parquet             	                    
-Location [not included in comparison]sql/core/spark-warehouse/table_comment
+Location [not included in comparison]/{warehouse_dir}/table_comment
 
 
 -- !query 7
@@ -123,7 +123,7 @@ Created By [not included in comparison]
 Type                	MANAGED             	                    
 Provider            	parquet             	                    
 Comment             	added comment       	                    
-Location [not included in comparison]sql/core/spark-warehouse/table_comment
+Location [not included in comparison]/{warehouse_dir}/table_comment
 
 
 -- !query 9
@@ -150,7 +150,7 @@ Last Access [not included in comparison]
 Created By [not included in comparison]
 Type                	MANAGED             	                    
 Provider            	parquet             	                    
-Location [not included in comparison]sql/core/spark-warehouse/table_comment
+Location [not included in comparison]/{warehouse_dir}/table_comment
 
 
 -- !query 11

--- a/sql/core/src/test/resources/sql-tests/results/describe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/describe.sql.out
@@ -131,7 +131,7 @@ Bucket Columns      	[`a`]
 Sort Columns        	[`b`]               	                    
 Comment             	table_comment       	                    
 Table Properties    	[t=test, e=3]       	                    
-Location [not included in comparison]sql/core/spark-warehouse/t	                    
+Location [not included in comparison]/{warehouse_dir}/t	                    
 Storage Properties  	[a=1, b=2]          	                    
 Partition Provider  	Catalog
 
@@ -163,7 +163,7 @@ Bucket Columns      	[`a`]
 Sort Columns        	[`b`]               	                    
 Comment             	table_comment       	                    
 Table Properties    	[t=test, e=3]       	                    
-Location [not included in comparison]sql/core/spark-warehouse/t	                    
+Location [not included in comparison]/{warehouse_dir}/t	                    
 Storage Properties  	[a=1, b=2]          	                    
 Partition Provider  	Catalog
 
@@ -203,7 +203,7 @@ Bucket Columns      	[`a`]
 Sort Columns        	[`b`]               	                    
 Comment             	table_comment       	                    
 Table Properties    	[t=test]            	                    
-Location [not included in comparison]sql/core/spark-warehouse/t	                    
+Location [not included in comparison]/{warehouse_dir}/t	                    
 Storage Properties  	[a=1, b=2]          	                    
 Partition Provider  	Catalog
 
@@ -242,7 +242,7 @@ Num Buckets         	2
 Bucket Columns      	[`a`]               	                    
 Sort Columns        	[`b`]               	                    
 Table Properties    	[t=test]            	                    
-Location [not included in comparison]sql/core/spark-warehouse/t	                    
+Location [not included in comparison]/{warehouse_dir}/t	                    
 Storage Properties  	[a=1, b=2]          	                    
 Partition Provider  	Catalog
 
@@ -280,7 +280,7 @@ d                   	string
 Database            	default             	                    
 Table               	t                   	                    
 Partition Values    	[c=Us, d=1]         	                    
-Location [not included in comparison]sql/core/spark-warehouse/t/c=Us/d=1	                    
+Location [not included in comparison]/{warehouse_dir}/t/c=Us/d=1	                    
 Storage Properties  	[a=1, b=2]          	                    
 Created Time [not included in comparison]
 Last Access [not included in comparison]
@@ -289,7 +289,7 @@ Last Access [not included in comparison]
 Num Buckets         	2                   	                    
 Bucket Columns      	[`a`]               	                    
 Sort Columns        	[`b`]               	                    
-Location [not included in comparison]sql/core/spark-warehouse/t	                    
+Location [not included in comparison]/{warehouse_dir}/t	                    
 Storage Properties  	[a=1, b=2]
 
 
@@ -311,7 +311,7 @@ d                   	string
 Database            	default             	                    
 Table               	t                   	                    
 Partition Values    	[c=Us, d=1]         	                    
-Location [not included in comparison]sql/core/spark-warehouse/t/c=Us/d=1	                    
+Location [not included in comparison]/{warehouse_dir}/t/c=Us/d=1	                    
 Storage Properties  	[a=1, b=2]          	                    
 Created Time [not included in comparison]
 Last Access [not included in comparison]
@@ -320,7 +320,7 @@ Last Access [not included in comparison]
 Num Buckets         	2                   	                    
 Bucket Columns      	[`a`]               	                    
 Sort Columns        	[`b`]               	                    
-Location [not included in comparison]sql/core/spark-warehouse/t	                    
+Location [not included in comparison]/{warehouse_dir}/t	                    
 Storage Properties  	[a=1, b=2]
 
 

--- a/sql/core/src/test/resources/sql-tests/results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain.sql.out
@@ -58,6 +58,12 @@ struct<plan:string>
 
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
+Batched: true
+DataFilters: [isnotnull(key#x), (key#x > 0)]
+Format: Parquet
+Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
+ReadSchema: struct<key:int,val:int>
      
 (2) ColumnarToRow [codegen id : 1]
 Input: [key#x, val#x]
@@ -110,6 +116,12 @@ struct<plan:string>
 
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
+Batched: true
+DataFilters: [isnotnull(key#x), (key#x > 0)]
+Format: Parquet
+Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
+ReadSchema: struct<key:int,val:int>
      
 (2) ColumnarToRow [codegen id : 1]
 Input: [key#x, val#x]
@@ -165,6 +177,12 @@ struct<plan:string>
 
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
+Batched: true
+DataFilters: [isnotnull(key#x), (key#x > 0)]
+Format: Parquet
+Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
+ReadSchema: struct<key:int,val:int>
      
 (2) ColumnarToRow [codegen id : 1]
 Input: [key#x, val#x]
@@ -179,6 +197,12 @@ Input     : [key#x, val#x]
      
 (5) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
+Batched: true
+DataFilters: [isnotnull(key#x), (key#x > 0)]
+Format: Parquet
+Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
+ReadSchema: struct<key:int,val:int>
      
 (6) ColumnarToRow [codegen id : 2]
 Input: [key#x, val#x]
@@ -227,6 +251,12 @@ struct<plan:string>
 
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
+Batched: true
+DataFilters: [isnotnull(key#x)]
+Format: Parquet
+Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+PushedFilters: [IsNotNull(key)]
+ReadSchema: struct<key:int,val:int>
      
 (2) ColumnarToRow [codegen id : 2]
 Input: [key#x, val#x]
@@ -241,6 +271,12 @@ Input     : [key#x, val#x]
      
 (5) Scan parquet default.explain_temp2 
 Output: [key#x, val#x]
+Batched: true
+DataFilters: [isnotnull(key#x)]
+Format: Parquet
+Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+PushedFilters: [IsNotNull(key)]
+ReadSchema: struct<key:int,val:int>
      
 (6) ColumnarToRow [codegen id : 1]
 Input: [key#x, val#x]
@@ -284,12 +320,22 @@ struct<plan:string>
 
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
+Batched: true
+Format: Parquet
+Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+ReadSchema: struct<key:int,val:int>
      
 (2) ColumnarToRow [codegen id : 2]
 Input: [key#x, val#x]
      
 (3) Scan parquet default.explain_temp2 
 Output: [key#x, val#x]
+Batched: true
+DataFilters: [isnotnull(key#x)]
+Format: Parquet
+Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+PushedFilters: [IsNotNull(key)]
+ReadSchema: struct<key:int,val:int>
      
 (4) ColumnarToRow [codegen id : 1]
 Input: [key#x, val#x]
@@ -334,6 +380,12 @@ struct<plan:string>
 
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
+Batched: true
+DataFilters: [isnotnull(key#x), isnotnull(val#x), (val#x > 3)]
+Format: Parquet
+Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+PushedFilters: [IsNotNull(key), IsNotNull(val), GreaterThan(val,3)]
+ReadSchema: struct<key:int,val:int>
      
 (2) ColumnarToRow [codegen id : 1]
 Input: [key#x, val#x]
@@ -360,6 +412,12 @@ Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 
 (5) Scan parquet default.explain_temp2 
 Output: [key#x, val#x]
+Batched: true
+DataFilters: [isnotnull(key#x), isnotnull(val#x), (val#x = 2)]
+Format: Parquet
+Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+PushedFilters: [IsNotNull(key), IsNotNull(val), EqualTo(val,2)]
+ReadSchema: struct<key:int,val:int>
      
 (6) ColumnarToRow [codegen id : 1]
 Input: [key#x, val#x]
@@ -393,6 +451,12 @@ Subquery:2 Hosting operator id = 7 Hosting Expression = Subquery scalar-subquery
 
 (12) Scan parquet default.explain_temp3 
 Output: [key#x, val#x]
+Batched: true
+DataFilters: [isnotnull(val#x), (val#x > 0)]
+Format: Parquet
+Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+PushedFilters: [IsNotNull(val), GreaterThan(val,0)]
+ReadSchema: struct<key:int,val:int>
      
 (13) ColumnarToRow [codegen id : 1]
 Input: [key#x, val#x]
@@ -437,6 +501,10 @@ struct<plan:string>
 
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
+Batched: true
+Format: Parquet
+Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+ReadSchema: struct<key:int,val:int>
      
 (2) ColumnarToRow [codegen id : 1]
 Input: [key#x, val#x]
@@ -459,6 +527,12 @@ Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 
 (4) Scan parquet default.explain_temp2 
 Output: [key#x, val#x]
+Batched: true
+DataFilters: [isnotnull(val#x), (val#x > 0)]
+Format: Parquet
+Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+PushedFilters: [IsNotNull(val), GreaterThan(val,0)]
+ReadSchema: struct<key:int,val:int>
      
 (5) ColumnarToRow [codegen id : 1]
 Input: [key#x, val#x]
@@ -492,6 +566,12 @@ Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 
 (11) Scan parquet default.explain_temp3 
 Output: [key#x, val#x]
+Batched: true
+DataFilters: [isnotnull(val#x), (val#x > 0)]
+Format: Parquet
+Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+PushedFilters: [IsNotNull(val), GreaterThan(val,0)]
+ReadSchema: struct<key:int,val:int>
      
 (12) ColumnarToRow [codegen id : 1]
 Input: [key#x, val#x]
@@ -529,6 +609,10 @@ struct<plan:string>
 
 (1) Scan parquet default.explain_temp1 
 Output: []
+Batched: true
+Format: Parquet
+Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+ReadSchema: struct<>
      
 (2) ColumnarToRow [codegen id : 1]
 Input: []
@@ -549,6 +633,10 @@ Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 
 (4) Scan parquet default.explain_temp1 
 Output: [key#x]
+Batched: true
+Format: Parquet
+Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+ReadSchema: struct<key:int>
      
 (5) ColumnarToRow [codegen id : 1]
 Input: [key#x]
@@ -591,6 +679,12 @@ struct<plan:string>
 
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
+Batched: true
+DataFilters: [isnotnull(key#x), (key#x > 10)]
+Format: Parquet
+Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+PushedFilters: [IsNotNull(key), GreaterThan(key,10)]
+ReadSchema: struct<key:int,val:int>
      
 (2) ColumnarToRow [codegen id : 2]
 Input: [key#x, val#x]
@@ -605,6 +699,12 @@ Input     : [key#x, val#x]
      
 (5) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
+Batched: true
+DataFilters: [isnotnull(key#x), (key#x > 10)]
+Format: Parquet
+Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+PushedFilters: [IsNotNull(key), GreaterThan(key,10)]
+ReadSchema: struct<key:int,val:int>
      
 (6) ColumnarToRow [codegen id : 1]
 Input: [key#x, val#x]
@@ -654,6 +754,12 @@ struct<plan:string>
 
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
+Batched: true
+DataFilters: [isnotnull(key#x), (key#x > 10)]
+Format: Parquet
+Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+PushedFilters: [IsNotNull(key), GreaterThan(key,10)]
+ReadSchema: struct<key:int,val:int>
      
 (2) ColumnarToRow [codegen id : 1]
 Input: [key#x, val#x]

--- a/sql/core/src/test/resources/sql-tests/results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain.sql.out
@@ -59,7 +59,6 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Format: Parquet
 Location [not included in comparison]
 PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
 ReadSchema: struct<key:int,val:int>
@@ -116,7 +115,6 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Format: Parquet
 Location [not included in comparison]
 PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
 ReadSchema: struct<key:int,val:int>
@@ -176,7 +174,6 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Format: Parquet
 Location [not included in comparison]
 PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
 ReadSchema: struct<key:int,val:int>
@@ -195,7 +192,6 @@ Input     : [key#x, val#x]
 (5) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Format: Parquet
 Location [not included in comparison]
 PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
 ReadSchema: struct<key:int,val:int>
@@ -248,7 +244,6 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Format: Parquet
 Location [not included in comparison]
 PushedFilters: [IsNotNull(key)]
 ReadSchema: struct<key:int,val:int>
@@ -267,7 +262,6 @@ Input     : [key#x, val#x]
 (5) Scan parquet default.explain_temp2 
 Output: [key#x, val#x]
 Batched: true
-Format: Parquet
 Location [not included in comparison]
 PushedFilters: [IsNotNull(key)]
 ReadSchema: struct<key:int,val:int>
@@ -315,7 +309,6 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Format: Parquet
 Location [not included in comparison]
 ReadSchema: struct<key:int,val:int>
      
@@ -325,7 +318,6 @@ Input: [key#x, val#x]
 (3) Scan parquet default.explain_temp2 
 Output: [key#x, val#x]
 Batched: true
-Format: Parquet
 Location [not included in comparison]
 PushedFilters: [IsNotNull(key)]
 ReadSchema: struct<key:int,val:int>
@@ -374,7 +366,6 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Format: Parquet
 Location [not included in comparison]
 PushedFilters: [IsNotNull(key), IsNotNull(val), GreaterThan(val,3)]
 ReadSchema: struct<key:int,val:int>
@@ -405,7 +396,6 @@ Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 (5) Scan parquet default.explain_temp2 
 Output: [key#x, val#x]
 Batched: true
-Format: Parquet
 Location [not included in comparison]
 PushedFilters: [IsNotNull(key), IsNotNull(val), EqualTo(val,2)]
 ReadSchema: struct<key:int,val:int>
@@ -443,7 +433,6 @@ Subquery:2 Hosting operator id = 7 Hosting Expression = Subquery scalar-subquery
 (12) Scan parquet default.explain_temp3 
 Output: [key#x, val#x]
 Batched: true
-Format: Parquet
 Location [not included in comparison]
 PushedFilters: [IsNotNull(val), GreaterThan(val,0)]
 ReadSchema: struct<key:int,val:int>
@@ -492,7 +481,6 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Format: Parquet
 Location [not included in comparison]
 ReadSchema: struct<key:int,val:int>
      
@@ -518,7 +506,6 @@ Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 (4) Scan parquet default.explain_temp2 
 Output: [key#x, val#x]
 Batched: true
-Format: Parquet
 Location [not included in comparison]
 PushedFilters: [IsNotNull(val), GreaterThan(val,0)]
 ReadSchema: struct<key:int,val:int>
@@ -556,7 +543,6 @@ Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 (11) Scan parquet default.explain_temp3 
 Output: [key#x, val#x]
 Batched: true
-Format: Parquet
 Location [not included in comparison]
 PushedFilters: [IsNotNull(val), GreaterThan(val,0)]
 ReadSchema: struct<key:int,val:int>
@@ -598,7 +584,6 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: []
 Batched: true
-Format: Parquet
 Location [not included in comparison]
 ReadSchema: struct<>
      
@@ -622,7 +607,6 @@ Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 (4) Scan parquet default.explain_temp1 
 Output: [key#x]
 Batched: true
-Format: Parquet
 Location [not included in comparison]
 ReadSchema: struct<key:int>
      
@@ -668,7 +652,6 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Format: Parquet
 Location [not included in comparison]
 PushedFilters: [IsNotNull(key), GreaterThan(key,10)]
 ReadSchema: struct<key:int,val:int>
@@ -687,7 +670,6 @@ Input     : [key#x, val#x]
 (5) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Format: Parquet
 Location [not included in comparison]
 PushedFilters: [IsNotNull(key), GreaterThan(key,10)]
 ReadSchema: struct<key:int,val:int>
@@ -741,7 +723,6 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Format: Parquet
 Location [not included in comparison]
 PushedFilters: [IsNotNull(key), GreaterThan(key,10)]
 ReadSchema: struct<key:int,val:int>

--- a/sql/core/src/test/resources/sql-tests/results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain.sql.out
@@ -59,7 +59,6 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-DataFilters: [isnotnull(key#x), (key#x > 0)]
 Format: Parquet
 Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
 PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
@@ -117,7 +116,6 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-DataFilters: [isnotnull(key#x), (key#x > 0)]
 Format: Parquet
 Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
 PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
@@ -178,7 +176,6 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-DataFilters: [isnotnull(key#x), (key#x > 0)]
 Format: Parquet
 Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
 PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
@@ -198,7 +195,6 @@ Input     : [key#x, val#x]
 (5) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-DataFilters: [isnotnull(key#x), (key#x > 0)]
 Format: Parquet
 Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
 PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
@@ -252,7 +248,6 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-DataFilters: [isnotnull(key#x)]
 Format: Parquet
 Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
 PushedFilters: [IsNotNull(key)]
@@ -272,7 +267,6 @@ Input     : [key#x, val#x]
 (5) Scan parquet default.explain_temp2 
 Output: [key#x, val#x]
 Batched: true
-DataFilters: [isnotnull(key#x)]
 Format: Parquet
 Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
 PushedFilters: [IsNotNull(key)]
@@ -331,7 +325,6 @@ Input: [key#x, val#x]
 (3) Scan parquet default.explain_temp2 
 Output: [key#x, val#x]
 Batched: true
-DataFilters: [isnotnull(key#x)]
 Format: Parquet
 Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
 PushedFilters: [IsNotNull(key)]
@@ -381,7 +374,6 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-DataFilters: [isnotnull(key#x), isnotnull(val#x), (val#x > 3)]
 Format: Parquet
 Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
 PushedFilters: [IsNotNull(key), IsNotNull(val), GreaterThan(val,3)]
@@ -413,7 +405,6 @@ Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 (5) Scan parquet default.explain_temp2 
 Output: [key#x, val#x]
 Batched: true
-DataFilters: [isnotnull(key#x), isnotnull(val#x), (val#x = 2)]
 Format: Parquet
 Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
 PushedFilters: [IsNotNull(key), IsNotNull(val), EqualTo(val,2)]
@@ -452,7 +443,6 @@ Subquery:2 Hosting operator id = 7 Hosting Expression = Subquery scalar-subquery
 (12) Scan parquet default.explain_temp3 
 Output: [key#x, val#x]
 Batched: true
-DataFilters: [isnotnull(val#x), (val#x > 0)]
 Format: Parquet
 Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
 PushedFilters: [IsNotNull(val), GreaterThan(val,0)]
@@ -528,7 +518,6 @@ Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 (4) Scan parquet default.explain_temp2 
 Output: [key#x, val#x]
 Batched: true
-DataFilters: [isnotnull(val#x), (val#x > 0)]
 Format: Parquet
 Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
 PushedFilters: [IsNotNull(val), GreaterThan(val,0)]
@@ -567,7 +556,6 @@ Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 (11) Scan parquet default.explain_temp3 
 Output: [key#x, val#x]
 Batched: true
-DataFilters: [isnotnull(val#x), (val#x > 0)]
 Format: Parquet
 Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
 PushedFilters: [IsNotNull(val), GreaterThan(val,0)]
@@ -680,7 +668,6 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-DataFilters: [isnotnull(key#x), (key#x > 10)]
 Format: Parquet
 Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
 PushedFilters: [IsNotNull(key), GreaterThan(key,10)]
@@ -700,7 +687,6 @@ Input     : [key#x, val#x]
 (5) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-DataFilters: [isnotnull(key#x), (key#x > 10)]
 Format: Parquet
 Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
 PushedFilters: [IsNotNull(key), GreaterThan(key,10)]
@@ -755,7 +741,6 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-DataFilters: [isnotnull(key#x), (key#x > 10)]
 Format: Parquet
 Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
 PushedFilters: [IsNotNull(key), GreaterThan(key,10)]

--- a/sql/core/src/test/resources/sql-tests/results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain.sql.out
@@ -59,7 +59,7 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]
+Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
 PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
 ReadSchema: struct<key:int,val:int>
      
@@ -115,7 +115,7 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]
+Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
 PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
 ReadSchema: struct<key:int,val:int>
      
@@ -174,7 +174,7 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]
+Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
 PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
 ReadSchema: struct<key:int,val:int>
      
@@ -192,7 +192,7 @@ Input     : [key#x, val#x]
 (5) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]
+Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
 PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
 ReadSchema: struct<key:int,val:int>
      
@@ -244,7 +244,7 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]
+Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
 PushedFilters: [IsNotNull(key)]
 ReadSchema: struct<key:int,val:int>
      
@@ -262,7 +262,7 @@ Input     : [key#x, val#x]
 (5) Scan parquet default.explain_temp2 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]
+Location [not included in comparison]sql/core/spark-warehouse/explain_temp2]
 PushedFilters: [IsNotNull(key)]
 ReadSchema: struct<key:int,val:int>
      
@@ -309,7 +309,7 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]
+Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
 ReadSchema: struct<key:int,val:int>
      
 (2) ColumnarToRow [codegen id : 2]
@@ -318,7 +318,7 @@ Input: [key#x, val#x]
 (3) Scan parquet default.explain_temp2 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]
+Location [not included in comparison]sql/core/spark-warehouse/explain_temp2]
 PushedFilters: [IsNotNull(key)]
 ReadSchema: struct<key:int,val:int>
      
@@ -366,7 +366,7 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]
+Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
 PushedFilters: [IsNotNull(key), IsNotNull(val), GreaterThan(val,3)]
 ReadSchema: struct<key:int,val:int>
      
@@ -396,7 +396,7 @@ Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 (5) Scan parquet default.explain_temp2 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]
+Location [not included in comparison]sql/core/spark-warehouse/explain_temp2]
 PushedFilters: [IsNotNull(key), IsNotNull(val), EqualTo(val,2)]
 ReadSchema: struct<key:int,val:int>
      
@@ -433,7 +433,7 @@ Subquery:2 Hosting operator id = 7 Hosting Expression = Subquery scalar-subquery
 (12) Scan parquet default.explain_temp3 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]
+Location [not included in comparison]sql/core/spark-warehouse/explain_temp3]
 PushedFilters: [IsNotNull(val), GreaterThan(val,0)]
 ReadSchema: struct<key:int,val:int>
      
@@ -481,7 +481,7 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]
+Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
 ReadSchema: struct<key:int,val:int>
      
 (2) ColumnarToRow [codegen id : 1]
@@ -506,7 +506,7 @@ Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 (4) Scan parquet default.explain_temp2 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]
+Location [not included in comparison]sql/core/spark-warehouse/explain_temp2]
 PushedFilters: [IsNotNull(val), GreaterThan(val,0)]
 ReadSchema: struct<key:int,val:int>
      
@@ -543,7 +543,7 @@ Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 (11) Scan parquet default.explain_temp3 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]
+Location [not included in comparison]sql/core/spark-warehouse/explain_temp3]
 PushedFilters: [IsNotNull(val), GreaterThan(val,0)]
 ReadSchema: struct<key:int,val:int>
      
@@ -584,7 +584,7 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: []
 Batched: true
-Location [not included in comparison]
+Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
 ReadSchema: struct<>
      
 (2) ColumnarToRow [codegen id : 1]
@@ -607,7 +607,7 @@ Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 (4) Scan parquet default.explain_temp1 
 Output: [key#x]
 Batched: true
-Location [not included in comparison]
+Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
 ReadSchema: struct<key:int>
      
 (5) ColumnarToRow [codegen id : 1]
@@ -652,7 +652,7 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]
+Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
 PushedFilters: [IsNotNull(key), GreaterThan(key,10)]
 ReadSchema: struct<key:int,val:int>
      
@@ -670,7 +670,7 @@ Input     : [key#x, val#x]
 (5) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]
+Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
 PushedFilters: [IsNotNull(key), GreaterThan(key,10)]
 ReadSchema: struct<key:int,val:int>
      
@@ -723,7 +723,7 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]
+Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
 PushedFilters: [IsNotNull(key), GreaterThan(key,10)]
 ReadSchema: struct<key:int,val:int>
      

--- a/sql/core/src/test/resources/sql-tests/results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain.sql.out
@@ -59,7 +59,7 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
+Location [not included in comparison]/{warehouse_dir}/explain_temp1]
 PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
 ReadSchema: struct<key:int,val:int>
      
@@ -115,7 +115,7 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
+Location [not included in comparison]/{warehouse_dir}/explain_temp1]
 PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
 ReadSchema: struct<key:int,val:int>
      
@@ -174,7 +174,7 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
+Location [not included in comparison]/{warehouse_dir}/explain_temp1]
 PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
 ReadSchema: struct<key:int,val:int>
      
@@ -192,7 +192,7 @@ Input     : [key#x, val#x]
 (5) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
+Location [not included in comparison]/{warehouse_dir}/explain_temp1]
 PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
 ReadSchema: struct<key:int,val:int>
      
@@ -244,7 +244,7 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
+Location [not included in comparison]/{warehouse_dir}/explain_temp1]
 PushedFilters: [IsNotNull(key)]
 ReadSchema: struct<key:int,val:int>
      
@@ -262,7 +262,7 @@ Input     : [key#x, val#x]
 (5) Scan parquet default.explain_temp2 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]sql/core/spark-warehouse/explain_temp2]
+Location [not included in comparison]/{warehouse_dir}/explain_temp2]
 PushedFilters: [IsNotNull(key)]
 ReadSchema: struct<key:int,val:int>
      
@@ -309,7 +309,7 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
+Location [not included in comparison]/{warehouse_dir}/explain_temp1]
 ReadSchema: struct<key:int,val:int>
      
 (2) ColumnarToRow [codegen id : 2]
@@ -318,7 +318,7 @@ Input: [key#x, val#x]
 (3) Scan parquet default.explain_temp2 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]sql/core/spark-warehouse/explain_temp2]
+Location [not included in comparison]/{warehouse_dir}/explain_temp2]
 PushedFilters: [IsNotNull(key)]
 ReadSchema: struct<key:int,val:int>
      
@@ -366,7 +366,7 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
+Location [not included in comparison]/{warehouse_dir}/explain_temp1]
 PushedFilters: [IsNotNull(key), IsNotNull(val), GreaterThan(val,3)]
 ReadSchema: struct<key:int,val:int>
      
@@ -396,7 +396,7 @@ Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 (5) Scan parquet default.explain_temp2 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]sql/core/spark-warehouse/explain_temp2]
+Location [not included in comparison]/{warehouse_dir}/explain_temp2]
 PushedFilters: [IsNotNull(key), IsNotNull(val), EqualTo(val,2)]
 ReadSchema: struct<key:int,val:int>
      
@@ -433,7 +433,7 @@ Subquery:2 Hosting operator id = 7 Hosting Expression = Subquery scalar-subquery
 (12) Scan parquet default.explain_temp3 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]sql/core/spark-warehouse/explain_temp3]
+Location [not included in comparison]/{warehouse_dir}/explain_temp3]
 PushedFilters: [IsNotNull(val), GreaterThan(val,0)]
 ReadSchema: struct<key:int,val:int>
      
@@ -481,7 +481,7 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
+Location [not included in comparison]/{warehouse_dir}/explain_temp1]
 ReadSchema: struct<key:int,val:int>
      
 (2) ColumnarToRow [codegen id : 1]
@@ -506,7 +506,7 @@ Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 (4) Scan parquet default.explain_temp2 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]sql/core/spark-warehouse/explain_temp2]
+Location [not included in comparison]/{warehouse_dir}/explain_temp2]
 PushedFilters: [IsNotNull(val), GreaterThan(val,0)]
 ReadSchema: struct<key:int,val:int>
      
@@ -543,7 +543,7 @@ Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 (11) Scan parquet default.explain_temp3 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]sql/core/spark-warehouse/explain_temp3]
+Location [not included in comparison]/{warehouse_dir}/explain_temp3]
 PushedFilters: [IsNotNull(val), GreaterThan(val,0)]
 ReadSchema: struct<key:int,val:int>
      
@@ -584,7 +584,7 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: []
 Batched: true
-Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
+Location [not included in comparison]/{warehouse_dir}/explain_temp1]
 ReadSchema: struct<>
      
 (2) ColumnarToRow [codegen id : 1]
@@ -607,7 +607,7 @@ Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 (4) Scan parquet default.explain_temp1 
 Output: [key#x]
 Batched: true
-Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
+Location [not included in comparison]/{warehouse_dir}/explain_temp1]
 ReadSchema: struct<key:int>
      
 (5) ColumnarToRow [codegen id : 1]
@@ -652,7 +652,7 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
+Location [not included in comparison]/{warehouse_dir}/explain_temp1]
 PushedFilters: [IsNotNull(key), GreaterThan(key,10)]
 ReadSchema: struct<key:int,val:int>
      
@@ -670,7 +670,7 @@ Input     : [key#x, val#x]
 (5) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
+Location [not included in comparison]/{warehouse_dir}/explain_temp1]
 PushedFilters: [IsNotNull(key), GreaterThan(key,10)]
 ReadSchema: struct<key:int,val:int>
      
@@ -723,7 +723,7 @@ struct<plan:string>
 (1) Scan parquet default.explain_temp1 
 Output: [key#x, val#x]
 Batched: true
-Location [not included in comparison]sql/core/spark-warehouse/explain_temp1]
+Location [not included in comparison]/{warehouse_dir}/explain_temp1]
 PushedFilters: [IsNotNull(key), GreaterThan(key,10)]
 ReadSchema: struct<key:int,val:int>
      

--- a/sql/core/src/test/resources/sql-tests/results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain.sql.out
@@ -60,7 +60,7 @@ struct<plan:string>
 Output: [key#x, val#x]
 Batched: true
 Format: Parquet
-Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+Location [not included in comparison]
 PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
 ReadSchema: struct<key:int,val:int>
      
@@ -117,7 +117,7 @@ struct<plan:string>
 Output: [key#x, val#x]
 Batched: true
 Format: Parquet
-Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+Location [not included in comparison]
 PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
 ReadSchema: struct<key:int,val:int>
      
@@ -177,7 +177,7 @@ struct<plan:string>
 Output: [key#x, val#x]
 Batched: true
 Format: Parquet
-Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+Location [not included in comparison]
 PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
 ReadSchema: struct<key:int,val:int>
      
@@ -196,7 +196,7 @@ Input     : [key#x, val#x]
 Output: [key#x, val#x]
 Batched: true
 Format: Parquet
-Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+Location [not included in comparison]
 PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
 ReadSchema: struct<key:int,val:int>
      
@@ -249,7 +249,7 @@ struct<plan:string>
 Output: [key#x, val#x]
 Batched: true
 Format: Parquet
-Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+Location [not included in comparison]
 PushedFilters: [IsNotNull(key)]
 ReadSchema: struct<key:int,val:int>
      
@@ -268,7 +268,7 @@ Input     : [key#x, val#x]
 Output: [key#x, val#x]
 Batched: true
 Format: Parquet
-Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+Location [not included in comparison]
 PushedFilters: [IsNotNull(key)]
 ReadSchema: struct<key:int,val:int>
      
@@ -316,7 +316,7 @@ struct<plan:string>
 Output: [key#x, val#x]
 Batched: true
 Format: Parquet
-Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+Location [not included in comparison]
 ReadSchema: struct<key:int,val:int>
      
 (2) ColumnarToRow [codegen id : 2]
@@ -326,7 +326,7 @@ Input: [key#x, val#x]
 Output: [key#x, val#x]
 Batched: true
 Format: Parquet
-Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+Location [not included in comparison]
 PushedFilters: [IsNotNull(key)]
 ReadSchema: struct<key:int,val:int>
      
@@ -375,7 +375,7 @@ struct<plan:string>
 Output: [key#x, val#x]
 Batched: true
 Format: Parquet
-Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+Location [not included in comparison]
 PushedFilters: [IsNotNull(key), IsNotNull(val), GreaterThan(val,3)]
 ReadSchema: struct<key:int,val:int>
      
@@ -406,7 +406,7 @@ Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 Output: [key#x, val#x]
 Batched: true
 Format: Parquet
-Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+Location [not included in comparison]
 PushedFilters: [IsNotNull(key), IsNotNull(val), EqualTo(val,2)]
 ReadSchema: struct<key:int,val:int>
      
@@ -444,7 +444,7 @@ Subquery:2 Hosting operator id = 7 Hosting Expression = Subquery scalar-subquery
 Output: [key#x, val#x]
 Batched: true
 Format: Parquet
-Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+Location [not included in comparison]
 PushedFilters: [IsNotNull(val), GreaterThan(val,0)]
 ReadSchema: struct<key:int,val:int>
      
@@ -493,7 +493,7 @@ struct<plan:string>
 Output: [key#x, val#x]
 Batched: true
 Format: Parquet
-Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+Location [not included in comparison]
 ReadSchema: struct<key:int,val:int>
      
 (2) ColumnarToRow [codegen id : 1]
@@ -519,7 +519,7 @@ Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 Output: [key#x, val#x]
 Batched: true
 Format: Parquet
-Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+Location [not included in comparison]
 PushedFilters: [IsNotNull(val), GreaterThan(val,0)]
 ReadSchema: struct<key:int,val:int>
      
@@ -557,7 +557,7 @@ Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 Output: [key#x, val#x]
 Batched: true
 Format: Parquet
-Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+Location [not included in comparison]
 PushedFilters: [IsNotNull(val), GreaterThan(val,0)]
 ReadSchema: struct<key:int,val:int>
      
@@ -599,7 +599,7 @@ struct<plan:string>
 Output: []
 Batched: true
 Format: Parquet
-Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+Location [not included in comparison]
 ReadSchema: struct<>
      
 (2) ColumnarToRow [codegen id : 1]
@@ -623,7 +623,7 @@ Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery
 Output: [key#x]
 Batched: true
 Format: Parquet
-Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+Location [not included in comparison]
 ReadSchema: struct<key:int>
      
 (5) ColumnarToRow [codegen id : 1]
@@ -669,7 +669,7 @@ struct<plan:string>
 Output: [key#x, val#x]
 Batched: true
 Format: Parquet
-Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+Location [not included in comparison]
 PushedFilters: [IsNotNull(key), GreaterThan(key,10)]
 ReadSchema: struct<key:int,val:int>
      
@@ -688,7 +688,7 @@ Input     : [key#x, val#x]
 Output: [key#x, val#x]
 Batched: true
 Format: Parquet
-Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+Location [not included in comparison]
 PushedFilters: [IsNotNull(key), GreaterThan(key,10)]
 ReadSchema: struct<key:int,val:int>
      
@@ -742,7 +742,7 @@ struct<plan:string>
 Output: [key#x, val#x]
 Batched: true
 Format: Parquet
-Location [not included in comparison]sql/core/spark-warehouse/[not included in comparison]
+Location [not included in comparison]
 PushedFilters: [IsNotNull(key), GreaterThan(key,10)]
 ReadSchema: struct<key:int,val:int>
      

--- a/sql/core/src/test/resources/sql-tests/results/show-tables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/show-tables.sql.out
@@ -140,7 +140,7 @@ Last Access [not included in comparison]
 Created By [not included in comparison]
 Type: MANAGED
 Provider: parquet
-Location [not included in comparison]sql/core/spark-warehouse/showdb.db/show_t1
+Location [not included in comparison]/{warehouse_dir}/showdb.db/show_t1
 Partition Provider: Catalog
 Partition Columns: [`c`, `d`]
 Schema: root
@@ -157,7 +157,7 @@ Last Access [not included in comparison]
 Created By [not included in comparison]
 Type: MANAGED
 Provider: parquet
-Location [not included in comparison]sql/core/spark-warehouse/showdb.db/show_t2
+Location [not included in comparison]/{warehouse_dir}/showdb.db/show_t2
 Schema: root
  |-- b: string (nullable = true)
  |-- d: integer (nullable = true)
@@ -183,7 +183,7 @@ SHOW TABLE EXTENDED LIKE 'show_t1' PARTITION(c='Us', d=1)
 struct<database:string,tableName:string,isTemporary:boolean,information:string>
 -- !query 14 output
 showdb	show_t1	false	Partition Values: [c=Us, d=1]
-Location [not included in comparison]sql/core/spark-warehouse/showdb.db/show_t1/c=Us/d=1
+Location [not included in comparison]/{warehouse_dir}/showdb.db/show_t1/c=Us/d=1
 Created Time [not included in comparison]
 Last Access [not included in comparison]
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -246,9 +246,17 @@ class ExplainSuite extends QueryTest with SharedSparkSession {
           val expected_pattern2 =
             "PartitionFilters: \\[isnotnull\\(k#xL\\), dynamicpruningexpression\\(k#xL " +
               "IN subquery#x\\)\\]"
+          val expected_pattern3 =
+            "Location: PrunedInMemoryFileIndex \\[.*org.apache.spark.sql.ExplainSuite" +
+              "/df2/.*, ... 99 entries\\]"
+          val expected_pattern4 =
+            "Location: PrunedInMemoryFileIndex \\[.*org.apache.spark.sql.ExplainSuite" +
+              "/df1/.*, ... 999 entries\\]"
           withNormalizedExplain(sqlText) { normalizedOutput =>
             assert(expected_pattern1.r.findAllMatchIn(normalizedOutput).length == 1)
             assert(expected_pattern2.r.findAllMatchIn(normalizedOutput).length == 1)
+            assert(expected_pattern3.r.findAllMatchIn(normalizedOutput).length == 2)
+            assert(expected_pattern4.r.findAllMatchIn(normalizedOutput).length == 1)
           }
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -241,9 +241,14 @@ class ExplainSuite extends QueryTest with SharedSparkSession {
               |FROM df1 JOIN df2 ON df1.k = df2.k AND df2.id < 2
               |""".stripMargin
 
-          val expected_pattern = "Subquery:1 Hosting operator id = 1 Hosting Expression = k#x"
+          val expected_pattern1 =
+            "Subquery:1 Hosting operator id = 1 Hosting Expression = k#xL IN subquery#x"
+          val expected_pattern2 =
+            "PartitionFilters: \\[isnotnull\\(k#xL\\), dynamicpruningexpression\\(k#xL " +
+              "IN subquery#x\\)\\]"
           withNormalizedExplain(sqlText) { normalizedOutput =>
-            assert(expected_pattern.r.findAllMatchIn(normalizedOutput).length == 1)
+            assert(expected_pattern1.r.findAllMatchIn(normalizedOutput).length == 1)
+            assert(expected_pattern2.r.findAllMatchIn(normalizedOutput).length == 1)
           }
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -437,7 +437,7 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession {
         s"Location.*/sql/core/spark-warehouse/$clsName/",
         s"Location ${notIncludedMsg}sql/core/spark-warehouse/")
       .replaceAll(
-        s"Location.*/sql/core/spark-warehouse.*\\.\\.\\.\\.",
+        s"Location.*/sql/core/spark-warehouse.*\\.\\.\\.",
         s"Location ${notIncludedMsg}sql/core/spark-warehouse/${notIncludedMsg}")
       .replaceAll("Created By.*", s"Created By $notIncludedMsg")
       .replaceAll("Created Time.*", s"Created Time $notIncludedMsg")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -434,8 +434,8 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession {
   protected def replaceNotIncludedMsg(line: String): String = {
     line.replaceAll("#\\d+", "#x")
       .replaceAll(
-        s"Location.*/sql/core/spark-warehouse/$clsName/",
-        s"Location ${notIncludedMsg}sql/core/spark-warehouse/")
+        s"Location.*$clsName/",
+        s"Location ${notIncludedMsg}/{warehouse_dir}/")
       .replaceAll("Created By.*", s"Created By $notIncludedMsg")
       .replaceAll("Created Time.*", s"Created Time $notIncludedMsg")
       .replaceAll("Last Access.*", s"Last Access $notIncludedMsg")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -436,6 +436,9 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession {
       .replaceAll(
         s"Location.*/sql/core/spark-warehouse/$clsName/",
         s"Location ${notIncludedMsg}sql/core/spark-warehouse/")
+      .replaceAll(
+        s"Location.*/sql/core/spark-warehouse.*\\.\\.\\.\\.",
+        s"Location ${notIncludedMsg}sql/core/spark-warehouse/${notIncludedMsg}")
       .replaceAll("Created By.*", s"Created By $notIncludedMsg")
       .replaceAll("Created Time.*", s"Created Time $notIncludedMsg")
       .replaceAll("Last Access.*", s"Last Access $notIncludedMsg")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -436,9 +436,6 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession {
       .replaceAll(
         s"Location.*/sql/core/spark-warehouse/$clsName/",
         s"Location ${notIncludedMsg}sql/core/spark-warehouse/")
-      .replaceAll(
-        s"Location.*\\.\\.\\.",
-        s"Location ${notIncludedMsg}")
       .replaceAll("Created By.*", s"Created By $notIncludedMsg")
       .replaceAll("Created Time.*", s"Created Time $notIncludedMsg")
       .replaceAll("Last Access.*", s"Last Access $notIncludedMsg")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -437,8 +437,8 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession {
         s"Location.*/sql/core/spark-warehouse/$clsName/",
         s"Location ${notIncludedMsg}sql/core/spark-warehouse/")
       .replaceAll(
-        s"Location.*/sql/core/spark-warehouse.*\\.\\.\\.",
-        s"Location ${notIncludedMsg}sql/core/spark-warehouse/${notIncludedMsg}")
+        s"Location.*\\.\\.\\.",
+        s"Location ${notIncludedMsg}")
       .replaceAll("Created By.*", s"Created By $notIncludedMsg")
       .replaceAll("Created Time.*", s"Created Time $notIncludedMsg")
       .replaceAll("Last Access.*", s"Last Access $notIncludedMsg")

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerQueryTestSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerQueryTestSuite.scala
@@ -100,7 +100,8 @@ class ThriftServerQueryTestSuite extends SQLQueryTestSuite {
     "subquery/in-subquery/in-group-by.sql",
     "subquery/in-subquery/simple-in.sql",
     "subquery/in-subquery/in-order-by.sql",
-    "subquery/in-subquery/in-set-operations.sql"
+    "subquery/in-subquery/in-set-operations.sql",
+    "explain.sql"
   )
 
   override def runQueries(

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerQueryTestSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerQueryTestSuite.scala
@@ -100,8 +100,7 @@ class ThriftServerQueryTestSuite extends SQLQueryTestSuite {
     "subquery/in-subquery/in-group-by.sql",
     "subquery/in-subquery/simple-in.sql",
     "subquery/in-subquery/in-order-by.sql",
-    "subquery/in-subquery/in-set-operations.sql",
-    "explain.sql"
+    "subquery/in-subquery/in-set-operations.sql"
   )
 
   override def runQueries(


### PR DESCRIPTION
# What changes were proposed in this pull request?
Currently we report only output attributes of a scan while doing EXPLAIN FORMATTED. 
This PR implements the ```verboseStringWithOperatorId``` in DataSourceScanExec to report additional information about a scan such as pushed down filters, partition filters, location etc.

**SQL**
```
EXPLAIN FORMATTED
  SELECT key, max(val) 
  FROM   explain_temp1 
  WHERE  key > 0 
  GROUP  BY key 
  ORDER  BY key
```
**Before**
```
== Physical Plan ==
* Sort (9)
+- Exchange (8)
   +- * HashAggregate (7)
      +- Exchange (6)
         +- * HashAggregate (5)
            +- * Project (4)
               +- * Filter (3)
                  +- * ColumnarToRow (2)
                     +- Scan parquet default.explain_temp1 (1)


(1) Scan parquet default.explain_temp1 
Output: [key#x, val#x]

....
....
....
```
**After**
```

== Physical Plan ==
* Sort (9)
+- Exchange (8)
   +- * HashAggregate (7)
      +- Exchange (6)
         +- * HashAggregate (5)
            +- * Project (4)
               +- * Filter (3)
                  +- * ColumnarToRow (2)
                     +- Scan parquet default.explain_temp1 (1)


(1) Scan parquet default.explain_temp1 
Output: [key#x, val#x]
Batched: true
DataFilters: [isnotnull(key#x), (key#x > 0)]
Format: Parquet
Location: InMemoryFileIndex[file:/tmp/apache/spark/spark-warehouse/explain_temp1]
PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
ReadSchema: struct<key:int,val:int>

...
...
...
```

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
