### PR TITLE
[SPARK-29375][SQL] Exchange reuse across all subquery levels

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -93,11 +93,13 @@ case class HashAggregateExec(
   // This is for testing. We force TungstenAggregationIterator to fall back to the unsafe row hash
   // map and/or the sort-based aggregation once it has processed a given number of input rows.
   private val testFallbackStartsAt: Option[(Int, Int)] = {
-    sqlContext.getConf("spark.sql.TungstenAggregate.testFallbackStartsAt", null) match {
-      case null | "" => None
-      case fallbackStartsAt =>
-        val splits = fallbackStartsAt.split(",").map(_.trim)
-        Some((splits.head.toInt, splits.last.toInt))
+    Option(sqlContext).flatMap {
+      _.getConf("spark.sql.TungstenAggregate.testFallbackStartsAt", null) match {
+        case null | "" => None
+        case fallbackStartsAt =>
+          val splits = fallbackStartsAt.split(",").map(_.trim)
+          Some((splits.head.toInt, splits.last.toInt))
+      }
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -61,7 +61,7 @@ case class ShuffleExchangeExec(
 
   override def nodeName: String = "Exchange"
 
-  private val serializer: Serializer =
+  private lazy val serializer: Serializer =
     new UnsafeRowSerializer(child.output.size, longMetric("dataSize"))
 
   @transient lazy val inputRDD: RDD[InternalRow] = child.execute()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
@@ -104,6 +104,10 @@ case class ScalarSubquery(
     require(updated, s"$this has not finished")
     Literal.create(result, dataType).doGenCode(ctx, ev)
   }
+
+  override lazy val canonicalized: ScalarSubquery = {
+    copy(plan = plan.canonicalized.asInstanceOf[BaseSubqueryExec], exprId = ExprId(0))
+  }
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -470,7 +470,7 @@ class PlannerSuite extends SharedSparkSession {
       Inner,
       None,
       shuffle,
-      shuffle)
+      shuffle.copy())
 
     val outputPlan = ReuseExchange(spark.sessionState.conf).apply(inputPlan)
     if (outputPlan.collect { case e: ReusedExchangeExec => true }.size != 1) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR:
- enables exchange reuse across all subquery levels
- adds minor optimization by using a map of canonicalized plans to look up reusable exchanges

Example query:
```
SELECT
  (SELECT max(a.key) FROM testData AS a JOIN testData AS b ON b.key = a.key),
  a.key
FROM testData AS a
JOIN testData AS b ON b.key = a.key
```
Plan before this PR:
```
*(5) Project [Subquery scalar-subquery#270, [id=#605] AS scalarsubquery()#277, key#13]
:  +- Subquery scalar-subquery#270, [id=#605]
:     +- *(6) HashAggregate(keys=[], functions=[max(key#13)], output=[max(key)#276])
:        +- Exchange SinglePartition, true, [id=#601]
:           +- *(5) HashAggregate(keys=[], functions=[partial_max(key#13)], output=[max#281])
:              +- *(5) Project [key#13]
:                 +- *(5) SortMergeJoin [key#13], [key#273], Inner
:                    :- *(2) Sort [key#13 ASC NULLS FIRST], false, 0
:                    :  +- Exchange hashpartitioning(key#13, 5), true, [id=#584]
:                    :     +- *(1) SerializeFromObject [knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$TestData, true])).key AS key#13]
:                    :        +- Scan[obj#12]
:                    +- *(4) Sort [key#273 ASC NULLS FIRST], false, 0
:                       +- Exchange hashpartitioning(key#273, 5), true, [id=#592]
:                          +- *(3) SerializeFromObject [knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$TestData, true])).key AS key#273]
:                             +- Scan[obj#12]
+- *(5) SortMergeJoin [key#13], [key#271], Inner
   :- *(2) Sort [key#13 ASC NULLS FIRST], false, 0
   :  +- Exchange hashpartitioning(key#13, 5), true, [id=#617]
   :     +- *(1) SerializeFromObject [knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$TestData, true])).key AS key#13]
   :        +- Scan[obj#12]
   +- *(4) Sort [key#271 ASC NULLS FIRST], false, 0
      +- Exchange hashpartitioning(key#271, 5), true, [id=#625]
         +- *(3) SerializeFromObject [knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$TestData, true])).key AS key#271]
            +- Scan[obj#12]
```
Plan after this PR:
```
*(5) Project [Subquery scalar-subquery#240, [id=#193] AS scalarsubquery()#247, key#13]
:  +- Subquery scalar-subquery#240, [id=#193]
:     +- *(6) HashAggregate(keys=[], functions=[max(key#13)], output=[max(key)#246])
:        +- Exchange SinglePartition, true, [id=#189]
:           +- *(5) HashAggregate(keys=[], functions=[partial_max(key#13)], output=[max#251])
:              +- *(5) Project [key#13]
:                 +- *(5) SortMergeJoin [key#13], [key#243], Inner
:                    :- *(2) Sort [key#13 ASC NULLS FIRST], false, 0
:                    :  +- Exchange hashpartitioning(key#13, 5), true, [id=#145]
:                    :     +- *(1) SerializeFromObject [knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$TestData, true])).key AS key#13]
:                    :        +- Scan[obj#12]
:                    +- *(4) Sort [key#243 ASC NULLS FIRST], false, 0
:                       +- ReusedExchange [key#243], Exchange hashpartitioning(key#13, 5), true, [id=#145]
+- *(5) SortMergeJoin [key#13], [key#241], Inner
   :- *(2) Sort [key#13 ASC NULLS FIRST], false, 0
   :  +- ReusedExchange [key#13], Exchange hashpartitioning(key#13, 5), true, [id=#145]
   +- *(4) Sort [key#241 ASC NULLS FIRST], false, 0
      +- ReusedExchange [key#241], Exchange hashpartitioning(key#13, 5), true, [id=#145]
```

### Why are the changes needed?
Performance improvement. 

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
Added a new UT.
