### PR TITLE
[SPARK-29380][ML] RFormula avoid repeated 'first' jobs to get vector size

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
@@ -215,7 +215,7 @@ class RFormula @Since("1.5.0") (@Since("1.5.0") override val uid: String)
       col
     }
 
-    val terms = resolvedFormula.terms.flatten.distinct
+    val terms = resolvedFormula.terms.flatten.distinct.sorted
     lazy val firstRow = dataset.select(terms.map(col): _*).first()
 
     // First we index each string column referenced by the input terms.


### PR DESCRIPTION
### What changes were proposed in this pull request?
get the first row lazily, and reuse it for each vector column.

### Why are the changes needed?
avoid unnecssary `first` jobs

### Does this PR introduce any user-facing change?
no

### How was this patch tested?
existing testsuites & local tests in repl