### PR TITLE
[SPARK-29379][SQL]SHOW FUNCTIONS  show '!=', '<>' , 'between', 'case'

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
@@ -172,10 +172,6 @@ case class DropFunctionCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
 
-    if (FunctionsCommand.virtualOperators.contains(functionName.toLowerCase(Locale.ROOT))) {
-      throw new AnalysisException(s"Cannot drop virtual function '$functionName'")
-    }
-
     if (isTemp) {
       if (databaseName.isDefined) {
         throw new AnalysisException(s"Specifying a database in DROP TEMPORARY FUNCTION " +
@@ -243,7 +239,6 @@ case class ShowFunctionsCommand(
 
 object FunctionsCommand {
   // operators that do not have corresponding functions.
-  // They should be handled `DescribeFunctionCommand`,
-  // `DropFunctionCommand` and `ShowFunctionsCommand`
+  // They should be handled `DescribeFunctionCommand`, `ShowFunctionsCommand`
   val virtualOperators = Seq("!=", "<>", "between", "case")
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
@@ -171,7 +171,6 @@ case class DropFunctionCommand(
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
-
     if (isTemp) {
       if (databaseName.isDefined) {
         throw new AnalysisException(s"Specifying a database in DROP TEMPORARY FUNCTION " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
@@ -223,8 +223,13 @@ case class ShowFunctionsCommand(
           case (f, "USER") if showUserFunctions => f.unquotedString
           case (f, "SYSTEM") if showSystemFunctions => f.unquotedString
         }
-    (functionNames ++
-      StringUtils.filterPattern(Seq("!=", "<>", "between", "case"), pattern.getOrElse("*")))
-      .sorted.map(Row(_))
+    if (showSystemFunctions) {
+      (functionNames ++
+        StringUtils.filterPattern(Seq("!=", "<>", "between", "case"), pattern.getOrElse("*")))
+        .sorted.map(Row(_))
+    } else {
+      functionNames.sorted.map(Row(_))
+    }
+
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
@@ -73,11 +73,6 @@ case class CreateFunctionCommand(
       s"is not allowed: '${databaseName.get}'")
   }
 
-  // Redefine a virtual function is not allowed
-  if (FunctionsCommand.virtualOperators.contains(functionName.toLowerCase(Locale.ROOT))) {
-    throw new AnalysisException(s"It's not allowed to redefine virtual function '$functionName'")
-  }
-
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
     val func = CatalogFunction(FunctionIdentifier(functionName, databaseName), className, resources)
@@ -248,7 +243,7 @@ case class ShowFunctionsCommand(
 
 object FunctionsCommand {
   // operators that do not have corresponding functions.
-  // They should be handled in `CreateFunctionCommand`, `DescribeFunctionCommand`,
+  // They should be handled `DescribeFunctionCommand`,
   // `DropFunctionCommand` and `ShowFunctionsCommand`
   val virtualOperators = Seq("!=", "<>", "between", "case")
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
@@ -222,6 +222,6 @@ case class ShowFunctionsCommand(
           case (f, "USER") if showUserFunctions => f.unquotedString
           case (f, "SYSTEM") if showSystemFunctions => f.unquotedString
         }
-    functionNames.sorted.map(Row(_))
+    (functionNames ++ Seq("!=", "<>", "between", "case")).sorted.map(Row(_))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.{FunctionRegistry, NoSuchFunctionException}
 import org.apache.spark.sql.catalyst.catalog.{CatalogFunction, FunctionResource}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, ExpressionInfo}
+import org.apache.spark.sql.catalyst.util.StringUtils
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 
 
@@ -222,6 +223,8 @@ case class ShowFunctionsCommand(
           case (f, "USER") if showUserFunctions => f.unquotedString
           case (f, "SYSTEM") if showSystemFunctions => f.unquotedString
         }
-    (functionNames ++ Seq("!=", "<>", "between", "case")).sorted.map(Row(_))
+    (functionNames ++
+      StringUtils.filterPattern(Seq("!=", "<>", "between", "case"), pattern.getOrElse("*")))
+      .sorted.map(Row(_))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -87,7 +87,9 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession {
     Seq("^c*", "*e$", "log*", "*date*").foreach { pattern =>
       // For the pattern part, only '*' and '|' are allowed as wildcards.
       // For '*', we need to replace it to '.*'.
-      checkAnswer(sql(s"SHOW FUNCTIONS '$pattern'"), getFunctions(pattern))
+      checkAnswer(sql(s"SHOW FUNCTIONS '$pattern'"),
+        getFunctions(pattern) ++
+          StringUtils.filterPattern(Seq("!=", "<>", "between", "case"), pattern).map(Row(_)))
     }
     dropFunction(functions)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -113,27 +113,6 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession {
     checkKeywordsExist(sql("describe functioN abcadf"), "Function: abcadf not found.")
   }
 
-  test("drop virtual functions") {
-    val e1 = intercept[AnalysisException] {
-      sql(
-        "drop function case")
-    }
-    assert(e1.message == "Cannot drop virtual function 'case'")
-    val e2 = intercept[AnalysisException] {
-      sql(
-        "drop function `!=`")
-    }
-    assert(e2.message == "Cannot drop virtual function '!='")
-  }
-
-  test("SPARK-14415: All functions should have own descriptions") {
-    for (f <- spark.sessionState.functionRegistry.listFunction()) {
-      if (!Seq("cube", "grouping", "grouping_id", "rollup", "window").contains(f.unquotedString)) {
-        checkKeywordsNotExist(sql(s"describe function `$f`"), "N/A.")
-      }
-    }
-  }
-
   test("using _FUNC_ instead of function names in examples") {
     val exampleRe = "(>.*;)".r
     val setStmtRe = "(?i)^(>\\s+set\\s+).+".r

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.catalyst.util.StringUtils
 import org.apache.spark.sql.execution.HiveResult.hiveResultString
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
+import org.apache.spark.sql.execution.command.FunctionsCommand
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
@@ -60,7 +61,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession {
     def getFunctions(pattern: String): Seq[Row] = {
       StringUtils.filterPattern(
         spark.sessionState.catalog.listFunctions("default").map(_._1.funcName)
-        ++ Seq("!=", "<>", "between", "case"), pattern)
+        ++ FunctionsCommand.virtualOperators, pattern)
         .map(Row(_))
     }
 
@@ -110,6 +111,19 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession {
     checkKeywordsNotExist(sql("describe functioN Upper"), "Extended Usage")
 
     checkKeywordsExist(sql("describe functioN abcadf"), "Function: abcadf not found.")
+  }
+
+  test("drop virtual functions") {
+    val e1 = intercept[AnalysisException] {
+      sql(
+        "drop function case")
+    }
+    assert(e1.message == "Cannot drop virtual function 'case'")
+    val e2 = intercept[AnalysisException] {
+      sql(
+        "drop function `!=`")
+    }
+    assert(e2.message == "Cannot drop virtual function '!='")
   }
 
   test("SPARK-14415: All functions should have own descriptions") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -80,7 +80,8 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession {
 
     createFunction(functions)
 
-    checkAnswer(sql("SHOW functions"), getFunctions("*"))
+    checkAnswer(sql("SHOW functions"), (getFunctions("*") ++
+      Seq(Row("!="), Row("<>"), Row("between"), Row("case"))))
     assert(sql("SHOW functions").collect().size > 200)
 
     Seq("^c*", "*e$", "log*", "*date*").foreach { pattern =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -113,19 +113,6 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession {
     checkKeywordsExist(sql("describe functioN abcadf"), "Function: abcadf not found.")
   }
 
-  test("drop virtual functions") {
-    val e1 = intercept[AnalysisException] {
-      sql(
-        "drop function case")
-    }
-    assert(e1.message == "Cannot drop virtual function 'case'")
-    val e2 = intercept[AnalysisException] {
-      sql(
-        "drop function `!=`")
-    }
-    assert(e2.message == "Cannot drop virtual function '!='")
-  }
-
   test("SPARK-14415: All functions should have own descriptions") {
     for (f <- spark.sessionState.functionRegistry.listFunction()) {
       if (!Seq("cube", "grouping", "grouping_id", "rollup", "window").contains(f.unquotedString)) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -113,6 +113,27 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession {
     checkKeywordsExist(sql("describe functioN abcadf"), "Function: abcadf not found.")
   }
 
+  test("drop virtual functions") {
+    val e1 = intercept[AnalysisException] {
+      sql(
+        "drop function case")
+    }
+    assert(e1.message == "Cannot drop virtual function 'case'")
+    val e2 = intercept[AnalysisException] {
+      sql(
+        "drop function `!=`")
+    }
+    assert(e2.message == "Cannot drop virtual function '!='")
+  }
+
+  test("SPARK-14415: All functions should have own descriptions") {
+    for (f <- spark.sessionState.functionRegistry.listFunction()) {
+      if (!Seq("cube", "grouping", "grouping_id", "rollup", "window").contains(f.unquotedString)) {
+        checkKeywordsNotExist(sql(s"describe function `$f`"), "N/A.")
+      }
+    }
+  }
+
   test("using _FUNC_ instead of function names in examples") {
     val exampleRe = "(>.*;)".r
     val setStmtRe = "(?i)^(>\\s+set\\s+).+".r

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2064,7 +2064,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
 
   test("show functions") {
     withUserDefinedFunction("add_one" -> true) {
-      val numFunctions = FunctionRegistry.functionSet.size.toLong + 4L
+      val numFunctions = FunctionRegistry.functionSet.size.toLong + FunctionsCommand.virtualOperators.size
       assert(sql("show functions").count() === numFunctions)
       assert(sql("show system functions").count() === numFunctions)
       assert(sql("show all functions").count() === numFunctions)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2066,13 +2066,13 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
     withUserDefinedFunction("add_one" -> true) {
       val numFunctions = FunctionRegistry.functionSet.size.toLong
       assert(sql("show functions").count() === numFunctions + 4L)
-      assert(sql("show system functions").count() === numFunctions)
-      assert(sql("show all functions").count() === numFunctions)
+      assert(sql("show system functions").count() === numFunctions + 4L)
+      assert(sql("show all functions").count() === numFunctions + 4L)
       assert(sql("show user functions").count() === 0L)
       spark.udf.register("add_one", (x: Long) => x + 1)
       assert(sql("show functions").count() === numFunctions + 5L)
-      assert(sql("show system functions").count() === numFunctions)
-      assert(sql("show all functions").count() === numFunctions + 1L)
+      assert(sql("show system functions").count() === numFunctions + 4L)
+      assert(sql("show all functions").count() === numFunctions + 5L)
       assert(sql("show user functions").count() === 1L)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2064,15 +2064,15 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
 
   test("show functions") {
     withUserDefinedFunction("add_one" -> true) {
-      val numFunctions = FunctionRegistry.functionSet.size.toLong
-      assert(sql("show functions").count() === numFunctions + 4L)
-      assert(sql("show system functions").count() === numFunctions + 4L)
-      assert(sql("show all functions").count() === numFunctions + 4L)
+      val numFunctions = FunctionRegistry.functionSet.size.toLong + 4L
+      assert(sql("show functions").count() === numFunctions)
+      assert(sql("show system functions").count() === numFunctions)
+      assert(sql("show all functions").count() === numFunctions)
       assert(sql("show user functions").count() === 0L)
       spark.udf.register("add_one", (x: Long) => x + 1)
-      assert(sql("show functions").count() === numFunctions + 5L)
-      assert(sql("show system functions").count() === numFunctions + 4L)
-      assert(sql("show all functions").count() === numFunctions + 5L)
+      assert(sql("show functions").count() === numFunctions + 1L)
+      assert(sql("show system functions").count() === numFunctions)
+      assert(sql("show all functions").count() === numFunctions + 1L)
       assert(sql("show user functions").count() === 1L)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2065,12 +2065,12 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
   test("show functions") {
     withUserDefinedFunction("add_one" -> true) {
       val numFunctions = FunctionRegistry.functionSet.size.toLong
-      assert(sql("show functions").count() === numFunctions)
+      assert(sql("show functions").count() === numFunctions + 4L)
       assert(sql("show system functions").count() === numFunctions)
       assert(sql("show all functions").count() === numFunctions)
       assert(sql("show user functions").count() === 0L)
       spark.udf.register("add_one", (x: Long) => x + 1)
-      assert(sql("show functions").count() === numFunctions + 1L)
+      assert(sql("show functions").count() === numFunctions + 5L)
       assert(sql("show system functions").count() === numFunctions)
       assert(sql("show all functions").count() === numFunctions + 1L)
       assert(sql("show user functions").count() === 1L)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2064,7 +2064,8 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
 
   test("show functions") {
     withUserDefinedFunction("add_one" -> true) {
-      val numFunctions = FunctionRegistry.functionSet.size.toLong + FunctionsCommand.virtualOperators.size
+      val numFunctions = FunctionRegistry.functionSet.size.toLong +
+        FunctionsCommand.virtualOperators.size.toLong
       assert(sql("show functions").count() === numFunctions)
       assert(sql("show system functions").count() === numFunctions)
       assert(sql("show all functions").count() === numFunctions)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -563,8 +563,8 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
         checkAnswer(
           sql("SELECT testUDFToListInt(s) FROM inputTable"),
           Seq(Row(Seq(1, 2, 3))))
-        assert(sql("show functions").count() == numFunc + 1)
-        assert(spark.catalog.listFunctions().count() == numFunc + 1)
+        assert(sql("show functions").count() == numFunc + 5)
+        assert(spark.catalog.listFunctions().count() == numFunc + 5)
       }
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -564,7 +564,7 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
           sql("SELECT testUDFToListInt(s) FROM inputTable"),
           Seq(Row(Seq(1, 2, 3))))
         assert(sql("show functions").count() == numFunc + 5)
-        assert(spark.catalog.listFunctions().count() == numFunc + 5)
+        assert(spark.catalog.listFunctions().count() == numFunc + 1)
       }
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -32,6 +32,7 @@ import org.apache.hadoop.io.{LongWritable, Writable}
 
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.catalyst.plans.logical.Project
+import org.apache.spark.sql.execution.command.FunctionsCommand
 import org.apache.spark.sql.functions.max
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.internal.SQLConf
@@ -563,7 +564,8 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
         checkAnswer(
           sql("SELECT testUDFToListInt(s) FROM inputTable"),
           Seq(Row(Seq(1, 2, 3))))
-        assert(sql("show functions").count() == numFunc + 5)
+        assert(sql("show functions").count() ==
+          numFunc + FunctionsCommand.virtualOperators.size + 1)
         assert(spark.catalog.listFunctions().count() == numFunc + 1)
       }
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -192,6 +192,11 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     allBuiltinFunctions.foreach { f =>
       assert(allFunctions.contains(f))
     }
+
+    Seq("!=", "<>", "between", "case").foreach { f =>
+      assert(allFunctions.contains(f))
+    }
+
     withTempDatabase { db =>
       def createFunction(names: Seq[String]): Unit = {
         names.foreach { name =>

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, Functio
 import org.apache.spark.sql.catalyst.catalog.{CatalogTableType, CatalogUtils, HiveTableRelation}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, SubqueryAlias}
-import org.apache.spark.sql.execution.command.LoadDataCommand
+import org.apache.spark.sql.execution.command.{FunctionsCommand, LoadDataCommand}
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.hive.{HiveExternalCatalog, HiveUtils}
@@ -193,7 +193,7 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       assert(allFunctions.contains(f))
     }
 
-    Seq("!=", "<>", "between", "case").foreach { f =>
+    FunctionsCommand.virtualOperators.foreach { f =>
       assert(allFunctions.contains(f))
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Current Spark SQL `SHOW FUNCTIONS` don't show `!=`, `<>`, `between`, `case`
But these expressions is truly functions. We should show it in SQL `SHOW FUNCTIONS`

### Why are the changes needed?

SHOW FUNCTIONS show '!=', '<>' , 'between', 'case'

### Does this PR introduce any user-facing change?
SHOW FUNCTIONS show '!=', '<>' , 'between', 'case'


### How was this patch tested?
UT
