### PR TITLE
[SPARK-24640][SQL][FOLLOWUP] Update the SQL migration guide about `size(NULL)`

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -213,7 +213,9 @@ license: |
     - `yesterday [zoneId]` - midnight yesterday
     - `tomorrow [zoneId]` - midnight tomorrow
     - `now` - current query start time
-  For example `SELECT timestamp 'tomorrow';`. 
+  For example `SELECT timestamp 'tomorrow';`.
+
+  - Since Spark 3.0, the `size` function returns `NULL` for the `NULL` input. In Spark version 2.4 and earlier, this function gives `-1` for the same input. To restore the behavior before Spark 3.0, you can set `spark.sql.legacy.sizeOfNull` to `true`.
 
 ## Upgrading from Spark SQL 2.4 to 2.4.1
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The commit https://github.com/apache/spark/commit/4e6d31f570d212ddb2044df88b5440ebb1108e3c changed default behavior of `size()` for the `NULL` input. In this PR, I propose to update the SQL migration guide.

### Why are the changes needed?
To inform users about new behavior of the `size()` function for the `NULL` input.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
N/A