### PR TITLE
[SPARK-29413][CORE][FOLLOWUP] A better parmap method signature

### DIFF
--- a/core/src/test/scala/org/apache/spark/util/ThreadUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/ThreadUtilsSuite.scala
@@ -160,4 +160,11 @@ class ThreadUtilsSuite extends SparkFunSuite {
       assert(!t.isAlive)
     }
   }
+
+  test("parmap should return the same collection type of input") {
+    val l1 = 1 :: 2 :: 3 :: Nil
+    // The explicit type is to verify the return type of `parmap`
+    val l2: List[Int] = ThreadUtils.parmap(l1, "test", 2)(_ + 1)
+    assert(l2 === l1.map(_ + 1))
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the `parmap` method signature to return the same type of `input` to make the method more flexible.

### Why are the changes needed?

`parmap` will be more flexible similar to `Future.sequence`.

### Does this PR introduce any user-facing change?

No. This PR updates an internal method.

### How was this patch tested?

The new test added in this PR.
