### PR TITLE
[SPARK-29440][SQL] Support java.time.Duration as an external type of CalendarIntervalType

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoders.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoders.scala
@@ -129,6 +129,14 @@ object Encoders {
   def INSTANT: Encoder[java.time.Instant] = ExpressionEncoder()
 
   /**
+   * Creates an encoder that serializes instances of the `java.time.Duration` class
+   * to the internal representation of nullable Catalyst's CalendarIntervalType.
+   *
+   * @since 3.0.0
+   */
+  def DURATION: Encoder[java.time.Duration] = ExpressionEncoder()
+
+  /**
    * An encoder for arrays of bytes.
    *
    * @since 1.6.1

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/DeserializerBuildHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/DeserializerBuildHelper.scala
@@ -118,6 +118,15 @@ object DeserializerBuildHelper {
       returnNullable = false)
   }
 
+  def createDeserializerForDuration(path: Expression): Expression = {
+    StaticInvoke(
+      DateTimeUtils.getClass,
+      ObjectType(classOf[java.time.Duration]),
+      "intervalToDuration",
+      path :: Nil,
+      returnNullable = false)
+  }
+
   def createDeserializerForJavaBigDecimal(
       path: Expression,
       returnNullable: Boolean): Expression = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/InternalRow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/InternalRow.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
 import org.apache.spark.sql.types._
-import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
 /**
  * An abstract class for row used internally in Spark SQL, which only contains the columns as
@@ -57,6 +57,8 @@ abstract class InternalRow extends SpecializedGetters with Serializable {
    * CAN NOT call setNullAt() for decimal column on UnsafeRow, call setDecimal(i, null, precision).
    */
   def setDecimal(i: Int, value: Decimal, precision: Int): Unit = update(i, value)
+
+  def setInterval(i: Int, value: CalendarInterval): Unit = update(i, value)
 
   /**
    * Make a copy of the current [[InternalRow]] object.
@@ -177,6 +179,8 @@ object InternalRow {
     case _: StructType => (input, v) => input.update(ordinal, v.asInstanceOf[InternalRow].copy())
     case _: ArrayType => (input, v) => input.update(ordinal, v.asInstanceOf[ArrayData].copy())
     case _: MapType => (input, v) => input.update(ordinal, v.asInstanceOf[MapData].copy())
+    case _: CalendarIntervalType =>
+      (input, v) => input.setInterval(ordinal, v.asInstanceOf[CalendarInterval])
     case _ => (input, v) => input.update(ordinal, v)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
@@ -106,6 +106,7 @@ object JavaTypeInference {
       case c: Class[_] if c == classOf[java.sql.Date] => (DateType, true)
       case c: Class[_] if c == classOf[java.time.Instant] => (TimestampType, true)
       case c: Class[_] if c == classOf[java.sql.Timestamp] => (TimestampType, true)
+      case c: Class[_] if c == classOf[java.time.Duration] => (CalendarIntervalType, true)
 
       case _ if typeToken.isArray =>
         val (dataType, nullable) = inferDataType(typeToken.getComponentType, seenTypeSet)
@@ -234,6 +235,9 @@ object JavaTypeInference {
 
       case c if c == classOf[java.sql.Timestamp] =>
         createDeserializerForSqlTimestamp(path)
+
+      case c if c == classOf[java.time.Duration] =>
+        createDeserializerForDuration(path)
 
       case c if c == classOf[java.lang.String] =>
         createDeserializerForString(path, returnNullable = true)
@@ -389,6 +393,8 @@ object JavaTypeInference {
         case c if c == classOf[java.time.LocalDate] => createSerializerForJavaLocalDate(inputObject)
 
         case c if c == classOf[java.sql.Date] => createSerializerForSqlDate(inputObject)
+
+        case c if c == classOf[java.time.Duration] => createSerializerForJavaDuration(inputObject)
 
         case c if c == classOf[java.math.BigDecimal] =>
           createSerializerForJavaBigDecimal(inputObject)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -230,6 +230,9 @@ object ScalaReflection extends ScalaReflection {
       case t if isSubtype(t, localTypeOf[java.sql.Timestamp]) =>
         createDeserializerForSqlTimestamp(path)
 
+      case t if isSubtype(t, localTypeOf[java.time.Duration]) =>
+        createDeserializerForDuration(path)
+
       case t if isSubtype(t, localTypeOf[java.lang.String]) =>
         createDeserializerForString(path, returnNullable = false)
 
@@ -496,6 +499,9 @@ object ScalaReflection extends ScalaReflection {
 
       case t if isSubtype(t, localTypeOf[java.sql.Date]) => createSerializerForSqlDate(inputObject)
 
+      case t if isSubtype(t, localTypeOf[java.time.Duration]) =>
+        createSerializerForJavaDuration(inputObject)
+
       case t if isSubtype(t, localTypeOf[BigDecimal]) =>
         createSerializerForScalaBigDecimal(inputObject)
 
@@ -671,6 +677,8 @@ object ScalaReflection extends ScalaReflection {
         Schema(TimestampType, nullable = true)
       case t if isSubtype(t, localTypeOf[java.time.LocalDate]) => Schema(DateType, nullable = true)
       case t if isSubtype(t, localTypeOf[java.sql.Date]) => Schema(DateType, nullable = true)
+      case t if isSubtype(t, localTypeOf[java.time.Duration]) =>
+        Schema(CalendarIntervalType, nullable = true)
       case t if isSubtype(t, localTypeOf[BigDecimal]) =>
         Schema(DecimalType.SYSTEM_DEFAULT, nullable = true)
       case t if isSubtype(t, localTypeOf[java.math.BigDecimal]) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -138,7 +138,7 @@ object ScalaReflection extends ScalaReflection {
    */
   def isNativeType(dt: DataType): Boolean = dt match {
     case NullType | BooleanType | ByteType | ShortType | IntegerType | LongType |
-         FloatType | DoubleType | BinaryType | CalendarIntervalType => true
+         FloatType | DoubleType | BinaryType => true
     case _ => false
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SerializerBuildHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SerializerBuildHelper.scala
@@ -101,6 +101,15 @@ object SerializerBuildHelper {
       returnNullable = false)
   }
 
+  def createSerializerForJavaDuration(inputObject: Expression): Expression = {
+    StaticInvoke(
+      DateTimeUtils.getClass,
+      CalendarIntervalType,
+      "durationToInterval",
+      inputObject :: Nil,
+      returnNullable = false)
+  }
+
   def createSerializerForJavaBigDecimal(inputObject: Expression): Expression = {
     CheckOverflow(StaticInvoke(
       Decimal.getClass,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/RowEncoder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/RowEncoder.scala
@@ -57,6 +57,7 @@ import org.apache.spark.sql.types._
  *   ArrayType -> scala.collection.Seq or Array
  *   MapType -> scala.collection.Map
  *   StructType -> org.apache.spark.sql.Row
+ *   CalendarIntervalType -> java.time.Duration
  * }}}
  */
 object RowEncoder {
@@ -107,6 +108,8 @@ object RowEncoder {
       } else {
         createSerializerForSqlDate(inputObject)
       }
+
+    case CalendarIntervalType => createSerializerForJavaDuration(inputObject)
 
     case d: DecimalType =>
       CheckOverflow(StaticInvoke(
@@ -226,6 +229,7 @@ object RowEncoder {
       } else {
         ObjectType(classOf[java.sql.Date])
       }
+    case CalendarIntervalType => ObjectType(classOf[java.time.Duration])
     case _: DecimalType => ObjectType(classOf[java.math.BigDecimal])
     case StringType => ObjectType(classOf[java.lang.String])
     case _: ArrayType => ObjectType(classOf[scala.collection.Seq[_]])
@@ -280,6 +284,8 @@ object RowEncoder {
       } else {
         createDeserializerForSqlDate(input)
       }
+
+    case CalendarIntervalType => createDeserializerForDuration(input)
 
     case _: DecimalType => createDeserializerForJavaBigDecimal(input, returnNullable = false)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -27,7 +27,7 @@ import java.lang.{Short => JavaShort}
 import java.math.{BigDecimal => JavaBigDecimal}
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Timestamp}
-import java.time.{Instant, LocalDate}
+import java.time.{Duration, Instant, LocalDate}
 import java.util
 import java.util.Objects
 import javax.xml.bind.DatatypeConverter
@@ -42,7 +42,7 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow, ScalaReflection}
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.util._
-import org.apache.spark.sql.catalyst.util.DateTimeUtils.instantToMicros
+import org.apache.spark.sql.catalyst.util.DateTimeUtils.{durationToInterval, instantToMicros}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types._
@@ -71,6 +71,7 @@ object Literal {
     case t: Timestamp => Literal(DateTimeUtils.fromJavaTimestamp(t), TimestampType)
     case ld: LocalDate => Literal(ld.toEpochDay.toInt, DateType)
     case d: Date => Literal(DateTimeUtils.fromJavaDate(d), DateType)
+    case d: Duration => Literal(durationToInterval(d), CalendarIntervalType)
     case a: Array[Byte] => Literal(a, BinaryType)
     case a: collection.mutable.WrappedArray[_] => apply(a.array)
     case a: Array[_] =>
@@ -120,6 +121,7 @@ object Literal {
     case _ if clz == classOf[BigInt] => DecimalType.SYSTEM_DEFAULT
     case _ if clz == classOf[BigDecimal] => DecimalType.SYSTEM_DEFAULT
     case _ if clz == classOf[CalendarInterval] => CalendarIntervalType
+    case _ if clz == classOf[Duration] => CalendarIntervalType
 
     case _ if clz.isArray => ArrayType(componentTypeToDataType(clz.getComponentType))
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit._
 import scala.util.control.NonFatal
 
 import org.apache.spark.sql.types.Decimal
-import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
 /**
  * Helper functions for converting between internal and external date and time representations.
@@ -958,5 +958,15 @@ object DateTimeUtils {
     } else {
       None
     }
+  }
+
+  def durationToInterval(duration: Duration): CalendarInterval = {
+    val micros = duration.getSeconds * MICROS_PER_SECOND + duration.getNano / NANOS_PER_MICROS
+    new CalendarInterval(0, micros)
+  }
+
+  def intervalToDuration(interval: CalendarInterval): Duration = {
+    val microsDuration = Duration.ofNanos(interval.microseconds * NANOS_PER_MICROS)
+    microsDuration.plusSeconds(interval.months * SECONDS_PER_MONTH)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst
 
-import java.time.{Instant, LocalDate}
+import java.time.{Duration, Instant, LocalDate}
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.Row
@@ -214,6 +214,20 @@ class CatalystTypeConvertersSuite extends SparkFunSuite with SQLHelper {
         val localDate = DateTimeUtils.daysToLocalDate(days)
         assert(CatalystTypeConverters.createToScalaConverter(DateType)(days) === localDate)
       }
+    }
+  }
+
+  test("converting java.time.Duration to CalendarIntervalType") {
+    Seq(
+      "P0D",
+      "PT0.000001S",
+      "PT-0.000001S",
+      "P1DT2H3M4.000001S",
+      "P-1DT2H3M4.000001S").foreach { time =>
+      val input = Duration.parse(time)
+      val result = CatalystTypeConverters.convertToCatalyst(input)
+      val expected = DateTimeUtils.durationToInterval(input)
+      assert(result === expected)
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.catalyst.util.{DateTimeUtils, GenericArrayData}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
-import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
 class CatalystTypeConvertersSuite extends SparkFunSuite with SQLHelper {
 
@@ -228,6 +228,18 @@ class CatalystTypeConvertersSuite extends SparkFunSuite with SQLHelper {
       val result = CatalystTypeConverters.convertToCatalyst(input)
       val expected = DateTimeUtils.durationToInterval(input)
       assert(result === expected)
+    }
+  }
+
+  test("converting CalendarIntervalType to java.time.Duration") {
+    Seq(
+      CalendarInterval.fromString("interval 0 days"),
+      CalendarInterval.fromString("interval 1 month"),
+      CalendarInterval.fromString("interval 1 month 1 microsecond"),
+      CalendarInterval.fromString("interval -1 month -1 microsecond"),
+      CalendarInterval.fromString("interval 10000 years -1 microsecond")).foreach { i =>
+      val duration = DateTimeUtils.intervalToDuration(i)
+      assert(CatalystTypeConverters.createToScalaConverter(CalendarIntervalType)(i) === duration)
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
@@ -333,15 +333,13 @@ class RowEncoderSuite extends CodegenInterpretedPlanTest {
   }
 
   test("encoding/decoding CalendarIntervalType to/from java.time.Duration") {
-    withSQLConf(SQLConf.DATETIME_JAVA8API_ENABLED.key -> "true") {
-      val schema = new StructType().add("i", CalendarIntervalType)
-      val encoder = RowEncoder(schema).resolveAndBind()
-      val duration = java.time.Duration.parse("P2DT3H4M")
-      val row = encoder.toRow(Row(duration))
-      assert(row.getInterval(0) === DateTimeUtils.durationToInterval(duration))
-      val readback = encoder.fromRow(row)
-      assert(readback.get(0).equals(duration))
-    }
+    val schema = new StructType().add("i", CalendarIntervalType)
+    val encoder = RowEncoder(schema).resolveAndBind()
+    val duration = java.time.Duration.parse("P2DT3H4M")
+    val row = encoder.toRow(Row(duration))
+    assert(row.getInterval(0) === DateTimeUtils.durationToInterval(duration))
+    val readback = encoder.fromRow(row)
+    assert(readback.get(0).equals(duration))
   }
 
   for {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
@@ -332,6 +332,18 @@ class RowEncoderSuite extends CodegenInterpretedPlanTest {
     }
   }
 
+  test("encoding/decoding CalendarIntervalType to/from java.time.Duration") {
+    withSQLConf(SQLConf.DATETIME_JAVA8API_ENABLED.key -> "true") {
+      val schema = new StructType().add("i", CalendarIntervalType)
+      val encoder = RowEncoder(schema).resolveAndBind()
+      val duration = java.time.Duration.parse("P2DT3H4M")
+      val row = encoder.toRow(Row(duration))
+      assert(row.getInterval(0) === DateTimeUtils.durationToInterval(duration))
+      val readback = encoder.fromRow(row)
+      assert(readback.get(0).equals(duration))
+    }
+  }
+
   for {
     elementType <- Seq(IntegerType, StringType)
     containsNull <- Seq(true, false)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
@@ -317,4 +317,22 @@ class LiteralExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
       assert(literalStr === expected)
     }
   }
+
+  test("construct literals from java.time.Duration") {
+    Seq(
+      Duration.ofSeconds(0),
+      Duration.ofSeconds(1, 999999000),
+      Duration.ofSeconds(-1, -999999000),
+      Duration.ofDays(365 * 10000),
+      Duration.ofDays(-365 * 10000)).foreach { duration =>
+      checkEvaluation(Literal(duration), duration)
+    }
+  }
+
+  test("construct literals from arrays of java.time.Duration") {
+    val duration0 = Duration.ofMinutes(10)
+    checkEvaluation(Literal(Array(duration0)), Array(duration0))
+    val duration1 = Duration.ofHours(3)
+    checkEvaluation(Literal(Array(duration0, duration1)), Array(duration0, duration1))
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
@@ -70,13 +70,13 @@ class LiteralExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
     withSQLConf(SQLConf.DATETIME_JAVA8API_ENABLED.key -> "false") {
       checkEvaluation(Literal.default(DateType), DateTimeUtils.toJavaDate(0))
       checkEvaluation(Literal.default(TimestampType), DateTimeUtils.toJavaTimestamp(0L))
-      checkEvaluation(Literal.default(CalendarIntervalType), new CalendarInterval(0, 0L))
     }
     withSQLConf(SQLConf.DATETIME_JAVA8API_ENABLED.key -> "true") {
       checkEvaluation(Literal.default(DateType), LocalDate.ofEpochDay(0))
       checkEvaluation(Literal.default(TimestampType), Instant.ofEpochSecond(0))
-      checkEvaluation(Literal.default(CalendarIntervalType), Duration.ofSeconds(0))
     }
+    checkEvaluation(Literal.default(CalendarIntervalType), new CalendarInterval(0, 0L))
+    checkEvaluation(Literal.default(CalendarIntervalType), Duration.ofSeconds(0))
     checkEvaluation(Literal.default(ArrayType(StringType)), Array())
     checkEvaluation(Literal.default(MapType(IntegerType, StringType)), Map())
     checkEvaluation(Literal.default(StructType(StructField("a", StringType) :: Nil)), Row(""))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import java.nio.charset.StandardCharsets
-import java.time.{Instant, LocalDate, LocalDateTime, ZoneOffset}
+import java.time.{Duration, Instant, LocalDate, LocalDateTime, ZoneOffset}
 import java.util.TimeZone
 
 import scala.reflect.runtime.universe.TypeTag
@@ -70,12 +70,13 @@ class LiteralExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
     withSQLConf(SQLConf.DATETIME_JAVA8API_ENABLED.key -> "false") {
       checkEvaluation(Literal.default(DateType), DateTimeUtils.toJavaDate(0))
       checkEvaluation(Literal.default(TimestampType), DateTimeUtils.toJavaTimestamp(0L))
+      checkEvaluation(Literal.default(CalendarIntervalType), new CalendarInterval(0, 0L))
     }
     withSQLConf(SQLConf.DATETIME_JAVA8API_ENABLED.key -> "true") {
       checkEvaluation(Literal.default(DateType), LocalDate.ofEpochDay(0))
       checkEvaluation(Literal.default(TimestampType), Instant.ofEpochSecond(0))
+      checkEvaluation(Literal.default(CalendarIntervalType), Duration.ofSeconds(0))
     }
-    checkEvaluation(Literal.default(CalendarIntervalType), new CalendarInterval(0, 0L))
     checkEvaluation(Literal.default(ArrayType(StringType)), Array())
     checkEvaluation(Literal.default(MapType(IntegerType, StringType)), Map())
     checkEvaluation(Literal.default(StructType(StructField("a", StringType) :: Nil)), Row(""))

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
@@ -88,6 +88,9 @@ abstract class SQLImplicits extends LowPrioritySQLImplicits {
   /** @since 3.0.0 */
   implicit def newInstantEncoder: Encoder[java.time.Instant] = Encoders.INSTANT
 
+  /** @since 3.0.0 */
+  implicit def newDurationEncoder: Encoder[java.time.Duration] = Encoders.DURATION
+
   // Boxed primitives
 
   /** @since 2.0.0 */

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.*;
@@ -408,6 +409,14 @@ public class JavaDatasetSuite implements Serializable {
     List<Tuple2<LocalDate, Instant>> data =
       Arrays.asList(new Tuple2<>(LocalDate.ofEpochDay(0), Instant.ofEpochSecond(0)));
     Dataset<Tuple2<LocalDate, Instant>> ds = spark.createDataset(data, encoder);
+    Assert.assertEquals(data, ds.collectAsList());
+  }
+
+  @Test
+  public void testDurationEncoder() {
+    Encoder<Duration> encoder = Encoders.DURATION();
+    List<Duration> data = Arrays.asList(Duration.ofHours(2));
+    Dataset<Duration> ds = spark.createDataset(data, encoder);
     Assert.assertEquals(data, ds.collectAsList());
   }
 

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaUDFSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaUDFSuite.java
@@ -18,6 +18,7 @@
 package test.org.apache.spark.sql;
 
 import java.io.Serializable;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -138,5 +139,15 @@ public class JavaUDFSuite implements Serializable {
     } finally {
       spark.conf().set(SQLConf.DATETIME_JAVA8API_ENABLED().key(), originConf);
     }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void udf8Test() {
+    spark.udf().register(
+            "plusDay",
+            (Duration d) -> d.plusDays(1), DataTypes.CalendarIntervalType);
+    Row result = spark.sql("SELECT plusDay(interval 40 minutes)").head();
+    Assert.assertEquals(Duration.ofMinutes(40).plusDays(1), result.get(0));
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1843,6 +1843,11 @@ class DatasetSuite extends QueryTest with SharedSparkSession {
     assert(spark.range(1).map { _ => instant }.head === instant)
   }
 
+  test("implicit encoder for Duration") {
+    val duration = java.time.Duration.ofMinutes(10)
+    assert(spark.range(1).map { _ => duration }.head === duration)
+  }
+
   val dotColumnTestModes = Table(
     ("caseSensitive", "colName"),
     ("true", "field.1"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
@@ -516,6 +516,14 @@ class UDFSuite extends QueryTest with SharedSparkSession {
     }
   }
 
+  test("Using java.time.Duration in UDF") {
+    val expected = java.time.Duration.ofMinutes(40).plusDays(1)
+    val plusDay = udf((i: java.time.Duration) => i.plusDays(1))
+    val df = spark.sql("SELECT interval 40 minutes as i")
+      .select(plusDay('i))
+    assert(df.collect().toSeq === Seq(Row(expected)))
+  }
+
   test("SPARK-28321 0-args Java UDF should not be called only once") {
     val nonDeterministicJavaUDF = udf(
       new UDF0[Int] {


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to convert values of the `CalendarIntervalType` Catalyst's type to the `java.time.Duration` values when such values are need outside of Spark, for example in UDF. If an `INTERVAL` values has non-zero `months` field, it is converted to number of seconds assuming `2629746` seconds per months. This average number of seconds per month was given by assuming that the average year of the Gregorian calendar `365.2425` days long (see https://en.wikipedia.org/wiki/Gregorian_calendar): `60 * 60 * 24 * 365.2425` = `31556952.0` = `12 * 2629746`.

For example:
```sql
scala> val plusDay = udf((i: java.time.Duration) => i.plusDays(1))
plusDay: org.apache.spark.sql.expressions.UserDefinedFunction = SparkUserDefinedFunction($Lambda$1855/165450258@485996f7,CalendarIntervalType,List(Some(Schema(CalendarIntervalType,true))),None,true,true)

scala> val df = spark.sql("SELECT interval 40 minutes as i")
df: org.apache.spark.sql.DataFrame = [i: interval]

scala> df.show
+-------------------+                                                           
|                  i|
+-------------------+
|interval 40 minutes|
+-------------------+

scala> df.select(plusDay('i)).show(false)
+--------------------------+
|UDF(i)                    |
+--------------------------+
|interval 1 days 40 minutes|
+--------------------------+
```
I added an implicit encoder for `java.time.Duration` which allows to create Spark dataframe from an external collections:
```sql
scala> Seq(Duration.ofDays(10), Duration.ofHours(10)).toDS.show(false)
+-----------------------+
|value                  |
+-----------------------+
|interval 1 weeks 3 days|
|interval 10 hours      |
+-----------------------+
```

### Why are the changes needed?
This should allow to users:
- Write UDF over interval inputs
- Use Java 8 libraries for `java.time.Duration` in manipulations on collected values or in UDFs
- Create dataframes from a collection of `java.time.Duration` values.

### Does this PR introduce any user-facing change?
Yes, currently `collect()` returns not public class `CalendarInterval`:
```
scala> spark.sql("select interval 1 week").collect().apply(0).get(0).isInstanceOf[org.apache.spark.unsafe.types.CalendarInterval]
res2: Boolean = true
```
After the changes:
```
scala> spark.sql("select interval 1 week").collect().apply(0).get(0).isInstanceOf[Duration]
res8: Boolean = true
```
### How was this patch tested?
- Added new testes to `CatalystTypeConvertersSuite` to check conversion of `CalendarIntervalType` to/from `java.time.Duration`
- By `JavaUDFSuite`/ `UDFSuite` to test usage of `Duration` type in Scala/Java UDFs.
