### PR TITLE
[SPARK-24915][Python] Fix Row handling with Schema.

### DIFF
--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -215,6 +215,52 @@ class TypesTests(ReusedSQLTestCase):
         self.assertEqual(df.dtypes, [("key", "bigint"), ("value", "string")])
         self.assertEqual(df.first(), Row(key=1, value="1"))
 
+    def test_create_dataframe_from_rows_mixed_with_datetype(self):
+        data = [Row(name='Alice', join_date=datetime.date(2014, 5, 26)),
+                Row(name='Bob', join_date=datetime.date(2016, 7, 26))]
+        schema1 = StructType([
+            StructField("join_date", DateType(), False),
+            StructField("name", StringType(), False),
+        ])
+        schema2 = StructType([
+            StructField("name", StringType(), False),
+            StructField("join_date", DateType(), False),
+        ])
+        df = self.spark.createDataFrame(data, schema=schema1)
+        self.assertEqual(df.dtypes, [("join_date", "date"), ("name", "string")])
+        self.assertEqual(df.first().asDict(),
+                         Row(name='Alice', join_date=datetime.date(2014, 5, 26)).asDict())
+        df = self.spark.createDataFrame(data, schema=schema2)
+        self.assertEqual(df.dtypes, [("name", "string"), ("join_date", "date")])
+        self.assertEqual(df.first().asDict(),
+                         Row(name='Alice', join_date=datetime.date(2014, 5, 26)).asDict())
+
+    def test_create_dataframe_from_rows_with_nested_row(self):
+        schema = StructType([
+            StructField('field2',
+                        StructType([
+                            StructField('sub_field', StringType(), False)
+                        ]), False),
+            StructField('field1', StringType(), False),
+        ])
+        row = Row(field1="Hello", field2=Row(sub_field='world'))
+        data = [row]
+        df = self.spark.createDataFrame(data, schema=schema)
+        self.assertEqual(df.dtypes, [('field2', 'struct<sub_field:string>'),
+                                     ('field1', 'string')])
+        self.assertEqual(df.first().asDict(), row.asDict())
+
+    def test_create_dataframe_from_tuple_rows(self):
+        data = [Row('Alice', datetime.date(2014, 5, 26)),
+                Row('Bob', datetime.date(2016, 7, 26))]
+        schema = StructType([
+            StructField("name", StringType(), False),
+            StructField("join_date", DateType(), False),
+        ])
+        df = self.spark.createDataFrame(data, schema=schema)
+        self.assertEqual(df.dtypes, [("name", "string"), ("join_date", "date")])
+        self.assertEqual(df.first(), Row('Alice', datetime.date(2014, 5, 26)))
+
     def test_apply_schema(self):
         from datetime import date, datetime
         rdd = self.sc.parallelize([(127, -128, -32768, 32767, 2147483647, 1.0,

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -599,6 +599,9 @@ class StructType(DataType):
             if isinstance(obj, dict):
                 return tuple(f.toInternal(obj.get(n)) if c else obj.get(n)
                              for n, f, c in zip(self.names, self.fields, self._needConversion))
+            elif isinstance(obj, Row) and getattr(obj, "__from_dict__", False):
+                return tuple(f.toInternal(obj[n]) if c else obj[n]
+                             for n, f, c in zip(self.names, self.fields, self._needConversion))
             elif isinstance(obj, (tuple, list)):
                 return tuple(f.toInternal(v) if c else v
                              for f, v, c in zip(self.fields, obj, self._needConversion))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This change implements a special handling of `pyspark.sql.Row` within the conversion of a `StructType` into an internal SQL object (`toInternal()`) to fix [SPARK-24915](https://issues.apache.org/jira/browse/SPARK-24915).

Previously, `Row` was processed as `tuple` (since it inherits from `tuple`). In particular, it was expected that values come in the "right" order. This works if the internal order of the `Row` (sorted by key in the current implementation) corresponds to the order of fields in the schema. If the fields have a different order *and* need special treatment (e.g. `_needConversion` is `True`) then exceptions happened when creating dataframes.

With this change, it will be processed as a `dict` if it has named columns and as tuple otherwise.

## Design

Re `asDict`: I first had an implementation for `Row` as type. However, that implementation would fail for fields that are unknown to the `Row` object, this is inconsistent with the handling of `dict`s. The most consistent implementation is to convert the `Row` to `dict`.

Note: The underlying problem is that `Row` inherits from `tuple`. This is visible in the tests, too. for `assertEqual` the `Row`s `Row(a=..., b=...)` and `Row(b=..., a=...)` are *not* equal because they are compared as lists (and the order is wrong) while a direct comparison returns `True` (For this reason the tests compare based on `asDict`).

### Why are the changes needed?

The code part being changed relies on `Row`s being RDD-style tuples but breaks for `Row`s created with `kwargs`.

This change fixes SPARK-24915, creating data frames from (pyspark.sql.)Rows which failed if the order of fields in the schema differed from the (internal) order of fields in the Row and the schema is "complicated".

Complicated can be if one type of the schema is nested (as in the JIRA issue) or one field needs conversion (e.g. `DateType()`)

Without the change, the following examples fail:

*From JIRA issue:*

```
from pyspark import SparkConf, SparkContext
from pyspark.sql import SparkSession
from pyspark.sql.types import StructType, StructField, StringType, Row

conf = SparkConf().setMaster("local").setAppName("repro") 
context = SparkContext(conf=conf) 
session = SparkSession(context)
schema = StructType([
    StructField('field2', StructType([StructField('sub_field', StringType(), False)]), False),
    StructField('field1', StringType(), False),
])
data = [Row(field1="Hello", field2=Row(sub_field='world'))]
df = session.createDataFrame(data, schema=schema) # this will throw a ValueError
df.show()
```

*Date example:*

```
import datetime as dt
from pyspark.sql import Row, SparkSession
from pyspark.sql.types import StringType, DateType, StructField, StructType
spark = SparkSession.builder.master("local").getOrCreate()
schema = StructType([
    StructField("join_date", DateType(), False),
    StructField("name", StringType(),False),
])
rows = [Row(name='Alice', age=23, join_date=dt.datetime(2019,10,1,23,45,56)),]
spark.createDataFrame(rows, schema=schema).collect()
```

### Does this PR introduce any user-facing change?

This change is not introducing User-facing changes for existing, working pyspark code.

Code that previously caused exceptions b/c of the fixed bug will now work (which - technically - is a user-facing change).

### How was this patch tested?

#### Standard Tests

`ARROW_PRE_0_15_IPC_FORMAT=1 ./dev/run-tests` succeeded on my machine

Python: 3.7.4  
Spark: master (`a42d894a4090c97a90ce23b0989163909ebf548d`)  
OS: MacOS 10.14.6. 

#### New Tests

I added the following tests in module `pyspark.sql.tests.test_types`:

- `test_create_dataframe_from_rows_mixed_with_datetype`: schema with date field doesn't cause exception
- `test_create_dataframe_from_rows_with_nested_row`: schema with nested field doesn't cause exception
- `test_create_dataframe_from_tuple_rows`: Regression test: RDD-style `Row`s still work

The latter corresponds to the test case from SPARK_24915.
