### PR TITLE
[SPARK-29490][SQL] Reset 'WritableColumnVector' in 'RowToColumnarExec'

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
@@ -454,6 +454,7 @@ case class RowToColumnarExec(child: SparkPlan) extends UnaryExecNode {
 
           override def next(): ColumnarBatch = {
             cb.setNumRows(0)
+            vectors.foreach(_.reset())
             var rowCount = 0
             while (rowCount < numRows && rowIterator.hasNext) {
               val row = rowIterator.next()

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
@@ -176,7 +176,7 @@ class SparkSessionExtensionSuite extends SparkFunSuite {
     val session = SparkSession.builder()
       .master("local[1]")
       .config(COLUMN_BATCH_SIZE.key, 2)
-      .withExtensions{ extensions =>
+      .withExtensions { extensions =>
         extensions.injectColumnar(session =>
           MyColumarRule(PreRuleReplaceAddWithBrokenVersion(), MyPostRule())) }
       .getOrCreate()
@@ -189,7 +189,6 @@ class SparkSessionExtensionSuite extends SparkFunSuite {
       val input = Seq((100L), (200L), (300L))
       val data = input.toDF("vals").repartition(1)
       val df = data.selectExpr("vals + 1")
-
       val result = df.collect()
       assert(result sameElements input.map(x => Row(x + 2)))
     } finally {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Reset the `WritableColumnVector` when getting "next" ColumnarBatch in `RowToColumnarExec`
### Why are the changes needed?
When converting `Iterator[InternalRow]` to `Iterator[ColumnarBatch]`, the vectors used to create a new `ColumnarBatch` should be reset in the iterator's "next()" method.
### Does this PR introduce any user-facing change?
No
### How was this patch tested?
N/A