### PR TITLE
[SPARK-27903][SQL] Improve the error messages of SQL parser

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
@@ -306,4 +306,17 @@ case object PostProcessor extends SqlBaseBaseListener {
       token.getStopIndex - stripMargins)
     parent.addChild(new TerminalNodeImpl(f(newToken)))
   }
+
+  def throwUnbalancedParenError(right: Boolean, ctx: ParserRuleContext): Nothing = {
+    val kind = if (right) "right" else "left"
+    throw new ParseException(s"Unbalanced parentheses (extra $kind)", ctx)
+  }
+
+  override def exitDanglingLeftParen(ctx: SqlBaseParser.DanglingLeftParenContext): Unit = {
+    throwUnbalancedParenError(false, ctx)
+  }
+
+  override def exitDanglingRightParen(ctx: SqlBaseParser.DanglingRightParenContext): Unit = {
+    throwUnbalancedParenError(true, ctx)
+  }
 }


### PR DESCRIPTION
Adding grammar rules to capture extra left and extra right parens for expressions and subqueries

Creating reusable parenthesized query rule and plugging into all the places that use it (and updating AstBuilder accordingly)

Adding new test to ErrorParserSuite for asserting the new type of errors

Removing now irrelevant test from ErrorParserSuite

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Tweaking the SQL grammar file in the following ways:

1. adding parenthesized query rule and swapping that out in various places that had the same definition
1. adding rule for detecting "dangling" (extra left or extra right) parentheses for parenthesized expressions within primary expressions, and subqueries

Also updating the `AstBuilder` in accordance with these changes.  Finally, added some tests for the new unbalanced parentheses `ParseException` instances.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To help make the error messages more user friendly, and also to allow people to more quickly narrow down on unbalanced parentheses within large, complicated expressions.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

There is a new type of parse error that can be shown, but there is no net behavior change to the SQL parser.

Consider two simple queries.

1. `select (r + 1))`
2. `select ((r + 1)`


Before, the error messages would be the following, respectively.

```
org.apache.spark.sql.catalyst.parser.ParseException: 
extraneous input ')' expecting <EOF>(line 1, pos 14)

== SQL ==
select (r + 1)) 
--------------^^^
org.apache.spark.sql.catalyst.parser.ParseException: 
no viable alternative at input '((r + 1) '(line 1, pos 16)

== SQL ==
select ((r + 1) 
----------------^^^
```

After:

```
org.apache.spark.sql.catalyst.parser.ParseException: 
Unbalanced parentheses (extra right)(line 1, pos 14)

== SQL ==
select (r + 1)) 
--------------^^^

org.apache.spark.sql.catalyst.parser.ParseException: 
Unbalanced parentheses (extra left)(line 1, pos 7)

== SQL ==
select ((r + 1) 
-------^^^
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

SQL module `sbt` tests run and confirmed.