### PR TITLE
[SPARK-29267][CORE] Support rdd.countApprox should stop when 'timeout'

### DIFF
--- a/core/src/main/scala/org/apache/spark/partial/CountEvaluator.scala
+++ b/core/src/main/scala/org/apache/spark/partial/CountEvaluator.scala
@@ -45,7 +45,7 @@ private[spark] class CountEvaluator(totalOutputs: Int, confidence: Double)
   }
 }
 
-private[partial] object CountEvaluator {
+private[spark] object CountEvaluator {
 
   def bound(confidence: Double, sum: Long, p: Double): BoundedDouble = {
     // "sum" elements have been observed having scanned a fraction


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Add 2 api method for spark core, similar to rdd.countApprox
- def countApprox(confidence: Double, samplePartitions: Int)
- def countApprox(confidence: Double, samplePercent: Double)

### Why are the changes needed?

Current countApprox(timeout: Long, confidence: Double = 0.95) can not stop when timeout comes, still running at background, this is a waste of resources.

### Does this PR introduce any user-facing change?

Yes,  user can using countApprox() like:
![image](https://user-images.githubusercontent.com/39302402/66997192-93012600-f104-11e9-800f-829717318e1f.png)

### How was this patch tested?

No test case added, but testing by spark-shell, like:
![image](https://user-images.githubusercontent.com/39302402/66997410-fc813480-f104-11e9-97df-d8ed02e45f5c.png)

