### PR TITLE
[SPARK-29501][SQL] SupportsPushDownRequiredColumns should report pruned schema immediately

### DIFF
--- a/external/avro/src/main/scala/org/apache/spark/sql/v2/avro/AvroScanBuilder.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/v2/avro/AvroScanBuilder.scala
@@ -31,6 +31,6 @@ class AvroScanBuilder (
     options: CaseInsensitiveStringMap)
   extends FileScanBuilder(sparkSession, fileIndex, dataSchema) {
   override def build(): Scan = {
-    AvroScan(sparkSession, fileIndex, dataSchema, readDataSchema(), readPartitionSchema(), options)
+    AvroScan(sparkSession, fileIndex, dataSchema, readDataSchema, readPartitionSchema, options)
   }
 }

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
@@ -420,10 +420,6 @@ private[kafka010] class KafkaSourceProvider extends DataSourceRegister
   class KafkaScan(options: CaseInsensitiveStringMap) extends Scan {
     val includeHeaders = options.getBoolean(INCLUDE_HEADERS, false)
 
-    override def readSchema(): StructType = {
-      KafkaRecordToRowConverter.kafkaSchema(includeHeaders)
-    }
-
     override def toBatch(): Batch = {
       val caseInsensitiveOptions = CaseInsensitiveMap(options.asScala.toMap)
       validateBatchOptions(caseInsensitiveOptions)

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/Scan.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/Scan.java
@@ -20,13 +20,11 @@ package org.apache.spark.sql.connector.read;
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.read.streaming.ContinuousStream;
 import org.apache.spark.sql.connector.read.streaming.MicroBatchStream;
-import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCapability;
 
 /**
- * A logical representation of a data source scan. This interface is used to provide logical
- * information, like what the actual read schema is.
+ * A logical representation of a data source scan.
  * <p>
  * This logical representation is shared between batch scan, micro-batch streaming scan and
  * continuous streaming scan. Data sources must implement the corresponding methods in this
@@ -39,15 +37,9 @@ import org.apache.spark.sql.connector.catalog.TableCapability;
 public interface Scan {
 
   /**
-   * Returns the actual schema of this data source scan, which may be different from the physical
-   * schema of the underlying storage, as column pruning or other optimizations may happen.
-   */
-  StructType readSchema();
-
-  /**
    * A description string of this scan, which may includes information like: what filters are
    * configured for this scan, what's the value of some important options like path, etc. The
-   * description doesn't need to include {@link #readSchema()}, as Spark already knows it.
+   * description doesn't need to include the schema, as Spark already knows it.
    * <p>
    * By default this returns the class name of the implementation. Please override it to provide a
    * meaningful description.

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownRequiredColumns.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownRequiredColumns.java
@@ -29,14 +29,11 @@ import org.apache.spark.sql.types.StructType;
 public interface SupportsPushDownRequiredColumns extends ScanBuilder {
 
   /**
-   * Applies column pruning w.r.t. the given requiredSchema.
+   * Applies column pruning w.r.t. the given `requiredSchema`, and returns the pruned schema.
    *
    * Implementation should try its best to prune the unnecessary columns or nested fields, but it's
    * also OK to do the pruning partially, e.g., a data source may not be able to prune nested
    * fields, and only prune top-level columns.
-   *
-   * Note that, {@link Scan#readSchema()} implementation should take care of the column
-   * pruning applied here.
    */
-  void pruneColumns(StructType requiredSchema);
+  StructType pruneColumns(StructType requiredSchema);
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTable.scala
@@ -84,8 +84,6 @@ class InMemoryTable(
   }
 
   class InMemoryBatchScan(data: Array[InputPartition]) extends Scan with Batch {
-    override def readSchema(): StructType = schema
-
     override def toBatch: Batch = this
 
     override def planInputPartitions(): Array[InputPartition] = data

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
@@ -133,9 +133,6 @@ abstract class FileScan(
 
   override def toBatch: Batch = this
 
-  override def readSchema(): StructType =
-    StructType(readDataSchema.fields ++ readPartitionSchema.fields)
-
   // Returns whether the two given arrays of [[Filter]]s are equivalent.
   protected def equivalentFilters(a: Array[Filter], b: Array[Filter]): Boolean = {
     a.sortBy(_.hashCode()).sameElements(b.sortBy(_.hashCode()))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVScanBuilder.scala
@@ -33,6 +33,6 @@ case class CSVScanBuilder(
   extends FileScanBuilder(sparkSession, fileIndex, dataSchema) {
 
   override def build(): Scan = {
-    CSVScan(sparkSession, fileIndex, dataSchema, readDataSchema(), readPartitionSchema(), options)
+    CSVScan(sparkSession, fileIndex, dataSchema, readDataSchema, readPartitionSchema, options)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonScanBuilder.scala
@@ -31,6 +31,6 @@ class JsonScanBuilder (
     options: CaseInsensitiveStringMap)
   extends FileScanBuilder(sparkSession, fileIndex, dataSchema) {
   override def build(): Scan = {
-    JsonScan(sparkSession, fileIndex, dataSchema, readDataSchema(), readPartitionSchema(), options)
+    JsonScan(sparkSession, fileIndex, dataSchema, readDataSchema, readPartitionSchema, options)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScanBuilder.scala
@@ -45,7 +45,7 @@ case class OrcScanBuilder(
 
   override def build(): Scan = {
     OrcScan(sparkSession, hadoopConf, fileIndex, dataSchema,
-      readDataSchema(), readPartitionSchema(), options, pushedFilters())
+      readDataSchema, readPartitionSchema, options, pushedFilters())
   }
 
   private var _pushedFilters: Array[Filter] = Array.empty

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetScanBuilder.scala
@@ -69,7 +69,7 @@ case class ParquetScanBuilder(
   override def pushedFilters(): Array[Filter] = pushedParquetFilters
 
   override def build(): Scan = {
-    ParquetScan(sparkSession, hadoopConf, fileIndex, dataSchema, readDataSchema(),
-      readPartitionSchema(), pushedParquetFilters, options)
+    ParquetScan(sparkSession, hadoopConf, fileIndex, dataSchema, readDataSchema,
+      readPartitionSchema, pushedParquetFilters, options)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/text/TextScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/text/TextScanBuilder.scala
@@ -33,6 +33,6 @@ case class TextScanBuilder(
   extends FileScanBuilder(sparkSession, fileIndex, dataSchema) {
 
   override def build(): Scan = {
-    TextScan(sparkSession, fileIndex, readDataSchema(), readPartitionSchema(), options)
+    TextScan(sparkSession, fileIndex, readDataSchema, readPartitionSchema, options)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/memory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/memory.scala
@@ -121,8 +121,6 @@ class MemoryStreamScanBuilder(stream: MemoryStreamBase[_]) extends ScanBuilder w
 
   override def description(): String = "MemoryStreamDataSource"
 
-  override def readSchema(): StructType = stream.fullSchema()
-
   override def toMicroBatchStream(checkpointLocation: String): MicroBatchStream = {
     stream.asInstanceOf[MicroBatchStream]
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/RateStreamProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/RateStreamProvider.scala
@@ -93,8 +93,6 @@ class RateStreamTable(
   }
 
   override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = () => new Scan {
-    override def readSchema(): StructType = RateStreamProvider.SCHEMA
-
     override def toMicroBatchStream(checkpointLocation: String): MicroBatchStream =
       new RateStreamMicroBatchStream(
         rowsPerSecond, rampUpTimeSeconds, numPartitions, options, checkpointLocation)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/TextSocketSourceProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/TextSocketSourceProvider.scala
@@ -85,8 +85,6 @@ class TextSocketTable(host: String, port: Int, numPartitions: Int, includeTimest
   }
 
   override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = () => new Scan {
-    override def readSchema(): StructType = schema()
-
     override def toMicroBatchStream(checkpointLocation: String): MicroBatchStream = {
       new TextSocketMicroBatchStream(host, port, numPartitions)
     }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaAdvancedDataSourceV2.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaAdvancedDataSourceV2.java
@@ -49,12 +49,8 @@ public class JavaAdvancedDataSourceV2 implements TableProvider {
     private Filter[] filters = new Filter[0];
 
     @Override
-    public void pruneColumns(StructType requiredSchema) {
+    public StructType pruneColumns(StructType requiredSchema) {
       this.requiredSchema = requiredSchema;
-    }
-
-    @Override
-    public StructType readSchema() {
       return requiredSchema;
     }
 

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaSchemaRequiredDataSource.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaSchemaRequiredDataSource.java
@@ -27,18 +27,6 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 public class JavaSchemaRequiredDataSource implements TableProvider {
 
   class MyScanBuilder extends JavaSimpleScanBuilder {
-
-    private StructType schema;
-
-    MyScanBuilder(StructType schema) {
-      this.schema = schema;
-    }
-
-    @Override
-    public StructType readSchema() {
-      return schema;
-    }
-
     @Override
     public InputPartition[] planInputPartitions() {
       return new InputPartition[0];
@@ -56,7 +44,7 @@ public class JavaSchemaRequiredDataSource implements TableProvider {
 
       @Override
       public ScanBuilder newScanBuilder(CaseInsensitiveStringMap options) {
-        return new MyScanBuilder(schema);
+        return new MyScanBuilder();
       }
     };
   }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaSimpleScanBuilder.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaSimpleScanBuilder.java
@@ -21,7 +21,6 @@ import org.apache.spark.sql.connector.read.Batch;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
 import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.ScanBuilder;
-import org.apache.spark.sql.types.StructType;
 
 abstract class JavaSimpleScanBuilder implements ScanBuilder, Scan, Batch {
 
@@ -33,11 +32,6 @@ abstract class JavaSimpleScanBuilder implements ScanBuilder, Scan, Batch {
   @Override
   public Batch toBatch() {
     return this;
-  }
-
-  @Override
-  public StructType readSchema() {
-    return new StructType().add("i", "int").add("j", "int");
   }
 
   @Override

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
@@ -431,8 +431,6 @@ abstract class SimpleScanBuilder extends ScanBuilder
 
   override def toBatch: Batch = this
 
-  override def readSchema(): StructType = new StructType().add("i", "int").add("j", "int")
-
   override def createReaderFactory(): PartitionReaderFactory = SimpleReaderFactory
 }
 
@@ -483,11 +481,10 @@ class AdvancedScanBuilder extends ScanBuilder
   var requiredSchema = new StructType().add("i", "int").add("j", "int")
   var filters = Array.empty[Filter]
 
-  override def pruneColumns(requiredSchema: StructType): Unit = {
+  override def pruneColumns(requiredSchema: StructType): StructType = {
     this.requiredSchema = requiredSchema
+    requiredSchema
   }
-
-  override def readSchema(): StructType = requiredSchema
 
   override def pushFilters(filters: Array[Filter]): Array[Filter] = {
     val (supported, unsupported) = filters.partition {
@@ -562,8 +559,6 @@ class SchemaRequiredDataSource extends TableProvider {
 
   class MyScanBuilder(schema: StructType) extends SimpleScanBuilder {
     override def planInputPartitions(): Array[InputPartition] = Array.empty
-
-    override def readSchema(): StructType = schema
   }
 
   override def getTable(options: CaseInsensitiveStringMap): Table = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/SimpleWritableDataSource.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/SimpleWritableDataSource.scala
@@ -42,8 +42,6 @@ import org.apache.spark.util.SerializableConfiguration
  */
 class SimpleWritableDataSource extends TableProvider with SessionConfigSupport {
 
-  private val tableSchema = new StructType().add("i", "long").add("j", "long")
-
   override def keyPrefix: String = "simpleWritableDataSource"
 
   class MyScanBuilder(path: String, conf: Configuration) extends SimpleScanBuilder {
@@ -66,8 +64,6 @@ class SimpleWritableDataSource extends TableProvider with SessionConfigSupport {
       val serializableConf = new SerializableConfiguration(conf)
       new CSVReaderFactory(serializableConf)
     }
-
-    override def readSchema(): StructType = tableSchema
   }
 
   class MyWriteBuilder(path: String) extends WriteBuilder with SupportsTruncate {
@@ -137,7 +133,9 @@ class SimpleWritableDataSource extends TableProvider with SessionConfigSupport {
     private val path = options.get("path")
     private val conf = SparkContext.getActive.get.hadoopConfiguration
 
-    override def schema(): StructType = tableSchema
+    override def schema(): StructType = {
+      new StructType().add("i", "long").add("j", "long")
+    }
 
     override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
       new MyScanBuilder(new Path(path).toUri.toString, conf)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/sources/StreamingDataSourceV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/sources/StreamingDataSourceV2Suite.scala
@@ -61,7 +61,6 @@ class FakeDataStream extends MicroBatchStream with ContinuousStream {
 
 class FakeScanBuilder extends ScanBuilder with Scan {
   override def build(): Scan = this
-  override def readSchema(): StructType = StructType(Seq())
   override def toMicroBatchStream(checkpointLocation: String): MicroBatchStream = new FakeDataStream
   override def toContinuousStream(checkpointLocation: String): ContinuousStream = new FakeDataStream
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
`SupportsPushDownRequiredColumns` should return the pruned schema, instead of building the `Scan` and get `readSchema` from `Scan`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
I found this problem while developing the v1 read fallback API following https://github.com/apache/spark/pull/25348.

The problem is that, v1 read fallback API needs to rely on `ScanBuilder` to do filter pushdown and column pruning, and create a v1 `BaseRelation` at the end.

However, the `SupportsPushDownRequiredColumns` is not well designed. Spark must create the v2 `Scan` to get the result of column pruning: the pruned schema. This is not possible for data sources implementing v1 read fallback API.

By doing this change, we also make it easier to implement DS v2: users don't need to implement schema twice (in `Table` and `Scan`) if they don't support column pruning.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
existing tests