### PR TITLE
[SPARK-27900][CORE][K8s] Add `spark.driver.killOnOOMError` flag in cluster mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -787,6 +787,14 @@ private[spark] class SparkSubmit extends Logging {
     }
     sparkConf.set(SUBMIT_PYTHON_FILES, formattedPyFiles.split(",").toSeq)
 
+    // set oom error handling in cluster mode
+    if (sparkConf.get(KILL_ON_OOM_ERROR) && deployMode == CLUSTER) {
+      val driverJavaOptions = sparkConf.getOption(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS)
+        .map( _ + " ")
+        .getOrElse("") + "-XX:OnOutOfMemoryError=\"kill -9 %p\""
+      sparkConf.set(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS, driverJavaOptions)
+    }
+
     (childArgs, childClasspath, sparkConf, childMainClass)
   }
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -111,6 +111,10 @@ package object config {
       .booleanConf
       .createWithDefault(false)
 
+  private[spark] val KILL_ON_OOM_ERROR = ConfigBuilder("spark.driver.killOnOOMError")
+    .doc("Whether to kill the driver on an oom error in cluster mode.")
+    .booleanConf.createWithDefault(true)
+
   private[spark] val EVENT_LOG_ENABLED = ConfigBuilder("spark.eventLog.enabled")
     .booleanConf
     .createWithDefault(false)
@@ -1431,5 +1435,4 @@ package object config {
     .doc("The amount of memory used per page in bytes")
     .bytesConf(ByteUnit.BYTE)
     .createOptional
-
 }

--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
@@ -60,11 +60,24 @@ if ! [ -z ${HADOOP_CONF_DIR+x} ]; then
   SPARK_CLASSPATH="$HADOOP_CONF_DIR:$SPARK_CLASSPATH";
 fi
 
+DRIVER_VERBOSE=${DRIVER_VERBOSE:-false}
+
+function get_verbose_flag()
+{
+  if [[ $DRIVER_VERBOSE == "true" ]]; then
+    echo "--verbose"
+  else
+    echo ""
+  fi
+}
+
 case "$1" in
   driver)
     shift 1
+    VERBOSE_FLAG=$(get_verbose_flag)
     CMD=(
       "$SPARK_HOME/bin/spark-submit"
+      $VERBOSE_FLAG
       --conf "spark.driver.bindAddress=$SPARK_DRIVER_BIND_ADDRESS"
       --deploy-mode client
       "$@"

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -161,13 +161,14 @@ class KubernetesSuite extends SparkFunSuite
       appResource: String = containerLocalSparkDistroExamplesJar,
       driverPodChecker: Pod => Unit = doBasicDriverPodCheck,
       executorPodChecker: Pod => Unit = doBasicExecutorPodCheck,
+      expectedLogOnCompletion: Seq[String] = Seq("Pi is roughly 3"),
       appArgs: Array[String] = Array.empty[String],
       appLocator: String = appLocator,
       isJVM: Boolean = true ): Unit = {
     runSparkApplicationAndVerifyCompletion(
       appResource,
       SPARK_PI_MAIN_CLASS,
-      Seq("Pi is roughly 3"),
+      expectedLogOnCompletion,
       appArgs,
       driverPodChecker,
       executorPodChecker,


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Adds a flag to make the driver exit in case of an oom error in cluster mode (enabled by default).
- Adds integration tests for the K8s manager.
- Adds verbose flag support within the driver's container.

### Why are the changes needed?
See for details Spark-27900. In addition, this follows the discussion here: #24796. Without this pods on K8s will keep running although Spark has failed. In addition current behavior creates a problem to the Spark Operator and any other operator as it cannot detect failure at the K8s level.

### How was this patch tested?
Manually by launching SparkPi with a large number 100000000 which leads to an oom due to the large number of tasks allocated.

```
$kubectl logs spark-pi-driver -n spark
19/10/18 09:47:02 INFO KubernetesClusterSchedulerBackend: SchedulerBackend is ready for scheduling beginning after reached minRegisteredResourcesRatio: 0.8
19/10/18 09:47:02 INFO BlockManagerMasterEndpoint: Registering block manager 172.17.0.6:33435 with 413.9 MiB RAM, BlockManagerId(2, 172.17.0.6, 33435, None)
#
# java.lang.OutOfMemoryError: Java heap space
# -XX:OnOutOfMemoryError="kill -9 %p"
#   Executing /bin/sh -c "kill -9 14"...
```
Also there are two integration tests for the K8s resource manager. Testing might be needed for the other managers.