### PR TITLE
[SPARK-21492][SQL] Fix memory leak in SortMergeJoin

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1437,6 +1437,14 @@ object SQLConf {
       .intConf
       .createWithDefault(SHUFFLE_SPILL_NUM_ELEMENTS_FORCE_SPILL_THRESHOLD.defaultValue.get)
 
+  val SORT_MERGE_JOIN_EXEC_EAGER_CLEANUP_RESOURCES =
+    buildConf("spark.sql.sortMergeJoinExec.eagerCleanupResources")
+      .internal()
+      .doc("When true, the SortMergeJoinExec will trigger all upstream resources cleanup right " +
+        "after it finishes computing.")
+      .booleanConf
+      .createWithDefault(true)
+
   val SORT_MERGE_JOIN_EXEC_BUFFER_IN_MEMORY_THRESHOLD =
     buildConf("spark.sql.sortMergeJoinExec.buffer.in.memory.threshold")
       .internal()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2432,6 +2432,9 @@ class SQLConf extends Serializable with Logging {
   def sortMergeJoinExecBufferSpillThreshold: Int =
     getConf(SORT_MERGE_JOIN_EXEC_BUFFER_SPILL_THRESHOLD)
 
+  def sortMergeJoinExecEagerCleanupResources: Boolean =
+    getConf(SORT_MERGE_JOIN_EXEC_EAGER_CLEANUP_RESOURCES)
+
   def cartesianProductExecBufferInMemoryThreshold: Int =
     getConf(CARTESIAN_PRODUCT_EXEC_BUFFER_IN_MEMORY_THRESHOLD)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1437,14 +1437,6 @@ object SQLConf {
       .intConf
       .createWithDefault(SHUFFLE_SPILL_NUM_ELEMENTS_FORCE_SPILL_THRESHOLD.defaultValue.get)
 
-  val SORT_MERGE_JOIN_EXEC_EAGER_CLEANUP_RESOURCES =
-    buildConf("spark.sql.sortMergeJoinExec.eagerCleanupResources")
-      .internal()
-      .doc("When true, the SortMergeJoinExec will trigger all upstream resources cleanup right " +
-        "after it finishes computing.")
-      .booleanConf
-      .createWithDefault(true)
-
   val SORT_MERGE_JOIN_EXEC_BUFFER_IN_MEMORY_THRESHOLD =
     buildConf("spark.sql.sortMergeJoinExec.buffer.in.memory.threshold")
       .internal()
@@ -2431,9 +2423,6 @@ class SQLConf extends Serializable with Logging {
 
   def sortMergeJoinExecBufferSpillThreshold: Int =
     getConf(SORT_MERGE_JOIN_EXEC_BUFFER_SPILL_THRESHOLD)
-
-  def sortMergeJoinExecEagerCleanupResources: Boolean =
-    getConf(SORT_MERGE_JOIN_EXEC_EAGER_CLEANUP_RESOURCES)
 
   def cartesianProductExecBufferInMemoryThreshold: Int =
     getConf(CARTESIAN_PRODUCT_EXEC_BUFFER_IN_MEMORY_THRESHOLD)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
@@ -135,7 +135,7 @@ case class SortExec(
   // Name of sorter variable used in codegen.
   private var sorterVariable: String = _
 
-  override protected[sql] def doProduce(ctx: CodegenContext): String = {
+  override protected def doProduce(ctx: CodegenContext): String = {
     val needToSort =
       ctx.addMutableState(CodeGenerator.JAVA_BOOLEAN, "needToSort", v => s"$v = true;")
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
@@ -71,7 +71,6 @@ case class SortExec(
    * should make it public.
    */
   def createSorter(): UnsafeExternalRowSorter = {
-    assert(rowSorter == null)
     val ordering = newOrdering(sortOrder, output)
 
     // The comparator for comparing prefix

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
@@ -62,6 +62,14 @@ case class SortExec(
     "peakMemory" -> SQLMetrics.createSizeMetric(sparkContext, "peak memory"),
     "spillSize" -> SQLMetrics.createSizeMetric(sparkContext, "spill size"))
 
+  private[sql] var rowSorter: UnsafeExternalRowSorter = _
+
+  /**
+   * This method gets invoked only once for each SortExec instance to initialize an
+   * UnsafeExternalRowSorter, both `plan.execute` and code generation are using it.
+   * In the code generation code path, we need to call this function outside the class so we
+   * should make it public.
+   */
   def createSorter(): UnsafeExternalRowSorter = {
     val ordering = newOrdering(sortOrder, output)
 
@@ -87,13 +95,13 @@ case class SortExec(
     }
 
     val pageSize = SparkEnv.get.memoryManager.pageSizeBytes
-    val sorter = UnsafeExternalRowSorter.create(
+    rowSorter = UnsafeExternalRowSorter.create(
       schema, ordering, prefixComparator, prefixComputer, pageSize, canUseRadixSort)
 
     if (testSpillFrequency > 0) {
-      sorter.setTestSpillFrequency(testSpillFrequency)
+      rowSorter.setTestSpillFrequency(testSpillFrequency)
     }
-    sorter
+    rowSorter
   }
 
   protected override def doExecute(): RDD[InternalRow] = {
@@ -127,7 +135,7 @@ case class SortExec(
   // Name of sorter variable used in codegen.
   private var sorterVariable: String = _
 
-  override protected def doProduce(ctx: CodegenContext): String = {
+  override protected[sql] def doProduce(ctx: CodegenContext): String = {
     val needToSort =
       ctx.addMutableState(CodeGenerator.JAVA_BOOLEAN, "needToSort", v => s"$v = true;")
 
@@ -180,5 +188,18 @@ case class SortExec(
        |${row.code}
        |$sorterVariable.insertRow((UnsafeRow)${row.value});
      """.stripMargin
+  }
+
+  /**
+   * In SortExec, we overwrites cleanupResources to close UnsafeExternalRowSorter.
+   */
+  override protected[sql] def cleanupResources(): Unit = {
+    super.cleanupResources()
+    if (rowSorter != null) {
+      // There's possible for rowSorter is null here, for example, in the scenario of empty
+      // iterator in the current task, the downstream physical node(like SortMergeJoinExec) will
+      // trigger cleanupResources before rowSorter initialized in createSorter.
+      rowSorter.cleanupResources()
+    }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
@@ -71,6 +71,7 @@ case class SortExec(
    * should make it public.
    */
   def createSorter(): UnsafeExternalRowSorter = {
+    assert(rowSorter == null)
     val ordering = newOrdering(sortOrder, output)
 
     // The comparator for comparing prefix
@@ -194,12 +195,12 @@ case class SortExec(
    * In SortExec, we overwrites cleanupResources to close UnsafeExternalRowSorter.
    */
   override protected[sql] def cleanupResources(): Unit = {
-    super.cleanupResources()
     if (rowSorter != null) {
       // There's possible for rowSorter is null here, for example, in the scenario of empty
       // iterator in the current task, the downstream physical node(like SortMergeJoinExec) will
       // trigger cleanupResources before rowSorter initialized in createSorter.
       rowSorter.cleanupResources()
     }
+    super.cleanupResources()
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -507,6 +507,15 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
     }
     newOrdering(order, Seq.empty)
   }
+
+  /**
+   * Cleans up the resources used by the physical operator (if any). In general, all the resources
+   * should be cleaned up when the task finishes but operators like SortMergeJoinExec and LimitExec
+   * may want eager cleanup to free up tight resources (e.g., memory).
+   */
+  protected[sql] def cleanupResources(): Unit = {
+    children.foreach(_.cleanupResources())
+  }
 }
 
 trait LeafExecNode extends SparkPlan {

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1049,7 +1049,7 @@ class JoinWithResourceCleanSuite extends JoinSuite with BeforeAndAfterAll {
   import testImplicits._
   import scala.collection.mutable.ArrayBuffer
 
-  private def checkCleanupResourceTriggered(plan: SparkPlan) : ArrayBuffer[SortExec] = {
+  private def checkCleanupResourceTriggered(plan: SparkPlan): ArrayBuffer[SortExec] = {
     // Check cleanupResources are finally triggered in SortExec node
     val sorts = new ArrayBuffer[SortExec]()
     plan.foreachUp {

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -20,11 +20,9 @@ package org.apache.spark.sql
 import java.util.Locale
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 
-import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
-import org.scalatest.BeforeAndAfterAll
 
 import org.apache.spark.TestUtils.{assertNotSpilled, assertSpilled}
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -40,6 +38,27 @@ import org.apache.spark.sql.types.StructType
 
 class JoinSuite extends QueryTest with SharedSparkSession {
   import testImplicits._
+
+  private def checkCleanupResourceTriggered(plan: SparkPlan): ArrayBuffer[SortExec] = {
+    // SPARK-21492: Check cleanupResources are finally triggered in SortExec node for every
+    // test case
+    val sorts = new ArrayBuffer[SortExec]()
+    plan.foreachUp {
+      case s: SortExec => sorts += s
+      case _ =>
+    }
+    sorts.foreach { sort =>
+      val sortExec = spy(sort)
+      verify(sortExec, atLeastOnce).cleanupResources()
+      verify(sortExec.rowSorter, atLeastOnce).cleanupResources()
+    }
+    sorts
+  }
+
+  override protected def checkAnswer(df: => DataFrame, rows: Seq[Row]): Unit = {
+    checkCleanupResourceTriggered(df.queryExecution.sparkPlan)
+    super.checkAnswer(df, rows)
+  }
 
   setupTestData()
 
@@ -1043,50 +1062,8 @@ class JoinSuite extends QueryTest with SharedSparkSession {
 
     checkAnswer(df, Row(1, 2, 1, 2) :: Nil)
   }
-}
 
-class JoinWithResourceCleanSuite extends JoinSuite with BeforeAndAfterAll {
-  import testImplicits._
-  import scala.collection.mutable.ArrayBuffer
-
-  private def checkCleanupResourceTriggered(plan: SparkPlan): ArrayBuffer[SortExec] = {
-    // Check cleanupResources are finally triggered in SortExec node
-    val sorts = new ArrayBuffer[SortExec]()
-    plan.foreachUp {
-      case s: SortExec => sorts += s
-      case _ =>
-    }
-    sorts.foreach { sort =>
-      val sortExec = spy(sort)
-      verify(sortExec, atLeastOnce).cleanupResources()
-      verify(sortExec.rowSorter, atLeastOnce).cleanupResources()
-    }
-    sorts
-  }
-
-  override protected def checkAnswer(df: => DataFrame, rows: Seq[Row]): Unit = {
-    checkCleanupResourceTriggered(df.queryExecution.sparkPlan)
-    super.checkAnswer(df, rows)
-  }
-
-  test("cleanupResource with code generation") {
-    withSQLConf(
-      SQLConf.SHUFFLE_PARTITIONS.key -> "1",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
-      val df1 = spark.range(0, 10, 1, 2)
-      val df2 = spark.range(10).select($"id".as("b1"), (- $"id").as("b2"))
-      val res = df1.join(df2, $"id" === $"b1" && $"id" === $"b2").select($"b1", $"b2", $"id")
-
-      val sorts = checkCleanupResourceTriggered(res.queryExecution.sparkPlan)
-      // Make sure SortExec did the code generation
-      sorts.foreach { sort =>
-        verify(spy(sort), atLeastOnce).doProduce(any())
-      }
-      checkAnswer(res, Row(0, 0, 0))
-    }
-  }
-
-  test("cleanupResource without code generation") {
+  test("SPARK-21492: cleanupResource without code generation") {
     withSQLConf(
       SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false",
       SQLConf.SHUFFLE_PARTITIONS.key -> "1",

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.types.StructType
 class JoinSuite extends QueryTest with SharedSparkSession {
   import testImplicits._
 
-  private def checkCleanupResourceTriggered(plan: SparkPlan): ArrayBuffer[SortExec] = {
+  private def attachCleanupResourceChecker(plan: SparkPlan): Unit = {
     // SPARK-21492: Check cleanupResources are finally triggered in SortExec node for every
     // test case
     val sorts = new ArrayBuffer[SortExec]()
@@ -52,11 +52,10 @@ class JoinSuite extends QueryTest with SharedSparkSession {
       verify(sortExec, atLeastOnce).cleanupResources()
       verify(sortExec.rowSorter, atLeastOnce).cleanupResources()
     }
-    sorts
   }
 
   override protected def checkAnswer(df: => DataFrame, rows: Seq[Row]): Unit = {
-    checkCleanupResourceTriggered(df.queryExecution.sparkPlan)
+    attachCleanupResourceChecker(df.queryExecution.sparkPlan)
     super.checkAnswer(df, rows)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1064,7 +1064,7 @@ class JoinWithResourceCleanSuite extends JoinSuite with BeforeAndAfterAll {
     sorts
   }
 
-  override def checkAnswer(df: => DataFrame, rows: Seq[Row]): Unit = {
+  override protected def checkAnswer(df: => DataFrame, rows: Seq[Row]): Unit = {
     withSQLConf(
       SQLConf.SORT_MERGE_JOIN_EXEC_EAGER_CLEANUP_RESOURCES.key -> "true") {
       checkCleanupResourceTriggered(df.queryExecution.sparkPlan)


### PR DESCRIPTION
### What changes were proposed in this pull request?
We shall have a new mechanism that the downstream operators may notify its parents that they may release the output data stream. In this PR, we implement the mechanism as below:
- Add function named `cleanupResources` in SparkPlan, which default call children's `cleanupResources` function, the operator which need a resource cleanup should rewrite this with the self cleanup and also call `super.cleanupResources`, like SortExec in this PR.
- Add logic support on the trigger side, in this PR is SortMergeJoinExec, which make sure and call the `cleanupResources` to do the cleanup job for all its upstream(children) operator.

### Why are the changes needed?
Bugfix for SortMergeJoin memory leak, and implement a general framework for SparkPlan resource cleanup.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
UT: Add new test suite JoinWithResourceCleanSuite to check both standard and code generation scenario.

Integrate Test: Test with driver/executor default memory set 1g, local mode 10 thread. The below test(thanks @taosaildrone for providing this test  [here](https://github.com/apache/spark/pull/23762#issuecomment-463303175)) will pass with this PR.

```
from pyspark.sql.functions import rand, col

spark.conf.set("spark.sql.join.preferSortMergeJoin", "true")
spark.conf.set("spark.sql.autoBroadcastJoinThreshold", -1)
# spark.conf.set("spark.sql.sortMergeJoinExec.eagerCleanupResources", "true")

r1 = spark.range(1, 1001).select(col("id").alias("timestamp1"))
r1 = r1.withColumn('value', rand())
r2 = spark.range(1000, 1001).select(col("id").alias("timestamp2"))
r2 = r2.withColumn('value2', rand())
joined = r1.join(r2, r1.timestamp1 == r2.timestamp2, "inner")
joined = joined.coalesce(1)
joined.explain()
joined.show()
```
