### PR TITLE
[SPARK-29524][SQL] Support unordered interval units in casting from strings

### DIFF
--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CalendarIntervalSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CalendarIntervalSuite.java
@@ -113,7 +113,7 @@ public class CalendarIntervalSuite {
       }
     }
 
-    for (String input : new String[]{"interval", "interval1 day", "foo", "foo 1 day"}) {
+    for (String input : new String[]{"interval", "interval1 day", "foo", "foo 1 day", "1 dday"}) {
       try {
         fromCaseInsensitiveString(input);
         fail("Expected to throw an exception for the invalid input");
@@ -122,7 +122,7 @@ public class CalendarIntervalSuite {
         if (input.trim().equalsIgnoreCase("interval")) {
           assertTrue(msg.contains("Interval string must have time units"));
         } else {
-          assertTrue(msg.contains("Invalid interval:"));
+          assertTrue(msg.contains("Invalid interval"));
         }
       }
     }
@@ -296,5 +296,28 @@ public class CalendarIntervalSuite {
 
     assertNull(fromString("INTERVAL"));
     assertNull(fromString("  Interval "));
+  }
+
+  @Test
+  public void uniqueUnitTest() {
+    String[] inputs = new String[]{
+      "1 year 2 years",
+      "2 months 1 month",
+      "interval 1 month 2 weeks 1 day 1 week",
+      "interval 1 day 2 weeks 3 days",
+      " 1 hour 1 hour",
+      "6 minutes 1 Minute ",
+      "7 SECONDS 1 Second",
+      "3 MilliSECONDS 1 MilliSecond",
+      "8 microseconds 10 MICROSECONDS"
+    };
+    for (String input : inputs) {
+      try {
+        fromCaseInsensitiveString(input);
+        fail("Expected to throw an exception for the invalid input");
+      } catch (IllegalArgumentException e) {
+        assertTrue(e.getMessage().contains("Interval units must be unique"));
+      }
+    }
   }
 }

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CalendarIntervalSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CalendarIntervalSuite.java
@@ -320,4 +320,20 @@ public class CalendarIntervalSuite {
       }
     }
   }
+
+  @Test
+  public void unorderedUnitsTest() {
+    Arrays.asList(
+      "interval   23   month -5  years  ",
+      "23   month  -5  years").forEach(input ->
+      assertEquals(fromString(input), new CalendarInterval(-5 * 12 + 23, 0))
+    );
+    Arrays.asList(
+      "interval 1 microsecond 2 milliseconds 3 seconds 4 minutes 5 hours",
+      "1 microsecond 2 milliseconds 3 seconds 4 minutes 5 hours",
+      "1 microsecond 5 hours 2 milliseconds 4 minutes 3 seconds ").forEach(input ->
+      assertEquals(fromString(input),
+        fromString("5 hours 4 minutes 3 seconds 2 milliseconds 1 microseconds"))
+    );
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to replace existing implementation of `CalendarInterval`.`fromCaseInsensitiveString` based on a regexp by another implementation using finite state machine. The existing regex assumes particular order of interval units from `YEAR` to `MICROSECOND`. Modification of the regexp becomes very hard to support new features.

### Why are the changes needed?
- This improves Spark SQL UX by allowing users to specify interval units in any order
- Existing regex is hard to extend
- To maintain feature parity with PostgreSQL

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
- By existing tests in `CalendarIntervalSuite`
- Add new test for invalid unit `dday`
- By new tests for uniqueness and unordered interval units in `CalendarIntervalSuite`
