### PR TITLE
[SPARK-29514][SQL] Add string function support for string_to_array

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -17,13 +17,13 @@
 
 package org.apache.spark.unsafe.types;
 
-import javax.annotation.Nonnull;
 import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoSerializable;

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -17,13 +17,13 @@
 
 package org.apache.spark.unsafe.types;
 
+import javax.annotation.Nonnull;
 import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
-import javax.annotation.Nonnull;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoSerializable;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -382,6 +382,7 @@ object FunctionRegistry {
     expression[XPathLong]("xpath_long"),
     expression[XPathShort]("xpath_short"),
     expression[XPathString]("xpath_string"),
+    expression[StringToArray]("string_to_array"),
 
     // datetime functions
     expression[AddMonths]("add_months"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
@@ -484,7 +484,7 @@ case class StringToMap(text: Expression, pairDelim: Expression, keyValueDelim: E
   examples = """
     Examples:
       > SELECT _FUNC_('xx~^~yy~^~zz~^~', '~^~', 'yy');
-       [xx,null,zz,""]
+       ["xx",null,"zz",""]
   """, since = "3.0.0")
 case class StringToArray(text: Expression, delimiter: Expression, replaced: Expression)
   extends TernaryExpression with CodegenFallback with ExpectsInputTypes {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
@@ -484,7 +484,7 @@ case class StringToMap(text: Expression, pairDelim: Expression, keyValueDelim: E
   examples = """
     Examples:
       > SELECT _FUNC_('xx~^~yy~^~zz~^~', '~^~', 'yy');
-       [xx,NULL,zz,""]
+       [xx,null,zz,""]
   """, since = "3.0.0")
 case class StringToArray(text: Expression, delimiter: Expression, replaced: Expression)
   extends TernaryExpression with CodegenFallback with ExpectsInputTypes {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
@@ -479,13 +479,13 @@ case class StringToMap(text: Expression, pairDelim: Expression, keyValueDelim: E
 }
 
 @ExpressionDescription(
-  usage = "_FUNC_(text, delimiter [, null_string]) - splits string into array elements using" +
+  usage = "_FUNC_(text, delimiter [, replaced]) - splits string into array elements using" +
     " supplied delimiter and optional null string",
   examples = """
     Examples:
       > SELECT _FUNC_('xx~^~yy~^~zz~^~', '~^~', 'yy');
        [xx,NULL,zz,""]
-  """)
+  """, since = "3.0.0")
 case class StringToArray(text: Expression, delimiter: Expression, replaced: Expression)
   extends TernaryExpression with CodegenFallback with ExpectsInputTypes {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
@@ -530,4 +530,33 @@ class StringFunctionsSuite extends QueryTest with SharedSparkSession {
     )
 
   }
+
+  test("string_to_array function") {
+    val df1 = Seq("xx~^~yy~^~zz~^~").toDF("a")
+
+    checkAnswer(
+      df1.selectExpr("string_to_array(a, '~^~', 'yy')"),
+      Seq(Row(Seq("xx", null, "zz", "")))
+    )
+    checkAnswer(
+      df1.selectExpr("string_to_array(a, '~^~')"),
+      Seq(Row(Seq("xx", "yy", "zz", "")))
+    )
+
+    checkAnswer(
+      df1.selectExpr("string_to_array(a, '~^~', '.*')"),
+      Seq(Row(Seq("xx", "yy", "zz", "")))
+    )
+
+    checkAnswer(
+      df1.selectExpr("string_to_array(a, null, 'y')"),
+      Seq(Row(Seq("x", "x", "~", "^", "~", null, null, "~", "^", "~", "z", "z", "~", "^", "~")))
+    )
+
+    val df2 = Seq(null.asInstanceOf[String]).toDF("a")
+    checkAnswer(df2.selectExpr("string_to_array(a, ',')"), Seq(Row(null)))
+
+    val df3 = Seq("").toDF("a")
+    checkAnswer(df3.selectExpr("string_to_array(a, ',')"), Seq(Row(Seq(""))))
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

string_to_array(text, text [, text]) | text[] | splits string into array elements using supplied delimiter and optional null string | `string_to_array('xx~^~yy~^~zz', '~^~', 'yy')` | {xx,NULL,zz}
-- | -- | -- | -- | --


_FUNC_(text, delimiter [, replaced]) - splits string into array elements using supplied delimiter and optional null string
arguments：
   text - the original string 
   delimiter - string literal or regex
   replaced - string literal or regex

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

supported by PostgreSQL

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

add a string function

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

add ut

```sql
postgres=# select string_to_array(' ', '~.~');
 string_to_array
-----------------
 {" "}
(1 row)

postgres=# select string_to_array('xx~^~yy~^~zz~^~', '~^~', 'yy');
 string_to_array
-----------------
 {xx,NULL,zz,""}
(1 row)

postgres=# select string_to_array('xx~^~yy~^~zz~^~', '.*', 'yy');
  string_to_array
-------------------
 {xx~^~yy~^~zz~^~}
(1 row)

postgres=# select string_to_array('xx~^~yy~^~zz~^~', '~^~', '.*');
 string_to_array
-----------------
 {xx,yy,zz,""}
(1 row)

postgres=# select string_to_array(null, '~^~', '.*');
 string_to_array
-----------------

(1 row)

postgres=# select string_to_array(null, null, '.*');
 string_to_array
-----------------

(1 row)

postgres=# select string_to_array('xx~^~yy~^~zz~^~', null);
         string_to_array
---------------------------------
 {x,x,~,^,~,y,y,~,^,~,z,z,~,^,~}
(1 row)
```
