### PR TITLE
[SPARK-29535][SQL] ADD some aggregate functions for Column in RelationalGroupedDataset.scala

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -248,6 +248,10 @@ class RelationalGroupedDataset protected[sql](
     aggregateNumericColumns(colNames : _*)(Average)
   }
 
+  def mean(col: Column, cols: Column*): DataFrame = {
+    mean(col.toString +: cols.map(col => col.toString) : _*)
+  }
+
   /**
    * Compute the max value for each numeric columns for each group.
    * The resulting `DataFrame` will also contain the grouping columns.
@@ -258,6 +262,10 @@ class RelationalGroupedDataset protected[sql](
   @scala.annotation.varargs
   def max(colNames: String*): DataFrame = {
     aggregateNumericColumns(colNames : _*)(Max)
+  }
+
+  def max(col: Column, cols: Column*): DataFrame = {
+    max(col.toString +: cols.map(col => col.toString) : _*)
   }
 
   /**
@@ -272,6 +280,10 @@ class RelationalGroupedDataset protected[sql](
     aggregateNumericColumns(colNames : _*)(Average)
   }
 
+  def avg(col: Column, cols: Column*): DataFrame = {
+    avg(col.toString +: cols.map(col => col.toString) : _*)
+  }
+
   /**
    * Compute the min value for each numeric column for each group.
    * The resulting `DataFrame` will also contain the grouping columns.
@@ -284,6 +296,10 @@ class RelationalGroupedDataset protected[sql](
     aggregateNumericColumns(colNames : _*)(Min)
   }
 
+  def min(col: Column, cols: Column*): DataFrame = {
+    min(col.toString +: cols.map(col => col.toString) : _*)
+  }
+
   /**
    * Compute the sum for each numeric columns for each group.
    * The resulting `DataFrame` will also contain the grouping columns.
@@ -294,6 +310,10 @@ class RelationalGroupedDataset protected[sql](
   @scala.annotation.varargs
   def sum(colNames: String*): DataFrame = {
     aggregateNumericColumns(colNames : _*)(Sum)
+  }
+
+  def sum(col: Column, cols: Column*): DataFrame = {
+    sum(col.toString +: cols.map(col => col.toString) : _*)
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->Add five aggregation functions with Column type parameters.
`mean(Column, Column*)`
`max(Column, Column*)`
`avg(Column, Column*)`
`min(Column, Column*)`
`sum(Column, Column*)`


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->If we want pass Column type parameters to some aggregation functions with agg(), but it's  redundant.
`df.groupBy("_c0").agg(max($"_c1"))`

Other aggregation functions such as pivot() can use Column arguments, but these aggregation functions can't use it.
`df.groupBy("_c0").max($"_c1")`

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->Yes. 
We will be able to pass Column type parameters to aggregation functions(mean, max, avg, min, sum) without agg().
`df.groupBy("_c0").max($"_c1")`



### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->Manually tested. 
