### PR TITLE
[SPARK-29537][SQL] throw exception when user defined a wrong base path

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
@@ -221,6 +221,12 @@ abstract class PartitioningAwareFileIndex(
         if (!fs.isDirectory(userDefinedBasePath)) {
           throw new IllegalArgumentException(s"Option '$BASE_PATH_PARAM' must be a directory")
         }
+        rootPaths.find(!_.toString.startsWith(userDefinedBasePath.toString)) match {
+          case Some(rp) => throw new IllegalArgumentException(
+            s"Wrong basePath $userDefinedBasePath for the root path: $rp")
+
+          case None => // valid basePath
+        }
         Set(fs.makeQualified(userDefinedBasePath))
 
       case None =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
@@ -221,7 +221,7 @@ abstract class PartitioningAwareFileIndex(
         if (!fs.isDirectory(userDefinedBasePath)) {
           throw new IllegalArgumentException(s"Option '$BASE_PATH_PARAM' must be a directory")
         }
-        rootPaths.find(!_.toString.startsWith(userDefinedBasePath.toString)) match {
+        rootPaths.find(!_.toUri.getPath.startsWith(userDefinedBasePath.toUri.getPath)) match {
           case Some(rp) => throw new IllegalArgumentException(
             s"Wrong basePath $userDefinedBasePath for the root path: $rp")
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
@@ -221,7 +221,11 @@ abstract class PartitioningAwareFileIndex(
         if (!fs.isDirectory(userDefinedBasePath)) {
           throw new IllegalArgumentException(s"Option '$BASE_PATH_PARAM' must be a directory")
         }
-        rootPaths.find(!_.toUri.getPath.startsWith(userDefinedBasePath.toUri.getPath)) match {
+        def qualifiedPath(path: Path): Path = path.makeQualified(fs.getUri, fs.getWorkingDirectory)
+
+        val qualifiedBasePath = qualifiedPath(userDefinedBasePath)
+        rootPaths.find(p => !qualifiedPath(p).toString.
+          startsWith(qualifiedBasePath.toString)) match {
           case Some(rp) => throw new IllegalArgumentException(
             s"Wrong basePath $userDefinedBasePath for the root path: $rp")
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
@@ -224,13 +224,12 @@ abstract class PartitioningAwareFileIndex(
         def qualifiedPath(path: Path): Path = path.makeQualified(fs.getUri, fs.getWorkingDirectory)
 
         val qualifiedBasePath = qualifiedPath(userDefinedBasePath)
-        rootPaths.find(p => !qualifiedPath(p).toString.
-          startsWith(qualifiedBasePath.toString)) match {
-          case Some(rp) => throw new IllegalArgumentException(
-            s"Wrong basePath $userDefinedBasePath for the root path: $rp")
-
-          case None => // valid basePath
-        }
+        rootPaths
+          .find(p => !qualifiedPath(p).toString.startsWith(qualifiedBasePath.toString))
+          .foreach { rp =>
+            throw new IllegalArgumentException(
+              s"Wrong basePath $userDefinedBasePath for the root path: $rp")
+          }
         Set(fs.makeQualified(userDefinedBasePath))
 
       case None =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
@@ -221,16 +221,15 @@ abstract class PartitioningAwareFileIndex(
         if (!fs.isDirectory(userDefinedBasePath)) {
           throw new IllegalArgumentException(s"Option '$BASE_PATH_PARAM' must be a directory")
         }
-        def qualifiedPath(path: Path): String = fs.makeQualified(path).toString
-
-        val qualifiedBasePath = qualifiedPath(userDefinedBasePath)
+        val qualifiedBasePath = fs.makeQualified(userDefinedBasePath)
+        val qualifiedBasePathStr = qualifiedBasePath.toString
         rootPaths
-          .find(p => !qualifiedPath(p).startsWith(qualifiedBasePath))
+          .find(!fs.makeQualified(_).toString.startsWith(qualifiedBasePathStr))
           .foreach { rp =>
             throw new IllegalArgumentException(
               s"Wrong basePath $userDefinedBasePath for the root path: $rp")
           }
-        Set(new Path(qualifiedBasePath))
+        Set(qualifiedBasePath)
 
       case None =>
         rootPaths.map { path =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
@@ -221,16 +221,16 @@ abstract class PartitioningAwareFileIndex(
         if (!fs.isDirectory(userDefinedBasePath)) {
           throw new IllegalArgumentException(s"Option '$BASE_PATH_PARAM' must be a directory")
         }
-        def qualifiedPath(path: Path): Path = path.makeQualified(fs.getUri, fs.getWorkingDirectory)
+        def qualifiedPath(path: Path): String = fs.makeQualified(path).toString
 
         val qualifiedBasePath = qualifiedPath(userDefinedBasePath)
         rootPaths
-          .find(p => !qualifiedPath(p).toString.startsWith(qualifiedBasePath.toString))
+          .find(p => !qualifiedPath(p).startsWith(qualifiedBasePath))
           .foreach { rp =>
             throw new IllegalArgumentException(
               s"Wrong basePath $userDefinedBasePath for the root path: $rp")
           }
-        Set(fs.makeQualified(userDefinedBasePath))
+        Set(new Path(qualifiedBasePath))
 
       case None =>
         rootPaths.map { path =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -360,6 +360,7 @@ class FileIndexSuite extends SharedSparkSession {
       stringToFile(file, "text")
       val path = new Path(dir.getCanonicalPath)
       val wrongBasePath = new File(dir, "unknown")
+      // basePath must be a directory
       wrongBasePath.mkdir()
       val parameters = Map("basePath" -> wrongBasePath.getCanonicalPath)
       val fileIndex = new InMemoryFileIndex(spark, Seq(path), parameters, None)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -363,10 +363,11 @@ class FileIndexSuite extends SharedSparkSession {
       wrongBasePath.mkdir()
       val parameters = Map("basePath" -> wrongBasePath.getCanonicalPath)
       val fileIndex = new InMemoryFileIndex(spark, Seq(path), parameters, None)
-      intercept[IllegalArgumentException] {
+      val msg = intercept[IllegalArgumentException] {
         // trigger inferPartitioning()
         fileIndex.partitionSpec()
-      }
+      }.getMessage
+      assert(msg === s"Wrong basePath ${wrongBasePath.getCanonicalPath} for the root path: $path")
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

When user defined a base path which is not an ancestor directory for all the input paths,
throw exception immediately.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Assuming that we have a DataFrame[c1, c2] be written out in parquet and partitioned by c1.

When using `spark.read.parquet("/path/to/data/c1=1")` to read the data, we'll have a DataFrame with column c2 only.

But if we use `spark.read.option("basePath", "/path/from").parquet("/path/to/data/c1=1")` to
read the data, we'll have a DataFrame with column c1 and c2.

This's happens because a wrong base path does not actually work in `parsePartition()`, so paring would continue until it reaches a directory without "=".

And I think the result of the second read way doesn't make sense.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

Yes, with this change, user would hit `IllegalArgumentException ` when given a wrong base path while previous behavior doesn't.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added UT.
