### PR TITLE
[SPARK-29577][MLLIB] Implement p-value simulation and unit tests for chi2 test

### DIFF
--- a/mllib/pom.xml
+++ b/mllib/pom.xml
@@ -130,6 +130,11 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-tags_${scala.binary.version}</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.tdunning</groupId>
+      <artifactId>t-digest</artifactId>
+      <version>3.2</version>
+    </dependency>
 
     <!--
       This spark-tags test-dep is needed even though it isn't used in this module, otherwise testing-cmds that exclude

--- a/mllib/src/test/scala/org/apache/spark/mllib/stat/test/ChiSqTestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/stat/test/ChiSqTestSuite.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.stat.test
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.internal.Logging
+import org.apache.spark.mllib.linalg.{Vector, Vectors}
+import org.apache.spark.mllib.util.MLlibTestSparkContext
+
+
+class ChiSqTestSuite extends SparkFunSuite with MLlibTestSparkContext with Logging {
+  /*
+   Generate test data for e.g. TWO categories
+
+   group | population | good_sample | bad_sample
+   A     | 10000      | 1000        | 5000
+   B     | 50000      | 5000        | 2000
+
+   */
+  val expected: Vector = Vectors.dense(Array[Double](10000, 50000))
+  val observedGood: Vector = Vectors.dense(Array[Double](1000, 5000))
+  val observedBad: Vector = Vectors.dense(Array[Double](5000, 2000))
+
+  test("theoretical chi2 test") {
+    val passResult: ChiSqTestResult =
+      ChiSqTest.chiSquared(observedGood, expected)
+    assert(passResult.degreesOfFreedom === 1, "degreesOfFreedom calculated correctly")
+    assert(passResult.pValue > 0.05, "pValue indicates that test passed")
+
+    val failResult: ChiSqTestResult =
+      ChiSqTest.chiSquared(observedBad, expected)
+    assert(failResult.degreesOfFreedom === 1, "degreesOfFreedom calculated correctly")
+    assert(failResult.pValue < 0.05, "pValue indicates that test failed")
+  }
+
+  test("simulated/empirical chi2 test") {
+    val passResult: ChiSqTestResult =
+      ChiSqTest.chiSquared(observedGood, expected, simulatePValue = true, numDraw = 5000)
+    assert(passResult.degreesOfFreedom === 1, "degreesOfFreedom calculated correctly")
+    assert(passResult.pValue > 0.05, "pValue indicates that test passed")
+
+    val failResult: ChiSqTestResult =
+      ChiSqTest.chiSquared(observedBad, expected, simulatePValue = true, numDraw = 5000)
+    assert(failResult.degreesOfFreedom === 1, "degreesOfFreedom calculated correctly")
+    assert(failResult.pValue < 0.05, "pValue indicates that test failed")
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR implements monte-carlo simulation of p-values for the ChiSqTest in mllib. For other implementations, see the following references:
* https://www.rdocumentation.org/packages/stats/versions/3.6.1/topics/chisq.test
* https://en.wikipedia.org/wiki/Generalized_p-value

### Why are the changes needed?
While monte-carlo simulation is a common approach to estimate p-values, a robust scalable implementation in Spark was non-trivial, so we hope others can re-use these efforts.

### Does this PR introduce any user-facing change?
We provide a new boolean parameter `simulatePValue` to the ChiSqTest so that users can request p-value simulation, and also an integer parameter `numDraw` so that users can specify the number of draws to take. The `getChi2Digest` method is also exposed in case users find value in the digest object itself which allows extraction of arbitrary quantiles, cdf, etc.

### How was this patch tested?
This PR also implements the `ChiSqTestSuite` with some tests to verify that both the ChiSqTest itself and the new p-value simulation are working correctly by evaluating that test cases expected to pass and fail a chi squared test actually work as expected. 

We ran these tests with the following results: 
```
$ build/mvn package -pl mllib -Dtest=none -DwildcardSuites=org.apache.spark.mllib.stat.test.ChiSqTestSuite
...
ChiSqTestSuite:
- theoretical chi2 test
- simulated/empirical chi2 test
Run completed in 1 minute, 22 seconds.
Total number of tests run: 2
Suites: completed 2, aborted 0
Tests: succeeded 2, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
...
[INFO] BUILD SUCCESS
```