### PR TITLE
[SPARK-29541][BUILD] Add below modules into the module list in spark-parent pom file to av…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,10 +86,12 @@
     <module>common/kvstore</module>
     <module>common/network-common</module>
     <module>common/network-shuffle</module>
+    <module>common/network-yarn</module>
     <module>common/unsafe</module>
     <module>common/tags</module>
     <module>core</module>
     <module>graphx</module>
+    <module>hadoop-cloud</module>
     <module>mllib</module>
     <module>mllib-local</module>
     <module>tools</module>
@@ -97,6 +99,7 @@
     <module>sql/catalyst</module>
     <module>sql/core</module>
     <module>sql/hive</module>
+    <module>sql/hive-thriftserver</module>
     <module>assembly</module>
     <module>examples</module>
     <module>repl</module>
@@ -106,9 +109,15 @@
     <module>external/kafka-0-10-assembly</module>
     <module>external/kafka-0-10-sql</module>
     <module>external/avro</module>
+    <module>external/docker-integration-tests</module>
+    <module>external/kinesis-asl-assembly</module>
+    <module>external/kinesis-asl</module>
+    <module>external/spark-ganglia-lgpl</module>
     <module>graph/api</module>
     <module>graph/cypher</module>
     <module>graph/graph</module>
+    <module>resource-managers/mesos</module>
+    <module>resource-managers/yarn</module>
     <!-- See additional modules enabled by profiles below -->
   </modules>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add below modules into the module list in spark-parent pom file : 
            common/network-yarn
            external/docker-integration-tests
            external/kinesis-asl-assembly
            external/kinesis-asl
            external/spark-ganglia-lgpl
            hadoop-cloud
            resource-managers/mesos
            resource-managers/yarn
            sql/hive-thriftserver

### Why are the changes needed?
To avoid failure when build individual module with command "mvn -pl" per spark build guide : https://spark.apache.org/docs/latest/building-spark.html#building-submodules-individually

### Does this PR introduce any user-facing change?
no

### How was this patch tested?
Tested by manually building the modules above in my local.
