### PR TITLE
[SPARK-28087][SQL] Add string function support for split_part

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -362,6 +362,7 @@ object FunctionRegistry {
     expression[SoundEx]("soundex"),
     expression[StringSpace]("space"),
     expression[StringSplit]("split"),
+    expression[SplitPart]("split_part"),
     expression[Substring]("substr"),
     expression[Substring]("substring"),
     expression[Left]("left"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
@@ -94,6 +94,21 @@ class StringFunctionsSuite extends QueryTest with SharedSparkSession {
       Row("300", "100") :: Row("400", "100") :: Row("400-400", "100") :: Nil)
   }
 
+  test("sting split_part") {
+    val df = Seq("abc~@~def~@~ghi").toDF("a")
+    checkAnswer(df.selectExpr("split_part(a, '~@~', 2)"), Seq(Row("def")))
+    checkAnswer(df.selectExpr("split_part(a, '~@~', -1)"), Seq(Row(null)))
+    checkAnswer(df.selectExpr("split_part(a, '~@~', 4)"), Seq(Row(null)))
+
+    checkAnswer(df.selectExpr("split_part(null, '~@~', 2)"), Seq(Row(null)))
+    checkAnswer(df.selectExpr("split_part(a, null, 2)"), Seq(Row(null)))
+    checkAnswer(df.selectExpr("split_part(a, '~@~', null)"), Seq(Row(null)))
+
+    val df2 = Seq("abc~.~def~@~ghi").toDF("a")
+    checkAnswer(df2.selectExpr("split_part(a, '~.~', 2)"), Seq(Row("def~@~ghi")))
+    checkAnswer(df2.selectExpr("split_part(a, '', 1)"), Seq(Row("abc~.~def~@~ghi")))
+  }
+
   test("non-matching optional group") {
     val df = Seq(Tuple1("aaaac")).toDF("s")
     checkAnswer(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


Function | Return Type | Description | Example | Result
-- | -- | -- | -- | --
split_part(string text,delimiter text, field int) | text | Split string on delimiter and return the given field (counting from one) | `split_part('abc~@~def~@~ghi', '~@~', 2)` | def

split_part(string text, delimiter text, field int) 
Arguments:
     text - the original string, results null if it is null
     delimiter - string literal, results null if it is null; results the text itself if it is empty and field=1
     field - the give field index, start from 1
 


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

https://www.postgresql.org/docs/11/functions-string.html
http://prestodb.github.io/docs/current/functions/string.html

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
add one new functions

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
add ut