### PR TITLE
[SPARK-29548][Core] Redirect system print stream to log4j and improve robustness

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -614,7 +614,8 @@ private[spark] class SparkSubmit extends Logging {
       OptionAssigner(args.supervise.toString, STANDALONE | MESOS, CLUSTER,
         confKey = DRIVER_SUPERVISE.key),
       OptionAssigner(args.ivyRepoPath, STANDALONE, CLUSTER, confKey = "spark.jars.ivy"),
-      OptionAssigner(args.redirectSystemPrintStream.toString, STANDALONE | MESOS | YARN | KUBERNETES,
+      OptionAssigner(args.redirectSystemPrintStream.toString,
+        STANDALONE | MESOS | YARN | KUBERNETES,
         ALL_DEPLOY_MODES, confKey = "spark.printstream.redirect"),
 
       // An internal option used only for spark-shell to add user jars to repl's classloader,

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -75,6 +75,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
   var principal: String = null
   var keytab: String = null
   private var dynamicAllocationEnabled: Boolean = false
+  var redirectSystemPrintStream: Boolean = false
 
   // Standalone cluster mode only
   var supervise: Boolean = false
@@ -208,6 +209,8 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
       .orNull
     dynamicAllocationEnabled =
       sparkProperties.get(DYN_ALLOCATION_ENABLED.key).exists("true".equalsIgnoreCase)
+    redirectSystemPrintStream =
+      sparkProperties.get("spark.printstream.redirect").exists("true".equalsIgnoreCase)
 
     // Global defaults. These should be keep to minimum to avoid confusing behavior.
     master = Option(master).getOrElse("local[*]")

--- a/core/src/main/scala/org/apache/spark/internal/LoggingPrintStream.scala
+++ b/core/src/main/scala/org/apache/spark/internal/LoggingPrintStream.scala
@@ -86,7 +86,7 @@ private[spark] class LoggingPrintStream(out: OutputStream) extends PrintStream(o
   }
 
   override def println(s: String) {
-    logInfo("++++Print+++" + s)
+    logInfo(s)
   }
 
   override def println(obj: Object) {

--- a/core/src/main/scala/org/apache/spark/internal/LoggingPrintStream.scala
+++ b/core/src/main/scala/org/apache/spark/internal/LoggingPrintStream.scala
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.internal
+
+import java.io.{OutputStream, PrintStream}
+
+// scalastyle:off println
+private[spark] class LoggingPrintStream(out: OutputStream) extends PrintStream(out) with Logging {
+  override def print(b: Boolean) {
+    println(b)
+  }
+
+  override def print(c: Char) {
+    println(c)
+  }
+
+  override def print(i: Int) {
+    println(i)
+  }
+
+  override def print(l: Long) {
+    println(l)
+  }
+
+  override def print(f: Float) {
+    println(f)
+  }
+
+  override def print(d: Double) {
+    println(d)
+  }
+
+  override def print(s: Array[Char]) {
+    println(s)
+  }
+
+  override def print(s: String) {
+    println(s)
+  }
+
+  override def print(obj: Object) {
+    println(obj)
+  }
+
+  override def println(b: Boolean) {
+    logInfo(String.valueOf(b))
+  }
+
+  override def println(c: Char) {
+    logInfo(String.valueOf(c))
+  }
+
+  override def println(s: Array[Char]) {
+    logInfo(String.valueOf(s))
+  }
+
+  override def println(i: Int) {
+    logInfo(String.valueOf(i))
+  }
+
+  override def println(l: Long) {
+    logInfo(String.valueOf(l))
+  }
+
+  override def println(f: Float) {
+    logInfo(String.valueOf(f))
+  }
+
+  override def println(d: Double) {
+    logInfo(String.valueOf(d))
+  }
+
+  override def println(s: String) {
+    logInfo("++++Print+++" + s)
+  }
+
+  override def println(obj: Object) {
+    logInfo(String.valueOf(obj))
+  }
+}
+// scalastyle:on println
+
+object LoggingPrintStream {
+  private val outInstance: PrintStream = new LoggingPrintStream(System.out)
+  private val errInstance: PrintStream = new LoggingPrintStream(System.err)
+
+  /**
+   * In a production environment, user behavior is highly random and uncertain.
+   * For example: Users use `System.out` or `System.err` to print information.
+   * But the system print stream may cause some trouble, such as: the disk file is too large.
+   * Redirecting the system print stream to `Log4j` can take advantage of `Log4j`'s split log.
+   */
+  def withOutSystem[A](redirect: Boolean, f: => A): A = {
+    val origErr = System.err
+    val origOut = System.out
+    try {
+      if (redirect) {
+        System.setOut(outInstance)
+        System.setErr(errInstance)
+      }
+
+      f
+    } finally {
+      if (redirect) {
+        System.setErr(origErr)
+        System.setOut(origOut)
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
### What changes were proposed in this pull request?
In a production environment, user behavior is highly random and uncertain.
For example: Users use `System.out` or `System.err` to print information.
But the system print stream may cause some trouble, such as: the disk file is too large.

In my production environment, it causes the disk to be full and let [NodeManager] works not fine.

A method of threat is to forbid the use of `System.out` or `System.err`. But unfriendly to the users.
A better method is to redirecting the system print stream to `Log4j` and Spark can take advantage of `Log4j`'s split log.


### Why are the changes needed?
Improve robustness about system `PrintStream`.


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Exists UT.
