### PR TITLE
[SPARK-29551][CORE] Fix a bug about fetch failed when an executor is lost

### DIFF
--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -510,6 +510,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     assert(initialMapStatus1.map{_.mapId}.toSet === Set(5, 6, 7))
 
     val initialMapStatus2 = mapOutputTracker.shuffleStatuses(secondShuffleId).mapStatuses
+    //  val initialMapStatus1 = mapOutputTracker.mapStatuses.get(0).get
     assert(initialMapStatus2.count(_ != null) === 3)
     assert(initialMapStatus2.map{_.location.executorId}.toSet ===
       Set("exec-hostA1", "exec-hostA2", "exec-hostB"))
@@ -536,14 +537,14 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     assert(mapStatus2(2).location.host === "hostB")
   }
 
-  test("All shuffle files on the executor should be cleaned up when executor lost " +
-    "and then causes 'fetch failed'") {
+  test("[SPARK-29551] All shuffle files on the executor should be cleaned up when " +
+    "executor lost and then causes 'fetch failed'") {
     // whether to kill Executor or not before FetchFailed
-    Seq(true, false).foreach { killExecutor => {
+    Seq(true, false).foreach { killExecutor =>
       afterEach()
       val conf = new SparkConf()
       conf.set(config.SHUFFLE_SERVICE_ENABLED.key, "true")
-      conf.set("spark.files.fetchFailure.unRegisterOutputOnHost", "false")
+      conf.set(config.UNREGISTER_OUTPUT_ON_HOST_ON_FETCH_FAILURE.key, "false")
       init(conf)
       runEvent(ExecutorAdded("exec-hostA1", "hostA"))
       runEvent(ExecutorAdded("exec-hostA2", "hostA"))
@@ -616,16 +617,15 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
       assert(mapStatus2(2).location.executorId === "exec-hostB")
       assert(mapStatus2(2).location.host === "hostB")
     }
-    }
   }
 
-  test("All shuffle files on the host should be cleaned up when host lost") {
+  test("[SPARK-29551] All shuffle files on the host should be cleaned up when host lost") {
     // whether to kill Executor or not before FetchFailed
-    Seq(true, false).foreach { killExecutor => {
+    Seq(true, false).foreach { killExecutor =>
       afterEach()
       val conf = new SparkConf()
       conf.set(config.SHUFFLE_SERVICE_ENABLED.key, "true")
-      conf.set("spark.files.fetchFailure.unRegisterOutputOnHost", "true")
+      conf.set(config.UNREGISTER_OUTPUT_ON_HOST_ON_FETCH_FAILURE.key, "true")
       init(conf)
       runEvent(ExecutorAdded("exec-hostA1", "hostA"))
       runEvent(ExecutorAdded("exec-hostA2", "hostA"))
@@ -695,7 +695,6 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
       assert(mapStatus2.count(_ != null) === 1)
       assert(mapStatus2(2).location.executorId === "exec-hostB")
       assert(mapStatus2(2).location.host === "hostB")
-    }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

When an executor lost with some reason and some things (e.g. the external shuffle service or host lost on the executor's host.) happened, and the executor loses time happens to be reduce stage fetch failed from it which is really bad, the previous only call `mapOutputTracker.unregisterMapOutput(shuffleId, mapIndex, bmAddress) ` to mark clear shuffle status for the mapper at this time , but the other mappers shuffle status on the executor are also unnavailable and the DagScheduler does Not  know that, so the reduce stages will fetch failed again when fetch them,  the unavailable shuffle status can only be resubmitted by a nest retry stage which is the regression.

As we all know that the previous will call ` mapOutputTracker.removeOutputsOnHost(host) `  to  mark clear shuffle status on the host  or `mapOutputTracker.removeOutputsOnExecutor(execId) ` to  mark clear shuffle status on the executor  when reduce stage fetches failed and the executor is active, while it does NOT nothing when the executor lost happened, which  is really bad .

So we should distinguish the failedEpoch of 'executor lost' from the fetchFailedEpoch of 'fetch failed' to solve the above problem.
 
### Why are the changes needed?

The regression  has been described above.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
Add unittests.