### PR TITLE
[WIP][SPARK-29540][SQL]Support cast StringType to DateType follow ansi

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -171,6 +171,7 @@ object Cast {
     case (_: CalendarIntervalType, StringType) => true
     case (DateType, TimestampType) => true
     case (TimestampType, DateType) => true
+    case (StringType, DateType) => true
 
     case (ArrayType(fromType, fn), ArrayType(toType, tn)) =>
       resolvableNullability(fn, tn) && canANSIStoreAssign(fromType, toType)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support cast StringType to DateType as PostgresSQL

### Why are the changes needed?
Parity feature between PostgreSQL and Spark

### Does this PR introduce any user-facing change?
Do SQL Like:
```
CREATE TABLE empsalary (                                                                                                                
    depname string,                                                                                                                     
    empno integer,                                                                                                                      
    salary int,                                                                                                                         
    enroll_date date                                                                                                                    
) USING parquet;  
INSERT INTO empsalary VALUES ('develop', 10, 5200, '2007-08-01');
```

### How was this patch tested?
Need add UT
