### PR TITLE
[SPARK-29554][SQL] Add `version` SQL function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -486,6 +486,7 @@ object FunctionRegistry {
     expression[CurrentDatabase]("current_database"),
     expression[CallMethodViaReflection]("reflect"),
     expression[CallMethodViaReflection]("java_method"),
+    expression[Version]("version"),
 
     // grouping sets
     expression[Cube]("cube"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -17,8 +17,7 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
-import java.util.UUID
-
+import org.apache.spark._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
@@ -163,4 +162,15 @@ case class Uuid(randomSeed: Option[Long] = None) extends LeafExpression with Sta
   }
 
   override def freshCopy(): Uuid = Uuid(randomSeed)
+}
+
+case class Version() extends LeafExpression with CodegenFallback {
+  override def nullable: Boolean = false
+
+  override def dataType: DataType = StringType
+
+  override def eval(input: InternalRow): Any = {
+    UTF8String.fromString(SPARK_VERSION + " " + SPARK_REVISION)
+  }
+
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -167,21 +167,13 @@ case class Uuid(randomSeed: Option[Long] = None) extends LeafExpression with Sta
 // scalastyle:off line.size.limit
 @ExpressionDescription(
   usage =
-    """_FUNC_() - Returns the Spark version. The string contains 2 fields, the first being a release or snapshot version and the second being a git revision.""".stripMargin,
-  examples = s"""
-    Examples:
-      > SELECT _FUNC_();
-       ${SPARK_VERSION + " " + SPARK_REVISION}
-  """,
+    """_FUNC_() - Returns the Spark version. The string contains 2 fields, the first being a release or snapshot version and the second being a git revision.""",
   since = """3.0.0""")
 // scalastyle:on line.size.limit
 case class Version() extends LeafExpression with CodegenFallback {
   override def nullable: Boolean = false
-
   override def dataType: DataType = StringType
-
   override def eval(input: InternalRow): Any = {
     UTF8String.fromString(SPARK_VERSION + " " + SPARK_REVISION)
   }
-
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -164,6 +164,17 @@ case class Uuid(randomSeed: Option[Long] = None) extends LeafExpression with Sta
   override def freshCopy(): Uuid = Uuid(randomSeed)
 }
 
+// scalastyle:off line.size.limit
+@ExpressionDescription(
+  usage =
+    """_FUNC_() - Returns the Spark version. The string contains 2 fields, the first being a release or snapshot version and the second being a git revision.""".stripMargin,
+  examples = s"""
+    Examples:
+      > SELECT _FUNC_();
+       ${SPARK_VERSION + " " + SPARK_REVISION}
+  """,
+  since = """3.0.0""")
+// scalastyle:on line.size.limit
 case class Version() extends LeafExpression with CodegenFallback {
   override def nullable: Boolean = false
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -166,7 +166,7 @@ case class Uuid(randomSeed: Option[Long] = None) extends LeafExpression with Sta
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = """_FUNC_() - Returns the Spark version. The string contains 2 fields, the first being a release or snapshot version and the second being a git revision.""",
+  usage = """_FUNC_() - Returns the Spark version. The string contains 2 fields, the first being a release version and the second being a git revision.""",
   since = "3.0.0")
 // scalastyle:on line.size.limit
 case class Version() extends LeafExpression with CodegenFallback {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
-import org.apache.spark._
+import org.apache.spark.{SPARK_REVISION, SPARK_VERSION_SHORT}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
@@ -166,14 +166,14 @@ case class Uuid(randomSeed: Option[Long] = None) extends LeafExpression with Sta
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage =
-    """_FUNC_() - Returns the Spark version. The string contains 2 fields, the first being a release or snapshot version and the second being a git revision.""",
-  since = """3.0.0""")
+  usage = """_FUNC_() - Returns the Spark version. The string contains 2 fields, the first being a release or snapshot version and the second being a git revision.""",
+  since = "3.0.0")
 // scalastyle:on line.size.limit
 case class Version() extends LeafExpression with CodegenFallback {
   override def nullable: Boolean = false
+  override def foldable: Boolean = true
   override def dataType: DataType = StringType
   override def eval(input: InternalRow): Any = {
-    UTF8String.fromString(SPARK_VERSION + " " + SPARK_REVISION)
+    UTF8String.fromString(SPARK_VERSION_SHORT + " " + SPARK_REVISION)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark._
+import org.apache.spark.{SPARK_REVISION, SPARK_VERSION_SHORT}
 import org.apache.spark.sql.test.SharedSparkSession
 
 class MiscFunctionsSuite extends QueryTest with SharedSparkSession {
@@ -36,7 +36,7 @@ class MiscFunctionsSuite extends QueryTest with SharedSparkSession {
   test("version") {
     checkAnswer(
       Seq("").toDF("a").selectExpr("version()"),
-      Row(SPARK_VERSION + " " + SPARK_REVISION))
+      Row(SPARK_VERSION_SHORT + " " + SPARK_REVISION))
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql
 
+import org.apache.spark._
 import org.apache.spark.sql.test.SharedSparkSession
 
 class MiscFunctionsSuite extends QueryTest with SharedSparkSession {
@@ -30,6 +31,12 @@ class MiscFunctionsSuite extends QueryTest with SharedSparkSession {
         s"reflect('$className', 'method1', a, b)",
         s"java_method('$className', 'method1', a, b)"),
       Row("m1one", "m1one"))
+  }
+
+  test("version") {
+    checkAnswer(
+      Seq("").toDF("a").selectExpr("version()"),
+      Row(SPARK_VERSION + " " + SPARK_REVISION))
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

```
hive> select version();
OK
3.1.1 rf4e0529634b6231a0072295da48af466cf2f10b7
Time taken: 2.113 seconds, Fetched: 1 row(s)
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
From hive behavior and I guess it is useful for debugging and developing etc. 

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

add a misc func

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
add ut