### PR TITLE
[SPARK-29563][SQL] CREATE TABLE LIKE should look up catalog/table like v2 commands

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -118,8 +118,8 @@ statement
         locationSpec |
         (TBLPROPERTIES tableProps=tablePropertyList))*
         (AS? query)?                                                   #createHiveTable
-    | CREATE TABLE (IF NOT EXISTS)? target=tableIdentifier
-        LIKE source=tableIdentifier locationSpec?                      #createTableLike
+    | CREATE TABLE (IF NOT EXISTS)? target=multipartIdentifier
+        LIKE source=multipartIdentifier locationSpec?                  #createTableLike
     | replaceTableHeader ('(' colTypeList ')')? tableProvider
         ((OPTIONS options=tablePropertyList) |
         (PARTITIONED BY partitioning=transformList) |

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
@@ -141,6 +141,18 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
         writeOptions = c.options.filterKeys(_ != "path"),
         ignoreIfExists = c.ifNotExists)
 
+    case CreateTableLikeStatement(
+         NonSessionCatalog(tCatalog, t), NonSessionCatalog(sCatalog, s), loc, ifNotExists ) =>
+      if (loc.nonEmpty) {
+        throw new AnalysisException("Location clause not supported for" +
+          " CREATE TABLE LIKE statement when tables are of V2 type.")
+      }
+      CreateTableLike(tCatalog.asTableCatalog,
+        t.asIdentifier,
+        sCatalog.asTableCatalog,
+        s.asIdentifier,
+        ifNotExists)
+
     case RefreshTableStatement(NonSessionCatalog(catalog, tableName)) =>
       RefreshTable(catalog.asTableCatalog, tableName.asIdentifier)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3180,4 +3180,20 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
       originalText = source(ctx.query),
       query = plan(ctx.query))
   }
+
+  /**
+   * Create a [[CreateTableLikeStatement]] logical plan.
+   *
+   * For example:
+   * {{{
+   *   CREATE TABLE [IF NOT EXISTS] multi_part_table_name
+   *   LIKE existing_multi_part_table_name [locationSpec]
+   * }}}
+   */
+  override def visitCreateTableLike(ctx: CreateTableLikeContext): LogicalPlan = withOrigin(ctx) {
+    val targetTable = visitMultipartIdentifier(ctx.target)
+    val sourceTable = visitMultipartIdentifier(ctx.source)
+    val location = Option(ctx.locationSpec).map(visitLocationSpec)
+    CreateTableLikeStatement(targetTable, sourceTable, location, ctx.EXISTS != null)
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
@@ -87,6 +87,14 @@ case class CreateTableAsSelectStatement(
 }
 
 /**
+ * A CREATE TABLE LIKE statement, as parsed from SQL
+ */
+case class CreateTableLikeStatement(
+    targetTable: Seq[String],
+    sourceTable: Seq[String],
+    location: Option[String],
+    ifNotExists: Boolean) extends ParsedStatement
+/**
  * A REPLACE TABLE command, as parsed from SQL.
  *
  * If the table exists prior to running this command, executing this statement

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -192,9 +192,9 @@ case class CreateTableAsSelect(
  */
 case class CreateTableLike(
     targetCatalog: TableCatalog,
-    targetTableName: Identifier,
-    sourceCatalog: TableCatalog,
-    sourceTableName: Identifier,
+    targetTableName: Seq[String],
+    sourceCatalog: Option[TableCatalog],
+    sourceTableName: Seq[String],
     ifNotExists: Boolean) extends Command
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -188,6 +188,16 @@ case class CreateTableAsSelect(
 }
 
 /**
+ * Create a new table with the same table definition of the source table.
+ */
+case class CreateTableLike(
+    targetCatalog: TableCatalog,
+    targetTableName: Identifier,
+    sourceCatalog: TableCatalog,
+    sourceTableName: Identifier,
+    ifNotExists: Boolean) extends Command
+
+/**
  * Replace a table with a v2 catalog.
  *
  * If the table does not exist, and orCreate is true, then it will be created.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -377,6 +377,24 @@ class DDLParserSuite extends AnalysisTest {
     }
   }
 
+  test("create table like") {
+    comparePlans(
+      parsePlan("CREATE TABLE a.b.c LIKE d.e.f"),
+      CreateTableLikeStatement(Seq("a", "b", "c"), Seq("d", "e", "f"), None, false))
+
+    comparePlans(
+      parsePlan("CREATE TABLE IF NOT EXISTS a.b.c LIKE d.e.f"),
+      CreateTableLikeStatement(Seq("a", "b", "c"), Seq("d", "e", "f"), None, true))
+
+    comparePlans(
+      parsePlan("CREATE TABLE a.b.c LIKE d.e.f LOCATION '/tmp'"),
+      CreateTableLikeStatement(Seq("a", "b", "c"), Seq("d", "e", "f"), Some("/tmp"), false))
+
+    comparePlans(
+      parsePlan("CREATE TABLE IF NOT EXISTS a.b.c LIKE d.e.f LOCATION '/tmp'"),
+      CreateTableLikeStatement(Seq("a", "b", "c"), Seq("d", "e", "f"), Some("/tmp"), true))
+  }
+
   test("drop table") {
     parseCompare("DROP TABLE testcat.ns1.ns2.tbl",
       DropTableStatement(Seq("testcat", "ns1", "ns2", "tbl"), ifExists = false, purge = false))

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -240,6 +240,11 @@ class ResolveSessionCatalog(
           ignoreIfExists = c.ifNotExists)
       }
 
+    case CreateTableLikeStatement(targetTable, sourceTable, location, ifNotExists) =>
+      val v1targetTable = parseV1Table(targetTable, "CREATE TABLE LIKE").asTableIdentifier
+      val v1sourceTable = parseV1Table(sourceTable, "CREATE TABLE LIKE").asTableIdentifier
+      CreateTableLikeCommand(v1targetTable, v1sourceTable, location, ifNotExists)
+
     case RefreshTableStatement(SessionCatalog(_, tableName)) =>
       RefreshTable(tableName.asTableIdentifier)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -627,22 +627,6 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
   }
 
   /**
-   * Create a [[CreateTableLikeCommand]] command.
-   *
-   * For example:
-   * {{{
-   *   CREATE TABLE [IF NOT EXISTS] [db_name.]table_name
-   *   LIKE [other_db_name.]existing_table_name [locationSpec]
-   * }}}
-   */
-  override def visitCreateTableLike(ctx: CreateTableLikeContext): LogicalPlan = withOrigin(ctx) {
-    val targetTable = visitTableIdentifier(ctx.target)
-    val sourceTable = visitTableIdentifier(ctx.source)
-    val location = Option(ctx.locationSpec).map(visitLocationSpec)
-    CreateTableLikeCommand(targetTable, sourceTable, location, ctx.EXISTS != null)
-  }
-
-  /**
    * Create a [[CatalogStorageFormat]] for creating tables.
    *
    * Format: STORED AS ...

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateTableLikeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateTableLikeExec.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog, TableChange}
+
+/**
+ * Physical plan node for altering a table.
+ */
+case class CreateTableLikeExec(
+    targetCatalog: TableCatalog,
+    targetTable: Identifier,
+    sourceCatalog: TableCatalog,
+    sourceTable: Identifier,
+    ifNotExists: Boolean) extends V2CommandExec {
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override def output: Seq[Attribute] = Seq.empty
+
+  override protected def run(): Seq[InternalRow] = {
+    val sourceTab = sourceCatalog.loadTable(sourceTable)
+    if (!targetCatalog.tableExists(targetTable)) {
+      try {
+        targetCatalog.createTable(targetTable,
+          sourceTab.schema,
+          sourceTab.partitioning,
+          sourceTab.properties())
+      } catch {
+        case _: TableAlreadyExistsException if ifNotExists =>
+          logWarning(s"Table ${targetTable.quoted} was created concurrently. Ignoring.")
+      }
+    } else if (!ifNotExists) {
+      throw new TableAlreadyExistsException(targetTable)
+    }
+
+    Seq.empty
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -22,7 +22,7 @@ import scala.collection.JavaConverters._
 import org.apache.spark.sql.{AnalysisException, Strategy}
 import org.apache.spark.sql.catalyst.expressions.{And, PredicateHelper, SubqueryExpression}
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
-import org.apache.spark.sql.catalyst.plans.logical.{AlterTable, AppendData, CreateNamespace, CreateTableAsSelect, CreateV2Table, DeleteFromTable, DescribeTable, DropNamespace, DropTable, LogicalPlan, OverwriteByExpression, OverwritePartitionsDynamic, RefreshTable, Repartition, ReplaceTable, ReplaceTableAsSelect, SetCatalogAndNamespace, ShowCurrentNamespace, ShowNamespaces, ShowTables}
+import org.apache.spark.sql.catalyst.plans.logical.{AlterTable, AppendData, CreateNamespace, CreateTableAsSelect, CreateTableLike, CreateV2Table, DeleteFromTable, DescribeTable, DropNamespace, DropTable, LogicalPlan, OverwriteByExpression, OverwritePartitionsDynamic, RefreshTable, Repartition, ReplaceTable, ReplaceTableAsSelect, SetCatalogAndNamespace, ShowCurrentNamespace, ShowNamespaces, ShowTables}
 import org.apache.spark.sql.connector.catalog.{StagingTableCatalog, TableCapability}
 import org.apache.spark.sql.connector.read.streaming.{ContinuousStream, MicroBatchStream}
 import org.apache.spark.sql.execution.{FilterExec, ProjectExec, SparkPlan}
@@ -95,6 +95,9 @@ object DataSourceV2Strategy extends Strategy with PredicateHelper {
           CreateTableAsSelectExec(
             catalog, ident, parts, query, planLater(query), props, writeOptions, ifNotExists) :: Nil
       }
+
+    case CreateTableLike(tCatalog, tTab, sCatalog, sTab, ifNotExists) =>
+      CreateTableLikeExec(tCatalog, tTab, sCatalog, sTab, ifNotExists) :: Nil
 
     case RefreshTable(catalog, ident) =>
       RefreshTableExec(catalog, ident) :: Nil

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -1562,6 +1562,27 @@ class DataSourceV2SQLSuite
     assert(e.message.contains("ALTER VIEW QUERY is only supported with v1 tables"))
   }
 
+  test("CREATE TABLE LIKE") {
+    val targetTable = "testcat.ns1.ns2.tbl1"
+    val sourceTable = "testcat.ns1.ns2.tbl2"
+
+    val e1 = intercept[AnalysisException] {
+      sql(s"CREATE TABLE $targetTable LIKE $sourceTable")
+    }
+    assert(e1.message.contains("CREATE TABLE LIKE is only supported with v1 tables"))
+
+    val e2 = intercept[AnalysisException] {
+      sql(s"CREATE TABLE IF NOT EXISTS $targetTable LIKE $sourceTable")
+    }
+    assert(e2.message.contains("CREATE TABLE LIKE is only supported with v1 tables"))
+
+    val e3 = intercept[AnalysisException] {
+      sql(s"CREATE TABLE IF NOT EXISTS $targetTable LIKE " +
+        s"$sourceTable LOCATION 'AnyLocation'")
+    }
+    assert(e3.message.contains("CREATE TABLE LIKE is only supported with v1 tables"))
+  }
+
   private def testV1Command(sqlCommand: String, sqlParams: String): Unit = {
     val e = intercept[AnalysisException] {
       sql(s"$sqlCommand $sqlParams")

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -24,8 +24,8 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.{CannotReplaceMissingTableException, NamespaceAlreadyExistsException, NoSuchDatabaseException, NoSuchNamespaceException, NoSuchTableException, TableAlreadyExistsException}
 import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
+import org.apache.spark.sql.connector.expressions.LogicalExpressions
 import org.apache.spark.sql.execution.datasources.v2.V2SessionCatalog
-import org.apache.spark.sql.connector.expressions.{Expression, LogicalExpressions, NamedReference, Transform}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION
 import org.apache.spark.sql.sources.SimpleScanSource

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
@@ -1104,29 +1104,4 @@ class DDLParserSuite extends AnalysisTest with SharedSparkSession {
     intercept(sql1, "Found duplicate clauses: COMMENT")
     intercept(sql2, "Found duplicate clauses: TBLPROPERTIES")
   }
-
-  test("load data") {
-    val v1 = "LOAD DATA INPATH 'path' INTO TABLE table1"
-    val (table, path, isLocal, isOverwrite, partition) = parser.parsePlan(v1).collect {
-      case LoadDataCommand(t, path, l, o, partition) => (t, path, l, o, partition)
-    }.head
-    assert(table.database.isEmpty)
-    assert(table.table == "table1")
-    assert(path == "path")
-    assert(!isLocal)
-    assert(!isOverwrite)
-    assert(partition.isEmpty)
-
-    val v2 = "LOAD DATA LOCAL INPATH 'path' OVERWRITE INTO TABLE table1 PARTITION(c='1', d='2')"
-    val (table2, path2, isLocal2, isOverwrite2, partition2) = parser.parsePlan(v2).collect {
-      case LoadDataCommand(t, path, l, o, partition) => (t, path, l, o, partition)
-    }.head
-    assert(table2.database.isEmpty)
-    assert(table2.table == "table1")
-    assert(path2 == "path")
-    assert(isLocal2)
-    assert(isOverwrite2)
-    assert(partition2.nonEmpty)
-    assert(partition2.get.apply("c") == "1" && partition2.get.apply("d") == "2")
-  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change to make sure ```CREATE TABLES LIKE```  statement go through the same catalog/table resolution framework of v2 commands.


### Why are the changes needed?
It's important to make all the commands have the same table resolution behavior, to avoid confusing end-users.

### Does this PR introduce any user-facing change?
Yes. Attempting to execute ```CREATE TABLE LIKE``` on v2 catalog results in an error.


### How was this patch tested?
Added unit tests.
