### PR TITLE
[WIP][SPARK-29564][SQL] Cluster deploy mode should support Spark Thrift server

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -281,8 +281,6 @@ private[spark] class SparkSubmit extends Logging {
         error("Cluster deploy mode is not applicable to Spark shells.")
       case (_, CLUSTER) if isSqlShell(args.mainClass) =>
         error("Cluster deploy mode is not applicable to Spark SQL shell.")
-      case (_, CLUSTER) if isThriftServer(args.mainClass) =>
-        error("Cluster deploy mode is not applicable to Spark Thrift server.")
       case _ =>
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Cluster deploy mode is not applicable to Spark Thrift server now. This restriction is too rude.
In our production, we use multiple Spark Thrift servers as long running services which are used yarn-cluster mode to launch. The life cycle of STS is managed by upper layer manager system which is also used to dispatcher user's JDBC connection to applicable STS.

### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Manually test with command:
```
sbin/start-thriftserver.sh --master yarn --deploy-mode cluster --queue myqueue
```
