### PR TITLE
[SPARK-21287][SQL] Move the validation of fetch size from JDBCOptions to JdbcDialect

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -147,14 +147,7 @@ class JDBCOptions(
      """.stripMargin
   )
 
-  val fetchSize = {
-    val size = parameters.getOrElse(JDBC_BATCH_FETCH_SIZE, "0").toInt
-    require(size >= 0,
-      s"Invalid value `${size.toString}` for parameter " +
-        s"`$JDBC_BATCH_FETCH_SIZE`. The minimum value is 0. When the value is 0, " +
-        "the JDBC driver ignores the value and does the estimates.")
-    size
-  }
+  val fetchSize = parameters.getOrElse(JDBC_BATCH_FETCH_SIZE, "0").toInt
 
   // ------------------------------------------------------------
   // Optional parameters only for writing

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.datasources.jdbc
 
 import java.sql.{Connection, PreparedStatement, ResultSet, SQLException}
 
+import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
 import org.apache.spark.{InterruptibleIterator, Partition, SparkContext, TaskContext}
@@ -184,7 +185,6 @@ private[jdbc] class JDBCRDD(
     options: JDBCOptions)
   extends RDD[InternalRow](sc, Nil) {
 
-  import scala.collection.JavaConverters._
   JdbcDialects.get(url).validateProperties(options.asProperties.asScala.toMap)
 
   /**
@@ -274,7 +274,6 @@ private[jdbc] class JDBCRDD(
     val part = thePart.asInstanceOf[JDBCPartition]
     conn = getConnection()
     val dialect = JdbcDialects.get(url)
-    import scala.collection.JavaConverters._
     dialect.beforeFetch(conn, options.asProperties.asScala.toMap)
 
     // This executes a generic SQL statement (or PL/SQL block) before reading

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -184,6 +184,9 @@ private[jdbc] class JDBCRDD(
     options: JDBCOptions)
   extends RDD[InternalRow](sc, Nil) {
 
+  import scala.collection.JavaConverters._
+  JdbcDialects.get(url).validateProperties(options.asProperties.asScala.toMap)
+
   /**
    * Retrieve the list of partitions corresponding to this RDD.
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -152,27 +152,17 @@ abstract class JdbcDialect extends Serializable {
   }
 
   /**
-   * Do some extra properties validation work in addition to the validation in [[JDBCOptions]],
-   * eg. [[validateFetchSize()]].
+   * Do some extra properties validation work in addition to the validation
+   * in [[org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions]].
    * @param properties The connection properties.  This is passed through from the relation.
    */
   def validateProperties(properties: Map[String, String]): Unit = {
     val fetchSize = properties.getOrElse(JDBCOptions.JDBC_BATCH_FETCH_SIZE, "0").toInt
-    validateFetchSize(fetchSize)
-  }
-
-  /**
-   * This is to validate the fetch size specified via [[JDBCOptions.JDBC_BATCH_FETCH_SIZE]].
-   * The implementation here requires the fetch size >= 0, sub classes may override it to meet
-   * requirement of different dialects.
-   * @param size the fetch size to validate.
-   */
-  protected def validateFetchSize(size: Int): Unit = {
-    require(size >= 0,
-          s"Invalid value `${size.toString}` for parameter " +
-            s"`${JDBCOptions.JDBC_BATCH_FETCH_SIZE}` for dialect ${this.getClass.getSimpleName}. " +
-            s"The minimum value is 0. When the value is 0, " +
-            "the JDBC driver ignores the value and does the estimates.")
+    require(fetchSize >= 0,
+      s"Invalid value `${fetchSize.toString}` for parameter " +
+        s"`${JDBCOptions.JDBC_BATCH_FETCH_SIZE}` for dialect ${this.getClass.getSimpleName}. " +
+        s"The minimum value is 0. When the value is 0, " +
+        "the JDBC driver ignores the value and does the estimates.")
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -165,7 +165,7 @@ abstract class JdbcDialect extends Serializable {
    * requirement of different dialects.
    * @param properties The connection properties.  This is passed through from the relation.
    */
-  def validateFetchSize(properties: Map[String, String]): Unit = {
+  protected def validateFetchSize(properties: Map[String, String]): Unit = {
     val size = properties.getOrElse(JDBCOptions.JDBC_BATCH_FETCH_SIZE, "0").toInt
     require(size >= 0,
           s"Invalid value `${size.toString}` for parameter " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -157,16 +157,17 @@ abstract class JdbcDialect extends Serializable {
    * @param properties The connection properties.  This is passed through from the relation.
    */
   def validateProperties(properties: Map[String, String]): Unit = {
-    validateFetchSize(properties)
+    val fetchSize = properties.getOrElse(JDBCOptions.JDBC_BATCH_FETCH_SIZE, "0").toInt
+    validateFetchSize(fetchSize)
   }
+
   /**
    * This is to validate the fetch size specified via [[JDBCOptions.JDBC_BATCH_FETCH_SIZE]].
    * The implementation here requires the fetch size >= 0, sub classes may override it to meet
    * requirement of different dialects.
-   * @param properties The connection properties.  This is passed through from the relation.
+   * @param size the fetch size to validate.
    */
-  protected def validateFetchSize(properties: Map[String, String]): Unit = {
-    val size = properties.getOrElse(JDBCOptions.JDBC_BATCH_FETCH_SIZE, "0").toInt
+  protected def validateFetchSize(size: Int): Unit = {
     require(size >= 0,
           s"Invalid value `${size.toString}` for parameter " +
             s"`${JDBCOptions.JDBC_BATCH_FETCH_SIZE}` for dialect ${this.getClass.getSimpleName}. " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -48,8 +48,7 @@ private case object MySQLDialect extends JdbcDialect {
 
   override def isCascadingTruncateTable(): Option[Boolean] = Some(false)
 
-  override def validateFetchSize(properties: Map[String, String]): Unit = {
-    val size = properties.getOrElse(JDBCOptions.JDBC_BATCH_FETCH_SIZE, "0").toInt
+  override def validateFetchSize(size: Int): Unit = {
     require(size >= 0 || size == Integer.MIN_VALUE,
       s"Invalid value `${size.toString}` for parameter " +
         s"`${JDBCOptions.JDBC_BATCH_FETCH_SIZE}` for MySQL. " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -48,9 +48,10 @@ private case object MySQLDialect extends JdbcDialect {
 
   override def isCascadingTruncateTable(): Option[Boolean] = Some(false)
 
-  override def validateFetchSize(size: Int): Unit = {
-    require(size >= 0 || size == Integer.MIN_VALUE,
-      s"Invalid value `${size.toString}` for parameter " +
+  override def validateProperties(properties: Map[String, String]): Unit = {
+    val fetchSize = properties.getOrElse(JDBCOptions.JDBC_BATCH_FETCH_SIZE, "0").toInt
+    require(fetchSize >= 0 || fetchSize == Integer.MIN_VALUE,
+      s"Invalid value `${fetchSize.toString}` for parameter " +
         s"`${JDBCOptions.JDBC_BATCH_FETCH_SIZE}` for MySQL. " +
         s"The value should be >= 0 or equal Integer.MIN_VALUE; " +
         s"When the value is 0, the JDBC driver ignores the value and does the estimates; " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -52,7 +52,7 @@ private case object MySQLDialect extends JdbcDialect {
     require(size >= 0 || size == Integer.MIN_VALUE,
       s"Invalid value `${size.toString}` for parameter " +
         s"`${JDBCOptions.JDBC_BATCH_FETCH_SIZE}` for MySQL. " +
-        s"The value should be >= 0 or equals Integer.MIN_VALUE; " +
+        s"The value should be >= 0 or equal Integer.MIN_VALUE; " +
         s"When the value is 0, the JDBC driver ignores the value and does the estimates; " +
         s"When the value is Integer.MIN_VALUE, the data will be fetched in streaming manner, " +
         s"namely, fetch one row at a time.")


### PR DESCRIPTION
### What changes were proposed in this pull request?
    Move the validation of fetch size from JDBCOptions to JdbcDialect, so that different dialects can have different validation logic for fetch size property.

### Why are the changes needed?
To fix  #SPARK-21287 , namely to support data fetch in stream manner  against MySQL database.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Unit tests (JDBCSuite).
