### PR TITLE
[SPARK-29582][PYSPARK] Support `TaskContext.get()` in a barrier task from Python side

### DIFF
--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -169,7 +169,7 @@ class BarrierTaskContext(TaskContext):
             A RuntimeError will raise if it is not in a barrier stage.
         """
         if not isinstance(cls._taskContext, BarrierTaskContext):
-            raise RuntimeError('''It is not in a barrier stage''')
+            raise Exception('It is not in a barrier stage')
         return cls._taskContext
 
     @classmethod

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -54,6 +54,10 @@ class TaskContext(object):
         return cls._taskContext
 
     @classmethod
+    def _setTaskContext(cls, taskContext):
+        cls._taskContext = taskContext
+
+    @classmethod
     def get(cls):
         """
         Return the currently active TaskContext. This can be called inside of
@@ -162,7 +166,10 @@ class BarrierTaskContext(TaskContext):
         running tasks.
 
         .. note:: Must be called on the worker, not the driver. Returns None if not initialized.
+            A RuntimeError will raise if it's not in a barrier stage.
         """
+        if not isinstance(cls._taskContext, BarrierTaskContext):
+            raise RuntimeError('''It's not in a barrier stage''')
         return cls._taskContext
 
     @classmethod

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -166,7 +166,7 @@ class BarrierTaskContext(TaskContext):
         running tasks.
 
         .. note:: Must be called on the worker, not the driver. Returns None if not initialized.
-            A RuntimeError will raise if it is not in a barrier stage.
+            A Exception will raise if it is not in a barrier stage.
         """
         if not isinstance(cls._taskContext, BarrierTaskContext):
             raise Exception('It is not in a barrier stage')

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -166,10 +166,10 @@ class BarrierTaskContext(TaskContext):
         running tasks.
 
         .. note:: Must be called on the worker, not the driver. Returns None if not initialized.
-            A RuntimeError will raise if it's not in a barrier stage.
+            A RuntimeError will raise if it is not in a barrier stage.
         """
         if not isinstance(cls._taskContext, BarrierTaskContext):
-            raise RuntimeError('''It's not in a barrier stage''')
+            raise RuntimeError('''It is not in a barrier stage''')
         return cls._taskContext
 
     @classmethod

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -166,7 +166,7 @@ class BarrierTaskContext(TaskContext):
         running tasks.
 
         .. note:: Must be called on the worker, not the driver. Returns None if not initialized.
-            A Exception will raise if it is not in a barrier stage.
+            An Exception will raise if it is not in a barrier stage.
         """
         if not isinstance(cls._taskContext, BarrierTaskContext):
             raise Exception('It is not in a barrier stage')

--- a/python/pyspark/tests/test_taskcontext.py
+++ b/python/pyspark/tests/test_taskcontext.py
@@ -246,22 +246,23 @@ class TaskContextTestsWithWorkerReuse(unittest.TestCase):
         # normal stage after normal stage
         normal_result = rdd.mapPartitions(context).collect()
         tps, bps, pids = zip(*normal_result)
-        self.assertTrue(tps == [0, 1])
-        self.assertTrue(bps == [-1, -1])
+        print(tps)
+        self.assertTrue(tps == (0, 1))
+        self.assertTrue(bps == (-1, -1))
         for pid in pids:
             self.assertTrue(pid in worker_pids)
         # barrier stage after normal stage
         barrier_result = rdd.barrier().mapPartitions(context).collect()
         tps, bps, pids = zip(*barrier_result)
-        self.assertTrue(tps == [0, 1])
-        self.assertTrue(bps == [0, 1])
+        self.assertTrue(tps == (0, 1))
+        self.assertTrue(bps == (0, 1))
         for pid in pids:
             self.assertTrue(pid in worker_pids)
         # normal stage after barrier stage
         normal_result2 = rdd.mapPartitions(context).collect()
         tps, bps, pids = zip(*normal_result2)
-        self.assertTrue(tps == [0, 1])
-        self.assertTrue(bps == [-1, -1])
+        self.assertTrue(tps == (0, 1))
+        self.assertTrue(bps == (-1, -1))
         for pid in pids:
             self.assertTrue(pid in worker_pids)
 

--- a/python/pyspark/tests/test_taskcontext.py
+++ b/python/pyspark/tests/test_taskcontext.py
@@ -25,6 +25,9 @@ import unittest
 from pyspark import SparkConf, SparkContext, TaskContext, BarrierTaskContext
 from pyspark.testing.utils import PySparkTestCase, SPARK_HOME
 
+if sys.version_info[0] >= 3:
+    xrange = range
+
 
 class TaskContextTests(PySparkTestCase):
 
@@ -227,9 +230,9 @@ class TaskContextTestsWithWorkerReuse(unittest.TestCase):
     def test_task_context_correct_with_python_worker_reuse(self):
         """Verify the task context correct when reused python worker"""
         # start a normal job first to start all workers and get all worker pids
-        worker_pids = self.sc.parallelize(range(2), 2).map(lambda x: os.getpid()).collect()
+        worker_pids = self.sc.parallelize(xrange(2), 2).map(lambda x: os.getpid()).collect()
         # the worker will reuse in this barrier job
-        rdd = self.sc.parallelize(range(10), 2)
+        rdd = self.sc.parallelize(xrange(10), 2)
 
         def context(iterator):
             tp = TaskContext.get().partitionId()

--- a/python/pyspark/tests/test_taskcontext.py
+++ b/python/pyspark/tests/test_taskcontext.py
@@ -294,7 +294,6 @@ class TaskContextTestsWithResources(unittest.TestCase):
         os.unlink(self.tempFile.name)
         self.sc.stop()
 
-
 if __name__ == "__main__":
     import unittest
     from pyspark.tests.test_taskcontext import *

--- a/python/pyspark/tests/test_taskcontext.py
+++ b/python/pyspark/tests/test_taskcontext.py
@@ -244,15 +244,15 @@ class TaskContextTestsWithWorkerReuse(unittest.TestCase):
             tps = list(map(lambda x: x[0], result))
             bps = list(map(lambda x: x[1], result))
             pids = list(map(lambda x: x[2], result))
-            self.assertTrue(tps, task_context_target)
-            self.assertTrue(bps, barrier_context_target)
+            self.assertTrue(tps == task_context_target)
+            self.assertTrue(bps == barrier_context_target)
             for pid in pids:
                 self.assertTrue(pid in worker_pids)
         # normal stage after normal stage
         normal_result = rdd.mapPartitions(context).collect()
         verify(normal_result, [0, 1], [-1, -1])
         # barrier stage after normal stage
-        barrier_result = rdd.mapPartitions(context).collect()
+        barrier_result = rdd.barrier().mapPartitions(context).collect()
         verify(barrier_result, [0, 1], [0, 1])
         # normal stage after barrier stage
         normal_result2 = rdd.mapPartitions(context).collect()

--- a/python/pyspark/tests/test_taskcontext.py
+++ b/python/pyspark/tests/test_taskcontext.py
@@ -243,23 +243,27 @@ class TaskContextTestsWithWorkerReuse(unittest.TestCase):
 
             yield (tp, bp, os.getpid())
 
-        def verify(result, task_context_target, barrier_context_target):
-            tps = list(map(lambda x: x[0], result))
-            bps = list(map(lambda x: x[1], result))
-            pids = list(map(lambda x: x[2], result))
-            self.assertTrue(tps == task_context_target)
-            self.assertTrue(bps == barrier_context_target)
-            for pid in pids:
-                self.assertTrue(pid in worker_pids)
         # normal stage after normal stage
         normal_result = rdd.mapPartitions(context).collect()
-        verify(normal_result, [0, 1], [-1, -1])
+        tps, bps, pids = zip(*normal_result)
+        self.assertTrue(tps == [0, 1])
+        self.assertTrue(bps == [-1, -1])
+        for pid in pids:
+            self.assertTrue(pid in worker_pids)
         # barrier stage after normal stage
         barrier_result = rdd.barrier().mapPartitions(context).collect()
-        verify(barrier_result, [0, 1], [0, 1])
+        tps, bps, pids = zip(*barrier_result)
+        self.assertTrue(tps == [0, 1])
+        self.assertTrue(bps == [0, 1])
+        for pid in pids:
+            self.assertTrue(pid in worker_pids)
         # normal stage after barrier stage
         normal_result2 = rdd.mapPartitions(context).collect()
-        verify(normal_result2, [0, 1], [-1, -1])
+        tps, bps, pids = zip(*normal_result2)
+        self.assertTrue(tps == [0, 1])
+        self.assertTrue(bps == [-1, -1])
+        for pid in pids:
+            self.assertTrue(pid in worker_pids)
 
     def tearDown(self):
         self.sc.stop()

--- a/python/pyspark/tests/test_taskcontext.py
+++ b/python/pyspark/tests/test_taskcontext.py
@@ -180,7 +180,7 @@ class TaskContextTests(PySparkTestCase):
         def f(iterator):
             try:
                 taskContext = BarrierTaskContext.get()
-            except RuntimeError:
+            except Exception:
                 yield -1
             else:
                 yield taskContext.partitionId()
@@ -238,7 +238,7 @@ class TaskContextTestsWithWorkerReuse(unittest.TestCase):
             tp = TaskContext.get().partitionId()
             try:
                 bp = BarrierTaskContext.get().partitionId()
-            except RuntimeError:
+            except Exception:
                 bp = -1
 
             yield (tp, bp, os.getpid())

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -503,11 +503,11 @@ def main(infile, outfile):
         if isBarrier:
             taskContext = BarrierTaskContext._getOrCreate()
             BarrierTaskContext._initialize(boundPort, secret)
+            # Set the task context instance here, so we can get it by TaskContext.get for
+            # both TaskContext and BarrierTaskContext
+            TaskContext._setTaskContext(taskContext)
         else:
             taskContext = TaskContext._getOrCreate()
-        # Set the task context instance here, so we can get it by TaskContext.get for
-        # both TaskContext and BarrierTaskContext
-        TaskContext._setTaskContext(taskContext)
         # read inputs for TaskContext info
         taskContext._stageId = read_int(infile)
         taskContext._partitionId = read_int(infile)

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -600,7 +600,8 @@ def main(infile, outfile):
         else:
             process()
 
-        # reset task context to None
+        # Reset task context to None. This is a guard code to avoid residual context when worker
+        # reuse.
         TaskContext._setTaskContext(None)
         BarrierTaskContext._setTaskContext(None)
     except Exception:

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -505,6 +505,9 @@ def main(infile, outfile):
             BarrierTaskContext._initialize(boundPort, secret)
         else:
             taskContext = TaskContext._getOrCreate()
+        # Set the task context instance here, so we can get it by TaskContext.get for
+        # both TaskContext and BarrierTaskContext
+        TaskContext._setTaskContext(taskContext)
         # read inputs for TaskContext info
         taskContext._stageId = read_int(infile)
         taskContext._partitionId = read_int(infile)
@@ -596,6 +599,10 @@ def main(infile, outfile):
             profiler.profile(process)
         else:
             process()
+
+        # reset task context to None
+        TaskContext._setTaskContext(None)
+        BarrierTaskContext._setTaskContext(None)
     except Exception:
         try:
             exc_info = traceback.format_exc()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add support of `TaskContext.get()` in a barrier task from Python side, this makes it easier to migrate legacy user code to barrier execution mode.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

In Spark Core, there is a `TaskContext` object which is a singleton. We set a task context instance which can be TaskContext or BarrierTaskContext before the task function startup, and unset it to none after the function end. So we can both get TaskContext and BarrierTaskContext with the object. However we can only get the BarrierTaskContext with `BarrierTaskContext`, we will get `None` if we get it by `TaskContext.get` in a barrier stage.

This is useful when people switch from normal code to barrier code, and only need a little update.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

Yes.
Previously:
```python
def func(iterator):
    task_context = TaskContext.get() . # this could be None.
    barrier_task_context = BarrierTaskContext.get() # get the BarrierTaskContext instance
    ...

rdd.barrier().mapPartitions(func)
```

Proposed:
```python
def func(iterator):
    task_context = TaskContext.get() . # this could also get the BarrierTaskContext instance which is same as barrier_task_context
    barrier_task_context = BarrierTaskContext.get() # get the BarrierTaskContext instance
    ...

rdd.barrier().mapPartitions(func)
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
New UT tests.