### PR TITLE
Fix SPARK-29594: Create a Dataset from a Sequence of Case class where a field name started with a number

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -136,7 +136,7 @@ object ScalaReflection extends ScalaReflection {
    * This method transforms the field names that are either java keywords or starting with
    * numbers, to the field names with ``. Example: abstract -> `abstract`
    */
-  private def transformFieldNames(fields: Seq[(String, Type)]): Seq[(String, Type)] = {
+  private def transformFieldNames(fields: Seq[(String, `Type`)]): Seq[(String, `Type`)] = {
     fields.map { case (fieldName, fieldType) =>
       if (javaKeywords.contains(fieldName) || fieldName.head.isDigit) {
         (s"`$fieldName`", fieldType)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -478,4 +478,30 @@ class DataTypeSuite extends SparkFunSuite {
 
     assert(result === expected)
   }
+
+  test("SPARK-29594: Create Dataset from fields that start with number or are java keywords") {
+    val numberType : DataType = StructType(Seq(
+      StructField("1a", DataTypes.IntegerType),
+      StructField("2b", DataTypes.IntegerType)))
+
+    val keywordType : DataType = StructType(Seq(
+      StructField("abstract", DataTypes.IntegerType),
+      StructField("default", DataTypes.StringType)))
+
+    val builder = new StringBuilder
+
+    MapType(numberType, keywordType).buildFormattedString(prefix = "", builder = builder)
+
+    val result = builder.toString()
+    val expected =
+      """-- key: struct
+        |    |-- `1a: integer (nullable = true)
+        |    |-- `2b`: integer (nullable = true)
+        |-- value: struct (valueContainsNull = true)
+        |    |-- `abstract`: integer (nullable = true)
+        |    |-- `default`: String (nullable = true)
+        |""".stripMargin
+
+    assert(result === expected)
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -478,30 +478,4 @@ class DataTypeSuite extends SparkFunSuite {
 
     assert(result === expected)
   }
-
-  test("SPARK-29594: Create Dataset from fields that start with number or are java keywords") {
-    val numberType : DataType = StructType(Seq(
-      StructField("1a", DataTypes.IntegerType),
-      StructField("2b", DataTypes.IntegerType)))
-
-    val keywordType : DataType = StructType(Seq(
-      StructField("abstract", DataTypes.IntegerType),
-      StructField("default", DataTypes.StringType)))
-
-    val builder = new StringBuilder
-
-    MapType(numberType, keywordType).buildFormattedString(prefix = "", builder = builder)
-
-    val result = builder.toString()
-    val expected =
-      """-- key: struct
-        |    |-- `1a: integer (nullable = true)
-        |    |-- `2b`: integer (nullable = true)
-        |-- value: struct (valueContainsNull = true)
-        |    |-- `abstract`: integer (nullable = true)
-        |    |-- `default`: String (nullable = true)
-        |""".stripMargin
-
-    assert(result === expected)
-  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1213,12 +1213,9 @@ class DatasetSuite extends QueryTest with SharedSparkSession {
     assert(result == Set(ClassData("a", 1) -> null, ClassData("b", 2) -> ClassData("x", 2)))
   }
 
-  test("better error message when use java reserved keyword as field name") {
-    val e = intercept[UnsupportedOperationException] {
-      Seq(InvalidInJava(1)).toDS()
-    }
-    assert(e.getMessage.contains(
-      "`abstract` is a reserved keyword and cannot be used as field name"))
+  test("SPARK-29594: Create a Dataset from a sequence of Case class with java keywords" +
+    " and starting with numbers as field names") {
+    checkDataset(Seq(InvalidInJava(1, "HelloWorld!")).toDS(), 1, "HelloWorld!")
   }
 
   test("Dataset should support flat input object to be null") {
@@ -1900,7 +1897,7 @@ case class ClassNullableData(a: String, b: Integer)
 case class NestedStruct(f: ClassData)
 case class DeepNestedStruct(f: NestedStruct)
 
-case class InvalidInJava(`abstract`: Int)
+case class InvalidInJava(`abstract`: Int, `1a`: String)
 
 /**
  * A class used to test serialization using encoders. This class throws exceptions when using

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1215,7 +1215,9 @@ class DatasetSuite extends QueryTest with SharedSparkSession {
 
   test("SPARK-29594: Create a Dataset from a sequence of Case class with java keywords" +
     " and starting with numbers as field names") {
-    checkDataset(Seq(InvalidInJava(1, "HelloWorld!")).toDS(), 1, "HelloWorld!")
+    val cc = InvalidInJava(1, "HelloWorld!")
+    val ds: Dataset[InvalidInJava] = Seq(cc).toDS()
+    assert(ds.collect() sameElements  Array(cc))
   }
 
   test("Dataset should support flat input object to be null") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr is to fix a bug discovered by me, [SPARK-29594], when creating a Dataset using .toDS() in a sequence of a case class that had a field name starting with a number.
Also changed the behaviour when it is a java keyword now toDS() handles it.


### Why are the changes needed?
Bug fix


### Does this PR introduce any user-facing change?
Yes, now it is possible to create Datasets from case classes with field names as java keywords


### How was this patch tested?
Tests were modified, but following the new logic: sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala 
