### PR TITLE
[SPARK-26544][SQL] Escape struct string in spark thriftserver to keep alignment with hive

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -770,7 +770,8 @@ object SQLConf {
     .intConf
     .createWithDefault(200)
 
-  val THRIFTSERVER_RESULT_ESCAPE_STRUCT_STRING = buildConf("spark.sql.thriftserver.result.escapeStructString.enabled")
+  val THRIFTSERVER_RESULT_ESCAPE_STRUCT_STRING =
+    buildConf("spark.sql.thriftserver.result.escapeStructString.enabled")
     .doc("When true, escape string when needed to ensure the result returned is a valid json.")
     .booleanConf
     .createWithDefault(false)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -770,6 +770,11 @@ object SQLConf {
     .intConf
     .createWithDefault(200)
 
+  val THRIFTSERVER_RESULT_ESCAPE_STRUCT_STRING = buildConf("spark.sql.thriftserver.result.escapeStructString.enabled")
+    .doc("When true, escape string when needed to ensure the result returned is a valid json.")
+    .booleanConf
+    .createWithDefault(false)
+
   // This is used to set the default data source
   val DEFAULT_DATA_SOURCE_NAME = buildConf("spark.sql.sources.default")
     .doc("The default data source to use in input/output.")
@@ -2312,6 +2317,8 @@ class SQLConf extends Serializable with Logging {
   def datetimeJava8ApiEnabled: Boolean = getConf(DATETIME_JAVA8API_ENABLED)
 
   def utcTimestampFuncEnabled: Boolean = getConf(UTC_TIMESTAMP_FUNC_ENABLED)
+
+  def escapeStructStringEnabled: Boolean = getConf(THRIFTSERVER_RESULT_ESCAPE_STRUCT_STRING)
 
   /**
    * Returns the [[Resolver]] for the current configuration, which can be used to determine if two

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/HiveResult.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/HiveResult.scala
@@ -90,7 +90,8 @@ object HiveResult {
           toHiveStructString((key, kType)) + ":" + toHiveStructString((value, vType))
       }.toSeq.sorted.mkString("{", ",", "}")
     case (null, _) => "null"
-    case (s: String, StringType) => "\"" + s + "\""
+    case (s: String, StringType) =>
+      "\"" + (if (SQLConf.get.escapeStructStringEnabled) escapeString(s) else s) + "\""
     case (decimal, DecimalType()) => decimal.toString
     case (interval: CalendarInterval, CalendarIntervalType) =>
       SQLConf.get.intervalOutputStyle match {
@@ -129,5 +130,47 @@ object HiveResult {
     case (interval, CalendarIntervalType) => interval.toString
     case (other, _ : UserDefinedType[_]) => other.toString
     case (other, tpe) if primitiveTypes.contains(tpe) => other.toString
+  }
+
+  // This piece of code was taken from org.apache.hadoop.hive.serde2.SerDeUtils
+  private def escapeString(str: String): String = {
+    val length = str.length
+    val escape = new StringBuilder(length + 16)
+
+    str.foreach {
+      case c @ ('"' | '\\') =>
+        escape.append('\\')
+        escape.append(c);
+      case '\b' =>
+        escape.append('\\')
+        escape.append('b')
+      case '\f' =>
+        escape.append('\\')
+        escape.append('f')
+      case '\n' =>
+        escape.append('\\')
+        escape.append('n')
+      case '\r' =>
+        escape.append('\\')
+        escape.append('r')
+      case '\t' =>
+        escape.append('\\')
+        escape.append('t')
+      case c =>
+        // Control characters! According to JSON RFC u0020
+        if (c < ' ') {
+          val hex = Integer.toHexString(c)
+          escape.append('\\')
+          escape.append('u')
+          for (_ <- hex.length() + 1 to 4) {
+            escape.append('0')
+          }
+          escape.append(hex)
+        } else {
+          escape.append(c)
+        }
+    }
+
+    return escape.toString()
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/HiveResultSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/HiveResultSuite.scala
@@ -19,7 +19,9 @@ package org.apache.spark.sql.execution
 
 import java.sql.{Date, Timestamp}
 
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.{ExamplePoint, ExamplePointUDT, SharedSparkSession}
+import org.apache.spark.sql.types.{DataTypes, MapType}
 
 class HiveResultSuite extends SharedSparkSession {
   import testImplicits._
@@ -57,5 +59,32 @@ class HiveResultSuite extends SharedSparkSession {
       .selectExpr(s"CAST(value AS decimal(38, 8))").queryExecution.executedPlan
     val result = HiveResult.hiveResultString(executedPlan)
     assert(result.head === "0.00000000")
+  }
+
+  test("SPARK-26544: toHiveString correctly escape map type") {
+    withSQLConf(SQLConf.THRIFTSERVER_RESULT_ESCAPE_STRUCT_STRING.key -> "true") {
+      val m = Map("log_pb" -> """{"impr_id":"20181231"}""", "request_id" -> "001")
+      val mapType = new MapType(DataTypes.StringType, DataTypes.StringType, true)
+      assert(HiveResult.toHiveString((m, mapType)) ===
+        """{"log_pb":"{\"impr_id\":\"20181231\"}","request_id":"001"}""")
+    }
+  }
+
+  test("SPARK-26544: toHiveString correctly escape map type with specially characters") {
+    withSQLConf(SQLConf.THRIFTSERVER_RESULT_ESCAPE_STRUCT_STRING.key -> "true") {
+      val specialChars = List(8, 9, 10, 13, 6).map(_.toChar).mkString("") // \b\t\n\r\u0006
+      val m = Map("log_pb" -> s"""{"impr_id":"special chars $specialChars"}""")
+      val mapType = new MapType(DataTypes.StringType, DataTypes.StringType, true)
+      val result = HiveResult.toHiveString((m, mapType))
+
+      val c1 = Array("\\", "b").mkString("")
+      val c2 = Array("\\", "t").mkString("")
+      val c3 = Array("\\", "n").mkString("")
+      val c4 = Array("\\", "r").mkString("")
+      val c5 = Array("\\", "u", "0", "0", "0", "6").mkString("")
+      val expected =
+        """{"log_pb":"{\"impr_id\":\"special chars """ + c1 + c2 + c3 + c4 + c5 + """\"}"}"""
+      assert(result === expected)
+    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
In this PR, I proposed to escape strings when serializing Map/Array/Struct type in Spark ThriftServer, so that the result is always a valid JSON, which is what Hive does. 
Add a conf to make sure it doesn't break compatibility.

### Why are the changes needed?
The string serialized from Map/Array/Struct type in Spark ThriftServer is not a valid JSON when  the elements of Map/Array/Struct contain special characters such as `"`. 

For example, select a field whose type is map<string, string>, the spark thrift server returns
BEFORE
```{"author_id":"123","log_pb":"{"impr_id":"20181231"}","request_id":"001"}```

AFTER
```{"author_id":"123", "log_pb":"{\"impr_id\":\"20181231\"}","request_id":"001"}```

### Does this PR introduce any user-facing change?
No


### How was this patch tested?
HiveResultSuite.scala 
