### PR TITLE
[SPARK-27736][Core][SHUFFLE] Improve handling of FetchFailures caused by ExternalShuffleService losing track of executor registrations

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
@@ -150,6 +150,11 @@ public class ExternalBlockHandler extends RpcHandler {
       int numRemovedBlocks = blockManager.removeBlocks(msg.appId, msg.execId, msg.blockIds);
       callback.onSuccess(new BlocksRemoved(numRemovedBlocks).toByteBuffer());
 
+    } else if (msgObj instanceof AreExecutorsRegistered) {
+      AreExecutorsRegistered msg = (AreExecutorsRegistered) msgObj;
+      checkAuth(client, msg.appId);
+      callback.onSuccess(blockManager.areExecutorsRegistered(msg.appId, msg.execIds));
+
     } else {
       throw new UnsupportedOperationException("Unexpected message: " + msgObj);
     }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -128,6 +128,18 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
     }
   }
 
+  public ByteBuffer queryExecutorStatus(
+      String host,
+      int port,
+      String[] execIds) throws IOException, InterruptedException{
+    checkInit();
+    logger.debug("Query executor statuses in External shuffle service from {}:{}", host, port);
+    TransportClient client = clientFactory.createClient(host, port);
+    ByteBuffer queryExecutorStatusMsg = new AreExecutorsRegistered(appId, execIds).toByteBuffer();
+    int timeout = conf.connectionTimeoutMs() + conf.ioRetryWaitTimeMs();
+    return client.sendRpcSync(queryExecutorStatusMsg, timeout);
+  }
+
   @Override
   public MetricSet shuffleMetrics() {
     checkInit();

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -128,16 +128,16 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
     }
   }
 
-  public ByteBuffer queryExecutorStatus(
+  public ByteBuffer queryExecutorStatuses(
       String host,
       int port,
       String[] execIds) throws IOException, InterruptedException{
     checkInit();
     logger.debug("Query executor statuses in External shuffle service from {}:{}", host, port);
     TransportClient client = clientFactory.createClient(host, port);
-    ByteBuffer queryExecutorStatusMsg = new AreExecutorsRegistered(appId, execIds).toByteBuffer();
+    ByteBuffer queryExecutorStatusesMsg = new AreExecutorsRegistered(appId, execIds).toByteBuffer();
     int timeout = conf.connectionTimeoutMs() + conf.ioRetryWaitTimeMs();
-    return client.sendRpcSync(queryExecutorStatusMsg, timeout);
+    return client.sendRpcSync(queryExecutorStatusesMsg, timeout);
   }
 
   @Override

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
@@ -18,6 +18,7 @@
 package org.apache.spark.network.shuffle;
 
 import java.io.*;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.ConcurrentMap;
@@ -162,6 +163,19 @@ public class ExternalShuffleBlockResolver {
       logger.error("Error saving registered executors", e);
     }
     executors.put(fullId, executorInfo);
+  }
+
+  /**
+   * Judge whether these executors are registered.
+   */
+  public ByteBuffer areExecutorsRegistered(String appId, String[] execIds) {
+    byte[] result = new byte[execIds.length];
+    for (int i = 0; i< execIds.length; i++) {
+      if(executors.containsKey(new AppExecId(appId, execIds[i]))) {
+        result[i] = 1;
+      }
+    }
+    return ByteBuffer.wrap(result);
   }
 
   /**

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
@@ -169,13 +169,13 @@ public class ExternalShuffleBlockResolver {
    * Judge whether these executors are registered.
    */
   public ByteBuffer areExecutorsRegistered(String appId, String[] execIds) {
-    byte[] result = new byte[execIds.length];
+    byte[] statuses = new byte[execIds.length];
     for (int i = 0; i < execIds.length; i++) {
       if(executors.containsKey(new AppExecId(appId, execIds[i]))) {
-        result[i] = 1;
+        statuses[i] = 1;
       }
     }
-    return ByteBuffer.wrap(result);
+    return ByteBuffer.wrap(statuses);
   }
 
   /**

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
@@ -170,7 +170,7 @@ public class ExternalShuffleBlockResolver {
    */
   public ByteBuffer areExecutorsRegistered(String appId, String[] execIds) {
     byte[] result = new byte[execIds.length];
-    for (int i = 0; i< execIds.length; i++) {
+    for (int i = 0; i < execIds.length; i++) {
       if(executors.containsKey(new AppExecId(appId, execIds[i]))) {
         result[i] = 1;
       }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/AreExecutorsRegistered.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/AreExecutorsRegistered.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle.protocol;
+
+import com.google.common.base.Objects;
+import io.netty.buffer.ByteBuf;
+import org.apache.spark.network.protocol.Encoders;
+
+import java.util.Arrays;
+
+// Needed by ScalaDoc. See SPARK-7726
+
+/** Request to query whether these executors are registered. */
+public class AreExecutorsRegistered extends BlockTransferMessage {
+  public final String appId;
+  public final String[] execIds;
+
+  public AreExecutorsRegistered(String appId, String[] execIds) {
+    this.appId = appId;
+    this.execIds = execIds;
+  }
+
+  @Override
+  protected Type type() { return Type.ARE_EXECUTORS_REGISTERED; }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(appId) * 41 + Arrays.hashCode(execIds);
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("appId", appId)
+      .add("execIds", Arrays.toString(execIds))
+      .toString();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other != null && other instanceof AreExecutorsRegistered) {
+      AreExecutorsRegistered o = (AreExecutorsRegistered) other;
+      return Objects.equal(appId, o.appId)
+        && Arrays.equals(execIds, o.execIds);
+    }
+    return false;
+  }
+
+  @Override
+  public int encodedLength() {
+    return Encoders.Strings.encodedLength(appId)
+      + Encoders.StringArrays.encodedLength(execIds);
+  }
+
+  @Override
+  public void encode(ByteBuf buf) {
+    Encoders.Strings.encode(buf, appId);
+    Encoders.StringArrays.encode(buf, execIds);
+  }
+
+  public static AreExecutorsRegistered decode(ByteBuf buf) {
+    String appId = Encoders.Strings.decode(buf);
+    String[] execIds = Encoders.StringArrays.decode(buf);
+    return new AreExecutorsRegistered(appId, execIds);
+  }
+}

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/BlockTransferMessage.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/BlockTransferMessage.java
@@ -47,7 +47,7 @@ public abstract class BlockTransferMessage implements Encodable {
   public enum Type {
     OPEN_BLOCKS(0), UPLOAD_BLOCK(1), REGISTER_EXECUTOR(2), STREAM_HANDLE(3), REGISTER_DRIVER(4),
     HEARTBEAT(5), UPLOAD_BLOCK_STREAM(6), REMOVE_BLOCKS(7), BLOCKS_REMOVED(8),
-    FETCH_SHUFFLE_BLOCKS(9);
+    FETCH_SHUFFLE_BLOCKS(9), ARE_EXECUTORS_REGISTERED(10);
 
     private final byte id;
 
@@ -76,6 +76,7 @@ public abstract class BlockTransferMessage implements Encodable {
         case 7: return RemoveBlocks.decode(buf);
         case 8: return BlocksRemoved.decode(buf);
         case 9: return FetchShuffleBlocks.decode(buf);
+        case 10: return AreExecutorsRegistered.decode(buf);
         default: throw new IllegalArgumentException("Unknown message type: " + type);
       }
     }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalBlockHandlerSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalBlockHandlerSuite.java
@@ -36,6 +36,7 @@ import org.apache.spark.network.client.RpcResponseCallback;
 import org.apache.spark.network.client.TransportClient;
 import org.apache.spark.network.server.OneForOneStreamManager;
 import org.apache.spark.network.server.RpcHandler;
+import org.apache.spark.network.shuffle.protocol.AreExecutorsRegistered;
 import org.apache.spark.network.shuffle.protocol.BlockTransferMessage;
 import org.apache.spark.network.shuffle.protocol.ExecutorShuffleInfo;
 import org.apache.spark.network.shuffle.protocol.FetchShuffleBlocks;
@@ -221,5 +222,15 @@ public class ExternalBlockHandlerSuite {
 
     verify(callback, never()).onSuccess(any(ByteBuffer.class));
     verify(callback, never()).onFailure(any(Throwable.class));
+  }
+
+  @Test
+  public void testAreExecutorsRegistered() {
+    RpcResponseCallback callback = mock(RpcResponseCallback.class);
+    String appId = "app0";
+    String[] execIds = new String[] {"exec1", "exec2"};
+    ByteBuffer areExecutorsRegistered = new AreExecutorsRegistered(appId, execIds).toByteBuffer();
+    handler.receive(client, areExecutorsRegistered, callback);
+    verify(blockResolver, times(1)).areExecutorsRegistered(appId, execIds);
   }
 }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -161,5 +162,14 @@ public class ExternalShuffleBlockResolverSuite {
     File file = new File(normPathname);
     String returnedPath = file.getPath();
     assertTrue(normPathname == returnedPath);
+  }
+
+  @Test
+  public void testAreExecutorsRegistered() throws IOException {
+    ExternalShuffleBlockResolver resolver = new ExternalShuffleBlockResolver(conf, null);
+    resolver.registerExecutor("app0", "exec2", dataContext.createExecutorInfo(SORT_MANAGER));
+    String[] execIds = new String[] {"exec2", "exec3"};
+    ByteBuffer status = resolver.areExecutorsRegistered("app0", execIds);
+    assert(status.equals(ByteBuffer.wrap(new byte[] {1, 0})));
   }
 }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
@@ -169,7 +169,7 @@ public class ExternalShuffleBlockResolverSuite {
     ExternalShuffleBlockResolver resolver = new ExternalShuffleBlockResolver(conf, null);
     resolver.registerExecutor("app0", "exec2", dataContext.createExecutorInfo(SORT_MANAGER));
     String[] execIds = new String[] {"exec2", "exec3"};
-    ByteBuffer status = resolver.areExecutorsRegistered("app0", execIds);
-    assert(status.equals(ByteBuffer.wrap(new byte[] {1, 0})));
+    ByteBuffer statuses = resolver.areExecutorsRegistered("app0", execIds);
+    assert(statuses.equals(ByteBuffer.wrap(new byte[] {1, 0})));
   }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1854,18 +1854,18 @@ private[spark] class DAGScheduler(
             val execIdsOnHost = mapOutputTracker.getExecutorsRegisteredOnHost(host)
             val port = SparkEnv.get.conf.get(config.SHUFFLE_SERVICE_PORT)
             try {
-              val status = SparkEnv.get.blockManager.blockStoreClient
+              val statuses = SparkEnv.get.blockManager.blockStoreClient
                 .asInstanceOf[ExternalBlockStoreClient]
-                .queryExecutorStatus(host, port, execIdsOnHost).array()
-              if (status.size == execIdsOnHost.size) {
-                val execIdsNotRegistered = execIdsOnHost.zip(status).filter(_._2 == 0).map(_._1)
+                .queryExecutorStatuses(host, port, execIdsOnHost).array()
+              if (statuses.size == execIdsOnHost.size) {
+                val execIdsNotRegistered = execIdsOnHost.zip(statuses).filter(_._2 == 0).map(_._1)
                 logInfo("Shuffle files lost for executors: %s (epoch %d)"
                   .format(execIdsNotRegistered.toString, currentEpoch))
                 mapOutputTracker.removeOutputsOnExecutors(execIdsNotRegistered)
               }
             } catch {
               case e: Exception =>
-                logInfo("Exception thrown when querying executor status", e)
+                logError("Exception thrown when querying executor statuses", e)
             }
           case (Some(host), true) =>
             logInfo("Shuffle files lost for host: %s (epoch %d)".format(host, currentEpoch))


### PR DESCRIPTION
### What changes were proposed in this pull request?
As described in https://issues.apache.org/jira/browse/SPARK-27736, if a single external shuffle service process reboots and fails to recover the list of registered executors, a lot FetchFailedExceptions would be thrown and it would cause application failed eventually.

In this PR, I let externalBlockClient can query  whether executors are registered on the External Shuffle Service.
And when fetchFailedException thrown, I will query whether the executors on this host are registered.
 If not,  unregister relative output.


### Why are the changes needed?
This PR improves handling of FetchFailures caused by ExternalShuffleService losing track of executor registrations 

### Does this PR introduce any user-facing change?
No.


### How was this patch tested?

Added UT.