### PR TITLE
[SPARK-29614][SQL][TEST] Fix failures of DateTimeUtilsSuite and TimestampFormatterSuite

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -586,12 +586,15 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers {
       val now = instantToMicros(LocalDateTime.now(zoneId).atZone(zoneId).toInstant)
       toTimestamp("NOW", zoneId).get should be (now +- tolerance)
       assert(toTimestamp("now UTC", zoneId) === None)
-      val today = instantToMicros(LocalDateTime.now(zoneId)
+      val localToday = LocalDateTime.now(zoneId)
         .`with`(LocalTime.MIDNIGHT)
-        .atZone(zoneId).toInstant)
-      toTimestamp(" Yesterday", zoneId).get should be (today - MICROS_PER_DAY +- tolerance)
+        .atZone(zoneId)
+      val yesterday = instantToMicros(localToday.minusDays(1).toInstant)
+      toTimestamp(" Yesterday", zoneId).get should be (yesterday +- tolerance)
+      val today = instantToMicros(localToday.toInstant)
       toTimestamp("Today ", zoneId).get should be (today +- tolerance)
-      toTimestamp(" tomorrow CET ", zoneId).get should be (today + MICROS_PER_DAY +- tolerance)
+      val tomorrow = instantToMicros(localToday.plusDays(1).toInstant)
+      toTimestamp(" tomorrow CET ", zoneId).get should be (tomorrow +- tolerance)
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -591,8 +591,7 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers {
         .atZone(zoneId).toInstant)
       toTimestamp(" Yesterday", zoneId).get should be (today - MICROS_PER_DAY +- tolerance)
       toTimestamp("Today ", zoneId).get should be (today +- tolerance)
-      toTimestamp(s" tomorrow ${zoneId.getId} ", zoneId).get should be
-        (today + MICROS_PER_DAY +- tolerance)
+      toTimestamp(" tomorrow CET ", zoneId).get should be (today + MICROS_PER_DAY +- tolerance)
     }
   }
 
@@ -604,7 +603,7 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers {
       assert(toDate(" Now ", zoneId).get === today)
       assert(toDate("now UTC", zoneId) === None) // "now" does not accept time zones
       assert(toDate("today", zoneId).get === today)
-      assert(toDate(s"tomorrow ${zoneId.getId} ", zoneId).get === today + 1)
+      assert(toDate("tomorrow CET ", zoneId).get === today + 1)
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -591,7 +591,8 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers {
         .atZone(zoneId).toInstant)
       toTimestamp(" Yesterday", zoneId).get should be (today - MICROS_PER_DAY +- tolerance)
       toTimestamp("Today ", zoneId).get should be (today +- tolerance)
-      toTimestamp(" tomorrow CET ", zoneId).get should be (today + MICROS_PER_DAY +- tolerance)
+      toTimestamp(s" tomorrow ${zoneId.getId} ", zoneId).get should be
+        (today + MICROS_PER_DAY +- tolerance)
     }
   }
 
@@ -603,7 +604,7 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers {
       assert(toDate(" Now ", zoneId).get === today)
       assert(toDate("now UTC", zoneId) === None) // "now" does not accept time zones
       assert(toDate("today", zoneId).get === today)
-      assert(toDate("tomorrow CET ", zoneId).get === today + 1)
+      assert(toDate(s"tomorrow ${zoneId.getId} ", zoneId).get === today + 1)
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/DateFormatterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/DateFormatterSuite.scala
@@ -113,7 +113,7 @@ class DateFormatterSuite extends SparkFunSuite with SQLHelper {
         assert(formatter.parse("Yesterday") === today - 1)
         assert(formatter.parse("now") === today)
         assert(formatter.parse("today ") === today)
-        assert(formatter.parse("tomorrow UTC") === today + 1)
+        assert(formatter.parse(s"tomorrow ${zoneId.getId}") === today + 1)
       }
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/DateFormatterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/DateFormatterSuite.scala
@@ -113,7 +113,7 @@ class DateFormatterSuite extends SparkFunSuite with SQLHelper {
         assert(formatter.parse("Yesterday") === today - 1)
         assert(formatter.parse("now") === today)
         assert(formatter.parse("today ") === today)
-        assert(formatter.parse(s"tomorrow ${zoneId.getId}") === today + 1)
+        assert(formatter.parse("tomorrow UTC") === today + 1)
       }
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/TimestampFormatterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/TimestampFormatterSuite.scala
@@ -25,7 +25,7 @@ import org.scalatest.Matchers
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.catalyst.util.{DateTimeTestUtils, DateTimeUtils, TimestampFormatter}
-import org.apache.spark.sql.catalyst.util.DateTimeUtils.{getZoneId, instantToMicros, MICROS_PER_DAY}
+import org.apache.spark.sql.catalyst.util.DateTimeUtils.{getZoneId, instantToMicros}
 import org.apache.spark.sql.internal.SQLConf
 
 class TimestampFormatterSuite extends SparkFunSuite with SQLHelper with Matchers {
@@ -146,12 +146,15 @@ class TimestampFormatterSuite extends SparkFunSuite with SQLHelper with Matchers
         assert(formatter.parse("EPOCH") === 0)
         val now = instantToMicros(LocalDateTime.now(zoneId).atZone(zoneId).toInstant)
         formatter.parse("now") should be (now +- tolerance)
-        val today = instantToMicros(LocalDateTime.now(zoneId)
+        val localToday = LocalDateTime.now(zoneId)
           .`with`(LocalTime.MIDNIGHT)
-          .atZone(zoneId).toInstant)
-        formatter.parse("yesterday CET") should be (today - MICROS_PER_DAY +- tolerance)
+          .atZone(zoneId)
+        val yesterday = instantToMicros(localToday.minusDays(1).toInstant)
+        formatter.parse("yesterday CET") should be (yesterday +- tolerance)
+        val today = instantToMicros(localToday.toInstant)
         formatter.parse(" TODAY ") should be (today +- tolerance)
-        formatter.parse("Tomorrow ") should be (today + MICROS_PER_DAY +- tolerance)
+        val tomorrow = instantToMicros(localToday.plusDays(1).toInstant)
+        formatter.parse("Tomorrow ") should be (tomorrow +- tolerance)
       }
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/TimestampFormatterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/TimestampFormatterSuite.scala
@@ -149,11 +149,9 @@ class TimestampFormatterSuite extends SparkFunSuite with SQLHelper with Matchers
         val today = instantToMicros(LocalDateTime.now(zoneId)
           .`with`(LocalTime.MIDNIGHT)
           .atZone(zoneId).toInstant)
-        formatter.parse(s"yesterday ${zoneId.getId}") should be
-          (today - MICROS_PER_DAY +- tolerance)
+        formatter.parse("yesterday CET") should be (today - MICROS_PER_DAY +- tolerance)
         formatter.parse(" TODAY ") should be (today +- tolerance)
-        formatter.parse(s"Tomorrow ${zoneId.getId}") should be
-          (today + MICROS_PER_DAY +- tolerance)
+        formatter.parse("Tomorrow ") should be (today + MICROS_PER_DAY +- tolerance)
       }
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/TimestampFormatterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/TimestampFormatterSuite.scala
@@ -149,9 +149,11 @@ class TimestampFormatterSuite extends SparkFunSuite with SQLHelper with Matchers
         val today = instantToMicros(LocalDateTime.now(zoneId)
           .`with`(LocalTime.MIDNIGHT)
           .atZone(zoneId).toInstant)
-        formatter.parse("yesterday CET") should be (today - MICROS_PER_DAY +- tolerance)
+        formatter.parse(s"yesterday ${zoneId.getId}") should be
+          (today - MICROS_PER_DAY +- tolerance)
         formatter.parse(" TODAY ") should be (today +- tolerance)
-        formatter.parse("Tomorrow ") should be (today + MICROS_PER_DAY +- tolerance)
+        formatter.parse(s"Tomorrow ${zoneId.getId}") should be
+          (today + MICROS_PER_DAY +- tolerance)
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The `DateTimeUtilsSuite` and `TimestampFormatterSuite` assume constant time difference between `timestamp'yesterday'`, `timestamp'today'` and `timestamp'tomorrow'` which is wrong on daylight switching day - day length can be 23 or 25 hours. In the PR, I propose to use Java 8 time API to calculate instances of `yesterday` and `tomorrow` timestamps.

### Why are the changes needed?
The changes fix test failures and make the tests tolerant to daylight time switching.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
By existing test suites `DateTimeUtilsSuite` and `TimestampFormatterSuite`.
