### PR TITLE
[SPARK-14922][SPARK-17732][SPARK-23866][SQL] Support partition filter in ALTER TABLE DROP PARTITION and batch dropping PARTITIONS

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -161,8 +161,8 @@ statement
         partitionSpecLocation+                                         #addTablePartition
     | ALTER TABLE multipartIdentifier
         from=partitionSpec RENAME TO to=partitionSpec                  #renameTablePartition
-    | ALTER (TABLE | VIEW) multipartIdentifier
-        DROP (IF EXISTS)? partitionSpec (',' partitionSpec)* PURGE?    #dropTablePartitions
+    | ALTER (TABLE | VIEW) multipartIdentifier DROP (IF EXISTS)?
+        dropPartitionSpec (',' dropPartitionSpec)* PURGE?              #dropTablePartitions
     | ALTER TABLE multipartIdentifier
         (partitionSpec)? SET locationSpec                              #setTableLocation
     | ALTER TABLE multipartIdentifier RECOVER PARTITIONS               #recoverPartitions
@@ -326,6 +326,14 @@ partitionVal
 database
     : DATABASE
     | SCHEMA
+    ;
+
+dropPartitionSpec
+    : PARTITION '(' dropPartitionVal (',' dropPartitionVal)* ')'
+    ;
+
+dropPartitionVal
+    : identifier (comparisonOperator constant)?
     ;
 
 describeFuncName

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -188,7 +188,8 @@ trait ExternalCatalog {
       parts: Seq[TablePartitionSpec],
       ignoreIfNotExists: Boolean,
       purge: Boolean,
-      retainData: Boolean): Unit
+      retainData: Boolean,
+      supportBatch: Boolean): Unit
 
   /**
    * Override the specs of one or many existing table partitions, assuming they exist.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
@@ -203,8 +203,10 @@ class ExternalCatalogWithListener(delegate: ExternalCatalog)
       partSpecs: Seq[TablePartitionSpec],
       ignoreIfNotExists: Boolean,
       purge: Boolean,
-      retainData: Boolean): Unit = {
-    delegate.dropPartitions(db, table, partSpecs, ignoreIfNotExists, purge, retainData)
+      retainData: Boolean,
+      supportBatch: Boolean): Unit = {
+    delegate.dropPartitions(db, table, partSpecs, ignoreIfNotExists, purge, retainData,
+      supportBatch)
   }
 
   override def renamePartitions(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -425,7 +425,8 @@ class InMemoryCatalog(
       partSpecs: Seq[TablePartitionSpec],
       ignoreIfNotExists: Boolean,
       purge: Boolean,
-      retainData: Boolean): Unit = synchronized {
+      retainData: Boolean,
+      supportBatch: Boolean): Unit = synchronized {
     requireTableExists(db, table)
     val existingParts = catalog(db).tables(table).partitions
     if (!ignoreIfNotExists) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -918,14 +918,16 @@ class SessionCatalog(
       specs: Seq[TablePartitionSpec],
       ignoreIfNotExists: Boolean,
       purge: Boolean,
-      retainData: Boolean): Unit = {
+      retainData: Boolean,
+      supportBatch: Boolean): Unit = {
     val db = formatDatabaseName(tableName.database.getOrElse(getCurrentDatabase))
     val table = formatTableName(tableName.table)
     requireDbExists(db)
     requireTableExists(TableIdentifier(table, Option(db)))
     requirePartialMatchedPartitionSpec(specs, getTableMetadata(tableName))
     requireNonEmptyValueInPartitionSpec(specs)
-    externalCatalog.dropPartitions(db, table, specs, ignoreIfNotExists, purge, retainData)
+    externalCatalog.dropPartitions(db, table, specs, ignoreIfNotExists, purge, retainData,
+      supportBatch)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -391,6 +391,35 @@ case class OuterReference(e: NamedExpression)
   override def newInstance(): NamedExpression = OuterReference(e.newInstance())
 }
 
+/**
+ * A place holder used to hold the name of the partition attributes specified when running commands
+ * involving partitions, eg. ALTER TABLE ... DROP PARTITIONS.
+ */
+case class PartitioningAttribute(
+    name: String,
+    override val exprId: ExprId = NamedExpression.newExprId)
+  extends Attribute with Unevaluable {
+  // We need a dataType to be used during analysis for resolving the expressions (see
+  // checkInputDataTypes). The String type is used because all the literals in PARTITION operations
+  // are parsed as strings and eventually casted later.
+  override def dataType: DataType = StringType
+  override def nullable: Boolean = false
+
+  override def qualifier: Seq[String] = throw new UnsupportedOperationException
+  override def withNullability(newNullability: Boolean): Attribute =
+    throw new UnsupportedOperationException
+  override def newInstance(): Attribute = throw new UnsupportedOperationException
+  override def withQualifier(newQualifier: Seq[String]): Attribute =
+    throw new UnsupportedOperationException
+  override def withName(newName: String): Attribute = throw new UnsupportedOperationException
+  override def withMetadata(newMetadata: Metadata): Attribute =
+    throw new UnsupportedOperationException
+
+  override lazy val canonicalized: Expression = this.copy(exprId = ExprId(0))
+
+  override def withExprId(newExprId: ExprId): Attribute = throw new UnsupportedOperationException
+}
+
 object VirtualColumn {
   // The attribute name used by Hive, which has different result than Spark, deprecated.
   val hiveGroupingIdName: String = "grouping__id"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -500,6 +500,29 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
   }
 
   /**
+   * Create a partition specification map with filters.
+   */
+  override def visitDropPartitionSpec(
+      ctx: DropPartitionSpecContext): Seq[Expression] = withOrigin(ctx) {
+    ctx.dropPartitionVal().asScala.map { pFilter =>
+      if (pFilter.constant() == null || pFilter.comparisonOperator() == null) {
+        throw new ParseException(s"Invalid partition spec: ${pFilter.getText}", ctx)
+      }
+      // We cannot use UnresolvedAttribute because resolution is performed after Analysis, when
+      // running the command.
+      val partition = PartitioningAttribute(pFilter.identifier().getText)
+      val value = Literal(visitStringConstant(pFilter.constant()))
+      val operator = pFilter.comparisonOperator().getChild(0).asInstanceOf[TerminalNode]
+      val comparison = buildComparison(partition, value, operator)
+      if (comparison.isInstanceOf[EqualNullSafe]) {
+        throw new ParseException(
+          "'<=>' operator is not supported in ALTER TABLE ... DROP PARTITION.", ctx)
+      }
+      comparison
+    }
+  }
+
+  /**
    * Convert a constant of any type into a string. This is typically used in DDL commands, and its
    * main purpose is to prevent slight differences due to back to back conversions i.e.:
    * String -> Literal -> String.
@@ -1321,6 +1344,23 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
     val left = expression(ctx.left)
     val right = expression(ctx.right)
     val operator = ctx.comparisonOperator().getChild(0).asInstanceOf[TerminalNode]
+    buildComparison(left, right, operator)
+  }
+
+  /**
+   * Creates a comparison expression. The following comparison operators are supported:
+   * - Equal: '=' or '=='
+   * - Null-safe Equal: '<=>'
+   * - Not Equal: '<>' or '!='
+   * - Less than: '<'
+   * - Less then or Equal: '<='
+   * - Greater than: '>'
+   * - Greater then or Equal: '>='
+   */
+  private def buildComparison(
+      left: Expression,
+      right: Expression,
+      operator: TerminalNode): Expression = {
     operator.getSymbol.getType match {
       case SqlBaseParser.EQ =>
         EqualTo(left, right)
@@ -3153,7 +3193,7 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
     }
     AlterTableDropPartitionStatement(
       visitMultipartIdentifier(ctx.multipartIdentifier),
-      ctx.partitionSpec.asScala.map(visitNonOptionalPartitionSpec),
+      ctx.dropPartitionSpec.asScala.map(visitDropPartitionSpec),
       ifExists = ctx.EXISTS != null,
       purge = ctx.PURGE != null,
       retainData = false)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
@@ -209,7 +209,7 @@ case class AlterTableRenamePartitionStatement(
  */
 case class AlterTableDropPartitionStatement(
     tableName: Seq[String],
-    specs: Seq[TablePartitionSpec],
+    specs: Seq[Seq[Expression]],
     ifExists: Boolean,
     purge: Boolean,
     retainData: Boolean) extends ParsedStatement

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -151,7 +151,7 @@ case class InsertIntoHadoopFsRelationCommand(
           if (mode == SaveMode.Overwrite && !dynamicPartitionOverwrite) {
             val deletedPartitions = initialMatchingPartitions.toSet -- updatedPartitions
             if (deletedPartitions.nonEmpty) {
-              AlterTableDropPartitionCommand(
+              AlterTableDropPartitionCommand.fromSpecs(
                 catalogTable.get.identifier, deletedPartitions.toSeq,
                 ifExists = true, purge = false,
                 retainData = true /* already deleted */).run(sparkSession)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -378,6 +378,16 @@ object PartitioningUtils {
     normalizedPartSpec.toMap
   }
 
+  def normalizePartitionColumn(
+      partition: String,
+      partColNames: Seq[String],
+      tblName: String,
+      resolver: Resolver): String = {
+    partColNames.find(resolver(_, partition)).getOrElse {
+      throw new AnalysisException(s"$partition is not a valid partition column in table $tblName.")
+    }
+  }
+
   /**
    * Resolves possible type conflicts between partitions by up-casting "lower" types using
    * [[findWiderTypeForPartitionColumn]].

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -991,10 +991,12 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       parts: Seq[TablePartitionSpec],
       ignoreIfNotExists: Boolean,
       purge: Boolean,
-      retainData: Boolean): Unit = withClient {
+      retainData: Boolean,
+      supportBatch: Boolean): Unit = withClient {
     requireTableExists(db, table)
     client.dropPartitions(
-      db, table, parts.map(lowerCasePartitionSpec), ignoreIfNotExists, purge, retainData)
+      db, table, parts.map(lowerCasePartitionSpec), ignoreIfNotExists, purge, retainData,
+      supportBatch)
   }
 
   override def renamePartitions(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
@@ -149,7 +149,8 @@ private[hive] trait HiveClient {
       specs: Seq[TablePartitionSpec],
       ignoreIfNotExists: Boolean,
       purge: Boolean,
-      retainData: Boolean): Unit
+      retainData: Boolean,
+      supportBatch: Boolean): Unit
 
   /**
    * Rename one or many existing table partitions, assuming they exist.

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -90,6 +90,55 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
     }
   }
 
+  test("create and drop partitions") {
+    Seq(true, false).foreach { batchDrop =>
+      val catalog = newEmptyCatalog()
+      val database = s"db_$batchDrop"
+      val table1 = "tbl1"
+      val table2 = "tbl2"
+      catalog.createDatabase(newDb(s"$database"), ignoreIfExists = false)
+      catalog.createTable(newTable(s"$table1", s"$database"),
+        ignoreIfExists = false)
+      catalog.createPartitions(s"$database", s"$table1",
+        Seq(part1, part2, part3), ignoreIfExists = false)
+      assert(catalogPartitionsEqual(catalog, s"$database", s"$table1",
+        Seq(part1, part2, part3)))
+
+      // drop partitions with only one partition
+      catalog.dropPartitions(
+        s"$database", s"$table1", Seq(part1.spec),
+        ignoreIfNotExists = false, purge = false, retainData = false,
+        supportBatch = batchDrop)
+      assert(catalogPartitionsEqual(catalog, s"$database", s"$table1", Seq(part2, part3)))
+
+      catalog.dropPartitions(
+        s"$database", s"$table1", Seq(part2.spec),
+        ignoreIfNotExists = false, purge = false, retainData = false, supportBatch = batchDrop)
+      assert(catalogPartitionsEqual(catalog, s"$database", s"$table1", Seq(part3)))
+
+      catalog.dropPartitions(
+        s"$database", s"$table1", Seq(part3.spec),
+        ignoreIfNotExists = false, purge = false, retainData = false, supportBatch = batchDrop)
+      assert(catalog.listPartitions(s"$database", s"$table1").isEmpty)
+
+      catalog.createTable(newTable(s"$table2", s"$database"), ignoreIfExists = false)
+      catalog.createPartitions(s"$database", s"$table2",
+        Seq(part1, part2, part3), ignoreIfExists = false)
+      assert(catalogPartitionsEqual(catalog, s"$database", s"$table2", Seq(part1, part2, part3)))
+
+      // drop partitions with some partitions
+      catalog.dropPartitions(
+        s"$database", s"$table2", Seq(part1.spec, part2.spec), ignoreIfNotExists = false,
+        purge = false, retainData = false, supportBatch = batchDrop)
+      assert(catalogPartitionsEqual(catalog, s"$database", s"$table2", Seq(part3)))
+
+      catalog.dropPartitions(
+        s"$database", s"$table2", Seq(part3.spec),
+        ignoreIfNotExists = false, purge = false, retainData = false, supportBatch = batchDrop)
+      assert(catalog.listPartitions(s"$database", s"$table2").isEmpty)
+    }
+  }
+
   test("SPARK-22306: alter table schema should not erase the bucketing metadata at hive side") {
     val catalog = newBasicCatalog()
     externalCatalog.client.runSqlHive(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
@@ -519,13 +519,13 @@ class VersionsSuite extends SparkFunSuite with Logging {
       // with a version that is older than the minimum (1.2 in this case).
       try {
         client.dropPartitions("default", "src_part", Seq(spec), ignoreIfNotExists = true,
-          purge = true, retainData = false)
+          purge = true, retainData = false, supportBatch = true)
         assert(!versionsWithoutPurge.contains(version))
       } catch {
         case _: UnsupportedOperationException =>
           assert(versionsWithoutPurge.contains(version))
           client.dropPartitions("default", "src_part", Seq(spec), ignoreIfNotExists = true,
-            purge = false, retainData = false)
+            purge = false, retainData = false, supportBatch = true)
       }
 
       assert(client.getPartitionOption("default", "src_part", spec).isEmpty)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Spark only  can drop partitions by exact values. For instance, Spark doesn't support:

>  ALTER TABLE mytable DROP PARTITION(mydate < '2018-04-06') 

The PR adds the support to this syntax.

The PR takes input from the effort in #19691 by @DazhuangSu ,  in #20999 by @mgaido91 ,
, there are some related PRs: #15987,#16036,#19691,#15704.
some related issues:
https://issues.apache.org/jira/browse/SPARK-14922
https://issues.apache.org/jira/browse/SPARK-17732
https://issues.apache.org/jira/browse/SPARK-23866
### How was this patch tested?
Add unittests.