### PR TITLE
[SPARK-29619][PYTHON][CORE] Add retry times when reading the daemon port.

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
@@ -216,7 +216,7 @@ private[spark] class PythonWorkerFactory(pythonExec: String, envVars: Map[String
           hasExcept = false
           try {
             daemon = pb.start()
-            val in = new DataInputStream(daemon.getInputStream)
+            in = new DataInputStream(daemon.getInputStream)
             daemonPort = in.readInt()
           } catch {
             case e: EOFException =>

--- a/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
@@ -222,7 +222,7 @@ private[spark] class PythonWorkerFactory(pythonExec: String, envVars: Map[String
             case e: EOFException =>
               if (numRetries <= maxRetries) {
                 hasExcept = true
-                logWarning("Exception occurred while reading the port number of the $daemonModule.", e)
+                logWarning("Exception occurred while reading the port number of the $daemonModule.")
               } else {
                 throw new SparkException(s"Start $daemonModule exceedes $maxRetries times.")
               }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR is related to https://github.com/apache/spark/pull/26510 and add retry mechanism to start process.
We have a lot job with PySpark. We only find a small number of job causes the issue. After some try will reduce the issue.
I think the root cause of the exit is the robust problem with the user code.
If when starting Python process, but exited caused by a unstable factor of system, do we need to make the effort to retry?

### Why are the changes needed?
In order to clarify the exception and try three times default.

### Does this PR introduce any user-facing change?
No.


### How was this patch tested?
Exists UT.
