### PR TITLE
[SPARK-29622][SQL] do not allow leading 'interval' in the interval string format

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/CalendarInterval.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/CalendarInterval.java
@@ -81,7 +81,7 @@ public final class CalendarInterval implements Serializable {
 
   @Override
   public String toString() {
-    StringBuilder sb = new StringBuilder("interval");
+    StringBuilder sb = new StringBuilder();
 
     if (months != 0) {
       appendUnit(sb, months / 12, "year");
@@ -98,18 +98,19 @@ public final class CalendarInterval implements Serializable {
       rest %= MICROS_PER_MINUTE;
       if (rest != 0) {
         String s = BigDecimal.valueOf(rest, 6).stripTrailingZeros().toPlainString();
-        sb.append(' ').append(s).append(" seconds");
+        sb.append(s).append(" seconds ");
       }
     } else if (months == 0 && days == 0) {
-      sb.append(" 0 microseconds");
+      sb.append("0 seconds ");
     }
 
+    sb.setLength(sb.length() - 1);
     return sb.toString();
   }
 
   private void appendUnit(StringBuilder sb, long value, String unit) {
     if (value != 0) {
-      sb.append(' ').append(value).append(' ').append(unit).append('s');
+      sb.append(value).append(' ').append(unit).append('s').append(' ');
     }
   }
 }

--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -220,6 +220,8 @@ license: |
 
   - Since Spark 3.0, the interval literal syntax does not allow multiple from-to units anymore. For example, `SELECT INTERVAL '1-1' YEAR TO MONTH '2-2' YEAR TO MONTH'` throws parser exception.
 
+  - Since Spark 3.0, when casting string to interval type, strings with leading "interval" such as "interval 1 day" will be treated as invalid and the cast returns null. In Spark version 2.4 and earlier, the leading "interval" is allowed and required. To allow the leading "interval", you can set `spark.sql.legacy.allowIntervalPrefixInCast` to true.
+
 ## Upgrading from Spark SQL 2.4 to 2.4.1
 
   - The value of `spark.executor.heartbeatInterval`, when specified without units like "30" rather than "30s", was

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -80,7 +80,7 @@ singleTableSchema
     ;
 
 singleInterval
-    : INTERVAL? multiUnitsInterval EOF
+    : multiUnitsInterval EOF
     ;
 
 statement

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -365,4 +365,13 @@ object IntervalUtils {
   def isNegative(interval: CalendarInterval, daysPerMonth: Int = 31): Boolean = {
     getDuration(interval, TimeUnit.MICROSECONDS, daysPerMonth) < 0
   }
+
+  def legacyCastStringToInterval(str: String): CalendarInterval = {
+    val trimmed = str.trim
+    if (trimmed.regionMatches(true, 0, "interval", 0, 8)) {
+      safeFromString(trimmed.drop(8))
+    } else {
+      safeFromString(trimmed)
+    }
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2042,6 +2042,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val LEGACY_ALLOW_INTERVAL_PREFIX_IN_CAST =
+    buildConf("spark.sql.legacy.allowIntervalPrefixInCast")
+      .doc("When true, it's allowed to have the 'interval' prefix in the string that is being " +
+        "casted to interval type. For example, `CAST('interval 1 day' AS INTERVAL)` returns " +
+        "null if this config is set to false.")
+      .booleanConf
+      .createWithDefault(false)
+
   val ADDITIONAL_REMOTE_REPOSITORIES =
     buildConf("spark.sql.additionalRemoteRepositories")
       .doc("A comma-delimited string config of the optional additional remote Maven mirror " +

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
@@ -50,7 +50,7 @@ class IntervalUtilsSuite extends SparkFunSuite {
       }
     }
 
-    for (input <- Seq("interval", "interval1 day", "foo", "foo 1 day")) {
+    for (input <- Seq("interval", "interval 1 day", "interval1 day", "foo", "foo 1 day")) {
       try {
         fromString(input)
         fail("Expected to throw an exception for the invalid input")
@@ -82,13 +82,11 @@ class IntervalUtilsSuite extends SparkFunSuite {
 
   private def testSingleUnit(
       unit: String, number: Int, months: Int, days: Int, microseconds: Long): Unit = {
-    for (prefix <- Seq("interval ", "")) {
-      val input1 = prefix + number + " " + unit
-      val input2 = prefix + number + " " + unit + "s"
-      val result = new CalendarInterval(months, days, microseconds)
-      assert(fromString(input1) == result)
-      assert(fromString(input2) == result)
-    }
+    val input1 = number + " " + unit
+    val input2 = number + " " + unit + "s"
+    val result = new CalendarInterval(months, days, microseconds)
+    assert(fromString(input1) == result)
+    assert(fromString(input2) == result)
   }
 
   test("from year-month string") {
@@ -185,5 +183,12 @@ class IntervalUtilsSuite extends SparkFunSuite {
     assert(!isNegative("0 months", 28))
     assert(!isNegative("1 year -360 days", 31))
     assert(!isNegative("-1 year 380 days", 31))
+  }
+
+  test("legacyCastStringToInterval") {
+    for (input <- Seq("inTERval 1 year", "1 year")) {
+      val result = new CalendarInterval(12, 0, 0)
+      assert(IntervalUtils.legacyCastStringToInterval(input) == result)
+    }
   }
 }

--- a/sql/core/src/test/resources/sql-tests/inputs/cast.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/cast.sql
@@ -58,5 +58,5 @@ DESC FUNCTION EXTENDED boolean;
 -- TODO: migrate all cast tests here.
 
 -- cast string to interval and interval to string
-SELECT CAST('interval 3 month 1 hour' AS interval);
+SELECT CAST('3 month 1 hour' AS interval);
 SELECT CAST(interval 3 month 1 hour AS string);

--- a/sql/core/src/test/resources/sql-tests/inputs/literals.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/literals.sql
@@ -123,7 +123,6 @@ SELECT 3.14, -3.14, 3.14e8, 3.14e-8, -3.14e8, -3.14e-8, 3.14e+8, 3.14E8, 3.14E-8
 select map(1, interval 1 day, 2, interval 3 week);
 
 -- typed interval expression
-select interval 'interval 3 year 1 hour';
 select interval '3 year 1 hour';
 
 -- typed integer expression
@@ -133,6 +132,7 @@ select integer '2147483648';
 
 -- malformed interval literal
 select interval;
+select interval 'interval 3 year 1 hour';
 select interval 1 fake_unit;
 select interval 1 year to month;
 select interval '1' year to second;

--- a/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
@@ -25,9 +25,9 @@ select
   '1' year,
   2  years
 -- !query 1 schema
-struct<interval 1 seconds:interval,interval 2 seconds:interval,interval 1 minutes:interval,interval 2 minutes:interval,interval 1 hours:interval,interval 2 hours:interval,interval 1 days:interval,interval 2 days:interval,interval 1 months:interval,interval 2 months:interval,interval 1 years:interval,interval 2 years:interval>
+struct<1 seconds:interval,2 seconds:interval,1 minutes:interval,2 minutes:interval,1 hours:interval,2 hours:interval,1 days:interval,2 days:interval,1 months:interval,2 months:interval,1 years:interval,2 years:interval>
 -- !query 1 output
-interval 1 seconds	interval 2 seconds	interval 1 minutes	interval 2 minutes	interval 1 hours	interval 2 hours	interval 1 days	interval 2 days	interval 1 months	interval 2 months	interval 1 years	interval 2 years
+1 seconds	2 seconds	1 minutes	2 minutes	1 hours	2 hours	1 days	2 days	1 months	2 months	1 years	2 years
 
 
 -- !query 2
@@ -36,9 +36,9 @@ select
   interval '10' year,
   interval '11' month
 -- !query 2 schema
-struct<interval 10 years 11 months:interval,interval 10 years:interval,interval 11 months:interval>
+struct<10 years 11 months:interval,10 years:interval,11 months:interval>
 -- !query 2 output
-interval 10 years 11 months	interval 10 years	interval 11 months
+10 years 11 months	10 years	11 months
 
 
 -- !query 3
@@ -47,9 +47,9 @@ select
   '10' year,
   '11' month
 -- !query 3 schema
-struct<interval 10 years 11 months:interval,interval 10 years:interval,interval 11 months:interval>
+struct<10 years 11 months:interval,10 years:interval,11 months:interval>
 -- !query 3 output
-interval 10 years 11 months	interval 10 years	interval 11 months
+10 years 11 months	10 years	11 months
 
 
 -- !query 4
@@ -61,9 +61,9 @@ select
   interval '13' second,
   interval '13.123456789' second
 -- !query 4 schema
-struct<interval 10 days 9 hours 8 minutes 7.987654 seconds:interval,interval 10 days:interval,interval 11 hours:interval,interval 12 minutes:interval,interval 13 seconds:interval,interval 13.123456 seconds:interval>
+struct<10 days 9 hours 8 minutes 7.987654 seconds:interval,10 days:interval,11 hours:interval,12 minutes:interval,13 seconds:interval,13.123456 seconds:interval>
 -- !query 4 output
-interval 10 days 9 hours 8 minutes 7.987654 seconds	interval 10 days	interval 11 hours	interval 12 minutes	interval 13 seconds	interval 13.123456 seconds
+10 days 9 hours 8 minutes 7.987654 seconds	10 days	11 hours	12 minutes	13 seconds	13.123456 seconds
 
 
 -- !query 5
@@ -75,25 +75,25 @@ select
   '13' second,
   '13.123456789' second
 -- !query 5 schema
-struct<interval 10 days 9 hours 8 minutes 7.987654 seconds:interval,interval 10 days:interval,interval 11 hours:interval,interval 12 minutes:interval,interval 13 seconds:interval,interval 13.123456 seconds:interval>
+struct<10 days 9 hours 8 minutes 7.987654 seconds:interval,10 days:interval,11 hours:interval,12 minutes:interval,13 seconds:interval,13.123456 seconds:interval>
 -- !query 5 output
-interval 10 days 9 hours 8 minutes 7.987654 seconds	interval 10 days	interval 11 hours	interval 12 minutes	interval 13 seconds	interval 13.123456 seconds
+10 days 9 hours 8 minutes 7.987654 seconds	10 days	11 hours	12 minutes	13 seconds	13.123456 seconds
 
 
 -- !query 6
 select map(1, interval 1 day, 2, interval 3 week)
 -- !query 6 schema
-struct<map(1, interval 1 days, 2, interval 21 days):map<int,interval>>
+struct<map(1, 1 days, 2, 21 days):map<int,interval>>
 -- !query 6 output
-{1:interval 1 days,2:interval 21 days}
+{1:1 days,2:21 days}
 
 
 -- !query 7
 select map(1, 1 day, 2, 3 week)
 -- !query 7 schema
-struct<map(1, interval 1 days, 2, interval 21 days):map<int,interval>>
+struct<map(1, 1 days, 2, 21 days):map<int,interval>>
 -- !query 7 output
-{1:interval 1 days,2:interval 21 days}
+{1:1 days,2:21 days}
 
 
 -- !query 8
@@ -118,7 +118,7 @@ select
   interval '2-2' year to month + dateval
 from interval_arithmetic
 -- !query 9 schema
-struct<dateval:date,CAST(CAST(dateval AS TIMESTAMP) - interval 2 years 2 months AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) - interval -2 years -2 months AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + interval 2 years 2 months AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + interval -2 years -2 months AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + (- interval 2 years 2 months) AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + interval 2 years 2 months AS DATE):date>
+struct<dateval:date,CAST(CAST(dateval AS TIMESTAMP) - 2 years 2 months AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) - -2 years -2 months AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + 2 years 2 months AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + -2 years -2 months AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + (- 2 years 2 months) AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + 2 years 2 months AS DATE):date>
 -- !query 9 output
 2012-01-01	2009-11-01	2014-03-01	2014-03-01	2009-11-01	2009-11-01	2014-03-01
 
@@ -134,7 +134,7 @@ select
   '2-2' year to month + dateval
 from interval_arithmetic
 -- !query 10 schema
-struct<dateval:date,CAST(CAST(dateval AS TIMESTAMP) - interval 2 years 2 months AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) - interval -2 years -2 months AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + interval 2 years 2 months AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + interval -2 years -2 months AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + (- interval 2 years 2 months) AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + interval 2 years 2 months AS DATE):date>
+struct<dateval:date,CAST(CAST(dateval AS TIMESTAMP) - 2 years 2 months AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) - -2 years -2 months AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + 2 years 2 months AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + -2 years -2 months AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + (- 2 years 2 months) AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + 2 years 2 months AS DATE):date>
 -- !query 10 output
 2012-01-01	2009-11-01	2014-03-01	2014-03-01	2009-11-01	2009-11-01	2014-03-01
 
@@ -150,7 +150,7 @@ select
   interval '2-2' year to month + tsval
 from interval_arithmetic
 -- !query 11 schema
-struct<tsval:timestamp,CAST(tsval - interval 2 years 2 months AS TIMESTAMP):timestamp,CAST(tsval - interval -2 years -2 months AS TIMESTAMP):timestamp,CAST(tsval + interval 2 years 2 months AS TIMESTAMP):timestamp,CAST(tsval + interval -2 years -2 months AS TIMESTAMP):timestamp,CAST(tsval + (- interval 2 years 2 months) AS TIMESTAMP):timestamp,CAST(tsval + interval 2 years 2 months AS TIMESTAMP):timestamp>
+struct<tsval:timestamp,CAST(tsval - 2 years 2 months AS TIMESTAMP):timestamp,CAST(tsval - -2 years -2 months AS TIMESTAMP):timestamp,CAST(tsval + 2 years 2 months AS TIMESTAMP):timestamp,CAST(tsval + -2 years -2 months AS TIMESTAMP):timestamp,CAST(tsval + (- 2 years 2 months) AS TIMESTAMP):timestamp,CAST(tsval + 2 years 2 months AS TIMESTAMP):timestamp>
 -- !query 11 output
 2012-01-01 00:00:00	2009-11-01 00:00:00	2014-03-01 00:00:00	2014-03-01 00:00:00	2009-11-01 00:00:00	2009-11-01 00:00:00	2014-03-01 00:00:00
 
@@ -166,7 +166,7 @@ select
   '2-2' year to month + tsval
 from interval_arithmetic
 -- !query 12 schema
-struct<tsval:timestamp,CAST(tsval - interval 2 years 2 months AS TIMESTAMP):timestamp,CAST(tsval - interval -2 years -2 months AS TIMESTAMP):timestamp,CAST(tsval + interval 2 years 2 months AS TIMESTAMP):timestamp,CAST(tsval + interval -2 years -2 months AS TIMESTAMP):timestamp,CAST(tsval + (- interval 2 years 2 months) AS TIMESTAMP):timestamp,CAST(tsval + interval 2 years 2 months AS TIMESTAMP):timestamp>
+struct<tsval:timestamp,CAST(tsval - 2 years 2 months AS TIMESTAMP):timestamp,CAST(tsval - -2 years -2 months AS TIMESTAMP):timestamp,CAST(tsval + 2 years 2 months AS TIMESTAMP):timestamp,CAST(tsval + -2 years -2 months AS TIMESTAMP):timestamp,CAST(tsval + (- 2 years 2 months) AS TIMESTAMP):timestamp,CAST(tsval + 2 years 2 months AS TIMESTAMP):timestamp>
 -- !query 12 output
 2012-01-01 00:00:00	2009-11-01 00:00:00	2014-03-01 00:00:00	2014-03-01 00:00:00	2009-11-01 00:00:00	2009-11-01 00:00:00	2014-03-01 00:00:00
 
@@ -177,9 +177,9 @@ select
   interval '2-2' year to month - interval '3-3' year to month
 from interval_arithmetic
 -- !query 13 schema
-struct<(interval 2 years 2 months + interval 3 years 3 months):interval,(interval 2 years 2 months - interval 3 years 3 months):interval>
+struct<(2 years 2 months + 3 years 3 months):interval,(2 years 2 months - 3 years 3 months):interval>
 -- !query 13 output
-interval 5 years 5 months	interval -1 years -1 months
+5 years 5 months	-1 years -1 months
 
 
 -- !query 14
@@ -188,9 +188,9 @@ select
   '2-2' year to month - '3-3' year to month
 from interval_arithmetic
 -- !query 14 schema
-struct<(interval 2 years 2 months + interval 3 years 3 months):interval,(interval 2 years 2 months - interval 3 years 3 months):interval>
+struct<(2 years 2 months + 3 years 3 months):interval,(2 years 2 months - 3 years 3 months):interval>
 -- !query 14 output
-interval 5 years 5 months	interval -1 years -1 months
+5 years 5 months	-1 years -1 months
 
 
 -- !query 15
@@ -204,7 +204,7 @@ select
   interval '99 11:22:33.123456789' day to second + dateval
 from interval_arithmetic
 -- !query 15 schema
-struct<dateval:date,CAST(CAST(dateval AS TIMESTAMP) - interval 99 days 11 hours 22 minutes 33.123456 seconds AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) - interval -99 days -11 hours -22 minutes -33.123456 seconds AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + interval 99 days 11 hours 22 minutes 33.123456 seconds AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + interval -99 days -11 hours -22 minutes -33.123456 seconds AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + (- interval 99 days 11 hours 22 minutes 33.123456 seconds) AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + interval 99 days 11 hours 22 minutes 33.123456 seconds AS DATE):date>
+struct<dateval:date,CAST(CAST(dateval AS TIMESTAMP) - 99 days 11 hours 22 minutes 33.123456 seconds AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) - -99 days -11 hours -22 minutes -33.123456 seconds AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + 99 days 11 hours 22 minutes 33.123456 seconds AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + -99 days -11 hours -22 minutes -33.123456 seconds AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + (- 99 days 11 hours 22 minutes 33.123456 seconds) AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + 99 days 11 hours 22 minutes 33.123456 seconds AS DATE):date>
 -- !query 15 output
 2012-01-01	2011-09-23	2012-04-09	2012-04-09	2011-09-23	2011-09-23	2012-04-09
 
@@ -220,7 +220,7 @@ select
   '99 11:22:33.123456789' day to second + dateval
 from interval_arithmetic
 -- !query 16 schema
-struct<dateval:date,CAST(CAST(dateval AS TIMESTAMP) - interval 99 days 11 hours 22 minutes 33.123456 seconds AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) - interval -99 days -11 hours -22 minutes -33.123456 seconds AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + interval 99 days 11 hours 22 minutes 33.123456 seconds AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + interval -99 days -11 hours -22 minutes -33.123456 seconds AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + (- interval 99 days 11 hours 22 minutes 33.123456 seconds) AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + interval 99 days 11 hours 22 minutes 33.123456 seconds AS DATE):date>
+struct<dateval:date,CAST(CAST(dateval AS TIMESTAMP) - 99 days 11 hours 22 minutes 33.123456 seconds AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) - -99 days -11 hours -22 minutes -33.123456 seconds AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + 99 days 11 hours 22 minutes 33.123456 seconds AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + -99 days -11 hours -22 minutes -33.123456 seconds AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + (- 99 days 11 hours 22 minutes 33.123456 seconds) AS DATE):date,CAST(CAST(dateval AS TIMESTAMP) + 99 days 11 hours 22 minutes 33.123456 seconds AS DATE):date>
 -- !query 16 output
 2012-01-01	2011-09-23	2012-04-09	2012-04-09	2011-09-23	2011-09-23	2012-04-09
 
@@ -236,7 +236,7 @@ select
   interval '99 11:22:33.123456789' day to second + tsval
 from interval_arithmetic
 -- !query 17 schema
-struct<tsval:timestamp,CAST(tsval - interval 99 days 11 hours 22 minutes 33.123456 seconds AS TIMESTAMP):timestamp,CAST(tsval - interval -99 days -11 hours -22 minutes -33.123456 seconds AS TIMESTAMP):timestamp,CAST(tsval + interval 99 days 11 hours 22 minutes 33.123456 seconds AS TIMESTAMP):timestamp,CAST(tsval + interval -99 days -11 hours -22 minutes -33.123456 seconds AS TIMESTAMP):timestamp,CAST(tsval + (- interval 99 days 11 hours 22 minutes 33.123456 seconds) AS TIMESTAMP):timestamp,CAST(tsval + interval 99 days 11 hours 22 minutes 33.123456 seconds AS TIMESTAMP):timestamp>
+struct<tsval:timestamp,CAST(tsval - 99 days 11 hours 22 minutes 33.123456 seconds AS TIMESTAMP):timestamp,CAST(tsval - -99 days -11 hours -22 minutes -33.123456 seconds AS TIMESTAMP):timestamp,CAST(tsval + 99 days 11 hours 22 minutes 33.123456 seconds AS TIMESTAMP):timestamp,CAST(tsval + -99 days -11 hours -22 minutes -33.123456 seconds AS TIMESTAMP):timestamp,CAST(tsval + (- 99 days 11 hours 22 minutes 33.123456 seconds) AS TIMESTAMP):timestamp,CAST(tsval + 99 days 11 hours 22 minutes 33.123456 seconds AS TIMESTAMP):timestamp>
 -- !query 17 output
 2012-01-01 00:00:00	2011-09-23 12:37:26.876544	2012-04-09 11:22:33.123456	2012-04-09 11:22:33.123456	2011-09-23 12:37:26.876544	2011-09-23 12:37:26.876544	2012-04-09 11:22:33.123456
 
@@ -252,7 +252,7 @@ select
   '99 11:22:33.123456789' day to second + tsval
 from interval_arithmetic
 -- !query 18 schema
-struct<tsval:timestamp,CAST(tsval - interval 99 days 11 hours 22 minutes 33.123456 seconds AS TIMESTAMP):timestamp,CAST(tsval - interval -99 days -11 hours -22 minutes -33.123456 seconds AS TIMESTAMP):timestamp,CAST(tsval + interval 99 days 11 hours 22 minutes 33.123456 seconds AS TIMESTAMP):timestamp,CAST(tsval + interval -99 days -11 hours -22 minutes -33.123456 seconds AS TIMESTAMP):timestamp,CAST(tsval + (- interval 99 days 11 hours 22 minutes 33.123456 seconds) AS TIMESTAMP):timestamp,CAST(tsval + interval 99 days 11 hours 22 minutes 33.123456 seconds AS TIMESTAMP):timestamp>
+struct<tsval:timestamp,CAST(tsval - 99 days 11 hours 22 minutes 33.123456 seconds AS TIMESTAMP):timestamp,CAST(tsval - -99 days -11 hours -22 minutes -33.123456 seconds AS TIMESTAMP):timestamp,CAST(tsval + 99 days 11 hours 22 minutes 33.123456 seconds AS TIMESTAMP):timestamp,CAST(tsval + -99 days -11 hours -22 minutes -33.123456 seconds AS TIMESTAMP):timestamp,CAST(tsval + (- 99 days 11 hours 22 minutes 33.123456 seconds) AS TIMESTAMP):timestamp,CAST(tsval + 99 days 11 hours 22 minutes 33.123456 seconds AS TIMESTAMP):timestamp>
 -- !query 18 output
 2012-01-01 00:00:00	2011-09-23 12:37:26.876544	2012-04-09 11:22:33.123456	2012-04-09 11:22:33.123456	2011-09-23 12:37:26.876544	2011-09-23 12:37:26.876544	2012-04-09 11:22:33.123456
 
@@ -263,9 +263,9 @@ select
   interval '99 11:22:33.123456789' day to second - interval '10 9:8:7.123456789' day to second
 from interval_arithmetic
 -- !query 19 schema
-struct<(interval 99 days 11 hours 22 minutes 33.123456 seconds + interval 10 days 9 hours 8 minutes 7.123456 seconds):interval,(interval 99 days 11 hours 22 minutes 33.123456 seconds - interval 10 days 9 hours 8 minutes 7.123456 seconds):interval>
+struct<(99 days 11 hours 22 minutes 33.123456 seconds + 10 days 9 hours 8 minutes 7.123456 seconds):interval,(99 days 11 hours 22 minutes 33.123456 seconds - 10 days 9 hours 8 minutes 7.123456 seconds):interval>
 -- !query 19 output
-interval 109 days 20 hours 30 minutes 40.246912 seconds	interval 89 days 2 hours 14 minutes 26 seconds
+109 days 20 hours 30 minutes 40.246912 seconds	89 days 2 hours 14 minutes 26 seconds
 
 
 -- !query 20
@@ -274,17 +274,17 @@ select
   '99 11:22:33.123456789' day to second - '10 9:8:7.123456789' day to second
 from interval_arithmetic
 -- !query 20 schema
-struct<(interval 99 days 11 hours 22 minutes 33.123456 seconds + interval 10 days 9 hours 8 minutes 7.123456 seconds):interval,(interval 99 days 11 hours 22 minutes 33.123456 seconds - interval 10 days 9 hours 8 minutes 7.123456 seconds):interval>
+struct<(99 days 11 hours 22 minutes 33.123456 seconds + 10 days 9 hours 8 minutes 7.123456 seconds):interval,(99 days 11 hours 22 minutes 33.123456 seconds - 10 days 9 hours 8 minutes 7.123456 seconds):interval>
 -- !query 20 output
-interval 109 days 20 hours 30 minutes 40.246912 seconds	interval 89 days 2 hours 14 minutes 26 seconds
+109 days 20 hours 30 minutes 40.246912 seconds	89 days 2 hours 14 minutes 26 seconds
 
 
 -- !query 21
 select 30 day
 -- !query 21 schema
-struct<interval 30 days:interval>
+struct<30 days:interval>
 -- !query 21 output
-interval 30 days
+30 days
 
 
 -- !query 22
@@ -318,7 +318,7 @@ select 30 day day day
 -- !query 24
 select date '2012-01-01' - 30 day
 -- !query 24 schema
-struct<CAST(CAST(DATE '2012-01-01' AS TIMESTAMP) - interval 30 days AS DATE):date>
+struct<CAST(CAST(DATE '2012-01-01' AS TIMESTAMP) - 30 days AS DATE):date>
 -- !query 24 output
 2011-12-02
 
@@ -354,7 +354,7 @@ select date '2012-01-01' - 30 day day day
 -- !query 27
 select date '2012-01-01' + '-30' day
 -- !query 27 schema
-struct<CAST(CAST(DATE '2012-01-01' AS TIMESTAMP) + interval -30 days AS DATE):date>
+struct<CAST(CAST(DATE '2012-01-01' AS TIMESTAMP) + -30 days AS DATE):date>
 -- !query 27 output
 2011-12-02
 
@@ -362,7 +362,7 @@ struct<CAST(CAST(DATE '2012-01-01' AS TIMESTAMP) + interval -30 days AS DATE):da
 -- !query 28
 select date '2012-01-01' + interval '-30' day
 -- !query 28 schema
-struct<CAST(CAST(DATE '2012-01-01' AS TIMESTAMP) + interval -30 days AS DATE):date>
+struct<CAST(CAST(DATE '2012-01-01' AS TIMESTAMP) + -30 days AS DATE):date>
 -- !query 28 output
 2011-12-02
 

--- a/sql/core/src/test/resources/sql-tests/results/cast.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cast.sql.out
@@ -274,16 +274,16 @@ Usage: boolean(expr) - Casts the value `expr` to the target data type `boolean`.
 
 
 -- !query 33
-SELECT CAST('interval 3 month 1 hour' AS interval)
+SELECT CAST('3 month 1 hour' AS interval)
 -- !query 33 schema
-struct<CAST(interval 3 month 1 hour AS INTERVAL):interval>
+struct<CAST(3 month 1 hour AS INTERVAL):interval>
 -- !query 33 output
-interval 3 months 1 hours
+3 months 1 hours
 
 
 -- !query 34
 SELECT CAST(interval 3 month 1 hour AS string)
 -- !query 34 schema
-struct<CAST(interval 3 months 1 hours AS STRING):string>
+struct<CAST(3 months 1 hours AS STRING):string>
 -- !query 34 output
-interval 3 months 1 hours
+3 months 1 hours

--- a/sql/core/src/test/resources/sql-tests/results/datetime.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/datetime.sql.out
@@ -128,7 +128,7 @@ select date '2001-10-01' - date '2001-09-28'
 -- !query 14 schema
 struct<subtractdates(DATE '2001-10-01', DATE '2001-09-28'):interval>
 -- !query 14 output
-interval 3 days
+3 days
 
 
 -- !query 15
@@ -136,7 +136,7 @@ select date'2020-01-01' - timestamp'2019-10-06 10:11:12.345678'
 -- !query 15 schema
 struct<subtracttimestamps(CAST(DATE '2020-01-01' AS TIMESTAMP), TIMESTAMP('2019-10-06 10:11:12.345678')):interval>
 -- !query 15 output
-interval 2078 hours 48 minutes 47.654322 seconds
+2078 hours 48 minutes 47.654322 seconds
 
 
 -- !query 16
@@ -144,4 +144,4 @@ select timestamp'2019-10-06 10:11:12.345678' - date'2020-01-01'
 -- !query 16 schema
 struct<subtracttimestamps(TIMESTAMP('2019-10-06 10:11:12.345678'), CAST(DATE '2020-01-01' AS TIMESTAMP)):interval>
 -- !query 16 output
-interval -2078 hours -48 minutes -47.654322 seconds
+-2078 hours -48 minutes -47.654322 seconds

--- a/sql/core/src/test/resources/sql-tests/results/literals.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/literals.sql.out
@@ -323,121 +323,121 @@ select timestamp '2016-33-11 20:54:00.000'
 -- !query 34
 select interval 13.123456789 seconds, interval -13.123456789 second
 -- !query 34 schema
-struct<interval 13.123456 seconds:interval,interval -13.123456 seconds:interval>
+struct<13.123456 seconds:interval,-13.123456 seconds:interval>
 -- !query 34 output
-interval 13.123456 seconds	interval -13.123456 seconds
+13.123456 seconds	-13.123456 seconds
 
 
 -- !query 35
 select interval 1 year 2 month 3 week 4 day 5 hour 6 minute 7 seconds 8 millisecond 9 microsecond
 -- !query 35 schema
-struct<interval 1 years 2 months 25 days 5 hours 6 minutes 7.008009 seconds:interval>
+struct<1 years 2 months 25 days 5 hours 6 minutes 7.008009 seconds:interval>
 -- !query 35 output
-interval 1 years 2 months 25 days 5 hours 6 minutes 7.008009 seconds
+1 years 2 months 25 days 5 hours 6 minutes 7.008009 seconds
 
 
 -- !query 36
 select interval '30' year '25' month '-100' day '40' hour '80' minute '299.889987299' second
 -- !query 36 schema
-struct<interval 32 years 1 months -100 days 41 hours 24 minutes 59.889987 seconds:interval>
+struct<32 years 1 months -100 days 41 hours 24 minutes 59.889987 seconds:interval>
 -- !query 36 output
-interval 32 years 1 months -100 days 41 hours 24 minutes 59.889987 seconds
+32 years 1 months -100 days 41 hours 24 minutes 59.889987 seconds
 
 
 -- !query 37
 select interval '0 0:0:0.1' day to second
 -- !query 37 schema
-struct<interval 0.1 seconds:interval>
+struct<0.1 seconds:interval>
 -- !query 37 output
-interval 0.1 seconds
+0.1 seconds
 
 
 -- !query 38
 select interval '10-9' year to month
 -- !query 38 schema
-struct<interval 10 years 9 months:interval>
+struct<10 years 9 months:interval>
 -- !query 38 output
-interval 10 years 9 months
+10 years 9 months
 
 
 -- !query 39
 select interval '20 15:40:32.99899999' day to hour
 -- !query 39 schema
-struct<interval 20 days 15 hours:interval>
+struct<20 days 15 hours:interval>
 -- !query 39 output
-interval 20 days 15 hours
+20 days 15 hours
 
 
 -- !query 40
 select interval '20 15:40:32.99899999' day to minute
 -- !query 40 schema
-struct<interval 20 days 15 hours 40 minutes:interval>
+struct<20 days 15 hours 40 minutes:interval>
 -- !query 40 output
-interval 20 days 15 hours 40 minutes
+20 days 15 hours 40 minutes
 
 
 -- !query 41
 select interval '20 15:40:32.99899999' day to second
 -- !query 41 schema
-struct<interval 20 days 15 hours 40 minutes 32.998999 seconds:interval>
+struct<20 days 15 hours 40 minutes 32.998999 seconds:interval>
 -- !query 41 output
-interval 20 days 15 hours 40 minutes 32.998999 seconds
+20 days 15 hours 40 minutes 32.998999 seconds
 
 
 -- !query 42
 select interval '15:40:32.99899999' hour to minute
 -- !query 42 schema
-struct<interval 15 hours 40 minutes:interval>
+struct<15 hours 40 minutes:interval>
 -- !query 42 output
-interval 15 hours 40 minutes
+15 hours 40 minutes
 
 
 -- !query 43
 select interval '15:40.99899999' hour to second
 -- !query 43 schema
-struct<interval 15 minutes 40.998999 seconds:interval>
+struct<15 minutes 40.998999 seconds:interval>
 -- !query 43 output
-interval 15 minutes 40.998999 seconds
+15 minutes 40.998999 seconds
 
 
 -- !query 44
 select interval '15:40' hour to second
 -- !query 44 schema
-struct<interval 15 hours 40 minutes:interval>
+struct<15 hours 40 minutes:interval>
 -- !query 44 output
-interval 15 hours 40 minutes
+15 hours 40 minutes
 
 
 -- !query 45
 select interval '15:40:32.99899999' hour to second
 -- !query 45 schema
-struct<interval 15 hours 40 minutes 32.998999 seconds:interval>
+struct<15 hours 40 minutes 32.998999 seconds:interval>
 -- !query 45 output
-interval 15 hours 40 minutes 32.998999 seconds
+15 hours 40 minutes 32.998999 seconds
 
 
 -- !query 46
 select interval '20 40:32.99899999' minute to second
 -- !query 46 schema
-struct<interval 20 days 40 minutes 32.998999 seconds:interval>
+struct<20 days 40 minutes 32.998999 seconds:interval>
 -- !query 46 output
-interval 20 days 40 minutes 32.998999 seconds
+20 days 40 minutes 32.998999 seconds
 
 
 -- !query 47
 select interval '40:32.99899999' minute to second
 -- !query 47 schema
-struct<interval 40 minutes 32.998999 seconds:interval>
+struct<40 minutes 32.998999 seconds:interval>
 -- !query 47 output
-interval 40 minutes 32.998999 seconds
+40 minutes 32.998999 seconds
 
 
 -- !query 48
 select interval '40:32' minute to second
 -- !query 48 schema
-struct<interval 40 minutes 32 seconds:interval>
+struct<40 minutes 32 seconds:interval>
 -- !query 48 output
-interval 40 minutes 32 seconds
+40 minutes 32 seconds
 
 
 -- !query 49
@@ -523,29 +523,29 @@ struct<3.14:decimal(3,2),-3.14:decimal(3,2),3.14E+8:decimal(3,-6),3.14E-8:decima
 -- !query 56
 select map(1, interval 1 day, 2, interval 3 week)
 -- !query 56 schema
-struct<map(1, interval 1 days, 2, interval 21 days):map<int,interval>>
+struct<map(1, 1 days, 2, 21 days):map<int,interval>>
 -- !query 56 output
-{1:interval 1 days,2:interval 21 days}
+{1:1 days,2:21 days}
 
 
 -- !query 57
-select interval 'interval 3 year 1 hour'
+select interval '3 year 1 hour'
 -- !query 57 schema
-struct<interval 3 years 1 hours:interval>
+struct<3 years 1 hours:interval>
 -- !query 57 output
-interval 3 years 1 hours
+3 years 1 hours
 
 
 -- !query 58
-select interval '3 year 1 hour'
+select integer '7'
 -- !query 58 schema
-struct<interval 3 years 1 hours:interval>
+struct<7:int>
 -- !query 58 output
-interval 3 years 1 hours
+7
 
 
 -- !query 59
-select integer '7'
+select integer'7'
 -- !query 59 schema
 struct<7:int>
 -- !query 59 output
@@ -553,18 +553,10 @@ struct<7:int>
 
 
 -- !query 60
-select integer'7'
--- !query 60 schema
-struct<7:int>
--- !query 60 output
-7
-
-
--- !query 61
 select integer '2147483648'
--- !query 61 schema
+-- !query 60 schema
 struct<>
--- !query 61 output
+-- !query 60 output
 org.apache.spark.sql.catalyst.parser.ParseException
 
 Cannot parse the Int value: 2147483648, java.lang.NumberFormatException: For input string: "2147483648"(line 1, pos 7)
@@ -574,17 +566,31 @@ select integer '2147483648'
 -------^^^
 
 
--- !query 62
+-- !query 61
 select interval
--- !query 62 schema
+-- !query 61 schema
 struct<>
--- !query 62 output
+-- !query 61 output
 org.apache.spark.sql.catalyst.parser.ParseException
 
 at least one time unit should be given for interval literal(line 1, pos 7)
 
 == SQL ==
 select interval
+-------^^^
+
+
+-- !query 62
+select interval 'interval 3 year 1 hour'
+-- !query 62 schema
+struct<>
+-- !query 62 output
+org.apache.spark.sql.catalyst.parser.ParseException
+
+Cannot parse the INTERVAL value: interval 3 year 1 hour(line 1, pos 7)
+
+== SQL ==
+select interval 'interval 3 year 1 hour'
 -------^^^
 
 

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/interval.sql.out
@@ -5,190 +5,190 @@
 -- !query 0
 SELECT interval '999' second
 -- !query 0 schema
-struct<interval 16 minutes 39 seconds:interval>
+struct<16 minutes 39 seconds:interval>
 -- !query 0 output
-interval 16 minutes 39 seconds
+16 minutes 39 seconds
 
 
 -- !query 1
 SELECT interval '999' minute
 -- !query 1 schema
-struct<interval 16 hours 39 minutes:interval>
+struct<16 hours 39 minutes:interval>
 -- !query 1 output
-interval 16 hours 39 minutes
+16 hours 39 minutes
 
 
 -- !query 2
 SELECT interval '999' hour
 -- !query 2 schema
-struct<interval 999 hours:interval>
+struct<999 hours:interval>
 -- !query 2 output
-interval 999 hours
+999 hours
 
 
 -- !query 3
 SELECT interval '999' day
 -- !query 3 schema
-struct<interval 999 days:interval>
+struct<999 days:interval>
 -- !query 3 output
-interval 999 days
+999 days
 
 
 -- !query 4
 SELECT interval '999' month
 -- !query 4 schema
-struct<interval 83 years 3 months:interval>
+struct<83 years 3 months:interval>
 -- !query 4 output
-interval 83 years 3 months
+83 years 3 months
 
 
 -- !query 5
 SELECT interval '1' year
 -- !query 5 schema
-struct<interval 1 years:interval>
+struct<1 years:interval>
 -- !query 5 output
-interval 1 years
+1 years
 
 
 -- !query 6
 SELECT interval '2' month
 -- !query 6 schema
-struct<interval 2 months:interval>
+struct<2 months:interval>
 -- !query 6 output
-interval 2 months
+2 months
 
 
 -- !query 7
 SELECT interval '3' day
 -- !query 7 schema
-struct<interval 3 days:interval>
+struct<3 days:interval>
 -- !query 7 output
-interval 3 days
+3 days
 
 
 -- !query 8
 SELECT interval '4' hour
 -- !query 8 schema
-struct<interval 4 hours:interval>
+struct<4 hours:interval>
 -- !query 8 output
-interval 4 hours
+4 hours
 
 
 -- !query 9
 SELECT interval '5' minute
 -- !query 9 schema
-struct<interval 5 minutes:interval>
+struct<5 minutes:interval>
 -- !query 9 output
-interval 5 minutes
+5 minutes
 
 
 -- !query 10
 SELECT interval '6' second
 -- !query 10 schema
-struct<interval 6 seconds:interval>
+struct<6 seconds:interval>
 -- !query 10 output
-interval 6 seconds
+6 seconds
 
 
 -- !query 11
 SELECT interval '1-2' year to month
 -- !query 11 schema
-struct<interval 1 years 2 months:interval>
+struct<1 years 2 months:interval>
 -- !query 11 output
-interval 1 years 2 months
+1 years 2 months
 
 
 -- !query 12
 SELECT interval '1 2:03' day to hour
 -- !query 12 schema
-struct<interval 1 days 2 hours:interval>
+struct<1 days 2 hours:interval>
 -- !query 12 output
-interval 1 days 2 hours
+1 days 2 hours
 
 
 -- !query 13
 SELECT interval '1 2:03:04' day to hour
 -- !query 13 schema
-struct<interval 1 days 2 hours:interval>
+struct<1 days 2 hours:interval>
 -- !query 13 output
-interval 1 days 2 hours
+1 days 2 hours
 
 
 -- !query 14
 SELECT interval '1 2:03' day to minute
 -- !query 14 schema
-struct<interval 1 days 2 hours 3 minutes:interval>
+struct<1 days 2 hours 3 minutes:interval>
 -- !query 14 output
-interval 1 days 2 hours 3 minutes
+1 days 2 hours 3 minutes
 
 
 -- !query 15
 SELECT interval '1 2:03:04' day to minute
 -- !query 15 schema
-struct<interval 1 days 2 hours 3 minutes:interval>
+struct<1 days 2 hours 3 minutes:interval>
 -- !query 15 output
-interval 1 days 2 hours 3 minutes
+1 days 2 hours 3 minutes
 
 
 -- !query 16
 SELECT interval '1 2:03' day to second
 -- !query 16 schema
-struct<interval 1 days 2 hours 3 minutes:interval>
+struct<1 days 2 hours 3 minutes:interval>
 -- !query 16 output
-interval 1 days 2 hours 3 minutes
+1 days 2 hours 3 minutes
 
 
 -- !query 17
 SELECT interval '1 2:03:04' day to second
 -- !query 17 schema
-struct<interval 1 days 2 hours 3 minutes 4 seconds:interval>
+struct<1 days 2 hours 3 minutes 4 seconds:interval>
 -- !query 17 output
-interval 1 days 2 hours 3 minutes 4 seconds
+1 days 2 hours 3 minutes 4 seconds
 
 
 -- !query 18
 SELECT interval '1 2:03' hour to minute
 -- !query 18 schema
-struct<interval 1 days 2 hours 3 minutes:interval>
+struct<1 days 2 hours 3 minutes:interval>
 -- !query 18 output
-interval 1 days 2 hours 3 minutes
+1 days 2 hours 3 minutes
 
 
 -- !query 19
 SELECT interval '1 2:03:04' hour to minute
 -- !query 19 schema
-struct<interval 1 days 2 hours 3 minutes:interval>
+struct<1 days 2 hours 3 minutes:interval>
 -- !query 19 output
-interval 1 days 2 hours 3 minutes
+1 days 2 hours 3 minutes
 
 
 -- !query 20
 SELECT interval '1 2:03' hour to second
 -- !query 20 schema
-struct<interval 1 days 2 hours 3 minutes:interval>
+struct<1 days 2 hours 3 minutes:interval>
 -- !query 20 output
-interval 1 days 2 hours 3 minutes
+1 days 2 hours 3 minutes
 
 
 -- !query 21
 SELECT interval '1 2:03:04' hour to second
 -- !query 21 schema
-struct<interval 1 days 2 hours 3 minutes 4 seconds:interval>
+struct<1 days 2 hours 3 minutes 4 seconds:interval>
 -- !query 21 output
-interval 1 days 2 hours 3 minutes 4 seconds
+1 days 2 hours 3 minutes 4 seconds
 
 
 -- !query 22
 SELECT interval '1 2:03' minute to second
 -- !query 22 schema
-struct<interval 1 days 2 minutes 3 seconds:interval>
+struct<1 days 2 minutes 3 seconds:interval>
 -- !query 22 output
-interval 1 days 2 minutes 3 seconds
+1 days 2 minutes 3 seconds
 
 
 -- !query 23
 SELECT interval '1 2:03:04' minute to second
 -- !query 23 schema
-struct<interval 1 days 2 hours 3 minutes 4 seconds:interval>
+struct<1 days 2 hours 3 minutes 4 seconds:interval>
 -- !query 23 output
-interval 1 days 2 hours 3 minutes 4 seconds
+1 days 2 hours 3 minutes 4 seconds

--- a/sql/core/src/test/resources/sql-tests/results/typeCoercion/native/dateTimeOperations.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/typeCoercion/native/dateTimeOperations.sql.out
@@ -16,7 +16,7 @@ select cast(1 as tinyint) + interval 2 day
 struct<>
 -- !query 1 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(CAST(1 AS TINYINT) + interval 2 days)' due to data type mismatch: differing types in '(CAST(1 AS TINYINT) + interval 2 days)' (tinyint and interval).; line 1 pos 7
+cannot resolve '(CAST(1 AS TINYINT) + 2 days)' due to data type mismatch: differing types in '(CAST(1 AS TINYINT) + 2 days)' (tinyint and interval).; line 1 pos 7
 
 
 -- !query 2
@@ -25,7 +25,7 @@ select cast(1 as smallint) + interval 2 day
 struct<>
 -- !query 2 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(CAST(1 AS SMALLINT) + interval 2 days)' due to data type mismatch: differing types in '(CAST(1 AS SMALLINT) + interval 2 days)' (smallint and interval).; line 1 pos 7
+cannot resolve '(CAST(1 AS SMALLINT) + 2 days)' due to data type mismatch: differing types in '(CAST(1 AS SMALLINT) + 2 days)' (smallint and interval).; line 1 pos 7
 
 
 -- !query 3
@@ -34,7 +34,7 @@ select cast(1 as int) + interval 2 day
 struct<>
 -- !query 3 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(CAST(1 AS INT) + interval 2 days)' due to data type mismatch: differing types in '(CAST(1 AS INT) + interval 2 days)' (int and interval).; line 1 pos 7
+cannot resolve '(CAST(1 AS INT) + 2 days)' due to data type mismatch: differing types in '(CAST(1 AS INT) + 2 days)' (int and interval).; line 1 pos 7
 
 
 -- !query 4
@@ -43,7 +43,7 @@ select cast(1 as bigint) + interval 2 day
 struct<>
 -- !query 4 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(CAST(1 AS BIGINT) + interval 2 days)' due to data type mismatch: differing types in '(CAST(1 AS BIGINT) + interval 2 days)' (bigint and interval).; line 1 pos 7
+cannot resolve '(CAST(1 AS BIGINT) + 2 days)' due to data type mismatch: differing types in '(CAST(1 AS BIGINT) + 2 days)' (bigint and interval).; line 1 pos 7
 
 
 -- !query 5
@@ -52,7 +52,7 @@ select cast(1 as float) + interval 2 day
 struct<>
 -- !query 5 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(CAST(1 AS FLOAT) + interval 2 days)' due to data type mismatch: differing types in '(CAST(1 AS FLOAT) + interval 2 days)' (float and interval).; line 1 pos 7
+cannot resolve '(CAST(1 AS FLOAT) + 2 days)' due to data type mismatch: differing types in '(CAST(1 AS FLOAT) + 2 days)' (float and interval).; line 1 pos 7
 
 
 -- !query 6
@@ -61,7 +61,7 @@ select cast(1 as double) + interval 2 day
 struct<>
 -- !query 6 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(CAST(1 AS DOUBLE) + interval 2 days)' due to data type mismatch: differing types in '(CAST(1 AS DOUBLE) + interval 2 days)' (double and interval).; line 1 pos 7
+cannot resolve '(CAST(1 AS DOUBLE) + 2 days)' due to data type mismatch: differing types in '(CAST(1 AS DOUBLE) + 2 days)' (double and interval).; line 1 pos 7
 
 
 -- !query 7
@@ -70,13 +70,13 @@ select cast(1 as decimal(10, 0)) + interval 2 day
 struct<>
 -- !query 7 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(CAST(1 AS DECIMAL(10,0)) + interval 2 days)' due to data type mismatch: differing types in '(CAST(1 AS DECIMAL(10,0)) + interval 2 days)' (decimal(10,0) and interval).; line 1 pos 7
+cannot resolve '(CAST(1 AS DECIMAL(10,0)) + 2 days)' due to data type mismatch: differing types in '(CAST(1 AS DECIMAL(10,0)) + 2 days)' (decimal(10,0) and interval).; line 1 pos 7
 
 
 -- !query 8
 select cast('2017-12-11' as string) + interval 2 day
 -- !query 8 schema
-struct<CAST(CAST(CAST(2017-12-11 AS STRING) AS TIMESTAMP) + interval 2 days AS STRING):string>
+struct<CAST(CAST(CAST(2017-12-11 AS STRING) AS TIMESTAMP) + 2 days AS STRING):string>
 -- !query 8 output
 2017-12-13 00:00:00
 
@@ -84,7 +84,7 @@ struct<CAST(CAST(CAST(2017-12-11 AS STRING) AS TIMESTAMP) + interval 2 days AS S
 -- !query 9
 select cast('2017-12-11 09:30:00' as string) + interval 2 day
 -- !query 9 schema
-struct<CAST(CAST(CAST(2017-12-11 09:30:00 AS STRING) AS TIMESTAMP) + interval 2 days AS STRING):string>
+struct<CAST(CAST(CAST(2017-12-11 09:30:00 AS STRING) AS TIMESTAMP) + 2 days AS STRING):string>
 -- !query 9 output
 2017-12-13 09:30:00
 
@@ -95,7 +95,7 @@ select cast('1' as binary) + interval 2 day
 struct<>
 -- !query 10 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(CAST('1' AS BINARY) + interval 2 days)' due to data type mismatch: differing types in '(CAST('1' AS BINARY) + interval 2 days)' (binary and interval).; line 1 pos 7
+cannot resolve '(CAST('1' AS BINARY) + 2 days)' due to data type mismatch: differing types in '(CAST('1' AS BINARY) + 2 days)' (binary and interval).; line 1 pos 7
 
 
 -- !query 11
@@ -104,13 +104,13 @@ select cast(1 as boolean) + interval 2 day
 struct<>
 -- !query 11 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(CAST(1 AS BOOLEAN) + interval 2 days)' due to data type mismatch: differing types in '(CAST(1 AS BOOLEAN) + interval 2 days)' (boolean and interval).; line 1 pos 7
+cannot resolve '(CAST(1 AS BOOLEAN) + 2 days)' due to data type mismatch: differing types in '(CAST(1 AS BOOLEAN) + 2 days)' (boolean and interval).; line 1 pos 7
 
 
 -- !query 12
 select cast('2017-12-11 09:30:00.0' as timestamp) + interval 2 day
 -- !query 12 schema
-struct<CAST(CAST(2017-12-11 09:30:00.0 AS TIMESTAMP) + interval 2 days AS TIMESTAMP):timestamp>
+struct<CAST(CAST(2017-12-11 09:30:00.0 AS TIMESTAMP) + 2 days AS TIMESTAMP):timestamp>
 -- !query 12 output
 2017-12-13 09:30:00
 
@@ -118,7 +118,7 @@ struct<CAST(CAST(2017-12-11 09:30:00.0 AS TIMESTAMP) + interval 2 days AS TIMEST
 -- !query 13
 select cast('2017-12-11 09:30:00' as date) + interval 2 day
 -- !query 13 schema
-struct<CAST(CAST(CAST(2017-12-11 09:30:00 AS DATE) AS TIMESTAMP) + interval 2 days AS DATE):date>
+struct<CAST(CAST(CAST(2017-12-11 09:30:00 AS DATE) AS TIMESTAMP) + 2 days AS DATE):date>
 -- !query 13 output
 2017-12-13
 
@@ -129,7 +129,7 @@ select interval 2 day + cast(1 as tinyint)
 struct<>
 -- !query 14 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(interval 2 days + CAST(1 AS TINYINT))' due to data type mismatch: differing types in '(interval 2 days + CAST(1 AS TINYINT))' (interval and tinyint).; line 1 pos 7
+cannot resolve '(2 days + CAST(1 AS TINYINT))' due to data type mismatch: differing types in '(2 days + CAST(1 AS TINYINT))' (interval and tinyint).; line 1 pos 7
 
 
 -- !query 15
@@ -138,7 +138,7 @@ select interval 2 day + cast(1 as smallint)
 struct<>
 -- !query 15 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(interval 2 days + CAST(1 AS SMALLINT))' due to data type mismatch: differing types in '(interval 2 days + CAST(1 AS SMALLINT))' (interval and smallint).; line 1 pos 7
+cannot resolve '(2 days + CAST(1 AS SMALLINT))' due to data type mismatch: differing types in '(2 days + CAST(1 AS SMALLINT))' (interval and smallint).; line 1 pos 7
 
 
 -- !query 16
@@ -147,7 +147,7 @@ select interval 2 day + cast(1 as int)
 struct<>
 -- !query 16 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(interval 2 days + CAST(1 AS INT))' due to data type mismatch: differing types in '(interval 2 days + CAST(1 AS INT))' (interval and int).; line 1 pos 7
+cannot resolve '(2 days + CAST(1 AS INT))' due to data type mismatch: differing types in '(2 days + CAST(1 AS INT))' (interval and int).; line 1 pos 7
 
 
 -- !query 17
@@ -156,7 +156,7 @@ select interval 2 day + cast(1 as bigint)
 struct<>
 -- !query 17 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(interval 2 days + CAST(1 AS BIGINT))' due to data type mismatch: differing types in '(interval 2 days + CAST(1 AS BIGINT))' (interval and bigint).; line 1 pos 7
+cannot resolve '(2 days + CAST(1 AS BIGINT))' due to data type mismatch: differing types in '(2 days + CAST(1 AS BIGINT))' (interval and bigint).; line 1 pos 7
 
 
 -- !query 18
@@ -165,7 +165,7 @@ select interval 2 day + cast(1 as float)
 struct<>
 -- !query 18 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(interval 2 days + CAST(1 AS FLOAT))' due to data type mismatch: differing types in '(interval 2 days + CAST(1 AS FLOAT))' (interval and float).; line 1 pos 7
+cannot resolve '(2 days + CAST(1 AS FLOAT))' due to data type mismatch: differing types in '(2 days + CAST(1 AS FLOAT))' (interval and float).; line 1 pos 7
 
 
 -- !query 19
@@ -174,7 +174,7 @@ select interval 2 day + cast(1 as double)
 struct<>
 -- !query 19 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(interval 2 days + CAST(1 AS DOUBLE))' due to data type mismatch: differing types in '(interval 2 days + CAST(1 AS DOUBLE))' (interval and double).; line 1 pos 7
+cannot resolve '(2 days + CAST(1 AS DOUBLE))' due to data type mismatch: differing types in '(2 days + CAST(1 AS DOUBLE))' (interval and double).; line 1 pos 7
 
 
 -- !query 20
@@ -183,13 +183,13 @@ select interval 2 day + cast(1 as decimal(10, 0))
 struct<>
 -- !query 20 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(interval 2 days + CAST(1 AS DECIMAL(10,0)))' due to data type mismatch: differing types in '(interval 2 days + CAST(1 AS DECIMAL(10,0)))' (interval and decimal(10,0)).; line 1 pos 7
+cannot resolve '(2 days + CAST(1 AS DECIMAL(10,0)))' due to data type mismatch: differing types in '(2 days + CAST(1 AS DECIMAL(10,0)))' (interval and decimal(10,0)).; line 1 pos 7
 
 
 -- !query 21
 select interval 2 day + cast('2017-12-11' as string)
 -- !query 21 schema
-struct<CAST(CAST(CAST(2017-12-11 AS STRING) AS TIMESTAMP) + interval 2 days AS STRING):string>
+struct<CAST(CAST(CAST(2017-12-11 AS STRING) AS TIMESTAMP) + 2 days AS STRING):string>
 -- !query 21 output
 2017-12-13 00:00:00
 
@@ -197,7 +197,7 @@ struct<CAST(CAST(CAST(2017-12-11 AS STRING) AS TIMESTAMP) + interval 2 days AS S
 -- !query 22
 select interval 2 day + cast('2017-12-11 09:30:00' as string)
 -- !query 22 schema
-struct<CAST(CAST(CAST(2017-12-11 09:30:00 AS STRING) AS TIMESTAMP) + interval 2 days AS STRING):string>
+struct<CAST(CAST(CAST(2017-12-11 09:30:00 AS STRING) AS TIMESTAMP) + 2 days AS STRING):string>
 -- !query 22 output
 2017-12-13 09:30:00
 
@@ -208,7 +208,7 @@ select interval 2 day + cast('1' as binary)
 struct<>
 -- !query 23 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(interval 2 days + CAST('1' AS BINARY))' due to data type mismatch: differing types in '(interval 2 days + CAST('1' AS BINARY))' (interval and binary).; line 1 pos 7
+cannot resolve '(2 days + CAST('1' AS BINARY))' due to data type mismatch: differing types in '(2 days + CAST('1' AS BINARY))' (interval and binary).; line 1 pos 7
 
 
 -- !query 24
@@ -217,13 +217,13 @@ select interval 2 day + cast(1 as boolean)
 struct<>
 -- !query 24 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(interval 2 days + CAST(1 AS BOOLEAN))' due to data type mismatch: differing types in '(interval 2 days + CAST(1 AS BOOLEAN))' (interval and boolean).; line 1 pos 7
+cannot resolve '(2 days + CAST(1 AS BOOLEAN))' due to data type mismatch: differing types in '(2 days + CAST(1 AS BOOLEAN))' (interval and boolean).; line 1 pos 7
 
 
 -- !query 25
 select interval 2 day + cast('2017-12-11 09:30:00.0' as timestamp)
 -- !query 25 schema
-struct<CAST(CAST(2017-12-11 09:30:00.0 AS TIMESTAMP) + interval 2 days AS TIMESTAMP):timestamp>
+struct<CAST(CAST(2017-12-11 09:30:00.0 AS TIMESTAMP) + 2 days AS TIMESTAMP):timestamp>
 -- !query 25 output
 2017-12-13 09:30:00
 
@@ -231,7 +231,7 @@ struct<CAST(CAST(2017-12-11 09:30:00.0 AS TIMESTAMP) + interval 2 days AS TIMEST
 -- !query 26
 select interval 2 day + cast('2017-12-11 09:30:00' as date)
 -- !query 26 schema
-struct<CAST(CAST(CAST(2017-12-11 09:30:00 AS DATE) AS TIMESTAMP) + interval 2 days AS DATE):date>
+struct<CAST(CAST(CAST(2017-12-11 09:30:00 AS DATE) AS TIMESTAMP) + 2 days AS DATE):date>
 -- !query 26 output
 2017-12-13
 
@@ -242,7 +242,7 @@ select cast(1 as tinyint) - interval 2 day
 struct<>
 -- !query 27 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(CAST(1 AS TINYINT) - interval 2 days)' due to data type mismatch: differing types in '(CAST(1 AS TINYINT) - interval 2 days)' (tinyint and interval).; line 1 pos 7
+cannot resolve '(CAST(1 AS TINYINT) - 2 days)' due to data type mismatch: differing types in '(CAST(1 AS TINYINT) - 2 days)' (tinyint and interval).; line 1 pos 7
 
 
 -- !query 28
@@ -251,7 +251,7 @@ select cast(1 as smallint) - interval 2 day
 struct<>
 -- !query 28 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(CAST(1 AS SMALLINT) - interval 2 days)' due to data type mismatch: differing types in '(CAST(1 AS SMALLINT) - interval 2 days)' (smallint and interval).; line 1 pos 7
+cannot resolve '(CAST(1 AS SMALLINT) - 2 days)' due to data type mismatch: differing types in '(CAST(1 AS SMALLINT) - 2 days)' (smallint and interval).; line 1 pos 7
 
 
 -- !query 29
@@ -260,7 +260,7 @@ select cast(1 as int) - interval 2 day
 struct<>
 -- !query 29 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(CAST(1 AS INT) - interval 2 days)' due to data type mismatch: differing types in '(CAST(1 AS INT) - interval 2 days)' (int and interval).; line 1 pos 7
+cannot resolve '(CAST(1 AS INT) - 2 days)' due to data type mismatch: differing types in '(CAST(1 AS INT) - 2 days)' (int and interval).; line 1 pos 7
 
 
 -- !query 30
@@ -269,7 +269,7 @@ select cast(1 as bigint) - interval 2 day
 struct<>
 -- !query 30 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(CAST(1 AS BIGINT) - interval 2 days)' due to data type mismatch: differing types in '(CAST(1 AS BIGINT) - interval 2 days)' (bigint and interval).; line 1 pos 7
+cannot resolve '(CAST(1 AS BIGINT) - 2 days)' due to data type mismatch: differing types in '(CAST(1 AS BIGINT) - 2 days)' (bigint and interval).; line 1 pos 7
 
 
 -- !query 31
@@ -278,7 +278,7 @@ select cast(1 as float) - interval 2 day
 struct<>
 -- !query 31 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(CAST(1 AS FLOAT) - interval 2 days)' due to data type mismatch: differing types in '(CAST(1 AS FLOAT) - interval 2 days)' (float and interval).; line 1 pos 7
+cannot resolve '(CAST(1 AS FLOAT) - 2 days)' due to data type mismatch: differing types in '(CAST(1 AS FLOAT) - 2 days)' (float and interval).; line 1 pos 7
 
 
 -- !query 32
@@ -287,7 +287,7 @@ select cast(1 as double) - interval 2 day
 struct<>
 -- !query 32 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(CAST(1 AS DOUBLE) - interval 2 days)' due to data type mismatch: differing types in '(CAST(1 AS DOUBLE) - interval 2 days)' (double and interval).; line 1 pos 7
+cannot resolve '(CAST(1 AS DOUBLE) - 2 days)' due to data type mismatch: differing types in '(CAST(1 AS DOUBLE) - 2 days)' (double and interval).; line 1 pos 7
 
 
 -- !query 33
@@ -296,13 +296,13 @@ select cast(1 as decimal(10, 0)) - interval 2 day
 struct<>
 -- !query 33 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(CAST(1 AS DECIMAL(10,0)) - interval 2 days)' due to data type mismatch: differing types in '(CAST(1 AS DECIMAL(10,0)) - interval 2 days)' (decimal(10,0) and interval).; line 1 pos 7
+cannot resolve '(CAST(1 AS DECIMAL(10,0)) - 2 days)' due to data type mismatch: differing types in '(CAST(1 AS DECIMAL(10,0)) - 2 days)' (decimal(10,0) and interval).; line 1 pos 7
 
 
 -- !query 34
 select cast('2017-12-11' as string) - interval 2 day
 -- !query 34 schema
-struct<CAST(CAST(CAST(2017-12-11 AS STRING) AS TIMESTAMP) - interval 2 days AS STRING):string>
+struct<CAST(CAST(CAST(2017-12-11 AS STRING) AS TIMESTAMP) - 2 days AS STRING):string>
 -- !query 34 output
 2017-12-09 00:00:00
 
@@ -310,7 +310,7 @@ struct<CAST(CAST(CAST(2017-12-11 AS STRING) AS TIMESTAMP) - interval 2 days AS S
 -- !query 35
 select cast('2017-12-11 09:30:00' as string) - interval 2 day
 -- !query 35 schema
-struct<CAST(CAST(CAST(2017-12-11 09:30:00 AS STRING) AS TIMESTAMP) - interval 2 days AS STRING):string>
+struct<CAST(CAST(CAST(2017-12-11 09:30:00 AS STRING) AS TIMESTAMP) - 2 days AS STRING):string>
 -- !query 35 output
 2017-12-09 09:30:00
 
@@ -321,7 +321,7 @@ select cast('1' as binary) - interval 2 day
 struct<>
 -- !query 36 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(CAST('1' AS BINARY) - interval 2 days)' due to data type mismatch: differing types in '(CAST('1' AS BINARY) - interval 2 days)' (binary and interval).; line 1 pos 7
+cannot resolve '(CAST('1' AS BINARY) - 2 days)' due to data type mismatch: differing types in '(CAST('1' AS BINARY) - 2 days)' (binary and interval).; line 1 pos 7
 
 
 -- !query 37
@@ -330,13 +330,13 @@ select cast(1 as boolean) - interval 2 day
 struct<>
 -- !query 37 output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(CAST(1 AS BOOLEAN) - interval 2 days)' due to data type mismatch: differing types in '(CAST(1 AS BOOLEAN) - interval 2 days)' (boolean and interval).; line 1 pos 7
+cannot resolve '(CAST(1 AS BOOLEAN) - 2 days)' due to data type mismatch: differing types in '(CAST(1 AS BOOLEAN) - 2 days)' (boolean and interval).; line 1 pos 7
 
 
 -- !query 38
 select cast('2017-12-11 09:30:00.0' as timestamp) - interval 2 day
 -- !query 38 schema
-struct<CAST(CAST(2017-12-11 09:30:00.0 AS TIMESTAMP) - interval 2 days AS TIMESTAMP):timestamp>
+struct<CAST(CAST(2017-12-11 09:30:00.0 AS TIMESTAMP) - 2 days AS TIMESTAMP):timestamp>
 -- !query 38 output
 2017-12-09 09:30:00
 
@@ -344,6 +344,6 @@ struct<CAST(CAST(2017-12-11 09:30:00.0 AS TIMESTAMP) - interval 2 days AS TIMEST
 -- !query 39
 select cast('2017-12-11 09:30:00' as date) - interval 2 day
 -- !query 39 schema
-struct<CAST(CAST(CAST(2017-12-11 09:30:00 AS DATE) AS TIMESTAMP) - interval 2 days AS DATE):date>
+struct<CAST(CAST(CAST(2017-12-11 09:30:00 AS DATE) AS TIMESTAMP) - 2 days AS DATE):date>
 -- !query 39 output
 2017-12-09


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
When parsing a string to interval, do not allow the leading "interval".

This PR also removes the leading "interval" from `CalendarInterval.toString`, to be consistent. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When parsing string to interval, we already know it's an interval and the leading "interval" in the string is kind of duplicated. The behavior is also consistent with pgsql
```
cloud0fan=# select 'interval 1 day'::interval;
ERROR:  invalid input syntax for type interval: "interval 1 day"
LINE 1: select 'interval 1 day'::interval;
               ^
cloud0fan=# select '1 day'::interval;
 interval 
----------
 1 day
(1 row)

cloud0fan=# select interval'interval 1 year';
ERROR:  invalid input syntax for type interval: " interval 1 year"
LINE 1: select interval' interval 1 year';

cloud0fan=# select interval'1 year';
 interval 
----------
 1 year
(1 row)
```

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
Yes. The `INTERVAL'...'` syntax is newly introduced in the master branch, so it's OK to change. The cast behavior in 2.4 is pretty weird: the leading "interval" in the string is required. I think it's better to change it (with a migration guide and legacy config).

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
updated tests