### PR TITLE
[SPARK-26739][SQL] Standardized Join Types for DataFrames

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/JoinType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/JoinType.scala
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import java.util.Locale
+
+import org.apache.spark.sql.catalyst.plans
+
+/**
+ * Enumeration for representing types of joins that can be performed
+ */
+object JoinType extends Enumeration {
+  case class JoinTypeVal private[JoinType] (catalyst: plans.CatalystJoinType) extends Val {
+    override def id: Int = super.id
+  }
+
+  type Type = JoinTypeVal
+
+  /**
+   * Inner Join
+   */
+  val Inner = JoinTypeVal(plans.Inner)
+
+  /**
+   * Cross Join
+   */
+  val Cross = JoinTypeVal(plans.Cross)
+
+  /**
+   * Left Outer (a.k.a. Left) Join
+   */
+  val LeftOuter = JoinTypeVal(plans.LeftOuter)
+
+  /**
+   * Right Outer (a.k.a. Right) Join
+   */
+  val RightOuter = JoinTypeVal(plans.RightOuter)
+
+  /**
+   * Full Outer Join
+   */
+  val FullOuter = JoinTypeVal(plans.FullOuter)
+
+  /**
+   * Left Semi Join
+   */
+  val LeftSemi = JoinTypeVal(plans.LeftSemi)
+
+  /**
+   * Left Anti Join
+   */
+  val LeftAnti = JoinTypeVal(plans.LeftAnti)
+
+  /**
+   * Constructs an instance of [[JoinType.JoinTypeVal]] from a given [[String]] representation
+   * @param joinTypeStr the [[String]] representation of the join type
+   * @return an instance of [[JoinType.JoinTypeVal]] corresponding to the input
+   * @throws [[IllegalArgumentException]] if an unsupported value is provided
+   */
+  def apply(joinTypeStr: String): JoinType.JoinTypeVal = {
+    val sanitizedType = joinTypeStr.toLowerCase(Locale.ROOT).replace("_", "")
+    sanitizedType match {
+      case "inner" => JoinType.Inner
+      case "outer" | "full" | "fullouter" => JoinType.FullOuter
+      case "leftouter" | "left" => JoinType.LeftOuter
+      case "rightouter" | "right" => JoinType.RightOuter
+      case "leftsemi" | "semi" => JoinType.LeftSemi
+      case "leftanti" | "anti" => JoinType.LeftAnti
+      case "cross" => JoinType.Cross
+      case _ =>
+        val supported = Seq(
+          "inner",
+          "outer",
+          "full",
+          "fullouter",
+          "full_outer",
+          "leftouter",
+          "left",
+          "left_outer",
+          "rightouter",
+          "right",
+          "right_outer",
+          "leftsemi",
+          "left_semi",
+          "semi",
+          "leftanti",
+          "left_anti",
+          "anti",
+          "cross")
+
+        throw new IllegalArgumentException(
+          s"Unsupported join type '$joinTypeStr'. " +
+            "Supported join types include: " + supported.mkString("'", "', '", "'") + ".")
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2555,7 +2555,7 @@ class Analyzer(
   private def commonNaturalJoinProcessing(
       left: LogicalPlan,
       right: LogicalPlan,
-      joinType: JoinType,
+      joinType: CatalystJoinType,
       joinNames: Seq[String],
       condition: Option[Expression],
       hint: JoinHint) = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.expressions.objects.Invoke
-import org.apache.spark.sql.catalyst.plans.{Inner, JoinType}
+import org.apache.spark.sql.catalyst.plans.{CatalystJoinType, Inner}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.types._
 
@@ -326,7 +326,7 @@ package object dsl {
 
       def join(
         otherPlan: LogicalPlan,
-        joinType: JoinType = Inner,
+        joinType: CatalystJoinType = Inner,
         condition: Option[Expression] = None): LogicalPlan =
         Join(logicalPlan, otherPlan, joinType, condition, JoinHint.NONE)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CostBasedJoinReorder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CostBasedJoinReorder.scala
@@ -21,7 +21,7 @@ import scala.collection.mutable
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.{And, Attribute, AttributeSet, Expression, PredicateHelper}
-import org.apache.spark.sql.catalyst.plans.{Inner, InnerLike, JoinType}
+import org.apache.spark.sql.catalyst.plans.{CatalystJoinType, Inner, InnerLike}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.internal.SQLConf
@@ -106,7 +106,7 @@ object CostBasedJoinReorder extends Rule[LogicalPlan] with PredicateHelper {
 case class OrderedJoin(
     left: LogicalPlan,
     right: LogicalPlan,
-    joinType: JoinType,
+    joinType: CatalystJoinType,
     condition: Option[Expression]) extends BinaryNode {
   override def output: Seq[Attribute] = left.output ++ right.output
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -140,7 +140,7 @@ object EliminateOuterJoin extends Rule[LogicalPlan] with PredicateHelper {
     v == null || v == false
   }
 
-  private def buildNewJoinType(filter: Filter, join: Join): JoinType = {
+  private def buildNewJoinType(filter: Filter, join: Join): CatalystJoinType = {
     val conditions = splitConjunctivePredicates(filter.condition) ++ filter.constraints
     val leftConditions = conditions.filter(_.references.subsetOf(join.left.outputSet))
     val rightConditions = conditions.filter(_.references.subsetOf(join.right.outputSet))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -48,7 +48,7 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
   private def buildJoin(
       outerPlan: LogicalPlan,
       subplan: LogicalPlan,
-      joinType: JoinType,
+      joinType: CatalystJoinType,
       condition: Option[Expression]): Join = {
     // Deduplicate conflicting attributes if any.
     val dedupSubplan = dedupSubqueryOnSelfJoin(outerPlan, subplan, None, condition)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -102,7 +102,7 @@ object PhysicalOperation extends PredicateHelper {
 object ExtractEquiJoinKeys extends Logging with PredicateHelper {
   /** (joinType, leftKeys, rightKeys, condition, leftChild, rightChild, joinHint) */
   type ReturnType =
-    (JoinType, Seq[Expression], Seq[Expression],
+    (CatalystJoinType, Seq[Expression], Seq[Expression],
       Option[Expression], LogicalPlan, LogicalPlan, JoinHint)
 
   def unapply(join: Join): Option[ReturnType] = join match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -305,7 +305,7 @@ case class Union(children: Seq[LogicalPlan]) extends LogicalPlan {
 case class Join(
     left: LogicalPlan,
     right: LogicalPlan,
-    joinType: JoinType,
+    joinType: CatalystJoinType,
     condition: Option[Expression],
     hint: JoinHint)
   extends BinaryNode with PredicateHelper {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.catalyst.ScalaReflection._
 import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogStorageFormat, CatalogTable, CatalogTableType, FunctionResource}
 import org.apache.spark.sql.catalyst.errors._
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.plans.JoinType
+import org.apache.spark.sql.catalyst.plans.CatalystJoinType
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, Partitioning}
 import org.apache.spark.sql.catalyst.util.StringUtils.PlanStringConcat
@@ -780,7 +780,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
     case exprId: ExprId => true
     case field: StructField => true
     case id: IdentifierWithDatabase => true
-    case join: JoinType => true
+    case join: CatalystJoinType => true
     case spec: BucketSpec => true
     case catalog: CatalogTable => true
     case partition: Partitioning => true

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/JoinTypesTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/JoinTypesTest.scala
@@ -15,50 +15,49 @@
  * limitations under the License.
  */
 
-
-package org.apache.spark.sql.catalyst.plans
+package org.apache.spark.sql
 
 import org.apache.spark.SparkFunSuite
 
 class JoinTypesTest extends SparkFunSuite {
 
   test("construct an Inner type") {
-    assert(JoinType("inner") === Inner)
+    assert(JoinType("inner") === JoinType.Inner)
   }
 
   test("construct a FullOuter type") {
-    assert(JoinType("fullouter") === FullOuter)
-    assert(JoinType("full_outer") === FullOuter)
-    assert(JoinType("outer") === FullOuter)
-    assert(JoinType("full") === FullOuter)
+    assert(JoinType("fullouter") === JoinType.FullOuter)
+    assert(JoinType("full_outer") === JoinType.FullOuter)
+    assert(JoinType("outer") === JoinType.FullOuter)
+    assert(JoinType("full") === JoinType.FullOuter)
   }
 
   test("construct a LeftOuter type") {
-    assert(JoinType("leftouter") === LeftOuter)
-    assert(JoinType("left_outer") === LeftOuter)
-    assert(JoinType("left") === LeftOuter)
+    assert(JoinType("leftouter") === JoinType.LeftOuter)
+    assert(JoinType("left_outer") === JoinType.LeftOuter)
+    assert(JoinType("left") === JoinType.LeftOuter)
   }
 
   test("construct a RightOuter type") {
-    assert(JoinType("rightouter") === RightOuter)
-    assert(JoinType("right_outer") === RightOuter)
-    assert(JoinType("right") === RightOuter)
+    assert(JoinType("rightouter") === JoinType.RightOuter)
+    assert(JoinType("right_outer") === JoinType.RightOuter)
+    assert(JoinType("right") === JoinType.RightOuter)
   }
 
   test("construct a LeftSemi type") {
-    assert(JoinType("leftsemi") === LeftSemi)
-    assert(JoinType("left_semi") === LeftSemi)
-    assert(JoinType("semi") === LeftSemi)
+    assert(JoinType("leftsemi") === JoinType.LeftSemi)
+    assert(JoinType("left_semi") === JoinType.LeftSemi)
+    assert(JoinType("semi") === JoinType.LeftSemi)
   }
 
   test("construct a LeftAnti type") {
-    assert(JoinType("leftanti") === LeftAnti)
-    assert(JoinType("left_anti") === LeftAnti)
-    assert(JoinType("anti") === LeftAnti)
+    assert(JoinType("leftanti") === JoinType.LeftAnti)
+    assert(JoinType("left_anti") === JoinType.LeftAnti)
+    assert(JoinType("anti") === JoinType.LeftAnti)
   }
 
   test("construct a Cross type") {
-    assert(JoinType("cross") === Cross)
+    assert(JoinType("cross") === JoinType.Cross)
   }
 
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CheckCartesianProductsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CheckCartesianProductsSuite.scala
@@ -82,7 +82,7 @@ class CheckCartesianProductsSuite extends PlanTest {
   }
 
   private def performCartesianProductCheck(
-      joinType: JoinType,
+      joinType: CatalystJoinType,
       condition: Option[Expression] = None): Unit = {
     val analyzedPlan = testRelation1.join(testRelation2, joinType, condition).analyze
     val optimizedPlan = Optimize.execute(analyzedPlan)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersFromConstraintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersFromConstraintsSuite.scala
@@ -46,7 +46,7 @@ class InferFiltersFromConstraintsSuite extends PlanTest {
       y: LogicalPlan,
       expectedLeft: LogicalPlan,
       expectedRight: LogicalPlan,
-      joinType: JoinType) = {
+      joinType: CatalystJoinType) = {
     val condition = Some("x.a".attr === "y.a".attr)
     val originalQuery = x.join(y, joinType, condition).analyze
     val correctAnswer = expectedLeft.join(expectedRight, joinType, condition).analyze

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -336,29 +336,30 @@ class PlanParserSuite extends AnalysisTest {
 
   test("joins") {
     // Test single joins.
-    val testUnconditionalJoin = (sql: String, jt: JoinType) => {
+    val testUnconditionalJoin = (sql: String, jt: CatalystJoinType) => {
       assertEqual(
         s"select * from t as tt $sql u",
         table("t").as("tt").join(table("u"), jt, None).select(star()))
     }
-    val testConditionalJoin = (sql: String, jt: JoinType) => {
+    val testConditionalJoin = (sql: String, jt: CatalystJoinType) => {
       assertEqual(
         s"select * from t $sql u as uu on a = b",
         table("t").join(table("u").as("uu"), jt, Option('a === 'b)).select(star()))
     }
-    val testNaturalJoin = (sql: String, jt: JoinType) => {
+    val testNaturalJoin = (sql: String, jt: CatalystJoinType) => {
       assertEqual(
         s"select * from t tt natural $sql u as uu",
         table("t").as("tt").join(table("u").as("uu"), NaturalJoin(jt), None).select(star()))
     }
-    val testUsingJoin = (sql: String, jt: JoinType) => {
+    val testUsingJoin = (sql: String, jt: CatalystJoinType) => {
       assertEqual(
         s"select * from t $sql u using(a, b)",
         table("t").join(table("u"), UsingJoin(jt, Seq("a", "b")), None).select(star()))
     }
     val testAll = Seq(testUnconditionalJoin, testConditionalJoin, testNaturalJoin, testUsingJoin)
     val testExistence = Seq(testUnconditionalJoin, testConditionalJoin, testUsingJoin)
-    def test(sql: String, jt: JoinType, tests: Seq[(String, JoinType) => Unit]): Unit = {
+    def test(sql: String, jt: CatalystJoinType,
+      tests: Seq[(String, CatalystJoinType) => Unit]): Unit = {
       tests.foreach(_(sql, jt))
     }
     test("cross join", Cross, Seq(testUnconditionalJoin))

--- a/sql/core/src/main/scala/org/apache/spark/sql/dynamicpruning/PartitionPruning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/dynamicpruning/PartitionPruning.scala
@@ -186,12 +186,12 @@ object PartitionPruning extends Rule[LogicalPlan] with PredicateHelper {
     !plan.isStreaming && hasSelectivePredicate(plan)
   }
 
-  private def canPruneLeft(joinType: JoinType): Boolean = joinType match {
+  private def canPruneLeft(joinType: CatalystJoinType): Boolean = joinType match {
     case Inner | LeftSemi | RightOuter => true
     case _ => false
   }
 
-  private def canPruneRight(joinType: JoinType): Boolean = joinType match {
+  private def canPruneRight(joinType: CatalystJoinType): Boolean = joinType match {
     case Inner | LeftOuter => true
     case _ => false
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -163,12 +163,12 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
       a.stats.sizeInBytes * 3 <= b.stats.sizeInBytes
     }
 
-    private def canBuildRight(joinType: JoinType): Boolean = joinType match {
+    private def canBuildRight(joinType: CatalystJoinType): Boolean = joinType match {
       case _: InnerLike | LeftOuter | LeftSemi | LeftAnti | _: ExistenceJoin => true
       case _ => false
     }
 
-    private def canBuildLeft(joinType: JoinType): Boolean = joinType match {
+    private def canBuildLeft(joinType: CatalystJoinType): Boolean = joinType match {
       case _: InnerLike | RightOuter => true
       case _ => false
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinExec.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.types.{BooleanType, LongType}
 case class BroadcastHashJoinExec(
     leftKeys: Seq[Expression],
     rightKeys: Seq[Expression],
-    joinType: JoinType,
+    joinType: CatalystJoinType,
     buildSide: BuildSide,
     condition: Option[Expression],
     left: SparkPlan,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastNestedLoopJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastNestedLoopJoinExec.scala
@@ -33,7 +33,7 @@ case class BroadcastNestedLoopJoinExec(
     left: SparkPlan,
     right: SparkPlan,
     buildSide: BuildSide,
-    joinType: JoinType,
+    joinType: CatalystJoinType,
     condition: Option[Expression]) extends BinaryExecNode {
 
   override lazy val metrics = Map(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
@@ -31,7 +31,7 @@ trait HashJoin {
 
   val leftKeys: Seq[Expression]
   val rightKeys: Seq[Expression]
-  val joinType: JoinType
+  val joinType: CatalystJoinType
   val buildSide: BuildSide
   val condition: Option[Expression]
   val left: SparkPlan

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.execution.metric.SQLMetrics
 case class ShuffledHashJoinExec(
     leftKeys: Seq[Expression],
     rightKeys: Seq[Expression],
-    joinType: JoinType,
+    joinType: CatalystJoinType,
     buildSide: BuildSide,
     condition: Option[Expression],
     left: SparkPlan,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -37,7 +37,7 @@ import org.apache.spark.util.collection.BitSet
 case class SortMergeJoinExec(
     leftKeys: Seq[Expression],
     rightKeys: Seq[Expression],
-    joinType: JoinType,
+    joinType: CatalystJoinType,
     condition: Option[Expression],
     left: SparkPlan,
     right: SparkPlan) extends BinaryExecNode with CodegenSupport {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
@@ -126,7 +126,7 @@ import org.apache.spark.util.{CompletionIterator, SerializableConfiguration}
 case class StreamingSymmetricHashJoinExec(
     leftKeys: Seq[Expression],
     rightKeys: Seq[Expression],
-    joinType: JoinType,
+    joinType: CatalystJoinType,
     condition: JoinConditionSplitPredicates,
     stateInfo: Option[StatefulOperatorStateInfo],
     eventTimeWatermark: Option[Long],
@@ -137,7 +137,7 @@ case class StreamingSymmetricHashJoinExec(
   def this(
       leftKeys: Seq[Expression],
       rightKeys: Seq[Expression],
-      joinType: JoinType,
+      joinType: CatalystJoinType,
       condition: Option[Expression],
       left: SparkPlan,
       right: SparkPlan) = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/ExistenceJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/ExistenceJoinSuite.scala
@@ -78,7 +78,7 @@ class ExistenceJoinSuite extends SparkPlanTest with SharedSparkSession {
   // the SQLContext should be used only within a test to keep SQL tests stable
   private def testExistenceJoin(
       testName: String,
-      joinType: JoinType,
+      joinType: CatalystJoinType,
       leftRows: => DataFrame,
       rightRows: => DataFrame,
       condition: => Expression,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/OuterJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/OuterJoinSuite.scala
@@ -67,7 +67,7 @@ class OuterJoinSuite extends SparkPlanTest with SharedSparkSession {
       testName: String,
       leftRows: => DataFrame,
       rightRows: => DataFrame,
-      joinType: JoinType,
+      joinType: CatalystJoinType,
       condition: => Expression,
       expectedAnswer: Seq[Product]): Unit = {
 


### PR DESCRIPTION
Adding overloads for all join methods that take the JoinType parameter instead of string

Testing @deprecated marking for string version

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Adding overloaded versions of all `join` methods in `Dataset` that take the strongly-typed `JoinType` as the `joinType` parameter, instead of `String`.

Keeping `String` versions, marking deprecated, and simply calling the new versions.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To make the `DataFrame` API easier to use.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

Yes, there are new join method overloads available that take `JoinType`.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

`sql` sbt tests were run.
