### PR TITLE
[SPARK-28158][SQL][FOLLOWUP] HiveUserDefinedTypeSuite: don't use RandomDataGenerator to create row for UDT backed by ArrayType

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveUserDefinedTypeSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveUserDefinedTypeSuite.scala
@@ -35,7 +35,7 @@ class HiveUserDefinedTypeSuite extends QueryTest with TestHiveSingleton {
   test("Support UDT in Hive UDF") {
     val functionName = "get_point_x"
     try {
-      val schema = new StructType().add("point", new ExamplePointUDT)
+      val schema = new StructType().add("point", new ExamplePointUDT, nullable = false)
       val inputGenerator = RandomDataGenerator.forType(schema, nullable = false).get
       val input = inputGenerator.apply().asInstanceOf[Row]
       val df = spark.createDataFrame(Array(input).toList.asJava, schema)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveUserDefinedTypeSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveUserDefinedTypeSuite.scala
@@ -30,16 +30,14 @@ import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.test.{ExamplePoint, ExamplePointUDT}
 import org.apache.spark.sql.types.StructType
 
-
 class HiveUserDefinedTypeSuite extends QueryTest with TestHiveSingleton {
   private val functionClass = classOf[org.apache.spark.sql.hive.TestUDF].getCanonicalName
 
   test("Support UDT in Hive UDF") {
-    val rand = new Random
     val functionName = "get_point_x"
     try {
       val schema = new StructType().add("point", new ExamplePointUDT, nullable = false)
-      val input = Row.fromSeq(Seq(new ExamplePoint(rand.nextDouble(), rand.nextDouble())))
+      val input = Row.fromSeq(Seq(new ExamplePoint(3.141592d, -3.141592d)))
       val df = spark.createDataFrame(Array(input).toList.asJava, schema)
       df.createOrReplaceTempView("src")
       spark.sql(s"CREATE FUNCTION $functionName AS '$functionClass'")


### PR DESCRIPTION
### What changes were proposed in this pull request?

There're some issues observed in `HiveUserDefinedTypeSuite."Support UDT in Hive UDF"`: 

1) Neither function (TestUDF) nor test take "nullable" point column into account.
2) ExamplePointUDT. sqlType is ArrayType which doesn't provide information how many elements are expected. RandomDataGenerator may provide less elements than needed.

This patch fixes `HiveUserDefinedTypeSuite."Support UDT in Hive UDF"` to change the type of "point" column to be non-nullable, as well as not use RandomDataGenerator to create row for UDT backed by ArrayType. 

### Why are the changes needed?

CI builds are failing in high occurrences.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Manually tested by running tests locally multiple times.