### PR TITLE
[SPARK-28560][SQL][followup] support the build side to local shuffle reader as far as possible in BroadcastHashJoin

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -525,7 +525,7 @@ object AdaptiveSparkPlanExec {
    * Apply a list of physical operator rules on a [[SparkPlan]].
    */
   def applyPhysicalRules(plan: SparkPlan, rules: Seq[Rule[SparkPlan]]): SparkPlan = {
-    rules.foldLeft(plan) { case (sp, rule) => rule.apply(sp)}
+    rules.foldLeft(plan) { case (sp, rule) => rule.apply(sp) }
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -333,7 +333,7 @@ case class AdaptiveSparkPlanExec(
   }
 
   private def newQueryStage(e: Exchange): QueryStageExec = {
-    val optimizedPlan = applyPhysicalRules(e.child, queryStageOptimizerRules, Some(e))
+    val optimizedPlan = applyPhysicalRules(e.child, queryStageOptimizerRules)
     val queryStage = e match {
       case s: ShuffleExchangeExec =>
         ShuffleQueryStageExec(currentStageId, s.copy(child = optimizedPlan))
@@ -524,16 +524,8 @@ object AdaptiveSparkPlanExec {
   /**
    * Apply a list of physical operator rules on a [[SparkPlan]].
    */
-  def applyPhysicalRules(
-    plan: SparkPlan, rules: Seq[Rule[SparkPlan]],
-    parent: Option[SparkPlan] = None): SparkPlan = {
-    rules.foldLeft(plan) {
-      case (sp, rule) =>
-        if (parent.nonEmpty && rule.isInstanceOf[OptimizeLocalShuffleReader]) {
-          rule.asInstanceOf[OptimizeLocalShuffleReader].parent = parent
-        }
-        rule.apply(sp)
-    }
+  def applyPhysicalRules(plan: SparkPlan, rules: Seq[Rule[SparkPlan]]): SparkPlan = {
+    rules.foldLeft(plan) { case (sp, rule) => rule.apply(sp)}
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -31,13 +31,11 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, ReturnAnswer}
 import org.apache.spark.sql.catalyst.rules.{Rule, RuleExecutor}
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec._
-import org.apache.spark.sql.execution.adaptive.rule.ReduceNumShufflePartitions
 import org.apache.spark.sql.execution.exchange._
 import org.apache.spark.sql.execution.ui.SparkListenerSQLAdaptiveExecutionUpdate
 import org.apache.spark.sql.internal.SQLConf

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
@@ -57,14 +57,6 @@ object BroadcastJoinWithShuffleRight {
  */
 case class OptimizeLocalShuffleReader(conf: SQLConf) extends Rule[SparkPlan] {
 
-  def canUseLocalShuffleReaderProbeLeft(join: BroadcastHashJoinExec): Boolean = {
-    join.buildSide == BuildRight &&  ShuffleQueryStageExec.isShuffleQueryStageExec(join.left)
-  }
-
-  def canUseLocalShuffleReaderProbeRight(join: BroadcastHashJoinExec): Boolean = {
-    join.buildSide == BuildLeft &&  ShuffleQueryStageExec.isShuffleQueryStageExec(join.right)
-  }
-
   override def apply(plan: SparkPlan): SparkPlan = {
     if (!conf.getConf(SQLConf.OPTIMIZE_LOCAL_SHUFFLE_READER_ENABLED)) {
       return plan

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
@@ -43,6 +43,8 @@ case class OptimizeLocalShuffleReader(conf: SQLConf) extends Rule[SparkPlan] {
 
     val optimizedPlan = if (shuffleStages.isEmpty ||
       !shuffleStages.forall(_.plan.canChangeNumPartitions)) {
+      // For the Exchange introduced by repartition,
+      // don't apply this rule to avoid additional shuffle introduced for the parent stage.
       plan
     } else {
       plan.transformUp {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ReduceNumShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ReduceNumShufflePartitions.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.execution.adaptive.rule
+package org.apache.spark.sql.execution.adaptive
 
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration.Duration

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ReduceNumShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ReduceNumShufflePartitions.scala
@@ -27,7 +27,6 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, UnknownPartitioning}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{ShuffledRowRDD, SparkPlan, UnaryExecNode}
-import org.apache.spark.sql.execution.adaptive.{LocalShuffleReaderExec, QueryStageExec, ReusedQueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.ThreadUtils
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ReduceNumShufflePartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ReduceNumShufflePartitionsSuite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.{MapOutputStatistics, SparkConf, SparkFunSuite}
 import org.apache.spark.internal.config.UI.UI_ENABLED
 import org.apache.spark.sql._
 import org.apache.spark.sql.execution.adaptive._
-import org.apache.spark.sql.execution.adaptive.rule.{CoalescedShuffleReaderExec, ReduceNumShufflePartitions}
+import org.apache.spark.sql.execution.adaptive.{CoalescedShuffleReaderExec, ReduceNumShufflePartitions}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -163,37 +163,27 @@ class AdaptiveQueryExecSuite
       assert(smj.size == 3)
       val bhj = findTopLevelBroadcastHashJoin(adaptivePlan)
       assert(bhj.size == 3)
-      // *(6) BroadcastHashJoin [b#24], [a#33], Inner, BuildLeft
-      // :- BroadcastQueryStage 6
-      // :  +- BroadcastExchange HashedRelationBroadcastMode
-      // :     +- LocalShuffleReader
-      // :        +- ShuffleQueryStage 5
-      // :           +- Exchange hashpartitioning(b#24, 5), true, [id=#437]
-      // :              +- *(5) BroadcastHashJoin [key#13], [a#23], Inner, BuildLeft
-      // :                 :- BroadcastQueryStage 4
-      // :                 :  +- BroadcastExchange HashedRelationBroadcastMode
-      // :                 :     +- LocalShuffleReader
-      // :                 :        +- ShuffleQueryStage 0
-      // :
-      // :                 +- LocalShuffleReader
-      // :                    +- ShuffleQueryStage 1
-      // :                       +- Exchange hashpartitioning(a#23, 5), true, [id=#213]
-      // :
-      // +- *(6) BroadcastHashJoin [n#93], [a#33], Inner, BuildRight
-      //    :- LocalShuffleReader
-      //    :  +- ShuffleQueryStage 2
-      //    :     +- Exchange hashpartitioning(n#93, 5), true, [id=#230]
-      //    :
-      //    +- BroadcastQueryStage 7
-      //       +- BroadcastExchange HashedRelationBroadcastMode
-      //          +- LocalShuffleReader
-      //             +- ShuffleQueryStage 3
+      // BroadcastHashJoin
+      // +- BroadcastExchange
+      //    +- LocalShuffleReader*
+      //       +- ShuffleExchange
+      //          +- BroadcastHashJoin
+      //             +- BroadcastExchange
+      //                +- LocalShuffleReader*
+      //                   +- ShuffleExchange
+      //             +- LocalShuffleReader*
+      //                +- ShuffleExchange
+      // +- BroadcastHashJoin
+      //    +- LocalShuffleReader*
+      //       +- ShuffleExchange
+      //    +- BroadcastExchange
+      //       +-LocalShuffleReader*
+      //             +- ShuffleExchange
 
       // After applied the 'OptimizeLocalShuffleReader' rule, we can convert all the four
       // shuffle reader to local shuffle reader in the bottom two 'BroadcastHashJoin'.
-      // For the opt level 'BroadcastHashJoin', the probe side is not shuffle query stage
+      // For the top level 'BroadcastHashJoin', the probe side is not shuffle query stage
       // and the build side shuffle query stage is also converted to local shuffle reader.
-
       checkNumLocalShuffleReaders(adaptivePlan, 5)
     }
   }
@@ -218,31 +208,23 @@ class AdaptiveQueryExecSuite
       assert(smj.size == 3)
       val bhj = findTopLevelBroadcastHashJoin(adaptivePlan)
       assert(bhj.size == 3)
-      // *(7) BroadcastHashJoin [b#24], [a#33], Inner, BuildLeft
-      // :- BroadcastQueryStage 6
-      // :  +- BroadcastExchange HashedRelationBroadcastMode(
-      // :     +- LocalShuffleReader
-      // :        +- ShuffleQueryStage 5
-      // :           +- Exchange hashpartitioning(b#24, 5), true, [id=#452]
-      // :              +- *(5) BroadcastHashJoin [key#13], [a#23], Inner, BuildLeft
-      // :                 :- BroadcastQueryStage 4
-      // :                 :  +- BroadcastExchange HashedRelationBroadcastMode(
-      // :                 :     +- LocalShuffleReader
-      // :                 :        +- ShuffleQueryStage 0
-      // :
-      // :                 +- LocalShuffleReader
-      // :                    +- ShuffleQueryStage 1
-      // :
-      // +- *(7) BroadcastHashJoin [n#93], [a#33], Inner, BuildRight
-      //    :- LocalShuffleReader
-      //    :  +- ShuffleQueryStage 2
-      //
-      //    +- BroadcastQueryStage 7
-      //       +- BroadcastExchange HashedRelationBroadcastMode
-      //          +- *(6) HashAggregate(keys=[a#33], functions=[sum(cast(b#34 as bigint))],
-      // output=[a#33, sum(b)#219L])
-      //             +- CoalescedShuffleReader [0]
-      //                +- ShuffleQueryStage 3
+      // BroadcastHashJoin
+      // +- BroadcastExchange
+      //    +- LocalShuffleReader*
+      //       +- ShuffleExchange
+      //          +- BroadcastHashJoin
+      //             +- BroadcastExchange
+      //                +- LocalShuffleReader*
+      //                   +- ShuffleExchange
+      //             +- LocalShuffleReader*
+      //                +- ShuffleExchange
+      // +- BroadcastHashJoin
+      //    +- LocalShuffleReader*
+      //       +- ShuffleExchange
+      //    +- BroadcastExchange
+      //       +-HashAggregate
+      //          +- CoalescedShuffleReader
+      //             +- ShuffleExchange
       checkNumLocalShuffleReaders(adaptivePlan, 4)
     }
   }
@@ -267,31 +249,24 @@ class AdaptiveQueryExecSuite
       assert(smj.size == 3)
       val bhj = findTopLevelBroadcastHashJoin(adaptivePlan)
       assert(bhj.size == 3)
-      // *(6) BroadcastHashJoin [cast(value#14 as int)], [a#220], Inner, BuildLeft
-      // :- BroadcastQueryStage 7
-      // :  +- BroadcastExchange HashedRelationBroadcastMode
-      // :     +- LocalShuffleReader
-      // :        +- ShuffleQueryStage 6
-      // :           +- Exchange hashpartitioning(cast(value#14 as int), 5), true, [id=#537]
-      // :              +- *(5) BroadcastHashJoin [key#13], [a#23], Inner, BuildLeft
-      // :                 :- BroadcastQueryStage 4
-      // :                 :  +- BroadcastExchange HashedRelationBroadcastMode
-      // :                 :     +- LocalShuffleReader
-      // :                 :        +- ShuffleQueryStage 0
-      // :
-      // :                 +- LocalShuffleReader
-      // :                    +- ShuffleQueryStage 1
-      // :
-      // +- *(6) BroadcastHashJoin [n#93], [b#218], Inner, BuildLeft
-      //    :- BroadcastQueryStage 5
-      //    :  +- BroadcastExchange HashedRelationBroadcastMode
-      //    :     +- LocalShuffleReader
-      //    :        +- ShuffleQueryStage 2
-      //    :
-      //    +- *(6) Filter isnotnull(b#218)
-      //       +- *(6) HashAggregate(keys=[a#220], functions=[max(b#221)], output=[a#220, b#218])
-      //          +- CoalescedShuffleReader [0]
-      //             +- ShuffleQueryStage 3
+      // BroadcastHashJoin
+      // +- BroadcastExchange
+      //    +- LocalShuffleReader*
+      //       +- ShuffleExchange
+      //          +- BroadcastHashJoin
+      //             +- BroadcastExchange
+      //                +- LocalShuffleReader*
+      //                   +- ShuffleExchange
+      //             +- LocalShuffleReader*
+      //                +- ShuffleExchange
+      // +- BroadcastHashJoin
+      //    +- Filter
+      //       +- HashAggregate
+      //          +- CoalescedShuffleReader
+      //             +- ShuffleExchange
+      //    +- BroadcastExchange
+      //       +-LocalShuffleReader*
+      //           +- ShuffleExchange
       checkNumLocalShuffleReaders(adaptivePlan, 4)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -308,7 +308,7 @@ class AdaptiveQueryExecSuite
       val bhj = findTopLevelBroadcastHashJoin(adaptivePlan)
       assert(bhj.size == 2)
       checkNumLocalShuffleReaders(adaptivePlan, 4)
-      // Even with local shuffle reader, the query statge reuse can also work.
+      // Even with local shuffle reader, the query stage reuse can also work.
       val ex = findReusedExchange(adaptivePlan)
       assert(ex.size == 1)
     }
@@ -326,7 +326,7 @@ class AdaptiveQueryExecSuite
       val bhj = findTopLevelBroadcastHashJoin(adaptivePlan)
       assert(bhj.size == 1)
       checkNumLocalShuffleReaders(adaptivePlan, 2)
-      // Even with local shuffle reader, the query statge reuse can also work.
+      // Even with local shuffle reader, the query stage reuse can also work.
       val ex = findReusedExchange(adaptivePlan)
       assert(ex.size == 1)
     }
@@ -346,7 +346,7 @@ class AdaptiveQueryExecSuite
       val bhj = findTopLevelBroadcastHashJoin(adaptivePlan)
       assert(bhj.size == 1)
       checkNumLocalShuffleReaders(adaptivePlan, 2)
-      // Even with local shuffle reader, the query statge reuse can also work.
+      // Even with local shuffle reader, the query stage reuse can also work.
       val ex = findReusedExchange(adaptivePlan)
       assert(ex.nonEmpty)
       val sub = findReusedSubquery(adaptivePlan)
@@ -367,7 +367,7 @@ class AdaptiveQueryExecSuite
       val bhj = findTopLevelBroadcastHashJoin(adaptivePlan)
       assert(bhj.size == 1)
       checkNumLocalShuffleReaders(adaptivePlan, 2)
-      // Even with local shuffle reader, the query statge reuse can also work.
+      // Even with local shuffle reader, the query stage reuse can also work.
       val ex = findReusedExchange(adaptivePlan)
       assert(ex.isEmpty)
       val sub = findReusedSubquery(adaptivePlan)
@@ -391,7 +391,7 @@ class AdaptiveQueryExecSuite
       val bhj = findTopLevelBroadcastHashJoin(adaptivePlan)
       assert(bhj.size == 1)
       checkNumLocalShuffleReaders(adaptivePlan, 2)
-      // Even with local shuffle reader, the query statge reuse can also work.
+      // Even with local shuffle reader, the query stage reuse can also work.
       val ex = findReusedExchange(adaptivePlan)
       assert(ex.nonEmpty)
       assert(ex.head.plan.isInstanceOf[BroadcastQueryStageExec])
@@ -468,9 +468,8 @@ class AdaptiveQueryExecSuite
       assert(smj.size == 2)
       val bhj = findTopLevelBroadcastHashJoin(adaptivePlan)
       assert(bhj.size == 1)
-      // Additional shuffle exchange introduced, so revert OptimizeLocalShuffleReader rule firstly.
-      // However when creating new broadcast query stage, we also can
-      // change the shuffle reader to local shuffle reader in build side.
+      // Even additional shuffle exchange introduced, we still
+      // can convert the shuffle reader to local reader in build side.
       checkNumLocalShuffleReaders(adaptivePlan, 1)
     }
   }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
[PR#25295](https://github.com/apache/spark/pull/25295) already implement the rule of converting the shuffle reader to local reader for the `BroadcastHashJoin` in probe side. This PR support converting the shuffle reader to local reader in build side.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Improve performance
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce any user-facing change?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->


### How was this patch tested?
existing unit tests
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
