### PR TITLE
[SPARK-29595][SQL] Insertion with named_struct should match by name

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -418,7 +418,7 @@ object DataType {
               wField.dataType, rField.dataType, byName, resolver, fieldContext,
               storeAssignmentPolicy, addError)
 
-            // [SPARK-29565] StructFields should always be matched.
+            // [SPARK-29595] StructFields should always be matched.
             if (!nameMatch) {
               addError(s"Struct '$context' $i-th field name does not match " +
                 s"(may be out of order): expected '${rField.name}', found '${wField.name}'")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -418,7 +418,8 @@ object DataType {
               wField.dataType, rField.dataType, byName, resolver, fieldContext,
               storeAssignmentPolicy, addError)
 
-            if (byName && !nameMatch) {
+            // [SPARK-29565] StructFields should always be matched.
+            if (!nameMatch) {
               addError(s"Struct '$context' $i-th field name does not match " +
                 s"(may be out of order): expected '${rField.name}', found '${wField.name}'")
               fieldCompatible = false

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DataSourceV2AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DataSourceV2AnalysisSuite.scala
@@ -535,14 +535,10 @@ abstract class DataSourceV2AnalysisBaseSuite extends AnalysisTest {
       val parsedPlan = byPosition(tableWithStructCol, query)
       assertNotResolved(parsedPlan)
 
-      val expectedQuery = Project(Seq(Alias(
-        Cast(
-          query.output.head,
-          new StructType().add("a", IntegerType).add("b", IntegerType),
-          Some(conf.sessionLocalTimeZone)),
-        "col")()),
-        query)
-      checkAnalysis(parsedPlan, byPosition(tableWithStructCol, expectedQuery))
+      assertAnalysisError(parsedPlan, Seq(
+        "Cannot write incompatible data to table", "'table-name'",
+        "Struct 'col' 0-th field name does not match", "expected 'a', found 'x'",
+        "Struct 'col' 1-th field name does not match", "expected 'b', found 'y'"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3318,17 +3318,17 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-29595: Unorder insertion in NAMED_STRUCT should throw exception") {
+  test("Unorder insertion in NAMED_STRUCT should throw exception") {
     sql("CREATE TABLE tb1 USING PARQUET AS (SELECT NAMED_STRUCT('a', 1, 'b', 2) AS data)")
     val error = intercept[AnalysisException] {
       sql("INSERT INTO tb1 VALUES NAMED_STRUCT('b', 4, 'a', 3)")
     }.getMessage
-    assert(error contains
+    assert(error.contains(
       "Struct 'data' 0-th field name does not match" +
-        " (may be out of order): expected 'a', found 'b'")
-    assert(error contains
+        " (may be out of order): expected 'a', found 'b'"))
+    assert(error.contains(
       "Struct 'data' 1-th field name does not match" +
-        " (may be out of order): expected 'b', found 'a'")
+        " (may be out of order): expected 'b', found 'a'"))
   }
 }
 


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
When data is inserted into table having column of type named_struct, field names is mandatory to be written and with this PR, field names of StructType will always be verified.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
named_struct is not validating field names before insertion.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce any user-facing change?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->


### How was this patch tested?
Tested manually.
```
$ create table str using parquet as(select named_struct('a', 1, 'b', 2) as data);
$ insert into str values named_struct('b', 4, 'a', 1);
Error in query: Cannot write incompatible data to table '`default`.`str`':
- Struct 'data' 0-th field name does not match (may be out of order): expected 'a', found 'b'
- Struct 'data' 1-th field name does not match (may be out of order): expected 'b', found 'a';
$ insert into str values named_struct('a', 4, 'b', 1);
$ select * from str;
{"a":4,"b":1}
{"a":1,"b":2}
```

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
