### PR TITLE
[SPARK-28938][K8S][2.4][FOLLOWUP] Use `/usr/bin/tini` instead of `/sbin/tini`

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
@@ -45,7 +45,7 @@ case "$SPARK_K8S_CMD" in
       ;;
     *)
       echo "Non-spark-on-k8s command provided, proceeding in pass-through mode..."
-      exec /sbin/tini -s -- "$@"
+      exec /usr/bin/tini -s -- "$@"
       ;;
 esac
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change entrypoint.sh script for the kubernetes manager image to reference /usr/sbin/tini

### Why are the changes needed?

This makes running commands like /bin/bash via pass-through work.

This was missing from #26046 

### Does this PR introduce any user-facing change?

It makes pass-through work.


### How was this patch tested?

I built an image and verified that the following worked:
`docker run -it --rm  image:version   /bin/bash`