### PR TITLE
[SPARK-29647][TESTS][2.4] Use Python 3.7 in GitHub Action to recover lint-python

### DIFF
--- a/.github/workflows/branch-2.4.yml
+++ b/.github/workflows/branch-2.4.yml
@@ -44,7 +44,7 @@ jobs:
         java-version: '1.8'
     - uses: actions/setup-python@v1
       with:
-        python-version: '3.x'
+        python-version: '3.7'
         architecture: 'x64'
     - name: Scala
       run: ./dev/lint-scala


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently, GitHub Action on `branch-2.4` is broken because `branch-2.4` is incompatible with Python 3.7. This PR aims to recover the GitHub Action `lint-python` first.
- https://github.com/apache/spark/commits/branch-2.4

### Why are the changes needed?

This recovers GitHub Action for the other PRs and commits.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

The GitHub Action on this PR should passed.
