### PR TITLE
[SPARK-29544][CORE] collect the runtime statistics of row count in map stage

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
@@ -165,8 +165,9 @@ final class BypassMergeSortShuffleWriter<K, V> extends ShuffleWriter<K, V> {
       }
 
       MapInfo mapInfo = writePartitionedData(mapOutputWriter);
+      partitionLengths = mapInfo.lengths;
       mapStatus = MapStatus$.MODULE$.apply(
-        blockManager.shuffleServerId(), mapInfo.lengths, mapInfo.records, mapId);
+        blockManager.shuffleServerId(), partitionLengths, mapInfo.records, mapId);
     } catch (Exception e) {
       try {
         mapOutputWriter.abort(e);

--- a/core/src/main/java/org/apache/spark/shuffle/sort/MapInfo.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/MapInfo.java
@@ -15,25 +15,16 @@
  * limitations under the License.
  */
 
+
 package org.apache.spark.shuffle.sort;
 
-import java.io.File;
+class MapInfo {
 
-import org.apache.spark.storage.TempShuffleBlockId;
+  final long[] lengths;
+  final long[] records;
 
-/**
- * Metadata for a block of data written by {@link ShuffleExternalSorter}.
- */
-final class SpillInfo {
-  final long[] partitionLengths;
-  final long[] partitionRecords;
-  final File file;
-  final TempShuffleBlockId blockId;
-
-  SpillInfo(int numPartitions, File file, TempShuffleBlockId blockId) {
-    this.partitionLengths = new long[numPartitions];
-    this.partitionRecords = new long[numPartitions];
-    this.file = file;
-    this.blockId = blockId;
+  public MapInfo(long[] lengths, long[] records) {
+    this.lengths = lengths;
+    this.records = records;
   }
 }

--- a/core/src/main/java/org/apache/spark/shuffle/sort/MapInfo.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/MapInfo.java
@@ -23,7 +23,7 @@ class MapInfo {
   final long[] lengths;
   final long[] records;
 
-  public MapInfo(long[] lengths, long[] records) {
+  MapInfo(long[] lengths, long[] records) {
     this.lengths = lengths;
     this.records = records;
   }

--- a/core/src/main/java/org/apache/spark/shuffle/sort/ShuffleExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/ShuffleExternalSorter.java
@@ -202,6 +202,7 @@ final class ShuffleExternalSorter extends MemoryConsumer {
           if (currentPartition != -1) {
             final FileSegment fileSegment = writer.commitAndGet();
             spillInfo.partitionLengths[currentPartition] = fileSegment.length();
+            spillInfo.partitionRecords[currentPartition] = fileSegment.record();
           }
           currentPartition = partition;
         }
@@ -229,6 +230,7 @@ final class ShuffleExternalSorter extends MemoryConsumer {
     // writeSortedFile() in that case.
     if (currentPartition != -1) {
       spillInfo.partitionLengths[currentPartition] = committedSegment.length();
+      spillInfo.partitionRecords[currentPartition] = committedSegment.record();
       spills.add(spillInfo);
     }
 

--- a/core/src/main/scala/org/apache/spark/MapOutputStatistics.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputStatistics.scala
@@ -24,4 +24,7 @@ package org.apache.spark
  * @param bytesByPartitionId approximate number of output bytes for each map output partition
  *   (may be inexact due to use of compressed map statuses)
  */
-private[spark] class MapOutputStatistics(val shuffleId: Int, val bytesByPartitionId: Array[Long])
+private[spark] class MapOutputStatistics(
+    val shuffleId: Int,
+    val bytesByPartitionId: Array[Long],
+    val recordsByPartitionId: Array[Long] = Array[Long]())

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -809,13 +809,27 @@ package object config {
       .checkValue(_ > 0, "The expire time for caching preferred locations cannot be non-positive.")
       .createOptional
 
-  private[spark] val SHUFFLE_ACCURATE_BLOCK_THRESHOLD =
+  private[spark] val SHUFFLE_ACCURATE_BLOCK_SIZE_THRESHOLD =
     ConfigBuilder("spark.shuffle.accurateBlockThreshold")
       .doc("Threshold in bytes above which the size of shuffle blocks in " +
         "HighlyCompressedMapStatus is accurately recorded. This helps to prevent OOM " +
         "by avoiding underestimating shuffle block size when fetch shuffle blocks.")
       .bytesConf(ByteUnit.BYTE)
       .createWithDefault(100 * 1024 * 1024)
+
+  private[spark] val SHUFFLE_STATISTICS_VERBOSE =
+    ConfigBuilder("spark.shuffle.statistics.verbose")
+      .doc("Collect shuffle statistics in verbose mode, including row counts etc.")
+      .booleanConf
+      .createWithDefault(false)
+
+  private[spark] val SHUFFLE_ACCURATE_BLOCK_RECORD_THRESHOLD =
+    ConfigBuilder("spark.shuffle.accurateBlockRecordThreshold")
+      .doc("When we compress the records number of shuffle blocks in HighlyCompressedMapStatus, " +
+        "we will record the number accurately if it's above this config. The record number will " +
+        "be used for data skew judgement when spark.shuffle.statistics.verbose is set true.")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefault(2 * 1024 * 1024)
 
   private[spark] val SHUFFLE_REGISTRATION_TIMEOUT =
     ConfigBuilder("spark.shuffle.registration.timeout")

--- a/core/src/main/scala/org/apache/spark/shuffle/ShufflePartitionPairsWriter.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShufflePartitionPairsWriter.scala
@@ -126,6 +126,10 @@ private[spark] class ShufflePartitionPairsWriter(
     }
   }
 
+  def getRecordsWritten(): Int = {
+    numRecordsWritten
+  }
+
   private def updateBytesWritten(): Unit = {
     val numBytesWritten = partitionWriter.getNumBytesWritten
     val bytesWrittenDiff = numBytesWritten - curNumBytesWritten

--- a/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala
@@ -66,9 +66,10 @@ private[spark] class SortShuffleWriter[K, V, C](
     // (see SPARK-3570).
     val mapOutputWriter = shuffleExecutorComponents.createMapOutputWriter(
       dep.shuffleId, mapId, dep.partitioner.numPartitions)
-    sorter.writePartitionedMapOutput(dep.shuffleId, mapId, mapOutputWriter)
+    val partitionRecords = sorter.writePartitionedMapOutput(dep.shuffleId, mapId,
+      dep.partitioner.numPartitions, mapOutputWriter)
     val partitionLengths = mapOutputWriter.commitAllPartitions()
-    mapStatus = MapStatus(blockManager.shuffleServerId, partitionLengths, mapId)
+    mapStatus = MapStatus(blockManager.shuffleServerId, partitionLengths, partitionRecords, mapId)
   }
 
   /** Close this writer, passing along whether the map completed */

--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockObjectWriter.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockObjectWriter.scala
@@ -183,7 +183,8 @@ private[spark] class DiskBlockObjectWriter(
       }
 
       val pos = channel.position()
-      val fileSegment = new FileSegment(file, committedPosition, pos - committedPosition)
+      val fileSegment = new FileSegment(file, committedPosition,
+        pos - committedPosition, numRecordsWritten)
       committedPosition = pos
       // In certain compression codecs, more bytes are written after streams are closed
       writeMetrics.incBytesWritten(committedPosition - reportedPosition)
@@ -191,7 +192,7 @@ private[spark] class DiskBlockObjectWriter(
       numRecordsWritten = 0
       fileSegment
     } else {
-      new FileSegment(file, committedPosition, 0)
+      new FileSegment(file, committedPosition, 0, 0)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/storage/FileSegment.scala
+++ b/core/src/main/scala/org/apache/spark/storage/FileSegment.scala
@@ -23,10 +23,12 @@ import java.io.File
  * References a particular segment of a file (potentially the entire file),
  * based off an offset and a length.
  */
-private[spark] class FileSegment(val file: File, val offset: Long, val length: Long) {
+private[spark] class FileSegment(
+  val file: File, val offset: Long, val length: Long, val record: Long) {
   require(offset >= 0, s"File segment offset cannot be negative (got $offset)")
   require(length >= 0, s"File segment length cannot be negative (got $length)")
+  require(record >= 0, s"File segment record cannot be negative (got $length)")
   override def toString: String = {
-    "(name=%s, offset=%d, length=%d)".format(file.getName, offset, length)
+    "(name=%s, offset=%d, length=%d, record=%d)".format(file.getName, offset, length, record)
   }
 }

--- a/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
+++ b/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.util.*;
 
+import org.apache.spark.*;
 import org.mockito.stubbing.Answer;
 import scala.Option;
 import scala.Product2;
@@ -37,10 +38,6 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import org.apache.spark.HashPartitioner;
-import org.apache.spark.ShuffleDependency;
-import org.apache.spark.SparkConf;
-import org.apache.spark.TaskContext;
 import org.apache.spark.executor.ShuffleWriteMetrics;
 import org.apache.spark.executor.TaskMetrics;
 import org.apache.spark.io.CompressionCodec$;
@@ -86,6 +83,7 @@ public class UnsafeShuffleWriterSuite {
   @Mock(answer = RETURNS_SMART_NULLS) DiskBlockManager diskBlockManager;
   @Mock(answer = RETURNS_SMART_NULLS) TaskContext taskContext;
   @Mock(answer = RETURNS_SMART_NULLS) ShuffleDependency<Object, Object, Object> shuffleDep;
+  @Mock(answer = RETURNS_SMART_NULLS) SparkEnv env;
 
   @After
   public void tearDown() {
@@ -110,6 +108,9 @@ public class UnsafeShuffleWriterSuite {
     taskMetrics = new TaskMetrics();
     memoryManager = new TestMemoryManager(conf);
     taskMemoryManager = new TaskMemoryManager(memoryManager, 0);
+
+    when(env.conf()).thenReturn(conf);
+    SparkEnv.set(env);
 
     // Some tests will override this manager because they change the configuration. This is a
     // default for tests that don't need a specific one.
@@ -260,6 +261,52 @@ public class UnsafeShuffleWriterSuite {
     assertEquals(0, taskMetrics.diskBytesSpilled());
     assertEquals(0, taskMetrics.memoryBytesSpilled());
   }
+
+  private void testMergingSpillsRecordStatistics(
+    boolean transferToEnabled) throws IOException {
+    conf.set("spark.shuffle.statistics.verbose", "true");
+
+    final UnsafeShuffleWriter<Object, Object> writer = createWriter(transferToEnabled);
+    final ArrayList<Product2<Object, Object>> dataToWrite = new ArrayList<>();
+    for (int i : new int[] { 1, 2, 3, 4, 4, 2 }) {
+      dataToWrite.add(new Tuple2<>(i, i));
+    }
+    writer.insertRecordIntoSorter(dataToWrite.get(0));
+    writer.insertRecordIntoSorter(dataToWrite.get(1));
+    writer.insertRecordIntoSorter(dataToWrite.get(2));
+    writer.insertRecordIntoSorter(dataToWrite.get(3));
+    writer.forceSorterToSpill();
+    writer.insertRecordIntoSorter(dataToWrite.get(4));
+    writer.insertRecordIntoSorter(dataToWrite.get(5));
+    writer.closeAndWriteOutput();
+    final Option<MapStatus> mapStatus = writer.stop(true);
+    assertTrue(mapStatus.isDefined());
+    assertTrue(mergedOutputFile.exists());
+    assertEquals(2, spillFilesCreated.size());
+
+    long sumOfPartitionSizes = 0;
+    for (long size: partitionSizesInMergedFile) {
+      sumOfPartitionSizes += size;
+    }
+    assertEquals(sumOfPartitionSizes, mergedOutputFile.length());
+
+    long sumOfPartitionRows = 0;
+    for (int i = 0; i < NUM_PARTITITONS; i++) {
+      sumOfPartitionRows += mapStatus.get().getRecordForBlock(i);
+    }
+    assertEquals(sumOfPartitionRows, 6);
+  }
+
+  @Test
+  public void mergeSpillsRecordStatisticsWithTransferTo() throws Exception {
+    testMergingSpillsRecordStatistics(true);
+  }
+
+  @Test
+  public void mergeSpillsRecordStatisticsWithFileStream() throws Exception {
+    testMergingSpillsRecordStatistics(false);
+  }
+
 
   @Test
   public void writeWithoutSpilling() throws Exception {

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -64,9 +64,9 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     val size1000 = MapStatus.decompressSize(MapStatus.compressSize(1000L))
     val size10000 = MapStatus.decompressSize(MapStatus.compressSize(10000L))
     tracker.registerMapOutput(10, 0, MapStatus(BlockManagerId("a", "hostA", 1000),
-        Array(1000L, 10000L), 5))
+        Array(1000L, 10000L), Array[Long](), 5))
     tracker.registerMapOutput(10, 1, MapStatus(BlockManagerId("b", "hostB", 1000),
-        Array(10000L, 1000L), 6))
+        Array(10000L, 1000L), Array[Long](), 6))
     val statuses = tracker.getMapSizesByExecutorId(10, 0)
     assert(statuses.toSet ===
       Seq((BlockManagerId("a", "hostA", 1000),
@@ -87,9 +87,9 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     val compressedSize1000 = MapStatus.compressSize(1000L)
     val compressedSize10000 = MapStatus.compressSize(10000L)
     tracker.registerMapOutput(10, 0, MapStatus(BlockManagerId("a", "hostA", 1000),
-      Array(compressedSize1000, compressedSize10000), 5))
+      Array(compressedSize1000, compressedSize10000), Array[Long](), 5))
     tracker.registerMapOutput(10, 1, MapStatus(BlockManagerId("b", "hostB", 1000),
-      Array(compressedSize10000, compressedSize1000), 6))
+      Array(compressedSize10000, compressedSize1000), Array[Long](), 6))
     assert(tracker.containsShuffle(10))
     assert(tracker.getMapSizesByExecutorId(10, 0).nonEmpty)
     assert(0 == tracker.getNumCachedSerializedBroadcast)
@@ -110,9 +110,9 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     val compressedSize1000 = MapStatus.compressSize(1000L)
     val compressedSize10000 = MapStatus.compressSize(10000L)
     tracker.registerMapOutput(10, 0, MapStatus(BlockManagerId("a", "hostA", 1000),
-        Array(compressedSize1000, compressedSize1000, compressedSize1000), 5))
+        Array(compressedSize1000, compressedSize1000, compressedSize1000), Array[Long](), 5))
     tracker.registerMapOutput(10, 1, MapStatus(BlockManagerId("b", "hostB", 1000),
-        Array(compressedSize10000, compressedSize1000, compressedSize1000), 6))
+        Array(compressedSize10000, compressedSize1000, compressedSize1000), Array[Long](), 6))
 
     assert(0 == tracker.getNumCachedSerializedBroadcast)
     // As if we had two simultaneous fetch failures
@@ -148,7 +148,7 @@ class MapOutputTrackerSuite extends SparkFunSuite {
 
     val size1000 = MapStatus.decompressSize(MapStatus.compressSize(1000L))
     masterTracker.registerMapOutput(10, 0, MapStatus(
-      BlockManagerId("a", "hostA", 1000), Array(1000L), 5))
+      BlockManagerId("a", "hostA", 1000), Array(1000L), Array[Long](), 5))
     slaveTracker.updateEpoch(masterTracker.getEpoch)
     assert(slaveTracker.getMapSizesByExecutorId(10, 0).toSeq ===
       Seq((BlockManagerId("a", "hostA", 1000),
@@ -186,7 +186,7 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     // Message size should be ~123B, and no exception should be thrown
     masterTracker.registerShuffle(10, 1)
     masterTracker.registerMapOutput(10, 0, MapStatus(
-      BlockManagerId("88", "mph", 1000), Array.fill[Long](10)(0), 5))
+      BlockManagerId("88", "mph", 1000), Array.fill[Long](10)(0), Array[Long](), 5))
     val senderAddress = RpcAddress("localhost", 12345)
     val rpcCallContext = mock(classOf[RpcCallContext])
     when(rpcCallContext.senderAddress).thenReturn(senderAddress)
@@ -220,11 +220,11 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     // on hostB with output size 3
     tracker.registerShuffle(10, 3)
     tracker.registerMapOutput(10, 0, MapStatus(BlockManagerId("a", "hostA", 1000),
-        Array(2L), 5))
+        Array(2L), Array[Long](), 5))
     tracker.registerMapOutput(10, 1, MapStatus(BlockManagerId("a", "hostA", 1000),
-        Array(2L), 6))
+        Array(2L), Array[Long](), 6))
     tracker.registerMapOutput(10, 2, MapStatus(BlockManagerId("b", "hostB", 1000),
-        Array(3L), 7))
+        Array(3L), Array[Long](), 7))
 
     // When the threshold is 50%, only host A should be returned as a preferred location
     // as it has 4 out of 7 bytes of output.
@@ -264,7 +264,7 @@ class MapOutputTrackerSuite extends SparkFunSuite {
       masterTracker.registerShuffle(20, 100)
       (0 until 100).foreach { i =>
         masterTracker.registerMapOutput(20, i, new CompressedMapStatus(
-          BlockManagerId("999", "mps", 1000), Array.fill[Long](4000000)(0), 5))
+          BlockManagerId("999", "mps", 1000), Array.fill[Long](4000000)(0), Array[Long](), 5))
       }
       val senderAddress = RpcAddress("localhost", 12345)
       val rpcCallContext = mock(classOf[RpcCallContext])
@@ -313,9 +313,9 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     val size1000 = MapStatus.decompressSize(MapStatus.compressSize(1000L))
     val size10000 = MapStatus.decompressSize(MapStatus.compressSize(10000L))
     tracker.registerMapOutput(10, 0, MapStatus(BlockManagerId("a", "hostA", 1000),
-      Array(size0, size1000, size0, size10000), 5))
+      Array(size0, size1000, size0, size10000), Array[Long](), 5))
     tracker.registerMapOutput(10, 1, MapStatus(BlockManagerId("b", "hostB", 1000),
-      Array(size10000, size0, size1000, size0), 6))
+      Array(size10000, size0, size1000, size0), Array[Long](), 6))
     assert(tracker.containsShuffle(10))
     assert(tracker.getMapSizesByExecutorId(10, 0, 4).toSeq ===
         Seq(

--- a/core/src/test/scala/org/apache/spark/MapStatusesSerDeserBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/MapStatusesSerDeserBenchmark.scala
@@ -58,7 +58,7 @@ object MapStatusesSerDeserBenchmark extends BenchmarkBase {
           Array.fill(blockSize) {
             // Creating block size ranging from 0byte to 1GB
             (r.nextDouble() * 1024 * 1024 * 1024).toLong
-          }, i))
+          }, Array[Long](), i))
     }
 
     val shuffleStatus = tracker.shuffleStatuses.get(shuffleId).head

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -3143,7 +3143,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
 
 object DAGSchedulerSuite {
   def makeMapStatus(host: String, reduces: Int, sizes: Byte = 2, mapTaskId: Long = -1): MapStatus =
-    MapStatus(makeBlockManagerId(host), Array.fill[Long](reduces)(sizes), mapTaskId)
+    MapStatus(makeBlockManagerId(host), Array.fill[Long](reduces)(sizes), Array[Long](), mapTaskId)
 
   def makeBlockManagerId(host: String): BlockManagerId =
     BlockManagerId("exec-" + host, host, 12345)

--- a/core/src/test/scala/org/apache/spark/scheduler/MapStatusSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/MapStatusSuite.scala
@@ -21,7 +21,7 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, 
 
 import scala.util.Random
 
-import org.mockito.Mockito.mock
+import org.mockito.Mockito._
 import org.roaringbitmap.RoaringBitmap
 
 import org.apache.spark.{SparkConf, SparkContext, SparkEnv, SparkFunSuite}
@@ -61,7 +61,7 @@ class MapStatusSuite extends SparkFunSuite {
       stddev <- Seq(0.0, 0.01, 0.5, 1.0)
     ) {
       val sizes = Array.fill[Long](numSizes)(abs(round(Random.nextGaussian() * stddev)) + mean)
-      val status = MapStatus(BlockManagerId("a", "b", 10), sizes, -1)
+      val status = MapStatus(BlockManagerId("a", "b", 10), sizes, Array[Long](), -1)
       val status1 = compressAndDecompressMapStatus(status)
       for (i <- 0 until numSizes) {
         if (sizes(i) != 0) {
@@ -75,12 +75,16 @@ class MapStatusSuite extends SparkFunSuite {
 
   test("large tasks should use " + classOf[HighlyCompressedMapStatus].getName) {
     val sizes = Array.fill[Long](2001)(150L)
-    val status = MapStatus(null, sizes, -1)
+    val status = MapStatus(null, sizes, Array[Long](), -1)
     assert(status.isInstanceOf[HighlyCompressedMapStatus])
     assert(status.getSizeForBlock(10) === 150L)
     assert(status.getSizeForBlock(50) === 150L)
     assert(status.getSizeForBlock(99) === 150L)
     assert(status.getSizeForBlock(2000) === 150L)
+    assert(status.getRecordForBlock(10) === -1L)
+    assert(status.getRecordForBlock(50) === -1L)
+    assert(status.getRecordForBlock(99) === -1L)
+    assert(status.getRecordForBlock(2000) === -1L)
   }
 
   test("HighlyCompressedMapStatus: estimated size should be the average non-empty block size") {
@@ -88,7 +92,7 @@ class MapStatusSuite extends SparkFunSuite {
     val avg = sizes.sum / sizes.count(_ != 0)
     val loc = BlockManagerId("a", "b", 10)
     val mapTaskAttemptId = 5
-    val status = MapStatus(loc, sizes, mapTaskAttemptId)
+    val status = MapStatus(loc, sizes, Array[Long](), mapTaskAttemptId)
     val status1 = compressAndDecompressMapStatus(status)
     assert(status1.isInstanceOf[HighlyCompressedMapStatus])
     assert(status1.location == loc)
@@ -103,7 +107,8 @@ class MapStatusSuite extends SparkFunSuite {
 
   test("SPARK-22540: ensure HighlyCompressedMapStatus calculates correct avgSize") {
     val threshold = 1000
-    val conf = new SparkConf().set(config.SHUFFLE_ACCURATE_BLOCK_THRESHOLD.key, threshold.toString)
+    val conf = new SparkConf().set(
+      config.SHUFFLE_ACCURATE_BLOCK_SIZE_THRESHOLD.key, threshold.toString)
     val env = mock(classOf[SparkEnv])
     doReturn(conf).when(env).conf
     SparkEnv.set(env)
@@ -111,7 +116,7 @@ class MapStatusSuite extends SparkFunSuite {
     val smallBlockSizes = sizes.filter(n => n > 0 && n < threshold)
     val avg = smallBlockSizes.sum / smallBlockSizes.length
     val loc = BlockManagerId("a", "b", 10)
-    val status = MapStatus(loc, sizes, 5)
+    val status = MapStatus(loc, sizes, Array[Long](), 5)
     val status1 = compressAndDecompressMapStatus(status)
     assert(status1.isInstanceOf[HighlyCompressedMapStatus])
     assert(status1.location == loc)
@@ -161,13 +166,13 @@ class MapStatusSuite extends SparkFunSuite {
 
   test("Blocks which are bigger than SHUFFLE_ACCURATE_BLOCK_THRESHOLD should not be " +
     "underestimated.") {
-    val conf = new SparkConf().set(config.SHUFFLE_ACCURATE_BLOCK_THRESHOLD.key, "1000")
+    val conf = new SparkConf().set(config.SHUFFLE_ACCURATE_BLOCK_SIZE_THRESHOLD.key, "1000")
     val env = mock(classOf[SparkEnv])
     doReturn(conf).when(env).conf
     SparkEnv.set(env)
     // Value of element in sizes is equal to the corresponding index.
     val sizes = (0L to 2000L).toArray
-    val status1 = MapStatus(BlockManagerId("exec-0", "host-0", 100), sizes, 5)
+    val status1 = MapStatus(BlockManagerId("exec-0", "host-0", 100), sizes, Array[Long](), 5)
     val arrayStream = new ByteArrayOutputStream(102400)
     val objectOutputStream = new ObjectOutputStream(arrayStream)
     assert(status1.isInstanceOf[HighlyCompressedMapStatus])
@@ -178,6 +183,84 @@ class MapStatusSuite extends SparkFunSuite {
     val status2 = objectInput.readObject().asInstanceOf[HighlyCompressedMapStatus]
     (1001 to 2000).foreach {
       case part => assert(status2.getSizeForBlock(part) >= sizes(part))
+    }
+  }
+
+  test("verbose statistics mode: large tasks should use " +
+    classOf[HighlyCompressedMapStatus].getName) {
+    val conf = new SparkConf().set(config.SHUFFLE_STATISTICS_VERBOSE.key, "true")
+    val env = mock(classOf[SparkEnv])
+    doReturn(conf).when(env).conf
+    SparkEnv.set(env)
+
+    val sizes = Array.fill[Long](2001)(150L)
+    val records = Array.fill[Long](2001)(10L)
+    val status = MapStatus(null, sizes, records, -1)
+    assert(status.isInstanceOf[HighlyCompressedMapStatus])
+    assert(status.getSizeForBlock(10) === 150L)
+    assert(status.getSizeForBlock(50) === 150L)
+    assert(status.getSizeForBlock(99) === 150L)
+    assert(status.getSizeForBlock(2000) === 150L)
+    assert(status.isInstanceOf[HighlyCompressedMapStatus])
+    assert(status.getRecordForBlock(10) === 10L)
+    assert(status.getRecordForBlock(50) === 10L)
+    assert(status.getRecordForBlock(99) === 10L)
+    assert(status.getRecordForBlock(2000) === 10L)
+  }
+
+  test("verbose statistics mode: HighlyCompressedMapStatus:" +
+    "estimated size/records should be the average non-empty block size/records") {
+    val conf = new SparkConf().set(config.SHUFFLE_STATISTICS_VERBOSE.key, "true")
+    val env = mock(classOf[SparkEnv])
+    doReturn(conf).when(env).conf
+    SparkEnv.set(env)
+
+    val sizes = Array.tabulate[Long](3000) { i => i.toLong }
+    val records = Array.tabulate[Long](3000) { i => (i / 30).toLong }
+
+    val avgSize = sizes.sum / sizes.count(_ != 0)
+    val avgRecord = records.sum / records.count(_ != 0)
+    val loc = BlockManagerId("a", "b", 10)
+    val status = MapStatus(loc, sizes, records, -1)
+    val status1 = compressAndDecompressMapStatus(status)
+    assert(status1.isInstanceOf[HighlyCompressedMapStatus])
+    assert(status1.location == loc)
+    for (i <- 0 until 3000) {
+      val estimateSize = status1.getSizeForBlock(i)
+      val estimateRecord = status1.getRecordForBlock(i)
+      if (sizes(i) > 0) {
+        assert(estimateSize === avgSize)
+      }
+      if (records(i) > 0) {
+        assert(estimateRecord === avgRecord)
+      }
+    }
+  }
+
+  test("verbose statistics mode: Blocks which are bigger than SHUFFLE_ACCURATE_RECORD_THRESHOLD" +
+    "should not be underestimated.") {
+    val conf = new SparkConf().set(config.SHUFFLE_STATISTICS_VERBOSE.key, "true")
+      .set(config.SHUFFLE_ACCURATE_BLOCK_SIZE_THRESHOLD.key, "1000")
+      .set(config.SHUFFLE_ACCURATE_BLOCK_RECORD_THRESHOLD.key, "1000")
+    val env = mock(classOf[SparkEnv])
+    doReturn(conf).when(env).conf
+    SparkEnv.set(env)
+    // Value of element in sizes is equal to the corresponding index.
+    val sizes = (0L to 2000L).toArray
+    val records = (0L to 2000L).toArray
+    val status1 = MapStatus(BlockManagerId("exec-0", "host-0", 100), sizes, records, -1)
+    val arrayStream = new ByteArrayOutputStream(204800)
+    val objectOutputStream = new ObjectOutputStream(arrayStream)
+    assert(status1.isInstanceOf[HighlyCompressedMapStatus])
+    objectOutputStream.writeObject(status1)
+    objectOutputStream.flush()
+    val array = arrayStream.toByteArray
+    val objectInput = new ObjectInputStream(new ByteArrayInputStream(array))
+    val status2 = objectInput.readObject().asInstanceOf[HighlyCompressedMapStatus]
+    (1001 to 2000).foreach {
+      case part =>
+        assert(status2.getSizeForBlock(part) >= sizes(part))
+        assert(status2.getRecordForBlock(part) >= records(part))
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/serializer/KryoSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/KryoSerializerSuite.scala
@@ -354,7 +354,7 @@ class KryoSerializerSuite extends SparkFunSuite with SharedSparkContext {
     Seq(denseBlockSizes, sparseBlockSizes).foreach { blockSizes =>
       mapTaskId += 1
       ser.serialize(HighlyCompressedMapStatus(
-        BlockManagerId("exec-1", "host", 1234), blockSizes, mapTaskId))
+        BlockManagerId("exec-1", "host", 1234), blockSizes, Array[Long](), mapTaskId))
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriterSuite.scala
@@ -20,10 +20,10 @@ package org.apache.spark.shuffle.sort
 import java.io.File
 import java.util.UUID
 
-import org.junit.Assert._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
+import org.junit.Assert._
 import org.mockito.{Mock, MockitoAnnotations}
 import org.mockito.Answers.RETURNS_SMART_NULLS
 import org.mockito.ArgumentMatchers.{any, anyInt, anyLong}
@@ -32,7 +32,7 @@ import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark._
 import org.apache.spark.executor.{ShuffleWriteMetrics, TaskMetrics}
-import org.apache.spark.memory.{MemoryTestingUtils, TaskMemoryManager, TestMemoryManager}
+import org.apache.spark.memory.{TaskMemoryManager, TestMemoryManager}
 import org.apache.spark.serializer.{JavaSerializer, SerializerInstance, SerializerManager}
 import org.apache.spark.shuffle.IndexShuffleBlockResolver
 import org.apache.spark.shuffle.api.ShuffleExecutorComponents


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Similar with the approach of collecting data size, this PR collect the row count info when shuffle write and wrap it in MapStatus, then driver can get the row count info from the returned MapStatus.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
In order to optimize the skewed partition, we need collect the row count statistics in map stage. 
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce any user-facing change?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->


### How was this patch tested?
unit tests
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
