### PR TITLE
[SPARK-29152][CORE] Executor Plugin shutdown when dynamic allocation is enabled

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -68,7 +68,7 @@ private[spark] class Executor(
   @volatile private var executorShutdown = false
   ShutdownHookManager.addShutdownHook(
     () => if (!executorShutdown) {
-      pluginShutdown()
+      stop()
     }
   )
   // Application dependencies (added through SparkContext) that we've fetched so far on this node.
@@ -300,13 +300,6 @@ private[spark] class Executor(
     threadPool.shutdown()
 
     // Notify plugins that executor is shutting down so they can terminate cleanly
-    pluginShutdown()
-    if (!isLocal) {
-      env.stop()
-    }
-  }
-
-  private def pluginShutdown(): Unit = {
     if (!executorShutdown) {
       executorShutdown = true
       Utils.withContextClassLoader(replClassLoader) {
@@ -320,6 +313,9 @@ private[spark] class Executor(
         }
       }
       plugins.foreach(_.shutdown())
+    }
+    if (!isLocal) {
+      env.stop()
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -67,9 +67,7 @@ private[spark] class Executor(
 
   @volatile private var executorShutdown = false
   ShutdownHookManager.addShutdownHook(
-    () => if (!executorShutdown) {
-      stop()
-    }
+    () => stop()
   )
   // Application dependencies (added through SparkContext) that we've fetched so far on this node.
   // Each map holds the master's timestamp for the version of that file or JAR we got.

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -283,8 +283,7 @@ private[spark] class Executor(
   }
 
   def stop(): Unit = {
-    if (!executorShutdown.get()) {
-      executorShutdown.compareAndSet(false, true)
+    if (!executorShutdown.getAndSet(true)) {
       env.metricsSystem.report()
       try {
         metricsPoller.stop()

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -284,24 +284,24 @@ private[spark] class Executor(
   }
 
   def stop(): Unit = {
-    env.metricsSystem.report()
-    try {
-      metricsPoller.stop()
-    } catch {
-      case NonFatal(e) =>
-        logWarning("Unable to stop executor metrics poller", e)
-    }
-    try {
-      heartbeater.stop()
-    } catch {
-      case NonFatal(e) =>
-        logWarning("Unable to stop heartbeater", e)
-    }
-    threadPool.shutdown()
-
-    // Notify plugins that executor is shutting down so they can terminate cleanly
     if (!executorShutdown) {
       executorShutdown = true
+      env.metricsSystem.report()
+      try {
+        metricsPoller.stop()
+      } catch {
+        case NonFatal(e) =>
+          logWarning("Unable to stop executor metrics poller", e)
+      }
+      try {
+        heartbeater.stop()
+      } catch {
+        case NonFatal(e) =>
+          logWarning("Unable to stop heartbeater", e)
+      }
+      threadPool.shutdown()
+
+      // Notify plugins that executor is shutting down so they can terminate cleanly
       Utils.withContextClassLoader(replClassLoader) {
         executorPlugins.foreach { plugin =>
           try {
@@ -313,9 +313,9 @@ private[spark] class Executor(
         }
       }
       plugins.foreach(_.shutdown())
-    }
-    if (!isLocal) {
-      env.stop()
+      if (!isLocal) {
+        env.stop()
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Added a shutdown hook which will ensure that shutdown method of executor plugin is getting called.

### Why are the changes needed?
When dynamic allocation is enabled and executors get killed after idle time out, shutdown method of executor plugin is not getting called.


### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Manual Testing
