### PR TITLE
[SPARK-29594][SQL] Provide better error message when creating a Dataset from a Sequence of Case class where a field name started with a number

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -543,11 +543,11 @@ object ScalaReflection extends ScalaReflection {
             throw new UnsupportedOperationException(s"`$fieldName` is a reserved keyword and " +
               "cannot be used as field name\n" + walkedTypePath)
           }
-          // It is ok to use head here because a variable name need to be non empty
+          // It is ok to use head here because a variable name needs to be non empty
           if (fieldName.head.isDigit) {
             throw new UnsupportedOperationException(s"`$fieldName` is a word that starts with a " +
-              "number and cannot be used as field name\n" + "A work around to this problem is to" +
-              " convert the case class to Json and then read the schema as Json\n" + walkedTypePath)
+              "number and cannot be used as field name" + "A work around to this problem is to " +
+              "convert the case class to Json and then read the schema as Json\n" + walkedTypePath)
           }
 
           // SPARK-26730 inputObject won't be null with If's guard below. And KnownNotNul

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -546,7 +546,7 @@ object ScalaReflection extends ScalaReflection {
           // It is ok to use head here because a variable name needs to be non empty
           if (fieldName.head.isDigit) {
             throw new UnsupportedOperationException(s"`$fieldName` is a word that starts with a " +
-              "number and cannot be used as field name" + "A work around to this problem is to " +
+              "number and cannot be used as field name. A workaround to this problem is to " +
               "convert the case class to Json and then read the schema as Json\n" + walkedTypePath)
           }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -543,6 +543,12 @@ object ScalaReflection extends ScalaReflection {
             throw new UnsupportedOperationException(s"`$fieldName` is a reserved keyword and " +
               "cannot be used as field name\n" + walkedTypePath)
           }
+          // It is ok to use head here because a variable name need to be non empty
+          if (fieldName.head.isDigit) {
+            throw new UnsupportedOperationException(s"`$fieldName` is a word that starts with a " +
+              "number and cannot be used as field name\n" + "A work around to this problem is to" +
+              " convert the case class to Json and then read the schema as Json\n" + walkedTypePath)
+          }
 
           // SPARK-26730 inputObject won't be null with If's guard below. And KnownNotNul
           // is necessary here. Because for a nullable nested inputObject with struct data

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -547,8 +547,8 @@ object ScalaReflection extends ScalaReflection {
           if (!Character.isJavaIdentifierStart(fieldName.head)) {
             throw new UnsupportedOperationException(s"`$fieldName` is a word that starts with" +
              " a character not allowed in Java and cannot be used as field name. " +
-              "A workaround to this problem is to convert the case class to Json" +
-              " and then read the schema as Json\n" + walkedTypePath)
+              "A workaround to this problem is to convert the case class to JSON" +
+              s" and then read the schema as JSON\n$walkedTypePath")
           }
 
           // SPARK-26730 inputObject won't be null with If's guard below. And KnownNotNul

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -545,10 +545,10 @@ object ScalaReflection extends ScalaReflection {
           }
           // It is ok to use head here because a variable name needs to be non empty
           if (!Character.isJavaIdentifierStart(fieldName.head)) {
-            throw new UnsupportedOperationException(s"`$fieldName` is a word that starts with a " +
-              "character not allowed in Java and cannot be used as field name. " +
-              "A workaround to this problem is to convert the case class to Json and then read the" + 
-              "schema as Json\n" + walkedTypePath)
+            throw new UnsupportedOperationException(s"`$fieldName` is a word that starts with" +
+             " a character not allowed in Java and cannot be used as field name. " +
+              "A workaround to this problem is to convert the case class to Json" + 
+              " and then read the schema as Json\n" + walkedTypePath)
           }
 
           // SPARK-26730 inputObject won't be null with If's guard below. And KnownNotNul

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -544,10 +544,11 @@ object ScalaReflection extends ScalaReflection {
               "cannot be used as field name\n" + walkedTypePath)
           }
           // It is ok to use head here because a variable name needs to be non empty
-          if (fieldName.head.isDigit) {
+          if (!Character.isJavaIdentifierStart(fieldName.head)) {
             throw new UnsupportedOperationException(s"`$fieldName` is a word that starts with a " +
-              "number and cannot be used as field name. A workaround to this problem is to " +
-              "convert the case class to Json and then read the schema as Json\n" + walkedTypePath)
+              "character not allowed in Java and cannot be used as field name. " +
+              "A workaround to this problem is to convert the case class to Json and then read the" + 
+              "schema as Json\n" + walkedTypePath)
           }
 
           // SPARK-26730 inputObject won't be null with If's guard below. And KnownNotNul

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -547,7 +547,7 @@ object ScalaReflection extends ScalaReflection {
           if (!Character.isJavaIdentifierStart(fieldName.head)) {
             throw new UnsupportedOperationException(s"`$fieldName` is a word that starts with" +
              " a character not allowed in Java and cannot be used as field name. " +
-              "A workaround to this problem is to convert the case class to Json" + 
+              "A workaround to this problem is to convert the case class to Json" +
               " and then read the schema as Json\n" + walkedTypePath)
           }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1220,7 +1220,8 @@ class DatasetSuite extends QueryTest with SharedSparkSession {
     assert(e.getMessage.contains(
       "`abstract` is a reserved keyword and cannot be used as field name"))
   }
-  test("better error message when use java field name starting with a number") {
+
+  test("SPARK-29594 better error message when use java field name starting with a number") {
     val e = intercept[UnsupportedOperationException] {
       Seq(InvalidInJavaForNumber("HelloWorld!")).toDS()
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1220,6 +1220,13 @@ class DatasetSuite extends QueryTest with SharedSparkSession {
     assert(e.getMessage.contains(
       "`abstract` is a reserved keyword and cannot be used as field name"))
   }
+  test("better error message when use java field name starting with a number") {
+    val e = intercept[UnsupportedOperationException] {
+      Seq(InvalidInJavaForNumber("HelloWorld!")).toDS()
+    }
+    assert(e.getMessage.contains(
+      "`1something` is a word that starts with a number and cannot be used as field name"))
+  }
 
   test("Dataset should support flat input object to be null") {
     checkDataset(Seq("a", null).toDS(), "a", null)
@@ -1901,6 +1908,7 @@ case class NestedStruct(f: ClassData)
 case class DeepNestedStruct(f: NestedStruct)
 
 case class InvalidInJava(`abstract`: Int)
+case class InvalidInJavaForNumber(`1something`: String)
 
 /**
  * A class used to test serialization using encoders. This class throws exceptions when using

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1221,14 +1221,6 @@ class DatasetSuite extends QueryTest with SharedSparkSession {
       "`abstract` is a reserved keyword and cannot be used as field name"))
   }
 
-  test("SPARK-29594 better error message when use java field name starting with a number") {
-    val e = intercept[UnsupportedOperationException] {
-      Seq(InvalidInJavaForNumber("HelloWorld!")).toDS()
-    }
-    assert(e.getMessage.contains(
-      "`1something` is a word that starts with a number and cannot be used as field name"))
-  }
-
   test("Dataset should support flat input object to be null") {
     checkDataset(Seq("a", null).toDS(), "a", null)
   }
@@ -1909,7 +1901,6 @@ case class NestedStruct(f: ClassData)
 case class DeepNestedStruct(f: NestedStruct)
 
 case class InvalidInJava(`abstract`: Int)
-private case class InvalidInJavaForNumber(`1something`: String)
 
 /**
  * A class used to test serialization using encoders. This class throws exceptions when using

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1909,7 +1909,7 @@ case class NestedStruct(f: ClassData)
 case class DeepNestedStruct(f: NestedStruct)
 
 case class InvalidInJava(`abstract`: Int)
-case class InvalidInJavaForNumber(`1something`: String)
+private[sql] case class InvalidInJavaForNumber(`1something`: String)
 
 /**
  * A class used to test serialization using encoders. This class throws exceptions when using

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1909,7 +1909,7 @@ case class NestedStruct(f: ClassData)
 case class DeepNestedStruct(f: NestedStruct)
 
 case class InvalidInJava(`abstract`: Int)
-private[sql] case class InvalidInJavaForNumber(`1something`: String)
+private case class InvalidInJavaForNumber(`1something`: String)
 
 /**
  * A class used to test serialization using encoders. This class throws exceptions when using


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr is to fix a bug discovered by me, [SPARK-29594], when creating a Dataset using .toDS() in a sequence of a case class that had a field name starting with a number.
The exception was improved, now explains why it breaks, and gives a work around of the problem.

### Why are the changes needed?

Bug fix

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

~~Tests were added, sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala~~

EDIT:

The tests could not be added because the documentation generation is in Java and doesn't allow to create a class with a variable starting with a number.

**How to reproduce this test:**

case class InvalidInJavaForNumber(`1something`: String)

 test("SPARK-29594 better error message when use java field name starting with a number") {
     val e = intercept[UnsupportedOperationException] {
       Seq(InvalidInJavaForNumber("HelloWorld!")).toDS()
     }
     assert(e.getMessage.contains(
       "`1something` is a word that starts with a number and cannot be used as field name"))
   }

   test("Dataset should support flat input object to be null") {
     checkDataset(Seq("a", null).toDS(), "a", null)
   }