### PR TITLE
[SPARK-29657][CORE] Iterator spill supporting radix sort with null prefix

### DIFF
--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
@@ -528,13 +528,15 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
           boolean canSpill = iterators.stream()
                   .allMatch(iterator -> iterator instanceof UnsafeInMemorySorter.SortedIterator);
           if (canSpill) {
-            ChainedIterator clonedChainedIterator = cloneChainedIterator((ChainedIterator) upstream);
+            ChainedIterator clonedChainedIterator =
+                    cloneChainedIterator((ChainedIterator) upstream);
             UnsafeInMemorySorter.SortedIterator current =
                     (UnsafeInMemorySorter.SortedIterator) ((ChainedIterator) upstream).current;
             return spillInt(clonedChainedIterator, current.getCurrentPageNumber());
           }
         } else if (upstream instanceof UnsafeInMemorySorter.SortedIterator) {
-          UnsafeInMemorySorter.SortedIterator sortedUpStream = (UnsafeInMemorySorter.SortedIterator) upstream;
+          UnsafeInMemorySorter.SortedIterator sortedUpStream =
+                  (UnsafeInMemorySorter.SortedIterator) upstream;
           UnsafeInMemorySorter.SortedIterator clonedInMemIterator = sortedUpStream.clone();
           return spillInt(clonedInMemIterator, sortedUpStream.getCurrentPageNumber());
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support ```ChainedIterator``` with ```SortedIterator``` spill

### Why are the changes needed?
In the case of radix sort, when the ```insertRecord``` part of the keyPrefix is null, the iterator type returned by ```getSortedIterator``` is ```ChainedIterator```.
Currently ```ChainedIterator``` does not support spill, causing ```UnsafeExternalSorter``` to take up a lot of execution memory, ```allocatePage``` fails, throw ```SparkOutOfMemoryError``` Unable to acquire xxx bytes of memory, got 0

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
add ut

