### PR TITLE
[SPARK-29677][DStreams] amazon-kinesis-client 1.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     <codahale.metrics.version>3.2.6</codahale.metrics.version>
     <avro.version>1.8.2</avro.version>
     <avro.mapred.classifier>hadoop2</avro.mapred.classifier>
-    <aws.kinesis.client.version>1.8.10</aws.kinesis.client.version>
+    <aws.kinesis.client.version>1.12.0</aws.kinesis.client.version>
     <!-- Should be consistent with Kinesis client dependency -->
     <aws.java.sdk.version>1.11.271</aws.java.sdk.version>
     <!-- the producer is used in tests -->


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrading the amazon-kinesis-client dependency to 1.12.0.


### Why are the changes needed?
The current amazon-kinesis-client version is 1.8.10. This version depends on the use of `describeStream`, which has a hard limit on an AWS account (10 reqs / second). Versions 1.9.0 and up leverage `listShards`, which has no such limit. For large customers, this can be a major problem. 


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Existing tests
