### PR TITLE
[SPARK-29689][WEB-UI] Enable show total shuffle read size even when task failed

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1399,8 +1399,20 @@ private[spark] class DAGScheduler(
           case _ =>
             updateAccumulators(event)
         }
-      case _: ExceptionFailure | _: TaskKilled => updateAccumulators(event)
-      case _ =>
+
+      case fail =>
+        if (task.metrics.shuffleReadMetrics.recordsRead == 0) {
+          val reduceId = task.partitionId
+          val shuffleReadSize = stage.parents.filter(_.isInstanceOf[ShuffleMapStage])
+            .map(_.asInstanceOf[ShuffleMapStage].shuffleDep.shuffleId)
+            .map(mapOutputTracker.shuffleStatuses.get(_)).map(_.get.mapStatuses)
+            .flatMap(_.map(_.getSizeForBlock(reduceId))).sum
+          task.metrics.shuffleReadMetrics.setRecordsRead(shuffleReadSize)
+        }
+        fail match {
+          case _: ExceptionFailure | _: TaskKilled => updateAccumulators(event)
+          case _ =>
+        }
     }
     postTaskEnd(event)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
If task failed during reading shuffle data or because of executor loss, its shuffle read size would be shown as 0.

But this size is important for user, it can help detect data skew.

In this PR, I compute this size and set it when task failed.

### Why are the changes needed?

As described in above section.


### Does this PR introduce any user-facing change?
Yes, User can see shuffle read size even if task failed.

### How was this patch tested?

