### PR TITLE
[SPARK-29707][SQL] Add configuration 'spark.sql.maxMetadataValueStringLength'

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1961,11 +1961,12 @@ object SQLConf {
     .intConf
     .createWithDefault(25)
 
-  val MAX_DATA_SOURCE_SCAN_METADATA_STRING_LENGTH =
-    buildConf("spark.sql.maxDataSourceScanMetadataStringLength")
-      .doc("Maximum string length for one metadata of `DataSourceScanExec`. This is used in " +
-        "`DataSourceScanExec.simpleString` to limit the length of each metadata string. " +
-        "If the metadata is longer than this value, it will be truncated and ended by '...'.")
+  val MAX_METADATA_VALUE_STRING_LENGTH =
+    buildConf("spark.sql.maxMetadataValueStringLength")
+      .doc("Maximum string length of one single metadata value. This can be used in " +
+        "the `simpleString` method of `TreeNode` and its sub classes to limit the " +
+        "string length of each metadata value. If a single metadata value string is longer " +
+        "than this value, it should be truncated and ended by '...'.")
       .intConf
       .createWithDefault(100)
 
@@ -2547,8 +2548,8 @@ class SQLConf extends Serializable with Logging {
 
   def maxToStringFields: Int = getConf(SQLConf.MAX_TO_STRING_FIELDS)
 
-  def maxDataSourceScanMetadataStringLength: Int =
-    getConf(SQLConf.MAX_DATA_SOURCE_SCAN_METADATA_STRING_LENGTH)
+  def maxMetadataValueStringLength: Int =
+    getConf(SQLConf.MAX_METADATA_VALUE_STRING_LENGTH)
 
   def maxPlanStringLength: Int = getConf(SQLConf.MAX_PLAN_STRING_LENGTH).toInt
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1961,6 +1961,14 @@ object SQLConf {
     .intConf
     .createWithDefault(25)
 
+  val MAX_DATA_SOURCE_SCAN_METADATA_STRING_LENGTH =
+    buildConf("spark.sql.maxDataSourceScanMetadataStringLength")
+      .doc("Maximum string length for one metadata of `DataSourceScanExec`. This is used in " +
+        "`DataSourceScanExec.simpleString` to limit the length of each metadata string. " +
+        "If the metadata is longer than this value, it will be truncated and ended by '...'.")
+      .intConf
+      .createWithDefault(100)
+
   val MAX_PLAN_STRING_LENGTH = buildConf("spark.sql.maxPlanStringLength")
     .doc("Maximum number of characters to output for a plan string.  If the plan is " +
       "longer, further output will be truncated.  The default setting always generates a full " +
@@ -2538,6 +2546,9 @@ class SQLConf extends Serializable with Logging {
     getConf(SQLConf.NAME_NON_STRUCT_GROUPING_KEY_AS_VALUE)
 
   def maxToStringFields: Int = getConf(SQLConf.MAX_TO_STRING_FIELDS)
+
+  def maxDataSourceScanMetadataStringLength: Int =
+    getConf(SQLConf.MAX_DATA_SOURCE_SCAN_METADATA_STRING_LENGTH)
 
   def maxPlanStringLength: Int = getConf(SQLConf.MAX_PLAN_STRING_LENGTH).toInt
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -59,7 +59,7 @@ trait DataSourceScanExec extends LeafExecNode {
     val metadataEntries = metadata.toSeq.sorted.map {
       case (key, value) =>
         key + ": " + StringUtils.abbreviate(redact(value),
-          SQLConf.get.maxDataSourceScanMetadataStringLength)
+          conf.maxDataSourceScanMetadataStringLength)
     }
     val metadataStr = truncatedString(metadataEntries, " ", ", ", "", maxFields)
     redact(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -58,7 +58,8 @@ trait DataSourceScanExec extends LeafExecNode {
   override def simpleString(maxFields: Int): String = {
     val metadataEntries = metadata.toSeq.sorted.map {
       case (key, value) =>
-        key + ": " + StringUtils.abbreviate(redact(value), 100)
+        key + ": " + StringUtils.abbreviate(redact(value),
+          SQLConf.get.maxDataSourceScanMetadataStringLength)
     }
     val metadataStr = truncatedString(metadataEntries, " ", ", ", "", maxFields)
     redact(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -59,7 +59,7 @@ trait DataSourceScanExec extends LeafExecNode {
     val metadataEntries = metadata.toSeq.sorted.map {
       case (key, value) =>
         key + ": " + StringUtils.abbreviate(redact(value),
-          conf.maxDataSourceScanMetadataStringLength)
+          conf.maxMetadataValueStringLength)
     }
     val metadataStr = truncatedString(metadataEntries, " ", ", ", "", maxFields)
     redact(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjectio
 import org.apache.spark.sql.connector.read.{Batch, InputPartition, Scan, Statistics, SupportsReportStatistics}
 import org.apache.spark.sql.execution.PartitionedFileUtil
 import org.apache.spark.sql.execution.datasources._
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.Utils
@@ -65,7 +66,7 @@ abstract class FileScan(
       case (key, value) =>
         val redactedValue =
           Utils.redact(sparkSession.sessionState.conf.stringRedactionPattern, value)
-        key + ": " + StringUtils.abbreviate(redactedValue, 100)
+        key + ": " + StringUtils.abbreviate(redactedValue, SQLConf.get.maxMetadataValueStringLength)
     }.mkString(", ")
     s"${this.getClass.getSimpleName} $metadataStr"
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add configuration 'spark.sql.maxDataSourceScanMetadataStringLength' to set the max string length of one metadata in DataSourceScanExec.



### Why are the changes needed?
To make the max length of metadata string of `DataSourceScanExec` configurable, please see [SPARK-29707](https://issues.apache.org/jira/browse/SPARK-29707) for details.


### Does this PR introduce any user-facing change?
Yes, user can configure the parameter to get more information about data source scan metadata.


### How was this patch tested?
Manual test.
