### PR TITLE
[SPARK-29711][SQL] Support dynamic adjust sql class log level

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -380,6 +380,15 @@ class SparkContext(config: SparkConf) extends Logging {
     Utils.setLogLevel(org.apache.log4j.Level.toLevel(upperCased))
   }
 
+  def setLogLevel(logLevel: String, className: String): Unit = {
+    // let's allow lowercase or mixed case too
+    val upperCased = logLevel.toUpperCase(Locale.ROOT)
+    require(SparkContext.VALID_LOG_LEVELS.contains(upperCased),
+      s"Supplied level $logLevel did not match one of:" +
+        s" ${SparkContext.VALID_LOG_LEVELS.mkString(",")}")
+    Utils.setLogLevel(org.apache.log4j.Level.toLevel(upperCased), className)
+  }
+
   try {
     _conf = config.clone()
     _conf.validateSettings()

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2339,6 +2339,8 @@ private[spark] object Utils extends Logging {
     }
   }
 
+  val changedLogLevelClassMap = new ConcurrentHashMap[String, org.apache.log4j.Level]()
+
   /**
    * configure a new log4j level
    */
@@ -2347,6 +2349,23 @@ private[spark] object Utils extends Logging {
     rootLogger.setLevel(l)
     // Setting threshold to null as rootLevel will define log level for spark-shell
     Logging.sparkShellThresholdLevel = null
+  }
+
+  /**
+   * configure a new log4j level
+   */
+  def setLogLevel(l: org.apache.log4j.Level, loggerName: String): Unit = {
+    val logger = org.apache.log4j.Logger.getLogger(loggerName)
+    changedLogLevelClassMap.put(loggerName, logger.getLevel)
+    logger.setLevel(l)
+  }
+
+  def restoreLogLevel(): Unit = {
+    changedLogLevelClassMap.asScala.foreach { case (loggerName, level) =>
+      val logger = org.apache.log4j.Logger.getLogger(loggerName)
+      logger.setLevel(level)
+    }
+    changedLogLevelClassMap.clear()
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2050,6 +2050,12 @@ object SQLConf {
       .stringConf
       .createWithDefault(
         "https://maven-central.storage-download.googleapis.com/repos/central/data/")
+
+  val SQL_DEBUG_CLASS = buildConf("spark.sql.debug.class")
+    .doc("If set, these classes log level will be changed to debug.")
+    .internal()
+    .stringConf
+    .createWithDefault("")
 }
 
 /**
@@ -2549,6 +2555,8 @@ class SQLConf extends Serializable with Logging {
   def defaultV2Catalog: Option[String] = getConf(DEFAULT_V2_CATALOG)
 
   def ignoreDataLocality: Boolean = getConf(SQLConf.IGNORE_DATA_LOCALITY)
+
+  def debugClasses(): String = getConf(SQLConf.SQL_DEBUG_CLASS)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
@@ -261,6 +261,8 @@ private[hive] class SparkExecuteStatementOperation(
 
   private def execute(): Unit = withSchedulerPool {
     try {
+      prepareLogLevel()
+
       synchronized {
         if (getStatus.getState.isTerminal) {
           logInfo(s"Query with $statementId in terminal state before it started running")
@@ -370,6 +372,16 @@ private[hive] class SparkExecuteStatementOperation(
       if (pool != null) {
         sqlContext.sparkContext.setLocalProperty(SparkContext.SPARK_SCHEDULER_POOL, null)
       }
+    }
+  }
+
+  private def prepareLogLevel(): Unit = {
+    val debugClasses = sqlContext.conf.debugClasses()
+    if (debugClasses == null || debugClasses == "") {
+      SparkUtils.restoreLogLevel()
+    } else {
+      debugClasses.split(",").map(_.trim)
+        .foreach(sqlContext.sparkContext.setLogLevel(_, "debug"))
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support dynamic change the log level in sql

### Why are the changes needed?
It is very convenient for us to debug some problem about sql. We will not restart the thriftserver to see some debug logs. And this change is very small.


### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
UT
