### PR TITLE
[SPARK-29601][WEBUI] JDBC ODBC Tab Statement column provide ellipsis for big SQL statement

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerPage.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerPage.scala
@@ -320,6 +320,16 @@ private[ui] class SqlStatsPagedTable(
       }
     }
 
+    def statement(infoData: ExecutionInfo):Seq[Node] = {
+      if (infoData.statement != null && infoData.statement.nonEmpty) {
+        <span class="description-input">
+          {infoData.statement}
+        </span>
+      } else {
+        Nil
+      }
+    }
+
     <tr>
       <td>
         {info.userName}
@@ -346,8 +356,8 @@ private[ui] class SqlStatsPagedTable(
       <td >
         {formatDurationVerbose(duration)}
       </td>
-      <td>
-        {info.statement}
+      <td >
+        {statement(info)}
       </td>
       <td>
         {info.state}

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerPage.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerPage.scala
@@ -320,7 +320,7 @@ private[ui] class SqlStatsPagedTable(
       }
     }
 
-    def statement(infoData: ExecutionInfo):Seq[Node] = {
+    def statement(infoData: ExecutionInfo): Seq[Node] = {
       if (infoData.statement != null && infoData.statement.nonEmpty) {
         <span class="description-input">
           {infoData.statement}

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerPage.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerPage.scala
@@ -320,16 +320,6 @@ private[ui] class SqlStatsPagedTable(
       }
     }
 
-    def statement(infoData: ExecutionInfo): Seq[Node] = {
-      if (infoData.statement != null && infoData.statement.nonEmpty) {
-        <span class="description-input">
-          {infoData.statement}
-        </span>
-      } else {
-        Nil
-      }
-    }
-
     <tr>
       <td>
         {info.userName}
@@ -356,8 +346,10 @@ private[ui] class SqlStatsPagedTable(
       <td >
         {formatDurationVerbose(duration)}
       </td>
-      <td >
-        {statement(info)}
+      <td>
+        <span class="description-input">
+          {info.statement}
+        </span>
       </td>
       <td>
         {info.state}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Provide Ellipses in Statement column , just like description in Jobs page . 

### Why are the changes needed?
When a query is executed the whole query statement is displayed no matter how big it is. When bigger queries are executed, it covers a large portion of the page display, when we have multiple queries it is difficult to scroll down to view all.

### Does this PR introduce any user-facing change?
No

Before:
![Screenshot from 2019-11-01 23-15-23](https://user-images.githubusercontent.com/51401130/68064468-ebaa0300-fd41-11e9-8787-c5144c1468d4.png)


After:
![Screenshot from 2019-11-02 07-07-21](https://user-images.githubusercontent.com/51401130/68064471-f19fe400-fd41-11e9-85c6-65f0faa64cc3.png)


### How was this patch tested?
Manual