### PR TITLE
[SPARK-29727][ML][PYTHON] Use UnaryTransformer as parent class for single input column transformers in PySpark

### DIFF
--- a/python/pyspark/ml/base.py
+++ b/python/pyspark/ml/base.py
@@ -207,7 +207,7 @@ class UnaryTransformer(HasInputCol, HasOutputCol, Transformer):
         return self._set(outputCol=value)
 
     @abstractmethod
-    def createTransformFunc(self):
+    def _createTransformFunc(self):
         """
         Creates the transform function using the given param map. The input param map already takes
         account of the embedded param map. So the param values should be determined
@@ -216,33 +216,33 @@ class UnaryTransformer(HasInputCol, HasOutputCol, Transformer):
         raise NotImplementedError()
 
     @abstractmethod
-    def outputDataType(self):
+    def _outputDataType(self):
         """
         Returns the data type of the output column.
         """
         raise NotImplementedError()
 
     @abstractmethod
-    def validateInputType(self, inputType):
+    def _validateInputType(self, inputType):
         """
         Validates the input type. Throw an exception if it is invalid.
         """
         raise NotImplementedError()
 
-    def transformSchema(self, schema):
+    def _transformSchema(self, schema):
         inputType = schema[self.getInputCol()].dataType
-        self.validateInputType(inputType)
+        self._validateInputType(inputType)
         if self.getOutputCol() in schema.names:
             raise ValueError("Output column %s already exists." % self.getOutputCol())
         outputFields = copy.copy(schema.fields)
         outputFields.append(StructField(self.getOutputCol(),
-                                        self.outputDataType(),
+                                        self._outputDataType(),
                                         nullable=False))
         return StructType(outputFields)
 
     def _transform(self, dataset):
-        self.transformSchema(dataset.schema)
-        transformUDF = udf(self.createTransformFunc(), self.outputDataType())
+        self._transformSchema(dataset.schema)
+        transformUDF = udf(self._createTransformFunc(), self._outputDataType())
         transformedDataset = dataset.withColumn(self.getOutputCol(),
                                                 transformUDF(dataset[self.getInputCol()]))
         return transformedDataset

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -24,7 +24,8 @@ from pyspark.rdd import ignore_unicode_prefix
 from pyspark.ml.linalg import _convert_to_vector
 from pyspark.ml.param.shared import *
 from pyspark.ml.util import JavaMLReadable, JavaMLWritable
-from pyspark.ml.wrapper import JavaEstimator, JavaModel, JavaParams, JavaTransformer, _jvm
+from pyspark.ml.wrapper import JavaEstimator, JavaModel, JavaParams, JavaTransformer, \
+    JavaUnaryTransformer, _jvm
 from pyspark.ml.common import inherit_doc
 
 __all__ = ['Binarizer',
@@ -929,7 +930,7 @@ class CountVectorizerModel(JavaModel, _CountVectorizerParams, JavaMLReadable, Ja
 
 
 @inherit_doc
-class DCT(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, JavaMLWritable):
+class DCT(JavaUnaryTransformer, JavaMLReadable, JavaMLWritable):
     """
     A feature transformer that takes the 1D discrete cosine transform
     of a real vector. No zero padding is performed on the input vector.
@@ -1014,10 +1015,24 @@ class DCT(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, JavaMLWrit
         """
         return self._set(outputCol=value)
 
+    @since("3.0.0")
+    def createTransformFunc(self):
+        self._transfer_params_to_java()
+        return self._java_obj.createTransformFunc()
+
+    @since("3.0.0")
+    def outputDataType(self):
+        self._transfer_params_to_java()
+        return self._java_obj.outputDataType()
+
+    @since("3.0.0")
+    def validateInputType(self, inputType):
+        self._transfer_params_to_java()
+        self._java_obj.validateInputType(inputType)
+
 
 @inherit_doc
-class ElementwiseProduct(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable,
-                         JavaMLWritable):
+class ElementwiseProduct(JavaUnaryTransformer, JavaMLReadable, JavaMLWritable):
     """
     Outputs the Hadamard product (i.e., the element-wise product) of each input vector
     with a provided "weight" vector. In other words, it scales each column of the dataset
@@ -1094,6 +1109,21 @@ class ElementwiseProduct(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReada
         Sets the value of :py:attr:`outputCol`.
         """
         return self._set(outputCol=value)
+
+    @since("3.0.0")
+    def createTransformFunc(self):
+        self._transfer_params_to_java()
+        return self._java_obj.createTransformFunc()
+
+    @since("3.0.0")
+    def outputDataType(self):
+        self._transfer_params_to_java()
+        return self._java_obj.outputDataType()
+
+    @since("3.0.0")
+    def validateInputType(self, inputType):
+        self._transfer_params_to_java()
+        self._java_obj.validateInputType(inputType)
 
 
 @inherit_doc
@@ -2192,7 +2222,7 @@ class MinMaxScalerModel(JavaModel, _MinMaxScalerParams, JavaMLReadable, JavaMLWr
 
 @inherit_doc
 @ignore_unicode_prefix
-class NGram(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, JavaMLWritable):
+class NGram(JavaUnaryTransformer, JavaMLReadable, JavaMLWritable):
     """
     A feature transformer that converts the input array of strings into an array of n-grams. Null
     values in the input array are ignored.
@@ -2282,9 +2312,24 @@ class NGram(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, JavaMLWr
         """
         return self._set(outputCol=value)
 
+    @since("3.0.0")
+    def createTransformFunc(self):
+        self._transfer_params_to_java()
+        return self._java_obj.createTransformFunc()
+
+    @since("3.0.0")
+    def outputDataType(self):
+        self._transfer_params_to_java()
+        return self._java_obj.outputDataType()
+
+    @since("3.0.0")
+    def validateInputType(self, inputType):
+        self._transfer_params_to_java()
+        self._java_obj.validateInputType(inputType)
+
 
 @inherit_doc
-class Normalizer(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, JavaMLWritable):
+class Normalizer(JavaUnaryTransformer, JavaMLReadable, JavaMLWritable):
     """
      Normalize a vector to have unit norm using the given p-norm.
 
@@ -2361,6 +2406,21 @@ class Normalizer(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, Jav
         Sets the value of :py:attr:`outputCol`.
         """
         return self._set(outputCol=value)
+
+    @since("3.0.0")
+    def createTransformFunc(self):
+        self._transfer_params_to_java()
+        return self._java_obj.createTransformFunc()
+
+    @since("3.0.0")
+    def outputDataType(self):
+        self._transfer_params_to_java()
+        return self._java_obj.outputDataType()
+
+    @since("3.0.0")
+    def validateInputType(self, inputType):
+        self._transfer_params_to_java()
+        self._java_obj.validateInputType(inputType)
 
 
 class _OneHotEncoderParams(HasInputCol, HasInputCols, HasOutputCol, HasOutputCols,
@@ -2561,8 +2621,7 @@ class OneHotEncoderModel(JavaModel, _OneHotEncoderParams, JavaMLReadable, JavaML
 
 
 @inherit_doc
-class PolynomialExpansion(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable,
-                          JavaMLWritable):
+class PolynomialExpansion(JavaUnaryTransformer, JavaMLReadable, JavaMLWritable):
     """
     Perform feature expansion in a polynomial space. As said in `wikipedia of Polynomial Expansion
     <http://en.wikipedia.org/wiki/Polynomial_expansion>`_, "In mathematics, an
@@ -2640,6 +2699,21 @@ class PolynomialExpansion(JavaTransformer, HasInputCol, HasOutputCol, JavaMLRead
         Sets the value of :py:attr:`outputCol`.
         """
         return self._set(outputCol=value)
+
+    @since("3.0.0")
+    def createTransformFunc(self):
+        self._transfer_params_to_java()
+        return self._java_obj.createTransformFunc()
+
+    @since("3.0.0")
+    def outputDataType(self):
+        self._transfer_params_to_java()
+        return self._java_obj.outputDataType()
+
+    @since("3.0.0")
+    def validateInputType(self, inputType):
+        self._transfer_params_to_java()
+        self._java_obj.validateInputType(inputType)
 
 
 @inherit_doc
@@ -3079,7 +3153,7 @@ class RobustScalerModel(JavaModel, _RobustScalerParams, JavaMLReadable, JavaMLWr
 
 @inherit_doc
 @ignore_unicode_prefix
-class RegexTokenizer(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, JavaMLWritable):
+class RegexTokenizer(JavaUnaryTransformer, JavaMLReadable, JavaMLWritable):
     """
     A regex based tokenizer that extracts tokens either by using the
     provided regex pattern (in Java dialect) to split the text
@@ -3221,6 +3295,21 @@ class RegexTokenizer(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable,
         Sets the value of :py:attr:`outputCol`.
         """
         return self._set(outputCol=value)
+
+    @since("3.0.0")
+    def createTransformFunc(self):
+        self._transfer_params_to_java()
+        return self._java_obj.createTransformFunc()
+
+    @since("3.0.0")
+    def outputDataType(self):
+        self._transfer_params_to_java()
+        return self._java_obj.outputDataType()
+
+    @since("3.0.0")
+    def validateInputType(self, inputType):
+        self._transfer_params_to_java()
+        self._java_obj.validateInputType(inputType)
 
 
 @inherit_doc
@@ -3901,7 +3990,7 @@ class StopWordsRemover(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadabl
 
 @inherit_doc
 @ignore_unicode_prefix
-class Tokenizer(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, JavaMLWritable):
+class Tokenizer(JavaUnaryTransformer, JavaMLReadable, JavaMLWritable):
     """
     A tokenizer that converts the input string to lowercase and then
     splits it by white spaces.
@@ -3965,6 +4054,21 @@ class Tokenizer(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, Java
         Sets the value of :py:attr:`outputCol`.
         """
         return self._set(outputCol=value)
+
+    @since("3.0.0")
+    def createTransformFunc(self):
+        self._transfer_params_to_java()
+        return self._java_obj.createTransformFunc()
+
+    @since("3.0.0")
+    def outputDataType(self):
+        self._transfer_params_to_java()
+        return self._java_obj.outputDataType()
+
+    @since("3.0.0")
+    def validateInputType(self, inputType):
+        self._transfer_params_to_java()
+        self._java_obj.validateInputType(inputType)
 
 
 @inherit_doc

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -1015,17 +1015,14 @@ class DCT(JavaUnaryTransformer, JavaMLReadable, JavaMLWritable):
         """
         return self._set(outputCol=value)
 
-    @since("3.0.0")
     def createTransformFunc(self):
         self._transfer_params_to_java()
         return self._java_obj.createTransformFunc()
 
-    @since("3.0.0")
     def outputDataType(self):
         self._transfer_params_to_java()
         return self._java_obj.outputDataType()
 
-    @since("3.0.0")
     def validateInputType(self, inputType):
         self._transfer_params_to_java()
         self._java_obj.validateInputType(inputType)
@@ -1110,17 +1107,14 @@ class ElementwiseProduct(JavaUnaryTransformer, JavaMLReadable, JavaMLWritable):
         """
         return self._set(outputCol=value)
 
-    @since("3.0.0")
     def createTransformFunc(self):
         self._transfer_params_to_java()
         return self._java_obj.createTransformFunc()
 
-    @since("3.0.0")
     def outputDataType(self):
         self._transfer_params_to_java()
         return self._java_obj.outputDataType()
 
-    @since("3.0.0")
     def validateInputType(self, inputType):
         self._transfer_params_to_java()
         self._java_obj.validateInputType(inputType)
@@ -2312,17 +2306,14 @@ class NGram(JavaUnaryTransformer, JavaMLReadable, JavaMLWritable):
         """
         return self._set(outputCol=value)
 
-    @since("3.0.0")
     def createTransformFunc(self):
         self._transfer_params_to_java()
         return self._java_obj.createTransformFunc()
 
-    @since("3.0.0")
     def outputDataType(self):
         self._transfer_params_to_java()
         return self._java_obj.outputDataType()
 
-    @since("3.0.0")
     def validateInputType(self, inputType):
         self._transfer_params_to_java()
         self._java_obj.validateInputType(inputType)
@@ -2407,17 +2398,14 @@ class Normalizer(JavaUnaryTransformer, JavaMLReadable, JavaMLWritable):
         """
         return self._set(outputCol=value)
 
-    @since("3.0.0")
     def createTransformFunc(self):
         self._transfer_params_to_java()
         return self._java_obj.createTransformFunc()
 
-    @since("3.0.0")
     def outputDataType(self):
         self._transfer_params_to_java()
         return self._java_obj.outputDataType()
 
-    @since("3.0.0")
     def validateInputType(self, inputType):
         self._transfer_params_to_java()
         self._java_obj.validateInputType(inputType)
@@ -2700,17 +2688,14 @@ class PolynomialExpansion(JavaUnaryTransformer, JavaMLReadable, JavaMLWritable):
         """
         return self._set(outputCol=value)
 
-    @since("3.0.0")
     def createTransformFunc(self):
         self._transfer_params_to_java()
         return self._java_obj.createTransformFunc()
 
-    @since("3.0.0")
     def outputDataType(self):
         self._transfer_params_to_java()
         return self._java_obj.outputDataType()
 
-    @since("3.0.0")
     def validateInputType(self, inputType):
         self._transfer_params_to_java()
         self._java_obj.validateInputType(inputType)
@@ -3296,17 +3281,14 @@ class RegexTokenizer(JavaUnaryTransformer, JavaMLReadable, JavaMLWritable):
         """
         return self._set(outputCol=value)
 
-    @since("3.0.0")
     def createTransformFunc(self):
         self._transfer_params_to_java()
         return self._java_obj.createTransformFunc()
 
-    @since("3.0.0")
     def outputDataType(self):
         self._transfer_params_to_java()
         return self._java_obj.outputDataType()
 
-    @since("3.0.0")
     def validateInputType(self, inputType):
         self._transfer_params_to_java()
         self._java_obj.validateInputType(inputType)
@@ -4055,17 +4037,14 @@ class Tokenizer(JavaUnaryTransformer, JavaMLReadable, JavaMLWritable):
         """
         return self._set(outputCol=value)
 
-    @since("3.0.0")
     def createTransformFunc(self):
         self._transfer_params_to_java()
         return self._java_obj.createTransformFunc()
 
-    @since("3.0.0")
     def outputDataType(self):
         self._transfer_params_to_java()
         return self._java_obj.outputDataType()
 
-    @since("3.0.0")
     def validateInputType(self, inputType):
         self._transfer_params_to_java()
         self._java_obj.validateInputType(inputType)

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -1015,15 +1015,15 @@ class DCT(JavaUnaryTransformer, JavaMLReadable, JavaMLWritable):
         """
         return self._set(outputCol=value)
 
-    def createTransformFunc(self):
+    def _createTransformFunc(self):
         self._transfer_params_to_java()
         return self._java_obj.createTransformFunc()
 
-    def outputDataType(self):
+    def _outputDataType(self):
         self._transfer_params_to_java()
         return self._java_obj.outputDataType()
 
-    def validateInputType(self, inputType):
+    def _validateInputType(self, inputType):
         self._transfer_params_to_java()
         self._java_obj.validateInputType(inputType)
 
@@ -1107,15 +1107,15 @@ class ElementwiseProduct(JavaUnaryTransformer, JavaMLReadable, JavaMLWritable):
         """
         return self._set(outputCol=value)
 
-    def createTransformFunc(self):
+    def _createTransformFunc(self):
         self._transfer_params_to_java()
         return self._java_obj.createTransformFunc()
 
-    def outputDataType(self):
+    def _outputDataType(self):
         self._transfer_params_to_java()
         return self._java_obj.outputDataType()
 
-    def validateInputType(self, inputType):
+    def _validateInputType(self, inputType):
         self._transfer_params_to_java()
         self._java_obj.validateInputType(inputType)
 
@@ -2306,15 +2306,15 @@ class NGram(JavaUnaryTransformer, JavaMLReadable, JavaMLWritable):
         """
         return self._set(outputCol=value)
 
-    def createTransformFunc(self):
+    def _createTransformFunc(self):
         self._transfer_params_to_java()
         return self._java_obj.createTransformFunc()
 
-    def outputDataType(self):
+    def _outputDataType(self):
         self._transfer_params_to_java()
         return self._java_obj.outputDataType()
 
-    def validateInputType(self, inputType):
+    def _validateInputType(self, inputType):
         self._transfer_params_to_java()
         self._java_obj.validateInputType(inputType)
 
@@ -2398,15 +2398,15 @@ class Normalizer(JavaUnaryTransformer, JavaMLReadable, JavaMLWritable):
         """
         return self._set(outputCol=value)
 
-    def createTransformFunc(self):
+    def _createTransformFunc(self):
         self._transfer_params_to_java()
         return self._java_obj.createTransformFunc()
 
-    def outputDataType(self):
+    def _outputDataType(self):
         self._transfer_params_to_java()
         return self._java_obj.outputDataType()
 
-    def validateInputType(self, inputType):
+    def _validateInputType(self, inputType):
         self._transfer_params_to_java()
         self._java_obj.validateInputType(inputType)
 
@@ -2688,15 +2688,15 @@ class PolynomialExpansion(JavaUnaryTransformer, JavaMLReadable, JavaMLWritable):
         """
         return self._set(outputCol=value)
 
-    def createTransformFunc(self):
+    def _createTransformFunc(self):
         self._transfer_params_to_java()
         return self._java_obj.createTransformFunc()
 
-    def outputDataType(self):
+    def _outputDataType(self):
         self._transfer_params_to_java()
         return self._java_obj.outputDataType()
 
-    def validateInputType(self, inputType):
+    def _validateInputType(self, inputType):
         self._transfer_params_to_java()
         self._java_obj.validateInputType(inputType)
 
@@ -3281,15 +3281,15 @@ class RegexTokenizer(JavaUnaryTransformer, JavaMLReadable, JavaMLWritable):
         """
         return self._set(outputCol=value)
 
-    def createTransformFunc(self):
+    def _createTransformFunc(self):
         self._transfer_params_to_java()
         return self._java_obj.createTransformFunc()
 
-    def outputDataType(self):
+    def _outputDataType(self):
         self._transfer_params_to_java()
         return self._java_obj.outputDataType()
 
-    def validateInputType(self, inputType):
+    def _validateInputType(self, inputType):
         self._transfer_params_to_java()
         self._java_obj.validateInputType(inputType)
 
@@ -4037,15 +4037,15 @@ class Tokenizer(JavaUnaryTransformer, JavaMLReadable, JavaMLWritable):
         """
         return self._set(outputCol=value)
 
-    def createTransformFunc(self):
+    def _createTransformFunc(self):
         self._transfer_params_to_java()
         return self._java_obj.createTransformFunc()
 
-    def outputDataType(self):
+    def _outputDataType(self):
         self._transfer_params_to_java()
         return self._java_obj.outputDataType()
 
-    def validateInputType(self, inputType):
+    def _validateInputType(self, inputType):
         self._transfer_params_to_java()
         self._java_obj.validateInputType(inputType)
 

--- a/python/pyspark/ml/tests/test_base.py
+++ b/python/pyspark/ml/tests/test_base.py
@@ -30,11 +30,11 @@ class UnaryTransformerTests(SparkSessionTestCase):
             .setInputCol("input").setOutputCol("output")
 
         # should not raise any errors
-        transformer.validateInputType(DoubleType())
+        transformer._validateInputType(DoubleType())
 
         with self.assertRaises(TypeError):
             # passing the wrong input type should raise an error
-            transformer.validateInputType(IntegerType())
+            transformer._validateInputType(IntegerType())
 
     def test_unary_transformer_transform(self):
         shiftVal = 3

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -23,7 +23,7 @@ if sys.version >= '3':
 from pyspark import since
 from pyspark import SparkContext
 from pyspark.sql import DataFrame
-from pyspark.ml import Estimator, Transformer, Model
+from pyspark.ml import Estimator, Transformer, Model, UnaryTransformer
 from pyspark.ml.param import Params
 from pyspark.ml.param.shared import HasFeaturesCol, HasLabelCol, HasPredictionCol
 from pyspark.ml.util import _jvm
@@ -327,6 +327,21 @@ class JavaEstimator(JavaParams, Estimator):
 class JavaTransformer(JavaParams, Transformer):
     """
     Base class for :py:class:`Transformer`s that wrap Java/Scala
+    implementations. Subclasses should ensure they have the transformer Java object
+    available as _java_obj.
+    """
+
+    __metaclass__ = ABCMeta
+
+    def _transform(self, dataset):
+        self._transfer_params_to_java()
+        return DataFrame(self._java_obj.transform(dataset._jdf), dataset.sql_ctx)
+
+
+@inherit_doc
+class JavaUnaryTransformer(JavaParams, UnaryTransformer):
+    """
+    Base class for :py:class:`UnaryTransformer`s that wrap Java/Scala
     implementations. Subclasses should ensure they have the transformer Java object
     available as _java_obj.
     """

--- a/python/pyspark/testing/mlutils.py
+++ b/python/pyspark/testing/mlutils.py
@@ -131,14 +131,14 @@ class MockUnaryTransformer(UnaryTransformer, DefaultParamsReadable, DefaultParam
     def setShift(self, shift):
         self._set(shift=shift)
 
-    def createTransformFunc(self):
+    def _createTransformFunc(self):
         shiftVal = self.getShift()
         return lambda x: x + shiftVal
 
-    def outputDataType(self):
+    def _outputDataType(self):
         return DoubleType()
 
-    def validateInputType(self, inputType):
+    def _validateInputType(self, inputType):
         if inputType != DoubleType():
             raise TypeError("Bad input type: {}. ".format(inputType) +
                             "Requires Double.")


### PR DESCRIPTION

### What changes were proposed in this pull request?
Use UnaryTransformer as parent class for single input column transformers in PySpark

### Why are the changes needed?
In Scala, UnaryTransformer is the parent class of all the single input column transformers. In PySpark, we have the corresponding Python version of UnaryTransformer but it's not really used. This Jira will make single input column transformers in Python to use UnaryTransformer as parent class. 


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Use existing tests.
