### PR TITLE
[SPARK-29726][WEBUI]Support KVStore for HiveThriftServer2Listener

### DIFF
--- a/sql/hive-thriftserver/pom.xml
+++ b/sql/hive-thriftserver/pom.xml
@@ -125,6 +125,11 @@
       <groupId>net.sf.jpam</groupId>
       <artifactId>jpam</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -310,9 +310,9 @@ object HiveThriftServer2 extends Logging {
     }
 
     /**
-      * Remove at least (retainedSize / 10) items to reduce friction. Because tracking may be done
-      * asynchronously, this method may return 0 in case enough items have been deleted already.
-      */
+     * Remove at least (retainedSize / 10) items to reduce friction. Because tracking may be done
+     * asynchronously, this method may return 0 in case enough items have been deleted already.
+     */
     private def calculateNumberToRemove(dataSize: Long, retainedSize: Long): Long = {
       if (dataSize > retainedSize) {
         math.max(retainedSize / 10L, dataSize - retainedSize)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/HiveThriftServer2AppStatusStore.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/HiveThriftServer2AppStatusStore.scala
@@ -18,9 +18,9 @@
 package org.apache.spark.sql.hive.thriftserver.ui
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
+
 import org.apache.spark.sql.hive.thriftserver.HiveThriftServer2.{ExecutionState, HiveThriftServer2Listener}
 import org.apache.spark.status.KVUtils.KVIndexParam
 import org.apache.spark.util.kvstore.KVStore

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/HiveThriftServer2AppStatusStore.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/HiveThriftServer2AppStatusStore.scala
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.thriftserver.ui
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+import org.apache.spark.sql.hive.thriftserver.HiveThriftServer2.{ExecutionState, HiveThriftServer2Listener}
+import org.apache.spark.status.KVUtils.KVIndexParam
+import org.apache.spark.util.kvstore.KVStore
+
+class HiveThriftServer2AppStatusStore(
+  store: KVStore,
+  val listener: Option[HiveThriftServer2Listener] = None) {
+
+  def getSessionList: Seq[LiveSessionData] = {
+    store.view(classOf[LiveSessionData]).asScala.toSeq
+  }
+
+  def getExecutionList: Seq[LiveExecutionData] = {
+    store.view(classOf[LiveExecutionData]).asScala.toSeq
+  }
+
+  def getOnlineSessionNum: Int = {
+    store.view(classOf[LiveSessionData]).asScala.count(_.finishTimestamp == 0)
+  }
+
+  def getSession(sessionId: String): Option[LiveSessionData] = {
+    try {
+      Some(store.read(classOf[LiveSessionData], sessionId))
+    } catch {
+      case _: NoSuchElementException => None
+    }
+  }
+
+  /**
+   * When an error or a cancellation occurs, we set the finishTimestamp of the statement.
+   * Therefore, when we count the number of running statements, we need to exclude errors and
+   * cancellations and count all statements that have not been closed so far.
+   */
+  def getTotalRunning: Int = {
+    store.view(classOf[LiveExecutionData]).asScala.count(isExecutionActive)
+  }
+
+  def isExecutionActive(execInfo: LiveExecutionData): Boolean = {
+    !(execInfo.state == ExecutionState.FAILED ||
+      execInfo.state == ExecutionState.CANCELED ||
+      execInfo.state == ExecutionState.CLOSED)
+  }
+}
+
+private[thriftserver] class LiveSessionData(
+  @KVIndexParam val sessionId: String,
+  val startTimestamp: Long,
+  val ip: String,
+  val userName: String,
+  val finishTimestamp: Long,
+  val totalExecution: Long) {
+
+  @JsonIgnore @KVIndexParam("sessionId")
+  def session: String = sessionId
+
+  def totalTime: Long = {
+    if (finishTimestamp == 0L) {
+      System.currentTimeMillis - startTimestamp
+    } else {
+      finishTimestamp - startTimestamp
+    }
+  }
+}
+
+private[thriftserver] class LiveExecutionData(
+  @KVIndexParam val execId: String,
+  val statement: String,
+  val sessionId: String,
+  val startTimestamp: Long,
+  val userName: String,
+  val finishTimestamp: Long,
+  val closeTimestamp: Long,
+  val executePlan: String,
+  val detail: String,
+  val state: ExecutionState.Value,
+  val jobId: ArrayBuffer[String],
+  val groupId: String) {
+
+  @JsonIgnore @KVIndexParam("execId")
+  def exec(): String = execId
+
+  def totalTime(endTime: Long): Long = {
+    if (endTime == 0L) {
+      System.currentTimeMillis - startTimestamp
+    } else {
+      endTime - startTimestamp
+    }
+  }
+}

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerSessionPage.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerSessionPage.scala
@@ -32,7 +32,7 @@ import org.apache.spark.util.Utils
 private[ui] class ThriftServerSessionPage(parent: ThriftServerTab)
   extends WebUIPage("session") with Logging {
 
-  private val listener = parent.listener
+  private val store = parent.store
   private val startTime = Calendar.getInstance().getTime()
 
   /** Render the page */
@@ -41,8 +41,8 @@ private[ui] class ThriftServerSessionPage(parent: ThriftServerTab)
     require(parameterId != null && parameterId.nonEmpty, "Missing id parameter")
 
     val content =
-      listener.synchronized { // make sure all parts in this page are consistent
-        val sessionStat = listener.getSession(parameterId).getOrElse(null)
+      store.synchronized { // make sure all parts in this page are consistent
+        val sessionStat = store.getSession(parameterId).getOrElse(null)
         require(sessionStat != null, "Invalid sessionID[" + parameterId + "]")
 
         generateBasicStats() ++
@@ -73,7 +73,7 @@ private[ui] class ThriftServerSessionPage(parent: ThriftServerTab)
 
   /** Generate stats of batch statements of the thrift server program */
   private def generateSQLStatsTable(request: HttpServletRequest, sessionID: String): Seq[Node] = {
-    val executionList = listener.getExecutionList
+    val executionList = store.getExecutionList
       .filter(_.sessionId == sessionID)
     val numStatement = executionList.size
     val table = if (numStatement > 0) {

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerTab.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerTab.scala
@@ -27,7 +27,9 @@ import org.apache.spark.ui.{SparkUI, SparkUITab}
  * Spark Web UI tab that shows statistics of jobs running in the thrift server.
  * This assumes the given SparkContext has enabled its SparkUI.
  */
-private[thriftserver] class ThriftServerTab(sparkContext: SparkContext)
+private[thriftserver] class ThriftServerTab(
+  val store: HiveThriftServer2AppStatusStore,
+  sparkContext: SparkContext)
   extends SparkUITab(getSparkUI(sparkContext), "sqlserver") with Logging {
 
   override val name = "JDBC/ODBC Server"

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2ListenerSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2ListenerSuite.scala
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.thriftserver
+
+import java.util.Properties
+
+import org.mockito.Mockito.{mock, RETURNS_SMART_NULLS}
+import org.scalatest.BeforeAndAfter
+
+import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
+import org.apache.spark.scheduler.SparkListenerJobStart
+import org.apache.spark.sql.hive.thriftserver.HiveThriftServer2.HiveThriftServer2Listener
+import org.apache.spark.sql.hive.thriftserver.ui.HiveThriftServer2AppStatusStore
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.status.ElementTrackingStore
+import org.apache.spark.util.kvstore.InMemoryStore
+
+class HiveThriftServer2ListenerSuite extends SparkFunSuite
+  with BeforeAndAfter with SharedSparkSession {
+
+    private var kvstore: ElementTrackingStore = _
+
+    after {
+      if (kvstore != null) {
+        kvstore.close()
+        kvstore = null
+      }
+    }
+
+    private def createProperties: Properties = {
+      val properties = new Properties()
+      properties.setProperty(SparkContext.SPARK_JOB_GROUP_ID, "groupId")
+      properties
+    }
+
+    private def createStatusStore(): HiveThriftServer2AppStatusStore = {
+      val conf = sqlContext.conf
+
+      kvstore = new ElementTrackingStore(new InMemoryStore, new SparkConf())
+      val server = mock(classOf[HiveThriftServer2], RETURNS_SMART_NULLS)
+      val listener = new HiveThriftServer2Listener(kvstore, server, conf)
+      new HiveThriftServer2AppStatusStore(kvstore, Some(listener))
+    }
+
+    test("listener events should store successfully") {
+      val statusStore = createStatusStore()
+      val listener = statusStore.listener.get
+
+      listener.onSessionCreated("localhost", "sessionId", "user")
+      listener.onStatementStart("id", "sessionId", "dummy query", "groupId", "user")
+      listener.onStatementParsed("id", "dummy plan")
+      listener.onJobStart(SparkListenerJobStart(
+        0,
+        System.currentTimeMillis(),
+        Nil,
+        createProperties))
+      listener.onStatementFinish("id")
+      listener.onOperationClosed("id")
+
+      assert(statusStore.getOnlineSessionNum == 1)
+
+      listener.onSessionClosed("sessionId")
+
+      assert(statusStore.getOnlineSessionNum == 0)
+      assert(statusStore.getExecutionList.size == 1)
+
+      val storeExecData = statusStore.getExecutionList.head
+
+      assert(storeExecData.execId == "id")
+      assert(storeExecData.sessionId == "sessionId")
+      assert(storeExecData.executePlan == "dummy plan")
+      assert(storeExecData.jobId == Seq("0"))
+    }
+  }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Support KVStore, HiveThriftServer2AppStatusStore for HiveThriftServer2Listener.
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently Historyserver cannot display JDBC/ODBC tab in the WebUI when it replays the event log. To get support of Historyserver, we need to create a KVstore for storing processed events and there by display in the UI from the store. This PR support storing live events in a status store. Also the PR is prerequisite for the Jira SPARK-29724

### Does this PR introduce any user-facing change?
No


### How was this patch tested?
UT and Manual tests.

![Screenshot 2019-11-03 at 3 07 36 AM](https://user-images.githubusercontent.com/23054875/68077286-25811500-fde7-11e9-85aa-c0657e49dc34.png)
