### PR TITLE
[SPARK-29736][TESTS] Improve stability of tests for special datetime values

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/SQLHelper.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/SQLHelper.scala
@@ -17,8 +17,13 @@
 package org.apache.spark.sql.catalyst.plans
 
 import java.io.File
+import java.time.ZoneId
+
+import scala.util.control.NonFatal
 
 import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.util.DateTimeTestUtils
+import org.apache.spark.sql.catalyst.util.DateTimeUtils.getZoneId
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.Utils
 
@@ -60,5 +65,22 @@ trait SQLHelper {
     val path = Utils.createTempDir()
     path.delete()
     try f(path) finally Utils.deleteRecursively(path)
+  }
+
+
+  def testSpecialDatetimeValues[T](test: ZoneId => T): Unit = {
+    DateTimeTestUtils.outstandingTimezonesIds.foreach { timeZone =>
+      withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> timeZone) {
+        val zoneId = getZoneId(timeZone)
+        // The test can fail around midnight if it gets the reference value
+        // before midnight but tested code resolves special value after midnight.
+        // Retry can guarantee that both values were taken on the same day.
+        try {
+          test(zoneId)
+        } catch {
+          case NonFatal(_) => test(zoneId)
+        }
+      }
+    }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/DateFormatterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/DateFormatterSuite.scala
@@ -103,18 +103,15 @@ class DateFormatterSuite extends SparkFunSuite with SQLHelper {
   }
 
   test("special date values") {
-    DateTimeTestUtils.outstandingTimezonesIds.foreach { timeZone =>
-      withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> timeZone) {
-        val zoneId = getZoneId(timeZone)
-        val formatter = DateFormatter(zoneId)
+    testSpecialDatetimeValues { zoneId =>
+      val formatter = DateFormatter(zoneId)
 
-        assert(formatter.parse("EPOCH") === 0)
-        val today = localDateToDays(LocalDate.now(zoneId))
-        assert(formatter.parse("Yesterday") === today - 1)
-        assert(formatter.parse("now") === today)
-        assert(formatter.parse("today ") === today)
-        assert(formatter.parse("tomorrow UTC") === today + 1)
-      }
+      assert(formatter.parse("EPOCH") === 0)
+      val today = localDateToDays(LocalDate.now(zoneId))
+      assert(formatter.parse("Yesterday") === today - 1)
+      assert(formatter.parse("now") === today)
+      assert(formatter.parse("today ") === today)
+      assert(formatter.parse("tomorrow UTC") === today + 1)
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/TimestampFormatterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/TimestampFormatterSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.util
 
-import java.time.{LocalDateTime, LocalTime, ZoneOffset}
+import java.time.{Instant, LocalDateTime, LocalTime, ZoneOffset}
 import java.util.concurrent.TimeUnit
 
 import org.scalatest.Matchers
@@ -140,21 +140,29 @@ class TimestampFormatterSuite extends SparkFunSuite with SQLHelper with Matchers
     DateTimeTestUtils.outstandingTimezonesIds.foreach { timeZone =>
       withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> timeZone) {
         val zoneId = getZoneId(timeZone)
-        val formatter = TimestampFormatter(zoneId)
-        val tolerance = TimeUnit.SECONDS.toMicros(30)
 
-        assert(formatter.parse("EPOCH") === 0)
-        val now = instantToMicros(LocalDateTime.now(zoneId).atZone(zoneId).toInstant)
-        formatter.parse("now") should be (now +- tolerance)
-        val localToday = LocalDateTime.now(zoneId)
-          .`with`(LocalTime.MIDNIGHT)
-          .atZone(zoneId)
-        val yesterday = instantToMicros(localToday.minusDays(1).toInstant)
-        formatter.parse("yesterday CET") should be (yesterday +- tolerance)
-        val today = instantToMicros(localToday.toInstant)
-        formatter.parse(" TODAY ") should be (today +- tolerance)
-        val tomorrow = instantToMicros(localToday.plusDays(1).toInstant)
-        formatter.parse("Tomorrow ") should be (tomorrow +- tolerance)
+        withClue(s"zoneId = $zoneId, current time = ${LocalDateTime.now(zoneId)}") {
+          // The test can fail around midnight if it gets the reference value
+          // before midnight but tested code resolves special value after midnight.
+          // Retry can guarantee that both values were taken on the same day.
+          retry(1) {
+            val formatter = TimestampFormatter(zoneId)
+            val tolerance = TimeUnit.SECONDS.toMicros(30)
+
+            assert(formatter.parse("EPOCH") === 0)
+            val now = instantToMicros(Instant.now())
+            formatter.parse("now") should be(now +- tolerance)
+            val localToday = LocalDateTime.now(zoneId)
+              .`with`(LocalTime.MIDNIGHT)
+              .atZone(zoneId)
+            val yesterday = instantToMicros(localToday.minusDays(1).toInstant)
+            formatter.parse("yesterday CET") should be(yesterday +- tolerance)
+            val today = instantToMicros(localToday.toInstant)
+            formatter.parse(" TODAY ") should be(today +- tolerance)
+            val tomorrow = instantToMicros(localToday.plusDays(1).toInstant)
+            formatter.parse("Tomorrow ") should be(tomorrow +- tolerance)
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Retry the tests for special date-time values on failure. The tests can potentially fail when reference values were taken before midnight and test code resolves special values after midnight. The retry can guarantees that the tests run during the same day.
- Simplify getting of the current timestamp via `Instant.now()`. This should avoid any issues of converting current local datetime to an instance. For example, the same local time can be mapped to 2 instants when clocks are turned backward 1 hour on daylight saving date.
- Extract common code to SQLHelper
- Set the tested zoneId to the session time zone in `DateTimeUtilsSuite`.

### Why are the changes needed?
To make the tests more stable.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
By existing test suites `Date`/`TimestampFormatterSuite` and `DateTimeUtilsSuite`.
