### PR TITLE
[SPARK-29738][SPARK-CORE]Add a shutdown hook log wrapper

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/ShutdownHookManager.scala
+++ b/core/src/main/scala/org/apache/spark/util/ShutdownHookManager.scala
@@ -189,12 +189,12 @@ private [util] class SparkShutdownHookManager {
     }
   }
 
-  def add(priority: Int, hook: () => Unit): AnyRef = {
+  def add(priority: Int, hook: () => Unit, hookName: String = "Anonymous Hook"): AnyRef = {
     hooks.synchronized {
       if (shuttingDown) {
         throw new IllegalStateException("Shutdown hooks cannot be modified during shutdown.")
       }
-      val hookRef = new SparkShutdownHook(priority, hook)
+      val hookRef = new SparkShutdownHook(priority, hook, hookName)
       hooks.add(hookRef)
       hookRef
     }
@@ -206,7 +206,8 @@ private [util] class SparkShutdownHookManager {
 
 }
 
-private class SparkShutdownHook(private val priority: Int, hook: () => Unit)
+private class SparkShutdownHook(private val priority: Int, hook: () => Unit,
+                                hookName: String)
   extends Comparable[SparkShutdownHook] {
 
   override def compareTo(other: SparkShutdownHook): Int = {
@@ -215,4 +216,5 @@ private class SparkShutdownHook(private val priority: Int, hook: () => Unit)
 
   def run(): Unit = hook()
 
+  def name: String = hookName
 }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1967,6 +1967,21 @@ private[spark] object Utils extends Logging {
     }
   }
 
+  /**
+   * To figure out which shutdown hook makes execution slow, a logWrapper for shutdown hook
+   * is used to record execute time for each shutdown hook.
+   */
+  def shutdownHookLogWrapper[T](f: => T, nextHook: SparkShutdownHook): Unit = {
+    val startTime = System.currentTimeMillis()
+    try {
+      logInfo(s"Shutdown hook ${nextHook.name} starts!")
+      f
+    } finally {
+      val duration = System.currentTimeMillis() - startTime
+      logInfo(s"Shutdown hook ${nextHook.name} ends! Duration: ${duration}ms")
+    }
+  }
+
   /** Executes the given block in a Try, logging any uncaught exceptions. */
   def tryLog[T](f: => T): Try[T] = {
     try {

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -744,7 +744,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     val hook1 = manager.add(1, () => output += 1)
     manager.add(3, () => output += 3)
     manager.add(2, () => output += 2)
-    manager.add(4, () => output += 4)
+    manager.add(4, () => output += 4, "Hook For Test")
     manager.remove(hook1)
 
     manager.runAll()


### PR DESCRIPTION
when program is shutdown, related shutdown hooks will be called. But if something wrong in shutdown hooks makes this process slow, existing log information will not help us figure out which hook makes it. So there's a log wrapper to record execute process of each shutdown hook.