### PR TITLE
[WIP][SPARK-29750][BUILD] Avoid dependency from joda-time

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -215,7 +215,6 @@ com.twitter:chill-java
 com.twitter:chill_2.12
 com.univocity:univocity-parsers
 javax.jdo:jdo-api
-joda-time:joda-time
 net.sf.opencsv:opencsv
 org.apache.derby:derby
 org.ehcache:ehcache

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -125,6 +125,7 @@ jetty-6.1.26.jar
 jetty-sslengine-6.1.26.jar
 jetty-util-6.1.26.jar
 jline-2.14.6.jar
+joda-time-2.9.9.jar
 jodd-core-3.5.2.jar
 jpam-1.1.jar
 json4s-ast_2.12-3.6.6.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -125,7 +125,6 @@ jetty-6.1.26.jar
 jetty-sslengine-6.1.26.jar
 jetty-util-6.1.26.jar
 jline-2.14.6.jar
-joda-time-2.10.5.jar
 jodd-core-3.5.2.jar
 jpam-1.1.jar
 json4s-ast_2.12-3.6.6.jar

--- a/dev/deps/spark-deps-hadoop-3.2
+++ b/dev/deps/spark-deps-hadoop-3.2
@@ -139,6 +139,7 @@ jersey-server-2.29.jar
 jetty-webapp-9.4.18.v20190429.jar
 jetty-xml-9.4.18.v20190429.jar
 jline-2.14.6.jar
+joda-time-2.8.1.jar
 jodd-core-3.5.2.jar
 jpam-1.1.jar
 json-1.8.jar

--- a/dev/deps/spark-deps-hadoop-3.2
+++ b/dev/deps/spark-deps-hadoop-3.2
@@ -139,7 +139,6 @@ jersey-server-2.29.jar
 jetty-webapp-9.4.18.v20190429.jar
 jetty-xml-9.4.18.v20190429.jar
 jline-2.14.6.jar
-joda-time-2.10.5.jar
 jodd-core-3.5.2.jar
 jpam-1.1.jar
 json-1.8.jar

--- a/hadoop-cloud/pom.xml
+++ b/hadoop-cloud/pom.xml
@@ -131,16 +131,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-
-    <!--
-    Add joda time to ensure that anything downstream which doesn't pull in spark-hive
-    gets the correct joda time artifact, so doesn't have auth failures on later Java 8 JVMs
-    -->
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <scope>${hadoop.deps.scope}</scope>
-    </dependency>
     <!-- explicitly declare the jackson artifacts desired -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,6 @@
     <datanucleus-core.version>3.2.10</datanucleus-core.version>
     <janino.version>3.0.15</janino.version>
     <jersey.version>2.29</jersey.version>
-    <joda.version>2.10.5</joda.version>
     <jodd.version>3.5.2</jodd.version>
     <jsr305.version>3.0.0</jsr305.version>
     <libthrift.version>0.12.0</libthrift.version>
@@ -2092,11 +2091,6 @@
         <groupId>org.codehaus.janino</groupId>
         <artifactId>commons-compiler</artifactId>
         <version>${janino.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>joda-time</groupId>
-        <artifactId>joda-time</artifactId>
-        <version>${joda.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jodd</groupId>

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -143,10 +143,6 @@
       <artifactId>commons-codec</artifactId>
     </dependency>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.jodd</groupId>
       <artifactId>jodd-core</artifactId>
     </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Removed direct dependency from joda-time.

### Why are the changes needed?
To reduce number of direct Spark dependencies.

### Does this PR introduce any user-facing change?
No, only if users depend on joda-time transitively.  

### How was this patch tested?
By building Spark via `./build/sbt -Phive -Phive-thriftserver package`