### PR TITLE
[SPARK-29755][CORE] Provide @JsonDeserialize for Option[Long] in LogInfo & AttemptInfoWrapper

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.deploy.history
 
 import java.io.{File, FileNotFoundException, IOException}
+import java.lang.{Long => JLong}
 import java.nio.file.Files
 import java.util.{Date, ServiceLoader}
 import java.util.concurrent.{ConcurrentHashMap, ExecutorService, Future, TimeUnit}
@@ -30,6 +31,7 @@ import scala.io.Source
 import scala.xml.Node
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.google.common.util.concurrent.MoreExecutors
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 import org.apache.hadoop.hdfs.DistributedFileSystem
@@ -1167,14 +1169,14 @@ private[history] case class LogInfo(
     appId: Option[String],
     attemptId: Option[String],
     fileSize: Long,
-    lastIndex: Option[Long],
+    @JsonDeserialize(contentAs = classOf[JLong]) lastIndex: Option[Long],
     isComplete: Boolean)
 
 private[history] class AttemptInfoWrapper(
     val info: ApplicationAttemptInfo,
     val logPath: String,
     val fileSize: Long,
-    val lastIndex: Option[Long],
+    @JsonDeserialize(contentAs = classOf[JLong]) val lastIndex: Option[Long],
     val adminAcls: Option[String],
     val viewAcls: Option[String],
     val adminAclsGroups: Option[String],

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -1169,14 +1169,16 @@ private[history] case class LogInfo(
     appId: Option[String],
     attemptId: Option[String],
     fileSize: Long,
-    @JsonDeserialize(contentAs = classOf[JLong]) lastIndex: Option[Long],
+    @JsonDeserialize(contentAs = classOf[JLong])
+    lastIndex: Option[Long],
     isComplete: Boolean)
 
 private[history] class AttemptInfoWrapper(
     val info: ApplicationAttemptInfo,
     val logPath: String,
     val fileSize: Long,
-    @JsonDeserialize(contentAs = classOf[JLong]) val lastIndex: Option[Long],
+    @JsonDeserialize(contentAs = classOf[JLong])
+    val lastIndex: Option[Long],
     val adminAcls: Option[String],
     val viewAcls: Option[String],
     val adminAclsGroups: Option[String],

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -1325,7 +1325,7 @@ class FsHistoryProviderSuite extends SparkFunSuite with Matchers with Logging {
     if (expected.isEmpty) {
       assert(opt.isEmpty)
     } else {
-      // The issue happens only the value in Option is being unboxed. Here we ensure unboxing
+      // The issue happens only when the value in Option is being unboxed. Here we ensure unboxing
       // to Long succeeds: even though IDE suggests `.toLong` is redundant, direct comparison
       // doesn't trigger unboxing and passes even without SPARK-29755, so don't remove
       // `.toLong` below. Please refer SPARK-29755 for more details.

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -1328,10 +1328,11 @@ class FsHistoryProviderSuite extends SparkFunSuite with Matchers with Logging {
     if (expected.isEmpty) {
       assert(opt.isEmpty)
     } else {
-      // The issue happens only the value in Option is being unboxed. Simple comparison sometimes
-      // doesn't go though unboxing the value, hence ClassCastException is not occurred.
-      // Here we ensure unboxing to Long succeeds. Please refer SPARK-29755 for more details.
-      assert(BoxesRunTime.unboxToLong(opt.get) === expected.get)
+      // The issue happens only the value in Option is being unboxed. Here we ensure unboxing
+      // to Long succeeds: even though IDE suggests `.toLong` is redundant, direct comparison
+      // doesn't trigger unboxing and passes even without SPARK-29755, so don't remove
+      // `.toLong` below. Please refer SPARK-29755 for more details.
+      assert(opt.get.toLong === expected.get.toLong)
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -25,7 +25,6 @@ import java.util.zip.{ZipInputStream, ZipOutputStream}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
-import scala.runtime.BoxesRunTime
 
 import com.google.common.io.{ByteStreams, Files}
 import org.apache.commons.io.FileUtils
@@ -52,7 +51,6 @@ import org.apache.spark.status.KVUtils.KVStoreScalaSerializer
 import org.apache.spark.status.api.v1.{ApplicationAttemptInfo, ApplicationInfo}
 import org.apache.spark.util.{Clock, JsonProtocol, ManualClock, Utils}
 import org.apache.spark.util.logging.DriverLogger
-
 
 class FsHistoryProviderSuite extends SparkFunSuite with Matchers with Logging {
 
@@ -1287,8 +1285,7 @@ class FsHistoryProviderSuite extends SparkFunSuite with Matchers with Logging {
 
   test("SPARK-29755 LogInfo should be serialized/deserialized by jackson properly") {
     def assertSerDe(serializer: KVStoreScalaSerializer, info: LogInfo): Unit = {
-      val infoAfterSerDe = serializer.deserialize(
-        serializer.serialize(info), classOf[LogInfo])
+      val infoAfterSerDe = serializer.deserialize(serializer.serialize(info), classOf[LogInfo])
       assert(infoAfterSerDe === info)
       assertOptionAfterSerde(infoAfterSerDe.lastIndex, info.lastIndex)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This patch adds `@JsonDeserialize` annotation for the field which type is `Option[Long]` in LogInfo/AttemptInfoWrapper. It hits https://github.com/FasterXML/jackson-module-scala/wiki/FAQ#deserializing-optionint-and-other-primitive-challenges - other existing json models take care of this, but we missed to add annotation to these classes.

### Why are the changes needed?

Without this change, SHS will throw ClassNotFoundException when rebuilding App UI.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Manually tested.