### PR TITLE
[SPARK-29756][ML] CountVectorizer forget to unpersist intermediate rdd

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
@@ -233,6 +233,8 @@ class CountVectorizer @Since("1.5.0") (@Since("1.5.0") override val uid: String)
       .top(math.min(fullVocabSize, vocSize).toInt)(Ordering.by(_._2))
       .map(_._1)
 
+    wordCounts.unpersist()
+
     require(vocab.length > 0, "The vocabulary size should be > 0. Lower minDF as necessary.")
     copyValues(new CountVectorizerModel(uid, vocab).setParent(this))
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
1,unpersist intermediate rdd `wordCounts`
2,if the `dataset` is already persisted, we do not need to persist rdd `input`
3,if both `minDF`&`maxDF` are gteq or lt than 1, we can compare & check them af first.

### Why are the changes needed?
we should unpersit unused rdd ASAP


### Does this PR introduce any user-facing change?
no

### How was this patch tested?
existing testsuites