### PR TITLE
[SPARK-24442][SQL] Added parameters to control dataset show defaults

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2050,6 +2050,19 @@ object SQLConf {
       .stringConf
       .createWithDefault(
         "https://maven-central.storage-download.googleapis.com/repos/central/data/")
+
+  val SQL_SHOW_DEFAULT_MAX_ROWS = buildConf("spark.sql.show.defaultNumRows")
+    .doc("the default number of rows to show when the show function is called without a user" +
+      " specified max number of rows.")
+    .intConf
+    .createWithDefault(20)
+
+  val SQL_SHOW_TRUNCATE_MAX_CHARS_PER_COLUMN = buildConf("spark.sql.show.truncateMaxCharsPerColumn")
+    .doc("the default max characters per column to show before truncation when" +
+      "the show function is called with truncate.")
+    .intConf
+    .createWithDefault(20)
+
 }
 
 /**
@@ -2549,6 +2562,11 @@ class SQLConf extends Serializable with Logging {
   def defaultV2Catalog: Option[String] = getConf(DEFAULT_V2_CATALOG)
 
   def ignoreDataLocality: Boolean = getConf(SQLConf.IGNORE_DATA_LOCALITY)
+
+  def sqlShowDefaultMaxRows: Int = getConf(SQLConf.SQL_SHOW_DEFAULT_MAX_ROWS)
+
+  def sqlShowTruncateMaxCharsPerColumn: Int =
+    getConf(SQLConf.SQL_SHOW_TRUNCATE_MAX_CHARS_PER_COLUMN)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -764,7 +764,7 @@ class Dataset[T] private[sql](
    * @group action
    * @since 1.6.0
    */
-  def show(): Unit = show(20)
+  def show(): Unit = show(sqlContext.conf.sqlShowDefaultMaxRows)
 
   /**
    * Displays the top 20 rows of Dataset in a tabular form.
@@ -775,7 +775,8 @@ class Dataset[T] private[sql](
    * @group action
    * @since 1.6.0
    */
-  def show(truncate: Boolean): Unit = show(20, truncate)
+  def show(truncate: Boolean): Unit =
+    show(sqlContext.conf.sqlShowDefaultMaxRows, truncate)
 
   /**
    * Displays the Dataset in a tabular form. For example:
@@ -796,7 +797,7 @@ class Dataset[T] private[sql](
    */
   // scalastyle:off println
   def show(numRows: Int, truncate: Boolean): Unit = if (truncate) {
-    println(showString(numRows, truncate = 20))
+    println(showString(numRows, truncate = sqlContext.conf.sqlShowTruncateMaxCharsPerColumn))
   } else {
     println(showString(numRows, truncate = 0))
   }


### PR DESCRIPTION
It's been a while.  I've finally had time to polish up this pull request.  See previous comments for issues I've addressed.

https://github.com/apache/spark/pull/22162


### What changes were proposed in this pull request?
https://issues.apache.org/jira/browse/SPARK-24442

### How was this patch tested?
Unit tests plus local testing. This change is designed to not modify default behavior unless a user set the following configs...

"spark.sql.show.defaultNumRows" ->default 20 (as it was before)

"spark.sql.show.truncateMaxCharsPerColumn" -> default 30 (as it was before)