### PR TITLE
[SPARK-29766][sql] Do metrics aggregation asynchronously in SQL listener.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListener.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.execution.ui
 
 import java.util.{Arrays, Date, NoSuchElementException}
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -94,7 +95,7 @@ class SQLAppStatusListener(
           executionData.jobs = sqlStoreData.jobs
           executionData.stages = sqlStoreData.stages
           executionData.metricsValues = sqlStoreData.metricValues
-          executionData.endEvents = sqlStoreData.jobs.size + 1
+          executionData.endEvents.set(sqlStoreData.jobs.size + 1)
           liveExecutions.put(executionId, executionData)
           Some(executionData)
         } catch {
@@ -138,7 +139,7 @@ class SQLAppStatusListener(
           case _ => JobExecutionStatus.FAILED
         }
         exec.jobs = exec.jobs + (event.jobId -> result)
-        exec.endEvents += 1
+        exec.endEvents.incrementAndGet()
         update(exec)
       }
     }
@@ -324,12 +325,12 @@ class SQLAppStatusListener(
       update(exec)
 
       // Aggregating metrics can be expensive for large queries, so do it asynchronously. The end
-      // event count is updated after the "update()" call above, to ensure that the metrics are not
-      // cleaned up.
-      exec.endEvents += 1
+      // event count is updated after the metrics have been aggregated, to prevent a job end event
+      // arriving during aggregation from cleaning up the metrics data.
       kvstore.doAsync {
         exec.metricsValues = aggregateMetrics(exec)
         removeStaleMetricsData(exec)
+        exec.endEvents.incrementAndGet()
         update(exec, force = true)
       }
     }
@@ -368,7 +369,7 @@ class SQLAppStatusListener(
 
   private def update(exec: LiveExecutionData, force: Boolean = false): Unit = {
     val now = System.nanoTime()
-    if (exec.endEvents >= exec.jobs.size + 1) {
+    if (exec.endEvents.get() >= exec.jobs.size + 1) {
       exec.write(kvstore, now)
       removeStaleMetricsData(exec)
       liveExecutions.remove(exec.executionId)
@@ -420,7 +421,7 @@ private class LiveExecutionData(val executionId: Long) extends LiveEntity {
 
   // Just in case job end and execution end arrive out of order, keep track of how many
   // end events arrived so that the listener can stop tracking the execution.
-  var endEvents = 0
+  val endEvents = new AtomicInteger()
 
   override protected def doUpdate(): Any = {
     new SQLExecutionUIData(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListener.scala
@@ -323,11 +323,11 @@ class SQLAppStatusListener(
       exec.completionTime = Some(new Date(time))
       update(exec)
 
-      // Aggregating metrics can be expensive for large queries, so do it asynchronously.
-      // The end event count is also only updated asynchronously, to ensure that the metrics
-      // are not cleaned up by the update() call above.
+      // Aggregating metrics can be expensive for large queries, so do it asynchronously. The end
+      // event count is updated after the "update()" call above, to ensure that the metrics are not
+      // cleaned up.
+      exec.endEvents += 1
       kvstore.doAsync {
-        exec.endEvents += 1
         exec.metricsValues = aggregateMetrics(exec)
         removeStaleMetricsData(exec)
         update(exec, force = true)


### PR DESCRIPTION
This unblocks the event handling thread, which should help avoid dropped
events when large queries are running.

Existing unit tests should already cover this code.