### PR TITLE
[SPARK-29781][BUILD][2.4] Override SBT Jackson dependency like Maven

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -549,6 +549,7 @@ object DockerIntegrationTests {
 object DependencyOverrides {
   lazy val settings = Seq(
     dependencyOverrides += "com.google.guava" % "guava" % "14.0.1",
+    dependencyOverrides += "com.fasterxml.jackson.core"  % "jackson-databind" % "2.6.7.1",
     dependencyOverrides += "jline" % "jline" % "2.14.6")
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to override SBT `jackson-databind` dependency like Maven in `branch-2.4`.

### Why are the changes needed?

Without this, SBT and Maven works differently in `branch-2.4`. We had better fix this in `branch-2.4` because it's our LTS branch.

```
$ build/sbt -Phadoop-3.1 "core/testOnly *.ShuffleDependencySuite"
[info] ShuffleDependencySuite:
[info] org.apache.spark.shuffle.ShuffleDependencySuite *** ABORTED ***
...
[info]   Cause: com.fasterxml.jackson.databind.JsonMappingException: Incompatible Jackson version: 2.7.8
```

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Manually do `build/sbt -Phadoop-3.1 "core/testOnly *.ShuffleDependencySuite"`.
