### PR TITLE
[SPARK-28859][Core] Requires MEMORY_OFFHEAP_SIZE value must be > 0 when user specifies

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -254,7 +254,7 @@ package object config {
       "consumption must fit within some hard limit then be sure to shrink your JVM heap size " +
       "accordingly. This must be set to a positive value when spark.memory.offHeap.enabled=true.")
     .bytesConf(ByteUnit.BYTE)
-    .checkValue(_ > 0, "The off-heap memory size must not be negative")
+    .checkValue(_ > 0, "The off-heap memory size must be positive.")
     .createWithDefault(0)
 
   private[spark] val MEMORY_STORAGE_FRACTION = ConfigBuilder("spark.memory.storageFraction")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -254,7 +254,7 @@ package object config {
       "consumption must fit within some hard limit then be sure to shrink your JVM heap size " +
       "accordingly. This must be set to a positive value when spark.memory.offHeap.enabled=true.")
     .bytesConf(ByteUnit.BYTE)
-    .checkValue(_ >= 0, "The off-heap memory size must not be negative")
+    .checkValue(_ > 0, "The off-heap memory size must not be negative")
     .createWithDefault(0)
 
   private[spark] val MEMORY_STORAGE_FRACTION = ConfigBuilder("spark.memory.storageFraction")

--- a/core/src/test/scala/org/apache/spark/memory/UnifiedMemoryManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/memory/UnifiedMemoryManagerSuite.scala
@@ -309,6 +309,15 @@ class UnifiedMemoryManagerSuite extends MemoryManagerSuite with PrivateMethodTes
     mm.invokePrivate[Unit](assertInvariants())
   }
 
+  test("invalid MEMORY_OFFHEAP_SIZE") {
+    val conf = new SparkConf()
+      .set(MEMORY_OFFHEAP_SIZE, 0)
+    val exception = intercept[IllegalArgumentException] {
+      UnifiedMemoryManager(conf, numCores = 1)
+    }
+    assert(exception.getMessage.contains("The off-heap memory size must be positive."))
+  }
+
   test("not enough free memory in the storage pool --OFF_HEAP") {
     val conf = new SparkConf()
       .set(MEMORY_OFFHEAP_SIZE, 1000L)

--- a/core/src/test/scala/org/apache/spark/memory/UnifiedMemoryManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/memory/UnifiedMemoryManagerSuite.scala
@@ -309,15 +309,6 @@ class UnifiedMemoryManagerSuite extends MemoryManagerSuite with PrivateMethodTes
     mm.invokePrivate[Unit](assertInvariants())
   }
 
-  test("invalid MEMORY_OFFHEAP_SIZE") {
-    val conf = new SparkConf()
-      .set(MEMORY_OFFHEAP_SIZE, 0)
-    val exception = intercept[IllegalArgumentException] {
-      UnifiedMemoryManager(conf, numCores = 1)
-    }
-    assert(exception.getMessage.contains("The off-heap memory size must be positive."))
-  }
-
   test("not enough free memory in the storage pool --OFF_HEAP") {
     val conf = new SparkConf()
       .set(MEMORY_OFFHEAP_SIZE, 1000L)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove value check of `MEMORY_OFFHEAP_SIZE` in declaration section. https://issues.apache.org/jira/browse/SPARK-28859

Required user to provide a value larger than 0 when specifying `MEMORY_OFFHEAP_SIZE`.

### Why are the changes needed?
In MemoryManager.scala Line 229, we validate that `MEMORY_OFFHEAP_SIZE` is > 0 if `MEMORY_OFFHEAP_ENABLED` is true.
For consistency, we should require the user to specify a value > 0.

### Does this PR introduce any user-facing change?
Yes, the user will need to provide values > 0 for `MEMORY_OFFHEAP_SIZE` in config.


### How was this patch tested?
Added unit test that checks the value is validated.
