### PR TITLE
[SPARK-29769][SQL] Support non-correlate "exists/not exists" condition as all type Join's on condition

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1315,11 +1315,7 @@ object PushPredicateThroughJoin extends Rule[LogicalPlan] with PredicateHelper {
         val (leftEvaluateCondition, commonCondition) =
           rest.partition(expr => expr.references.subsetOf(left.outputSet))
         (leftEvaluateCondition, rightEvaluateCondition, commonCondition ++ nonDeterministic)
-      case FullOuter =>
-        val (bothEvaluateCondition, commonCondition) =
-          pushDownCandidates.partition(cond =>
-            cond.references.subsetOf(left.outputSet) && cond.references.subsetOf(right.outputSet))
-        (bothEvaluateCondition, bothEvaluateCondition, commonCondition)
+      case FullOuter => (null, null, null)
       case NaturalJoin(_) => (null, null, null)
       case UsingJoin(_, _) => (null, null, null)
     }
@@ -1406,12 +1402,7 @@ object PushPredicateThroughJoin extends Rule[LogicalPlan] with PredicateHelper {
 
           Join(newLeft, newRight, joinType, newJoinCond, hint)
         case FullOuter =>
-          val newLeft = leftJoinConditions.
-            reduceLeftOption(And).map(Filter(_, left)).getOrElse(left)
-          val newRight = rightJoinConditions.
-            reduceLeftOption(And).map(Filter(_, right)).getOrElse(right)
-          val newJoinCond = commonJoinCondition.reduceLeftOption(And)
-          Join(newLeft, newRight, FullOuter, newJoinCond, hint)
+          j
         case NaturalJoin(_) => sys.error("Untransformed NaturalJoin node")
         case UsingJoin(_, _) => sys.error("Untransformed Using join node")
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -380,6 +380,15 @@ class SubquerySuite extends QueryTest with SharedSparkSession {
       checkAnswer(
         sql(
           """
+            | SELECT s1.id, s2.id as id2 FROM s1
+            | RIGHT OUTER JOIN  s2 ON s1.id = s2.id
+            | AND NOT EXISTS (SELECT * from s3 where s3.id > 6)
+          """.stripMargin),
+        Row(null, 1) :: Row(null, 3) :: Row(null, 4) :: Row(null, 6) :: Row(null, 9) :: Nil)
+
+      checkAnswer(
+        sql(
+          """
             | SELECT s1.id FROM s1
             | LEFT SEMI JOIN  s2 ON s1.id = s2.id
             | AND EXISTS (SELECT * from s3 where s3.id > 6)
@@ -390,10 +399,28 @@ class SubquerySuite extends QueryTest with SharedSparkSession {
         sql(
           """
             | SELECT s1.id FROM s1
+            | LEFT SEMI JOIN  s2 ON s1.id = s2.id
+            | AND NOT EXISTS (SELECT * from s3 where s3.id > 6)
+          """.stripMargin),
+      Nil)
+
+      checkAnswer(
+        sql(
+          """
+            | SELECT s1.id FROM s1
             | LEFT ANTI JOIN  s2 ON s1.id = s2.id
             | AND EXISTS (SELECT * from s3 where s3.id > 6)
           """.stripMargin),
         Row(5) :: Row(7) :: Nil)
+
+      checkAnswer(
+        sql(
+          """
+            | SELECT s1.id FROM s1
+            | LEFT ANTI JOIN  s2 ON s1.id = s2.id
+            | AND NOT EXISTS (SELECT * from s3 where s3.id > 6)
+          """.stripMargin),
+        Row(1) :: Row(3):: Row(5) :: Row(7) :: Row(9) :: Nil)
 
       checkAnswer(
         sql(
@@ -408,11 +435,10 @@ class SubquerySuite extends QueryTest with SharedSparkSession {
         sql(
           """
             | SELECT s1.id, s2.id as id2 FROM s1
-            | FULL OUTER JOIN  s2 ON s1.id = s2.id
-            | AND EXISTS (SELECT * from s3 where s3.id > 6)
+            | LEFT OUTER JOIN s2 ON s1.id = s2.id
+            | AND NOT EXISTS (SELECT * from s3 where s3.id > 6)
           """.stripMargin),
-        Row(1, 1) :: Row(3, 3) :: Row(5, null) :: Row(7, null) ::
-          Row(null, 4) :: Row(null, 6) :: Row(9, 9) :: Nil)
+        Row(1, null) :: Row(3, null) :: Row(5, null) :: Row(7, null) :: Row(9, null) :: Nil)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -352,6 +352,71 @@ class SubquerySuite extends QueryTest with SharedSparkSession {
     }
   }
 
+
+  test("SPARK-29769: JOIN Condition use EXISTS/NOT EXISTS") {
+    withTempView("s1", "s2", "s3") {
+      Seq(1, 3, 5, 7, 9).toDF("id").createOrReplaceTempView("s1")
+      Seq(1, 3, 4, 6, 9).toDF("id").createOrReplaceTempView("s2")
+      Seq(3, 4, 6, 9).toDF("id").createOrReplaceTempView("s3")
+
+      checkAnswer(
+        sql(
+          """
+            | SELECT s1.id FROM s1
+            | JOIN s2 ON s1.id = s2.id
+            | AND EXISTS (SELECT * from s3 where s3.id > 6)
+          """.stripMargin),
+        Row(1) :: Row(3) :: Row(9) :: Nil)
+
+      checkAnswer(
+        sql(
+          """
+            | SELECT s1.id, s2.id as id2 FROM s1
+            | RIGHT OUTER JOIN  s2 ON s1.id = s2.id
+            | AND EXISTS (SELECT * from s3 where s3.id > 6)
+          """.stripMargin),
+        Row(1, 1) :: Row(3, 3) :: Row(null, 4) :: Row(null, 6) :: Row(9, 9) :: Nil)
+
+      checkAnswer(
+      sql(
+        """
+          | SELECT s1.id FROM s1
+          | LEFT SEMI JOIN  s2 ON s1.id = s2.id
+          | AND EXISTS (SELECT * from s3 where s3.id > 6)
+        """.stripMargin),
+        Row(1) :: Row(3) :: Row(9) :: Nil)
+
+      checkAnswer(
+        sql(
+          """
+            | SELECT s1.id FROM s1
+            | LEFT ANTI JOIN  s2 ON s1.id = s2.id
+            | AND EXISTS (SELECT * from s3 where s3.id > 6)
+          """.stripMargin),
+        Row(5) :: Row(7) :: Nil)
+
+
+      checkAnswer(
+        sql(
+          """
+            | SELECT s1.id, s2.id as id2 FROM s1
+            | LEFT OUTER JOIN s2 ON s1.id = s2.id
+            | AND EXISTS (SELECT * from s3 where s3.id > 6)
+          """.stripMargin),
+        Row(1, 1) :: Row(3, 3) :: Row(5, null) :: Row(7, null) :: Row(9, 9) :: Nil)
+
+
+      checkAnswer(
+        sql(
+          """
+            | SELECT s1.id, s2.id as id2 FROM s1
+            | FULL OUTER JOIN  s2 ON s1.id = s2.id
+            | AND EXISTS (SELECT * from s3 where s3.id > 6)
+          """.stripMargin),
+        Row(1, 1) :: Row(3, 3) :: Row(5, null) :: Row(7, null) :: Row(null, 4) :: Row(null, 6) :: Row(9, 9) :: Nil)
+    }
+  }
+
   test("SPARK-14791: scalar subquery inside broadcast join") {
     val df = sql("select a, sum(b) as s from l group by a having a > (select avg(a) from l)")
     val expected = Row(3, 2.0, 3, 3.0) :: Row(6, null, 6, null) :: Nil

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -378,12 +378,12 @@ class SubquerySuite extends QueryTest with SharedSparkSession {
         Row(1, 1) :: Row(3, 3) :: Row(null, 4) :: Row(null, 6) :: Row(9, 9) :: Nil)
 
       checkAnswer(
-      sql(
-        """
-          | SELECT s1.id FROM s1
-          | LEFT SEMI JOIN  s2 ON s1.id = s2.id
-          | AND EXISTS (SELECT * from s3 where s3.id > 6)
-        """.stripMargin),
+        sql(
+          """
+            | SELECT s1.id FROM s1
+            | LEFT SEMI JOIN  s2 ON s1.id = s2.id
+            | AND EXISTS (SELECT * from s3 where s3.id > 6)
+          """.stripMargin),
         Row(1) :: Row(3) :: Row(9) :: Nil)
 
       checkAnswer(
@@ -394,7 +394,7 @@ class SubquerySuite extends QueryTest with SharedSparkSession {
             | AND EXISTS (SELECT * from s3 where s3.id > 6)
           """.stripMargin),
         Row(5) :: Row(7) :: Nil)
-      
+
       checkAnswer(
         sql(
           """

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -394,8 +394,7 @@ class SubquerySuite extends QueryTest with SharedSparkSession {
             | AND EXISTS (SELECT * from s3 where s3.id > 6)
           """.stripMargin),
         Row(5) :: Row(7) :: Nil)
-
-
+      
       checkAnswer(
         sql(
           """
@@ -405,7 +404,6 @@ class SubquerySuite extends QueryTest with SharedSparkSession {
           """.stripMargin),
         Row(1, 1) :: Row(3, 3) :: Row(5, null) :: Row(7, null) :: Row(9, 9) :: Nil)
 
-
       checkAnswer(
         sql(
           """
@@ -413,7 +411,8 @@ class SubquerySuite extends QueryTest with SharedSparkSession {
             | FULL OUTER JOIN  s2 ON s1.id = s2.id
             | AND EXISTS (SELECT * from s3 where s3.id > 6)
           """.stripMargin),
-        Row(1, 1) :: Row(3, 3) :: Row(5, null) :: Row(7, null) :: Row(null, 4) :: Row(null, 6) :: Row(9, 9) :: Nil)
+        Row(1, 1) :: Row(3, 3) :: Row(5, null) :: Row(7, null) ::
+          Row(null, 4) :: Row(null, 6) :: Row(9, 9) :: Nil)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
As I show in https://issues.apache.org/jira/browse/SPARK-29769
we can't use `EXISTS/NOT EXISTS` as on condition in `LEFTE OUTER JOIN/ FULL OUTER JOIN / LEFT ANTI JOIN` 
This pr is to support this. 



### Why are the changes needed?
Support EXISTS/NOT EXISTS  as join's on condition


### Does this PR introduce any user-facing change?
People can use exits like 
```
SELECT s1.id FROM s1
LEFT OUTER  JOIN s2 ON s1.id = s2.id
 AND EXISTS (SELECT * from s3 where s3.id > 6)

SELECT s1.id FROM s1
RIGHT OUTER JOIN  s2 ON s1.id = s2.id
AND EXISTS (SELECT * from s3 where s3.id > 6)

SELECT s1.id FROM s1
LEFT SEMI  JOIN s2 ON s1.id = s2.id
AND EXISTS (SELECT * from s3 where s3.id > 6)


SELECT s1.id FROM s1
LEFT ANTI  JOIN s2 ON s1.id = s2.id
AND EXISTS (SELECT * from s3 where s3.id > 6)

SELECT s1.id FROM s1
FULL OUTER JOIN  s2 ON s1.id = s2.id
AND EXISTS (SELECT * from s3 where s3.id > 6)
```


### How was this patch tested?
Added UT
