### PR TITLE
[SPARK-29771][K8S] Add configure to limit executor failures

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1074,6 +1074,13 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
 </tr>
 <tr>
+  <td><code>spark.kubernetes.max.executor.failure</code></td>
+  <td>numExecutors * 2, with minimum of 3</td>
+  <td>
+    The maximum number of executor failures before failing the application.
+  </td>
+</tr>
+<tr>
   <td><code>spark.kubernetes.submission.connectionTimeout</code></td>
   <td>10000</td>
   <td>

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1074,7 +1074,7 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
 </tr>
 <tr>
-  <td><code>spark.kubernetes.max.executor.failure</code></td>
+  <td><code>spark.kubernetes.max.executor.failures</code></td>
   <td>numExecutors * 2, with minimum of 3</td>
   <td>
     The maximum number of executor failures before failing the application.

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -188,6 +188,12 @@ private[spark] object Config extends Logging {
       .checkValue(value => value > 0, "Allocation batch delay must be a positive time value.")
       .createWithDefaultString("1s")
 
+  val KUBERNETES_MAX_EXECUTOR_FAILURES =
+    ConfigBuilder("spark.kubernetes.max.executor.failures")
+      .doc("")
+      .intConf
+      .createOptional
+
   val KUBERNETES_EXECUTOR_LOST_REASON_CHECK_MAX_ATTEMPTS =
     ConfigBuilder("spark.kubernetes.executor.lostCheck.maxAttempts")
       .doc("Maximum number of attempts allowed for checking the reason of an executor loss " +

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -190,7 +190,7 @@ private[spark] object Config extends Logging {
 
   val KUBERNETES_MAX_EXECUTOR_FAILURES =
     ConfigBuilder("spark.kubernetes.max.executor.failures")
-      .doc("")
+      .doc("The maximum number of executor failures before failing the application.")
       .intConf
       .createOptional
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
@@ -130,7 +130,7 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
 
   test("SPARK-29771: shutdown application while too many executors failed.") {
     // define a NoExitSecurityManager to capture System.exit
-    case class ExitException(status: Int) extends SecurityException("There is no escape!")
+    case class ExitException(status: Int) extends SecurityException("No escape")
     class NoExitSecurityManager extends java.lang.SecurityManager {
       override def checkPermission(perm: Permission): Unit = {}
       override def checkExit(status: Int): Unit = throw ExitException(status)
@@ -150,7 +150,7 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     } catch {
       case e: ExitException =>
         assert(podsAllocatorUnderTest.EXIT_MAX_EXECUTOR_FAILURES == e.status,
-          s"exit num show be ${podsAllocatorUnderTest.EXIT_MAX_EXECUTOR_FAILURES}")
+          s"Exit status should be ${podsAllocatorUnderTest.EXIT_MAX_EXECUTOR_FAILURES}")
     } finally {
       // reset SecurityManager
       System.setSecurityManager(preSecurityManager)


### PR DESCRIPTION
 ### What changes were proposed in this pull request?
ExecutorPodsAllocator does not limit the number of executor errors or deletions, which may cause executor restart continuously without application failure.
A simple example for this, add `--conf spark.executor.extraJavaOptions=-Xmse` after spark-submit, which can make executor restart thousands of times without application failure.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Run suites and add suite test
