### PR TITLE
[SPARK-29821][SQL] Allow calling non-aggregate SQL functions with column name

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -513,6 +513,8 @@ def isnan(col):
     [Row(r1=False, r2=False), Row(r1=True, r2=True)]
     """
     sc = SparkContext._active_spark_context
+    if type(col) is str:
+        return Column(sc._jvm.functions.isnan(col))
     return Column(sc._jvm.functions.isnan(_to_java_column(col)))
 
 
@@ -525,6 +527,8 @@ def isnull(col):
     [Row(r1=False, r2=False), Row(r1=True, r2=True)]
     """
     sc = SparkContext._active_spark_context
+    if type(col) is str:
+        return Column(sc._jvm.functions.isnull(col))
     return Column(sc._jvm.functions.isnull(_to_java_column(col)))
 
 
@@ -577,6 +581,8 @@ def nanvl(col1, col2):
     [Row(r1=1.0, r2=1.0), Row(r1=2.0, r2=2.0)]
     """
     sc = SparkContext._active_spark_context
+    if type(col1) is str and type(col2) is str:
+        return Column(sc._jvm.functions.nanvl(col1, col2))
     return Column(sc._jvm.functions.nanvl(_to_java_column(col1), _to_java_column(col2)))
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -1083,12 +1083,28 @@ object functions {
   def isnan(e: Column): Column = withExpr { IsNaN(e.expr) }
 
   /**
+   * Return true iff the column is NaN.
+   *
+   * @group normal_funcs
+   * @since 1.6.0
+   */
+  def isnan(columnName: String): Column = isnan(Column(columnName))
+
+  /**
    * Return true iff the column is null.
    *
    * @group normal_funcs
    * @since 1.6.0
    */
   def isnull(e: Column): Column = withExpr { IsNull(e.expr) }
+
+  /**
+   * Return true iff the column is null.
+   *
+   * @group normal_funcs
+   * @since 1.6.0
+   */
+  def isnull(columnName: String): Column = isnull(Column(columnName))
 
   /**
    * A column expression that generates monotonically increasing 64-bit integers.
@@ -1121,6 +1137,16 @@ object functions {
   def nanvl(col1: Column, col2: Column): Column = withExpr { NaNvl(col1.expr, col2.expr) }
 
   /**
+   * Returns col1 if it is not NaN, or col2 if col1 is NaN.
+   *
+   * Both inputs should be floating point columns (DoubleType or FloatType).
+   *
+   * @group normal_funcs
+   * @since 1.5.0
+   */
+  def nanvl(col1Name: String, col2Name: String): Column = nanvl(Column(col1Name), Column(col2Name))
+
+  /**
    * Unary minus, i.e. negate the expression.
    * {{{
    *   // Select the amount column and negates all values.
@@ -1137,6 +1163,22 @@ object functions {
   def negate(e: Column): Column = -e
 
   /**
+   * Unary minus, i.e. negate the expression.
+   * {{{
+   *   // Select the amount column and negates all values.
+   *   // Scala:
+   *   df.select( -df("amount") )
+   *
+   *   // Java:
+   *   df.select( negate(df.col("amount")) );
+   * }}}
+   *
+   * @group normal_funcs
+   * @since 1.3.0
+   */
+  def negate(columnName: String): Column = negate(Column(columnName))
+
+  /**
    * Inversion of boolean expression, i.e. NOT.
    * {{{
    *   // Scala: select rows that are not active (isActive === false)
@@ -1150,6 +1192,21 @@ object functions {
    * @since 1.3.0
    */
   def not(e: Column): Column = !e
+
+  /**
+   * Inversion of boolean expression, i.e. NOT.
+   * {{{
+   *   // Scala: select rows that are not active (isActive === false)
+   *   df.filter( !df("isActive") )
+   *
+   *   // Java:
+   *   df.filter( not(df.col("isActive")) );
+   * }}}
+   *
+   * @group normal_funcs
+   * @since 1.3.0
+   */
+  def not(columnName: String): Column = not(Column(columnName))
 
   /**
    * Generate a random column with independent and identically distributed (i.i.d.) samples
@@ -1277,6 +1334,14 @@ object functions {
    * @since 1.4.0
    */
   def bitwiseNOT(e: Column): Column = withExpr { BitwiseNot(e.expr) }
+
+  /**
+   * Computes bitwise NOT (~) of a number.
+   *
+   * @group normal_funcs
+   * @since 1.4.0
+   */
+  def bitwiseNOT(columnName: String): Column = bitwiseNOT(Column(columnName))
 
   /**
    * Parses the expression string into the column that it represents, similar to


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
I added functions that can be called with the column name for the functions in the non-aggregate functions section of `functions.scala`.

* `isnan(columnName: String): Column`
* `isnull(columnName: String): Column`
* `nanvl(col1Name: String, col2Name: String): Column`
* `negate(columnName: String): Column`
* `not(columnName: String): Column`
* `bitwiseNOT(columnName: String): Column `

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This pull requests makes it possible to check for nan values in the column `x` by calling `isnan("x")`, instead of `isnan($"x")`. PySpark: `isnan("x")`, instead of `isnan(col("x"))`. This way, users don't need to remember to transform the value to a column. This makes it consistent with other functions such as `sqrt` that can already be called with the column name.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
Yes
See previous section.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I couldn't find a test file, where sql functions and pyspark sql functions are tested. Please point me in the right direction.