### PR TITLE
[SPARK-29528][BUILD] Upgrade scala-maven-plugin to 4.3.0 for Scala 2.13.1

### DIFF
--- a/R/README.md
+++ b/R/README.md
@@ -1,4 +1,4 @@
-# R on Spark
+# R on Spark!
 
 SparkR is an R package that provides a light-weight frontend to use Spark from R.
 

--- a/R/README.md
+++ b/R/README.md
@@ -1,4 +1,4 @@
-# R on Spark!
+# R on Spark
 
 SparkR is an R package that provides a light-weight frontend to use Spark from R.
 

--- a/pom.xml
+++ b/pom.xml
@@ -2241,7 +2241,7 @@
         <plugin>
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
-          <version>4.2.0</version>
+          <version>4.3.0</version>
           <executions>
             <execution>
               <id>eclipse-add-source</id>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `scala-maven-plugin` to `4.3.0` for Scala `2.13.1`.
We tried 4.2.4, but it's reverted due to Windows build issue. Now, `4.3.0` has a Window fix.

### Why are the changes needed?
Scala 2.13.1 seems to break the binary compatibility.

We need to upgrade `scala-maven-plugin` to bring the the following fixes for the latest Scala 2.13.1.
- https://github.com/davidB/scala-maven-plugin/issues/363
- https://github.com/sbt/zinc/issues/698

Also, `4.3.0` has the following Window fix.
- https://github.com/davidB/scala-maven-plugin/issues/370 (4.2.4 throws error on Windows)

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

- For now, we don't support Scala-2.13. This PR at least needs to pass the existing Jenkins with Maven to get prepared for Scala-2.13.
- `AppVeyor` passed. (https://ci.appveyor.com/project/ApacheSoftwareFoundation/spark/builds/28745383)