### PR TITLE
[SPARK-29820][INFRA][FOLLOWUP][2.4] Use scala version instead of java version

### DIFF
--- a/.github/workflows/branch-2.4.yml
+++ b/.github/workflows/branch-2.4.yml
@@ -24,15 +24,15 @@ jobs:
     - uses: actions/cache@v1
       with:
         path: ~/.m2/repository/com
-        key: ${{ matrix.java }}-${{ matrix.hadoop }}-maven-com-${{ hashFiles('**/pom.xml') }}
+        key: ${{ matrix.scala }}-${{ matrix.hadoop }}-maven-com-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ matrix.java }}-${{ matrix.hadoop }}-maven-com-
+          ${{ matrix.scala }}-${{ matrix.hadoop }}-maven-com-
     - uses: actions/cache@v1
       with:
         path: ~/.m2/repository/org
-        key: ${{ matrix.java }}-${{ matrix.hadoop }}-maven-org-${{ hashFiles('**/pom.xml') }}
+        key: ${{ matrix.scala }}-${{ matrix.hadoop }}-maven-org-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ matrix.java }}-${{ matrix.hadoop }}-maven-org-
+          ${{ matrix.scala }}-${{ matrix.hadoop }}-maven-org-
     - name: Set up JDK 8
       uses: actions/setup-java@v1
       with:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a followup to fix the cache key to use `scala` version instead of `java` version in `branch-2.4`.

### Why are the changes needed?

In `branch-2.4`, we have different build combinations.

**Before**
```
Cache not found for input keys: -hadoop-2.6-maven-com-73f091c178d11734dd9a888d0c5d208d72850eefd9db3821d806518289c61371, -hadoop-2.6-maven-com-.
```
**After**
```
Cache not found for input keys: 2.11-hadoop-2.6-maven-com-73f091c178d11734dd9a888d0c5d208d72850eefd9db3821d806518289c61371, 2.11-hadoop-2.6-maven-com-.
```

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Manually check the log of GitHub Action of this PR.