### PR TITLE
[SPARK-29831][SQL] Scan Hive partitioned table should not dramatically increase data parallelism

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -155,6 +155,16 @@ private[spark] object HiveUtils extends Logging {
     .booleanConf
     .createWithDefault(true)
 
+  val HIVE_TABLE_SCAN_MAX_PARALLELISM = buildConf("spark.sql.hive.tableScan.maxParallelism")
+    .doc("When reading Hive partitioned table, the default parallelism is the sum of Hive " +
+      "partition RDDs' parallelism. For Hive table of many partitions with many files, " +
+      "the parallelism could be very big and not good for Spark job scheduling. This optional " +
+      "config can set a maximum parallelism for reading Hive partitioned table. If the result " +
+      "RDD of reading such table is larger than this value, Spark will reduce the partition " +
+      "number by doing a coalesce on the RDD.")
+    .intConf
+    .createOptional
+
   /**
    * The version of the hive client that will be used to communicate with the metastore.  Note that
    * this does not necessarily need to be the same version of Hive that is used internally by


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Hive table scan operator reads each Hive partition as a HadoopRDD and unions all RDDs. The data parallelism of the result RDD can be dramatically increased, when reading a lot of partitions with a lot of files.

This patch proposes to add a config to limit the maximum of the data parallelism for scanning Hive partitioned table, when we can not convert the Hive table to datasource table.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Although users can also do coalesce by themselves, this patch proposes to add a config to limit the maximum of the data parallelism. Because:

1. end-users might not understand details and get confused by big partition number. end-users might not know why/when/where to add coalesce.
2. end-users need to add coalesce to each time Hive table scan. It is annoying. From the perspective of of cluster operator, it is much easier to config instead of asking each end-users to know the details and add coalesce.

Although we convert Hive table scan to datasource table scan most of time, we still have some inconvertible tables. For datasource table scan node, the parallelism is controlled by configs `spark.default.parallelism` and `spark.sql.files.maxPartitionBytes`.

But for Hive table scan node, we have nothing to control it.

So currently, when reading datasource table, end-users do not worry parallelism. When reading Hive table, end-users need to add custom coalesce hints if big parallelism is seen.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

No, if not set the config.

If set a maximum value by the config, when scanning Hive partitioned table, once the number of partitions exceeds the maximum, Spark coalesces the result RDD.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
