### PR TITLE
[SPARK-27042][SS] Invalidate cached Kafka producer in case of task retry

### DIFF
--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/CachedKafkaProducer.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/CachedKafkaProducer.scala
@@ -94,7 +94,7 @@ private[kafka010] object CachedKafkaProducer extends Logging {
         .build()
     val key = toCacheKey(updatedKafkaParams)
     if (TaskContext.get != null && TaskContext.get.attemptNumber >= 1) {
-      logDebug(s"Task re-attempt detected, invalidating producers with key $key")
+      logDebug(s"Invalidating key $key")
       producerPool.invalidateKey(key)
     }
     producerPool.borrowObject(key, updatedKafkaParams)

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaDataConsumer.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaDataConsumer.scala
@@ -628,6 +628,8 @@ private[kafka010] object KafkaDataConsumer extends Logging {
     if (TaskContext.get != null && TaskContext.get.attemptNumber >= 1) {
       val cacheKey = new CacheKey(topicPartition, kafkaParams)
 
+      logDebug(s"Task re-attempt detected, invalidating consumers with key $cacheKey")
+
       // If this is reattempt at running the task, then invalidate cached consumer if any.
       consumerPool.invalidateKey(cacheKey)
 

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaDataConsumer.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaDataConsumer.scala
@@ -627,8 +627,7 @@ private[kafka010] object KafkaDataConsumer extends Logging {
       kafkaParams: ju.Map[String, Object]): KafkaDataConsumer = {
     if (TaskContext.get != null && TaskContext.get.attemptNumber >= 1) {
       val cacheKey = new CacheKey(topicPartition, kafkaParams)
-
-      logDebug(s"Task re-attempt detected, invalidating consumers with key $cacheKey")
+      logDebug(s"Invalidating key $cacheKey")
 
       // If this is reattempt at running the task, then invalidate cached consumer if any.
       consumerPool.invalidateKey(cacheKey)


### PR DESCRIPTION
### What changes were proposed in this pull request?
If a task is failing due to a corrupt cached Kafka producer and the task is retried in the same executor, then the task may get the same producer over and over again. After several retries the query may stop.

In this PR I'm invalidating the old cached producers for a specific key and re-opening a new one. This will reduce the possibility of a faulty producer re-use. It must be mentioned if a producer under the key is used by another task, then in won't be closed. The functionality is similar to the consumer side [here](https://github.com/apache/spark/blob/d06a9cc4bdcc1fb330f50daf219e9e8d908a16c4/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaDataConsumer.scala#L628).

### Why are the changes needed?
Increase producer side availability.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
Existing + additional unit tests.
