### PR TITLE
[SPARK-29853][SQL]lpad returning empty instead of NULL for empty pad …

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -882,7 +882,10 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
    */
   public UTF8String lpad(int len, UTF8String pad) {
     int spaces = len - this.numChars(); // number of char need to pad
-    if (spaces <= 0 || pad.numBytes() == 0) {
+    if (len > 0 && pad.numBytes() == 0) {
+      // no padding at all, return the null
+      return null;
+    } else if (spaces <= 0) {
       // no padding at all, return the substring of the current string
       return substring(0, len);
     } else {

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
@@ -361,9 +361,9 @@ public class UTF8StringSuite {
 
     assertEquals(EMPTY_UTF8, fromString("数据砖头").lpad(-10, fromString("孙行者")));
     assertEquals(EMPTY_UTF8, fromString("数据砖头").lpad(-10, EMPTY_UTF8));
-    assertEquals(fromString("数据砖头"), fromString("数据砖头").lpad(5, EMPTY_UTF8));
-    assertEquals(fromString("数据砖"), fromString("数据砖头").lpad(3, EMPTY_UTF8));
-    assertEquals(EMPTY_UTF8, EMPTY_UTF8.lpad(3, EMPTY_UTF8));
+    assertEquals(fromString(null), fromString("数据砖头").lpad(5, EMPTY_UTF8));
+    assertEquals(fromString(null), fromString("数据砖头").lpad(3, EMPTY_UTF8));
+    assertEquals(fromString(null), EMPTY_UTF8.lpad(3, EMPTY_UTF8));
 
     assertEquals(EMPTY_UTF8, fromString("数据砖头").rpad(-10, fromString("孙行者")));
     assertEquals(EMPTY_UTF8, fromString("数据砖头").rpad(-10, EMPTY_UTF8));


### PR DESCRIPTION
### What changes were proposed in this pull request?
lpad returning NULL instead of empty for empty pad value.

### Why are the changes needed?
Need to add check-point if padding string is empty and require length is greater then zero.

### Does this PR introduce any user-facing change?
NO

### How was this patch tested?
Old unit tests correct as per this jira.
