### PR TITLE
[SPARK-29867][ML][PYTHON] Add __repr__ in Python ML Models

### DIFF
--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -192,11 +192,11 @@ class LinearSVC(JavaClassifier, _LinearSVCParams, JavaMLWritable, JavaMLReadable
     0.01
     >>> model = svm.fit(df)
     >>> model.setPredictionCol("newPrediction")
-    LinearSVC...
+    LinearSVCModel...
     >>> model.getPredictionCol()
     'newPrediction'
     >>> model.setThreshold(0.5)
-    LinearSVC...
+    LinearSVCModel...
     >>> model.getThreshold()
     0.5
     >>> model.coefficients
@@ -355,6 +355,9 @@ class LinearSVCModel(JavaClassificationModel, _LinearSVCParams, JavaMLWritable, 
         Model intercept of Linear SVM Classifier.
         """
         return self._call_java("intercept")
+
+    def __repr__(self):
+        return self._call_java("toString")
 
 
 class _LogisticRegressionParams(_JavaProbabilisticClassifierParams, HasRegParam,
@@ -1921,7 +1924,7 @@ class NaiveBayes(JavaProbabilisticClassifier, _NaiveBayesParams, HasThresholds, 
     >>> nb = NaiveBayes(smoothing=1.0, modelType="multinomial", weightCol="weight")
     >>> model = nb.fit(df)
     >>> model.setFeaturesCol("features")
-    NaiveBayes_...
+    NaiveBayesModel...
     >>> model.getSmoothing()
     1.0
     >>> model.pi
@@ -2040,6 +2043,9 @@ class NaiveBayesModel(JavaProbabilisticClassificationModel, _NaiveBayesParams, J
         """
         return self._call_java("theta")
 
+    def __repr__(self):
+        return self._call_java("toString")
+
 
 class _MultilayerPerceptronParams(_JavaProbabilisticClassifierParams, HasSeed, HasMaxIter,
                                   HasTol, HasStepSize, HasSolver):
@@ -2114,7 +2120,7 @@ class MultilayerPerceptronClassifier(JavaProbabilisticClassifier, _MultilayerPer
     100
     >>> model = mlp.fit(df)
     >>> model.setFeaturesCol("features")
-    MultilayerPerceptronClassifier...
+    MultilayerPerceptronClassificationModel...
     >>> model.layers
     [2, 2, 2]
     >>> model.weights.size
@@ -2267,6 +2273,9 @@ class MultilayerPerceptronClassificationModel(JavaProbabilisticClassificationMod
         the weights of layers.
         """
         return self._call_java("weights")
+
+    def __repr__(self):
+        return self._call_java("toString")
 
 
 class _OneVsRestParams(_JavaClassifierParams, HasWeightCol):

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -356,9 +356,6 @@ class LinearSVCModel(JavaClassificationModel, _LinearSVCParams, JavaMLWritable, 
         """
         return self._call_java("intercept")
 
-    def __repr__(self):
-        return self._call_java("toString")
-
 
 class _LogisticRegressionParams(_JavaProbabilisticClassifierParams, HasRegParam,
                                 HasElasticNetParam, HasMaxIter, HasFitIntercept, HasTol,
@@ -814,9 +811,6 @@ class LogisticRegressionModel(JavaProbabilisticClassificationModel, _LogisticReg
             raise ValueError("dataset must be a DataFrame but got %s." % type(dataset))
         java_blr_summary = self._call_java("evaluate", dataset)
         return BinaryLogisticRegressionSummary(java_blr_summary)
-
-    def __repr__(self):
-        return self._call_java("toString")
 
 
 class LogisticRegressionSummary(JavaWrapper):
@@ -2043,9 +2037,6 @@ class NaiveBayesModel(JavaProbabilisticClassificationModel, _NaiveBayesParams, J
         """
         return self._call_java("theta")
 
-    def __repr__(self):
-        return self._call_java("toString")
-
 
 class _MultilayerPerceptronParams(_JavaProbabilisticClassifierParams, HasSeed, HasMaxIter,
                                   HasTol, HasStepSize, HasSolver):
@@ -2273,9 +2264,6 @@ class MultilayerPerceptronClassificationModel(JavaProbabilisticClassificationMod
         the weights of layers.
         """
         return self._call_java("weights")
-
-    def __repr__(self):
-        return self._call_java("toString")
 
 
 class _OneVsRestParams(_JavaClassifierParams, HasWeightCol):

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -191,9 +191,6 @@ class GaussianMixtureModel(JavaModel, _GaussianMixtureParams, JavaMLWritable, Ja
         """
         return self._call_java("predictProbability", value)
 
-    def __repr__(self):
-        return self._call_java("toString")
-
 
 @inherit_doc
 class GaussianMixture(JavaEstimator, _GaussianMixtureParams, JavaMLWritable, JavaMLReadable):
@@ -512,9 +509,6 @@ class KMeansModel(JavaModel, _KMeansParams, GeneralJavaMLWritable, JavaMLReadabl
         """
         return self._call_java("predict", value)
 
-    def __repr__(self):
-        return self._call_java("toString")
-
 
 @inherit_doc
 class KMeans(JavaEstimator, _KMeansParams, JavaMLWritable, JavaMLReadable):
@@ -767,9 +761,6 @@ class BisectingKMeansModel(JavaModel, _BisectingKMeansParams, JavaMLWritable, Ja
         Predict label for the given features.
         """
         return self._call_java("predict", value)
-
-    def __repr__(self):
-        return self._call_java("toString")
 
 
 @inherit_doc
@@ -1160,9 +1151,6 @@ class LDAModel(JavaModel, _LDAParams):
         then this returns the fixed (given) value for the :py:attr:`LDA.docConcentration` parameter.
         """
         return self._call_java("estimatedDocConcentration")
-
-    def __repr__(self):
-        return self._call_java("toString")
 
 
 @inherit_doc

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -191,6 +191,9 @@ class GaussianMixtureModel(JavaModel, _GaussianMixtureParams, JavaMLWritable, Ja
         """
         return self._call_java("predictProbability", value)
 
+    def __repr__(self):
+        return self._call_java("toString")
+
 
 @inherit_doc
 class GaussianMixture(JavaEstimator, _GaussianMixtureParams, JavaMLWritable, JavaMLReadable):
@@ -234,7 +237,7 @@ class GaussianMixture(JavaEstimator, _GaussianMixtureParams, JavaMLWritable, Jav
     >>> model.getFeaturesCol()
     'features'
     >>> model.setPredictionCol("newPrediction")
-    GaussianMixture...
+    GaussianMixtureModel...
     >>> model.predict(df.head().features)
     2
     >>> model.predictProbability(df.head().features)
@@ -509,6 +512,9 @@ class KMeansModel(JavaModel, _KMeansParams, GeneralJavaMLWritable, JavaMLReadabl
         """
         return self._call_java("predict", value)
 
+    def __repr__(self):
+        return self._call_java("toString")
+
 
 @inherit_doc
 class KMeans(JavaEstimator, _KMeansParams, JavaMLWritable, JavaMLReadable):
@@ -532,7 +538,7 @@ class KMeans(JavaEstimator, _KMeansParams, JavaMLWritable, JavaMLReadable):
     >>> model.getDistanceMeasure()
     'euclidean'
     >>> model.setPredictionCol("newPrediction")
-    KMeans...
+    KMeansModel...
     >>> model.predict(df.head().features)
     0
     >>> centers = model.clusterCenters()
@@ -762,6 +768,9 @@ class BisectingKMeansModel(JavaModel, _BisectingKMeansParams, JavaMLWritable, Ja
         """
         return self._call_java("predict", value)
 
+    def __repr__(self):
+        return self._call_java("toString")
+
 
 @inherit_doc
 class BisectingKMeans(JavaEstimator, _BisectingKMeansParams, JavaMLWritable, JavaMLReadable):
@@ -794,7 +803,7 @@ class BisectingKMeans(JavaEstimator, _BisectingKMeansParams, JavaMLWritable, Jav
     >>> model.getMaxIter()
     20
     >>> model.setPredictionCol("newPrediction")
-    BisectingKMeans...
+    BisectingKMeansModel...
     >>> model.predict(df.head().features)
     0
     >>> centers = model.clusterCenters()
@@ -1152,6 +1161,9 @@ class LDAModel(JavaModel, _LDAParams):
         """
         return self._call_java("estimatedDocConcentration")
 
+    def __repr__(self):
+        return self._call_java("toString")
+
 
 @inherit_doc
 class DistributedLDAModel(LDAModel, JavaMLReadable, JavaMLWritable):
@@ -1265,6 +1277,8 @@ class LDA(JavaEstimator, _LDAParams, JavaMLReadable, JavaMLWritable):
     10
     >>> lda.clear(lda.maxIter)
     >>> model = lda.fit(df)
+    >>> model.setSeed(1)
+    DistributedLDAModel...
     >>> model.getTopicDistributionCol()
     'topicDistribution'
     >>> model.isDistributed()

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -284,6 +284,9 @@ class _LSHModel(JavaModel, _LSHParams):
         threshold = TypeConverters.toFloat(threshold)
         return self._call_java("approxSimilarityJoin", datasetA, datasetB, threshold, distCol)
 
+    def __repr__(self):
+        return self._call_java("toString")
+
 
 class _BucketedRandomProjectionLSHParams():
     """
@@ -337,6 +340,8 @@ class BucketedRandomProjectionLSH(_LSH, _BucketedRandomProjectionLSHParams,
     >>> model = brp.fit(df)
     >>> model.getBucketLength()
     1.0
+    >>> model.setOutputCol("hashes")
+    BucketedRandomProjectionLSHModel...
     >>> model.transform(df).head()
     Row(id=0, features=DenseVector([-1.0, -1.0]), hashes=[DenseVector([-1.0])])
     >>> data2 = [(4, Vectors.dense([2.0, 2.0 ]),),
@@ -733,6 +738,8 @@ class CountVectorizer(JavaEstimator, _CountVectorizerParams, JavaMLReadable, Jav
     >>> cv.setOutputCol("vectors")
     CountVectorizer...
     >>> model = cv.fit(df)
+    >>> model.setInputCol("raw")
+    CountVectorizerModel...
     >>> model.transform(df).show(truncate=False)
     +-----+---------------+-------------------------+
     |label|raw            |vectors                  |
@@ -926,6 +933,9 @@ class CountVectorizerModel(JavaModel, _CountVectorizerParams, JavaMLReadable, Ja
         Sets the value of :py:attr:`binary`.
         """
         return self._set(binary=value)
+
+    def __repr__(self):
+        return self._call_java("toString")
 
 
 @inherit_doc
@@ -1345,6 +1355,8 @@ class IDF(JavaEstimator, _IDFParams, JavaMLReadable, JavaMLWritable):
     >>> idf.setOutputCol("idf")
     IDF...
     >>> model = idf.fit(df)
+    >>> model.setOutputCol("idf")
+    IDFModel...
     >>> model.getMinDocFreq()
     3
     >>> model.idf
@@ -1463,6 +1475,9 @@ class IDFModel(JavaModel, _IDFParams, JavaMLReadable, JavaMLWritable):
         """
         return self._call_java("numDocs")
 
+    def __repr__(self):
+        return self._call_java("toString")
+
 
 class _ImputerParams(HasInputCol, HasInputCols, HasOutputCol, HasOutputCols, HasRelativeError):
     """
@@ -1519,6 +1534,8 @@ class Imputer(JavaEstimator, _ImputerParams, JavaMLReadable, JavaMLWritable):
     >>> imputer.getRelativeError()
     0.001
     >>> model = imputer.fit(df)
+    >>> model.setInputCols(["a", "b"])
+    ImputerModel...
     >>> model.getStrategy()
     'mean'
     >>> model.surrogateDF.show()
@@ -1715,6 +1732,9 @@ class ImputerModel(JavaModel, _ImputerParams, JavaMLReadable, JavaMLWritable):
         """
         return self._call_java("surrogateDF")
 
+    def __repr__(self):
+        return self._call_java("toString")
+
 
 @inherit_doc
 class Interaction(JavaTransformer, HasInputCols, HasOutputCol, JavaMLReadable, JavaMLWritable):
@@ -1810,7 +1830,7 @@ class MaxAbsScaler(JavaEstimator, _MaxAbsScalerParams, JavaMLReadable, JavaMLWri
     MaxAbsScaler...
     >>> model = maScaler.fit(df)
     >>> model.setOutputCol("scaledOutput")
-    MaxAbsScaler...
+    MaxAbsScalerModel...
     >>> model.transform(df).show()
     +-----+------------+
     |    a|scaledOutput|
@@ -1901,6 +1921,9 @@ class MaxAbsScalerModel(JavaModel, _MaxAbsScalerParams, JavaMLReadable, JavaMLWr
         """
         return self._call_java("maxAbs")
 
+    def __repr__(self):
+        return self._call_java("toString")
+
 
 @inherit_doc
 class MinHashLSH(_LSH, HasInputCol, HasOutputCol, HasSeed, JavaMLReadable, JavaMLWritable):
@@ -1928,6 +1951,8 @@ class MinHashLSH(_LSH, HasInputCol, HasOutputCol, HasSeed, JavaMLReadable, JavaM
     >>> mh.setSeed(12345)
     MinHashLSH...
     >>> model = mh.fit(df)
+    >>> model.setInputCol("features")
+    MinHashLSHModel...
     >>> model.transform(df).head()
     Row(id=0, features=SparseVector(6, {0: 1.0, 1: 1.0, 2: 1.0}), hashes=[DenseVector([6179668...
     >>> data2 = [(3, Vectors.sparse(6, [1, 3, 5], [1.0, 1.0, 1.0]),),
@@ -2056,7 +2081,7 @@ class MinMaxScaler(JavaEstimator, _MinMaxScalerParams, JavaMLReadable, JavaMLWri
     MinMaxScaler...
     >>> model = mmScaler.fit(df)
     >>> model.setOutputCol("scaledOutput")
-    MinMaxScaler...
+    MinMaxScalerModel...
     >>> model.originalMin
     DenseVector([0.0])
     >>> model.originalMax
@@ -2188,6 +2213,9 @@ class MinMaxScalerModel(JavaModel, _MinMaxScalerParams, JavaMLReadable, JavaMLWr
         Max value for each original column during fitting.
         """
         return self._call_java("originalMax")
+
+    def __repr__(self):
+        return self._call_java("toString")
 
 
 @inherit_doc
@@ -2421,6 +2449,8 @@ class OneHotEncoder(JavaEstimator, _OneHotEncoderParams, JavaMLReadable, JavaMLW
     >>> ohe.setOutputCols(["output"])
     OneHotEncoder...
     >>> model = ohe.fit(df)
+    >>> model.setOutputCols(["output"])
+    OneHotEncoderModel...
     >>> model.getHandleInvalid()
     'error'
     >>> model.transform(df).head().output
@@ -2558,6 +2588,9 @@ class OneHotEncoderModel(JavaModel, _OneHotEncoderParams, JavaMLReadable, JavaML
         The array contains one value for each input column, in order.
         """
         return self._call_java("categorySizes")
+
+    def __repr__(self):
+        return self._call_java("toString")
 
 
 @inherit_doc
@@ -2935,7 +2968,7 @@ class RobustScaler(JavaEstimator, _RobustScalerParams, JavaMLReadable, JavaMLWri
     RobustScaler...
     >>> model = scaler.fit(df)
     >>> model.setOutputCol("output")
-    RobustScaler...
+    RobustScalerModel...
     >>> model.median
     DenseVector([2.0, -2.0])
     >>> model.range
@@ -3075,6 +3108,9 @@ class RobustScalerModel(JavaModel, _RobustScalerParams, JavaMLReadable, JavaMLWr
         Quantile range of the RobustScalerModel.
         """
         return self._call_java("range")
+
+    def __repr__(self):
+        return self._call_java("toString")
 
 
 @inherit_doc
@@ -3330,7 +3366,7 @@ class StandardScaler(JavaEstimator, _StandardScalerParams, JavaMLReadable, JavaM
     >>> model.getInputCol()
     'a'
     >>> model.setOutputCol("output")
-    StandardScaler...
+    StandardScalerModel...
     >>> model.mean
     DenseVector([1.0])
     >>> model.std
@@ -3441,6 +3477,9 @@ class StandardScalerModel(JavaModel, _StandardScalerParams, JavaMLReadable, Java
         """
         return self._call_java("mean")
 
+    def __repr__(self):
+        return self._call_java("toString")
+
 
 class _StringIndexerParams(JavaParams, HasHandleInvalid, HasInputCol, HasOutputCol,
                            HasInputCols, HasOutputCols):
@@ -3490,6 +3529,8 @@ class StringIndexer(JavaEstimator, _StringIndexerParams, JavaMLReadable, JavaMLW
     >>> stringIndexer.setHandleInvalid("error")
     StringIndexer...
     >>> model = stringIndexer.fit(stringIndDf)
+    >>> model.setHandleInvalid("error")
+    StringIndexerModel...
     >>> td = model.transform(stringIndDf)
     >>> sorted(set([(i[0], i[1]) for i in td.select(td.id, td.indexed).collect()]),
     ...     key=lambda x: x[0])
@@ -3707,6 +3748,9 @@ class StringIndexerModel(JavaModel, _StringIndexerParams, JavaMLReadable, JavaML
         Ordered list of labels, corresponding to indices to be assigned.
         """
         return self._call_java("labels")
+
+    def __repr__(self):
+        return self._call_java("toString")
 
 
 @inherit_doc
@@ -4137,7 +4181,7 @@ class VectorIndexer(JavaEstimator, _VectorIndexerParams, JavaMLReadable, JavaMLW
     >>> indexer.getHandleInvalid()
     'error'
     >>> model.setOutputCol("output")
-    VectorIndexer...
+    VectorIndexerModel...
     >>> model.transform(df).head().output
     DenseVector([1.0, 0.0])
     >>> model.numFeatures
@@ -4273,6 +4317,9 @@ class VectorIndexerModel(JavaModel, _VectorIndexerParams, JavaMLReadable, JavaML
         If a feature is not in this map, it is treated as continuous.
         """
         return self._call_java("javaCategoryMaps")
+
+    def __repr__(self):
+        return self._call_java("toString")
 
 
 @inherit_doc
@@ -4458,6 +4505,8 @@ class Word2Vec(JavaEstimator, _Word2VecParams, JavaMLReadable, JavaMLWritable):
     >>> model = word2Vec.fit(doc)
     >>> model.getMinCount()
     5
+    >>> model.setInputCol("sentence")
+    Word2VecModel...
     >>> model.getVectors().show()
     +----+--------------------+
     |word|              vector|
@@ -4648,6 +4697,9 @@ class Word2VecModel(JavaModel, _Word2VecParams, JavaMLReadable, JavaMLWritable):
         tuples = self._java_obj.findSynonymsArray(word, num)
         return list(map(lambda st: (st._1(), st._2()), list(tuples)))
 
+    def __repr__(self):
+        return self._call_java("toString")
+
 
 class _PCAParams(HasInputCol, HasOutputCol):
     """
@@ -4685,7 +4737,7 @@ class PCA(JavaEstimator, _PCAParams, JavaMLReadable, JavaMLWritable):
     >>> model.getK()
     2
     >>> model.setOutputCol("output")
-    PCA...
+    PCAModel...
     >>> model.transform(df).collect()[0].output
     DenseVector([1.648..., -4.013...])
     >>> model.explainedVariance
@@ -4787,6 +4839,9 @@ class PCAModel(JavaModel, _PCAParams, JavaMLReadable, JavaMLWritable):
         explained by each principal component.
         """
         return self._call_java("explainedVariance")
+
+    def __repr__(self):
+        return self._call_java("toString")
 
 
 class _RFormulaParams(HasFeaturesCol, HasLabelCol, HasHandleInvalid):
@@ -4998,6 +5053,9 @@ class RFormulaModel(JavaModel, _RFormulaParams, JavaMLReadable, JavaMLWritable):
         resolvedFormula = self._call_java("resolvedFormula")
         return "RFormulaModel(%s) (uid=%s)" % (resolvedFormula, self.uid)
 
+    def __repr__(self):
+        return self._call_java("toString")
+
 
 class _ChiSqSelectorParams(HasFeaturesCol, HasOutputCol, HasLabelCol):
     """
@@ -5110,6 +5168,8 @@ class ChiSqSelector(JavaEstimator, _ChiSqSelectorParams, JavaMLReadable, JavaMLW
     >>> model = selector.fit(df)
     >>> model.getFeaturesCol()
     'features'
+    >>> model.setFeaturesCol("features")
+    ChiSqSelectorModel...
     >>> model.transform(df).head().selectedFeatures
     DenseVector([18.0])
     >>> model.selectedFeatures
@@ -5255,6 +5315,9 @@ class ChiSqSelectorModel(JavaModel, _ChiSqSelectorParams, JavaMLReadable, JavaML
         List of indices to select (filter).
         """
         return self._call_java("selectedFeatures")
+
+    def __repr__(self):
+        return self._call_java("toString")
 
 
 @inherit_doc

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -284,9 +284,6 @@ class _LSHModel(JavaModel, _LSHParams):
         threshold = TypeConverters.toFloat(threshold)
         return self._call_java("approxSimilarityJoin", datasetA, datasetB, threshold, distCol)
 
-    def __repr__(self):
-        return self._call_java("toString")
-
 
 class _BucketedRandomProjectionLSHParams():
     """
@@ -934,9 +931,6 @@ class CountVectorizerModel(JavaModel, _CountVectorizerParams, JavaMLReadable, Ja
         """
         return self._set(binary=value)
 
-    def __repr__(self):
-        return self._call_java("toString")
-
 
 @inherit_doc
 class DCT(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, JavaMLWritable):
@@ -1475,9 +1469,6 @@ class IDFModel(JavaModel, _IDFParams, JavaMLReadable, JavaMLWritable):
         """
         return self._call_java("numDocs")
 
-    def __repr__(self):
-        return self._call_java("toString")
-
 
 class _ImputerParams(HasInputCol, HasInputCols, HasOutputCol, HasOutputCols, HasRelativeError):
     """
@@ -1732,9 +1723,6 @@ class ImputerModel(JavaModel, _ImputerParams, JavaMLReadable, JavaMLWritable):
         """
         return self._call_java("surrogateDF")
 
-    def __repr__(self):
-        return self._call_java("toString")
-
 
 @inherit_doc
 class Interaction(JavaTransformer, HasInputCols, HasOutputCol, JavaMLReadable, JavaMLWritable):
@@ -1920,9 +1908,6 @@ class MaxAbsScalerModel(JavaModel, _MaxAbsScalerParams, JavaMLReadable, JavaMLWr
         Max Abs vector.
         """
         return self._call_java("maxAbs")
-
-    def __repr__(self):
-        return self._call_java("toString")
 
 
 @inherit_doc
@@ -2213,9 +2198,6 @@ class MinMaxScalerModel(JavaModel, _MinMaxScalerParams, JavaMLReadable, JavaMLWr
         Max value for each original column during fitting.
         """
         return self._call_java("originalMax")
-
-    def __repr__(self):
-        return self._call_java("toString")
 
 
 @inherit_doc
@@ -2588,9 +2570,6 @@ class OneHotEncoderModel(JavaModel, _OneHotEncoderParams, JavaMLReadable, JavaML
         The array contains one value for each input column, in order.
         """
         return self._call_java("categorySizes")
-
-    def __repr__(self):
-        return self._call_java("toString")
 
 
 @inherit_doc
@@ -3109,9 +3088,6 @@ class RobustScalerModel(JavaModel, _RobustScalerParams, JavaMLReadable, JavaMLWr
         """
         return self._call_java("range")
 
-    def __repr__(self):
-        return self._call_java("toString")
-
 
 @inherit_doc
 @ignore_unicode_prefix
@@ -3477,9 +3453,6 @@ class StandardScalerModel(JavaModel, _StandardScalerParams, JavaMLReadable, Java
         """
         return self._call_java("mean")
 
-    def __repr__(self):
-        return self._call_java("toString")
-
 
 class _StringIndexerParams(JavaParams, HasHandleInvalid, HasInputCol, HasOutputCol,
                            HasInputCols, HasOutputCols):
@@ -3748,9 +3721,6 @@ class StringIndexerModel(JavaModel, _StringIndexerParams, JavaMLReadable, JavaML
         Ordered list of labels, corresponding to indices to be assigned.
         """
         return self._call_java("labels")
-
-    def __repr__(self):
-        return self._call_java("toString")
 
 
 @inherit_doc
@@ -4318,9 +4288,6 @@ class VectorIndexerModel(JavaModel, _VectorIndexerParams, JavaMLReadable, JavaML
         """
         return self._call_java("javaCategoryMaps")
 
-    def __repr__(self):
-        return self._call_java("toString")
-
 
 @inherit_doc
 class VectorSlicer(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, JavaMLWritable):
@@ -4697,9 +4664,6 @@ class Word2VecModel(JavaModel, _Word2VecParams, JavaMLReadable, JavaMLWritable):
         tuples = self._java_obj.findSynonymsArray(word, num)
         return list(map(lambda st: (st._1(), st._2()), list(tuples)))
 
-    def __repr__(self):
-        return self._call_java("toString")
-
 
 class _PCAParams(HasInputCol, HasOutputCol):
     """
@@ -4839,9 +4803,6 @@ class PCAModel(JavaModel, _PCAParams, JavaMLReadable, JavaMLWritable):
         explained by each principal component.
         """
         return self._call_java("explainedVariance")
-
-    def __repr__(self):
-        return self._call_java("toString")
 
 
 class _RFormulaParams(HasFeaturesCol, HasLabelCol, HasHandleInvalid):
@@ -5052,9 +5013,6 @@ class RFormulaModel(JavaModel, _RFormulaParams, JavaMLReadable, JavaMLWritable):
     def __str__(self):
         resolvedFormula = self._call_java("resolvedFormula")
         return "RFormulaModel(%s) (uid=%s)" % (resolvedFormula, self.uid)
-
-    def __repr__(self):
-        return self._call_java("toString")
 
 
 class _ChiSqSelectorParams(HasFeaturesCol, HasOutputCol, HasLabelCol):
@@ -5315,9 +5273,6 @@ class ChiSqSelectorModel(JavaModel, _ChiSqSelectorParams, JavaMLReadable, JavaML
         List of indices to select (filter).
         """
         return self._call_java("selectedFeatures")
-
-    def __repr__(self):
-        return self._call_java("toString")
 
 
 @inherit_doc

--- a/python/pyspark/ml/fpm.py
+++ b/python/pyspark/ml/fpm.py
@@ -131,9 +131,6 @@ class FPGrowthModel(JavaModel, _FPGrowthParams, JavaMLWritable, JavaMLReadable):
         """
         return self._call_java("associationRules")
 
-    def __repr__(self):
-        return self._call_java("toString")
-
 
 @ignore_unicode_prefix
 class FPGrowth(JavaEstimator, _FPGrowthParams, JavaMLWritable, JavaMLReadable):

--- a/python/pyspark/ml/fpm.py
+++ b/python/pyspark/ml/fpm.py
@@ -131,6 +131,9 @@ class FPGrowthModel(JavaModel, _FPGrowthParams, JavaMLWritable, JavaMLReadable):
         """
         return self._call_java("associationRules")
 
+    def __repr__(self):
+        return self._call_java("toString")
+
 
 @ignore_unicode_prefix
 class FPGrowth(JavaEstimator, _FPGrowthParams, JavaMLWritable, JavaMLReadable):
@@ -166,7 +169,7 @@ class FPGrowth(JavaEstimator, _FPGrowthParams, JavaMLWritable, JavaMLReadable):
     >>> fp = FPGrowth(minSupport=0.2, minConfidence=0.7)
     >>> fpm = fp.fit(data)
     >>> fpm.setPredictionCol("newPrediction")
-    FPGrowth...
+    FPGrowthModel...
     >>> fpm.freqItemsets.show(5)
     +---------+----+
     |    items|freq|

--- a/python/pyspark/ml/recommendation.py
+++ b/python/pyspark/ml/recommendation.py
@@ -225,6 +225,8 @@ class ALS(JavaEstimator, _ALSParams, JavaMLWritable, JavaMLReadable):
     >>> model = als.fit(df)
     >>> model.getUserCol()
     'user'
+    >>> model.setUserCol("user")
+    ALSModel...
     >>> model.getItemCol()
     'item'
     >>> model.setPredictionCol("newPrediction")
@@ -552,6 +554,9 @@ class ALSModel(JavaModel, _ALSModelParams, JavaMLWritable, JavaMLReadable):
                  stored as an array of (userCol, rating) Rows.
         """
         return self._call_java("recommendForItemSubset", dataset, numUsers)
+
+    def __repr__(self):
+        return self._call_java("toString")
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/recommendation.py
+++ b/python/pyspark/ml/recommendation.py
@@ -555,9 +555,6 @@ class ALSModel(JavaModel, _ALSModelParams, JavaMLWritable, JavaMLReadable):
         """
         return self._call_java("recommendForItemSubset", dataset, numUsers)
 
-    def __repr__(self):
-        return self._call_java("toString")
-
 
 if __name__ == "__main__":
     import doctest

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -2272,6 +2272,9 @@ class GeneralizedLinearRegressionTrainingSummary(GeneralizedLinearRegressionSumm
         """
         return self._call_java("pValues")
 
+    def __repr__(self):
+        return self._call_java("toString")
+
 
 if __name__ == "__main__":
     import doctest

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -105,9 +105,9 @@ class LinearRegression(JavaPredictor, _LinearRegressionParams, JavaMLWritable, J
     LinearRegression...
     >>> model = lr.fit(df)
     >>> model.setFeaturesCol("features")
-    LinearRegression...
+    LinearRegressionModel...
     >>> model.setPredictionCol("newPrediction")
-    LinearRegression...
+    LinearRegressionModel...
     >>> model.getMaxIter()
     5
     >>> test0 = spark.createDataFrame([(Vectors.dense(-1.0),)], ["features"])
@@ -309,6 +309,9 @@ class LinearRegressionModel(JavaPredictionModel, _LinearRegressionParams, Genera
             raise ValueError("dataset must be a DataFrame but got %s." % type(dataset))
         java_lr_summary = self._call_java("evaluate", dataset)
         return LinearRegressionSummary(java_lr_summary)
+
+    def __repr__(self):
+        return self._call_java("toString")
 
 
 class LinearRegressionSummary(JavaWrapper):
@@ -591,7 +594,7 @@ class IsotonicRegression(JavaEstimator, _IsotonicRegressionParams, HasWeightCol,
     >>> ir = IsotonicRegression()
     >>> model = ir.fit(df)
     >>> model.setFeaturesCol("features")
-    IsotonicRegression...
+    IsotonicRegressionModel...
     >>> test0 = spark.createDataFrame([(Vectors.dense(-1.0),)], ["features"])
     >>> model.transform(test0).head().prediction
     0.0
@@ -725,6 +728,9 @@ class IsotonicRegressionModel(JavaModel, _IsotonicRegressionParams, JavaMLWritab
         regression.
         """
         return self._call_java("predictions")
+
+    def __repr__(self):
+        return self._call_java("toString")
 
 
 class _DecisionTreeRegressorParams(_DecisionTreeParams, _TreeRegressorParams, HasVarianceCol):
@@ -1546,7 +1552,7 @@ class AFTSurvivalRegression(JavaEstimator, _AFTSurvivalRegressionParams,
     >>> aftsr.clear(aftsr.maxIter)
     >>> model = aftsr.fit(df)
     >>> model.setFeaturesCol("features")
-    AFTSurvivalRegression...
+    AFTSurvivalRegressionModel...
     >>> model.predict(Vectors.dense(6.3))
     1.0
     >>> model.predictQuantiles(Vectors.dense(6.3))
@@ -1760,6 +1766,9 @@ class AFTSurvivalRegressionModel(JavaModel, _AFTSurvivalRegressionParams,
         """
         return self._call_java("predict", features)
 
+    def __repr__(self):
+        return self._call_java("toString")
+
 
 class _GeneralizedLinearRegressionParams(_JavaPredictorParams, HasFitIntercept, HasMaxIter,
                                          HasTol, HasRegParam, HasWeightCol, HasSolver,
@@ -1881,7 +1890,7 @@ class GeneralizedLinearRegression(JavaPredictor, _GeneralizedLinearRegressionPar
     >>> glr.clear(glr.maxIter)
     >>> model = glr.fit(df)
     >>> model.setFeaturesCol("features")
-    GeneralizedLinearRegression...
+    GeneralizedLinearRegressionModel...
     >>> model.getMaxIter()
     25
     >>> model.getAggregationDepth()
@@ -2103,6 +2112,9 @@ class GeneralizedLinearRegressionModel(JavaPredictionModel, _GeneralizedLinearRe
             raise ValueError("dataset must be a DataFrame but got %s." % type(dataset))
         java_glr_summary = self._call_java("evaluate", dataset)
         return GeneralizedLinearRegressionSummary(java_glr_summary)
+
+    def __repr__(self):
+        return self._call_java("toString")
 
 
 class GeneralizedLinearRegressionSummary(JavaWrapper):

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -310,9 +310,6 @@ class LinearRegressionModel(JavaPredictionModel, _LinearRegressionParams, Genera
         java_lr_summary = self._call_java("evaluate", dataset)
         return LinearRegressionSummary(java_lr_summary)
 
-    def __repr__(self):
-        return self._call_java("toString")
-
 
 class LinearRegressionSummary(JavaWrapper):
     """
@@ -728,9 +725,6 @@ class IsotonicRegressionModel(JavaModel, _IsotonicRegressionParams, JavaMLWritab
         regression.
         """
         return self._call_java("predictions")
-
-    def __repr__(self):
-        return self._call_java("toString")
 
 
 class _DecisionTreeRegressorParams(_DecisionTreeParams, _TreeRegressorParams, HasVarianceCol):
@@ -1766,9 +1760,6 @@ class AFTSurvivalRegressionModel(JavaModel, _AFTSurvivalRegressionParams,
         """
         return self._call_java("predict", features)
 
-    def __repr__(self):
-        return self._call_java("toString")
-
 
 class _GeneralizedLinearRegressionParams(_JavaPredictorParams, HasFitIntercept, HasMaxIter,
                                          HasTol, HasRegParam, HasWeightCol, HasSolver,
@@ -2113,9 +2104,6 @@ class GeneralizedLinearRegressionModel(JavaPredictionModel, _GeneralizedLinearRe
         java_glr_summary = self._call_java("evaluate", dataset)
         return GeneralizedLinearRegressionSummary(java_glr_summary)
 
-    def __repr__(self):
-        return self._call_java("toString")
-
 
 class GeneralizedLinearRegressionSummary(JavaWrapper):
     """
@@ -2283,9 +2271,6 @@ class GeneralizedLinearRegressionTrainingSummary(GeneralizedLinearRegressionSumm
         then the last element returned corresponds to the intercept.
         """
         return self._call_java("pValues")
-
-    def __repr__(self):
-        return self._call_java("toString")
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tree.py
+++ b/python/pyspark/ml/tree.py
@@ -56,9 +56,6 @@ class _DecisionTreeModel(JavaPredictionModel):
         """
         return self._call_java("predictLeaf", value)
 
-    def __repr__(self):
-        return self._call_java("toString")
-
 
 class _DecisionTreeParams(HasCheckpointInterval, HasSeed, HasWeightCol):
     """
@@ -207,9 +204,6 @@ class _TreeEnsembleModel(JavaPredictionModel):
         Predict the indices of the leaves corresponding to the feature vector.
         """
         return self._call_java("predictLeaf", value)
-
-    def __repr__(self):
-        return self._call_java("toString")
 
 
 class _TreeEnsembleParams(_DecisionTreeParams):

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -372,6 +372,9 @@ class JavaModel(JavaTransformer, Model):
 
             self._resetUid(java_model.uid())
 
+    def __repr__(self):
+        return self._call_java("toString")
+
 
 @inherit_doc
 class _JavaPredictorParams(HasLabelCol, HasFeaturesCol, HasPredictionCol):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add ```__repr__``` in Python ML Models


### Why are the changes needed?
In Python ML Models, some of them have ```__repr__```, others don't. In the doctest, when calling Model.setXXX, some of the Models print out the xxxModel... correctly, some of them can't because of lacking the  ```__repr__``` method. For example:
```
    >>> gm = GaussianMixture(k=3, tol=0.0001, seed=10)
    >>> model = gm.fit(df)
    >>> model.setPredictionCol("newPrediction")
    GaussianMixture...
```
After the change, the above code will become the following:
```
    >>> gm = GaussianMixture(k=3, tol=0.0001, seed=10)
    >>> model = gm.fit(df)
    >>> model.setPredictionCol("newPrediction")
    GaussianMixtureModel...
```



### Does this PR introduce any user-facing change?
Yes.



### How was this patch tested?
doctest
