### PR TITLE
[SPARK-28795][FOLLOW-UP] Links should point to html instead of md files

### DIFF
--- a/docs/sql-ref-syntax-ddl-create-view.md
+++ b/docs/sql-ref-syntax-ddl-create-view.md
@@ -78,5 +78,5 @@ CREATE GLOBAL TEMPORARY VIEW IF NOT EXISTS subscribed_movies
 {% endhighlight %}
 
 ### Related Statements
-- [ALTER VIEW](sql-ref-syntax-ddl-alter-view.md)
-- [DROP VIEW](sql-ref-syntax-ddl-drop-view.md)
+- [ALTER VIEW](sql-ref-syntax-ddl-alter-view.html)
+- [DROP VIEW](sql-ref-syntax-ddl-drop-view.html)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use html files for the links 

### Why are the changes needed?
links not working 


### Does this PR introduce any user-facing change?
Yes

### How was this patch tested?
Used jekyll build and serve to verify.