### PR TITLE
[SPARK-29872] Improper cache strategy in examples

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/ml/LogisticRegressionSummaryExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/LogisticRegressionSummaryExample.scala
@@ -60,7 +60,7 @@ object LogisticRegressionSummaryExample {
     println(s"areaUnderROC: ${trainingSummary.areaUnderROC}")
 
     // Set the model threshold to maximize F-Measure
-    val fMeasure = trainingSummary.fMeasureByThreshold
+    val fMeasure = trainingSummary.fMeasureByThreshold.cache()
     val maxFMeasure = fMeasure.select(max("F-Measure")).head().getDouble(0)
     val bestThreshold = fMeasure.where($"F-Measure" === maxFMeasure)
       .select("threshold").head().getDouble(0)

--- a/examples/src/main/scala/org/apache/spark/examples/sql/SparkSQLExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/SparkSQLExample.scala
@@ -198,6 +198,7 @@ object SparkSQLExample {
       .textFile("examples/src/main/resources/people.txt")
       .map(_.split(","))
       .map(attributes => Person(attributes(0), attributes(1).trim.toInt))
+      .cache()
       .toDF()
     // Register the DataFrame as a temporary view
     peopleDF.createOrReplaceTempView("people")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Correct some cache strategy in examples.

### Why are the changes needed?
These changes can improve the performance of examples.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Manually
