### PR TITLE
[SPARK-29879][CORE]Support unbounded waiting for RPC reply

### DIFF
--- a/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
@@ -124,7 +124,7 @@ class BarrierTaskContext private[spark] (
           barrierEpoch),
         // Set a fixed timeout for RPC here, so users shall get a SparkException thrown by
         // BarrierCoordinator on timeout, instead of RPCTimeoutException from the RPC framework.
-        timeout = new RpcTimeout(365.days, "barrierTimeout"))
+        timeout = new RpcTimeout(Duration.Inf, "barrierTimeout"))
 
       // Wait the RPC future to be completed, but every 1 second it will jump out waiting
       // and check whether current spark task is killed. If killed, then throw

--- a/core/src/main/scala/org/apache/spark/rpc/RpcTimeout.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/RpcTimeout.scala
@@ -33,13 +33,13 @@ private[rpc] class RpcTimeoutException(message: String, cause: TimeoutException)
 
 
 /**
- * Associates a timeout with a description so that a when a TimeoutException occurs, additional
+ * Associates a timeout with a description so that when a TimeoutException occurs, additional
  * context about the timeout can be amended to the exception message.
  *
- * @param duration timeout duration in seconds
+ * @param duration timeout duration in seconds, or [[Duration.Inf]] for unbounded waiting
  * @param timeoutProp the configuration property that controls this timeout
  */
-private[spark] class RpcTimeout(val duration: FiniteDuration, val timeoutProp: String)
+private[spark] class RpcTimeout(val duration: Duration, val timeoutProp: String)
   extends Serializable {
 
   /** Amends the standard message of TimeoutException to include the description */


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Support unbounded waiting for RPC reply with the call `RpcEndpointRef.askSync[T: ClassTag](message: Any, timeout: RpcTimeout)`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
At present, we hard code long duration to represent never timeout as below
```scala
timeout = new RpcTimeout(365.days, "barrierTimeout")
```
with the support of unbounded waiting, we can do as below
```scala
timeout = new RpcTimeout(Duration.Inf, "barrierTimeout")
```

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
N/A