### PR TITLE
[SPARK-29886][SQL] Add support for spark style hash patitioning to v2 data sources

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/partitioning/ClusteredPartitioning.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/partitioning/ClusteredPartitioning.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.read.partitioning;
+
+import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.connector.read.PartitionReader;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A concrete implementation of {@link Partitioning}. Represents a partitioning where records that
+ * share the same values for the {@link #clusteredColumns} will be produced by the same
+ * {@link PartitionReader}.
+ */
+@Evolving
+public class ClusteredPartitioning implements Partitioning {
+    /**
+     * The names of the clustered columns. Note that they are order insensitive.
+     */
+    public final List<String> clusteredColumns;
+
+    public final int numberOfPartitions;
+
+    public ClusteredPartitioning(String[] clusteredColumns, int numberOfPartitions) {
+        this.clusteredColumns = Arrays.asList(clusteredColumns);
+        this.numberOfPartitions = numberOfPartitions;
+    }
+
+    @Override
+    public int numPartitions() {
+        return numberOfPartitions;
+    }
+
+    @Override
+    public boolean satisfy(Distribution distribution) {
+        if(distribution instanceof ClusteredDistribution){
+            ClusteredDistribution clustDist = (ClusteredDistribution)distribution;
+            List<String> clustCols = Arrays.asList(clustDist.clusteredColumns);
+            if(clusteredColumns.stream().allMatch(col -> clustCols.contains(col))){
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/partitioning/SparkHashClusteredDistribution.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/partitioning/SparkHashClusteredDistribution.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.read.partitioning;
+
+import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.connector.read.PartitionReader;
+
+/**
+ * A concrete implementation of {@link Distribution}. Represents a distribution where records that
+ * share the same values for the {@link #clusteredColumns} will be produced by the same
+ * {@link PartitionReader}.
+ */
+@Evolving
+public class SparkHashClusteredDistribution implements Distribution {
+
+  /**
+   * The names of the clustered columns. Note that they are order insensitive.
+   */
+  public final String[] clusteredColumns;
+
+  public final int numberOfPartitions;
+
+  public SparkHashClusteredDistribution(String[] clusteredColumns, int numberOfPartitions) {
+      this.clusteredColumns = clusteredColumns;
+      this.numberOfPartitions = numberOfPartitions;
+  }
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/partitioning/SparkHashPartitioning.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/partitioning/SparkHashPartitioning.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.read.partitioning;
+
+import org.apache.spark.annotation.Evolving;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A concrete implementation of {@link Partitioning}. Represents a partitioning where rows are
+ * split up across partitions based on the spark defined hash of columns. that
+ * share the same values for the {@link #clusteredColumns} will be produced by the same
+ * {@link org.apache.spark.sql.connector.read.PartitionReader} and that the index will be
+ * consistent.
+ */
+@Evolving
+public class SparkHashPartitioning implements Partitioning {
+    /**
+     * The names of the clustered columns. Note that they are order insensitive.
+     */
+    public final List<String> clusteredColumns;
+
+    public final int numberOfPartitions;
+
+    public SparkHashPartitioning(String[] clusteredColumns, int numberOfPartitions) {
+        this.clusteredColumns = Arrays.asList(clusteredColumns);
+        this.numberOfPartitions = numberOfPartitions;
+    }
+
+    @Override
+    public int numPartitions() {
+        return numberOfPartitions;
+    }
+
+    @Override
+    public boolean satisfy(Distribution distribution) {
+        if(distribution instanceof SparkHashClusteredDistribution){
+            SparkHashClusteredDistribution hashDist = (SparkHashClusteredDistribution)distribution;
+            if(hashDist.numberOfPartitions == numberOfPartitions
+            && Arrays.stream(hashDist.clusteredColumns).allMatch(c -> clusteredColumns.contains(c))
+            && hashDist.clusteredColumns.length == clusteredColumns.size()){
+                return true;
+            }
+        }
+        if(distribution instanceof ClusteredDistribution){
+            ClusteredDistribution clustDist = (ClusteredDistribution)distribution;
+            List<String> clustCols = Arrays.asList(clustDist.clusteredColumns);
+            if(clusteredColumns.stream().allMatch(col -> clustCols.contains(col))){
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-29886

WARNING: this is a preview of a potential way in which to add spark style hash partitioning to v2 datasources.

### What changes were proposed in this pull request?

Adds support for spark style hash partitioning to v2 datasources which allows for bucket joins.  Adds concrete classes that are usable by users to define this type of partitioning.

### Why are the changes needed?

Currently V2 Datasources are unable to provide support for bucket joins.

### Does this PR introduce any user-facing change?

Yes this adds a concrerte implementation of v2 datasource partitioning and cluster so that users can specify spark style hash partitioning.


### How was this patch tested?

Unit tests
