### PR TITLE
[SPARK-29898][SQL] Support Avro Custom Logical Types

### DIFF
--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
@@ -39,7 +39,11 @@ import org.apache.spark.unsafe.types.UTF8String
 /**
  * A deserializer to deserialize data in avro format to data in catalyst format.
  */
-class AvroDeserializer(rootAvroType: Schema, rootCatalystType: DataType) {
+class AvroDeserializer(
+  rootAvroType: Schema,
+  rootCatalystType: DataType,
+  logicalTypeUpdater: AvroLogicalTypeCatalystMapper) {
+
   private lazy val decimalConversions = new DecimalConversion()
 
   private val converter: Any => Any = rootCatalystType match {
@@ -78,6 +82,9 @@ class AvroDeserializer(rootAvroType: Schema, rootCatalystType: DataType) {
       catalystType: DataType,
       path: List[String]): (CatalystDataUpdater, Int, Any) => Unit =
     (avroType.getType, catalystType) match {
+      case _ if logicalTypeUpdater.deserialize.isDefinedAt(avroType.getLogicalType) =>
+        logicalTypeUpdater.deserialize(avroType.getLogicalType)
+
       case (NULL, NullType) => (updater, ordinal, _) =>
         updater.setNullAt(ordinal)
 
@@ -348,50 +355,4 @@ class AvroDeserializer(rootAvroType: Schema, rootCatalystType: DataType) {
     case _ => new GenericArrayData(new Array[Any](length))
   }
 
-  /**
-   * A base interface for updating values inside catalyst data structure like `InternalRow` and
-   * `ArrayData`.
-   */
-  sealed trait CatalystDataUpdater {
-    def set(ordinal: Int, value: Any): Unit
-
-    def setNullAt(ordinal: Int): Unit = set(ordinal, null)
-    def setBoolean(ordinal: Int, value: Boolean): Unit = set(ordinal, value)
-    def setByte(ordinal: Int, value: Byte): Unit = set(ordinal, value)
-    def setShort(ordinal: Int, value: Short): Unit = set(ordinal, value)
-    def setInt(ordinal: Int, value: Int): Unit = set(ordinal, value)
-    def setLong(ordinal: Int, value: Long): Unit = set(ordinal, value)
-    def setDouble(ordinal: Int, value: Double): Unit = set(ordinal, value)
-    def setFloat(ordinal: Int, value: Float): Unit = set(ordinal, value)
-    def setDecimal(ordinal: Int, value: Decimal): Unit = set(ordinal, value)
-  }
-
-  final class RowUpdater(row: InternalRow) extends CatalystDataUpdater {
-    override def set(ordinal: Int, value: Any): Unit = row.update(ordinal, value)
-
-    override def setNullAt(ordinal: Int): Unit = row.setNullAt(ordinal)
-    override def setBoolean(ordinal: Int, value: Boolean): Unit = row.setBoolean(ordinal, value)
-    override def setByte(ordinal: Int, value: Byte): Unit = row.setByte(ordinal, value)
-    override def setShort(ordinal: Int, value: Short): Unit = row.setShort(ordinal, value)
-    override def setInt(ordinal: Int, value: Int): Unit = row.setInt(ordinal, value)
-    override def setLong(ordinal: Int, value: Long): Unit = row.setLong(ordinal, value)
-    override def setDouble(ordinal: Int, value: Double): Unit = row.setDouble(ordinal, value)
-    override def setFloat(ordinal: Int, value: Float): Unit = row.setFloat(ordinal, value)
-    override def setDecimal(ordinal: Int, value: Decimal): Unit =
-      row.setDecimal(ordinal, value, value.precision)
-  }
-
-  final class ArrayDataUpdater(array: ArrayData) extends CatalystDataUpdater {
-    override def set(ordinal: Int, value: Any): Unit = array.update(ordinal, value)
-
-    override def setNullAt(ordinal: Int): Unit = array.setNullAt(ordinal)
-    override def setBoolean(ordinal: Int, value: Boolean): Unit = array.setBoolean(ordinal, value)
-    override def setByte(ordinal: Int, value: Byte): Unit = array.setByte(ordinal, value)
-    override def setShort(ordinal: Int, value: Short): Unit = array.setShort(ordinal, value)
-    override def setInt(ordinal: Int, value: Int): Unit = array.setInt(ordinal, value)
-    override def setLong(ordinal: Int, value: Long): Unit = array.setLong(ordinal, value)
-    override def setDouble(ordinal: Int, value: Double): Unit = array.setDouble(ordinal, value)
-    override def setFloat(ordinal: Int, value: Float): Unit = array.setFloat(ordinal, value)
-    override def setDecimal(ordinal: Int, value: Decimal): Unit = array.update(ordinal, value)
-  }
 }

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroFileFormat.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroFileFormat.scala
@@ -124,7 +124,8 @@ private[sql] class AvroFileFormat extends FileFormat
         val stop = file.start + file.length
 
         val deserializer =
-          new AvroDeserializer(userProvidedSchema.getOrElse(reader.getSchema), requiredSchema)
+          new AvroDeserializer(userProvidedSchema.getOrElse(reader.getSchema), requiredSchema,
+            parsedOptions.logicalTypeCatalystUpdater)
 
         new Iterator[InternalRow] {
           private[this] var completed = false

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroLogicalTypeCatalystMapper.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroLogicalTypeCatalystMapper.scala
@@ -21,8 +21,6 @@ package org.apache.spark.sql.avro
 import org.apache.avro.{LogicalType, Schema}
 
 import org.apache.spark.sql.avro.SchemaConverters.SchemaType
-import org.apache.spark.sql.catalyst.expressions.SpecializedGetters
-import org.apache.spark.sql.types.AbstractDataType
 
 /**
  * Mapping interface between Catalyst struct type and Avro schemas
@@ -36,31 +34,33 @@ trait AvroLogicalTypeCatalystMapper extends Serializable {
   def toSqlType: PartialFunction[LogicalType, SchemaType]
 
   /**
-   * Given Catalyst type returns mapped Avro schema type
-   * @return catalyst mappings
+   * Given a [[org.apache.spark.sql.avro.RecordInfo]] returns mapped Avro schema type
+   * @return partial function with mappings
    */
-  def toAvroSchema: PartialFunction[(AbstractDataType, String, String), Schema]
+  def toAvroSchema: PartialFunction[RecordInfo, Schema]
 
   /**
-   * Given Avro logical type and the Avro data value update the value to Catalyst data.
+   * Given Avro logical type and a [[org.apache.spark.sql.avro.DataDeserializer]] deserialize
+   * de given Avro data to Catalyst data using the catalyst updater.
    * @return Avro deserialization mappings
    */
-  def deserialize: PartialFunction[LogicalType, (CatalystDataUpdater, Int, Any) => Unit]
+  def deserialize: PartialFunction[LogicalType, DataDeserializer => Unit]
 
   /**
-   * Given Avro logical type and the Catalyst data value update the value to Avro data.
+   * Given Avro logical type and a [[org.apache.spark.sql.avro.DataSerializer]] serialize
+   * de given Catalyst data to Avro data.
    * @return Avro serialization mappings
    */
-  def serialize: PartialFunction[LogicalType, (SpecializedGetters, Int) => Any]
+  def serialize: PartialFunction[LogicalType, DataSerializer => Any]
 }
 
 class DefaultAvroLogicalTypeCatalystMapper extends AvroLogicalTypeCatalystMapper {
   override def toSqlType: PartialFunction[LogicalType, SchemaType] =
     Map.empty
-  override def toAvroSchema: PartialFunction[(AbstractDataType, String, String), Schema] =
+  override def toAvroSchema: PartialFunction[RecordInfo, Schema] =
     Map.empty
-  override def deserialize: PartialFunction[LogicalType, (CatalystDataUpdater, Int, Any) => Unit] =
+  override def deserialize: PartialFunction[LogicalType, DataDeserializer => Unit] =
     Map.empty
-  override def serialize: PartialFunction[LogicalType, (SpecializedGetters, Int) => Any] =
+  override def serialize: PartialFunction[LogicalType, DataSerializer => Any] =
     Map.empty
 }

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroLogicalTypeCatalystMapper.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroLogicalTypeCatalystMapper.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.spark.sql.avro
+
+import org.apache.avro.{LogicalType, Schema}
+
+import org.apache.spark.sql.avro.SchemaConverters.SchemaType
+import org.apache.spark.sql.catalyst.expressions.SpecializedGetters
+import org.apache.spark.sql.types.AbstractDataType
+
+/**
+ * Mapping interface between Catalyst struct type and Avro schemas
+ */
+trait AvroLogicalTypeCatalystMapper extends Serializable {
+
+  /**
+   * Given Avro logical type returns mapped Catalyst type
+   * @return sql mappings
+   */
+  def toSqlType: PartialFunction[LogicalType, SchemaType]
+
+  /**
+   * Given Catalyst type returns mapped Avro schema type
+   * @return catalyst mappings
+   */
+  def toAvroSchema: PartialFunction[(AbstractDataType, String, String), Schema]
+
+  /**
+   * Given Avro logical type and the Avro data value update the value to Catalyst data.
+   * @return Avro deserialization mappings
+   */
+  def deserialize: PartialFunction[LogicalType, (CatalystDataUpdater, Int, Any) => Unit]
+
+  /**
+   * Given Avro logical type and the Catalyst data value update the value to Avro data.
+   * @return Avro serialization mappings
+   */
+  def serialize: PartialFunction[LogicalType, (SpecializedGetters, Int) => Any]
+}
+
+class DefaultAvroLogicalTypeCatalystMapper extends AvroLogicalTypeCatalystMapper {
+  override def toSqlType: PartialFunction[LogicalType, SchemaType] =
+    Map.empty
+  override def toAvroSchema: PartialFunction[(AbstractDataType, String, String), Schema] =
+    Map.empty
+  override def deserialize: PartialFunction[LogicalType, (CatalystDataUpdater, Int, Any) => Unit] =
+    Map.empty
+  override def serialize: PartialFunction[LogicalType, (SpecializedGetters, Int) => Any] =
+    Map.empty
+}

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroLogicalTypeCatalystMapper.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroLogicalTypeCatalystMapper.scala
@@ -41,14 +41,14 @@ trait AvroLogicalTypeCatalystMapper extends Serializable {
 
   /**
    * Given Avro logical type and a [[org.apache.spark.sql.avro.DataDeserializer]] deserialize
-   * de given Avro data to Catalyst data using the catalyst updater.
+   * the given Avro data to Catalyst data using the catalyst updater.
    * @return Avro deserialization mappings
    */
   def deserialize: PartialFunction[LogicalType, DataDeserializer => Unit]
 
   /**
    * Given Avro logical type and a [[org.apache.spark.sql.avro.DataSerializer]] serialize
-   * de given Catalyst data to Avro data.
+   * the given Catalyst data to Avro data.
    * @return Avro serialization mappings
    */
   def serialize: PartialFunction[LogicalType, DataSerializer => Any]

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
@@ -23,6 +23,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, FailFastMode, ParseMode}
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.util.Utils
 
 /**
  * Options for Avro Reader and Writer stored in case insensitive manner.
@@ -52,6 +53,19 @@ class AvroOptions(
    * See Avro spec for details: https://avro.apache.org/docs/1.8.2/spec.html#schema_record .
    */
   val recordNamespace: String = parameters.getOrElse("recordNamespace", "")
+
+  /**
+   * Avro logical type converter class name.
+   * Default value is "[[org.apache.spark.sql.avro.DefaultAvroLogicalTypeCatalystMapper]]".
+   */
+  val logicalTypeCatalystUpdater: AvroLogicalTypeCatalystMapper = {
+    parameters.get("logicalTypeMapper")
+      .map(Utils.classForName[AvroLogicalTypeCatalystMapper](_)
+        .getDeclaredConstructor()
+        .newInstance()
+      ).getOrElse(new DefaultAvroLogicalTypeCatalystMapper())
+  }
+
 
   /**
    * The `ignoreExtension` option controls ignoring of files without `.avro` extensions in read.

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOutputWriter.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOutputWriter.scala
@@ -36,10 +36,12 @@ private[avro] class AvroOutputWriter(
     path: String,
     context: TaskAttemptContext,
     schema: StructType,
-    avroSchema: Schema) extends OutputWriter {
+    avroSchema: Schema,
+    options: AvroOptions) extends OutputWriter {
 
   // The input rows will never be null.
-  private lazy val serializer = new AvroSerializer(schema, avroSchema, nullable = false)
+  private lazy val serializer = new AvroSerializer(schema, avroSchema, nullable = false,
+    options.logicalTypeCatalystUpdater)
 
   /**
    * Overrides the couple of methods responsible for generating the output streams / files so

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOutputWriterFactory.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOutputWriterFactory.scala
@@ -30,7 +30,8 @@ import org.apache.spark.sql.types.StructType
  */
 private[sql] class AvroOutputWriterFactory(
     catalystSchema: StructType,
-    avroSchemaAsJsonString: String) extends OutputWriterFactory {
+    avroSchemaAsJsonString: String,
+    options: AvroOptions) extends OutputWriterFactory {
 
   private lazy val avroSchema = new Schema.Parser().parse(avroSchemaAsJsonString)
 
@@ -40,6 +41,6 @@ private[sql] class AvroOutputWriterFactory(
       path: String,
       dataSchema: StructType,
       context: TaskAttemptContext): OutputWriter = {
-    new AvroOutputWriter(path, context, catalystSchema, avroSchema)
+    new AvroOutputWriter(path, context, catalystSchema, avroSchema, options)
   }
 }

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
@@ -39,7 +39,10 @@ import org.apache.spark.sql.types._
 /**
  * A serializer to serialize data in catalyst format to data in avro format.
  */
-class AvroSerializer(rootCatalystType: DataType, rootAvroType: Schema, nullable: Boolean)
+class AvroSerializer(rootCatalystType: DataType,
+                     rootAvroType: Schema,
+                     nullable: Boolean,
+                     logicalTypeUpdater: AvroLogicalTypeCatalystMapper)
   extends Logging {
 
   def serialize(catalystData: Any): Any = {
@@ -76,6 +79,8 @@ class AvroSerializer(rootCatalystType: DataType, rootAvroType: Schema, nullable:
 
   private def newConverter(catalystType: DataType, avroType: Schema): Converter = {
     (catalystType, avroType.getType) match {
+      case _ if logicalTypeUpdater.serialize.isDefinedAt(avroType.getLogicalType) =>
+        logicalTypeUpdater.serialize(avroType.getLogicalType)
       case (NullType, NULL) =>
         (getter, ordinal) => null
       case (BooleanType, BOOLEAN) =>

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
@@ -148,13 +148,13 @@ object SchemaConverters {
       nullable: Boolean = false,
       recordName: String = "topLevelRecord",
       nameSpace: String = "",
-      logicalTypeMappings: PartialFunction[(AbstractDataType, String, String), Schema] = Map.empty)
+      logicalTypeMappings: PartialFunction[RecordInfo, Schema] = Map.empty)
     : Schema = {
     val builder = SchemaBuilder.builder()
 
     val schema = catalystType match {
-      case t if logicalTypeMappings.isDefinedAt((t, recordName, nameSpace)) =>
-        logicalTypeMappings((t, recordName, nameSpace))
+      case cType if logicalTypeMappings.isDefinedAt(RecordInfo(cType, recordName, nameSpace)) =>
+        logicalTypeMappings(RecordInfo(cType, recordName, nameSpace))
       case BooleanType => builder.booleanType()
       case ByteType | ShortType | IntegerType => builder.intType()
       case LongType => builder.longType()

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/catalystUpdaters.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/catalystUpdaters.scala
@@ -18,8 +18,9 @@
 package org.apache.spark.sql.avro
 
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.SpecializedGetters
 import org.apache.spark.sql.catalyst.util.ArrayData
-import org.apache.spark.sql.types.Decimal
+import org.apache.spark.sql.types.{AbstractDataType, Decimal}
 
 
 /**
@@ -68,3 +69,7 @@ final class ArrayDataUpdater(array: ArrayData) extends CatalystDataUpdater {
   override def setFloat(ordinal: Int, value: Float): Unit = array.setFloat(ordinal, value)
   override def setDecimal(ordinal: Int, value: Decimal): Unit = array.update(ordinal, value)
 }
+
+case class DataDeserializer(updater: CatalystDataUpdater, ordinal: Int, value: Any)
+case class DataSerializer(getter: SpecializedGetters, ordinal: Int)
+case class RecordInfo(catalystType: AbstractDataType, name: String, namespace: String)

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/catalystUpdaters.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/catalystUpdaters.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.avro
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.util.ArrayData
+import org.apache.spark.sql.types.Decimal
+
+
+/**
+* A base interface for updating values inside catalyst data structure like `InternalRow` and
+* `ArrayData`.
+*/
+sealed trait CatalystDataUpdater {
+  def set(ordinal: Int, value: Any): Unit
+
+  def setNullAt(ordinal: Int): Unit = set(ordinal, null)
+  def setBoolean(ordinal: Int, value: Boolean): Unit = set(ordinal, value)
+  def setByte(ordinal: Int, value: Byte): Unit = set(ordinal, value)
+  def setShort(ordinal: Int, value: Short): Unit = set(ordinal, value)
+  def setInt(ordinal: Int, value: Int): Unit = set(ordinal, value)
+  def setLong(ordinal: Int, value: Long): Unit = set(ordinal, value)
+  def setDouble(ordinal: Int, value: Double): Unit = set(ordinal, value)
+  def setFloat(ordinal: Int, value: Float): Unit = set(ordinal, value)
+  def setDecimal(ordinal: Int, value: Decimal): Unit = set(ordinal, value)
+}
+
+final class RowUpdater(row: InternalRow) extends CatalystDataUpdater {
+  override def set(ordinal: Int, value: Any): Unit = row.update(ordinal, value)
+
+  override def setNullAt(ordinal: Int): Unit = row.setNullAt(ordinal)
+  override def setBoolean(ordinal: Int, value: Boolean): Unit = row.setBoolean(ordinal, value)
+  override def setByte(ordinal: Int, value: Byte): Unit = row.setByte(ordinal, value)
+  override def setShort(ordinal: Int, value: Short): Unit = row.setShort(ordinal, value)
+  override def setInt(ordinal: Int, value: Int): Unit = row.setInt(ordinal, value)
+  override def setLong(ordinal: Int, value: Long): Unit = row.setLong(ordinal, value)
+  override def setDouble(ordinal: Int, value: Double): Unit = row.setDouble(ordinal, value)
+  override def setFloat(ordinal: Int, value: Float): Unit = row.setFloat(ordinal, value)
+  override def setDecimal(ordinal: Int, value: Decimal): Unit =
+    row.setDecimal(ordinal, value, value.precision)
+}
+
+final class ArrayDataUpdater(array: ArrayData) extends CatalystDataUpdater {
+  override def set(ordinal: Int, value: Any): Unit = array.update(ordinal, value)
+
+  override def setNullAt(ordinal: Int): Unit = array.setNullAt(ordinal)
+  override def setBoolean(ordinal: Int, value: Boolean): Unit = array.setBoolean(ordinal, value)
+  override def setByte(ordinal: Int, value: Byte): Unit = array.setByte(ordinal, value)
+  override def setShort(ordinal: Int, value: Short): Unit = array.setShort(ordinal, value)
+  override def setInt(ordinal: Int, value: Int): Unit = array.setInt(ordinal, value)
+  override def setLong(ordinal: Int, value: Long): Unit = array.setLong(ordinal, value)
+  override def setDouble(ordinal: Int, value: Double): Unit = array.setDouble(ordinal, value)
+  override def setFloat(ordinal: Int, value: Float): Unit = array.setFloat(ordinal, value)
+  override def setDecimal(ordinal: Int, value: Decimal): Unit = array.update(ordinal, value)
+}

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/functions.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/functions.scala
@@ -67,12 +67,11 @@ object functions {
    * Converts a column into binary of avro format.
    *
    * @param data the data column.
-   *
    * @since 3.0.0
    */
   @Experimental
   def to_avro(data: Column): Column = {
-    new Column(CatalystDataToAvro(data.expr, None))
+    new Column(CatalystDataToAvro(data.expr, None, Map.empty))
   }
 
   /**
@@ -80,11 +79,26 @@ object functions {
    *
    * @param data the data column.
    * @param jsonFormatSchema user-specified output avro schema in JSON string format.
-   *
    * @since 3.0.0
    */
   @Experimental
   def to_avro(data: Column, jsonFormatSchema: String): Column = {
-    new Column(CatalystDataToAvro(data.expr, Some(jsonFormatSchema)))
+    new Column(CatalystDataToAvro(data.expr, Some(jsonFormatSchema), Map.empty))
+  }
+
+  /**
+   * Converts a column into binary of avro format.
+   *
+   * @param data the data column.
+   * @param jsonFormatSchema user-specified output avro schema in JSON string format.
+   * @param options options to control how the Avro record is parsed.
+   * @since 3.0.0
+   */
+  @Experimental
+  def to_avro(
+     data: Column,
+     jsonFormatSchema: String,
+     options: java.util.Map[String, String]): Column = {
+    new Column(CatalystDataToAvro(data.expr, Some(jsonFormatSchema), options.asScala.toMap))
   }
 }

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/functions.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/functions.scala
@@ -91,7 +91,7 @@ object functions {
    *
    * @param data the data column.
    * @param jsonFormatSchema user-specified output avro schema in JSON string format.
-   * @param options options to control how the Avro record is parsed.
+   * @param options options to control how the Avro record is serialized.
    * @since 3.0.0
    */
   @Experimental

--- a/external/avro/src/main/scala/org/apache/spark/sql/v2/avro/AvroPartitionReaderFactory.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/v2/avro/AvroPartitionReaderFactory.scala
@@ -90,7 +90,8 @@ case class AvroPartitionReaderFactory(
       val stop = partitionedFile.start + partitionedFile.length
 
       val deserializer =
-        new AvroDeserializer(userProvidedSchema.getOrElse(reader.getSchema), readDataSchema)
+        new AvroDeserializer(userProvidedSchema.getOrElse(reader.getSchema), readDataSchema,
+          parsedOptions.logicalTypeCatalystUpdater)
 
       val fileReader = new PartitionReader[InternalRow] {
         private[this] var completed = false

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroCatalystDataConversionSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroCatalystDataConversionSuite.scala
@@ -36,9 +36,10 @@ class AvroCatalystDataConversionSuite extends SparkFunSuite
     checkResult(data, avroType.toString, data.eval())
   }
 
-  private def checkResult(data: Literal, schema: String, expected: Any): Unit = {
+  private def checkResult(data: Literal, schema: String, expected: Any,
+                          options: Map[String, String] = Map.empty): Unit = {
     checkEvaluation(
-      AvroDataToCatalyst(CatalystDataToAvro(data, None), schema, Map.empty),
+      AvroDataToCatalyst(CatalystDataToAvro(data, None), schema, options),
       prepareExpectedResult(expected))
   }
 
@@ -246,4 +247,5 @@ class AvroCatalystDataConversionSuite extends SparkFunSuite
     }.getMessage
     assert(message ==  "Cannot convert Catalyst type StringType to Avro type \"long\".")
   }
+
 }

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/logicalTypesExt.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/logicalTypesExt.scala
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.avro
+
+import java.sql.Timestamp
+import java.time.{Instant, OffsetDateTime, ZoneOffset}
+import java.time.format.DateTimeFormatter
+
+import scala.util.Try
+
+import org.apache.avro.{LogicalType, LogicalTypes, Schema, SchemaBuilder}
+import org.apache.avro.util.Utf8
+
+import org.apache.spark.sql.avro.SchemaConverters.SchemaType
+import org.apache.spark.sql.catalyst.expressions.SpecializedGetters
+import org.apache.spark.sql.types.{AbstractDataType, TimestampType}
+import org.apache.spark.unsafe.types.UTF8String
+
+object ISODatetimeLogicalType extends LogicalType("datetime") {
+  def register(): Unit = LogicalTypes.register(getName, new LogicalTypes.LogicalTypeFactory() {
+    override def fromSchema(schema: Schema): LogicalType = ISODatetimeLogicalType.this
+  })
+  override def validate(schema: Schema): Unit = {
+    if (schema.getType ne Schema.Type.STRING) {
+      throw new IllegalArgumentException(
+        "Datetime (iso8601) can only be used with an underlying string type")
+    }
+  }
+}
+
+class TestSuitAvroLogicalCatalystMapper extends AvroLogicalTypeCatalystMapper {
+  override def deserialize
+  : PartialFunction[LogicalType, (CatalystDataUpdater, Int, Any) => Unit] = {
+    case ISODatetimeLogicalType =>
+      (updater, ordinal, value) =>
+        val datetime = value match {
+          case s: String => UTF8String.fromString(s)
+          case s: Utf8 => val bytes = new Array[Byte](s.getByteLength)
+            System.arraycopy(s.getBytes, 0, bytes, 0, s.getByteLength)
+            UTF8String.fromBytes(bytes)
+        }
+        val timestamp = Timestamp.from(
+          OffsetDateTime.parse(datetime.toString)
+            .atZoneSameInstant(ZoneOffset.UTC)
+            .toInstant
+        )
+        updater.setLong(ordinal, timestamp.toInstant.toEpochMilli * 1000L)
+  }
+
+  override def toSqlType: PartialFunction[LogicalType, SchemaConverters.SchemaType] = {
+    case ISODatetimeLogicalType => SchemaType(TimestampType, nullable = false)
+  }
+
+  override def toAvroSchema: PartialFunction[(AbstractDataType, String, String), Schema] = {
+    case (TimestampType, _, _) =>
+      ISODatetimeLogicalType.addToSchema(SchemaBuilder.builder().stringType())
+  }
+
+  override def serialize: PartialFunction[LogicalType, (SpecializedGetters, Int) => Any] = {
+    case ISODatetimeLogicalType =>
+      (getter, ordinal) =>
+        val datetime = OffsetDateTime.ofInstant(
+          Instant.ofEpochMilli(getter.getLong(ordinal) / 1000), ZoneOffset.UTC
+        ).toString
+
+        Try(DateTimeFormatter.ISO_DATE_TIME.parse(datetime))
+          .map(_ => datetime)
+          .getOrElse(throw new IncompatibleSchemaException(
+            s"Cannot Serialize to Avro logical type ISO8601Datetime: " +
+              s"'$datetime' is not a valid datetime."))
+
+  }
+
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Extends options for the Spark Avro formatter allowing to use custom Avro logical types.

### Why are the changes needed?

At the moment only timestamp and decimal logical types are supported at Spark but Avro support any conversion that you could need. This change keep the default mappings and allow to add news.

```scala
spark
    .read
    .format("avro")
    .option("logicalTypeMapper", "org.example.CustomAvroLogicalCatalystMapper")
    .load()     
```

Only you need is register your custom Avro logical type and then implement `AvroLogicalTypeCatalystMapper`

#### Example of mapper implementation: 

```scala
object ISODatetimeLogicalType extends LogicalType("datetime") {
  def register(): Unit = LogicalTypes.register(getName, new LogicalTypes.LogicalTypeFactory() {
    override def fromSchema(schema: Schema): LogicalType = ISODatetimeLogicalType.this
  })
  override def validate(schema: Schema): Unit = {
    if (schema.getType ne Schema.Type.STRING) {
      throw new IllegalArgumentException(
        "Datetime (iso8601) can only be used with an underlying string type")
    }
  }
}

class CustomAvroLogicalCatalystMapper extends AvroLogicalTypeCatalystMapper {
  override def toSqlType: PartialFunction[LogicalType, SchemaConverters.SchemaType] = {
    case ISODatetimeLogicalType => SchemaType(TimestampType, nullable = false)
  }

  override def toAvroSchema: PartialFunction[RecordInfo, Schema] = {
    case RecordInfo(TimestampType, _, _) =>
      ISODatetimeLogicalType.addToSchema(SchemaBuilder.builder().stringType())
  }

  override def deserialize
  : PartialFunction[LogicalType, DataDeserializer => Unit] = {
    case ISODatetimeLogicalType =>
      dataUpdater =>
        val datetime = dataUpdater.value match {
          case s: String => UTF8String.fromString(s)
          case s: Utf8 => val bytes = new Array[Byte](s.getByteLength)
            System.arraycopy(s.getBytes, 0, bytes, 0, s.getByteLength)
            UTF8String.fromBytes(bytes)
        }
        val timestamp = Timestamp.from(
          OffsetDateTime.parse(datetime.toString)
            .atZoneSameInstant(ZoneOffset.UTC)
            .toInstant
        )
        dataUpdater.updater
          .setLong(dataUpdater.ordinal, timestamp.toInstant.toEpochMilli * 1000L)
  }

  override def serialize: PartialFunction[LogicalType, DataSerializer => Any] = {
    case ISODatetimeLogicalType =>
      dataSerializer =>
        val datetime = OffsetDateTime.ofInstant(
          Instant.ofEpochMilli(dataSerializer
            .getter
            .getLong(dataSerializer.ordinal) / 1000),
          ZoneOffset.UTC
        ).toString

        Try(DateTimeFormatter.ISO_DATE_TIME.parse(datetime))
          .map(_ => datetime)
          .getOrElse(throw new IncompatibleSchemaException(
            s"Cannot Serialize to Avro logical type ISO8601Datetime: " +
              s"'$datetime' is not a valid datetime."))

  } 
}
```

### Does this PR introduce any user-facing change?

Yes, at the moment of use the Spark Avro formatter and `to_avro` & `from_avro` functions. now you can pass the class name of the logical types mapper as an optional parameter.


### How was this patch tested?

- AvroSuit: struct <=> schema types conversions test.
- AvroLogicalTypeSuit: Avro formatter test.