### PR TITLE
[SPARK-29902][Doc][Minor]Add listener event queue capacity configuration to documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1889,7 +1889,7 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.scheduler.listenerbus.eventqueue.capacity</code></td>
   <td>
     Capacity for eventLog queue in Spark listener bus, which hold events for Event logging listeners
-    that write events to eventLogs. Consider increasing value if listener events corresponding to eventLog queue
+    that write events to eventLogs. Consider increasing value if the listener events corresponding to eventLog queue
     are dropped. Increasing this value may result in the driver using more memory.
   </td>
 </tr>
@@ -1898,8 +1898,8 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.scheduler.listenerbus.eventqueue.capacity</code></td>
   <td>
     Capacity for streams queue in Spark listener bus, which hold events for internal streaming listener.
-    Consider increasing value if listener events corresponding to streams queue are dropped. Increasing this
-    value may result in the driver using more memory.
+    Consider increasing value if the listener events corresponding to streams queue are dropped. Increasing
+    this value may result in the driver using more memory.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1861,21 +1861,17 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.scheduler.listenerbus.eventqueue.shared.capacity</code></td>
   <td><code>spark.scheduler.listenerbus.eventqueue.capacity</code></td>
   <td>
-    Capacity for shared event queue in Spark listener bus, must be greater than 0.
-    Unless otherwise specified it uses <code>spark.scheduler.listenerbus.eventqueue.capacity</code>.
-    shared event queue hold events for external listener that register to listener bus.
-    Consider increasing value if listener events corresponding to shared queue are dropped.
-    Increasing this value may result in the driver using more memory.
+    Capacity for shared event queue in Spark listener bus, which hold events for external listener(s)
+    that register to the listener bus. Consider increasing value, if the listener events corresponding
+    to shared queue are dropped. Increasing this value may result in the driver using more memory.
   </td>
 </tr>
 <tr>
   <td><code>spark.scheduler.listenerbus.eventqueue.appStatus.capacity</code></td>
   <td><code>spark.scheduler.listenerbus.eventqueue.capacity</code></td>
   <td>
-    Capacity for appStatus event queue in Spark listener bus, must be greater than 0.
-    Unless otherwise specified it uses <code>spark.scheduler.listenerbus.eventqueue.capacity</code>.
-    appStatus event queue hold events for internal application status listeners. Consider increasing
-    value if listener events corresponding to appStatus queue are dropped.
+    Capacity for appStatus event queue, which hold events for internal application status listeners.
+    Consider increasing value, if the listener events corresponding to appStatus queue are dropped.
     Increasing this value may result in the driver using more memory.
   </td>
 </tr>
@@ -1883,33 +1879,27 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.scheduler.listenerbus.eventqueue.executorManagement.capacity</code></td>
   <td><code>spark.scheduler.listenerbus.eventqueue.capacity</code></td>
   <td>
-    Capacity for executorManagement event queue in Spark listener bus, must be greater than 0.
-    Unless otherwise specified it uses <code>spark.scheduler.listenerbus.eventqueue.capacity</code>.
-    This queue hold events for internal executor management listeners.
-    Consider increasing value if listener events corresponding to executorManagement queue are dropped.
-    Increasing this value may result in the driver using more memory.
+    Capacity for executorManagement event queue in Spark listener bus, which hold events for internal
+    executor management listeners. Consider increasing value if the listener events corresponding to
+    executorManagement queue are dropped. Increasing this value may result in the driver using more memory.
   </td>
 </tr>
 <tr>
   <td><code>spark.scheduler.listenerbus.eventqueue.eventLog.capacity</code></td>
   <td><code>spark.scheduler.listenerbus.eventqueue.capacity</code></td>
   <td>
-    Capacity for eventLog queue in Spark listener bus, must be greater than 0.
-    Unless otherwise specified it uses <code>spark.scheduler.listenerbus.eventqueue.capacity</code>.
-    This queue hold events for Event logging listeners that write events to eventLogs.
-    Consider increasing value if listener events corresponding to eventLog queue are dropped.
-    Increasing this value may result in the driver using more memory.
+    Capacity for eventLog queue in Spark listener bus, which hold events for Event logging listeners
+    that write events to eventLogs. Consider increasing value if listener events corresponding to eventLog queue
+    are dropped. Increasing this value may result in the driver using more memory.
   </td>
 </tr>
 <tr>
   <td><code>spark.scheduler.listenerbus.eventqueue.streams.capacity</code></td>
   <td><code>spark.scheduler.listenerbus.eventqueue.capacity</code></td>
   <td>
-    Capacity for streams queue in Spark listener bus, must be greater than 0.
-    Unless otherwise specified it uses <code>spark.scheduler.listenerbus.eventqueue.capacity</code>.
-    This queue hold events for internal streaming listener. Consider increasing value if listener
-    events corresponding to streams queue are dropped. Increasing this value may result in the
-    driver using more memory.
+    Capacity for streams queue in Spark listener bus, which hold events for internal streaming listener.
+    Consider increasing value if listener events corresponding to streams queue are dropped. Increasing this
+    value may result in the driver using more memory.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1858,6 +1858,61 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.scheduler.listenerbus.eventqueue.shared.capacity</code></td>
+  <td><code>spark.scheduler.listenerbus.eventqueue.capacity</code></td>
+  <td>
+    Capacity for shared event queue in Spark listener bus, must be greater than 0.
+    Unless otherwise specified it uses <code>spark.scheduler.listenerbus.eventqueue.capacity</code>.
+    shared event queue hold events for external listener that register to listener bus.
+    Consider increasing value if listener events corresponding to shared queue are dropped.
+    Increasing this value may result in the driver using more memory.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.scheduler.listenerbus.eventqueue.appStatus.capacity</code></td>
+  <td><code>spark.scheduler.listenerbus.eventqueue.capacity</code></td>
+  <td>
+    Capacity for appStatus event queue in Spark listener bus, must be greater than 0.
+    Unless otherwise specified it uses <code>spark.scheduler.listenerbus.eventqueue.capacity</code>.
+    appStatus event queue hold events for internal application status listeners. Consider increasing
+    value if listener events corresponding to appStatus queue are dropped.
+    Increasing this value may result in the driver using more memory.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.scheduler.listenerbus.eventqueue.executorManagement.capacity</code></td>
+  <td><code>spark.scheduler.listenerbus.eventqueue.capacity</code></td>
+  <td>
+    Capacity for executorManagement event queue in Spark listener bus, must be greater than 0.
+    Unless otherwise specified it uses <code>spark.scheduler.listenerbus.eventqueue.capacity</code>.
+    This queue hold events for internal executor management listeners.
+    Consider increasing value if listener events corresponding to executorManagement queue are dropped.
+    Increasing this value may result in the driver using more memory.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.scheduler.listenerbus.eventqueue.eventLog.capacity</code></td>
+  <td><code>spark.scheduler.listenerbus.eventqueue.capacity</code></td>
+  <td>
+    Capacity for eventLog queue in Spark listener bus, must be greater than 0.
+    Unless otherwise specified it uses <code>spark.scheduler.listenerbus.eventqueue.capacity</code>.
+    This queue hold events for Event logging listeners that write events to eventLogs.
+    Consider increasing value if listener events corresponding to eventLog queue are dropped.
+    Increasing this value may result in the driver using more memory.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.scheduler.listenerbus.eventqueue.streams.capacity</code></td>
+  <td><code>spark.scheduler.listenerbus.eventqueue.capacity</code></td>
+  <td>
+    Capacity for streams queue in Spark listener bus, must be greater than 0.
+    Unless otherwise specified it uses <code>spark.scheduler.listenerbus.eventqueue.capacity</code>.
+    This queue hold events for internal streaming listener. Consider increasing value if listener
+    events corresponding to streams queue are dropped. Increasing this value may result in the
+    driver using more memory.
+  </td>
+</tr>
+<tr>
   <td><code>spark.scheduler.blacklist.unschedulableTaskSetTimeout</code></td>
   <td>120s</td>
   <td>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add listener event queue capacity configuration to documentation
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
We some time see many event drops happening in eventLog listener queue. So, instead of increasing all the queues size, using this config we just need to increase eventLog queue capacity.

```
scala> sc.parallelize(1 to 100000, 100000).count()
[Stage 0:=================================================>(98299 + 4) / 100000]19/11/14 20:56:35 ERROR AsyncEventQueue: Dropping event from queue eventLog. This likely means one of the listeners is too slow and cannot keep up with the rate at which tasks are being started by the scheduler.
19/11/14 20:56:35 WARN AsyncEventQueue: Dropped 1 events from eventLog since the application started.
```

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing tests