### PR TITLE
[SPARK-25694][SQL] Add a config for `URL.setURLStreamHandlerFactory`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -199,7 +199,7 @@ object SharedState extends Logging {
 
   private def setFsUrlStreamHandlerFactory(conf: SparkConf): Unit = {
     if (conf.get(DEFAULT_URL_STREAM_HANDLER_FACTORY_ENABLED) &&
-        fsUrlStreamHandlerFactoryInitialized.compareAndSet(false, true)) {
+        !fsUrlStreamHandlerFactoryInitialized.getAndSet(true)) {
       try {
         URL.setURLStreamHandlerFactory(new FsUrlStreamHandlerFactory())
       } catch {

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -194,24 +194,13 @@ private[sql] class SharedState(
 }
 
 object SharedState extends Logging {
-  @volatile private var factory: Option[FsUrlStreamHandlerFactory] = None
-  private lazy val defaultFactory = new FsUrlStreamHandlerFactory()
   private def setFsUrlStreamHandlerFactory(conf: SparkConf): Unit = {
-    factory match {
-      case Some(_) =>
-        logWarning("FsUrlStreamHandlerFactory has been already initialized, " +
-          "so it can not be modified")
-      case None => synchronized {
-        try {
-          if (conf.get(DEFAULT_URL_STREAM_HANDLER_FACTORY_ENABLED)) {
-            URL.setURLStreamHandlerFactory(defaultFactory)
-            factory = Some(defaultFactory)
-          }
-        } catch {
-          case e: Error =>
-            logWarning("URL.setURLStreamHandlerFactory failed to set " +
-              "FsUrlStreamHandlerFactory", e)
-        }
+    if (conf.get(DEFAULT_URL_STREAM_HANDLER_FACTORY_ENABLED)) {
+      try {
+        URL.setURLStreamHandlerFactory(new FsUrlStreamHandlerFactory())
+      } catch {
+        case _: Error =>
+          logWarning("URL.setURLStreamHandlerFactory failed to set FsUrlStreamHandlerFactory")
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -196,15 +196,14 @@ private[sql] class SharedState(
 object SharedState extends Logging {
   private def setFsUrlStreamHandlerFactory(conf: SparkConf): Unit = {
     if (conf.get(DEFAULT_URL_STREAM_HANDLER_FACTORY_ENABLED) && factory.isEmpty) {
-      factory.synchronized {
+      synchronized {
         if (factory.isEmpty) {
           try {
             URL.setURLStreamHandlerFactory(defaultFactory)
             factory = Some(defaultFactory)
           } catch {
-            case NonFatal(e) =>
-              logWarning("URL.setURLStreamHandlerFactory failed to set " +
-                "FsUrlStreamHandlerFactory", e)
+            case NonFatal(_) =>
+              logWarning("URL.setURLStreamHandlerFactory failed to set FsUrlStreamHandlerFactory")
           }
         }
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -199,8 +199,8 @@ object SharedState extends Logging {
       try {
         URL.setURLStreamHandlerFactory(new FsUrlStreamHandlerFactory())
       } catch {
-        case _: Error =>
-          logWarning("URL.setURLStreamHandlerFactory failed to set FsUrlStreamHandlerFactory")
+        case NonFatal(e) =>
+          logWarning("URL.setURLStreamHandlerFactory failed to set FsUrlStreamHandlerFactory", e)
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -36,6 +36,7 @@ import org.apache.spark.sql.execution.CacheManager
 import org.apache.spark.sql.execution.streaming.StreamExecution
 import org.apache.spark.sql.execution.ui.{SQLAppStatusListener, SQLAppStatusStore, SQLTab}
 import org.apache.spark.sql.internal.StaticSQLConf._
+import org.apache.spark.sql.internal.config.DEFAULT_URL_STREAM_HANDLER_FACTORY_ENABLED
 import org.apache.spark.sql.streaming.StreamingQuery
 import org.apache.spark.status.ElementTrackingStore
 import org.apache.spark.util.Utils
@@ -202,7 +203,7 @@ object SharedState extends Logging {
           "so it can not be modified")
       case None => synchronized {
         try {
-          if (conf.getBoolean("spark.fsUrlStreamHandlerFactory.enabled", true)) {
+          if (conf.get(DEFAULT_URL_STREAM_HANDLER_FACTORY_ENABLED)) {
             URL.setURLStreamHandlerFactory(defaultFactory)
             factory = Some(defaultFactory)
           }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/config/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/config/package.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.internal
+
+import org.apache.spark.internal.config.ConfigBuilder
+
+package object config {
+
+  private[spark] val DEFAULT_URL_STREAM_HANDLER_FACTORY_ENABLED =
+    ConfigBuilder("spark.sql.defaultUrlStreamHandlerFactory.enabled")
+      .doc("When true, set FsUrlStreamHandlerFactory to support ADD JAR against HDFS locations")
+      .booleanConf
+      .createWithDefault(true)
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a property `spark.fsUrlStreamHandlerFactory.enabled` to allow users turn off the default registration of `org.apache.hadoop.fs.FsUrlStreamHandlerFactory`

### Why are the changes needed?

This [SPARK-25694](https://issues.apache.org/jira/browse/SPARK-25694) is a long-standing issue. Originally, [[SPARK-12868][SQL] Allow adding jars from hdfs](https://github.com/apache/spark/pull/17342 ) added this for better Hive support. However, this have a side-effect when the users use Apache Spark without `-Phive`. This causes exceptions when the users tries to use another custom factories or 3rd party library (trying to set this). This configuration will unblock those non-hive users.

### Does this PR introduce any user-facing change?

Yes. This provides a new user-configurable property.
By default, the behavior is unchanged.

### How was this patch tested?

Manual testing.

**BEFORE**
```
$ build/sbt package
$ bin/spark-shell
scala> sql("show tables").show
+--------+---------+-----------+
|database|tableName|isTemporary|
+--------+---------+-----------+
+--------+---------+-----------+


scala> java.net.URL.setURLStreamHandlerFactory(new org.apache.hadoop.fs.FsUrlStreamHandlerFactory())
java.lang.Error: factory already defined
  at java.net.URL.setURLStreamHandlerFactory(URL.java:1134)
  ... 47 elided
```

**AFTER**
```
$ build/sbt package
$ bin/spark-shell --conf spark.sql.defaultUrlStreamHandlerFactory.enabled=false
scala> sql("show tables").show
+--------+---------+-----------+
|database|tableName|isTemporary|
+--------+---------+-----------+
+--------+---------+-----------+

scala> java.net.URL.setURLStreamHandlerFactory(new org.apache.hadoop.fs.FsUrlStreamHandlerFactory())
```