### PR TITLE
[SPARK-29343][SQL][FOLLOW-UP] Remove floating-point Sum/Average/CentralMomentAgg from order-insensitive aggregates

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1007,6 +1007,8 @@ object EliminateSorts extends Rule[LogicalPlan] {
       case _: Max => true
       case _: Count => true
       case _: CentralMomentAgg => true
+      // Floating-piont Average aggregates are order-sensitive
+      case a: Average => !Seq(FloatType, DoubleType).exists(_.sameType(a.child.dataType))
       case _ => false
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1002,13 +1002,13 @@ object EliminateSorts extends Rule[LogicalPlan] {
 
   private def isOrderIrrelevantAggs(aggs: Seq[NamedExpression]): Boolean = {
     def isOrderIrrelevantAggFunction(func: AggregateFunction): Boolean = func match {
-      case _: Sum => true
       case _: Min => true
       case _: Max => true
       case _: Count => true
-      case _: CentralMomentAgg => true
-      // Floating-piont Average aggregates are order-sensitive
-      case a: Average => !Seq(FloatType, DoubleType).exists(_.sameType(a.child.dataType))
+      // Arithmetic operations for floating-point values are order-sensitive
+      // (they are not associative).
+      case _: Sum | _: Average | _: CentralMomentAgg =>
+        !Seq(FloatType, DoubleType).exists(_.sameType(func.children.head.dataType))
       case _ => false
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1002,9 +1002,7 @@ object EliminateSorts extends Rule[LogicalPlan] {
 
   private def isOrderIrrelevantAggs(aggs: Seq[NamedExpression]): Boolean = {
     def isOrderIrrelevantAggFunction(func: AggregateFunction): Boolean = func match {
-      case _: Min => true
-      case _: Max => true
-      case _: Count => true
+      case _: Min | _: Max | _: Count => true
       // Arithmetic operations for floating-point values are order-sensitive
       // (they are not associative).
       case _: Sum | _: Average | _: CentralMomentAgg =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1006,7 +1006,6 @@ object EliminateSorts extends Rule[LogicalPlan] {
       case _: Min => true
       case _: Max => true
       case _: Count => true
-      case _: Average => true
       case _: CentralMomentAgg => true
       case _ => false
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -1275,7 +1275,7 @@ class SubquerySuite extends QueryTest with SharedSparkSession {
     Seq("float", "double").foreach { typeName =>
       Seq("SUM", "AVG", "KURTOSIS", "SKEWNESS", "STDDEV_POP", "STDDEV_SAMP",
           "VAR_POP", "VAR_SAMP").foreach { aggName =>
-        val query1 =
+        val query =
           s"""
             |SELECT k, $aggName(v) FROM (
             |  SELECT k, v
@@ -1283,7 +1283,7 @@ class SubquerySuite extends QueryTest with SharedSparkSession {
             |  ORDER BY v)
             |GROUP BY k
           """.stripMargin
-        assert(getNumSortsInQuery(query1) == 1)
+        assert(getNumSortsInQuery(query) == 1)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -1271,6 +1271,18 @@ class SubquerySuite extends QueryTest with SharedSparkSession {
     }
   }
 
+  test("Cannot remove sort for AVG from subquery plan because it is order-sensitive") {
+    val query =
+      """
+        |SELECT k, AVG(v) FROM (
+        |  SELECT k, v
+        |  FROM VALUES (1, 2), (2, 1) t(k, v)
+        |  ORDER BY v)
+        |GROUP BY k
+      """.stripMargin
+    assert(getNumSortsInQuery(query) == 1)
+  }
+
   test("SPARK-25482: Forbid pushdown to datasources of filters containing subqueries") {
     withTempView("t1", "t2") {
       sql("create temporary view t1(a int) using parquet")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr is to remove floating-point `Sum/Average/CentralMomentAgg` from order-insensitive aggregates in `EliminateSorts`.

This pr comes from the @gatorsmile suggestion: https://github.com/apache/spark/pull/26011#discussion_r344583899

### Why are the changes needed?

Bug fix.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Added tests in `SubquerySuite`.
