### PR TITLE
[WIP][SPARK-29848][SQL] PostgreSQL dialect: cast to long

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/PostgreSQLDialect.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/PostgreSQLDialect.scala
@@ -19,15 +19,15 @@ package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.Cast
-import org.apache.spark.sql.catalyst.expressions.postgreSQL.PostgreCastToBoolean
+import org.apache.spark.sql.catalyst.expressions.postgreSQL.{PostgreCastToBoolean, PostgreCastToLong}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{BooleanType, StringType}
+import org.apache.spark.sql.types.{BooleanType, LongType, StringType}
 
 object PostgreSQLDialect {
   val postgreSQLDialectRules: List[Rule[LogicalPlan]] =
-    CastToBoolean ::
+    CastToBoolean :: CastToLong ::
       Nil
 
   object CastToBoolean extends Rule[LogicalPlan] with Logging {
@@ -40,6 +40,23 @@ object PostgreSQLDialect {
           case Cast(child, dataType, timeZoneId)
             if child.dataType != BooleanType && dataType == BooleanType =>
             PostgreCastToBoolean(child, timeZoneId)
+        }
+      } else {
+        plan
+      }
+    }
+  }
+
+  object CastToLong extends Rule[LogicalPlan] with Logging {
+    override def apply(plan: LogicalPlan): LogicalPlan = {
+      // The SQL configuration `spark.sql.dialect` can be changed in runtime.
+      // To make sure the configuration is effective, we have to check it during rule execution.
+      val conf = SQLConf.get
+      if (conf.usePostgreSQLDialect) {
+        plan.transformExpressions {
+          case Cast(child, dataType, timeZoneId)
+            if child.dataType != LongType && dataType == LongType =>
+            PostgreCastToLong(child, timeZoneId)
         }
       } else {
         plan

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -471,7 +471,7 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
   }
 
   // LongConverter
-  private[this] def castToLong(from: DataType): Any => Any = from match {
+  protected[this] def castToLong(from: DataType): Any => Any = from match {
     case StringType =>
       val result = new LongWrapper()
       buildCast[UTF8String](_, s => if (s.toLong(result)) result.value else null)
@@ -1422,7 +1422,9 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
       (c, evPrim, evNull) => code"$evPrim = (int) $c;"
   }
 
-  private[this] def castToLongCode(from: DataType, ctx: CodegenContext): CastFunction = from match {
+  protected[this] def castToLongCode(
+      from: DataType,
+      ctx: CodegenContext): CastFunction = from match {
     case StringType =>
       val wrapper = ctx.freshVariable("longWrapper", classOf[UTF8String.LongWrapper])
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/postgreSQL/PostgreCastToLong.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/postgreSQL/PostgreCastToLong.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.expressions.postgreSQL
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
+import org.apache.spark.sql.catalyst.expressions.{CastBase, Expression, TimeZoneAwareExpression}
+import org.apache.spark.sql.catalyst.expressions.codegen.Block._
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.unsafe.types.UTF8String.LongWrapper
+
+case class PostgreCastToLong(child: Expression, timeZoneId: Option[String])
+  extends CastBase {
+  override def dataType: DataType = LongType
+
+  override protected def ansiEnabled: Boolean =
+    throw new AnalysisException("")
+
+  override def checkInputDataTypes(): TypeCheckResult = child.dataType match {
+    case DateType | TimestampType | NullType =>
+      TypeCheckResult.TypeCheckFailure(s"cannot cast type ${child.dataType} to long")
+    case _ =>
+      TypeCheckResult.TypeCheckSuccess
+  }
+  /** Returns a copy of this expression with the specified timeZoneId. */
+  override def withTimeZone(timeZoneId: String): TimeZoneAwareExpression =
+    copy(timeZoneId = Option(timeZoneId))
+
+  override def castToLong(from: DataType): Any => Any = from match {
+    case StringType =>
+      val result = new LongWrapper()
+      buildCast[UTF8String](_, s => if (s.toLong(result)) result.value
+      else throw new AnalysisException(s"invalid input syntax for type long: $s"))
+    case BooleanType =>
+      buildCast[Boolean](_, b => if (b) 1L else 0L)
+    case x: NumericType =>
+      b => x.numeric.asInstanceOf[Numeric[Any]].toLong(b)
+  }
+
+  override def castToLongCode(from: DataType, ctx: CodegenContext): CastFunction = from match {
+      case StringType =>
+        val wrapper = ctx.freshVariable("longWrapper", classOf[UTF8String.LongWrapper])
+        (c, evPrim, _) =>
+          code"""
+          UTF8String.LongWrapper $wrapper = new UTF8String.LongWrapper();
+          if ($c.toLong($wrapper)) {
+            $evPrim = $wrapper.value;
+          } else {
+            throw new AnalysisException(s"invalid input syntax for type long: $c");
+          }
+          $wrapper = null;
+        """
+      case BooleanType =>
+        (c, evPrim, _) => code"$evPrim = $c ? 1L : 0L;"
+      case DecimalType() =>
+        (c, evPrim, _) => code"$evPrim = $c.to${"long".capitalize}();"
+      case NumericType() =>
+        (c, evPrim, _) => code"$evPrim = (long) $c;"
+    }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/postgreSQL/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/postgreSQL/CastSuite.scala
@@ -70,4 +70,8 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
     assert(PostgreCastToBoolean(Literal(1.toDouble), None).checkInputDataTypes().isFailure)
     assert(PostgreCastToBoolean(Literal(1.toFloat), None).checkInputDataTypes().isFailure)
   }
+
+  test("unsupported data types to cast to long") {
+    // TODO: Test cases to be added
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/PostgreSQLDialectQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/PostgreSQLDialectQuerySuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.DateType
 
 class PostgreSQLDialectQuerySuite extends QueryTest with SharedSparkSession {
 
@@ -38,5 +39,9 @@ class PostgreSQLDialectQuerySuite extends QueryTest with SharedSparkSession {
     Seq("o", "abc", "").foreach { input =>
       intercept[IllegalArgumentException](sql(s"select cast('$input' as boolean)").collect())
     }
+  }
+
+  test("cast to long") {
+    // TODO: Add test cases
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
To make SparkSQL's `cast as long` behavior consistent with PostgreSQL when spark.sql.dialect is configured as PostgreSQL.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
SparkSQL and PostgreSQL have a lot different cast behavior between types by default. We should make SparkSQL's cast behavior be consistent with PostgreSQL when spark.sql.dialect is configured as PostgreSQL.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce any user-facing change?
Yes. If user switches to PostgreSQL dialect now, they will

- get an AnalysisException if they try to cast to long from `TimestampType` and `DateType`.

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->


### How was this patch tested?
Test cases to be added
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
