### PR TITLE
[SPARK-29914][ML] ML models attach metadata in `transform`/`transformSchema`

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.ml
 
 import org.apache.spark.annotation.{DeveloperApi, Since}
-import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.feature.{Instance, LabeledPoint}
 import org.apache.spark.ml.linalg.{Vector, VectorUDT}
 import org.apache.spark.ml.param._
@@ -226,9 +225,7 @@ abstract class PredictionModel[FeaturesType, M <: PredictionModel[FeaturesType, 
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = validateAndTransformSchema(schema, fitting = false, featuresDataType)
     if ($(predictionCol).nonEmpty) {
-      val attr = NumericAttribute.defaultAttr
-        .withName($(predictionCol))
-      outputSchema = SchemaUtils.updateMeta(outputSchema, attr.toStructField)
+      outputSchema = SchemaUtils.updateNumeric(outputSchema, $(predictionCol))
     }
     outputSchema
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.ml
 
 import org.apache.spark.annotation.{DeveloperApi, Since}
+import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.feature.{Instance, LabeledPoint}
 import org.apache.spark.ml.linalg.{Vector, VectorUDT}
 import org.apache.spark.ml.param._
@@ -223,7 +224,13 @@ abstract class PredictionModel[FeaturesType, M <: PredictionModel[FeaturesType, 
   protected def featuresDataType: DataType = new VectorUDT
 
   override def transformSchema(schema: StructType): StructType = {
-    validateAndTransformSchema(schema, fitting = false, featuresDataType)
+    var outputSchema = validateAndTransformSchema(schema, fitting = false, featuresDataType)
+    if ($(predictionCol).nonEmpty) {
+      val attr = NumericAttribute.defaultAttr
+        .withName($(predictionCol))
+      outputSchema = SchemaUtils.updateMeta(outputSchema, attr.toStructField)
+    }
+    outputSchema
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
@@ -245,10 +245,12 @@ abstract class PredictionModel[FeaturesType, M <: PredictionModel[FeaturesType, 
   }
 
   protected def transformImpl(dataset: Dataset[_]): DataFrame = {
-    val predictUDF = udf { (features: Any) =>
+    val outputSchema = transformSchema(dataset.schema, logging = true)
+    val predictUDF = udf { features: Any =>
       predict(features.asInstanceOf[FeaturesType])
     }
-    dataset.withColumn($(predictionCol), predictUDF(col($(featuresCol))))
+    dataset.withColumn($(predictionCol), predictUDF(col($(featuresCol))),
+      outputSchema($(predictionCol)).metadata)
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
@@ -88,8 +88,9 @@ private[ml] trait PredictorParams extends Params
    * and put it in an RDD with strong types.
    * Validate the output instances with the given function.
    */
-  protected def extractInstances(dataset: Dataset[_],
-                                 validateInstance: Instance => Unit): RDD[Instance] = {
+  protected def extractInstances(
+      dataset: Dataset[_],
+      validateInstance: Instance => Unit): RDD[Instance] = {
     extractInstances(dataset).map { instance =>
       validateInstance(instance)
       instance

--- a/mllib/src/main/scala/org/apache/spark/ml/Transformer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Transformer.scala
@@ -117,9 +117,10 @@ abstract class UnaryTransformer[IN, OUT, T <: UnaryTransformer[IN, OUT, T]]
   }
 
   override def transform(dataset: Dataset[_]): DataFrame = {
-    transformSchema(dataset.schema, logging = true)
+    val outputSchema = transformSchema(dataset.schema, logging = true)
     val transformUDF = udf(this.createTransformFunc, outputDataType)
-    dataset.withColumn($(outputCol), transformUDF(dataset($(inputCol))))
+    dataset.withColumn($(outputCol), transformUDF(dataset($(inputCol))),
+      outputSchema($(outputCol)).metadata)
   }
 
   override def copy(extra: ParamMap): T = defaultCopy(extra)

--- a/mllib/src/main/scala/org/apache/spark/ml/attribute/AttributeGroup.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/attribute/AttributeGroup.scala
@@ -250,9 +250,4 @@ object AttributeGroup {
       new AttributeGroup(field.name)
     }
   }
-
-  private[ml] def toMeta(name: String, numAttributes: Int): Metadata = {
-    val attrGroup = new AttributeGroup(name, numAttributes)
-    attrGroup.toMetadata()
-  }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/attribute/AttributeGroup.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/attribute/AttributeGroup.scala
@@ -250,4 +250,9 @@ object AttributeGroup {
       new AttributeGroup(field.name)
     }
   }
+
+  private[ml] def toMeta(name: String, numAttributes: Int): Metadata = {
+    val attrGroup = new AttributeGroup(name, numAttributes)
+    attrGroup.toMetadata()
+  }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
@@ -187,7 +187,7 @@ abstract class ClassificationModel[FeaturesType, M <: ClassificationModel[Featur
 
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = super.transformSchema(schema)
-    if (outputSchema.contains($(predictionCol))) {
+    if ($(predictionCol).nonEmpty) {
       val attr = if (numClasses == 2) {
         new BinaryAttribute(name = Some($(predictionCol)))
       } else {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
@@ -189,9 +189,12 @@ abstract class ClassificationModel[FeaturesType, M <: ClassificationModel[Featur
     var outputSchema = super.transformSchema(schema)
     if ($(predictionCol).nonEmpty) {
       val attr = if (numClasses == 2) {
-        new BinaryAttribute(name = Some($(predictionCol)))
+        BinaryAttribute.defaultAttr
+          .withName($(predictionCol))
       } else {
-        new NominalAttribute(name = Some($(predictionCol)), numValues = Some(numClasses))
+        NominalAttribute.defaultAttr
+          .withName($(predictionCol))
+          .withNumValues(numClasses)
       }
       outputSchema = SchemaUtils.updateMeta(outputSchema, attr.toStructField)
     }
@@ -235,7 +238,8 @@ abstract class ClassificationModel[FeaturesType, M <: ClassificationModel[Featur
         }
         predictUDF(col(getFeaturesCol))
       }
-      outputData = outputData.withColumn(getPredictionCol, predUDF)
+      outputData = outputData.withColumn(getPredictionCol, predUDF,
+        outputSchema($(predictionCol)).metadata)
       numColsOutput += 1
     }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
@@ -20,7 +20,6 @@ package org.apache.spark.ml.classification
 import org.apache.spark.SparkException
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.ml.{PredictionModel, Predictor, PredictorParams}
-import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.feature.{Instance, LabeledPoint}
 import org.apache.spark.ml.linalg.{Vector, VectorUDT}
 import org.apache.spark.ml.param.shared.HasRawPredictionCol
@@ -188,15 +187,8 @@ abstract class ClassificationModel[FeaturesType, M <: ClassificationModel[Featur
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = super.transformSchema(schema)
     if ($(predictionCol).nonEmpty) {
-      val attr = if (numClasses == 2) {
-        BinaryAttribute.defaultAttr
-          .withName($(predictionCol))
-      } else {
-        NominalAttribute.defaultAttr
-          .withName($(predictionCol))
-          .withNumValues(numClasses)
-      }
-      outputSchema = SchemaUtils.updateMeta(outputSchema, attr.toStructField)
+      outputSchema = SchemaUtils.updateNumValues(schema,
+        $(predictionCol), numClasses)
     }
     if ($(rawPredictionCol).nonEmpty) {
       outputSchema = SchemaUtils.updateAttributeGroupSize(outputSchema,

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
@@ -230,7 +230,7 @@ abstract class ClassificationModel[FeaturesType, M <: ClassificationModel[Featur
       numColsOutput += 1
     }
     if (getPredictionCol != "") {
-      val predUDF = if (getRawPredictionCol != "") {
+      val predCol = if (getRawPredictionCol != "") {
         udf(raw2prediction _).apply(col(getRawPredictionCol))
       } else {
         val predictUDF = udf { features: Any =>
@@ -238,7 +238,7 @@ abstract class ClassificationModel[FeaturesType, M <: ClassificationModel[Featur
         }
         predictUDF(col(getFeaturesCol))
       }
-      outputData = outputData.withColumn(getPredictionCol, predUDF,
+      outputData = outputData.withColumn(getPredictionCol, predCol,
         outputSchema($(predictionCol)).metadata)
       numColsOutput += 1
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
@@ -188,8 +188,12 @@ abstract class ClassificationModel[FeaturesType, M <: ClassificationModel[Featur
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = super.transformSchema(schema)
     if (outputSchema.contains($(predictionCol))) {
-      val attr = new NominalAttribute(numValues = Some(numClasses))
-      outputSchema = SchemaUtils.updateMeta(outputSchema, $(predictionCol), attr.toMetadata)
+      val attr = if (numClasses == 2) {
+        new BinaryAttribute(name = Some($(predictionCol)))
+      } else {
+        new NominalAttribute(name = Some($(predictionCol)), numValues = Some(numClasses))
+      }
+      outputSchema = SchemaUtils.updateMeta(outputSchema, attr.toStructField)
     }
     if ($(rawPredictionCol).nonEmpty) {
       outputSchema = SchemaUtils.updateAttributeGroupSize(outputSchema,

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -203,7 +203,7 @@ class DecisionTreeClassificationModel private[ml] (
     rootNode.predictImpl(features).prediction
   }
 
-  @Since("1.4.0")
+  @Since("3.0.0")
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = super.transformSchema(schema)
     if ($(leafCol).nonEmpty) {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -36,6 +36,7 @@ import org.apache.spark.mllib.tree.model.{DecisionTreeModel => OldDecisionTreeMo
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Dataset}
 import org.apache.spark.sql.functions.{col, udf}
+import org.apache.spark.sql.types.StructType
 
 /**
  * Decision tree learning algorithm (http://en.wikipedia.org/wiki/Decision_tree_learning)
@@ -202,13 +203,23 @@ class DecisionTreeClassificationModel private[ml] (
     rootNode.predictImpl(features).prediction
   }
 
+  @Since("1.4.0")
+  override def transformSchema(schema: StructType): StructType = {
+    var outputSchema = super.transformSchema(schema)
+    if ($(leafCol).nonEmpty) {
+      outputSchema = SchemaUtils.updateMeta(outputSchema, getLeafField($(leafCol)))
+    }
+    outputSchema
+  }
+
   override def transform(dataset: Dataset[_]): DataFrame = {
-    transformSchema(dataset.schema, logging = true)
+    val outputSchema = transformSchema(dataset.schema, logging = true)
 
     val outputData = super.transform(dataset)
     if ($(leafCol).nonEmpty) {
       val leafUDF = udf { features: Vector => predictLeaf(features) }
-      outputData.withColumn($(leafCol), leafUDF(col($(featuresCol))))
+      outputData.withColumn($(leafCol), leafUDF(col($(featuresCol))),
+        outputSchema($(leafCol)).metadata)
     } else {
       outputData
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -207,7 +207,7 @@ class DecisionTreeClassificationModel private[ml] (
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = super.transformSchema(schema)
     if ($(leafCol).nonEmpty) {
-      outputSchema = SchemaUtils.updateMeta(outputSchema, getLeafField($(leafCol)))
+      outputSchema = SchemaUtils.updateField(outputSchema, getLeafField($(leafCol)))
     }
     outputSchema
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -294,12 +294,11 @@ class GBTClassificationModel private[ml](
 
   @Since("1.6.0")
   override def transformSchema(schema: StructType): StructType = {
-    val outputSchema = super.transformSchema(schema)
+    var outputSchema = super.transformSchema(schema)
     if ($(leafCol).nonEmpty) {
-      SchemaUtils.appendColumn(schema, getLeafField($(leafCol)))
-    } else {
-      outputSchema
+      outputSchema = SchemaUtils.updateMeta(outputSchema, getLeafField($(leafCol)))
     }
+    outputSchema
   }
 
   override def transform(dataset: Dataset[_]): DataFrame = {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -296,7 +296,7 @@ class GBTClassificationModel private[ml](
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = super.transformSchema(schema)
     if ($(leafCol).nonEmpty) {
-      outputSchema = SchemaUtils.updateMeta(outputSchema, getLeafField($(leafCol)))
+      outputSchema = SchemaUtils.updateField(outputSchema, getLeafField($(leafCol)))
     }
     outputSchema
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -23,6 +23,7 @@ import org.json4s.JsonDSL._
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.internal.Logging
+import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.feature.Instance
 import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
 import org.apache.spark.ml.param.ParamMap
@@ -297,7 +298,8 @@ class GBTClassificationModel private[ml](
     val outputData = super.transform(dataset)
     if ($(leafCol).nonEmpty) {
       val leafUDF = udf { features: Vector => predictLeaf(features) }
-      outputData.withColumn($(leafCol), leafUDF(col($(featuresCol))))
+      outputData.withColumn($(leafCol), leafUDF(col($(featuresCol))),
+        AttributeGroup.toMeta($(leafCol), trees.length))
     } else {
       outputData
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -161,13 +161,19 @@ final class OneVsRestModel private[ml] (
 
   @Since("1.4.0")
   override def transformSchema(schema: StructType): StructType = {
-    validateAndTransformSchema(schema, fitting = false, getClassifier.featuresDataType)
+    var outputSchema = validateAndTransformSchema(schema, fitting = false,
+      getClassifier.featuresDataType)
+    if ($(rawPredictionCol).nonEmpty) {
+      outputSchema = SchemaUtils.updateAttributeGroupSize(schema,
+        $(rawPredictionCol), numClasses)
+    }
+    outputSchema
   }
 
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
     // Check schema
-    transformSchema(dataset.schema, logging = true)
+    val outputSchema = transformSchema(dataset.schema, logging = true)
 
     if (getPredictionCol.isEmpty && getRawPredictionCol.isEmpty) {
       logWarning(s"$uid: OneVsRestModel.transform() does nothing" +
@@ -230,7 +236,7 @@ final class OneVsRestModel private[ml] (
 
       predictionColNames :+= getRawPredictionCol
       predictionColumns :+= rawPredictionUDF(col(accColName))
-        .as(getRawPredictionCol, AttributeGroup.toMeta(getRawPredictionCol, models.length))
+        .as($(rawPredictionCol), outputSchema($(rawPredictionCol)).metadata)
     }
 
     if (getPredictionCol.nonEmpty) {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -175,7 +175,7 @@ final class OneVsRestModel private[ml] (
       outputSchema = SchemaUtils.updateMeta(outputSchema, attr.toStructField)
     }
     if ($(rawPredictionCol).nonEmpty) {
-      outputSchema = SchemaUtils.updateAttributeGroupSize(schema,
+      outputSchema = SchemaUtils.updateAttributeGroupSize(outputSchema,
         $(rawPredictionCol), numClasses)
     }
     outputSchema

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -230,6 +230,7 @@ final class OneVsRestModel private[ml] (
 
       predictionColNames :+= getRawPredictionCol
       predictionColumns :+= rawPredictionUDF(col(accColName))
+        .as(getRawPredictionCol, AttributeGroup.toMeta(getRawPredictionCol, models.length))
     }
 
     if (getPredictionCol.nonEmpty) {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -163,6 +163,17 @@ final class OneVsRestModel private[ml] (
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = validateAndTransformSchema(schema, fitting = false,
       getClassifier.featuresDataType)
+    if ($(predictionCol).nonEmpty) {
+      val attr = if (numClasses == 2) {
+        BinaryAttribute.defaultAttr
+          .withName($(predictionCol))
+      } else {
+        NominalAttribute.defaultAttr
+          .withName($(predictionCol))
+          .withNumValues(numClasses)
+      }
+      outputSchema = SchemaUtils.updateMeta(outputSchema, attr.toStructField)
+    }
     if ($(rawPredictionCol).nonEmpty) {
       outputSchema = SchemaUtils.updateAttributeGroupSize(schema,
         $(rawPredictionCol), numClasses)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -164,15 +164,8 @@ final class OneVsRestModel private[ml] (
     var outputSchema = validateAndTransformSchema(schema, fitting = false,
       getClassifier.featuresDataType)
     if ($(predictionCol).nonEmpty) {
-      val attr = if (numClasses == 2) {
-        BinaryAttribute.defaultAttr
-          .withName($(predictionCol))
-      } else {
-        NominalAttribute.defaultAttr
-          .withName($(predictionCol))
-          .withNumValues(numClasses)
-      }
-      outputSchema = SchemaUtils.updateMeta(outputSchema, attr.toStructField)
+      outputSchema = SchemaUtils.updateNumValues(outputSchema,
+        $(predictionCol), numClasses)
     }
     if ($(rawPredictionCol).nonEmpty) {
       outputSchema = SchemaUtils.updateAttributeGroupSize(outputSchema,

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -153,7 +153,8 @@ abstract class ProbabilisticClassificationModel[
         }
         predictUDF(col($(featuresCol)))
       }
-      outputData = outputData.withColumn($(predictionCol), predUDF)
+      outputData = outputData.withColumn($(predictionCol), predUDF,
+        outputSchema($(predictionCol)).metadata)
       numColsOutput += 1
     }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -130,7 +130,7 @@ abstract class ProbabilisticClassificationModel[
       numColsOutput += 1
     }
     if ($(probabilityCol).nonEmpty) {
-      val probUDF = if ($(rawPredictionCol).nonEmpty) {
+      val probCol = if ($(rawPredictionCol).nonEmpty) {
         udf(raw2probability _).apply(col($(rawPredictionCol)))
       } else {
         val probabilityUDF = udf { features: Any =>
@@ -138,12 +138,12 @@ abstract class ProbabilisticClassificationModel[
         }
         probabilityUDF(col($(featuresCol)))
       }
-      outputData = outputData.withColumn($(probabilityCol), probUDF,
+      outputData = outputData.withColumn($(probabilityCol), probCol,
         outputSchema($(probabilityCol)).metadata)
       numColsOutput += 1
     }
     if ($(predictionCol).nonEmpty) {
-      val predUDF = if ($(rawPredictionCol).nonEmpty) {
+      val predCol = if ($(rawPredictionCol).nonEmpty) {
         udf(raw2prediction _).apply(col($(rawPredictionCol)))
       } else if ($(probabilityCol).nonEmpty) {
         udf(probability2prediction _).apply(col($(probabilityCol)))
@@ -153,7 +153,7 @@ abstract class ProbabilisticClassificationModel[
         }
         predictUDF(col($(featuresCol)))
       }
-      outputData = outputData.withColumn($(predictionCol), predUDF,
+      outputData = outputData.withColumn($(predictionCol), predCol,
         outputSchema($(predictionCol)).metadata)
       numColsOutput += 1
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -91,12 +91,12 @@ abstract class ProbabilisticClassificationModel[
   }
 
   override def transformSchema(schema: StructType): StructType = {
-    val outputSchema = super.transformSchema(schema)
+    var outputSchema = super.transformSchema(schema)
     if ($(probabilityCol).nonEmpty) {
-      SchemaUtils.updateAttributeGroupSize(outputSchema, $(probabilityCol), numClasses)
-    } else {
-      outputSchema
+      outputSchema = SchemaUtils.updateAttributeGroupSize(outputSchema,
+        $(probabilityCol), numClasses)
     }
+    outputSchema
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
@@ -21,6 +21,7 @@ import org.json4s.{DefaultFormats, JObject}
 import org.json4s.JsonDSL._
 
 import org.apache.spark.annotation.Since
+import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.feature.Instance
 import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
 import org.apache.spark.ml.param.ParamMap
@@ -216,7 +217,8 @@ class RandomForestClassificationModel private[ml] (
     val outputData = super.transform(dataset)
     if ($(leafCol).nonEmpty) {
       val leafUDF = udf { features: Vector => predictLeaf(features) }
-      outputData.withColumn($(leafCol), leafUDF(col($(featuresCol))))
+      outputData.withColumn($(leafCol), leafUDF(col($(featuresCol))),
+        AttributeGroup.toMeta($(leafCol), trees.length))
     } else {
       outputData
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
@@ -215,7 +215,7 @@ class RandomForestClassificationModel private[ml] (
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = super.transformSchema(schema)
     if ($(leafCol).nonEmpty) {
-      outputSchema = SchemaUtils.updateMeta(outputSchema, getLeafField($(leafCol)))
+      outputSchema = SchemaUtils.updateField(outputSchema, getLeafField($(leafCol)))
     }
     outputSchema
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
@@ -213,12 +213,11 @@ class RandomForestClassificationModel private[ml] (
 
   @Since("1.4.0")
   override def transformSchema(schema: StructType): StructType = {
-    val outputSchema = super.transformSchema(schema)
+    var outputSchema = super.transformSchema(schema)
     if ($(leafCol).nonEmpty) {
-      SchemaUtils.appendColumn(schema, getLeafField($(leafCol)))
-    } else {
-      outputSchema
+      outputSchema = SchemaUtils.updateMeta(outputSchema, getLeafField($(leafCol)))
     }
+    outputSchema
   }
 
   override def transform(dataset: Dataset[_]): DataFrame = {

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/BisectingKMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/BisectingKMeans.scala
@@ -124,9 +124,12 @@ class BisectingKMeansModel private[ml] (
     val k = parentModel.k
     if ($(predictionCol).nonEmpty) {
       val attr = if (k == 2) {
-        new BinaryAttribute(name = Some($(predictionCol)))
+        BinaryAttribute.defaultAttr
+          .withName($(predictionCol))
       } else {
-        new NominalAttribute(name = Some($(predictionCol)), numValues = Some(k))
+        NominalAttribute.defaultAttr
+          .withName($(predictionCol))
+          .withNumValues(k)
       }
       outputSchema = SchemaUtils.updateMeta(outputSchema, attr.toStructField)
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/BisectingKMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/BisectingKMeans.scala
@@ -21,7 +21,6 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.{Estimator, Model}
-import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
@@ -121,17 +120,9 @@ class BisectingKMeansModel private[ml] (
   @Since("2.0.0")
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = validateAndTransformSchema(schema)
-    val k = parentModel.k
     if ($(predictionCol).nonEmpty) {
-      val attr = if (k == 2) {
-        BinaryAttribute.defaultAttr
-          .withName($(predictionCol))
-      } else {
-        NominalAttribute.defaultAttr
-          .withName($(predictionCol))
-          .withNumValues(k)
-      }
-      outputSchema = SchemaUtils.updateMeta(outputSchema, attr.toStructField)
+      outputSchema = SchemaUtils.updateNumValues(outputSchema,
+        $(predictionCol), parentModel.k)
     }
     outputSchema
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
@@ -23,7 +23,6 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.annotation.Since
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.ml.{Estimator, Model}
-import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.impl.Utils.EPSILON
 import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.param._
@@ -149,21 +148,13 @@ class GaussianMixtureModel private[ml] (
   @Since("2.0.0")
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = validateAndTransformSchema(schema)
-    val k = weights.length
     if ($(predictionCol).nonEmpty) {
-      val attr = if (k == 2) {
-        BinaryAttribute.defaultAttr
-          .withName($(predictionCol))
-      } else {
-        NominalAttribute.defaultAttr
-          .withName($(predictionCol))
-          .withNumValues(k)
-      }
-      outputSchema = SchemaUtils.updateMeta(outputSchema, attr.toStructField)
+      outputSchema = SchemaUtils.updateNumValues(outputSchema,
+        $(predictionCol), weights.length)
     }
     if ($(probabilityCol).nonEmpty) {
       outputSchema = SchemaUtils.updateAttributeGroupSize(outputSchema,
-        $(probabilityCol), k)
+        $(probabilityCol), weights.length)
     }
     outputSchema
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
@@ -23,6 +23,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.annotation.Since
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.ml.{Estimator, Model}
+import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.impl.Utils.EPSILON
 import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.param._
@@ -120,7 +121,8 @@ class GaussianMixtureModel private[ml] (
 
     if ($(probabilityCol).nonEmpty) {
       val probUDF = udf((vector: Vector) => predictProbability(vector))
-      outputData = outputData.withColumn($(probabilityCol), probUDF(vectorCol))
+      outputData = outputData.withColumn($(probabilityCol), probUDF(vectorCol),
+        AttributeGroup.toMeta($(probabilityCol), weights.length))
       numColsOutput += 1
     }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -143,9 +143,12 @@ class KMeansModel private[ml] (
     val k = parentModel.k
     if ($(predictionCol).nonEmpty) {
       val attr = if (k == 2) {
-        new BinaryAttribute(name = Some($(predictionCol)))
+        BinaryAttribute.defaultAttr
+          .withName($(predictionCol))
       } else {
-        new NominalAttribute(name = Some($(predictionCol)), numValues = Some(k))
+        NominalAttribute.defaultAttr
+          .withName($(predictionCol))
+          .withNumValues(k)
       }
       outputSchema = SchemaUtils.updateMeta(outputSchema, attr.toStructField)
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -23,6 +23,7 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.{Estimator, Model, PipelineStage}
+import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
@@ -127,17 +128,28 @@ class KMeansModel private[ml] (
 
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
-    transformSchema(dataset.schema, logging = true)
+    val outputSchema = transformSchema(dataset.schema, logging = true)
 
     val predictUDF = udf((vector: Vector) => predict(vector))
 
     dataset.withColumn($(predictionCol),
-      predictUDF(DatasetUtils.columnToVector(dataset, getFeaturesCol)))
+      predictUDF(DatasetUtils.columnToVector(dataset, getFeaturesCol)),
+      outputSchema($(predictionCol)).metadata)
   }
 
   @Since("1.5.0")
   override def transformSchema(schema: StructType): StructType = {
-    validateAndTransformSchema(schema)
+    var outputSchema = validateAndTransformSchema(schema)
+    val k = parentModel.k
+    if ($(predictionCol).nonEmpty) {
+      val attr = if (k == 2) {
+        new BinaryAttribute(name = Some($(predictionCol)))
+      } else {
+        new NominalAttribute(name = Some($(predictionCol)), numValues = Some(k))
+      }
+      outputSchema = SchemaUtils.updateMeta(outputSchema, attr.toStructField)
+    }
+    outputSchema
   }
 
   @Since("3.0.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -23,7 +23,6 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.{Estimator, Model, PipelineStage}
-import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
@@ -140,17 +139,9 @@ class KMeansModel private[ml] (
   @Since("1.5.0")
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = validateAndTransformSchema(schema)
-    val k = parentModel.k
     if ($(predictionCol).nonEmpty) {
-      val attr = if (k == 2) {
-        BinaryAttribute.defaultAttr
-          .withName($(predictionCol))
-      } else {
-        NominalAttribute.defaultAttr
-          .withName($(predictionCol))
-          .withNumValues(k)
-      }
-      outputSchema = SchemaUtils.updateMeta(outputSchema, attr.toStructField)
+      outputSchema = SchemaUtils.updateNumValues(outputSchema,
+        $(predictionCol), parentModel.k)
     }
     outputSchema
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
@@ -505,9 +505,10 @@ abstract class LDAModel private[ml] (
 
   @Since("1.6.0")
   override def transformSchema(schema: StructType): StructType = {
+    val k = oldLocalModel.k
     val outputSchema = validateAndTransformSchema(schema)
     if ($(topicDistributionCol).nonEmpty) {
-      SchemaUtils.updateAttributeGroupSize(outputSchema, $(topicDistributionCol), $(k))
+      SchemaUtils.updateAttributeGroupSize(outputSchema, $(topicDistributionCol), k)
     } else {
       outputSchema
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
@@ -505,13 +505,13 @@ abstract class LDAModel private[ml] (
 
   @Since("1.6.0")
   override def transformSchema(schema: StructType): StructType = {
+    var outputSchema = validateAndTransformSchema(schema)
     val k = oldLocalModel.k
-    val outputSchema = validateAndTransformSchema(schema)
     if ($(topicDistributionCol).nonEmpty) {
-      SchemaUtils.updateAttributeGroupSize(outputSchema, $(topicDistributionCol), k)
-    } else {
-      outputSchema
+      outputSchema = SchemaUtils.updateAttributeGroupSize(outputSchema,
+        $(topicDistributionCol), k)
     }
+    outputSchema
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
@@ -29,6 +29,7 @@ import org.json4s.jackson.JsonMethods._
 import org.apache.spark.annotation.{DeveloperApi, Since}
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.{Estimator, Model}
+import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared.{HasCheckpointInterval, HasFeaturesCol, HasMaxIter, HasSeed}
@@ -464,7 +465,8 @@ abstract class LDAModel private[ml] (
     val func = getTopicDistributionMethod
     val transformer = udf(func)
     dataset.withColumn($(topicDistributionCol),
-      transformer(DatasetUtils.columnToVector(dataset, getFeaturesCol)))
+      transformer(DatasetUtils.columnToVector(dataset, getFeaturesCol)),
+      AttributeGroup.toMeta($(topicDistributionCol), oldLocalModel.k))
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
@@ -506,10 +506,9 @@ abstract class LDAModel private[ml] (
   @Since("1.6.0")
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = validateAndTransformSchema(schema)
-    val k = oldLocalModel.k
     if ($(topicDistributionCol).nonEmpty) {
       outputSchema = SchemaUtils.updateAttributeGroupSize(outputSchema,
-        $(topicDistributionCol), k)
+        $(topicDistributionCol), oldLocalModel.k)
     }
     outputSchema
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Binarizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Binarizer.scala
@@ -21,7 +21,7 @@ import scala.collection.mutable.ArrayBuilder
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.Transformer
-import org.apache.spark.ml.attribute.BinaryAttribute
+import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
@@ -193,7 +193,12 @@ final class Binarizer @Since("1.4.0") (@Since("1.4.0") override val uid: String)
         case DoubleType =>
           BinaryAttribute.defaultAttr.withName(outputColName).toStructField()
         case _: VectorUDT =>
-          StructField(outputColName, new VectorUDT)
+          val size = AttributeGroup.fromStructField(schema(inputColName)).size
+          if (size < 0) {
+            StructField(outputColName, new VectorUDT)
+          } else {
+            new AttributeGroup(outputColName, numAttributes = size).toStructField()
+          }
         case _ =>
           throw new IllegalArgumentException(s"Data type $inputType is not supported.")
       }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
@@ -289,8 +289,7 @@ final class ChiSqSelectorModel private[ml] (
   override def transformSchema(schema: StructType): StructType = {
     SchemaUtils.checkColumnType(schema, $(featuresCol), new VectorUDT)
     val newField = prepOutputField(schema)
-    val outputFields = schema.fields :+ newField
-    StructType(outputFields)
+    SchemaUtils.appendColumn(schema, newField)
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
@@ -336,7 +336,7 @@ class CountVectorizerModel(
     if ($(outputCol).nonEmpty) {
       val attrs: Array[Attribute] = vocabulary.map(_ => new NumericAttribute)
       val field = new AttributeGroup($(outputCol), attrs).toStructField()
-      outputSchema = SchemaUtils.updateMeta(schema, field)
+      outputSchema = SchemaUtils.updateField(outputSchema, field)
     }
     outputSchema
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/DCT.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/DCT.scala
@@ -81,7 +81,8 @@ class DCT @Since("1.5.0") (@Since("1.5.0") override val uid: String)
     if ($(inputCol).nonEmpty && $(outputCol).nonEmpty) {
       val size = AttributeGroup.fromStructField(schema($(inputCol))).size
       if (size >= 0) {
-        outputSchema = SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), size)
+        outputSchema = SchemaUtils.updateAttributeGroupSize(outputSchema,
+          $(outputCol), size)
       }
     }
     outputSchema

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/DCT.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/DCT.scala
@@ -21,10 +21,11 @@ import org.jtransforms.dct._
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.UnaryTransformer
+import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.linalg.{Vector, Vectors, VectorUDT}
 import org.apache.spark.ml.param.BooleanParam
 import org.apache.spark.ml.util._
-import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types._
 
 /**
  * A feature transformer that takes the 1D discrete cosine transform of a real vector. No zero
@@ -74,6 +75,17 @@ class DCT @Since("1.5.0") (@Since("1.5.0") override val uid: String)
   }
 
   override protected def outputDataType: DataType = new VectorUDT
+
+  override def transformSchema(schema: StructType): StructType = {
+    var outputSchema = super.transformSchema(schema)
+    if ($(inputCol).nonEmpty && $(outputCol).nonEmpty) {
+      val size = AttributeGroup.fromStructField(schema($(inputCol))).size
+      if (size >= 0) {
+        outputSchema = SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), size)
+      }
+    }
+    outputSchema
+  }
 
   @Since("3.0.0")
   override def toString: String = {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ElementwiseProduct.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ElementwiseProduct.scala
@@ -85,7 +85,8 @@ class ElementwiseProduct @Since("1.4.0") (@Since("1.4.0") override val uid: Stri
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = super.transformSchema(schema)
     if ($(outputCol).nonEmpty) {
-      outputSchema = SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), $(scalingVec).size)
+      outputSchema = SchemaUtils.updateAttributeGroupSize(outputSchema,
+        $(outputCol), $(scalingVec).size)
     }
     outputSchema
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ElementwiseProduct.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ElementwiseProduct.scala
@@ -21,10 +21,10 @@ import org.apache.spark.annotation.Since
 import org.apache.spark.ml.UnaryTransformer
 import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.param.Param
-import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
+import org.apache.spark.ml.util._
 import org.apache.spark.mllib.feature.{ElementwiseProduct => OldElementwiseProduct}
 import org.apache.spark.mllib.linalg.{Vectors => OldVectors}
-import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types._
 
 /**
  * Outputs the Hadamard product (i.e., the element-wise product) of each input vector with a
@@ -81,6 +81,14 @@ class ElementwiseProduct @Since("1.4.0") (@Since("1.4.0") override val uid: Stri
   }
 
   override protected def outputDataType: DataType = new VectorUDT()
+
+  override def transformSchema(schema: StructType): StructType = {
+    var outputSchema = super.transformSchema(schema)
+    if ($(outputCol).nonEmpty) {
+      outputSchema = SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), $(scalingVec).size)
+    }
+    outputSchema
+  }
 
   @Since("3.0.0")
   override def toString: String = {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/IDF.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/IDF.scala
@@ -131,7 +131,7 @@ class IDFModel private[ml] (
 
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
-    transformSchema(dataset.schema, logging = true)
+    val outputSchema = transformSchema(dataset.schema, logging = true)
 
     val func = { vector: Vector =>
       vector match {
@@ -149,7 +149,8 @@ class IDFModel private[ml] (
     }
 
     val transformer = udf(func)
-    dataset.withColumn($(outputCol), transformer(col($(inputCol))))
+    dataset.withColumn($(outputCol), transformer(col($(inputCol))),
+      outputSchema($(outputCol)).metadata)
   }
 
   @Since("1.4.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/IDF.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/IDF.scala
@@ -154,7 +154,11 @@ class IDFModel private[ml] (
 
   @Since("1.4.0")
   override def transformSchema(schema: StructType): StructType = {
-    validateAndTransformSchema(schema)
+    var outputSchema = validateAndTransformSchema(schema)
+    if ($(outputCol).nonEmpty) {
+      outputSchema = SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), idf.size)
+    }
+    outputSchema
   }
 
   @Since("1.4.1")
@@ -180,7 +184,7 @@ class IDFModel private[ml] (
 
   @Since("3.0.0")
   override def toString: String = {
-    s"IDFModel: uid=$uid, numDocs=$numDocs"
+    s"IDFModel: uid=$uid, numDocs=$numDocs, numFeatures=${idf.size}"
   }
 }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/IDF.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/IDF.scala
@@ -157,7 +157,8 @@ class IDFModel private[ml] (
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = validateAndTransformSchema(schema)
     if ($(outputCol).nonEmpty) {
-      outputSchema = SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), idf.size)
+      outputSchema = SchemaUtils.updateAttributeGroupSize(outputSchema,
+        $(outputCol), idf.size)
     }
     outputSchema
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/MaxAbsScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/MaxAbsScaler.scala
@@ -132,7 +132,8 @@ class MaxAbsScalerModel private[ml] (
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = validateAndTransformSchema(schema)
     if ($(outputCol).nonEmpty) {
-      outputSchema = SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), maxAbs.size)
+      outputSchema = SchemaUtils.updateAttributeGroupSize(outputSchema,
+        $(outputCol), maxAbs.size)
     }
     outputSchema
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/MaxAbsScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/MaxAbsScaler.scala
@@ -130,12 +130,11 @@ class MaxAbsScalerModel private[ml] (
 
   @Since("2.0.0")
   override def transformSchema(schema: StructType): StructType = {
-    val outputSchema = validateAndTransformSchema(schema)
+    var outputSchema = validateAndTransformSchema(schema)
     if ($(outputCol).nonEmpty) {
-      SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), maxAbs.size)
-    } else {
-      outputSchema
+      outputSchema = SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), maxAbs.size)
     }
+    outputSchema
   }
 
   @Since("2.0.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/MaxAbsScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/MaxAbsScaler.scala
@@ -21,6 +21,7 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.{Estimator, Model}
+import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.linalg.{Vector, Vectors, VectorUDT}
 import org.apache.spark.ml.param.{ParamMap, Params}
 import org.apache.spark.ml.param.shared.{HasInputCol, HasOutputCol}
@@ -124,7 +125,8 @@ class MaxAbsScalerModel private[ml] (
       Array.empty, scale, false, true)
     val transformer = udf(func)
 
-    dataset.withColumn($(outputCol), transformer(col($(inputCol))))
+    dataset.withColumn($(outputCol), transformer(col($(inputCol))),
+      AttributeGroup.toMeta($(outputCol), maxAbs.size))
   }
 
   @Since("2.0.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/MinMaxScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/MinMaxScaler.scala
@@ -216,12 +216,11 @@ class MinMaxScalerModel private[ml] (
 
   @Since("1.5.0")
   override def transformSchema(schema: StructType): StructType = {
-    val outputSchema = validateAndTransformSchema(schema)
+    var outputSchema = validateAndTransformSchema(schema)
     if ($(outputCol).nonEmpty) {
-      SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), originalMin.size)
-    } else {
-      outputSchema
+      outputSchema = SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), originalMin.size)
     }
+    outputSchema
   }
 
   @Since("1.5.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/MinMaxScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/MinMaxScaler.scala
@@ -21,6 +21,7 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.{Estimator, Model}
+import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.linalg.{Vector, Vectors, VectorUDT}
 import org.apache.spark.ml.param.{DoubleParam, ParamMap, Params}
 import org.apache.spark.ml.param.shared.{HasInputCol, HasOutputCol}
@@ -210,7 +211,8 @@ class MinMaxScalerModel private[ml] (
       Vectors.dense(values).compressed
     }
 
-    dataset.withColumn($(outputCol), transformer(col($(inputCol))))
+    dataset.withColumn($(outputCol), transformer(col($(inputCol))),
+      AttributeGroup.toMeta($(outputCol), originalMin.size))
   }
 
   @Since("1.5.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/MinMaxScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/MinMaxScaler.scala
@@ -218,7 +218,8 @@ class MinMaxScalerModel private[ml] (
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = validateAndTransformSchema(schema)
     if ($(outputCol).nonEmpty) {
-      outputSchema = SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), originalMin.size)
+      outputSchema = SchemaUtils.updateAttributeGroupSize(outputSchema,
+        $(outputCol), originalMin.size)
     }
     outputSchema
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Normalizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Normalizer.scala
@@ -19,12 +19,13 @@ package org.apache.spark.ml.feature
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.UnaryTransformer
+import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.linalg.{Vector, VectorUDT}
 import org.apache.spark.ml.param.{DoubleParam, ParamValidators}
 import org.apache.spark.ml.util._
 import org.apache.spark.mllib.feature
 import org.apache.spark.mllib.linalg.{Vectors => OldVectors}
-import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types._
 
 /**
  * Normalize a vector to have unit norm using the given p-norm.
@@ -65,6 +66,17 @@ class Normalizer @Since("1.4.0") (@Since("1.4.0") override val uid: String)
   }
 
   override protected def outputDataType: DataType = new VectorUDT()
+
+  override def transformSchema(schema: StructType): StructType = {
+    var outputSchema = super.transformSchema(schema)
+    if ($(inputCol).nonEmpty && $(outputCol).nonEmpty) {
+      val size = AttributeGroup.fromStructField(schema($(inputCol))).size
+      if (size >= 0) {
+        outputSchema = SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), size)
+      }
+    }
+    outputSchema
+  }
 
   @Since("3.0.0")
   override def toString: String = {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Normalizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Normalizer.scala
@@ -67,6 +67,7 @@ class Normalizer @Since("1.4.0") (@Since("1.4.0") override val uid: String)
 
   override protected def outputDataType: DataType = new VectorUDT()
 
+  @Since("1.4.0")
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = super.transformSchema(schema)
     if ($(inputCol).nonEmpty && $(outputCol).nonEmpty) {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Normalizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Normalizer.scala
@@ -72,7 +72,8 @@ class Normalizer @Since("1.4.0") (@Since("1.4.0") override val uid: String)
     if ($(inputCol).nonEmpty && $(outputCol).nonEmpty) {
       val size = AttributeGroup.fromStructField(schema($(inputCol))).size
       if (size >= 0) {
-        outputSchema = SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), size)
+        outputSchema = SchemaUtils.updateAttributeGroupSize(outputSchema,
+          $(outputCol), size)
       }
     }
     outputSchema

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/PCA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/PCA.scala
@@ -21,6 +21,7 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml._
+import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
@@ -149,7 +150,8 @@ class PCAModel private[ml] (
 
     val transposed = pc.transpose
     val transformer = udf { vector: Vector => transposed.multiply(vector) }
-    dataset.withColumn($(outputCol), transformer(col($(inputCol))))
+    dataset.withColumn($(outputCol), transformer(col($(inputCol))),
+      AttributeGroup.toMeta($(outputCol), $(k)))
   }
 
   @Since("1.5.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/PCA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/PCA.scala
@@ -153,7 +153,11 @@ class PCAModel private[ml] (
 
   @Since("1.5.0")
   override def transformSchema(schema: StructType): StructType = {
-    validateAndTransformSchema(schema)
+    var outputSchema = validateAndTransformSchema(schema)
+    if ($(outputCol).nonEmpty) {
+      outputSchema = SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), pc.numRows)
+    }
+    outputSchema
   }
 
   @Since("1.5.0")
@@ -167,7 +171,7 @@ class PCAModel private[ml] (
 
   @Since("3.0.0")
   override def toString: String = {
-    s"PCAModel: uid=$uid, k=${$(k)}"
+    s"PCAModel: uid=$uid, k=${pc.numCols}, numFeatures=${pc.numRows}"
   }
 }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/PCA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/PCA.scala
@@ -155,7 +155,8 @@ class PCAModel private[ml] (
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = validateAndTransformSchema(schema)
     if ($(outputCol).nonEmpty) {
-      outputSchema = SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), $(k))
+      outputSchema = SchemaUtils.updateAttributeGroupSize(outputSchema,
+        $(outputCol), $(k))
     }
     outputSchema
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/PCA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/PCA.scala
@@ -155,7 +155,7 @@ class PCAModel private[ml] (
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = validateAndTransformSchema(schema)
     if ($(outputCol).nonEmpty) {
-      outputSchema = SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), pc.numRows)
+      outputSchema = SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), $(k))
     }
     outputSchema
   }
@@ -171,7 +171,7 @@ class PCAModel private[ml] (
 
   @Since("3.0.0")
   override def toString: String = {
-    s"PCAModel: uid=$uid, k=${pc.numCols}, numFeatures=${pc.numRows}"
+    s"PCAModel: uid=$uid, k=${$(k)}"
   }
 }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/PCA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/PCA.scala
@@ -21,7 +21,6 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml._
-import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
@@ -30,7 +29,7 @@ import org.apache.spark.mllib.feature
 import org.apache.spark.mllib.linalg.{DenseMatrix => OldDenseMatrix, Vectors => OldVectors}
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.{StructField, StructType}
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.VersionUtils.majorVersion
 
 /**
@@ -53,10 +52,8 @@ private[feature] trait PCAParams extends Params with HasInputCol with HasOutputC
     SchemaUtils.checkColumnType(schema, $(inputCol), new VectorUDT)
     require(!schema.fieldNames.contains($(outputCol)),
       s"Output column ${$(outputCol)} already exists.")
-    val outputFields = schema.fields :+ StructField($(outputCol), new VectorUDT, false)
-    StructType(outputFields)
+    SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), $(k))
   }
-
 }
 
 /**
@@ -146,12 +143,12 @@ class PCAModel private[ml] (
    */
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
-    transformSchema(dataset.schema, logging = true)
+    val outputSchema = transformSchema(dataset.schema, logging = true)
 
     val transposed = pc.transpose
     val transformer = udf { vector: Vector => transposed.multiply(vector) }
     dataset.withColumn($(outputCol), transformer(col($(inputCol))),
-      AttributeGroup.toMeta($(outputCol), $(k)))
+      outputSchema($(outputCol)).metadata)
   }
 
   @Since("1.5.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RobustScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RobustScaler.scala
@@ -243,12 +243,11 @@ class RobustScalerModel private[ml] (
   }
 
   override def transformSchema(schema: StructType): StructType = {
-    val outputSchema = validateAndTransformSchema(schema)
+    var outputSchema = validateAndTransformSchema(schema)
     if ($(outputCol).nonEmpty) {
-      SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), median.size)
-    } else {
-      outputSchema
+      outputSchema = SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), median.size)
     }
+    outputSchema
   }
 
   override def copy(extra: ParamMap): RobustScalerModel = {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RobustScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RobustScaler.scala
@@ -245,7 +245,8 @@ class RobustScalerModel private[ml] (
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = validateAndTransformSchema(schema)
     if ($(outputCol).nonEmpty) {
-      outputSchema = SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), median.size)
+      outputSchema = SchemaUtils.updateAttributeGroupSize(outputSchema,
+        $(outputCol), median.size)
     }
     outputSchema
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RobustScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RobustScaler.scala
@@ -21,6 +21,7 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.{Estimator, Model}
+import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared.{HasInputCol, HasOutputCol, HasRelativeError}
@@ -238,7 +239,8 @@ class RobustScalerModel private[ml] (
       shift, scale, $(withCentering), $(withScaling))
     val transformer = udf(func)
 
-    dataset.withColumn($(outputCol), transformer(col($(inputCol))))
+    dataset.withColumn($(outputCol), transformer(col($(inputCol))),
+      AttributeGroup.toMeta($(outputCol), median.size))
   }
 
   override def transformSchema(schema: StructType): StructType = {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
@@ -174,7 +174,8 @@ class StandardScalerModel private[ml] (
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = validateAndTransformSchema(schema)
     if ($(outputCol).nonEmpty) {
-      outputSchema = SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), mean.size)
+      outputSchema = SchemaUtils.updateAttributeGroupSize(outputSchema,
+        $(outputCol), mean.size)
     }
     outputSchema
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
@@ -21,6 +21,7 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml._
+import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
@@ -166,7 +167,8 @@ class StandardScalerModel private[ml] (
     val func = getTransformFunc(shift, scale, $(withMean), $(withStd))
     val transformer = udf(func)
 
-    dataset.withColumn($(outputCol), transformer(col($(inputCol))))
+    dataset.withColumn($(outputCol), transformer(col($(inputCol))),
+      AttributeGroup.toMeta($(outputCol), mean.size))
   }
 
   @Since("1.4.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
@@ -172,12 +172,11 @@ class StandardScalerModel private[ml] (
 
   @Since("1.4.0")
   override def transformSchema(schema: StructType): StructType = {
-    val outputSchema = validateAndTransformSchema(schema)
+    var outputSchema = validateAndTransformSchema(schema)
     if ($(outputCol).nonEmpty) {
-      SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), mean.size)
-    } else {
-      outputSchema
+      outputSchema = SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), mean.size)
     }
+    outputSchema
   }
 
   @Since("1.4.1")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/VectorSlicer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/VectorSlicer.scala
@@ -153,8 +153,7 @@ final class VectorSlicer @Since("1.5.0") (@Since("1.5.0") override val uid: Stri
     }
     val numFeaturesSelected = $(indices).length + $(names).length
     val outputAttr = new AttributeGroup($(outputCol), numFeaturesSelected)
-    val outputFields = schema.fields :+ outputAttr.toStructField()
-    StructType(outputFields)
+    SchemaUtils.appendColumn(schema, outputAttr.toStructField)
   }
 
   @Since("1.5.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
@@ -314,12 +314,11 @@ class Word2VecModel private[ml] (
 
   @Since("1.4.0")
   override def transformSchema(schema: StructType): StructType = {
-    val outputSchema = validateAndTransformSchema(schema)
+    var outputSchema = validateAndTransformSchema(schema)
     if ($(outputCol).nonEmpty) {
-      SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), $(vectorSize))
-    } else {
-      outputSchema
+      outputSchema = SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), $(vectorSize))
     }
+    outputSchema
   }
 
   @Since("1.4.1")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
@@ -294,9 +294,10 @@ class Word2VecModel private[ml] (
       .map(identity) // mapValues doesn't return a serializable map (SI-7005)
     val bVectors = dataset.sparkSession.sparkContext.broadcast(vectors)
     val d = $(vectorSize)
+    val emptyVec = Vectors.sparse(d, Array.emptyIntArray, Array.emptyDoubleArray)
     val word2Vec = udf { sentence: Seq[String] =>
       if (sentence.isEmpty) {
-        Vectors.sparse(d, Array.empty[Int], Array.empty[Double])
+        emptyVec
       } else {
         val sum = Vectors.zeros(d)
         sentence.foreach { word =>

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
@@ -316,7 +316,8 @@ class Word2VecModel private[ml] (
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = validateAndTransformSchema(schema)
     if ($(outputCol).nonEmpty) {
-      outputSchema = SchemaUtils.updateAttributeGroupSize(schema, $(outputCol), $(vectorSize))
+      outputSchema = SchemaUtils.updateAttributeGroupSize(outputSchema,
+        $(outputCol), $(vectorSize))
     }
     outputSchema
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
@@ -22,6 +22,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.annotation.Since
 import org.apache.spark.internal.config.Kryo.KRYO_SERIALIZER_MAX_BUFFER_SIZE
 import org.apache.spark.ml.{Estimator, Model}
+import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.linalg.{BLAS, Vector, Vectors, VectorUDT}
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
@@ -308,7 +309,8 @@ class Word2VecModel private[ml] (
         sum
       }
     }
-    dataset.withColumn($(outputCol), word2Vec(col($(inputCol))))
+    dataset.withColumn($(outputCol), word2Vec(col($(inputCol))),
+      AttributeGroup.toMeta($(outputCol), ${vectorSize}))
   }
 
   @Since("1.4.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
@@ -28,7 +28,6 @@ import org.apache.spark.annotation.Since
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.{Estimator, Model}
-import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.linalg.{BLAS, Vector, Vectors, VectorUDT}
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
@@ -382,9 +381,7 @@ class AFTSurvivalRegressionModel private[ml] (
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = validateAndTransformSchema(schema, fitting = false)
     if ($(predictionCol).nonEmpty) {
-      val attr = NumericAttribute.defaultAttr
-        .withName($(predictionCol))
-      outputSchema = SchemaUtils.updateMeta(outputSchema, attr.toStructField)
+      outputSchema = SchemaUtils.updateNumeric(outputSchema, $(predictionCol))
     }
     if (isDefined(quantilesCol) && $(quantilesCol).nonEmpty) {
       outputSchema = SchemaUtils.updateAttributeGroupSize(outputSchema,

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
@@ -36,7 +36,7 @@ import org.apache.spark.mllib.tree.model.{DecisionTreeModel => OldDecisionTreeMo
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Column, DataFrame, Dataset}
 import org.apache.spark.sql.functions._
-
+import org.apache.spark.sql.types.StructType
 
 /**
  * <a href="http://en.wikipedia.org/wiki/Decision_tree_learning">Decision tree</a>
@@ -202,9 +202,18 @@ class DecisionTreeRegressionModel private[ml] (
     rootNode.predictImpl(features).impurityStats.calculate()
   }
 
+  @Since("1.4.0")
+  override def transformSchema(schema: StructType): StructType = {
+    var outputSchema = super.transformSchema(schema)
+    if ($(leafCol).nonEmpty) {
+      outputSchema = SchemaUtils.updateMeta(outputSchema, getLeafField($(leafCol)))
+    }
+    outputSchema
+  }
+
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
-    transformSchema(dataset.schema, logging = true)
+    val outputSchema = transformSchema(dataset.schema, logging = true)
 
     var predictionColNames = Seq.empty[String]
     var predictionColumns = Seq.empty[Column]
@@ -213,6 +222,7 @@ class DecisionTreeRegressionModel private[ml] (
       val predictUDF = udf { features: Vector => predict(features) }
       predictionColNames :+= $(predictionCol)
       predictionColumns :+= predictUDF(col($(featuresCol)))
+        .as($(predictionCol), outputSchema($(predictionCol)).metadata)
     }
 
     if (isDefined(varianceCol) && $(varianceCol).nonEmpty) {
@@ -225,6 +235,7 @@ class DecisionTreeRegressionModel private[ml] (
       val leafUDF = udf { features: Vector => predictLeaf(features) }
       predictionColNames :+= $(leafCol)
       predictionColumns :+= leafUDF(col($(featuresCol)))
+        .as($(leafCol), outputSchema($(leafCol)).metadata)
     }
 
     if (predictionColNames.nonEmpty) {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
@@ -23,7 +23,6 @@ import org.json4s.JsonDSL._
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.{PredictionModel, Predictor}
-import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.feature.Instance
 import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.ml.param.ParamMap
@@ -207,12 +206,10 @@ class DecisionTreeRegressionModel private[ml] (
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = super.transformSchema(schema)
     if (isDefined(varianceCol) && $(varianceCol).nonEmpty) {
-      val attr = NumericAttribute.defaultAttr
-        .withName($(varianceCol))
-      outputSchema = SchemaUtils.updateMeta(outputSchema, attr.toStructField)
+      outputSchema = SchemaUtils.updateNumeric(outputSchema, $(varianceCol))
     }
     if ($(leafCol).nonEmpty) {
-      outputSchema = SchemaUtils.updateMeta(outputSchema, getLeafField($(leafCol)))
+      outputSchema = SchemaUtils.updateField(outputSchema, getLeafField($(leafCol)))
     }
     outputSchema
   }
@@ -235,7 +232,7 @@ class DecisionTreeRegressionModel private[ml] (
       val predictVarianceUDF = udf { features: Vector => predictVariance(features) }
       predictionColNames :+= $(varianceCol)
       predictionColumns :+= predictVarianceUDF(col($(featuresCol)))
-          .as($(varianceCol), outputSchema($(varianceCol)).metadata)
+        .as($(varianceCol), outputSchema($(varianceCol)).metadata)
     }
 
     if ($(leafCol).nonEmpty) {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
@@ -23,6 +23,7 @@ import org.json4s.JsonDSL._
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.{PredictionModel, Predictor}
+import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.feature.Instance
 import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.ml.param.ParamMap
@@ -205,6 +206,11 @@ class DecisionTreeRegressionModel private[ml] (
   @Since("1.4.0")
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = super.transformSchema(schema)
+    if (isDefined(varianceCol) && $(varianceCol).nonEmpty) {
+      val attr = NumericAttribute.defaultAttr
+        .withName($(varianceCol))
+      outputSchema = SchemaUtils.updateMeta(outputSchema, attr.toStructField)
+    }
     if ($(leafCol).nonEmpty) {
       outputSchema = SchemaUtils.updateMeta(outputSchema, getLeafField($(leafCol)))
     }
@@ -229,6 +235,7 @@ class DecisionTreeRegressionModel private[ml] (
       val predictVarianceUDF = udf { features: Vector => predictVariance(features) }
       predictionColNames :+= $(varianceCol)
       predictionColumns :+= predictVarianceUDF(col($(featuresCol)))
+          .as($(varianceCol), outputSchema($(varianceCol)).metadata)
     }
 
     if ($(leafCol).nonEmpty) {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -260,7 +260,7 @@ class GBTRegressionModel private[ml](
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = super.transformSchema(schema)
     if ($(leafCol).nonEmpty) {
-      outputSchema = SchemaUtils.updateMeta(outputSchema, getLeafField($(leafCol)))
+      outputSchema = SchemaUtils.updateField(outputSchema, getLeafField($(leafCol)))
     }
     outputSchema
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -277,6 +277,7 @@ class GBTRegressionModel private[ml](
       val predictUDF = udf { features: Vector => bcastModel.value.predict(features) }
       predictionColNames :+= $(predictionCol)
       predictionColumns :+= predictUDF(col($(featuresCol)))
+        .as($(featuresCol), outputSchema($(featuresCol)).metadata)
     }
 
     if ($(leafCol).nonEmpty) {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -24,6 +24,7 @@ import org.json4s.JsonDSL._
 import org.apache.spark.annotation.Since
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.{PredictionModel, Predictor}
+import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.tree._
@@ -273,6 +274,7 @@ class GBTRegressionModel private[ml](
       val leafUDF = udf { features: Vector => bcastModel.value.predictLeaf(features) }
       predictionColNames :+= $(leafCol)
       predictionColumns :+= leafUDF(col($(featuresCol)))
+        .as($(leafCol), AttributeGroup.toMeta($(leafCol), trees.length))
     }
 
     if (predictionColNames.nonEmpty) {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -258,12 +258,11 @@ class GBTRegressionModel private[ml](
 
   @Since("1.4.0")
   override def transformSchema(schema: StructType): StructType = {
-    val outputSchema = super.transformSchema(schema)
+    var outputSchema = super.transformSchema(schema)
     if ($(leafCol).nonEmpty) {
-      SchemaUtils.appendColumn(schema, getLeafField($(leafCol)))
-    } else {
-      outputSchema
+      outputSchema = SchemaUtils.updateMeta(outputSchema, getLeafField($(leafCol)))
     }
+    outputSchema
   }
 
   override def transform(dataset: Dataset[_]): DataFrame = {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -27,7 +27,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.annotation.Since
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.PredictorParams
-import org.apache.spark.ml.attribute.AttributeGroup
+import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.feature.{Instance, OffsetInstance}
 import org.apache.spark.ml.linalg.{BLAS, Vector, Vectors}
 import org.apache.spark.ml.optim._
@@ -213,7 +213,9 @@ private[regression] trait GeneralizedLinearRegressionBase extends PredictorParam
     }
 
     if (hasLinkPredictionCol) {
-      SchemaUtils.appendColumn(newSchema, $(linkPredictionCol), DoubleType)
+      val attr = NumericAttribute.defaultAttr
+        .withName($(linkPredictionCol))
+      SchemaUtils.appendColumn(newSchema, attr.toStructField())
     } else {
       newSchema
     }
@@ -1043,6 +1045,8 @@ class GeneralizedLinearRegressionModel private[ml] (
   }
 
   override protected def transformImpl(dataset: Dataset[_]): DataFrame = {
+    val outputSchema = transformSchema(dataset.schema, logging = true)
+
     val offset = if (!hasOffsetCol) lit(0.0) else col($(offsetCol)).cast(DoubleType)
     var outputData = dataset
     var numColsOutput = 0
@@ -1050,17 +1054,20 @@ class GeneralizedLinearRegressionModel private[ml] (
     if (hasLinkPredictionCol) {
       val predLinkUDF = udf((features: Vector, offset: Double) => predictLink(features, offset))
       outputData = outputData
-        .withColumn($(linkPredictionCol), predLinkUDF(col($(featuresCol)), offset))
+        .withColumn($(linkPredictionCol), predLinkUDF(col($(featuresCol)), offset),
+          outputSchema($(linkPredictionCol)).metadata)
       numColsOutput += 1
     }
 
     if ($(predictionCol).nonEmpty) {
       if (hasLinkPredictionCol) {
         val predUDF = udf((eta: Double) => familyAndLink.fitted(eta))
-        outputData = outputData.withColumn($(predictionCol), predUDF(col($(linkPredictionCol))))
+        outputData = outputData.withColumn($(predictionCol), predUDF(col($(linkPredictionCol))),
+          outputSchema($(predictionCol)).metadata)
       } else {
         val predUDF = udf((features: Vector, offset: Double) => predict(features, offset))
-        outputData = outputData.withColumn($(predictionCol), predUDF(col($(featuresCol)), offset))
+        outputData = outputData.withColumn($(predictionCol), predUDF(col($(featuresCol)), offset),
+          outputSchema($(predictionCol)).metadata)
       }
       numColsOutput += 1
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/IsotonicRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/IsotonicRegression.scala
@@ -22,7 +22,6 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.annotation.Since
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.{Estimator, Model}
-import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.linalg.{Vector, Vectors, VectorUDT}
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
@@ -257,9 +256,7 @@ class IsotonicRegressionModel private[ml] (
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = validateAndTransformSchema(schema, fitting = false)
     if ($(predictionCol).nonEmpty) {
-      val attr = NumericAttribute.defaultAttr
-        .withName($(predictionCol))
-      outputSchema = SchemaUtils.updateMeta(outputSchema, attr.toStructField)
+      outputSchema = SchemaUtils.updateNumeric(outputSchema, $(predictionCol))
     }
     outputSchema
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -195,12 +195,11 @@ class RandomForestRegressionModel private[ml] (
 
   @Since("1.4.0")
   override def transformSchema(schema: StructType): StructType = {
-    val outputSchema = super.transformSchema(schema)
+    var outputSchema = super.transformSchema(schema)
     if ($(leafCol).nonEmpty) {
-      SchemaUtils.appendColumn(schema, getLeafField($(leafCol)))
-    } else {
-      outputSchema
+      outputSchema = SchemaUtils.updateMeta(outputSchema, getLeafField($(leafCol)))
     }
+    outputSchema
   }
 
   override def transform(dataset: Dataset[_]): DataFrame = {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -22,6 +22,7 @@ import org.json4s.JsonDSL._
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.{PredictionModel, Predictor}
+import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.tree._
@@ -210,6 +211,7 @@ class RandomForestRegressionModel private[ml] (
       val leafUDF = udf { features: Vector => bcastModel.value.predictLeaf(features) }
       predictionColNames :+= $(leafCol)
       predictionColumns :+= leafUDF(col($(featuresCol)))
+        .as($(leafCol), AttributeGroup.toMeta($(leafCol), trees.length))
     }
 
     if (predictionColNames.nonEmpty) {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -214,6 +214,7 @@ class RandomForestRegressionModel private[ml] (
       val predictUDF = udf { features: Vector => bcastModel.value.predict(features) }
       predictionColNames :+= $(predictionCol)
       predictionColumns :+= predictUDF(col($(featuresCol)))
+        .as($(predictionCol), outputSchema($(predictionCol)).metadata)
     }
 
     if ($(leafCol).nonEmpty) {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -197,7 +197,7 @@ class RandomForestRegressionModel private[ml] (
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = super.transformSchema(schema)
     if ($(leafCol).nonEmpty) {
-      outputSchema = SchemaUtils.updateMeta(outputSchema, getLeafField($(leafCol)))
+      outputSchema = SchemaUtils.updateField(outputSchema, getLeafField($(leafCol)))
     }
     outputSchema
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
@@ -90,10 +90,10 @@ private[spark] trait DecisionTreeModel {
     }
   }
 
-  @transient private[ml] lazy val numLeave: Int =
+  private[ml] lazy val numLeave: Int =
     leafIterator(rootNode).size
 
-  @transient private[ml] lazy val leafAttr = {
+  private[ml] lazy val leafAttr = {
     if (numLeave == 2) {
       BinaryAttribute.defaultAttr
     } else {

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
@@ -161,7 +161,7 @@ private[ml] trait TreeEnsembleModel[M <: DecisionTreeModel] {
   }
 
   private[ml] def getLeafField(leafCol: String) = {
-    new AttributeGroup(leafCol, trees.map(_.leafAttr)).toStructField()
+    new AttributeGroup(leafCol, attrs = trees.map(_.leafAttr)).toStructField()
   }
 }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
@@ -94,12 +94,8 @@ private[spark] trait DecisionTreeModel {
     leafIterator(rootNode).size
 
   private[ml] lazy val leafAttr = {
-    if (numLeave == 2) {
-      BinaryAttribute.defaultAttr
-    } else {
-      NominalAttribute.defaultAttr
-        .withNumValues(numLeave)
-    }
+    NominalAttribute.defaultAttr
+      .withNumValues(numLeave)
   }
 
   private[ml] def getLeafField(leafCol: String) = {

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
@@ -95,9 +95,10 @@ private[spark] trait DecisionTreeModel {
 
   @transient private[ml] lazy val leafAttr = {
     if (numLeave == 2) {
-      new BinaryAttribute()
+      BinaryAttribute.defaultAttr
     } else {
-      new NominalAttribute(numValues = Some(numLeave))
+      NominalAttribute.defaultAttr
+        .withNumValues(numLeave)
     }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
@@ -135,14 +135,9 @@ private[spark] object SchemaUtils {
       schema: StructType,
       colName: String,
       numValues: Int): StructType = {
-    val attr = if (numValues == 2) {
-      BinaryAttribute.defaultAttr
-        .withName(colName)
-    } else {
-      NominalAttribute.defaultAttr
-        .withName(colName)
-        .withNumValues(numValues)
-    }
+    val attr = NominalAttribute.defaultAttr
+      .withName(colName)
+      .withNumValues(numValues)
     val field = attr.toStructField
     updateField(schema, field, true)
   }
@@ -166,16 +161,19 @@ private[spark] object SchemaUtils {
    * Update the metadata of an existing column. If this column do not exist, append it.
    * @param schema input schema
    * @param field struct field
+   * @param overwriteMetadata whether to overwrite the metadata. If true, the metadata in the
+   *                          schema will be overwritten. If false, the metadata in `field`
+   *                          and `schema` will be merged to generate output metadata.
    * @return new schema
    */
   def updateField(
       schema: StructType,
       field: StructField,
-      overrideMeta: Boolean = true): StructType = {
+      overwriteMetadata: Boolean = true): StructType = {
     if (schema.fieldNames.contains(field.name)) {
       val newFields = schema.fields.map { f =>
         if (f.name == field.name) {
-          if (overrideMeta) {
+          if (overwriteMetadata) {
             field
           } else {
             val newMeta = new MetadataBuilder()

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -318,15 +318,18 @@ class DecisionTreeClassifierSuite extends MLTest with DefaultReadWriteTest {
   test("model support predict leaf index") {
     val model = new DecisionTreeClassificationModel("dtc", TreeTests.root0, 3, 2)
     model.setLeafCol("predictedLeafId")
-      .setRawPredictionCol("")
-      .setPredictionCol("")
-      .setProbabilityCol("")
 
     val data = TreeTests.getSingleTreeLeafData
     data.foreach { case (leafId, vec) => assert(leafId === model.predictLeaf(vec)) }
 
     val df = sc.parallelize(data, 1).toDF("leafId", "features")
-    model.transform(df).select("leafId", "predictedLeafId")
+    val transformed = model.transform(df)
+    checkNominalOnDF(transformed, "prediction", model.numClasses)
+    checkNominalOnDF(transformed, "predictedLeafId", 3)
+    checkVectorSizeOnDF(transformed, "rawPrediction", model.numClasses)
+    checkVectorSizeOnDF(transformed, "probability", model.numClasses)
+
+    transformed.select("leafId", "predictedLeafId")
       .collect()
       .foreach { case Row(leafId: Double, predictedLeafId: Double) =>
         assert(leafId === predictedLeafId)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
@@ -258,18 +258,15 @@ class GBTClassifierSuite extends MLTest with DefaultReadWriteTest {
     val model1 = new DecisionTreeRegressionModel("dtc", TreeTests.root1, 3)
     val model = new GBTClassificationModel("gbtc", Array(model0, model1), Array(1.0, 1.0), 3, 2)
     model.setLeafCol("predictedLeafId")
+      .setRawPredictionCol("")
+      .setPredictionCol("")
+      .setProbabilityCol("")
 
     val data = TreeTests.getTwoTreesLeafData
     data.foreach { case (leafId, vec) => assert(leafId === model.predictLeaf(vec)) }
 
     val df = sc.parallelize(data, 1).toDF("leafId", "features")
-    val transformed = model.transform(df)
-    checkNominalOnDF(transformed, "prediction", model.numClasses)
-    checkVectorSizeOnDF(transformed, "predictedLeafId", model.numTrees)
-    checkVectorSizeOnDF(transformed, "rawPrediction", model.numClasses)
-    checkVectorSizeOnDF(transformed, "probability", model.numClasses)
-
-    transformed.select("leafId", "predictedLeafId")
+    model.transform(df).select("leafId", "predictedLeafId")
       .collect()
       .foreach { case Row(leafId: Vector, predictedLeafId: Vector) =>
         assert(leafId === predictedLeafId)
@@ -476,6 +473,13 @@ class GBTClassifierSuite extends MLTest with DefaultReadWriteTest {
       .setCheckpointInterval(5)
       .setSeed(123)
     val model = gbt.fit(df)
+    model.setLeafCol("predictedLeafId")
+
+    val transformed = model.transform(df)
+    checkNominalOnDF(transformed, "prediction", model.numClasses)
+    checkVectorSizeOnDF(transformed, "predictedLeafId", model.trees.length)
+    checkVectorSizeOnDF(transformed, "rawPrediction", model.numClasses)
+    checkVectorSizeOnDF(transformed, "probability", model.numClasses)
 
     model.trees.foreach (i => {
       assert(i.getMaxDepth === model.getMaxDepth)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LinearSVCSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LinearSVCSuite.scala
@@ -112,8 +112,13 @@ class LinearSVCSuite extends MLTest with DefaultReadWriteTest {
     assert(lsvc.getFeaturesCol === "features")
     assert(lsvc.getPredictionCol === "prediction")
     assert(lsvc.getRawPredictionCol === "rawPrediction")
+
     val model = lsvc.setMaxIter(5).fit(smallBinaryDataset)
-    model.transform(smallBinaryDataset)
+    val transformed = model.transform(smallBinaryDataset)
+    checkNominalOnDF(transformed, "prediction", model.numClasses)
+    checkVectorSizeOnDF(transformed, "rawPrediction", model.numClasses)
+
+    transformed
       .select("label", "prediction", "rawPrediction")
       .collect()
     assert(model.getThreshold === 0.0)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -155,8 +155,14 @@ class LogisticRegressionSuite extends MLTest with DefaultReadWriteTest {
     assert(!lr.isDefined(lr.weightCol))
     assert(lr.getFitIntercept)
     assert(lr.getStandardization)
+
     val model = lr.fit(smallBinaryDataset)
-    model.transform(smallBinaryDataset)
+    val transformed = model.transform(smallBinaryDataset)
+    checkNominalOnDF(transformed, "prediction", model.numClasses)
+    checkVectorSizeOnDF(transformed, "rawPrediction", model.numClasses)
+    checkVectorSizeOnDF(transformed, "probability", model.numClasses)
+
+    transformed
       .select("label", "probability", "prediction", "rawPrediction")
       .collect()
     assert(model.getThreshold === 0.5)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
@@ -81,6 +81,8 @@ class OneVsRestSuite extends MLTest with DefaultReadWriteTest {
 
     assert(ovaModel.numClasses === numClasses)
     val transformedDataset = ovaModel.transform(dataset)
+    checkNominalOnDF(transformedDataset, "prediction", ovaModel.numClasses)
+    checkVectorSizeOnDF(transformedDataset, "rawPrediction", ovaModel.numClasses)
 
     // check for label metadata in prediction col
     val predictionColSchema = transformedDataset.schema(ovaModel.getPredictionCol)

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/BisectingKMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/BisectingKMeansSuite.scala
@@ -174,6 +174,8 @@ class BisectingKMeansSuite extends MLTest with DefaultReadWriteTest {
       .setSeed(1)
       .fit(df)
     val predictionDf = model.transform(df)
+    checkNominalOnDF(predictionDf, "prediction", model.getK)
+
     assert(predictionDf.select("prediction").distinct().count() == 3)
     val predictionsMap = predictionDf.collect().map(row =>
       row.getAs[Vector]("features") -> row.getAs[Int]("prediction")).toMap

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
@@ -71,9 +71,14 @@ class GaussianMixtureSuite extends MLTest with DefaultReadWriteTest {
     assert(gm.getK === 2)
     assert(gm.getFeaturesCol === "features")
     assert(gm.getPredictionCol === "prediction")
+    assert(gm.getProbabilityCol === "probability")
     assert(gm.getMaxIter === 100)
     assert(gm.getTol === 0.01)
     val model = gm.setMaxIter(1).fit(dataset)
+
+    val transformed = model.transform(dataset)
+    checkNominalOnDF(transformed, "prediction", model.weights.length)
+    checkVectorSizeOnDF(transformed, "probability", model.weights.length)
 
     MLTestingUtils.checkCopyAndUids(gm, model)
     assert(model.hasSummary)

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -60,6 +60,9 @@ class KMeansSuite extends MLTest with DefaultReadWriteTest with PMMLReadWriteTes
     assert(kmeans.getDistanceMeasure === DistanceMeasure.EUCLIDEAN)
     val model = kmeans.setMaxIter(1).fit(dataset)
 
+    val transformed = model.transform(dataset)
+    checkNominalOnDF(transformed, "prediction", model.clusterCenters.length)
+
     MLTestingUtils.checkCopyAndUids(kmeans, model)
     assert(model.hasSummary)
     val copiedModel = model.copy(ParamMap.empty)

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/IDFSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/IDFSuite.scala
@@ -68,6 +68,9 @@ class IDFSuite extends MLTest with DefaultReadWriteTest {
       .setOutputCol("idfValue")
     val idfModel = idfEst.fit(df)
 
+    val transformed = idfModel.transform(df)
+    checkVectorSizeOnDF(transformed, "idfValue", idfModel.idf.size)
+
     MLTestingUtils.checkCopyAndUids(idfEst, idfModel)
 
     testTransformer[(Vector, Vector)](df, idfModel, "idfValue", "expected") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/MaxAbsScalerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/MaxAbsScalerSuite.scala
@@ -44,6 +44,9 @@ class MaxAbsScalerSuite extends MLTest with DefaultReadWriteTest {
       .setOutputCol("scaled")
 
     val model = scaler.fit(df)
+    val transformed = model.transform(df)
+    checkVectorSizeOnDF(transformed, "scaled", model.maxAbs.size)
+
     testTransformer[(Vector, Vector)](df, model, "expected", "scaled") {
       case Row(expectedVec: Vector, actualVec: Vector) =>
         assert(expectedVec === actualVec,

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/MinMaxScalerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/MinMaxScalerSuite.scala
@@ -46,6 +46,9 @@ class MinMaxScalerSuite extends MLTest with DefaultReadWriteTest {
       .setMax(5)
 
     val model = scaler.fit(df)
+    val transformed = model.transform(df)
+    checkVectorSizeOnDF(transformed, "scaled", model.originalMin.size)
+
     testTransformer[(Vector, Vector)](df, model, "expected", "scaled") {
       case Row(vector1: Vector, vector2: Vector) =>
         assert(vector1 === vector2, "Transformed vector is different with expected.")

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/NormalizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/NormalizerSuite.scala
@@ -86,7 +86,7 @@ class NormalizerSuite extends MLTest with DefaultReadWriteTest {
 
     val vectorSize = data.head.size
 
-    // Can not infer size of ouput vector, since no metadata is provided
+    // Can not infer size of output vector, since no metadata is provided
     intercept[TestFailedException] {
       val transformed = normalizer.transform(dataFrame)
       checkVectorSizeOnDF(transformed, "normalized", vectorSize)

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/NormalizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/NormalizerSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.feature
 
+import org.scalatest.exceptions.TestFailedException
+
 import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest}
 import org.apache.spark.ml.util.TestingUtils._
@@ -81,6 +83,22 @@ class NormalizerSuite extends MLTest with DefaultReadWriteTest {
         assertTypeOfVector(normalized, features)
         assertValues(normalized, expected)
     }
+
+    val vectorSize = data.head.size
+
+    // Can not infer size of ouput vector, since no metadata is provided
+    intercept[TestFailedException] {
+      val transformed = normalizer.transform(dataFrame)
+      checkVectorSizeOnDF(transformed, "normalized", vectorSize)
+    }
+
+    val dataFrame2 = new VectorSizeHint()
+      .setSize(vectorSize)
+      .setInputCol("features")
+      .transform(dataFrame)
+
+    val transformed2 = normalizer.transform(dataFrame2)
+    checkVectorSizeOnDF(transformed2, "normalized", vectorSize)
   }
 
   test("Normalization with setter") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/PCASuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/PCASuite.scala
@@ -58,6 +58,8 @@ class PCASuite extends MLTest with DefaultReadWriteTest {
       .setK(3)
 
     val pcaModel = pca.fit(df)
+    val transformed = pcaModel.transform(df)
+    checkVectorSizeOnDF(transformed, "pca_features", pcaModel.getK)
 
     MLTestingUtils.checkCopyAndUids(pca, pcaModel)
     testTransformer[(Vector, Vector)](df, pcaModel, "pca_features", "expected") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/Word2VecSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/Word2VecSuite.scala
@@ -61,6 +61,9 @@ class Word2VecSuite extends MLTest with DefaultReadWriteTest {
       .setSeed(42L)
     val model = w2v.fit(docDF)
 
+    val transformed = model.transform(docDF)
+    checkVectorSizeOnDF(transformed, "result", model.getVectorSize)
+
     MLTestingUtils.checkCopyAndUids(w2v, model)
 
     // These expectations are just magic values, characterizing the current

--- a/mllib/src/test/scala/org/apache/spark/ml/util/MLTest.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/util/MLTest.scala
@@ -71,7 +71,8 @@ trait MLTest extends StreamTest with TempDirectory { self: Suite =>
       vecSize: Int): Unit = {
     import dataframe.sparkSession.implicits._
     val group = AttributeGroup.fromStructField(dataframe.schema(vecColName))
-    assert(group.size === vecSize)
+    assert(group.size === vecSize,
+      s"the vector size obtained from schema should be $vecSize, but got ${group.size}")
     val sizeUDF = udf { vector: Vector => vector.size }
     assert(dataframe.select(sizeUDF(col(vecColName)))
       .as[Int]
@@ -88,7 +89,8 @@ trait MLTest extends StreamTest with TempDirectory { self: Suite =>
       case binAttr: BinaryAttribute => Some(2)
       case nomAttr: NominalAttribute => nomAttr.getNumValues
     }
-    assert(n.isDefined && n.get === numValues)
+    assert(n.isDefined && n.get === numValues,
+      s"the number of values obtained from schema should be $numValues, but got $n")
     assert(dataframe.select(colName)
       .as[Double]
       .collect()

--- a/mllib/src/test/scala/org/apache/spark/ml/util/MLTest.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/util/MLTest.scala
@@ -24,10 +24,11 @@ import org.scalatest.Suite
 import org.apache.spark.{DebugFilesystem, SparkConf, SparkContext, TestUtils}
 import org.apache.spark.internal.config.UNSAFE_EXCEPTION_ON_MEMORY_LEAK
 import org.apache.spark.ml.{Model, PredictionModel, Transformer}
+import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.sql.{DataFrame, Dataset, Encoder, Row}
 import org.apache.spark.sql.execution.streaming.MemoryStream
-import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.test.TestSparkSession
@@ -62,6 +63,36 @@ trait MLTest extends StreamTest with TempDirectory { self: Suite =>
     } finally {
       super.afterAll()
     }
+  }
+
+  private[ml] def checkVectorSizeOnDF(
+      dataframe: DataFrame,
+      vecColName: String,
+      vecSize: Int): Unit = {
+    import dataframe.sparkSession.implicits._
+    val group = AttributeGroup.fromStructField(dataframe.schema(vecColName))
+    assert(group.size === vecSize)
+    val sizeUDF = udf { vector: Vector => vector.size }
+    assert(dataframe.select(sizeUDF(col(vecColName)))
+      .as[Int]
+      .collect()
+      .forall(_ === vecSize))
+  }
+
+  private[ml] def checkNominalOnDF(
+      dataframe: DataFrame,
+      colName: String,
+      numValues: Int): Unit = {
+    import dataframe.sparkSession.implicits._
+    val n = Attribute.fromStructField(dataframe.schema(colName)) match {
+      case binAttr: BinaryAttribute => Some(2)
+      case nomAttr: NominalAttribute => nomAttr.getNumValues
+    }
+    assert(n.isDefined && n.get === numValues)
+    assert(dataframe.select(colName)
+      .as[Double]
+      .collect()
+      .forall(v => v === v.toInt && v >= 0 && v < numValues))
   }
 
   private[util] def testTransformerOnStreamData[A : Encoder](


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, `predictionCol` in `ml.classification` & `ml.clustering` add `NominalAttribute`
2, `rawPredictionCol` in `ml.classification` add `AttributeGroup` containing vectorsize=`numClasses`
3, `probabilityCol` in `ml.classification` & `ml.clustering` add `AttributeGroup` containing vectorsize=`numClasses`/`k`
4, `leafCol` in GBT/RF  add `AttributeGroup` containing vectorsize=`numTrees`
5, `leafCol` in DecisionTree  add `NominalAttribute`
6, `outputCol` in models in `ml.feature` add `AttributeGroup` containing vectorsize
7, `outputCol` in `UnaryTransformer`s in `ml.feature` add `AttributeGroup` containing vectorsize

### Why are the changes needed?
Appened metadata can be used in downstream ops, like `Classifier.getNumClasses`

There are many impls (like `Binarizer`/`Bucketizer`/`VectorAssembler`/`OneHotEncoder`/`FeatureHasher`/`HashingTF`/`VectorSlicer`/...) in `.ml` that append appropriate metadata in `transform`/`transformSchema` method.

However there are also many impls return no metadata in transformation, even some metadata like `vector.size`/`numAttrs`/`attrs` can be ealily inferred.


### Does this PR introduce any user-facing change?
Yes, add some metadatas in transformed dataset.


### How was this patch tested?
existing testsuites and added testsuites
