### PR TITLE
[SPARK-29918][SQL] RecordBinaryComparator should check endianness when compared by long

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/RecordBinaryComparator.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/RecordBinaryComparator.java
@@ -20,13 +20,12 @@ package org.apache.spark.sql.execution;
 import org.apache.spark.unsafe.Platform;
 import org.apache.spark.util.collection.unsafe.sort.RecordComparator;
 
+import java.nio.ByteOrder;
+
 public final class RecordBinaryComparator extends RecordComparator {
 
-  boolean isLittlenEndian;
-
-  public RecordBinaryComparator(boolean isLittlenEndian) {
-    this.isLittlenEndian = isLittlenEndian;
-  }
+  private static final boolean LITTLE_ENDIAN =
+      ByteOrder.nativeOrder().equals(ByteOrder.LITTLE_ENDIAN);
 
   @Override
   public int compare(
@@ -58,7 +57,7 @@ public final class RecordBinaryComparator extends RecordComparator {
         long v1 = Platform.getLong(leftObj, leftOff + i);
         long v2 = Platform.getLong(rightObj, rightOff + i);
         if (v1 != v2) {
-          if (isLittlenEndian) {
+          if (LITTLE_ENDIAN) {
             // if read as little-endian, we have to reverse bytes so that the long comparison result
             // is equivalent to byte-by-byte comparison result.
             // See discussion in https://github.com/apache/spark/pull/26548#issuecomment-554645859

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.execution.exchange
 
-import java.nio.ByteOrder
 import java.util.Random
 import java.util.function.Supplier
 
@@ -244,8 +243,7 @@ object ShuffleExchangeExec {
       val newRdd = if (isRoundRobin && SQLConf.get.sortBeforeRepartition) {
         rdd.mapPartitionsInternal { iter =>
           val recordComparatorSupplier = new Supplier[RecordComparator] {
-            val isLittlenEndian = ByteOrder.nativeOrder.equals(ByteOrder.LITTLE_ENDIAN)
-            override def get: RecordComparator = new RecordBinaryComparator(isLittlenEndian)
+            override def get: RecordComparator = new RecordBinaryComparator()
           }
           // The comparator for comparing row hashcode, which should always be Integer.
           val prefixComparator = PrefixComparators.LONG

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.exchange
 
+import java.nio.ByteOrder
 import java.util.Random
 import java.util.function.Supplier
 
@@ -243,7 +244,8 @@ object ShuffleExchangeExec {
       val newRdd = if (isRoundRobin && SQLConf.get.sortBeforeRepartition) {
         rdd.mapPartitionsInternal { iter =>
           val recordComparatorSupplier = new Supplier[RecordComparator] {
-            override def get: RecordComparator = new RecordBinaryComparator()
+            val isLittlenEndian = ByteOrder.nativeOrder.equals(ByteOrder.LITTLE_ENDIAN)
+            override def get: RecordComparator = new RecordBinaryComparator(isLittlenEndian)
           }
           // The comparator for comparing row hashcode, which should always be Integer.
           val prefixComparator = PrefixComparators.LONG

--- a/sql/core/src/test/java/test/org/apache/spark/sql/execution/sort/RecordBinaryComparatorSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/execution/sort/RecordBinaryComparatorSuite.java
@@ -323,7 +323,8 @@ public class RecordBinaryComparatorSuite {
   }
 
   @Test
-  public void testBinaryComparatorGenerateSameResultBetweenComparedByteByByteAndComparedByLong() throws Exception {
+  public void testBinaryComparatorGiveSameResultWhenComparedByteByByteAndComparedByLong()
+      throws Exception {
     int numFields = 1;
 
     UnsafeRow row1 = new UnsafeRow(numFields);

--- a/sql/core/src/test/java/test/org/apache/spark/sql/execution/sort/RecordBinaryComparatorSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/execution/sort/RecordBinaryComparatorSuite.java
@@ -33,6 +33,7 @@ import org.apache.spark.unsafe.types.UTF8String;
 import org.apache.spark.util.collection.unsafe.sort.*;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -330,15 +331,18 @@ public class RecordBinaryComparatorSuite {
     Platform.putLong(arr1, arrayOffset, 0x0100000000000000L);
     long[] arr2 = new long[2];
     Platform.putLong(arr2, arrayOffset + 4, 0x0000000000000001L);
+    // leftBaseOffset is not aligned while rightBaseOffset is aligned,
+    // it will start by comparing long
     int result1 = binaryComparator.compare(arr1, arrayOffset, 8, arr2, arrayOffset + 4, 8);
 
     long[] arr3 = new long[2];
     Platform.putLong(arr3, arrayOffset, 0x0100000000000000L);
     long[] arr4 = new long[2];
     Platform.putLong(arr4, arrayOffset, 0x0000000000000001L);
+    // both left and right offset is not aligned, it will start with byte-by-byte comparison
     int result2 = binaryComparator.compare(arr3, arrayOffset, 8, arr4, arrayOffset, 8);
 
-    assert(result1 == result2);
+    Assert.assertEquals(result1, result2);
   }
 
   @Test
@@ -349,7 +353,7 @@ public class RecordBinaryComparatorSuite {
     Platform.putLong(arr1, arrayOffset + 4, 0xa000000000000000L);
     long[] arr2 = new long[2];
     Platform.putLong(arr2, arrayOffset + 4, 0x0000000000000000L);
-    // both leftBaseOffset and rightBaseOffset are aligned, so it will start by comparing longs
+    // both leftBaseOffset and rightBaseOffset are aligned, so it will start by comparing long
     int result1 = binaryComparator.compare(arr1, arrayOffset + 4, 8, arr2, arrayOffset + 4, 8);
 
     long[] arr3 = new long[2];
@@ -357,10 +361,9 @@ public class RecordBinaryComparatorSuite {
     long[] arr4 = new long[2];
     Platform.putLong(arr4, arrayOffset, 0x0000000000000000L);
     // both leftBaseOffset and rightBaseOffset are not aligned,
-    // so it will start with 4 bytes byte-by-byte comparison,
-    // followed by a long comparison, and at last 4 bytes byte-by-byte comparison
+    // so it will start with byte-by-byte comparison
     int result2 = binaryComparator.compare(arr3, arrayOffset, 8, arr4, arrayOffset, 8);
 
-    assert(result1 == result2);
+    Assert.assertEquals(result1, result2);
   }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/execution/sort/RecordBinaryComparatorSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/execution/sort/RecordBinaryComparatorSuite.java
@@ -56,8 +56,8 @@ public class RecordBinaryComparatorSuite {
 
   @Before
   public void beforeEach() {
-    // Only compare between two input rows.
-    array = consumer.allocateArray(2);
+    // At most three input rows
+    array = consumer.allocateArray(3);
     pos = 0;
 
     dataPage = memoryManager.allocatePage(4096, consumer);
@@ -88,7 +88,7 @@ public class RecordBinaryComparatorSuite {
     Platform.copyMemory(recordBase, recordOffset, baseObject, pageCursor, recordLength);
     pageCursor += recordLength;
 
-    assert(pos < 2);
+    assert(pos < 3);
     array.set(pos, recordAddress);
     pos++;
   }
@@ -108,7 +108,7 @@ public class RecordBinaryComparatorSuite {
         baseOffset2, recordLength2);
   }
 
-  private final RecordComparator binaryComparator = new RecordBinaryComparator();
+  private final RecordComparator binaryComparator = new RecordBinaryComparator(true);
 
   // Compute the most compact size for UnsafeRow's backing data.
   private int computeSizeInBytes(int originalSize) {
@@ -320,5 +320,69 @@ public class RecordBinaryComparatorSuite {
     insertRow(row2);
 
     assert(compare(0, 1) < 0);
+  }
+
+  @Test
+  public void testBinaryComparatorGenerateSameResultBetweenComparedByteByByteAndComparedByLong() throws Exception {
+    int numFields = 1;
+
+    UnsafeRow row1 = new UnsafeRow(numFields);
+    byte[] data1 = new byte[100];
+    row1.pointTo(data1, computeSizeInBytes(numFields * 8));
+    row1.setLong(0, 0x0800000000000000L);
+
+    UnsafeRow row2 = new UnsafeRow(numFields);
+    byte[] data2 = new byte[100];
+    row2.pointTo(data2, computeSizeInBytes(numFields * 8));
+    row2.setLong(0, 0x0000008000000000L);
+
+    UnsafeRow row3 = new UnsafeRow(numFields);
+    byte[] data3 = new byte[100];
+    row3.pointTo(data3, computeSizeInBytes(numFields * 8));
+    row3.setLong(0, 0x0000008000000000L);
+
+    insertRow(row1);
+    insertRow(row2);
+    insertRow(row3);
+
+    // the bytes in row2 and row3 are the same.
+    // the base offset of row1 is 20, row2 is 40, row3 is 60
+    // so the RecordBinaryComparator will compare row1 and row2 with two long comparison directly,
+    // while the comparison between row1 and row3 is started with 4 bytes byte-by-byte comparison,
+    // followed by a long comparison, and lastly 4 bytes byte-by-byte comparison.
+    assert(compare(0, 1) < 0);
+    assert(compare(0, 2) < 0);
+  }
+
+  @Test
+  public void testBinaryComparatorShouldComparedWithUnsignedLong() throws Exception {
+    int numFields = 1;
+
+    UnsafeRow row1 = new UnsafeRow(numFields);
+    byte[] data1 = new byte[100];
+    row1.pointTo(data1, computeSizeInBytes(numFields * 8));
+    row1.setLong(0, 0xa000000000000000L);
+
+    UnsafeRow row2 = new UnsafeRow(numFields);
+    byte[] data2 = new byte[100];
+    row2.pointTo(data2, computeSizeInBytes(numFields * 8));
+    row2.setLong(0, 0x0000000000000000L);
+
+    UnsafeRow row3 = new UnsafeRow(numFields);
+    byte[] data3 = new byte[100];
+    row3.pointTo(data3, computeSizeInBytes(numFields * 8));
+    row3.setLong(0, 0x0000000000000000L);
+
+    insertRow(row1);
+    insertRow(row2);
+    insertRow(row3);
+
+    // the bytes in row2 and row3 are the same.
+    // the base offset of row1 is 20, row2 is 40, row3 is 60
+    // so the RecordBinaryComparator will compare row1 and row2 with two long comparison directly,
+    // while the comparison between row1 and row3 is started with 4 bytes byte-by-byte comparison,
+    // followed by a long comparison, and lastly 4 bytes byte-by-byte comparison.
+    assert(compare(0, 1) > 0);
+    assert(compare(0, 2) > 0);
   }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/execution/sort/RecordBinaryComparatorSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/execution/sort/RecordBinaryComparatorSuite.java
@@ -356,7 +356,8 @@ public class RecordBinaryComparatorSuite {
     Platform.putLong(arr3, arrayOffset, 0xa000000000000000L);
     long[] arr4 = new long[2];
     Platform.putLong(arr4, arrayOffset, 0x0000000000000000L);
-    // both leftBaseOffset and rightBaseOffset are not aligned, so it will start with 4 bytes byte-by-byte comparison,
+    // both leftBaseOffset and rightBaseOffset are not aligned,
+    // so it will start with 4 bytes byte-by-byte comparison,
     // followed by a long comparison, and at last 4 bytes byte-by-byte comparison
     int result2 = binaryComparator.compare(arr3, arrayOffset, 8, arr4, arrayOffset, 8);
 

--- a/sql/core/src/test/java/test/org/apache/spark/sql/execution/sort/RecordBinaryComparatorSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/execution/sort/RecordBinaryComparatorSuite.java
@@ -273,7 +273,7 @@ public class RecordBinaryComparatorSuite {
     insertRow(row1);
     insertRow(row2);
 
-    assert(compare(0, 1) < 0);
+    assert(compare(0, 1) > 0);
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR try to make sure the comparison results of  `compared by 8 bytes at a time` and `compared by bytes wise` in RecordBinaryComparator is *consistent*, by reverse long bytes if it is little-endian and using Long.compareUnsigned. 

### Why are the changes needed?
If the architecture supports unaligned or the offset is 8 bytes aligned, `RecordBinaryComparator` compare 8 bytes at a time by reading 8 bytes as a long.  Related code is
```
    if (Platform.unaligned() || (((leftOff + i) % 8 == 0) && ((rightOff + i) % 8 == 0))) {
      while (i <= leftLen - 8) {
        final long v1 = Platform.getLong(leftObj, leftOff + i);
        final long v2 = Platform.getLong(rightObj, rightOff + i);
        if (v1 != v2) {
          return v1 > v2 ? 1 : -1;
        }
        i += 8;
      }
    }
```

Otherwise, it will compare bytes by bytes.  Related code is
```
    while (i < leftLen) {
      final int v1 = Platform.getByte(leftObj, leftOff + i) & 0xff;
      final int v2 = Platform.getByte(rightObj, rightOff + i) & 0xff;
      if (v1 != v2) {
        return v1 > v2 ? 1 : -1;
      }
      i += 1;
    }
```

However, on little-endian machine,  the result of *compared by a long value* and *compared bytes by bytes* maybe different. 

For two same records, its offsets may vary in the first run and second run, which will lead to compare them using long comparison or byte-by-byte comparison, the result maybe different.


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Add new test cases in RecordBinaryComparatorSuite
