### PR TITLE
[WIP][SPARK-29334][ML][MLLIB] Support for basic vector operators

### DIFF
--- a/mllib-local/src/main/scala/org/apache/spark/ml/linalg/Vectors.scala
+++ b/mllib-local/src/main/scala/org/apache/spark/ml/linalg/Vectors.scala
@@ -197,6 +197,17 @@ sealed trait Vector extends Serializable {
     that
   }
 
+  /**
+   * Divide a vector by a scalar.
+   */
+  @Since("3.0.0")
+  def /(a: Double): Vector = {
+    a match {
+      case 0 => throw new IllegalArgumentException("division by zero")
+      case _ => this * (1 / a)
+    }
+  }
+
 }
 
 /**

--- a/mllib-local/src/main/scala/org/apache/spark/ml/linalg/Vectors.scala
+++ b/mllib-local/src/main/scala/org/apache/spark/ml/linalg/Vectors.scala
@@ -220,6 +220,12 @@ sealed trait Vector extends Serializable {
   @Since("3.0.0")
   def +(v: Vector): Vector
 
+  /**
+   * Vector subtraction.
+   */
+  @Since("3.0.0")
+  def -(v: Vector): Vector = this + (-v)
+
 }
 
 /**

--- a/mllib-local/src/main/scala/org/apache/spark/ml/linalg/Vectors.scala
+++ b/mllib-local/src/main/scala/org/apache/spark/ml/linalg/Vectors.scala
@@ -208,6 +208,12 @@ sealed trait Vector extends Serializable {
     }
   }
 
+  /**
+   * Negate a vector.
+   */
+  @Since("3.0.0")
+  def unary_- : Vector = this * -1
+
 }
 
 /**

--- a/mllib-local/src/main/scala/org/apache/spark/ml/linalg/Vectors.scala
+++ b/mllib-local/src/main/scala/org/apache/spark/ml/linalg/Vectors.scala
@@ -186,6 +186,17 @@ sealed trait Vector extends Serializable {
    */
   @Since("3.0.0")
   def dot(v: Vector): Double = BLAS.dot(this, v)
+
+  /**
+   * Multiply a vector by a scalar.
+   */
+  @Since("3.0.0")
+  def *(a: Double): Vector = {
+    val that = copy
+    BLAS.scal(a, that)
+    that
+  }
+
 }
 
 /**

--- a/mllib-local/src/test/scala/org/apache/spark/ml/linalg/VectorsSuite.scala
+++ b/mllib-local/src/test/scala/org/apache/spark/ml/linalg/VectorsSuite.scala
@@ -433,4 +433,12 @@ class VectorsSuite extends SparkMLFunSuite {
     intercept[IllegalArgumentException]{sv / 0}
   }
 
+  test("vector negation") {
+    val dv = Vectors.dense(arr)
+    assert((-dv).toArray === Array(-0.1, 0.0, -0.3, -0.4))
+
+    val sv = Vectors.sparse(n, indices, values)
+    assert((-sv).toArray === Array(-0.1, 0.0, -0.3, -0.4))
+  }
+
 }

--- a/mllib-local/src/test/scala/org/apache/spark/ml/linalg/VectorsSuite.scala
+++ b/mllib-local/src/test/scala/org/apache/spark/ml/linalg/VectorsSuite.scala
@@ -454,9 +454,21 @@ class VectorsSuite extends SparkMLFunSuite {
     val sv3 = Vectors.sparse(3, Array(2), Array(1))
 
     assert((sv2 + sv3).toArray === Array(1, 0, 1))
+  }
 
-    // pure sparse vector addition may introduce new zero values
-    assert((sv + (-sv)).numNonzeros === 0)
+  test("vector subtraction") {
+    val dv = Vectors.dense(arr)
+    val sv = Vectors.sparse(n, indices, values)
+
+    assert((dv - dv).toArray === Array(0, 0, 0, 0))
+    assert((dv - sv).toArray === Array(0, 0, 0, 0))
+    assert((sv - dv).toArray === Array(0, 0, 0, 0))
+    assert((sv - sv).toArray === Array(0, 0, 0, 0))
+
+    val sv2 = Vectors.sparse(3, Array(0), Array(1))
+    val sv3 = Vectors.sparse(3, Array(2), Array(1))
+
+    assert((sv2 - sv3).toArray === Array(1, 0, -1))
   }
 
 }

--- a/mllib-local/src/test/scala/org/apache/spark/ml/linalg/VectorsSuite.scala
+++ b/mllib-local/src/test/scala/org/apache/spark/ml/linalg/VectorsSuite.scala
@@ -403,4 +403,13 @@ class VectorsSuite extends SparkMLFunSuite {
     assert(sv.dot(dv) === 0.26)
     assert(dv.dot(sv) === 0.26)
   }
+
+  test("scalar multiplication") {
+    val dv = Vectors.dense(arr)
+    assert((dv * 10).toArray === Array(1, 0, 3, 4))
+
+    val sv = Vectors.sparse(n, indices, values)
+    assert((sv * 10).toArray === Array(1, 0, 3, 4))
+  }
+
 }

--- a/mllib-local/src/test/scala/org/apache/spark/ml/linalg/VectorsSuite.scala
+++ b/mllib-local/src/test/scala/org/apache/spark/ml/linalg/VectorsSuite.scala
@@ -412,4 +412,25 @@ class VectorsSuite extends SparkMLFunSuite {
     assert((sv * 10).toArray === Array(1, 0, 3, 4))
   }
 
+  test("scalar division") {
+    val tol = 1e-15 // margin for round-off error
+
+    val dv = Vectors.dense(arr)
+    val dAns = (dv / 10).toArray
+    assert(dAns(0) ~== 0.01 relTol tol)
+    assert(dAns(1) ~== 0.00 relTol tol)
+    assert(dAns(2) ~== 0.03 relTol tol)
+    assert(dAns(3) ~== 0.04 relTol tol)
+
+    val sv = Vectors.sparse(n, indices, values)
+    val sAns = (sv / 10).toArray
+    assert(sAns(0) ~== 0.01 relTol tol)
+    assert(sAns(1) ~== 0.00 relTol tol)
+    assert(sAns(2) ~== 0.03 relTol tol)
+    assert(sAns(3) ~== 0.04 relTol tol)
+
+    intercept[IllegalArgumentException]{dv / 0}
+    intercept[IllegalArgumentException]{sv / 0}
+  }
+
 }

--- a/mllib-local/src/test/scala/org/apache/spark/ml/linalg/VectorsSuite.scala
+++ b/mllib-local/src/test/scala/org/apache/spark/ml/linalg/VectorsSuite.scala
@@ -471,4 +471,20 @@ class VectorsSuite extends SparkMLFunSuite {
     assert((sv2 - sv3).toArray === Array(1, 0, -1))
   }
 
+  test("vector addition/subtraction only supports vectors of same size") {
+    val dv4 = Vectors.dense(arr)
+    val dv3 = Vectors.dense(arr.tail)
+    val sv4 = Vectors.sparse(n, indices, values)
+    val sv5 = Vectors.sparse(n + 1, indices, values)
+
+    intercept[IllegalArgumentException]{dv3 + dv4}
+    intercept[IllegalArgumentException]{dv3 - dv4}
+    intercept[IllegalArgumentException]{dv3 + sv4}
+    intercept[IllegalArgumentException]{dv3 - sv4}
+    intercept[IllegalArgumentException]{sv5 + dv4}
+    intercept[IllegalArgumentException]{sv5 - dv4}
+    intercept[IllegalArgumentException]{sv4 + sv5}
+    intercept[IllegalArgumentException]{sv4 - sv5}
+  }
+
 }

--- a/mllib-local/src/test/scala/org/apache/spark/ml/linalg/VectorsSuite.scala
+++ b/mllib-local/src/test/scala/org/apache/spark/ml/linalg/VectorsSuite.scala
@@ -441,4 +441,22 @@ class VectorsSuite extends SparkMLFunSuite {
     assert((-sv).toArray === Array(-0.1, 0.0, -0.3, -0.4))
   }
 
+  test("vector addition") {
+    val dv = Vectors.dense(arr)
+    val sv = Vectors.sparse(n, indices, values)
+
+    assert((dv + dv).toArray === Array(0.2, 0.0, 0.6, 0.8))
+    assert((dv + sv).toArray === Array(0.2, 0.0, 0.6, 0.8))
+    assert((sv + dv).toArray === Array(0.2, 0.0, 0.6, 0.8))
+    assert((sv + sv).toArray === Array(0.2, 0.0, 0.6, 0.8))
+
+    val sv2 = Vectors.sparse(3, Array(0), Array(1))
+    val sv3 = Vectors.sparse(3, Array(2), Array(1))
+
+    assert((sv2 + sv3).toArray === Array(1, 0, 1))
+
+    // pure sparse vector addition may introduce new zero values
+    assert((sv + (-sv)).numNonzeros === 0)
+  }
+
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Basic operator support for `ml.linalg.Vector`, and `mllib.linagl.Vector`:

- negation
- scalar multiplication and division
- vector addition and subtraction 

### Why are the changes needed?

To improve parity with Vector operators provided with pySpark.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Unit tests in the appropriate places.  To run quickly:

```
sbt "mllib-local/testOnly org.apache.spark.ml.linalg.VectorsSuite"
```