### PR TITLE
[SPARK-29906][SQL] Reading of csv file fails with adaptive execution turned on

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
@@ -111,7 +111,7 @@ object TextInputCSVDataSource extends CSVDataSource {
       inputPaths: Seq[FileStatus],
       parsedOptions: CSVOptions): StructType = {
     val csv = createBaseDataset(sparkSession, inputPaths, parsedOptions)
-    val maybeFirstLine = CSVUtils.filterCommentAndEmpty(csv, parsedOptions).take(1).headOption
+    val maybeFirstLine = CSVUtils.filterCommentAndEmpty(csv, parsedOptions).rdd.take(1).headOption
     inferFromDataset(sparkSession, csv, maybeFirstLine, parsedOptions)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Switch to rdd to avoid adaptive execution when reading first line, because it seems adaptive execution can insert a ShuffleMapStage after which the first line read is not necessarily the csv header anymore.

Note that this is a workaround. It is not clear to me why adaptive exection inserts a shuffle stage when all we are doing is filtering and reading first line. If this is unwanted behavior then the fix should be in adaptive execution.

### Why are the changes needed?

Without this change spark can read csv files incorrectly when adaptive execution is turned on resulting in errors and/or data corruption.

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

It is not clear to me how reproduce issue in a unit test, because so far the issue only shows up with 6+ executors and decent sized files. This patch was only tested by rebuilding spark and re-running the steps as decribed in the jira and confirming the issue did not show up again.