### PR TITLE
[SPARK-29870][SQL][FOLLOW-UP] Keep CalendarInterval's toString

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/CalendarInterval.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/CalendarInterval.java
@@ -18,6 +18,7 @@
 package org.apache.spark.unsafe.types;
 
 import java.io.Serializable;
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Period;
 import java.time.temporal.ChronoUnit;
@@ -79,8 +80,39 @@ public final class CalendarInterval implements Serializable, Comparable<Calendar
 
   @Override
   public String toString() {
-    return "CalendarInterval(months= " + months + ", days = " + days + ", microsecond = " +
-      microseconds + ")";
+    if (months == 0 && days == 0 && microseconds == 0) {
+      return "0 seconds";
+    }
+
+    StringBuilder sb = new StringBuilder();
+
+    if (months != 0) {
+      appendUnit(sb, months / 12, "years");
+      appendUnit(sb, months % 12, "months");
+    }
+
+    appendUnit(sb, days, "days");
+
+    if (microseconds != 0) {
+      long rest = microseconds;
+      appendUnit(sb, rest / MICROS_PER_HOUR, "hours");
+      rest %= MICROS_PER_HOUR;
+      appendUnit(sb, rest / MICROS_PER_MINUTE, "minutes");
+      rest %= MICROS_PER_MINUTE;
+      if (rest != 0) {
+        String s = BigDecimal.valueOf(rest, 6).stripTrailingZeros().toPlainString();
+        sb.append(s).append(" seconds ");
+      }
+    }
+
+    sb.setLength(sb.length() - 1);
+    return sb.toString();
+  }
+
+  private void appendUnit(StringBuilder sb, long value, String unit) {
+    if (value != 0) {
+      sb.append(value).append(' ').append(unit).append(' ');
+    }
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -409,7 +409,6 @@ case class Literal (value: Any, dataType: DataType) extends LeafExpression {
         DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))
       s"TIMESTAMP('${formatter.format(v)}')"
     case (v: Array[Byte], BinaryType) => s"X'${DatatypeConverter.printHexBinary(v)}'"
-    case (v: CalendarInterval, CalendarIntervalType) => IntervalUtils.toMultiUnitsString(v)
     case _ => value.toString
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonGenerator.scala
@@ -119,10 +119,6 @@ private[sql] class JacksonGenerator(
       (row: SpecializedGetters, ordinal: Int) =>
         gen.writeNumber(row.getDouble(ordinal))
 
-    case CalendarIntervalType =>
-      (row: SpecializedGetters, ordinal: Int) =>
-        gen.writeString(IntervalUtils.toMultiUnitsString(row.getInterval(ordinal)))
-
     case StringType =>
       (row: SpecializedGetters, ordinal: Int) =>
         gen.writeString(row.getUTF8String(ordinal).toString)
@@ -218,15 +214,10 @@ private[sql] class JacksonGenerator(
   private def writeMapData(
       map: MapData, mapType: MapType, fieldWriter: ValueWriter): Unit = {
     val keyArray = map.keyArray()
-    val keyString = mapType.keyType match {
-      case CalendarIntervalType =>
-        (i: Int) => IntervalUtils.toMultiUnitsString(keyArray.getInterval(i))
-      case _ => (i: Int) => keyArray.get(i, mapType.keyType).toString
-    }
     val valueArray = map.valueArray()
     var i = 0
     while (i < map.numElements()) {
-      gen.writeFieldName(keyString(i))
+      gen.writeFieldName(keyArray.get(i, mapType.keyType).toString)
       if (!valueArray.isNullAt(i)) {
         fieldWriter.apply(valueArray, i)
       } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -334,10 +334,6 @@ object IntervalUtils {
 
   def toMultiUnitsString(interval: CalendarInterval): String = interval.toString
 
-  private def appendUnit(sb: StringBuilder, value: Long, unit: String): Unit = {
-    if (value != 0) sb.append(value).append(' ').append(unit).append(' ')
-  }
-
   def toSqlStandardString(interval: CalendarInterval): String = {
     val yearMonthPart = if (interval.months < 0) {
       val ma = math.abs(interval.months)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -332,30 +332,7 @@ object IntervalUtils {
     fromDoubles(interval.months / num, interval.days / num, interval.microseconds / num)
   }
 
-  def toMultiUnitsString(interval: CalendarInterval): String = {
-    if (interval.months == 0 && interval.days == 0 && interval.microseconds == 0) {
-      return "0 seconds"
-    }
-    val sb = new StringBuilder
-    if (interval.months != 0) {
-      appendUnit(sb, interval.months / 12, "years")
-      appendUnit(sb, interval.months % 12, "months")
-    }
-    appendUnit(sb, interval.days, "days")
-    if (interval.microseconds != 0) {
-      var rest = interval.microseconds
-      appendUnit(sb, rest / MICROS_PER_HOUR, "hours")
-      rest %= MICROS_PER_HOUR
-      appendUnit(sb, rest / MICROS_PER_MINUTE, "minutes")
-      rest %= MICROS_PER_MINUTE
-      if (rest != 0) {
-        val s = BigDecimal.valueOf(rest, 6).stripTrailingZeros.toPlainString
-        sb.append(s).append(" seconds ")
-      }
-    }
-    sb.setLength(sb.length - 1)
-    sb.toString
-  }
+  def toMultiUnitsString(interval: CalendarInterval): String = interval.toString
 
   private def appendUnit(sb: StringBuilder, value: Long, unit: String): Unit = {
     if (value != 0) sb.append(value).append(' ').append(unit).append(' ')

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -332,6 +332,7 @@ object IntervalUtils {
     fromDoubles(interval.months / num, interval.days / num, interval.microseconds / num)
   }
 
+  // `toString` implementation in CalendarInterval is the multi-units format currently.
   def toMultiUnitsString(interval: CalendarInterval): String = interval.toString
 
   def toSqlStandardString(interval: CalendarInterval): String = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a followup of https://github.com/apache/spark/pull/26418. This PR removed `CalendarInterval`'s `toString` with an unfinished changes.

### Why are the changes needed?

1. Ideally we should make each PR isolated and separate targeting one issue without touching unrelated codes.

2. There are some other places where the string formats were exposed to users. For example:

    ```scala
    scala> sql("select interval 1 days as a").selectExpr("to_csv(struct(a))").show()
    ```
    ```
    +--------------------------+
    |to_csv(named_struct(a, a))|
    +--------------------------+
    |      "CalendarInterval...|
    +--------------------------+
    ```

3.  Such fixes:

    ```diff
     private def writeMapData(
        map: MapData, mapType: MapType, fieldWriter: ValueWriter): Unit = {
      val keyArray = map.keyArray()
    + val keyString = mapType.keyType match {
    +   case CalendarIntervalType =>
    +    (i: Int) => IntervalUtils.toMultiUnitsString(keyArray.getInterval(i))
    +   case _ => (i: Int) => keyArray.get(i, mapType.keyType).toString
    + }
    ```

    can cause performance regression due to type dispatch for each map.

### Does this PR introduce any user-facing change?

Yes, see 2. case above.

### How was this patch tested?

Manually tested.
