### PR TITLE
[SPARK-29926][SQL] Fix weird interval string whose value is only a dangling decimal point

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -505,7 +505,7 @@ object IntervalUtils {
     var days: Int = 0
     var microseconds: Long = 0
     var fractionScale: Int = 0
-    val validOriginFractionScale = (NANOS_PER_SECOND / 10).toInt
+    val initialFractionScale = (NANOS_PER_SECOND / 10).toInt
     var fraction: Int = 0
 
     def trimToNextState(b: Byte, next: ParseState): Unit = {
@@ -557,7 +557,7 @@ object IntervalUtils {
               isNegative = false
             case '.' =>
               isNegative = false
-              fractionScale = validOriginFractionScale
+              fractionScale = initialFractionScale
               i += 1
               state = VALUE_FRACTIONAL_PART
             case _ => throwIAE( s"unrecognized number '$currentWord'")
@@ -573,7 +573,7 @@ object IntervalUtils {
               }
             case ' ' => state = TRIM_BEFORE_UNIT
             case '.' =>
-              fractionScale = validOriginFractionScale
+              fractionScale = initialFractionScale
               state = VALUE_FRACTIONAL_PART
             case _ => throwIAE(s"invalid value '$currentWord'")
           }
@@ -583,7 +583,7 @@ object IntervalUtils {
             case _ if '0' <= b && b <= '9' && fractionScale > 0 =>
               fraction += (b - '0') * fractionScale
               fractionScale /= 10
-            case ' ' if fractionScale != validOriginFractionScale =>
+            case ' ' if fractionScale != initialFractionScale =>
               fraction /= NANOS_PER_MICROS.toInt
               state = TRIM_BEFORE_UNIT
             case _ if '0' <= b && b <= '9' =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -583,7 +583,7 @@ object IntervalUtils {
             case _ if '0' <= b && b <= '9' && fractionScale > 0 =>
               fraction += (b - '0') * fractionScale
               fractionScale /= 10
-            case ' ' if fractionScale != initialFractionScale =>
+            case ' ' if fractionScale < initialFractionScale =>
               fraction /= NANOS_PER_MICROS.toInt
               state = TRIM_BEFORE_UNIT
             case _ if '0' <= b && b <= '9' =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -505,6 +505,7 @@ object IntervalUtils {
     var days: Int = 0
     var microseconds: Long = 0
     var fractionScale: Int = 0
+    val validOriginFractionScale = (NANOS_PER_SECOND / 10).toInt
     var fraction: Int = 0
 
     def trimToNextState(b: Byte, next: ParseState): Unit = {
@@ -556,7 +557,7 @@ object IntervalUtils {
               isNegative = false
             case '.' =>
               isNegative = false
-              fractionScale = (NANOS_PER_SECOND / 10).toInt
+              fractionScale = validOriginFractionScale
               i += 1
               state = VALUE_FRACTIONAL_PART
             case _ => throwIAE( s"unrecognized number '$currentWord'")
@@ -572,7 +573,7 @@ object IntervalUtils {
               }
             case ' ' => state = TRIM_BEFORE_UNIT
             case '.' =>
-              fractionScale = (NANOS_PER_SECOND / 10).toInt
+              fractionScale = validOriginFractionScale
               state = VALUE_FRACTIONAL_PART
             case _ => throwIAE(s"invalid value '$currentWord'")
           }
@@ -582,7 +583,7 @@ object IntervalUtils {
             case _ if '0' <= b && b <= '9' && fractionScale > 0 =>
               fraction += (b - '0') * fractionScale
               fractionScale /= 10
-            case ' ' =>
+            case ' ' if fractionScale != validOriginFractionScale =>
               fraction /= NANOS_PER_MICROS.toInt
               state = TRIM_BEFORE_UNIT
             case _ if '0' <= b && b <= '9' =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
@@ -105,7 +105,7 @@ class IntervalUtilsSuite extends SparkFunSuite {
     checkFromString("1 day 10 day", new CalendarInterval(0, 11, 0))
     // Only the seconds units can have the fractional part
     checkFromInvalidString("1.5 days", "'days' cannot have fractional part")
-    checkFromInvalidString("1. hour", "invalid value '1.'")
+    checkFromInvalidString("1. hour", "'hour' cannot have fractional part")
     checkFromInvalidString("1 hourX", "invalid unit 'hourx'")
     checkFromInvalidString("~1 hour", "unrecognized number '~1'")
     checkFromInvalidString("1 Mour", "invalid unit 'mour'")
@@ -115,12 +115,12 @@ class IntervalUtilsSuite extends SparkFunSuite {
     checkFromInvalidString("2234567890 days", "integer overflow")
     checkFromInvalidString("\n", "Error parsing '\n' to interval")
     checkFromInvalidString("\t", "Error parsing '\t' to interval")
-    checkFromInvalidString("1. seconds", "invalid value '1.'")
     checkFromInvalidString(". seconds", "invalid value '.'")
   }
 
   test("string to interval: seconds with fractional part") {
     checkFromString("0.1 seconds", new CalendarInterval(0, 0, 100000))
+    checkFromString("1. seconds", new CalendarInterval(0, 0, 1000000))
     checkFromString("123.001 seconds", new CalendarInterval(0, 0, 123001000))
     checkFromString("1.001001 seconds", new CalendarInterval(0, 0, 1001001))
     checkFromString("1 minute 1.001001 seconds", new CalendarInterval(0, 0, 61001001))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
@@ -105,7 +105,7 @@ class IntervalUtilsSuite extends SparkFunSuite {
     checkFromString("1 day 10 day", new CalendarInterval(0, 11, 0))
     // Only the seconds units can have the fractional part
     checkFromInvalidString("1.5 days", "'days' cannot have fractional part")
-    checkFromInvalidString("1. hour", "'hour' cannot have fractional part")
+    checkFromInvalidString("1. hour", "invalid value '1.'")
     checkFromInvalidString("1 hourX", "invalid unit 'hourx'")
     checkFromInvalidString("~1 hour", "unrecognized number '~1'")
     checkFromInvalidString("1 Mour", "invalid unit 'mour'")
@@ -115,12 +115,12 @@ class IntervalUtilsSuite extends SparkFunSuite {
     checkFromInvalidString("2234567890 days", "integer overflow")
     checkFromInvalidString("\n", "Error parsing '\n' to interval")
     checkFromInvalidString("\t", "Error parsing '\t' to interval")
-
+    checkFromInvalidString("1. seconds", "invalid value '1.'")
+    checkFromInvalidString(". seconds", "invalid value '.'")
   }
 
   test("string to interval: seconds with fractional part") {
     checkFromString("0.1 seconds", new CalendarInterval(0, 0, 100000))
-    checkFromString("1. seconds", new CalendarInterval(0, 0, 1000000))
     checkFromString("123.001 seconds", new CalendarInterval(0, 0, 123001000))
     checkFromString("1.001001 seconds", new CalendarInterval(0, 0, 1001001))
     checkFromString("1 minute 1.001001 seconds", new CalendarInterval(0, 0, 61001001))


### PR DESCRIPTION
### What changes were proposed in this pull request?


Currently, we support to parse '1. second' to 1s or even '. second' to 0s. 

```sql
-- !query 118
select interval '1. seconds'
-- !query 118 schema
struct<1 seconds:interval>
-- !query 118 output
1 seconds


-- !query 119
select interval '. seconds'
-- !query 119 schema
struct<0 seconds:interval>
-- !query 119 output
0 seconds
```

```sql
postgres=# select interval '1. second';
ERROR:  invalid input syntax for type interval: "1. second"
LINE 1: select interval '1. second';

postgres=# select interval '. second';
ERROR:  invalid input syntax for type interval: ". second"
LINE 1: select interval '. second';
```
We fix this by fixing the new interval parser's VALUE_FRACTIONAL_PART state

With further digging, we found that 1. is valid in python, r, scala, and presto and so on... so this PR
ONLY forbid the invalid interval value in the form of  '. seconds'.


### Why are the changes needed?

bug fix

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

yes, now we treat '. second' .... as invalid intervals
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
add ut