### PR TITLE
[SPARK-29942][ML] Impl Complement Naive Bayes Classifier

### DIFF
--- a/docs/ml-classification-regression.md
+++ b/docs/ml-classification-regression.md
@@ -479,16 +479,17 @@ For prediction, it applies Bayes' theorem to compute the conditional probability
 of each label given an observation.
 
 MLlib supports [Multinomial naive Bayes](http://en.wikipedia.org/wiki/Naive_Bayes_classifier#Multinomial_naive_Bayes),
+[Complement naive Bayes](https://people.csail.mit.edu/jrennie/papers/icml03-nb.pdf),
 [Bernoulli naive Bayes](http://nlp.stanford.edu/IR-book/html/htmledition/the-bernoulli-model-1.html)
 and [Gaussian naive Bayes](https://en.wikipedia.org/wiki/Naive_Bayes_classifier#Gaussian_naive_Bayes).
 
 *Input data*:
-These Multinomial and Bernoulli models are typically used for [document classification](http://nlp.stanford.edu/IR-book/html/htmledition/naive-bayes-text-classification-1.html).
+These Multinomial, Complement and Bernoulli models are typically used for [document classification](http://nlp.stanford.edu/IR-book/html/htmledition/naive-bayes-text-classification-1.html).
 Within that context, each observation is a document and each feature represents a term.
-A feature's value is the frequency of the term (in multinomial Naive Bayes) or
+A feature's value is the frequency of the term (in Multinomial or Complement Naive Bayes) or
 a zero or one indicating whether the term was found in the document (in Bernoulli Naive Bayes).
 Feature values for Multinomial and Bernoulli models must be *non-negative*. The model type is selected with an optional parameter
-"multinomial" or "bernoulli" with "multinomial" as the default.
+"multinomial", "complement", "bernoulli" or "gaussian", with "multinomial" as the default.
 For document classification, the input feature vectors should usually be sparse vectors.
 Since the training data is only used once, it is not necessary to cache it.
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
@@ -468,18 +468,18 @@ class NaiveBayesModel private[ml] (
     requireNonnegativeValues(features)
     val probArray = theta.multiply(features).toArray
     // the following lines equal to:
-    // val logSumExp = math.log(prob.toArray.map(math.exp).sum)
+    // val logSumExp = math.log(probArray.map(math.exp).sum)
     // However, it easily returns Infinity/NaN values.
     // Here follows 'scipy.special.logsumexp' (which is used in Scikit-Learn's ComplementNB)
     // to compute the log of the sum of exponentials of elements in a numeric-stable way.
-    val maxProb = probArray.max
+    val max = probArray.max
     var sumExp = 0.0
     var j = 0
     while (j < probArray.length) {
-      sumExp += math.exp(probArray(j) - maxProb)
+      sumExp += math.exp(probArray(j) - max)
       j += 1
     }
-    val logSumExp = math.log(sumExp) + maxProb
+    val logSumExp = math.log(sumExp) + max
 
     j = 0
     while (j < probArray.length) {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/NaiveBayesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/NaiveBayesSuite.scala
@@ -471,7 +471,7 @@ class NaiveBayesSuite extends MLTest with DefaultReadWriteTest {
             [-37126.4015229 ,      0.        ],
             [-27649.81038619,      0.        ],
             [-28767.84075587,      0.        ]])
-     >>> clf.predict_proba[:, -5:]
+     >>> clf.predict_proba(X[:5])
      array([[1., 0.],
             [0., 1.],
             [0., 1.],

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -1974,7 +1974,7 @@ class NaiveBayes(JavaProbabilisticClassifier, _NaiveBayesParams, HasThresholds, 
     DenseMatrix(2, 2, [0.0, 0.25, 0.0, 0.0], 1)
     >>> nb5 = NaiveBayes(smoothing=1.0, modelType="complement", weightCol="weight")
     >>> model5 = nb5.fit(df)
-    >>> model5.getModelType
+    >>> model5.getModelType()
     'complement'
     >>> model5.theta
     DenseMatrix(2, 2, [...], 1)

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -1972,6 +1972,14 @@ class NaiveBayes(JavaProbabilisticClassifier, _NaiveBayesParams, HasThresholds, 
     'gaussian'
     >>> model4.sigma
     DenseMatrix(2, 2, [0.0, 0.25, 0.0, 0.0], 1)
+    >>> nb5 = NaiveBayes(smoothing=1.0, modelType="complement", weightCol="weight")
+    >>> model5 = nb5.fit(df)
+    >>> model5.getModelType
+    'complement'
+    >>> model5.theta
+    DenseMatrix(2, 2, [...], 1)
+    >>> model5.sigma == None
+    True
 
     .. versionadded:: 1.5.0
     """

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -1909,6 +1909,11 @@ class NaiveBayes(JavaProbabilisticClassifier, _NaiveBayesParams, HasThresholds, 
     binary (0/1) data, it can also be used as `Bernoulli NB
     <http://nlp.stanford.edu/IR-book/html/htmledition/the-bernoulli-model-1.html>`_.
     The input feature values for Multinomial NB and Bernoulli NB must be nonnegative.
+    Since 3.0.0, it supports Complement NB which is an adaptation of the Multinomial NB.
+    Specifically, Complement NB uses statistics from the complement of each class to compute
+    the model's coefficients. The inventors of Complement NB show empirically that the parameter
+    estimates for CNB are more stable than those for Multinomial NB. Like Multinomial NB, the
+    input feature values for Complement NB must be nonnegative.
     Since 3.0.0, it also supports Gaussian NB
     <https://en.wikipedia.org/wiki/Naive_Bayes_classifier#Gaussian_naive_Bayes>`_.
     which can handle continuous data.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Impl Complement Naive Bayes Classifier as a `modelType` option in `NaiveBayes`

### Why are the changes needed?
1, it is a better choice for text classification: it is said in [scikit-learn](https://scikit-learn.org/stable/modules/naive_bayes.html#complement-naive-bayes) that 'CNB regularly outperforms MNB (often by a considerable margin) on text classification tasks.'
2, CNB is highly similar to existing MNB, only a small part of existing MNB need to be changed, so it is a easy win to support CNB.


### Does this PR introduce any user-facing change?
yes, a new `modelType` is supported


### How was this patch tested?
added testsuites
