### PR TITLE
[SPARK-29943][SQL] Improve error messages for unsupported data type

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -493,9 +493,8 @@ private[spark] object HiveUtils extends Logging {
       val hiveTable = HiveClientImpl.toHiveTable(table)
       // Note: Hive separates partition columns and the schema, but for us the
       // partition columns are part of the schema
-      val partCols = hiveTable.getPartCols.asScala.map(c =>
-        HiveClientImpl.fromHiveColumn(c, hiveTable))
-      val dataCols = hiveTable.getCols.asScala.map(c => HiveClientImpl.fromHiveColumn(c, hiveTable))
+      val partCols = hiveTable.getPartCols.asScala.map(HiveClientImpl.fromHiveColumn)
+      val dataCols = hiveTable.getCols.asScala.map(HiveClientImpl.fromHiveColumn)
       table.copy(schema = StructType(dataCols ++ partCols))
     }
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -493,7 +493,8 @@ private[spark] object HiveUtils extends Logging {
       val hiveTable = HiveClientImpl.toHiveTable(table)
       // Note: Hive separates partition columns and the schema, but for us the
       // partition columns are part of the schema
-      val partCols = hiveTable.getPartCols.asScala.map(c => HiveClientImpl.fromHiveColumn(c, hiveTable))
+      val partCols = hiveTable.getPartCols.asScala.map(c =>
+        HiveClientImpl.fromHiveColumn(c, hiveTable))
       val dataCols = hiveTable.getCols.asScala.map(c => HiveClientImpl.fromHiveColumn(c, hiveTable))
       table.copy(schema = StructType(dataCols ++ partCols))
     }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -493,8 +493,8 @@ private[spark] object HiveUtils extends Logging {
       val hiveTable = HiveClientImpl.toHiveTable(table)
       // Note: Hive separates partition columns and the schema, but for us the
       // partition columns are part of the schema
-      val partCols = hiveTable.getPartCols.asScala.map(HiveClientImpl.fromHiveColumn)
-      val dataCols = hiveTable.getCols.asScala.map(HiveClientImpl.fromHiveColumn)
+      val partCols = hiveTable.getPartCols.asScala.map(c => HiveClientImpl.fromHiveColumn(c, hiveTable))
+      val dataCols = hiveTable.getCols.asScala.map(c => HiveClientImpl.fromHiveColumn(c, hiveTable))
       table.copy(schema = StructType(dataCols ++ partCols))
     }
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -440,8 +440,8 @@ private[hive] class HiveClientImpl(
   private def convertHiveTableToCatalogTable(h: HiveTable): CatalogTable = {
     // Note: Hive separates partition columns and the schema, but for us the
     // partition columns are part of the schema
-    val cols = h.getCols.asScala.map(fromHiveColumn)
-    val partCols = h.getPartCols.asScala.map(fromHiveColumn)
+    val cols = h.getCols.asScala.map(c => HiveClientImpl.fromHiveColumn(c, h))
+    val partCols = h.getPartCols.asScala.map(c => HiveClientImpl.fromHiveColumn(c, h))
     val schema = StructType(cols ++ partCols)
 
     val bucketSpec = if (h.getNumBuckets > 0) {
@@ -977,18 +977,20 @@ private[hive] object HiveClientImpl {
   }
 
   /** Get the Spark SQL native DataType from Hive's FieldSchema. */
-  private def getSparkSQLDataType(hc: FieldSchema): DataType = {
+  private def getSparkSQLDataType(hc: FieldSchema, t: HiveTable = null): DataType = {
     try {
       CatalystSqlParser.parseDataType(hc.getType)
     } catch {
       case e: ParseException =>
-        throw new SparkException("Cannot recognize hive type string: " + hc.getType, e)
+        throw new SparkException(s"Cannot recognize hive type string: ${hc.getType}," +
+          (if (t != null) s"db: ${t.getDbName},table: ${t.getTableName}," else "") +
+          s"column: ${hc.getName}", e)
     }
   }
 
   /** Builds the native StructField from Hive's FieldSchema. */
-  def fromHiveColumn(hc: FieldSchema): StructField = {
-    val columnType = getSparkSQLDataType(hc)
+  def fromHiveColumn(hc: FieldSchema, t: HiveTable): StructField = {
+    val columnType = getSparkSQLDataType(hc, t)
     val metadata = if (hc.getType != columnType.catalogString) {
       new MetadataBuilder().putString(HIVE_TYPE_STRING, hc.getType).build()
     } else {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -445,7 +445,7 @@ private[hive] class HiveClientImpl(
     } catch {
       case ex: SparkException =>
         throw new SparkException(
-          ex.getMessage + s", db: ${h.getDbName}, table: ${h.getTableName}", ex)
+          s"${ex.getMessage}, db: ${h.getDbName}, table: ${h.getTableName}", ex)
     }
     val schema = StructType(cols ++ partCols)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -441,12 +441,11 @@ private[hive] class HiveClientImpl(
     // Note: Hive separates partition columns and the schema, but for us the
     // partition columns are part of the schema
     val (cols, partCols) = try {
-      (h.getCols.asScala.map(fromHiveColumn),
-        h.getPartCols.asScala.map(fromHiveColumn))
+      (h.getCols.asScala.map(fromHiveColumn), h.getPartCols.asScala.map(fromHiveColumn))
     } catch {
       case ex: SparkException =>
-        throw new SparkException(ex.getMessage
-          + s".db: ${h.getDbName},table: ${h.getTableName},", ex);
+        throw new SparkException(
+          ex.getMessage + s", db: ${h.getDbName}, table: ${h.getTableName}", ex)
     }
     val schema = StructType(cols ++ partCols)
 
@@ -988,8 +987,8 @@ private[hive] object HiveClientImpl {
       CatalystSqlParser.parseDataType(hc.getType)
     } catch {
       case e: ParseException =>
-        throw new SparkException(s"Cannot recognize hive type string: ${hc.getType}," +
-          s"column: ${hc.getName}", e)
+        throw new SparkException(
+          s"Cannot recognize hive type string: ${hc.getType}, column: ${hc.getName}", e)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Improve error messages for unsupported data type.

### Why are the changes needed?
When the spark reads the hive table and encounters an unsupported field type, the exception message has only one unsupported type, and the user cannot know which field of which table.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
```create view t AS SELECT STRUCT('a' AS `$a`, 1 AS b) as q;```
current:
org.apache.spark.SparkException: Cannot recognize hive type string: struct<$a:string,b:int>
change:
org.apache.spark.SparkException: Cannot recognize hive type string: struct<$a:string,b:int>, column: q

```select * from t,t_normal_1,t_normal_2```
current:
org.apache.spark.SparkException: Cannot recognize hive type string: struct<$a:string,b:int>
change:
org.apache.spark.SparkException: Cannot recognize hive type string: struct<$a:string,b:int>, column: q, db: default, table: t
