### PR TITLE
[SPARK-29949][SQL][2.4] Fix formatting of timestamps by JSON/CSV datasources

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonGenerator.scala
@@ -20,10 +20,11 @@ package org.apache.spark.sql.catalyst.json
 import java.io.Writer
 
 import com.fasterxml.jackson.core._
+
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.SpecializedGetters
-import org.apache.spark.sql.catalyst.util.DateTimeUtils.TimestampParser
 import org.apache.spark.sql.catalyst.util.{ArrayData, DateTimeUtils, MapData}
+import org.apache.spark.sql.catalyst.util.DateTimeUtils.TimestampParser
 import org.apache.spark.sql.types._
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonGenerator.scala
@@ -20,9 +20,9 @@ package org.apache.spark.sql.catalyst.json
 import java.io.Writer
 
 import com.fasterxml.jackson.core._
-
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.SpecializedGetters
+import org.apache.spark.sql.catalyst.util.DateTimeUtils.TimestampParser
 import org.apache.spark.sql.catalyst.util.{ArrayData, DateTimeUtils, MapData}
 import org.apache.spark.sql.types._
 
@@ -74,6 +74,8 @@ private[sql] class JacksonGenerator(
 
   private val lineSeparator: String = options.lineSeparatorInWrite
 
+  @transient private lazy val timestampParser = new TimestampParser(options.timestampFormat)
+
   private def makeWriter(dataType: DataType): ValueWriter = dataType match {
     case NullType =>
       (row: SpecializedGetters, ordinal: Int) =>
@@ -113,8 +115,7 @@ private[sql] class JacksonGenerator(
 
     case TimestampType =>
       (row: SpecializedGetters, ordinal: Int) =>
-        val timestampString =
-          options.timestampFormat.format(DateTimeUtils.toJavaTimestamp(row.getLong(ordinal)))
+        val timestampString = timestampParser.format(row.getLong(ordinal))
         gen.writeString(timestampString)
 
     case DateType =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -731,4 +731,44 @@ class DateTimeUtilsSuite extends SparkFunSuite {
       }
     }
   }
+
+  test("formatting timestamp strings up to microsecond precision") {
+    DateTimeTestUtils.outstandingTimezones.foreach { timeZone =>
+      def check(pattern: String, input: String, expected: String): Unit = {
+        val parser = new TimestampParser(FastDateFormat.getInstance(pattern, timeZone, Locale.US))
+        val timestamp = DateTimeUtils.stringToTimestamp(
+          UTF8String.fromString(input), timeZone).get
+        val actual = parser.format(timestamp)
+        assert(actual === expected)
+      }
+
+      check(
+        "yyyy-MM-dd HH:mm:ss.SSSSSSS", "2019-10-14T09:39:07.123456",
+        "2019-10-14 09:39:07.1234560")
+      check(
+        "yyyy-MM-dd HH:mm:ss.SSSSSS", "1960-01-01T09:39:07.123456",
+        "1960-01-01 09:39:07.123456")
+      check(
+        "yyyy-MM-dd HH:mm:ss.SSSSS", "0001-10-14T09:39:07.1",
+        "0001-10-14 09:39:07.10000")
+      check(
+        "yyyy-MM-dd HH:mm:ss.SSSS", "9999-12-31T23:59:59.999",
+        "9999-12-31 23:59:59.9990")
+      check(
+        "yyyy-MM-dd HH:mm:ss.SSS", "1970-01-01T00:00:00.0101",
+        "1970-01-01 00:00:00.010")
+      check(
+        "yyyy-MM-dd HH:mm:ss.SS", "2019-10-14T09:39:07.09",
+        "2019-10-14 09:39:07.09")
+      check(
+        "yyyy-MM-dd HH:mm:ss.S", "2019-10-14T09:39:07.2",
+        "2019-10-14 09:39:07.2")
+      check(
+        "yyyy-MM-dd HH:mm:ss.S", "2019-10-14T09:39:07",
+        "2019-10-14 09:39:07.0")
+      check(
+        "yyyy-MM-dd HH:mm:ss", "2019-10-14T09:39:07.123456",
+        "2019-10-14 09:39:07")
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -528,4 +528,11 @@ class JsonFunctionsSuite extends QueryTest with SharedSQLContext {
       df.select(from_json($"value", schema, options)),
       Row(Row(java.sql.Timestamp.valueOf("1970-01-01 00:00:00.123456"))))
   }
+
+  test("to_json - timestamp in micros") {
+    val s = "2019-11-18 11:56:00.123456"
+    val df = Seq(java.sql.Timestamp.valueOf(s)).toDF("t").select(
+      to_json(struct($"t"), Map("timestampFormat" -> "yyyy-MM-dd HH:mm:ss.SSSSSS")))
+    checkAnswer(df, Row(s"""{"t":"$s"}"""))
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -41,7 +41,6 @@ import org.apache.spark.sql.test.{SharedSQLContext, SQLTestUtils}
 import org.apache.spark.sql.types._
 
 class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with TestCsvData {
-
   import testImplicits._
 
   private val carsFile = "test-data/cars.csv"
@@ -67,13 +66,13 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
 
   /** Verifies data and schema. */
   private def verifyCars(
-    df: DataFrame,
-    withHeader: Boolean,
-    numCars: Int = 3,
-    numFields: Int = 5,
-    checkHeader: Boolean = true,
-    checkValues: Boolean = true,
-    checkTypes: Boolean = false): Unit = {
+      df: DataFrame,
+      withHeader: Boolean,
+      numCars: Int = 3,
+      numFields: Int = 5,
+      checkHeader: Boolean = true,
+      checkValues: Boolean = true,
+      checkTypes: Boolean = false): Unit = {
 
     val numColumns = numFields
     val numRows = if (withHeader) numCars else numCars + 1
@@ -213,9 +212,9 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
       // scalastyle:off
       spark.sql(
         s"""
-           |CREATE TEMPORARY VIEW carsTable USING csv
-           |OPTIONS (path "${testFile(carsFile8859)}", header "true",
-           |charset "iso-8859-1", delimiter "þ")
+          |CREATE TEMPORARY VIEW carsTable USING csv
+          |OPTIONS (path "${testFile(carsFile8859)}", header "true",
+          |charset "iso-8859-1", delimiter "þ")
          """.stripMargin.replaceAll("\n", " "))
       // scalastyle:on
       verifyCars(spark.table("carsTable"), withHeader = true)
@@ -240,8 +239,8 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
     withView("carsTable") {
       spark.sql(
         s"""
-           |CREATE TEMPORARY VIEW carsTable USING csv
-           |OPTIONS (path "${testFile(carsTsvFile)}", header "true", delimiter "\t")
+          |CREATE TEMPORARY VIEW carsTable USING csv
+          |OPTIONS (path "${testFile(carsTsvFile)}", header "true", delimiter "\t")
          """.stripMargin.replaceAll("\n", " "))
 
       verifyCars(spark.table("carsTable"), numFields = 6, withHeader = true, checkHeader = false)
@@ -252,11 +251,11 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
     withView("carsTable") {
       spark.sql(
         s"""
-           |CREATE TEMPORARY VIEW carsTable
-           |(yearMade double, makeName string, modelName string, priceTag decimal,
-           | comments string, grp string)
-           |USING csv
-           |OPTIONS (path "${testFile(carsTsvFile)}", header "true", delimiter "\t")
+          |CREATE TEMPORARY VIEW carsTable
+          |(yearMade double, makeName string, modelName string, priceTag decimal,
+          | comments string, grp string)
+          |USING csv
+          |OPTIONS (path "${testFile(carsTsvFile)}", header "true", delimiter "\t")
          """.stripMargin.replaceAll("\n", " "))
 
       assert(
@@ -339,10 +338,10 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
     withView("carsTable") {
       spark.sql(
         s"""
-           |CREATE TEMPORARY VIEW carsTable
-           |(yearMade double, makeName string, modelName string, comments string, grp string)
-           |USING csv
-           |OPTIONS (path "${testFile(emptyFile)}", header "false")
+          |CREATE TEMPORARY VIEW carsTable
+          |(yearMade double, makeName string, modelName string, comments string, grp string)
+          |USING csv
+          |OPTIONS (path "${testFile(emptyFile)}", header "false")
          """.stripMargin.replaceAll("\n", " "))
 
       assert(spark.sql("SELECT count(*) FROM carsTable").collect().head(0) === 0)
@@ -353,10 +352,10 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
     withView("carsTable") {
       spark.sql(
         s"""
-           |CREATE TEMPORARY VIEW carsTable
-           |(yearMade double, makeName string, modelName string, comments string, blank string)
-           |USING csv
-           |OPTIONS (path "${testFile(carsFile)}", header "true")
+          |CREATE TEMPORARY VIEW carsTable
+          |(yearMade double, makeName string, modelName string, comments string, blank string)
+          |USING csv
+          |OPTIONS (path "${testFile(carsFile)}", header "true")
          """.stripMargin.replaceAll("\n", " "))
 
       val cars = spark.table("carsTable")
@@ -581,8 +580,8 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
 
     val expected =
       Seq(Seq(1, 2, 3, 4, 5.01D, Timestamp.valueOf("2015-08-20 15:57:00")),
-        Seq(6, 7, 8, 9, 0, Timestamp.valueOf("2015-08-21 16:58:01")),
-        Seq(1, 2, 3, 4, 5, Timestamp.valueOf("2015-08-23 18:00:42")))
+          Seq(6, 7, 8, 9, 0, Timestamp.valueOf("2015-08-21 16:58:01")),
+          Seq(1, 2, 3, 4, 5, Timestamp.valueOf("2015-08-23 18:00:42")))
 
     assert(results.toSeq.map(_.toSeq) === expected)
   }
@@ -805,7 +804,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
 
     assert(
       df.schema.fields.map(field => field.dataType).deep ==
-        Array(IntegerType, IntegerType, IntegerType, IntegerType).deep)
+      Array(IntegerType, IntegerType, IntegerType, IntegerType).deep)
   }
 
   test("old csv data source name works") {
@@ -1085,7 +1084,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
       Seq("1").toDF().write.text(path.getAbsolutePath)
       val schema = StructType(
         StructField("a", IntegerType, true) ::
-          StructField("b", IntegerType, true) :: Nil)
+        StructField("b", IntegerType, true) :: Nil)
       val df = spark.read
         .schema(schema)
         .option("header", "false")
@@ -1107,8 +1106,8 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
         .csv(testFile(valueMalformedFile))
       checkAnswer(df1,
         Row(null, null) ::
-          Row(1, java.sql.Date.valueOf("1983-08-04")) ::
-          Nil)
+        Row(1, java.sql.Date.valueOf("1983-08-04")) ::
+        Nil)
 
       // If `schema` has `columnNameOfCorruptRecord`, it should handle corrupt records
       val columnNameOfCorruptRecord = "_unparsed"
@@ -1122,8 +1121,8 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
         .csv(testFile(valueMalformedFile))
       checkAnswer(df2,
         Row(null, null, "0,2013-111-11 12:13:14") ::
-          Row(1, java.sql.Date.valueOf("1983-08-04"), null) ::
-          Nil)
+        Row(1, java.sql.Date.valueOf("1983-08-04"), null) ::
+        Nil)
 
       // We put a `columnNameOfCorruptRecord` field in the middle of a schema
       val schemaWithCorrField2 = new StructType()
@@ -1139,8 +1138,8 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
         .csv(testFile(valueMalformedFile))
       checkAnswer(df3,
         Row(null, "0,2013-111-11 12:13:14", null) ::
-          Row(1, null, java.sql.Date.valueOf("1983-08-04")) ::
-          Nil)
+        Row(1, null, java.sql.Date.valueOf("1983-08-04")) ::
+        Nil)
 
       val errMsg = intercept[AnalysisException] {
         spark
@@ -1196,7 +1195,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
         "92233720368547758070",
         "\n\n1.7976931348623157E308",
         "true",
-        null)
+         null)
       checkAnswer(df, expected)
     }
   }
@@ -1606,10 +1605,10 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
       odf.write.option("header", false).csv(path.getCanonicalPath)
       val ischema = new StructType().add("f2", DoubleType).add("f1", DoubleType)
       val idf = spark.read
-        .schema(ischema)
-        .option("header", false)
-        .option("enforceSchema", false)
-        .csv(path.getCanonicalPath)
+          .schema(ischema)
+          .option("header", false)
+          .option("enforceSchema", false)
+          .csv(path.getCanonicalPath)
 
       checkAnswer(idf, odf)
     }
@@ -1676,11 +1675,8 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
   test("SPARK-23786: warning should be printed if CSV header doesn't conform to schema") {
     class TestAppender extends AppenderSkeleton {
       var events = new java.util.ArrayList[LoggingEvent]
-
       override def close(): Unit = {}
-
       override def requiresLayout: Boolean = false
-
       protected def append(event: LoggingEvent): Unit = events.add(event)
     }
 
@@ -1799,7 +1795,6 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
 
       assert(df.count() == expected)
     }
-
     def checkCount(expected: Long): Unit = {
       val validRec = "1"
       val inputs = Seq(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -41,6 +41,7 @@ import org.apache.spark.sql.test.{SharedSQLContext, SQLTestUtils}
 import org.apache.spark.sql.types._
 
 class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with TestCsvData {
+
   import testImplicits._
 
   private val carsFile = "test-data/cars.csv"
@@ -66,13 +67,13 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
 
   /** Verifies data and schema. */
   private def verifyCars(
-      df: DataFrame,
-      withHeader: Boolean,
-      numCars: Int = 3,
-      numFields: Int = 5,
-      checkHeader: Boolean = true,
-      checkValues: Boolean = true,
-      checkTypes: Boolean = false): Unit = {
+    df: DataFrame,
+    withHeader: Boolean,
+    numCars: Int = 3,
+    numFields: Int = 5,
+    checkHeader: Boolean = true,
+    checkValues: Boolean = true,
+    checkTypes: Boolean = false): Unit = {
 
     val numColumns = numFields
     val numRows = if (withHeader) numCars else numCars + 1
@@ -212,9 +213,9 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
       // scalastyle:off
       spark.sql(
         s"""
-          |CREATE TEMPORARY VIEW carsTable USING csv
-          |OPTIONS (path "${testFile(carsFile8859)}", header "true",
-          |charset "iso-8859-1", delimiter "þ")
+           |CREATE TEMPORARY VIEW carsTable USING csv
+           |OPTIONS (path "${testFile(carsFile8859)}", header "true",
+           |charset "iso-8859-1", delimiter "þ")
          """.stripMargin.replaceAll("\n", " "))
       // scalastyle:on
       verifyCars(spark.table("carsTable"), withHeader = true)
@@ -239,8 +240,8 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
     withView("carsTable") {
       spark.sql(
         s"""
-          |CREATE TEMPORARY VIEW carsTable USING csv
-          |OPTIONS (path "${testFile(carsTsvFile)}", header "true", delimiter "\t")
+           |CREATE TEMPORARY VIEW carsTable USING csv
+           |OPTIONS (path "${testFile(carsTsvFile)}", header "true", delimiter "\t")
          """.stripMargin.replaceAll("\n", " "))
 
       verifyCars(spark.table("carsTable"), numFields = 6, withHeader = true, checkHeader = false)
@@ -251,11 +252,11 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
     withView("carsTable") {
       spark.sql(
         s"""
-          |CREATE TEMPORARY VIEW carsTable
-          |(yearMade double, makeName string, modelName string, priceTag decimal,
-          | comments string, grp string)
-          |USING csv
-          |OPTIONS (path "${testFile(carsTsvFile)}", header "true", delimiter "\t")
+           |CREATE TEMPORARY VIEW carsTable
+           |(yearMade double, makeName string, modelName string, priceTag decimal,
+           | comments string, grp string)
+           |USING csv
+           |OPTIONS (path "${testFile(carsTsvFile)}", header "true", delimiter "\t")
          """.stripMargin.replaceAll("\n", " "))
 
       assert(
@@ -338,10 +339,10 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
     withView("carsTable") {
       spark.sql(
         s"""
-          |CREATE TEMPORARY VIEW carsTable
-          |(yearMade double, makeName string, modelName string, comments string, grp string)
-          |USING csv
-          |OPTIONS (path "${testFile(emptyFile)}", header "false")
+           |CREATE TEMPORARY VIEW carsTable
+           |(yearMade double, makeName string, modelName string, comments string, grp string)
+           |USING csv
+           |OPTIONS (path "${testFile(emptyFile)}", header "false")
          """.stripMargin.replaceAll("\n", " "))
 
       assert(spark.sql("SELECT count(*) FROM carsTable").collect().head(0) === 0)
@@ -352,10 +353,10 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
     withView("carsTable") {
       spark.sql(
         s"""
-          |CREATE TEMPORARY VIEW carsTable
-          |(yearMade double, makeName string, modelName string, comments string, blank string)
-          |USING csv
-          |OPTIONS (path "${testFile(carsFile)}", header "true")
+           |CREATE TEMPORARY VIEW carsTable
+           |(yearMade double, makeName string, modelName string, comments string, blank string)
+           |USING csv
+           |OPTIONS (path "${testFile(carsFile)}", header "true")
          """.stripMargin.replaceAll("\n", " "))
 
       val cars = spark.table("carsTable")
@@ -580,8 +581,8 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
 
     val expected =
       Seq(Seq(1, 2, 3, 4, 5.01D, Timestamp.valueOf("2015-08-20 15:57:00")),
-          Seq(6, 7, 8, 9, 0, Timestamp.valueOf("2015-08-21 16:58:01")),
-          Seq(1, 2, 3, 4, 5, Timestamp.valueOf("2015-08-23 18:00:42")))
+        Seq(6, 7, 8, 9, 0, Timestamp.valueOf("2015-08-21 16:58:01")),
+        Seq(1, 2, 3, 4, 5, Timestamp.valueOf("2015-08-23 18:00:42")))
 
     assert(results.toSeq.map(_.toSeq) === expected)
   }
@@ -804,7 +805,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
 
     assert(
       df.schema.fields.map(field => field.dataType).deep ==
-      Array(IntegerType, IntegerType, IntegerType, IntegerType).deep)
+        Array(IntegerType, IntegerType, IntegerType, IntegerType).deep)
   }
 
   test("old csv data source name works") {
@@ -1084,7 +1085,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
       Seq("1").toDF().write.text(path.getAbsolutePath)
       val schema = StructType(
         StructField("a", IntegerType, true) ::
-        StructField("b", IntegerType, true) :: Nil)
+          StructField("b", IntegerType, true) :: Nil)
       val df = spark.read
         .schema(schema)
         .option("header", "false")
@@ -1106,8 +1107,8 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
         .csv(testFile(valueMalformedFile))
       checkAnswer(df1,
         Row(null, null) ::
-        Row(1, java.sql.Date.valueOf("1983-08-04")) ::
-        Nil)
+          Row(1, java.sql.Date.valueOf("1983-08-04")) ::
+          Nil)
 
       // If `schema` has `columnNameOfCorruptRecord`, it should handle corrupt records
       val columnNameOfCorruptRecord = "_unparsed"
@@ -1121,8 +1122,8 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
         .csv(testFile(valueMalformedFile))
       checkAnswer(df2,
         Row(null, null, "0,2013-111-11 12:13:14") ::
-        Row(1, java.sql.Date.valueOf("1983-08-04"), null) ::
-        Nil)
+          Row(1, java.sql.Date.valueOf("1983-08-04"), null) ::
+          Nil)
 
       // We put a `columnNameOfCorruptRecord` field in the middle of a schema
       val schemaWithCorrField2 = new StructType()
@@ -1138,8 +1139,8 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
         .csv(testFile(valueMalformedFile))
       checkAnswer(df3,
         Row(null, "0,2013-111-11 12:13:14", null) ::
-        Row(1, null, java.sql.Date.valueOf("1983-08-04")) ::
-        Nil)
+          Row(1, null, java.sql.Date.valueOf("1983-08-04")) ::
+          Nil)
 
       val errMsg = intercept[AnalysisException] {
         spark
@@ -1195,7 +1196,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
         "92233720368547758070",
         "\n\n1.7976931348623157E308",
         "true",
-         null)
+        null)
       checkAnswer(df, expected)
     }
   }
@@ -1605,10 +1606,10 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
       odf.write.option("header", false).csv(path.getCanonicalPath)
       val ischema = new StructType().add("f2", DoubleType).add("f1", DoubleType)
       val idf = spark.read
-          .schema(ischema)
-          .option("header", false)
-          .option("enforceSchema", false)
-          .csv(path.getCanonicalPath)
+        .schema(ischema)
+        .option("header", false)
+        .option("enforceSchema", false)
+        .csv(path.getCanonicalPath)
 
       checkAnswer(idf, odf)
     }
@@ -1675,8 +1676,11 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
   test("SPARK-23786: warning should be printed if CSV header doesn't conform to schema") {
     class TestAppender extends AppenderSkeleton {
       var events = new java.util.ArrayList[LoggingEvent]
+
       override def close(): Unit = {}
+
       override def requiresLayout: Boolean = false
+
       protected def append(event: LoggingEvent): Unit = events.add(event)
     }
 
@@ -1795,6 +1799,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
 
       assert(df.count() == expected)
     }
+
     def checkCount(expected: Long): Unit = {
       val validRec = "1"
       val inputs = Seq(
@@ -1885,6 +1890,21 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils with Te
         .option("timestampFormat", "yyyy-MM-dd HH:mm:ss.SSSSSS")
         .csv(path.getAbsolutePath)
       checkAnswer(readback, Row(Timestamp.valueOf(t)))
+    }
+  }
+
+  test("Roundtrip in reading and writing timestamps in microsecond precision") {
+    withTempPath { path =>
+      val timestamp = Timestamp.valueOf("2019-11-18 11:56:00.123456")
+      Seq(timestamp).toDF("t")
+        .write
+        .option("timestampFormat", "yyyy-MM-dd HH:mm:ss.SSSSSS")
+        .csv(path.getAbsolutePath)
+      val readback = spark.read
+        .schema("t timestamp")
+        .option("timestampFormat", "yyyy-MM-dd HH:mm:ss.SSSSSS")
+        .csv(path.getAbsolutePath)
+      checkAnswer(readback, Row(timestamp))
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to use the `format()` method of `FastDateFormat` which accepts an instance of the `Calendar` type. This allows to adjust the `MILLISECOND` field of the calendar directly before formatting. I added new method `format()` to `DateTimeUtils.TimestampParser`. This method splits the input timestamp to a part truncated to seconds and the seconds fractional part. The calendar is initialized by the first part in normal way, and the last one is converted to a form appropriate for correctly formatting by `FastDateFormat` as the second fraction up to microsecond precision.

I refactored `MicrosCalendar` by passing the number of digits from the fraction pattern as a parameter to the default constructor because it is used by the existing `getMicros()` and new one `setMicros()`. `setMicros()` is used to set the seconds fraction to calendar's `MILLISECOND` field directly before formatting. 

This PR supports various patterns for seconds fractions from `S` up to `SSSSSS`. If the patterns has more than 6 `S`, the first 6 digits reflect to milliseconds and microseconds of the input timestamp but the rest digits are set to `0`.  

### Why are the changes needed?
This fixes a bug of incorrectly formatting timestamps in microsecond precision. For example:
```scala
Seq(java.sql.Timestamp.valueOf("2019-11-18 11:56:00.123456")).toDF("t")
  .select(to_json(struct($"t"), Map("timestampFormat" -> "yyyy-MM-dd HH:mm:ss.SSSSSS")).as("json"))
  .show(false)
+----------------------------------+
|json                              |
+----------------------------------+
|{"t":"2019-11-18 11:56:00.000123"}|
+----------------------------------+
```

### Does this PR introduce any user-facing change?
Yes. The example above outputs:
```scala
+----------------------------------+
|json                              |
+----------------------------------+
|{"t":"2019-11-18 11:56:00.123456"}|
+----------------------------------+
```

### How was this patch tested?
- By new tests for formatting by different patterns from `S` to `SSSSSS` in `DateTimeUtilsSuite`
- A test for `to_json()` in `JsonFunctionsSuite`
- A roundtrp test for writing and reading back a timestamp in a CSV file.
