### PR TITLE
[SPARK-22340][PYTHON][FOLLOW-UP] Add a better message and improve documentation for pinned thread mode

### DIFF
--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -1024,12 +1024,12 @@ class SparkContext(object):
             Workaround class can be written as below (unofficial way):
 
             >>> class CustomThread(threading.Thread):
-            >>>     def __init__(self, sc, target, *args, **kwargs):
-            >>>         properties = sc._jsc.sc().getLocalProperties()
-            >>>         def copy_local_properties(*a, **k):
-            >>>             sc._jsc.sc().setLocalProperties(properties)
-            >>>             return target(*a, **k)
-            >>>         super(CustomThread, self).__init__(
+            ...     def __init__(self, sc, target, *args, **kwargs):
+            ...         properties = sc._jsc.sc().getLocalProperties()
+            ...         def copy_local_properties(*a, **k):
+            ...             sc._jsc.sc().setLocalProperties(properties)
+            ...             return target(*a, **k)
+            ...         super(CustomThread, self).__init__(
             ...             target=copy_local_properties, *args, **kwargs)
         """
         _warn_pin_thread("setJobGroup")
@@ -1055,12 +1055,12 @@ class SparkContext(object):
             Workaround class can be written as below (unofficial way):
 
             >>> class CustomThread(threading.Thread):
-            >>>     def __init__(self, sc, target, *args, **kwargs):
-            >>>         properties = sc._jsc.sc().getLocalProperties()
-            >>>         def copy_local_properties(*a, **k):
-            >>>             sc._jsc.sc().setLocalProperties(properties)
-            >>>             return target(*a, **k)
-            >>>         super(CustomThread, self).__init__(
+            ...     def __init__(self, sc, target, *args, **kwargs):
+            ...         properties = sc._jsc.sc().getLocalProperties()
+            ...         def copy_local_properties(*a, **k):
+            ...             sc._jsc.sc().setLocalProperties(properties)
+            ...             return target(*a, **k)
+            ...         super(CustomThread, self).__init__(
             ...             target=copy_local_properties, *args, **kwargs)
         """
         _warn_pin_thread("setLocalProperty")
@@ -1092,12 +1092,12 @@ class SparkContext(object):
             Workaround class can be written as below (unofficial way):
 
             >>> class CustomThread(threading.Thread):
-            >>>     def __init__(self, sc, target, *args, **kwargs):
-            >>>         properties = sc._jsc.sc().getLocalProperties()
-            >>>         def copy_local_properties(*a, **k):
-            >>>             sc._jsc.sc().setLocalProperties(properties)
-            >>>             return target(*a, **k)
-            >>>         super(CustomThread, self).__init__(
+            ...     def __init__(self, sc, target, *args, **kwargs):
+            ...         properties = sc._jsc.sc().getLocalProperties()
+            ...         def copy_local_properties(*a, **k):
+            ...             sc._jsc.sc().setLocalProperties(properties)
+            ...             return target(*a, **k)
+            ...         super(CustomThread, self).__init__(
             ...             target=copy_local_properties, *args, **kwargs)
         """
         _warn_pin_thread("setJobDescription")

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -1021,16 +1021,6 @@ class SparkContext(object):
 
             To work around this, you should manually copy and set the local
             properties from the parent thread to the child thread when you create another thread.
-            Workaround class can be written as below (unofficial way):
-
-            >>> class CustomThread(threading.Thread):
-            ...     def __init__(self, sc, target, *args, **kwargs):
-            ...         properties = sc._jsc.sc().getLocalProperties()
-            ...         def copy_local_properties(*a, **k):
-            ...             sc._jsc.sc().setLocalProperties(properties)
-            ...             return target(*a, **k)
-            ...         super(CustomThread, self).__init__(
-            ...             target=copy_local_properties, *args, **kwargs)
         """
         _warn_pin_thread("setJobGroup")
         self._jsc.setJobGroup(groupId, description, interruptOnCancel)
@@ -1052,16 +1042,6 @@ class SparkContext(object):
 
             To work around this, you should manually copy and set the local
             properties from the parent thread to the child thread when you create another thread.
-            Workaround class can be written as below (unofficial way):
-
-            >>> class CustomThread(threading.Thread):
-            ...     def __init__(self, sc, target, *args, **kwargs):
-            ...         properties = sc._jsc.sc().getLocalProperties()
-            ...         def copy_local_properties(*a, **k):
-            ...             sc._jsc.sc().setLocalProperties(properties)
-            ...             return target(*a, **k)
-            ...         super(CustomThread, self).__init__(
-            ...             target=copy_local_properties, *args, **kwargs)
         """
         _warn_pin_thread("setLocalProperty")
         self._jsc.setLocalProperty(key, value)
@@ -1089,16 +1069,6 @@ class SparkContext(object):
 
             To work around this, you should manually copy and set the local
             properties from the parent thread to the child thread when you create another thread.
-            Workaround class can be written as below (unofficial way):
-
-            >>> class CustomThread(threading.Thread):
-            ...     def __init__(self, sc, target, *args, **kwargs):
-            ...         properties = sc._jsc.sc().getLocalProperties()
-            ...         def copy_local_properties(*a, **k):
-            ...             sc._jsc.sc().setLocalProperties(properties)
-            ...             return target(*a, **k)
-            ...         super(CustomThread, self).__init__(
-            ...             target=copy_local_properties, *args, **kwargs)
         """
         _warn_pin_thread("setJobDescription")
         self._jsc.setJobDescription(value)

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -40,6 +40,7 @@ from pyspark.rdd import RDD, _load_from_socket, ignore_unicode_prefix
 from pyspark.traceback_utils import CallSite, first_spark_call
 from pyspark.status import StatusTracker
 from pyspark.profiler import ProfilerCollector, BasicProfiler
+from pyspark.util import _warn_pin_thread
 
 if sys.version > '3':
     xrange = range
@@ -1008,30 +1009,30 @@ class SparkContext(object):
         ensure that the tasks are actually stopped in a timely manner, but is off by default due
         to HDFS-1208, where HDFS may respond to Thread.interrupt() by marking nodes as dead.
 
-        .. note:: Currently, setting a group ID (set to local properties) with a thread does
-            not properly work. Internally threads on PVM and JVM are not synced, and JVM thread
-            can be reused for multiple threads on PVM, which fails to isolate local properties
-            for each thread on PVM. To work around this, you can set `PYSPARK_PIN_THREAD` to
+        .. note:: Currently, setting a group ID (set to local properties) with multiple threads
+            does not properly work. Internally threads on PVM and JVM are not synced, and JVM
+            thread can be reused for multiple threads on PVM, which fails to isolate local
+            properties for each thread on PVM.
+
+            To work around this, you can set `PYSPARK_PIN_THREAD` to
             `'true'` (see SPARK-22340). However, note that it cannot inherit the local properties
             from the parent thread although it isolates each thread on PVM and JVM with its own
-            local properties. To work around this, you should manually copy and set the local
+            local properties.
+
+            To work around this, you should manually copy and set the local
             properties from the parent thread to the child thread when you create another thread.
+            Workaround class can be written as below (unofficial way):
+
+            >>> class CustomThread(threading.Thread):
+            >>>     def __init__(self, sc, target, *args, **kwargs):
+            >>>         properties = sc._jsc.sc().getLocalProperties()
+            >>>         def copy_local_properties(*a, **k):
+            >>>             sc._jsc.sc().setLocalProperties(properties)
+            >>>             return target(*a, **k)
+            >>>         super(CustomThread, self).__init__(
+            ...             target=copy_local_properties, *args, **kwargs)
         """
-        warnings.warn(
-            "Currently, setting a group ID (set to local properties) with a thread does "
-            "not properly work. "
-            "\n"
-            "Internally threads on PVM and JVM are not synced, and JVM thread can be reused "
-            "for multiple threads on PVM, which fails to isolate local properties for each "
-            "thread on PVM. "
-            "\n"
-            "To work around this, you can set PYSPARK_PIN_THREAD to true (see SPARK-22340). "
-            "However, note that it cannot inherit the local properties from the parent thread "
-            "although it isolates each thread on PVM and JVM with its own local properties. "
-            "\n"
-            "To work around this, you should manually copy and set the local properties from "
-            "the parent thread to the child thread when you create another thread.",
-            UserWarning)
+        _warn_pin_thread("setJobGroup")
         self._jsc.setJobGroup(groupId, description, interruptOnCancel)
 
     def setLocalProperty(self, key, value):
@@ -1039,29 +1040,30 @@ class SparkContext(object):
         Set a local property that affects jobs submitted from this thread, such as the
         Spark fair scheduler pool.
 
-        .. note:: Currently, setting a local property with a thread does
-            not properly work. Internally threads on PVM and JVM are not synced, and JVM thread
+        .. note:: Currently, setting a local property with multiple threads does not properly work.
+            Internally threads on PVM and JVM are not synced, and JVM thread
             can be reused for multiple threads on PVM, which fails to isolate local properties
-            for each thread on PVM. To work around this, you can set `PYSPARK_PIN_THREAD` to
+            for each thread on PVM.
+
+            To work around this, you can set `PYSPARK_PIN_THREAD` to
             `'true'` (see SPARK-22340). However, note that it cannot inherit the local properties
             from the parent thread although it isolates each thread on PVM and JVM with its own
-            local properties. To work around this, you should manually copy and set the local
+            local properties.
+
+            To work around this, you should manually copy and set the local
             properties from the parent thread to the child thread when you create another thread.
+            Workaround class can be written as below (unofficial way):
+
+            >>> class CustomThread(threading.Thread):
+            >>>     def __init__(self, sc, target, *args, **kwargs):
+            >>>         properties = sc._jsc.sc().getLocalProperties()
+            >>>         def copy_local_properties(*a, **k):
+            >>>             sc._jsc.sc().setLocalProperties(properties)
+            >>>             return target(*a, **k)
+            >>>         super(CustomThread, self).__init__(
+            ...             target=copy_local_properties, *args, **kwargs)
         """
-        warnings.warn(
-            "Currently, setting a local property with a thread does not properly work. "
-            "\n"
-            "Internally threads on PVM and JVM are not synced, and JVM thread can be reused "
-            "for multiple threads on PVM, which fails to isolate local properties for each "
-            "thread on PVM. "
-            "\n"
-            "To work around this, you can set PYSPARK_PIN_THREAD to true (see SPARK-22340). "
-            "However, note that it cannot inherit the local properties from the parent thread "
-            "although it isolates each thread on PVM and JVM with its own local properties. "
-            "\n"
-            "To work around this, you should manually copy and set the local properties from "
-            "the parent thread to the child thread when you create another thread.",
-            UserWarning)
+        _warn_pin_thread("setLocalProperty")
         self._jsc.setLocalProperty(key, value)
 
     def getLocalProperty(self, key):
@@ -1075,30 +1077,30 @@ class SparkContext(object):
         """
         Set a human readable description of the current job.
 
-        .. note:: Currently, setting a job description (set to local properties) with a thread does
-            not properly work. Internally threads on PVM and JVM are not synced, and JVM thread
-            can be reused for multiple threads on PVM, which fails to isolate local properties
-            for each thread on PVM. To work around this, you can set `PYSPARK_PIN_THREAD` to
+        .. note:: Currently, setting a job description (set to local properties) with multiple
+            threads does not properly work. Internally threads on PVM and JVM are not synced,
+            and JVM thread can be reused for multiple threads on PVM, which fails to isolate
+            local properties for each thread on PVM.
+
+            To work around this, you can set `PYSPARK_PIN_THREAD` to
             `'true'` (see SPARK-22340). However, note that it cannot inherit the local properties
             from the parent thread although it isolates each thread on PVM and JVM with its own
-            local properties. To work around this, you should manually copy and set the local
+            local properties.
+
+            To work around this, you should manually copy and set the local
             properties from the parent thread to the child thread when you create another thread.
+            Workaround class can be written as below (unofficial way):
+
+            >>> class CustomThread(threading.Thread):
+            >>>     def __init__(self, sc, target, *args, **kwargs):
+            >>>         properties = sc._jsc.sc().getLocalProperties()
+            >>>         def copy_local_properties(*a, **k):
+            >>>             sc._jsc.sc().setLocalProperties(properties)
+            >>>             return target(*a, **k)
+            >>>         super(CustomThread, self).__init__(
+            ...             target=copy_local_properties, *args, **kwargs)
         """
-        warnings.warn(
-            "Currently, setting a job description (set to local properties) with a thread does "
-            "not properly work. "
-            "\n"
-            "Internally threads on PVM and JVM are not synced, and JVM thread can be reused "
-            "for multiple threads on PVM, which fails to isolate local properties for each "
-            "thread on PVM. "
-            "\n"
-            "To work around this, you can set PYSPARK_PIN_THREAD to true (see SPARK-22340). "
-            "However, note that it cannot inherit the local properties from the parent thread "
-            "although it isolates each thread on PVM and JVM with its own local properties. "
-            "\n"
-            "To work around this, you should manually copy and set the local properties from "
-            "the parent thread to the child thread when you create another thread.",
-            UserWarning)
+        _warn_pin_thread("setJobDescription")
         self._jsc.setJobDescription(value)
 
     def sparkUser(self):

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -19,6 +19,8 @@
 import re
 import sys
 import traceback
+import os
+import warnings
 import inspect
 from py4j.protocol import Py4JJavaError
 
@@ -110,6 +112,33 @@ def fail_on_stopiteration(f):
             )
 
     return wrapper
+
+
+def _warn_pin_thread(name):
+    if os.environ.get("PYSPARK_PIN_THREAD", "false").lower() == "true":
+        msg = (
+            "PYSPARK_PIN_THREAD feature is enabled. "
+            "However, note that it cannot inherit the local properties from the parent thread "
+            "although it isolates each thread on PVM and JVM with its own local properties. "
+            "\n"
+            "To work around this, you should manually copy and set the local properties from "
+            "the parent thread to the child thread when you create another thread.")
+    else:
+        msg = (
+            "Currently, '%s' (set to local properties) with multiple threads does "
+            "not properly work. "
+            "\n"
+            "Internally threads on PVM and JVM are not synced, and JVM thread can be reused "
+            "for multiple threads on PVM, which fails to isolate local properties for each "
+            "thread on PVM. "
+            "\n"
+            "To work around this, you can set PYSPARK_PIN_THREAD to true (see SPARK-22340). "
+            "However, note that it cannot inherit the local properties from the parent thread "
+            "although it isolates each thread on PVM and JVM with its own local properties. "
+            "\n"
+            "To work around this, you should manually copy and set the local properties from "
+            "the parent thread to the child thread when you create another thread." % name)
+    warnings.warn(msg, UserWarning)
 
 
 def _print_missing_jar(lib_name, pkg_name, jar_name, spark_version):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to show different warning message when the pinned thread mode is enabled:

When enabled:

> PYSPARK_PIN_THREAD feature is enabled. However, note that it cannot inherit the local properties from the parent thread although it isolates each thread on PVM and JVM with its own local properties.
> To work around this, you should manually copy and set the local properties from the parent thread to the child thread when you create another thread.

When disabled:

> Currently, 'setLocalProperty' (set to local properties) with multiple threads does not properly work.
> Internally threads on PVM and JVM are not synced, and JVM thread can be reused for multiple threads on PVM, which fails to isolate local properties for each thread on PVM.
> To work around this, you can set PYSPARK_PIN_THREAD to true (see SPARK-22340). However, note that it cannot inherit the local properties from the parent thread although it isolates each thread on PVM and JVM with its own local properties.
> To work around this, you should manually copy and set the local properties from the parent thread to the child thread when you create another thread.

### Why are the changes needed?

Currently, it shows the same warning message regardless of PYSPARK_PIN_THREAD being set. In the warning message it says "you can set PYSPARK_PIN_THREAD to true ..." which is confusing.

### Does this PR introduce any user-facing change?

Documentation and warning message as shown above.

### How was this patch tested?

Manually tested.

```bash
$ PYSPARK_PIN_THREAD=true ./bin/pyspark
```

```python
sc.setJobGroup("a", "b")
```

```
.../pyspark/util.py:141: UserWarning: PYSPARK_PIN_THREAD feature is enabled. However, note that it cannot inherit the local properties from the parent thread although it isolates each thread on PVM and JVM with its own local properties.
To work around this, you should manually copy and set the local properties from the parent thread to the child thread when you create another thread.
  warnings.warn(msg, UserWarning)
```


```bash
$ ./bin/pyspark
```

```python
sc.setJobGroup("a", "b")
```

```
.../pyspark/util.py:141: UserWarning: Currently, 'setJobGroup' (set to local properties) with multiple threads does not properly work.
Internally threads on PVM and JVM are not synced, and JVM thread can be reused for multiple threads on PVM, which fails to isolate local properties for each thread on PVM.
To work around this, you can set PYSPARK_PIN_THREAD to true (see SPARK-22340). However, note that it cannot inherit the local properties from the parent thread although it isolates each thread on PVM and JVM with its own local properties.
To work around this, you should manually copy and set the local properties from the parent thread to the child thread when you create another thread.
  warnings.warn(msg, UserWarning)
```
