### PR TITLE
[SPARK-29890][SQL] DataFrameNaFunctions.fill should handle duplicate columns

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
@@ -130,20 +130,20 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
    *
    * @since 2.2.0
    */
-  def fill(value: Long): DataFrame = fillValue(value)
+  def fill(value: Long): DataFrame = fill(value, Seq.empty)
 
   /**
    * Returns a new `DataFrame` that replaces null or NaN values in numeric columns with `value`.
    * @since 1.3.1
    */
-  def fill(value: Double): DataFrame = fillValue(value)
+  def fill(value: Double): DataFrame = fill(value, Seq.empty)
 
   /**
    * Returns a new `DataFrame` that replaces null values in string columns with `value`.
    *
    * @since 1.3.1
    */
-  def fill(value: String): DataFrame = fillValue(value)
+  def fill(value: String): DataFrame = fill(value, Seq.empty)
 
   /**
    * Returns a new `DataFrame` that replaces null or NaN values in specified numeric columns.
@@ -167,7 +167,7 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
    *
    * @since 2.2.0
    */
-  def fill(value: Long, cols: Seq[String]): DataFrame = fillValue(value, cols)
+  def fill(value: Long, cols: Seq[String]): DataFrame = fillValue(value, toAttributes(cols))
 
   /**
    * (Scala-specific) Returns a new `DataFrame` that replaces null or NaN values in specified
@@ -175,7 +175,7 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
    *
    * @since 1.3.1
    */
-  def fill(value: Double, cols: Seq[String]): DataFrame = fillValue(value, cols)
+  def fill(value: Double, cols: Seq[String]): DataFrame = fillValue(value, toAttributes(cols))
 
 
   /**
@@ -192,14 +192,14 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
    *
    * @since 1.3.1
    */
-  def fill(value: String, cols: Seq[String]): DataFrame = fillValue(value, cols)
+  def fill(value: String, cols: Seq[String]): DataFrame = fillValue(value, toAttributes(cols))
 
   /**
    * Returns a new `DataFrame` that replaces null values in boolean columns with `value`.
    *
    * @since 2.3.0
    */
-  def fill(value: Boolean): DataFrame = fillValue(value)
+  def fill(value: Boolean): DataFrame = fill(value, Seq.empty)
 
   /**
    * (Scala-specific) Returns a new `DataFrame` that replaces null values in specified
@@ -207,7 +207,7 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
    *
    * @since 2.3.0
    */
-  def fill(value: Boolean, cols: Seq[String]): DataFrame = fillValue(value, cols)
+  def fill(value: Boolean, cols: Seq[String]): DataFrame = fillValue(value, toAttributes(cols))
 
   /**
    * Returns a new `DataFrame` that replaces null values in specified boolean columns.
@@ -444,17 +444,13 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
    * Returns a [[Column]] expression that replaces null value in `expr` with `replacement`.
    * It uses the given `expr` as a column.
    */
-  private def fillCol[T](
-      dataType: DataType,
-      colName: String,
-      expr: Column,
-      replacement: T): Column = {
+  private def fillCol[T](dataType: DataType, name: String, expr: Column, replacement: T): Column = {
     val colValue = dataType match {
       case DoubleType | FloatType =>
         nanvl(expr, lit(null)) // nanvl only supports these types
       case _ => expr
     }
-    coalesce(colValue, lit(replacement).cast(dataType)).as(colName)
+    coalesce(colValue, lit(replacement).cast(dataType)).as(name)
   }
 
   /**
@@ -481,60 +477,43 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
       s"Unsupported value type ${v.getClass.getName} ($v).")
   }
 
-  private def getTargetType[T](value: T): AbstractDataType = {
-    value match {
-      case _: Double | _: Long => NumericType
-      case _: String => StringType
-      case _: Boolean => BooleanType
-      case _ =>
-        throw new IllegalArgumentException(
-          s"Unsupported value type for fill(): ${value.getClass.getName} ($value).")
-    }
-  }
-
-  private def typeMatches(targetType: AbstractDataType, sourceType: DataType): Boolean = {
-    (targetType, sourceType) match {
-      case (NumericType, dt) => dt.isInstanceOf[NumericType]
-      case (StringType, dt) => dt == StringType
-      case (BooleanType, dt) => dt == BooleanType
-      case _ =>
-        throw new IllegalArgumentException(s"$targetType is not matched for fill().")
-    }
+  private def toAttributes(cols: Seq[String]): Seq[Attribute] = {
+    cols.map(df.col(_).named.toAttribute)
   }
 
   /**
    * Returns a new `DataFrame` that replaces null or NaN values in specified
    * numeric, string columns. If a specified column is not a numeric, string
-   * or boolean column it is ignored.
+   * or boolean column it is ignored. If `cols` is empty, fill() is applied to
+   * all the eligible columns.
    */
-  private def fillValue[T](value: T, cols: Seq[String]): DataFrame = {
-    // the fill[T] which T is Long/Double,
+  private def fillValue[T](value: T, cols: Seq[Attribute]): DataFrame = {
+    // the fill[T] which T is  Long/Double,
     // should apply on all the NumericType Column, for example:
     // val input = Seq[(java.lang.Integer, java.lang.Double)]((null, 164.3)).toDF("a","b")
     // input.na.fill(3.1)
     // the result is (3,164.3), not (null, 164.3)
-    val targetType = getTargetType(value)
-
-    val columnEquals = df.sparkSession.sessionState.analyzer.resolver
-    val filledColumns = df.schema.fields.filter { f =>
-      // Only fill if the column is part of the cols list.
-      typeMatches(targetType, f.dataType) && cols.exists(col => columnEquals(f.name, col))
+    val targetType = value match {
+      case _: Double | _: Long => NumericType
+      case _: String => StringType
+      case _: Boolean => BooleanType
+      case _ => throw new IllegalArgumentException(
+        s"Unsupported value type ${value.getClass.getName} ($value).")
     }
 
-    df.withColumns(filledColumns.map(_.name), filledColumns.map(fillCol[T](_, value)))
-  }
-
-  /**
-   * Returns a new `DataFrame` that replaces null or NaN values for all the supported columns.
-   * Note that this handles the `DataFrame` with duplicate column names (e.g., self-joined).
-   */
-  private def fillValue[T](value: T): DataFrame = {
-    val targetType = getTargetType(value)
-    val projections = df.queryExecution.analyzed.output.map { attr =>
-      if (typeMatches(targetType, attr.dataType)) {
-        fillCol(attr.dataType, attr.name, Column(attr), value)
+    val projections = df.queryExecution.analyzed.output.map { col =>
+      val typeMatches = (targetType, col.dataType) match {
+        case (NumericType, dt) => dt.isInstanceOf[NumericType]
+        case (StringType, dt) => dt == StringType
+        case (BooleanType, dt) => dt == BooleanType
+        case _ =>
+          throw new IllegalArgumentException(s"$targetType is not matched at fillValue")
+      }
+      // Only fill if the column is part of the cols list.
+      if (typeMatches && (cols.isEmpty || cols.exists(_.semanticEquals(col)))) {
+        fillCol(col.dataType, col.name, Column(col), value)
       } else {
-        Column(attr)
+        Column(col)
       }
     }
     df.select(projections : _*)

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
@@ -478,13 +478,11 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
   }
 
   private def toAttributes(cols: Seq[String]): Seq[Attribute] = {
-    def resolve(colName: String) : Attribute = {
-      df.col(colName).named.toAttribute match {
+    cols.flatMap { colName =>
+      df.col(colName).expr.collect {
         case a: Attribute => a
-        case _ => throw new IllegalArgumentException(s"'$colName' is not a top level column.")
       }
     }
-    cols.map(resolve)
   }
 
   private def outputAttributes: Seq[Attribute] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
@@ -478,10 +478,8 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
   }
 
   private def toAttributes(cols: Seq[String]): Seq[Attribute] = {
-    cols.flatMap { colName =>
-      df.col(colName).expr.collect {
-        case a: Attribute => a
-      }
+    cols.map(name => df.col(name).expr).collect {
+      case a: Attribute => a
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
@@ -130,20 +130,20 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
    *
    * @since 2.2.0
    */
-  def fill(value: Long): DataFrame = fillValue(value, df.queryExecution.analyzed.output)
+  def fill(value: Long): DataFrame = fillValue(value, outputAttributes)
 
   /**
    * Returns a new `DataFrame` that replaces null or NaN values in numeric columns with `value`.
    * @since 1.3.1
    */
-  def fill(value: Double): DataFrame = fillValue(value, df.queryExecution.analyzed.output)
+  def fill(value: Double): DataFrame = fillValue(value, outputAttributes)
 
   /**
    * Returns a new `DataFrame` that replaces null values in string columns with `value`.
    *
    * @since 1.3.1
    */
-  def fill(value: String): DataFrame = fillValue(value, df.queryExecution.analyzed.output)
+  def fill(value: String): DataFrame = fillValue(value, outputAttributes)
 
   /**
    * Returns a new `DataFrame` that replaces null or NaN values in specified numeric columns.
@@ -199,7 +199,7 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
    *
    * @since 2.3.0
    */
-  def fill(value: Boolean): DataFrame = fillValue(value, df.queryExecution.analyzed.output)
+  def fill(value: Boolean): DataFrame = fillValue(value, outputAttributes)
 
   /**
    * (Scala-specific) Returns a new `DataFrame` that replaces null values in specified
@@ -349,7 +349,7 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
    *
    *   // Replaces all occurrences of "UNKNOWN" with "unnamed" in column "firstname" and "lastname".
    *   df.na.replace("firstname" :: "lastname" :: Nil, Map("UNKNOWN" -> "unnamed"));
-   * }}}
+   * }}}outputAttributes
    *
    * @param cols list of columns to apply the value replacement. If `col` is "*",
    *             replacement is applied on all string, numeric or boolean columns.
@@ -481,6 +481,10 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
     cols.map(df.col(_).named.toAttribute)
   }
 
+  private def outputAttributes: Seq[Attribute] = {
+    df.queryExecution.analyzed.output
+  }
+
   /**
    * Returns a new `DataFrame` that replaces null or NaN values in specified
    * numeric, string columns. If a specified column is not a numeric, string
@@ -501,7 +505,7 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
         s"Unsupported value type ${value.getClass.getName} ($value).")
     }
 
-    val projections = df.queryExecution.analyzed.output.map { col =>
+    val projections = outputAttributes.map { col =>
       val typeMatches = (targetType, col.dataType) match {
         case (NumericType, dt) => dt.isInstanceOf[NumericType]
         case (StringType, dt) => dt == StringType

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
@@ -130,20 +130,20 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
    *
    * @since 2.2.0
    */
-  def fill(value: Long): DataFrame = fill(value, Seq.empty)
+  def fill(value: Long): DataFrame = fillValue(value, df.queryExecution.analyzed.output)
 
   /**
    * Returns a new `DataFrame` that replaces null or NaN values in numeric columns with `value`.
    * @since 1.3.1
    */
-  def fill(value: Double): DataFrame = fill(value, Seq.empty)
+  def fill(value: Double): DataFrame = fillValue(value, df.queryExecution.analyzed.output)
 
   /**
    * Returns a new `DataFrame` that replaces null values in string columns with `value`.
    *
    * @since 1.3.1
    */
-  def fill(value: String): DataFrame = fill(value, Seq.empty)
+  def fill(value: String): DataFrame = fillValue(value, df.queryExecution.analyzed.output)
 
   /**
    * Returns a new `DataFrame` that replaces null or NaN values in specified numeric columns.
@@ -199,7 +199,7 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
    *
    * @since 2.3.0
    */
-  def fill(value: Boolean): DataFrame = fill(value, Seq.empty)
+  def fill(value: Boolean): DataFrame = fillValue(value, df.queryExecution.analyzed.output)
 
   /**
    * (Scala-specific) Returns a new `DataFrame` that replaces null values in specified
@@ -510,7 +510,7 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
           throw new IllegalArgumentException(s"$targetType is not matched at fillValue")
       }
       // Only fill if the column is part of the cols list.
-      if (typeMatches && (cols.isEmpty || cols.exists(_.semanticEquals(col)))) {
+      if (typeMatches && cols.exists(_.semanticEquals(col))) {
         fillCol(col.dataType, col.name, Column(col), value)
       } else {
         Column(col)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
@@ -281,13 +281,14 @@ class DataFrameNaFunctionsSuite extends QueryTest with SharedSparkSession {
 
     val data = Seq(
       Row(Row(null, "a2")),
-      Row(Row("b1", "b2")))
+      Row(Row("b1", "b2")),
+      Row(null))
 
     val df = spark.createDataFrame(
       spark.sparkContext.parallelize(data), schema)
 
     checkAnswer(df.select("c1.c1-1"),
-      Row(null) :: Row("b1") :: Nil)
+      Row(null) :: Row("b1") :: Row(null) :: Nil)
 
     // Nested columns are ignored for fill().
     checkAnswer(df.na.fill("a1", Seq("c1.c1-1")), data)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
@@ -346,7 +346,7 @@ class DataFrameNaFunctionsSuite extends QueryTest with SharedSparkSession {
     val right = Seq(("1", "2"), ("3", null)).toDF("col1", "col2")
     val df = left.join(right, Seq("col1"))
 
-    // If column names are specified, the following fails due to unambiguity.
+    // If column names are specified, the following fails due to ambiguity.
     val exception = intercept[AnalysisException] {
       df.na.fill("hello", Seq("col2"))
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
@@ -340,4 +340,21 @@ class DataFrameNaFunctionsSuite extends QueryTest with SharedSparkSession {
       )).na.drop("name" :: Nil).select("name"),
       Row("Alice") :: Row("David") :: Nil)
   }
+
+  test("SPARK-29890: duplicate names are allowed for fill() if column names are not specified.") {
+    val left = Seq(("1", null), ("3", "4")).toDF("col1", "col2")
+    val right = Seq(("1", "2"), ("3", null)).toDF("col1", "col2")
+    val df = left.join(right, Seq("col1"))
+
+    // If column names are specified, the following fails due to unambiguity.
+    val exception = intercept[AnalysisException] {
+      df.na.fill("hello", Seq("col2"))
+    }
+    assert(exception.getMessage.contains("Reference 'col2' is ambiguous"))
+
+    // If column names are not specified, fill() is applied to all the eligible columns.
+    checkAnswer(
+      df.na.fill("hello"),
+      Row("1", "hello", "2") :: Row("3", "4", "hello") :: Nil)
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
`DataFrameNaFunctions.fill` doesn't handle duplicate columns even when column names are not specified.

```Scala
val left = Seq(("1", null), ("3", "4")).toDF("col1", "col2")
val right = Seq(("1", "2"), ("3", null)).toDF("col1", "col2")
val df = left.join(right, Seq("col1"))
df.printSchema
df.na.fill("hello").show
```
produces
```
root
 |-- col1: string (nullable = true)
 |-- col2: string (nullable = true)
 |-- col2: string (nullable = true)

org.apache.spark.sql.AnalysisException: Reference 'col2' is ambiguous, could be: col2, col2.;
  at org.apache.spark.sql.catalyst.expressions.package$AttributeSeq.resolve(package.scala:259)
  at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.resolveQuoted(LogicalPlan.scala:121)
  at org.apache.spark.sql.Dataset.resolve(Dataset.scala:221)
  at org.apache.spark.sql.Dataset.col(Dataset.scala:1268)
```
The reason for the above failure is that columns are looked up with `DataSet.col()` which tries to resolve a column by name and if there are multiple columns with the same name, it will fail due to ambiguity.

This PR updates `DataFrameNaFunctions.fill` such that if the columns to fill are not specified, it will resolve ambiguity gracefully by applying `fill` to all the eligible columns. (Note that if the user specifies the columns, it will still continue to fail due to ambiguity).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
If column names are not specified, `fill` should not fail due to ambiguity since it should still be able to apply `fill` to the eligible columns.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
Yes, now the above example displays the following:
```
+----+-----+-----+
|col1| col2| col2|
+----+-----+-----+
|   1|hello|    2|
|   3|    4|hello|
+----+-----+-----+

```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added new unit tests.
