### PR TITLE
[SPARK-29959][ML][PYSPARK] Summarizer support more metrics

### DIFF
--- a/docs/ml-statistics.md
+++ b/docs/ml-statistics.md
@@ -109,8 +109,8 @@ Refer to the [`ChiSquareTest` Python docs](api/python/index.html#pyspark.ml.stat
 ## Summarizer
 
 We provide vector column summary statistics for `Dataframe` through `Summarizer`.
-Available metrics are the column-wise max, min, mean, sum, variance, std, squared sum, and number of nonzeros,
-as well as the total count and sum of weights.
+Available metrics are the column-wise max, min, mean, sum, variance, std, and number of nonzeros,
+as well as the total count.
 
 <div class="codetabs">
 <div data-lang="scala" markdown="1">

--- a/docs/ml-statistics.md
+++ b/docs/ml-statistics.md
@@ -109,7 +109,8 @@ Refer to the [`ChiSquareTest` Python docs](api/python/index.html#pyspark.ml.stat
 ## Summarizer
 
 We provide vector column summary statistics for `Dataframe` through `Summarizer`.
-Available metrics are the column-wise max, min, mean, variance, and number of nonzeros, as well as the total count.
+Available metrics are the column-wise max, min, mean, sum, variance, std, squared sum, and number of nonzeros,
+as well as the total count and sum of weights.
 
 <div class="codetabs">
 <div data-lang="scala" markdown="1">

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LinearSVC.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LinearSVC.scala
@@ -170,7 +170,7 @@ class LinearSVC @Since("2.2.0") (
       regParam, maxIter, fitIntercept, tol, standardization, threshold, aggregationDepth)
 
     val (summarizer, labelSummarizer) = instances.treeAggregate(
-      (createSummarizerBuffer("mean", "variance", "count"), new MultiClassSummarizer))(
+      (createSummarizerBuffer("mean", "std", "count"), new MultiClassSummarizer))(
       seqOp = (c: (SummarizerBuffer, MultiClassSummarizer), instance: Instance) =>
         (c._1.add(instance.features, instance.weight), c._2.add(instance.label, instance.weight)),
       combOp = (c1: (SummarizerBuffer, MultiClassSummarizer),
@@ -207,7 +207,7 @@ class LinearSVC @Since("2.2.0") (
         throw new SparkException(msg)
       }
 
-      val featuresStd = summarizer.variance.toArray.map(math.sqrt)
+      val featuresStd = summarizer.std.toArray
       val getFeaturesStd = (j: Int) => featuresStd(j)
       val regParamL2 = $(regParam)
       val bcFeaturesStd = instances.context.broadcast(featuresStd)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -501,7 +501,7 @@ class LogisticRegression @Since("1.2.0") (
       fitIntercept)
 
     val (summarizer, labelSummarizer) = instances.treeAggregate(
-      (createSummarizerBuffer("mean", "variance", "count"), new MultiClassSummarizer))(
+      (createSummarizerBuffer("mean", "std", "count"), new MultiClassSummarizer))(
       seqOp = (c: (SummarizerBuffer, MultiClassSummarizer), instance: Instance) =>
         (c._1.add(instance.features, instance.weight), c._2.add(instance.label, instance.weight)),
       combOp = (c1: (SummarizerBuffer, MultiClassSummarizer),
@@ -582,7 +582,7 @@ class LogisticRegression @Since("1.2.0") (
         }
 
         val featuresMean = summarizer.mean.toArray
-        val featuresStd = summarizer.variance.toArray.map(math.sqrt)
+        val featuresStd = summarizer.std.toArray
 
         if (!$(fitIntercept) && (0 until numFeatures).exists { i =>
           featuresStd(i) == 0.0 && featuresMean(i) != 0.0 }) {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
@@ -108,12 +108,10 @@ class StandardScaler @Since("1.4.0") (
   override def fit(dataset: Dataset[_]): StandardScalerModel = {
     transformSchema(dataset.schema, logging = true)
 
-    val Row(mean: Vector, variance: Vector) = dataset
-      .select(Summarizer.metrics("mean", "variance").summary(col($(inputCol))).as("summary"))
-      .select("summary.mean", "summary.variance")
+    val Row(mean: Vector, std: Vector) = dataset
+      .select(Summarizer.metrics("mean", "std").summary(col($(inputCol))).as("summary"))
+      .select("summary.mean", "summary.std")
       .first()
-
-    val std = Vectors.dense(variance.toArray.map(math.sqrt))
 
     copyValues(new StandardScalerModel(uid, std.compressed, mean.compressed).setParent(this))
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
@@ -215,13 +215,13 @@ class AFTSurvivalRegression @Since("1.6.0") (@Since("1.6.0") override val uid: S
     if (handlePersistence) instances.persist(StorageLevel.MEMORY_AND_DISK)
 
     val featuresSummarizer = instances.treeAggregate(
-      createSummarizerBuffer("mean", "variance", "count"))(
+      createSummarizerBuffer("mean", "std", "count"))(
       seqOp = (c: SummarizerBuffer, v: AFTPoint) => c.add(v.features),
       combOp = (c1: SummarizerBuffer, c2: SummarizerBuffer) => c1.merge(c2),
       depth = $(aggregationDepth)
     )
 
-    val featuresStd = featuresSummarizer.variance.toArray.map(math.sqrt)
+    val featuresStd = featuresSummarizer.std.toArray
     val numFeatures = featuresStd.size
 
     instr.logPipelineStage(this)

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/Summarizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/Summarizer.scala
@@ -89,12 +89,17 @@ object Summarizer extends Logging {
    *
    * The following metrics are accepted (case sensitive):
    *  - mean: a vector that contains the coefficient-wise mean.
+   *  - sum: a vector that contains the coefficient-wise sum.
    *  - variance: a vector tha contains the coefficient-wise variance.
+   *  - std: a vector tha contains the coefficient-wise standard deviation.
    *  - count: the count of all vectors seen.
+   *  - weightSum: the sum of all weights seen.
+   *  - numFeatures: the size of vectors.
    *  - numNonzeros: a vector with the number of non-zeros for each coefficients
    *  - max: the maximum for each coefficient.
    *  - min: the minimum for each coefficient.
    *  - normL2: the Euclidean norm for each coefficient.
+   *  - sumL2: a vector that contains the coefficient-wise squared sum.
    *  - normL1: the L1 norm of each coefficient (sum of the absolute values).
    * @param metrics metrics that can be provided.
    * @return a builder.
@@ -106,7 +111,7 @@ object Summarizer extends Logging {
   @Since("2.3.0")
   @scala.annotation.varargs
   def metrics(metrics: String*): SummaryBuilder = {
-    require(metrics.size >= 1, "Should include at least one metric")
+    require(metrics.nonEmpty, "Should include at least one metric")
     val (typedMetrics, computeMetrics) = getRelevantMetrics(metrics)
     new SummaryBuilderImpl(typedMetrics, computeMetrics)
   }
@@ -119,6 +124,14 @@ object Summarizer extends Logging {
   @Since("2.3.0")
   def mean(col: Column): Column = mean(col, lit(1.0))
 
+  @Since("3.0.0")
+  def sum(col: Column, weightCol: Column): Column = {
+    getSingleMetric(col, weightCol, "sum")
+  }
+
+  @Since("3.0.0")
+  def sum(col: Column): Column = sum(col, lit(1.0))
+
   @Since("2.3.0")
   def variance(col: Column, weightCol: Column): Column = {
     getSingleMetric(col, weightCol, "variance")
@@ -127,6 +140,14 @@ object Summarizer extends Logging {
   @Since("2.3.0")
   def variance(col: Column): Column = variance(col, lit(1.0))
 
+  @Since("3.0.0")
+  def std(col: Column, weightCol: Column): Column = {
+    getSingleMetric(col, weightCol, "std")
+  }
+
+  @Since("3.0.0")
+  def std(col: Column): Column = std(col, lit(1.0))
+
   @Since("2.3.0")
   def count(col: Column, weightCol: Column): Column = {
     getSingleMetric(col, weightCol, "count")
@@ -134,6 +155,22 @@ object Summarizer extends Logging {
 
   @Since("2.3.0")
   def count(col: Column): Column = count(col, lit(1.0))
+
+  @Since("3.0.0")
+  def weightSum(col: Column, weightCol: Column): Column = {
+    getSingleMetric(col, weightCol, "weightSum")
+  }
+
+  @Since("3.0.0")
+  def weightSum(col: Column): Column = weightSum(col, lit(1.0))
+
+  @Since("3.0.0")
+  def numFeatures(col: Column, weightCol: Column): Column = {
+    getSingleMetric(col, weightCol, "numFeatures")
+  }
+
+  @Since("3.0.0")
+  def numFeatures(col: Column): Column = numFeatures(col, lit(1.0))
 
   @Since("2.3.0")
   def numNonZeros(col: Column, weightCol: Column): Column = {
@@ -174,6 +211,14 @@ object Summarizer extends Logging {
 
   @Since("2.3.0")
   def normL2(col: Column): Column = normL2(col, lit(1.0))
+
+  @Since("3.0.0")
+  def sumL2(col: Column, weightCol: Column): Column = {
+    getSingleMetric(col, weightCol, "sumL2")
+  }
+
+  @Since("3.0.0")
+  def sumL2(col: Column): Column = sumL2(col, lit(1.0))
 
   private def getSingleMetric(col: Column, weightCol: Column, metric: String): Column = {
     val c1 = metrics(metric).summary(col, weightCol)
@@ -245,12 +290,17 @@ private[ml] object SummaryBuilderImpl extends Logging {
    */
   private val allMetrics: Seq[(String, Metric, DataType, Seq[ComputeMetric])] = Seq(
     ("mean", Mean, vectorUDT, Seq(ComputeMean, ComputeWeightSum)),
+    ("sum", Sum, vectorUDT, Seq(ComputeMean, ComputeWeightSum)),
     ("variance", Variance, vectorUDT, Seq(ComputeWeightSum, ComputeMean, ComputeM2n)),
+    ("std", Std, vectorUDT, Seq(ComputeWeightSum, ComputeMean, ComputeM2n)),
     ("count", Count, LongType, Seq()),
+    ("weightSum", WeightSum, DoubleType, Seq()),
+    ("numFeatures", NumFeatures, IntegerType, Seq()),
     ("numNonZeros", NumNonZeros, vectorUDT, Seq(ComputeNNZ)),
     ("max", Max, vectorUDT, Seq(ComputeMax, ComputeNNZ)),
     ("min", Min, vectorUDT, Seq(ComputeMin, ComputeNNZ)),
     ("normL2", NormL2, vectorUDT, Seq(ComputeM2)),
+    ("sumL2", SumL2, vectorUDT, Seq(ComputeM2)),
     ("normL1", NormL1, vectorUDT, Seq(ComputeL1))
   )
 
@@ -259,12 +309,17 @@ private[ml] object SummaryBuilderImpl extends Logging {
    */
   sealed trait Metric extends Serializable
   private[stat] case object Mean extends Metric
+  private[stat] case object Sum extends Metric
   private[stat] case object Variance extends Metric
+  private[stat] case object Std extends Metric
   private[stat] case object Count extends Metric
+  private[stat] case object WeightSum extends Metric
+  private[stat] case object NumFeatures extends Metric
   private[stat] case object NumNonZeros extends Metric
   private[stat] case object Max extends Metric
   private[stat] case object Min extends Metric
   private[stat] case object NormL2 extends Metric
+  private[stat] case object SumL2 extends Metric
   private[stat] case object NormL1 extends Metric
 
   /**
@@ -295,14 +350,15 @@ private[ml] object SummaryBuilderImpl extends Logging {
     private var totalCnt: Long = 0
     private var totalWeightSum: Double = 0.0
     private var weightSquareSum: Double = 0.0
-    private var weightSum: Array[Double] = null
+    private var currWeightSum: Array[Double] = null
     private var nnz: Array[Long] = null
     private var currMax: Array[Double] = null
     private var currMin: Array[Double] = null
 
     def this() {
       this(
-        Seq(Mean, Variance, Count, NumNonZeros, Max, Min, NormL2, NormL1),
+        Seq(Mean, Sum, Variance, Std, Count, WeightSum, NumFeatures,
+          NumNonZeros, Max, Min, NormL2, SumL2, NormL1),
         Seq(ComputeMean, ComputeM2n, ComputeM2, ComputeL1,
           ComputeWeightSum, ComputeNNZ, ComputeMax, ComputeMin)
       )
@@ -323,7 +379,9 @@ private[ml] object SummaryBuilderImpl extends Logging {
         if (requestedCompMetrics.contains(ComputeM2n)) { currM2n = Array.ofDim[Double](n) }
         if (requestedCompMetrics.contains(ComputeM2)) { currM2 = Array.ofDim[Double](n) }
         if (requestedCompMetrics.contains(ComputeL1)) { currL1 = Array.ofDim[Double](n) }
-        if (requestedCompMetrics.contains(ComputeWeightSum)) { weightSum = Array.ofDim[Double](n) }
+        if (requestedCompMetrics.contains(ComputeWeightSum)) {
+          currWeightSum = Array.ofDim[Double](n)
+        }
         if (requestedCompMetrics.contains(ComputeNNZ)) { nnz = Array.ofDim[Long](n) }
         if (requestedCompMetrics.contains(ComputeMax)) {
           currMax = Array.fill[Double](n)(Double.MinValue)
@@ -340,7 +398,7 @@ private[ml] object SummaryBuilderImpl extends Logging {
       val localCurrM2n = currM2n
       val localCurrM2 = currM2
       val localCurrL1 = currL1
-      val localWeightSum = weightSum
+      val localCurrWeightSum = currWeightSum
       val localNumNonzeros = nnz
       val localCurrMax = currMax
       val localCurrMin = currMin
@@ -353,17 +411,18 @@ private[ml] object SummaryBuilderImpl extends Logging {
             localCurrMin(index) = value
           }
 
-          if (localWeightSum != null) {
+          if (localCurrWeightSum != null) {
             if (localCurrMean != null) {
               val prevMean = localCurrMean(index)
               val diff = value - prevMean
-              localCurrMean(index) = prevMean + weight * diff / (localWeightSum(index) + weight)
+              localCurrMean(index) = prevMean +
+                weight * diff / (localCurrWeightSum(index) + weight)
 
               if (localCurrM2n != null) {
                 localCurrM2n(index) += weight * (value - localCurrMean(index)) * diff
               }
             }
-            localWeightSum(index) += weight
+            localCurrWeightSum(index) += weight
           }
 
           if (localCurrM2 != null) {
@@ -402,9 +461,9 @@ private[ml] object SummaryBuilderImpl extends Logging {
         weightSquareSum += other.weightSquareSum
         var i = 0
         while (i < n) {
-          if (weightSum != null) {
-            val thisWeightSum = weightSum(i)
-            val otherWeightSum = other.weightSum(i)
+          if (currWeightSum != null) {
+            val thisWeightSum = currWeightSum(i)
+            val otherWeightSum = other.currWeightSum(i)
             val totalWeightSum = thisWeightSum + otherWeightSum
 
             if (totalWeightSum != 0.0) {
@@ -420,7 +479,7 @@ private[ml] object SummaryBuilderImpl extends Logging {
                 }
               }
             }
-            weightSum(i) = totalWeightSum
+            currWeightSum(i) = totalWeightSum
           }
 
           // merge m2 together
@@ -442,7 +501,7 @@ private[ml] object SummaryBuilderImpl extends Logging {
         this.totalCnt = other.totalCnt
         this.totalWeightSum = other.totalWeightSum
         this.weightSquareSum = other.weightSquareSum
-        if (other.weightSum != null) { this.weightSum = other.weightSum.clone() }
+        if (other.currWeightSum != null) { this.currWeightSum = other.currWeightSum.clone() }
         if (other.nnz != null) { this.nnz = other.nnz.clone() }
         if (other.currMax != null) { this.currMax = other.currMax.clone() }
         if (other.currMin != null) { this.currMin = other.currMin.clone() }
@@ -460,10 +519,26 @@ private[ml] object SummaryBuilderImpl extends Logging {
       val realMean = Array.ofDim[Double](n)
       var i = 0
       while (i < n) {
-        realMean(i) = currMean(i) * (weightSum(i) / totalWeightSum)
+        realMean(i) = currMean(i) * (currWeightSum(i) / totalWeightSum)
         i += 1
       }
       Vectors.dense(realMean)
+    }
+
+    /**
+     * Sum of each dimension.
+     */
+    def sum: Vector = {
+      require(requestedMetrics.contains(Sum))
+      require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
+
+      val realSum = Array.ofDim[Double](n)
+      var i = 0
+      while (i < n) {
+        realSum(i) = currMean(i) * currWeightSum(i)
+        i += 1
+      }
+      Vectors.dense(realSum)
     }
 
     /**
@@ -484,8 +559,8 @@ private[ml] object SummaryBuilderImpl extends Logging {
         val len = currM2n.length
         while (i < len) {
           // We prevent variance from negative value caused by numerical error.
-          realVariance(i) = math.max((currM2n(i) + deltaMean(i) * deltaMean(i) * weightSum(i) *
-            (totalWeightSum - weightSum(i)) / totalWeightSum) / denominator, 0.0)
+          realVariance(i) = math.max((currM2n(i) + deltaMean(i) * deltaMean(i) * currWeightSum(i) *
+            (totalWeightSum - currWeightSum(i)) / totalWeightSum) / denominator, 0.0)
           i += 1
         }
       }
@@ -493,9 +568,49 @@ private[ml] object SummaryBuilderImpl extends Logging {
     }
 
     /**
+     * Unbiased estimate of standard deviation of each dimension.
+     */
+    def std: Vector = {
+      require(requestedMetrics.contains(Std))
+      require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
+
+      val realStd = Array.ofDim[Double](n)
+
+      val denominator = totalWeightSum - (weightSquareSum / totalWeightSum)
+
+      // Sample variance is computed, if the denominator is less than 0, the variance is just 0.
+      if (denominator > 0.0) {
+        val deltaMean = currMean
+        var i = 0
+        val len = currM2n.length
+        while (i < len) {
+          // We prevent variance from negative value caused by numerical error.
+          val variance = math.max((currM2n(i) + deltaMean(i) * deltaMean(i) * currWeightSum(i) *
+            (totalWeightSum - currWeightSum(i)) / totalWeightSum) / denominator, 0.0)
+          realStd(i) = math.sqrt(variance)
+          i += 1
+        }
+      }
+      Vectors.dense(realStd)
+    }
+
+    /**
      * Sample size.
      */
     def count: Long = totalCnt
+
+    /**
+     * Sum of weights.
+     */
+    def weightSum: Double = totalWeightSum
+
+    /**
+     * Number of features.
+     */
+    def numFeatures: Int = {
+      require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
+      n
+    }
 
     /**
      * Number of nonzero elements in each dimension.
@@ -557,6 +672,16 @@ private[ml] object SummaryBuilderImpl extends Logging {
     }
 
     /**
+     * Squared sum of each dimension.
+     */
+    def sumL2: Vector = {
+      require(requestedMetrics.contains(SumL2))
+      require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
+
+      Vectors.dense(currM2)
+    }
+
+    /**
      * L1 norm of each dimension.
      */
     def normL1: Vector = {
@@ -579,12 +704,17 @@ private[ml] object SummaryBuilderImpl extends Logging {
     override def eval(state: SummarizerBuffer): Any = {
       val metrics = requestedMetrics.map {
         case Mean => vectorUDT.serialize(state.mean)
+        case Sum => vectorUDT.serialize(state.sum)
         case Variance => vectorUDT.serialize(state.variance)
+        case Std => vectorUDT.serialize(state.std)
         case Count => state.count
+        case WeightSum => state.weightSum
+        case NumFeatures => state.numFeatures
         case NumNonZeros => vectorUDT.serialize(state.numNonzeros)
         case Max => vectorUDT.serialize(state.max)
         case Min => vectorUDT.serialize(state.min)
         case NormL2 => vectorUDT.serialize(state.normL2)
+        case SumL2 => vectorUDT.serialize(state.sumL2)
         case NormL1 => vectorUDT.serialize(state.normL1)
       }
       InternalRow.apply(metrics: _*)

--- a/mllib/src/test/scala/org/apache/spark/ml/stat/SummarizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/stat/SummarizerSuite.scala
@@ -86,7 +86,7 @@ class SummarizerSuite extends SparkFunSuite with MLlibTestSparkContext {
     registerTest(s"$name - sum only") {
       val (df, c, w) = wrappedInit()
       val weightSum = summarizer.weightSum
-      val expected1 = summarizer.mean.asML
+      val expected1 = summarizer.mean.asML.copy
       BLAS.scal(weightSum, expected1)
       val expected2 = exp.mean.copy
       BLAS.scal(weightSum, expected2)
@@ -97,7 +97,7 @@ class SummarizerSuite extends SparkFunSuite with MLlibTestSparkContext {
     registerTest(s"$name - sum only w/o weight") {
       val (df, c, _) = wrappedInit()
       val weightSum = summarizerWithoutWeight.weightSum
-      val expected1 = summarizerWithoutWeight.mean.asML
+      val expected1 = summarizerWithoutWeight.mean.asML.copy
       BLAS.scal(weightSum, expected1)
       val expected2 = expWithoutWeight.mean.copy
       BLAS.scal(weightSum, expected2)

--- a/mllib/src/test/scala/org/apache/spark/ml/stat/SummarizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/stat/SummarizerSuite.scala
@@ -128,7 +128,7 @@ class SummarizerSuite extends SparkFunSuite with MLlibTestSparkContext {
     registerTest(s"$name - std only w/o weight") {
       val (df, c, _) = wrappedInit()
       val expected1 = Vectors.dense(summarizerWithoutWeight.variance.toArray.map(math.sqrt))
-      val expected2 = Vectors.dense(summarizerWithoutWeight.variance.toArray.map(math.sqrt))
+      val expected2 = Vectors.dense(expWithoutWeight.variance.toArray.map(math.sqrt))
       compareRow(df.select(metrics("std").summary(c), std(c)).first(),
         Row(Row(expected1), expected2))
     }

--- a/python/pyspark/ml/stat.py
+++ b/python/pyspark/ml/stat.py
@@ -200,21 +200,21 @@ class Summarizer(object):
     >>> from pyspark.ml.stat import Summarizer
     >>> from pyspark.sql import Row
     >>> from pyspark.ml.linalg import Vectors
-    >>> summarizer = Summarizer.metrics("mean", "count", "numFeatures")
+    >>> summarizer = Summarizer.metrics("mean", "count")
     >>> df = sc.parallelize([Row(weight=1.0, features=Vectors.dense(1.0, 1.0, 1.0)),
     ...                      Row(weight=0.0, features=Vectors.dense(1.0, 2.0, 3.0))]).toDF()
     >>> df.select(summarizer.summary(df.features, df.weight)).show(truncate=False)
     +-----------------------------------+
     |aggregate_metrics(features, weight)|
     +-----------------------------------+
-    |[[1.0,1.0,1.0], 1, 3]              |
+    |[[1.0,1.0,1.0], 1]                 |
     +-----------------------------------+
     <BLANKLINE>
     >>> df.select(summarizer.summary(df.features)).show(truncate=False)
     +--------------------------------+
     |aggregate_metrics(features, 1.0)|
     +--------------------------------+
-    |[[1.0,1.5,2.0], 2, 3]           |
+    |[[1.0,1.5,2.0], 2]              |
     +--------------------------------+
     <BLANKLINE>
     >>> df.select(Summarizer.mean(df.features, df.weight)).show(truncate=False)
@@ -230,13 +230,6 @@ class Summarizer(object):
     +--------------+
     |[1.0,1.5,2.0] |
     +--------------+
-    <BLANKLINE>
-    >>> df.select(Summarizer.sum(df.features), Summarizer.sumL2(df.features)).show(truncate=False)
-    +-------------+---------------+
-    |sum(features)|sumL2(features)|
-    +-------------+---------------+
-    |[2.0,3.0,4.0]|[2.0,5.0,10.0] |
-    +-------------+---------------+
     <BLANKLINE>
 
     .. versionadded:: 2.4.0
@@ -283,22 +276,6 @@ class Summarizer(object):
         return Summarizer._get_single_metric(col, weightCol, "count")
 
     @staticmethod
-    @since("3.0.0")
-    def weightSum(col, weightCol=None):
-        """
-        return a column of weightSum summary
-        """
-        return Summarizer._get_single_metric(col, weightCol, "weightSum")
-
-    @staticmethod
-    @since("3.0.0")
-    def numFeatures(col, weightCol=None):
-        """
-        return a column of numFeatures summary
-        """
-        return Summarizer._get_single_metric(col, weightCol, "numFeatures")
-
-    @staticmethod
     @since("2.4.0")
     def numNonZeros(col, weightCol=None):
         """
@@ -337,14 +314,6 @@ class Summarizer(object):
         return a column of normL2 summary
         """
         return Summarizer._get_single_metric(col, weightCol, "normL2")
-
-    @staticmethod
-    @since("3.0.0")
-    def sumL2(col, weightCol=None):
-        """
-        return a column of sumL2 summary
-        """
-        return Summarizer._get_single_metric(col, weightCol, "sumL2")
 
     @staticmethod
     def _check_param(featuresCol, weightCol):

--- a/python/pyspark/ml/stat.py
+++ b/python/pyspark/ml/stat.py
@@ -343,13 +343,10 @@ class Summarizer(object):
          - variance: a vector tha contains the coefficient-wise variance.
          - std: a vector tha contains the coefficient-wise standard deviation.
          - count: the count of all vectors seen.
-         - weightSum: the sum of all weights seen.
-         - numFeatures: the size of vectors.
          - numNonzeros: a vector with the number of non-zeros for each coefficients
          - max: the maximum for each coefficient.
          - min: the minimum for each coefficient.
          - normL2: the Euclidean norm for each coefficient.
-         - sumL2: a vector that contains the coefficient-wise squared sum.
          - normL1: the L1 norm of each coefficient (sum of the absolute values).
 
         :param metrics:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Summarizer support more metrics: sum, std

### Why are the changes needed?
Those metrics are widely used, it will be convenient to directly obtain them other than a conversion.
in `NaiveBayes`: we want the sum of vectors,  mean & weightSum need to computed then multiplied
in `StandardScaler`,`AFTSurvivalRegression`,`LinearRegression`,`LinearSVC`,`LogisticRegression`: we need to obtain `variance` and then sqrt it to get std

### Does this PR introduce any user-facing change?
yes, new metrics are exposed to end users


### How was this patch tested?
added testsuites
