### PR TITLE
[SPARK-29861][CORE] Reduce downtime in Spark standalone HA master switch

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/ZookeeperSuspensionTolerantErrorPolicy.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ZookeeperSuspensionTolerantErrorPolicy.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.master
+
+import org.apache.curator.framework.state.ConnectionState
+import org.apache.curator.framework.state.ConnectionStateErrorPolicy
+
+/**
+ * This policy treats only {@link ConnectionState#LOST} as errors
+ */
+class ZookeeperSuspensionTolerantErrorPolicy extends ConnectionStateErrorPolicy{
+
+    override def isErrorState(state: ConnectionState): Boolean = {
+        return (state == ConnectionState.LOST);
+    }
+
+}

--- a/dev/deps/spark-deps-hadoop-2.7-hive-1.2
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-1.2
@@ -52,9 +52,9 @@ commons-pool-1.5.4.jar
 commons-text-1.6.jar
 compress-lzf-1.0.3.jar
 core-1.1.2.jar
-curator-client-2.7.1.jar
-curator-framework-2.7.1.jar
-curator-recipes-2.7.1.jar
+curator-client-4.2.0.jar
+curator-framework-4.2.0.jar
+curator-recipes-4.2.0.jar
 datanucleus-api-jdo-3.2.6.jar
 datanucleus-core-3.2.10.jar
 datanucleus-rdbms-3.2.9.jar

--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -50,9 +50,9 @@ commons-pool-1.5.4.jar
 commons-text-1.6.jar
 compress-lzf-1.0.3.jar
 core-1.1.2.jar
-curator-client-2.7.1.jar
-curator-framework-2.7.1.jar
-curator-recipes-2.7.1.jar
+curator-client-4.2.0.jar
+curator-framework-4.2.0.jar
+curator-recipes-4.2.0.jar
 datanucleus-api-jdo-4.2.4.jar
 datanucleus-core-4.1.17.jar
 datanucleus-rdbms-4.1.19.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -47,9 +47,9 @@ commons-pool-1.5.4.jar
 commons-text-1.6.jar
 compress-lzf-1.0.3.jar
 core-1.1.2.jar
-curator-client-2.13.0.jar
-curator-framework-2.13.0.jar
-curator-recipes-2.13.0.jar
+curator-client-4.2.0.jar
+curator-framework-4.2.0.jar
+curator-recipes-4.2.0.jar
 datanucleus-api-jdo-4.2.4.jar
 datanucleus-core-4.1.17.jar
 datanucleus-rdbms-4.1.19.jar

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <protobuf.version>2.5.0</protobuf.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <zookeeper.version>3.4.14</zookeeper.version>
-    <curator.version>2.7.1</curator.version>
+    <curator.version>4.2.0</curator.version>
     <okapi.version>0.4.2</okapi.version>
     <hive.group>org.apache.hive</hive.group>
     <hive.classifier>core</hive.classifier>
@@ -957,8 +957,14 @@
       <dependency>
         <groupId>org.apache.curator</groupId>
         <artifactId>curator-test</artifactId>
-        <version>${curator.version}</version>
+        <version>2.12.0</version>
         <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
@@ -1030,6 +1036,10 @@
           <exclusion>
             <groupId>net.java.dev.jets3t</groupId>
             <artifactId>jets3t</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>*</artifactId>
           </exclusion>
           <!-- Hadoop-3.2 -->
           <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -2953,7 +2953,6 @@
       <id>hadoop-3.2</id>
       <properties>
         <hadoop.version>3.2.0</hadoop.version>
-        <curator.version>2.13.0</curator.version>
       </properties>
     </profile>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Close open zookeeper connections during spark shutdown (SIGTERM)
2. Bump the curator version to 4.2.0
3. Implement a custom error policy that is tolerant to a zookeeper connection suspension.

### Why are the changes needed?
As described in [SPARK-29861](https://issues.apache.org/jira/browse/SPARK-29861), the recovery process of Spark (standalone) master in HA with zookeeper took about 1-2 minutes. During this time no spark master is active, which makes interaction with spark essentially impossible.

Justification for the changes:
1. because the spark master election does not properly restart if there are still open zookeeper connections
2. as a precondition for 3
3. to not restart spark when the connection is suspended temporarily, but only if it is really closed.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
* Set up spark with two masters in standalone mode and zookeeper
* Kill active master
* Observe that the second master takes over immediately (within a few milliseconds)
