### PR TITLE
[SPARK-29966][SQL] Add version method in TableCatalog to avoid load table twice

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DelegatingCatalogExtension.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DelegatingCatalogExtension.java
@@ -52,6 +52,11 @@ public abstract class DelegatingCatalogExtension implements CatalogExtension {
   public final void initialize(String name, CaseInsensitiveStringMap options) {}
 
   @Override
+  public TableVersion version() {
+    return asTableCatalog().version();
+  }
+
+  @Override
   public Identifier[] listTables(String[] namespace) throws NoSuchNamespaceException {
     return asTableCatalog().listTables(namespace);
   }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableCatalog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableCatalog.java
@@ -38,6 +38,14 @@ import java.util.Map;
 @Experimental
 public interface TableCatalog extends CatalogPlugin {
   /**
+   * Get table catalog version without load table
+   * If implement this interface, user should always set this with V2
+   *
+   * @return TableVersion
+   */
+  TableVersion version();
+
+  /**
    * List the tables in a namespace from the catalog.
    * <p>
    * If the catalog supports views, this must return identifiers for only tables and not views.

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableVersion.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableVersion.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.catalog;
+
+public enum TableVersion {
+    V1,
+    V2
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
@@ -216,6 +216,10 @@ private[sql] object CatalogV2Util {
     new StructType(newFields)
   }
 
+  def getTableVersion(catalog: CatalogPlugin): TableVersion = {
+    catalog.asTableCatalog.version()
+  }
+
   def loadTable(catalog: CatalogPlugin, ident: Identifier): Option[Table] =
     try {
       Option(catalog.asTableCatalog.loadTable(ident))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTableCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTableCatalog.scala
@@ -47,6 +47,8 @@ class BasicInMemoryTableCatalog extends TableCatalog {
 
   override def name: String = _name.get
 
+  override def version(): TableVersion = TableVersion.V2
+
   override def listTables(namespace: Array[String]): Array[Identifier] = {
     tables.keySet.asScala.filter(_.namespace.sameElements(namespace)).toArray
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
@@ -25,8 +25,8 @@ import scala.collection.mutable
 
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{NamespaceAlreadyExistsException, NoSuchNamespaceException, NoSuchTableException, TableAlreadyExistsException}
-import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogDatabase, CatalogTable, CatalogTableType, CatalogUtils, SessionCatalog}
-import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogV2Util, Identifier, NamespaceChange, SupportsNamespaces, Table, TableCatalog, TableChange, V1Table}
+import org.apache.spark.sql.catalyst.catalog._
+import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.catalog.NamespaceChange.RemoveProperty
 import org.apache.spark.sql.connector.expressions.{BucketTransform, FieldReference, IdentityTransform, Transform}
 import org.apache.spark.sql.execution.datasources.DataSource
@@ -48,6 +48,8 @@ class V2SessionCatalog(catalog: SessionCatalog, conf: SQLConf)
 
   // This class is instantiated by Spark, so `initialize` method will not be called.
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {}
+
+  override def version(): TableVersion = TableVersion.V1
 
   override def listTables(namespace: Array[String]): Array[Identifier] = {
     namespace match {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Now resolve logic plan will load table twice which are in ResolveTables and ResolveRelations. The ResolveRelations is old code path, and ResolveTables is v2 code path, and the reason why load table twice is that ResolveTables will load table and rollback v1 table to ResolveRelations code path.
The same scene also exists in ResolveSessionCatalog.

It affect that execute command will cost double time than spark 2.4.

Here is the idea that add a table version method in TableCatalog, and rules should always get table version firstly without load table.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Improve sql performance.
E.G. with hive metastore
```
create table test(c int);
desc test;
```
spark3.0 will cost about 0.3-0.4s, and spark2.4 cost about 0.1-0.2s.
And after this pr, spark3.0 cost about 0.1-0.2s.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Exists UT.