### PR TITLE
[SPARK-29877][GRAPHX] static PageRank allow checkPoint from previous computations

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/GraphOps.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/GraphOps.scala
@@ -415,11 +415,11 @@ class GraphOps[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED]) extends Seriali
   }
 
   /**
-    * Run PageRank for a fixed number of iterations returning a graph with vertex attributes
-    * containing the PageRank and edge attributes the normalized edge weight.
-    *
-    * @see [[org.apache.spark.graphx.lib.PageRank$#run]]
-    */
+   * Run PageRank for a fixed number of iterations returning a graph with vertex attributes
+   * containing the PageRank and edge attributes the normalized edge weight.
+   *
+   * @see [[org.apache.spark.graphx.lib.PageRank$#run]]
+   */
   def staticPageRank(numIter: Int, resetProb: Double = 0.15): Graph[Double, Double] = {
     PageRank.run(graph, numIter, resetProb)
   }
@@ -429,11 +429,11 @@ class GraphOps[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED]) extends Seriali
    * containing the PageRank and edge attributes the normalized edge weight, optionally including
    * including a previous pageRank computation to be used as a start point for the new iterations
    *
-   * @see [[org.apache.spark.graphx.lib.PageRank$#run]]
+   * @see [[org.apache.spark.graphx.lib.PageRank$#runWithOptionsWithPreviousPageRank]]
    */
   def staticPageRank(numIter: Int, resetProb: Double,
-                     prePageRank: Option[Graph[Double, Double]]): Graph[Double, Double] = {
-    PageRank.run(graph, numIter, resetProb, prePageRank)
+                     prePageRank: Graph[Double, Double]): Graph[Double, Double] = {
+    PageRank.runWithOptionsWithPreviousPageRank(graph, numIter, resetProb, None, prePageRank)
   }
 
   /**

--- a/graphx/src/main/scala/org/apache/spark/graphx/GraphOps.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/GraphOps.scala
@@ -420,8 +420,9 @@ class GraphOps[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED]) extends Seriali
    *
    * @see [[org.apache.spark.graphx.lib.PageRank$#run]]
    */
-  def staticPageRank(numIter: Int, resetProb: Double = 0.15): Graph[Double, Double] = {
-    PageRank.run(graph, numIter, resetProb)
+  def staticPageRank(numIter: Int, resetProb: Double = 0.15,
+                     prePageRank: Option[Graph[Double, Double]] = None): Graph[Double, Double] = {
+    PageRank.run(graph, numIter, resetProb, prePageRank)
   }
 
   /**

--- a/graphx/src/main/scala/org/apache/spark/graphx/GraphOps.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/GraphOps.scala
@@ -415,13 +415,24 @@ class GraphOps[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED]) extends Seriali
   }
 
   /**
+    * Run PageRank for a fixed number of iterations returning a graph with vertex attributes
+    * containing the PageRank and edge attributes the normalized edge weight.
+    *
+    * @see [[org.apache.spark.graphx.lib.PageRank$#run]]
+    */
+  def staticPageRank(numIter: Int, resetProb: Double = 0.15): Graph[Double, Double] = {
+    PageRank.run(graph, numIter, resetProb)
+  }
+
+  /**
    * Run PageRank for a fixed number of iterations returning a graph with vertex attributes
-   * containing the PageRank and edge attributes the normalized edge weight.
+   * containing the PageRank and edge attributes the normalized edge weight, optionally including
+   * including a previous pageRank computation to be used as a start point for the new iterations
    *
    * @see [[org.apache.spark.graphx.lib.PageRank$#run]]
    */
-  def staticPageRank(numIter: Int, resetProb: Double = 0.15,
-                     prePageRank: Option[Graph[Double, Double]] = None): Graph[Double, Double] = {
+  def staticPageRank(numIter: Int, resetProb: Double,
+                     prePageRank: Option[Graph[Double, Double]]): Graph[Double, Double] = {
     PageRank.run(graph, numIter, resetProb, prePageRank)
   }
 

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
@@ -176,7 +176,6 @@ object PageRank extends Logging {
       logInfo(s"PageRank finished iteration $iteration.")
       prevRankGraph.vertices.unpersist()
       prevRankGraph.edges.unpersist()
-
       iteration += 1
     }
 
@@ -236,7 +235,6 @@ object PageRank extends Logging {
       logInfo(s"PageRank finished iteration $iteration.")
       prevRankGraph.vertices.unpersist()
       prevRankGraph.edges.unpersist()
-      
       iteration += 1
     }
 

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
@@ -80,10 +80,45 @@ object PageRank extends Logging {
    *         containing the normalized weight.
    */
   def run[VD: ClassTag, ED: ClassTag](
-      graph: Graph[VD, ED], numIter: Int, resetProb: Double = 0.15,
-      prePageRank: Option[Graph[Double, Double]] = None): Graph[Double, Double] =
+      graph: Graph[VD, ED], numIter: Int, resetProb: Double = 0.15): Graph[Double, Double] =
   {
-    runWithOptions(graph, numIter, resetProb, None, prePageRank)
+    runWithOptions(graph, numIter, resetProb, None)
+  }
+
+  /**
+   * Run an update pass of PageRank algorithm. Update the values of every node in the
+   * pageRank
+   *
+   * @param rankGraph the current PageRank
+   * @param personalized True if personalized pageRank
+   * @param resetProb the random reset probability (alpha)
+   * @param src the source vertex for a Personalized Page Rank
+   *
+   * @return the graph containing with each vertex containing the PageRank and each edge
+   *         containing the normalized weight.
+   *
+   */
+  private def runUpdate(rankGraph: Graph[Double, Double], personalized: Boolean,
+                resetProb: Double, src: VertexId): Graph[Double, Double] = {
+
+    def delta(u: VertexId, v: VertexId): Double = { if (u == v) 1.0 else 0.0 }
+    // Compute the outgoing rank contributions of each vertex, perform local preaggregation, and
+    // do the final aggregation at the receiving vertices. Requires a shuffle for aggregation.
+    val rankUpdates = rankGraph.aggregateMessages[Double](
+      ctx => ctx.sendToDst(ctx.srcAttr * ctx.attr), _ + _, TripletFields.Src)
+
+    // Apply the final rank updates to get the new ranks, using join to preserve ranks of vertices
+    // that didn't receive a message. Requires a shuffle for broadcasting updated ranks to the
+    // edge partitions.
+    val rPrb = if (personalized) {
+      (src: VertexId, id: VertexId) => resetProb * delta(src, id)
+    } else {
+      (src: VertexId, id: VertexId) => resetProb
+    }
+
+    rankGraph.outerJoinVertices(rankUpdates) {
+      (id, oldRank, msgSumOpt) => rPrb(src, id) + (1.0 - resetProb) * msgSumOpt.getOrElse(0.0)
+    }
   }
 
   /**
@@ -104,8 +139,9 @@ object PageRank extends Logging {
    *
    */
   def runWithOptions[VD: ClassTag, ED: ClassTag](
-      graph: Graph[VD, ED], numIter: Int, resetProb: Double = 0.15, srcId: Option[VertexId] = None,
-      preRankGraph: Option[Graph[Double, Double]] = None): Graph[Double, Double] = {
+      graph: Graph[VD, ED], numIter: Int, resetProb: Double = 0.15,
+      srcId: Option[VertexId] = None): Graph[Double, Double] = {
+
     require(numIter > 0, s"Number of iterations must be greater than 0," +
       s" but got ${numIter}")
     require(resetProb >= 0 && resetProb <= 1, s"Random reset probability must belong" +
@@ -118,52 +154,90 @@ object PageRank extends Logging {
     // weight 1/outDegree and each vertex with attribute 1.0.
     // When running personalized pagerank, only the source vertex
     // has an attribute 1.0. All others are set to 0.
-    var rankGraph: Graph[Double, Double] = {
-      preRankGraph match {
-        case Some(pageRank) => pageRank
-        case None => graph
-            // Associate the degree with each vertex
-            .outerJoinVertices(graph.outDegrees) { (vid, vdata, deg) => deg.getOrElse(0) }
-            // Set the weight on the edges based on the degree
-            .mapTriplets(e => 1.0 / e.srcAttr, TripletFields.Src)
-            // Set the vertex attributes to the initial pagerank values
-            .mapVertices { (id, attr) =>
-            if (!(id != src && personalized)) 1.0 else 0.0
+    var rankGraph: Graph[Double, Double] = graph
+          // Associate the degree with each vertex
+          .outerJoinVertices(graph.outDegrees) { (vid, vdata, deg) => deg.getOrElse(0) }
+          // Set the weight on the edges based on the degree
+          .mapTriplets(e => 1.0 / e.srcAttr, TripletFields.Src)
+          // Set the vertex attributes to the initial pagerank values
+          .mapVertices { (id, attr) =>
+          if (!(id != src && personalized)) 1.0 else 0.0
           }
-      }
-    }
-
-    def delta(u: VertexId, v: VertexId): Double = { if (u == v) 1.0 else 0.0 }
 
     var iteration = 0
     var prevRankGraph: Graph[Double, Double] = null
+
     while (iteration < numIter) {
       rankGraph.cache()
-
-      // Compute the outgoing rank contributions of each vertex, perform local preaggregation, and
-      // do the final aggregation at the receiving vertices. Requires a shuffle for aggregation.
-      val rankUpdates = rankGraph.aggregateMessages[Double](
-        ctx => ctx.sendToDst(ctx.srcAttr * ctx.attr), _ + _, TripletFields.Src)
-
-      // Apply the final rank updates to get the new ranks, using join to preserve ranks of vertices
-      // that didn't receive a message. Requires a shuffle for broadcasting updated ranks to the
-      // edge partitions.
       prevRankGraph = rankGraph
-      val rPrb = if (personalized) {
-        (src: VertexId, id: VertexId) => resetProb * delta(src, id)
-      } else {
-        (src: VertexId, id: VertexId) => resetProb
-      }
 
-      rankGraph = rankGraph.outerJoinVertices(rankUpdates) {
-        (id, oldRank, msgSumOpt) => rPrb(src, id) + (1.0 - resetProb) * msgSumOpt.getOrElse(0.0)
-      }.cache()
-
+      rankGraph = runUpdate(rankGraph, personalized, resetProb, src)
+      rankGraph.cache()
       rankGraph.edges.foreachPartition(x => {}) // also materializes rankGraph.vertices
       logInfo(s"PageRank finished iteration $iteration.")
+
       prevRankGraph.vertices.unpersist()
       prevRankGraph.edges.unpersist()
+      iteration += 1
+    }
 
+    // SPARK-18847 If the graph has sinks (vertices with no outgoing edges) correct the sum of ranks
+    normalizeRankSum(rankGraph, personalized)
+  }
+
+  /**
+   * Run PageRank for a fixed number of iterations returning a graph
+   * with vertex attributes containing the PageRank and edge
+   * attributes the normalized edge weight.
+   *
+   * @tparam VD the original vertex attribute (not used)
+   * @tparam ED the original edge attribute (not used)
+   *
+   * @param graph the graph on which to compute PageRank
+   * @param numIter the number of iterations of PageRank to run
+   * @param resetProb the random reset probability (alpha)
+   * @param srcId the source vertex for a Personalized Page Rank (optional)
+   * @param preRankGraph PageRank graph from which to keep iterating
+   *
+   * @return the graph containing with each vertex containing the PageRank and each edge
+   *         containing the normalized weight.
+   *
+   */
+  def runWithOptionsWithPreviousPageRank[VD: ClassTag, ED: ClassTag](
+      graph: Graph[VD, ED], numIter: Int, resetProb: Double, srcId: Option[VertexId],
+      preRankGraph: Graph[Double, Double]): Graph[Double, Double] = {
+    require(numIter > 0, s"Number of iterations must be greater than 0," +
+      s" but got ${numIter}")
+    require(resetProb >= 0 && resetProb <= 1, s"Random reset probability must belong" +
+      s" to [0, 1], but got ${resetProb}")
+    val graphVertices = graph.numVertices
+    val prePageRankVertices = preRankGraph.numVertices
+    require(graphVertices == prePageRankVertices, s"Graph and previous pageRankGraph" +
+      s" must have the same number of vertices but got ${graphVertices} and ${prePageRankVertices}")
+
+    val personalized = srcId.isDefined
+    val src: VertexId = srcId.getOrElse(-1L)
+
+    // Initialize the PageRank graph with each edge attribute having
+    // weight 1/outDegree and each vertex with attribute 1.0.
+    // When running personalized pagerank, only the source vertex
+    // has an attribute 1.0. All others are set to 0.
+    var rankGraph: Graph[Double, Double] = preRankGraph
+
+    var iteration = 0
+    var prevRankGraph: Graph[Double, Double] = null
+
+    while (iteration < numIter) {
+      rankGraph.cache()
+      prevRankGraph = rankGraph
+
+      rankGraph = runUpdate(rankGraph, personalized, resetProb, src)
+      rankGraph.cache()
+      rankGraph.edges.foreachPartition(x => {}) // also materializes rankGraph.vertices
+      logInfo(s"PageRank finished iteration $iteration.")
+
+      prevRankGraph.vertices.unpersist()
+      prevRankGraph.edges.unpersist()
       iteration += 1
     }
 

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
@@ -158,7 +158,7 @@ object PageRank extends Logging {
       // Associate the degree with each vertex
       .outerJoinVertices(graph.outDegrees) { (vid, vdata, deg) => deg.getOrElse(0) }
       // Set the weight on the edges based on the degree
-      .mapTriplets(e => 1.0 / e.srcAttr, TripletFields.Src)
+      .mapTriplets( e => 1.0 / e.srcAttr, TripletFields.Src )
       // Set the vertex attributes to the initial pagerank values
       .mapVertices { (id, attr) =>
         if (!(id != src && personalized)) 1.0 else 0.0
@@ -234,9 +234,9 @@ object PageRank extends Logging {
       rankGraph.cache()
       rankGraph.edges.foreachPartition(x => {}) // also materializes rankGraph.vertices
       logInfo(s"PageRank finished iteration $iteration.")
-
       prevRankGraph.vertices.unpersist()
       prevRankGraph.edges.unpersist()
+      
       iteration += 1
     }
 

--- a/graphx/src/test/scala/org/apache/spark/graphx/lib/PageRankSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/lib/PageRankSuite.scala
@@ -267,7 +267,6 @@ class PageRankSuite extends SparkFunSuite with LocalSparkContext {
       // In this case checkPoint does not help but it does not take more iterations
       assert(totalIters == 10)
       assert(iterAfterHalfCheckPoint == 10)
-
     }
   } // end of Grid PageRank
 
@@ -334,7 +333,6 @@ class PageRankSuite extends SparkFunSuite with LocalSparkContext {
       val ranks = VertexRDD(sc.parallelize(1L to 4L zip igraphPR))
       assert(compareRanks(staticRanks, ranks) < errorTol)
       assert(compareRanks(dynamicRanks, ranks) < errorTol)
-
     }
   }
 
@@ -352,7 +350,6 @@ class PageRankSuite extends SparkFunSuite with LocalSparkContext {
       // In this case checkPoint helps a lot
       assert(totalIters == 34)
       assert(iterAfterHalfCheckPoint == 17)
-
     }
   }
 

--- a/graphx/src/test/scala/org/apache/spark/graphx/lib/PageRankSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/lib/PageRankSuite.scala
@@ -413,7 +413,6 @@ class PageRankSuite extends SparkFunSuite with LocalSparkContext {
       // In this case checkPoint helps a lot
       assert(totalIters == 15)
       assert(iterAfterHalfCheckPoint == 9)
-
     }
   }
 }

--- a/graphx/src/test/scala/org/apache/spark/graphx/lib/PageRankSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/lib/PageRankSuite.scala
@@ -85,7 +85,7 @@ class PageRankSuite extends SparkFunSuite with LocalSparkContext {
     var iterWithCheckPoint = 1
     var staticGraphRankWithCheckPoint = graph.ops.staticPageRank(iterWithCheckPoint,
       resetProb, Some(staticGraphRankPartial)).vertices.cache()
-    while (!(compareRanks(staticGraphRankWithCheckPoint, dynamicRanks) < errorTol)) {
+    while (compareRanks(staticGraphRankWithCheckPoint, dynamicRanks) >= errorTol) {
       iterWithCheckPoint += 1
       staticGraphRankWithCheckPoint = graph.ops.staticPageRank(iterWithCheckPoint,
         resetProb, Some(staticGraphRankPartial)).vertices.cache()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add an optional parameter to the staticPageRank computation with the result of a previous PageRank computation. This would make the algorithm start from a different starting point closer to the convergence configuration


### Why are the changes needed?
https://issues.apache.org/jira/browse/SPARK-29877

It would be really helpful to have the possibility, when computing staticPageRank to use a previous computation as a checkpoint to continue the iterations.


### Does this PR introduce any user-facing change?
Yes, it allows to start the static  page Rank computation from the point where an earlier one finished.

Example: Compute 10 iteration first, and continue for 3 more iterations
```scala
val partialPageRank = graph.ops.staticPageRank(numIter=10, resetProb=0.15)
val continuationPageRank = graph.ops.staticPageRank(numIter=3,  resetProb=0.15, Some(partialPageRank))
 ```


### How was this patch tested?
Yes, some tests were added.
Testing was done as follow:
- Check how many iterations it takes for a static Page Rank computation to converge
- Run the static Page Rank computation for half of these iterations and take result as checkpoint
- Restart computation and check that number of iterations it takes to converge. It never has to be larger than the original one and in most of the cases it is much smaller.

Due to the presence of sinks and the normalization done in [[SPARK-18847]] it is not exactly equivalent to compute static page rank for 2 iterations, take the result at checkpoint and run for 2 more iterations than to compute directly for 4 iterations.

However this checkpointing can give the algorithm a hint about the true distribution of pageRanks in the graph
