### PR TITLE
[SPARK-29976][CORE] Trigger speculation for stages with too few tasks

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1464,8 +1464,9 @@ package object config {
   private[spark] val SPECULATION_TASK_DURATION_THRESHOLD =
     ConfigBuilder("spark.speculation.task.duration.threshold")
       .doc("Task duration after which scheduler would try to speculative run the task. If " +
-        "provided, tasks would be rerun as long as they exceed the threshold no matter whether" +
-        "the speculation quantile has been reached or not.")
+        "provided, tasks would be speculatively run if there are less unfinished tasks than " +
+        "the number of slots on a single executor and the task is taking longer time than " +
+        "the threshold. This config helps speculate stage with very few tasks.")
       .timeConf(TimeUnit.MILLISECONDS)
       .createOptional
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1461,6 +1461,16 @@ package object config {
       .doubleConf
       .createWithDefault(0.75)
 
+  private[spark] val SPECULATION_SINGLETASKSTAGE_ENABLED =
+    ConfigBuilder("spark.speculation.singleTaskStage.enabled")
+      .booleanConf
+      .createWithDefault(false)
+
+  private[spark] val SPECULATION_SINGLETASKSTAGE_DURATION_THRESHOLD =
+    ConfigBuilder("spark.speculation.singleTaskStage.duration.threshold")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("30min")
+
   private[spark] val STAGING_DIR = ConfigBuilder("spark.yarn.stagingDir")
     .doc("Staging directory used while submitting applications.")
     .stringConf

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1463,6 +1463,9 @@ package object config {
 
   private[spark] val SPECULATION_TASK_DURATION_THRESHOLD =
     ConfigBuilder("spark.speculation.task.duration.threshold")
+      .doc("Task duration after which scheduler would try to speculative run the task. If " +
+        "provided, tasks would be rerun as long as they exceed the threshold no matter whether" +
+        "the speculation quantile has been reached or not.")
       .timeConf(TimeUnit.MILLISECONDS)
       .createOptional
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1461,15 +1461,10 @@ package object config {
       .doubleConf
       .createWithDefault(0.75)
 
-  private[spark] val SPECULATION_SINGLETASKSTAGE_ENABLED =
-    ConfigBuilder("spark.speculation.singleTaskStage.enabled")
-      .booleanConf
-      .createWithDefault(false)
-
-  private[spark] val SPECULATION_SINGLETASKSTAGE_DURATION_THRESHOLD =
-    ConfigBuilder("spark.speculation.singleTaskStage.duration.threshold")
+  private[spark] val SPECULATION_TASK_DURATION_THRESHOLD =
+    ConfigBuilder("spark.speculation.task.duration.threshold")
       .timeConf(TimeUnit.MILLISECONDS)
-      .createWithDefaultString("30min")
+      .createOptional
 
   private[spark] val STAGING_DIR = ConfigBuilder("spark.yarn.stagingDir")
     .doc("Staging directory used while submitting applications.")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1464,9 +1464,12 @@ package object config {
   private[spark] val SPECULATION_TASK_DURATION_THRESHOLD =
     ConfigBuilder("spark.speculation.task.duration.threshold")
       .doc("Task duration after which scheduler would try to speculative run the task. If " +
-        "provided, tasks would be speculatively run if current stage contains less tasks than " +
-        "the number of slots on a single executor and the task is taking longer time than " +
-        "the threshold. This config helps speculate stage with very few tasks.")
+        "provided, tasks would be speculatively run if current stage contains less tasks " +
+        "than or equal to the number of slots on a single executor and the task is taking " +
+        "longer time than the threshold. This config helps speculate stage with very few " +
+        "tasks. Regular speculation configs may also apply if the executor slots are " +
+        "large enough. E.g. tasks might be re-launched if there are enough successful runs " +
+        "even though the threshold hasn't been reached.")
       .timeConf(TimeUnit.MILLISECONDS)
       .createOptional
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1464,7 +1464,7 @@ package object config {
   private[spark] val SPECULATION_TASK_DURATION_THRESHOLD =
     ConfigBuilder("spark.speculation.task.duration.threshold")
       .doc("Task duration after which scheduler would try to speculative run the task. If " +
-        "provided, tasks would be speculatively run if there are less unfinished tasks than " +
+        "provided, tasks would be speculatively run if current stage contains less tasks than " +
         "the number of slots on a single executor and the task is taking longer time than " +
         "the threshold. This config helps speculate stage with very few tasks.")
       .timeConf(TimeUnit.MILLISECONDS)

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -85,7 +85,7 @@ private[spark] class TaskSetManager(
   val speculationTaskDurationThresOpt = conf.get(SPECULATION_TASK_DURATION_THRESHOLD)
   // Only when unfinished tasks are less than this threshold, we would try speculative run based
   // on the time threshold. SPARK-29976: We set this value to be the max number of slots on a
-  // single executor so that we wouldn't speculate too aggressive but still handle basic cases.
+  // single executor so that we wouldn't speculate too aggressively but still handle basic cases.
   val speculationTaskNumThres = conf.get(EXECUTOR_CORES) / conf.get(CPUS_PER_TASK)
 
   // For each task, tracks whether a copy of the task has succeeded. A task will also be

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -959,6 +959,10 @@ private[spark] class TaskSetManager(
     recomputeLocality()
   }
 
+  /**
+   * Check if the task associated with the given tid has past the time threshold and should be
+   * speculative run.
+   */
   private def checkAndSubmitSpeculatableTask(
       tid: Long,
       currentTimeMillis: Long,

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -83,9 +83,10 @@ private[spark] class TaskSetManager(
   val minFinishedForSpeculation = math.max((speculationQuantile * numTasks).floor.toInt, 1)
   // User provided threshold for speculation regardless of whether the quantile has been reached
   val speculationTaskDurationThresOpt = conf.get(SPECULATION_TASK_DURATION_THRESHOLD)
-  // Only when unfinished tasks are less than this threshold, we would try speculative run based
-  // on the time threshold. SPARK-29976: We set this value to be the max number of slots on a
-  // single executor so that we wouldn't speculate too aggressively but still handle basic cases.
+  // Only when the total number of tasks in the stage is less than this threshold, we would try
+  // speculative run based on the time threshold. SPARK-29976: We set this value to be the number
+  // of slots on a single executor so that we wouldn't speculate too aggressively but still
+  // handle basic cases.
   val speculationTaskNumThres = conf.get(EXECUTOR_CORES) / conf.get(CPUS_PER_TASK)
 
   // For each task, tracks whether a copy of the task has succeeded. A task will also be
@@ -1007,7 +1008,6 @@ private[spark] class TaskSetManager(
     // `successfulTaskDurations` may not equal to `tasksSuccessful`. Here we should only count the
     // tasks that are submitted by this `TaskSetManager` and are completed successfully.
     val numSuccessfulTasks = successfulTaskDurations.size()
-    val numUnfinishedTasks = numTasks - numSuccessfulTasks
     if (numSuccessfulTasks >= minFinishedForSpeculation) {
       val time = clock.getTimeMillis()
       val medianDuration = successfulTaskDurations.median
@@ -1018,8 +1018,7 @@ private[spark] class TaskSetManager(
       for (tid <- runningTasksSet) {
         foundTasks |= checkAndSubmitSpeculatableTask(tid, time, threshold)
       }
-    } else if (speculationTaskDurationThresOpt.isDefined &&
-        numUnfinishedTasks <= speculationTaskNumThres) {
+    } else if (speculationTaskDurationThresOpt.isDefined && numTasks <= speculationTaskNumThres) {
       val time = clock.getTimeMillis()
       val threshold = speculationTaskDurationThresOpt.get
       logDebug(s"Tasks taking longer time than provided speculation threshold: $threshold")

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -87,7 +87,7 @@ private[spark] class TaskSetManager(
   // number of slots on a single executor, would the task manager speculative run the tasks if
   // their duration is longer than the given threshold. In this way, we wouldn't speculate too
   // aggressively but still handle basic cases.
-  val speculationTasksLessEqToSlots = numTasks <= (sched.CPUS_PER_TASK / conf.get(CPUS_PER_TASK))
+  val speculationTasksLessEqToSlots = numTasks <= (conf.get(EXECUTOR_CORES) / sched.CPUS_PER_TASK)
 
   // For each task, tracks whether a copy of the task has succeeded. A task will also be
   // marked as "succeeded" if it failed with a fetch failure, in which case it should not

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -1783,6 +1783,11 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
       numTasks: Int): Unit = {
     sc = new SparkContext("local", "test")
     sc.conf.set(config.SPECULATION_ENABLED, true)
+    // Set the quantile to be 1.0 so that regular speculation would not be triggered
+    sc.conf.set(config.SPECULATION_QUANTILE.key, "1.0")
+    // Set the number of slots per executor
+    sc.conf.set(config.EXECUTOR_CORES.key, "2")
+    sc.conf.set(config.CPUS_PER_TASK.key, "1")
     // Set the threshold to be 60 minutes
     if (speculationThresholdProvided) {
       sc.conf.set(config.SPECULATION_TASK_DURATION_THRESHOLD.key, "60min")

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -1780,8 +1780,6 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
 
   private def testSingleTaskSpeculation(singleTaskEnabled: Boolean): Unit = {
     sc = new SparkContext("local", "test")
-    // Set the speculation multiplier to be 0 so speculative tasks are launched immediately
-    sc.conf.set(config.SPECULATION_MULTIPLIER, 0.0)
     sc.conf.set(config.SPECULATION_ENABLED, true)
     sc.conf.set(config.SPECULATION_SINGLETASKSTAGE_ENABLED, singleTaskEnabled)
     // Set the threshold to be 60 minutes
@@ -1791,6 +1789,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     val taskSet = FakeTask.createTaskSet(1)
     val clock = new ManualClock()
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
+    manager.isZombie = false
 
     // Offer resources for the task to start
     manager.resourceOffer("exec1", "host1", NO_PREF)

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -1838,7 +1838,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
   }
 
   test("SPARK-29976 when a speculation time threshold is provided, should not speculative " +
-    "if there are too many unfinished tasks even though time threshold is provided") {
+      "if there are too many unfinished tasks even though time threshold is provided") {
     testSpeculationDurationThreshold(true, 2, 1)
   }
 

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -1819,7 +1819,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
       assert(!manager.checkSpeculatableTasks(0))
       assert(sched.speculativeTasks.size == numTasks)
     } else {
-      // If the feature flag is turned off, shouldn't do speculative run if there is only one task
+      // If the feature flag is turned off, or the stage contains too few tasks
       assert(!manager.checkSpeculatableTasks(0))
       assert(sched.speculativeTasks.size == 0)
     }
@@ -1838,7 +1838,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
   }
 
   test("SPARK-29976 when a speculation time threshold is provided, should not speculative " +
-      "if there are too many unfinished tasks even though time threshold is provided") {
+      "if there are too many tasks in the stage even though time threshold is provided") {
     testSpeculationDurationThreshold(true, 2, 1)
   }
 

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -1794,7 +1794,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
       sc.conf.set(config.SPECULATION_TASK_DURATION_THRESHOLD.key, "60min")
     }
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"))
-    // Create a task set with only one task
+    // Create a task set with the given number of tasks
     val taskSet = FakeTask.createTaskSet(numTasks)
     val clock = new ManualClock()
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
@@ -1819,7 +1819,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
       assert(!manager.checkSpeculatableTasks(0))
       assert(sched.speculativeTasks.size == numTasks)
     } else {
-      // If the feature flag is turned off, or the stage contains too few tasks
+      // If the feature flag is turned off, or the stage contains too many tasks
       assert(!manager.checkSpeculatableTasks(0))
       assert(sched.speculativeTasks.size == 0)
     }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2032,6 +2032,16 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.speculation.task.duration.threshold</code></td>
+  <td>None</td>
+  <td>
+    Task duration after which scheduler would try to speculative run the task. If provided, tasks
+    would be speculatively run if there are less unfinished tasks than the number of slots on a
+    single executor and the task is taking longer time than the threshold. This config helps
+    speculate stage with very few tasks.
+  </td>
+</tr>
+<tr>
   <td><code>spark.task.cpus</code></td>
   <td>1</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2036,9 +2036,12 @@ Apart from these, the following properties are also available, and may be useful
   <td>None</td>
   <td>
     Task duration after which scheduler would try to speculative run the task. If provided, tasks
-    would be speculatively run if current stage contains less tasks than the number of slots on a
-    single executor and the task is taking longer time than the threshold. This config helps
-    speculate stage with very few tasks.
+    would be speculatively run if current stage contains less tasks than or equal to the number of
+    slots on a single executor and the task is taking longer time than the threshold. This config
+    helps speculate stage with very few tasks. Regular speculation configs may also apply if the
+    executor slots are large enough. E.g. tasks might be re-launched if there are enough successful
+    runs even though the threshold hasn't been reached.
+    Default unit is bytes, unless otherwise specified.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2036,7 +2036,7 @@ Apart from these, the following properties are also available, and may be useful
   <td>None</td>
   <td>
     Task duration after which scheduler would try to speculative run the task. If provided, tasks
-    would be speculatively run if there are less unfinished tasks than the number of slots on a
+    would be speculatively run if current stage contains less tasks than the number of slots on a
     single executor and the task is taking longer time than the threshold. This config helps
     speculate stage with very few tasks.
   </td>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
This PR add an optional spark conf for speculation to allow speculative runs for stages where there are only a few tasks.
```
spark.speculation.task.duration.threshold
```

If provided, tasks would be speculatively run if the TaskSet contains less tasks than the number of slots on a single executor and the task is taking longer time than the threshold.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
This change helps avoid scenarios where there is single executor that could hang forever due to disk issue and we unfortunately assigned the single task in a TaskSet to that executor and cause the whole job to hang forever.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce any user-facing change?
yes. If the new config `spark.speculation.task.duration.threshold` is provided and the TaskSet contains less tasks than the number of slots on a single executor and the task is taking longer time than the threshold, then speculative tasks would be submitted for the running tasks in the TaskSet.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->


### How was this patch tested?
Unit tests are added to TaskSetManagerSuite.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
