### PR TITLE
[SPARK-29983][SQL] Add an independent config for an optional INTERVAL clause

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -53,7 +53,7 @@ grammar SqlBase;
   /**
    * When true, an INTERVAL keyword can be optional for interval values in SQL statements.
    */
-  public boolean optional_interval = false;
+  public boolean optional_interval_prefix = false;
 }
 
 singleStatement
@@ -793,7 +793,7 @@ booleanValue
 
 interval
     : INTERVAL (errorCapturingMultiUnitsInterval | errorCapturingUnitToUnitInterval)?
-    | {optional_interval}? (errorCapturingMultiUnitsInterval | errorCapturingUnitToUnitInterval)
+    | {optional_interval_prefix}? (errorCapturingMultiUnitsInterval | errorCapturingUnitToUnitInterval)
     ;
 
 errorCapturingMultiUnitsInterval

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -49,6 +49,11 @@ grammar SqlBase;
    * When true, the behavior of keywords follows ANSI SQL standard.
    */
   public boolean SQL_standard_keyword_behavior = false;
+
+  /**
+   * When true, an INTERVAL keyword can be optional for interval values in SQL statements.
+   */
+  public boolean optional_interval = false;
 }
 
 singleStatement
@@ -788,7 +793,7 @@ booleanValue
 
 interval
     : INTERVAL (errorCapturingMultiUnitsInterval | errorCapturingUnitToUnitInterval)?
-    | {SQL_standard_keyword_behavior}? (errorCapturingMultiUnitsInterval | errorCapturingUnitToUnitInterval)
+    | {optional_interval}? (errorCapturingMultiUnitsInterval | errorCapturingUnitToUnitInterval)
     ;
 
 errorCapturingMultiUnitsInterval

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
@@ -101,6 +101,7 @@ abstract class AbstractSqlParser(conf: SQLConf) extends ParserInterface with Log
     lexer.addErrorListener(ParseErrorListener)
     lexer.legacy_setops_precedence_enbled = conf.setOpsPrecedenceEnforced
     lexer.SQL_standard_keyword_behavior = SQLStandardKeywordBehavior
+    lexer.optional_interval = conf.optionalInterval
 
     val tokenStream = new CommonTokenStream(lexer)
     val parser = new SqlBaseParser(tokenStream)
@@ -109,6 +110,7 @@ abstract class AbstractSqlParser(conf: SQLConf) extends ParserInterface with Log
     parser.addErrorListener(ParseErrorListener)
     parser.legacy_setops_precedence_enbled = conf.setOpsPrecedenceEnforced
     parser.SQL_standard_keyword_behavior = SQLStandardKeywordBehavior
+    parser.optional_interval = conf.optionalInterval
 
     try {
       try {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1788,7 +1788,7 @@ object SQLConf {
   }
 
   val OPTIONAL_INTERVAL =
-    buildConf("spark.sql.optionalInterval")
+    buildConf("spark.sql.parser.optionalInterval")
       .doc("When true, an INTERVAL keyword can be optional for interval values in SQL statements," +
         " e.g., 'SELECT 1 day'.")
       .booleanConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1787,6 +1787,13 @@ object SQLConf {
     val SQL_STANDARD, ISO_8601, MULTI_UNITS = Value
   }
 
+  val OPTIONAL_INTERVAL =
+    buildConf("spark.sql.optionalInterval")
+      .doc("When true, an INTERVAL keyword can be optional for interval values in SQL statements," +
+        " e.g., 'SELECT 1 day'.")
+      .booleanConf
+      .createWithDefault(false)
+
   val INTERVAL_STYLE = buildConf("spark.sql.intervalOutputStyle")
     .doc("When converting interval values to strings (i.e. for display), this config decides the" +
       " interval string format. The value SQL_STANDARD will produce output matching SQL standard" +
@@ -2512,6 +2519,8 @@ class SQLConf extends Serializable with Logging {
 
   def storeAssignmentPolicy: StoreAssignmentPolicy.Value =
     StoreAssignmentPolicy.withName(getConf(STORE_ASSIGNMENT_POLICY))
+
+  def optionalInterval: Boolean = getConf(OPTIONAL_INTERVAL)
 
   def intervalOutputStyle: IntervalStyle.Value = IntervalStyle.withName(getConf(INTERVAL_STYLE))
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1787,8 +1787,8 @@ object SQLConf {
     val SQL_STANDARD, ISO_8601, MULTI_UNITS = Value
   }
 
-  val OPTIONAL_INTERVAL =
-    buildConf("spark.sql.parser.optionalInterval")
+  val OPTIONAL_INTERVAL_PREFIX =
+    buildConf("spark.sql.parser.optionalIntervalPrefix")
       .doc("When true, an INTERVAL keyword can be optional for interval values in SQL statements," +
         " e.g., 'SELECT 1 day'.")
       .booleanConf
@@ -2520,7 +2520,7 @@ class SQLConf extends Serializable with Logging {
   def storeAssignmentPolicy: StoreAssignmentPolicy.Value =
     StoreAssignmentPolicy.withName(getConf(STORE_ASSIGNMENT_POLICY))
 
-  def optionalInterval: Boolean = getConf(OPTIONAL_INTERVAL)
+  def optionalIntervalPrefix: Boolean = getConf(OPTIONAL_INTERVAL_PREFIX)
 
   def intervalOutputStyle: IntervalStyle.Value = IntervalStyle.withName(getConf(INTERVAL_STYLE))
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -615,8 +615,8 @@ class ExpressionParserSuite extends AnalysisTest {
       ).foreach { case (sign, expectedLiteral) =>
         assertEqual(s"${sign}interval $intervalValue", expectedLiteral)
 
-        // SPARK-23264 Support interval values without INTERVAL clauses if ANSI SQL enabled
-        withSQLConf(SQLConf.DIALECT_SPARK_ANSI_ENABLED.key -> "true") {
+        // Checks if we can make INTERVAL optional
+        withSQLConf(SQLConf.OPTIONAL_INTERVAL.key -> "true") {
           assertEqual(intervalValue, expected)
         }
       }
@@ -703,12 +703,12 @@ class ExpressionParserSuite extends AnalysisTest {
 
   test("SPARK-23264 Interval Compatibility tests") {
     def checkIntervals(intervalValue: String, expected: Literal): Unit = {
-      withSQLConf(SQLConf.DIALECT_SPARK_ANSI_ENABLED.key -> "true") {
+      withSQLConf(SQLConf.OPTIONAL_INTERVAL.key -> "true") {
         assertEqual(intervalValue, expected)
       }
 
       // Compatibility tests: If ANSI SQL disabled, `intervalValue` should be parsed as an alias
-      withSQLConf(SQLConf.DIALECT_SPARK_ANSI_ENABLED.key -> "false") {
+      withSQLConf(SQLConf.OPTIONAL_INTERVAL.key -> "false") {
         val aliases = defaultParser.parseExpression(intervalValue).collect {
           case a @ Alias(_: Literal, name)
             if intervalUnits.exists { unit => name.startsWith(unit.toString) } => a

--- a/sql/core/src/test/resources/sql-tests/inputs/ansi/interval.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/ansi/interval.sql
@@ -1,4 +1,4 @@
---SET spark.sql.optionalInterval=true
+--SET spark.sql.parser.optionalInterval=true
 --IMPORT interval.sql
 
 -- the `interval` keyword can be omitted with ansi mode

--- a/sql/core/src/test/resources/sql-tests/inputs/ansi/interval.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/ansi/interval.sql
@@ -1,3 +1,4 @@
+--SET spark.sql.optionalInterval=true
 --IMPORT interval.sql
 
 -- the `interval` keyword can be omitted with ansi mode

--- a/sql/core/src/test/resources/sql-tests/inputs/ansi/interval.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/ansi/interval.sql
@@ -1,18 +1,6 @@
---SET spark.sql.parser.optionalInterval=true
+--SET spark.sql.parser.optionalIntervalPrefix=false
 --IMPORT interval.sql
 
--- the `interval` keyword can be omitted with ansi mode
-select 1 year 2 days;
-select '10-9' year to month;
-select '20 15:40:32.99899999' day to second;
-select 30 day day;
-select date'2012-01-01' - '2-2' year to month;
-select 1 month - 1 day;
-
--- malformed interval literal with ansi mode
-select 1 year to month;
-select '1' year to second;
-select 1 year '2-1' year to month;
-select (-30) day;
-select (a + 1) day;
-select 30 day day day;
+-- Cannot make INTERVAL keywords optional with the ANSI mode enabled and
+-- `spark.sql.parser.optionalIntervalPrefix=false`.
+--IMPORT ansi/optional-interval.sql

--- a/sql/core/src/test/resources/sql-tests/inputs/ansi/optional-interval.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/ansi/optional-interval.sql
@@ -1,0 +1,20 @@
+--SET spark.sql.parser.optionalIntervalPrefix=true
+--IMPORT interval.sql
+
+-- the `interval` keyword can be omitted with ansi mode enabled and
+-- `spark.sql.parser.optionalIntervalPrefix=true`.
+select 1 year 2 days;
+select '10-9' year to month;
+select '20 15:40:32.99899999' day to second;
+select 30 day day;
+select date'2012-01-01' - '2-2' year to month;
+select 1 month - 1 day;
+
+-- malformed interval literal with ansi mode enabled and
+-- `spark.sql.parser.optionalIntervalPrefix=true`.
+select 1 year to month;
+select '1' year to second;
+select 1 year '2-1' year to month;
+select (-30) day;
+select (a + 1) day;
+select 30 day day day;

--- a/sql/core/src/test/resources/sql-tests/results/ansi/optional-interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/optional-interval.sql.out
@@ -1118,43 +1118,25 @@ struct<(INTERVAL '99 days 11 hours 22 minutes 33.123456 seconds' + INTERVAL '10 
 -- !query 118
 select 1 year 2 days
 -- !query 118 schema
-struct<>
+struct<INTERVAL '1 years 2 days':interval>
 -- !query 118 output
-org.apache.spark.sql.catalyst.parser.ParseException
-
-no viable alternative at input '1'(line 1, pos 7)
-
-== SQL ==
-select 1 year 2 days
--------^^^
+1 years 2 days
 
 
 -- !query 119
 select '10-9' year to month
 -- !query 119 schema
-struct<>
+struct<INTERVAL '10 years 9 months':interval>
 -- !query 119 output
-org.apache.spark.sql.catalyst.parser.ParseException
-
-no viable alternative at input ''10-9''(line 1, pos 7)
-
-== SQL ==
-select '10-9' year to month
--------^^^
+10 years 9 months
 
 
 -- !query 120
 select '20 15:40:32.99899999' day to second
 -- !query 120 schema
-struct<>
+struct<INTERVAL '20 days 15 hours 40 minutes 32.998999 seconds':interval>
 -- !query 120 output
-org.apache.spark.sql.catalyst.parser.ParseException
-
-no viable alternative at input ''20 15:40:32.99899999''(line 1, pos 7)
-
-== SQL ==
-select '20 15:40:32.99899999' day to second
--------^^^
+20 days 15 hours 40 minutes 32.998999 seconds
 
 
 -- !query 121
@@ -1164,39 +1146,27 @@ struct<>
 -- !query 121 output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-no viable alternative at input '30'(line 1, pos 7)
+no viable alternative at input 'day'(line 1, pos 14)
 
 == SQL ==
 select 30 day day
--------^^^
+--------------^^^
 
 
 -- !query 122
 select date'2012-01-01' - '2-2' year to month
 -- !query 122 schema
-struct<>
+struct<CAST(CAST(DATE '2012-01-01' AS TIMESTAMP) - INTERVAL '2 years 2 months' AS DATE):date>
 -- !query 122 output
-org.apache.spark.sql.catalyst.parser.ParseException
-
-no viable alternative at input ''2-2''(line 1, pos 26)
-
-== SQL ==
-select date'2012-01-01' - '2-2' year to month
---------------------------^^^
+2009-11-01
 
 
 -- !query 123
 select 1 month - 1 day
 -- !query 123 schema
-struct<>
+struct<INTERVAL '1 months -1 days':interval>
 -- !query 123 output
-org.apache.spark.sql.catalyst.parser.ParseException
-
-no viable alternative at input '1'(line 1, pos 7)
-
-== SQL ==
-select 1 month - 1 day
--------^^^
+1 months -1 days
 
 
 -- !query 124
@@ -1206,7 +1176,7 @@ struct<>
 -- !query 124 output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-no viable alternative at input '1'(line 1, pos 7)
+The value of from-to unit must be a string(line 1, pos 7)
 
 == SQL ==
 select 1 year to month
@@ -1220,7 +1190,7 @@ struct<>
 -- !query 125 output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-no viable alternative at input ''1''(line 1, pos 7)
+Intervals FROM year TO second are not supported.(line 1, pos 7)
 
 == SQL ==
 select '1' year to second
@@ -1234,11 +1204,11 @@ struct<>
 -- !query 126 output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-no viable alternative at input '1'(line 1, pos 7)
+Can only have a single from-to unit in the interval literal syntax(line 1, pos 14)
 
 == SQL ==
 select 1 year '2-1' year to month
--------^^^
+--------------^^^
 
 
 -- !query 127
@@ -1276,8 +1246,8 @@ struct<>
 -- !query 129 output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-no viable alternative at input '30'(line 1, pos 7)
+no viable alternative at input 'day'(line 1, pos 14)
 
 == SQL ==
 select 30 day day day
--------^^^
+--------------^^^

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -255,8 +255,8 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession {
 
     // If `--IMPORT` found, load code from another test case file, then insert them
     // into the head in this test.
-    val importedTestCaseName = comments.filter(_.startsWith("--IMPORT ")).map(_.substring(9))
-    val importedCode = importedTestCaseName.flatMap { testCaseName =>
+    val importedTestCaseNames = comments.filter(_.startsWith("--IMPORT ")).map(_.substring(9))
+    val importedCode = importedTestCaseNames.flatMap { testCaseName =>
       listTestCases.find(_.name == testCaseName).map { testCase =>
         val input = fileToString(new File(testCase.inputFile))
         val (_, code) = input.split("\n").partition(_.trim.startsWith("--"))
@@ -277,7 +277,7 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession {
     // When we use '--SET' and '--IMPORT' together for those import queries, we want to run the
     // same queries from the original file but with different settings and save the answers. So the
     // `--SET` will be respected in this case.
-    if ((regenerateGoldenFiles && importedTestCaseName.isEmpty) || !isTestWithConfigSets) {
+    if ((regenerateGoldenFiles && importedTestCaseNames.isEmpty) || !isTestWithConfigSets) {
       runQueries(queries, testCase, None)
     } else {
       val configSets = {

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerQueryTestSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerQueryTestSuite.scala
@@ -106,7 +106,8 @@ class ThriftServerQueryTestSuite extends SQLQueryTestSuite {
     "subquery/in-subquery/in-set-operations.sql",
     // SPARK-29783: need to set conf
     "interval-display-iso_8601.sql",
-    "interval-display-sql_standard.sql"
+    "interval-display-sql_standard.sql",
+    "ansi/optional-interval.sql"
   )
 
   override def runQueries(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This pr is to add a new config only for an optional INTERVAL clause. In the master, this feature is enabled when `spark.sql.ansi.enabled`=true. This pr proposes to split off the optional interval flag from `spark.sql.ansi.enabled`.

This comes from the @cloud-fan suggestion: https://github.com/apache/spark/pull/26584#discussion_r347939499

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Actually, an INTERVAL keyword is not optional in the ANSI/SQL standard.
```
<interval literal> ::=
  INTERVAL [ <sign> ] <interval string> <interval qualifier>

<interval string> ::=
  <quote> <unquoted interval string> <quote>
```

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
No.