### PR TITLE
[SPARK-8981][CORE][test-hadoop3.2][test-java11] Add MDC support in Executor 

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -322,10 +322,11 @@ private[spark] class Executor(
     val taskId = taskDescription.taskId
     val threadName = s"Executor task launch worker for task $taskId"
     val taskName = taskDescription.name
-    val mdcProperties = taskDescription.properties.asScala.filter(_._1.startsWith("mdc.")).map { item =>
-      val key = item._1.substring(4)
-      (key, item._2)
-    }.toMap
+    val mdcProperties = taskDescription.properties.asScala
+      .filter(_._1.startsWith("mdc.")).map { item =>
+        val key = item._1.substring(4)
+        (key, item._2)
+      }.toMap
 
     /** If specified, this task has been killed and this option contains the reason. */
     @volatile private var reasonIfKilled: Option[String] = None

--- a/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
@@ -134,14 +134,6 @@ private[spark] object ThreadUtils {
   }
 
   /**
-   * Wrapper over newCachedThreadPool. Thread names are formatted as prefix-ID, where ID is a
-   * unique, sequentially assigned integer.
-   */
-  def newCachedThreadPool(threadFactory: ThreadFactory): ThreadPoolExecutor = {
-    Executors.newCachedThreadPool(threadFactory).asInstanceOf[ThreadPoolExecutor]
-  }
-
-  /**
    * Create a cached thread pool whose max number of threads is `maxThreadNumber`. Thread names
    * are formatted as prefix-ID, where ID is a unique, sequentially assigned integer.
    */

--- a/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.util
 
-import java.util
 import java.util.concurrent._
 import java.util.concurrent.{Future => JFuture}
 import java.util.concurrent.locks.ReentrantLock
@@ -32,99 +31,6 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder
 import org.apache.spark.SparkException
 
 private[spark] object ThreadUtils {
-
-  object MDCAwareThreadPoolExecutor {
-    def newCachedThreadPool(threadFactory: ThreadFactory): ThreadPoolExecutor = {
-      // The values needs to be synced with `Executors.newCachedThreadPool`
-      new MDCAwareThreadPoolExecutor(
-        0,
-        Integer.MAX_VALUE,
-        60L,
-        TimeUnit.SECONDS,
-        new SynchronousQueue[Runnable],
-        threadFactory)
-    }
-
-    def newFixedThreadPool(nThreads: Int, threadFactory: ThreadFactory): ThreadPoolExecutor = {
-      // The values needs to be synced with `Executors.newFixedThreadPool`
-      new MDCAwareThreadPoolExecutor(
-        nThreads,
-        nThreads,
-        0L,
-        TimeUnit.MILLISECONDS,
-        new LinkedBlockingQueue[Runnable],
-        threadFactory)
-    }
-
-    /**
-     * This method differ from the `java.util.concurrent.Executors#newSingleThreadExecutor` in
-     * 2 ways:
-     *   1. It use `org.apache.spark.util.ThreadUtils.MDCAwareThreadPoolExecutor`
-     *   as underline `java.util.concurrent.ExecutorService`
-     *   2. It does not use the
-     *   `java.util.concurrent.Executors#FinalizableDelegatedExecutorService` from JDK
-     */
-    def newSingleThreadExecutor(threadFactory: ThreadFactory): ExecutorService = {
-      // The values needs to be synced with `Executors.newSingleThreadExecutor`
-      Executors.unconfigurableExecutorService(
-        new MDCAwareThreadPoolExecutor(
-          1,
-          1,
-          0L,
-          TimeUnit.MILLISECONDS,
-          new LinkedBlockingQueue[Runnable],
-          threadFactory)
-        )
-    }
-
-  }
-
-  class MDCAwareRunnable(proxy: Runnable) extends Runnable {
-    val callerThreadMDC: util.Map[String, String] = getMDCMap
-
-    @inline
-    private def getMDCMap: util.Map[String, String] = {
-      org.slf4j.MDC.getCopyOfContextMap match {
-        case null => new util.HashMap[String, String]()
-        case m => m
-      }
-    }
-
-    override def run(): Unit = {
-      val threadMDC = getMDCMap
-      org.slf4j.MDC.setContextMap(callerThreadMDC)
-      try {
-        proxy.run()
-      } finally {
-        org.slf4j.MDC.setContextMap(threadMDC)
-      }
-    }
-  }
-
-  class MDCAwareScheduledThreadPoolExecutor(
-      corePoolSize: Int,
-      threadFactory: ThreadFactory)
-    extends ScheduledThreadPoolExecutor(corePoolSize, threadFactory) {
-
-    override def execute(runnable: Runnable) {
-      super.execute(new MDCAwareRunnable(runnable))
-    }
-  }
-
-  class MDCAwareThreadPoolExecutor(
-      corePoolSize: Int,
-      maximumPoolSize: Int,
-      keepAliveTime: Long,
-      unit: TimeUnit,
-      workQueue: BlockingQueue[Runnable],
-      threadFactory: ThreadFactory)
-    extends ThreadPoolExecutor(corePoolSize, maximumPoolSize,
-      keepAliveTime, unit, workQueue, threadFactory) {
-
-    override def execute(runnable: Runnable) {
-      super.execute(new MDCAwareRunnable(runnable))
-    }
-  }
 
   private val sameThreadExecutionContext =
     ExecutionContext.fromExecutorService(sameThreadExecutorService())
@@ -224,15 +130,7 @@ private[spark] object ThreadUtils {
    */
   def newDaemonCachedThreadPool(prefix: String): ThreadPoolExecutor = {
     val threadFactory = namedThreadFactory(prefix)
-    MDCAwareThreadPoolExecutor.newCachedThreadPool(threadFactory)
-  }
-
-  /**
-   * Wrapper over newCachedThreadPool. Thread names are formatted as prefix-ID, where ID is a
-   * unique, sequentially assigned integer.
-   */
-  def newCachedThreadPool(threadFactory: ThreadFactory): ThreadPoolExecutor = {
-    MDCAwareThreadPoolExecutor.newCachedThreadPool(threadFactory)
+    Executors.newCachedThreadPool(threadFactory).asInstanceOf[ThreadPoolExecutor]
   }
 
   /**
@@ -242,7 +140,7 @@ private[spark] object ThreadUtils {
   def newDaemonCachedThreadPool(
       prefix: String, maxThreadNumber: Int, keepAliveSeconds: Int = 60): ThreadPoolExecutor = {
     val threadFactory = namedThreadFactory(prefix)
-    val threadPool = new MDCAwareThreadPoolExecutor(
+    val threadPool = new ThreadPoolExecutor(
       maxThreadNumber, // corePoolSize: the max number of threads to create before queuing the tasks
       maxThreadNumber, // maximumPoolSize: because we use LinkedBlockingDeque, this one is not used
       keepAliveSeconds,
@@ -267,7 +165,7 @@ private[spark] object ThreadUtils {
    */
   def newDaemonSingleThreadExecutor(threadName: String): ExecutorService = {
     val threadFactory = new ThreadFactoryBuilder().setDaemon(true).setNameFormat(threadName).build()
-    MDCAwareThreadPoolExecutor.newSingleThreadExecutor(threadFactory)
+    Executors.newSingleThreadExecutor(threadFactory)
   }
 
   /**
@@ -275,7 +173,7 @@ private[spark] object ThreadUtils {
    */
   def newDaemonSingleThreadScheduledExecutor(threadName: String): ScheduledExecutorService = {
     val threadFactory = new ThreadFactoryBuilder().setDaemon(true).setNameFormat(threadName).build()
-    val executor = new MDCAwareScheduledThreadPoolExecutor(1, threadFactory)
+    val executor = new ScheduledThreadPoolExecutor(1, threadFactory)
     // By default, a cancelled task is not automatically removed from the work queue until its delay
     // elapses. We have to enable it manually.
     executor.setRemoveOnCancelPolicy(true)
@@ -291,7 +189,7 @@ private[spark] object ThreadUtils {
       .setDaemon(true)
       .setNameFormat(s"$threadNamePrefix-%d")
       .build()
-    val executor = new MDCAwareScheduledThreadPoolExecutor(numThreads, threadFactory)
+    val executor = new ScheduledThreadPoolExecutor(numThreads, threadFactory)
     // By default, a cancelled task is not automatically removed from the work queue until its delay
     // elapses. We have to enable it manually.
     executor.setRemoveOnCancelPolicy(true)

--- a/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
@@ -259,7 +259,7 @@ private[spark] object ThreadUtils {
    */
   def newDaemonFixedThreadPool(nThreads: Int, prefix: String): ThreadPoolExecutor = {
     val threadFactory = namedThreadFactory(prefix)
-    MDCAwareThreadPoolExecutor.newFixedThreadPool(nThreads, threadFactory)
+    Executors.newFixedThreadPool(nThreads, threadFactory).asInstanceOf[ThreadPoolExecutor]
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
@@ -134,6 +134,14 @@ private[spark] object ThreadUtils {
   }
 
   /**
+   * Wrapper over newCachedThreadPool. Thread names are formatted as prefix-ID, where ID is a
+   * unique, sequentially assigned integer.
+   */
+  def newCachedThreadPool(threadFactory: ThreadFactory): ThreadPoolExecutor = {
+    Executors.newCachedThreadPool(threadFactory).asInstanceOf[ThreadPoolExecutor]
+  }
+
+  /**
    * Create a cached thread pool whose max number of threads is `maxThreadNumber`. Thread names
    * are formatted as prefix-ID, where ID is a unique, sequentially assigned integer.
    */

--- a/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.util
 
+import java.util
 import java.util.concurrent._
 import java.util.concurrent.{Future => JFuture}
 import java.util.concurrent.locks.ReentrantLock
@@ -31,6 +32,99 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder
 import org.apache.spark.SparkException
 
 private[spark] object ThreadUtils {
+
+  object MDCAwareThreadPoolExecutor {
+    def newCachedThreadPool(threadFactory: ThreadFactory): ThreadPoolExecutor = {
+      // The values needs to be synced with `Executors.newCachedThreadPool`
+      new MDCAwareThreadPoolExecutor(
+        0,
+        Integer.MAX_VALUE,
+        60L,
+        TimeUnit.SECONDS,
+        new SynchronousQueue[Runnable],
+        threadFactory)
+    }
+
+    def newFixedThreadPool(nThreads: Int, threadFactory: ThreadFactory): ThreadPoolExecutor = {
+      // The values needs to be synced with `Executors.newFixedThreadPool`
+      new MDCAwareThreadPoolExecutor(
+        nThreads,
+        nThreads,
+        0L,
+        TimeUnit.MILLISECONDS,
+        new LinkedBlockingQueue[Runnable],
+        threadFactory)
+    }
+
+    /**
+     * This method differ from the `java.util.concurrent.Executors#newSingleThreadExecutor` in
+     * 2 ways:
+     *   1. It use `org.apache.spark.util.ThreadUtils.MDCAwareThreadPoolExecutor`
+     *   as underline `java.util.concurrent.ExecutorService`
+     *   2. It does not use the
+     *   `java.util.concurrent.Executors#FinalizableDelegatedExecutorService` from JDK
+     */
+    def newSingleThreadExecutor(threadFactory: ThreadFactory): ExecutorService = {
+      // The values needs to be synced with `Executors.newSingleThreadExecutor`
+      Executors.unconfigurableExecutorService(
+        new MDCAwareThreadPoolExecutor(
+          1,
+          1,
+          0L,
+          TimeUnit.MILLISECONDS,
+          new LinkedBlockingQueue[Runnable],
+          threadFactory)
+        )
+    }
+
+  }
+
+  class MDCAwareRunnable(proxy: Runnable) extends Runnable {
+    val callerThreadMDC: util.Map[String, String] = getMDCMap
+
+    @inline
+    private def getMDCMap: util.Map[String, String] = {
+      org.slf4j.MDC.getCopyOfContextMap match {
+        case null => new util.HashMap[String, String]()
+        case m => m
+      }
+    }
+
+    override def run(): Unit = {
+      val threadMDC = getMDCMap
+      org.slf4j.MDC.setContextMap(callerThreadMDC)
+      try {
+        proxy.run()
+      } finally {
+        org.slf4j.MDC.setContextMap(threadMDC)
+      }
+    }
+  }
+
+  class MDCAwareScheduledThreadPoolExecutor(
+      corePoolSize: Int,
+      threadFactory: ThreadFactory)
+    extends ScheduledThreadPoolExecutor(corePoolSize, threadFactory) {
+
+    override def execute(runnable: Runnable) {
+      super.execute(new MDCAwareRunnable(runnable))
+    }
+  }
+
+  class MDCAwareThreadPoolExecutor(
+      corePoolSize: Int,
+      maximumPoolSize: Int,
+      keepAliveTime: Long,
+      unit: TimeUnit,
+      workQueue: BlockingQueue[Runnable],
+      threadFactory: ThreadFactory)
+    extends ThreadPoolExecutor(corePoolSize, maximumPoolSize,
+      keepAliveTime, unit, workQueue, threadFactory) {
+
+    override def execute(runnable: Runnable) {
+      super.execute(new MDCAwareRunnable(runnable))
+    }
+  }
 
   private val sameThreadExecutionContext =
     ExecutionContext.fromExecutorService(sameThreadExecutorService())
@@ -130,7 +224,15 @@ private[spark] object ThreadUtils {
    */
   def newDaemonCachedThreadPool(prefix: String): ThreadPoolExecutor = {
     val threadFactory = namedThreadFactory(prefix)
-    Executors.newCachedThreadPool(threadFactory).asInstanceOf[ThreadPoolExecutor]
+    MDCAwareThreadPoolExecutor.newCachedThreadPool(threadFactory)
+  }
+
+  /**
+   * Wrapper over newCachedThreadPool. Thread names are formatted as prefix-ID, where ID is a
+   * unique, sequentially assigned integer.
+   */
+  def newCachedThreadPool(threadFactory: ThreadFactory): ThreadPoolExecutor = {
+    MDCAwareThreadPoolExecutor.newCachedThreadPool(threadFactory)
   }
 
   /**
@@ -140,7 +242,7 @@ private[spark] object ThreadUtils {
   def newDaemonCachedThreadPool(
       prefix: String, maxThreadNumber: Int, keepAliveSeconds: Int = 60): ThreadPoolExecutor = {
     val threadFactory = namedThreadFactory(prefix)
-    val threadPool = new ThreadPoolExecutor(
+    val threadPool = new MDCAwareThreadPoolExecutor(
       maxThreadNumber, // corePoolSize: the max number of threads to create before queuing the tasks
       maxThreadNumber, // maximumPoolSize: because we use LinkedBlockingDeque, this one is not used
       keepAliveSeconds,
@@ -157,7 +259,7 @@ private[spark] object ThreadUtils {
    */
   def newDaemonFixedThreadPool(nThreads: Int, prefix: String): ThreadPoolExecutor = {
     val threadFactory = namedThreadFactory(prefix)
-    Executors.newFixedThreadPool(nThreads, threadFactory).asInstanceOf[ThreadPoolExecutor]
+    MDCAwareThreadPoolExecutor.newFixedThreadPool(nThreads, threadFactory)
   }
 
   /**
@@ -165,7 +267,7 @@ private[spark] object ThreadUtils {
    */
   def newDaemonSingleThreadExecutor(threadName: String): ExecutorService = {
     val threadFactory = new ThreadFactoryBuilder().setDaemon(true).setNameFormat(threadName).build()
-    Executors.newSingleThreadExecutor(threadFactory)
+    MDCAwareThreadPoolExecutor.newSingleThreadExecutor(threadFactory)
   }
 
   /**
@@ -173,7 +275,7 @@ private[spark] object ThreadUtils {
    */
   def newDaemonSingleThreadScheduledExecutor(threadName: String): ScheduledExecutorService = {
     val threadFactory = new ThreadFactoryBuilder().setDaemon(true).setNameFormat(threadName).build()
-    val executor = new ScheduledThreadPoolExecutor(1, threadFactory)
+    val executor = new MDCAwareScheduledThreadPoolExecutor(1, threadFactory)
     // By default, a cancelled task is not automatically removed from the work queue until its delay
     // elapses. We have to enable it manually.
     executor.setRemoveOnCancelPolicy(true)
@@ -189,7 +291,7 @@ private[spark] object ThreadUtils {
       .setDaemon(true)
       .setNameFormat(s"$threadNamePrefix-%d")
       .build()
-    val executor = new ScheduledThreadPoolExecutor(numThreads, threadFactory)
+    val executor = new MDCAwareScheduledThreadPoolExecutor(numThreads, threadFactory)
     // By default, a cancelled task is not automatically removed from the work queue until its delay
     // elapses. We have to enable it manually.
     executor.setRemoveOnCancelPolicy(true)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2955,7 +2955,7 @@ Spark uses [log4j](http://logging.apache.org/log4j/) for logging. You can config
 `log4j.properties` file in the `conf` directory. One way to start is to copy the existing
 `log4j.properties.template` located there.
 
-By default, Spark adds 1 record to the MDC: `taskName`, which shows something
+By default, Spark adds 1 record to the MDC (Mapped Diagnostic Context): `taskName`, which shows something
 like `task 1.0 in stage 0.0`. You can add `%X{taskName}` to your patternLayout in
 order to print it in the logs.
 Moreover, you can use `spark.sparkContext.setLocalProperty("mdc." + name, "value")` to add user specific data into MDC.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2955,6 +2955,12 @@ Spark uses [log4j](http://logging.apache.org/log4j/) for logging. You can config
 `log4j.properties` file in the `conf` directory. One way to start is to copy the existing
 `log4j.properties.template` located there.
 
+By default, Spark adds 1 record to the MDC: `taskName`, which shows something
+like `task 1.0 in stage 0.0`. You can add `%X{taskName}` to your patternLayout in
+order to print it in the logs.
+Moreover, you can use `spark.sparkContext.setLocalProperty("mdc." + name, "value")` to add user specific data into MDC.
+The key in MDC will be the string after the `mdc.` prefix.
+
 # Overriding configuration directory
 
 To specify a different configuration directory other than the default "SPARK_HOME/conf",


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added MDC support in all thread pools.
ThreaddUtils create new pools that pass over MDC.

### Why are the changes needed?
In many cases, it is very hard to understand from which actions the logs in the executor come from.
when you are doing multi-thread work in the driver and send actions in parallel.

### Does this PR introduce any user-facing change?
No


### How was this patch tested?
No test added because no new functionality added it is thread pull change and all current tests pass. 
