### PR TITLE
[SPARK-29768][SQL] Column pruning through nondeterministic expressions 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -97,7 +97,7 @@ object PhysicalOperation extends OperationHelper with PredicateHelper {
     }
 }
 
-object FileSourceOperation extends OperationHelper with PredicateHelper {
+object ScanOperation extends OperationHelper with PredicateHelper {
 
   private val invalid: LogicalPlan => (Option[Seq[NamedExpression]], Seq[Expression],
     LogicalPlan, Boolean, AttributeMap[Expression]) =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -114,8 +114,9 @@ object ScanOperation extends OperationHelper with PredicateHelper {
     }
   }
 
-  private def hasCommonNonDeterministic(expr: Seq[Expression], aliases: AttributeMap[Expression])
-    : Boolean = {
+  private def hasCommonNonDeterministic(
+      expr: Seq[Expression],
+      aliases: AttributeMap[Expression]): Boolean = {
     expr.exists(_.collect {
       case a: AttributeReference if aliases.contains(a) => aliases(a)
     }.exists(!_.deterministic))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -104,6 +104,8 @@ object PhysicalOperation extends OperationHelper with PredicateHelper {
  * will return immediately.
  */
 object ScanOperation extends OperationHelper with PredicateHelper {
+  type ScanReturnType = Option[(Option[Seq[NamedExpression]],
+    Seq[Expression], LogicalPlan, AttributeMap[Expression])]
 
   def unapply(plan: LogicalPlan): Option[ReturnType] = {
     collectProjectsAndFilters(plan) match {
@@ -123,9 +125,7 @@ object ScanOperation extends OperationHelper with PredicateHelper {
     }.exists(!_.deterministic))
   }
 
-  private def collectProjectsAndFilters(plan: LogicalPlan)
-    : Option[(Option[Seq[NamedExpression]], Seq[Expression], LogicalPlan,
-    AttributeMap[Expression])] =
+  private def collectProjectsAndFilters(plan: LogicalPlan): ScanReturnType =
       plan match {
         case Project(fields, child) =>
           collectProjectsAndFilters(child) match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -117,10 +117,7 @@ object ScanOperation extends OperationHelper with PredicateHelper {
   private def hasCommonNonDeterministic(expr: Seq[Expression], aliases: AttributeMap[Expression])
     : Boolean = {
     expr.exists(_.collect {
-      case Alias(ref: AttributeReference, _) if aliases.contains(ref) =>
-        aliases(ref)
-      case a: AttributeReference if aliases.contains(a) =>
-        aliases(a)
+      case a: AttributeReference if aliases.contains(a) => aliases(a)
     }.exists(!_.deterministic))
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -114,7 +114,7 @@ object ScanOperation extends OperationHelper with PredicateHelper {
         case Project(fields, child) =>
           collectProjectsAndFilters(child) match {
             case Some((_, filters, other, aliases)) =>
-              val hasCommonNonDeterministic = filters.exists(_.collect {
+              val hasCommonNonDeterministic = fields.exists(_.collect {
                 case Alias(ref: AttributeReference, _) if aliases.contains(ref) =>
                   aliases(ref)
                 case a: AttributeReference if aliases.contains(a) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans._
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, _}
+import org.apache.spark.sql.catalyst.plans.logical._
 
 trait OperationHelper {
   type ReturnType = (Seq[NamedExpression], Seq[Expression], LogicalPlan)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -143,7 +143,8 @@ object ScanOperation extends OperationHelper with PredicateHelper {
         case Filter(condition, child) =>
           collectProjectsAndFilters(child) match {
             case Some((fields, filters, other, aliases)) =>
-              if (condition.deterministic && !hasCommonNonDeterministic(Seq(condition), aliases)) {
+              if (filters.forall(_.deterministic) &&
+                !hasCommonNonDeterministic(Seq(condition), aliases)) {
                 val substitutedCondition = substitute(aliases)(condition)
                 Some((fields, filters ++ splitConjunctivePredicates(substitutedCondition),
                   other, aliases))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -98,10 +98,9 @@ object PhysicalOperation extends OperationHelper with PredicateHelper {
 }
 
 /**
- * Unlike PhysicalOperation, this operation would firstly search the first non-Project
- * and non-Filter LogicalPlan without non-deterministic expression check and then do that
- * check when it back track. Once there's a failed check during backtracking, the backtracking
- * will return immediately.
+ * A variant of [[PhysicalOperation]]. It matches any number of project or filter
+ * operations even if they are non-deterministic, as long as they satisfy the
+ * requirement of CollapseProject and CombineFilters.
  */
 object ScanOperation extends OperationHelper with PredicateHelper {
   type ScanReturnType = Option[(Option[Seq[NamedExpression]],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -97,6 +97,12 @@ object PhysicalOperation extends OperationHelper with PredicateHelper {
     }
 }
 
+/**
+ * Unlike PhysicalOperation, this operation would firstly search the first non-Project
+ * and non-Filter LogicalPlan without non-deterministic expression check and then do that
+ * check when it back track. Once there's a failed check during backtracking, the backtracking
+ * will return immediately.
+ */
 object ScanOperation extends OperationHelper with PredicateHelper {
 
   def unapply(plan: LogicalPlan): Option[ReturnType] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -26,6 +26,28 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, _}
 
+trait OperationHelper {
+  type ReturnType = (Seq[NamedExpression], Seq[Expression], LogicalPlan)
+
+  protected def collectAliases(fields: Seq[Expression]): AttributeMap[Expression] =
+    AttributeMap(fields.collect {
+      case a: Alias => (a.toAttribute, a.child)
+    })
+
+  protected def substitute(aliases: AttributeMap[Expression])(expr: Expression): Expression = {
+    expr.transform {
+      case a @ Alias(ref: AttributeReference, name) =>
+        aliases.get(ref)
+          .map(Alias(_, name)(a.exprId, a.qualifier))
+          .getOrElse(a)
+
+      case a: AttributeReference =>
+        aliases.get(a)
+          .map(Alias(_, a.name)(a.exprId, a.qualifier)).getOrElse(a)
+    }
+  }
+}
+
 /**
  * A pattern that matches any number of project or filter operations on top of another relational
  * operator.  All filter operators are collected and their conditions are broken up and returned
@@ -33,8 +55,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, _}
  * [[org.apache.spark.sql.catalyst.expressions.Alias Aliases]] are in-lined/substituted if
  * necessary.
  */
-object PhysicalOperation extends PredicateHelper {
-  type ReturnType = (Seq[NamedExpression], Seq[Expression], LogicalPlan)
+object PhysicalOperation extends OperationHelper with PredicateHelper {
 
   def unapply(plan: LogicalPlan): Option[ReturnType] = {
     val (fields, filters, child, _) = collectProjectsAndFilters(plan)
@@ -74,39 +95,13 @@ object PhysicalOperation extends PredicateHelper {
       case other =>
         (None, Nil, other, AttributeMap(Seq()))
     }
-
-  private def collectAliases(fields: Seq[Expression]): AttributeMap[Expression] =
-    AttributeMap(fields.collect {
-      case a: Alias => (a.toAttribute, a.child)
-    })
-
-  private def substitute(aliases: AttributeMap[Expression])(expr: Expression): Expression = {
-    expr.transform {
-      case a @ Alias(ref: AttributeReference, name) =>
-        aliases.get(ref)
-          .map(Alias(_, name)(a.exprId, a.qualifier))
-          .getOrElse(a)
-
-      case a: AttributeReference =>
-        aliases.get(a)
-          .map(Alias(_, a.name)(a.exprId, a.qualifier)).getOrElse(a)
-    }
-  }
 }
 
-// Filter: 1. projectList; 2. filters
-// Project: P1 && P2 combined ?
-object FileSourceOperation extends PredicateHelper {
-  type ReturnType = (Seq[NamedExpression], Seq[Expression], LogicalPlan)
+object FileSourceOperation extends OperationHelper with PredicateHelper {
 
   def unapply(plan: LogicalPlan): Option[ReturnType] = {
-    println("FileSourceOperation unapply")
-    val (fields, filters, child, _, _, valid) = collectProjectsAndFilters(plan)
-    println(s"valid=$valid")
+    val (fields, filters, child, valid, _, _) = collectProjectsAndFilters(plan)
     if (valid) {
-      val fs = fields.getOrElse(child.output)
-      println(s"Fields: ${fs.map(_.name).mkString(", ")}")
-      println(s"Child: ${child.nodeName}")
       Some((fields.getOrElse(child.output), filters, child))
     } else {
       None
@@ -114,76 +109,48 @@ object FileSourceOperation extends PredicateHelper {
   }
 
   private def collectProjectsAndFilters(plan: LogicalPlan)
-    : (Option[Seq[NamedExpression]], Seq[Expression], LogicalPlan,
-    AttributeMap[Expression], AttributeSet, Boolean) =
+    : (Option[Seq[NamedExpression]], Seq[Expression], LogicalPlan, Boolean,
+    AttributeMap[Expression], Set[String]) =
       plan match {
         case p @ Project(fields, child) =>
-          println("---> Project")
-          val (_, filters, other, aliases, nonDeterministics, valid) =
+          val (_, filters, other, valid, aliases, nonDeterministics) =
             collectProjectsAndFilters(child)
           if (valid) {
             val substitutedFields =
               fields.map(substitute(aliases)).asInstanceOf[Seq[NamedExpression]]
-            val thisNonDeterministics = AttributeSet(substitutedFields.filter(!_.deterministic))
+            val thisNonDeterministics =
+              substitutedFields.filterNot(_.deterministic).map(_.name).toSet
             if (thisNonDeterministics.intersect(nonDeterministics).isEmpty) {
-              println("---> Project common non-Deterministic empty")
-              (Some(substitutedFields), filters, other, collectAliases(substitutedFields),
-                thisNonDeterministics, true)
+              (Some(substitutedFields), filters, other, true,
+                collectAliases(substitutedFields), thisNonDeterministics)
             } else {
-              println("---> Project common non-Deterministic nonEmpty")
-              (None, Nil, p, AttributeMap(Seq()), AttributeSet.empty, false)
+              (None, Nil, p, false, AttributeMap(Seq()), Set.empty)
             }
           } else {
-            println("---> Project not valid")
-            (None, Nil, p, AttributeMap(Seq()), AttributeSet.empty, false)
+            (None, Nil, p, false, AttributeMap(Seq()), Set.empty)
           }
 
-          // SELECT c1 FROM (SELECT key AS c1 FROM t1) t2 WHERE c1 > 10
-          // SELECT c1 AS c2 FROM (SELECT key AS c1 FROM t1) t2 WHERE c1 > 10
         case f @ Filter(condition, child) =>
-          println("---> Filter")
-          val (fields, filters, other, aliases, nonDeterministics, valid) =
+          val (fields, filters, other, valid, aliases, nonDeterministics) =
             collectProjectsAndFilters(child)
-          if (valid && condition.deterministic) {
+          if (valid) {
             val substitutedCondition = substitute(aliases)(condition)
-            if (substitutedCondition.references.intersect(nonDeterministics).isEmpty) {
-              println("---> Filter non-Deterministic empty")
+            if (substitutedCondition.deterministic) {
               (fields, filters ++ splitConjunctivePredicates(substitutedCondition),
-                other, aliases, nonDeterministics, true)
+                other, true, aliases, nonDeterministics)
             } else {
-              println("---> Filter non-Deterministic nonEmpty")
-              (None, Nil, f, AttributeMap(Seq()), AttributeSet.empty, false)
+              (None, Nil, f, false, AttributeMap(Seq()), Set.empty)
             }
           } else {
-            println("---> Filter not valid")
-            (None, Nil, f, AttributeMap(Seq()), AttributeSet.empty, false)
+            (None, Nil, f, false, AttributeMap(Seq()), Set.empty)
           }
 
         case h: ResolvedHint =>
           collectProjectsAndFilters(h.child)
 
         case other =>
-          println("---> other")
-          (None, Nil, other, AttributeMap(Seq()), AttributeSet.empty, true)
+          (None, Nil, other, true, AttributeMap(Seq()), Set.empty)
       }
-
-  private def collectAliases(fields: Seq[Expression]): AttributeMap[Expression] =
-    AttributeMap(fields.collect {
-      case a: Alias => (a.toAttribute, a.child)
-    })
-
-  private def substitute(aliases: AttributeMap[Expression])(expr: Expression): Expression = {
-    expr.transform {
-      case a @ Alias(ref: AttributeReference, name) =>
-        aliases.get(ref)
-          .map(Alias(_, name)(a.exprId, a.qualifier))
-          .getOrElse(a)
-
-      case a: AttributeReference =>
-        aliases.get(a)
-          .map(Alias(_, a.name)(a.exprId, a.qualifier)).getOrElse(a)
-    }
-  }
 }
 
 /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/ScanOperationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/ScanOperationSuite.scala
@@ -25,18 +25,17 @@ import org.apache.spark.sql.types.{DoubleType, StringType}
 case class TestRelation() extends LeafNode {
   override def output: Seq[Attribute] = Seq(
     AttributeReference("a", StringType)(),
-    AttributeReference("b", StringType)(),
-    AttributeReference("c", StringType)())
+    AttributeReference("b", StringType)())
 }
 
 class ScanOperationSuite extends SparkFunSuite {
   test("Collect projects and filters through non-deterministic expressions") {
-    val colA = AttributeReference("a", StringType)()
-    val colB = AttributeReference("b", StringType)()
+    val relation = TestRelation()
+    val colA = relation.output(0)
+    val colB = relation.output(1)
     val aliasR = Alias(Rand(1), "r")()
     val aliasId = Alias(MonotonicallyIncreasingID(), "id")()
     val colR = AttributeReference("r", DoubleType)(aliasR.exprId, aliasR.qualifier)
-    val relation = TestRelation()
 
     // Project with a non-deterministic field and a deterministic child Filter
     val project1 = Project(Seq(colB, aliasR), Filter(EqualTo(colA, Literal(1)), relation))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/ScanOperationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/ScanOperationSuite.scala
@@ -31,7 +31,6 @@ case class TestRelation() extends LeafNode {
 
 class ScanOperationSuite extends SparkFunSuite {
   test("Collect projects and filters through non-deterministic expressions") {
-    OneRowRelation
     val colA = AttributeReference("a", StringType)()
     val colB = AttributeReference("b", StringType)()
     val aliasR = Alias(Rand(1), "r")()

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/ScanOperationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/ScanOperationSuite.scala
@@ -51,7 +51,13 @@ class ScanOperationSuite extends SparkFunSuite {
 
     // Project with all deterministic fields but a non-deterministic Filter
     val project2 = Project(Seq(colA, colB), Filter(EqualTo(aliasR, Literal(1)), relation))
-    assert(ScanOperation.unapply(project2).isEmpty)
+    project2 match {
+      case ScanOperation(projects, filters, _: TestRelation) =>
+        assert(projects.size === 2)
+        assert(projects(0) === colA)
+        assert(projects(1) === colB)
+        assert(filters.size === 1)
+    }
 
     // Project which has the same non-deterministic expression with its child Project
     val project3 = Project(Seq(colA, colR), Project(Seq(colA, aliasR), relation))
@@ -79,5 +85,10 @@ class ScanOperationSuite extends SparkFunSuite {
         assert(projects(1) === aliasR)
         assert(filters.size === 1)
     }
+
+    // Filter which has a non-deterministic child Filter
+    val filter3 = Filter(EqualTo(colA, Literal(1)), Filter(EqualTo(aliasR, Literal(1)), relation))
+    assert(ScanOperation.unapply(filter3).isEmpty)
+
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/ScanOperationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/ScanOperationSuite.scala
@@ -1,10 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.sql.catalyst.planning
 
-/**
-  *
-  * @author wuyi
-  * @date 2019/11/24
-  */
-class ScanOperationSuite {
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, EqualTo, Literal, MonotonicallyIncreasingID, Rand}
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, LeafNode, OneRowRelation, Project}
+import org.apache.spark.sql.types.{DoubleType, StringType}
 
+case class TestRelation() extends LeafNode {
+  override def output: Seq[Attribute] = Seq(
+    AttributeReference("a", StringType)(),
+    AttributeReference("b", StringType)(),
+    AttributeReference("c", StringType)())
+}
+
+class ScanOperationSuite extends SparkFunSuite {
+  test("Collect projects and filters through non-deterministic expressions") {
+    OneRowRelation
+    val colA = AttributeReference("a", StringType)()
+    val colB = AttributeReference("b", StringType)()
+    val aliasR = Alias(Rand(1), "r")()
+    val aliasId = Alias(MonotonicallyIncreasingID(), "id")()
+    val colR = AttributeReference("r", DoubleType)(aliasR.exprId, aliasR.qualifier)
+    val relation = TestRelation()
+
+    // Project with a non-deterministic field and a deterministic child Filter
+    val project1 = Project(Seq(colB, aliasR), Filter(EqualTo(colA, Literal(1)), relation))
+    project1 match {
+      case ScanOperation(projects, filters, _: TestRelation) =>
+        assert(projects.size === 2)
+        assert(projects(0) === colB)
+        assert(projects(1) === aliasR)
+        assert(filters.size === 1)
+    }
+
+    // Project with all deterministic fields but a non-deterministic Filter
+    val project2 = Project(Seq(colA, colB), Filter(EqualTo(aliasR, Literal(1)), relation))
+    assert(ScanOperation.unapply(project2).isEmpty)
+
+    // Project which has the same non-deterministic expression with its child Project
+    val project3 = Project(Seq(colA, colR), Project(Seq(colA, aliasR), relation))
+    assert(ScanOperation.unapply(project3).isEmpty)
+
+    // Project which has different non-deterministic expressions with its child Project
+    val project4 = Project(Seq(colA, aliasId), Project(Seq(colA, aliasR), relation))
+    project4 match {
+      case ScanOperation(projects, _, _: TestRelation) =>
+        assert(projects.size === 2)
+        assert(projects(0) === colA)
+        assert(projects(1) === aliasId)
+    }
+
+    // Filter which has the same non-deterministic expression with its child Project
+    val filter1 = Filter(EqualTo(colR, Literal(1)), Project(Seq(colA, aliasR), relation))
+    assert(ScanOperation.unapply(filter1).isEmpty)
+
+    // Filter which doesn't have the same non-deterministic expression with its child Project
+    val filter2 = Filter(EqualTo(colA, Literal(1)), Project(Seq(colA, aliasR), relation))
+    filter2 match {
+      case ScanOperation(projects, filters, _: TestRelation) =>
+        assert(projects.size === 2)
+        assert(projects(0) === colA)
+        assert(projects(1) === aliasR)
+        assert(filters.size === 1)
+    }
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/ScanOperationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/ScanOperationSuite.scala
@@ -1,0 +1,10 @@
+package org.apache.spark.sql.catalyst.planning
+
+/**
+  *
+  * @author wuyi
+  * @date 2019/11/24
+  */
+class ScanOperationSuite {
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.planning.PhysicalOperation
+import org.apache.spark.sql.catalyst.planning.ScanOperation
 import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoDir, InsertIntoStatement, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{RowDataSourceScanExec, SparkPlan}
@@ -264,7 +264,7 @@ case class DataSourceStrategy(conf: SQLConf) extends Strategy with Logging with 
   import DataSourceStrategy._
 
   def apply(plan: LogicalPlan): Seq[execution.SparkPlan] = plan match {
-    case PhysicalOperation(projects, filters, l @ LogicalRelation(t: CatalystScan, _, _, _)) =>
+    case ScanOperation(projects, filters, l @ LogicalRelation(t: CatalystScan, _, _, _)) =>
       pruneFilterProjectRaw(
         l,
         projects,
@@ -272,7 +272,7 @@ case class DataSourceStrategy(conf: SQLConf) extends Strategy with Logging with 
         (requestedColumns, allPredicates, _) =>
           toCatalystRDD(l, requestedColumns, t.buildScan(requestedColumns, allPredicates))) :: Nil
 
-    case PhysicalOperation(projects, filters,
+    case ScanOperation(projects, filters,
                            l @ LogicalRelation(t: PrunedFilteredScan, _, _, _)) =>
       pruneFilterProject(
         l,
@@ -280,7 +280,7 @@ case class DataSourceStrategy(conf: SQLConf) extends Strategy with Logging with 
         filters,
         (a, f) => toCatalystRDD(l, a, t.buildScan(a.map(_.name).toArray, f))) :: Nil
 
-    case PhysicalOperation(projects, filters, l @ LogicalRelation(t: PrunedScan, _, _, _)) =>
+    case ScanOperation(projects, filters, l @ LogicalRelation(t: PrunedScan, _, _, _)) =>
       pruneFilterProject(
         l,
         projects,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -137,7 +137,7 @@ object FileSourceStrategy extends Strategy with Logging {
   }
 
   def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
-    case PhysicalOperation(projects, filters,
+    case FileSourceOperation(projects, filters,
       l @ LogicalRelation(fsRelation: HadoopFsRelation, _, table, _)) =>
       println("into FileSourceOperation")
       // Filters on this relation fall into four categories based on where we can use them to avoid

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -139,7 +139,6 @@ object FileSourceStrategy extends Strategy with Logging {
   def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
     case FileSourceOperation(projects, filters,
       l @ LogicalRelation(fsRelation: HadoopFsRelation, _, table, _)) =>
-      println("into FileSourceOperation")
       // Filters on this relation fall into four categories based on where we can use them to avoid
       // reading unneeded data:
       //  - partition keys only - used to prune directories to read
@@ -174,7 +173,6 @@ object FileSourceStrategy extends Strategy with Logging {
 
       val dataColumns =
         l.resolve(fsRelation.dataSchema, fsRelation.sparkSession.sessionState.analyzer.resolver)
-      println(s"dataColumns: ${dataColumns.toStructType.catalogString}")
 
       // Partition keys are not available in the statistics of the files.
       val dataFilters =
@@ -183,7 +181,6 @@ object FileSourceStrategy extends Strategy with Logging {
       // Predicates with both partition keys and attributes need to be evaluated after the scan.
       val afterScanFilters = filterSet -- partitionKeyFilters.filter(_.references.nonEmpty)
       logInfo(s"Post-Scan Filters: ${afterScanFilters.mkString(",")}")
-      println(s"Post-Scan Filters: ${afterScanFilters.mkString(",")}")
 
       val filterAttributes = AttributeSet(afterScanFilters)
       val requiredExpressions: Seq[NamedExpression] = filterAttributes.toSeq ++ projects
@@ -195,7 +192,6 @@ object FileSourceStrategy extends Strategy with Logging {
           .filterNot(partitionColumns.contains)
       val outputSchema = readDataColumns.toStructType
       logInfo(s"Output Data Schema: ${outputSchema.simpleString(5)}")
-      println(s"Output Data Schema: ${outputSchema.simpleString(5)}")
 
       val outputAttributes = readDataColumns ++ partitionColumns
 
@@ -220,7 +216,6 @@ object FileSourceStrategy extends Strategy with Logging {
       withProjections :: Nil
 
     case _ =>
-      println("not into FileSourceOperation")
       Nil
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.planning.{FileSourceOperation, PhysicalOperation}
+import org.apache.spark.sql.catalyst.planning.FileSourceOperation
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
 import org.apache.spark.util.collection.BitSet
@@ -215,7 +215,6 @@ object FileSourceStrategy extends Strategy with Logging {
 
       withProjections :: Nil
 
-    case _ =>
-      Nil
+    case _ => Nil
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.planning.FileSourceOperation
+import org.apache.spark.sql.catalyst.planning.ScanOperation
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
 import org.apache.spark.util.collection.BitSet
@@ -137,7 +137,7 @@ object FileSourceStrategy extends Strategy with Logging {
   }
 
   def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
-    case FileSourceOperation(projects, filters,
+    case ScanOperation(projects, filters,
       l @ LogicalRelation(fsRelation: HadoopFsRelation, _, table, _)) =>
       // Filters on this relation fall into four categories based on where we can use them to avoid
       // reading unneeded data:

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -21,7 +21,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.{AnalysisException, Strategy}
 import org.apache.spark.sql.catalyst.expressions.{And, PredicateHelper, SubqueryExpression}
-import org.apache.spark.sql.catalyst.planning.PhysicalOperation
+import org.apache.spark.sql.catalyst.planning.{FileSourceOperation, PhysicalOperation}
 import org.apache.spark.sql.catalyst.plans.logical.{AlterNamespaceSetProperties, AlterTable, AppendData, CreateNamespace, CreateTableAsSelect, CreateV2Table, DeleteFromTable, DescribeNamespace, DescribeTable, DropNamespace, DropTable, LogicalPlan, OverwriteByExpression, OverwritePartitionsDynamic, RefreshTable, RenameTable, Repartition, ReplaceTable, ReplaceTableAsSelect, SetCatalogAndNamespace, ShowCurrentNamespace, ShowNamespaces, ShowTableProperties, ShowTables}
 import org.apache.spark.sql.connector.catalog.{StagingTableCatalog, TableCapability}
 import org.apache.spark.sql.connector.read.streaming.{ContinuousStream, MicroBatchStream}
@@ -36,6 +36,7 @@ object DataSourceV2Strategy extends Strategy with PredicateHelper {
 
   override def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
     case PhysicalOperation(project, filters, relation: DataSourceV2ScanRelation) =>
+      println("into DataSourceV2Strategy.PhysicalOperation")
       // projection and filters were already pushed down in the optimizer.
       // this uses PhysicalOperation to get the projection and ensure that if the batch scan does
       // not support columnar, a projection is added to convert the rows to UnsafeRow.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -21,7 +21,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.{AnalysisException, Strategy}
 import org.apache.spark.sql.catalyst.expressions.{And, PredicateHelper, SubqueryExpression}
-import org.apache.spark.sql.catalyst.planning.{FileSourceOperation, PhysicalOperation}
+import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.{AlterNamespaceSetProperties, AlterTable, AppendData, CreateNamespace, CreateTableAsSelect, CreateV2Table, DeleteFromTable, DescribeNamespace, DescribeTable, DropNamespace, DropTable, LogicalPlan, OverwriteByExpression, OverwritePartitionsDynamic, RefreshTable, RenameTable, Repartition, ReplaceTable, ReplaceTableAsSelect, SetCatalogAndNamespace, ShowCurrentNamespace, ShowNamespaces, ShowTableProperties, ShowTables}
 import org.apache.spark.sql.connector.catalog.{StagingTableCatalog, TableCapability}
 import org.apache.spark.sql.connector.read.streaming.{ContinuousStream, MicroBatchStream}
@@ -36,7 +36,6 @@ object DataSourceV2Strategy extends Strategy with PredicateHelper {
 
   override def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
     case PhysicalOperation(project, filters, relation: DataSourceV2ScanRelation) =>
-      println("into DataSourceV2Strategy.PhysicalOperation")
       // projection and filters were already pushed down in the optimizer.
       // this uses PhysicalOperation to get the projection and ensure that if the batch scan does
       // not support columnar, a projection is added to convert the rows to UnsafeRow.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.datasources.v2
 
 import org.apache.spark.sql.catalyst.expressions.{And, SubqueryExpression}
-import org.apache.spark.sql.catalyst.planning.FileSourceOperation
+import org.apache.spark.sql.catalyst.planning.ScanOperation
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
@@ -27,7 +27,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] {
   import DataSourceV2Implicits._
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan transformDown {
-    case FileSourceOperation(project, filters, relation: DataSourceV2Relation) =>
+    case ScanOperation(project, filters, relation: DataSourceV2Relation) =>
       val scanBuilder = relation.table.asReadable.newScanBuilder(relation.options)
 
       val (withSubquery, withoutSubquery) = filters.partition(SubqueryExpression.hasSubquery)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.datasources.v2
 
 import org.apache.spark.sql.catalyst.expressions.{And, SubqueryExpression}
-import org.apache.spark.sql.catalyst.planning.PhysicalOperation
+import org.apache.spark.sql.catalyst.planning.{FileSourceOperation, PhysicalOperation}
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
@@ -27,7 +27,8 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] {
   import DataSourceV2Implicits._
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan transformDown {
-    case PhysicalOperation(project, filters, relation: DataSourceV2Relation) =>
+    case FileSourceOperation(project, filters, relation: DataSourceV2Relation) =>
+      println("into V2ScanRelationPushDown.PhysicalOperation")
       val scanBuilder = relation.table.asReadable.newScanBuilder(relation.options)
 
       val (withSubquery, withoutSubquery) = filters.partition(SubqueryExpression.hasSubquery)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -28,7 +28,6 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] {
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan transformDown {
     case FileSourceOperation(project, filters, relation: DataSourceV2Relation) =>
-      println("into V2ScanRelationPushDown.PhysicalOperation")
       val scanBuilder = relation.table.asReadable.newScanBuilder(relation.options)
 
       val (withSubquery, withoutSubquery) = filters.partition(SubqueryExpression.hasSubquery)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.datasources.v2
 
 import org.apache.spark.sql.catalyst.expressions.{And, SubqueryExpression}
-import org.apache.spark.sql.catalyst.planning.{FileSourceOperation, PhysicalOperation}
+import org.apache.spark.sql.catalyst.planning.FileSourceOperation
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Support columnar pruning through non-deterministic expressions.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

In some cases, columns can still be pruned even though nondeterministic expressions appears.
e.g. for the plan  `Filter('a = 1, Project(Seq('a, rand() as 'r), LogicalRelation('a, 'b)))`, we shall still prune column b while non-deterministic expression appears. 


### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added a new test file: `ScanOperationSuite`.
Added test in `FileSourceStrategySuite` to verify the right prune behavior for both DS v1 and v2.