### PR TITLE
[SPARK-29994][CORE] Add WILDCARD task location

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskLocation.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskLocation.scala
@@ -54,7 +54,7 @@ private [spark] case class HDFSCacheTaskLocation(override val host: String) exte
  * preferred locations to indicate that the task can be assigned to any host if it cannot get any
  * desired location immediately.
  */
-private [spark] case class WildcardLocation() extends TaskLocation {
+private [spark] case object WildcardLocation extends TaskLocation {
   override val host: String = "*"
   override def toString: String = host
 }
@@ -81,7 +81,7 @@ private[spark] object TaskLocation {
     val hstr = str.stripPrefix(inMemoryLocationTag)
     if (hstr.equals(str)) {
       if (str == "*") {
-        new WildcardLocation()
+        WildcardLocation
       } else if (str.startsWith(executorLocationTag)) {
         val hostAndExecutorId = str.stripPrefix(executorLocationTag)
         val splits = hostAndExecutorId.split("_", 2)

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskLocation.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskLocation.scala
@@ -51,11 +51,11 @@ private [spark] case class HDFSCacheTaskLocation(override val host: String) exte
 
 /**
  * A location that can match any host. This can be used as one of the locations in
- * [[org.apache.spark.rdd.RDD.getPreferredLocations]] to indicate that the task can be assigned to
- * any host if none of the other desired locations can be satisfied immediately.
+ * `RDD.getPreferredLocations` to indicate that the task can be assigned to any host if none of
+ * the other desired locations can be satisfied immediately.
  *
  * This location is only used internally by DAGScheduler to skip delayed scheduling for individual
- * RDDs. [[DAGScheduler.getPreferredLocs]] does not contain this location.
+ * RDDs. `DAGScheduler.getPreferredLocs` does not contain this location.
  *
  * @note This class is experimental and may be replaced by a more complete solution for delayed
  *       scheduling.

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskLocation.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskLocation.scala
@@ -54,8 +54,11 @@ private [spark] case class HDFSCacheTaskLocation(override val host: String) exte
  * [[org.apache.spark.rdd.RDD.getPreferredLocations]] to indicate that the task can be assigned to
  * any host if none of the other desired locations can be satisfied immediately.
  *
- * Note that this location is only used to skip delayed scheduling in DAGScheduler, and
- * [[DAGScheduler.getPreferredLocs]] does not contain this location.
+ * This location is only used internally by DAGScheduler to skip delayed scheduling for individual
+ * RDDs. [[DAGScheduler.getPreferredLocs]] does not contain this location.
+ *
+ * @note This class is experimental and may be replaced by a more complete solution for delayed
+ *       scheduling.
  */
 private [spark] case object WildcardLocation extends TaskLocation {
   override val host: String = "*"

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -218,7 +218,7 @@ private[spark] class TaskSetManager(
       speculatable: Boolean = false): Unit = {
     val pendingTaskSetToAddTo = if (speculatable) pendingSpeculatableTasks else pendingTasks
     for (loc <- tasks(index).preferredLocations) {
-      if (loc.isInstanceOf[WildcardLocation]) {
+      if (loc == WildcardLocation) {
         pendingTaskSetToAddTo.noPrefs += index
       } else {
         loc match {

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -217,39 +217,35 @@ private[spark] class TaskSetManager(
       resolveRacks: Boolean = true,
       speculatable: Boolean = false): Unit = {
     val pendingTaskSetToAddTo = if (speculatable) pendingSpeculatableTasks else pendingTasks
-    for (loc <- tasks(index).preferredLocations) {
-      if (loc == WildcardLocation) {
-        pendingTaskSetToAddTo.noPrefs += index
-      } else {
-        loc match {
-          case e: ExecutorCacheTaskLocation =>
-            pendingTaskSetToAddTo.forExecutor.getOrElseUpdate(e.executorId, new ArrayBuffer) +=
-              index
-          case e: HDFSCacheTaskLocation =>
-            val exe = sched.getExecutorsAliveOnHost(loc.host)
-            exe match {
-              case Some(set) =>
-                for (e <- set) {
-                  pendingTaskSetToAddTo.forExecutor.getOrElseUpdate(e, new ArrayBuffer) += index
-                }
-                logInfo(s"Pending task $index has a cached location at ${e.host} " +
-                  ", where there are executors " + set.mkString(","))
-              case None => logDebug(s"Pending task $index has a cached location at ${e.host} " +
-                ", but there are no executors alive there.")
-            }
-          case _ =>
-        }
-        pendingTaskSetToAddTo.forHost.getOrElseUpdate(loc.host, new ArrayBuffer) += index
-
-        if (resolveRacks) {
-          sched.getRackForHost(loc.host).foreach { rack =>
-            pendingTaskSetToAddTo.forRack.getOrElseUpdate(rack, new ArrayBuffer) += index
+    val preferredLocations = tasks(index).preferredLocations
+    for (loc <- preferredLocations.filter(_ != WildcardLocation)) {
+      loc match {
+        case e: ExecutorCacheTaskLocation =>
+          pendingTaskSetToAddTo.forExecutor.getOrElseUpdate(e.executorId, new ArrayBuffer) += index
+        case e: HDFSCacheTaskLocation =>
+          val exe = sched.getExecutorsAliveOnHost(loc.host)
+          exe match {
+            case Some(set) =>
+              for (e <- set) {
+                pendingTaskSetToAddTo.forExecutor.getOrElseUpdate(e, new ArrayBuffer) += index
+              }
+              logInfo(s"Pending task $index has a cached location at ${e.host} " +
+                ", where there are executors " + set.mkString(","))
+            case None => logDebug(s"Pending task $index has a cached location at ${e.host} " +
+              ", but there are no executors alive there.")
           }
+        case _ =>
+      }
+      pendingTaskSetToAddTo.forHost.getOrElseUpdate(loc.host, new ArrayBuffer) += index
+
+      if (resolveRacks) {
+        sched.getRackForHost(loc.host).foreach { rack =>
+          pendingTaskSetToAddTo.forRack.getOrElseUpdate(rack, new ArrayBuffer) += index
         }
       }
     }
 
-    if (tasks(index).preferredLocations == Nil) {
+    if (preferredLocations == Nil || preferredLocations.contains(WildcardLocation)) {
       pendingTaskSetToAddTo.noPrefs += index
     }
 

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -1289,44 +1289,6 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     assert(ArrayBuffer("1") === taskDescriptions(1).resources.get(GPU).get.addresses)
   }
 
-  test("Tasks with wildcard location can run immediately if preferred location not available") {
-    val conf = new SparkConf()
-      .set(config.LOCALITY_WAIT.key, "3s")
-    sc = new SparkContext("local", "TaskSchedulerImplSuite", conf)
-
-    // we create a manual clock just so we can be sure the clock doesn't advance at all in this test
-    val clock = new ManualClock()
-    val taskScheduler = new TaskSchedulerImpl(sc) {
-      override def createTaskSetManager(taskSet: TaskSet, maxTaskFailures: Int): TaskSetManager = {
-        new TaskSetManager(this, taskSet, maxTaskFailures, blacklistTrackerOpt, clock)
-      }
-    }
-    // Need to initialize a DAGScheduler for the taskScheduler to use for callbacks.
-    new DAGScheduler(sc, taskScheduler) {
-      override def taskStarted(task: Task[_], taskInfo: TaskInfo): Unit = {}
-      override def executorAdded(execId: String, host: String): Unit = {}
-    }
-    taskScheduler.initialize(new FakeSchedulerBackend)
-    // make an offer on the preferred host so the scheduler knows its alive.  This is necessary
-    // so that the taskset knows that it *could* take advantage of locality.
-    taskScheduler.resourceOffers(IndexedSeq(WorkerOffer("exec1", "host1", 1)))
-
-    // Submit a taskset with locality preferences.
-    val taskSet = FakeTask.createTaskSet(
-      1, stageId = 1, stageAttemptId = 0, Seq(TaskLocation("host1", "exec1"), TaskLocation("*")))
-    taskScheduler.submitTasks(taskSet)
-    val tsm = taskScheduler.taskSetManagerForAttempt(1, 0).get
-    // make sure we've setup our test correctly, so that the taskset knows it *could* use local
-    // offers.
-    assert(tsm.myLocalityLevels.contains(TaskLocality.NODE_LOCAL))
-    // make an offer on a non-preferred location.  Since the delay is 0, we should still schedule
-    // immediately.
-    val taskDescs =
-    taskScheduler.resourceOffers(IndexedSeq(WorkerOffer("exec2", "host2", 1))).flatten
-    assert(taskDescs.size === 1)
-    assert(taskDescs.head.executorId === "exec2")
-  }
-
   /**
    * Used by tests to simulate a task failure. This calls the failure handler explicitly, to ensure
    * that all the state is updated when this method returns. Otherwise, there's no way to know when

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -1801,9 +1801,9 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     sc = new SparkContext("local", "test")
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"), ("exec3", "host3"))
     val taskSet = FakeTask.createTaskSet(3,
-      Seq(TaskLocation("host1"), TaskLocation("*")),
-      Seq(TaskLocation("host1"), TaskLocation("*")),
-      Seq(TaskLocation("host2"), TaskLocation("*"))
+      Seq(TaskLocation("host1"), WildcardLocation),
+      Seq(TaskLocation("host1"), WildcardLocation),
+      Seq(TaskLocation("host2"), WildcardLocation)
     )
     val clock = new ManualClock
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds a new WILDCARD task location that can match any host. This WILDCARD location can be used together with other regular locations in the list of preferred locations to indicate that the task can be assigned to any host/executor if none of the preferred locations is available.

### Why are the changes needed?
This is motivated by the requirement from LocalShuffledRowRDD. When the number of initial mappers of LocalShuffledRowRDD is smaller than the number of worker nodes, it can cause serious regressions if short-running tasks all wait on their preferred locations while they could have otherwise finished quickly on non-preferred locations too.

We have a "locality wait time" configuration that allows a task set to downgrade locality requirement after a certain time has passed. Yet, this configuration affects all task sets in the scheduler, and tasks all differ in penalty of locality miss. Thus, we need this finer-grained option for individual tasks to opt out of locality.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
Added UT.