### PR TITLE
[SPARK-28812][SQL][DOC] Document SHOW PARTITIONS in SQL Reference

### DIFF
--- a/docs/sql-ref-syntax-aux-show-partitions.md
+++ b/docs/sql-ref-syntax-aux-show-partitions.md
@@ -26,29 +26,19 @@ partition spec.
 
 ### Syntax
 {% highlight sql %}
-SHOW PARTITIONS table_identifier [partition_spec]
+SHOW PARTITIONS table_name
+    [ PARTITION ( partition_col_name [ = partition_col_val ] [ , ... ] ) ]
 {% endhighlight %}
 
 ### Parameters
 <dl>
-  <dt><code><em>table_identifier</em></code></dt>
-  <dd>
-    Specifies a table name, which may be optionally qualified with a database name.<br><br>
-    <b>Syntax:</b>
-      <code>
-        [database_name.]table_name
-      </code>
-  </dd>
-  <dt><code><em>partition_spec</em></code></dt>
-  <dd>
-    An optional parameter that specifies a comma separated list of key and value pairs
-    for partitions. When specified, the partitions that match the partition spec
-    are returned.<br><br>
-    <b>Syntax:</b>
-      <code>
-        PARTITION (partition_col_name  = partition_col_val [ , ... ])
-      </code>
-  </dd>
+  <dt><code><em>table_name</em></code></dt>
+  <dd>The name of an existing table.</dd>
+</dl>
+<dl>
+  <dt><code><em>PARTITION ( partition_col_name [ = partition_col_val ] [ , ... ] )</em></code></dt>
+  <dd>An optional parameter that specifies a comma separated list of key and value pairs for
+      partitions. When specified, the partitions that match the partition spec are returned.</dd>
 </dl>
 
 ### Examples

--- a/docs/sql-ref-syntax-aux-show-partitions.md
+++ b/docs/sql-ref-syntax-aux-show-partitions.md
@@ -18,5 +18,96 @@ license: |
   See the License for the specific language governing permissions and
   limitations under the License.
 ---
+### Description
 
-**This page is under construction**
+The `SHOW PARTITIONS` statement is used to list partitions of a table. An optional
+partition spec may be specified to return the partitions matching the supplied
+partition spec.
+
+### Syntax
+{% highlight sql %}
+SHOW PARTITIONS table_identifier [partition_spec]
+{% endhighlight %}
+
+### Parameters
+<dl>
+  <dt><code><em>table_identifier</em></code></dt>
+  <dd>
+    Specifies a table name, which may be optionally qualified with a database name.<br><br>
+    <b>Syntax:</b>
+      <code>
+        [database_name.]table_name
+      </code>
+  </dd>
+  <dt><code><em>partition_spec</em></code></dt>
+  <dd>
+    An optional parameter that specifies a comma separated list of key and value pairs
+    for partitions. When specified, the partitions that matches the partition spec
+    are returned.<br><br>
+    <b>Syntax:</b>
+      <code>
+        PARTITION (partition_col_name  = partition_col_val [ , ... ])
+      </code>
+  </dd>
+</dl>
+
+### Example
+{% highlight sql %}
+-- create a partitioned table and insert a few rows.
+USE salesdb;
+CREATE TABLE customer(id INT, name STRING) PARTITIONED BY (state STRING, city STRING);
+INSERT INTO customer PARTITION (state = 'CA', city = 'Fremont') VALUES (100, 'John');
+INSERT INTO customer PARTITION (state = 'CA', city = 'San Jose') VALUES (200, 'Marry');
+INSERT INTO customer PARTITION (state = 'AZ', city = 'Peoria') VALUES (300, 'Daniel');
+
+-- Lists all partitions for table `customer`
+SHOW PARTITIONS customer;
+  +----------------------+
+  |partition             |
+  +----------------------+
+  |state=AZ/city=Peoria  |
+  |state=CA/city=Fremont |
+  |state=CA/city=San Jose|
+  +----------------------+
+
+-- Lists all partitions for the qualified table `customer`
+SHOW PARTITIONS salesdb.customer;
+  +----------------------+
+  |partition             |
+  +----------------------+
+  |state=AZ/city=Peoria  |
+  |state=CA/city=Fremont |
+  |state=CA/city=San Jose|
+  +----------------------+
+
+-- Specify a full partition spec to list specific partition
+SHOW PARTITIONS customer PARTITION (state = 'CA', city = 'Fremont');
+  +---------------------+
+  |partition            |
+  +---------------------+
+  |state=CA/city=Fremont|
+  +---------------------+
+
+-- Specify a partial partition spec to list the specific partitions
+SHOW PARTITIONS customer PARTITION (state = 'CA');
+  +----------------------+
+  |partition             |
+  +----------------------+
+  |state=CA/city=Fremont |
+  |state=CA/city=San Jose|
+  +----------------------+
+
+-- Specify a partial spec to list specific partition
+SHOW PARTITIONS customer PARTITION (city =  'San Jose');
+  +----------------------+
+  |partition             |
+  +----------------------+
+  |state=CA/city=San Jose|
+  +----------------------+
+{% endhighlight %}
+
+### Related statements
+- [CREATE TABLE](sql-ref-syntax-ddl-create-table.html)
+- [INSERT STATEMENT](sql-ref-syntax-dml-insert.html)
+- [DESCRIBE TABLE](sql-ref-syntax-aux-describe-table.html)
+- [SHOW TABLE](sql-ref-syntax-aux-show-table.html)

--- a/docs/sql-ref-syntax-aux-show-partitions.md
+++ b/docs/sql-ref-syntax-aux-show-partitions.md
@@ -42,7 +42,7 @@ SHOW PARTITIONS table_identifier [partition_spec]
   <dt><code><em>partition_spec</em></code></dt>
   <dd>
     An optional parameter that specifies a comma separated list of key and value pairs
-    for partitions. When specified, the partitions that matches the partition spec
+    for partitions. When specified, the partitions that match the partition spec
     are returned.<br><br>
     <b>Syntax:</b>
       <code>
@@ -51,7 +51,7 @@ SHOW PARTITIONS table_identifier [partition_spec]
   </dd>
 </dl>
 
-### Example
+### Examples
 {% highlight sql %}
 -- create a partitioned table and insert a few rows.
 USE salesdb;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Document SHOW PARTITIONS statement in SQL Reference Guide. 

### Why are the changes needed?
Currently Spark lacks documentation on the supported SQL constructs causing
confusion among users who sometimes have to look at the code to understand the
usage. This is aimed at addressing this issue.

### Does this PR introduce any user-facing change?
Yes. 

**Before**
**After**
![image](https://user-images.githubusercontent.com/14225158/69405056-89468180-0cb3-11ea-8eb7-93046eaf551c.png)
![image](https://user-images.githubusercontent.com/14225158/69405067-93688000-0cb3-11ea-810a-11cab9e4a041.png)
![image](https://user-images.githubusercontent.com/14225158/69405120-c01c9780-0cb3-11ea-91c0-91eeaa9238a0.png)

