### PR TITLE
[MINOR][INFRA] Use GitHub Action Cache for `build`

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -31,6 +31,12 @@ jobs:
     # We split caches because GitHub Action Cache has a 400MB-size limit.
     - uses: actions/cache@v1
       with:
+        path: build
+        key: build-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          build-
+    - uses: actions/cache@v1
+      with:
         path: ~/.m2/repository/com
         key: ${{ matrix.java }}-${{ matrix.hadoop }}-maven-com-${{ hashFiles('**/pom.xml') }}
         restore-keys: |


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds `GitHub Action Cache` task on `build` directory.

### Why are the changes needed?

This will replace the Maven downloading with the cache.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Manually check the GitHub Action log of this PR.