### PR TITLE
[SPARK-30009][CORE][SQL] Support different floating-point Ordering for Scala 2.12 / 2.13

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -26,12 +26,15 @@
   </parent>
 
   <artifactId>spark-core_2.12</artifactId>
-  <properties>
-    <sbt.project.name>core</sbt.project.name>
-  </properties>
   <packaging>jar</packaging>
   <name>Spark Project Core</name>
   <url>http://spark.apache.org/</url>
+
+  <properties>
+    <sbt.project.name>core</sbt.project.name>
+    <extra.source.dir>src/main/scala-${scala.binary.version}</extra.source.dir>
+  </properties>
+  
   <dependencies>
     <dependency>
       <groupId>com.thoughtworks.paranamer</groupId>
@@ -512,6 +515,24 @@
                 guava,jetty-io,jetty-servlet,jetty-servlets,jetty-continuation,jetty-http,jetty-plus,jetty-util,jetty-server,jetty-security,jetty-proxy,jetty-client
               </includeArtifactIds>
               <silent>true</silent>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-sources</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${extra.source.dir}</source>
+              </sources>
             </configuration>
           </execution>
         </executions>

--- a/core/src/main/scala-2.12/org/apache/spark/util/OrderingUtil.scala
+++ b/core/src/main/scala-2.12/org/apache/spark/util/OrderingUtil.scala
@@ -25,7 +25,7 @@ package org.apache.spark.util
  * It functions like Ordering.Double in Scala 2.12.
  */
 private[spark] object OrderingUtil {
-  
+
   def compareDouble(x: Double, y: Double): Int = Ordering.Double.compare(x, y)
 
   def compareFloat(x: Float, y: Float): Int = Ordering.Float.compare(x, y)

--- a/core/src/main/scala-2.12/org/apache/spark/util/OrderingUtil.scala
+++ b/core/src/main/scala-2.12/org/apache/spark/util/OrderingUtil.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+/**
+ * This class only exists to bridge the difference between Scala 2.12 and Scala 2.13's
+ * support for floating-point ordering. It is implemented separately for both as there
+ * is no method that exists in both for comparison.
+ *
+ * It functions like Ordering.Double in Scala 2.12.
+ */
+private[spark] object OrderingUtil {
+  
+  def compareDouble(x: Double, y: Double): Int = Ordering.Double.compare(x, y)
+
+  def compareFloat(x: Float, y: Float): Int = Ordering.Float.compare(x, y)
+
+}

--- a/core/src/main/scala-2.13/org/apache/spark/util/OrderingUtil.scala
+++ b/core/src/main/scala-2.13/org/apache/spark/util/OrderingUtil.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+/**
+ * This class only exists to bridge the difference between Scala 2.12 and Scala 2.13's
+ * support for floating-point ordering. It is implemented separately for both as there
+ * is no method that exists in both for comparison.
+ * 
+ * It functions like Ordering.Double.TotalOrdering in Scala 2.13, which matches java.lang.Double
+ * rather than Scala 2.12's Ordering.Double in handling of NaN.
+ */
+private[spark] object OrderingUtil {
+  
+  def compareDouble(x: Double, y: Double): Int = Ordering.Double.TotalOrdering.compare(x, y)
+
+  def compareFloat(x: Float, y: Float): Int = Ordering.Float.TotalOrdering.compare(x, y)
+
+}

--- a/core/src/main/scala-2.13/org/apache/spark/util/OrderingUtil.scala
+++ b/core/src/main/scala-2.13/org/apache/spark/util/OrderingUtil.scala
@@ -26,7 +26,7 @@ package org.apache.spark.util
  * rather than Scala 2.12's Ordering.Double in handling of NaN.
  */
 private[spark] object OrderingUtil {
-  
+
   def compareDouble(x: Double, y: Double): Int = Ordering.Double.TotalOrdering.compare(x, y)
 
   def compareFloat(x: Float, y: Float): Int = Ordering.Float.TotalOrdering.compare(x, y)

--- a/core/src/test/scala/org/apache/spark/util/collection/SorterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/SorterSuite.scala
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.internal.Logging
+import org.apache.spark.util.OrderingUtil
 import org.apache.spark.util.Utils.timeIt
 import org.apache.spark.util.random.XORShiftRandom
 
@@ -59,7 +60,7 @@ class SorterSuite extends SparkFunSuite with Logging {
 
     Arrays.sort(keys)
     new Sorter(new KVArraySortDataFormat[Double, Number])
-      .sort(keyValueArray, 0, keys.length, Ordering.Double)
+      .sort(keyValueArray, 0, keys.length, OrderingUtil.compareDouble)
 
     keys.zipWithIndex.foreach { case (k, i) =>
       assert(k === keyValueArray(2 * i))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
@@ -21,7 +21,7 @@ import scala.math.Numeric._
 import scala.math.Ordering
 
 import org.apache.spark.sql.types.Decimal.DecimalIsConflicted
-
+import org.apache.spark.util.OrderingUtil
 
 object ByteExactNumeric extends ByteIsIntegral with Ordering.ByteOrdering {
   private def checkOverflow(res: Int, x: Byte, y: Byte, op: String): Unit = {
@@ -118,7 +118,7 @@ object LongExactNumeric extends LongIsIntegral with Ordering.LongOrdering {
     }
 }
 
-object FloatExactNumeric extends FloatIsFractional with Ordering.FloatOrdering {
+object FloatExactNumeric extends FloatIsFractional {
   private def overflowException(x: Float, dataType: String) =
     throw new ArithmeticException(s"Casting $x to $dataType causes overflow")
 
@@ -148,9 +148,11 @@ object FloatExactNumeric extends FloatIsFractional with Ordering.FloatOrdering {
       overflowException(x, "int")
     }
   }
+
+  override def compare(x: Float, y: Float): Int = OrderingUtil.compareFloat(x, y)
 }
 
-object DoubleExactNumeric extends DoubleIsFractional with Ordering.DoubleOrdering {
+object DoubleExactNumeric extends DoubleIsFractional {
   private def overflowException(x: Double, dataType: String) =
     throw new ArithmeticException(s"Casting $x to $dataType causes overflow")
 
@@ -174,6 +176,8 @@ object DoubleExactNumeric extends DoubleIsFractional with Ordering.DoubleOrderin
       overflowException(x, "long")
     }
   }
+
+  override def compare(x: Double, y: Double): Int = OrderingUtil.compareDouble(x, y)
 }
 
 object DecimalExactNumeric extends DecimalIsConflicted {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make separate source trees for Scala 2.12/2.13 in order to accommodate mutually-incompatible support for Ordering of double, float.

Note: This isn't the last change that will need a split source tree for 2.13. But this particular change could go several ways:

- (Split source tree)
- Inline the Scala 2.12 implementation
- Reflection

For this change alone any are possible, and splitting the source tree is a bit overkill. But if it will be necessary for other JIRAs (see umbrella SPARK-25075), then it might be the easiest way to implement this.

### Why are the changes needed?

Scala 2.13 split Ordering.Double into Ordering.Double.TotalOrdering and Ordering.Double.IeeeOrdering. Neither can be used in a single build that supports 2.12 and 2.13.

TotalOrdering works like java.lang.Double.compare. IeeeOrdering works like Scala 2.12 Ordering.Double. They differ in how NaN is handled - compares always above other values? or always compares as 'false'? In theory they have different uses: TotalOrdering is important if floating-point values are sorted. IeeeOrdering behaves like 2.12 and JVM comparison operators.

I chose TotalOrdering as I think we care more about stable sorting, and because elsewhere we rely on java.lang comparisons. It is also possible to support with two methods.

### Does this PR introduce any user-facing change?

Pending tests, will see if it obviously affects any sort order. We need to see if it changes NaN sort order.

### How was this patch tested?

Existing tests so far.