### PR TITLE
[SPARK-29293][BUILD] Move scalafmt to Scala 2.12 profile; bump to 0.12

### DIFF
--- a/dev/scalafmt
+++ b/dev/scalafmt
@@ -17,4 +17,7 @@
 # limitations under the License.
 #
 
-./build/mvn mvn-scalafmt_2.12:format -Dscalafmt.skip=false
+# by default, format only files that differ from git master
+params="${@:---diff}"
+
+./build/mvn -Pscala-2.12 mvn-scalafmt_2.12:format -Dscalafmt.skip=false -Dscalafmt.parameters="$params"

--- a/dev/scalafmt
+++ b/dev/scalafmt
@@ -17,7 +17,4 @@
 # limitations under the License.
 #
 
-# by default, format only files that differ from git master
-params="${@:---diff}"
-
-./build/mvn mvn-scalafmt_2.12:format -Dscalafmt.skip=false -Dscalafmt.parameters="$params"
+./build/mvn mvn-scalafmt_2.12:format -Dscalafmt.skip=false

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,7 @@
     <commons.collections.version>3.2.2</commons.collections.version>
     <scala.version>2.12.10</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
+    <scalafmt.parameters>--diff --test</scalafmt.parameters>
     <!-- for now, not running scalafmt as part of default verify pipeline -->
     <scalafmt.skip>true</scalafmt.skip>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
@@ -2611,24 +2612,6 @@
             </lifecycleMappingMetadata>
           </configuration>
         </plugin>
-        <plugin>
-          <groupId>org.antipathy</groupId>
-          <artifactId>mvn-scalafmt_${scala.binary.version}</artifactId>
-          <version>1.0.2</version>
-          <configuration>
-            <skipSources>${scalafmt.skip}</skipSources> <!-- (Optional) skip formatting -->
-            <skipTestSources>${scalafmt.skip}</skipTestSources> <!-- (Optional) skip formatting -->
-            <configLocation>dev/.scalafmt.conf</configLocation> <!-- (Optional) config location -->
-          </configuration>
-          <executions>
-            <execution>
-              <phase>validate</phase>
-              <goals>
-                <goal>format</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -3005,9 +2988,35 @@
       </properties>
     </profile>
 
-    <!-- Exists for backwards compatibility; profile doesn't do anything -->
     <profile>
       <id>scala-2.12</id>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <!-- SPARK-29293 currently not able to update to 1.x for Scala 2.13 -->
+            <plugin>
+              <groupId>org.antipathy</groupId>
+              <artifactId>mvn-scalafmt_2.12</artifactId>
+              <version>0.12_1.5.1</version>
+              <configuration>
+                <parameters>${scalafmt.parameters}</parameters> <!-- (Optional) Additional command line arguments -->
+                <skip>${scalafmt.skip}</skip> <!-- (Optional) skip formatting -->
+                <skipSources>${scalafmt.skip}</skipSources>
+                <skipTestSources>${scalafmt.skip}</skipTestSources>
+                <configLocation>dev/.scalafmt.conf</configLocation> <!-- (Optional) config location -->
+              </configuration>
+              <executions>
+                <execution>
+                  <phase>validate</phase>
+                  <goals>
+                    <goal>format</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
     </profile>
     
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,6 @@
     <commons.collections.version>3.2.2</commons.collections.version>
     <scala.version>2.12.10</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
-    <scalafmt.parameters>--diff --test</scalafmt.parameters>
     <!-- for now, not running scalafmt as part of default verify pipeline -->
     <scalafmt.skip>true</scalafmt.skip>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
@@ -2612,6 +2611,24 @@
             </lifecycleMappingMetadata>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.antipathy</groupId>
+          <artifactId>mvn-scalafmt_${scala.binary.version}</artifactId>
+          <version>1.0.2</version>
+          <configuration>
+            <skipSources>${scalafmt.skip}</skipSources> <!-- (Optional) skip formatting -->
+            <skipTestSources>${scalafmt.skip}</skipTestSources> <!-- (Optional) skip formatting -->
+            <configLocation>dev/.scalafmt.conf</configLocation> <!-- (Optional) config location -->
+          </configuration>
+          <executions>
+            <execution>
+              <phase>validate</phase>
+              <goals>
+                <goal>format</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -2823,24 +2840,6 @@
                 <exclude>log4j.properties</exclude>
               </excludes>
             </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.antipathy</groupId>
-        <artifactId>mvn-scalafmt_${scala.binary.version}</artifactId>
-        <version>1.0.2</version>
-        <configuration>
-          <parameters>${scalafmt.parameters}</parameters> <!-- (Optional) Additional command line arguments -->
-          <skip>${scalafmt.skip}</skip> <!-- (Optional) skip formatting -->
-          <configLocation>dev/.scalafmt.conf</configLocation> <!-- (Optional) config location -->
-        </configuration>
-        <executions>
-          <execution>
-            <phase>validate</phase>
-            <goals>
-              <goal>format</goal>
-            </goals>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -2828,12 +2828,12 @@
       </plugin>
       <plugin>
         <groupId>org.antipathy</groupId>
-        <artifactId>mvn-scalafmt_2.12</artifactId>
-        <version>0.9_1.5.1</version>
+        <artifactId>mvn-scalafmt_${scala.binary.version}</artifactId>
+        <version>1.0.2</version>
         <configuration>
           <parameters>${scalafmt.parameters}</parameters> <!-- (Optional) Additional command line arguments -->
           <skip>${scalafmt.skip}</skip> <!-- (Optional) skip formatting -->
-          <configLocation>dev/.scalafmt.conf</configLocation> <!-- (Optional) config locataion -->
+          <configLocation>dev/.scalafmt.conf</configLocation> <!-- (Optional) config location -->
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Move scalafmt to Scala 2.12 profile; bump to 0.12.

### Why are the changes needed?

To facilitate a future Scala 2.13 build.

### Does this PR introduce any user-facing change?

None.

### How was this patch tested?

This isn't covered by tests, it's a convenience for contributors.
