### PR TITLE
[SPARK-29981][SQL][FOLLOWUP] Fix failing to run SQLQueryTestSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -43,23 +43,29 @@ import org.apache.spark.tags.ExtendedSQLTest
  *
  * To run the entire test suite:
  * {{{
- *   build/sbt "sql/test-only *SQLQueryTestSuite"
+ *   build/sbt -Phive-1.2 "sql/test-only *SQLQueryTestSuite"
  * }}}
  *
  * To run a single test file upon change:
  * {{{
- *   build/sbt "~sql/test-only *SQLQueryTestSuite -- -z inline-table.sql"
+ *   build/sbt -Phive-1.2 "~sql/test-only *SQLQueryTestSuite -- -z inline-table.sql"
  * }}}
  *
  * To re-generate golden files for entire suite, run:
  * {{{
- *   SPARK_GENERATE_GOLDEN_FILES=1 build/sbt "sql/test-only *SQLQueryTestSuite"
+ *   SPARK_GENERATE_GOLDEN_FILES=1 build/sbt -Phive-1.2 "sql/test-only *SQLQueryTestSuite"
  * }}}
  *
  * To re-generate golden file for a single test, run:
  * {{{
- *   SPARK_GENERATE_GOLDEN_FILES=1 build/sbt "sql/test-only *SQLQueryTestSuite -- -z describe.sql"
+ *   SPARK_GENERATE_GOLDEN_FILES=1 build/sbt -Phive-1.2 "sql/test-only *SQLQueryTestSuite --
+ *   -z describe.sql"
  * }}}
+ *
+ * Change profiles:
+ * We use `hadoop-2.7` as default now, so the above scripts is equivalent to
+ * `-Phadoop-2.7 -Phive-1.2`. You can change profiles to `-Phadoop-3.2 -Phive-2.3` to verify higher
+ * hadoop and hive versions.
  *
  * The format for input files is simple:
  *  1. A list of SQL queries separated by semicolon.

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerQueryTestSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerQueryTestSuite.scala
@@ -41,12 +41,18 @@ import org.apache.spark.sql.types._
  * To run the entire test suite:
  * {{{
  *   build/sbt "hive-thriftserver/test-only *ThriftServerQueryTestSuite" -Phive-thriftserver
+ *   -Phive-1.2
  * }}}
  *
  * This test suite won't generate golden files. To re-generate golden files for entire suite, run:
  * {{{
- *   SPARK_GENERATE_GOLDEN_FILES=1 build/sbt "sql/test-only *SQLQueryTestSuite"
+ *   SPARK_GENERATE_GOLDEN_FILES=1 build/sbt -Phive-1.2 "sql/test-only *SQLQueryTestSuite"
  * }}}
+ *
+ * Change profiles:
+ * We use `hadoop-2.7` as default now, so the above scripts is equivalent to
+ * `-Phadoop-2.7 -Phive-1.2`. You can change profiles to `-Phadoop-3.2 -Phive-2.3` to verify higher
+ * hadoop and hive versions.
  *
  * TODO:
  *   1. Support UDF testing.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Running `SQLQueryTestSuite` for testing,  i.e.
```scala
 SPARK_GENERATE_GOLDEN_FILES=1 build/sbt "sql/test-only *SQLQueryTestSuite -- -z cast.sql"
```
will fail with hive2.3 dependecies. Because the hadoop version used here is 2.7.4 by default.
```scala
....
....
....

[error] /Users/kentyao/spark/sql/core/v2.3/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcShimUtils.scala:64: not found: type HiveDecimalWritable
[error]       new HiveDecimalWritable(HiveDecimal.create(d.toJavaBigDecimal))
[error]           ^
[error] /Users/kentyao/spark/sql/core/v2.3/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcShimUtils.scala:64: not found: value HiveDecimal
[error]       new HiveDecimalWritable(HiveDecimal.create(d.toJavaBigDecimal))
[error]                               ^
[warn] two warnings found
[error] 39 errors found
[error] (sql/compile:compileIncremental) Compilation failed
[error] Total time: 64 s, completed 2019-11-25 13:22:12
```
This pr is a followup, only update the doc to run SQLQueryTestSuite correctly.

```scala
SPARK_GENERATE_GOLDEN_FILES=1 build/sbt -Phive-1.2 "sql/test-only *SQLQueryTestSuite -- -z cast.sql"
```

```scala
[info] ScalaTest
[info] Run completed in 10 seconds, 191 milliseconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 1, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[success] Total time: 85 s, completed 2019-11-25 13:29:34
```
### Why are the changes needed?

the default scripts fail to run tests because the underlying profile changed.


### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
no. developer side change.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
existing ut