### PR TITLE
[SPARK-30030][BUILD][FOLLOWUP] Remove unused org.apache.commons.lang

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -164,11 +164,6 @@
       <version>${javaxservlet.version}</version>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove the unused test dependency `commons-lang:commons-lang` from `core` module.

### Why are the changes needed?

SPARK-30030 already removed all usage of `Apache Commons Lang2` in `core`.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Pass the Jenkins.
