### PR TITLE
[MINOR][SS] Note that writer should not be closed in RateStreamMicroBatchStream.serialize

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/HDFSMetadataLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/HDFSMetadataLog.scala
@@ -90,6 +90,7 @@ class HDFSMetadataLog[T <: AnyRef : ClassTag](sparkSession: SparkSession, path: 
     }
   }
 
+  // Writer should not close the given stream when overriding methods.
   protected def serialize(metadata: T, out: OutputStream): Unit = {
     // called inside a try-finally where the underlying stream is closed in the caller
     Serialization.write(metadata, out)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/RateStreamMicroBatchStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/RateStreamMicroBatchStream.scala
@@ -62,7 +62,6 @@ class RateStreamMicroBatchStream(
 
     val metadataLog =
       new HDFSMetadataLog[LongOffset](session.get, checkpointLocation) {
-        // Writer should not close the given stream when overriding methods.
         override def serialize(metadata: LongOffset, out: OutputStream): Unit = {
           val writer = new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8))
           writer.write("v" + VERSION + "\n")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/RateStreamMicroBatchStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/RateStreamMicroBatchStream.scala
@@ -62,6 +62,7 @@ class RateStreamMicroBatchStream(
 
     val metadataLog =
       new HDFSMetadataLog[LongOffset](session.get, checkpointLocation) {
+        // Writer should not close the given stream when overriding methods.
         override def serialize(metadata: LongOffset, out: OutputStream): Unit = {
           val writer = new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8))
           writer.write("v" + VERSION + "\n")


### PR DESCRIPTION

### What changes were proposed in this pull request?
a small contribution
BufferedWriter should be closed when the content has been flushed.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
it maybe fail for some reason,and it should be closed.

### How was this patch tested?

