### PR TITLE
[WIP][SPARK-18886][CORE] Make locality wait time be the time since a TSM's available slots were fully utilized

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/Pool.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Pool.scala
@@ -126,10 +126,11 @@ private[spark] class Pool(
         val usableWeights = schedulableQueue.asScala
           .map(s => if (s.getSortedTaskSetQueue.nonEmpty) (s, s.weight) else (s, 0))
         val totalWeights = usableWeights.map(_._2).sum
-        usableWeights.foreach({case (schedulable, usableWeight) =>
+        usableWeights.foreach { case (schedulable, usableWeight) =>
           schedulable.updateAvailableSlots(
             Math.max(numSlots * usableWeight / totalWeights, schedulable.minShare))
-        })
+        }
+      // for FIFO, allocate all slots to the first taskset in the queue
       case SchedulingMode.FIFO =>
         val sortedSchedulableQueue =
           schedulableQueue.asScala.toSeq.sortWith(taskSetSchedulingAlgorithm.comparator)

--- a/core/src/main/scala/org/apache/spark/scheduler/Schedulable.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Schedulable.scala
@@ -39,6 +39,7 @@ private[spark] trait Schedulable {
   def stageId: Int
   def name: String
 
+  def updateAvailableSlots(numSlots: Float): Unit
   def addSchedulable(schedulable: Schedulable): Unit
   def removeSchedulable(schedulable: Schedulable): Unit
   def getSchedulableByName(name: String): Schedulable

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -406,6 +406,7 @@ private[spark] class TaskSchedulerImpl(
       if (!executorIdToRunningTaskIds.contains(o.executorId)) {
         hostToExecutors(o.host) += o.executorId
         executorAdded(o.executorId, o.host)
+        // Assumes the first offer will include all cores (free cores == all cores)
         executorIdToCores(o.executorId) = o.cores
         totalSlots += o.cores / CPUS_PER_TASK
         executorIdToHost(o.executorId) = o.host

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -201,7 +201,8 @@ private[spark] class TaskSetManager(
   private[scheduler] var localityWaits = myLocalityLevels.map(getLocalityWait)
 
   // Delay scheduling variables: we keep track of our current locality level and the time we
-  // last launched a task at that level and were also fully utilizing all slots
+  // last launched a task at that level and were also fully utilizing all "available" slots.
+  // See Pool.updateAvailableSlots() for how the number of available slots is calculated.
   // Move up a level when localityWaits[curLevel] expires.
   // We then move down if we manage to launch a "more local" task.
   private var currentLocalityIndex = 0 // Index of our current locality level in validLocalityLevels

--- a/core/src/test/scala/org/apache/spark/scheduler/PoolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/PoolSuite.scala
@@ -50,6 +50,7 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
     nextTaskSetToSchedule.get.addRunningTask(taskId)
     assert(nextTaskSetToSchedule.get.stageId === expectedStageId)
   }
+
   test("validate FIFO slot distributions") {
     sc = new SparkContext(LOCAL, APP_NAME)
     val taskScheduler = new TaskSchedulerImpl(sc)

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -200,9 +200,6 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     val clock = new ManualClock
     val conf = new SparkConf()
     sc = new SparkContext("local", "TaskSchedulerImplSuite", conf)
-    // import org.slf4j.{Logger, LoggerFactory}
-    import org.apache.log4j.{Logger, Level}
-    Logger.getLogger("org.apache.spark.scheduler.TaskSetManager").setLevel(Level.DEBUG)
     val taskScheduler = new TaskSchedulerImpl(sc,
       sc.conf.get(config.TASK_MAX_FAILURES),
       clock = clock) {
@@ -249,7 +246,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
       .flatten.head
     assert(task2.index === 2)
     taskScheduler.statusUpdate(task1.taskId, TaskState.FINISHED, ByteBuffer.allocate(0))
-    assert(taskScheduler.resourceOffers(IndexedSeq(WorkerOffer("exec1", "host2", 1)))
+    assert(taskScheduler.resourceOffers(IndexedSeq(WorkerOffer("exec1", "host1", 1)))
       .flatten.head.index === 3)
     assert(taskScheduler.resourceOffers(IndexedSeq(WorkerOffer("exec2", "host2", 1)))
       .flatten.isEmpty)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently the time window that locality wait times are measuring is the time since the last task launched for a TSM. The proposed change is to instead measure the time since this TSM's available slots were fully utilized.

The number of available slots for a TSM is determined by dividing all slots among the TSMs according to the scheduling policy (FIFO vs FAIR). 

### Why are the changes needed?

- cluster can become heavily underutilized as described in [SPARK-18886](https://issues.apache.org/jira/browse/SPARK-18886?jql=project%20%3D%20SPARK%20AND%20text%20~%20delay)


### How was this patch tested?
PoolSuite
TaskSchedulerImplSuite
TaskSetManagerSuite

Thoughts on this approach?
@viirya 
@squito 
@kayousterhout 