### PR TITLE
[SPARK-30075][CORE][TESTS] Fix the hashCode implementation of ArrayKeyIndexType correctly

### DIFF
--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/ArrayKeyIndexType.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/ArrayKeyIndexType.java
@@ -38,7 +38,7 @@ public class ArrayKeyIndexType {
 
   @Override
   public int hashCode() {
-    return key.hashCode();
+    return Arrays.hashCode(key);
   }
 
 }

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/ArrayKeyIndexType.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/ArrayKeyIndexType.java
@@ -38,7 +38,7 @@ public class ArrayKeyIndexType {
 
   @Override
   public int hashCode() {
-    return Arrays.hashCode(key);
+    return Arrays.hashCode(key) ^ Arrays.hashCode(id);
   }
 
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This patch fixes the bug on ArrayKeyIndexType.hashCode() as it is simply calling Array.hashCode() which in turn calls Object.hashCode(). That should be Arrays.hashCode() to reflect the elements in the array.

### Why are the changes needed?

I've encountered the bug in #25811 while adding test codes for #25811, and I've split the fix into individual PR to speed up reviewing. Without this patch, ArrayKeyIndexType would bring various issues when it's used as type of collections.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

I've skipped adding UT as ArrayKeyIndexType is in test and the patch is pretty simple one-liner.