### PR TITLE
[SPARK-30079][TESTS] set locale en_US in pom.xml for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2367,6 +2367,9 @@
               <spark.ui.showConsoleProgress>false</spark.ui.showConsoleProgress>
               <spark.unsafe.exceptionOnMemoryLeak>true</spark.unsafe.exceptionOnMemoryLeak>
               <spark.memory.debugFill>true</spark.memory.debugFill>
+              <!-- let tests checking for exception messages or formatted numbers pass in environments other than en_US -->
+              <user.language>en</user.language>
+              <user.region>US</user.region>
               <!-- Needed by sql/hive tests. -->
               <test.src.tables>src</test.src.tables>
             </systemProperties>
@@ -2416,6 +2419,9 @@
               <spark.ui.enabled>false</spark.ui.enabled>
               <spark.ui.showConsoleProgress>false</spark.ui.showConsoleProgress>
               <spark.unsafe.exceptionOnMemoryLeak>true</spark.unsafe.exceptionOnMemoryLeak>
+              <!-- let tests checking for exception messages or formatted numbers pass in en_US environments -->
+              <user.language>en</user.language>
+              <user.region>US</user.region>
               <!-- Needed by sql/hive tests. -->
               <test.src.tables>__not_used__</test.src.tables>
             </systemProperties>


### PR DESCRIPTION
Added system-properties for tests (surefire & scalatest) to enforce locale en_US.

Some tests fail in other environments, because assertions assume english messages and formatting of numbers.

### What changes were proposed in this pull request?

configuration in pom.xml, so surefire and scalatest run with locale en_US.

### Why are the changes needed?

some tests fail on systems with different locales. E.g. org.apache.spark.deploy.SparkSubmitSuite
Some assert messages of exceptions, which depend on the language of the environment.
Others failed, because numbers are formatted differently. E.g. "," instead of ".".

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

- checkout master
- build fails with locale de_DE
- switch system locale to en_US build success.
- added proposed properties to pom.xml and reset system to de_DE.
- tests still green.

no new tests added. existing tests started working.