### PR TITLE
[SPARK-25100][CORE] Register TaskCommitMessage to KyroSerializer

### DIFF
--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -40,6 +40,7 @@ import org.apache.spark._
 import org.apache.spark.api.python.PythonBroadcast
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.Kryo._
+import org.apache.spark.internal.io.FileCommitProtocol._
 import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.scheduler.{CompressedMapStatus, HighlyCompressedMapStatus}
 import org.apache.spark.storage._
@@ -469,7 +470,8 @@ private[serializer] object KryoSerializer {
     classOf[Array[String]],
     classOf[Array[Array[String]]],
     classOf[BoundedPriorityQueue[_]],
-    classOf[SparkConf]
+    classOf[SparkConf],
+    classOf[TaskCommitMessage]
   )
 
   private val toRegisterSerializer = Map[Class[_], KryoClassSerializer[_]](

--- a/core/src/test/scala/org/apache/spark/FileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FileSuite.scala
@@ -705,11 +705,11 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
   test("SPARK-25100: Using KryoSerializer and" +
       "setting registrationRequired true can lead job failed") {
     val tempDir = Utils.createTempDir()
-    val inputDir = tempDir.getAbsolutePath + "/input"
+    val inputFile = tempDir.getAbsolutePath + "/input"
     val textFileOutputDir = tempDir.getAbsolutePath + "/out1"
-    val datasetDir = tempDir.getAbsolutePath + "/out2"
+    val dataSetDir = tempDir.getAbsolutePath + "/out2"
 
-    val writer = new PrintWriter(new File(inputDir))
+    val writer = new PrintWriter(new File(inputFile))
 
     for(i <- 1 to 100) {
       writer.print(i)
@@ -725,10 +725,10 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
     val jobConf = new JobConf()
     jobConf.setOutputKeyClass(classOf[IntWritable])
     jobConf.setOutputValueClass(classOf[IntWritable])
-    jobConf.set("mapred.output.dir", datasetDir)
+    jobConf.set("mapred.output.dir", dataSetDir)
 
     val sc = new SparkContext(conf)
-    val rdd = sc.textFile(inputDir)
+    val rdd = sc.textFile(inputFile)
     val pair = rdd.map(x => (x, 1))
 
     pair.saveAsTextFile(textFileOutputDir)

--- a/core/src/test/scala/org/apache/spark/FileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FileSuite.scala
@@ -725,10 +725,9 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
     jobConf.set("mapred.output.dir", dataSetDir)
 
     sc = new SparkContext(conf)
-    val rdd = sc.textFile(inputFile)
-    val pair = rdd.map(x => (x, 1))
+    val pairRDD = sc.textFile(inputFile).map(x => (x, 1))
 
-    pair.saveAsTextFile(textFileOutputDir)
-    pair.saveAsNewAPIHadoopDataset(jobConf)
+    pairRDD.saveAsTextFile(textFileOutputDir)
+    pairRDD.saveAsNewAPIHadoopDataset(jobConf)
   }
 }

--- a/core/src/test/scala/org/apache/spark/serializer/KryoSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/KryoSerializerSuite.scala
@@ -375,7 +375,9 @@ class KryoSerializerSuite extends SparkFunSuite with SharedSparkContext {
     val taskCommitMessage1 = new TaskCommitMessage(addedAbsPathFiles.toMap -> partitionPaths.toSet)
     val taskCommitMessage2 = new TaskCommitMessage(Map.empty -> Set.empty)
     Seq(taskCommitMessage1, taskCommitMessage2).foreach { taskCommitMessage =>
-      ser.serialize(taskCommitMessage)
+      val obj1 = ser.deserialize[TaskCommitMessage](ser.serialize(taskCommitMessage)).obj
+      val obj2 = taskCommitMessage.obj
+      assert(obj1 == obj2)
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/serializer/KryoSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/KryoSerializerSuite.scala
@@ -30,6 +30,7 @@ import scala.reflect.ClassTag
 import com.esotericsoftware.kryo.{Kryo, KryoException}
 import com.esotericsoftware.kryo.io.{Input => KryoInput, Output => KryoOutput}
 import org.roaringbitmap.RoaringBitmap
+
 import org.apache.spark.{SharedSparkContext, SparkConf, SparkFunSuite}
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.Kryo._


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the bug when invoking saveAsNewAPIHadoopDataset to store data, the job will fail because the class TaskCommitMessage hasn't be registered if serializer is KryoSerializer and spark.kryo.registrationRequired is true

## How was this patch tested?

UT