### PR TITLE
[SPARK-30077][SQL] Create TEMPORARY VIEW USING should look up catalog/table like v2 commands

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -172,7 +172,7 @@ statement
          (TBLPROPERTIES tablePropertyList))*
         AS query                                                       #createView
     | CREATE (OR REPLACE)? GLOBAL? TEMPORARY VIEW
-        tableIdentifier ('(' colTypeList ')')? tableProvider
+        multipartIdentifier ('(' colTypeList ')')? tableProvider
         (OPTIONS tablePropertyList)?                                   #createTempViewUsing
     | ALTER VIEW multipartIdentifier AS? query                         #alterViewQuery
     | CREATE (OR REPLACE)? TEMPORARY? FUNCTION (IF NOT EXISTS)?

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2642,9 +2642,9 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
           ifNotExists = ifNotExists)
 
       case None if temp =>
-        // CREATE TEMPORARY TABLE ... USING ... is not supported by the catalyst parser.
+        // CREATE TEMPORARY TABLE ... USING ... is not supported.
         // Use CREATE TEMPORARY VIEW ... USING ... instead.
-        operationNotAllowed("CREATE TEMPORARY TABLE IF NOT EXISTS", ctx)
+        operationNotAllowed("CREATE TEMPORARY TABLE", ctx)
 
       case _ =>
         CreateTableStatement(table, schema.getOrElse(new StructType), partitioning, bucketSpec,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3280,6 +3280,20 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
   }
 
   /**
+   * Creates a [[CreateTempViewUsingStatement]].
+   */
+  override def visitCreateTempViewUsing(
+      ctx: CreateTempViewUsingContext): LogicalPlan = withOrigin(ctx) {
+    CreateTempViewUsingStatement(
+      visitMultipartIdentifier(ctx.multipartIdentifier),
+      Option(ctx.colTypeList()).map(createSchema),
+      ctx.REPLACE != null,
+      ctx.GLOBAL != null,
+      ctx.tableProvider.multipartIdentifier.getText,
+      Option(ctx.tablePropertyList).map(visitPropertyKeyValues).getOrElse(Map.empty))
+  }
+
+  /**
    * Alter the query of a view. This creates a [[AlterViewAsStatement]]
    *
    * For example:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
@@ -102,7 +102,7 @@ case class CreateViewStatement(
     viewType: ViewType) extends ParsedStatement
 
 /**
- * A CREATE TEMP VIEW USINGstatement, as parsed from SQL.
+ * A CREATE TEMP VIEW USING statement, as parsed from SQL.
  */
 case class CreateTempViewUsingStatement(
     viewName: Seq[String],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
@@ -102,6 +102,17 @@ case class CreateViewStatement(
     viewType: ViewType) extends ParsedStatement
 
 /**
+ * A CREATE TEMP VIEW USINGstatement, as parsed from SQL.
+ */
+case class CreateTempViewUsingStatement(
+    viewName: Seq[String],
+    userSpecifiedSchema: Option[StructType],
+    replace: Boolean,
+    global: Boolean,
+    provider: String,
+    options: Map[String, String]) extends ParsedStatement
+
+/**
  * A REPLACE TABLE command, as parsed from SQL.
  *
  * If the table exists prior to running this command, executing this statement

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -1768,6 +1768,20 @@ class DDLParserSuite extends AnalysisTest {
     intercept(sql2, "Found duplicate clauses: TBLPROPERTIES")
   }
 
+  test("create temp view using") {
+    val v = "CREATE TEMPORARY VIEW a.b.c USING JSON"
+    val parsed = parsePlan(v)
+
+    val expected = CreateTempViewUsingStatement(
+      Seq("a", "b", "c"),
+      None,
+      false,
+      false,
+      "JSON",
+      Map.empty[String, String])
+    comparePlans(parsed, expected)
+  }
+
   test("SHOW TBLPROPERTIES table") {
     comparePlans(
       parsePlan("SHOW TBLPROPERTIES a.b.c"),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -1769,12 +1769,12 @@ class DDLParserSuite extends AnalysisTest {
   }
 
   test("create temp view using") {
-    val v = "CREATE TEMPORARY VIEW a.b.c USING JSON"
+    val v = "CREATE TEMPORARY VIEW a.b.c (col int) USING JSON"
     val parsed = parsePlan(v)
-
     val expected = CreateTempViewUsingStatement(
       Seq("a", "b", "c"),
-      None,
+      Some(new StructType()
+        .add("col", IntegerType, nullable = true)),
       false,
       false,
       "JSON",

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -24,10 +24,10 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogTable, CatalogTableType, CatalogUtils}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogPlugin, LookupCatalog, SupportsNamespaces, Table, TableCatalog, TableChange, V1Table}
+import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogPlugin, LookupCatalog, SupportsNamespaces, TableCatalog, TableChange, V1Table}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.execution.command._
-import org.apache.spark.sql.execution.datasources.{CreateTable, DataSource, RefreshTable}
+import org.apache.spark.sql.execution.datasources.{CreateTable, CreateTempViewUsing, DataSource, RefreshTable}
 import org.apache.spark.sql.execution.datasources.v2.FileDataSourceV2
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{HIVE_TYPE_STRING, HiveStringType, MetadataBuilder, StructField, StructType}
@@ -466,6 +466,18 @@ class ResolveSessionCatalog(
         allowExisting,
         replace,
         viewType)
+
+    case CreateTempViewUsingStatement(
+      tableName, userSpecifiedSchema, replace, global, provider, options) =>
+
+      val v1TableName = parseV1Table(tableName, "CREATE TEMP VIEW USING")
+      CreateTempViewUsing(
+        v1TableName.asTableIdentifier,
+        userSpecifiedSchema,
+        replace,
+        global,
+        provider,
+        options)
 
     case ShowTablePropertiesStatement(SessionCatalog(_, tableName), propertyKey) =>
       ShowTablePropertiesCommand(

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -1745,7 +1745,7 @@ class DataSourceV2SQLSuite
   test("CREATE TEMP VIEW USING") {
     val v = "testcat.ns1.ns2.v"
     val e = intercept[AnalysisException] {
-      sql(s"CREATE TEMPORARY VIEW $v USING JSON")
+      sql(s"CREATE TEMPORARY VIEW $v (c1 int) USING JSON")
     }
     assert(e.message.contains("CREATE TEMP VIEW USING is only supported with v1 tables"))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -1742,6 +1742,14 @@ class DataSourceV2SQLSuite
     assert(e.message.contains("CREATE VIEW is only supported with v1 tables"))
   }
 
+  test("CREATE TEMP VIEW USING") {
+    val v = "testcat.ns1.ns2.v"
+    val e = intercept[AnalysisException] {
+      sql(s"CREATE TEMPORARY VIEW $v USING JSON")
+    }
+    assert(e.message.contains("CREATE TEMP VIEW USING is only supported with v1 tables"))
+  }
+
   test("SHOW TBLPROPERTIES: v2 table") {
     val t = "testcat.ns1.ns2.tbl"
     withTable(t) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -1004,7 +1004,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
     withTempView("tab1") {
       sql(
         """
-          |CREATE TEMPORARY TABLE tab1
+          |CREATE TEMPORARY VIEW tab1
           |USING org.apache.spark.sql.sources.DDLScanSource
           |OPTIONS (
           |  From '1',
@@ -1067,7 +1067,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
     withTempView("tab1", "tab2") {
       sql(
         """
-          |CREATE TEMPORARY TABLE tab1
+          |CREATE TEMPORARY VIEW tab1
           |USING org.apache.spark.sql.sources.DDLScanSource
           |OPTIONS (
           |  From '1',
@@ -1078,7 +1078,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
 
       sql(
         """
-          |CREATE TEMPORARY TABLE tab2
+          |CREATE TEMPORARY VIEW tab2
           |USING org.apache.spark.sql.sources.DDLScanSource
           |OPTIONS (
           |  From '1',
@@ -1993,7 +1993,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
     withTempView("t_temp") {
       sql("CREATE TEMPORARY VIEW t_temp AS SELECT 1, 2")
       val e = intercept[TempTableAlreadyExistsException] {
-        sql("CREATE TEMPORARY TABLE t_temp (c3 int, c4 string) USING JSON")
+        sql("CREATE TEMPORARY VIEW t_temp (c3 int, c4 string) USING JSON")
       }.getMessage
       assert(e.contains("Temporary view 't_temp' already exists"))
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add CreateTempViewUsingStatement and make CREARE TEMPORARY VIEW go through the same catalog/table resolution framework of v2 commands.
### Why are the changes needed?
It's important to make all the commands have the same table resolution behavior, to avoid confusing end-users. 
### Does this PR introduce any user-facing change?
Yes. When running CREATE TEMPORARY VIEW USING ...,  Spark fails the command if the current catalog is set to a v2 catalog, or the view name specified a v2 catalog.
### How was this patch tested?
unit tests
